### PR TITLE
Limit mobile event history to prevent freezes

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -445,6 +445,7 @@ struct AutomationRunsQuery {
 #[derive(Debug, Deserialize)]
 struct ThreadEventsQuery {
     since_seq: Option<u64>,
+    replay_limit: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2397,10 +2398,15 @@ async fn stream_thread_events(
         .await
         .map_err(map_thread_err)?;
 
-    let backlog = state
+    let mut backlog = state
         .runtime_threads
         .events_since(&id, query.since_seq)
         .map_err(|e| ApiError::internal(e.to_string()))?;
+    if let Some(limit) = query.replay_limit
+        && backlog.len() > limit
+    {
+        backlog = backlog.split_off(backlog.len() - limit);
+    }
     let mut last_seq = query.since_seq.unwrap_or(0);
     if let Some(last) = backlog.last() {
         last_seq = last.seq;
@@ -6072,6 +6078,8 @@ mod tests {
         let html = enabled.text().await?;
         assert!(html.contains("CodeWhale Mobile"));
         assert!(html.contains("/v1/approvals/"));
+        assert!(html.contains("MAX_VISIBLE_EVENTS = 100"));
+        assert!(html.contains("replay_limit="));
 
         handle.abort();
         Ok(())

--- a/crates/tui/src/runtime_mobile.html
+++ b/crates/tui/src/runtime_mobile.html
@@ -261,6 +261,7 @@
 
   <script>
     const $ = (id) => document.getElementById(id);
+    const MAX_VISIBLE_EVENTS = 100;
     const state = {
       threadId: "",
       activeTurnId: "",
@@ -361,6 +362,13 @@
       return { id: approvalId };
     }
 
+    function pruneVisibleEvents() {
+      const events = $("events");
+      while (events.childElementCount > MAX_VISIBLE_EVENTS) {
+        events.firstElementChild.remove();
+      }
+    }
+
     async function decideApproval(approvalId, decision, container) {
       for (const button of container.querySelectorAll("button")) button.disabled = true;
       const remember = $("remember-approval").checked;
@@ -408,8 +416,10 @@
       }
 
       $("events").appendChild(item);
+      pruneVisibleEvents();
       state.eventCount += 1;
-      $("event-count").textContent = state.eventCount + " events";
+      const visible = Math.min(state.eventCount, MAX_VISIBLE_EVENTS);
+      $("event-count").textContent = visible + " of " + state.eventCount + " events";
       $("events").scrollTop = $("events").scrollHeight;
     }
 
@@ -455,7 +465,8 @@
       $("active-title").textContent = title || id;
       $("events").innerHTML = "";
       if (state.source) state.source.close();
-      const qs = "?since_seq=0" + (token() ? "&token=" + encodeURIComponent(token()) : "");
+      const qs = "?since_seq=0&replay_limit=" + MAX_VISIBLE_EVENTS +
+        (token() ? "&token=" + encodeURIComponent(token()) : "");
       const source = new EventSource("/v1/threads/" + encodeURIComponent(id) + "/events" + qs);
       state.source = source;
       const names = [


### PR DESCRIPTION
Fixes browser readability and freeze issues observed with codewhale serve --mobile on long code-generation threads. The mobile page now keeps only the latest 100 visible entries in the DOM, the thread events SSE endpoint accepts replay_limit so old threads do not replay the entire history into the browser, consecutive item.delta chunks are appended into the current agent event div until another event type arrives, and item.completed/item.failed renders full item.detail when available instead of the truncated summary. Tested locally with serve --mobile on a long generation thread; the mobile browser stayed responsive and streamed output is easier to read.