### PR TITLE
test(provider): pin SiliconFlow TokenHub route diagnostics

### DIFF
--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -2995,6 +2995,26 @@ fn siliconflow_cn_config_falls_back_to_shared_table_when_unset() {
 }
 
 #[test]
+fn siliconflow_cn_first_class_config_preserves_provider_scoped_route() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let mut config = ConfigToml {
+        provider: ProviderKind::SiliconflowCN,
+        ..ConfigToml::default()
+    };
+    config.providers.siliconflow_cn.api_key = Some("sf-cn-file-key".to_string());
+    config.providers.siliconflow_cn.base_url = Some(DEFAULT_SILICONFLOW_CN_BASE_URL.to_string());
+    config.providers.siliconflow_cn.model = Some(DEFAULT_SILICONFLOW_MODEL.to_string());
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::SiliconflowCN);
+    assert_eq!(resolved.api_key.as_deref(), Some("sf-cn-file-key"));
+    assert_eq!(resolved.base_url, DEFAULT_SILICONFLOW_CN_BASE_URL);
+    assert_eq!(resolved.model, DEFAULT_SILICONFLOW_MODEL);
+}
+
+#[test]
 fn moonshot_provider_defaults_to_kimi_k27_code() {
     let _lock = env_lock();
     let _env = EnvGuard::without_deepseek_runtime_overrides();
@@ -4044,6 +4064,26 @@ fn openrouter_custom_base_url_preserves_provider_model() {
     assert_eq!(resolved.provider, ProviderKind::Openrouter);
     assert_eq!(resolved.base_url, "https://gateway.example.com/v1");
     assert_eq!(resolved.model, "DeepSeek-V4-Pro");
+}
+
+#[test]
+fn openai_compatible_tokenhub_route_preserves_provider_scope() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let mut config = ConfigToml {
+        provider: ProviderKind::Openai,
+        ..ConfigToml::default()
+    };
+    config.providers.openai.api_key = Some("tokenhub-file-key".to_string());
+    config.providers.openai.base_url = Some("https://tokenhub.tencentmaas.com/v1".to_string());
+    config.providers.openai.model = Some("deepseek-ai/DeepSeek-V4-Pro".to_string());
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::Openai);
+    assert_eq!(resolved.api_key.as_deref(), Some("tokenhub-file-key"));
+    assert_eq!(resolved.base_url, "https://tokenhub.tencentmaas.com/v1");
+    assert_eq!(resolved.model, "deepseek-ai/DeepSeek-V4-Pro");
 }
 
 #[test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -2019,6 +2019,57 @@ mod tests {
     }
 
     #[test]
+    fn siliconflow_cn_uses_bearer_header_and_pins_content_type() {
+        let mut extra = HashMap::new();
+        extra.insert("Authorization".to_string(), "Bearer wrong".to_string());
+        extra.insert("Content-Type".to_string(), "text/plain".to_string());
+        let headers = DeepSeekClient::default_headers_for_provider(
+            "sf-cn-test",
+            &extra,
+            ApiProvider::SiliconflowCn,
+            crate::config::DEFAULT_SILICONFLOW_CN_BASE_URL,
+        )
+        .expect("headers");
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer sf-cn-test")
+        );
+        assert_eq!(
+            headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+        assert!(headers.get("api-key").is_none());
+    }
+
+    #[test]
+    fn tokenhub_openai_compatible_route_uses_bearer_header() {
+        let mut extra = HashMap::new();
+        extra.insert("api-key".to_string(), "wrong".to_string());
+        extra.insert("x-api-key".to_string(), "wrong".to_string());
+        let headers = DeepSeekClient::default_headers_for_provider(
+            "tokenhub-test",
+            &extra,
+            ApiProvider::Openai,
+            "https://tokenhub.tencentmaas.com/v1",
+        )
+        .expect("headers");
+
+        assert_eq!(
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer tokenhub-test")
+        );
+        assert!(headers.get("api-key").is_none());
+        assert!(headers.get("x-api-key").is_none());
+    }
+
+    #[test]
     fn custom_api_key_header_is_allowed_without_primary_provider_key() {
         let mut extra = HashMap::new();
         extra.insert("api-key".to_string(), "gateway-key".to_string());

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3412,6 +3412,7 @@ fn run_doctor_json(
         },
         "base_url": crate::client::redact_url_for_display(&api_target.base_url),
         "default_text_model": api_target.model,
+        "route": doctor_route_report(config),
         "strict_tool_mode": {
             "enabled": strict_tool_mode.enabled,
             "status": strict_tool_mode.status,
@@ -3539,6 +3540,120 @@ fn provider_capability_report(config: &Config) -> serde_json::Value {
         "request_payload_mode": serde_json::to_value(cap.request_payload_mode).unwrap_or_default(),
         "alias_deprecation": cap.alias_deprecation,
     })
+}
+
+fn doctor_route_report(config: &Config) -> serde_json::Value {
+    use serde_json::json;
+
+    let target = doctor_api_target(config);
+    let provider = config.api_provider();
+    let redacted_base_url = crate::client::redact_url_for_display(&target.base_url);
+
+    json!({
+        "provider": target.provider,
+        "provider_source": doctor_provider_source(config),
+        "provider_config_table": provider_config_table_key(provider),
+        "model": target.model,
+        "wire_protocol": doctor_wire_protocol(provider),
+        "base_url": {
+            "redacted": redacted_base_url,
+            "class": doctor_base_url_class(provider, &target.base_url),
+            "fingerprint": crate::utils::redacted_identifier_for_log(&target.base_url),
+        },
+        "auth": {
+            "scheme": doctor_auth_scheme(config),
+            "source": doctor_api_key_source_label(resolve_api_key_source(config)),
+        },
+    })
+}
+
+fn doctor_provider_source(config: &Config) -> &'static str {
+    if config
+        .provider
+        .as_ref()
+        .is_some_and(|provider| !provider.trim().is_empty())
+    {
+        "config"
+    } else {
+        "default"
+    }
+}
+
+fn doctor_wire_protocol(provider: crate::config::ApiProvider) -> &'static str {
+    match provider
+        .metadata()
+        .map(|metadata| metadata.wire())
+        .unwrap_or(codewhale_config::provider::WireFormat::ChatCompletions)
+    {
+        codewhale_config::provider::WireFormat::ChatCompletions => "chat_completions",
+        codewhale_config::provider::WireFormat::Responses => "responses",
+        codewhale_config::provider::WireFormat::AnthropicMessages => "anthropic_messages",
+    }
+}
+
+fn doctor_base_url_class(provider: crate::config::ApiProvider, base_url: &str) -> &'static str {
+    let normalized = base_url.trim_end_matches('/').to_ascii_lowercase();
+    if normalized.starts_with("http://localhost")
+        || normalized.starts_with("http://127.0.0.1")
+        || normalized.starts_with("http://[::1]")
+    {
+        return "local";
+    }
+    if normalized
+        == provider
+            .default_base_url()
+            .trim_end_matches('/')
+            .to_ascii_lowercase()
+    {
+        "default"
+    } else {
+        "custom"
+    }
+}
+
+fn doctor_auth_scheme(config: &Config) -> &'static str {
+    let provider = config.api_provider();
+    if provider == crate::config::ApiProvider::Anthropic {
+        "x-api-key"
+    } else if provider == crate::config::ApiProvider::XiaomiMimo
+        && (doctor_xiaomi_mimo_base_url_uses_token_plan(&config.deepseek_base_url())
+            || config
+                .deepseek_api_key()
+                .ok()
+                .is_some_and(|key| key.trim_start().starts_with("tp-")))
+    {
+        "api-key"
+    } else if matches!(
+        provider,
+        crate::config::ApiProvider::Sglang
+            | crate::config::ApiProvider::Vllm
+            | crate::config::ApiProvider::Ollama
+    ) && config.deepseek_api_key().is_err()
+    {
+        "none"
+    } else {
+        "bearer"
+    }
+}
+
+fn doctor_xiaomi_mimo_base_url_uses_token_plan(base_url: &str) -> bool {
+    let normalized = base_url.trim_end_matches('/').to_ascii_lowercase();
+    [
+        crate::config::XIAOMI_MIMO_TOKEN_PLAN_CN_BASE_URL,
+        crate::config::XIAOMI_MIMO_TOKEN_PLAN_SGP_BASE_URL,
+        crate::config::XIAOMI_MIMO_TOKEN_PLAN_AMS_BASE_URL,
+    ]
+    .iter()
+    .any(|candidate| normalized == candidate.trim_end_matches('/').to_ascii_lowercase())
+}
+
+fn doctor_api_key_source_label(source: ApiKeySource) -> &'static str {
+    match source {
+        ApiKeySource::Env => "env",
+        ApiKeySource::Config => "config",
+        ApiKeySource::Keyring => "keyring",
+        ApiKeySource::Missing => "missing",
+    }
 }
 
 fn doctor_search_provider_line(config: &Config) -> String {
@@ -6861,6 +6976,70 @@ mod doctor_endpoint_tests {
 
         assert_eq!(report["resolved_model"], "deepseek-v4-flash");
         assert!(report["alias_deprecation"].is_null());
+    }
+
+    #[test]
+    fn doctor_route_report_exposes_tokenhub_openai_compatible_route_without_secret() {
+        let mut providers = crate::config::ProvidersConfig::default();
+        providers.openai.api_key = Some("tokenhub-secret-value".to_string());
+        providers.openai.base_url = Some("https://tokenhub.tencentmaas.com/v1".to_string());
+        providers.openai.model = Some("deepseek-ai/DeepSeek-V4-Pro".to_string());
+        let config = Config {
+            provider: Some("openai".to_string()),
+            providers: Some(providers),
+            ..Default::default()
+        };
+
+        let report = doctor_route_report(&config);
+        let serialized = report.to_string();
+
+        assert_eq!(report["provider"], "openai");
+        assert_eq!(report["provider_source"], "config");
+        assert_eq!(report["provider_config_table"], "openai");
+        assert_eq!(report["model"], "deepseek-ai/DeepSeek-V4-Pro");
+        assert_eq!(report["wire_protocol"], "chat_completions");
+        assert_eq!(
+            report["base_url"]["redacted"],
+            "https://tokenhub.tencentmaas.com/v1"
+        );
+        assert_eq!(report["base_url"]["class"], "custom");
+        assert_eq!(report["auth"]["scheme"], "bearer");
+        assert_eq!(report["auth"]["source"], "config");
+        assert!(
+            report["base_url"]["fingerprint"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("<redacted:"))
+        );
+        assert!(!serialized.contains("tokenhub-secret-value"));
+    }
+
+    #[test]
+    fn doctor_route_report_exposes_siliconflow_cn_provider_route() {
+        let mut providers = crate::config::ProvidersConfig::default();
+        providers.siliconflow_cn.api_key = Some("sf-cn-secret-value".to_string());
+        providers.siliconflow_cn.base_url =
+            Some(crate::config::DEFAULT_SILICONFLOW_CN_BASE_URL.to_string());
+        providers.siliconflow_cn.model = Some(crate::config::DEFAULT_SILICONFLOW_MODEL.to_string());
+        let config = Config {
+            provider: Some("siliconflow-CN".to_string()),
+            providers: Some(providers),
+            ..Default::default()
+        };
+
+        let report = doctor_route_report(&config);
+        let serialized = report.to_string();
+
+        assert_eq!(report["provider"], "siliconflow-CN");
+        assert_eq!(report["provider_config_table"], "siliconflow_cn");
+        assert_eq!(report["model"], crate::config::DEFAULT_SILICONFLOW_MODEL);
+        assert_eq!(
+            report["base_url"]["redacted"],
+            crate::config::DEFAULT_SILICONFLOW_CN_BASE_URL
+        );
+        assert_eq!(report["base_url"]["class"], "default");
+        assert_eq!(report["auth"]["scheme"], "bearer");
+        assert_eq!(report["auth"]["source"], "config");
+        assert!(!serialized.contains("sf-cn-secret-value"));
     }
 
     #[test]


### PR DESCRIPTION
## Goal
Preserve #2629 as a provider-scoped route/auth/base-url regression fixture for SiliconFlow-CN and TokenHub-style OpenAI-compatible gateways.

## Changes
- added config resolver fixtures proving `siliconflow-CN` stays first-class and TokenHub stays `[providers.openai]` with `deepseek-ai/DeepSeek-V4-Pro` preserved as a provider-scoped wire ID
- added client header fixtures proving SiliconFlow-CN and TokenHub-style OpenAI-compatible routes use `Authorization: Bearer <key>`, pin `Content-Type: application/json`, and drop conflicting auth override headers
- added an additive `doctor --json.route` object with provider, provider source, provider config table, model, wire protocol, redacted base URL, base URL class/fingerprint, auth scheme, and auth source class
- added doctor route tests that assert API keys are not serialized

## Verification
- `cargo test -p codewhale-config --locked siliconflow`
- `cargo test -p codewhale-config --locked openai_compatible_tokenhub_route_preserves_provider_scope`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked siliconflow_cn_uses_bearer_header_and_pins_content_type`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tokenhub_openai_compatible_route_uses_bearer_header`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked doctor_route_report`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked doctor`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked route_resolver` (0 matching tests)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_adapter` (0 matching tests)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked custom_provider`
- `python3 scripts/check-provider-registry.py`
- `cargo fmt --all -- --check`
- `git diff --check`

## Risks
- `doctor --json.route.provider_source` is derived from the resolved TUI config and currently reports `config` vs `default`, not the full config/env/CLI provenance available in `codewhale-config::ResolvedRuntimeOptions`.
- This does not add a TokenHub-specific provider; TokenHub remains documented and tested as a generic OpenAI-compatible endpoint under `[providers.openai]`.

Fixes #2629.