### PR TITLE
docs: add Linux build-time deps to cargo install guides

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -27,6 +27,10 @@ cargo install codewhale-cli --locked
 cargo install codewhale-tui --locked
 ```
 
+> **Linux ユーザーへ:** ビルド依存パッケージを先にインストールしてください:
+> `sudo apt-get install -y build-essential pkg-config libdbus-1-dev`。
+> 詳細は [INSTALL.md](docs/INSTALL.md#4-install-via-cargo-any-tier-1-rust-target) を参照。
+
 その他の経路:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ cargo install codewhale-cli --locked
 cargo install codewhale-tui --locked
 ```
 
+> **Linux users:** install system build dependencies first:
+> `sudo apt-get install -y build-essential pkg-config libdbus-1-dev`.
+> See [INSTALL.md](docs/INSTALL.md#4-install-via-cargo-any-tier-1-rust-target).
+
 Every other path:
 
 ```bash

--- a/README.vi.md
+++ b/README.vi.md
@@ -33,6 +33,10 @@ cargo install codewhale-cli --locked
 cargo install codewhale-tui --locked
 ```
 
+> **Người dùng Linux:** cài đặt các gói build trước:
+> `sudo apt-get install -y build-essential pkg-config libdbus-1-dev`.
+> Xem [INSTALL.md](docs/INSTALL.md#4-install-via-cargo-any-tier-1-rust-target).
+
 Mọi đường cài đặt khác:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,10 @@ cargo install codewhale-cli --locked
 cargo install codewhale-tui --locked
 ```
 
+> **Linux 用户注意：** 请先安装系统构建依赖：
+> `sudo apt-get install -y build-essential pkg-config libdbus-1-dev`。
+> 详见 [INSTALL.md](docs/INSTALL.md#4-install-via-cargo-any-tier-1-rust-target)。
+
 如果访问 GitHub 不稳定，推荐直接走下面的 CNB 镜像。其他安装路径：
 
 ```bash

--- a/docs/CNB_MIRROR.md
+++ b/docs/CNB_MIRROR.md
@@ -169,6 +169,9 @@ behind GitHub-blocking networks should use one of these paths:
   ```
   (Both binaries are required — the dispatcher and the TUI ship
   separately; see `AGENTS.md` for the two-binary install rationale.)
+  Linux build-time dependencies (`build-essential`, `pkg-config`,
+  `libdbus-1-dev` on Debian/Ubuntu) are required — see
+  [INSTALL.md](INSTALL.md#4-install-via-cargo-any-tier-1-rust-target).
 
 - **CNB release assets** for Linux x64, when the matching CNB tag pipeline has
   completed successfully. Download `codewhale-linux-x64`,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -158,6 +158,24 @@ cargo install codewhale-tui     --locked   # provides `codewhale-tui`
 codewhale --version
 ```
 
+> **Linux: install build-time dependencies first.** `cargo install` compiles
+> from source, and on Linux the `codewhale-tui` crate links against
+> `libdbus-1` (used by the D-Bus secret-service backend for credential
+> storage). Install the required system packages before running `cargo install`:
+>
+> ```bash
+> # Debian / Ubuntu
+> sudo apt-get install -y build-essential pkg-config libdbus-1-dev
+>
+> # Fedora / RHEL
+> sudo dnf install -y gcc make pkgconf-pkg-config dbus-devel
+> ```
+>
+> If you use the npm wrapper or download GitHub Release binaries, these
+> build-time packages are **not** required — the prebuilt binary only
+> needs the runtime library (`libdbus-1`), which is already present on
+> most desktop Linux installs.
+
 ### China / mirror-friendly install
 
 When installing from mainland China, configure mirrors for both **rustup**

--- a/scripts/tencent-lighthouse/bootstrap-ubuntu.sh
+++ b/scripts/tencent-lighthouse/bootstrap-ubuntu.sh
@@ -25,6 +25,7 @@ apt-get install -y \
   openssh-client \
   build-essential \
   pkg-config \
+  libdbus-1-dev \
   libssl-dev \
   nodejs \
   npm \


### PR DESCRIPTION
## Summary

`cargo install` fails on a bare Ubuntu 24.04 because `codewhale-tui` links against `libdbus-1` (via `dbus-secret-service` → `dbus` → `libdbus-sys`) which requires `libdbus-1-dev` and `pkg-config` at build time.

The "Build from source" section (`docs/INSTALL.md` §7) already listed these deps, but the "Install via Cargo" section (§4) and every localized README omitted them — so users following the `cargo install` path hit the `libdbus-sys` panic on a fresh Ubuntu install.

**Changes** (7 files, +38 lines):

| File | Change |
|------|--------|
| `docs/INSTALL.md` | Add Debian/Ubuntu + Fedora/RHEL build-dep commands in §4, plus note that prebuilt binaries don't need them |
| `README.md` | One-line hint + pointer to INSTALL.md after `cargo install` block |
| `README.zh-CN.md` | Same (Chinese) |
| `README.ja-JP.md` | Same (Japanese) |
| `README.vi.md` | Same (Vietnamese) |
| `docs/CNB_MIRROR.md` | Same note in the CNB `cargo install --git` section |
| `scripts/tencent-lighthouse/bootstrap-ubuntu.sh` | Add missing `libdbus-1-dev` to apt package list |

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features` 
- [ ] `cargo test --workspace --all-features` 

**all doc modify, no code change.**

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant 
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address 

Fixes: #3268
