### PR TITLE
perf(prompts): move volatile workspace path out of the static system prefix

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1489,6 +1489,10 @@ impl Engine {
 
         let mut lines = vec![
             format!("Current local date: {today}"),
+            // Workspace path moved here from the static `## Environment` block so
+            // the static system prefix stays byte-stable across sessions (see
+            // `render_environment_block` for the prefix-cache rationale).
+            format!("Current workspace: {}", self.config.workspace.display()),
             format!("Current model: {routed_model}"),
         ];
         if auto_model {

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -165,23 +165,34 @@ for the current turn."
 /// in `prompts/base.md` can reference it without the model having to
 /// guess from the user's first message. `locale_tag` is resolved by
 /// the caller from `Settings` so this function stays I/O-free.
-fn render_environment_block(workspace: &Path, locale_tag: &str) -> String {
+fn render_environment_block(_workspace: &Path, locale_tag: &str) -> String {
     let codewhale_version = env!("CARGO_PKG_VERSION");
     let platform = std::env::consts::OS;
     let shell = crate::shell_dispatcher::global_dispatcher()
         .kind()
         .binary()
         .to_string();
-    let pwd = workspace.display();
 
+    // The workspace path (`pwd`) is intentionally delivered per-turn via the
+    // `<turn_meta>` block (see `turn_metadata_block`) rather than embedded here.
+    //
+    // Rationale: when the workspace path changes between sessions (e.g. an
+    // ephemeral per-session workspace), a volatile value inside the otherwise
+    // static system prefix invalidates the inference server's prefix cache at
+    // that exact point. The cache then only partially matches and the tail must
+    // be re-prefilled from the divergence boundary. On backends that pair prefix
+    // caching with speculative decoding, this partial re-prefill can perturb the
+    // logits at the boundary enough to degrade structured tool-call emission
+    // (the model regresses to bare text). Keeping the static system prefix
+    // byte-identical across sessions lets the prefix cache be reused; the live
+    // workspace path still reaches the model every turn through `turn_meta`.
     format!(
         "## Environment\n\
          \n\
          - lang: {locale_tag}\n\
          - codewhale_version: {codewhale_version}\n\
          - platform: {platform}\n\
-         - shell: {shell}\n\
-         - pwd: {pwd}"
+         - shell: {shell}"
     )
 }
 
@@ -1942,7 +1953,8 @@ mod tests {
             "- codewhale_version: {}",
             env!("CARGO_PKG_VERSION")
         )));
-        assert!(block.contains(&format!("- pwd: {}", tmp.path().display())));
+        // pwd is now delivered per-turn via `turn_meta`, not in the static block.
+        assert!(!block.contains("- pwd:"));
         assert!(block.contains("- platform:"));
         assert!(block.contains("- shell:"));
     }


### PR DESCRIPTION
## Problem

The `## Environment` block in the system prompt includes the current workspace
path as `- pwd: <path>`. When each session gets its own workspace directory
(e.g. an ephemeral / per-session temp workspace), this path differs between
sessions.

Because `pwd` sits inside the otherwise-static system prefix, a new session's
prompt matches a previous session's cached prefix only up to the `pwd` line and
then diverges. The inference server's prefix cache **partially** hits, and the
tail (from the divergence point onward) is re-prefilled.

On backends that pair `--enable-prefix-caching` with speculative decoding, this
partial re-prefill empirically perturbs generation at the divergence boundary
enough to **degrade structured tool-call emission** — the model emits bare
`<tool_name>` text instead of a proper tool call. It also wastes prefill on
every new session even when it doesn't regress.

## Fix

Move the workspace path out of the static `render_environment_block` and deliver
it per-turn via the existing `turn_meta` block (`Current workspace`, next to
`Current local date` / `Current model`). `turn_meta` lives in the user turn, not
the cached static prefix, so:

- the static system prefix is byte-identical across sessions → the prefix cache
  is fully reused (no partial-hit re-prefill);
- the live workspace path still reaches the model every turn.

`## Environment` keeps `lang` / `codewhale_version` / `platform` / `shell` (all
stable within a process); only the volatile `pwd` moves.

## Measured impact

In a setup with prefix caching + speculative decoding and a fresh per-session
workspace, a single-tool-call scenario went from **~25% to ~100%** correct
tool-call rate after this change (the failures were exactly the "bare text
instead of tool call" regression described above). A full prefix-cache hit also
removes the per-session tail re-prefill.
