### PR TITLE
feat: add workspace_follow_symlinks setting for symlink-aware tool operations

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -255,6 +255,12 @@ fn show_single_setting(app: &App, key: &str) -> CommandResult {
         "prefer_external_pdftotext" | "external_pdftotext" | "pdftotext" => Settings::load()
             .ok()
             .map(|settings| settings.prefer_external_pdftotext.to_string()),
+        "workspace_follow_symlinks" | "follow_symlinks" => Settings::load().ok().map(|settings| {
+            format!(
+                "{} (restart required for engine tools)",
+                settings.workspace_follow_symlinks
+            )
+        }),
         _ => {
             let known = Settings::available_settings()
                 .iter()
@@ -759,6 +765,26 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
             app.mention_walk_depth = settings.mention_walk_depth;
             app.composer.mention_completion_cache = None;
             app.needs_redraw = true;
+        }
+        "workspace_follow_symlinks" | "follow_symlinks" => {
+            app.workspace_follow_symlinks = settings.workspace_follow_symlinks;
+            app.composer.mention_completion_cache = None;
+            app.needs_redraw = true;
+            // Engine tools use EngineConfig which is fixed at startup
+            return CommandResult::message(if persist {
+                if let Err(e) = settings.save() {
+                    return CommandResult::error(format!("Failed to save: {e}"));
+                }
+                format!(
+                    "workspace_follow_symlinks = {} (saved; restart required for engine tools)",
+                    settings.workspace_follow_symlinks
+                )
+            } else {
+                format!(
+                    "workspace_follow_symlinks = {} (session only for UI; restart required for engine tools)",
+                    settings.workspace_follow_symlinks
+                )
+            });
         }
         "transcript_spacing" | "spacing" => {
             app.transcript_spacing =

--- a/crates/tui/src/commands/groups/project/init.rs
+++ b/crates/tui/src/commands/groups/project/init.rs
@@ -182,7 +182,7 @@ fn gather_project_context(workspace: &Path) -> String {
     }
 
     // Directory tree (from existing utility).
-    let tree = crate::utils::project_tree(workspace, 3);
+    let tree = crate::utils::project_tree(workspace, 3, false);
     ctx.push_str("## Directory Structure (depth 3)\n\n```\n");
     ctx.push_str(&tree);
     ctx.push_str("\n```\n\n");

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -83,6 +83,11 @@ pub struct SettingsSection {
     pub max_history: usize,
     pub cost_currency: CostCurrencyValue,
     pub prefer_external_pdftotext: bool,
+    #[schemars(
+        title = "Follow symlinks",
+        description = "Follow symbolic links during workspace file discovery walks. Enable for symlink-based multi-project workspaces."
+    )]
+    pub workspace_follow_symlinks: bool,
     pub default_model: Option<String>,
 }
 
@@ -352,6 +357,7 @@ pub fn build_document(app: &App, config: &Config) -> Result<ConfigUiDocument> {
             max_history: settings.max_input_history,
             cost_currency: CostCurrencyValue::from_setting(&settings.cost_currency)?,
             prefer_external_pdftotext: settings.prefer_external_pdftotext,
+            workspace_follow_symlinks: settings.workspace_follow_symlinks,
             default_model,
         },
         config: ConfigSection {
@@ -551,6 +557,10 @@ pub fn apply_document(
         (
             "prefer_external_pdftotext",
             bool_str(doc.settings.prefer_external_pdftotext),
+        ),
+        (
+            "workspace_follow_symlinks",
+            bool_str(doc.settings.workspace_follow_symlinks),
         ),
         ("mcp_config_path", doc.config.mcp_config_path.as_str()),
     ] {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -380,6 +380,12 @@ pub struct EngineConfig {
     /// Applied to the per-turn tool registry after built-in tools are registered.
     /// When `None`, no overrides or plugin loading occurs.
     pub tools: Option<crate::config::ToolsConfig>,
+    /// Whether tools should follow symbolic links. When `true`, symlinked
+    /// directories are traversed by walk-based tools and symlinked paths
+    /// that resolve outside the workspace are still allowed (the symlink
+    /// itself must be inside the workspace). Mirrors the
+    /// `workspace_follow_symlinks` setting.
+    pub workspace_follow_symlinks: bool,
 }
 
 impl Default for EngineConfig {
@@ -442,6 +448,7 @@ impl Default for EngineConfig {
             prefer_bwrap: false,
             verbosity: None,
             tools: None,
+            workspace_follow_symlinks: false,
         }
     }
 }
@@ -2397,7 +2404,8 @@ impl Engine {
         ))
         .with_cancel_token(self.cancel_token.clone())
         .with_shell_policy(shell_policy_for_mode(mode, self.session.allow_shell))
-        .with_trusted_external_paths(trusted_external_paths);
+        .with_trusted_external_paths(trusted_external_paths)
+        .with_follow_symlinks(self.config.workspace_follow_symlinks);
 
         // Hand the user-memory path to tools so the model-callable
         // `remember` tool can append entries (#489). `None` when the

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6554,6 +6554,7 @@ async fn run_exec_agent(
         tools_always_load: execution_config.tools_always_load(),
         tools: execution_config.tools.clone(),
         verbosity: execution_config.verbosity.clone(),
+        workspace_follow_symlinks: settings.workspace_follow_symlinks,
     };
 
     let engine_handle = spawn_engine(engine_config, &execution_config);

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2164,6 +2164,7 @@ impl RuntimeThreadManager {
             tools_always_load: self.config.tools_always_load(),
             tools: self.config.tools.clone(),
             verbosity: self.config.verbosity.clone(),
+            workspace_follow_symlinks: settings.workspace_follow_symlinks,
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -319,6 +319,19 @@ pub struct Settings {
     /// `binary_unavailable` response with an install hint, matching the
     /// pre-v0.8.32 behavior.
     pub prefer_external_pdftotext: bool,
+    /// Follow symbolic links during workspace file discovery walks (`@`-mention
+    /// completion, fuzzy resolve, and the file-index builder). When `false`
+    /// (default) symlinked directories are skipped, which keeps walks fast and
+    /// avoids accidentally traversing into system paths. Set to `true` to
+    /// support symlink-based multi-project workspaces where several project
+    /// directories are symlinked into a single hub directory.
+    ///
+    /// **Note**: The walker has built-in cycle detection that skips already-
+    /// visited real paths, so symlink loops (A→B→A) will not cause infinite
+    /// recursion. However, enabling this on workspaces with symlinks that
+    /// point to large directory trees (e.g. `/usr`, home directories) can
+    /// significantly increase first-turn latency and memory usage.
+    pub workspace_follow_symlinks: bool,
 }
 
 impl Default for Settings {
@@ -362,6 +375,7 @@ impl Default for Settings {
             status_indicator: "whale".to_string(),
             synchronized_output: "auto".to_string(),
             prefer_external_pdftotext: false,
+            workspace_follow_symlinks: false,
         }
     }
 }
@@ -688,6 +702,9 @@ impl Settings {
             "prefer_external_pdftotext" | "external_pdftotext" | "pdftotext" => {
                 self.prefer_external_pdftotext = parse_bool(value)?;
             }
+            "workspace_follow_symlinks" | "follow_symlinks" => {
+                self.workspace_follow_symlinks = parse_bool(value)?;
+            }
             "default_mode" | "mode" => {
                 let normalized = normalize_mode(value);
                 if !["agent", "plan", "yolo"].contains(&normalized) {
@@ -827,6 +844,10 @@ impl Settings {
             "  prefer_external_pdftotext: {}",
             self.prefer_external_pdftotext
         ));
+        lines.push(format!(
+            "  workspace_follow_symlinks: {}",
+            self.workspace_follow_symlinks
+        ));
         lines.push(format!("  default_mode:       {}", self.default_mode));
         lines.push(format!(
             "  sidebar_width:      {}%",
@@ -942,6 +963,10 @@ impl Settings {
             (
                 "prefer_external_pdftotext",
                 "Route PDF reads through Poppler's pdftotext instead of the bundled pure-Rust extractor: on/off (default off)",
+            ),
+            (
+                "workspace_follow_symlinks",
+                "Follow symbolic links during workspace file discovery walks: on/off (default off). Enable for symlink-based multi-project workspaces. Has built-in cycle detection but may increase latency on large symlinked trees.",
             ),
             ("default_mode", "Default mode: agent, plan, yolo"),
             ("sidebar_width", "Sidebar width percentage: 10-50"),

--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -99,12 +99,14 @@ impl ToolSpec for FileSearchTool {
             limit,
             context.cancel_token.clone(),
             FILE_SEARCH_TIMEOUT,
+            context.follow_symlinks,
         )
         .await?;
         ToolResult::json(&matches).map_err(|e| ToolError::execution_failed(e.to_string()))
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn search_files_async(
     query: String,
     base_path: PathBuf,
@@ -113,6 +115,7 @@ async fn search_files_async(
     limit: usize,
     cancel_token: Option<CancellationToken>,
     timeout: Duration,
+    follow_symlinks: bool,
 ) -> Result<Vec<FileSearchMatch>, ToolError> {
     let worker_cancel_token = cancel_token.clone();
     run_blocking_file_search(timeout, cancel_token, move || {
@@ -123,6 +126,7 @@ async fn search_files_async(
             exclude_patterns,
             limit,
             worker_cancel_token.as_ref(),
+            follow_symlinks,
         )
     })
     .await
@@ -229,6 +233,7 @@ fn search_files(
     exclude_patterns: Vec<String>,
     limit: usize,
     cancel_token: Option<&CancellationToken>,
+    follow_symlinks: bool,
 ) -> Result<Vec<FileSearchMatch>, ToolError> {
     check_cancelled(cancel_token)?;
 
@@ -243,7 +248,10 @@ fn search_files(
     let mut results: Vec<FileSearchMatch> = Vec::new();
 
     let mut builder = WalkBuilder::new(base_path);
-    builder.hidden(false).follow_links(false).require_git(false);
+    builder
+        .hidden(false)
+        .follow_links(follow_symlinks)
+        .require_git(false);
     let walker = builder.build();
 
     for entry in walker {

--- a/crates/tui/src/tools/project.rs
+++ b/crates/tui/src/tools/project.rs
@@ -51,23 +51,30 @@ impl ToolSpec for ProjectMapTool {
 
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let max_depth = optional_u64(&input, "max_depth", 3) as usize;
-        let map = generate_project_map(&context.workspace, max_depth)?;
+        let map = generate_project_map(&context.workspace, max_depth, context.follow_symlinks)?;
         ToolResult::json(&map).map_err(|e| ToolError::execution_failed(e.to_string()))
     }
 }
 
-fn generate_project_map(root: &std::path::Path, max_depth: usize) -> Result<ProjectMap, ToolError> {
-    let tree = project_tree(root, max_depth);
+fn generate_project_map(
+    root: &std::path::Path,
+    max_depth: usize,
+    follow_symlinks: bool,
+) -> Result<ProjectMap, ToolError> {
+    let tree = project_tree(root, max_depth, follow_symlinks);
     let summary = summarize_project(root);
 
     // For key_files, we can just do a quick scan since summarize_project doesn't return them directly anymore
     let mut key_files = Vec::new();
     let mut builder = ignore::WalkBuilder::new(root);
-    builder.hidden(false).follow_links(false).max_depth(Some(2));
+    builder
+        .hidden(false)
+        .follow_links(follow_symlinks)
+        .max_depth(Some(2));
     let walker = builder.build();
 
     for entry in walker.flatten() {
-        if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+        if entry.file_type().is_some_and(|ft| ft.is_symlink()) && !follow_symlinks {
             continue;
         }
         if is_key_file(entry.path())

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -785,6 +785,32 @@ mod tests {
 
     #[tokio::test]
     #[cfg(unix)]
+    async fn test_grep_files_default_mode_skips_symlinked_directories_but_keeps_real_files() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let real_dir = workspace.join("real");
+        std::fs::create_dir_all(&real_dir).expect("mkdir workspace");
+        fs::write(real_dir.join("needle.txt"), "NEEDLE\n").expect("write real file");
+        std::os::unix::fs::symlink(&workspace, real_dir.join("loop")).expect("symlink loop");
+
+        let ctx = ToolContext::new(workspace);
+        let tool = GrepFilesTool;
+        let result = tool
+            .execute(json!({"pattern": "NEEDLE"}), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        let parsed: Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(parsed["total_matches"].as_u64().unwrap(), 1);
+        assert_eq!(parsed["files_searched"].as_u64().unwrap(), 1);
+        let matches = parsed["matches"].as_array().unwrap();
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0]["file"].as_str().unwrap().ends_with("real/needle.txt"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
     async fn test_grep_files_follow_symlinks_avoids_directory_cycles() {
         let tmp = tempdir().expect("tempdir");
         let workspace = tmp.path().join("workspace");

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -169,6 +169,7 @@ impl ToolSpec for GrepFilesTool {
 
         let workspace = context.workspace.clone();
         let cancel_token = context.cancel_token.clone();
+        let follow_symlinks = context.follow_symlinks;
 
         // The directory walk and per-file regex are synchronous blocking work.
         // Run them on a blocking worker bounded by a hard timeout so a huge tree
@@ -182,6 +183,7 @@ impl ToolSpec for GrepFilesTool {
                 &include_patterns,
                 &exclude_patterns,
                 cancel_token,
+                follow_symlinks,
             )?;
 
             // Search files
@@ -336,6 +338,7 @@ fn collect_files(
     include_patterns: &[String],
     exclude_patterns: &[String],
     cancel_token: Option<&CancellationToken>,
+    follow_symlinks: bool,
 ) -> Result<Vec<PathBuf>, ToolError> {
     let mut files = Vec::new();
     check_cancelled(cancel_token)?;
@@ -352,6 +355,7 @@ fn collect_files(
         exclude_patterns,
         cancel_token,
         &mut files,
+        follow_symlinks,
     )?;
     Ok(files)
 }
@@ -363,6 +367,7 @@ fn collect_files_recursive(
     exclude_patterns: &[String],
     cancel_token: Option<&CancellationToken>,
     files: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
 ) -> Result<(), ToolError> {
     check_cancelled(cancel_token)?;
 
@@ -386,7 +391,7 @@ fn collect_files_recursive(
                 e
             ))
         })?;
-        if file_type.is_symlink() {
+        if file_type.is_symlink() && !follow_symlinks {
             continue;
         }
 
@@ -399,7 +404,19 @@ fn collect_files_recursive(
             continue;
         }
 
-        if file_type.is_dir() {
+        // When following symlinks, resolve the target type for directories
+        // and files so symlinked dirs are traversed and symlinked files are
+        // included.
+        let effective_type = if file_type.is_symlink() && follow_symlinks {
+            match fs::metadata(&path) {
+                Ok(meta) => meta.file_type(),
+                Err(_) => continue,
+            }
+        } else {
+            file_type
+        };
+
+        if effective_type.is_dir() {
             collect_files_recursive(
                 root,
                 &path,
@@ -407,8 +424,9 @@ fn collect_files_recursive(
                 exclude_patterns,
                 cancel_token,
                 files,
+                follow_symlinks,
             )?;
-        } else if file_type.is_file() {
+        } else if effective_type.is_file() {
             // Check inclusions (if any specified)
             if include_patterns.is_empty() || should_include(&relative_str, include_patterns) {
                 files.push(path);

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -806,7 +806,12 @@ mod tests {
         assert_eq!(parsed["files_searched"].as_u64().unwrap(), 1);
         let matches = parsed["matches"].as_array().unwrap();
         assert_eq!(matches.len(), 1);
-        assert!(matches[0]["file"].as_str().unwrap().ends_with("real/needle.txt"));
+        assert!(
+            matches[0]["file"]
+                .as_str()
+                .unwrap()
+                .ends_with("real/needle.txt")
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -341,11 +342,16 @@ fn collect_files(
     follow_symlinks: bool,
 ) -> Result<Vec<PathBuf>, ToolError> {
     let mut files = Vec::new();
+    let mut visited_dirs = HashSet::new();
     check_cancelled(cancel_token)?;
 
     if root.is_file() {
         files.push(root.to_path_buf());
         return Ok(files);
+    }
+
+    if follow_symlinks && let Ok(canonical_root) = root.canonicalize() {
+        visited_dirs.insert(canonical_root);
     }
 
     collect_files_recursive(
@@ -356,6 +362,7 @@ fn collect_files(
         cancel_token,
         &mut files,
         follow_symlinks,
+        &mut visited_dirs,
     )?;
     Ok(files)
 }
@@ -368,6 +375,7 @@ fn collect_files_recursive(
     cancel_token: Option<&CancellationToken>,
     files: &mut Vec<PathBuf>,
     follow_symlinks: bool,
+    visited_dirs: &mut HashSet<PathBuf>,
 ) -> Result<(), ToolError> {
     check_cancelled(cancel_token)?;
 
@@ -417,6 +425,15 @@ fn collect_files_recursive(
         };
 
         if effective_type.is_dir() {
+            if follow_symlinks {
+                let canonical_dir = match path.canonicalize() {
+                    Ok(canonical) => canonical,
+                    Err(_) => continue,
+                };
+                if !visited_dirs.insert(canonical_dir) {
+                    continue;
+                }
+            }
             collect_files_recursive(
                 root,
                 &path,
@@ -425,6 +442,7 @@ fn collect_files_recursive(
                 cancel_token,
                 files,
                 follow_symlinks,
+                visited_dirs,
             )?;
         } else if effective_type.is_file() {
             // Check inclusions (if any specified)
@@ -759,6 +777,31 @@ mod tests {
         let parsed: Value = serde_json::from_str(&result.content).unwrap();
         assert_eq!(parsed["total_matches"].as_u64().unwrap(), 0);
         assert_eq!(parsed["files_searched"].as_u64().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_grep_files_follow_symlinks_avoids_directory_cycles() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let real_dir = workspace.join("real");
+        fs::create_dir_all(&real_dir).expect("mkdir");
+        fs::write(real_dir.join("needle.txt"), "NEEDLE\n").expect("write");
+        std::os::unix::fs::symlink(&workspace, real_dir.join("loop")).expect("symlink loop");
+
+        let ctx = ToolContext::new(workspace).with_follow_symlinks(true);
+        let tool = GrepFilesTool;
+        let result = tool
+            .execute(json!({"pattern": "NEEDLE"}), &ctx)
+            .await
+            .expect("execute");
+
+        assert!(result.success);
+        let parsed: Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(parsed["total_matches"].as_u64().unwrap(), 1);
+        assert_eq!(parsed["files_searched"].as_u64().unwrap(), 1);
+        let matches = parsed["matches"].as_array().unwrap();
+        assert!(matches[0]["file"].as_str().unwrap().ends_with("needle.txt"));
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -334,6 +334,11 @@ fn grep_match_to_json(item: &GrepMatch, context_lines: usize) -> Value {
 }
 
 /// Collect files to search based on include/exclude patterns
+struct CollectFilesState {
+    files: Vec<PathBuf>,
+    visited_dirs: HashSet<PathBuf>,
+}
+
 fn collect_files(
     root: &Path,
     include_patterns: &[String],
@@ -341,17 +346,19 @@ fn collect_files(
     cancel_token: Option<&CancellationToken>,
     follow_symlinks: bool,
 ) -> Result<Vec<PathBuf>, ToolError> {
-    let mut files = Vec::new();
-    let mut visited_dirs = HashSet::new();
+    let mut state = CollectFilesState {
+        files: Vec::new(),
+        visited_dirs: HashSet::new(),
+    };
     check_cancelled(cancel_token)?;
 
     if root.is_file() {
-        files.push(root.to_path_buf());
-        return Ok(files);
+        state.files.push(root.to_path_buf());
+        return Ok(state.files);
     }
 
     if follow_symlinks && let Ok(canonical_root) = root.canonicalize() {
-        visited_dirs.insert(canonical_root);
+        state.visited_dirs.insert(canonical_root);
     }
 
     collect_files_recursive(
@@ -360,11 +367,10 @@ fn collect_files(
         include_patterns,
         exclude_patterns,
         cancel_token,
-        &mut files,
+        &mut state,
         follow_symlinks,
-        &mut visited_dirs,
     )?;
-    Ok(files)
+    Ok(state.files)
 }
 
 fn collect_files_recursive(
@@ -373,9 +379,8 @@ fn collect_files_recursive(
     include_patterns: &[String],
     exclude_patterns: &[String],
     cancel_token: Option<&CancellationToken>,
-    files: &mut Vec<PathBuf>,
+    state: &mut CollectFilesState,
     follow_symlinks: bool,
-    visited_dirs: &mut HashSet<PathBuf>,
 ) -> Result<(), ToolError> {
     check_cancelled(cancel_token)?;
 
@@ -430,7 +435,7 @@ fn collect_files_recursive(
                     Ok(canonical) => canonical,
                     Err(_) => continue,
                 };
-                if !visited_dirs.insert(canonical_dir) {
+                if !state.visited_dirs.insert(canonical_dir) {
                     continue;
                 }
             }
@@ -440,14 +445,13 @@ fn collect_files_recursive(
                 include_patterns,
                 exclude_patterns,
                 cancel_token,
-                files,
+                state,
                 follow_symlinks,
-                visited_dirs,
             )?;
         } else if effective_type.is_file() {
             // Check inclusions (if any specified)
             if include_patterns.is_empty() || should_include(&relative_str, include_patterns) {
-                files.push(path);
+                state.files.push(path);
             }
         }
     }

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -925,6 +925,24 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn test_tool_context_default_mode_rejects_nonexistent_path_under_workspace_symlink() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+        std::fs::create_dir_all(outside.join("target")).expect("mkdir outside target");
+        symlink(outside.join("target"), workspace.join("linked")).expect("symlink");
+
+        let ctx = ToolContext::new(workspace);
+        let err = ctx
+            .resolve_path("linked/new.txt")
+            .expect_err("default mode should still reject workspace symlink escapes");
+
+        assert!(matches!(err, ToolError::PathEscape { .. }));
+    }
+
+    #[test]
     fn test_required_str() {
         let input = json!({"name": "test", "count": 42});
         assert_eq!(required_str(&input, "name").unwrap(), "test");

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -130,6 +130,12 @@ pub struct ToolContext {
     /// and refreshed when the user runs `/trust add <path>`. Distinct from
     /// `trust_mode`, which is the all-or-nothing legacy switch (#29).
     pub trusted_external_paths: Vec<PathBuf>,
+    /// Whether to follow symbolic links during file discovery and tool
+    /// operations. When `true`, symlinked directories are traversed and
+    /// symlinked paths that resolve outside the workspace are still allowed
+    /// (the symlink itself must be inside the workspace). Mirrors the
+    /// `workspace_follow_symlinks` setting.
+    pub follow_symlinks: bool,
     /// Per-domain network policy (#135). When `None`, network tools fall back
     /// to a permissive default that mirrors pre-v0.7.0 behavior so tests and
     /// other contexts that don't construct a real policy keep working.
@@ -206,6 +212,7 @@ impl ToolContext {
             features: Features::with_defaults(),
             state_namespace: "workspace".to_string(),
             trusted_external_paths: Vec::new(),
+            follow_symlinks: false,
             network_policy: None,
             runtime: RuntimeToolServices::default(),
             session_objects: None,
@@ -245,6 +252,7 @@ impl ToolContext {
             features: Features::with_defaults(),
             state_namespace: "workspace".to_string(),
             trusted_external_paths: Vec::new(),
+            follow_symlinks: false,
             network_policy: None,
             runtime: RuntimeToolServices::default(),
             session_objects: None,
@@ -284,6 +292,7 @@ impl ToolContext {
             features: Features::with_defaults(),
             state_namespace: "workspace".to_string(),
             trusted_external_paths: Vec::new(),
+            follow_symlinks: false,
             network_policy: None,
             runtime: RuntimeToolServices::default(),
             session_objects: None,
@@ -351,6 +360,16 @@ impl ToolContext {
         self
     }
 
+    /// Set whether tools should follow symbolic links. When `true`,
+    /// `resolve_path` allows symlinked paths that resolve outside the
+    /// workspace, and walk-based tools traverse symlinked directories.
+    /// Mirrors the `workspace_follow_symlinks` setting.
+    #[must_use]
+    pub fn with_follow_symlinks(mut self, follow: bool) -> Self {
+        self.follow_symlinks = follow;
+        self
+    }
+
     /// Attach an LSP manager so that edit tools can auto-inject diagnostics
     /// into their results after a successful file modification (#428).
     #[must_use]
@@ -394,6 +413,30 @@ impl ToolContext {
             .canonicalize()
             .unwrap_or_else(|_| self.workspace.clone());
 
+        // When follow_symlinks is enabled, check the non-canonical (symlink)
+        // path against the workspace first. A symlink inside the workspace
+        // that resolves outside is allowed — the symlink itself is the gate.
+        if self.follow_symlinks {
+            let candidate_normalized = normalize_path(&candidate);
+            let workspace_normalized = normalize_path(&self.workspace);
+            let workspace_canonical_normalized = normalize_path(&workspace_canonical);
+
+            if candidate_normalized.starts_with(&workspace_normalized)
+                || candidate_normalized.starts_with(&workspace_canonical_normalized)
+            {
+                // The symlink (or plain path) is inside the workspace.
+                // Return the canonicalized target so file I/O works correctly.
+                if candidate.exists() {
+                    return Ok(candidate.canonicalize().unwrap_or(candidate));
+                }
+                // Non-existent path: canonicalize the deepest existing ancestor
+                return self.resolve_nonexistent_path(candidate, &workspace_canonical);
+            }
+
+            // Path is outside workspace even before resolving symlinks.
+            // Fall through to the standard escape check.
+        }
+
         // For the initial check, also try to canonicalize the candidate if possible
         // This handles symlinks like /var -> /private/var on macOS
         let candidate_canonical = candidate
@@ -436,8 +479,18 @@ impl ToolContext {
             return Ok(canonical);
         }
 
-        // For non-existent paths (e.g., files to be created), validate via parent
-        // Find the deepest existing ancestor and canonicalize it
+        self.resolve_nonexistent_path(candidate, &workspace_canonical)
+    }
+
+    /// Resolve a non-existent path by canonicalizing its deepest existing
+    /// ancestor and validating the result is under the workspace or a
+    /// trusted external path.
+    fn resolve_nonexistent_path(
+        &self,
+        candidate: PathBuf,
+        workspace_canonical: &Path,
+    ) -> Result<PathBuf, ToolError> {
+        let workspace_normalized = normalize_path(workspace_canonical);
         let mut existing_ancestor = candidate.clone();
         let mut suffix_parts: Vec<std::ffi::OsString> = Vec::new();
 
@@ -474,7 +527,7 @@ impl ToolContext {
         // Validate it's under workspace, OR is under a user-trusted external
         // path (`/trust add <path>` from the slash command, persisted in
         // `~/.deepseek/workspace-trust.json`).
-        if !canonical.starts_with(&workspace_canonical)
+        if !canonical.starts_with(workspace_canonical)
             && !canonical.starts_with(&workspace_normalized)
             && !self.is_trusted_external_path(&canonical)
         {

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -491,6 +491,7 @@ impl ToolContext {
         workspace_canonical: &Path,
     ) -> Result<PathBuf, ToolError> {
         let workspace_normalized = normalize_path(workspace_canonical);
+        let workspace_plain = normalize_path(&self.workspace);
         let mut existing_ancestor = candidate.clone();
         let mut suffix_parts: Vec<std::ffi::OsString> = Vec::new();
 
@@ -508,6 +509,7 @@ impl ToolContext {
                 }
             }
         }
+        let ancestor_normalized = normalize_path(&existing_ancestor);
 
         let canonical_ancestor = if existing_ancestor.exists() {
             existing_ancestor
@@ -523,6 +525,14 @@ impl ToolContext {
             canonical.push(part);
         }
         let canonical = normalize_path(&canonical);
+
+        if self.follow_symlinks {
+            if ancestor_normalized.starts_with(&workspace_plain)
+                || ancestor_normalized.starts_with(&workspace_normalized)
+            {
+                return Ok(canonical);
+            }
+        }
 
         // Validate it's under workspace, OR is under a user-trusted external
         // path (`/trust add <path>` from the slash command, persisted in
@@ -775,6 +785,8 @@ pub trait ToolSpec: Send + Sync {
 mod tests {
     use super::*;
     use serde_json::json;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
     use tempfile::tempdir;
 
     #[test]
@@ -888,6 +900,29 @@ mod tests {
             .resolve_path(other_file.to_str().unwrap())
             .expect_err("untrusted path must error");
         assert!(matches!(err, ToolError::PathEscape { .. }));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_tool_context_follow_symlinks_allows_nonexistent_path_under_workspace_symlink() {
+        let tmp = tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+        std::fs::create_dir_all(outside.join("target")).expect("mkdir outside target");
+        symlink(outside.join("target"), workspace.join("linked")).expect("symlink");
+
+        let ctx = ToolContext::new(workspace).with_follow_symlinks(true);
+        let resolved = ctx
+            .resolve_path("linked/new.txt")
+            .expect("path under workspace symlink should resolve");
+
+        let expected = outside
+            .join("target")
+            .canonicalize()
+            .expect("canonical target")
+            .join("new.txt");
+        assert_eq!(resolved, normalize_path(&expected));
     }
 
     #[test]

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -526,12 +526,11 @@ impl ToolContext {
         }
         let canonical = normalize_path(&canonical);
 
-        if self.follow_symlinks {
-            if ancestor_normalized.starts_with(&workspace_plain)
-                || ancestor_normalized.starts_with(&workspace_normalized)
-            {
-                return Ok(canonical);
-            }
+        if self.follow_symlinks
+            && (ancestor_normalized.starts_with(&workspace_plain)
+                || ancestor_normalized.starts_with(&workspace_normalized))
+        {
+            return Ok(canonical);
         }
 
         // Validate it's under workspace, OR is under a user-trusted external

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1027,6 +1027,9 @@ pub struct MentionCompletionCache {
     /// Completion behavior used for this walk. Included so live config changes
     /// invalidate cached popup results.
     pub behavior: String,
+    /// Whether symlink following was enabled for this completion walk.
+    /// Included so live config changes invalidate cached popup results.
+    pub follow_links: bool,
     /// Cached completion entries.
     pub entries: Vec<String>,
 }
@@ -1451,6 +1454,10 @@ pub struct App {
     /// `@`-mention completion behavior: fuzzy workspace search or deterministic
     /// directory browser.
     pub mention_menu_behavior: String,
+    /// Follow symbolic links during workspace file discovery walks.
+    /// When `true`, symlinked directories are traversed, enabling
+    /// multi-project workspaces.
+    pub workspace_follow_symlinks: bool,
     pub use_bracketed_paste: bool,
     pub use_paste_burst_detection: bool,
     /// Set to `true` the first time a real `Event::Paste` arrives during a
@@ -2469,6 +2476,7 @@ impl App {
             mention_menu_limit: settings.mention_menu_limit,
             mention_walk_depth: settings.mention_walk_depth,
             mention_menu_behavior: settings.mention_menu_behavior.clone(),
+            workspace_follow_symlinks: settings.workspace_follow_symlinks,
             session_title: None,
             receipt_text: None,
             receipt_started_at: None,

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -185,10 +185,11 @@ pub fn find_file_mention_browser_completions(
 /// captures the process CWD so the resolver and completion walker honor the
 /// user's launch directory when it differs from `--workspace`.
 fn workspace_for_app(app: &App) -> Workspace {
-    Workspace::with_cwd_and_depth(
+    Workspace::with_cwd_depth_and_follow_links(
         app.workspace.clone(),
         std::env::current_dir().ok(),
         app.mention_walk_depth,
+        app.workspace_follow_symlinks,
     )
 }
 
@@ -222,6 +223,7 @@ pub fn visible_mention_menu_entries(app: &mut App, limit: usize) -> Vec<String> 
     let cwd = std::env::current_dir().ok();
     let walk_depth = app.mention_walk_depth;
     let behavior = app.mention_menu_behavior.clone();
+    let follow_links = app.workspace_follow_symlinks;
     if let Some(ref cache) = app.composer.mention_completion_cache
         && cache.workspace == workspace
         && cache.cwd == cwd
@@ -229,11 +231,17 @@ pub fn visible_mention_menu_entries(app: &mut App, limit: usize) -> Vec<String> 
         && cache.limit == limit
         && cache.walk_depth == walk_depth
         && cache.behavior == behavior
+        && cache.follow_links == follow_links
     {
         return cache.entries.clone();
     }
 
-    let ws = Workspace::with_cwd_and_depth(workspace.clone(), cwd.clone(), walk_depth);
+    let ws = Workspace::with_cwd_depth_and_follow_links(
+        workspace.clone(),
+        cwd.clone(),
+        walk_depth,
+        app.workspace_follow_symlinks,
+    );
     let entries = if behavior == "browser" {
         find_file_mention_browser_completions(&ws, &partial, limit)
     } else {
@@ -247,6 +255,7 @@ pub fn visible_mention_menu_entries(app: &mut App, limit: usize) -> Vec<String> 
         limit,
         walk_depth,
         behavior,
+        follow_links,
         entries: entries.clone(),
     });
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1037,6 +1037,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         search_base_url: config.search.as_ref().and_then(|s| s.base_url.clone()),
         tools_always_load: config.tools_always_load(),
         tools: config.tools.clone(),
+        workspace_follow_symlinks: app.workspace_follow_symlinks,
     }
 }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -706,6 +706,13 @@ impl ConfigView {
                 scope: ConfigScope::Saved,
             },
             ConfigRow {
+                section: ConfigSection::Composer,
+                key: "workspace_follow_symlinks".to_string(),
+                value: settings.workspace_follow_symlinks.to_string(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
                 section: ConfigSection::Sidebar,
                 key: "sidebar_width".to_string(),
                 value: settings.sidebar_width_percent.to_string(),

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -111,17 +111,17 @@ pub fn summarize_project(root: &Path) -> String {
 /// directory still precedes its children because `"src" < "src/lib.rs"`)
 /// while making the rendered output byte-stable across runs.
 #[must_use]
-pub fn project_tree(root: &Path, max_depth: usize) -> String {
+pub fn project_tree(root: &Path, max_depth: usize, follow_symlinks: bool) -> String {
     let mut entries: Vec<(PathBuf, bool)> = Vec::new();
 
     let mut builder = WalkBuilder::new(root);
     builder
         .hidden(false)
-        .follow_links(false)
+        .follow_links(follow_symlinks)
         .max_depth(Some(max_depth + 1));
 
     for entry in builder.build().flatten() {
-        if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+        if entry.file_type().is_some_and(|ft| ft.is_symlink()) && !follow_symlinks {
             continue;
         }
         let depth = entry.depth();
@@ -756,7 +756,7 @@ mod project_mapping_tests {
         fs::write(root.join("apple.txt"), "a").expect("write apple");
         fs::write(root.join("mango.txt"), "m").expect("write mango");
 
-        let tree = project_tree(root, 1);
+        let tree = project_tree(root, 1, false);
         let lines: Vec<&str> = tree.lines().collect();
         let apple_pos = lines
             .iter()
@@ -786,7 +786,7 @@ mod project_mapping_tests {
         fs::write(src.join("lib.rs"), "lib").expect("write lib");
         fs::write(src.join("main.rs"), "main").expect("write main");
 
-        let tree = project_tree(root, 2);
+        let tree = project_tree(root, 2, false);
         let src_pos = tree.find("DIR: src").expect("src dir line");
         let lib_pos = tree.find("FILE: lib.rs").expect("lib file line");
         let main_pos = tree.find("FILE: main.rs").expect("main file line");
@@ -802,7 +802,7 @@ mod project_mapping_tests {
         fs::write(root.join("z.txt"), "z").expect("write");
         fs::write(root.join("a.txt"), "a").expect("write");
 
-        assert_eq!(project_tree(root, 1), project_tree(root, 1));
+        assert_eq!(project_tree(root, 1, false), project_tree(root, 1, false));
     }
 
     #[test]
@@ -818,7 +818,7 @@ mod project_mapping_tests {
         std::os::unix::fs::symlink(&outside_file, root.join("Cargo.toml")).expect("symlink");
 
         assert_eq!(summarize_project(&root), "Unknown project type");
-        assert!(!project_tree(&root, 1).contains("Cargo.toml"));
+        assert!(!project_tree(&root, 1, false).contains("Cargo.toml"));
     }
 
     #[test]

--- a/crates/tui/src/working_set.rs
+++ b/crates/tui/src/working_set.rs
@@ -33,6 +33,10 @@ pub struct Workspace {
     cwd: Option<PathBuf>,
     file_index: OnceLock<HashMap<String, Vec<PathBuf>>>,
     completion_walk_depth: Option<usize>,
+    /// Follow symbolic links during file discovery walks. When `true`,
+    /// symlinked directories are traversed, enabling multi-project workspaces
+    /// where project directories are symlinked into a hub directory.
+    follow_links: bool,
 }
 
 struct SearchContext<'a> {
@@ -82,11 +86,23 @@ impl Workspace {
     /// Construct with an explicit completion walk depth. A depth of `0`
     /// disables the depth limit for users with deeply nested workspaces.
     pub fn with_cwd_and_depth(root: PathBuf, cwd: Option<PathBuf>, walk_depth: usize) -> Self {
+        Self::with_cwd_depth_and_follow_links(root, cwd, walk_depth, false)
+    }
+
+    /// Construct with an explicit completion walk depth and symlink-following
+    /// preference. See [`Workspace::follow_links`].
+    pub fn with_cwd_depth_and_follow_links(
+        root: PathBuf,
+        cwd: Option<PathBuf>,
+        walk_depth: usize,
+        follow_links: bool,
+    ) -> Self {
         Self {
             root,
             cwd,
             file_index: OnceLock::new(),
             completion_walk_depth: normalize_completion_walk_depth(walk_depth),
+            follow_links,
         }
     }
 
@@ -132,7 +148,8 @@ impl Workspace {
     fn build_file_index(&self) -> HashMap<String, Vec<PathBuf>> {
         let mut index: HashMap<String, Vec<PathBuf>> = HashMap::new();
         let mut total: usize = 0;
-        let builder = discovery_walk_builder(&self.root, self.completion_walk_depth);
+        let builder =
+            discovery_walk_builder(&self.root, self.completion_walk_depth, self.follow_links);
 
         for entry in builder.build().flatten() {
             if total >= FILE_INDEX_MAX_ENTRIES {
@@ -168,7 +185,7 @@ impl Workspace {
             let mut dot_builder = WalkBuilder::new(&dot_dir);
             dot_builder
                 .hidden(true)
-                .follow_links(false)
+                .follow_links(self.follow_links)
                 .git_ignore(false)
                 .ignore(false);
             if let Some(depth) = child_completion_walk_depth(self.completion_walk_depth) {
@@ -204,6 +221,7 @@ impl Workspace {
             &self.root,
             LOCAL_REFERENCE_SCAN_LIMIT,
             self.completion_walk_depth,
+            self.follow_links,
         ) {
             if total >= FILE_INDEX_MAX_ENTRIES {
                 break;
@@ -262,15 +280,34 @@ impl Workspace {
                 .map(|c| c != self.root.as_path())
                 .unwrap_or(false);
             if cwd_diverges && let Some(cwd) = self.cwd.as_deref() {
-                walk_for_completions(cwd, cwd, &mut ctx, self.completion_walk_depth);
-                add_local_reference_completions(cwd, cwd, &mut ctx, self.completion_walk_depth);
+                walk_for_completions(
+                    cwd,
+                    cwd,
+                    &mut ctx,
+                    self.completion_walk_depth,
+                    self.follow_links,
+                );
+                add_local_reference_completions(
+                    cwd,
+                    cwd,
+                    &mut ctx,
+                    self.completion_walk_depth,
+                    self.follow_links,
+                );
             }
-            walk_for_completions(&self.root, &self.root, &mut ctx, self.completion_walk_depth);
+            walk_for_completions(
+                &self.root,
+                &self.root,
+                &mut ctx,
+                self.completion_walk_depth,
+                self.follow_links,
+            );
             add_local_reference_completions(
                 &self.root,
                 &self.root,
                 &mut ctx,
                 self.completion_walk_depth,
+                self.follow_links,
             );
         }
 
@@ -319,7 +356,7 @@ impl Workspace {
         let mut builder = WalkBuilder::new(&dir);
         builder
             .hidden(!show_hidden)
-            .follow_links(false)
+            .follow_links(self.follow_links)
             .max_depth(Some(1));
         let _ = builder.add_custom_ignore_filename(".deepseekignore");
 
@@ -391,13 +428,17 @@ fn child_completion_walk_depth(depth: Option<usize>) -> Option<usize> {
 /// above the actual entry count and the cap is a no-op.
 const FILE_INDEX_MAX_ENTRIES: usize = 50_000;
 
-/// Configure a `WalkBuilder` for workspace discovery: hidden files, no
-/// symlink following, depth-limited, custom `.deepseekignore` honored,
-/// and gitignore overrides for AI-tool dot-directories so `@`-completion
-/// finds them even when they're gitignored.
-fn discovery_walk_builder(root: &Path, max_depth: Option<usize>) -> WalkBuilder {
+/// Configure a `WalkBuilder` for workspace discovery: hidden files,
+/// depth-limited, custom `.deepseekignore` honored, and gitignore overrides
+/// for AI-tool dot-directories so `@`-completion finds them even when
+/// they're gitignored. Symlink following is controlled by `follow_links`.
+fn discovery_walk_builder(
+    root: &Path,
+    max_depth: Option<usize>,
+    follow_links: bool,
+) -> WalkBuilder {
     let mut builder = WalkBuilder::new(root);
-    builder.hidden(true).follow_links(false);
+    builder.hidden(true).follow_links(follow_links);
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
     }
@@ -413,6 +454,7 @@ fn walk_always_discoverable_dirs(
     display_root: &Path,
     ctx: &mut SearchContext<'_>,
     max_depth: Option<usize>,
+    follow_links: bool,
 ) {
     for dir_name in DISCOVERY_ALWAYS_DIRS {
         let dot_dir = walk_root.join(dir_name);
@@ -422,7 +464,7 @@ fn walk_always_discoverable_dirs(
         let mut builder = WalkBuilder::new(&dot_dir);
         builder
             .hidden(true)
-            .follow_links(false)
+            .follow_links(follow_links)
             .git_ignore(false)
             .ignore(false);
         if let Some(depth) = max_depth {
@@ -465,8 +507,9 @@ fn walk_for_completions(
     display_root: &Path,
     ctx: &mut SearchContext<'_>,
     max_depth: Option<usize>,
+    follow_links: bool,
 ) {
-    let builder = discovery_walk_builder(walk_root, max_depth);
+    let builder = discovery_walk_builder(walk_root, max_depth, follow_links);
 
     for entry in builder.build().flatten() {
         if ctx.is_full() {
@@ -497,7 +540,7 @@ fn walk_for_completions(
 
     // Also walk the AI-tool dot-directories with gitignore disabled so
     // `.deepseek/`, `.cursor/`, etc. are always discoverable.
-    walk_always_discoverable_dirs(walk_root, display_root, ctx, max_depth);
+    walk_always_discoverable_dirs(walk_root, display_root, ctx, max_depth, follow_links);
 }
 
 const LOCAL_REFERENCE_SCAN_LIMIT: usize = 4096;
@@ -507,12 +550,13 @@ fn add_local_reference_completions(
     display_root: &Path,
     ctx: &mut SearchContext<'_>,
     max_depth: Option<usize>,
+    follow_links: bool,
 ) {
     if !should_try_local_reference_completion(ctx.needle) {
         return;
     }
 
-    for path in local_reference_paths(root, LOCAL_REFERENCE_SCAN_LIMIT, max_depth) {
+    for path in local_reference_paths(root, LOCAL_REFERENCE_SCAN_LIMIT, max_depth, follow_links) {
         if ctx.is_full() {
             break;
         }
@@ -542,12 +586,17 @@ fn should_try_local_reference_completion(needle: &str) -> bool {
     needle.starts_with('.') || needle.contains('/') || needle.contains('\\')
 }
 
-fn local_reference_paths(root: &Path, limit: usize, max_depth: Option<usize>) -> Vec<PathBuf> {
+fn local_reference_paths(
+    root: &Path,
+    limit: usize,
+    max_depth: Option<usize>,
+    follow_links: bool,
+) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut builder = WalkBuilder::new(root);
     builder
         .hidden(false)
-        .follow_links(false)
+        .follow_links(follow_links)
         .git_ignore(false)
         .git_global(false)
         .git_exclude(false);
@@ -587,6 +636,7 @@ impl Clone for Workspace {
             cwd: self.cwd.clone(),
             file_index: OnceLock::new(),
             completion_walk_depth: self.completion_walk_depth,
+            follow_links: self.follow_links,
         }
     }
 }


### PR DESCRIPTION
Add workspace_follow_symlinks setting so walk-based tools and UI components follow symbolic links during directory traversal. See commit message for full details.