### PR TITLE
fix(config): restore huggingface env precedence

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use crate::audit::log_sensitive_event;
-use crate::features::{is_known_feature_key, Features, FeaturesToml};
+use crate::features::{Features, FeaturesToml, is_known_feature_key};
 use crate::hooks::HooksConfig;
 
 pub const DEFAULT_MAX_SUBAGENTS: usize = 20;
@@ -5736,8 +5736,6 @@ fn provider_config_table_name(provider: ApiProvider) -> Result<String> {
 }
 
 fn provider_env_api_key(provider: ApiProvider) -> Option<String> {
-    // Keep the Hugging Face env precedence explicit here so runtime behavior
-    // stays aligned with the shipped provider-registry contract.
     if matches!(provider, ApiProvider::Huggingface) {
         return std::env::var("HUGGINGFACE_API_KEY")
             .ok()
@@ -6057,7 +6055,7 @@ pub fn clear_active_provider_api_key(provider: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{lock_test_env, EnvVarGuard};
+    use crate::test_support::{EnvVarGuard, lock_test_env};
     use std::collections::HashMap;
     use std::env;
     use std::ffi::OsString;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use crate::audit::log_sensitive_event;
-use crate::features::{Features, FeaturesToml, is_known_feature_key};
+use crate::features::{is_known_feature_key, Features, FeaturesToml};
 use crate::hooks::HooksConfig;
 
 pub const DEFAULT_MAX_SUBAGENTS: usize = 20;
@@ -5526,7 +5526,7 @@ pub fn active_provider_has_config_api_key(config: &Config) -> bool {
         return crate::oauth::auth_file_path().exists();
     }
     if matches!(provider, ApiProvider::Huggingface)
-        && std::env::var("HF_TOKEN").is_ok_and(|k| !k.trim().is_empty())
+        && provider_env_api_key(ApiProvider::Huggingface).is_some()
     {
         return true;
     }
@@ -5736,6 +5736,19 @@ fn provider_config_table_name(provider: ApiProvider) -> Result<String> {
 }
 
 fn provider_env_api_key(provider: ApiProvider) -> Option<String> {
+    // Keep the Hugging Face env precedence explicit here so runtime behavior
+    // stays aligned with the shipped provider-registry contract.
+    if matches!(provider, ApiProvider::Huggingface) {
+        return std::env::var("HUGGINGFACE_API_KEY")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("HF_TOKEN")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            });
+    }
+
     provider.env_vars().iter().find_map(|var| {
         std::env::var(var)
             .ok()
@@ -6044,7 +6057,7 @@ pub fn clear_active_provider_api_key(provider: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{EnvVarGuard, lock_test_env};
+    use crate::test_support::{lock_test_env, EnvVarGuard};
     use std::collections::HashMap;
     use std::env;
     use std::ffi::OsString;


### PR DESCRIPTION
This restores the Hugging Face API key env precedence on the TUI config surface so `scripts/check-provider-registry.py` (the `CI/Lint` gate) passes again on `main`.

Background
- `crates/tui/src/config.rs` previously expressed the precedence through a helper (`provider_env_api_key`), but the registry lint script checks for the literal `std::env::var("HUGGINGFACE_API_KEY")` / `std::env::var("HF_TOKEN")` strings in this file and fails when it cannot find them in the expected order.
- That drift is unrelated to the work in #3300 (session/thread process preservation), so it is being fixed here on its own branch off the latest `main`.

What changed
- `provider_env_api_key()` now spells out the Hugging Face env order explicitly: `HUGGINGFACE_API_KEY` first, falling back to `HF_TOKEN`.
- Behavior on the runtime side is unchanged: `HF_TOKEN` alone still works, `HUGGINGFACE_API_KEY` still wins when both are set, empty values are ignored, and the rest of the providers continue to flow through the existing helper path.
- The Hugging Face config tests (`huggingface_hf_token_env_api_key_resolves`, `huggingface_short_env_fallbacks_configure_route`, `huggingface_env_overrides_key_base_url_and_model`, `huggingface_missing_key_error_mentions_env_fallbacks`, etc.) still pass.

Validation
- `python3 scripts/check-provider-registry.py` now reports `Provider registry drift check passed.`
- `cargo test -p codewhale-tui huggingface_` is green (6 passed).

Out of scope
- The failing `tools::shell` tests on `windows-latest` for #3300 are unrelated to this file and are tracked separately.