### PR TITLE
feat(tui): honor ask permission rules at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "codewhale-config",
+ "codewhale-execpolicy",
  "codewhale-protocol",
  "codewhale-release",
  "codewhale-secrets",

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.100"
 codewhale-config = { path = "../config", version = "0.8.61" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.61" }
 codewhale-protocol = { path = "../protocol", version = "0.8.61" }
 codewhale-release = { path = "../release", version = "0.8.61" }
 codewhale-secrets = { path = "../secrets", version = "0.8.61" }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use codewhale_execpolicy::ExecPolicyEngine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 #[cfg(unix)]
@@ -1961,6 +1962,13 @@ pub struct Config {
     /// Vision model configuration for the `image_analyze` tool.
     #[serde(default)]
     pub vision_model: Option<VisionModelConfig>,
+
+    /// Sibling `permissions.toml` ask-rules compiled for runtime checks.
+    ///
+    /// This is deliberately not part of `config.toml`; it is loaded from the
+    /// companion permissions file after profile/env/managed config resolution.
+    #[serde(skip)]
+    pub exec_policy_engine: ExecPolicyEngine,
 }
 
 /// How a user wants to replace or disable a built-in tool.
@@ -2351,6 +2359,7 @@ impl Config {
         apply_managed_overrides(&mut config)?;
         apply_requirements(&mut config)?;
         normalize_model_config(&mut config);
+        config.exec_policy_engine = load_sibling_exec_policy_engine(path.as_deref())?;
         config.validate()?;
         config.warn_on_misplaced_root_base_url();
         Ok(config)
@@ -5045,6 +5054,36 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         strict_tool_mode: override_cfg.strict_tool_mode.or(base.strict_tool_mode),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
         workshop: override_cfg.workshop.or(base.workshop),
+        exec_policy_engine: override_cfg.exec_policy_engine,
+    }
+}
+
+fn load_sibling_exec_policy_engine(config_path: Option<&Path>) -> Result<ExecPolicyEngine> {
+    let Some(config_path) = config_path else {
+        return Ok(ExecPolicyEngine::new(Vec::new(), Vec::new()));
+    };
+    let permissions_path = codewhale_config::permissions_path_for_config_path(config_path);
+    if !permissions_path.exists() {
+        return Ok(ExecPolicyEngine::new(Vec::new(), Vec::new()));
+    }
+
+    let raw = fs::read_to_string(&permissions_path).with_context(|| {
+        format!(
+            "Failed to read permissions file: {}",
+            permissions_path.display()
+        )
+    })?;
+    let permissions: codewhale_config::PermissionsToml =
+        toml::from_str(&raw).with_context(|| {
+            format!(
+                "Failed to parse permissions file: {}",
+                permissions_path.display()
+            )
+        })?;
+    if permissions.is_empty() {
+        Ok(ExecPolicyEngine::new(Vec::new(), Vec::new()))
+    } else {
+        Ok(ExecPolicyEngine::with_rulesets(vec![permissions.ruleset()]))
     }
 }
 
@@ -6278,6 +6317,76 @@ mod tests {
             ..Default::default()
         };
         assert!(config.prompt_suggestion_enabled());
+    }
+
+    #[test]
+    fn config_loads_sibling_permissions_into_exec_policy_engine() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("config.toml");
+        fs::write(&config_path, "model = \"deepseek-v4-pro\"\n").expect("write config");
+        fs::write(
+            dir.path().join(codewhale_config::PERMISSIONS_FILE_NAME),
+            r#"
+[[rules]]
+tool = "exec_shell"
+command = "cargo test"
+"#,
+        )
+        .expect("write permissions");
+
+        let config = Config::load(Some(config_path), None).expect("load config");
+        let decision = config
+            .exec_policy_engine
+            .check(codewhale_execpolicy::ExecPolicyContext {
+                command: "cargo test --workspace",
+                cwd: dir.path().to_string_lossy().as_ref(),
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: codewhale_execpolicy::AskForApproval::OnFailure,
+                sandbox_mode: None,
+            })
+            .expect("check permission");
+
+        assert!(decision.allow);
+        assert!(decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=cargo test")
+        );
+    }
+
+    #[test]
+    fn config_loads_sibling_permissions_when_config_file_is_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            dir.path().join(codewhale_config::PERMISSIONS_FILE_NAME),
+            r#"
+[[rules]]
+tool = "exec_shell"
+command = "npm test"
+"#,
+        )
+        .expect("write permissions");
+
+        let config = Config::load(Some(config_path), None).expect("load config");
+        let decision = config
+            .exec_policy_engine
+            .check(codewhale_execpolicy::ExecPolicyContext {
+                command: "npm test -- --runInBand",
+                cwd: dir.path().to_string_lossy().as_ref(),
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: codewhale_execpolicy::AskForApproval::OnFailure,
+                sandbox_mode: None,
+            })
+            .expect("check permission");
+
+        assert!(decision.requires_approval);
+        assert_eq!(
+            decision.matched_rule.as_deref(),
+            Some("tool=exec_shell command=npm test")
+        );
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -10,14 +10,15 @@
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::Result;
+use codewhale_execpolicy::{AskForApproval, ExecPolicyContext};
 use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
-use serde_json::json;
+use serde_json::{Value, json};
 use tokio::sync::{Mutex as AsyncMutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
@@ -370,6 +371,8 @@ pub struct EngineConfig {
     /// Applied to the per-turn tool registry after built-in tools are registered.
     /// When `None`, no overrides or plugin loading occurs.
     pub tools: Option<crate::config::ToolsConfig>,
+    /// Ask-only permission rules loaded from sibling `permissions.toml`.
+    pub exec_policy_engine: codewhale_execpolicy::ExecPolicyEngine,
 }
 
 impl Default for EngineConfig {
@@ -431,6 +434,7 @@ impl Default for EngineConfig {
             prefer_bwrap: false,
             verbosity: None,
             tools: None,
+            exec_policy_engine: codewhale_execpolicy::ExecPolicyEngine::new(Vec::new(), Vec::new()),
         }
     }
 }
@@ -1010,9 +1014,25 @@ impl Engine {
                 "Tool 'exec_shell' is disabled by feature flag".to_string(),
             ))
         } else if let Some(spec) = registry.get(&tool_name) {
-            let approval_required = spec.approval_requirement() != ApprovalRequirement::Auto
+            let mut approval_required = spec.approval_requirement() != ApprovalRequirement::Auto
                 && !registry.context().auto_approve;
-            if approval_required {
+            let mut approval_description = spec.description().to_string();
+            let mut approval_force_prompt = false;
+            let ask_rule_decision = exec_shell_ask_rule_decision(
+                &self.config,
+                &tool_name,
+                &tool_input,
+                &self.session.workspace,
+                self.session.approval_mode,
+            );
+            if let Some(ExecShellAskRuleDecision::Prompt(reason)) = ask_rule_decision.as_ref() {
+                approval_required = true;
+                approval_description = reason.clone();
+                approval_force_prompt = true;
+            }
+            if let Some(ExecShellAskRuleDecision::Block(reason)) = ask_rule_decision {
+                Err(ToolError::permission_denied(reason))
+            } else if approval_required {
                 emit_tool_audit(json!({
                     "event": "tool.approval_required",
                     "tool_id": tool_id.clone(),
@@ -1033,10 +1053,11 @@ impl Engine {
                         id: tool_id.clone(),
                         tool_name: tool_name.clone(),
                         input: tool_input.clone(),
-                        description: spec.description().to_string(),
+                        description: approval_description,
                         approval_key,
                         approval_grouping_key,
                         intent_summary: None,
+                        approval_force_prompt,
                     })
                     .await;
 
@@ -2889,6 +2910,54 @@ fn agent_approval_mode_for_turn(
         crate::tui::approval::ApprovalMode::Auto
     } else {
         approval_mode
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ExecShellAskRuleDecision {
+    Prompt(String),
+    Block(String),
+}
+
+pub(super) fn exec_shell_ask_rule_decision(
+    config: &EngineConfig,
+    tool_name: &str,
+    tool_input: &Value,
+    workspace: &Path,
+    approval_mode: crate::tui::approval::ApprovalMode,
+) -> Option<ExecShellAskRuleDecision> {
+    if tool_name != "exec_shell" {
+        return None;
+    }
+    let command = tool_input.get("command").and_then(Value::as_str)?;
+    let cwd = workspace.to_string_lossy();
+    let ask_for_approval = match approval_mode {
+        crate::tui::approval::ApprovalMode::Never => AskForApproval::Never,
+        crate::tui::approval::ApprovalMode::Auto | crate::tui::approval::ApprovalMode::Suggest => {
+            AskForApproval::OnFailure
+        }
+    };
+    let decision = config
+        .exec_policy_engine
+        .check(ExecPolicyContext {
+            command,
+            cwd: cwd.as_ref(),
+            tool: Some(tool_name),
+            path: None,
+            ask_for_approval,
+            sandbox_mode: None,
+        })
+        .ok()?;
+    if !decision.allow {
+        Some(ExecShellAskRuleDecision::Block(
+            decision.reason().to_string(),
+        ))
+    } else if decision.requires_approval {
+        Some(ExecShellAskRuleDecision::Prompt(
+            decision.reason().to_string(),
+        ))
+    } else {
+        None
     }
 }
 

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -45,6 +45,7 @@ pub(super) struct ToolExecutionPlan {
     pub(super) interactive: bool,
     pub(super) approval_required: bool,
     pub(super) approval_description: String,
+    pub(super) approval_force_prompt: bool,
     pub(super) supports_parallel: bool,
     pub(super) read_only: bool,
     pub(super) detached_start: bool,

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 use tempfile::tempdir;
 
@@ -231,12 +231,84 @@ fn make_plan_at(
         interactive,
         approval_required,
         approval_description: "desc".to_string(),
+        approval_force_prompt: false,
         supports_parallel,
         read_only,
         detached_start: false,
         blocked_error: None,
         guard_result: None,
     }
+}
+
+fn ask_rule_engine(command: &str) -> codewhale_execpolicy::ExecPolicyEngine {
+    codewhale_execpolicy::ExecPolicyEngine::with_rulesets(vec![
+        codewhale_execpolicy::Ruleset::user(vec![], vec![])
+            .with_ask_rules(vec![codewhale_execpolicy::ToolAskRule::exec_shell(command)]),
+    ])
+}
+
+#[test]
+fn exec_shell_ask_rule_decision_prompts_for_matching_auto_command() {
+    let config = EngineConfig {
+        exec_policy_engine: ask_rule_engine("cargo test"),
+        ..EngineConfig::default()
+    };
+
+    let decision = exec_shell_ask_rule_decision(
+        &config,
+        "exec_shell",
+        &json!({"command": "cargo test --workspace"}),
+        Path::new("/repo"),
+        crate::tui::approval::ApprovalMode::Auto,
+    );
+
+    assert_eq!(
+        decision,
+        Some(ExecShellAskRuleDecision::Prompt(
+            "Typed ask rule 'tool=exec_shell command=cargo test' requires approval.".to_string()
+        ))
+    );
+}
+
+#[test]
+fn exec_shell_ask_rule_decision_blocks_matching_never_command() {
+    let config = EngineConfig {
+        exec_policy_engine: ask_rule_engine("cargo test"),
+        ..EngineConfig::default()
+    };
+
+    let decision = exec_shell_ask_rule_decision(
+        &config,
+        "exec_shell",
+        &json!({"command": "cargo test --workspace"}),
+        Path::new("/repo"),
+        crate::tui::approval::ApprovalMode::Never,
+    );
+
+    assert_eq!(
+        decision,
+        Some(ExecShellAskRuleDecision::Block(
+            "Typed ask rule 'tool=exec_shell command=cargo test' requires approval, but approval policy is never.".to_string()
+        ))
+    );
+}
+
+#[test]
+fn exec_shell_ask_rule_decision_ignores_unmatched_command() {
+    let config = EngineConfig {
+        exec_policy_engine: ask_rule_engine("cargo test"),
+        ..EngineConfig::default()
+    };
+
+    let decision = exec_shell_ask_rule_decision(
+        &config,
+        "exec_shell",
+        &json!({"command": "git status"}),
+        Path::new("/repo"),
+        crate::tui::approval::ApprovalMode::Auto,
+    );
+
+    assert_eq!(decision, None);
 }
 
 fn api_tool(name: &str) -> Tool {

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1372,6 +1372,7 @@ impl Engine {
 
                 let mut approval_required = false;
                 let mut approval_description = "Tool execution requires approval".to_string();
+                let mut approval_force_prompt = false;
                 let mut supports_parallel = false;
                 let mut read_only = false;
                 let mut detached_start = false;
@@ -1540,6 +1541,29 @@ impl Engine {
                     approval_required = true;
                 }
 
+                if blocked_error.is_none()
+                    && let Some(decision) = exec_shell_ask_rule_decision(
+                        &self.config,
+                        &tool_name,
+                        &tool_input,
+                        &self.session.workspace,
+                        self.session.approval_mode,
+                    )
+                {
+                    match decision {
+                        ExecShellAskRuleDecision::Prompt(reason) => {
+                            approval_required = true;
+                            approval_description = reason;
+                            approval_force_prompt = true;
+                        }
+                        ExecShellAskRuleDecision::Block(reason) => {
+                            approval_required = false;
+                            approval_force_prompt = false;
+                            blocked_error = Some(ToolError::permission_denied(reason));
+                        }
+                    }
+                }
+
                 let should_emit_hydration_status =
                     !deferred_tools_hydrated_this_batch.contains(&tool_name);
                 if blocked_error.is_none()
@@ -1582,6 +1606,7 @@ impl Engine {
                     interactive,
                     approval_required,
                     approval_description,
+                    approval_force_prompt,
                     supports_parallel,
                     read_only,
                     detached_start,
@@ -2027,6 +2052,7 @@ impl Engine {
                                     } else {
                                         intent_summary.clone()
                                     },
+                                    approval_force_prompt: plan.approval_force_prompt,
                                 })
                                 .await;
 

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -207,6 +207,9 @@ pub enum Event {
         /// Displayed in the approval view so users understand *why* the change
         /// is being made before reviewing *what* will change.
         intent_summary: Option<String>,
+        /// When true, the UI must show the prompt instead of consuming
+        /// session/auto approval shortcuts.
+        approval_force_prompt: bool,
     },
 
     /// Request user input for a tool call

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6556,6 +6556,7 @@ async fn run_exec_agent(
         tools_always_load: execution_config.tools_always_load(),
         tools: execution_config.tools.clone(),
         verbosity: execution_config.verbosity.clone(),
+        exec_policy_engine: execution_config.exec_policy_engine.clone(),
     };
 
     let engine_handle = spawn_engine(engine_config, &execution_config);

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2157,6 +2157,7 @@ impl RuntimeThreadManager {
             tools_always_load: self.config.tools_always_load(),
             tools: self.config.tools.clone(),
             verbosity: self.config.verbosity.clone(),
+            exec_policy_engine: self.config.exec_policy_engine.clone(),
         };
 
         let engine = spawn_engine(engine_cfg, &self.config);
@@ -4448,6 +4449,7 @@ mod tests {
                 description: "stale approval".to_string(),
                 input: serde_json::json!({}),
                 intent_summary: None,
+                approval_force_prompt: false,
             })
             .await?;
 
@@ -4527,6 +4529,7 @@ mod tests {
                 description: "external allow".to_string(),
                 input: serde_json::json!({}),
                 intent_summary: Some("I will update the config file.".to_string()),
+                approval_force_prompt: false,
             })
             .await?;
 
@@ -4624,6 +4627,7 @@ mod tests {
                 description: "external deny".to_string(),
                 input: serde_json::json!({}),
                 intent_summary: None,
+                approval_force_prompt: false,
             })
             .await?;
 
@@ -4820,6 +4824,7 @@ mod tests {
                 description: "remember=true".to_string(),
                 input: serde_json::json!({}),
                 intent_summary: None,
+                approval_force_prompt: false,
             })
             .await?;
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -213,6 +213,17 @@ fn is_session_denied_for_key(app: &App, approval_key: &str) -> bool {
     app.approval_session_denied.contains(approval_key)
 }
 
+fn should_auto_approve_approval_request(
+    app: &App,
+    tool_name: &str,
+    grouping_key: &str,
+    approval_force_prompt: bool,
+) -> bool {
+    !approval_force_prompt
+        && (is_session_approved_for_tool(app, tool_name, grouping_key)
+            || app.approval_mode == ApprovalMode::Auto)
+}
+
 fn sidebar_width_for_chat_area(app: &App, chat_width: u16) -> Option<u16> {
     if app.sidebar_focus == SidebarFocus::Hidden || chat_width < SIDEBAR_VISIBLE_MIN_WIDTH {
         return None;
@@ -1036,6 +1047,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         search_base_url: config.search.as_ref().and_then(|s| s.base_url.clone()),
         tools_always_load: config.tools_always_load(),
         tools: config.tools.clone(),
+        exec_policy_engine: config.exec_policy_engine.clone(),
     }
 }
 
@@ -2565,9 +2577,8 @@ async fn run_event_loop(
                         approval_key,
                         approval_grouping_key,
                         intent_summary,
+                        approval_force_prompt,
                     } => {
-                        let session_approved =
-                            is_session_approved_for_tool(app, &tool_name, &approval_grouping_key);
                         let session_denied = is_session_denied_for_key(app, &approval_key);
                         if session_denied {
                             // The user already said no to this exact tool /
@@ -2583,7 +2594,12 @@ async fn run_event_loop(
                                 }),
                             );
                             let _ = engine_handle.deny_tool_call(id.clone()).await;
-                        } else if session_approved || app.approval_mode == ApprovalMode::Auto {
+                        } else if should_auto_approve_approval_request(
+                            app,
+                            &tool_name,
+                            &approval_grouping_key,
+                            approval_force_prompt,
+                        ) {
                             log_sensitive_event(
                                 "tool.approval.auto_approve",
                                 serde_json::json!({

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1645,6 +1645,55 @@ fn session_approved_cache_keeps_tool_name_session_grants() {
     );
 }
 
+#[test]
+fn forced_approval_prompt_bypasses_auto_mode_shortcut() {
+    let mut app = create_test_app();
+    app.approval_mode = ApprovalMode::Auto;
+
+    assert!(!should_auto_approve_approval_request(
+        &app,
+        "exec_shell",
+        "shell:exec_shell:cargo test",
+        true,
+    ));
+}
+
+#[test]
+fn forced_approval_prompt_bypasses_session_approval_shortcut() {
+    let mut app = create_test_app();
+    app.approval_session_approved
+        .insert("shell:exec_shell:cargo test".to_string());
+
+    assert!(!should_auto_approve_approval_request(
+        &app,
+        "exec_shell",
+        "shell:exec_shell:cargo test",
+        true,
+    ));
+}
+
+#[test]
+fn non_forced_approval_request_keeps_existing_auto_shortcuts() {
+    let mut app = create_test_app();
+    app.approval_mode = ApprovalMode::Auto;
+    assert!(should_auto_approve_approval_request(
+        &app,
+        "exec_shell",
+        "shell:exec_shell:cargo test",
+        false,
+    ));
+
+    app.approval_mode = ApprovalMode::Suggest;
+    app.approval_session_approved
+        .insert("shell:exec_shell:cargo test".to_string());
+    assert!(should_auto_approve_approval_request(
+        &app,
+        "exec_shell",
+        "shell:exec_shell:cargo test",
+        false,
+    ));
+}
+
 fn create_test_options() -> TuiOptions {
     TuiOptions {
         model: "deepseek-v4-pro".to_string(),

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -73,7 +73,9 @@ checked before trusted prefixes and block matching commands regardless of layer.
 Trusted prefixes only skip approval in modes that permit trust shortcuts. Typed
 ask records are currently a narrow foundation: when one matches under
 `AskForApproval::Never`, the command is rejected because the runtime cannot ask
-the user; existing allow/deny behavior is otherwise unchanged.
+the user; existing allow/deny behavior is otherwise unchanged. The TUI runtime
+loads ask-only records from the sibling `permissions.toml` file and applies
+matching `exec_shell` command ask-rules before Auto/session approval shortcuts.
 
 ### MCP manager and palette discovery
 


### PR DESCRIPTION
Summary:
Wire ask-only `permissions.toml` records into the TUI runtime approval path.

Scope:
- Load sibling `permissions.toml` ask-rules into TUI `Config` as an `ExecPolicyEngine`
- Thread the loaded policy engine into `EngineConfig`
- Apply matching `exec_shell` ask-rules for model tool calls and composer `!` shell commands
- Force approval prompts for matching ask-rules even when Auto/session approval would otherwise skip them
- Block matching ask-rules under `ApprovalMode::Never`
- Document the current ask-only runtime behavior in `docs/TOOL_SURFACE.md`
- Add config, engine, and UI regression tests

Not in this slice:
- Typed allow/deny permission rules
- File-tool/path permission routing
- Approval modal persistence or "save this rule" UI
- Any change to existing `auto_allow` / `auto_deny` behavior

Builds on:
- The landed ask-only `permissions.toml` schema/loading work
- The existing `execpolicy` typed ask-rule semantics

Issues:
Refs #1186 (partial)
Refs #2242 (partial)

Validation:
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check -p codewhale-tui --bin codewhale-tui`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --all-features -- -D warnings`
- `cargo test -p codewhale-tui --bin codewhale-tui config_loads_sibling_permissions -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui exec_shell_ask_rule_decision -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui forced_approval_prompt -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui non_forced_approval_request_keeps_existing_auto_shortcuts -- --nocapture`