### PR TITLE
feat(runtime-api): add PUT /v1/sessions endpoint for engine-based session save

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -66,7 +66,7 @@ use super::capacity_memory::{
 };
 use super::coherence::{CoherenceSignal, CoherenceState, next_coherence_state};
 use super::events::{Event, TurnOutcomeStatus};
-use super::ops::{Op, USER_SHELL_TOOL_ID_PREFIX};
+use super::ops::{Op, SessionSnapshot, USER_SHELL_TOOL_ID_PREFIX};
 use super::session::Session;
 use super::tool_parser;
 use super::turn::{TurnContext, TurnToolCall, post_turn_snapshot, pre_turn_snapshot};
@@ -1343,6 +1343,21 @@ impl Engine {
                 }
                 Op::CompactContext => {
                     self.handle_manual_compaction().await;
+                }
+                Op::GetSessionSnapshot { tx } => {
+                    let total_tokens = self.session.total_usage.input_tokens
+                        + self.session.total_usage.output_tokens;
+                    let snapshot = SessionSnapshot {
+                        messages: self.session.messages.to_vec(),
+                        total_tokens,
+                        model: self.session.model.clone(),
+                        workspace: self.session.workspace.clone(),
+                        system_prompt: self.session.system_prompt.clone(),
+                        mode: self.current_mode.as_setting().to_string(),
+                    };
+                    if let Some(tx) = tx.lock().ok().and_then(|mut g| g.take()) {
+                        let _ = tx.send(snapshot);
+                    }
                 }
                 Op::PurgeContext => {
                     self.handle_purge().await;

--- a/crates/tui/src/core/engine/handle.rs
+++ b/crates/tui/src/core/engine/handle.rs
@@ -128,4 +128,14 @@ impl EngineHandle {
         self.tx_steer.send(content.into()).await?;
         Ok(())
     }
+
+    /// Request a snapshot of the current session state.
+    /// Returns the snapshot directly via a oneshot channel, avoiding
+    /// competition with the SSE event stream on the mpsc receiver.
+    pub async fn get_session_snapshot(&self) -> Result<crate::core::ops::SessionSnapshot> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let tx = std::sync::Arc::new(std::sync::Mutex::new(Some(tx)));
+        self.send(Op::GetSessionSnapshot { tx }).await?;
+        rx.await.map_err(|_| anyhow::anyhow!("Engine dropped session snapshot oneshot"))
+    }
 }

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -12,6 +12,18 @@ use std::path::PathBuf;
 /// Prefix used for tool-call ids created by local composer shell shortcuts.
 pub const USER_SHELL_TOOL_ID_PREFIX: &str = "user_shell_";
 
+/// Snapshot of session state for saving to disk.
+/// Returned by `Op::GetSessionSnapshot` via a oneshot channel.
+#[derive(Debug, Clone)]
+pub struct SessionSnapshot {
+    pub messages: Vec<Message>,
+    pub total_tokens: u64,
+    pub model: String,
+    pub workspace: PathBuf,
+    pub system_prompt: Option<SystemPrompt>,
+    pub mode: String,
+}
+
 /// Operations that can be submitted to the engine.
 #[derive(Debug, Clone)]
 pub enum Op {
@@ -100,6 +112,13 @@ pub enum Op {
 
     /// Run context compaction immediately.
     CompactContext,
+
+    /// Get a snapshot of the current session state (messages, tokens, etc.)
+    /// for saving to disk. Returns the result via the oneshot sender so
+    /// the caller doesn't have to compete with the SSE event stream.
+    GetSessionSnapshot {
+        tx: std::sync::Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<SessionSnapshot>>>>,
+    },
 
     /// Run agent-driven context purging.
     PurgeContext,

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -547,7 +547,9 @@ pub fn build_router(state: RuntimeApiState) -> Router {
     let api_routes = Router::new()
         .route(
             "/v1/sessions",
-            get(list_sessions).post(create_session_from_thread),
+            get(list_sessions)
+                .post(create_session_from_thread)
+                .put(save_current_session),
         )
         .route("/v1/sessions/{id}", get(get_session).delete(delete_session))
         .route(
@@ -998,6 +1000,129 @@ fn messages_from_thread_detail(detail: &ThreadDetail) -> Vec<Message> {
     }
 
     messages
+}
+
+// ── Session save (engine-snapshot path) ────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct SaveSessionRequest {
+    /// Thread ID to save as a session. If omitted, saves the most recently
+    /// active thread.
+    #[serde(default)]
+    thread_id: Option<String>,
+    /// If provided, update the existing session with this ID instead of
+    /// creating a new one. This matches TUI's `build_session_snapshot`
+    /// behavior where it updates the current session in-place.
+    #[serde(default)]
+    session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SaveSessionResponse {
+    session_id: String,
+    session: SessionDetailResponse,
+}
+
+/// `PUT /v1/sessions` — save a thread's current engine state as a session.
+///
+/// Unlike `POST /v1/sessions` (which reconstructs messages from stored turn
+/// items), this endpoint asks the engine for its live session snapshot so
+/// token counts and message ordering are authoritative.
+async fn save_current_session(
+    State(state): State<RuntimeApiState>,
+    Json(req): Json<SaveSessionRequest>,
+) -> Result<Json<SaveSessionResponse>, ApiError> {
+    // Find the thread to save.
+    let thread_id = match req.thread_id {
+        Some(id) => id,
+        None => {
+            // Find the most recently updated thread.
+            let threads = state
+                .runtime_threads
+                .list_threads(ThreadListFilter::IncludeArchived, Some(100))
+                .await
+                .map_err(map_thread_err)?;
+            threads
+                .into_iter()
+                .max_by_key(|t| t.updated_at)
+                .map(|t| t.id)
+                .ok_or_else(|| ApiError::bad_request("No threads to save"))?
+        }
+    };
+
+    // Get the engine handle (loads the thread into an engine if needed),
+    // then request a session snapshot. This reuses the same code path as
+    // TUI's `build_session_snapshot`: the engine holds the authoritative
+    // messages and token usage, so we don't need to reconstruct from turns.
+    let engine = state
+        .runtime_threads
+        .get_engine(&thread_id)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to get engine for thread: {e}")))?;
+
+    let snapshot = engine
+        .get_session_snapshot()
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to get session snapshot: {e}")))?;
+
+    let manager = SessionManager::new(state.sessions_dir.clone())
+        .map_err(|e| ApiError::internal(format!("Failed to open sessions dir: {e}")))?;
+
+    // Build or update the session, mirroring TUI's `build_session_snapshot`.
+    // Only `io::ErrorKind::NotFound` falls back to creating a new session;
+    // other I/O errors (e.g. PermissionDenied) are propagated so callers
+    // don't silently overwrite a corrupt or inaccessible session file.
+    let session = if let Some(ref existing_id) = req.session_id {
+        match manager.load_session(existing_id) {
+            Ok(existing) => {
+                let mut updated = crate::session_manager::update_session(
+                    existing,
+                    &snapshot.messages,
+                    snapshot.total_tokens,
+                    snapshot.system_prompt.as_ref(),
+                );
+                updated.metadata.model = snapshot.model.clone();
+                updated.metadata.mode = Some(snapshot.mode.clone());
+                updated
+            }
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    crate::session_manager::create_saved_session_with_id_and_mode(
+                        existing_id.clone(),
+                        &snapshot.messages,
+                        &snapshot.model,
+                        &snapshot.workspace,
+                        snapshot.total_tokens,
+                        snapshot.system_prompt.as_ref(),
+                        Some(snapshot.mode.as_str()),
+                    )
+                } else {
+                    return Err(ApiError::internal(format!(
+                        "Failed to load session {existing_id}: {e}"
+                    )));
+                }
+            }
+        }
+    } else {
+        crate::session_manager::create_saved_session_with_mode(
+            &snapshot.messages,
+            &snapshot.model,
+            &snapshot.workspace,
+            snapshot.total_tokens,
+            snapshot.system_prompt.as_ref(),
+            Some(snapshot.mode.as_str()),
+        )
+    };
+
+    // Save the session.
+    manager
+        .save_session(&session)
+        .map_err(|e| ApiError::internal(format!("Failed to save session: {e}")))?;
+
+    Ok(Json(SaveSessionResponse {
+        session_id: session.metadata.id.clone(),
+        session: session_to_detail(session),
+    }))
 }
 
 fn total_tokens_from_thread_detail(detail: &ThreadDetail) -> u64 {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2136,6 +2136,13 @@ impl RuntimeThreadManager {
         Ok(engine)
     }
 
+    /// Get the engine handle for a thread, loading it if necessary.
+    /// Public wrapper around the private `ensure_engine_loaded`.
+    pub async fn get_engine(&self, thread_id: &str) -> Result<EngineHandle> {
+        let thread = self.get_thread(thread_id).await?;
+        self.ensure_engine_loaded(&thread).await
+    }
+
     fn reconstruct_messages_from_turns(&self, turns: &[TurnRecord]) -> Result<Vec<Message>> {
         let mut messages = Vec::new();
         for turn in turns {


### PR DESCRIPTION
Focused slice from #2808: add a PUT /v1/sessions endpoint that saves a thread's current engine state as a session. This is the session-save slice that @Hmbown identified as the next harvest target.

**New endpoint**: PUT /v1/sessions saves a thread live engine state as a session via a oneshot channel, so token counts and message ordering are authoritative. Unlike POST /v1/sessions (which reconstructs from turn items), this matches TUI build_session_snapshot behavior. Backward compatible: existing POST endpoint is preserved.

**Implementation**: SessionSnapshot struct + Op::GetSessionSnapshot variant (ops.rs), engine loop handler (engine.rs), get_session_snapshot method (handle.rs), get_engine public wrapper (runtime_threads.rs), PUT /v1/sessions route + save_current_session handler (runtime_api.rs).

**Bug fix**: load_session errors were silently swallowed by Err(_) wildcard. Only io::ErrorKind::NotFound now falls back to creating a new session; other I/O errors (e.g. PermissionDenied) are propagated.

**Not included** (need atomicity tests): undo, patch-undo, retry, restore-snapshot, ToolCall/FileChange reconstruction.

Ref: #2808