### PR TITLE
docs: add Ponytail personality to project instructions

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,6 +13,12 @@ Each repo can carry two distinct, complementary files:
   canonical file for "how should an agent work in this repo." Run `/init` to
   scaffold one. `CLAUDE.md` and `.claude/instructions.md` are read as
   compatibility fallbacks.
+
+  For a pre-built personality that enforces lazy, minimal-code discipline,
+  copy [Ponytail's `AGENTS.md`](https://github.com/DietrichGebert/ponytail/blob/main/AGENTS.md)
+  as your project instructions. It cuts 80–94% of generated code in benchmarks
+  by forcing the agent to try stdlib, native features, and one-liners before
+  writing anything. No install, no plugin — just the instruction file.
 - **`.codewhale/constitution.json`** — CodeWhale-specific **repo authority /
   prioritization policy**: when local sources conflict, which should CodeWhale
   trust first, and what to verify before claiming a task is done. `.codewhale/`


### PR DESCRIPTION
Blocked by [DietrichGebert/ponytail#124](https://github.com/DietrichGebert/ponytail/pull/124) — Ponytail must officially list CodeWhale as a supported agent before CodeWhale recommends Ponytail to its users.

---

Adds a reference to [Ponytail](https://github.com/DietrichGebert/ponytail) in the Project instructions section of CONFIGURATION.md.

## What

Ponytail is a personality overlay (a pre-built `AGENTS.md`) that makes any AI agent lazy-efficient:
- 80–94% less code
- 47–77% cheaper
- 3–6× faster

## Why here

CodeWhale already reads `AGENTS.md` natively. Ponytail users can already copy the file and it works. This PR just surfaces that option in the docs so CodeWhale users know it exists.

## What changes

One paragraph in `docs/CONFIGURATION.md`, under the `AGENTS.md` bullet. No code changes.

## Prior art

- 14 agent adapters supported (Claude Code, Codex, Gemini, OpenCode, Cursor, Windsurf, Cline, Copilot, Kiro, Zed, Antigravity, OpenClaw, Pi, CodeWhale)
- 38k+ GitHub stars
- MIT licensed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
