### PR TITLE
feat(tui): show the active checklist in the plan confirmation modal

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1693,8 +1693,8 @@ pub struct App {
     pub plan_prompt_pending: bool,
     /// Whether update_plan was called during the current turn
     pub plan_tool_used_in_turn: bool,
-    /// Todo list for `TodoWriteTool`
-    #[allow(dead_code)] // For future engine integration
+    /// Todo list for `TodoWriteTool`. Read by the plan confirmation modal to
+    /// show the active checklist alongside the plan.
     pub todos: SharedTodoList,
     /// Durable runtime services exposed to model-visible task/automation tools.
     pub runtime_services: RuntimeToolServices,

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -10,6 +10,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::palette;
 use crate::tools::plan::{PlanSnapshot, StepStatus};
+use crate::tools::todo::{TodoListSnapshot, TodoStatus};
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
 struct PlanOption {
@@ -130,6 +131,10 @@ pub struct PlanPromptView {
     confirming_exit: bool,
     /// The plan snapshot to display (if update_plan was called).
     plan: Option<PlanSnapshot>,
+    /// The checklist/todo snapshot to display (if `checklist_write` was used).
+    /// Kept separate from the plan so the most actionable view of progress is
+    /// visible inside the plan confirmation modal.
+    todos: Option<TodoListSnapshot>,
 }
 
 impl PlanPromptView {
@@ -141,7 +146,17 @@ impl PlanPromptView {
             last_max_scroll: Cell::new(0),
             confirming_exit: false,
             plan,
+            todos: None,
         }
+    }
+
+    /// Attach the current checklist/todo snapshot so it renders inside the plan
+    /// confirmation modal alongside the plan steps. Existing callers default to
+    /// `None`, so this is opt-in at the production construction site only.
+    #[must_use]
+    pub fn with_todos(mut self, todos: Option<TodoListSnapshot>) -> Self {
+        self.todos = todos;
+        self
     }
 
     fn max_index(&self) -> usize {
@@ -374,6 +389,12 @@ impl ModalView for PlanPromptView {
             push_plan_snapshot_lines(&mut lines, plan, content_width);
         }
 
+        // v0.8.62: render the active checklist so the most actionable view of
+        // progress is visible inside the plan confirmation modal.
+        if let Some(ref todos) = self.todos {
+            push_todo_snapshot_lines(&mut lines, todos, content_width);
+        }
+
         for (idx, option) in PLAN_OPTIONS.iter().enumerate() {
             let number = idx + 1;
             push_option_lines(
@@ -568,6 +589,42 @@ fn push_plan_snapshot_lines(
         )));
         lines.push(Line::from(""));
     }
+}
+
+/// Render the active checklist/todo snapshot beneath the plan details.
+///
+/// Mirrors the plan-step glyph language (`·` pending, `▶` in progress, `✓`
+/// completed) so the two read as one surface. Completed items are dimmed so
+/// attention lands on what remains.
+fn push_todo_snapshot_lines(
+    lines: &mut Vec<Line<'static>>,
+    todos: &TodoListSnapshot,
+    content_width: usize,
+) {
+    if todos.items.is_empty() {
+        return;
+    }
+    lines.push(Line::from(Span::styled(
+        format!("Checklist ({}% complete):", todos.completion_pct),
+        Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+    )));
+    for (i, item) in todos.items.iter().enumerate() {
+        let status_mark = match item.status {
+            TodoStatus::Pending => "\u{b7}",
+            TodoStatus::InProgress => "\u{25b6}",
+            TodoStatus::Completed => "\u{2713}",
+        };
+        let item_text = format!("  {status_mark} {}. {}", i + 1, &item.content);
+        let style = if matches!(item.status, TodoStatus::Completed) {
+            Style::default().fg(palette::TEXT_MUTED)
+        } else {
+            Style::default().fg(palette::TEXT_PRIMARY)
+        };
+        for line in wrap_text(&item_text, content_width) {
+            lines.push(Line::from(Span::styled(line, style)));
+        }
+    }
+    lines.push(Line::from(""));
 }
 
 fn plan_uses_rich_artifact_shape(plan: &PlanSnapshot) -> bool {
@@ -802,6 +859,55 @@ mod tests {
         assert!(rendered.contains("Verification plan:"));
         assert!(rendered.contains("Handoff packet:"));
         assert!(rendered.contains("Render rich sections"));
+    }
+
+    #[test]
+    fn plan_prompt_renders_active_checklist_when_provided() {
+        use crate::tools::todo::{TodoItem, TodoListSnapshot, TodoStatus};
+
+        let todos = TodoListSnapshot {
+            items: vec![
+                TodoItem {
+                    id: 1,
+                    content: "Read the brief".to_string(),
+                    status: TodoStatus::Completed,
+                },
+                TodoItem {
+                    id: 2,
+                    content: "Render the checklist".to_string(),
+                    status: TodoStatus::InProgress,
+                },
+                TodoItem {
+                    id: 3,
+                    content: "Ship the PR".to_string(),
+                    status: TodoStatus::Pending,
+                },
+            ],
+            completion_pct: 33,
+            in_progress_id: Some(2),
+        };
+        let view = PlanPromptView::new(None).with_todos(Some(todos));
+        let rendered = render_view(&view, 160, 120);
+
+        assert!(rendered.contains("Checklist (33% complete):"));
+        assert!(rendered.contains("Read the brief"));
+        assert!(rendered.contains("Render the checklist"));
+        assert!(rendered.contains("Ship the PR"));
+    }
+
+    #[test]
+    fn plan_prompt_omits_checklist_section_when_empty() {
+        use crate::tools::todo::TodoListSnapshot;
+
+        let todos = TodoListSnapshot {
+            items: vec![],
+            completion_pct: 0,
+            in_progress_id: None,
+        };
+        let view = PlanPromptView::new(None).with_todos(Some(todos));
+        let rendered = render_view(&view, 160, 120);
+
+        assert!(!rendered.contains("Checklist"));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2337,7 +2337,9 @@ async fn run_event_loop(
                             });
                             if app.view_stack.top_kind() != Some(ModalKind::PlanPrompt) {
                                 let plan = Some(app.plan_state.lock().await.snapshot());
-                                app.view_stack.push(PlanPromptView::new(plan));
+                                let todos = Some(app.todos.lock().await.snapshot());
+                                app.view_stack
+                                    .push(PlanPromptView::new(plan).with_todos(todos));
                             }
                         }
                         app.plan_tool_used_in_turn = false;


### PR DESCRIPTION
## What

The Plan-mode confirmation modal (`PlanPromptView`) rendered the plan objective and plan steps, but it **omitted the live checklist** produced by `checklist_write` — the most actionable view of progress. This PR renders the active checklist inside that modal, directly beneath the plan details.

## Why

The checklist is the primary progress surface, but it was invisible at the exact moment the user is asked to accept/revise a plan. Surfacing it there lets the user review the proposed plan *and* the concrete work breakdown in one place before committing to implementation. (Adjacent to #1846 — proposed changes visibility before approval.)

## How

- Added an opt-in `with_todos(Option<TodoListSnapshot>)` builder on `PlanPromptView`. The existing `new(plan)` signature is unchanged, so all ~26 call sites and tests are untouched.
- At the production construction site (`ui.rs`), snapshot `app.todos` and pass it via `.with_todos(...)`.
- New `push_todo_snapshot_lines` renders the checklist using the **same glyph language as plan steps** (`·` pending, `▶` in progress, `✓` completed), with a `Checklist (N% complete):` header, and dims completed items so attention lands on what remains. Empty checklists render nothing.
- Dropped the now-obsolete `#[allow(dead_code)]` on the `app.todos` field.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test -p codewhale-tui --bins plan_prompt --locked` — **27 passed, 0 failed** (incl. 2 new: `plan_prompt_renders_active_checklist_when_provided`, `plan_prompt_omits_checklist_section_when_empty`)
- `cargo clippy -p codewhale-tui` — **no new warnings in touched code** (the crate has pre-existing clippy lint debt in unrelated files; not introduced here and out of scope)

## Notes

- Targets the 0.8.62 release lane directly so it ships with 0.8.62.
- A one-line CHANGELOG bullet for the 0.8.62 section is recommended (the 0.8.62 CHANGELOG is currently mid-edit in the working tree, so left out of this commit to keep it code-only).