### PR TITLE
feat(tui): Ctrl+P / Ctrl+N navigate slash-command autocomplete

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3901,6 +3901,11 @@ async fn run_event_loop(
                 KeyCode::Up if key.modifiers.is_empty() && slash_menu_open => {
                     select_previous_slash_menu_entry(app, slash_menu_entries.len());
                 }
+                KeyCode::Char('p')
+                    if key.modifiers.contains(KeyModifiers::CONTROL) && slash_menu_open =>
+                {
+                    select_previous_slash_menu_entry(app, slash_menu_entries.len());
+                }
                 KeyCode::Up
                     if key.modifiers.is_empty()
                         && app.selected_composer_attachment_index().is_some() =>
@@ -3945,6 +3950,11 @@ async fn run_event_loop(
                         .min(mention_menu_entries.len().saturating_sub(1));
                 }
                 KeyCode::Down if key.modifiers.is_empty() && slash_menu_open => {
+                    select_next_slash_menu_entry(app, slash_menu_entries.len());
+                }
+                KeyCode::Char('n')
+                    if key.modifiers.contains(KeyModifiers::CONTROL) && slash_menu_open =>
+                {
                     select_next_slash_menu_entry(app, slash_menu_entries.len());
                 }
                 KeyCode::Down

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3386,10 +3386,11 @@ async fn run_event_loop(
             }
 
             // Ctrl+P opens the fuzzy file-picker overlay. Bound only when the
-            // composer is focused (no other modal on top of the stack) and the
+            // composer is focused (no other modal or inline popup on top) and the
             // engine is not actively streaming a turn.
             if key.code == KeyCode::Char('p')
                 && key.modifiers.contains(KeyModifiers::CONTROL)
+                && visible_slash_menu_entries(app, SLASH_MENU_LIMIT).is_empty()
                 && app.view_stack.is_empty()
                 && !app.is_loading
             {

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -80,11 +80,11 @@ When `[memory] enabled = true`, typing `# foo` and pressing `Enter` appends `foo
 
 ## Slash-command palette (after `Ctrl-K` or typing `/`)
 
-| Chord                | Action                                              |
-|----------------------|-----------------------------------------------------|
-| `↑` / `↓`            | Move selection                                     |
-| `Enter` / `Tab`      | Run / complete the highlighted command             |
-| `Esc`                | Dismiss palette                                     |
+| Chord                          | Action                                              |
+|--------------------------------|-----------------------------------------------------|
+| `↑` / `↓` / `Ctrl+P` / `Ctrl+N`| Move selection                                     |
+| `Enter` / `Tab`                | Run / complete the highlighted command             |
+| `Esc`                          | Dismiss palette                                     |
 
 ## Session Picker (`Ctrl-R` or `/sessions`)
 


### PR DESCRIPTION
## Summary
Adds Ctrl+P (up) and Ctrl+N (down) as alternatives to arrow keys for navigating the inline slash-command autocomplete popup. Includes an additional guard on the global Ctrl+P file-picker handler so it yields when the slash menu is open.

## Verification
- [x] cargo check -p codewhale-tui
- [x] cargo clippy -p codewhale-tui (clean, 4 pre-existing fleet warnings unrelated)
- [x] cargo test -p codewhale-tui -- slash_menu_up_wraps slash_menu_down_wraps (2/2 pass)
- [x] cargo build --release -p codewhale-tui
- [x] feature works when using the app