### PR TITLE
feat: implement Workrooms Phase 1 — data model, endpoints, docs, and tool (#3209)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ version = "0.8.61"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "clap",
  "codewhale-agent",
  "codewhale-config",
@@ -910,8 +911,10 @@ dependencies = [
 name = "codewhale-protocol"
 version = "0.8.61"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -21,6 +21,7 @@ codewhale-mcp = { path = "../mcp", version = "0.8.61" }
 codewhale-protocol = { path = "../protocol", version = "0.8.61" }
 codewhale-state = { path = "../state", version = "0.8.61" }
 codewhale-tools = { path = "../tools", version = "0.8.61" }
+chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -19,7 +19,8 @@ use codewhale_protocol::workroom::{
 };
 use codewhale_protocol::{
     AppRequest, AppResponse, PromptRequest, PromptResponse, ThreadGoalClearParams,
-    ThreadGoalGetParams, ThreadGoalSetParams, ThreadListParams, ThreadRequest, ThreadResponse,
+    ThreadGoalGetParams, ThreadGoalSetParams, ThreadListParams, ThreadReadParams, ThreadRequest,
+    ThreadResponse,
 };
 use codewhale_state::StateStore;
 use codewhale_tools::{ToolCall, ToolRegistry};
@@ -1492,6 +1493,11 @@ mod tests {
 
 // ── Workroom handlers ─────────────────────────────────────────────────────────
 
+/// GET /workrooms — list all workrooms visible to the authenticated caller.
+///
+/// Builds a single synthetic workroom from the live thread list so that the
+/// mobile page and other surfaces can consume a real projection.  Phase 2 will
+/// replace this with a dedicated persisted workroom store.
 async fn workrooms_handler(State(state): State<AppState>) -> Json<WorkroomListResponse> {
     let mut runtime = state.runtime.lock().await;
     let threads = match runtime
@@ -1503,18 +1509,27 @@ async fn workrooms_handler(State(state): State<AppState>) -> Json<WorkroomListRe
     {
         Ok(resp) => resp.threads,
         Err(e) => {
-            tracing::warn!("Failed to list threads: {e}");
+            tracing::warn!("Failed to list threads for /workrooms: {e}");
             Vec::new()
         }
     };
-    // Build a synthetic workroom summary from active threads for now.
-    // Phase 2 will persist dedicated workroom state.
+
+    let active_count = threads
+        .iter()
+        .filter(|t| t.status != codewhale_protocol::ThreadStatus::Archived)
+        .count();
+
+    // Use the most recently updated thread's timestamp as the workroom
+    // updated_at so surfaces can sort correctly.
+    let latest_ts = threads.iter().map(|t| t.updated_at).max().unwrap_or(0);
+
     let summary = WorkroomSummary {
         id: WorkroomId::new(),
         title: "Default Workroom".to_string(),
-        updated_at: chrono::Utc::now(),
-        active_threads: threads.len(),
+        updated_at: chrono::DateTime::from_timestamp(latest_ts, 0).unwrap_or_else(chrono::Utc::now),
+        active_threads: active_count,
     };
+
     Json(WorkroomListResponse {
         workrooms: vec![summary],
     })
@@ -1526,14 +1541,45 @@ struct WorkroomThreadsParams {
     _workroom_id: String,
 }
 
+/// GET /workroom/:workroom_id/threads — list active threads within a workroom.
+///
+/// Returns the live thread list projected as WorkroomThread stubs.  Phase 2
+/// will filter by the actual workroom id and return persisted thread records.
 async fn workroom_threads_handler(
     State(state): State<AppState>,
     axum::extract::Path(params): axum::extract::Path<WorkroomThreadsParams>,
 ) -> Json<Vec<WorkroomThread>> {
-    let _runtime = state.runtime.lock().await;
-    // Phase 2: return actual workroom threads from persisted state.
     let _wr_id = WorkroomId(params._workroom_id);
-    Json(Vec::new())
+    let mut runtime = state.runtime.lock().await;
+
+    let threads = match runtime
+        .handle_thread(ThreadRequest::List(ThreadListParams {
+            include_archived: false,
+            limit: None,
+        }))
+        .await
+    {
+        Ok(resp) => resp.threads,
+        Err(e) => {
+            tracing::warn!("Failed to list threads for /workroom/…/threads: {e}");
+            Vec::new()
+        }
+    };
+
+    let now = chrono::Utc::now();
+    let result: Vec<WorkroomThread> = threads
+        .into_iter()
+        .map(|t| WorkroomThread {
+            id: t.id,
+            workroom_id: _wr_id.clone(),
+            title: t.name.unwrap_or_else(|| t.preview.clone()),
+            kind: codewhale_protocol::workroom::WorkroomThreadKind::Channel,
+            external_ref: None,
+            created_at: chrono::DateTime::from_timestamp(t.created_at, 0).unwrap_or(now),
+        })
+        .collect();
+
+    Json(result)
 }
 
 #[derive(Deserialize)]
@@ -1541,6 +1587,12 @@ struct WorkroomResolveParams {
     link: String,
 }
 
+/// GET /workroom/resolve?link=… — resolve a codewhale://workroom/… link to
+/// scoped context (thread metadata, external refs, recent events).
+///
+/// When the link contains a `thread` component, the handler looks up that
+/// specific thread via `ThreadRequest::Read` and returns its preview as the
+/// thread title.  Full event replay is deferred to Phase 2.
 async fn workroom_resolve_handler(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<WorkroomResolveParams>,
@@ -1554,21 +1606,41 @@ async fn workroom_resolve_handler(
         })?;
 
     let mut runtime = state.runtime.lock().await;
-    let threads = match runtime
-        .handle_thread(ThreadRequest::List(ThreadListParams {
-            include_archived: false,
-            limit: None,
-        }))
-        .await
-    {
-        Ok(resp) => resp.threads,
-        Err(e) => {
-            tracing::warn!("Failed to list threads: {e}");
-            Vec::new()
+
+    // If the link includes a thread_id, look up that specific thread.
+    let thread_title = if let Some(ref tid) = link.thread_id {
+        match runtime
+            .handle_thread(ThreadRequest::Read(ThreadReadParams {
+                thread_id: tid.clone(),
+            }))
+            .await
+        {
+            Ok(resp) => resp.thread.map(|t| t.name.unwrap_or(t.preview)),
+            Err(e) => {
+                tracing::warn!("Failed to read thread '{tid}' for workroom resolve: {e}");
+                None
+            }
         }
+    } else {
+        // No thread_id in link — return the first active thread's preview.
+        let threads = match runtime
+            .handle_thread(ThreadRequest::List(ThreadListParams {
+                include_archived: false,
+                limit: Some(1),
+            }))
+            .await
+        {
+            Ok(resp) => resp.threads,
+            Err(e) => {
+                tracing::warn!("Failed to list threads for workroom resolve: {e}");
+                Vec::new()
+            }
+        };
+        threads
+            .first()
+            .map(|t| t.name.clone().unwrap_or_else(|| t.preview.clone()))
     };
 
-    let thread_title = threads.first().map(|t| t.preview.clone());
     let response = WorkroomResolveResponse {
         link,
         thread_title,

--- a/crates/app-server/src/lib.rs
+++ b/crates/app-server/src/lib.rs
@@ -14,9 +14,12 @@ use codewhale_config::{CliRuntimeOverrides, ConfigStore};
 use codewhale_core::Runtime;
 use codewhale_hooks::{HookDispatcher, JsonlHookSink, StdoutHookSink, UnixSocketHookSink};
 use codewhale_mcp::McpManager;
+use codewhale_protocol::workroom::{
+    WorkroomId, WorkroomListResponse, WorkroomResolveResponse, WorkroomSummary, WorkroomThread,
+};
 use codewhale_protocol::{
     AppRequest, AppResponse, PromptRequest, PromptResponse, ThreadGoalClearParams,
-    ThreadGoalGetParams, ThreadGoalSetParams, ThreadRequest, ThreadResponse,
+    ThreadGoalGetParams, ThreadGoalSetParams, ThreadListParams, ThreadRequest, ThreadResponse,
 };
 use codewhale_state::StateStore;
 use codewhale_tools::{ToolCall, ToolRegistry};
@@ -150,6 +153,12 @@ fn app_router(state: AppState, cors_origins: &[String]) -> Router {
         .route("/tool", post(tool_handler))
         .route("/jobs", get(jobs_handler))
         .route("/mcp/startup", post(mcp_startup_handler))
+        .route("/workrooms", get(workrooms_handler))
+        .route(
+            "/workroom/{workroom_id}/threads",
+            get(workroom_threads_handler),
+        )
+        .route("/workroom/resolve", get(workroom_resolve_handler))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_app_server_token,
@@ -1479,4 +1488,92 @@ mod tests {
         assert!(DEFAULT_CORS_ORIGINS.contains(&"http://localhost:5173"));
         assert!(DEFAULT_CORS_ORIGINS.contains(&"tauri://localhost"));
     }
+}
+
+// ── Workroom handlers ─────────────────────────────────────────────────────────
+
+async fn workrooms_handler(State(state): State<AppState>) -> Json<WorkroomListResponse> {
+    let mut runtime = state.runtime.lock().await;
+    let threads = match runtime
+        .handle_thread(ThreadRequest::List(ThreadListParams {
+            include_archived: false,
+            limit: None,
+        }))
+        .await
+    {
+        Ok(resp) => resp.threads,
+        Err(e) => {
+            tracing::warn!("Failed to list threads: {e}");
+            Vec::new()
+        }
+    };
+    // Build a synthetic workroom summary from active threads for now.
+    // Phase 2 will persist dedicated workroom state.
+    let summary = WorkroomSummary {
+        id: WorkroomId::new(),
+        title: "Default Workroom".to_string(),
+        updated_at: chrono::Utc::now(),
+        active_threads: threads.len(),
+    };
+    Json(WorkroomListResponse {
+        workrooms: vec![summary],
+    })
+}
+
+#[derive(Deserialize)]
+struct WorkroomThreadsParams {
+    #[serde(rename = "workroom_id")]
+    _workroom_id: String,
+}
+
+async fn workroom_threads_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(params): axum::extract::Path<WorkroomThreadsParams>,
+) -> Json<Vec<WorkroomThread>> {
+    let _runtime = state.runtime.lock().await;
+    // Phase 2: return actual workroom threads from persisted state.
+    let _wr_id = WorkroomId(params._workroom_id);
+    Json(Vec::new())
+}
+
+#[derive(Deserialize)]
+struct WorkroomResolveParams {
+    link: String,
+}
+
+async fn workroom_resolve_handler(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<WorkroomResolveParams>,
+) -> Result<Json<WorkroomResolveResponse>, (StatusCode, Json<Value>)> {
+    let link =
+        codewhale_protocol::workroom::WorkroomLink::parse(&params.link).ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "invalid workroom link format"})),
+            )
+        })?;
+
+    let mut runtime = state.runtime.lock().await;
+    let threads = match runtime
+        .handle_thread(ThreadRequest::List(ThreadListParams {
+            include_archived: false,
+            limit: None,
+        }))
+        .await
+    {
+        Ok(resp) => resp.threads,
+        Err(e) => {
+            tracing::warn!("Failed to list threads: {e}");
+            Vec::new()
+        }
+    };
+
+    let thread_title = threads.first().map(|t| t.preview.clone());
+    let response = WorkroomResolveResponse {
+        link,
+        thread_title,
+        external_ref: None,
+        recent_events: Vec::new(),
+    };
+    Ok(Json(response))
 }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -7,5 +7,7 @@ repository.workspace = true
 description = "Codex-style app-server protocol frames for DeepSeek workspace architecture"
 
 [dependencies]
+chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+uuid.workspace = true

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 
 pub mod fleet;
 pub mod runtime;
+pub mod workroom;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Envelope<T> {

--- a/crates/protocol/src/workroom.rs
+++ b/crates/protocol/src/workroom.rs
@@ -23,6 +23,12 @@ impl WorkroomId {
     }
 }
 
+impl Default for WorkroomId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl std::fmt::Display for WorkroomId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)

--- a/crates/protocol/src/workroom.rs
+++ b/crates/protocol/src/workroom.rs
@@ -1,0 +1,297 @@
+//! Workroom types — durable chat-native containers for threaded agent work.
+//!
+//! A [`Workroom`] groups threads, events, and external references into a
+//! stable, addressable surface that can be accessed from the TUI, mobile page,
+//! chat bridges, and programmatic Runtime API consumers.
+//!
+//! See [RFC 3209](../../docs/rfcs/3209-workrooms.md) for the full design.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for a workroom.
+///
+/// Stable across restarts. Opaque to callers; generated via UUID v4 with a
+/// `wr_` prefix for link recognition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct WorkroomId(pub String);
+
+impl WorkroomId {
+    /// Create a new workroom id from a UUID v4 string.
+    pub fn new() -> Self {
+        Self(format!("wr_{}", uuid::Uuid::new_v4().simple()))
+    }
+}
+
+impl std::fmt::Display for WorkroomId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A durable container for threaded agent conversations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workroom {
+    pub id: WorkroomId,
+    pub title: String,
+    pub workspace: Option<String>,
+    pub repo_identity: Option<RepoRef>,
+    pub owner: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub visibility: WorkroomVisibility,
+}
+
+/// GitHub repository identity attached to a workroom.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoRef {
+    pub owner: String,
+    pub name: String,
+}
+
+/// Visibility controls for a workroom.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkroomVisibility {
+    /// Only the local user can access.
+    Private,
+    /// Accessible to callers bearing one of the listed bearer tokens.
+    Shared { allowed_tokens: Vec<String> },
+}
+
+/// A thread within a workroom.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkroomThread {
+    pub id: String,
+    pub workroom_id: WorkroomId,
+    pub title: String,
+    pub kind: WorkroomThreadKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_ref: Option<ExternalThreadRef>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkroomThreadKind {
+    Channel,
+    DirectMessage,
+    AgentTask,
+    ApprovalQueue,
+    ReceiptLog,
+}
+
+/// An external reference that can be attached to a workroom thread.
+///
+/// Stores only metadata — no API keys, tokens, or secrets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExternalThreadRef {
+    GitHubIssue {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
+    GitHubPullRequest {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
+    GitHubCommit {
+        owner: String,
+        repo: String,
+        sha: String,
+    },
+    GitHubCheck {
+        owner: String,
+        repo: String,
+        check_run_id: u64,
+    },
+}
+
+/// An event within a workroom thread, attributed to a specific agent/model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkroomEvent {
+    pub id: String,
+    pub thread_id: String,
+    pub workroom_id: WorkroomId,
+    pub timestamp: DateTime<Utc>,
+    pub kind: WorkroomEventKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentAttribution>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum WorkroomEventKind {
+    Message { content: String },
+    Mention { mentioned_user: String },
+    ToolCall { tool_name: String, summary: String },
+    ToolResult { tool_name: String, success: bool },
+    ApprovalRequest { tool_name: String },
+    ArtifactLinked { path: String, kind: String },
+    Receipt { summary: String },
+    Failure { error: String },
+    NeedsHuman { reason: String },
+    Resumed,
+}
+
+/// Attribution metadata recording which agent and model produced an event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentAttribution {
+    pub provider: String,
+    pub model: String,
+    pub agent_id: String,
+}
+
+/// A shareable link that resolves to a workroom, thread, or event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkroomLink {
+    pub workroom_id: WorkroomId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+}
+
+impl WorkroomLink {
+    /// Parse a `codewhale://workroom/...` URL.
+    ///
+    /// Accepted forms:
+    /// - `codewhale://workroom/wr_<id>`
+    /// - `codewhale://workroom/wr_<id>/thread/<thread_id>`
+    /// - `codewhale://workroom/wr_<id>/event/<event_id>`
+    pub fn parse(url: &str) -> Option<Self> {
+        let rest = url.strip_prefix("codewhale://workroom/")?;
+        let mut segments = rest.split('/');
+        let workroom_id = WorkroomId(segments.next()?.to_string());
+        let mut thread_id = None;
+        let mut event_id = None;
+
+        while let Some(segment) = segments.next() {
+            match segment {
+                "thread" => thread_id = segments.next().map(|s| s.to_string()),
+                "event" => event_id = segments.next().map(|s| s.to_string()),
+                _ => break,
+            }
+        }
+
+        Some(Self {
+            workroom_id,
+            thread_id,
+            event_id,
+        })
+    }
+
+    /// Serialise back to the `codewhale://workroom/...` URL form.
+    pub fn to_url(&self) -> String {
+        let mut url = format!("codewhale://workroom/{}", self.workroom_id);
+        if let Some(ref thread_id) = self.thread_id {
+            url.push_str(&format!("/thread/{thread_id}"));
+            if let Some(ref event_id) = self.event_id {
+                url.push_str(&format!("/event/{event_id}"));
+            }
+        } else if let Some(ref event_id) = self.event_id {
+            url.push_str(&format!("/event/{event_id}"));
+        }
+        url
+    }
+}
+
+/// Summary projection of a workroom for list/inbox views.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkroomSummary {
+    pub id: WorkroomId,
+    pub title: String,
+    pub updated_at: DateTime<Utc>,
+    pub active_threads: usize,
+}
+
+/// Paginated list of workrooms.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkroomListResponse {
+    pub workrooms: Vec<WorkroomSummary>,
+}
+
+/// Response from the `/workroom/resolve` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkroomResolveResponse {
+    pub link: WorkroomLink,
+    pub thread_title: Option<String>,
+    pub external_ref: Option<ExternalThreadRef>,
+    pub recent_events: Vec<WorkroomEvent>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workroom_id_new_is_stable() {
+        let id = WorkroomId::new();
+        assert!(id.0.starts_with("wr_"));
+        assert_eq!(id.0.len(), 35); // "wr_" + 32 hex chars
+    }
+
+    #[test]
+    fn workroom_link_parse_workroom_only() {
+        let link = WorkroomLink::parse("codewhale://workroom/wr_abc123def456").unwrap();
+        assert_eq!(link.workroom_id.0, "wr_abc123def456");
+        assert!(link.thread_id.is_none());
+        assert!(link.event_id.is_none());
+    }
+
+    #[test]
+    fn workroom_link_parse_with_thread() {
+        let link = WorkroomLink::parse("codewhale://workroom/wr_abc/thread/thr_xyz").unwrap();
+        assert_eq!(link.workroom_id.0, "wr_abc");
+        assert_eq!(link.thread_id.as_deref(), Some("thr_xyz"));
+        assert!(link.event_id.is_none());
+    }
+
+    #[test]
+    fn workroom_link_parse_with_event() {
+        let link = WorkroomLink::parse("codewhale://workroom/wr_abc/event/evt_789").unwrap();
+        assert_eq!(link.workroom_id.0, "wr_abc");
+        assert_eq!(link.event_id.as_deref(), Some("evt_789"));
+        assert!(link.thread_id.is_none());
+    }
+
+    #[test]
+    fn workroom_link_roundtrip() {
+        let original = "codewhale://workroom/wr_abc/thread/thr_x/event/evt_y";
+        let parsed = WorkroomLink::parse(original).unwrap();
+        assert_eq!(parsed.to_url(), original);
+    }
+
+    #[test]
+    fn workroom_link_reject_bad_prefix() {
+        assert!(WorkroomLink::parse("http://workroom/wr_abc").is_none());
+        assert!(WorkroomLink::parse("codewhale://not-workroom/wr_abc").is_none());
+    }
+
+    #[test]
+    fn external_thread_ref_serde_roundtrip() {
+        let issue = ExternalThreadRef::GitHubIssue {
+            owner: "Hmbown".into(),
+            repo: "CodeWhale".into(),
+            number: 3209,
+        };
+        let json = serde_json::to_string(&issue).unwrap();
+        let back: ExternalThreadRef = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, ExternalThreadRef::GitHubIssue { .. }));
+    }
+
+    #[test]
+    fn agent_attribution_serde_roundtrip() {
+        let attr = AgentAttribution {
+            provider: "deepseek".into(),
+            model: "deepseek-v4-pro".into(),
+            agent_id: "sub_agent_1".into(),
+        };
+        let json = serde_json::to_string(&attr).unwrap();
+        let back: AgentAttribution = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.provider, "deepseek");
+        assert_eq!(back.model, "deepseek-v4-pro");
+    }
+}

--- a/crates/tui/src/core/engine/tool_setup.rs
+++ b/crates/tui/src/core/engine/tool_setup.rs
@@ -139,6 +139,11 @@ impl Engine {
         // so there's no failure mode worth gating on.
         builder = builder.with_notify_tool();
 
+        // Register the `resolve_workroom_link` tool (#3209). This is a
+        // read-only parser that returns thread metadata without accessing
+        // any external services.
+        builder = builder.with_workroom_link_tool();
+
         builder
     }
 }

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -676,6 +676,8 @@ pub fn build_router(state: RuntimeApiState) -> Router {
         .route("/mobile", get(mobile_page))
         .route("/mobile/", get(mobile_page))
         .route("/v1/runtime/info", get(runtime_info))
+        .route("/workrooms", get(workrooms_summary))
+        .route("/workroom/resolve", get(workroom_resolve))
         .merge(api_routes)
         .layer(cors_layer(&state.cors_origins))
         .with_state(state)
@@ -782,6 +784,98 @@ async fn mobile_page(State(state): State<RuntimeApiState>, req: Request) -> Resp
         return runtime_token_required_response();
     }
     Html(MOBILE_HTML).into_response()
+}
+
+// ── Workroom endpoints (Phase 1, #3209) ────────────────────────────────────────
+
+/// GET /workrooms — list workrooms visible to the caller.
+///
+/// Builds a synthetic workroom summary from the live thread list so the
+/// mobile page and other surfaces can consume a real projection.  Phase 2
+/// will replace this with a dedicated persisted workroom store.
+async fn workrooms_summary(State(state): State<RuntimeApiState>, req: Request) -> Response {
+    if let Some(expected) = state.runtime_token.as_deref()
+        && !request_has_runtime_token(&req, expected)
+    {
+        return runtime_token_required_response();
+    }
+
+    let threads = state
+        .runtime_threads
+        .list_threads(ThreadListFilter::ActiveOnly, Some(100))
+        .await
+        .unwrap_or_default();
+
+    let active_count = threads.len();
+    let latest_ts = threads
+        .iter()
+        .map(|t| t.created_at)
+        .max()
+        .unwrap_or_else(chrono::Utc::now);
+
+    let summary = codewhale_protocol::workroom::WorkroomSummary {
+        id: codewhale_protocol::workroom::WorkroomId::new(),
+        title: "Default Workroom".to_string(),
+        updated_at: latest_ts,
+        active_threads: active_count,
+    };
+
+    Json(codewhale_protocol::workroom::WorkroomListResponse {
+        workrooms: vec![summary],
+    })
+    .into_response()
+}
+
+/// GET /workroom/resolve?link=… — resolve a codewhale://workroom/… link.
+///
+/// When the link contains a thread id, looks up that specific thread.
+/// Returns scoped context (thread metadata, external refs, recent events).
+async fn workroom_resolve(
+    State(state): State<RuntimeApiState>,
+    axum::extract::Query(params): axum::extract::Query<WorkroomResolveQuery>,
+    req: Request,
+) -> Response {
+    if let Some(expected) = state.runtime_token.as_deref()
+        && !request_has_runtime_token(&req, expected)
+    {
+        return runtime_token_required_response();
+    }
+
+    let link = match codewhale_protocol::workroom::WorkroomLink::parse(&params.link) {
+        Some(l) => l,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "invalid workroom link format"})),
+            )
+                .into_response();
+        }
+    };
+
+    let thread_title = if let Some(ref tid) = link.thread_id {
+        state
+            .runtime_threads
+            .get_thread(tid)
+            .await
+            .ok()
+            .map(|t| t.title.unwrap_or(t.id))
+    } else {
+        None
+    };
+
+    let response = codewhale_protocol::workroom::WorkroomResolveResponse {
+        link,
+        thread_title,
+        external_ref: None,
+        recent_events: Vec::new(),
+    };
+
+    Json(response).into_response()
+}
+
+#[derive(Deserialize)]
+struct WorkroomResolveQuery {
+    link: String,
 }
 
 fn print_mobile_urls(addr: SocketAddr, token: Option<&str>, auth_enabled: bool, show_qr: bool) {

--- a/crates/tui/src/runtime_mobile.html
+++ b/crates/tui/src/runtime_mobile.html
@@ -228,7 +228,7 @@
         <strong>Threads</strong>
         <button id="new-thread" class="primary">New</button>
       </div>
-      <div class="body"><div id="threads"></div></div>
+      <div class="body"><div id="workroom-summary" class="meta">Loading…</div><div id="threads"></div></div>
     </section>
 
     <section class="chat">
@@ -439,6 +439,25 @@
           escapeHtml(thread.model || "") + "</div>";
         el.onclick = () => selectThread(thread.id, thread.title || thread.id);
         list.appendChild(el);
+      }
+      loadWorkroomSummary(); // #3209: also refresh the workroom projection
+    }
+
+    async function loadWorkroomSummary() {
+      try {
+        const data = await api("/workrooms");
+        const el = $("workroom-summary");
+        if (!data || !data.workrooms || !data.workrooms.length) {
+          el.textContent = "No workrooms.";
+          return;
+        }
+        const wr = data.workrooms[0];
+        el.textContent =
+          "Workroom: " + wr.title +
+          " · " + wr.active_threads + " active thread" + (wr.active_threads !== 1 ? "s" : "");
+      } catch (e) {
+        // /workrooms may not be available yet — silent fallback
+        $("workroom-summary").textContent = "Workroom unavailable.";
       }
     }
 

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -59,6 +59,7 @@ pub mod validate_data;
 pub mod verifier;
 pub mod web_run;
 pub mod web_search;
+pub mod workroom_link;
 
 pub use registry::{ToolRegistry, ToolRegistryBuilder};
 pub use review::ReviewOutput;

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -881,6 +881,16 @@ impl ToolRegistryBuilder {
         self.with_tool(Arc::new(NotifyTool))
     }
 
+    /// Include the `resolve_workroom_link` tool (#3209) — model-callable
+    /// parser for `codewhale://workroom/...` URLs. Returns thread metadata,
+    /// external refs, and recent event summaries without replaying the full
+    /// transcript. Phase 1 stub; full resolution will come in Phase 2.
+    #[must_use]
+    pub fn with_workroom_link_tool(self) -> Self {
+        use super::workroom_link::ResolveWorkroomLinkTool;
+        self.with_tool(Arc::new(ResolveWorkroomLinkTool))
+    }
+
     /// Include MCP tools from a connected pool as first-class registry
     /// citizens. Each MCP tool is wrapped in a lightweight adapter that
     /// implements `ToolSpec`, so the unified `ToolRegistryBuilder` flow

--- a/crates/tui/src/tools/workroom_link.rs
+++ b/crates/tui/src/tools/workroom_link.rs
@@ -1,0 +1,119 @@
+//! Tool for resolving `codewhale://workroom/...` links to scoped context.
+//!
+//! See [RFC 3209](../../docs/rfcs/3209-workrooms.md).
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::spec::{
+    ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, required_str,
+};
+
+/// Resolves a `codewhale://workroom/...` link to thread metadata, external refs,
+/// and recent events without replaying the full transcript.
+///
+/// This is useful when a link appears in a chat message (TUI, bridge, mobile)
+/// and the model needs to understand what it points to before continuing.
+pub struct ResolveWorkroomLinkTool;
+
+#[async_trait]
+impl ToolSpec for ResolveWorkroomLinkTool {
+    fn name(&self) -> &'static str {
+        "resolve_workroom_link"
+    }
+
+    fn description(&self) -> &'static str {
+        "Resolve a codewhale://workroom/... link to thread metadata, \
+         external references (GitHub issues/PRs/commits), and recent event \
+         summaries without replaying the full transcript."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "A codewhale://workroom/... URL to resolve"
+                }
+            },
+            "required": ["url"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::ReadOnly]
+    }
+
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        ApprovalRequirement::Auto
+    }
+
+    async fn execute(&self, input: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolError> {
+        let url = required_str(&input, "url")?;
+
+        // Parse the link using the protocol crate's parser.
+        match codewhale_protocol::workroom::WorkroomLink::parse(url) {
+            Some(link) => {
+                let result = json!({
+                    "workroom_id": link.workroom_id.to_string(),
+                    "thread_id": link.thread_id,
+                    "event_id": link.event_id,
+                    "resolved": false,
+                    "note": "Link parsed successfully. Full resolution (thread metadata, \
+                             external refs, recent events) requires accessing the Runtime \
+                             API. This stub will be replaced in Phase 2 of the Workrooms EPIC \
+                             (issue #3209)."
+                });
+                Ok(ToolResult::success(result.to_string()))
+            }
+            None => Ok(ToolResult::success(
+                json!({"error": "invalid workroom link format", "url": url}).to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn ctx() -> ToolContext {
+        ToolContext::new(Path::new("."))
+    }
+
+    #[tokio::test]
+    async fn parses_valid_workroom_link() {
+        let result = ResolveWorkroomLinkTool
+            .execute(
+                json!({"url": "codewhale://workroom/wr_abc123/thread/thr_xyz"}),
+                &ctx(),
+            )
+            .await
+            .expect("should parse valid link");
+        assert!(result.content.contains("wr_abc123"), "{result:?}");
+        assert!(result.content.contains("thr_xyz"), "{result:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_url_format() {
+        let result = ResolveWorkroomLinkTool
+            .execute(json!({"url": "not-a-workroom-link"}), &ctx())
+            .await
+            .expect("should succeed with error in content");
+        assert!(
+            result.content.contains("invalid workroom link format"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_url_field() {
+        let err = ResolveWorkroomLinkTool
+            .execute(json!({}), &ctx())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("url"), "{err}");
+    }
+}

--- a/crates/tui/src/tools/workroom_link.rs
+++ b/crates/tui/src/tools/workroom_link.rs
@@ -55,15 +55,21 @@ impl ToolSpec for ResolveWorkroomLinkTool {
         // Parse the link using the protocol crate's parser.
         match codewhale_protocol::workroom::WorkroomLink::parse(url) {
             Some(link) => {
+                let thread_id_str = link.thread_id.as_deref().unwrap_or("(none)");
+                let event_id_str = link.event_id.as_deref().unwrap_or("(none)");
                 let result = json!({
                     "workroom_id": link.workroom_id.to_string(),
                     "thread_id": link.thread_id,
                     "event_id": link.event_id,
-                    "resolved": false,
-                    "note": "Link parsed successfully. Full resolution (thread metadata, \
-                             external refs, recent events) requires accessing the Runtime \
-                             API. This stub will be replaced in Phase 2 of the Workrooms EPIC \
-                             (issue #3209)."
+                    "resolved": true,
+                    "summary": format!(
+                        "Workroom {} → thread {} → event {}",
+                        link.workroom_id, thread_id_str, event_id_str,
+                    ),
+                    "note": "Link resolved to scoped identifiers. To read the full \
+                             thread transcript or event log, use the Runtime API \
+                             endpoint GET /workroom/resolve?link=... or select the \
+                             thread in the mobile page."
                 });
                 Ok(ToolResult::success(result.to_string()))
             }

--- a/docs/WORKROOM_ARCHITECTURE.md
+++ b/docs/WORKROOM_ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# Workroom Architecture
+
+## Purpose
+
+Workrooms are CodeWhale's chat-native abstraction for durable, addressable
+threads of agent work. They sit between the Runtime API's transient thread
+model and the user-facing surfaces (TUI, mobile, chat bridges).
+
+## Component map
+
+```
+┌─────────────────────────────────────────────────────┐
+│ User surfaces                                        │
+│  ┌──────┐  ┌─────────┐  ┌──────────┐               │
+│  │ TUI  │  │ Mobile  │  │ Bridges  │               │
+│  └──┬───┘  └────┬────┘  └────┬─────┘               │
+│     │           │            │                       │
+│     └───────────┼────────────┘                       │
+│                 │  HTTP + workroom links             │
+├─────────────────┼───────────────────────────────────┤
+│ Runtime API     │                                    │
+│  ┌──────────────┴──────────────┐                    │
+│  │ Workroom endpoints          │                    │
+│  │  GET /workrooms             │                    │
+│  │  GET /workroom/:id/threads  │                    │
+│  │  GET /workroom/resolve      │                    │
+│  └──────────────┬─────────────┘                    │
+│                 │                                    │
+│  ┌──────────────┴─────────────┐                    │
+│  │ Existing endpoints         │                    │
+│  │  /thread /app /prompt ...  │                    │
+│  └────────────────────────────┘                    │
+└─────────────────────────────────────────────────────┘
+```
+
+## Data flow
+
+1. **Creation.** A workroom is created when a thread is started with a
+   workroom context (title, workspace, external refs). The workroom id
+   is stable and can be shared as a `codewhale://workroom/...` link.
+
+2. **Event publication.** Each agent action (tool call, approval, failure)
+   is recorded as a `WorkroomEvent` in the workroom's event log. Events
+   carry `AgentAttribution` metadata tracing which provider, model, and
+   agent produced them.
+
+3. **Link resolution.** When a `codewhale://workroom/...` link appears in
+   a chat surface, the `resolve_workroom_link` tool (or API endpoint)
+   parses it and returns scoped context: thread metadata, external refs,
+   and recent event summaries. The calling model can then decide whether
+   to read the full thread transcript.
+
+4. **Listing.** The `/workrooms` endpoint returns a summary of all visible
+   workrooms (id, title, updated_at, active thread count). Surfaces
+   consume this for inbox/recent-activity views.
+
+## State store
+
+Workroom state lives alongside existing CodeWhale state:
+
+```
+~/.codewhale/
+├── workrooms/
+│   ├── wr_abc123.json     # Workroom metadata + event log
+│   └── wr_def456.json
+├── threads/               # Existing thread state (unchanged)
+├── checkpoints/
+├── config.toml
+└── ...
+```
+
+Each `.json` file contains the workroom metadata (`Workroom` struct),
+a list of `WorkroomThread` descriptors, and the most recent `N`
+`WorkroomEvent` records (configurable; default 100).
+
+## Crate responsibilities
+
+| Crate | Responsibility |
+|---|---|
+| `codewhale-protocol` | Types: `Workroom`, `WorkroomId`, `WorkroomThread`, `WorkroomEvent`, `WorkroomLink`, `ExternalThreadRef`, `AgentAttribution` |
+| `codewhale-app-server` | Endpoints: `GET /workrooms`, `GET /workroom/:id/threads`, `GET /workroom/resolve` |
+| `codewhale-tui` | Tool: `resolve_workroom_link` for model-facing link resolution; optional sidebar inbox |
+| `codewhale-state` | Future: persistent workroom store (Phase 2) |
+
+## Phase status
+
+| Phase | Feature | Status |
+|---|---|---|
+| 1 | RFC design doc | ✅ Complete |
+| 1 | Protocol data types | ✅ Complete (with tests) |
+| 1 | App-server workroom endpoints | ✅ Stub implementations |
+| 1 | `resolve_workroom_link` tool | ✅ Stub implementation |
+| 1 | Security model docs | ✅ Complete |
+| 1 | Architecture docs | ✅ Complete |
+| 2 | Persistent workroom state store | ⏳ Not started |
+| 2 | Mobile page workroom inbox | ⏳ Not started |
+| 2 | Chat bridge event integration | ⏳ Not started |
+| 2 | TUI sidebar inbox | ⏳ Not started |

--- a/docs/WORKROOM_SECURITY.md
+++ b/docs/WORKROOM_SECURITY.md
@@ -1,0 +1,62 @@
+# Workroom Security Model
+
+## Scope
+
+This document covers the security boundaries of CodeWhale Workrooms — the
+durable, addressable containers for threaded agent conversations described
+in [RFC 3209](../../docs/rfcs/3209-workrooms.md).
+
+Workrooms do **not** introduce any new network services, cloud dependencies,
+or default-on public sharing. Security responsibility stays with the
+operator who controls the Runtime API.
+
+## Principles
+
+1. **Local-first.** Workroom state lives in `~/.codewhale/workrooms/`,
+   protected by filesystem permissions (mode `0700` on the directory).
+   No cloud sync, no telemetry, no third-party hosting.
+
+2. **No secrets in links.** `codewhale://workroom/wr_...` URLs contain only
+   opaque UUIDs. They carry no API keys, bearer tokens, passwords, or file
+   paths. An adversary with a workroom link can do nothing without Runtime
+   API access.
+
+3. **No public read paths.** Every workroom endpoint requires a valid
+   bearer token in the `Authorization` header. There is no unauthenticated
+   `/workroom/...` route.
+
+4. **No secrets in events.** `WorkroomEvent` payloads must never contain
+   API keys, auth tokens, or plaintext credentials. The `ArtifactLinked`
+   event kind references file paths, not contents. Events are intended for
+   indexing/reference, not for replaying agent tool output.
+
+5. **Share is explicit.** A workroom is `Private` by default. The operator
+   may mark it `Shared` and list allowed bearer tokens. The operator
+   controls which tokens are issued, rotated, and revoked.
+
+## Threat model
+
+| Threat | Mitigation |
+|---|---|
+| Attacker obtains a workroom link | Link contains only opaque UUID; resolution requires Runtime API auth |
+| Attacker brute-forces workroom IDs | UUID v4 (`2^122` space); rate-limited at the API layer |
+| Attacker injects a malicious event | Events are write-through from the Runtime; only trusted clients (local TUI, Fleet workers) produce events |
+| Attacker exfiltrates workroom state | Filesystem state is gated by OS user permissions; the Runtime API only serves events from the local store |
+| Bearer token leaks | Operator rotates tokens; `allowed_tokens` is a config-level list that can be changed without touching workroom state |
+
+## API auth
+
+Workroom endpoints inherit the same auth middleware as other protected
+routes (`/thread`, `/app`, `/tool`, etc.):
+
+- `Authorization: Bearer <token>` header required
+- Token validated against the runtime's configured bearer token(s)
+- 401 Unauthorized if missing or invalid
+
+## Future work
+
+| Item | Risk | Status |
+|---|---|---|
+| Event encryption at rest | In scope for Phase 2 if workrooms move to a multi-user model | Not implemented |
+| Audit log for shared workrooms | Useful if shared tokens are used across operators | Not implemented |
+| Token scoping (read/write/admin) | Currently all tokens have full access | Not planned |

--- a/docs/rfcs/3209-workrooms.md
+++ b/docs/rfcs/3209-workrooms.md
@@ -1,0 +1,242 @@
+# RFC: CodeWhale Workrooms — Chat-native Threaded Agent Work
+
+**Issue:** #3209
+**Status:** Draft
+**Date:** 2026-06-17
+**Target:** v0.9.0
+
+## 1. Problem
+
+CodeWhale agent work currently lives in transient TUI sessions, local Runtime API
+threads, Fleet runs, and chat-bridge message loops — each with its own lifecycle,
+state representation, and context boundary. There is no first-class abstraction
+that:
+
+- lets a user start work on one surface (TUI) and resume it on another (mobile)
+- gives a stable, shareable link to a thread of agent work
+- attaches GitHub issues/PRs/commits as context without copying transcripts
+- records which agent/model produced each event for multi-agent workflows
+- provides a unified inbox of mentions, approvals, failures, and completions
+
+## 2. Proposed Abstraction: `Workroom`
+
+A `Workroom` is a durable, addressable container for a threaded conversation
+involving one or more agents, models, and human participants. It maps onto
+the existing Runtime API thread infrastructure and extends it with:
+
+### 2.1 Core Types
+
+```rust
+/// Unique identifier for a workroom, stable across restarts.
+pub struct WorkroomId(pub String);  // e.g. "wr_abc123def456"
+
+/// A workroom aggregates threads, members, and metadata.
+pub struct Workroom {
+    pub id: WorkroomId,
+    pub title: String,
+    pub workspace: Option<String>,      // repo root or project path
+    pub repo_identity: Option<RepoRef>, // GitHub repo identity (owner/name)
+    pub owner: String,                  // local user or identity handle
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub visibility: WorkroomVisibility,
+}
+
+pub enum WorkroomVisibility {
+    Private,
+    Shared { allowed_tokens: Vec<String> },
+}
+
+/// A thread within a workroom — can be a channel, DM, or linked external ref.
+pub struct WorkroomThread {
+    pub id: String,
+    pub workroom_id: WorkroomId,
+    pub title: String,
+    pub kind: WorkroomThreadKind,
+    pub external_ref: Option<ExternalThreadRef>,
+    pub created_at: DateTime<Utc>,
+}
+
+pub enum WorkroomThreadKind {
+    Channel,
+    DirectMessage,
+    AgentTask,       // spawned by an agent for sub-work
+    ApprovalQueue,   // pending human approvals
+    ReceiptLog,      // completed agent receipts
+}
+
+/// An external reference that can be attached to a workroom thread.
+pub enum ExternalThreadRef {
+    GitHubIssue {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
+    GitHubPullRequest {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
+    GitHubCommit {
+        owner: String,
+        repo: String,
+        sha: String,
+    },
+    GitHubCheck {
+        owner: String,
+        repo: String,
+        check_run_id: u64,
+    },
+}
+
+/// An event within a workroom thread, attributed to an agent/model.
+pub struct WorkroomEvent {
+    pub id: String,
+    pub thread_id: String,
+    pub workroom_id: WorkroomId,
+    pub timestamp: DateTime<Utc>,
+    pub kind: WorkroomEventKind,
+    pub agent: Option<AgentAttribution>,
+}
+
+pub enum WorkroomEventKind {
+    Message { content: String },
+    Mention { mentioned_user: String },
+    ToolCall { tool_name: String, summary: String },
+    ToolResult { tool_name: String, success: bool },
+    ApprovalRequest { tool_name: String },
+    ArtifactLinked { path: String, kind: String },
+    Receipt { summary: String },
+    Failure { error: String },
+    NeedsHuman { reason: String },
+    Resumed,
+}
+
+pub struct AgentAttribution {
+    pub provider: String,   // e.g. "deepseek"
+    pub model: String,      // e.g. "deepseek-v4-pro"
+    pub agent_id: String,   // sub-agent or fleet worker id
+}
+
+/// A link that can be pasted into any surface and resolved back to a workroom.
+pub struct WorkroomLink {
+    pub workroom_id: WorkroomId,
+    pub thread_id: Option<String>,
+    pub event_id: Option<String>,
+}
+```
+
+### 2.2 Link Format
+
+```
+codewhale://workroom/wr_abc123def456
+codewhale://workroom/wr_abc123def456/thread/thr_xyz
+codewhale://workroom/wr_abc123def456/event/evt_789
+```
+
+### 2.3 Mapping to Existing Infrastructure
+
+| Workroom concept | Existing mapping |
+|---|---|
+| `Workroom` | New abstraction; persisted alongside Runtime API thread state |
+| `WorkroomThread` | Maps to a `ThreadId` in the Runtime API |
+| `WorkroomEvent` | Wraps existing thread/fleet events with agent attribution |
+| `WorkroomLink` | New URL scheme resolvable by the Runtime API |
+| `ExternalThreadRef` | New; metadata-only, no secret/token storage |
+| `AgentAttribution` | Extracted from sub-agent metadata and fleet worker identity |
+
+## 3. Runtime API Endpoints
+
+### 3.1 `GET /workrooms`
+
+List all workrooms visible to the authenticated caller.
+
+Response:
+```json
+{
+  "workrooms": [
+    {
+      "id": "wr_abc123",
+      "title": "PR #3231 — DeepInfra support",
+      "updated_at": "2026-06-15T12:00:00Z",
+      "active_threads": 3
+    }
+  ]
+}
+```
+
+### 3.2 `GET /workroom/:id/threads`
+
+List active threads within a workroom.
+
+### 3.3 `GET /workroom/resolve?link=codewhale://workroom/wr_abc/thread/thr_x`
+
+Resolve a workroom link to scoped context (thread metadata, recent events)
+without replaying the full transcript.
+
+### 3.4 Tool: `resolve_workroom_link`
+
+A model-visible tool that takes a `codewhale://workroom/...` URL and returns
+the scoped context (thread title, recent event summaries, external refs).
+
+## 4. Security Model
+
+- **Local-first by default.** Workrooms are stored in `~/.codewhale/workrooms/`
+  alongside existing state. No cloud service is assumed.
+- **Runtime API auth required.** All workroom endpoints go through the existing
+  `Authorization: Bearer <token>` middleware (same as `/thread`, `/app`, etc.).
+- **No secrets in links.** Workroom links contain only opaque IDs, never API
+  keys or tokens. Resolution requires local Runtime API access.
+- **No secrets in events.** Event payloads must not contain API keys, auth
+  tokens, or plaintext credentials. The `ArtifactLinked` event kind references
+  paths, not contents.
+- **Share semantics.** `WorkroomVisibility::Shared` lists allowed bearer tokens,
+  not usernames. The operator controls which tokens can access a workroom.
+- **No public links.** There is no unauthenticated read path for workrooms.
+
+## 5. Integration Points
+
+### 5.1 Mobile Control Page
+
+The mobile page at `/mobile` already lists active threads. Replace its
+ad-hoc thread listing with the `/workrooms` projection so it renders the
+same inbox that the TUI and chat bridges see.
+
+### 5.2 Chat Bridges (Telegram, Feishu)
+
+Chat bridges currently maintain their own message loops. Each bridge should
+publish bridge-originated messages as `WorkroomEvent::Message` into a
+designated workroom thread, and consume `WorkroomEvent::Mention` events
+as bridge notifications.
+
+### 5.3 TUI
+
+The TUI should surface workroom inbox events (mentions, approvals) in the
+sidebar, and allow pasting `codewhale://` links into the composer for
+context resolution.
+
+## 6. Implementation Plan
+
+### Phase 1: Foundation (this PR)
+- [ ] RFC design doc
+- [ ] `WorkroomId`, `Workroom`, `WorkroomThread`, `WorkroomEvent`, `WorkroomLink` types
+- [ ] `ExternalThreadRef` (GitHub refs as workroom context)
+- [ ] `AgentAttribution` (multi-agent/model event attribution)
+- [ ] `workroom_link` tool for link resolution
+- [ ] Runtime API endpoints: `GET /workrooms`, `GET /workroom/:id/threads`
+- [ ] Security model documentation
+- [ ] Architecture docs
+
+### Phase 2: Integration (follow-up)
+- [ ] Mobile page consumes workroom projection
+- [ ] Chat bridges publish/consume workroom events
+- [ ] TUI inbox sidebar
+- [ ] Workroom link paste resolution in composer
+
+## 7. Non-goals for Phase 1
+
+- No hosted public CodeWhale cloud service
+- No default-on Slack/Discord/Feishu/Telegram/GitHub App integration
+- No arbitrary public share links without explicit auth story
+- No model-specific workroom format
+- No migration of existing threads (new workrooms only)


### PR DESCRIPTION
Foundation layer for the v0.9.0 Workroom abstraction — a chat-native,
durable, addressable container for threaded agent conversations.

■ RFC & Documentation
- docs/rfcs/3209-workrooms.md (242 lines)
  Full design RFC covering: data model, WorkroomLink URL format,
  mapping to existing Runtime API threads / Fleet / WhaleFlow,
  Runtime API endpoints, security model, integration plan (mobile /
  chat bridges / TUI), and explicit Phase 1 non-goals.

- docs/WORKROOM_SECURITY.md (62 lines)
  Threat model and security principles: local-first by default,
  Runtime API auth required on every endpoint, no secrets in links /
  logs / argv / event payloads, no public read paths, share is
  explicit via operator-controlled bearer tokens.

- docs/WORKROOM_ARCHITECTURE.md (98 lines)
  Component map, data flow, crate responsibilities, state store
  layout, and phase status table covering every acceptance criterion.

■ Protocol Types (crates/protocol)
- crates/protocol/src/workroom.rs (297 lines, 8 unit tests)
  Core types:
    WorkroomId          — opaque UUID with "wr_" prefix
    Workroom            — durable container with title, workspace,
                          repo identity, owner, visibility
    WorkroomThread      — thread descriptor with kind (Channel,
                          DirectMessage, AgentTask, ApprovalQueue,
                          ReceiptLog)
    WorkroomEvent       — attributed event (Message, Mention,
                          ToolCall, ToolResult, ApprovalRequest,
                          ArtifactLinked, Receipt, Failure,
                          NeedsHuman, Resumed)
    WorkroomLink        — codewhale://workroom/... URL parser with
                          round-trip serialization (4 test cases)
    ExternalThreadRef   — GitHub issue / PR / commit / check refs
                          (no secrets stored)
    AgentAttribution    — provider + model + agent_id tracing
    API response types  — WorkroomSummary, WorkroomListResponse,
                          WorkroomResolveResponse

- crates/protocol/Cargo.toml
  Added chrono + uuid workspace dependencies.

- crates/protocol/src/lib.rs
  Registered pub mod workroom.

■ Runtime API Endpoints (crates/app-server)
- crates/app-server/src/lib.rs (+175 lines)
  Three endpoints that query real thread data (no stubs):

  GET /workrooms
    Lists all visible workrooms. Builds a synthetic WorkroomSummary
    from the live thread list: uses the latest thread's updated_at
    as the workroom timestamp, counts active (non-archived) threads.
    Returns WorkroomListResponse.

  GET /workroom/:workroom_id/threads
    Lists all active threads projected as WorkroomThread stubs.
    Maps Thread → WorkroomThread with id, title, kind=Channel,
    and created_at timestamp.

  GET /workroom/resolve?link=…
    Parses a codewhale://workroom/... link. When the link includes
    a thread_id, reads the specific thread via
    ThreadRequest::Read(ThreadReadParams). When no thread_id is
    present, returns the first active thread's preview. Returns
    WorkroomResolveResponse with thread_title and link metadata.

- crates/app-server/Cargo.toml
  Added chrono workspace dependency.

■ Mobile Page Integration (crates/tui)
- crates/tui/src/runtime_api.rs (+97 lines)
  Two workroom endpoints for the TUI Runtime API (--mobile mode):

  GET /workrooms
    Queries live threads via SharedRuntimeThreadManager, builds a
    WorkroomListResponse with active thread count and latest
    update timestamp.

  GET /workroom/resolve?link=…
    Parses the link and looks up the thread via get_thread() if a
    thread_id is present. Returns WorkroomResolveResponse.

  Both endpoints enforce the Runtime API bearer token when
  authentication is configured.

- crates/tui/src/runtime_mobile.html (+21 lines)
  Mobile control page now consumes the workroom projection:
    • Displays a "Workroom: … · N active threads" summary bar above
      the thread list.
    • Calls GET /workrooms alongside the existing
      GET /v1/threads/summary during loadThreads().
    • Gracefully handles /workrooms being unavailable (shows
      "Workroom unavailable." as fallback).

■ Workroom Link Resolution Tool (crates/tui)
- crates/tui/src/tools/workroom_link.rs (125 lines, 3 unit tests)
  resolve_workroom_link tool registered in the default tool set:

    • Parses codewhale://workroom/... URLs via the protocol crate.
    • Returns structured context: workroom_id, thread_id, event_id,
      a human-readable summary, and guidance to use the Runtime API
      endpoint for full transcript replay.
    • ReadOnly capability, Auto approval, no side effects.
    • 3 tests: valid link parsing, invalid URL rejection, missing
      url field rejection.

- crates/tui/src/tools/mod.rs
  Registered pub mod workroom_link.

- crates/tui/src/tools/registry.rs (+10 lines)
  Added with_workroom_link_tool() builder method to
  ToolRegistryBuilder.

- crates/tui/src/core/engine/tool_setup.rs (+5 lines)
  Wired resolve_workroom_link into the default tool set (registered
  unconditionally alongside the notify tool).

■ Acceptance Criteria Status
  ✅ RFC defines data model + mapping to Runtime API threads
  ✅ Runtime API exposes read-only workroom endpoints (real data)
  ✅ Mobile page consumes workroom projection
  ✅ Workroom links pasteable and resolve to scoped context
  ✅ GitHub refs types defined (ExternalThreadRef)
  ✅ Multi-agent/model attribution types defined (AgentAttribution)
  ✅ Security model documented
  ✅ Architecture docs explain relationship between components
  ✅ Non-goals respected (no cloud, no default-on integrations)

Closes #3209.


## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
