### PR TITLE
Fix: Plan/Agent Mode Toggle — approval_mode restore + auto‑execution guard

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -985,6 +985,12 @@ struct YoloRestoreState {
     approval_mode: ApprovalMode,
 }
 
+/// Saved approval mode to restore when leaving Plan mode (#3279).
+#[derive(Debug, Clone, Copy)]
+struct PlanRestoreState {
+    approval_mode: ApprovalMode,
+}
+
 // === Sub-state structs for App field organization (#377) ===
 
 /// Vim modal editing mode for the composer input area.
@@ -1618,6 +1624,7 @@ pub struct App {
     #[allow(dead_code)]
     pub yolo: bool,
     yolo_restore: Option<YoloRestoreState>,
+    plan_restore: Option<PlanRestoreState>,
     // Clipboard handler
     pub clipboard: ClipboardHandler,
     // Tool approval session allowlist
@@ -2373,6 +2380,7 @@ impl App {
             hooks,
             yolo: initial_mode == AppMode::Yolo,
             yolo_restore,
+            plan_restore: None,
             clipboard: ClipboardHandler::new(),
             approval_session_approved: HashSet::new(),
             approval_session_denied: HashSet::new(),
@@ -2569,9 +2577,13 @@ impl App {
 
         let entering_yolo = mode == AppMode::Yolo && previous_mode != AppMode::Yolo;
         let leaving_yolo = previous_mode == AppMode::Yolo && mode != AppMode::Yolo;
+        let entering_plan = mode == AppMode::Plan && previous_mode != AppMode::Plan;
+        let leaving_plan = previous_mode == AppMode::Plan && mode != AppMode::Plan;
         self.mode = mode;
         self.status_message = Some(format!("Switched to {} mode", mode.label()));
 
+        // YOLO save/restore: captures the full pre-YOLO permission surface so
+        // exiting YOLO puts the user back exactly where they were.
         if entering_yolo {
             self.yolo_restore = Some(YoloRestoreState {
                 allow_shell: self.allow_shell,
@@ -2585,6 +2597,21 @@ impl App {
             self.allow_shell = restore.allow_shell;
             self.trust_mode = restore.trust_mode;
             self.approval_mode = restore.approval_mode;
+        }
+
+        // Plan save/restore (#3279): Plan mode derives its write-blocking from
+        // the mode itself (turn_loop), but the TUI approval surface reads
+        // `app.approval_mode` without consulting `app.mode`.  Save the Agent-era
+        // approval mode when entering Plan so it is restored when the user
+        // switches back to Agent.
+        if entering_plan {
+            self.plan_restore = Some(PlanRestoreState {
+                approval_mode: self.approval_mode,
+            });
+        } else if leaving_plan {
+            if let Some(restore) = self.plan_restore.take() {
+                self.approval_mode = restore.approval_mode;
+            }
         }
 
         self.yolo = mode == AppMode::Yolo;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2608,10 +2608,8 @@ impl App {
             self.plan_restore = Some(PlanRestoreState {
                 approval_mode: self.approval_mode,
             });
-        } else if leaving_plan {
-            if let Some(restore) = self.plan_restore.take() {
-                self.approval_mode = restore.approval_mode;
-            }
+        } else if leaving_plan && let Some(restore) = self.plan_restore.take() {
+            self.approval_mode = restore.approval_mode;
         }
 
         self.yolo = mode == AppMode::Yolo;

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7764,7 +7764,13 @@ async fn apply_plan_choice(
         PlanChoice::ExitPlan => {
             apply_mode_update(app, engine_handle, AppMode::Agent).await;
             app.add_message(HistoryCell::System {
-                content: "Exited Plan mode. Switched to Agent mode.".to_string(),
+                content: concat!(
+                    "Exited Plan mode. Switched to Agent mode.\n\n",
+                    "The plan above is for reference only. ",
+                    "Do NOT execute it until the user explicitly asks you to. ",
+                    "Wait for the user's next instruction before taking any action.",
+                )
+                .to_string(),
             });
         }
     }


### PR DESCRIPTION
Two fixes for Plan/Agent mode toggle inconsistency reported in #3279.
---
## Bug A — `approval_mode` not restored after Plan → Agent switch

### Root cause

`App::set_mode` only saved and restored `approval_mode`, `allow_shell`, and
`trust_mode` during YOLO transitions (entering / leaving YOLO).  Plan ↔ Agent
transitions only updated `self.mode` and a few Plan‑specific flags
(`plan_prompt_pending`, `plan_tool_used_in_turn`).

The TUI approval surface (`ui.rs:2569‑2609`) reads `app.approval_mode` without
consulting `app.mode`, so any runtime change to `approval_mode` that occurred
while Plan mode was active would **persist** after switching to Agent, causing
tools to be auto‑denied with "denied by user" even though the UI showed Agent
mode.

### Fix

- Add `PlanRestoreState { approval_mode }` struct (mirrors the existing
  `YoloRestoreState` pattern).
- Add `plan_restore: Option<PlanRestoreState>` field to `App`.
- In `set_mode`:
  - When **entering** Plan mode from a non‑Plan mode → save current
    `approval_mode` into `plan_restore`.
  - When **leaving** Plan mode for a non‑Plan mode (Agent or YOLO) → restore
    the saved value.
- Initialize `plan_restore: None` in `App::new`.

**File:** `crates/tui/src/tui/app.rs` (+27 lines)

### Code diff

```rust
// --- new struct (after YoloRestoreState) ---
struct PlanRestoreState {
    approval_mode: ApprovalMode,
}

// --- new field in App ---
plan_restore: Option<PlanRestoreState>,

// --- in set_mode() ---
let entering_plan = mode == AppMode::Plan && previous_mode != AppMode::Plan;
let leaving_plan = previous_mode == AppMode::Plan && mode != AppMode::Plan;

if entering_plan {
    self.plan_restore = Some(PlanRestoreState {
        approval_mode: self.approval_mode,
    });
} else if leaving_plan {
    if let Some(restore) = self.plan_restore.take() {
        self.approval_mode = restore.approval_mode;
    }
}

// --- in App::new() ---
plan_restore: None,
```

---

## Bug B — AI auto‑executing after Plan exit without user consent

### Root cause

The `ExitPlan` handler added a short system message ("Exited Plan mode.
Switched to Agent mode.") into the conversation history.  When the model then
received a follow‑up message, it saw the plan output in context, had newly
granted Agent‑mode tools, and began executing the plan without waiting for the
user to explicitly ask for execution.

This was especially likely after `/restore`, where the restored transcript
included the completed plan but no explicit "stop" instruction.

### Fix

Extend the `ExitPlan` system message with an explicit instruction to the model:

> "The plan above is for reference only. Do NOT execute it until the user
> explicitly asks you to. Wait for the user's next instruction before taking
> any action."

**File:** `crates/tui/src/tui/ui.rs` (+8 / −1)

### Code diff

```rust
// Before:
PlanChoice::ExitPlan => {
    apply_mode_update(app, engine_handle, AppMode::Agent).await;
    app.add_message(HistoryCell::System {
        content: "Exited Plan mode. Switched to Agent mode.".to_string(),
    });
}

// After:
PlanChoice::ExitPlan => {
    apply_mode_update(app, engine_handle, AppMode::Agent).await;
    app.add_message(HistoryCell::System {
        content: concat!(
            "Exited Plan mode. Switched to Agent mode.\n\n",
            "The plan above is for reference only. ",
            "Do NOT execute it until the user explicitly asks you to. ",
            "Wait for the user's next instruction before taking any action.",
        )
        .to_string(),
    });
}
```

---

Close https://github.com/Hmbown/CodeWhale/issues/3279

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
