### PR TITLE
fix(tui): accept Together-owned DeepSeek routes

### DIFF
--- a/crates/tui/src/commands/groups/core/provider.rs
+++ b/crates/tui/src/commands/groups/core/provider.rs
@@ -69,7 +69,10 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
         Some(raw) if provider_passes_model_through(target) => Some(raw.trim().to_string()),
         Some(raw) => {
             let expanded = expand_model_alias_for_provider(target, raw);
-            let normalized = if matches!(target, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+            let normalized = if matches!(
+                target,
+                ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::Together
+            ) {
                 normalize_model_name_for_provider(target, &expanded)
             } else {
                 normalize_model_name(&expanded)
@@ -173,7 +176,7 @@ fn expand_model_alias_for_provider(provider: ApiProvider, name: &str) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config::{Config, DEFAULT_TOGETHER_FLASH_MODEL, DEFAULT_TOGETHER_MODEL};
     use crate::tui::app::TuiOptions;
     use std::path::PathBuf;
 
@@ -366,6 +369,28 @@ mod tests {
             Some(AppAction::SwitchProvider { provider, model }) => {
                 assert_eq!(provider, ApiProvider::SiliconflowCn);
                 assert_eq!(model.as_deref(), Some("deepseek-v4-flash"));
+            }
+            other => panic!("expected SwitchProvider, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn switch_to_together_accepts_provider_owned_deepseek_aliases() {
+        let mut app = create_test_app();
+        let result = provider(&mut app, Some("together deepseek-v4-pro"));
+        match result.action {
+            Some(AppAction::SwitchProvider { provider, model }) => {
+                assert_eq!(provider, ApiProvider::Together);
+                assert_eq!(model.as_deref(), Some(DEFAULT_TOGETHER_MODEL));
+            }
+            other => panic!("expected SwitchProvider, got {other:?}"),
+        }
+
+        let result = provider(&mut app, Some("together flash"));
+        match result.action {
+            Some(AppAction::SwitchProvider { provider, model }) => {
+                assert_eq!(provider, ApiProvider::Together);
+                assert_eq!(model.as_deref(), Some(DEFAULT_TOGETHER_FLASH_MODEL));
             }
             other => panic!("expected SwitchProvider, got {other:?}"),
         }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -183,6 +183,7 @@ pub const DEFAULT_DEEPINFRA_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 pub const DEFAULT_DEEPINFRA_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub const DEFAULT_DEEPINFRA_BASE_URL: &str = "https://api.deepinfra.com/v1/openai";
 pub const DEFAULT_TOGETHER_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
+pub const DEFAULT_TOGETHER_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub const DEFAULT_TOGETHER_BASE_URL: &str = "https://api.together.xyz/v1";
 pub const DEFAULT_OPENAI_CODEX_MODEL: &str = "gpt-5.5";
 pub const DEFAULT_OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api";
@@ -1107,6 +1108,12 @@ pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> 
     }
 
     let normalized = normalize_model_name(model)?;
+    if matches!(provider, ApiProvider::Together) {
+        let provider_model = model_for_provider(provider, normalized.clone());
+        if provider_model != normalized {
+            return Some(provider_model);
+        }
+    }
     if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
         && let Some(canonical) = canonical_official_deepseek_model_id(&normalized)
     {
@@ -1185,7 +1192,7 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
         ApiProvider::Volcengine => vec![DEFAULT_VOLCENGINE_MODEL, DEFAULT_VOLCENGINE_FLASH_MODEL],
         ApiProvider::Ollama => Vec::new(),
         ApiProvider::Openai | ApiProvider::Atlascloud => OFFICIAL_DEEPSEEK_MODELS.to_vec(),
-        ApiProvider::Together => vec![DEFAULT_TOGETHER_MODEL],
+        ApiProvider::Together => vec![DEFAULT_TOGETHER_MODEL, DEFAULT_TOGETHER_FLASH_MODEL],
         ApiProvider::OpenaiCodex => vec![DEFAULT_OPENAI_CODEX_MODEL],
         ApiProvider::Zai => vec![DEFAULT_ZAI_MODEL, ZAI_GLM_5_1_MODEL, ZAI_GLM_5_TURBO_MODEL],
         ApiProvider::Stepfun => vec![DEFAULT_STEPFUN_MODEL],
@@ -3878,6 +3885,7 @@ fn root_deepseek_model_is_foreign_to_direct_provider(provider: ApiProvider, mode
             | ApiProvider::Siliconflow
             | ApiProvider::SiliconflowCn
             | ApiProvider::Deepinfra
+            | ApiProvider::Together
             | ApiProvider::Sglang
             | ApiProvider::Vllm
             | ApiProvider::Volcengine
@@ -5294,6 +5302,13 @@ fn model_for_provider(provider: ApiProvider, normalized: String) -> String {
         (ApiProvider::Deepinfra, "deepseek-v4-flash" | "deepseek-chat" | "deepseek-reasoner") => {
             DEFAULT_DEEPINFRA_FLASH_MODEL.to_string()
         }
+        (ApiProvider::Together, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_TOGETHER_MODEL.to_string()
+        }
+        (
+            ApiProvider::Together,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner",
+        ) => DEFAULT_TOGETHER_FLASH_MODEL.to_string(),
         (
             ApiProvider::Moonshot,
             "kimi"

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2867,6 +2867,9 @@ fn validate_route_rejects_mismatched_provider_model_tuple() {
     assert!(validate_route(ApiProvider::Openai, "deepseek-v4-pro").is_ok());
     assert!(validate_route(ApiProvider::Openrouter, "deepseek-v4-pro").is_ok());
     assert!(validate_route(ApiProvider::NvidiaNim, "deepseek-v4-pro").is_ok());
+    assert!(validate_route(ApiProvider::Together, DEFAULT_TOGETHER_MODEL).is_ok());
+    assert!(validate_route(ApiProvider::Together, DEFAULT_TOGETHER_FLASH_MODEL).is_ok());
+    assert!(validate_route(ApiProvider::Together, "deepseek-v4-pro").is_ok());
 }
 
 #[test]
@@ -2882,6 +2885,14 @@ fn wire_model_for_provider_matches_active_provider_shape() {
     assert_eq!(
         wire_model_for_provider(ApiProvider::NvidiaNim, DEFAULT_TEXT_MODEL),
         DEFAULT_NVIDIA_NIM_MODEL
+    );
+    assert_eq!(
+        wire_model_for_provider(ApiProvider::Together, DEFAULT_TEXT_MODEL),
+        DEFAULT_TOGETHER_MODEL
+    );
+    assert_eq!(
+        wire_model_for_provider(ApiProvider::Together, "deepseek-v4-flash"),
+        DEFAULT_TOGETHER_FLASH_MODEL
     );
     assert_eq!(
         wire_model_for_provider(ApiProvider::Openai, DEFAULT_OPENROUTER_MODEL),
@@ -2935,6 +2946,14 @@ fn normalize_model_name_for_provider_keeps_provider_specific_ids() {
     assert_eq!(
         normalize_model_name_for_provider(ApiProvider::Siliconflow, "deepseek-v3.2").as_deref(),
         Some("deepseek-v3.2")
+    );
+    assert_eq!(
+        normalize_model_name_for_provider(ApiProvider::Together, "deepseek-v4-pro").as_deref(),
+        Some(DEFAULT_TOGETHER_MODEL)
+    );
+    assert_eq!(
+        normalize_model_name_for_provider(ApiProvider::Together, "deepseek-chat").as_deref(),
+        Some(DEFAULT_TOGETHER_FLASH_MODEL)
     );
 }
 
@@ -3074,6 +3093,14 @@ fn model_completion_names_for_deepseek_api_are_deduplicated_bare_ids() {
     assert_eq!(
         model_completion_names_for_provider(ApiProvider::Deepseek),
         vec!["deepseek-v4-pro", "deepseek-v4-flash"]
+    );
+}
+
+#[test]
+fn model_completion_names_for_together_include_provider_owned_models() {
+    assert_eq!(
+        model_completion_names_for_provider(ApiProvider::Together),
+        vec![DEFAULT_TOGETHER_MODEL, DEFAULT_TOGETHER_FLASH_MODEL]
     );
 }
 


### PR DESCRIPTION
## Summary
- allow Together provider routes to validate its DeepSeek V4 Pro and Flash wire IDs
- add Together Flash completion/default mapping alongside Pro
- resolve `/provider together deepseek-v4-pro` and `/provider together flash` through Together-scoped model IDs

## Verification
- `cargo test -p codewhale-tui --bin codewhale-tui --locked validate_route`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked wire_model_for_provider`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked normalize_model_name_for_provider_keeps_provider_specific_ids`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked model_completion_names_for_together_include_provider_owned_models`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked switch_to_together_accepts_provider_owned_deepseek_aliases`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked commands::groups::core::provider`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked route_resolver` (0 matching tests)
- `python3 scripts/check-provider-registry.py`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #3382.