### PR TITLE
[codex] Rename DeepSeek blue consumers to whale accent

### DIFF
--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -66,7 +66,7 @@ impl Theme {
             section_border_type: BorderType::Plain,
             section_border_color: palette::BORDER_COLOR,
             section_bg: palette::DEEPSEEK_INK,
-            section_title_color: palette::DEEPSEEK_BLUE,
+            section_title_color: palette::WHALE_ACCENT_PRIMARY,
             // Horizontal padding only. `Padding::uniform(1)` ate two rows of
             // each sidebar panel — for compact terminals where Work/Tasks/Agents
             // get ~3 rows total via the 25% layout split, that left zero rows
@@ -97,20 +97,20 @@ impl Theme {
             section_border_type: BorderType::Plain,
             section_border_color: palette::LIGHT_BORDER,
             section_bg: palette::LIGHT_PANEL,
-            section_title_color: palette::DEEPSEEK_BLUE,
+            section_title_color: palette::WHALE_ACCENT_PRIMARY,
             section_padding: Padding::horizontal(1),
             tool_title_color: palette::LIGHT_TEXT_SOFT,
             tool_value_color: palette::LIGHT_TEXT_MUTED,
             tool_label_color: palette::LIGHT_TEXT_HINT,
-            tool_running_accent: palette::DEEPSEEK_BLUE,
+            tool_running_accent: palette::WHALE_ACCENT_PRIMARY,
             tool_success_accent: palette::LIGHT_TEXT_HINT,
             tool_failed_accent: palette::DEEPSEEK_RED,
-            plan_progress_color: palette::DEEPSEEK_BLUE,
+            plan_progress_color: palette::WHALE_ACCENT_PRIMARY,
             plan_summary_color: palette::LIGHT_TEXT_MUTED,
             plan_explanation_color: palette::LIGHT_TEXT_HINT,
             plan_pending_color: palette::LIGHT_TEXT_MUTED,
             plan_in_progress_color: Color::Rgb(180, 83, 9),
-            plan_completed_color: palette::DEEPSEEK_BLUE,
+            plan_completed_color: palette::WHALE_ACCENT_PRIMARY,
         }
     }
 
@@ -237,7 +237,7 @@ mod tests {
         assert_eq!(theme.variant, Variant::Dark);
         assert_eq!(theme.section_border_color, palette::BORDER_COLOR);
         assert_eq!(theme.section_bg, palette::DEEPSEEK_INK);
-        assert_eq!(theme.section_title_color, palette::DEEPSEEK_BLUE);
+        assert_eq!(theme.section_title_color, palette::WHALE_ACCENT_PRIMARY);
         assert_eq!(theme.tool_title_color, palette::TEXT_SOFT);
         assert_eq!(theme.tool_value_color, palette::TEXT_MUTED);
         assert_eq!(theme.tool_label_color, palette::TEXT_DIM);

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2268,14 +2268,16 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
     use crate::palette;
     use colored::Colorize;
 
-    let (blue_r, blue_g, blue_b) = palette::DEEPSEEK_BLUE_RGB;
+    let (accent_r, accent_g, accent_b) = palette::WHALE_ACCENT_PRIMARY_RGB;
     let (sky_r, sky_g, sky_b) = palette::DEEPSEEK_SKY_RGB;
     let (aqua_r, aqua_g, aqua_b) = palette::DEEPSEEK_SKY_RGB;
     let (red_r, red_g, red_b) = palette::DEEPSEEK_RED_RGB;
 
     println!(
         "{}",
-        "codewhale Doctor".truecolor(blue_r, blue_g, blue_b).bold()
+        "codewhale Doctor"
+            .truecolor(accent_r, accent_g, accent_b)
+            .bold()
     );
     println!("{}", "==================".truecolor(sky_r, sky_g, sky_b));
     println!();
@@ -3959,7 +3961,7 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     use colored::Colorize;
     use session_manager::{SessionManager, format_session_line};
 
-    let (blue_r, blue_g, blue_b) = palette::DEEPSEEK_BLUE_RGB;
+    let (accent_r, accent_g, accent_b) = palette::WHALE_ACCENT_PRIMARY_RGB;
     let (sky_r, sky_g, sky_b) = palette::DEEPSEEK_SKY_RGB;
     let (aqua_r, aqua_g, aqua_b) = palette::DEEPSEEK_SKY_RGB;
 
@@ -3975,14 +3977,16 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
         println!("{}", "No sessions found.".truecolor(sky_r, sky_g, sky_b));
         println!(
             "Start a new session with: {}",
-            "codewhale".truecolor(blue_r, blue_g, blue_b)
+            "codewhale".truecolor(accent_r, accent_g, accent_b)
         );
         return Ok(());
     }
 
     println!(
         "{}",
-        "Saved Sessions".truecolor(blue_r, blue_g, blue_b).bold()
+        "Saved Sessions"
+            .truecolor(accent_r, accent_g, accent_b)
+            .bold()
     );
     println!("{}", "==============".truecolor(sky_r, sky_g, sky_b));
     println!();
@@ -4008,12 +4012,12 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     println!();
     println!(
         "Resume with: {} {}",
-        sessions_resume_command().truecolor(blue_r, blue_g, blue_b),
+        sessions_resume_command().truecolor(accent_r, accent_g, accent_b),
         "<session-id>".dimmed()
     );
     println!(
         "Continue latest in this workspace: {}",
-        "codewhale --continue".truecolor(blue_r, blue_g, blue_b)
+        "codewhale --continue".truecolor(accent_r, accent_g, accent_b)
     );
 
     Ok(())

--- a/crates/tui/src/palette.rs
+++ b/crates/tui/src/palette.rs
@@ -78,7 +78,12 @@ pub const WHALE_TOOL_OUTPUT_RGB: (u8, u8, u8) = (194, 208, 224); // #C2D0E0
 pub const WHALE_TOOL_SURFACE_RGB: (u8, u8, u8) = (28, 40, 62); // #1C283E
 pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = (38, 54, 80); // #263650
 
-// Backward-compatible aliases for existing call sites.
+// Backward-compatible aliases for existing downstream users.
+#[allow(dead_code)]
+#[deprecated(
+    since = "0.8.61",
+    note = "use WHALE_ACCENT_PRIMARY_RGB instead; this alias will be removed after the rename window"
+)]
 pub const DEEPSEEK_BLUE_RGB: (u8, u8, u8) = WHALE_ACCENT_PRIMARY_RGB;
 pub const DEEPSEEK_SKY_RGB: (u8, u8, u8) = WHALE_INFO_RGB;
 pub const DEEPSEEK_INK_RGB: (u8, u8, u8) = WHALE_BG_RGB;
@@ -217,11 +222,17 @@ pub const MATRIX_BORDER_RGB: (u8, u8, u8) = (0, 204, 0); // #00CC00
 // New semantic colors
 pub const BORDER_COLOR_RGB: (u8, u8, u8) = WHALE_BORDER_RGB; // #2A4A7F
 
-pub const DEEPSEEK_BLUE: Color = Color::Rgb(
-    DEEPSEEK_BLUE_RGB.0,
-    DEEPSEEK_BLUE_RGB.1,
-    DEEPSEEK_BLUE_RGB.2,
+pub const WHALE_ACCENT_PRIMARY: Color = Color::Rgb(
+    WHALE_ACCENT_PRIMARY_RGB.0,
+    WHALE_ACCENT_PRIMARY_RGB.1,
+    WHALE_ACCENT_PRIMARY_RGB.2,
 );
+#[allow(dead_code)]
+#[deprecated(
+    since = "0.8.61",
+    note = "use WHALE_ACCENT_PRIMARY instead; this alias will be removed after the rename window"
+)]
+pub const DEEPSEEK_BLUE: Color = WHALE_ACCENT_PRIMARY;
 /// Now maps to the secondary accent (Seafoam) for backward compat.
 pub const DEEPSEEK_SKY: Color =
     Color::Rgb(DEEPSEEK_SKY_RGB.0, DEEPSEEK_SKY_RGB.1, DEEPSEEK_SKY_RGB.2);
@@ -1513,7 +1524,7 @@ fn adapt_fg_for_light_palette(color: Color) -> Color {
     } else if color == BORDER_COLOR {
         LIGHT_BORDER
     } else if color == TEXT_ACCENT || color == DEEPSEEK_SKY || color == ACCENT_TOOL_LIVE {
-        DEEPSEEK_BLUE
+        WHALE_ACCENT_PRIMARY
     } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
         Color::Rgb(146, 64, 14)
     } else if color == ACCENT_TOOL_ISSUE {
@@ -1711,7 +1722,7 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
         ui.error_fg
     } else if color == DIFF_ADDED || color == USER_BODY {
         theme_green(ui)
-    } else if color == DEEPSEEK_BLUE {
+    } else if color == WHALE_ACCENT_PRIMARY {
         ui.mode_agent
     } else {
         color
@@ -1774,7 +1785,7 @@ fn adapt_fg_for_grayscale_palette(color: Color) -> Color {
         || color == LIGHT_TEXT_SOFT
         || color == TEXT_ACCENT
         || color == DEEPSEEK_SKY
-        || color == DEEPSEEK_BLUE
+        || color == WHALE_ACCENT_PRIMARY
         || color == ACCENT_TOOL_LIVE
         || color == STATUS_SUCCESS
         || color == STATUS_INFO

--- a/crates/tui/src/tui/context_menu.rs
+++ b/crates/tui/src/tui/context_menu.rs
@@ -189,7 +189,7 @@ impl ModalView for ContextMenuView {
                 let style = if idx == self.selected {
                     Style::default()
                         .fg(palette::TEXT_PRIMARY)
-                        .bg(palette::DEEPSEEK_BLUE)
+                        .bg(palette::WHALE_ACCENT_PRIMARY)
                         .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default()

--- a/crates/tui/src/tui/diff_render.rs
+++ b/crates/tui/src/tui/diff_render.rs
@@ -274,7 +274,7 @@ fn render_header_line(line: &str, width: u16) -> Vec<Line<'static>> {
 }
 
 fn render_hunk_header(line: &str, width: u16) -> Vec<Line<'static>> {
-    let style = Style::default().fg(palette::DEEPSEEK_BLUE);
+    let style = Style::default().fg(palette::WHALE_ACCENT_PRIMARY);
     wrap_with_style(line, style, width)
 }
 

--- a/crates/tui/src/tui/file_picker.rs
+++ b/crates/tui/src/tui/file_picker.rs
@@ -338,7 +338,7 @@ impl ModalView for FilePickerView {
         let title = Line::from(vec![Span::styled(
             " File Picker ",
             Style::default()
-                .fg(palette::DEEPSEEK_BLUE)
+                .fg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD),
         )]);
         let footer_text = format!(

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1266,7 +1266,7 @@ impl ReviewCell {
         lines.push(Line::from(Span::styled(
             "Issues",
             Style::default()
-                .fg(palette::DEEPSEEK_BLUE)
+                .fg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD),
         )));
         if output.issues.is_empty() {
@@ -1300,7 +1300,7 @@ impl ReviewCell {
         lines.push(Line::from(Span::styled(
             "Suggestions",
             Style::default()
-                .fg(palette::DEEPSEEK_BLUE)
+                .fg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD),
         )));
         if output.suggestions.is_empty() {
@@ -3025,11 +3025,11 @@ fn is_cycle_boundary(content: &str) -> bool {
 }
 
 /// Render a cycle-boundary system message with distinct visual styling (#395):
-/// full-width line with DEEPSEEK_BLUE text and bold weight, plus a thin
+/// full-width line with primary accent text and bold weight, plus a thin
 /// horizontal rule above for visual separation.
 fn render_cycle_boundary(content: &str, width: u16) -> Vec<Line<'static>> {
     let style = Style::default()
-        .fg(palette::DEEPSEEK_BLUE)
+        .fg(palette::WHALE_ACCENT_PRIMARY)
         .add_modifier(Modifier::BOLD);
     let rule_style = Style::default().fg(palette::TEXT_DIM);
     let content_width = usize::from(width.saturating_sub(2).max(1));
@@ -3086,7 +3086,7 @@ fn file_line_style(text: &str) -> Option<Style> {
 fn diff_line_style(text: &str) -> Option<Style> {
     let trimmed = text.trim_start();
     if trimmed.starts_with("@@") {
-        Some(Style::default().fg(palette::DEEPSEEK_BLUE))
+        Some(Style::default().fg(palette::WHALE_ACCENT_PRIMARY))
     } else if trimmed.starts_with('+') && !trimmed.starts_with("+++") {
         Some(Style::default().fg(palette::DIFF_ADDED))
     } else if trimmed.starts_with('-') && !trimmed.starts_with("---") {

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -286,7 +286,7 @@ pub fn render_parsed_tagged(
             }
             Block::Paragraph { text } => {
                 let link_style = Style::default()
-                    .fg(palette::DEEPSEEK_BLUE)
+                    .fg(palette::WHALE_ACCENT_PRIMARY)
                     .add_modifier(Modifier::UNDERLINED);
                 out.extend(render_line_with_links_tagged(
                     text, width, base_style, link_style,
@@ -1119,7 +1119,7 @@ fn render_table_group(blocks: &[Block], width: usize, base_style: Style) -> Vec<
 
 fn link_style() -> Style {
     Style::default()
-        .fg(palette::DEEPSEEK_BLUE)
+        .fg(palette::WHALE_ACCENT_PRIMARY)
         .add_modifier(Modifier::UNDERLINED)
 }
 

--- a/crates/tui/src/tui/onboarding/language.rs
+++ b/crates/tui/src/tui/onboarding/language.rs
@@ -48,7 +48,7 @@ pub fn lines(app: &App) -> Vec<Line<'static>> {
         let is_current = current == *tag;
         let bullet = if is_current { "●" } else { "○" };
         let bullet_color = if is_current {
-            palette::DEEPSEEK_BLUE
+            palette::WHALE_ACCENT_PRIMARY
         } else {
             palette::TEXT_MUTED
         };

--- a/crates/tui/src/tui/onboarding/mod.rs
+++ b/crates/tui/src/tui/onboarding/mod.rs
@@ -46,7 +46,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             .title(Line::from(Span::styled(
                 " CodeWhale ",
                 Style::default()
-                    .fg(palette::DEEPSEEK_BLUE)
+                    .fg(palette::WHALE_ACCENT_PRIMARY)
                     .add_modifier(Modifier::BOLD),
             )))
             .borders(Borders::ALL)

--- a/crates/tui/src/tui/onboarding/welcome.rs
+++ b/crates/tui/src/tui/onboarding/welcome.rs
@@ -10,7 +10,7 @@ pub fn lines() -> Vec<Line<'static>> {
         Line::from(Span::styled(
             "codewhale",
             Style::default()
-                .fg(palette::DEEPSEEK_BLUE)
+                .fg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -50,7 +50,7 @@ fn modal_block() -> Block<'static> {
     Block::default()
         .title(Line::from(vec![Span::styled(
             " Plan Confirmation ",
-            Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
         )]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -27,7 +27,7 @@ fn modal_block(title: &str) -> Block<'static> {
         .title(Line::from(vec![Span::styled(
             title.to_string(),
             Style::default()
-                .fg(palette::DEEPSEEK_BLUE)
+                .fg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD),
         )]))
         .borders(Borders::ALL)
@@ -668,7 +668,7 @@ fn build_list_lines(
         let style = if idx == selected {
             Style::default()
                 .fg(palette::SELECTION_TEXT)
-                .bg(palette::DEEPSEEK_BLUE)
+                .bg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(palette::TEXT_PRIMARY)
@@ -1109,7 +1109,7 @@ mod tests {
             .expect("selected row should have a span");
 
         assert_eq!(span.style.fg, Some(palette::SELECTION_TEXT));
-        assert_eq!(span.style.bg, Some(palette::DEEPSEEK_BLUE));
+        assert_eq!(span.style.bg, Some(palette::WHALE_ACCENT_PRIMARY));
         assert!(span.style.add_modifier.contains(Modifier::BOLD));
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7451,7 +7451,7 @@ fn render(f: &mut Frame, app: &mut App) {
 
             let handle_style = if app.sidebar_resizing {
                 Style::default()
-                    .bg(palette::DEEPSEEK_BLUE)
+                    .bg(palette::WHALE_ACCENT_PRIMARY)
                     .fg(palette::TEXT_PRIMARY)
             } else if mouse_over {
                 Style::default()
@@ -7514,7 +7514,7 @@ fn render(f: &mut Frame, app: &mut App) {
                         .block(
                             Block::default()
                                 .borders(ratatui::widgets::Borders::ALL)
-                                .border_style(Style::default().fg(palette::DEEPSEEK_BLUE))
+                                .border_style(Style::default().fg(palette::WHALE_ACCENT_PRIMARY))
                                 .style(
                                     Style::default()
                                         .bg(palette::SURFACE_ELEVATED)

--- a/crates/tui/src/tui/user_input.rs
+++ b/crates/tui/src/tui/user_input.rs
@@ -15,7 +15,7 @@ fn modal_block(title: &str) -> Block<'static> {
     Block::default()
         .title(Line::from(vec![Span::styled(
             title.to_string(),
-            Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
         )]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))
@@ -321,7 +321,7 @@ impl ModalView for UserInputView {
                     } else {
                         self.other_input.clone()
                     },
-                    Style::default().fg(palette::DEEPSEEK_BLUE),
+                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
                 ),
             ]));
         }

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -733,7 +733,7 @@ mod tests {
 
         assert!(
             found_highlight,
-            "selected row should use a strong blue highlight"
+            "selected row should use a strong primary-accent highlight"
         );
     }
 

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -441,7 +441,7 @@ impl ModalView for HelpView {
                         lines.push(Line::from(Span::styled(
                             format!("  {} ({})", section.label(self.locale), count),
                             Style::default()
-                                .fg(palette::DEEPSEEK_BLUE)
+                                .fg(palette::WHALE_ACCENT_PRIMARY)
                                 .add_modifier(Modifier::BOLD),
                         )));
                     }
@@ -451,7 +451,7 @@ impl ModalView for HelpView {
                         let style = if is_selected {
                             Style::default()
                                 .fg(palette::SELECTION_TEXT)
-                                .bg(palette::DEEPSEEK_BLUE)
+                                .bg(palette::WHALE_ACCENT_PRIMARY)
                                 .add_modifier(Modifier::BOLD)
                         } else {
                             Style::default().fg(palette::TEXT_PRIMARY)
@@ -470,7 +470,7 @@ impl ModalView for HelpView {
             .title(Line::from(vec![Span::styled(
                 format!(" {} ", self.tr(MessageId::HelpTitle)),
                 Style::default()
-                    .fg(palette::DEEPSEEK_BLUE)
+                    .fg(palette::WHALE_ACCENT_PRIMARY)
                     .add_modifier(Modifier::BOLD),
             )]))
             .title_bottom(Line::from(vec![
@@ -699,7 +699,7 @@ mod tests {
                 let cell = &buf[(x, y)];
                 row.push_str(cell.symbol());
                 row_has_highlight |=
-                    cell.bg == palette::DEEPSEEK_BLUE && cell.fg == palette::SELECTION_TEXT;
+                    cell.bg == palette::WHALE_ACCENT_PRIMARY && cell.fg == palette::SELECTION_TEXT;
             }
             if row_has_highlight && row.contains(&selected_label) {
                 highlighted_label = true;
@@ -724,7 +724,7 @@ mod tests {
         for y in area.top()..area.bottom() {
             for x in area.left()..area.right() {
                 let cell = &buf[(x, y)];
-                if cell.bg == palette::DEEPSEEK_BLUE && cell.fg == palette::SELECTION_TEXT {
+                if cell.bg == palette::WHALE_ACCENT_PRIMARY && cell.fg == palette::SELECTION_TEXT {
                     found_highlight = true;
                     break;
                 }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -1391,7 +1391,7 @@ impl ModalView for ConfigView {
             let mut lines: Vec<Line> = vec![
                 Line::from(vec![Span::styled(
                     self.tr(MessageId::ConfigTitle),
-                    Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
                 )]),
                 Line::from(vec![
                     Span::styled("  Search: ", Style::default().fg(palette::TEXT_MUTED)),
@@ -1441,7 +1441,7 @@ impl ModalView for ConfigView {
                         let style = if selected {
                             Style::default()
                                 .fg(ratatui::style::Color::White)
-                                .bg(palette::DEEPSEEK_BLUE)
+                                .bg(palette::WHALE_ACCENT_PRIMARY)
                                 .add_modifier(ratatui::style::Modifier::BOLD)
                         } else {
                             Style::default().fg(palette::TEXT_PRIMARY)
@@ -1518,7 +1518,7 @@ impl ModalView for ConfigView {
         let block = Block::default()
             .title(Line::from(vec![Span::styled(
                 self.tr(MessageId::ConfigModalTitle),
-                Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+                Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
             )]))
             .title_bottom(Line::from(Span::styled(
                 footer,
@@ -1849,7 +1849,7 @@ impl ModalView for SubAgentsView {
                 Block::default()
                     .title(Line::from(vec![Span::styled(
                         " Sub-agents ",
-                        Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+                        Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
                     )]))
                     .title_bottom(Line::from(vec![
                         Span::styled(" Esc to close ", Style::default().fg(palette::TEXT_MUTED)),
@@ -2005,7 +2005,7 @@ fn format_agent_status(
         SubAgentStatus::Running => ("running", Style::default().fg(palette::DEEPSEEK_SKY), None),
         SubAgentStatus::Completed => (
             "completed",
-            Style::default().fg(palette::DEEPSEEK_BLUE),
+            Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
             None,
         ),
         SubAgentStatus::Interrupted(reason) => (

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1454,7 +1454,7 @@ fn approval_palette(risk: RiskLevel) -> ApprovalColors {
 fn approval_selected_style() -> Style {
     Style::default()
         .fg(palette::SELECTION_TEXT)
-        .bg(palette::DEEPSEEK_BLUE)
+        .bg(palette::WHALE_ACCENT_PRIMARY)
         .add_modifier(Modifier::BOLD)
 }
 
@@ -2099,7 +2099,7 @@ fn build_empty_state_lines(app: &App, area: Rect) -> Vec<Line<'static>> {
     let body = vec![
         Line::from(Span::styled(
             format!("{inset}>_ codewhale (v{})", env!("CARGO_PKG_VERSION")),
-            Style::default().fg(palette::DEEPSEEK_BLUE).bold(),
+            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -4068,14 +4068,14 @@ mod tests {
         let selected_row = (area.y..area.y.saturating_add(area.height))
             .find(|&y| {
                 (area.x..area.x.saturating_add(area.width))
-                    .any(|x| buf[(x, y)].bg == palette::DEEPSEEK_BLUE)
+                    .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY)
             })
             .expect("selected approval row should use blue background");
         let highlighted_cells = (area.x..area.x.saturating_add(area.width))
             .filter(|&x| {
                 let cell = &buf[(x, selected_row)];
                 !cell.symbol().trim().is_empty()
-                    && cell.bg == palette::DEEPSEEK_BLUE
+                    && cell.bg == palette::WHALE_ACCENT_PRIMARY
                     && cell.fg == palette::SELECTION_TEXT
             })
             .count();

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -4070,7 +4070,7 @@ mod tests {
                 (area.x..area.x.saturating_add(area.width))
                     .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY)
             })
-            .expect("selected approval row should use blue background");
+            .expect("selected approval row should use the primary accent background");
         let highlighted_cells = (area.x..area.x.saturating_add(area.width))
             .filter(|&x| {
                 let cell = &buf[(x, selected_row)];
@@ -4082,7 +4082,7 @@ mod tests {
 
         assert!(
             highlighted_cells >= 4,
-            "selected destructive option should render visible blue/white text"
+            "selected destructive option should render visible primary-accent/selection text"
         );
     }
 

--- a/crates/tui/tests/palette_audit.rs
+++ b/crates/tui/tests/palette_audit.rs
@@ -81,21 +81,27 @@ fn verify_status_success_uses_success_token() {
     );
     assert_ne!(
         palette::STATUS_SUCCESS,
-        palette::DEEPSEEK_BLUE,
-        "STATUS_SUCCESS should not regress to deprecated blue"
+        palette::WHALE_ACCENT_PRIMARY,
+        "STATUS_SUCCESS should not regress to the primary accent"
     );
 }
 
 #[test]
+#[allow(deprecated)]
 fn verify_brand_aliases_follow_whale_tokens() {
     assert_eq!(palette::WHALE_ACCENT_PRIMARY_RGB, (246, 196, 83));
     assert_eq!(palette::WHALE_INFO_RGB, (106, 174, 242));
     assert_eq!(palette::WHALE_ERROR_RGB, (255, 92, 122));
+    assert_eq!(
+        color_to_rgb(palette::WHALE_ACCENT_PRIMARY),
+        palette::WHALE_ACCENT_PRIMARY_RGB
+    );
 
     assert_eq!(
         palette::DEEPSEEK_BLUE_RGB,
         palette::WHALE_ACCENT_PRIMARY_RGB
     );
+    assert_eq!(palette::DEEPSEEK_BLUE, palette::WHALE_ACCENT_PRIMARY);
     assert_eq!(palette::DEEPSEEK_SKY_RGB, palette::WHALE_INFO_RGB);
     assert_eq!(palette::DEEPSEEK_RED_RGB, palette::WHALE_ERROR_RGB);
 }


### PR DESCRIPTION
Closes #3069.

## Summary

- Add `palette::WHALE_ACCENT_PRIMARY` as the `Color`-level semantic token for `WHALE_ACCENT_PRIMARY_RGB`.
- Keep `DEEPSEEK_BLUE` / `DEEPSEEK_BLUE_RGB` as deprecated compatibility aliases for the rename window.
- Move TUI consumers from `palette::DEEPSEEK_BLUE` to `palette::WHALE_ACCENT_PRIMARY` while leaving `DEEPSEEK_SKY` unchanged.
- Extend palette audit coverage so the new token and deprecated aliases continue to resolve to the same RGB values.

## Validation

Passed:

- `cargo fmt -p codewhale-tui`
- `cargo test -p codewhale-tui --test palette_audit`
- `cargo test -p codewhale-tui --bin codewhale-tui deepseek_theme::tests`
- `cargo clippy -p codewhale-tui --bin codewhale-tui -- -D warnings`

Broader checks attempted:

- `cargo test -p codewhale-tui` completed with 4443 passed / 4 failed. The failures were outside this rename path: two `session_manager::tests::*latest_session_for_workspace*` assertions selected `other-workspace`, and two `tools::pandoc::tests::*` failed because local pandoc returned `getXdgDirectory:sHGetFolderPath: illegal operation`.
- `cargo clippy -p codewhale-tui --all-targets --all-features -- -D warnings` reached a pre-existing test lint at `crates/tui/src/tui/ui/tests.rs:3218` (`field_reassign_with_default`), outside this palette rename.