### PR TITLE
fix(telegram): keep polling while turns stream

### DIFF
--- a/integrations/telegram-bridge/src/index.mjs
+++ b/integrations/telegram-bridge/src/index.mjs
@@ -157,15 +157,17 @@ const config = {
 };
 
 const threadStore = await ThreadStore.open(config.threadMapPath);
+const activeTurnTasks = new Map();
 let stopping = false;
 let updateOffset = Number(process.env.TELEGRAM_UPDATE_OFFSET || 0);
 
-process.once("SIGINT", () => {
+function requestStop() {
   stopping = true;
-});
-process.once("SIGTERM", () => {
-  stopping = true;
-});
+  abortActiveTurnStreams();
+}
+
+process.once("SIGINT", requestStop);
+process.once("SIGTERM", requestStop);
 
 console.log("Starting CodeWhale Telegram bridge");
 console.log(`Runtime: ${config.runtimeUrl}`);
@@ -301,7 +303,7 @@ async function handleCommand(chatId, command) {
       await setChatModel(chatId, action.modelName);
       return;
     case "prompt":
-      await runPrompt(chatId, action.prompt);
+      startPromptTurn(chatId, action.prompt);
       return;
     default:
       await sendText(chatId, helpText(), { replyMarkup: controlKeyboard() });
@@ -339,7 +341,9 @@ async function handleCallbackQuery(query) {
     return;
   }
 
-  await answerCallback(query.id, "Working...");
+  answerCallback(query.id, "Working...").catch((error) => {
+    console.warn("failed to acknowledge Telegram callback", error);
+  });
   await handleModalAction(identity.chatId, action, query);
 }
 
@@ -451,7 +455,67 @@ async function ensureThread(chatId, { forceNew = false } = {}) {
   return state;
 }
 
-async function runPrompt(chatId, prompt) {
+function startPromptTurn(chatId, prompt) {
+  if (activeTurnTasks.has(chatId)) {
+    void sendText(chatId, "Thread already has an active turn. Wait for it to finish or send /interrupt.", {
+      replyMarkup: activeTurnKeyboard()
+    }).catch((error) => {
+      console.error("failed to report active Telegram bridge turn", error);
+    });
+    return;
+  }
+
+  const controller = new AbortController();
+  const task = { controller };
+  activeTurnTasks.set(chatId, task);
+  void runPrompt(chatId, prompt, { signal: controller.signal })
+    .catch((error) => {
+      console.error("failed to run Telegram bridge prompt", error);
+    })
+    .finally(() => {
+      if (activeTurnTasks.get(chatId) === task) {
+        activeTurnTasks.delete(chatId);
+      }
+    });
+}
+
+function abortActiveTurnStreams() {
+  for (const task of activeTurnTasks.values()) {
+    task.controller?.abort();
+  }
+}
+
+async function clearActiveTurn(chatId) {
+  await threadStore.patchChat(chatId, {
+    activeTurnId: null,
+    updatedAt: new Date().toISOString()
+  }).catch((error) => {
+    console.error("failed to clear Telegram bridge active turn", error);
+  });
+}
+
+function startTrackedTurnStream(chatId, threadId, turnId, sinceSeq) {
+  if (activeTurnTasks.has(chatId)) return false;
+
+  const controller = new AbortController();
+  const task = { controller };
+  activeTurnTasks.set(chatId, task);
+  void streamTurnEvents(chatId, threadId, turnId, sinceSeq, { signal: controller.signal })
+    .catch((error) => {
+      console.error("failed to stream Telegram bridge turn", error);
+    })
+    .finally(async () => {
+      if (activeTurnTasks.get(chatId) === task) {
+        activeTurnTasks.delete(chatId);
+      }
+      if (!stopping) {
+        await clearActiveTurn(chatId);
+      }
+    });
+  return true;
+}
+
+async function runPrompt(chatId, prompt, options = {}) {
   if (!prompt.trim()) {
     await sendText(chatId, helpText(), { replyMarkup: controlKeyboard() });
     return;
@@ -500,12 +564,11 @@ async function runPrompt(chatId, prompt) {
   });
 
   try {
-    await streamTurnEvents(chatId, state.threadId, turnId, sinceSeq);
+    await streamTurnEvents(chatId, state.threadId, turnId, sinceSeq, options);
   } finally {
-    await threadStore.patchChat(chatId, {
-      activeTurnId: null,
-      updatedAt: new Date().toISOString()
-    });
+    if (!stopping) {
+      await clearActiveTurn(chatId);
+    }
   }
 }
 
@@ -535,20 +598,23 @@ async function reattachActiveTurns() {
       chatId,
       `Bridge restarted. Reattaching to active turn ${turnId} from seq ${sinceSeq}.`
     );
-    try {
-      await streamTurnEvents(chatId, state.threadId, turnId, sinceSeq);
-    } finally {
-      await threadStore.patchChat(chatId, {
-        activeTurnId: null,
-        updatedAt: new Date().toISOString()
-      });
-    }
+    startTrackedTurnStream(chatId, state.threadId, turnId, sinceSeq);
   }
 }
 
-async function streamTurnEvents(chatId, threadId, turnId, sinceSeq) {
+async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), config.turnTimeoutMs);
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, config.turnTimeoutMs);
+  const abortFromCaller = () => controller.abort();
+  if (options.signal?.aborted) {
+    controller.abort();
+  } else {
+    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
   let responseText = "";
   let latestSeq = sinceSeq;
   let sentProgressAt = Date.now();
@@ -650,12 +716,17 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq) {
     }
   } catch (error) {
     if (error.name === "AbortError") {
-      await sendText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
+      if (timedOut) {
+        await sendText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
+      } else if (!stopping) {
+        await sendText(chatId, "Turn stream aborted.");
+      }
       return;
     }
     throw error;
   } finally {
     clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", abortFromCaller);
   }
 }
 

--- a/integrations/telegram-bridge/src/index.mjs
+++ b/integrations/telegram-bridge/src/index.mjs
@@ -709,7 +709,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
       if (record.event === "turn.lifecycle") {
         const status = record.payload?.turn?.status || record.payload?.status;
         if (["failed", "canceled", "interrupted"].includes(status)) {
-      await sendText(chatId, `Turn ${status}.`, { replyMarkup: controlKeyboard() });
+          await sendText(chatId, `Turn ${status}.`, { replyMarkup: controlKeyboard() });
           return;
         }
       }

--- a/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
+++ b/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function readBridgeSource() {
+  return fs.readFile(path.join(__dirname, "../src/index.mjs"), "utf8");
+}
+
+function extractFunction(source, name) {
+  const asyncMarker = `async function ${name}`;
+  const marker = source.includes(asyncMarker) ? asyncMarker : `function ${name}`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `${name} should exist`);
+
+  let depth = 0;
+  let opened = false;
+  const bodyStart = source.indexOf("{", source.indexOf(")", start));
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") {
+      depth += 1;
+      opened = true;
+    } else if (char === "}") {
+      depth -= 1;
+      if (opened && depth === 0) {
+        return source.slice(start, index + 1);
+      }
+    }
+  }
+  assert.fail(`${name} body should close`);
+}
+
+test("prompt command starts a tracked background turn instead of blocking update dispatch", async () => {
+  const source = await readBridgeSource();
+  const handleCommand = extractFunction(source, "handleCommand");
+  const promptCase = handleCommand.slice(handleCommand.indexOf('case "prompt":'));
+
+  assert.match(source, /const activeTurnTasks = new Map\(\);/);
+  assert.match(promptCase, /startPromptTurn\(chatId, action\.prompt\);/);
+  assert.doesNotMatch(promptCase, /await\s+runPrompt\(/);
+
+  const starter = extractFunction(source, "startPromptTurn");
+  assert.ok(
+    starter.indexOf("activeTurnTasks.set(chatId") < starter.indexOf("void runPrompt"),
+    "turn registry entry must be installed before runPrompt can await"
+  );
+});
+
+test("stale callback acknowledgements cannot skip modal actions", async () => {
+  const source = await readBridgeSource();
+  const callbackHandler = extractFunction(source, "handleCallbackQuery");
+
+  assert.doesNotMatch(callbackHandler, /await\s+answerCallback\(query\.id,\s*"Working\.\.\."\)/);
+  assert.match(callbackHandler, /answerCallback\(query\.id,\s*"Working\.\.\."\)\.catch/);
+  assert.match(callbackHandler, /await handleModalAction\(identity\.chatId, action, query\);/);
+});
+
+test("reattached streams are detached and shutdown preserves active turn state", async () => {
+  const source = await readBridgeSource();
+  const reattach = extractFunction(source, "reattachActiveTurns");
+  const runPrompt = extractFunction(source, "runPrompt");
+
+  assert.match(reattach, /startTrackedTurnStream\(chatId, state\.threadId, turnId, sinceSeq\);/);
+  assert.doesNotMatch(reattach, /await\s+streamTurnEvents\(/);
+  assert.match(source, /async function clearActiveTurn\(chatId\)/);
+  assert.match(runPrompt, /if \(!stopping\) {\s*await clearActiveTurn\(chatId\);\s*}/);
+
+  const trackedStream = extractFunction(source, "startTrackedTurnStream");
+  assert.match(trackedStream, /if \(!stopping\) {\s*await clearActiveTurn\(chatId\);\s*}/);
+});


### PR DESCRIPTION
## Summary

Fixes #2966.

- start Telegram prompt turns in a tracked background task so long runtime event streams do not block `getUpdates`
- keep callback modal actions running even if the Telegram callback acknowledgement is stale or fails
- reattach active turns through the same per-chat stream registry and abort active streams on shutdown

## Testing

- [x] `npm test` (from `integrations/telegram-bridge`)
- [x] `npm run check` (from `integrations/telegram-bridge`)
- [x] `git diff --check upstream/main...HEAD`
- [x] diff-level credential-shaped scan
- [ ] `cargo fmt --all -- --check` (not run; this change is limited to the Node-only Telegram bridge package)
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; this change is limited to the Node-only Telegram bridge package)
- [ ] `cargo test --workspace --all-features` (not run; this change is limited to the Node-only Telegram bridge package)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (not applicable; no TUI change)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable; no co-authors)