### PR TITLE
docs(provider): document OpenRouter-compatible base URLs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -363,6 +363,10 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_OPENROUTER_API_KEY"
 # base_url = "https://openrouter.ai/api/v1"
 # model = "deepseek/deepseek-v4-pro"
+# OpenRouter-compatible gateways can reuse this provider so reasoning/cache
+# parsing stays on the OpenRouter-compatible path instead of generic OpenAI:
+# base_url = "https://openrouter-compatible.example/v1"
+# model = "deepseek/deepseek-v4-pro"
 # Recent large model IDs also accepted here include arcee-ai/trinity-large-thinking,
 # minimax/minimax-m3, minimax/minimax-2.7, xiaomi/mimo-v2.5-pro, qwen/qwen3.6-flash,
 # qwen/qwen3.6-35b-a3b, qwen/qwen3.6-max-preview, qwen/qwen3.6-27b, qwen/qwen3.6-plus,

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -4047,6 +4047,28 @@ fn openrouter_custom_base_url_preserves_provider_model() {
 }
 
 #[test]
+fn openrouter_compatible_base_url_preserves_namespaced_wire_model() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let mut config = ConfigToml {
+        provider: ProviderKind::Openrouter,
+        ..ConfigToml::default()
+    };
+    config.providers.openrouter.base_url = Some("https://openrouter-compatible.example/v1".into());
+    config.providers.openrouter.model = Some("deepseek/deepseek-v4-pro".into());
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::Openrouter);
+    assert_eq!(resolved.provider_source, ProviderSource::Config);
+    assert_eq!(
+        resolved.base_url,
+        "https://openrouter-compatible.example/v1"
+    );
+    assert_eq!(resolved.model, "deepseek/deepseek-v4-pro");
+}
+
+#[test]
 fn fireworks_custom_base_url_preserves_provider_model() {
     let _lock = env_lock();
     let _env = EnvGuard::without_deepseek_runtime_overrides();

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -190,6 +190,30 @@ includes `mimo-v2.5` for image input. CodeWhale exposes image analysis through t
 separate `[vision_model]` / `image_analyze` path; set that model to
 `mimo-v2.5` when using MiMo for vision.
 
+### OpenRouter-Compatible Base URLs
+
+OpenRouter-compatible gateways should usually stay on the `openrouter`
+provider with a provider-scoped `base_url` override instead of moving through
+the generic `openai` route. That keeps OpenRouter-style reasoning, streaming,
+cache usage, and namespaced wire model parsing attached to the selected route:
+
+```toml
+provider = "openrouter"
+
+[providers.openrouter]
+api_key = "sk-..."
+base_url = "https://openrouter-compatible.example/v1"
+model = "deepseek/deepseek-v4-pro"
+```
+
+CodeWhale preserves the `deepseek/` wire-model prefix under the OpenRouter
+provider scope; it does not infer a switch to the direct DeepSeek provider from
+that model string. Cache fields such as `prompt_cache_hit_tokens`,
+`prompt_cache_miss_tokens`, and `prompt_tokens_details.cached_tokens` are
+parsed when the upstream gateway sends them. If a key/account type omits those
+fields, CodeWhale treats them as absent for that response rather than as a
+different provider route.
+
 ### Recent OpenRouter Large Models
 
 OpenRouter completions and static registry rows include the April 2026 onward


### PR DESCRIPTION
## Summary

Goal: finish the validation/docs slice of #1978 for OpenRouter-compatible custom base URLs.

Changes:
- Documents the supported `provider = "openrouter"` + `[providers.openrouter].base_url` shape for OpenRouter-compatible gateways.
- Adds the same example to `config.example.toml`.
- Adds a config regression proving an OpenRouter-compatible custom `base_url` preserves a namespaced wire model like `deepseek/deepseek-v4-pro` under the OpenRouter provider scope.

Issue: Refs #1978

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

Focused verification run locally:
- [x] `cargo test -p codewhale-config --locked openrouter` - 9 passed
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked openrouter` - 22 passed
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked parse_usage` - 5 passed
- [x] `python3 scripts/check-provider-registry.py` - passed
- [x] `git diff --check`

## Risks

Low. This branch documents and tests existing OpenRouter-compatible behavior; it does not add a ZenMux/default gateway endorsement and does not change request routing.

Live credential retesting remains manual because no OpenRouter-compatible proxy credentials were available in this checkout.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
