### PR TITLE
test(provider): document DashScope OpenAI-compatible fixture

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -338,6 +338,9 @@ max_subagents = 10 # optional (1-20)
 # Gateway example:
 # base_url = "https://gateway.example/v1"
 # model = "your-deepseek-compatible-model"
+# Alibaba Bailian / Model Studio DashScope OpenAI-compatible example:
+# base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+# model = "qwen-plus"
 # insecure_skip_tls_verify = true # last resort for private gateways; prefer SSL_CERT_FILE
 
 # AtlasCloud OpenAI-compatible endpoint (https://www.atlascloud.ai/docs/models/llm)

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -1011,6 +1011,30 @@ fn insecure_skip_tls_verify_resolves_only_for_active_provider() {
 }
 
 #[test]
+fn openai_provider_accepts_dashscope_bailian_base_url_and_model() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let mut config = ConfigToml {
+        provider: ProviderKind::Openai,
+        ..ConfigToml::default()
+    };
+    config.providers.openai.api_key = Some("dashscope-table-key".to_string());
+    config.providers.openai.base_url =
+        Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1".to_string());
+    config.providers.openai.model = Some("qwen-plus".to_string());
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::Openai);
+    assert_eq!(resolved.api_key.as_deref(), Some("dashscope-table-key"));
+    assert_eq!(
+        resolved.base_url,
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    );
+    assert_eq!(resolved.model, "qwen-plus");
+}
+
+#[test]
 fn http_headers_env_overrides_config() {
     let _lock = env_lock();
     let _env = EnvGuard::without_deepseek_runtime_overrides();

--- a/crates/tui/src/commands/groups/core/provider.rs
+++ b/crates/tui/src/commands/groups/core/provider.rs
@@ -320,6 +320,19 @@ mod tests {
     }
 
     #[test]
+    fn switch_to_openai_preserves_dashscope_model_id() {
+        let mut app = create_test_app();
+        let result = provider(&mut app, Some("openai qwen-plus"));
+        match result.action {
+            Some(AppAction::SwitchProvider { provider, model }) => {
+                assert_eq!(provider, ApiProvider::Openai);
+                assert_eq!(model.as_deref(), Some("qwen-plus"));
+            }
+            other => panic!("expected SwitchProvider, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn switch_to_novita_emits_action() {
         let mut app = create_test_app();
         let result = provider(&mut app, Some("novita"));

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2865,6 +2865,7 @@ fn validate_route_rejects_mismatched_provider_model_tuple() {
     // Pass-through / aggregator providers stay permissive — the upstream
     // API remains the authority for them.
     assert!(validate_route(ApiProvider::Openai, "deepseek-v4-pro").is_ok());
+    assert!(validate_route(ApiProvider::Openai, "qwen-plus").is_ok());
     assert!(validate_route(ApiProvider::Openrouter, "deepseek-v4-pro").is_ok());
     assert!(validate_route(ApiProvider::NvidiaNim, "deepseek-v4-pro").is_ok());
 }
@@ -4113,6 +4114,45 @@ model = "glm-5"
         "https://openai-compatible.example/api/coding/paas/v4"
     );
     assert_eq!(config.default_model(), "glm-5");
+    Ok(())
+}
+
+#[test]
+fn openai_provider_accepts_dashscope_bailian_fixture() -> Result<()> {
+    let _lock = lock_test_env();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_root = env::temp_dir().join(format!(
+        "codewhale-tui-dashscope-openai-{}-{}",
+        std::process::id(),
+        nanos
+    ));
+    fs::create_dir_all(&temp_root)?;
+    let _guard = EnvGuard::new(&temp_root);
+
+    let config_path = temp_root.join(".deepseek").join("config.toml");
+    ensure_parent_dir(&config_path)?;
+    fs::write(
+        &config_path,
+        r#"provider = "openai"
+
+[providers.openai]
+api_key = "dashscope-table-key"
+base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+model = "qwen-plus"
+"#,
+    )?;
+
+    let config = Config::load(None, None)?;
+    assert_eq!(config.api_provider(), ApiProvider::Openai);
+    assert_eq!(config.deepseek_api_key()?, "dashscope-table-key");
+    assert_eq!(
+        config.deepseek_base_url(),
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+    );
+    assert_eq!(config.default_model(), "qwen-plus");
     Ok(())
 }
 

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -1171,6 +1171,8 @@ mod tests {
             .insert("deepseek".to_string(), "deepseek-v4-pro".to_string());
         app.provider_models
             .insert("moonshot".to_string(), "kimi-k2.6".to_string());
+        app.provider_models
+            .insert("openai".to_string(), "qwen-plus".to_string());
 
         let view = ModelPickerView::new(&app);
         let model_ids = view.visible_model_ids();
@@ -1180,6 +1182,7 @@ mod tests {
         // Cross-provider saved models are now visible.
         assert!(model_ids.contains(&"deepseek-v4-pro"));
         assert!(model_ids.contains(&"kimi-k2.6"));
+        assert!(model_ids.contains(&"qwen-plus"));
         assert!(!view.show_custom_model_row);
 
         // Each cross-provider row carries its own provider so applying it
@@ -1192,6 +1195,15 @@ mod tests {
         assert_eq!(
             deepseek_row.provider,
             Some(crate::config::ApiProvider::Deepseek)
+        );
+        let dashscope_row = view
+            .visible_model_rows()
+            .iter()
+            .find(|row| row.id == "qwen-plus")
+            .expect("qwen-plus row present");
+        assert_eq!(
+            dashscope_row.provider,
+            Some(crate::config::ApiProvider::Openai)
         );
 
         // Active-provider model must appear before any cross-provider tail row.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -222,6 +222,22 @@ legacy top-level `base_url`, so the OpenAI-compatible provider receives it.
 provider tables in one config, `[providers.openai].model` can be used as the
 OpenAI-provider-specific override.
 
+Alibaba Bailian / Model Studio DashScope Qwen routes use the same OpenAI
+provider shape:
+
+```toml
+provider = "openai"
+
+[providers.openai]
+api_key = "YOUR_DASHSCOPE_API_KEY"
+base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+model = "qwen-plus"
+```
+
+Use the regional DashScope `compatible-mode/v1` base URL that matches the
+region of your API key. CodeWhale keeps `qwen-plus` scoped to the `openai`
+provider route and does not infer a different provider from the model prefix.
+
 If the gateway accepts `POST /chat/completions` but rejects
 `/v1/chat/completions`, set a provider-local `path_suffix`:
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -109,6 +109,27 @@ base_url = "https://gateway.example/v1"
 model = "your-deepseek-compatible-model"
 ```
 
+Alibaba Bailian / Model Studio DashScope exposes Qwen through an
+OpenAI-compatible Chat Completions endpoint. Configure it as an explicit
+`openai` provider route so the API key, base URL, and wire model stay scoped to
+that provider:
+
+```toml
+provider = "openai"
+
+[providers.openai]
+api_key = "YOUR_DASHSCOPE_API_KEY"
+base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+model = "qwen-plus"
+```
+
+The Singapore endpoint above sends chat requests to `/chat/completions`;
+Alibaba also documents regional `compatible-mode/v1` base URLs for Virginia,
+Beijing, Hong Kong, and Frankfurt. Keep the API key and base URL from the same
+region. The `qwen-plus` model ID is preserved as an OpenAI provider-scoped wire
+ID; CodeWhale does not infer a switch to OpenRouter, DeepSeek, or another
+provider from the `qwen` prefix.
+
 Private gateways with broken or intercepted certificates should use
 `SSL_CERT_FILE` with a trusted CA bundle. The legacy
 `insecure_skip_tls_verify = true` key is still parsed so `codewhale doctor` can
@@ -126,7 +147,7 @@ endpoint.
 | --- | --- | --- | --- | --- | --- |
 | `deepseek` | `[providers.deepseek]` | `DEEPSEEK_API_KEY` | `CODEWHALE_BASE_URL` / `DEEPSEEK_BASE_URL`; default `https://api.deepseek.com/beta` | `deepseek-v4-pro`, `deepseek-v4-flash`; compatibility aliases `deepseek-chat`, `deepseek-reasoner` | First-class default. Beta URL enables strict tool mode, chat prefix completion, and FIM completion. Set `https://api.deepseek.com` or `/v1` explicitly to opt out of beta-only features. |
 | `nvidia-nim` | `[providers.nvidia_nim]` | `NVIDIA_API_KEY`, `NVIDIA_NIM_API_KEY`, fallback `DEEPSEEK_API_KEY` | `NVIDIA_NIM_BASE_URL`, `NIM_BASE_URL`, `NVIDIA_BASE_URL`; default `https://integrate.api.nvidia.com/v1` | `deepseek-ai/deepseek-v4-pro`, `deepseek-ai/deepseek-v4-flash` | Hosted DeepSeek V4 through NVIDIA NIM. `NVIDIA_NIM_MODEL` is accepted by the TUI config path. |
-| `openai` | `[providers.openai]` | `OPENAI_API_KEY` | `OPENAI_BASE_URL`; default `https://api.openai.com/v1` | Registry entries: `deepseek-v4-pro`, `deepseek-v4-flash`; default config model `deepseek-v4-pro` | Generic OpenAI-compatible route for gateways and custom endpoints. Use this for explicit third-party OpenAI-compatible routes instead of inventing a new provider ID. `OPENAI_MODEL` is accepted. |
+| `openai` | `[providers.openai]` | `OPENAI_API_KEY` | `OPENAI_BASE_URL`; default `https://api.openai.com/v1` | Registry entries: `deepseek-v4-pro`, `deepseek-v4-flash`; default config model `deepseek-v4-pro` | Generic OpenAI-compatible route for gateways and custom endpoints, including Alibaba Bailian / Model Studio DashScope when configured with that endpoint. Use this for explicit third-party OpenAI-compatible routes instead of inventing a new provider ID. `OPENAI_MODEL` is accepted. |
 | `atlascloud` | `[providers.atlascloud]` | `ATLASCLOUD_API_KEY` | `ATLASCLOUD_BASE_URL`; default `https://api.atlascloud.ai/v1` | Default `deepseek-ai/deepseek-v4-flash`; explicit `vendor/model-id` values pass through when AtlasCloud is selected | OpenAI-compatible hosted route. `ATLASCLOUD_MODEL` is accepted by the TUI config path, the static `ModelRegistry` keeps DeepSeek V4 fallback rows, and provider-hinted CLI model IDs are sent to AtlasCloud exactly as requested. Use Atlas Cloud's own catalog or Coding Plan page for the current provider-owned model list and pricing. |
 | `wanjie-ark` | `[providers.wanjie_ark]` | `WANJIE_ARK_API_KEY`, `WANJIE_API_KEY`, `WANJIE_MAAS_API_KEY` | `WANJIE_ARK_BASE_URL`, `WANJIE_BASE_URL`, `WANJIE_MAAS_BASE_URL`; default `https://maas-openapi.wanjiedata.com/api/v1` | `deepseek-reasoner` | OpenAI-compatible hosted route. `WANJIE_ARK_MODEL`, `WANJIE_MODEL`, and `WANJIE_MAAS_MODEL` are accepted. |
 | `volcengine` | `[providers.volcengine]` | `VOLCENGINE_API_KEY`, `VOLCENGINE_ARK_API_KEY`, `ARK_API_KEY` | `VOLCENGINE_BASE_URL`, `VOLCENGINE_ARK_BASE_URL`, `ARK_BASE_URL`; default `https://ark.cn-beijing.volces.com/api/coding/v3` | `DeepSeek-V4-Pro`, `DeepSeek-V4-Flash` | Volcengine/Volcano Engine Ark OpenAI-compatible coding endpoint. `VOLCENGINE_MODEL` and `VOLCENGINE_ARK_MODEL` are accepted. |


### PR DESCRIPTION
## Summary

- Document Alibaba Bailian / Model Studio DashScope as an explicit OpenAI-compatible route using `[providers.openai]`, a regional `compatible-mode/v1` base URL, and `qwen-plus`.
- Add config and TUI regressions so DashScope/Bailian keeps its API key, base URL, and wire model scoped to the `openai` provider.
- Cover `/provider openai qwen-plus`, route validation, and saved-model picker rows so `qwen-plus` is preserved instead of inferred as another provider.

Refs #3320.

## Testing

- [x] `cargo test -p codewhale-config --locked openai`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked openai_provider_accepts_dashscope_bailian_fixture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked requested_model_for_provider_is_permissive_off_deepseek`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked validate_route_rejects_mismatched_provider_model_tuple`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked switch_to_openai_preserves_dashscope_model_id`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked picker_lists_saved_models_from_other_providers`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked has_api_key_for_detects_env_and_config_per_provider`
- [x] `python3 scripts/check-provider-registry.py`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address

## Notes

This is a bounded onboarding fixture for #3320. It does not add a new first-class `bailian` provider ID, live model catalog, or dedicated env-var family; those remain separate provider-registry work if needed.
