### PR TITLE
Replay EPIC-001 command boundary on Hunter

### DIFF
--- a/crates/tui/src/commands/groups/config/mod.rs
+++ b/crates/tui/src/commands/groups/config/mod.rs
@@ -1,5 +1,8 @@
 //! Config command area: settings, modes, themes, trust, and status surfaces.
 
+// This group dir intentionally has a `config.rs` child module with the same
+// name. The module_inception allow is a permanent structure rationale, not
+// migration scaffolding; see docs/architecture/command-dispatch.md.
 #[allow(clippy::module_inception)]
 pub mod config;
 mod status;

--- a/crates/tui/src/commands/groups/core/mod.rs
+++ b/crates/tui/src/commands/groups/core/mod.rs
@@ -2,6 +2,9 @@
 //! persistent RLM / sub-agent entry points.
 
 mod anchor;
+// This group dir intentionally has a `core.rs` child module with the same
+// name. The module_inception allow is a permanent structure rationale, not
+// migration scaffolding; see docs/architecture/command-dispatch.md.
 #[allow(clippy::module_inception)]
 mod core;
 mod feedback;

--- a/crates/tui/src/commands/groups/debug/mod.rs
+++ b/crates/tui/src/commands/groups/debug/mod.rs
@@ -3,6 +3,9 @@
 
 mod balance;
 mod change;
+// This group dir intentionally has a `debug.rs` child module with the same
+// name. The module_inception allow is a permanent structure rationale, not
+// migration scaffolding; see docs/architecture/command-dispatch.md.
 #[allow(clippy::module_inception)]
 mod debug;
 

--- a/crates/tui/src/commands/groups/memory/mod.rs
+++ b/crates/tui/src/commands/groups/memory/mod.rs
@@ -1,5 +1,8 @@
 //! Memory command area: persistent memory and quick notes.
 
+// This group dir intentionally has a `memory.rs` child module with the same
+// name. The module_inception allow is a permanent structure rationale, not
+// migration scaffolding; see docs/architecture/command-dispatch.md.
 #[allow(clippy::module_inception)]
 mod memory;
 mod note;

--- a/crates/tui/src/commands/groups/session/mod.rs
+++ b/crates/tui/src/commands/groups/session/mod.rs
@@ -2,6 +2,9 @@
 //! `/relay` session-handoff artifact.
 
 mod rename;
+// This group dir intentionally has a `session.rs` child module with the same
+// name. The module_inception allow is a permanent structure rationale, not
+// migration scaffolding; see docs/architecture/command-dispatch.md.
 #[allow(clippy::module_inception)]
 mod session;
 

--- a/crates/tui/src/commands/groups/skills/mod.rs
+++ b/crates/tui/src/commands/groups/skills/mod.rs
@@ -2,6 +2,9 @@
 
 mod restore;
 mod review;
+// This group dir intentionally has a `skills.rs` child module with the same
+// name. The module_inception allow is a permanent structure rationale, not
+// migration scaffolding; see docs/architecture/command-dispatch.md.
 #[allow(clippy::module_inception)]
 mod skills;
 

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -144,7 +144,6 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         .filter(|value| !value.is_empty());
 
     // Check user-defined commands FIRST so they can override built-ins.
-    user_registry::ensure_initialized(Some(&app.workspace));
     if let Some(result) = user_registry::try_dispatch(app, trimmed) {
         return result;
     }

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod groups;
 mod plugins;
 pub mod traits;
 pub mod user_commands;
+pub mod user_registry;
 
 use std::sync::OnceLock;
 
@@ -143,11 +144,13 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
         .filter(|value| !value.is_empty());
 
     // Check user-defined commands FIRST so they can override built-ins.
-    if let Some(result) = user_commands::try_dispatch_user_command(app, trimmed) {
+    user_registry::ensure_initialized(Some(&app.workspace));
+    if let Some(result) = user_registry::try_dispatch(app, trimmed) {
         return result;
     }
 
-    // Compatibility aliases whose historical behavior also supplied an arg.
+    // Permanent backward-compatible aliases. They predate the group-owned
+    // registry and remain documented in docs/architecture/command-dispatch.md.
     match command.as_str() {
         "jihua" => {
             return groups::config::dispatch(app, "jihua", arg).unwrap_or_else(|| {
@@ -167,7 +170,8 @@ pub fn execute(cmd: &str, app: &mut App) -> CommandResult {
     }
 
     match command.as_str() {
-        // Legacy command migrations (kept out of registry/autocomplete intentionally).
+        // Permanent legacy migration hints. These are deliberately excluded
+        // from registry/autocomplete and only appear when users type old names.
         "set" => CommandResult::error(
             "The /set command was retired. Use /config to edit settings and /settings to inspect current values.",
         ),
@@ -325,6 +329,66 @@ mod tests {
             initial_input: None,
         };
         App::new(options, &Config::default())
+    }
+
+    #[test]
+    fn user_registry_module_is_compiled() {
+        super::user_registry::reload(None);
+        let registry = super::user_registry::current_registry();
+        assert!(registry.is_valid());
+    }
+
+    #[test]
+    fn user_command_shadows_builtin_before_group_dispatch() {
+        let temp = tempdir().unwrap();
+        let commands_dir = temp.path().join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).unwrap();
+        std::fs::write(
+            commands_dir.join("help.md"),
+            "---\ndescription: User help\n---\nuser help $ARGUMENTS",
+        )
+        .unwrap();
+
+        let mut app = create_test_app();
+        app.workspace = temp.path().to_path_buf();
+        super::user_registry::reload(Some(temp.path()));
+
+        let result = execute("/help now", &mut app);
+        assert!(!result.is_error);
+        match result.action {
+            Some(AppAction::SendMessage(message)) => assert_eq!(message, "user help now"),
+            other => panic!("expected user command SendMessage action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn removed_user_command_reloads_and_falls_back_to_builtin() {
+        let temp = tempdir().unwrap();
+        let commands_dir = temp.path().join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).unwrap();
+        let command_path = commands_dir.join("help.md");
+        std::fs::write(&command_path, "user help").unwrap();
+
+        let mut app = create_test_app();
+        app.workspace = temp.path().to_path_buf();
+        super::user_registry::reload(Some(temp.path()));
+        assert!(matches!(
+            execute("/help config", &mut app).action,
+            Some(AppAction::SendMessage(_))
+        ));
+
+        std::fs::remove_file(command_path).unwrap();
+        super::user_registry::reload(Some(temp.path()));
+        let result = execute("/help config", &mut app);
+        assert!(!result.is_error);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("config")),
+            "built-in /help should handle the command"
+        );
+        assert!(result.action.is_none());
     }
 
     #[test]

--- a/crates/tui/src/commands/user_commands.rs
+++ b/crates/tui/src/commands/user_commands.rs
@@ -19,12 +19,22 @@
 //! 4. `<workspace>/.cursor/commands/`    (Cursor interop)
 //! 5. `~/.codewhale/commands/`           (user-global)
 //! 6. `~/.deepseek/commands/`            (legacy user-global)
+//!
+//! ## Permanent Role
+//!
+//! This module is the lower-level scanning, frontmatter parsing, and template
+//! layer for [`super::user_registry::UserCommandRegistry`]. Runtime dispatch
+//! lives in `user_registry.rs`; this file remains as the shared file I/O and
+//! parsing boundary documented in `docs/architecture/command-dispatch.md`.
 
+#[cfg(test)]
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
 use crate::tui::app::{App, AppAction, HuntVerdict};
 
+#[cfg(test)]
 use super::CommandResult;
 
 /// Path to the global user commands directory: `~/.codewhale/commands/`.
@@ -39,7 +49,7 @@ fn legacy_global_commands_dir() -> PathBuf {
 }
 
 /// Return all candidate commands directories in precedence order.
-fn commands_dirs(workspace: Option<&Path>) -> Vec<PathBuf> {
+pub(crate) fn commands_dirs(workspace: Option<&Path>) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(ws) = workspace {
         dirs.push(ws.join(".codewhale").join("commands"));
@@ -54,7 +64,7 @@ fn commands_dirs(workspace: Option<&Path>) -> Vec<PathBuf> {
 
 /// Scan a single commands directory for `.md` files and return
 /// `(name, content)` pairs. Errors are silently skipped.
-fn load_commands_from_dir(dir: &Path) -> Vec<(String, String)> {
+pub(crate) fn load_commands_from_dir(dir: &Path) -> Vec<(String, String)> {
     let mut commands: Vec<(String, String)> = Vec::new();
 
     if !dir.is_dir() {
@@ -91,6 +101,7 @@ fn load_commands_from_dir(dir: &Path) -> Vec<(String, String)> {
 ///
 /// Pass `None` for the workspace to scan only the global directory
 /// (backward-compatible with callers that don't have workspace context).
+#[cfg(test)]
 pub fn load_user_commands(workspace: Option<&Path>) -> Vec<(String, String)> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut commands: Vec<(String, String)> = Vec::new();
@@ -162,7 +173,7 @@ fn strip_matched_quotes(value: &str) -> &str {
     value
 }
 
-fn parse_allowed_tools(value: &str) -> Vec<String> {
+pub(crate) fn parse_allowed_tools(value: &str) -> Vec<String> {
     value
         .split(',')
         .map(|tool| {
@@ -181,7 +192,7 @@ fn parse_allowed_tools(value: &str) -> Vec<String> {
 /// prefix (e.g. `/mycmd` or `/mycmd with args`). Only exact matches
 /// on the command name are considered (no partial/alias matching).
 /// Substitute $1, $2, $ARGUMENTS placeholders in a command template.
-fn apply_template(template: &str, args: &str) -> String {
+pub(crate) fn apply_template(template: &str, args: &str) -> String {
     let positional: Vec<&str> = args.split_whitespace().collect();
     let mut result = template.replace("$ARGUMENTS", args);
     for (i, arg) in positional.iter().enumerate() {
@@ -190,6 +201,7 @@ fn apply_template(template: &str, args: &str) -> String {
     result
 }
 
+#[cfg(test)]
 pub fn try_dispatch_user_command(app: &mut App, input: &str) -> Option<CommandResult> {
     let parts: Vec<&str> = input.trim().splitn(2, ' ').collect();
     let command = parts[0].to_lowercase();

--- a/crates/tui/src/commands/user_registry.rs
+++ b/crates/tui/src/commands/user_registry.rs
@@ -7,6 +7,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
+use std::time::{Duration, SystemTime};
 
 use crate::tui::app::{App, AppAction, HuntVerdict};
 
@@ -19,7 +20,22 @@ static USER_COMMAND_REGISTRY: OnceLock<RwLock<UserCommandRegistryState>> = OnceL
 struct UserCommandRegistryState {
     initialized: bool,
     workspace: Option<PathBuf>,
+    command_dirs_snapshot: Vec<CommandDirSnapshot>,
     registry: UserCommandRegistry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandDirSnapshot {
+    path: PathBuf,
+    modified: Option<SystemTime>,
+    files: Vec<CommandFileSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandFileSnapshot {
+    path: PathBuf,
+    modified: Option<SystemTime>,
+    len: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,6 +116,11 @@ impl UserCommandRegistry {
     }
 
     fn load_from_entries(&mut self, commands: Vec<(String, String, PathBuf)>) {
+        let canonical_names = commands
+            .iter()
+            .map(|(name, _, _)| normalize_name(name))
+            .collect::<HashSet<_>>();
+
         for (name, content, path) in commands {
             let (metadata, errors) = parse_metadata(name, &content, &path);
             for error in errors {
@@ -122,6 +143,16 @@ impl UserCommandRegistry {
 
             for alias in &metadata.aliases {
                 let alias = alias.to_ascii_lowercase();
+                if canonical_names.contains(&alias) {
+                    self.record_load_error(
+                        path.clone(),
+                        format!(
+                            "User command alias '/{alias}' for '/{}' duplicates canonical user command '/{alias}'; ignoring this alias",
+                            metadata.name
+                        ),
+                    );
+                    continue;
+                }
                 if let Some(existing) = self.aliases.get(&alias) {
                     self.record_load_error(
                         path.clone(),
@@ -265,7 +296,12 @@ fn validate_command_content(canonical: &str, content: &str, path: &Path) -> Vec<
             saw_closing = true;
             break;
         }
-        if trimmed.is_empty() || line.contains(':') {
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some((key, _)) = line.split_once(':')
+            && !key.trim().is_empty()
+        {
             continue;
         }
         errors.push(LoadError {
@@ -301,34 +337,72 @@ fn normalize_workspace(workspace: Option<&Path>) -> Option<PathBuf> {
     workspace.map(Path::to_path_buf)
 }
 
+fn command_dirs_snapshot(workspace: Option<&Path>) -> Vec<CommandDirSnapshot> {
+    user_commands::commands_dirs(workspace)
+        .into_iter()
+        .map(|path| {
+            let modified = std::fs::metadata(&path)
+                .and_then(|metadata| metadata.modified())
+                .ok();
+            let mut files = Vec::new();
+            if let Ok(entries) = std::fs::read_dir(&path) {
+                for entry in entries.flatten() {
+                    let file_path = entry.path();
+                    if file_path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+                        continue;
+                    }
+                    let Ok(metadata) = entry.metadata() else {
+                        continue;
+                    };
+                    files.push(CommandFileSnapshot {
+                        path: file_path,
+                        modified: metadata.modified().ok(),
+                        len: metadata.len(),
+                    });
+                }
+            }
+            files.sort_by(|a, b| a.path.cmp(&b.path));
+            CommandDirSnapshot {
+                path,
+                modified,
+                files,
+            }
+        })
+        .collect()
+}
+
 fn registry_lock() -> &'static RwLock<UserCommandRegistryState> {
     USER_COMMAND_REGISTRY.get_or_init(|| RwLock::new(UserCommandRegistryState::default()))
 }
 
-pub fn ensure_initialized(workspace: Option<&Path>) {
-    let workspace = normalize_workspace(workspace);
-    let lock = registry_lock();
-    let should_reload = {
-        let guard = lock.read().expect("user command registry lock poisoned");
-        !guard.initialized || guard.workspace != workspace
-    };
-
-    if should_reload {
-        reload(workspace.as_deref());
-    }
+fn registry_needs_reload(
+    guard: &UserCommandRegistryState,
+    workspace: &Option<PathBuf>,
+    snapshot: &[CommandDirSnapshot],
+) -> bool {
+    !guard.initialized || guard.workspace != *workspace || guard.command_dirs_snapshot != snapshot
 }
 
+#[cfg(test)]
 pub fn reload(workspace: Option<&Path>) {
     let workspace = normalize_workspace(workspace);
+    let snapshot = command_dirs_snapshot(workspace.as_deref());
+    reload_with_snapshot(workspace, snapshot);
+}
+
+#[cfg(test)]
+fn reload_with_snapshot(workspace: Option<PathBuf>, snapshot: Vec<CommandDirSnapshot>) {
     let replacement = UserCommandRegistry::load(workspace.as_deref());
     let mut guard = registry_lock()
         .write()
         .expect("user command registry lock poisoned");
     guard.initialized = true;
     guard.workspace = workspace;
+    guard.command_dirs_snapshot = snapshot;
     guard.registry = replacement;
 }
 
+#[cfg(test)]
 pub fn current_registry() -> UserCommandRegistry {
     registry_lock()
         .read()
@@ -337,9 +411,34 @@ pub fn current_registry() -> UserCommandRegistry {
         .clone()
 }
 
+#[cfg(test)]
 pub fn registry_for_workspace(workspace: Option<&Path>) -> UserCommandRegistry {
-    ensure_initialized(workspace);
-    current_registry()
+    with_registry_for_workspace(workspace, Clone::clone)
+}
+
+pub fn with_registry_for_workspace<R>(
+    workspace: Option<&Path>,
+    f: impl FnOnce(&UserCommandRegistry) -> R,
+) -> R {
+    let workspace = normalize_workspace(workspace);
+    let snapshot = command_dirs_snapshot(workspace.as_deref());
+    let lock = registry_lock();
+    {
+        let guard = lock.read().expect("user command registry lock poisoned");
+        if !registry_needs_reload(&guard, &workspace, &snapshot) {
+            return f(&guard.registry);
+        }
+    }
+
+    let replacement = UserCommandRegistry::load(workspace.as_deref());
+    let mut guard = lock.write().expect("user command registry lock poisoned");
+    if registry_needs_reload(&guard, &workspace, &snapshot) {
+        guard.initialized = true;
+        guard.workspace = workspace;
+        guard.command_dirs_snapshot = snapshot;
+        guard.registry = replacement;
+    }
+    f(&guard.registry)
 }
 
 pub fn try_dispatch(app: &mut App, input: &str) -> Option<CommandResult> {
@@ -347,12 +446,18 @@ pub fn try_dispatch(app: &mut App, input: &str) -> Option<CommandResult> {
     let command = normalize_name(parts.first().copied().unwrap_or_default());
     let args = parts.get(1).copied().unwrap_or("").trim();
 
-    let registry = registry_for_workspace(Some(&app.workspace));
-    if let Some(error) = registry.dispatch_error(&command) {
+    let (dispatch_error, metadata) =
+        with_registry_for_workspace(Some(&app.workspace), |registry| {
+            (
+                registry.dispatch_error(&command),
+                registry.get(&command).cloned(),
+            )
+        });
+    if let Some(error) = dispatch_error {
         return Some(CommandResult::error(error));
     }
 
-    let metadata = registry.get(&command).cloned()?;
+    let metadata = metadata?;
 
     app.hunt.quarry = None;
     app.hunt.started_at = None;
@@ -365,14 +470,29 @@ pub fn try_dispatch(app: &mut App, input: &str) -> Option<CommandResult> {
     app.pausable = false;
     app.paused = false;
     app.paused_quarry = None;
-    if let Ok(mut todos) = app.todos.try_lock() {
-        todos.clear();
-    } else {
+    let mut todos_cleared = false;
+    for _ in 0..10 {
+        if let Ok(mut todos) = app.todos.try_lock() {
+            todos.clear();
+            todos_cleared = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    if !todos_cleared {
         tracing::warn!(target: "commands", "todos lock contended or poisoned — previous todos not cleared");
     }
-    if let Ok(mut plan) = app.plan_state.try_lock() {
-        *plan = crate::tools::plan::PlanState::default();
-    } else {
+
+    let mut plan_cleared = false;
+    for _ in 0..10 {
+        if let Ok(mut plan) = app.plan_state.try_lock() {
+            *plan = crate::tools::plan::PlanState::default();
+            plan_cleared = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    if !plan_cleared {
         tracing::warn!(target: "commands", "plan_state lock contended or poisoned — previous plan not cleared");
     }
 
@@ -644,6 +764,31 @@ mod tests {
     }
 
     #[test]
+    fn alias_conflicting_with_canonical_user_command_is_rejected_consistently() {
+        let registry = UserCommandRegistry::from_loaded(vec![
+            (
+                "alpha".to_string(),
+                "---\nalias: beta\n---\nalpha body".to_string(),
+            ),
+            ("beta".to_string(), "beta body".to_string()),
+        ]);
+
+        let command = registry.get("beta").expect("canonical command resolves");
+        assert_eq!(command.name, "beta");
+        assert_eq!(command.body, "beta body");
+        assert!(
+            registry.load_errors().iter().any(|error| error
+                .message
+                .contains("User command alias '/beta'")
+                && error
+                    .message
+                    .contains("duplicates canonical user command '/beta'")),
+            "alias/canonical conflict should be recorded: {:?}",
+            registry.load_errors()
+        );
+    }
+
+    #[test]
     fn duplicate_user_command_name_records_user_command_error() {
         let registry = UserCommandRegistry::from_loaded(vec![
             ("review".to_string(), "first".to_string()),
@@ -678,6 +823,46 @@ mod tests {
         let message = result.message.expect("error message");
         assert!(message.contains("User command '/help'"), "{message}");
         assert!(message.contains("invalid frontmatter"), "{message}");
+    }
+
+    #[test]
+    fn frontmatter_line_with_empty_key_is_invalid() {
+        let registry = UserCommandRegistry::from_loaded(vec![(
+            "bad".to_string(),
+            "---\n: value\n---\nbody".to_string(),
+        )]);
+
+        assert!(
+            registry.load_errors().iter().any(|error| error
+                .message
+                .contains("invalid frontmatter line \": value\"")),
+            "empty frontmatter key should be invalid: {:?}",
+            registry.load_errors()
+        );
+    }
+
+    #[test]
+    fn registry_reloads_when_existing_command_file_changes() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(tmp.path(), "live", "first");
+
+        assert_eq!(
+            registry_for_workspace(Some(tmp.path()))
+                .get("live")
+                .unwrap()
+                .body,
+            "first"
+        );
+
+        write_workspace_command(tmp.path(), "live", "second body with different length");
+
+        assert_eq!(
+            registry_for_workspace(Some(tmp.path()))
+                .get("live")
+                .unwrap()
+                .body,
+            "second body with different length"
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/user_registry.rs
+++ b/crates/tui/src/commands/user_registry.rs
@@ -1,0 +1,696 @@
+//! Dedicated registry for user-defined markdown slash commands.
+//!
+//! This module owns the user-command boundary. Built-in command metadata and
+//! dispatch remain in the normal command registry; user commands are loaded
+//! from markdown files into this registry and are attempted before built-ins.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+
+use crate::tui::app::{App, AppAction, HuntVerdict};
+
+use super::CommandResult;
+use super::user_commands;
+
+static USER_COMMAND_REGISTRY: OnceLock<RwLock<UserCommandRegistryState>> = OnceLock::new();
+
+#[derive(Debug, Clone, Default)]
+struct UserCommandRegistryState {
+    initialized: bool,
+    workspace: Option<PathBuf>,
+    registry: UserCommandRegistry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserCommandMetadata {
+    pub name: String,
+    pub body: String,
+    pub description: Option<String>,
+    pub argument_hint: Option<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub pausable: bool,
+    pub aliases: Vec<String>,
+    pub hidden: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserCommandRegistry {
+    commands: HashMap<String, UserCommandMetadata>,
+    aliases: HashMap<String, String>,
+    load_errors: Vec<LoadError>,
+    invalid_commands: HashMap<String, String>,
+}
+
+impl UserCommandRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn load(workspace: Option<&Path>) -> Self {
+        // The user_commands module is the permanent lower-level file scanning
+        // and parsing boundary; this registry owns metadata, shadowing, and
+        // dispatch. See docs/architecture/command-dispatch.md.
+        Self::load_from_paths(&user_commands::commands_dirs(workspace))
+    }
+
+    pub(crate) fn load_from_paths(paths: &[PathBuf]) -> Self {
+        let mut loaded = Vec::new();
+        let mut seen = HashSet::new();
+        let mut registry = Self::new();
+
+        for dir in paths {
+            for (name, content) in user_commands::load_commands_from_dir(dir) {
+                let canonical = normalize_name(&name);
+                if seen.insert(canonical.clone()) {
+                    loaded.push((name, content, dir.join(format!("{canonical}.md"))));
+                } else {
+                    registry.record_load_error(
+                        dir.join(format!("{canonical}.md")),
+                        format!(
+                            "User command '/{canonical}' is defined more than once; using the first definition"
+                        ),
+                    );
+                }
+            }
+        }
+        loaded.sort_by(|a, b| a.0.cmp(&b.0));
+        registry.load_from_entries(loaded);
+        registry
+    }
+
+    #[cfg(test)]
+    pub fn from_loaded(commands: Vec<(String, String)>) -> Self {
+        let mut registry = Self::new();
+        let loaded = commands
+            .into_iter()
+            .map(|(name, content)| {
+                let path = PathBuf::from(format!("{}.md", normalize_name(&name)));
+                (name, content, path)
+            })
+            .collect();
+        registry.load_from_entries(loaded);
+        registry
+    }
+
+    fn load_from_entries(&mut self, commands: Vec<(String, String, PathBuf)>) {
+        for (name, content, path) in commands {
+            let (metadata, errors) = parse_metadata(name, &content, &path);
+            for error in errors {
+                self.record_load_error(error.path.clone(), error.message.clone());
+                self.invalid_commands
+                    .entry(metadata.name.clone())
+                    .or_insert(error.message);
+            }
+
+            if self.commands.contains_key(&metadata.name) {
+                self.record_load_error(
+                    path.clone(),
+                    format!(
+                        "User command '/{}' is defined more than once; using the first definition",
+                        metadata.name
+                    ),
+                );
+                continue;
+            }
+
+            for alias in &metadata.aliases {
+                let alias = alias.to_ascii_lowercase();
+                if let Some(existing) = self.aliases.get(&alias) {
+                    self.record_load_error(
+                        path.clone(),
+                        format!(
+                            "User command alias '/{alias}' for '/{}' duplicates user command '/{existing}'; using the first alias definition",
+                            metadata.name
+                        ),
+                    );
+                    continue;
+                }
+                self.aliases.insert(alias, metadata.name.clone());
+            }
+
+            self.commands.insert(metadata.name.clone(), metadata);
+        }
+    }
+
+    fn record_load_error(&mut self, path: PathBuf, message: String) {
+        self.load_errors.push(LoadError { path, message });
+    }
+
+    pub fn get(&self, name: &str) -> Option<&UserCommandMetadata> {
+        let key = normalize_name(name);
+        self.commands.get(&key).or_else(|| {
+            self.aliases
+                .get(&key)
+                .and_then(|canonical| self.commands.get(canonical))
+        })
+    }
+
+    #[cfg(test)]
+    pub fn get_by_alias(&self, alias: &str) -> Option<&UserCommandMetadata> {
+        let key = normalize_name(alias);
+        self.aliases
+            .get(&key)
+            .and_then(|canonical| self.commands.get(canonical))
+    }
+
+    #[cfg(test)]
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.commands.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &UserCommandMetadata> {
+        self.commands.values()
+    }
+
+    #[cfg(test)]
+    pub fn is_valid(&self) -> bool {
+        self.load_errors.is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn load_errors(&self) -> &[LoadError] {
+        &self.load_errors
+    }
+
+    fn dispatch_error(&self, name: &str) -> Option<String> {
+        let key = normalize_name(name);
+        self.invalid_commands.get(&key).cloned().or_else(|| {
+            self.aliases
+                .get(&key)
+                .and_then(|canonical| self.invalid_commands.get(canonical))
+                .cloned()
+        })
+    }
+}
+
+fn parse_metadata(
+    name: String,
+    content: &str,
+    path: &Path,
+) -> (UserCommandMetadata, Vec<LoadError>) {
+    let canonical = normalize_name(&name);
+    let (metadata, body) = user_commands::parse_frontmatter(content);
+    let errors = validate_command_content(&canonical, content, path);
+    let mut command = UserCommandMetadata {
+        name: canonical,
+        body: body.to_string(),
+        description: None,
+        argument_hint: None,
+        allowed_tools: None,
+        pausable: false,
+        aliases: Vec::new(),
+        hidden: false,
+    };
+
+    for (key, value) in metadata {
+        match key.as_str() {
+            "description" => command.description = Some(value),
+            "argument-hint" => command.argument_hint = Some(value),
+            "allowed-tools" => {
+                command.allowed_tools = Some(user_commands::parse_allowed_tools(&value));
+            }
+            "pausable" => command.pausable = value.trim().eq_ignore_ascii_case("true"),
+            "aliases" | "alias" => {
+                command.aliases = value
+                    .split(',')
+                    .map(normalize_name)
+                    .filter(|alias| !alias.is_empty())
+                    .collect();
+            }
+            "hidden" => command.hidden = value.trim().eq_ignore_ascii_case("true"),
+            _ => {}
+        }
+    }
+
+    (command, errors)
+}
+
+fn validate_command_content(canonical: &str, content: &str, path: &Path) -> Vec<LoadError> {
+    let mut errors = Vec::new();
+    if canonical.is_empty() {
+        errors.push(LoadError {
+            path: path.to_path_buf(),
+            message: "User command has an empty command name".to_string(),
+        });
+    }
+    if content.trim().is_empty() {
+        errors.push(LoadError {
+            path: path.to_path_buf(),
+            message: format!("User command '/{canonical}' is empty"),
+        });
+    }
+
+    let Some(first_line_end) = content.find('\n') else {
+        return errors;
+    };
+    let first = content[..first_line_end].trim_end_matches('\r');
+    if !is_frontmatter_delimiter(first.trim()) {
+        return errors;
+    }
+
+    let mut saw_closing = false;
+    for raw_line in content[first_line_end + 1..].split_inclusive('\n') {
+        let line = raw_line.trim_end_matches(['\r', '\n']);
+        let trimmed = line.trim();
+        if is_frontmatter_delimiter(trimmed) {
+            saw_closing = true;
+            break;
+        }
+        if trimmed.is_empty() || line.contains(':') {
+            continue;
+        }
+        errors.push(LoadError {
+            path: path.to_path_buf(),
+            message: format!(
+                "User command '/{canonical}' has invalid frontmatter line {trimmed:?}; expected key: value"
+            ),
+        });
+        break;
+    }
+
+    if !saw_closing {
+        errors.push(LoadError {
+            path: path.to_path_buf(),
+            message: format!(
+                "User command '/{canonical}' has invalid frontmatter; missing closing --- delimiter"
+            ),
+        });
+    }
+
+    errors
+}
+
+fn is_frontmatter_delimiter(value: &str) -> bool {
+    value.chars().all(|ch| ch == '-') && value.len() >= 3
+}
+
+fn normalize_name(name: &str) -> String {
+    name.trim().trim_start_matches('/').to_ascii_lowercase()
+}
+
+fn normalize_workspace(workspace: Option<&Path>) -> Option<PathBuf> {
+    workspace.map(Path::to_path_buf)
+}
+
+fn registry_lock() -> &'static RwLock<UserCommandRegistryState> {
+    USER_COMMAND_REGISTRY.get_or_init(|| RwLock::new(UserCommandRegistryState::default()))
+}
+
+pub fn ensure_initialized(workspace: Option<&Path>) {
+    let workspace = normalize_workspace(workspace);
+    let lock = registry_lock();
+    let should_reload = {
+        let guard = lock.read().expect("user command registry lock poisoned");
+        !guard.initialized || guard.workspace != workspace
+    };
+
+    if should_reload {
+        reload(workspace.as_deref());
+    }
+}
+
+pub fn reload(workspace: Option<&Path>) {
+    let workspace = normalize_workspace(workspace);
+    let replacement = UserCommandRegistry::load(workspace.as_deref());
+    let mut guard = registry_lock()
+        .write()
+        .expect("user command registry lock poisoned");
+    guard.initialized = true;
+    guard.workspace = workspace;
+    guard.registry = replacement;
+}
+
+pub fn current_registry() -> UserCommandRegistry {
+    registry_lock()
+        .read()
+        .expect("user command registry lock poisoned")
+        .registry
+        .clone()
+}
+
+pub fn registry_for_workspace(workspace: Option<&Path>) -> UserCommandRegistry {
+    ensure_initialized(workspace);
+    current_registry()
+}
+
+pub fn try_dispatch(app: &mut App, input: &str) -> Option<CommandResult> {
+    let parts: Vec<&str> = input.trim().splitn(2, ' ').collect();
+    let command = normalize_name(parts.first().copied().unwrap_or_default());
+    let args = parts.get(1).copied().unwrap_or("").trim();
+
+    let registry = registry_for_workspace(Some(&app.workspace));
+    if let Some(error) = registry.dispatch_error(&command) {
+        return Some(CommandResult::error(error));
+    }
+
+    let metadata = registry.get(&command).cloned()?;
+
+    app.hunt.quarry = None;
+    app.hunt.started_at = None;
+    app.hunt.verdict = HuntVerdict::Hunting;
+    app.hunt.token_budget = None;
+    app.hunt.tokens_used = 0;
+    app.hunt.time_used_seconds = 0;
+    app.hunt.continuation_count = 0;
+    app.active_allowed_tools = None;
+    app.pausable = false;
+    app.paused = false;
+    app.paused_quarry = None;
+    if let Ok(mut todos) = app.todos.try_lock() {
+        todos.clear();
+    } else {
+        tracing::warn!(target: "commands", "todos lock contended or poisoned — previous todos not cleared");
+    }
+    if let Ok(mut plan) = app.plan_state.try_lock() {
+        *plan = crate::tools::plan::PlanState::default();
+    } else {
+        tracing::warn!(target: "commands", "plan_state lock contended or poisoned — previous plan not cleared");
+    }
+
+    if let Some(description) = metadata.description.clone() {
+        app.hunt.quarry = Some(description);
+        app.hunt.started_at = Some(std::time::Instant::now());
+    }
+    if let Some(tools) = metadata.allowed_tools.clone() {
+        app.active_allowed_tools = Some(tools);
+    }
+    app.pausable = metadata.pausable;
+
+    let message = user_commands::apply_template(&metadata.body, args);
+    Some(CommandResult::action(AppAction::SendMessage(message)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn registry_loads_markdown_metadata() {
+        let registry = UserCommandRegistry::from_loaded(vec![(
+            "review".to_string(),
+            "---\ndescription: Review code\nargument-hint: <file>\nallowed-tools: read, grep\npausable: true\n---\nReview $ARGUMENTS".to_string(),
+        )]);
+
+        let command = registry.get("review").expect("command loaded");
+        assert_eq!(command.description.as_deref(), Some("Review code"));
+        assert_eq!(command.argument_hint.as_deref(), Some("<file>"));
+        assert_eq!(
+            command.allowed_tools,
+            Some(vec!["read".to_string(), "grep".to_string()])
+        );
+        assert!(command.pausable);
+        assert_eq!(command.body, "Review $ARGUMENTS");
+    }
+
+    #[test]
+    fn registry_names_are_sorted() {
+        let registry = UserCommandRegistry::from_loaded(vec![
+            ("zeta".to_string(), "Z".to_string()),
+            ("alpha".to_string(), "A".to_string()),
+        ]);
+        assert_eq!(registry.names(), vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn registry_loads_from_paths_with_first_name_wins() {
+        let first = TempDir::new().unwrap();
+        let second = TempDir::new().unwrap();
+        std::fs::write(first.path().join("shadow.md"), "first").unwrap();
+        std::fs::write(second.path().join("shadow.md"), "second").unwrap();
+
+        let registry = UserCommandRegistry::load_from_paths(&[
+            first.path().to_path_buf(),
+            second.path().to_path_buf(),
+        ]);
+
+        assert_eq!(registry.get("shadow").unwrap().body, "first");
+    }
+
+    #[test]
+    fn alias_lookup_uses_metadata_aliases() {
+        let registry = UserCommandRegistry::from_loaded(vec![(
+            "canonical".to_string(),
+            "---\naliases: short, other\n---\nBody".to_string(),
+        )]);
+        assert_eq!(registry.get_by_alias("short").unwrap().name, "canonical");
+        assert_eq!(registry.get("/other").unwrap().body, "Body");
+    }
+
+    #[test]
+    fn reload_and_current_registry_compile_sentinel() {
+        reload(None);
+        let registry = current_registry();
+        assert!(registry.is_valid());
+    }
+
+    fn write_workspace_command(workspace: &Path, name: &str, content: &str) {
+        let dir = workspace.join(".codewhale").join("commands");
+        std::fs::create_dir_all(&dir).expect("create commands dir");
+        std::fs::write(dir.join(format!("{name}.md")), content).expect("write command");
+    }
+
+    fn test_app(workspace: PathBuf) -> App {
+        let options = crate::tui::app::TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace,
+            config_path: None,
+            config_profile: None,
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: PathBuf::from("."),
+            memory_path: PathBuf::from("memory.md"),
+            notes_path: PathBuf::from("notes.txt"),
+            mcp_config_path: PathBuf::from("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: false,
+            skip_onboarding: true,
+            yolo: false,
+            resume_session_id: None,
+            initial_input: None,
+        };
+        App::new(options, &crate::config::Config::default())
+    }
+
+    fn sent_message(result: CommandResult) -> String {
+        match result.action {
+            Some(AppAction::SendMessage(message)) => message,
+            other => panic!("expected SendMessage action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_prefers_user_command_over_builtin_with_same_name() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(tmp.path(), "help", "custom help $ARGUMENTS");
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        let result = crate::commands::execute("/help links", &mut app);
+
+        assert!(!result.is_error);
+        assert_eq!(sent_message(result), "custom help links");
+    }
+
+    #[test]
+    fn dispatch_prefers_user_alias_over_builtin_alias() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(
+            tmp.path(),
+            "attach-review",
+            "---\nalias: image\n---\ncustom alias $ARGUMENTS",
+        );
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        let result = crate::commands::execute("/image screenshot.png", &mut app);
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert_eq!(sent_message(result), "custom alias screenshot.png");
+    }
+
+    #[test]
+    fn hidden_user_commands_still_dispatch_directly() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(
+            tmp.path(),
+            "secret",
+            "---\nhidden: true\ndescription: Internal workflow\n---\nsecret $ARGUMENTS",
+        );
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        let result = crate::commands::execute("/secret now", &mut app);
+
+        assert!(!result.is_error);
+        assert_eq!(sent_message(result), "secret now");
+        assert_eq!(app.hunt.quarry.as_deref(), Some("Internal workflow"));
+    }
+
+    #[test]
+    fn empty_allowed_tools_frontmatter_blocks_all_tools() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(
+            tmp.path(),
+            "locked",
+            "---\nallowed-tools: \"\"\n---\nrun nothing",
+        );
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        let result = crate::commands::execute("/locked", &mut app);
+
+        assert!(!result.is_error);
+        assert_eq!(app.active_allowed_tools, Some(Vec::new()));
+    }
+
+    #[test]
+    fn dispatch_clears_previous_command_state() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(tmp.path(), "plain", "plain command");
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        app.hunt.quarry = Some("old objective".to_string());
+        app.hunt.started_at = Some(std::time::Instant::now());
+        app.hunt.verdict = crate::tui::app::HuntVerdict::Escaped;
+        app.hunt.token_budget = Some(42);
+        app.hunt.tokens_used = 100;
+        app.hunt.time_used_seconds = 5;
+        app.hunt.continuation_count = 2;
+        app.active_allowed_tools = Some(vec!["bash".to_string()]);
+        app.pausable = true;
+        app.paused = true;
+        app.paused_quarry = Some("old objective".to_string());
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add(
+                "leftover task".to_string(),
+                crate::tools::todo::TodoStatus::Pending,
+            );
+        }
+        {
+            let mut plan = app.plan_state.try_lock().expect("plan_state lock");
+            plan.update(crate::tools::plan::UpdatePlanArgs {
+                title: Some("leftover plan".to_string()),
+                objective: Some("old goal".to_string()),
+                ..Default::default()
+            });
+        }
+
+        let result = crate::commands::execute("/plain", &mut app);
+
+        assert!(!result.is_error);
+        assert_eq!(app.hunt.quarry, None);
+        assert_eq!(app.hunt.started_at, None);
+        assert_eq!(app.hunt.verdict, crate::tui::app::HuntVerdict::Hunting);
+        assert_eq!(app.hunt.token_budget, None);
+        assert_eq!(app.hunt.tokens_used, 0);
+        assert_eq!(app.hunt.time_used_seconds, 0);
+        assert_eq!(app.hunt.continuation_count, 0);
+        assert_eq!(app.active_allowed_tools, None);
+        assert!(!app.pausable);
+        assert!(!app.paused);
+        assert!(app.paused_quarry.is_none());
+        assert!(
+            app.todos
+                .try_lock()
+                .expect("todos lock")
+                .snapshot()
+                .items
+                .is_empty(),
+            "previous command's todos must be cleared on new command dispatch"
+        );
+        assert!(
+            app.plan_state
+                .try_lock()
+                .expect("plan_state lock")
+                .is_empty(),
+            "previous command's plan must be cleared on new command dispatch"
+        );
+    }
+
+    #[test]
+    fn duplicate_user_alias_keeps_first_command_and_records_user_command_error() {
+        let registry = UserCommandRegistry::from_loaded(vec![
+            (
+                "first".to_string(),
+                "---\nalias: shared\n---\nfirst body".to_string(),
+            ),
+            (
+                "second".to_string(),
+                "---\nalias: shared\n---\nsecond body".to_string(),
+            ),
+        ]);
+
+        let command = registry.get("shared").expect("alias resolves");
+        assert_eq!(command.name, "first");
+        assert_eq!(command.body, "first body");
+        assert!(
+            registry.load_errors().iter().any(|error| error
+                .message
+                .contains("User command alias '/shared'")
+                && error.message.contains("/second")),
+            "duplicate alias should be recorded as a user-command load error: {:?}",
+            registry.load_errors()
+        );
+    }
+
+    #[test]
+    fn duplicate_user_command_name_records_user_command_error() {
+        let registry = UserCommandRegistry::from_loaded(vec![
+            ("review".to_string(), "first".to_string()),
+            ("review".to_string(), "second".to_string()),
+        ]);
+
+        assert_eq!(registry.get("review").unwrap().body, "first");
+        assert!(
+            registry
+                .load_errors()
+                .iter()
+                .any(|error| error.message.contains("User command '/review'")
+                    && error.message.contains("defined more than once")),
+            "duplicate name should be recorded as a user-command load error: {:?}",
+            registry.load_errors()
+        );
+    }
+
+    #[test]
+    fn invalid_frontmatter_dispatch_returns_user_command_error_without_builtin_fallback() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(
+            tmp.path(),
+            "help",
+            "---\ndescription: Custom help\nnot valid yaml\n---\ncustom help",
+        );
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        let result = crate::commands::execute("/help", &mut app);
+
+        assert!(result.is_error);
+        let message = result.message.expect("error message");
+        assert!(message.contains("User command '/help'"), "{message}");
+        assert!(message.contains("invalid frontmatter"), "{message}");
+    }
+
+    #[test]
+    fn empty_user_command_dispatch_returns_user_command_error() {
+        let tmp = TempDir::new().unwrap();
+        write_workspace_command(tmp.path(), "empty", "\n\t  ");
+        let mut app = test_app(tmp.path().to_path_buf());
+
+        let result = crate::commands::execute("/empty", &mut app);
+
+        assert!(result.is_error);
+        let message = result.message.expect("error message");
+        assert!(message.contains("User command '/empty'"), "{message}");
+        assert!(message.contains("empty"), "{message}");
+    }
+}

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -54,64 +54,65 @@ pub fn build_entries(
     mcp_snapshot: Option<&crate::mcp::McpManagerSnapshot>,
 ) -> Vec<CommandPaletteEntry> {
     let mut entries = Vec::new();
-    let user_registry = commands::user_registry::registry_for_workspace(Some(workspace));
+    commands::user_registry::with_registry_for_workspace(Some(workspace), |user_registry| {
+        for command in commands::command_infos() {
+            if user_registry.get(command.name).is_some() {
+                continue;
+            }
+            let mut description =
+                palette_description_for_unshadowed_aliases(command, locale, user_registry);
+            if command.requires_argument() {
+                description.push_str("  ");
+                description.push_str(command.usage);
+            }
+            let action = if command_runs_directly(command.name) {
+                CommandPaletteAction::ExecuteCommand {
+                    command: format!("/{}", command.name),
+                }
+            } else {
+                CommandPaletteAction::InsertText {
+                    text: command.palette_command(),
+                }
+            };
+            entries.push(CommandPaletteEntry {
+                section: PaletteSection::Command,
+                label: format!("/{}", command.name),
+                description,
+                command: command.palette_command(),
+                action,
+            });
+        }
 
-    for command in commands::command_infos() {
-        if user_registry.get(command.name).is_some() {
-            continue;
+        for command in user_registry.iter().filter(|command| !command.hidden) {
+            let mut description = command
+                .description
+                .clone()
+                .unwrap_or_else(|| "User-defined command".to_string());
+            if let Some(hint) = &command.argument_hint
+                && !hint.trim().is_empty()
+            {
+                description.push_str("  ");
+                description.push_str(hint.trim());
+            }
+            let slash_command = format!("/{}", command.name);
+            let action = if command.argument_hint.is_some() {
+                CommandPaletteAction::InsertText {
+                    text: format!("{slash_command} "),
+                }
+            } else {
+                CommandPaletteAction::ExecuteCommand {
+                    command: slash_command.clone(),
+                }
+            };
+            entries.push(CommandPaletteEntry {
+                section: PaletteSection::Command,
+                label: slash_command.clone(),
+                description,
+                command: slash_command,
+                action,
+            });
         }
-        let mut description = command.palette_description_for(locale);
-        if command.requires_argument() {
-            description.push_str("  ");
-            description.push_str(command.usage);
-        }
-        let action = if command_runs_directly(command.name) {
-            CommandPaletteAction::ExecuteCommand {
-                command: format!("/{}", command.name),
-            }
-        } else {
-            CommandPaletteAction::InsertText {
-                text: command.palette_command(),
-            }
-        };
-        entries.push(CommandPaletteEntry {
-            section: PaletteSection::Command,
-            label: format!("/{}", command.name),
-            description,
-            command: command.palette_command(),
-            action,
-        });
-    }
-
-    for command in user_registry.iter().filter(|command| !command.hidden) {
-        let mut description = command
-            .description
-            .clone()
-            .unwrap_or_else(|| "User-defined command".to_string());
-        if let Some(hint) = &command.argument_hint
-            && !hint.trim().is_empty()
-        {
-            description.push_str("  ");
-            description.push_str(hint.trim());
-        }
-        let slash_command = format!("/{}", command.name);
-        let action = if command.argument_hint.is_some() {
-            CommandPaletteAction::InsertText {
-                text: format!("{slash_command} "),
-            }
-        } else {
-            CommandPaletteAction::ExecuteCommand {
-                command: slash_command.clone(),
-            }
-        };
-        entries.push(CommandPaletteEntry {
-            section: PaletteSection::Command,
-            label: slash_command.clone(),
-            description,
-            command: slash_command,
-            action,
-        });
-    }
+    });
 
     let skills = skills::discover_for_workspace_and_dir(workspace, skills_dir);
     for skill in skills.list() {
@@ -201,6 +202,28 @@ pub fn build_entries(
     entries.sort_by(|a, b| a.label.cmp(&b.label));
     entries.sort_by_key(|entry| entry.section);
     entries
+}
+
+fn palette_description_for_unshadowed_aliases(
+    command: &commands::CommandInfo,
+    locale: Locale,
+    user_registry: &commands::user_registry::UserCommandRegistry,
+) -> String {
+    let desc = command.description_for(locale);
+    let aliases = command
+        .aliases
+        .iter()
+        .copied()
+        .filter(|alias| user_registry.get(alias).is_none())
+        .collect::<Vec<_>>();
+    if aliases.len() == command.aliases.len() {
+        return command.palette_description_for(locale);
+    }
+    if aliases.is_empty() {
+        desc.to_string()
+    } else {
+        format!("{}  aliases: {}", desc, aliases.join(", "))
+    }
 }
 
 fn build_mcp_entries(
@@ -1236,6 +1259,46 @@ mod tests {
             !entries
                 .iter()
                 .any(|entry| entry.section == PaletteSection::Command && entry.label == "/secret")
+        );
+    }
+
+    #[test]
+    fn command_palette_filters_shadowed_builtin_aliases_from_description() {
+        let tmp = TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let commands_dir = workspace.join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).expect("create commands dir");
+        std::fs::write(
+            commands_dir.join("image-review.md"),
+            "---\ndescription: Review an image\nalias: image\n---\nreview image",
+        )
+        .expect("write user command");
+
+        let entries = build_entries(
+            Locale::En,
+            tmp.path().join("skills").as_path(),
+            workspace.as_path(),
+            tmp.path().join("mcp.json").as_path(),
+            None,
+        );
+        let attach = entries
+            .iter()
+            .find(|entry| entry.section == PaletteSection::Command && entry.label == "/attach")
+            .expect("built-in canonical command should remain visible");
+
+        assert!(
+            !attach.description.contains("aliases: image")
+                && !attach.description.contains(", image")
+                && !attach.description.contains("image,"),
+            "shadowed /image alias must not be advertised by /attach: {}",
+            attach.description
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.section == PaletteSection::Command
+                    && entry.label == "/image-review"),
+            "user command that owns the /image alias should be visible"
         );
     }
 

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -54,8 +54,12 @@ pub fn build_entries(
     mcp_snapshot: Option<&crate::mcp::McpManagerSnapshot>,
 ) -> Vec<CommandPaletteEntry> {
     let mut entries = Vec::new();
+    let user_registry = commands::user_registry::registry_for_workspace(Some(workspace));
 
     for command in commands::command_infos() {
+        if user_registry.get(command.name).is_some() {
+            continue;
+        }
         let mut description = command.palette_description_for(locale);
         if command.requires_argument() {
             description.push_str("  ");
@@ -75,6 +79,36 @@ pub fn build_entries(
             label: format!("/{}", command.name),
             description,
             command: command.palette_command(),
+            action,
+        });
+    }
+
+    for command in user_registry.iter().filter(|command| !command.hidden) {
+        let mut description = command
+            .description
+            .clone()
+            .unwrap_or_else(|| "User-defined command".to_string());
+        if let Some(hint) = &command.argument_hint
+            && !hint.trim().is_empty()
+        {
+            description.push_str("  ");
+            description.push_str(hint.trim());
+        }
+        let slash_command = format!("/{}", command.name);
+        let action = if command.argument_hint.is_some() {
+            CommandPaletteAction::InsertText {
+                text: format!("{slash_command} "),
+            }
+        } else {
+            CommandPaletteAction::ExecuteCommand {
+                command: slash_command.clone(),
+            }
+        };
+        entries.push(CommandPaletteEntry {
+            section: PaletteSection::Command,
+            label: slash_command.clone(),
+            description,
+            command: slash_command,
             action,
         });
     }
@@ -1147,6 +1181,65 @@ mod tests {
     }
 
     #[test]
+    fn command_palette_includes_workspace_user_commands() {
+        let tmp = TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let commands_dir = workspace.join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).expect("create commands dir");
+        std::fs::write(
+            commands_dir.join("review.md"),
+            "---\ndescription: Review with context\nargument-hint: <path>\n---\nReview $ARGUMENTS",
+        )
+        .expect("write user command");
+
+        let entries = build_entries(
+            Locale::En,
+            tmp.path().join("skills").as_path(),
+            workspace.as_path(),
+            tmp.path().join("mcp.json").as_path(),
+            None,
+        );
+        let user_entry = entries
+            .iter()
+            .find(|entry| entry.section == PaletteSection::Command && entry.label == "/review")
+            .expect("user command should appear in command palette");
+
+        assert!(user_entry.description.contains("Review with context"));
+        assert!(user_entry.description.contains("<path>"));
+        assert!(matches!(
+            &user_entry.action,
+            CommandPaletteAction::InsertText { text } if text == "/review "
+        ));
+    }
+
+    #[test]
+    fn command_palette_excludes_hidden_user_commands() {
+        let tmp = TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let commands_dir = workspace.join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).expect("create commands dir");
+        std::fs::write(
+            commands_dir.join("secret.md"),
+            "---\ndescription: Internal workflow\nhidden: true\n---\nsecret",
+        )
+        .expect("write hidden user command");
+
+        let entries = build_entries(
+            Locale::En,
+            tmp.path().join("skills").as_path(),
+            workspace.as_path(),
+            tmp.path().join("mcp.json").as_path(),
+            None,
+        );
+
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| entry.section == PaletteSection::Command && entry.label == "/secret")
+        );
+    }
+
+    #[test]
     fn command_palette_has_one_entry_for_every_registered_command() {
         let tmp = TempDir::new().expect("tempdir");
         let skills_dir = tmp.path().join("skills");
@@ -1163,9 +1256,24 @@ mod tests {
             .iter()
             .filter(|entry| entry.section == PaletteSection::Command)
             .collect::<Vec<_>>();
-        assert_eq!(command_entries.len(), commands::command_infos().len());
+        let user_registry = commands::user_registry::registry_for_workspace(Some(tmp.path()));
+        let visible_user_commands = user_registry
+            .iter()
+            .filter(|command| !command.hidden)
+            .count();
+        let shadowed_builtins = commands::command_infos()
+            .iter()
+            .filter(|command| user_registry.get(command.name).is_some())
+            .count();
+        assert_eq!(
+            command_entries.len(),
+            commands::command_infos().len() - shadowed_builtins + visible_user_commands
+        );
 
         for command in commands::command_infos() {
+            if user_registry.get(command.name).is_some() {
+                continue;
+            }
             let label = format!("/{}", command.name);
             let matching = command_entries
                 .iter()

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2319,137 +2319,131 @@ pub(crate) fn slash_completion_hints(
         return Vec::new();
     }
     let mut entries: Vec<SlashMenuEntry> = Vec::new();
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let prefix_lower = prefix.to_ascii_lowercase();
-    let all_user_commands: Vec<commands::user_registry::UserCommandMetadata> =
-        if completing_skill_arg.is_none() {
-            commands::user_registry::registry_for_workspace(workspace)
-                .iter()
-                .cloned()
-                .collect()
-        } else {
-            Vec::new()
-        };
-    let user_commands: Vec<_> = all_user_commands
-        .iter()
-        .filter(|cmd| !cmd.hidden)
-        .cloned()
-        .collect();
 
     // ── Phase 1: prefix (starts_with) matches ─────────────────────────
     // Highest priority — preserves existing exact-prefix completion.
     if completing_skill_arg.is_none() {
-        for name in all_command_names_matching_loaded(prefix, &user_commands, &all_user_commands) {
-            seen.insert(name.clone());
-            let command_key = name.trim_start_matches('/');
-            push_command_entry(
-                &mut entries,
-                &name,
-                command_key,
-                &prefix_lower,
-                locale,
-                &user_commands,
-            );
-        }
-    }
-
-    // ── Phase 2: contains (substring) matches ─────────────────────────
-    // Medium priority — broader catching.
-    if completing_skill_arg.is_none() {
-        for cmd in commands::command_infos() {
-            let name = format!("/{}", cmd.name);
-            if seen.contains(&name) {
-                continue;
-            }
-            let cmd_lower = cmd.name.to_ascii_lowercase();
-            let name_match = cmd_lower.contains(&prefix_lower);
-            let alias_matches = |alias: &str| alias.to_ascii_lowercase().contains(&prefix_lower);
-            if builtin_visible_for_completion_match(
-                cmd,
-                &all_user_commands,
-                name_match,
-                alias_matches,
-            ) {
-                seen.insert(name.clone());
-                push_command_entry(
-                    &mut entries,
-                    &name,
-                    cmd.name,
-                    &prefix_lower,
-                    locale,
-                    &user_commands,
-                );
-            }
-        }
-        for cmd in &user_commands {
-            let name = format!("/{}", cmd.name);
-            if seen.contains(&name) {
-                continue;
-            }
-            let alias_match = cmd.aliases.iter().any(|a| a.contains(&prefix_lower));
-            if cmd.name.contains(&prefix_lower) || alias_match {
-                seen.insert(name.clone());
-                push_command_entry(
-                    &mut entries,
-                    &name,
-                    &cmd.name,
-                    &prefix_lower,
-                    locale,
-                    &user_commands,
-                );
-            }
-        }
-    }
-
-    // ── Phase 3: fuzzy subsequence matches ────────────────────────────
-    // Lowest priority — characters in order, not necessarily consecutive.
-    if completing_skill_arg.is_none() {
-        for cmd in commands::command_infos() {
-            let name = format!("/{}", cmd.name);
-            if seen.contains(&name) {
-                continue;
-            }
-            let cmd_lower = cmd.name.to_ascii_lowercase();
-            let name_match = fuzzy_chars_in_order(&prefix_lower, &cmd_lower);
-            let alias_matches = |alias: &str| fuzzy_chars_in_order(&prefix_lower, alias);
-            if builtin_visible_for_completion_match(
-                cmd,
-                &all_user_commands,
-                name_match,
-                alias_matches,
-            ) {
-                seen.insert(name.clone());
-                push_command_entry(
-                    &mut entries,
-                    &name,
-                    cmd.name,
-                    &prefix_lower,
-                    locale,
-                    &user_commands,
-                );
-            }
-        }
-        for cmd in &user_commands {
-            let name = format!("/{}", cmd.name);
-            if seen.contains(&name) {
-                continue;
-            }
-            let alias_match = cmd
-                .aliases
+        commands::user_registry::with_registry_for_workspace(workspace, |registry| {
+            let all_user_commands = registry.iter().collect::<Vec<_>>();
+            let user_commands = all_user_commands
                 .iter()
-                .any(|a| fuzzy_chars_in_order(&prefix_lower, a));
-            if fuzzy_chars_in_order(&prefix_lower, &cmd.name) || alias_match {
+                .copied()
+                .filter(|cmd| !cmd.hidden)
+                .collect::<Vec<_>>();
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+            for name in
+                all_command_names_matching_loaded(prefix, &user_commands, &all_user_commands)
+            {
                 seen.insert(name.clone());
+                let command_key = name.trim_start_matches('/');
                 push_command_entry(
                     &mut entries,
                     &name,
-                    &cmd.name,
+                    command_key,
                     &prefix_lower,
                     locale,
                     &user_commands,
                 );
             }
-        }
+
+            // ── Phase 2: contains (substring) matches ─────────────────────────
+            // Medium priority — broader catching.
+            for cmd in commands::command_infos() {
+                let name = format!("/{}", cmd.name);
+                if seen.contains(&name) {
+                    continue;
+                }
+                let cmd_lower = cmd.name.to_ascii_lowercase();
+                let name_match = cmd_lower.contains(&prefix_lower);
+                let alias_matches =
+                    |alias: &str| alias.to_ascii_lowercase().contains(&prefix_lower);
+                if builtin_visible_for_completion_match(
+                    cmd,
+                    &all_user_commands,
+                    name_match,
+                    alias_matches,
+                ) {
+                    seen.insert(name.clone());
+                    push_command_entry(
+                        &mut entries,
+                        &name,
+                        cmd.name,
+                        &prefix_lower,
+                        locale,
+                        &user_commands,
+                    );
+                }
+            }
+            for cmd in &user_commands {
+                let name = format!("/{}", cmd.name);
+                if seen.contains(&name) {
+                    continue;
+                }
+                let alias_match = cmd.aliases.iter().any(|a| a.contains(&prefix_lower));
+                if cmd.name.contains(&prefix_lower) || alias_match {
+                    seen.insert(name.clone());
+                    push_command_entry(
+                        &mut entries,
+                        &name,
+                        &cmd.name,
+                        &prefix_lower,
+                        locale,
+                        &user_commands,
+                    );
+                }
+            }
+
+            // ── Phase 3: fuzzy subsequence matches ────────────────────────────
+            // Lowest priority — characters in order, not necessarily consecutive.
+            for cmd in commands::command_infos() {
+                let name = format!("/{}", cmd.name);
+                if seen.contains(&name) {
+                    continue;
+                }
+                let cmd_lower = cmd.name.to_ascii_lowercase();
+                let name_match = fuzzy_chars_in_order(&prefix_lower, &cmd_lower);
+                let alias_matches = |alias: &str| fuzzy_chars_in_order(&prefix_lower, alias);
+                if builtin_visible_for_completion_match(
+                    cmd,
+                    &all_user_commands,
+                    name_match,
+                    alias_matches,
+                ) {
+                    seen.insert(name.clone());
+                    push_command_entry(
+                        &mut entries,
+                        &name,
+                        cmd.name,
+                        &prefix_lower,
+                        locale,
+                        &user_commands,
+                    );
+                }
+            }
+            for cmd in &user_commands {
+                let name = format!("/{}", cmd.name);
+                if seen.contains(&name) {
+                    continue;
+                }
+                let alias_match = cmd
+                    .aliases
+                    .iter()
+                    .any(|a| fuzzy_chars_in_order(&prefix_lower, a));
+                if fuzzy_chars_in_order(&prefix_lower, &cmd.name) || alias_match {
+                    seen.insert(name.clone());
+                    push_command_entry(
+                        &mut entries,
+                        &name,
+                        &cmd.name,
+                        &prefix_lower,
+                        locale,
+                        &user_commands,
+                    );
+                }
+            }
+        });
     }
 
     // ── Skills (only after user has typed `/skill `) ──────────────────
@@ -2542,8 +2536,8 @@ pub(crate) fn slash_completion_hints(
 
 fn all_command_names_matching_loaded(
     prefix: &str,
-    user_commands: &[commands::user_registry::UserCommandMetadata],
-    all_user_commands: &[commands::user_registry::UserCommandMetadata],
+    user_commands: &[&commands::user_registry::UserCommandMetadata],
+    all_user_commands: &[&commands::user_registry::UserCommandMetadata],
 ) -> Vec<String> {
     let prefix = prefix.strip_prefix('/').unwrap_or(prefix).to_lowercase();
     let mut result: Vec<String> = commands::command_infos()
@@ -2575,7 +2569,7 @@ fn all_command_names_matching_loaded(
 
 fn builtin_visible_for_completion_match(
     builtin: &commands::CommandInfo,
-    user_commands: &[commands::user_registry::UserCommandMetadata],
+    user_commands: &[&commands::user_registry::UserCommandMetadata],
     canonical_name_matches: bool,
     alias_matches: impl Fn(&str) -> bool,
 ) -> bool {
@@ -2602,7 +2596,7 @@ fn builtin_visible_for_completion_match(
 
 fn user_command_shadows_builtin_canonical(
     builtin: &commands::CommandInfo,
-    user_commands: &[commands::user_registry::UserCommandMetadata],
+    user_commands: &[&commands::user_registry::UserCommandMetadata],
 ) -> bool {
     user_commands.iter().any(|user| {
         user.name == builtin.name || user.aliases.iter().any(|alias| alias == builtin.name)
@@ -2611,7 +2605,7 @@ fn user_command_shadows_builtin_canonical(
 
 fn user_command_shadows_builtin_alias(
     builtin_alias: &str,
-    user_commands: &[commands::user_registry::UserCommandMetadata],
+    user_commands: &[&commands::user_registry::UserCommandMetadata],
 ) -> bool {
     user_commands.iter().any(|user| {
         user.name == builtin_alias || user.aliases.iter().any(|alias| alias == builtin_alias)
@@ -2626,7 +2620,7 @@ fn push_command_entry(
     command_key: &str,
     prefix_lower: &str,
     locale: crate::localization::Locale,
-    user_commands: &[commands::user_registry::UserCommandMetadata],
+    user_commands: &[&commands::user_registry::UserCommandMetadata],
 ) {
     let user_command = user_commands
         .iter()
@@ -3534,7 +3528,7 @@ mod tests {
             "deploy".to_string(),
             "---\ndescription: Deploy target\nargument-hint: <env>\n---\ndeploy".to_string(),
         )]);
-        let user_commands: Vec<_> = registry.iter().cloned().collect();
+        let user_commands: Vec<_> = registry.iter().collect();
         let mut entries = Vec::new();
 
         push_command_entry(

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2321,16 +2321,25 @@ pub(crate) fn slash_completion_hints(
     let mut entries: Vec<SlashMenuEntry> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let prefix_lower = prefix.to_ascii_lowercase();
-    let user_commands = if completing_skill_arg.is_none() {
-        commands::user_commands::load_user_commands(workspace)
-    } else {
-        Vec::new()
-    };
+    let all_user_commands: Vec<commands::user_registry::UserCommandMetadata> =
+        if completing_skill_arg.is_none() {
+            commands::user_registry::registry_for_workspace(workspace)
+                .iter()
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+    let user_commands: Vec<_> = all_user_commands
+        .iter()
+        .filter(|cmd| !cmd.hidden)
+        .cloned()
+        .collect();
 
     // ── Phase 1: prefix (starts_with) matches ─────────────────────────
     // Highest priority — preserves existing exact-prefix completion.
     if completing_skill_arg.is_none() {
-        for name in all_command_names_matching_loaded(prefix, &user_commands) {
+        for name in all_command_names_matching_loaded(prefix, &user_commands, &all_user_commands) {
             seen.insert(name.clone());
             let command_key = name.trim_start_matches('/');
             push_command_entry(
@@ -2353,16 +2362,37 @@ pub(crate) fn slash_completion_hints(
                 continue;
             }
             let cmd_lower = cmd.name.to_ascii_lowercase();
-            let alias_match = cmd
-                .aliases
-                .iter()
-                .any(|a| a.to_ascii_lowercase().contains(&prefix_lower));
-            if cmd_lower.contains(&prefix_lower) || alias_match {
+            let name_match = cmd_lower.contains(&prefix_lower);
+            let alias_matches = |alias: &str| alias.to_ascii_lowercase().contains(&prefix_lower);
+            if builtin_visible_for_completion_match(
+                cmd,
+                &all_user_commands,
+                name_match,
+                alias_matches,
+            ) {
                 seen.insert(name.clone());
                 push_command_entry(
                     &mut entries,
                     &name,
                     cmd.name,
+                    &prefix_lower,
+                    locale,
+                    &user_commands,
+                );
+            }
+        }
+        for cmd in &user_commands {
+            let name = format!("/{}", cmd.name);
+            if seen.contains(&name) {
+                continue;
+            }
+            let alias_match = cmd.aliases.iter().any(|a| a.contains(&prefix_lower));
+            if cmd.name.contains(&prefix_lower) || alias_match {
+                seen.insert(name.clone());
+                push_command_entry(
+                    &mut entries,
+                    &name,
+                    &cmd.name,
                     &prefix_lower,
                     locale,
                     &user_commands,
@@ -2380,16 +2410,40 @@ pub(crate) fn slash_completion_hints(
                 continue;
             }
             let cmd_lower = cmd.name.to_ascii_lowercase();
-            let alias_match = cmd
-                .aliases
-                .iter()
-                .any(|a| fuzzy_chars_in_order(&prefix_lower, &a.to_ascii_lowercase()));
-            if fuzzy_chars_in_order(&prefix_lower, &cmd_lower) || alias_match {
+            let name_match = fuzzy_chars_in_order(&prefix_lower, &cmd_lower);
+            let alias_matches = |alias: &str| fuzzy_chars_in_order(&prefix_lower, alias);
+            if builtin_visible_for_completion_match(
+                cmd,
+                &all_user_commands,
+                name_match,
+                alias_matches,
+            ) {
                 seen.insert(name.clone());
                 push_command_entry(
                     &mut entries,
                     &name,
                     cmd.name,
+                    &prefix_lower,
+                    locale,
+                    &user_commands,
+                );
+            }
+        }
+        for cmd in &user_commands {
+            let name = format!("/{}", cmd.name);
+            if seen.contains(&name) {
+                continue;
+            }
+            let alias_match = cmd
+                .aliases
+                .iter()
+                .any(|a| fuzzy_chars_in_order(&prefix_lower, a));
+            if fuzzy_chars_in_order(&prefix_lower, &cmd.name) || alias_match {
+                seen.insert(name.clone());
+                push_command_entry(
+                    &mut entries,
+                    &name,
+                    &cmd.name,
                     &prefix_lower,
                     locale,
                     &user_commands,
@@ -2488,27 +2542,80 @@ pub(crate) fn slash_completion_hints(
 
 fn all_command_names_matching_loaded(
     prefix: &str,
-    user_commands: &[(String, String)],
+    user_commands: &[commands::user_registry::UserCommandMetadata],
+    all_user_commands: &[commands::user_registry::UserCommandMetadata],
 ) -> Vec<String> {
     let prefix = prefix.strip_prefix('/').unwrap_or(prefix).to_lowercase();
     let mut result: Vec<String> = commands::command_infos()
         .iter()
         .filter(|cmd| {
-            cmd.name.starts_with(&prefix) || cmd.aliases.iter().any(|a| a.starts_with(&prefix))
+            builtin_visible_for_completion_match(
+                cmd,
+                all_user_commands,
+                cmd.name.starts_with(&prefix),
+                |alias| alias.starts_with(&prefix),
+            )
         })
         .map(|cmd| format!("/{}", cmd.name))
         .collect();
 
-    result.extend(
-        user_commands
+    result.extend(user_commands.iter().filter_map(|command| {
+        let name_matches = command.name.starts_with(&prefix);
+        let alias_matches = command
+            .aliases
             .iter()
-            .filter(|(name, _)| name.starts_with(&prefix))
-            .map(|(name, _)| format!("/{name}")),
-    );
+            .any(|alias| alias.starts_with(&prefix));
+        (name_matches || alias_matches).then(|| format!("/{}", command.name))
+    }));
 
     result.sort();
     result.dedup();
     result
+}
+
+fn builtin_visible_for_completion_match(
+    builtin: &commands::CommandInfo,
+    user_commands: &[commands::user_registry::UserCommandMetadata],
+    canonical_name_matches: bool,
+    alias_matches: impl Fn(&str) -> bool,
+) -> bool {
+    if user_command_shadows_builtin_canonical(builtin, user_commands) {
+        return false;
+    }
+
+    // Keep the canonical built-in visible when the typed text matches the
+    // canonical name, even if a user command shadows one of the built-in's
+    // aliases. Example: a user command with alias `/image` must not hide
+    // canonical `/attach` for `/att`.
+    if canonical_name_matches {
+        return true;
+    }
+
+    // If the built-in is visible only through an alias, hide it when that
+    // specific alias is shadowed by a user command. Example: `/image` should
+    // complete to the user command, not built-in `/attach` via its `/image`
+    // alias.
+    builtin.aliases.iter().any(|alias| {
+        alias_matches(alias) && !user_command_shadows_builtin_alias(alias, user_commands)
+    })
+}
+
+fn user_command_shadows_builtin_canonical(
+    builtin: &commands::CommandInfo,
+    user_commands: &[commands::user_registry::UserCommandMetadata],
+) -> bool {
+    user_commands.iter().any(|user| {
+        user.name == builtin.name || user.aliases.iter().any(|alias| alias == builtin.name)
+    })
+}
+
+fn user_command_shadows_builtin_alias(
+    builtin_alias: &str,
+    user_commands: &[commands::user_registry::UserCommandMetadata],
+) -> bool {
+    user_commands.iter().any(|user| {
+        user.name == builtin_alias || user.aliases.iter().any(|alias| alias == builtin_alias)
+    })
 }
 
 /// Push a built-in command entry to the slash menu, resolving description
@@ -2519,9 +2626,39 @@ fn push_command_entry(
     command_key: &str,
     prefix_lower: &str,
     locale: crate::localization::Locale,
-    user_commands: &[(String, String)],
+    user_commands: &[commands::user_registry::UserCommandMetadata],
 ) {
-    let (description, alias_hint) = if let Some(info) = commands::get_command_info(command_key) {
+    let user_command = user_commands
+        .iter()
+        .find(|command| command.name == command_key);
+
+    let (description, alias_hint) = if let Some(command) = user_command {
+        // User command shadows any built-in — use user metadata.
+        let mut description = command
+            .description
+            .clone()
+            .unwrap_or_else(|| String::from("User-defined command"));
+        if let Some(hint) = &command.argument_hint
+            && !hint.trim().is_empty()
+        {
+            description.push_str("  ");
+            description.push_str(hint.trim());
+        }
+        let alias_hint = if !command_key.to_ascii_lowercase().starts_with(prefix_lower) {
+            command
+                .aliases
+                .iter()
+                .find(|alias| {
+                    alias.starts_with(prefix_lower)
+                        || alias.contains(prefix_lower)
+                        || fuzzy_chars_in_order(prefix_lower, alias)
+                })
+                .cloned()
+        } else {
+            None
+        };
+        (description, alias_hint)
+    } else if let Some(info) = commands::get_command_info(command_key) {
         let hint = if !command_key.to_ascii_lowercase().starts_with(prefix_lower) {
             info.aliases
                 .iter()
@@ -2549,25 +2686,7 @@ fn push_command_entry(
         };
         (desc, hint)
     } else {
-        let mut description = String::from("User-defined command");
-        let mut argument_hint = None;
-        if let Some((_, content)) = user_commands.iter().find(|(key, _)| key == command_key) {
-            let (metadata, _) = commands::user_commands::parse_frontmatter(content);
-            for (key, value) in metadata {
-                match key.as_str() {
-                    "description" => description = value,
-                    "argument-hint" => argument_hint = Some(value),
-                    _ => {}
-                }
-            }
-        }
-        if let Some(hint) = argument_hint
-            && !hint.trim().is_empty()
-        {
-            description.push_str("  ");
-            description.push_str(hint.trim());
-        }
-        (description, None)
+        (String::from("User-defined command"), None)
     };
     entries.push(SlashMenuEntry {
         name: name.to_string(),
@@ -3290,11 +3409,132 @@ mod tests {
     }
 
     #[test]
+    fn slash_completion_hints_exclude_hidden_user_commands() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let commands_dir = tmp.path().join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).unwrap();
+        std::fs::write(
+            commands_dir.join("secret.md"),
+            "---\ndescription: Internal command\nhidden: true\n---\nsecret",
+        )
+        .unwrap();
+
+        let hints = slash_completion_hints(
+            "/secret",
+            128,
+            &[],
+            Locale::En,
+            Some(tmp.path()),
+            ApiProvider::Deepseek,
+        );
+
+        assert!(!hints.iter().any(|hint| hint.name == "/secret"));
+    }
+
+    #[test]
+    fn slash_completion_hints_match_user_command_aliases() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let commands_dir = tmp.path().join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).unwrap();
+        std::fs::write(
+            commands_dir.join("deploy-target.md"),
+            "---\ndescription: Deploy target\nalias: ship\n---\ndeploy",
+        )
+        .unwrap();
+
+        let hints = slash_completion_hints(
+            "/ship",
+            128,
+            &[],
+            Locale::En,
+            Some(tmp.path()),
+            ApiProvider::Deepseek,
+        );
+        let entry = hints
+            .iter()
+            .find(|hint| hint.name == "/deploy-target")
+            .expect("user command should be matched by alias");
+
+        assert_eq!(entry.alias_hint.as_deref(), Some("ship"));
+        assert_eq!(entry.description, "Deploy target");
+    }
+
+    #[test]
+    fn slash_completion_hints_keep_builtin_canonical_when_only_builtin_alias_is_shadowed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let commands_dir = tmp.path().join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).unwrap();
+        std::fs::write(
+            commands_dir.join("attach-review.md"),
+            "---\ndescription: Review image\nalias: image\n---\nreview image",
+        )
+        .unwrap();
+
+        let canonical_hints = slash_completion_hints(
+            "/att",
+            128,
+            &[],
+            Locale::En,
+            Some(tmp.path()),
+            ApiProvider::Deepseek,
+        );
+
+        assert!(
+            canonical_hints.iter().any(|hint| hint.name == "/attach"),
+            "canonical /attach should remain visible when only its /image alias is shadowed"
+        );
+
+        let alias_hints = slash_completion_hints(
+            "/image",
+            128,
+            &[],
+            Locale::En,
+            Some(tmp.path()),
+            ApiProvider::Deepseek,
+        );
+
+        assert!(
+            alias_hints.iter().any(|hint| hint.name == "/attach-review"),
+            "user command should complete through its /image alias"
+        );
+        assert!(
+            !alias_hints.iter().any(|hint| hint.name == "/attach"),
+            "built-in /attach should not complete through shadowed /image alias"
+        );
+    }
+
+    #[test]
+    fn slash_completion_hints_prefer_user_metadata_for_shadowed_builtin() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let commands_dir = tmp.path().join(".codewhale").join("commands");
+        std::fs::create_dir_all(&commands_dir).unwrap();
+        std::fs::write(
+            commands_dir.join("help.md"),
+            "---\ndescription: Custom help workflow\nargument-hint: <topic>\n---\nhelp",
+        )
+        .unwrap();
+
+        let hints = slash_completion_hints(
+            "/help",
+            128,
+            &[],
+            Locale::En,
+            Some(tmp.path()),
+            ApiProvider::Deepseek,
+        );
+        let help_entries: Vec<_> = hints.iter().filter(|hint| hint.name == "/help").collect();
+
+        assert_eq!(help_entries.len(), 1);
+        assert_eq!(help_entries[0].description, "Custom help workflow  <topic>");
+    }
+
+    #[test]
     fn review_regression_push_command_entry_uses_preloaded_user_command_frontmatter() {
-        let user_commands = vec![(
+        let registry = crate::commands::user_registry::UserCommandRegistry::from_loaded(vec![(
             "deploy".to_string(),
             "---\ndescription: Deploy target\nargument-hint: <env>\n---\ndeploy".to_string(),
-        )];
+        )]);
+        let user_commands: Vec<_> = registry.iter().cloned().collect();
         let mut entries = Vec::new();
 
         push_command_entry(

--- a/docs/architecture/command-dispatch.md
+++ b/docs/architecture/command-dispatch.md
@@ -1,0 +1,94 @@
+# Command Dispatch Architecture
+
+**Target branch:** `hunter/0.8.62-glm-subagents`
+**Related EPIC:** [#2870](https://github.com/Hmbown/CodeWhale/issues/2870)
+**Related issue:** [#2791](https://github.com/Hmbown/CodeWhale/issues/2791)
+
+This document records the command-dispatch ownership model after the
+EPIC-001 replay onto the Hunter branch. It is the public reference for the
+module boundaries, dispatch precedence, and permanent exceptions that remain
+after the command-boundary refactor.
+
+## Dispatch Flow
+
+`commands::execute()` owns the slash-command dispatch gate. The order is
+intentional:
+
+| Step | Source | Behavior |
+|------|--------|----------|
+| 0 | `$skill` compatibility | `$name` is resolved as `/skill name` before slash parsing. |
+| 1 | User commands | `user_registry::try_dispatch()` checks workspace and global markdown commands first, so user commands can shadow built-ins. |
+| 2 | Legacy aliases | `/jihua` and `/zidong` route through config mode dispatch for backward compatibility. |
+| 3 | Built-in registry | `CommandRegistry` resolves group-owned built-in commands by canonical name or alias. |
+| 4 | Legacy migration hints | Retired commands such as `/set` and `/deepseek` return targeted replacement guidance. |
+| 5 | Skills fallback | If no command matches, a skill with the same name may run before unknown-command suggestions are shown. |
+
+## Module Boundaries
+
+| Module | Responsibility |
+|--------|----------------|
+| `crates/tui/src/commands/mod.rs` | Central dispatch gate, registry initialization, public command lookup helpers, and unknown-command suggestions. |
+| `crates/tui/src/commands/traits.rs` | Built-in command metadata, trait-backed command objects, command groups, and registry lookup. |
+| `crates/tui/src/commands/groups/` | Group-owned built-in command areas. Each group owns its command metadata and handlers. |
+| `crates/tui/src/commands/user_registry.rs` | User-command registry boundary: markdown metadata, aliases, hidden entries, validation errors, dispatch state resets, and shadowing behavior. |
+| `crates/tui/src/commands/user_commands.rs` | Lower-level file scanning, frontmatter parsing, allowed-tools parsing, and template substitution used by the registry. |
+| `crates/tui/src/tui/command_palette.rs` | Palette entries for built-ins and visible user commands, with user commands shadowing built-ins. |
+| `crates/tui/src/tui/widgets/mod.rs` | Slash completion, user-command metadata display, and alias-shadowing behavior. |
+
+## Built-In Command Groups
+
+| Group | Scope |
+|-------|-------|
+| `core` | Help, model/provider selection, queue, hooks, subagents, links, feedback, voice, and core navigation. |
+| `config` | Config, settings, status surfaces, mode, theme, trust, logout, and related settings commands. |
+| `debug` | Token/cost introspection, cache, system/context, diff/edit, undo, and retry. |
+| `memory` | Persistent memory and notes. |
+| `project` | Project initialization, sharing, LSP, and goal/hunt commands. |
+| `session` | Rename, save, fork/new/load sessions, compaction, purge, relay, and export. |
+| `skills` | Skill listing, execution, review, and restore. |
+| `utility` | Attachments, tasks/jobs, MCP, network, and plugins. |
+
+## User Commands
+
+User commands are markdown files loaded from these locations in precedence
+order:
+
+1. `<workspace>/.codewhale/commands/`
+2. `<workspace>/.deepseek/commands/`
+3. `<workspace>/.claude/commands/`
+4. `<workspace>/.cursor/commands/`
+5. `~/.codewhale/commands/`
+6. `~/.deepseek/commands/`
+
+Supported frontmatter fields:
+
+| Field | Meaning |
+|-------|---------|
+| `description` | Work objective and UI description. |
+| `argument-hint` | Palette/completion hint for expected arguments. |
+| `allowed-tools` | Restricts command execution tools. An explicit empty value blocks all tools. |
+| `pausable` | Marks the command as pause/resume capable. |
+| `alias` / `aliases` | Additional user-command names that can shadow built-in aliases. |
+| `hidden` | Hides the command from palette/completion while allowing direct dispatch. |
+
+Dispatch through `user_registry` resets stale command state before sending the
+new command body: hunt objective fields, token/time counters, continuation
+count, allowed tools, pause state, todos, and plan state.
+
+## Permanent Exceptions
+
+| Exception | Rationale |
+|-----------|-----------|
+| `/jihua` and `/zidong` | Backward-compatible config mode aliases. |
+| `/set` and `/deepseek` migration hints | Retired commands kept only as direct typed guidance. They are excluded from registry and autocomplete. |
+| `#[allow(clippy::module_inception)]` in matching group modules | Group directories intentionally contain same-named child modules such as `core/core.rs`. |
+| `user_commands.rs` lower layer | The registry owns runtime behavior, while this module remains the shared filesystem and parser layer. |
+| `#[cfg(test)]` helpers in `user_commands.rs` | Deferred test migration compatibility while registry-specific tests are added. |
+
+## Replay Status
+
+FEAT-001's group-owned built-in command direction is represented on Hunter by
+the newer trait-backed registry and nested group tree. FEAT-002 is replayed as
+the dedicated user-command registry boundary. FEAT-003 is replayed as public
+architecture and PR/issue evidence documentation, updated for the Hunter target
+instead of the old `release/v0.8.60` branch.

--- a/docs/architecture/pr-issue-evidence-prep.md
+++ b/docs/architecture/pr-issue-evidence-prep.md
@@ -1,0 +1,79 @@
+# EPIC-001 Hunter Replay Evidence
+
+**Target branch:** `hunter/0.8.62-glm-subagents`
+**Replay branch:** `feat/replay-epic-001-on-hunter`
+**Related EPIC:** [#2870](https://github.com/Hmbown/CodeWhale/issues/2870)
+**Related issue:** [#2791](https://github.com/Hmbown/CodeWhale/issues/2791)
+
+This file is the working PR/issue evidence checklist for replaying EPIC-001
+FEAT-001, FEAT-002, and FEAT-003 onto the Hunter branch.
+
+## Replay Scope
+
+| Feature | Hunter replay decision |
+|---------|------------------------|
+| FEAT-001 | No raw cherry-pick. Hunter already contains the newer group-owned command tree and trait-backed registry. |
+| FEAT-002 | Replayed semantically as `user_registry.rs`, wired into dispatch, palette, and slash completion. Adapted to keep newer Hunter command-state reset behavior. |
+| FEAT-003 | Replayed as public architecture and PR/issue evidence docs for the Hunter target. Old release-branch validation claims were not copied. |
+
+## PR Summary Draft
+
+```markdown
+## Summary
+
+Replays the completed EPIC-001 command-boundary work onto
+`hunter/0.8.62-glm-subagents`.
+
+## Changes
+
+- Keep Hunter's existing trait-backed built-in command registry and nested
+  group-owned command tree as the FEAT-001 result.
+- Add a dedicated `UserCommandRegistry` boundary for markdown user commands.
+- Route user command dispatch, command palette entries, and slash completion
+  through the registry.
+- Preserve Hunter's newer command-state reset behavior when a user command
+  starts, including todos and plan state.
+- Preserve empty `allowed-tools` semantics: an explicit empty value blocks all
+  tools.
+- Add public architecture and PR/issue evidence docs for the Hunter target.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo check -p codewhale-tui`
+- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui commands::`
+- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui command_palette`
+- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui slash_completion`
+- `git diff --check`
+```
+
+## Issue #2870 Comment Draft
+
+```markdown
+EPIC-001 has been replayed onto the Hunter target as a semantic replay rather
+than raw cherry-picks.
+
+- FEAT-001: represented by Hunter's current trait-backed registry and
+  group-owned command tree.
+- FEAT-002: replayed as the user-command registry boundary, adapted to preserve
+  current Hunter behavior.
+- FEAT-003: replayed as public architecture and evidence docs for the Hunter
+  target.
+
+Validation evidence is included in the PR body.
+
+Paulo Aboim Pinto
+```
+
+## Validation Results
+
+Record live results here before opening or updating the PR.
+
+| Check | Result |
+|-------|--------|
+| `cargo fmt --all -- --check` | Pass |
+| `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo check -p codewhale-tui` | Pass |
+| `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui commands::` | Pass: 456 command tests |
+| `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui command_palette` | Pass: 18 tests |
+| `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui slash_completion` | Pass: 17 tests |
+| `git diff --check` | Pass |


### PR DESCRIPTION
## Summary

Replays the completed EPIC-001 command-boundary work onto `hunter/0.8.62-glm-subagents`.

Related: #2870, #2791

## Changes

- Keep Hunter's existing trait-backed built-in command registry and nested group-owned command tree as the FEAT-001 result.
- Add a dedicated `UserCommandRegistry` boundary for markdown user commands.
- Route user command dispatch, command palette entries, and slash completion through the registry.
- Preserve Hunter's newer command-state reset behavior when a user command starts, including todos and plan state.
- Preserve empty `allowed-tools` semantics: an explicit empty value blocks all tools.
- Add public architecture and PR/issue evidence docs for the Hunter target.
- Address Gemini review feedback for hot-path registry borrowing, alias/canonical collision checks, frontmatter validation, hot reload, lock contention, and shadowed alias descriptions.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo check -p codewhale-tui`
- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui commands::user_registry` - 17 tests passed
- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui command_palette` - 19 tests passed
- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui slash_completion` - 17 tests passed
- `CARGO_TARGET_DIR=/tmp/codewhale-hunter-target cargo test -p codewhale-tui commands::` - 459 command tests passed
- `git diff --check`
- `git diff --cached --check`

Paulo Aboim Pinto