### PR TITLE
fix(exec): honour DEEPSEEK_BASE_URL and DEEPSEEK_MODEL env vars

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2530,7 +2530,9 @@ impl Config {
             let api_key = config_api_key.or(env_api_key.as_deref());
             resolve_xiaomi_mimo_base_url(configured_base_url, api_key, mode)
         } else {
-            configured_base_url.unwrap_or_else(|| {
+            configured_base_url
+                .or_else(|| env_base_url_override())
+                .unwrap_or_else(|| {
                 match provider {
                     ApiProvider::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
                     ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
@@ -3454,7 +3456,16 @@ fn default_memory_path() -> Option<PathBuf> {
 
 // === Environment Overrides ===
 
-/// Read a CodeWhale env var, preferring the `CODEWHALE_*` form over the
+/// Read the `DEEPSEEK_BASE_URL` / `CODEWHALE_BASE_URL` env var that the CLI
+/// dispatcher forwards from `--base-url`.  Returns `None` when the var is
+/// absent or empty so that provider-specific defaults still apply.
+fn env_base_url_override() -> Option<String> {
+    codewhale_env_var("CODEWHALE_BASE_URL", "DEEPSEEK_BASE_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+}
+
+/// Resolve an env var, preferring the `CODEWHALE_*` form over the
 /// legacy `DEEPSEEK_*` form. Empty values are ignored so a blank shell export
 /// does not erase configured provider settings.
 fn codewhale_env_var(

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2533,41 +2533,41 @@ impl Config {
             configured_base_url
                 .or_else(|| env_base_url_override())
                 .unwrap_or_else(|| {
-                match provider {
-                    ApiProvider::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
-                    ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
-                    ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
-                    ApiProvider::Openai => DEFAULT_OPENAI_BASE_URL,
-                    ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL,
-                    ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
-                    ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
-                    ApiProvider::XiaomiMimo => DEFAULT_XIAOMI_MIMO_BASE_URL,
-                    ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
-                    ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
-                    ApiProvider::Siliconflow => DEFAULT_SILICONFLOW_BASE_URL,
-                    ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
-                    ApiProvider::Arcee => DEFAULT_ARCEE_BASE_URL,
-                    ApiProvider::Moonshot => {
-                        if self
-                            .provider_config()
-                            .is_some_and(provider_config_uses_kimi_oauth)
-                        {
-                            DEFAULT_KIMI_CODE_BASE_URL
-                        } else {
-                            DEFAULT_MOONSHOT_BASE_URL
+                    match provider {
+                        ApiProvider::Deepseek => DEFAULT_DEEPSEEK_BASE_URL,
+                        ApiProvider::DeepseekCN => DEFAULT_DEEPSEEKCN_BASE_URL,
+                        ApiProvider::NvidiaNim => DEFAULT_NVIDIA_NIM_BASE_URL,
+                        ApiProvider::Openai => DEFAULT_OPENAI_BASE_URL,
+                        ApiProvider::Atlascloud => DEFAULT_ATLASCLOUD_BASE_URL,
+                        ApiProvider::WanjieArk => DEFAULT_WANJIE_ARK_BASE_URL,
+                        ApiProvider::Openrouter => DEFAULT_OPENROUTER_BASE_URL,
+                        ApiProvider::XiaomiMimo => DEFAULT_XIAOMI_MIMO_BASE_URL,
+                        ApiProvider::Novita => DEFAULT_NOVITA_BASE_URL,
+                        ApiProvider::Fireworks => DEFAULT_FIREWORKS_BASE_URL,
+                        ApiProvider::Siliconflow => DEFAULT_SILICONFLOW_BASE_URL,
+                        ApiProvider::SiliconflowCn => DEFAULT_SILICONFLOW_CN_BASE_URL,
+                        ApiProvider::Arcee => DEFAULT_ARCEE_BASE_URL,
+                        ApiProvider::Moonshot => {
+                            if self
+                                .provider_config()
+                                .is_some_and(provider_config_uses_kimi_oauth)
+                            {
+                                DEFAULT_KIMI_CODE_BASE_URL
+                            } else {
+                                DEFAULT_MOONSHOT_BASE_URL
+                            }
                         }
+                        ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
+                        ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
+                        ApiProvider::Ollama => DEFAULT_OLLAMA_BASE_URL,
+                        ApiProvider::Volcengine => DEFAULT_VOLCENGINE_BASE_URL,
+                        ApiProvider::Huggingface => DEFAULT_HUGGINGFACE_BASE_URL,
+                        ApiProvider::Together => DEFAULT_TOGETHER_BASE_URL,
+                        ApiProvider::OpenaiCodex => DEFAULT_OPENAI_CODEX_BASE_URL,
+                        ApiProvider::Anthropic => DEFAULT_ANTHROPIC_BASE_URL,
                     }
-                    ApiProvider::Sglang => DEFAULT_SGLANG_BASE_URL,
-                    ApiProvider::Vllm => DEFAULT_VLLM_BASE_URL,
-                    ApiProvider::Ollama => DEFAULT_OLLAMA_BASE_URL,
-                    ApiProvider::Volcengine => DEFAULT_VOLCENGINE_BASE_URL,
-                    ApiProvider::Huggingface => DEFAULT_HUGGINGFACE_BASE_URL,
-                    ApiProvider::Together => DEFAULT_TOGETHER_BASE_URL,
-                    ApiProvider::OpenaiCodex => DEFAULT_OPENAI_CODEX_BASE_URL,
-                    ApiProvider::Anthropic => DEFAULT_ANTHROPIC_BASE_URL,
-                }
-                .to_string()
-            })
+                    .to_string()
+                })
         };
         normalize_base_url(&base)
     }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -464,7 +464,19 @@ fn resolve_exec_model(config: &Config, explicit_model: Option<&str>) -> String {
         .map(str::trim)
         .filter(|model| !model.is_empty())
         .map(ToOwned::to_owned)
+        .or_else(exec_model_env_override)
         .unwrap_or_else(|| config.default_model())
+}
+
+fn exec_model_env_override() -> Option<String> {
+    ["CODEWHALE_MODEL", "DEEPSEEK_MODEL"]
+        .into_iter()
+        .find_map(|key| {
+            std::env::var(key)
+                .ok()
+                .map(|model| model.trim().to_string())
+                .filter(|model| !model.is_empty())
+        })
 }
 
 fn top_level_prompt_initial_input(parts: &[String]) -> Option<tui::InitialInput> {
@@ -978,6 +990,16 @@ async fn main() -> Result<()> {
                 });
                 let mut config = config.clone();
                 merge_user_workspace_config(&mut config, cli.config.clone(), &workspace);
+                // Honour DEEPSEEK_BASE_URL forwarded by the CLI dispatcher from --base-url.
+                if let Ok(env_url) = std::env::var("DEEPSEEK_BASE_URL") {
+                    let trimmed = env_url.trim();
+                    eprintln!("DEBUG DEEPSEEK_BASE_URL='{trimmed}'");
+                    if !trimmed.is_empty() {
+                        config.base_url = Some(trimmed.to_string());
+                    }
+                } else {
+                    eprintln!("DEBUG DEEPSEEK_BASE_URL not set");
+                }
                 let model = resolve_exec_model(&config, args.model.as_deref());
                 let prompt = join_prompt_parts(&args.prompt);
                 let resume_session_id = resolve_exec_resume_session_id(&args, &workspace)?;


### PR DESCRIPTION
## Summary

`codewhale --provider wanjie-ark --base-url <url> --model auto exec ...` does not work because the TUI binary ignores the `DEEPSEEK_BASE_URL` and `DEEPSEEK_MODEL` environment variables that the CLI dispatcher forwards.

## Root cause

Three gaps:

1. **`resolve_exec_model`** only reads the explicit `--model` arg, but `ExecArgs.prompt` has `trailing_var_arg=true` which eats `--model auto` as prompt text. The CLI dispatcher forwards `--model` via `DEEPSEEK_MODEL` env var, but this function doesn't read it.

2. **Exec command handler** doesn't read `DEEPSEEK_BASE_URL`. The CLI dispatcher forwards `--base-url` via this env var, but the handler creates the client with the config's default base_url.

3. **`deepseek_base_url()`** only considers provider-specific config entries and provider defaults. It doesn't fall back to `DEEPSEEK_BASE_URL` / `CODEWHALE_BASE_URL` env vars.

## Fix

1. `resolve_exec_model`: add `exec_model_env_override()` that checks `CODEWHALE_MODEL` then `DEEPSEEK_MODEL`.

2. Exec handler: read `DEEPSEEK_BASE_URL` and set `config.base_url` before creating the client.

3. `deepseek_base_url()`: add `env_base_url_override()` as a fallback between configured base_url and provider default.