### PR TITLE
[codex] Gate cross-tool skill discovery

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -579,6 +579,7 @@ max_subagents = 10 # optional (1-20)
 # [skills]
 # registry_url = "https://raw.githubusercontent.com/Hmbown/deepseek-skills/main/index.json"
 # max_install_size_bytes = 5_242_880
+# scan_codewhale_only = false # true: ignore Claude/OpenCode/Cursor/agentskills.io skill dirs
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # TUI

--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -21,20 +21,31 @@ thread_local! {
 
 #[cfg(not(test))]
 fn discover_visible_skills(app: &App) -> SkillRegistry {
-    crate::skills::discover_for_workspace_and_dir(&app.workspace, &app.skills_dir)
+    crate::skills::discover_for_workspace_and_dir_with_mode(
+        &app.workspace,
+        &app.skills_dir,
+        crate::skills::SkillDiscoveryMode::from_codewhale_only(app.skills_scan_codewhale_only),
+    )
 }
 
 #[cfg(test)]
 fn discover_visible_skills(app: &App) -> SkillRegistry {
+    let mode =
+        crate::skills::SkillDiscoveryMode::from_codewhale_only(app.skills_scan_codewhale_only);
     TEST_HOME_DIR.with(|home| {
         if let Some(home) = home.borrow().as_deref() {
-            crate::skills::discover_for_workspace_and_dir_with_home(
+            crate::skills::discover_for_workspace_and_dir_with_home_and_mode(
                 &app.workspace,
                 &app.skills_dir,
                 Some(home),
+                mode,
             )
         } else {
-            crate::skills::discover_for_workspace_and_dir(&app.workspace, &app.skills_dir)
+            crate::skills::discover_for_workspace_and_dir_with_mode(
+                &app.workspace,
+                &app.skills_dir,
+                mode,
+            )
         }
     })
 }
@@ -956,6 +967,43 @@ mod tests {
 
         assert!(msg.contains("/workspace-skill"), "got: {msg}");
         assert!(msg.contains("/configured-skill"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_list_skills_respects_codewhale_only_scan() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        let claude_skill_dir = tmpdir
+            .path()
+            .join(".claude")
+            .join("skills")
+            .join("claude-skill");
+        std::fs::create_dir_all(&claude_skill_dir).unwrap();
+        std::fs::write(
+            claude_skill_dir.join("SKILL.md"),
+            "---\nname: claude-skill\ndescription: Claude skill\n---\nbody",
+        )
+        .unwrap();
+        let codewhale_skill_dir = tmpdir
+            .path()
+            .join(".codewhale")
+            .join("skills")
+            .join("codewhale-skill");
+        std::fs::create_dir_all(&codewhale_skill_dir).unwrap();
+        std::fs::write(
+            codewhale_skill_dir.join("SKILL.md"),
+            "---\nname: codewhale-skill\ndescription: CodeWhale skill\n---\nbody",
+        )
+        .unwrap();
+
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.skills_dir = tmpdir.path().join(".codewhale").join("skills");
+        app.skills_scan_codewhale_only = true;
+        let result = list_skills(&mut app, None);
+        let msg = result.message.unwrap();
+
+        assert!(msg.contains("/codewhale-skill"), "got: {msg}");
+        assert!(!msg.contains("/claude-skill"), "got: {msg}");
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -5025,7 +5025,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         features: merge_features(base.features, override_cfg.features),
         notifications: override_cfg.notifications.or(base.notifications),
         network: override_cfg.network.or(base.network),
-        skills: override_cfg.skills.or(base.skills),
+        skills: merge_skills_config(base.skills, override_cfg.skills),
         snapshots: override_cfg.snapshots.or(base.snapshots),
         search: override_cfg.search.or(base.search),
         memory: override_cfg.memory.or(base.memory),
@@ -5063,6 +5063,26 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         strict_tool_mode: override_cfg.strict_tool_mode.or(base.strict_tool_mode),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),
         workshop: override_cfg.workshop.or(base.workshop),
+    }
+}
+
+fn merge_skills_config(
+    base: Option<SkillsConfig>,
+    override_cfg: Option<SkillsConfig>,
+) -> Option<SkillsConfig> {
+    match (base, override_cfg) {
+        (None, None) => None,
+        (Some(base), None) => Some(base),
+        (None, Some(override_cfg)) => Some(override_cfg),
+        (Some(base), Some(override_cfg)) => Some(SkillsConfig {
+            registry_url: override_cfg.registry_url.or(base.registry_url),
+            max_install_size_bytes: override_cfg
+                .max_install_size_bytes
+                .or(base.max_install_size_bytes),
+            scan_codewhale_only: override_cfg
+                .scan_codewhale_only
+                .or(base.scan_codewhale_only),
+        }),
     }
 }
 
@@ -8936,6 +8956,41 @@ scan_codewhale_only = true
 
         let merged = apply_profile(config, Some("work")).expect("profile");
         assert_eq!(merged.context.enabled, Some(true));
+    }
+
+    #[test]
+    fn profile_skills_config_merges_individual_fields() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "strict".to_string(),
+            Config {
+                skills: Some(SkillsConfig {
+                    scan_codewhale_only: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        let config = ConfigFile {
+            base: Config {
+                skills: Some(SkillsConfig {
+                    registry_url: Some("https://registry.example/skills.json".to_string()),
+                    max_install_size_bytes: Some(1234),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            profiles: Some(profiles),
+        };
+
+        let merged = apply_profile(config, Some("strict")).expect("profile");
+        let skills = merged.skills.expect("merged skills config");
+        assert_eq!(
+            skills.registry_url.as_deref(),
+            Some("https://registry.example/skills.json")
+        );
+        assert_eq!(skills.max_install_size_bytes, Some(1234));
+        assert_eq!(skills.scan_codewhale_only, Some(true));
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2029,6 +2029,11 @@ pub struct SkillsConfig {
     /// this limit are rejected during validation. Defaults to 5 MiB.
     #[serde(default)]
     pub max_install_size_bytes: Option<u64>,
+    /// When true, skill discovery scans only CodeWhale-owned skill roots
+    /// (plus any explicit `skills_dir`) instead of importing compatible
+    /// directories from other AI tools such as Claude, OpenCode, or Cursor.
+    #[serde(default, alias = "scanCodewhaleOnly")]
+    pub scan_codewhale_only: Option<bool>,
 }
 
 impl SkillsConfig {
@@ -2045,6 +2050,13 @@ impl SkillsConfig {
     pub fn max_install_size_bytes(&self) -> u64 {
         self.max_install_size_bytes
             .unwrap_or(crate::skills::install::DEFAULT_MAX_SIZE_BYTES)
+    }
+
+    /// Resolve whether session-time discovery should ignore cross-tool skill
+    /// directories. Defaults to the compatibility-preserving broad scan.
+    #[must_use]
+    pub fn scan_codewhale_only(&self) -> bool {
+        self.scan_codewhale_only.unwrap_or(false)
     }
 }
 
@@ -3362,6 +3374,12 @@ impl Config {
     #[must_use]
     pub fn snapshots_config(&self) -> SnapshotsConfig {
         self.snapshots.clone().unwrap_or_default()
+    }
+
+    /// Resolve community skill settings with defaults applied.
+    #[must_use]
+    pub fn skills_config(&self) -> SkillsConfig {
+        self.skills.clone().unwrap_or_default()
     }
 
     /// Resolve startup update-check settings with defaults applied.
@@ -8211,6 +8229,21 @@ api_key = "old-openrouter-key"
             expected_skills.components().collect::<Vec<_>>()
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn skills_scan_codewhale_only_defaults_false_and_parses_true() -> Result<()> {
+        assert!(!Config::default().skills_config().scan_codewhale_only());
+
+        let config: Config = toml::from_str(
+            r#"
+[skills]
+scan_codewhale_only = true
+"#,
+        )?;
+
+        assert!(config.skills_config().scan_codewhale_only());
         Ok(())
     }
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -250,6 +250,9 @@ pub struct EngineConfig {
     pub mcp_config_path: PathBuf,
     /// Directory containing discoverable skills.
     pub skills_dir: PathBuf,
+    /// Restrict skill discovery to CodeWhale-owned roots plus explicit
+    /// `skills_dir` configuration.
+    pub skills_scan_codewhale_only: bool,
     /// Sources injected as `<instructions source="…">` blocks in the system
     /// prompt (#454). Each entry is either a disk path (read at render time)
     /// or an inline string. Loaded in declared order from the user's
@@ -382,6 +385,7 @@ impl Default for EngineConfig {
             notes_path: PathBuf::from("notes.txt"),
             mcp_config_path: PathBuf::from("mcp.json"),
             skills_dir: crate::skills::default_skills_dir(),
+            skills_scan_codewhale_only: false,
             instructions: Vec::new(),
             project_context_pack_enabled: true,
             translation_enabled: false,
@@ -798,6 +802,7 @@ impl Engine {
                     ),
                     show_thinking: config.show_thinking,
                     verbosity: config.verbosity.as_deref(),
+                    skills_scan_codewhale_only: config.skills_scan_codewhale_only,
                 },
             );
         let stable_prompt = Some(system_prompt);
@@ -2466,6 +2471,10 @@ impl Engine {
         .with_features(self.config.features.clone())
         .with_shell_manager(self.shell_manager.clone())
         .with_runtime_services(self.config.runtime_services.clone())
+        .with_skills_config(
+            self.config.skills_dir.clone(),
+            self.config.skills_scan_codewhale_only,
+        )
         .with_session_objects(crate::rlm::session::SessionObjectSnapshot::new(
             self.session.id.clone(),
             self.session.model.clone(),
@@ -2696,6 +2705,7 @@ impl Engine {
                 ),
                 show_thinking: self.config.show_thinking,
                 verbosity: self.config.verbosity.as_deref(),
+                skills_scan_codewhale_only: self.config.skills_scan_codewhale_only,
             },
         );
         let mut stable_prompt =

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6484,6 +6484,7 @@ async fn run_exec_agent(
         notes_path: execution_config.notes_path(),
         mcp_config_path: execution_config.mcp_config_path(),
         skills_dir: execution_config.skills_dir(),
+        skills_scan_codewhale_only: execution_config.skills_config().scan_codewhale_only(),
         instructions: {
             let mut instrs: Vec<crate::prompts::InstructionSource> = execution_config
                 .instructions_paths()

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -44,6 +44,9 @@ pub struct PromptSessionContext<'a> {
     /// Optional output-verbosity mode. `concise` appends a short output
     /// discipline block; unset keeps the normal conversational prompt.
     pub verbosity: Option<&'a str>,
+    /// Restrict skill discovery to CodeWhale-owned roots plus explicit
+    /// `skills_dir` configuration.
+    pub skills_scan_codewhale_only: bool,
 }
 
 impl Default for PromptSessionContext<'_> {
@@ -58,6 +61,7 @@ impl Default for PromptSessionContext<'_> {
             context_window_override: None,
             show_thinking: true,
             verbosity: None,
+            skills_scan_codewhale_only: false,
         }
     }
 }
@@ -1000,6 +1004,7 @@ pub fn system_prompt_for_mode_with_context_and_skills(
             context_window_override: None,
             show_thinking: true,
             verbosity: None,
+            skills_scan_codewhale_only: false,
         },
     )
 }
@@ -1098,19 +1103,28 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
         );
     }
 
-    // 3. Skills block. #432: walks every candidate workspace
-    // skills directory (`.agents/skills`, `skills`,
-    // `.opencode/skills`, `.claude/skills`, `.cursor/skills`) plus global
-    // `~/.agents/skills` / `~/.deepseek/skills` so skills installed for any
-    // AI-tool convention show up in the catalogue. When an explicit
+    // 3. Skills block. #432: default discovery walks every compatible
+    // workspace/global skill directory so skills installed for other AI-tool
+    // conventions show up in the catalogue. Users can opt into a CodeWhale-only
+    // scan with `[skills] scan_codewhale_only = true`. When an explicit
     // `skills_dir` is configured, union it with the workspace view instead of
     // treating it as a fallback; the workspace view often returns Some and
     // would otherwise shadow the configured directory entirely.
+    let skill_discovery_mode = crate::skills::SkillDiscoveryMode::from_codewhale_only(
+        session_context.skills_scan_codewhale_only,
+    );
     let skills_block = match skills_dir {
         Some(dir) => {
-            crate::skills::render_available_skills_context_for_workspace_and_dir(workspace, dir)
+            crate::skills::render_available_skills_context_for_workspace_and_dir_with_mode(
+                workspace,
+                dir,
+                skill_discovery_mode,
+            )
         }
-        None => crate::skills::render_available_skills_context_for_workspace(workspace),
+        None => crate::skills::render_available_skills_context_for_workspace_with_mode(
+            workspace,
+            skill_discovery_mode,
+        ),
     };
     if let Some(block) = skills_block {
         full_prompt = format!("{full_prompt}\n\n{block}");
@@ -1882,6 +1896,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1953,6 +1968,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -1997,6 +2013,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: false,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2051,6 +2068,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2156,6 +2174,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2194,6 +2213,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2224,6 +2244,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2283,6 +2304,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2313,6 +2335,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2584,6 +2607,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -2620,6 +2644,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: None,
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,
@@ -3162,6 +3187,7 @@ mod tests {
                 context_window_override: None,
                 show_thinking: true,
                 verbosity: Some(" Concise "),
+                skills_scan_codewhale_only: false,
             },
         ) {
             SystemPrompt::Text(text) => text,

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2933,14 +2933,11 @@ fn current_git_head(workspace: &std::path::Path) -> Option<String> {
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
     if config.skills_config().scan_codewhale_only() {
-        let canonical_workspace = match fs::canonicalize(workspace) {
-            Ok(path) => path,
-            Err(_) => return config.skills_dir(),
-        };
-        let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
-        if let Ok(canonical_skills) = fs::canonicalize(&codewhale_skills_dir)
-            && canonical_skills.starts_with(&canonical_workspace)
-            && canonical_skills.is_dir()
+        if config.skills_dir.is_some() {
+            return config.skills_dir();
+        }
+        if let Some(codewhale_skills_dir) = crate::skills::codewhale_workspace_skills_dir(workspace)
+            && let Ok(canonical_skills) = fs::canonicalize(&codewhale_skills_dir)
         {
             return canonical_skills;
         }
@@ -6454,6 +6451,28 @@ mod tests {
 
         let expected = fs::canonicalize(&codewhale_skills).expect("canonical codewhale skills");
         assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_skills_dir_preserves_explicit_dir_in_codewhale_only_scan() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let codewhale_skills = workspace.join(".codewhale").join("skills");
+        let configured_skills = tmp.path().join("configured-skills");
+        fs::create_dir_all(&codewhale_skills).expect("create codewhale skills dir");
+        fs::create_dir_all(&configured_skills).expect("create configured skills dir");
+
+        let config = Config {
+            skills_dir: Some(configured_skills.to_string_lossy().into_owned()),
+            skills: Some(crate::config::SkillsConfig {
+                scan_codewhale_only: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let resolved = resolve_skills_dir(&config, &workspace);
+
+        assert_eq!(resolved, configured_skills);
     }
 
     #[test]

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1848,7 +1848,11 @@ async fn list_skills(
     State(state): State<RuntimeApiState>,
 ) -> Result<Json<SkillsResponse>, ApiError> {
     let skills_dir = resolve_skills_dir(&state.config, &state.workspace);
-    let (registry, directories) = discover_skills_for_runtime_api(&state.workspace, &skills_dir);
+    let mode = crate::skills::SkillDiscoveryMode::from_codewhale_only(
+        state.config.skills_config().scan_codewhale_only(),
+    );
+    let (registry, directories) =
+        discover_skills_for_runtime_api(&state.workspace, &skills_dir, mode);
     let skill_state = state.skill_state.lock().await;
     let skills = registry
         .list()
@@ -1875,7 +1879,11 @@ async fn set_skill_enabled(
     Json(req): Json<SetSkillEnabledRequest>,
 ) -> Result<Json<SetSkillEnabledResponse>, ApiError> {
     let skills_dir = resolve_skills_dir(&state.config, &state.workspace);
-    let (registry, directories) = discover_skills_for_runtime_api(&state.workspace, &skills_dir);
+    let mode = crate::skills::SkillDiscoveryMode::from_codewhale_only(
+        state.config.skills_config().scan_codewhale_only(),
+    );
+    let (registry, directories) =
+        discover_skills_for_runtime_api(&state.workspace, &skills_dir, mode);
     let exists = registry.list().iter().any(|skill| skill.name == name);
     if !exists {
         return Err(ApiError::not_found(format!(
@@ -2924,6 +2932,14 @@ fn current_git_head(workspace: &std::path::Path) -> Option<String> {
 }
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
+    if config.skills_config().scan_codewhale_only() {
+        let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
+        if codewhale_skills_dir.is_dir() {
+            return codewhale_skills_dir;
+        }
+        return config.skills_dir();
+    }
+
     // Canonicalize the workspace once so the symlink-containment check below
     // compares like-for-like. If the workspace can't be canonicalized at all
     // (e.g. it doesn't exist on disk yet) fall back to the configured global
@@ -2950,19 +2966,20 @@ fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
     config.skills_dir()
 }
 
-fn skills_search_directories(workspace: &FsPath, skills_dir: &FsPath) -> Vec<PathBuf> {
-    let mut directories = crate::skills::skills_directories(workspace);
-    if skills_dir.is_dir() && !directories.iter().any(|path| path == skills_dir) {
-        directories.push(skills_dir.to_path_buf());
-    }
-    directories
+fn skills_search_directories(
+    workspace: &FsPath,
+    skills_dir: &FsPath,
+    mode: crate::skills::SkillDiscoveryMode,
+) -> Vec<PathBuf> {
+    crate::skills::skill_directories_for_workspace_and_dir(workspace, skills_dir, mode)
 }
 
 fn discover_skills_for_runtime_api(
     workspace: &FsPath,
     skills_dir: &FsPath,
+    mode: crate::skills::SkillDiscoveryMode,
 ) -> (crate::skills::SkillRegistry, Vec<PathBuf>) {
-    let directories = skills_search_directories(workspace, skills_dir);
+    let directories = skills_search_directories(workspace, skills_dir, mode);
     let registry = crate::skills::discover_from_directories(directories.clone());
     (registry, directories)
 }
@@ -6411,6 +6428,27 @@ mod tests {
     }
 
     #[test]
+    fn resolve_skills_dir_respects_codewhale_only_scan() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path();
+        let agents_skills = workspace.join(".agents").join("skills");
+        let codewhale_skills = workspace.join(".codewhale").join("skills");
+        fs::create_dir_all(&agents_skills).expect("create agents skills dir");
+        fs::create_dir_all(&codewhale_skills).expect("create codewhale skills dir");
+
+        let config = Config {
+            skills: Some(crate::config::SkillsConfig {
+                scan_codewhale_only: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let resolved = resolve_skills_dir(&config, workspace);
+
+        assert_eq!(resolved, codewhale_skills);
+    }
+
+    #[test]
     fn skills_search_directories_includes_custom_skills_dir() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let workspace = tmp.path().join("workspace");
@@ -6418,7 +6456,11 @@ mod tests {
         fs::create_dir_all(&workspace).expect("create workspace");
         fs::create_dir_all(&custom_skills).expect("create custom skills");
 
-        let directories = skills_search_directories(&workspace, &custom_skills);
+        let directories = skills_search_directories(
+            &workspace,
+            &custom_skills,
+            crate::skills::SkillDiscoveryMode::Compatible,
+        );
 
         assert!(
             directories.iter().any(|dir| dir == &custom_skills),

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2933,9 +2933,16 @@ fn current_git_head(workspace: &std::path::Path) -> Option<String> {
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {
     if config.skills_config().scan_codewhale_only() {
+        let canonical_workspace = match fs::canonicalize(workspace) {
+            Ok(path) => path,
+            Err(_) => return config.skills_dir(),
+        };
         let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
-        if codewhale_skills_dir.is_dir() {
-            return codewhale_skills_dir;
+        if let Ok(canonical_skills) = fs::canonicalize(&codewhale_skills_dir)
+            && canonical_skills.starts_with(&canonical_workspace)
+            && canonical_skills.is_dir()
+        {
+            return canonical_skills;
         }
         return config.skills_dir();
     }
@@ -6445,7 +6452,8 @@ mod tests {
         };
         let resolved = resolve_skills_dir(&config, workspace);
 
-        assert_eq!(resolved, codewhale_skills);
+        let expected = fs::canonicalize(&codewhale_skills).expect("canonical codewhale skills");
+        assert_eq!(resolved, expected);
     }
 
     #[test]
@@ -6548,6 +6556,41 @@ mod tests {
             resolved,
             config.skills_dir(),
             "with no valid in-workspace skills dir, resolution should fall back to config"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_skills_dir_rejects_codewhale_only_symlink_escaping_workspace() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace_root = tmp.path().join("workspace");
+        let escape_target = tmp.path().join("escape_target");
+        fs::create_dir_all(&workspace_root).expect("create workspace");
+        fs::create_dir_all(&escape_target).expect("create escape target");
+
+        let dotcodewhale = workspace_root.join(".codewhale");
+        fs::create_dir_all(&dotcodewhale).expect("create .codewhale");
+        let bad_link = dotcodewhale.join("skills");
+        std::os::unix::fs::symlink(&escape_target, &bad_link).expect("symlink");
+
+        let config = Config {
+            skills: Some(crate::config::SkillsConfig {
+                scan_codewhale_only: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let resolved = resolve_skills_dir(&config, &workspace_root);
+
+        let canon_escape = fs::canonicalize(&escape_target).expect("canon escape");
+        assert_ne!(
+            resolved, canon_escape,
+            "CodeWhale-only symlink escaping workspace must not be resolved as skills dir"
+        );
+        assert_eq!(
+            resolved,
+            config.skills_dir(),
+            "with no valid in-workspace CodeWhale skills dir, resolution should fall back to config"
         );
     }
 }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2088,6 +2088,7 @@ impl RuntimeThreadManager {
             notes_path: self.config.notes_path(),
             mcp_config_path: self.config.mcp_config_path(),
             skills_dir: self.config.skills_dir(),
+            skills_scan_codewhale_only: self.config.skills_config().scan_codewhale_only(),
             instructions: self
                 .config
                 .instructions_paths()

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -524,7 +524,7 @@ fn skills_directories_with_home_and_mode(
     existing_skill_dirs(candidates)
 }
 
-fn codewhale_workspace_skills_dir(workspace: &Path) -> Option<PathBuf> {
+pub(crate) fn codewhale_workspace_skills_dir(workspace: &Path) -> Option<PathBuf> {
     let skills_dir = workspace.join(".codewhale").join("skills");
     let canonical_workspace = fs::canonicalize(workspace).ok()?;
     let canonical_skills = fs::canonicalize(&skills_dir).ok()?;

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -502,9 +502,9 @@ fn skills_directories_with_home_and_mode(
             workspace.join(".cursor").join("skills"),
             workspace.join(".codewhale").join("skills"),
         ],
-        SkillDiscoveryMode::CodeWhaleOnly => {
-            vec![workspace.join(".codewhale").join("skills")]
-        }
+        SkillDiscoveryMode::CodeWhaleOnly => codewhale_workspace_skills_dir(workspace)
+            .into_iter()
+            .collect(),
     };
     if let Some(home) = home_dir {
         match mode {
@@ -522,6 +522,14 @@ fn skills_directories_with_home_and_mode(
         candidates.push(PathBuf::from("/tmp/codewhale/skills"));
     }
     existing_skill_dirs(candidates)
+}
+
+fn codewhale_workspace_skills_dir(workspace: &Path) -> Option<PathBuf> {
+    let skills_dir = workspace.join(".codewhale").join("skills");
+    let canonical_workspace = fs::canonicalize(workspace).ok()?;
+    let canonical_skills = fs::canonicalize(&skills_dir).ok()?;
+    (canonical_skills.is_dir() && canonical_skills.starts_with(canonical_workspace))
+        .then_some(skills_dir)
 }
 
 fn existing_skill_dirs(candidates: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
@@ -1317,6 +1325,34 @@ mod tests {
         let names: Vec<&str> = registry.list().iter().map(|s| s.name.as_str()).collect();
 
         assert_eq!(names, vec!["configured-skill"]);
+    }
+
+    #[test]
+    fn codewhale_only_mode_rejects_workspace_codewhale_symlink_escape() {
+        let tmpdir = TempDir::new().unwrap();
+        let workspace = tmpdir.path().join("workspace");
+        let home = tmpdir.path().join("home");
+        let escape_target = tmpdir.path().join("escape-target");
+        std::fs::create_dir_all(workspace.join(".codewhale")).unwrap();
+        write_skill(&escape_target, "escaped-skill", "escaped skill", "body");
+
+        let link_path = workspace.join(".codewhale").join("skills");
+        if let Err(err) = create_dir_symlink(&escape_target, &link_path) {
+            eprintln!("skipping symlink escape assertion: {err}");
+            return;
+        }
+
+        let registry = super::discover_for_workspace_and_dir_with_home_and_mode(
+            &workspace,
+            &tmpdir.path().join("missing-configured-skills"),
+            Some(&home),
+            super::SkillDiscoveryMode::CodeWhaleOnly,
+        );
+
+        assert!(
+            registry.get("escaped-skill").is_none(),
+            "CodeWhale-only mode must not follow workspace .codewhale/skills outside the workspace"
+        );
     }
 
     #[test]

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -42,6 +42,28 @@ pub fn agents_global_skills_dir() -> Option<PathBuf> {
 
 // === Types ===
 
+/// Session-time skill discovery scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillDiscoveryMode {
+    /// Preserve the existing broad compatibility scan across CodeWhale,
+    /// agentskills.io, Claude, OpenCode, Cursor, and legacy DeepSeek roots.
+    Compatible,
+    /// Scan only CodeWhale-owned roots. Callers that also pass an explicit
+    /// `skills_dir` still get that directory because it is user configuration.
+    CodeWhaleOnly,
+}
+
+impl SkillDiscoveryMode {
+    #[must_use]
+    pub fn from_codewhale_only(value: bool) -> Self {
+        if value {
+            Self::CodeWhaleOnly
+        } else {
+            Self::Compatible
+        }
+    }
+}
+
 /// Parsed representation of a SKILL.md definition.
 #[derive(Debug, Clone)]
 pub struct Skill {
@@ -455,25 +477,47 @@ impl SkillRegistry {
 /// need to filter further. Returns an empty vec when nothing is
 /// installed (the system-prompt skills block is then suppressed).
 #[must_use]
+#[allow(dead_code)]
 pub fn skills_directories(workspace: &Path) -> Vec<PathBuf> {
-    let home = dirs::home_dir();
-    skills_directories_with_home(workspace, home.as_deref())
+    skills_directories_for_mode(workspace, SkillDiscoveryMode::Compatible)
 }
 
-fn skills_directories_with_home(workspace: &Path, home_dir: Option<&Path>) -> Vec<PathBuf> {
-    let mut candidates = vec![
-        workspace.join(".agents").join("skills"),
-        workspace.join("skills"),
-        workspace.join(".opencode").join("skills"),
-        workspace.join(".claude").join("skills"),
-        workspace.join(".cursor").join("skills"),
-        workspace.join(".codewhale").join("skills"),
-    ];
+#[must_use]
+pub fn skills_directories_for_mode(workspace: &Path, mode: SkillDiscoveryMode) -> Vec<PathBuf> {
+    let home = dirs::home_dir();
+    skills_directories_with_home_and_mode(workspace, home.as_deref(), mode)
+}
+
+fn skills_directories_with_home_and_mode(
+    workspace: &Path,
+    home_dir: Option<&Path>,
+    mode: SkillDiscoveryMode,
+) -> Vec<PathBuf> {
+    let mut candidates = match mode {
+        SkillDiscoveryMode::Compatible => vec![
+            workspace.join(".agents").join("skills"),
+            workspace.join("skills"),
+            workspace.join(".opencode").join("skills"),
+            workspace.join(".claude").join("skills"),
+            workspace.join(".cursor").join("skills"),
+            workspace.join(".codewhale").join("skills"),
+        ],
+        SkillDiscoveryMode::CodeWhaleOnly => {
+            vec![workspace.join(".codewhale").join("skills")]
+        }
+    };
     if let Some(home) = home_dir {
-        candidates.push(home.join(".agents").join("skills"));
-        candidates.push(home.join(".claude").join("skills"));
-        candidates.push(home.join(".codewhale").join("skills"));
-        candidates.push(home.join(".deepseek").join("skills"));
+        match mode {
+            SkillDiscoveryMode::Compatible => {
+                candidates.push(home.join(".agents").join("skills"));
+                candidates.push(home.join(".claude").join("skills"));
+                candidates.push(home.join(".codewhale").join("skills"));
+                candidates.push(home.join(".deepseek").join("skills"));
+            }
+            SkillDiscoveryMode::CodeWhaleOnly => {
+                candidates.push(home.join(".codewhale").join("skills"));
+            }
+        }
     } else {
         candidates.push(PathBuf::from("/tmp/codewhale/skills"));
     }
@@ -504,8 +548,16 @@ fn existing_skill_dirs(candidates: impl IntoIterator<Item = PathBuf>) -> Vec<Pat
 /// load.
 #[must_use]
 pub fn discover_in_workspace(workspace: &Path) -> SkillRegistry {
+    discover_in_workspace_with_mode(workspace, SkillDiscoveryMode::Compatible)
+}
+
+#[must_use]
+pub fn discover_in_workspace_with_mode(
+    workspace: &Path,
+    mode: SkillDiscoveryMode,
+) -> SkillRegistry {
     let mut merged = SkillRegistry::default();
-    for dir in skills_directories(workspace) {
+    for dir in skills_directories_for_mode(workspace, mode) {
         let registry = SkillRegistry::discover(&dir);
         for skill in registry.skills {
             if !merged.skills.iter().any(|s| s.name == skill.name) {
@@ -525,10 +577,30 @@ pub fn discover_in_workspace(workspace: &Path) -> SkillRegistry {
 /// outside that set so explicit configuration cannot be buried by large global
 /// libraries.
 #[must_use]
+#[allow(dead_code)]
 pub fn discover_for_workspace_and_dir(workspace: &Path, skills_dir: &Path) -> SkillRegistry {
-    let mut dirs = skills_directories(workspace);
-    insert_configured_skills_dir(&mut dirs, workspace, skills_dir);
+    discover_for_workspace_and_dir_with_mode(workspace, skills_dir, SkillDiscoveryMode::Compatible)
+}
+
+#[must_use]
+pub fn discover_for_workspace_and_dir_with_mode(
+    workspace: &Path,
+    skills_dir: &Path,
+    mode: SkillDiscoveryMode,
+) -> SkillRegistry {
+    let dirs = skill_directories_for_workspace_and_dir(workspace, skills_dir, mode);
     discover_from_directories(dirs)
+}
+
+#[must_use]
+pub fn skill_directories_for_workspace_and_dir(
+    workspace: &Path,
+    skills_dir: &Path,
+    mode: SkillDiscoveryMode,
+) -> Vec<PathBuf> {
+    let mut dirs = skills_directories_for_mode(workspace, mode);
+    insert_configured_skills_dir(&mut dirs, workspace, skills_dir);
+    dirs
 }
 
 fn insert_configured_skills_dir(dirs: &mut Vec<PathBuf>, workspace: &Path, skills_dir: &Path) {
@@ -579,7 +651,22 @@ pub(crate) fn discover_for_workspace_and_dir_with_home(
     skills_dir: &Path,
     home_dir: Option<&Path>,
 ) -> SkillRegistry {
-    let mut dirs = skills_directories_with_home(workspace, home_dir);
+    discover_for_workspace_and_dir_with_home_and_mode(
+        workspace,
+        skills_dir,
+        home_dir,
+        SkillDiscoveryMode::Compatible,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn discover_for_workspace_and_dir_with_home_and_mode(
+    workspace: &Path,
+    skills_dir: &Path,
+    home_dir: Option<&Path>,
+    mode: SkillDiscoveryMode,
+) -> SkillRegistry {
+    let mut dirs = skills_directories_with_home_and_mode(workspace, home_dir, mode);
     insert_configured_skills_dir(&mut dirs, workspace, skills_dir);
     discover_from_directories(dirs)
 }
@@ -591,6 +678,15 @@ pub(crate) fn discover_for_workspace_and_dir_with_home(
 #[must_use]
 pub fn render_available_skills_context_for_workspace(workspace: &Path) -> Option<String> {
     let registry = discover_in_workspace(workspace);
+    render_skills_block(&registry)
+}
+
+#[must_use]
+pub fn render_available_skills_context_for_workspace_with_mode(
+    workspace: &Path,
+    mode: SkillDiscoveryMode,
+) -> Option<String> {
+    let registry = discover_in_workspace_with_mode(workspace, mode);
     render_skills_block(&registry)
 }
 
@@ -615,7 +711,20 @@ pub fn render_available_skills_context_for_workspace_and_dir(
     workspace: &Path,
     skills_dir: &Path,
 ) -> Option<String> {
-    let registry = discover_for_workspace_and_dir(workspace, skills_dir);
+    render_available_skills_context_for_workspace_and_dir_with_mode(
+        workspace,
+        skills_dir,
+        SkillDiscoveryMode::Compatible,
+    )
+}
+
+#[must_use]
+pub fn render_available_skills_context_for_workspace_and_dir_with_mode(
+    workspace: &Path,
+    skills_dir: &Path,
+    mode: SkillDiscoveryMode,
+) -> Option<String> {
+    let registry = discover_for_workspace_and_dir_with_mode(workspace, skills_dir, mode);
     render_skills_block(&registry)
 }
 
@@ -1135,6 +1244,79 @@ mod tests {
         let rendered =
             super::render_available_skills_context_for_workspace(workspace).expect("non-empty");
         assert!(rendered.contains("from-claude"));
+    }
+
+    #[test]
+    fn codewhale_only_mode_ignores_cross_tool_skill_dirs() {
+        let tmpdir = TempDir::new().unwrap();
+        let workspace = tmpdir.path().join("workspace");
+        let home = tmpdir.path().join("home");
+        let configured_dir = home.join(".codewhale").join("skills");
+        std::fs::create_dir_all(&workspace).unwrap();
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "from-claude",
+            "claude-style skill",
+            "body",
+        );
+        write_skill(
+            &workspace.join(".codewhale").join("skills"),
+            "from-codewhale",
+            "codewhale skill",
+            "body",
+        );
+        write_skill(
+            &home.join(".agents").join("skills"),
+            "from-agents",
+            "agents skill",
+            "body",
+        );
+        write_skill(
+            &configured_dir,
+            "configured-codewhale",
+            "configured skill",
+            "body",
+        );
+
+        let registry = super::discover_for_workspace_and_dir_with_home_and_mode(
+            &workspace,
+            &configured_dir,
+            Some(&home),
+            super::SkillDiscoveryMode::CodeWhaleOnly,
+        );
+        let names: Vec<&str> = registry.list().iter().map(|s| s.name.as_str()).collect();
+
+        assert!(names.contains(&"from-codewhale"));
+        assert!(names.contains(&"configured-codewhale"));
+        assert!(
+            !names.contains(&"from-claude") && !names.contains(&"from-agents"),
+            "CodeWhale-only mode must not import cross-tool skills: {names:?}"
+        );
+    }
+
+    #[test]
+    fn codewhale_only_mode_still_honors_explicit_configured_dir() {
+        let tmpdir = TempDir::new().unwrap();
+        let workspace = tmpdir.path().join("workspace");
+        let home = tmpdir.path().join("home");
+        let configured_dir = tmpdir.path().join("my-skills");
+        std::fs::create_dir_all(&workspace).unwrap();
+        write_skill(
+            &configured_dir,
+            "configured-skill",
+            "explicit configured skill",
+            "body",
+        );
+
+        let registry = super::discover_for_workspace_and_dir_with_home_and_mode(
+            &workspace,
+            &configured_dir,
+            Some(&home),
+            super::SkillDiscoveryMode::CodeWhaleOnly,
+        );
+        let names: Vec<&str> = registry.list().iter().map(|s| s.name.as_str()).collect();
+
+        assert_eq!(names, vec!["configured-skill"]);
     }
 
     #[test]

--- a/crates/tui/src/tools/skill.rs
+++ b/crates/tui/src/tools/skill.rs
@@ -27,7 +27,11 @@
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use crate::skills::{Skill, discover_in_workspace, skills_directories};
+use crate::skills::{
+    Skill, SkillDiscoveryMode, discover_for_workspace_and_dir_with_mode,
+    discover_in_workspace_with_mode, skill_directories_for_workspace_and_dir,
+    skills_directories_for_mode,
+};
 
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
@@ -91,17 +95,40 @@ impl ToolSpec for LoadSkillTool {
         // tool's lookup mirrors what the system-prompt skills block
         // already lists, so the model never asks for a name it
         // can't find.
-        let registry = discover_in_workspace(&context.workspace);
+        let discovery_mode =
+            SkillDiscoveryMode::from_codewhale_only(context.skills_scan_codewhale_only);
+        let registry = if let Some(skills_dir) = context.skills_dir.as_deref() {
+            discover_for_workspace_and_dir_with_mode(&context.workspace, skills_dir, discovery_mode)
+        } else {
+            discover_in_workspace_with_mode(&context.workspace, discovery_mode)
+        };
         let Some(skill) = registry.get(name) else {
             let available: Vec<&str> = registry.list().iter().map(|s| s.name.as_str()).collect();
             let hint = if available.is_empty() {
-                let dirs: Vec<String> = skills_directories(&context.workspace)
+                let dirs: Vec<String> = context
+                    .skills_dir
+                    .as_deref()
+                    .map(|skills_dir| {
+                        skill_directories_for_workspace_and_dir(
+                            &context.workspace,
+                            skills_dir,
+                            discovery_mode,
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        skills_directories_for_mode(&context.workspace, discovery_mode)
+                    })
                     .iter()
                     .map(|p| p.display().to_string())
                     .collect();
                 if dirs.is_empty() {
-                    "no skills directories found; install skills under `<workspace>/.agents/skills/<name>/SKILL.md`, `~/.codewhale/skills/<name>/SKILL.md`, or `~/.deepseek/skills/<name>/SKILL.md`"
-                        .to_string()
+                    if context.skills_scan_codewhale_only {
+                        "no skills directories found; install skills under `<workspace>/.codewhale/skills/<name>/SKILL.md` or `~/.codewhale/skills/<name>/SKILL.md`"
+                            .to_string()
+                    } else {
+                        "no skills directories found; install skills under `<workspace>/.agents/skills/<name>/SKILL.md`, `~/.codewhale/skills/<name>/SKILL.md`, or `~/.deepseek/skills/<name>/SKILL.md`"
+                            .to_string()
+                    }
                 } else {
                     format!("no skills installed. Searched: {}", dirs.join(", "))
                 }
@@ -336,6 +363,44 @@ mod tests {
         assert!(
             path_str.contains(".opencode"),
             "skill_path should point at the .opencode dir: {path_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_respects_codewhale_only_skill_discovery() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().to_path_buf();
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "claude-only",
+            "Claude skill",
+            "Body content marker.",
+        );
+        let codewhale_dir = workspace.join(".codewhale").join("skills");
+        write_skill(
+            &codewhale_dir,
+            "codewhale-only",
+            "CodeWhale skill",
+            "Body content marker.",
+        );
+
+        let context = ToolContext::new(workspace).with_skills_config(codewhale_dir, true);
+        let tool = LoadSkillTool;
+
+        let result = tool
+            .execute(json!({"name": "codewhale-only"}), &context)
+            .await
+            .expect("CodeWhale skill should load");
+        assert!(result.success);
+
+        let err = tool
+            .execute(json!({"name": "claude-only"}), &context)
+            .await
+            .expect_err("Claude skill should be hidden in CodeWhale-only mode");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("claude-only") && msg.contains("codewhale-only"),
+            "error should name the missing skill and available strict catalog: {msg}"
         );
     }
 

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -110,6 +110,10 @@ pub struct ToolContext {
     /// MCP configuration path
     #[allow(dead_code)]
     pub mcp_config_path: PathBuf,
+    /// Explicit skills directory used for model-visible skill discovery.
+    pub skills_dir: Option<PathBuf>,
+    /// Restrict skill discovery to CodeWhale-owned roots plus `skills_dir`.
+    pub skills_scan_codewhale_only: bool,
     /// Elevated sandbox policy override (used when retrying after sandbox denial).
     /// This overrides the default sandbox behavior for shell commands.
     pub elevated_sandbox_policy: Option<crate::sandbox::SandboxPolicy>,
@@ -199,6 +203,8 @@ impl ToolContext {
             sandbox_policy: SandboxPolicy::None,
             notes_path,
             mcp_config_path,
+            skills_dir: None,
+            skills_scan_codewhale_only: false,
             elevated_sandbox_policy: None,
             shell_network_denied_hint: None,
             auto_approve: false,
@@ -238,6 +244,8 @@ impl ToolContext {
             sandbox_policy: SandboxPolicy::None,
             notes_path: notes_path.into(),
             mcp_config_path: mcp_config_path.into(),
+            skills_dir: None,
+            skills_scan_codewhale_only: false,
             elevated_sandbox_policy: None,
             shell_network_denied_hint: None,
             auto_approve: false,
@@ -277,6 +285,8 @@ impl ToolContext {
             sandbox_policy: SandboxPolicy::None,
             notes_path: notes_path.into(),
             mcp_config_path: mcp_config_path.into(),
+            skills_dir: None,
+            skills_scan_codewhale_only: false,
             elevated_sandbox_policy: None,
             shell_network_denied_hint: None,
             auto_approve,
@@ -310,6 +320,19 @@ impl ToolContext {
     #[must_use]
     pub fn with_runtime_services(mut self, runtime: RuntimeToolServices) -> Self {
         self.runtime = runtime;
+        self
+    }
+
+    /// Attach skill discovery settings for tools that need to resolve
+    /// model-visible skills by name.
+    #[must_use]
+    pub fn with_skills_config(
+        mut self,
+        skills_dir: impl Into<PathBuf>,
+        scan_codewhale_only: bool,
+    ) -> Self {
+        self.skills_dir = Some(skills_dir.into());
+        self.skills_scan_codewhale_only = scan_codewhale_only;
         self
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -73,8 +73,8 @@ pub(crate) fn resolve_skills_dir(
         if config.skills_dir.is_some() {
             return global_skills_dir.to_path_buf();
         }
-        let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
-        if codewhale_skills_dir.is_dir() {
+        if let Some(codewhale_skills_dir) = crate::skills::codewhale_workspace_skills_dir(workspace)
+        {
             return codewhale_skills_dir;
         }
         return global_skills_dir.to_path_buf();
@@ -5599,6 +5599,16 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    fn create_dir_symlink(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn create_dir_symlink(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_dir(target, link)
+    }
+
     #[test]
     fn initial_input_prefill_waits_for_manual_submit() {
         let mut options = test_options(false);
@@ -6682,6 +6692,49 @@ mod tests {
                 .iter()
                 .any(|(name, _)| name == "configured-skill"),
             "explicit configured skills_dir should still be cached: {:?}",
+            app.cached_skills
+        );
+    }
+
+    #[test]
+    fn cached_skills_reject_codewhale_only_workspace_symlink_escape() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let escape_target = tmp.path().join("escape-target");
+        let escaped_skill_dir = escape_target.join("escaped-skill");
+        std::fs::create_dir_all(workspace.join(".codewhale")).expect("codewhale dir");
+        std::fs::create_dir_all(&escaped_skill_dir).expect("escaped skill dir");
+        std::fs::write(
+            escaped_skill_dir.join("SKILL.md"),
+            "---\nname: escaped-skill\ndescription: Escaped skill\n---\nbody\n",
+        )
+        .expect("write escaped skill");
+
+        let link_path = workspace.join(".codewhale").join("skills");
+        if let Err(err) = create_dir_symlink(&escape_target, &link_path) {
+            eprintln!("skipping symlink escape assertion: {err}");
+            return;
+        }
+
+        let global_skills_dir = tmp.path().join("global-skills");
+        let mut options = test_options(false);
+        options.workspace = workspace.clone();
+        options.skills_dir = global_skills_dir.clone();
+        let config = Config {
+            skills: Some(crate::config::SkillsConfig {
+                scan_codewhale_only: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let app = App::new(options, &config);
+
+        assert_eq!(app.skills_dir, global_skills_dir);
+        assert!(
+            !app.cached_skills
+                .iter()
+                .any(|(name, _)| name == "escaped-skill"),
+            "strict app cache must not follow escaped workspace CodeWhale symlinks: {:?}",
             app.cached_skills
         );
     }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -70,6 +70,9 @@ pub(crate) fn resolve_skills_dir(
     config: &Config,
 ) -> PathBuf {
     if config.skills_config().scan_codewhale_only() {
+        if config.skills_dir.is_some() {
+            return global_skills_dir.to_path_buf();
+        }
         let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
         if codewhale_skills_dir.is_dir() {
             return codewhale_skills_dir;
@@ -6624,6 +6627,61 @@ mod tests {
                 .any(|(name, description)| name == "configured-skill"
                     && description == "Configured skill"),
             "configured skill dir should be merged: {:?}",
+            app.cached_skills
+        );
+    }
+
+    #[test]
+    fn cached_skills_preserve_configured_directory_in_codewhale_only_scan() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+
+        let codewhale_skill_dir = workspace
+            .join(".codewhale")
+            .join("skills")
+            .join("workspace-codewhale");
+        std::fs::create_dir_all(&codewhale_skill_dir).expect("workspace codewhale skill dir");
+        std::fs::write(
+            codewhale_skill_dir.join("SKILL.md"),
+            "---\nname: workspace-codewhale\ndescription: Workspace CodeWhale skill\n---\nbody\n",
+        )
+        .expect("write workspace codewhale skill");
+
+        let configured_dir = tmp.path().join("configured-skills");
+        let configured_skill_dir = configured_dir.join("configured-skill");
+        std::fs::create_dir_all(&configured_skill_dir).expect("configured skill dir");
+        std::fs::write(
+            configured_skill_dir.join("SKILL.md"),
+            "---\nname: configured-skill\ndescription: Configured skill\n---\nbody\n",
+        )
+        .expect("write configured skill");
+
+        let mut options = test_options(false);
+        options.workspace = workspace.clone();
+        options.skills_dir = configured_dir.clone();
+        let config = Config {
+            skills_dir: Some(configured_dir.to_string_lossy().into_owned()),
+            skills: Some(crate::config::SkillsConfig {
+                scan_codewhale_only: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let app = App::new(options, &config);
+
+        assert_eq!(app.skills_dir, configured_dir);
+        assert!(
+            app.cached_skills
+                .iter()
+                .any(|(name, _)| name == "workspace-codewhale"),
+            "workspace CodeWhale skill should still be cached: {:?}",
+            app.cached_skills
+        );
+        assert!(
+            app.cached_skills
+                .iter()
+                .any(|(name, _)| name == "configured-skill"),
+            "explicit configured skills_dir should still be cached: {:?}",
             app.cached_skills
         );
     }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -69,6 +69,14 @@ pub(crate) fn resolve_skills_dir(
     global_skills_dir: &Path,
     config: &Config,
 ) -> PathBuf {
+    if config.skills_config().scan_codewhale_only() {
+        let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
+        if codewhale_skills_dir.exists() {
+            return codewhale_skills_dir;
+        }
+        return global_skills_dir.to_path_buf();
+    }
+
     let agents_skills_dir = workspace.join(".agents").join("skills");
     if agents_skills_dir.exists() {
         return agents_skills_dir;
@@ -1445,6 +1453,7 @@ pub struct App {
     pub config_profile: Option<String>,
     pub mcp_config_path: PathBuf,
     pub skills_dir: PathBuf,
+    pub skills_scan_codewhale_only: bool,
     /// Path to the user-memory file (#489). Always populated; only
     /// consulted when `use_memory` is `true`.
     pub memory_path: PathBuf,
@@ -2210,8 +2219,10 @@ impl App {
         // Initialize plan state
         let plan_state = new_shared_plan_state();
 
+        let skills_scan_codewhale_only = config.skills_config().scan_codewhale_only();
         let skills_dir = resolve_skills_dir(&workspace, &global_skills_dir, config);
-        let cached_skills = Self::discover_cached_skills(&workspace, &skills_dir);
+        let cached_skills =
+            Self::discover_cached_skills(&workspace, &skills_dir, skills_scan_codewhale_only);
 
         let input_history = crate::composer_history::load_history();
         let (initial_input_text, initial_input_cursor, auto_submit_initial_input) =
@@ -2299,6 +2310,7 @@ impl App {
             config_profile,
             mcp_config_path: mcp_config_path.clone(),
             skills_dir,
+            skills_scan_codewhale_only,
             memory_path,
             use_memory,
             use_alt_screen,
@@ -2497,17 +2509,26 @@ impl App {
     fn discover_cached_skills(
         workspace: &std::path::Path,
         skills_dir: &std::path::Path,
+        scan_codewhale_only: bool,
     ) -> Vec<(String, String)> {
-        crate::skills::discover_for_workspace_and_dir(workspace, skills_dir)
-            .list()
-            .iter()
-            .map(|s| (s.name.clone(), s.description.clone()))
-            .collect()
+        crate::skills::discover_for_workspace_and_dir_with_mode(
+            workspace,
+            skills_dir,
+            crate::skills::SkillDiscoveryMode::from_codewhale_only(scan_codewhale_only),
+        )
+        .list()
+        .iter()
+        .map(|s| (s.name.clone(), s.description.clone()))
+        .collect()
     }
 
     pub fn refresh_skill_cache(&mut self) {
         let skills_dir = self.skills_dir.clone();
-        self.cached_skills = Self::discover_cached_skills(&self.workspace, &skills_dir);
+        self.cached_skills = Self::discover_cached_skills(
+            &self.workspace,
+            &skills_dir,
+            self.skills_scan_codewhale_only,
+        );
     }
 
     pub fn submit_api_key(&mut self) -> Result<SavedCredential, ApiKeyError> {
@@ -6488,6 +6509,64 @@ mod tests {
                 .any(|(name, description)| name == "foo" && description == "Real foo skill"),
             "cached_skills should fall through to lower-precedence dir when higher-precedence one has an empty stub: {:?}",
             app.cached_skills,
+        );
+    }
+
+    #[test]
+    fn cached_skills_respect_codewhale_only_scan_config() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+
+        let claude_dir = workspace
+            .join(".claude")
+            .join("skills")
+            .join("claude-skill");
+        std::fs::create_dir_all(&claude_dir).expect("claude skill dir");
+        std::fs::write(
+            claude_dir.join("SKILL.md"),
+            "---\nname: claude-skill\ndescription: Claude skill\n---\nbody\n",
+        )
+        .expect("write claude skill");
+
+        let codewhale_dir = workspace
+            .join(".codewhale")
+            .join("skills")
+            .join("codewhale-skill");
+        std::fs::create_dir_all(&codewhale_dir).expect("codewhale skill dir");
+        std::fs::write(
+            codewhale_dir.join("SKILL.md"),
+            "---\nname: codewhale-skill\ndescription: CodeWhale skill\n---\nbody\n",
+        )
+        .expect("write codewhale skill");
+
+        let mut options = test_options(false);
+        options.workspace = workspace.clone();
+        options.skills_dir = tmp.path().join("global-skills");
+        let app = App::new(
+            options,
+            &Config {
+                skills: Some(crate::config::SkillsConfig {
+                    scan_codewhale_only: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(app.skills_dir, workspace.join(".codewhale").join("skills"));
+        assert!(
+            app.cached_skills
+                .iter()
+                .any(|(name, _)| name == "codewhale-skill"),
+            "CodeWhale skill should be cached: {:?}",
+            app.cached_skills
+        );
+        assert!(
+            !app.cached_skills
+                .iter()
+                .any(|(name, _)| name == "claude-skill"),
+            "strict scan should not cache Claude skills: {:?}",
+            app.cached_skills
         );
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -71,7 +71,7 @@ pub(crate) fn resolve_skills_dir(
 ) -> PathBuf {
     if config.skills_config().scan_codewhale_only() {
         let codewhale_skills_dir = workspace.join(".codewhale").join("skills");
-        if codewhale_skills_dir.exists() {
+        if codewhale_skills_dir.is_dir() {
             return codewhale_skills_dir;
         }
         return global_skills_dir.to_path_buf();
@@ -6568,6 +6568,31 @@ mod tests {
             "strict scan should not cache Claude skills: {:?}",
             app.cached_skills
         );
+    }
+
+    #[test]
+    fn resolve_skills_dir_requires_codewhale_skills_to_be_directory() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(workspace.join(".codewhale")).expect("codewhale dir");
+        std::fs::write(
+            workspace.join(".codewhale").join("skills"),
+            "not a directory",
+        )
+        .expect("skills file");
+
+        let global_skills_dir = tmp.path().join("global-skills");
+        let config = Config {
+            skills: Some(crate::config::SkillsConfig {
+                scan_codewhale_only: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let resolved = resolve_skills_dir(&workspace, &global_skills_dir, &config);
+
+        assert_eq!(resolved, global_skills_dir);
     }
 
     #[test]

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -49,6 +49,7 @@ pub struct CommandPaletteView {
 pub fn build_entries(
     locale: Locale,
     skills_dir: &Path,
+    skills_scan_codewhale_only: bool,
     workspace: &Path,
     mcp_config_path: &Path,
     mcp_snapshot: Option<&crate::mcp::McpManagerSnapshot>,
@@ -79,7 +80,11 @@ pub fn build_entries(
         });
     }
 
-    let skills = skills::discover_for_workspace_and_dir(workspace, skills_dir);
+    let skills = skills::discover_for_workspace_and_dir_with_mode(
+        workspace,
+        skills_dir,
+        skills::SkillDiscoveryMode::from_codewhale_only(skills_scan_codewhale_only),
+    );
     for skill in skills.list() {
         entries.push(CommandPaletteEntry {
             section: PaletteSection::Skill,
@@ -1110,6 +1115,7 @@ mod tests {
         let entries = build_entries(
             Locale::En,
             configured_dir.as_path(),
+            false,
             workspace.as_path(),
             Path::new("mcp.json"),
             None,
@@ -1125,10 +1131,54 @@ mod tests {
     }
 
     #[test]
+    fn command_palette_skills_respect_codewhale_only_scan() {
+        let tmp = TempDir::new().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let claude_skill_dir = workspace
+            .join(".claude")
+            .join("skills")
+            .join("claude-skill");
+        std::fs::create_dir_all(&claude_skill_dir).expect("create claude skill dir");
+        std::fs::write(
+            claude_skill_dir.join("SKILL.md"),
+            "---\nname: claude-skill\ndescription: Claude skill\n---\nbody",
+        )
+        .expect("write claude skill");
+        let codewhale_skill_dir = workspace
+            .join(".codewhale")
+            .join("skills")
+            .join("codewhale-skill");
+        std::fs::create_dir_all(&codewhale_skill_dir).expect("create codewhale skill dir");
+        std::fs::write(
+            codewhale_skill_dir.join("SKILL.md"),
+            "---\nname: codewhale-skill\ndescription: CodeWhale skill\n---\nbody",
+        )
+        .expect("write codewhale skill");
+
+        let entries = build_entries(
+            Locale::En,
+            workspace.join(".codewhale").join("skills").as_path(),
+            true,
+            workspace.as_path(),
+            Path::new("mcp.json"),
+            None,
+        );
+        let skill_labels: Vec<&str> = entries
+            .iter()
+            .filter(|entry| entry.section == PaletteSection::Skill)
+            .map(|entry| entry.label.as_str())
+            .collect();
+
+        assert!(skill_labels.contains(&"$codewhale-skill"));
+        assert!(!skill_labels.contains(&"$claude-skill"));
+    }
+
+    #[test]
     fn command_palette_command_entries_include_links_and_config_but_not_removed_commands() {
         let entries = build_entries(
             Locale::En,
             Path::new("."),
+            false,
             Path::new("."),
             Path::new("mcp.json"),
             None,
@@ -1154,6 +1204,7 @@ mod tests {
         let entries = build_entries(
             Locale::En,
             skills_dir.as_path(),
+            false,
             tmp.path(),
             mcp_config_path.as_path(),
             None,
@@ -1203,6 +1254,7 @@ mod tests {
         let entries = build_entries(
             Locale::En,
             Path::new("."),
+            false,
             Path::new("."),
             Path::new("mcp.json"),
             None,
@@ -1224,6 +1276,7 @@ mod tests {
         let entries = build_entries(
             Locale::En,
             Path::new("."),
+            false,
             Path::new("."),
             Path::new("mcp.json"),
             None,
@@ -1285,6 +1338,7 @@ mod tests {
         let entries = build_entries(
             Locale::En,
             Path::new("."),
+            false,
             Path::new("."),
             Path::new("mcp.json"),
             Some(&snapshot),
@@ -1339,6 +1393,7 @@ mod tests {
         let entries = build_entries(
             Locale::En,
             Path::new("."),
+            false,
             Path::new("."),
             Path::new("mcp.json"),
             Some(&snapshot),

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -275,6 +275,7 @@ impl HotbarAction for AppHotbarAction {
                     .push(CommandPaletteView::new(build_command_palette_entries(
                         app.ui_locale,
                         &app.skills_dir,
+                        app.skills_scan_codewhale_only,
                         &app.workspace,
                         &app.mcp_config_path,
                         app.mcp_snapshot.as_ref(),

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -877,6 +877,7 @@ pub(crate) fn handle_context_menu_action(app: &mut App, action: ContextMenuActio
                 .push(CommandPaletteView::new(build_command_palette_entries(
                     app.ui_locale,
                     &app.skills_dir,
+                    app.skills_scan_codewhale_only,
                     &app.workspace,
                     &app.mcp_config_path,
                     app.mcp_snapshot.as_ref(),

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -970,6 +970,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         notes_path: config.notes_path(),
         mcp_config_path: config.mcp_config_path(),
         skills_dir: app.skills_dir.clone(),
+        skills_scan_codewhale_only: app.skills_scan_codewhale_only,
         instructions: config
             .instructions_paths()
             .into_iter()
@@ -3426,6 +3427,7 @@ async fn run_event_loop(
                     .push(CommandPaletteView::new(build_command_palette_entries(
                         app.ui_locale,
                         &app.skills_dir,
+                        app.skills_scan_codewhale_only,
                         &app.workspace,
                         &app.mcp_config_path,
                         app.mcp_snapshot.as_ref(),
@@ -5861,6 +5863,7 @@ async fn dispatch_user_message(
                 ),
                 show_thinking: app.show_thinking,
                 verbosity: app.verbosity.as_deref(),
+                skills_scan_codewhale_only: app.skills_scan_codewhale_only,
             },
         ),
     );
@@ -7204,6 +7207,7 @@ fn apply_workspace_runtime_state(app: &mut App, config: &Config, workspace: Path
         workspace.clone(),
     );
     app.skills_dir = crate::tui::app::resolve_skills_dir(&workspace, &config.skills_dir(), config);
+    app.skills_scan_codewhale_only = config.skills_config().scan_codewhale_only();
     app.refresh_skill_cache();
     app.workspace_context = None;
     if let Ok(mut cell) = app.workspace_context_cell.lock() {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1010,6 +1010,11 @@ If you are upgrading from older releases:
   documents, presentations, spreadsheets, PDFs, and Feishu/Lark. See
   [CLAUDE_PLUGIN_COMPAT.md](CLAUDE_PLUGIN_COMPAT.md) for the supported boundary
   between portable `SKILL.md` bundles and Claude Code plugin runtimes.
+- `[skills].scan_codewhale_only` (bool, default `false`): when `true`, session
+  skill discovery ignores cross-tool roots such as `.claude/skills`,
+  `.opencode/skills`, `.cursor/skills`, and `~/.agents/skills`. CodeWhale still
+  scans `<workspace>/.codewhale/skills`, `~/.codewhale/skills`, and any explicit
+  `skills_dir` override.
 - `mcp_config_path` (string, optional): defaults to `~/.codewhale/mcp.json`, with
   legacy `~/.deepseek/mcp.json` fallback when the CodeWhale path is absent.
   It is visible in `/config` and can be changed from the TUI. The new path is


### PR DESCRIPTION
## Summary
- Adds `[skills].scan_codewhale_only` so users can keep session-time skill discovery scoped to CodeWhale roots while preserving the default broad compatibility scan.
- Threads the setting through prompt assembly, `load_skill`, `/skills`, command palette/slash cache, runtime API, and CLI/runtime engine construction.
- Documents the setting in the example config and configuration guide.

Fixes #3264

## Validation
- `cargo fmt`
- `git diff --check` (line-ending warnings only for `config.example.toml` and `docs/CONFIGURATION.md`)
- `cargo check -p codewhale-tui`
- `cargo test -p codewhale-tui --bin codewhale-tui codewhale_only`
- `cargo test -p codewhale-tui --bin codewhale-tui skills::tests::`
- `cargo test -p codewhale-tui --bin codewhale-tui tools::skill::tests::`
- `cargo test -p codewhale-tui --bin codewhale-tui command_palette_skills`
- `cargo test -p codewhale-tui --bin codewhale-tui system_prompt_merges_workspace_and_configured_skills_dir`

## Local full-test note
- `cargo test -p codewhale-tui --bin codewhale-tui` still has unrelated local failures in `session_manager::tests::latest_session_for_workspace_ignores_newer_other_directory` and `session_manager::tests::latest_session_for_workspace_ignores_invalid_parent_git_marker`.
- The two pandoc tests that failed in the full parallel run passed when rerun individually.
- `cargo test -p codewhale-tui codewhale_only` matched the new tests but then tried to start the `skill_install` integration test binary and hit Windows `os error 740`; `--bin codewhale-tui` avoids that unrelated elevation path.