### PR TITLE
fix(snapshots): respect snapshots.enabled=false for pre-tool snapshots (#3292)

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2079,10 +2079,12 @@ impl Engine {
                         // Per-tool snapshot for surgical undo (#384): capture workspace
                         // state before file-modifying tools execute so `/undo` can
                         // revert the most recent write_file/edit_file/apply_patch.
+                        // Gated by snapshots_enabled like the pre/post-turn sites so
+                        // `snapshots.enabled = false` suppresses these too (#3292).
                         if result_override.is_none()
-                            && matches!(
+                            && crate::core::turn::should_pre_tool_snapshot(
+                                self.config.snapshots_enabled,
                                 tool_name.as_str(),
-                                "write_file" | "edit_file" | "apply_patch"
                             )
                         {
                             let ws = self.session.workspace.clone();

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -184,6 +184,18 @@ pub fn pre_tool_snapshot(workspace: &Path, call_id: &str, cap_bytes: u64) -> Opt
     snapshot_with_label(workspace, &format!("tool:{call_id}"), cap_bytes)
 }
 
+/// Whether a pre-tool snapshot (#384) should be captured before `tool_name`
+/// executes. Only file-modifying tools warrant a snapshot, and only when
+/// workspace snapshots are enabled.
+///
+/// The `snapshots_enabled` gate mirrors the pre/post-turn snapshot call sites;
+/// without it, `snapshots.enabled = false` was silently ignored on the
+/// per-tool path and snapshots kept accumulating (#3292).
+#[must_use]
+pub fn should_pre_tool_snapshot(snapshots_enabled: bool, tool_name: &str) -> bool {
+    snapshots_enabled && matches!(tool_name, "write_file" | "edit_file" | "apply_patch")
+}
+
 /// Take a `post-turn:<seq>` workspace snapshot. Same failure model as
 /// [`pre_turn_snapshot`].
 pub fn post_turn_snapshot(
@@ -218,6 +230,38 @@ fn snapshot_with_label(workspace: &Path, label: &str, cap_bytes: u64) -> Option<
         Err(e) => {
             tracing::warn!(target: "snapshot", "snapshot repo init failed: {e}");
             None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_pre_tool_snapshot;
+
+    #[test]
+    fn pre_tool_snapshot_suppressed_when_snapshots_disabled() {
+        // #3292: `snapshots.enabled = false` must suppress per-tool snapshots.
+        for tool in ["write_file", "edit_file", "apply_patch"] {
+            assert!(
+                !should_pre_tool_snapshot(false, tool),
+                "{tool} must not snapshot when snapshots are disabled"
+            );
+        }
+    }
+
+    #[test]
+    fn pre_tool_snapshot_only_for_file_modifying_tools_when_enabled() {
+        for tool in ["write_file", "edit_file", "apply_patch"] {
+            assert!(
+                should_pre_tool_snapshot(true, tool),
+                "{tool} should snapshot when snapshots are enabled"
+            );
+        }
+        for tool in ["read_file", "exec_shell", "grep", ""] {
+            assert!(
+                !should_pre_tool_snapshot(true, tool),
+                "{tool} must not trigger a pre-tool snapshot"
+            );
         }
     }
 }


### PR DESCRIPTION
## Problem

Fixes #3292 — with `[snapshots] enabled = false` in `config.toml`, per-tool snapshots are still taken. One user found their entire git repo copied into `~/.deepseek/snapshots/.../.git`, taking GBs of disk.

## Root cause

There are three snapshot call sites, but only two honor `snapshots_enabled`:

| Snapshot call | Gated by `snapshots_enabled`? | Location |
|---|---|---|
| `pre_turn_snapshot` | ✅ | `core/engine.rs:979` |
| `post_turn_snapshot` | ✅ | `core/engine.rs:2120` |
| **`pre_tool_snapshot`** | ❌ | `core/engine/turn_loop.rs:2082` |

The per-tool site (#384) only checked the tool name (`write_file`/`edit_file`/`apply_patch`), never `snapshots_enabled`, so `snapshots.enabled = false` was silently ignored there and `tool:call_*` snapshots kept accumulating.

## Fix

- Add `should_pre_tool_snapshot(snapshots_enabled, tool_name)` in `core/turn.rs` (next to `pre_tool_snapshot`) — `snapshots_enabled && file-modifying tool`.
- Gate the turn-loop call site on it, matching the pre/post-turn gates.

## Testing

- New unit tests in `core/turn.rs`: snapshots disabled → no per-tool snapshot for any tool; enabled → only `write_file`/`edit_file`/`apply_patch` snapshot, never `read_file`/`exec_shell`/etc.
- `cargo clippy -p codewhale-tui --all-features` clean; `cargo test -p codewhale-tui --all-features` green.
