### PR TITLE
feat(release): build static Linux x64 binaries with musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           components: clippy, rustfmt
       - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-musl'
         run: |
           for i in 1 2 3 4 5; do
             sudo apt-get update && break
@@ -111,7 +111,7 @@ jobs:
         include:
           # --- codewhale (cli dispatcher, canonical) ---
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             binary: codewhale
             artifact_name: codewhale-linux-x64
           - os: ubuntu-latest
@@ -136,7 +136,7 @@ jobs:
             artifact_name: codewhale-windows-x64.exe
           # --- codewhale-tui (TUI runtime, canonical) ---
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             binary: codewhale-tui
             artifact_name: codewhale-tui-linux-x64
           - os: ubuntu-latest
@@ -171,7 +171,7 @@ jobs:
         with:
           cache-bin: false
       - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-musl'
         run: |
           for i in 1 2 3 4 5; do
             sudo apt-get update && break
@@ -179,6 +179,14 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Build static Linux x64 binary (musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --locked --target x86_64-unknown-linux-musl
       - name: Install RISC-V cross-compilation toolchain
         if: matrix.target == 'riscv64gc-unknown-linux-gnu'
         run: |
@@ -215,6 +223,7 @@ jobs:
           sudo apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/arm64.sources -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0
           sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross libdbus-1-dev:arm64 pkg-config
       - name: Build
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         shell: bash
         env:
           DEEPSEEK_BUILD_SHA: ${{ needs.resolve.outputs.sha }}


### PR DESCRIPTION
## Summary

Switch Linux x64 release builds from dynamic glibc (`x86_64-unknown-linux-gnu`) to static musl (`x86_64-unknown-linux-musl`) in the GitHub Actions release workflow.

This is the GitHub Actions counterpart to **PR #2903** which added musl static builds to the CNB pipeline (`.cnb.yml`).

### Changes

| Area | Before | After |
|------|--------|-------|
| Matrix target (codewhale) | `x86_64-unknown-linux-gnu` | `x86_64-unknown-linux-musl` |
| Matrix target (codewhale-tui) | `x86_64-unknown-linux-gnu` | `x86_64-unknown-linux-musl` |
| Linux deps install | All Linux targets | Exclude musl (no libdbus needed) |
| Build step | Single generic `cargo build` | Dedicated musl step + generic step (skip musl) |

### Details

- **Matrix**: Change `target` for `codewhale-linux-x64` and `codewhale-tui-linux-x64` from `gnu` to `musl`
- **Dedicated musl build step**: Installs `musl-tools`, adds `x86_64-unknown-linux-musl` target, then builds
- **Skip libdbus for musl**: The `keyring` feature is already gated behind `target != musl` in `crates/secrets` (from PR #2903), so no `libdbus-1-dev` needed
- **Skip generic Build step for musl**: The dedicated step handles musl builds; generic step runs for all other targets

### Why

Static musl binaries have **no glibc/libdbus runtime dependency** and run on any Linux distribution without additional packages — matching what the CNB pipeline already produces.

### Testing

This change mirrors the CNB pipeline approach (PR #2903, merged). The GitHub Actions workflow will be validated on the next release dispatch.