### PR TITLE
feat(config): persist ask-only permission rules atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,9 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
+ "tempfile",
  "toml 0.9.11+spec-1.1.0",
+ "toml_edit",
  "tracing",
 ]
 
@@ -5446,6 +5448,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 0.7.14",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 semver = "1.0.28"
 thiserror = "2.0"
+tempfile = "3.16"
 tokio = { version = "1.49.0", features = ["full"] }
 toml = "0.9.7"
+toml_edit = "0.23.10"
 sha2 = "0.10"
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -13,5 +13,7 @@ codewhale-secrets = { path = "../secrets", version = "0.8.61" }
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 tracing.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3,7 +3,6 @@ pub mod provider;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
-#[cfg(unix)]
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
@@ -377,7 +376,7 @@ pub struct ProvidersToml {
 ///
 /// This slice is intentionally ask-only: each rule is a typed condition that
 /// means "ask before this tool invocation." Typed allow/deny records and UI
-/// persistence are expected to land in follow-up PRs.
+/// actions are expected to land in follow-up PRs.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PermissionsToml {
@@ -3391,6 +3390,70 @@ impl ConfigStore {
             ExecPolicyEngine::with_rulesets(vec![self.permissions.ruleset()])
         }
     }
+
+    /// Atomically append ask-only permission rules to the sibling
+    /// `permissions.toml` file.
+    ///
+    /// Existing comments and formatting are preserved. Exact duplicate rules
+    /// are ignored, and the in-memory permissions snapshot is refreshed after
+    /// a successful write.
+    pub fn append_ask_rules(&mut self, rules: &[ToolAskRule]) -> Result<usize> {
+        if rules.is_empty() {
+            return Ok(0);
+        }
+
+        let path = self.permissions_path();
+        let raw = if path.exists() {
+            fs::read_to_string(&path)
+                .with_context(|| format!("failed to read permissions at {}", path.display()))?
+        } else {
+            String::new()
+        };
+        let mut permissions = if raw.trim().is_empty() {
+            PermissionsToml::default()
+        } else {
+            toml::from_str(&raw)
+                .with_context(|| format!("failed to parse permissions at {}", path.display()))?
+        };
+        let mut document = if raw.trim().is_empty() {
+            toml_edit::DocumentMut::new()
+        } else {
+            raw.parse::<toml_edit::DocumentMut>()
+                .with_context(|| format!("failed to edit permissions at {}", path.display()))?
+        };
+
+        if !document.contains_key("rules") {
+            document["rules"] = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+        }
+        let rules_item = document
+            .get_mut("rules")
+            .expect("rules entry was inserted above");
+
+        let mut added = 0;
+        for rule in rules {
+            if permissions.rules.contains(rule) {
+                continue;
+            }
+            append_ask_rule(rules_item, rule)?;
+            permissions.rules.push(rule.clone());
+            added += 1;
+        }
+        if added == 0 {
+            self.permissions = permissions;
+            return Ok(0);
+        }
+
+        let body = document.to_string();
+        let persisted: PermissionsToml = toml::from_str(&body).with_context(|| {
+            format!(
+                "generated invalid permissions document for {}",
+                path.display()
+            )
+        })?;
+        write_permissions_atomic(&path, body.as_bytes())?;
+        self.permissions = persisted;
+        Ok(added)
+    }
 }
 
 /// Process-wide default [`Secrets`] façade. The first caller wins; the
@@ -3564,6 +3627,91 @@ fn load_sibling_permissions(config_path: &Path) -> Result<PermissionsToml> {
             permissions_path.display()
         )
     })
+}
+
+fn append_ask_rule(item: &mut toml_edit::Item, rule: &ToolAskRule) -> Result<()> {
+    match item {
+        toml_edit::Item::ArrayOfTables(rules) => {
+            rules.push(ask_rule_table(rule));
+            Ok(())
+        }
+        toml_edit::Item::Value(value) => {
+            let Some(rules) = value.as_array_mut() else {
+                bail!("`rules` in permissions.toml must be an array");
+            };
+            rules.push(toml_edit::Value::InlineTable(ask_rule_inline_table(rule)));
+            Ok(())
+        }
+        _ => bail!("`rules` in permissions.toml must be an array"),
+    }
+}
+
+fn ask_rule_table(rule: &ToolAskRule) -> toml_edit::Table {
+    let mut table = toml_edit::Table::new();
+    table["tool"] = toml_edit::value(rule.tool.clone());
+    if let Some(command) = rule.command.as_deref() {
+        table["command"] = toml_edit::value(command);
+    }
+    if let Some(path) = rule.path.as_deref() {
+        table["path"] = toml_edit::value(path);
+    }
+    table
+}
+
+fn ask_rule_inline_table(rule: &ToolAskRule) -> toml_edit::InlineTable {
+    let mut table = toml_edit::InlineTable::new();
+    table.insert("tool", toml_edit::Value::from(rule.tool.clone()));
+    if let Some(command) = rule.command.as_deref() {
+        table.insert("command", toml_edit::Value::from(command));
+    }
+    if let Some(path) = rule.path.as_deref() {
+        table.insert("path", toml_edit::Value::from(path));
+    }
+    table
+}
+
+fn write_permissions_atomic(path: &Path, body: &[u8]) -> Result<()> {
+    let parent = path.parent().with_context(|| {
+        format!(
+            "permissions path has no parent directory: {}",
+            path.display()
+        )
+    })?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create permissions directory {}",
+            parent.display()
+        )
+    })?;
+
+    let mut temporary = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "failed to create temporary permissions file in {}",
+            parent.display()
+        )
+    })?;
+    #[cfg(unix)]
+    temporary
+        .as_file()
+        .set_permissions(fs::Permissions::from_mode(0o600))
+        .with_context(|| {
+            format!(
+                "failed to secure temporary permissions file for {}",
+                path.display()
+            )
+        })?;
+    temporary
+        .write_all(body)
+        .with_context(|| format!("failed to write permissions at {}", path.display()))?;
+    temporary
+        .as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync permissions at {}", path.display()))?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace permissions at {}", path.display()))?;
+    Ok(())
 }
 
 pub fn default_config_path() -> Result<PathBuf> {
@@ -4364,6 +4512,152 @@ action = "mode.agent"
         );
 
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn config_store_appends_ask_rules_without_losing_comments_or_duplicates() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        let permissions_path = dir.path().join(PERMISSIONS_FILE_NAME);
+        fs::write(&config_path, "model = \"deepseek-v4-flash\"\n").expect("write config");
+        fs::write(
+            &permissions_path,
+            r#"# keep this permission note
+[[rules]]
+tool = "exec_shell"
+command = "cargo check"
+"#,
+        )
+        .expect("write permissions");
+
+        let mut store = ConfigStore::load(Some(config_path)).expect("load config store");
+        let existing = ToolAskRule::exec_shell("cargo check");
+        let added_rule = ToolAskRule::file_path("read_file", "docs/README.md");
+        let added = store
+            .append_ask_rules(&[existing, added_rule.clone(), added_rule.clone()])
+            .expect("append ask rules");
+
+        assert_eq!(added, 1);
+        assert_eq!(
+            store.permissions().rules,
+            vec![ToolAskRule::exec_shell("cargo check"), added_rule.clone(),]
+        );
+        let body = fs::read_to_string(&permissions_path).expect("read permissions");
+        assert!(body.contains("# keep this permission note"));
+        assert_eq!(body.matches("docs/README.md").count(), 1);
+        assert!(!body.contains("decision"));
+
+        let before_duplicate_append = body;
+        assert_eq!(
+            store
+                .append_ask_rules(&[added_rule])
+                .expect("dedupe ask rule"),
+            0
+        );
+        assert_eq!(
+            fs::read_to_string(&permissions_path).expect("read unchanged permissions"),
+            before_duplicate_append
+        );
+
+        let reloaded = ConfigStore::load(Some(dir.path().join(CONFIG_FILE_NAME)))
+            .expect("reload config store");
+        assert_eq!(reloaded.permissions(), store.permissions());
+    }
+
+    #[test]
+    fn config_store_appends_ask_rule_to_inline_rules_array() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        let permissions_path = dir.path().join(PERMISSIONS_FILE_NAME);
+        fs::write(
+            &permissions_path,
+            "# inline rules stay valid\nrules = [{ tool = \"exec_shell\", command = \"cargo check\" }]\n",
+        )
+        .expect("write permissions");
+
+        let mut store = ConfigStore::load(Some(config_path)).expect("load config store");
+        assert_eq!(
+            store
+                .append_ask_rules(&[ToolAskRule::file_path("read_file", "README.md")])
+                .expect("append inline ask rule"),
+            1
+        );
+
+        let body = fs::read_to_string(&permissions_path).expect("read permissions");
+        assert!(body.contains("# inline rules stay valid"));
+        let parsed: PermissionsToml = toml::from_str(&body).expect("parse persisted permissions");
+        assert_eq!(
+            parsed.rules,
+            vec![
+                ToolAskRule::exec_shell("cargo check"),
+                ToolAskRule::file_path("read_file", "README.md"),
+            ]
+        );
+    }
+
+    #[test]
+    fn config_store_does_not_overwrite_invalid_permissions_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        let permissions_path = dir.path().join(PERMISSIONS_FILE_NAME);
+        let mut store = ConfigStore::load(Some(config_path)).expect("load config store");
+        let invalid = "rules = \"not-an-array\"\n";
+        fs::write(&permissions_path, invalid).expect("write invalid permissions");
+
+        let error = store
+            .append_ask_rules(&[ToolAskRule::exec_shell("cargo test")])
+            .expect_err("invalid permissions should fail");
+
+        assert!(error.to_string().contains("failed to parse permissions"));
+        assert_eq!(
+            fs::read_to_string(&permissions_path).expect("read invalid permissions"),
+            invalid
+        );
+        assert!(store.permissions().is_empty());
+    }
+
+    #[test]
+    fn duplicate_append_refreshes_permissions_changed_on_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        let permissions_path = dir.path().join(PERMISSIONS_FILE_NAME);
+        let mut store = ConfigStore::load(Some(config_path)).expect("load config store");
+        fs::write(
+            permissions_path,
+            "[[rules]]\ntool = \"exec_shell\"\ncommand = \"cargo check\"\n",
+        )
+        .expect("write external permissions update");
+
+        assert_eq!(
+            store
+                .append_ask_rules(&[ToolAskRule::exec_shell("cargo check")])
+                .expect("dedupe external ask rule"),
+            0
+        );
+        assert_eq!(
+            store.permissions().rules,
+            vec![ToolAskRule::exec_shell("cargo check")]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_store_secures_persisted_permissions_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        let permissions_path = dir.path().join(PERMISSIONS_FILE_NAME);
+        let mut store = ConfigStore::load(Some(config_path)).expect("load config store");
+
+        store
+            .append_ask_rules(&[ToolAskRule::exec_shell("cargo test")])
+            .expect("append ask rule");
+
+        let mode = fs::metadata(permissions_path)
+            .expect("permissions metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     struct EnvGuard {

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,13 +9,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.61] - 2026-06-14
 
+This release lands the **runtime control plane** for multi-agent work: the TUI stays
+responsive while sub-agents run, sub-agents converge toward fleet-style durable workers
+with per-role model routing, and provider/model routes are isolated per session. It also
+folds in several community contributions.
+
 ### Added
 
-- Initial v0.8.61 integration branch. Changes will be listed as they land.
+- **WhaleFlow runtime foundations** — worker runtime profiles (role / permissions / shell /
+  tools / model-route, with non-escalating child derivation), a cross-provider model registry
+  with offline catalog hydration, and provider-readiness / context-budget / provider-adapter /
+  resource-telemetry services. (#3217, #3071, #3072, #3073)
+- **Per-role, heterogeneous-model sub-agent routing** — sub-agents can be assigned a model and
+  provider per role (e.g. scout vs. synthesis; verifiers route to a fast model). (#2027, #1768)
+- **Durable goal mode** — cross-turn goal progress with token/time accounting and a
+  verifier-as-judge gate before a goal may complete. (#3215, #891, #1976, #2058, #2029)
+- Parent-visible worker interaction contract — a recommended action per worker. (#3226)
+- Maintainer GitHub workflow skills; ACP registry submission prepared. (#3192)
 
 ### Changed
 
+- **Sub-agents converge toward fleet-style durable workers** — real worker lifecycle states are
+  projected to the sidebar instead of a hardcoded "running", and a sub-agent returns a structured
+  needs-input checkpoint instead of parking. (#3226, #3096, #3154)
+- The per-turn runtime tag exposes capability posture instead of human-facing mode labels. (#3213)
+- Independent shell and verifier work defaults to background jobs with nonblocking waits and a
+  completion notification; blocking now requires an explicit wait. (#3212)
+- Plan mode is strictly read-only (no shell tools), consistent with its runtime posture.
+- `/swarm` is gated behind the durable worker substrate. (#3218)
+- Legacy `deepseek` install/update path resolves to `codewhale`. (#2960, #2924, #2917)
+
 ### Fixed
+
+- **TUI freeze when multiple sub-agents spawn (launch blocker)** — the terminal input pump runs
+  off the render thread, AgentProgress events are coalesced, and sub-agents no longer park on
+  input with no orchestrator to answer; a six-worker stress test guards input/render/cancel
+  liveness. (#3216, #3096)
+- **Provider/model route isolation** — provider and model state is session-local, and a
+  mismatched provider+model tuple is rejected at the route boundary. (#3227)
+- Route-effective context-window metadata, over-limit preflight, and bounded recovery from
+  `context_length_exceeded` instead of re-looping. (#3204)
+- Synchronous tools (`file_search`, `grep_files`, `list_dir`) are cancellable and no longer hold
+  a turn open against cancellation. (#1791)
+- MCP stdio proxy startup prompts no longer strand YOLO / non-interactive runs. (#2475)
+- Stalled / failed background-shell recovery; configurable sub-agent API timeout. (#1737, #1786, #1806)
+- Composer: reliable queued steering + Ctrl+S send (#3203, #3224); footer busy/idle indicator
+  (#2982); CJK word-wrap (#963); clickable sidebar stop targets (#3028); live token throughput
+  (#3190); auto-expiring terminal sub-agent cards (#3078).
+- Linux glibc preflight in the installer/update path with a clear error. (#3207, #1067)
+
+### Community contributions
+
+- Non-DeepSeek model pricing — thanks @mvanhorn (#3201)
+- Telegram polling transport — thanks @cyq1017 (#3195)
+- Mobile event history — thanks @RobertEmprechtinger (#3220)
+- Runtime-API session save — thanks @gaord (#3199)
+- Whale-accent rename — thanks @nightt5879 (#3197)
+- `DEEPSEEK_BASE_URL` / `MODEL` honored in `exec` — thanks @hongchen1993 (#3221)
+- VS Code read-only API documentation — thanks @cyq1017 (#3013)
 
 ## [0.8.60] - 2026-06-13
 

--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -816,7 +816,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut adapter = LocalProcessFleetHostAdapter::new(tmp.path());
         let script = if cfg!(windows) {
-            "echo 0123456789abcdef & ping -n 30 127.0.0.1 >NUL"
+            "echo 0123456789abcdef& ping -n 30 127.0.0.1 >NUL"
         } else {
             "printf 0123456789abcdef; sleep 30"
         };

--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -821,7 +821,8 @@ mod tests {
             "printf 0123456789abcdef; sleep 30"
         };
         let mut request = FleetWorkerStartRequest::new("local-1", shell_command(script));
-        request.log_limit_bytes = 16;
+        let line_ending_bytes = if cfg!(windows) { 2 } else { 0 };
+        request.log_limit_bytes = 16 + line_ending_bytes;
 
         let handle = adapter.start_worker(request).unwrap();
         assert_eq!(handle.host_kind, FleetHostKind::LocalProcess);
@@ -830,8 +831,10 @@ mod tests {
         assert_eq!(status.state, FleetHostWorkerState::Running);
 
         let logs = wait_for_log(&adapter, "local-1", "abcdef");
-        assert!(logs.ends_with("0123456789abcdef") || logs.contains("0123456789abcdef"));
-        let bounded = adapter.read_logs("local-1", 6).unwrap();
+        let logs = logs.trim_end_matches(&['\r', '\n'][..]);
+        assert!(logs.ends_with("0123456789abcdef"), "{logs:?}");
+        let bounded = adapter.read_logs("local-1", 6 + line_ending_bytes).unwrap();
+        let bounded = bounded.trim_end_matches(&['\r', '\n'][..]);
         assert!(bounded.ends_with("abcdef"), "{bounded:?}");
 
         let status = adapter.stop_worker("local-1").unwrap();

--- a/crates/tui/src/remote_setup/bundle.rs
+++ b/crates/tui/src/remote_setup/bundle.rs
@@ -41,11 +41,7 @@ impl ProviderInfo {
     pub fn from_slug(slug: &str) -> Option<Self> {
         let kind = codewhale_config::ProviderKind::parse(slug)?;
         let p = codewhale_config::provider::provider_for_kind(kind);
-        let key_var = p
-            .env_vars()
-            .first()
-            .copied()
-            .unwrap_or("CODEWHALE_API_KEY");
+        let key_var = p.env_vars().first().copied().unwrap_or("CODEWHALE_API_KEY");
         Some(Self {
             slug: p.id().to_string(),
             display: p.display_name().to_string(),
@@ -160,7 +156,10 @@ fn render_runtime_env(i: &BundleInputs) -> String {
         "# Provider API key ({}). Replace the placeholder with your real key.\n",
         i.provider.display
     ));
-    out.push_str(&format!("{}={}\n", i.provider.key_var, i.provider_key_value));
+    out.push_str(&format!(
+        "{}={}\n",
+        i.provider.key_var, i.provider_key_value
+    ));
     out.push_str(&format!(
         "CODEWHALE_MODEL={}   # provider default is {}\n",
         i.model, i.provider.default_model
@@ -174,7 +173,9 @@ fn render_runtime_env(i: &BundleInputs) -> String {
     out.push_str("RUST_LOG=info\n\n");
 
     if i.provider.slug == "deepseek" {
-        out.push_str("# Legacy aliases (still honored): DEEPSEEK_RUNTIME_TOKEN, DEEPSEEK_API_KEY,\n");
+        out.push_str(
+            "# Legacy aliases (still honored): DEEPSEEK_RUNTIME_TOKEN, DEEPSEEK_API_KEY,\n",
+        );
         out.push_str("# DEEPSEEK_RUNTIME_PORT, DEEPSEEK_RUNTIME_WORKERS.\n");
     } else {
         out.push_str("# Legacy aliases (still honored): DEEPSEEK_RUNTIME_TOKEN,\n");
@@ -222,13 +223,22 @@ fn render_bridge_env(i: &BundleInputs) -> String {
         bridge_env_prefix(i.bridge),
         i.bridge.slug
     ));
-    out.push_str(&format!("{}_ALLOW_GROUPS=false\n", bridge_env_prefix(i.bridge)));
+    out.push_str(&format!(
+        "{}_ALLOW_GROUPS=false\n",
+        bridge_env_prefix(i.bridge)
+    ));
     out.push_str(&format!(
         "{}_REQUIRE_PREFIX_IN_GROUP=true\n",
         bridge_env_prefix(i.bridge)
     ));
-    out.push_str(&format!("{}_GROUP_PREFIX=/cw\n", bridge_env_prefix(i.bridge)));
-    out.push_str(&format!("{}_MAX_REPLY_CHARS=3500\n", bridge_env_prefix(i.bridge)));
+    out.push_str(&format!(
+        "{}_GROUP_PREFIX=/cw\n",
+        bridge_env_prefix(i.bridge)
+    ));
+    out.push_str(&format!(
+        "{}_MAX_REPLY_CHARS=3500\n",
+        bridge_env_prefix(i.bridge)
+    ));
     if i.bridge.slug == "telegram" {
         out.push_str("TELEGRAM_POLL_TIMEOUT_SECONDS=50\n");
     }
@@ -333,7 +343,9 @@ fn render_runbook(i: &BundleInputs) -> String {
 
     out.push_str("## What was generated\n\n");
     out.push_str("| File | Purpose |\n|---|---|\n");
-    out.push_str("| `runtime.env` | Provider + runtime config (the only place the provider is set). |\n");
+    out.push_str(
+        "| `runtime.env` | Provider + runtime config (the only place the provider is set). |\n",
+    );
     out.push_str(&format!(
         "| `{}.env` | {} bridge transport config (token, allowlist, runtime URL). |\n",
         i.bridge.slug, i.bridge.display
@@ -384,7 +396,10 @@ fn render_runbook(i: &BundleInputs) -> String {
     out.push_str("yourself (commands shown as data — review before running):\n\n");
     for (n, step) in plan.iter().enumerate() {
         out.push_str(&format!("{}. {}\n", n + 1, step.description));
-        out.push_str(&format!("   ```sh\n   {}\n   ```\n", step.display_command()));
+        out.push_str(&format!(
+            "   ```sh\n   {}\n   ```\n",
+            step.display_command()
+        ));
     }
     out.push('\n');
     if i.cloud.secret_store == SecretStore::KeyVault {
@@ -419,14 +434,22 @@ sudo systemctl enable --now codewhale-runtime {unit}\n```\n\n",
     match i.bridge.slug {
         "telegram" => {
             out.push_str("1. With `TELEGRAM_CHAT_ALLOWLIST` empty, temporarily set\n");
-            out.push_str("   `TELEGRAM_ALLOW_UNLISTED=true`, restart the bridge, and DM your bot once.\n");
-            out.push_str("2. Read the chat id the bridge logs, add it to `TELEGRAM_CHAT_ALLOWLIST`,\n");
+            out.push_str(
+                "   `TELEGRAM_ALLOW_UNLISTED=true`, restart the bridge, and DM your bot once.\n",
+            );
+            out.push_str(
+                "2. Read the chat id the bridge logs, add it to `TELEGRAM_CHAT_ALLOWLIST`,\n",
+            );
             out.push_str("   set `TELEGRAM_ALLOW_UNLISTED=false`, and restart the bridge.\n");
         }
         "feishu" => {
             out.push_str("1. With `FEISHU_CHAT_ALLOWLIST` empty, temporarily set\n");
-            out.push_str("   `FEISHU_ALLOW_UNLISTED=true`, restart the bridge, and message the app once.\n");
-            out.push_str("2. Read the open id the bridge logs, add it to `FEISHU_CHAT_ALLOWLIST`,\n");
+            out.push_str(
+                "   `FEISHU_ALLOW_UNLISTED=true`, restart the bridge, and message the app once.\n",
+            );
+            out.push_str(
+                "2. Read the open id the bridge logs, add it to `FEISHU_CHAT_ALLOWLIST`,\n",
+            );
             out.push_str("   set `FEISHU_ALLOW_UNLISTED=false`, and restart the bridge.\n");
         }
         _ => {
@@ -464,7 +487,12 @@ mod tests {
         let bridge_secret_values = bridge
             .secret_keys
             .iter()
-            .map(|k| ((*k).to_string(), format!("replace-{}", k.to_ascii_lowercase())))
+            .map(|k| {
+                (
+                    (*k).to_string(),
+                    format!("replace-{}", k.to_ascii_lowercase()),
+                )
+            })
             .collect();
         BundleInputs {
             cloud,
@@ -490,7 +518,10 @@ mod tests {
         let oai = ProviderInfo::from_slug("openai").unwrap();
         assert_eq!(oai.key_var, "OPENAI_API_KEY");
         // Provider-registry aliases resolve to the canonical slug.
-        assert_eq!(ProviderInfo::from_slug("nvidia").unwrap().slug, "nvidia-nim");
+        assert_eq!(
+            ProviderInfo::from_slug("nvidia").unwrap().slug,
+            "nvidia-nim"
+        );
         assert_eq!(ProviderInfo::from_slug("kimi").unwrap().slug, "moonshot");
         assert!(ProviderInfo::from_slug("not-a-provider").is_none());
     }
@@ -586,8 +617,7 @@ mod tests {
                         .unwrap()
                         .contents;
                     assert!(runtime.contains(&format!("CODEWHALE_PROVIDER={provider_slug}")));
-                    let token_line =
-                        format!("CODEWHALE_RUNTIME_TOKEN={}", inputs.runtime_token);
+                    let token_line = format!("CODEWHALE_RUNTIME_TOKEN={}", inputs.runtime_token);
                     assert!(runtime.contains(&token_line));
 
                     let bridge_env = &files

--- a/crates/tui/src/remote_setup/mod.rs
+++ b/crates/tui/src/remote_setup/mod.rs
@@ -115,12 +115,13 @@ pub fn run_remote_setup(args: RemoteSetupArgs) -> Result<()> {
     if args.apply {
         // MVP: the auto-provision path is intentionally not implemented yet.
         println!();
-        println!(
-            "auto-provision not yet implemented; bundle generated, follow RUNBOOK.md"
-        );
+        println!("auto-provision not yet implemented; bundle generated, follow RUNBOOK.md");
     } else {
         println!();
-        println!("Next: open {}/RUNBOOK.md and follow the steps.", out_dir.display());
+        println!(
+            "Next: open {}/RUNBOOK.md and follow the steps.",
+            out_dir.display()
+        );
     }
 
     Ok(())
@@ -145,7 +146,10 @@ fn resolve_cloud(args: &RemoteSetupArgs) -> Result<&'static CloudTarget> {
             .ok_or_else(|| anyhow::anyhow!("unknown cloud '{slug}'. {}", cloud_choices()));
     }
     if args.non_interactive {
-        bail!("--cloud is required in --non-interactive mode. {}", cloud_choices());
+        bail!(
+            "--cloud is required in --non-interactive mode. {}",
+            cloud_choices()
+        );
     }
     let idx = prompt_choice(
         "Cloud target",
@@ -163,7 +167,10 @@ fn resolve_bridge(args: &RemoteSetupArgs) -> Result<&'static BridgeSpec> {
             .ok_or_else(|| anyhow::anyhow!("unknown bridge '{slug}'. {}", bridge_choices()));
     }
     if args.non_interactive {
-        bail!("--bridge is required in --non-interactive mode. {}", bridge_choices());
+        bail!(
+            "--bridge is required in --non-interactive mode. {}",
+            bridge_choices()
+        );
     }
     let idx = prompt_choice(
         "Chat bridge",
@@ -217,7 +224,11 @@ fn cloud_choices() -> String {
 fn bridge_choices() -> String {
     format!(
         "Choices: {}",
-        BRIDGES.iter().map(|b| b.slug).collect::<Vec<_>>().join(", ")
+        BRIDGES
+            .iter()
+            .map(|b| b.slug)
+            .collect::<Vec<_>>()
+            .join(", ")
     )
 }
 
@@ -305,7 +316,12 @@ mod tests {
             non_interactive: true,
             ..Default::default()
         };
-        assert!(resolve_cloud(&args).unwrap_err().to_string().contains("--cloud is required"));
+        assert!(
+            resolve_cloud(&args)
+                .unwrap_err()
+                .to_string()
+                .contains("--cloud is required")
+        );
     }
 
     #[test]

--- a/crates/tui/src/remote_setup/registry.rs
+++ b/crates/tui/src/remote_setup/registry.rs
@@ -300,7 +300,14 @@ fn azure_plan(inputs: &DeployInputs) -> Vec<ProvisionStep> {
         ProvisionStep::new(
             "Create the resource group",
             "az",
-            &["group", "create", "--name", &rg, "--location", &inputs.region],
+            &[
+                "group",
+                "create",
+                "--name",
+                &rg,
+                "--location",
+                &inputs.region,
+            ],
         ),
         ProvisionStep::new(
             "Create the Key Vault that holds the provider key + runtime token",
@@ -508,11 +515,7 @@ mod tests {
         let inputs = DeployInputs::default();
         for c in CLOUD_TARGETS {
             let steps = (c.plan)(&inputs);
-            assert!(
-                !steps.is_empty(),
-                "cloud {} produced an empty plan",
-                c.slug
-            );
+            assert!(!steps.is_empty(), "cloud {} produced an empty plan", c.slug);
             // First step's program is the cloud's own tooling or a host script.
             assert!(
                 steps
@@ -539,7 +542,8 @@ mod tests {
 
     #[test]
     fn display_command_redacts_secret_args() {
-        let mut step = ProvisionStep::new("set secret", "az", &["keyvault", "secret", "set", "VALUE"]);
+        let mut step =
+            ProvisionStep::new("set secret", "az", &["keyvault", "secret", "set", "VALUE"]);
         step.secret_args = vec![3];
         let rendered = step.display_command();
         assert!(rendered.contains("<redacted>"));

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3305,10 +3305,11 @@ fn turn_liveness_does_not_abort_running_tool() {
 #[test]
 fn turn_liveness_does_not_abort_running_tool_with_recent_heartbeat() {
     let mut app = create_test_app();
-    let now = Instant::now();
+    let started_at = Instant::now();
+    let now = started_at + TOOL_HANG_WATCHDOG_TIMEOUT + Duration::from_secs(30);
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
-    app.turn_started_at = Some(now - TOOL_HANG_WATCHDOG_TIMEOUT - Duration::from_secs(30));
+    app.turn_started_at = Some(started_at);
     app.turn_last_activity_at = Some(now - Duration::from_secs(10));
     let mut active = ActiveCell::new();
     active.push_tool(
@@ -3337,11 +3338,12 @@ fn turn_liveness_does_not_abort_running_tool_with_recent_heartbeat() {
 #[test]
 fn turn_liveness_recovers_running_tool_without_heartbeat() {
     let mut app = create_test_app();
-    let now = Instant::now();
+    let started_at = Instant::now();
+    let now = started_at + TOOL_HANG_WATCHDOG_TIMEOUT + Duration::from_secs(1);
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
     app.runtime_turn_id = Some("stale-tool-turn".to_string());
-    app.turn_started_at = Some(now - TOOL_HANG_WATCHDOG_TIMEOUT - Duration::from_secs(1));
+    app.turn_started_at = Some(started_at);
     app.turn_last_activity_at = app.turn_started_at;
     app.user_scrolled_during_stream = true;
     let mut active = ActiveCell::new();

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -8,8 +8,8 @@ and capability metadata that the code already knows about.
 DeepSeek remains the first-class default provider. NVIDIA NIM, OpenRouter,
 Volcengine Ark, Xiaomi MiMo, Novita, Fireworks, SiliconFlow, Arcee AI, generic
 OpenAI-compatible endpoints, self-hosted runtimes, Moonshot/Kimi, and Hugging
-Face Inference Providers are additive routes for running the same terminal
-harness against other hosted or local model endpoints.
+Face Inference Providers, StepFun, and MiniMax are additive routes for running
+the same terminal harness against other hosted or local model endpoints.
 
 Sources to keep in sync:
 
@@ -30,8 +30,8 @@ The canonical provider IDs are:
 
 `deepseek`, `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `volcengine`,
 `openrouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`,
-`siliconflow-CN`, `arcee`, `moonshot`, `sglang`, `vllm`, `ollama`,
-`huggingface`, `together`, `openai-codex`, and `anthropic`.
+`siliconflow-CN`, `arcee`, `moonshot`, `zai`, `stepfun`, `minimax`, `sglang`,
+`vllm`, `ollama`, `huggingface`, `together`, `openai-codex`, and `anthropic`.
 
 Use any of these surfaces to select a provider:
 
@@ -137,6 +137,7 @@ endpoint.
 | `arcee` | `[providers.arcee]` | `ARCEE_API_KEY` | `ARCEE_BASE_URL`; default `https://api.arcee.ai/api/v1` | `trinity-large-thinking`, `trinity-large-preview` | Arcee AI direct OpenAI-compatible route, tracked as 256K-context BF16 serving. `ARCEE_MODEL` is accepted. OpenRouter's `arcee-ai/trinity-large-thinking` remains the OpenRouter namespaced model ID; direct Arcee uses the bare `trinity-large-thinking` ID. |
 | `moonshot` | `[providers.moonshot]` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` | `MOONSHOT_BASE_URL`, `KIMI_BASE_URL`; default `https://api.moonshot.ai/v1` | `kimi-k2.7-code`, `kimi-k2.6`; Kimi Code path uses `kimi-for-coding` at `https://api.kimi.com/coding/v1` | Moonshot/Kimi route. `kimi` and `kimi-k2` aliases select `kimi-k2.7-code`; `MOONSHOT_MODEL`, `KIMI_MODEL_NAME`, and `KIMI_MODEL` are accepted. Kimi thinking streams through `reasoning_content`; CodeWhale keeps it in Thinking cells and replays it for thinking/tool-call continuity. `[providers.moonshot] auth_mode = "kimi_oauth"` reads Kimi Code OAuth credentials from `KIMI_CODE_HOME`/`~/.kimi-code`, with legacy `KIMI_SHARE_DIR`/`~/.kimi` fallback. |
 | `zai` | `[providers.zai]` | `ZAI_API_KEY`, `Z_AI_API_KEY` | `ZAI_BASE_URL`, `Z_AI_BASE_URL`; default `https://api.z.ai/api/coding/paas/v4`; general API `https://api.z.ai/api/paas/v4` | `GLM-5.1` default; `GLM-5.2` opt-in preview | Z.AI GLM Coding Plan route. Keep `GLM-5.1` as the default until 5.2 is generally documented; set `model = "GLM-5.2"` or `ZAI_MODEL=GLM-5.2` to try the preview. |
+| `stepfun` | `[providers.stepfun]` | `STEPFUN_API_KEY` | `STEPFUN_BASE_URL`; default `https://api.stepfun.ai/v1` | `step-3.7-flash` | StepFun / StepFlash OpenAI-compatible route. `STEPFUN_MODEL` is accepted, and provider-hinted custom model IDs pass through unchanged. |
 | `minimax` | `[providers.minimax]` | `MINIMAX_API_KEY` | `MINIMAX_BASE_URL`; default `https://api.minimax.io/v1`; Anthropic-compatible routes are `https://api.minimax.io/anthropic` globally and `https://api.minimaxi.com/anthropic` in China | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` | MiniMax direct OpenAI-compatible route. CodeWhale sends `reasoning_split = true` so MiniMax thinking arrives separately from answer text, and direct MiniMax IDs stay distinct from OpenRouter namespaced IDs such as `minimax/minimax-m3`. |
 | `sglang` | `[providers.sglang]` | Optional `SGLANG_API_KEY` | `SGLANG_BASE_URL`; default `http://localhost:30000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted OpenAI-compatible route. Localhost deployments commonly omit auth. `SGLANG_MODEL` is accepted. |
 | `vllm` | `[providers.vllm]` | Optional `VLLM_API_KEY` | `VLLM_BASE_URL`; default `http://localhost:8000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted vLLM OpenAI-compatible route. Localhost deployments commonly omit auth. `VLLM_MODEL` is accepted. |
@@ -226,6 +227,7 @@ endpoint when the endpoint supports model listing.
 | `arcee` | `trinity-large-thinking`, `trinity-large-preview`; provider-hinted custom model IDs pass through | yes | yes for `trinity-large-thinking`; no for `trinity-large-preview` |
 | `moonshot` | `kimi-k2.7-code`, `kimi-k2.6` | yes | yes |
 | `zai` | `GLM-5.1`, `GLM-5.2`; provider-hinted custom model IDs pass through | yes | yes |
+| `stepfun` | `step-3.7-flash`; provider-hinted custom model IDs pass through | yes | no |
 | `minimax` | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` | yes | yes |
 | `sglang` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | yes | yes |
 | `vllm` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | yes | yes |


### PR DESCRIPTION
## Summary

Add a config-only persistence API for ask-only typed permission rules.

This extracts the persistence foundation from the broader persistent-permissions work without adding approval UI actions or changing approval semantics.

## Scope

- Add `ConfigStore::append_ask_rules`.
- Re-read `permissions.toml` before each update.
- Preserve existing comments and formatting with `toml_edit`.
- Deduplicate exact typed ask rules.
- Support both `[[rules]]` and inline rule arrays.
- Validate the generated document before writing.
- Write through a temporary file with sync and atomic replacement.
- Apply owner-only `0600` permissions on Unix.
- Refresh the in-memory permissions snapshot after disk changes.
- Fail without modifying malformed permission files.

## Not in this slice

- No approval UI or “save this rule” action.
- No automatic rule generation from tool calls.
- No typed allow/deny records.
- No glob expansion.
- No approval precedence changes.

## Builds on

- #2404: typed ask-rule foundation.
- `3df01899`: sibling `permissions.toml` schema and loading.
- `17dbed13`: runtime ask-rule wiring.
- #2971: matched approval-rule metadata.

## Issues

Refs #1186 (partial)  
Refs #2242 (partial)

## Validation

- `cargo fmt --package codewhale-config --check`
- `cargo test -p codewhale-config --all-features --locked`
- `cargo clippy -p codewhale-config --all-targets --all-features --locked -- -D warnings`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-features --locked`

All workspace tests passed.

`cargo fmt --all --check` currently reports pre-existing formatting differences in the `remote_setup` files from current `main`. This PR does not modify those files.