### PR TITLE
fix(tui): respect snapshots.enabled for per-tool snapshots (#3292)

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2079,12 +2079,12 @@ impl Engine {
                         // Per-tool snapshot for surgical undo (#384): capture workspace
                         // state before file-modifying tools execute so `/undo` can
                         // revert the most recent write_file/edit_file/apply_patch.
-                        if result_override.is_none()
-                            && matches!(
-                                tool_name.as_str(),
-                                "write_file" | "edit_file" | "apply_patch"
-                            )
-                        {
+                        // See `should_pre_tool_snapshot` for the gating rationale (#3292).
+                        if should_pre_tool_snapshot(
+                            self.config.snapshots_enabled,
+                            result_override.is_some(),
+                            tool_name.as_str(),
+                        ) {
                             let ws = self.session.workspace.clone();
                             let tid = tool_id.clone();
                             let cap = self.config.snapshots_max_workspace_bytes;
@@ -2526,6 +2526,25 @@ fn stream_chunk_timeout_budget(config: &EngineConfig) -> (u64, Duration) {
     (secs, Duration::from_secs(secs))
 }
 
+/// Whether a per-tool pre-execution snapshot should be taken before running
+/// `tool_name` (#384).
+///
+/// Gated on `snapshots.enabled` (#3292) so that disabling snapshots suppresses
+/// the per-tool `tool:<call_id>` commits, matching the pre/post-turn snapshot
+/// call sites which already honor the same flag. A tool whose result is already
+/// overridden (denied, hook-supplied, or otherwise short-circuited) never
+/// executes a file write, so it is skipped too. Only the file-modifying tools
+/// produce undoable workspace changes worth snapshotting.
+fn should_pre_tool_snapshot(
+    snapshots_enabled: bool,
+    has_result_override: bool,
+    tool_name: &str,
+) -> bool {
+    snapshots_enabled
+        && !has_result_override
+        && matches!(tool_name, "write_file" | "edit_file" | "apply_patch")
+}
+
 /// Synthesize the tool result recorded for a tool call that never executed
 /// because the turn was cancelled mid-batch (#3216 / #2211).
 ///
@@ -2557,6 +2576,49 @@ mod cancel_batch_tests {
             "interrupted result should explain the cancellation: {:?}",
             result.content
         );
+    }
+}
+
+#[cfg(test)]
+mod pre_tool_snapshot_gate_tests {
+    use super::*;
+
+    // #3292: disabling snapshots must suppress the per-tool `tool:<call_id>`
+    // commits, just like the pre/post-turn snapshot sites.
+    #[test]
+    fn disabled_snapshots_suppress_per_tool_snapshot() {
+        for tool in ["write_file", "edit_file", "apply_patch"] {
+            assert!(
+                !should_pre_tool_snapshot(false, false, tool),
+                "snapshots.enabled=false must skip per-tool snapshot for {tool}"
+            );
+        }
+    }
+
+    #[test]
+    fn enabled_snapshots_snapshot_file_modifying_tools() {
+        for tool in ["write_file", "edit_file", "apply_patch"] {
+            assert!(
+                should_pre_tool_snapshot(true, false, tool),
+                "snapshots.enabled=true must snapshot {tool} before it runs"
+            );
+        }
+    }
+
+    #[test]
+    fn overridden_result_skips_snapshot() {
+        // A denied/short-circuited tool never executes a write, so no snapshot.
+        assert!(!should_pre_tool_snapshot(true, true, "write_file"));
+    }
+
+    #[test]
+    fn non_modifying_tools_are_never_snapshotted() {
+        for tool in ["read_file", "shell", "grep", "list_dir"] {
+            assert!(
+                !should_pre_tool_snapshot(true, false, tool),
+                "{tool} does not modify the workspace and must not be snapshotted"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #3292.

Per-tool snapshots (#384) wrote a `tool:<call_id>` commit before every
`write_file` / `edit_file` / `apply_patch` **even when `snapshots.enabled = false`**.
The per-tool call site in `turn_loop.rs` lacked the `snapshots.enabled` guard that
the pre-turn and post-turn snapshot sites already have, so disabling snapshots did
not actually stop per-tool snapshots.

This change gates the per-tool snapshot on `snapshots.enabled`, so all three
snapshot sites honor the same config flag. The condition is extracted into a small
`should_pre_tool_snapshot` predicate (mirroring the existing
`should_hold_turn_for_subagents` style in the same file) so the gating is unit
testable. No behavior change when snapshots are enabled.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` — 0 warnings / 0 errors
- [x] `cargo test --workspace --all-features` — 4863 passed; new gate tests pass.
      One unrelated test (`tools::test_runner::tests::run_tests_succeeds_on_fresh_project`)
      fails only under the full concurrent run because it spawns a nested `cargo test`
      that contends on a shared `CARGO_TARGET_DIR`; it passes standalone and is
      independent of this change.

New unit tests (`pre_tool_snapshot_gate_tests`) cover:
- `snapshots.enabled = false` suppresses per-tool snapshots for all file-modifying tools
- `snapshots.enabled = true` snapshots `write_file` / `edit_file` / `apply_patch`
- an overridden/short-circuited tool result skips the snapshot
- non-modifying tools (`read_file`, `shell`, `grep`, `list_dir`) are never snapshotted

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — n/a (no UI change)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a (single-author)
