### PR TITLE
fix(auto): allow heuristic-only auto routing when flash router unavailable

### DIFF
--- a/crates/tui/src/model_inventory.rs
+++ b/crates/tui/src/model_inventory.rs
@@ -126,6 +126,7 @@ impl ModelInventory {
         })
     }
 
+    #[allow(dead_code)] // kept for future inventory consumers
     pub(crate) fn active_default(&self) -> Option<&ModelRouteCandidate> {
         self.candidates
             .iter()

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -61,7 +61,9 @@ pub(crate) fn provider_router_candidates(
         | ApiProvider::Siliconflow
         | ApiProvider::SiliconflowCn
         | ApiProvider::Sglang
-        | ApiProvider::Vllm => RouterCandidates {
+        | ApiProvider::Vllm
+        | ApiProvider::WanjieArk
+        | ApiProvider::Volcengine => RouterCandidates {
             big: crate::config::wire_model_for_provider(provider, "deepseek-v4-pro"),
             cheap: Some(crate::config::wire_model_for_provider(
                 provider,
@@ -426,9 +428,13 @@ pub(crate) async fn resolve_auto_route_with_inventory(
 ) -> Result<AutoRouteSelection> {
     let inventory = ModelInventory::from_config(config);
     if !inventory.router_available {
-        bail!(
-            "model auto requires a DeepSeek API key so codewhale can use deepseek-v4-flash as the non-thinking router. Run `codewhale auth set --provider deepseek` or choose an explicit model."
-        );
+        // Fall back to heuristic-only auto routing when the flash router
+        // is unavailable (e.g. non-DeepSeek providers like wanjie-ark).
+        return Ok(auto_route_from_inventory_heuristic(
+            config,
+            latest_request,
+            &inventory,
+        ));
     }
 
     let heuristic = auto_route_from_inventory_heuristic(config, latest_request, &inventory);
@@ -534,10 +540,12 @@ fn auto_route_from_inventory_heuristic(
     latest_request: &str,
     inventory: &ModelInventory,
 ) -> AutoRouteSelection {
-    let fallback = inventory
-        .active_default()
-        .or_else(|| inventory.candidates.first());
-    let Some(candidate) = fallback else {
+    let candidates = &inventory.candidates;
+    let Some(active) = candidates
+        .iter()
+        .find(|c| c.provider == config.api_provider())
+        .or_else(|| candidates.first())
+    else {
         return AutoRouteSelection {
             provider: config.api_provider(),
             model: config.default_model(),
@@ -545,9 +553,16 @@ fn auto_route_from_inventory_heuristic(
             source: AutoRouteSource::Heuristic,
         };
     };
+    // Use the candidates' cheap/big info for complexity-based routing.
+    let router_candidates = provider_router_candidates(config.api_provider(), &active.model);
+    let chosen = if router_candidates.cheap.is_some() {
+        auto_model_heuristic_for_candidates(latest_request, &active.model, &router_candidates)
+    } else {
+        active.model.clone()
+    };
     AutoRouteSelection {
-        provider: candidate.provider,
-        model: candidate.model.clone(),
+        provider: active.provider,
+        model: chosen,
         reasoning_effort: Some(crate::auto_reasoning::select(false, latest_request)),
         source: AutoRouteSource::Heuristic,
     }

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 use crate::client::DeepSeekClient;
 use crate::config::{ApiProvider, Config, normalize_model_name_for_provider};


### PR DESCRIPTION
## Summary

`codewhale --provider wanjie-ark --model auto exec ...` fails with "model auto requires a DeepSeek API key" because `resolve_auto_route_with_inventory()` bails when `router_available` is false.

## Root cause

Two issues:

1. **`resolve_auto_route_with_inventory()`** bails with an error when the flash router is unavailable (no DeepSeek key configured). This prevents any non-DeepSeek provider from using auto routing at all.

2. **`provider_router_candidates()`** doesn't include `WanjieArk` or `Volcengine` in the cheap/big branch, so even if auto routing were allowed, these providers would fall through to the catch-all branch with `cheap: None`, making heuristic routing impossible.

## Fix

1. When `router_available` is false, fall back to heuristic-only auto routing instead of bailing. This uses complexity-based cheap/big selection without requiring a flash router call.

2. Add `WanjieArk` and `Volcengine` to `provider_router_candidates()` so they get cheap/big model pairs (`deepseek-v4-flash` / `deepseek-v4-pro`) for heuristic routing.

## Verification

Tested on Volcengine Ark Agent Plan endpoint:

```
codewhale --provider wanjie-ark \
  --base-url https://ark.cn-beijing.volces.com/api/plan/v3 \
  --model auto \
  exec '只回复 OK'
→ OK ✅

codewhale --provider wanjie-ark \
  --base-url https://ark.cn-beijing.volces.com/api/plan/v3 \
  --model auto \
  exec '请帮我分析架构...'
→ 正常返回 ✅
```

Previously both would fail with "model auto requires a DeepSeek API key".