### PR TITLE
[codex] accept dollar skill aliases

### DIFF
--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,13 +9,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.61] - 2026-06-14
 
+This release lands the **runtime control plane** for multi-agent work: the TUI stays
+responsive while sub-agents run, sub-agents converge toward fleet-style durable workers
+with per-role model routing, and provider/model routes are isolated per session. It also
+folds in several community contributions.
+
 ### Added
 
-- Initial v0.8.61 integration branch. Changes will be listed as they land.
+- **WhaleFlow runtime foundations** — worker runtime profiles (role / permissions / shell /
+  tools / model-route, with non-escalating child derivation), a cross-provider model registry
+  with offline catalog hydration, and provider-readiness / context-budget / provider-adapter /
+  resource-telemetry services. (#3217, #3071, #3072, #3073)
+- **Per-role, heterogeneous-model sub-agent routing** — sub-agents can be assigned a model and
+  provider per role (e.g. scout vs. synthesis; verifiers route to a fast model). (#2027, #1768)
+- **Durable goal mode** — cross-turn goal progress with token/time accounting and a
+  verifier-as-judge gate before a goal may complete. (#3215, #891, #1976, #2058, #2029)
+- Parent-visible worker interaction contract — a recommended action per worker. (#3226)
+- Maintainer GitHub workflow skills; ACP registry submission prepared. (#3192)
 
 ### Changed
 
+- **Sub-agents converge toward fleet-style durable workers** — real worker lifecycle states are
+  projected to the sidebar instead of a hardcoded "running", and a sub-agent returns a structured
+  needs-input checkpoint instead of parking. (#3226, #3096, #3154)
+- The per-turn runtime tag exposes capability posture instead of human-facing mode labels. (#3213)
+- Independent shell and verifier work defaults to background jobs with nonblocking waits and a
+  completion notification; blocking now requires an explicit wait. (#3212)
+- Plan mode is strictly read-only (no shell tools), consistent with its runtime posture.
+- `/swarm` is gated behind the durable worker substrate. (#3218)
+- Legacy `deepseek` install/update path resolves to `codewhale`. (#2960, #2924, #2917)
+
 ### Fixed
+
+- **TUI freeze when multiple sub-agents spawn (launch blocker)** — the terminal input pump runs
+  off the render thread, AgentProgress events are coalesced, and sub-agents no longer park on
+  input with no orchestrator to answer; a six-worker stress test guards input/render/cancel
+  liveness. (#3216, #3096)
+- **Provider/model route isolation** — provider and model state is session-local, and a
+  mismatched provider+model tuple is rejected at the route boundary. (#3227)
+- Route-effective context-window metadata, over-limit preflight, and bounded recovery from
+  `context_length_exceeded` instead of re-looping. (#3204)
+- Synchronous tools (`file_search`, `grep_files`, `list_dir`) are cancellable and no longer hold
+  a turn open against cancellation. (#1791)
+- MCP stdio proxy startup prompts no longer strand YOLO / non-interactive runs. (#2475)
+- Stalled / failed background-shell recovery; configurable sub-agent API timeout. (#1737, #1786, #1806)
+- Composer: reliable queued steering + Ctrl+S send (#3203, #3224); footer busy/idle indicator
+  (#2982); CJK word-wrap (#963); clickable sidebar stop targets (#3028); live token throughput
+  (#3190); auto-expiring terminal sub-agent cards (#3078).
+- Linux glibc preflight in the installer/update path with a clear error. (#3207, #1067)
+
+### Community contributions
+
+- Non-DeepSeek model pricing — thanks @mvanhorn (#3201)
+- Telegram polling transport — thanks @cyq1017 (#3195)
+- Mobile event history — thanks @RobertEmprechtinger (#3220)
+- Runtime-API session save — thanks @gaord (#3199)
+- Whale-accent rename — thanks @nightt5879 (#3197)
+- `DEEPSEEK_BASE_URL` / `MODEL` honored in `exec` — thanks @hongchen1993 (#3221)
+- VS Code read-only API documentation — thanks @cyq1017 (#3013)
 
 ## [0.8.60] - 2026-06-13
 

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -107,12 +107,13 @@ pub fn get_command_info(name: &str) -> Option<&'static CommandInfo> {
 pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
     let trimmed = cmd.trim();
     if let Some(rest) = trimmed.strip_prefix('$') {
-        let parts: Vec<&str> = rest.splitn(2, char::is_whitespace).collect();
-        let skill_name = parts.first().copied().unwrap_or_default().trim();
-        let arg = parts
-            .get(1)
-            .map(|value| value.trim())
-            .filter(|value| !value.is_empty());
+        let (skill_name, arg) = match rest.split_once(char::is_whitespace) {
+            Some((skill_name, arg)) => (
+                skill_name.trim(),
+                Some(arg.trim()).filter(|value| !value.is_empty()),
+            ),
+            None => (rest.trim(), None),
+        };
 
         if skill_name.is_empty() || arg.is_some() {
             return CommandResult::error("Usage: $<skill-name> or /skill <name>");

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -106,6 +106,33 @@ pub fn get_command_info(name: &str) -> Option<&'static CommandInfo> {
 /// Execute a slash command
 pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
     let trimmed = cmd.trim();
+    if let Some(rest) = trimmed.strip_prefix('$') {
+        let parts: Vec<&str> = rest.splitn(2, char::is_whitespace).collect();
+        let skill_name = parts.first().copied().unwrap_or_default().trim();
+        let arg = parts
+            .get(1)
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty());
+
+        if skill_name.is_empty() || arg.is_some() {
+            return CommandResult::error("Usage: $<skill-name> or /skill <name>");
+        }
+
+        if let Some(result) = groups::skills::run_skill_by_name(app, skill_name, None) {
+            return result;
+        }
+        let normalized_skill_name = skill_name.to_ascii_lowercase();
+        if normalized_skill_name != skill_name
+            && let Some(result) =
+                groups::skills::run_skill_by_name(app, normalized_skill_name.as_str(), None)
+        {
+            return result;
+        }
+        return CommandResult::error(format!(
+            "Unknown skill: ${skill_name}. Run /skills to list available skills."
+        ));
+    }
+
     let parts: Vec<&str> = trimmed.splitn(2, char::is_whitespace).collect();
     let command = parts
         .first()
@@ -942,6 +969,43 @@ mod tests {
         };
         assert!(message.contains(r#"content: "inspect   this   corpus""#));
         assert!(message.contains("sub_rlm_max_depth: 3"));
+    }
+
+    #[test]
+    fn dollar_skill_alias_activates_named_skill() {
+        let (mut app, tmpdir, _guard) = create_isolated_test_app();
+        let skill_dir = tmpdir.path().join("skills").join("dollar-alias");
+        std::fs::create_dir_all(&skill_dir).expect("skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: dollar-alias\ndescription: Dollar alias\n---\nUse the dollar alias.\n",
+        )
+        .expect("skill file");
+
+        let result = execute("$dollar-alias", &mut app);
+
+        assert!(!result.is_error, "got: {:?}", result.message);
+        assert!(app.active_skill.is_some());
+        assert!(
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Skill 'dollar-alias' activated")
+        );
+    }
+
+    #[test]
+    fn dollar_skill_alias_reports_unknown_skill() {
+        let (mut app, _tmpdir, _guard) = create_isolated_test_app();
+
+        let result = execute("$missing-skill", &mut app);
+
+        assert!(result.is_error);
+        assert_eq!(
+            result.message.as_deref(),
+            Some("Error: Unknown skill: $missing-skill. Run /skills to list available skills.")
+        );
     }
 
     #[test]

--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -816,7 +816,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut adapter = LocalProcessFleetHostAdapter::new(tmp.path());
         let script = if cfg!(windows) {
-            "echo 0123456789abcdef & ping -n 30 127.0.0.1 >NUL"
+            "<NUL set /p dummy=0123456789abcdef& ping -n 30 127.0.0.1 >NUL"
         } else {
             "printf 0123456789abcdef; sleep 30"
         };

--- a/crates/tui/src/remote_setup/bundle.rs
+++ b/crates/tui/src/remote_setup/bundle.rs
@@ -41,11 +41,7 @@ impl ProviderInfo {
     pub fn from_slug(slug: &str) -> Option<Self> {
         let kind = codewhale_config::ProviderKind::parse(slug)?;
         let p = codewhale_config::provider::provider_for_kind(kind);
-        let key_var = p
-            .env_vars()
-            .first()
-            .copied()
-            .unwrap_or("CODEWHALE_API_KEY");
+        let key_var = p.env_vars().first().copied().unwrap_or("CODEWHALE_API_KEY");
         Some(Self {
             slug: p.id().to_string(),
             display: p.display_name().to_string(),
@@ -160,7 +156,10 @@ fn render_runtime_env(i: &BundleInputs) -> String {
         "# Provider API key ({}). Replace the placeholder with your real key.\n",
         i.provider.display
     ));
-    out.push_str(&format!("{}={}\n", i.provider.key_var, i.provider_key_value));
+    out.push_str(&format!(
+        "{}={}\n",
+        i.provider.key_var, i.provider_key_value
+    ));
     out.push_str(&format!(
         "CODEWHALE_MODEL={}   # provider default is {}\n",
         i.model, i.provider.default_model
@@ -174,7 +173,9 @@ fn render_runtime_env(i: &BundleInputs) -> String {
     out.push_str("RUST_LOG=info\n\n");
 
     if i.provider.slug == "deepseek" {
-        out.push_str("# Legacy aliases (still honored): DEEPSEEK_RUNTIME_TOKEN, DEEPSEEK_API_KEY,\n");
+        out.push_str(
+            "# Legacy aliases (still honored): DEEPSEEK_RUNTIME_TOKEN, DEEPSEEK_API_KEY,\n",
+        );
         out.push_str("# DEEPSEEK_RUNTIME_PORT, DEEPSEEK_RUNTIME_WORKERS.\n");
     } else {
         out.push_str("# Legacy aliases (still honored): DEEPSEEK_RUNTIME_TOKEN,\n");
@@ -222,13 +223,22 @@ fn render_bridge_env(i: &BundleInputs) -> String {
         bridge_env_prefix(i.bridge),
         i.bridge.slug
     ));
-    out.push_str(&format!("{}_ALLOW_GROUPS=false\n", bridge_env_prefix(i.bridge)));
+    out.push_str(&format!(
+        "{}_ALLOW_GROUPS=false\n",
+        bridge_env_prefix(i.bridge)
+    ));
     out.push_str(&format!(
         "{}_REQUIRE_PREFIX_IN_GROUP=true\n",
         bridge_env_prefix(i.bridge)
     ));
-    out.push_str(&format!("{}_GROUP_PREFIX=/cw\n", bridge_env_prefix(i.bridge)));
-    out.push_str(&format!("{}_MAX_REPLY_CHARS=3500\n", bridge_env_prefix(i.bridge)));
+    out.push_str(&format!(
+        "{}_GROUP_PREFIX=/cw\n",
+        bridge_env_prefix(i.bridge)
+    ));
+    out.push_str(&format!(
+        "{}_MAX_REPLY_CHARS=3500\n",
+        bridge_env_prefix(i.bridge)
+    ));
     if i.bridge.slug == "telegram" {
         out.push_str("TELEGRAM_POLL_TIMEOUT_SECONDS=50\n");
     }
@@ -333,7 +343,9 @@ fn render_runbook(i: &BundleInputs) -> String {
 
     out.push_str("## What was generated\n\n");
     out.push_str("| File | Purpose |\n|---|---|\n");
-    out.push_str("| `runtime.env` | Provider + runtime config (the only place the provider is set). |\n");
+    out.push_str(
+        "| `runtime.env` | Provider + runtime config (the only place the provider is set). |\n",
+    );
     out.push_str(&format!(
         "| `{}.env` | {} bridge transport config (token, allowlist, runtime URL). |\n",
         i.bridge.slug, i.bridge.display
@@ -384,7 +396,10 @@ fn render_runbook(i: &BundleInputs) -> String {
     out.push_str("yourself (commands shown as data — review before running):\n\n");
     for (n, step) in plan.iter().enumerate() {
         out.push_str(&format!("{}. {}\n", n + 1, step.description));
-        out.push_str(&format!("   ```sh\n   {}\n   ```\n", step.display_command()));
+        out.push_str(&format!(
+            "   ```sh\n   {}\n   ```\n",
+            step.display_command()
+        ));
     }
     out.push('\n');
     if i.cloud.secret_store == SecretStore::KeyVault {
@@ -419,14 +434,22 @@ sudo systemctl enable --now codewhale-runtime {unit}\n```\n\n",
     match i.bridge.slug {
         "telegram" => {
             out.push_str("1. With `TELEGRAM_CHAT_ALLOWLIST` empty, temporarily set\n");
-            out.push_str("   `TELEGRAM_ALLOW_UNLISTED=true`, restart the bridge, and DM your bot once.\n");
-            out.push_str("2. Read the chat id the bridge logs, add it to `TELEGRAM_CHAT_ALLOWLIST`,\n");
+            out.push_str(
+                "   `TELEGRAM_ALLOW_UNLISTED=true`, restart the bridge, and DM your bot once.\n",
+            );
+            out.push_str(
+                "2. Read the chat id the bridge logs, add it to `TELEGRAM_CHAT_ALLOWLIST`,\n",
+            );
             out.push_str("   set `TELEGRAM_ALLOW_UNLISTED=false`, and restart the bridge.\n");
         }
         "feishu" => {
             out.push_str("1. With `FEISHU_CHAT_ALLOWLIST` empty, temporarily set\n");
-            out.push_str("   `FEISHU_ALLOW_UNLISTED=true`, restart the bridge, and message the app once.\n");
-            out.push_str("2. Read the open id the bridge logs, add it to `FEISHU_CHAT_ALLOWLIST`,\n");
+            out.push_str(
+                "   `FEISHU_ALLOW_UNLISTED=true`, restart the bridge, and message the app once.\n",
+            );
+            out.push_str(
+                "2. Read the open id the bridge logs, add it to `FEISHU_CHAT_ALLOWLIST`,\n",
+            );
             out.push_str("   set `FEISHU_ALLOW_UNLISTED=false`, and restart the bridge.\n");
         }
         _ => {
@@ -464,7 +487,12 @@ mod tests {
         let bridge_secret_values = bridge
             .secret_keys
             .iter()
-            .map(|k| ((*k).to_string(), format!("replace-{}", k.to_ascii_lowercase())))
+            .map(|k| {
+                (
+                    (*k).to_string(),
+                    format!("replace-{}", k.to_ascii_lowercase()),
+                )
+            })
             .collect();
         BundleInputs {
             cloud,
@@ -490,7 +518,10 @@ mod tests {
         let oai = ProviderInfo::from_slug("openai").unwrap();
         assert_eq!(oai.key_var, "OPENAI_API_KEY");
         // Provider-registry aliases resolve to the canonical slug.
-        assert_eq!(ProviderInfo::from_slug("nvidia").unwrap().slug, "nvidia-nim");
+        assert_eq!(
+            ProviderInfo::from_slug("nvidia").unwrap().slug,
+            "nvidia-nim"
+        );
         assert_eq!(ProviderInfo::from_slug("kimi").unwrap().slug, "moonshot");
         assert!(ProviderInfo::from_slug("not-a-provider").is_none());
     }
@@ -586,8 +617,7 @@ mod tests {
                         .unwrap()
                         .contents;
                     assert!(runtime.contains(&format!("CODEWHALE_PROVIDER={provider_slug}")));
-                    let token_line =
-                        format!("CODEWHALE_RUNTIME_TOKEN={}", inputs.runtime_token);
+                    let token_line = format!("CODEWHALE_RUNTIME_TOKEN={}", inputs.runtime_token);
                     assert!(runtime.contains(&token_line));
 
                     let bridge_env = &files

--- a/crates/tui/src/remote_setup/mod.rs
+++ b/crates/tui/src/remote_setup/mod.rs
@@ -115,12 +115,13 @@ pub fn run_remote_setup(args: RemoteSetupArgs) -> Result<()> {
     if args.apply {
         // MVP: the auto-provision path is intentionally not implemented yet.
         println!();
-        println!(
-            "auto-provision not yet implemented; bundle generated, follow RUNBOOK.md"
-        );
+        println!("auto-provision not yet implemented; bundle generated, follow RUNBOOK.md");
     } else {
         println!();
-        println!("Next: open {}/RUNBOOK.md and follow the steps.", out_dir.display());
+        println!(
+            "Next: open {}/RUNBOOK.md and follow the steps.",
+            out_dir.display()
+        );
     }
 
     Ok(())
@@ -145,7 +146,10 @@ fn resolve_cloud(args: &RemoteSetupArgs) -> Result<&'static CloudTarget> {
             .ok_or_else(|| anyhow::anyhow!("unknown cloud '{slug}'. {}", cloud_choices()));
     }
     if args.non_interactive {
-        bail!("--cloud is required in --non-interactive mode. {}", cloud_choices());
+        bail!(
+            "--cloud is required in --non-interactive mode. {}",
+            cloud_choices()
+        );
     }
     let idx = prompt_choice(
         "Cloud target",
@@ -163,7 +167,10 @@ fn resolve_bridge(args: &RemoteSetupArgs) -> Result<&'static BridgeSpec> {
             .ok_or_else(|| anyhow::anyhow!("unknown bridge '{slug}'. {}", bridge_choices()));
     }
     if args.non_interactive {
-        bail!("--bridge is required in --non-interactive mode. {}", bridge_choices());
+        bail!(
+            "--bridge is required in --non-interactive mode. {}",
+            bridge_choices()
+        );
     }
     let idx = prompt_choice(
         "Chat bridge",
@@ -217,7 +224,11 @@ fn cloud_choices() -> String {
 fn bridge_choices() -> String {
     format!(
         "Choices: {}",
-        BRIDGES.iter().map(|b| b.slug).collect::<Vec<_>>().join(", ")
+        BRIDGES
+            .iter()
+            .map(|b| b.slug)
+            .collect::<Vec<_>>()
+            .join(", ")
     )
 }
 
@@ -305,7 +316,12 @@ mod tests {
             non_interactive: true,
             ..Default::default()
         };
-        assert!(resolve_cloud(&args).unwrap_err().to_string().contains("--cloud is required"));
+        assert!(
+            resolve_cloud(&args)
+                .unwrap_err()
+                .to_string()
+                .contains("--cloud is required")
+        );
     }
 
     #[test]

--- a/crates/tui/src/remote_setup/registry.rs
+++ b/crates/tui/src/remote_setup/registry.rs
@@ -300,7 +300,14 @@ fn azure_plan(inputs: &DeployInputs) -> Vec<ProvisionStep> {
         ProvisionStep::new(
             "Create the resource group",
             "az",
-            &["group", "create", "--name", &rg, "--location", &inputs.region],
+            &[
+                "group",
+                "create",
+                "--name",
+                &rg,
+                "--location",
+                &inputs.region,
+            ],
         ),
         ProvisionStep::new(
             "Create the Key Vault that holds the provider key + runtime token",
@@ -508,11 +515,7 @@ mod tests {
         let inputs = DeployInputs::default();
         for c in CLOUD_TARGETS {
             let steps = (c.plan)(&inputs);
-            assert!(
-                !steps.is_empty(),
-                "cloud {} produced an empty plan",
-                c.slug
-            );
+            assert!(!steps.is_empty(), "cloud {} produced an empty plan", c.slug);
             // First step's program is the cloud's own tooling or a host script.
             assert!(
                 steps
@@ -539,7 +542,8 @@ mod tests {
 
     #[test]
     fn display_command_redacts_secret_args() {
-        let mut step = ProvisionStep::new("set secret", "az", &["keyvault", "secret", "set", "VALUE"]);
+        let mut step =
+            ProvisionStep::new("set secret", "az", &["keyvault", "secret", "set", "VALUE"]);
         step.secret_args = vec![3];
         let rendered = step.display_command();
         assert!(rendered.contains("<redacted>"));

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -96,6 +96,10 @@ pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
         if rest.is_empty() {
             return true;
         }
+        if rest.chars().next().is_some_and(|ch| ch.is_whitespace()) {
+            return false;
+        }
+        let rest = rest.trim_end();
         return !rest.chars().any(char::is_whitespace) && !rest.contains('/');
     }
 
@@ -5937,6 +5941,7 @@ mod tests {
         assert!(looks_like_slash_command_input("/help"));
         assert!(looks_like_slash_command_input("/model deepseek-v4-pro"));
         assert!(looks_like_slash_command_input("$getting-started"));
+        assert!(looks_like_slash_command_input("$getting-started "));
         assert!(looks_like_slash_command_input("  $getting-started"));
         assert!(looks_like_slash_command_input("$"));
         assert!(!looks_like_slash_command_input("/ hello"));

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -91,7 +91,15 @@ pub(crate) fn resolve_skills_dir(
 }
 
 pub(crate) fn looks_like_slash_command_input(input: &str) -> bool {
-    let Some(rest) = input.trim_start().strip_prefix('/') else {
+    let input = input.trim_start();
+    if let Some(rest) = input.strip_prefix('$') {
+        if rest.is_empty() {
+            return true;
+        }
+        return !rest.chars().any(char::is_whitespace) && !rest.contains('/');
+    }
+
+    let Some(rest) = input.strip_prefix('/') else {
         return false;
     };
     if rest.chars().next().is_some_and(|ch| ch.is_whitespace()) {
@@ -5928,8 +5936,13 @@ mod tests {
         assert!(looks_like_slash_command_input("/"));
         assert!(looks_like_slash_command_input("/help"));
         assert!(looks_like_slash_command_input("/model deepseek-v4-pro"));
+        assert!(looks_like_slash_command_input("$getting-started"));
+        assert!(looks_like_slash_command_input("  $getting-started"));
+        assert!(looks_like_slash_command_input("$"));
         assert!(!looks_like_slash_command_input("/ hello"));
         assert!(!looks_like_slash_command_input("  / hello"));
+        assert!(!looks_like_slash_command_input("$ getting-started"));
+        assert!(!looks_like_slash_command_input("$getting-started now"));
         assert!(!looks_like_slash_command_input(
             "/usr/lib/x86_64-linux-gnu/ 是标准路径吗？"
         ));

--- a/crates/tui/src/tui/slash_menu.rs
+++ b/crates/tui/src/tui/slash_menu.rs
@@ -20,10 +20,10 @@ pub fn visible_slash_menu_entries(app: &App, limit: usize) -> Vec<SlashMenuEntry
     if app.slash_menu_hidden {
         return Vec::new();
     }
-    if let Some((_byte_start, partial)) =
+    if let Some((_byte_start, trigger, partial)) =
         partial_inline_skill_mention_at_cursor(&app.input, app.cursor_position)
     {
-        return skill_mention_entries(&partial, limit, &app.cached_skills);
+        return skill_mention_entries(trigger, &partial, limit, &app.cached_skills);
     }
     slash_completion_hints(
         &app.input,
@@ -51,13 +51,13 @@ pub fn apply_slash_menu_selection(
     let selected = &entries[selected_idx];
 
     if selected.is_skill
-        && let Some((byte_start, partial)) =
+        && let Some((byte_start, trigger, partial)) =
             partial_inline_skill_mention_at_cursor(&app.input, app.cursor_position)
         && let Some(skill_name) = skill_name_from_menu_entry(selected)
     {
-        replace_inline_skill_mention(app, byte_start, &partial, &skill_name);
+        replace_inline_skill_mention(app, byte_start, trigger, &partial, &skill_name);
         app.slash_menu_hidden = false;
-        app.status_message = Some(format!("Skill selected: /{skill_name}"));
+        app.status_message = Some(format!("Skill selected: {trigger}{skill_name}"));
         return true;
     }
 
@@ -86,7 +86,7 @@ pub fn apply_slash_menu_selection(
 pub(crate) fn partial_inline_skill_mention_at_cursor(
     input: &str,
     cursor_chars: usize,
-) -> Option<(usize, String)> {
+) -> Option<(usize, char, String)> {
     if looks_like_slash_command_input(input) {
         return None;
     }
@@ -97,9 +97,11 @@ pub(crate) fn partial_inline_skill_mention_at_cursor(
     }
 
     let mut start_chars = cursor_chars;
+    let mut trigger = None;
     while start_chars > 0 {
         let prev = chars[start_chars - 1];
-        if prev == '/' {
+        if matches!(prev, '/' | '$') {
+            trigger = Some(prev);
             start_chars -= 1;
             break;
         }
@@ -109,7 +111,8 @@ pub(crate) fn partial_inline_skill_mention_at_cursor(
         start_chars -= 1;
     }
 
-    if start_chars == cursor_chars || chars.get(start_chars) != Some(&'/') {
+    let trigger = trigger?;
+    if start_chars == cursor_chars || chars.get(start_chars) != Some(&trigger) {
         return None;
     }
     if !is_inline_skill_mention_start(&chars, start_chars) {
@@ -126,11 +129,11 @@ pub(crate) fn partial_inline_skill_mention_at_cursor(
         end_chars += 1;
     }
     let partial: String = chars[start_chars + 1..end_chars].iter().collect();
-    if partial.contains('/') {
+    if partial.contains('/') || partial.contains('$') {
         return None;
     }
 
-    Some((byte_start, partial))
+    Some((byte_start, trigger, partial))
 }
 
 fn is_inline_skill_mention_start(chars: &[char], idx: usize) -> bool {
@@ -143,6 +146,7 @@ fn is_inline_skill_mention_start(chars: &[char], idx: usize) -> bool {
 }
 
 fn skill_mention_entries(
+    trigger: char,
     partial: &str,
     limit: usize,
     cached_skills: &[(String, String)],
@@ -155,7 +159,7 @@ fn skill_mention_entries(
         .iter()
         .filter(|(skill_name, _)| skill_name.to_ascii_lowercase().starts_with(&partial_lower))
         .map(|(skill_name, skill_desc)| SlashMenuEntry {
-            name: format!("/{skill_name}"),
+            name: format!("{trigger}{skill_name}"),
             description: skill_desc.clone(),
             is_skill: true,
             alias_hint: None,
@@ -173,6 +177,9 @@ fn skill_name_from_menu_entry(entry: &SlashMenuEntry) -> Option<String> {
     if let Some(name) = entry.name.strip_prefix("/skill ") {
         return Some(name.trim().to_string());
     }
+    if let Some(name) = entry.name.strip_prefix('$') {
+        return Some(name.trim().to_string());
+    }
     entry
         .name
         .strip_prefix('/')
@@ -181,13 +188,20 @@ fn skill_name_from_menu_entry(entry: &SlashMenuEntry) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn replace_inline_skill_mention(app: &mut App, byte_start: usize, partial: &str, skill_name: &str) {
-    let original_token_len = '/'.len_utf8() + partial.len();
+fn replace_inline_skill_mention(
+    app: &mut App,
+    byte_start: usize,
+    trigger: char,
+    partial: &str,
+    skill_name: &str,
+) {
+    let original_token_len = trigger.len_utf8() + partial.len();
     let original_token_end = byte_start + original_token_len;
-    let mut new_input =
-        String::with_capacity(app.input.len() - original_token_len + 1 + skill_name.len());
+    let mut new_input = String::with_capacity(
+        app.input.len() - original_token_len + trigger.len_utf8() + skill_name.len(),
+    );
     new_input.push_str(&app.input[..byte_start]);
-    new_input.push('/');
+    new_input.push(trigger);
     new_input.push_str(skill_name);
     if original_token_end < app.input.len() {
         new_input.push_str(&app.input[original_token_end..]);
@@ -222,24 +236,26 @@ pub fn try_autocomplete_slash_command(app: &mut App) -> bool {
         return false;
     }
 
-    let prefix = app.input.trim_start_matches('/');
+    let trimmed = app.input.trim_start();
+    let trigger = if trimmed.starts_with('$') { '$' } else { '/' };
+    let prefix = trimmed.strip_prefix(trigger).unwrap_or(trimmed);
     let refs: Vec<&str> = candidates
         .iter()
-        .map(|name| name.trim_start_matches('/'))
+        .map(|name| name.trim_start_matches(trigger))
         .collect();
     let shared = crate::tui::file_mention::longest_common_prefix(&refs);
 
     if !shared.is_empty() && shared.len() > prefix.len() {
-        app.input = format!("/{shared}");
+        app.input = format!("{trigger}{shared}");
         app.cursor_position = app.input.chars().count();
         app.slash_menu_hidden = false;
-        app.status_message = Some(format!("Autocomplete: /{shared}"));
+        app.status_message = Some(format!("Autocomplete: {trigger}{shared}"));
         return true;
     }
 
     if candidates.len() == 1 {
         let mut completed = candidates[0].clone();
-        if !completed.ends_with(' ') {
+        if !completed.starts_with('$') && !completed.ends_with(' ') {
             completed.push(' ');
         }
         app.input = completed.clone();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5431,6 +5431,23 @@ fn inline_skill_slash_popup_lists_cached_skills_in_message() {
 }
 
 #[test]
+fn inline_skill_dollar_popup_lists_cached_skills_in_message() {
+    let mut app = create_test_app();
+    app.cached_skills = vec![
+        ("search-files".to_string(), "Search files".to_string()),
+        ("my-review".to_string(), "Review code".to_string()),
+    ];
+    app.input = "please use $".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    let entries = visible_slash_menu_entries(&app, 128);
+
+    assert!(entries.iter().any(|entry| entry.name == "$search-files"));
+    assert!(entries.iter().any(|entry| entry.name == "$my-review"));
+    assert!(entries.iter().all(|entry| entry.is_skill));
+}
+
+#[test]
 fn inline_skill_slash_popup_filters_partial_without_leaking_to_command_position() {
     let mut app = create_test_app();
     app.cached_skills = vec![
@@ -5453,6 +5470,36 @@ fn inline_skill_slash_popup_filters_partial_without_leaking_to_command_position(
             .iter()
             .any(|entry| entry.name == "/search-files" && entry.is_skill),
         "command-position slash menu should not include inline skill mentions"
+    );
+}
+
+#[test]
+fn inline_skill_dollar_popup_filters_partial_without_leaking_to_command_position() {
+    let mut app = create_test_app();
+    app.cached_skills = vec![
+        ("search-files".to_string(), "Search files".to_string()),
+        ("my-review".to_string(), "Review code".to_string()),
+    ];
+    app.input = "please use $my".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    let entries = visible_slash_menu_entries(&app, 128);
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].name, "$my-review");
+
+    app.input = "$se".to_string();
+    app.cursor_position = app.input.chars().count();
+    let command_entries = visible_slash_menu_entries(&app, 128);
+    assert!(
+        command_entries
+            .iter()
+            .all(|entry| entry.name.starts_with('$')),
+        "command-position dollar menu should only include dollar skill aliases: {:?}",
+        command_entries
+            .iter()
+            .map(|entry| &entry.name)
+            .collect::<Vec<_>>()
     );
 }
 
@@ -5499,6 +5546,26 @@ fn apply_slash_menu_selection_splices_inline_skill_mention() {
 }
 
 #[test]
+fn apply_slash_menu_selection_splices_inline_dollar_skill_mention() {
+    let mut app = create_test_app();
+    app.input = "please use $se here".to_string();
+    app.cursor_position = "please use $se".chars().count();
+    let entries = vec![crate::tui::widgets::SlashMenuEntry {
+        name: "$search-files".to_string(),
+        description: "Search files".to_string(),
+        is_skill: true,
+        alias_hint: None,
+    }];
+
+    assert!(apply_slash_menu_selection(&mut app, &entries, true));
+    assert_eq!(app.input, "please use $search-files here");
+    assert_eq!(
+        app.cursor_position,
+        "please use $search-files".chars().count()
+    );
+}
+
+#[test]
 fn try_autocomplete_slash_command_completes_skill_argument() {
     let mut app = create_test_app();
     app.cached_skills = vec![
@@ -5510,6 +5577,20 @@ fn try_autocomplete_slash_command_completes_skill_argument() {
 
     assert!(try_autocomplete_slash_command(&mut app));
     assert_eq!(app.input, "/skill my-review");
+}
+
+#[test]
+fn try_autocomplete_slash_command_completes_dollar_skill_alias() {
+    let mut app = create_test_app();
+    app.cached_skills = vec![
+        ("search-files".to_string(), "Search files".to_string()),
+        ("my-review".to_string(), "Review code".to_string()),
+    ];
+    app.input = "$my".to_string();
+    app.cursor_position = app.input.chars().count();
+
+    assert!(try_autocomplete_slash_command(&mut app));
+    assert_eq!(app.input, "$my-review");
 }
 
 #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3305,10 +3305,11 @@ fn turn_liveness_does_not_abort_running_tool() {
 #[test]
 fn turn_liveness_does_not_abort_running_tool_with_recent_heartbeat() {
     let mut app = create_test_app();
-    let now = Instant::now();
+    let started_at = Instant::now();
+    let now = started_at + TOOL_HANG_WATCHDOG_TIMEOUT + Duration::from_secs(30);
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
-    app.turn_started_at = Some(now - TOOL_HANG_WATCHDOG_TIMEOUT - Duration::from_secs(30));
+    app.turn_started_at = Some(started_at);
     app.turn_last_activity_at = Some(now - Duration::from_secs(10));
     let mut active = ActiveCell::new();
     active.push_tool(
@@ -3337,11 +3338,12 @@ fn turn_liveness_does_not_abort_running_tool_with_recent_heartbeat() {
 #[test]
 fn turn_liveness_recovers_running_tool_without_heartbeat() {
     let mut app = create_test_app();
-    let now = Instant::now();
+    let started_at = Instant::now();
+    let now = started_at + TOOL_HANG_WATCHDOG_TIMEOUT + Duration::from_secs(1);
     app.is_loading = true;
     app.runtime_turn_status = Some("in_progress".to_string());
     app.runtime_turn_id = Some("stale-tool-turn".to_string());
-    app.turn_started_at = Some(now - TOOL_HANG_WATCHDOG_TIMEOUT - Duration::from_secs(1));
+    app.turn_started_at = Some(started_at);
     app.turn_last_activity_at = app.turn_started_at;
     app.user_scrolled_during_stream = true;
     let mut active = ActiveCell::new();

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2279,6 +2279,10 @@ pub(crate) fn slash_completion_hints(
         return Vec::new();
     }
 
+    if let Some(skill_prefix) = input.trim_start().strip_prefix('$') {
+        return dollar_skill_completion_hints(skill_prefix, limit, cached_skills);
+    }
+
     let prefix = input.trim_start_matches('/');
     let completing_skill_arg = prefix.strip_prefix("skill ").map(str::trim_start);
     if input.contains(char::is_whitespace) && completing_skill_arg.is_none() {
@@ -2449,6 +2453,64 @@ pub(crate) fn slash_completion_hints(
     };
     entries.sort_by(|a, b| rank(a).cmp(&rank(b)).then_with(|| a.name.cmp(&b.name)));
     entries.dedup_by(|a, b| a.name == b.name);
+    entries.into_iter().take(limit).collect()
+}
+
+fn dollar_skill_completion_hints(
+    skill_prefix: &str,
+    limit: usize,
+    cached_skills: &[(String, String)],
+) -> Vec<SlashMenuEntry> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let skill_prefix = skill_prefix.to_ascii_lowercase();
+    let mut entries: Vec<SlashMenuEntry> = Vec::new();
+
+    for (skill_name, skill_desc) in cached_skills {
+        let skill_name_lower = skill_name.to_ascii_lowercase();
+        if skill_name_lower.starts_with(&skill_prefix) {
+            entries.push(SlashMenuEntry {
+                name: format!("${skill_name}"),
+                description: skill_desc.clone(),
+                is_skill: true,
+                alias_hint: None,
+            });
+        }
+    }
+    for (skill_name, skill_desc) in cached_skills {
+        let skill_name_lower = skill_name.to_ascii_lowercase();
+        let entry_name = format!("${skill_name}");
+        if skill_name_lower.contains(&skill_prefix)
+            && !entries.iter().any(|entry| entry.name == entry_name)
+        {
+            entries.push(SlashMenuEntry {
+                name: entry_name,
+                description: skill_desc.clone(),
+                is_skill: true,
+                alias_hint: None,
+            });
+        }
+    }
+    for (skill_name, skill_desc) in cached_skills {
+        let skill_name_lower = skill_name.to_ascii_lowercase();
+        let entry_name = format!("${skill_name}");
+        if !skill_name_lower.starts_with(&skill_prefix)
+            && !skill_name_lower.contains(&skill_prefix)
+            && fuzzy_chars_in_order(&skill_prefix, &skill_name_lower)
+            && !entries.iter().any(|entry| entry.name == entry_name)
+        {
+            entries.push(SlashMenuEntry {
+                name: entry_name,
+                description: skill_desc.clone(),
+                is_skill: true,
+                alias_hint: None,
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
     entries.into_iter().take(limit).collect()
 }
 
@@ -3350,6 +3412,25 @@ mod tests {
         );
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].name, "/skill my-review");
+        assert!(hints[0].is_skill);
+    }
+
+    #[test]
+    fn slash_completion_hints_complete_dollar_skill_alias_prefix() {
+        let cached_skills = vec![
+            ("search-files".to_string(), "Search files".to_string()),
+            ("my-review".to_string(), "Review code".to_string()),
+        ];
+        let hints = slash_completion_hints(
+            "$my",
+            128,
+            &cached_skills,
+            Locale::En,
+            None,
+            ApiProvider::Deepseek,
+        );
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].name, "$my-review");
         assert!(hints[0].is_skill);
     }
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2466,52 +2466,35 @@ fn dollar_skill_completion_hints(
     }
 
     let skill_prefix = skill_prefix.to_ascii_lowercase();
-    let mut entries: Vec<SlashMenuEntry> = Vec::new();
+    let mut matches: Vec<(u8, &String, &String)> = Vec::new();
 
     for (skill_name, skill_desc) in cached_skills {
         let skill_name_lower = skill_name.to_ascii_lowercase();
-        if skill_name_lower.starts_with(&skill_prefix) {
-            entries.push(SlashMenuEntry {
-                name: format!("${skill_name}"),
-                description: skill_desc.clone(),
-                is_skill: true,
-                alias_hint: None,
-            });
-        }
-    }
-    for (skill_name, skill_desc) in cached_skills {
-        let skill_name_lower = skill_name.to_ascii_lowercase();
-        let entry_name = format!("${skill_name}");
-        if skill_name_lower.contains(&skill_prefix)
-            && !entries.iter().any(|entry| entry.name == entry_name)
-        {
-            entries.push(SlashMenuEntry {
-                name: entry_name,
-                description: skill_desc.clone(),
-                is_skill: true,
-                alias_hint: None,
-            });
-        }
-    }
-    for (skill_name, skill_desc) in cached_skills {
-        let skill_name_lower = skill_name.to_ascii_lowercase();
-        let entry_name = format!("${skill_name}");
-        if !skill_name_lower.starts_with(&skill_prefix)
-            && !skill_name_lower.contains(&skill_prefix)
-            && fuzzy_chars_in_order(&skill_prefix, &skill_name_lower)
-            && !entries.iter().any(|entry| entry.name == entry_name)
-        {
-            entries.push(SlashMenuEntry {
-                name: entry_name,
-                description: skill_desc.clone(),
-                is_skill: true,
-                alias_hint: None,
-            });
-        }
+        let rank = if skill_name_lower.starts_with(&skill_prefix) {
+            0
+        } else if skill_name_lower.contains(&skill_prefix) {
+            1
+        } else if fuzzy_chars_in_order(&skill_prefix, &skill_name_lower) {
+            2
+        } else {
+            continue;
+        };
+        matches.push((rank, skill_name, skill_desc));
     }
 
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
-    entries.into_iter().take(limit).collect()
+    matches.sort_by(|(rank_a, name_a, _), (rank_b, name_b, _)| {
+        rank_a.cmp(rank_b).then_with(|| name_a.cmp(name_b))
+    });
+    matches
+        .into_iter()
+        .take(limit)
+        .map(|(_, skill_name, skill_desc)| SlashMenuEntry {
+            name: format!("${skill_name}"),
+            description: skill_desc.clone(),
+            is_skill: true,
+            alias_hint: None,
+        })
+        .collect()
 }
 
 fn all_command_names_matching_loaded(
@@ -3432,6 +3415,28 @@ mod tests {
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0].name, "$my-review");
         assert!(hints[0].is_skill);
+    }
+
+    #[test]
+    fn slash_completion_hints_rank_dollar_skill_alias_matches() {
+        let cached_skills = vec![
+            ("a-my".to_string(), "Contains match".to_string()),
+            ("my-review".to_string(), "Prefix match".to_string()),
+            ("z-my".to_string(), "Contains match".to_string()),
+        ];
+        let hints = slash_completion_hints(
+            "$my",
+            128,
+            &cached_skills,
+            Locale::En,
+            None,
+            ApiProvider::Deepseek,
+        );
+        let names = hints
+            .iter()
+            .map(|hint| hint.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["$my-review", "$a-my", "$z-my"]);
     }
 
     #[test]

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -30,8 +30,9 @@ The canonical provider IDs are:
 
 `deepseek`, `nvidia-nim`, `openai`, `atlascloud`, `wanjie-ark`, `volcengine`,
 `openrouter`, `xiaomi-mimo`, `novita`, `fireworks`, `siliconflow`,
-`siliconflow-CN`, `arcee`, `moonshot`, `sglang`, `vllm`, `ollama`,
-`huggingface`, `together`, `openai-codex`, and `anthropic`.
+`siliconflow-CN`, `arcee`, `moonshot`, `zai`, `stepfun`, `minimax`,
+`sglang`, `vllm`, `ollama`, `huggingface`, `together`, `openai-codex`, and
+`anthropic`.
 
 Use any of these surfaces to select a provider:
 
@@ -137,6 +138,7 @@ endpoint.
 | `arcee` | `[providers.arcee]` | `ARCEE_API_KEY` | `ARCEE_BASE_URL`; default `https://api.arcee.ai/api/v1` | `trinity-large-thinking`, `trinity-large-preview` | Arcee AI direct OpenAI-compatible route, tracked as 256K-context BF16 serving. `ARCEE_MODEL` is accepted. OpenRouter's `arcee-ai/trinity-large-thinking` remains the OpenRouter namespaced model ID; direct Arcee uses the bare `trinity-large-thinking` ID. |
 | `moonshot` | `[providers.moonshot]` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` | `MOONSHOT_BASE_URL`, `KIMI_BASE_URL`; default `https://api.moonshot.ai/v1` | `kimi-k2.7-code`, `kimi-k2.6`; Kimi Code path uses `kimi-for-coding` at `https://api.kimi.com/coding/v1` | Moonshot/Kimi route. `kimi` and `kimi-k2` aliases select `kimi-k2.7-code`; `MOONSHOT_MODEL`, `KIMI_MODEL_NAME`, and `KIMI_MODEL` are accepted. Kimi thinking streams through `reasoning_content`; CodeWhale keeps it in Thinking cells and replays it for thinking/tool-call continuity. `[providers.moonshot] auth_mode = "kimi_oauth"` reads Kimi Code OAuth credentials from `KIMI_CODE_HOME`/`~/.kimi-code`, with legacy `KIMI_SHARE_DIR`/`~/.kimi` fallback. |
 | `zai` | `[providers.zai]` | `ZAI_API_KEY`, `Z_AI_API_KEY` | `ZAI_BASE_URL`, `Z_AI_BASE_URL`; default `https://api.z.ai/api/coding/paas/v4`; general API `https://api.z.ai/api/paas/v4` | `GLM-5.1` default; `GLM-5.2` opt-in preview | Z.AI GLM Coding Plan route. Keep `GLM-5.1` as the default until 5.2 is generally documented; set `model = "GLM-5.2"` or `ZAI_MODEL=GLM-5.2` to try the preview. |
+| `stepfun` | `[providers.stepfun]` | `STEPFUN_API_KEY`, `STEP_API_KEY` | `STEPFUN_BASE_URL`, `STEP_BASE_URL`; default `https://api.stepfun.ai/v1` | `step-3.7-flash` | StepFun / StepFlash OpenAI-compatible route. `STEPFUN_MODEL` and `STEP_MODEL` are accepted, and provider-hinted custom model IDs pass through. |
 | `minimax` | `[providers.minimax]` | `MINIMAX_API_KEY` | `MINIMAX_BASE_URL`; default `https://api.minimax.io/v1`; Anthropic-compatible routes are `https://api.minimax.io/anthropic` globally and `https://api.minimaxi.com/anthropic` in China | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` | MiniMax direct OpenAI-compatible route. CodeWhale sends `reasoning_split = true` so MiniMax thinking arrives separately from answer text, and direct MiniMax IDs stay distinct from OpenRouter namespaced IDs such as `minimax/minimax-m3`. |
 | `sglang` | `[providers.sglang]` | Optional `SGLANG_API_KEY` | `SGLANG_BASE_URL`; default `http://localhost:30000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted OpenAI-compatible route. Localhost deployments commonly omit auth. `SGLANG_MODEL` is accepted. |
 | `vllm` | `[providers.vllm]` | Optional `VLLM_API_KEY` | `VLLM_BASE_URL`; default `http://localhost:8000/v1` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | Self-hosted vLLM OpenAI-compatible route. Localhost deployments commonly omit auth. `VLLM_MODEL` is accepted. |
@@ -226,6 +228,7 @@ endpoint when the endpoint supports model listing.
 | `arcee` | `trinity-large-thinking`, `trinity-large-preview`; provider-hinted custom model IDs pass through | yes | yes for `trinity-large-thinking`; no for `trinity-large-preview` |
 | `moonshot` | `kimi-k2.7-code`, `kimi-k2.6` | yes | yes |
 | `zai` | `GLM-5.1`, `GLM-5.2`; provider-hinted custom model IDs pass through | yes | yes |
+| `stepfun` | `step-3.7-flash`; provider-hinted custom model IDs pass through | yes | no |
 | `minimax` | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` | yes | yes |
 | `sglang` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | yes | yes |
 | `vllm` | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | yes | yes |


### PR DESCRIPTION
## Summary
- Accept `$skill-name` at the start of the composer as a direct alias for activating a skill.
- Add `$skill-name` skill completion entries and inline `$skill` mention selection alongside existing `/skill` and `/<skill>` flows.
- Preserve backwards-compatible `/skill <name>`, `/skills`, and inline `/<skill>` behavior.

Closes #3237

## Validation
- `rustfmt --edition 2024 --check crates/tui/src/commands/mod.rs crates/tui/src/tui/app.rs crates/tui/src/tui/widgets/mod.rs crates/tui/src/tui/slash_menu.rs crates/tui/src/tui/ui/tests.rs`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui dollar`
- `cargo test -p codewhale-tui --bin codewhale-tui slash_command_classifier_treats_absolute_path_as_message`
- `cargo test -p codewhale-tui --bin codewhale-tui inline_skill_slash_popup`
- `cargo test -p codewhale-tui --bin codewhale-tui skill_argument`
- `cargo test -p codewhale-tui --bin codewhale-tui apply_slash_menu_selection_splices_inline_skill_mention`

## Notes
- I also ran the full `cargo test -p codewhale-tui --bin codewhale-tui` suite locally. The `$skill` coverage passed, but the full suite has existing local failures outside this change: two `session_manager` workspace selection tests, one fleet host log assertion, and two pandoc tests that passed when rerun individually. I did not change those unrelated areas.