### PR TITLE
fix(tui): write composer history under .codewhale, not legacy .deepseek

### DIFF
--- a/crates/tui/src/composer_history.rs
+++ b/crates/tui/src/composer_history.rs
@@ -1,8 +1,10 @@
 //! Cross-session composer input history (#366).
 //!
-//! Persists user-typed prompts to `~/.deepseek/composer_history.txt` so
-//! pressing Up-arrow at the composer recalls submissions from previous
-//! sessions, not just the current one. One entry per line, oldest first,
+//! Persists user-typed prompts to `~/.codewhale/composer_history.txt`
+//! (falling back to a legacy `~/.deepseek/composer_history.txt` only when
+//! one already exists, #3240) so pressing Up-arrow at the composer recalls
+//! submissions from previous sessions, not just the current one. One entry
+//! per line, oldest first,
 //! capped at [`MAX_HISTORY_ENTRIES`] entries (older entries are pruned
 //! at append time).
 //!
@@ -35,7 +37,29 @@ pub const MAX_HISTORY_ENTRIES: usize = 1000;
 const HISTORY_FILE_NAME: &str = "composer_history.txt";
 
 fn default_history_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".deepseek").join(HISTORY_FILE_NAME))
+    history_path_with_home(dirs::home_dir())
+}
+
+/// Resolve the composer-history file under `home`, preferring the CodeWhale
+/// root and only falling back to the legacy `.deepseek` root when a legacy
+/// file already exists.
+///
+/// On a fresh install (neither file present) this returns the `.codewhale`
+/// path, so the writer never recreates `~/.deepseek/` at runtime (#3240),
+/// while users who haven't migrated keep reading and appending to their
+/// existing legacy history. Mirrors the primary/legacy resolution used by
+/// `snapshot::paths` and `artifacts`.
+fn history_path_with_home(home: Option<PathBuf>) -> Option<PathBuf> {
+    let home = home?;
+    let primary = home.join(".codewhale").join(HISTORY_FILE_NAME);
+    if primary.exists() {
+        return Some(primary);
+    }
+    let legacy = home.join(".deepseek").join(HISTORY_FILE_NAME);
+    if legacy.exists() {
+        return Some(legacy);
+    }
+    Some(primary)
 }
 
 /// Read the persisted history into memory. Returns an empty vec if the
@@ -283,6 +307,45 @@ mod tests {
         done_rx
             .recv_timeout(timeout)
             .expect("history writer flush timed out");
+    }
+
+    // #3240: a fresh install must resolve the history file under `.codewhale`,
+    // never the legacy `.deepseek` dir, so normal use doesn't recreate it.
+    #[test]
+    fn fresh_install_uses_codewhale_not_legacy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = history_path_with_home(Some(tmp.path().to_path_buf()))
+            .expect("path resolves with a home dir");
+        assert_eq!(path, tmp.path().join(".codewhale").join(HISTORY_FILE_NAME));
+        assert!(
+            !path.starts_with(tmp.path().join(".deepseek")),
+            "fresh install must not target the legacy .deepseek dir: {path:?}"
+        );
+    }
+
+    // Migration care: an existing legacy history is still read/appended.
+    #[test]
+    fn existing_legacy_history_is_still_used() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let legacy = tmp.path().join(".deepseek").join(HISTORY_FILE_NAME);
+        fs::create_dir_all(legacy.parent().expect("legacy parent")).expect("mkdir legacy");
+        fs::write(&legacy, "old entry\n").expect("seed legacy history");
+        let path = history_path_with_home(Some(tmp.path().to_path_buf())).expect("path resolves");
+        assert_eq!(path, legacy);
+    }
+
+    // Once a `.codewhale` history exists it wins over any legacy file.
+    #[test]
+    fn codewhale_history_preferred_over_legacy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let primary = tmp.path().join(".codewhale").join(HISTORY_FILE_NAME);
+        let legacy = tmp.path().join(".deepseek").join(HISTORY_FILE_NAME);
+        for p in [&primary, &legacy] {
+            fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+            fs::write(p, "x\n").expect("seed");
+        }
+        let path = history_path_with_home(Some(tmp.path().to_path_buf())).expect("path resolves");
+        assert_eq!(path, primary);
     }
 
     #[test]


### PR DESCRIPTION
`default_history_path` hardcoded `~/.deepseek/composer_history.txt` for both read and write, so `append_history` ran `create_dir_all` on the legacy dir on every non-slash prompt submission — recreating `~/.deepseek/` at runtime even on fresh installs (e.g. alongside `.codewhale` on Windows).

Resolve the history path with the same primary/legacy pattern already used by `snapshot::paths` and `artifacts`: prefer `~/.codewhale/`, and fall back to the legacy `~/.deepseek/` file only when one already exists. Fresh installs now target `.codewhale` and never recreate the legacy directory, while un-migrated users keep reading and appending to their existing legacy history.

Refs #3240 (partial: composer history; other legacy write sites remain).

## Summary

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
