### PR TITLE
Add configured SearXNG web_search backend

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -517,25 +517,28 @@ max_subagents = 10 # optional (1-20)
 # ─────────────────────────────────────────────────────────────────────────────────
 # Choose which backend `web_search` uses. Default is DuckDuckGo HTML scraping
 # with Bing fallback — no API key needed. Bing remains selectable for users who
-# explicitly prefer it. Switch to Tavily, Bocha, Metaso, or Baidu for
-# API-backed search.
+# explicitly prefer it. Switch to Tavily, Bocha, Metaso, Baidu, Volcengine,
+# Sofya, or a trusted SearXNG instance for API-backed search.
 #
 # [search]
-# provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | baidu | volcengine | sofya
+# provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | searxng | baidu | volcengine | sofya
 #                            # duckduckgo: HTML scrape with Bing fallback
 #                            # bing:       HTML scrape, no API key
 #                            # tavily:     https://tavily.com — AI search, needs api_key
 #                            # bocha:      https://bochaai.com — 博查AI搜索，国内友好，需api_key
 #                            # metaso:     https://metaso.cn — 秘塔AI搜索，每天 100 次免费
 #                            #             设置 METASO_API_KEY 或 [search] api_key 可提升额度
+#                            # searxng:    https://docs.searxng.org — trusted/self-hosted JSON API,
+#                            #             set base_url; no public instance is used by default
 #                            # baidu:      百度 AI Search via qianfan.baidubce.com，需 api_key
 #                            # volcengine: 火山引擎 Ark web_search (免费 2 万次/月), 需 api_key
 #                            #             也回退到 VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY 环境变量
 #                            # sofya:      https://sofya.co — AI search returning full page
 #                            #             content (not snippets), needs api_key (ay_live_...);
 #                            #             also falls back to the SOFYA_API_KEY env var
-# base_url = "https://search.example/html/" # optional DuckDuckGo-compatible HTML endpoint
-# api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, baidu, volcengine, and sofya; optional for metaso
+# base_url = "https://search.example/" # optional DuckDuckGo-compatible HTML endpoint;
+#                                      # required SearXNG root or /search endpoint
+# api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, baidu, volcengine, and sofya; optional for metaso; unused by searxng
 #                             # WARNING: treat config.toml like a secret file when
 #                             # storing API keys. Prefer env vars for local smoke tests.
 #

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1456,6 +1456,9 @@ pub enum SearchProvider {
     /// or `METASO_API_KEY` env var; configurable via `[search] api_key`.
     #[serde(alias = "metaso")]
     Metaso,
+    /// SearXNG JSON search API. Requires a trusted/self-hosted `base_url`.
+    #[serde(alias = "searx", alias = "searx-ng", alias = "searx_ng")]
+    Searxng,
     /// Baidu AI Search API (<https://qianfan.baidubce.com>). Requires api_key.
     #[serde(
         alias = "baidu-search",
@@ -1493,6 +1496,7 @@ impl SearchProvider {
             "tavily" => Some(Self::Tavily),
             "bocha" => Some(Self::Bocha),
             "metaso" => Some(Self::Metaso),
+            "searxng" | "searx" | "searx-ng" | "searx_ng" => Some(Self::Searxng),
             "baidu" | "baidu-search" | "baidu_search" | "baidu-ai-search" | "baidu_ai_search" => {
                 Some(Self::Baidu)
             }
@@ -1510,6 +1514,7 @@ impl SearchProvider {
             Self::Tavily => "tavily",
             Self::Bocha => "bocha",
             Self::Metaso => "metaso",
+            Self::Searxng => "searxng",
             Self::Baidu => "baidu",
             Self::Volcengine => "volcengine",
             Self::Sofya => "sofya",
@@ -1544,15 +1549,15 @@ pub struct SearchProviderResolution {
 /// Web search provider configuration (`[search]` table in config.toml).
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct SearchConfig {
-    /// Search provider: `bing` | `duckduckgo` | `tavily` | `bocha` | `metaso` | `baidu` | `volcengine`. Default: `duckduckgo`.
+    /// Search provider: `bing` | `duckduckgo` | `tavily` | `bocha` | `metaso` | `searxng` | `baidu` | `volcengine`. Default: `duckduckgo`.
     #[serde(default)]
     pub provider: Option<SearchProvider>,
-    /// Optional DuckDuckGo-compatible HTML endpoint. When set with the
-    /// DuckDuckGo provider, `web_search` appends the `q` query parameter to
-    /// this URL instead of using `https://html.duckduckgo.com/html/`.
+    /// Optional search endpoint. With `duckduckgo`, this is a
+    /// DuckDuckGo-compatible HTML endpoint. With `searxng`, this is the trusted
+    /// SearXNG instance root or `/search` endpoint.
     #[serde(default)]
     pub base_url: Option<String>,
-    /// API key for Tavily, Bocha, Metaso, Baidu, or Volcengine. Not required for Bing or DuckDuckGo.
+    /// API key for Tavily, Bocha, Metaso, Baidu, or Volcengine. Not required for Bing, DuckDuckGo, or SearXNG.
     /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in default.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY` env var.
     /// Volcengine also falls back to `VOLCENGINE_API_KEY` / `VOLCENGINE_ARK_API_KEY` / `ARK_API_KEY` env vars.
@@ -2100,8 +2105,10 @@ pub struct Config {
     pub snapshots: Option<SnapshotsConfig>,
 
     /// Web search provider configuration. When absent, defaults to DuckDuckGo.
-    /// Set `provider` to `bing`, `tavily`, or `bocha` to use those services
-    /// instead; Tavily and Bocha also require an `api_key`.
+    /// Set `provider` to another supported backend such as `bing`, `tavily`,
+    /// `bocha`, `metaso`, `searxng`, `baidu`, `volcengine`, or `sofya`.
+    /// API-backed services require provider-specific credentials; SearXNG
+    /// requires a trusted `base_url`.
     #[serde(default)]
     pub search: Option<SearchConfig>,
 

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -558,6 +558,46 @@ fn search_config_preserves_custom_base_url() {
 }
 
 #[test]
+fn explicit_searxng_search_provider_is_preserved() {
+    let config: Config = toml::from_str(
+        r#"
+        [search]
+        provider = "searxng"
+        base_url = "https://search.internal.example/"
+        "#,
+    )
+    .expect("search config");
+
+    let search = config.search.expect("search table");
+    assert_eq!(search.provider, Some(SearchProvider::Searxng));
+    assert_eq!(
+        search.base_url.as_deref(),
+        Some("https://search.internal.example/")
+    );
+}
+
+#[test]
+fn searxng_search_provider_aliases_parse_and_round_trip() {
+    assert_eq!(
+        SearchProvider::parse("searxng"),
+        Some(SearchProvider::Searxng)
+    );
+    assert_eq!(
+        SearchProvider::parse("searx-ng"),
+        Some(SearchProvider::Searxng)
+    );
+    assert_eq!(
+        SearchProvider::parse("searx_ng"),
+        Some(SearchProvider::Searxng)
+    );
+    assert_eq!(
+        SearchProvider::parse("searx"),
+        Some(SearchProvider::Searxng)
+    );
+    assert_eq!(SearchProvider::Searxng.as_str(), "searxng");
+}
+
+#[test]
 fn explicit_baidu_search_provider_is_preserved() {
     let config: Config = toml::from_str(
         r#"

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1,14 +1,14 @@
 //! Web search tool backed by multiple providers: Bing HTML scrape, DuckDuckGo
 //! (HTML scrape with Bing fallback), Tavily API, Bocha (博查) API,
-//! Metaso API (<https://metaso.cn>), Baidu AI Search, Volcengine Ark, and
-//! Sofya (<https://sofya.co>).
+//! Metaso API (<https://metaso.cn>), SearXNG JSON API, Baidu AI Search,
+//! Volcengine Ark, and Sofya (<https://sofya.co>).
 //!
 //! This is the primary web search surface for agents. For browsing workflows
 //! (page open, click, screenshot) use a direct URL approach instead.
 //!
 //! Set `[search]` in config.toml to switch providers:
-//!   provider = "duckduckgo"  # or tavily/bocha/metaso/baidu/volcengine/sofya
-//!   base_url = "https://search.example/html/"  # optional DDG-compatible URL
+//!   provider = "duckduckgo"  # or tavily/bocha/metaso/searxng/baidu/volcengine/sofya
+//!   base_url = "https://search.example/"  # DDG-compatible URL or SearXNG instance
 //!   api_key = "tvly-..."
 
 use super::spec::{
@@ -142,7 +142,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web and return ranked results with URLs and snippets. Default backend is DuckDuckGo with Bing fallback; set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml to switch backends, or `[search] base_url` for a DuckDuckGo-compatible endpoint. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
+        "Search the web and return ranked results with URLs and snippets. Default backend is DuckDuckGo with Bing fallback; set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml to switch backends, or `[search] base_url` for a DuckDuckGo-compatible endpoint or trusted SearXNG instance. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {
@@ -204,10 +204,13 @@ impl ToolSpec for WebSearchTool {
         let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
 
         if configured_search_base_url(context.search_base_url.as_deref()).is_some()
-            && !matches!(context.search_provider, SearchProvider::DuckDuckGo)
+            && !matches!(
+                context.search_provider,
+                SearchProvider::DuckDuckGo | SearchProvider::Searxng
+            )
         {
             return Err(ToolError::invalid_input(format!(
-                "[search].base_url is only supported with provider = \"duckduckgo\"; current provider is \"{}\"",
+                "[search].base_url is only supported with provider = \"duckduckgo\" or \"searxng\"; current provider is \"{}\"",
                 context.search_provider.as_str()
             )));
         }
@@ -234,6 +237,11 @@ impl ToolSpec for WebSearchTool {
                 check_policy(decider, "metaso.cn")?;
                 return self
                     .run_metaso_search(&query, max_results, timeout_ms, context)
+                    .await;
+            }
+            SearchProvider::Searxng => {
+                return self
+                    .run_searxng_search(&query, max_results, timeout_ms, context)
                     .await;
             }
             SearchProvider::Baidu => {
@@ -378,7 +386,11 @@ fn search_tool_result(
     message_suffix: Option<&str>,
 ) -> Result<ToolResult, ToolError> {
     let message = if results.is_empty() {
-        "No results found".to_string()
+        if let Some(suffix) = message_suffix {
+            format!("No results found. {suffix}")
+        } else {
+            "No results found".to_string()
+        }
     } else if let Some(suffix) = message_suffix {
         format!("Found {} result(s). {suffix}", results.len())
     } else {
@@ -397,6 +409,68 @@ fn search_tool_result(
 }
 
 impl WebSearchTool {
+    /// Search via a configured SearXNG JSON API.
+    ///
+    /// SearXNG exposes `/search?q=...&format=json`, but public instances often
+    /// disable JSON output or rate-limit automation. CodeWhale therefore uses
+    /// only the trusted instance configured in `[search] base_url`.
+    async fn run_searxng_search(
+        &self,
+        query: &str,
+        max_results: usize,
+        timeout_ms: u64,
+        context: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let (url, host) = searxng_search_url(context.search_base_url.as_deref(), query)?;
+        check_policy(context.network_policy.as_ref(), &host)?;
+
+        let client = crate::tls::reqwest_client_builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .user_agent(USER_AGENT)
+            .build()
+            .map_err(|e| {
+                ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
+            })?;
+
+        let resp = client
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                ToolError::execution_failed(format!("SearXNG search request to {host} failed: {e}"))
+            })?;
+
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| {
+            ToolError::execution_failed(format!("Failed to read SearXNG response from {host}: {e}"))
+        })?;
+
+        if !status.is_success() {
+            let truncated = truncate_error_body(&body);
+            let msg = match status.as_u16() {
+                403 => format!(
+                    "SearXNG search failed: HTTP 403 from {host}. Check that JSON output is enabled and this instance permits API access. {truncated}"
+                ),
+                429 => format!(
+                    "SearXNG search failed: HTTP 429 from {host}. The configured instance is rate-limiting requests; use a trusted/self-hosted instance or retry later. {truncated}"
+                ),
+                code => format!("SearXNG search failed: HTTP {code} from {host}. {truncated}"),
+            };
+            return Err(ToolError::execution_failed(msg));
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+            ToolError::execution_failed(format!(
+                "Failed to parse SearXNG JSON response from {host}: {e}. Ensure the instance supports format=json and JSON output is enabled."
+            ))
+        })?;
+
+        let results = parse_searxng_results(&parsed, max_results);
+        let suffix = format!("Backend: searxng at {host}");
+        search_tool_result(query.to_string(), "searxng", results, Some(&suffix))
+    }
+
     /// Search via Tavily AI Search API (<https://tavily.com>).
     async fn run_tavily_search(
         &self,
@@ -1071,6 +1145,29 @@ fn parse_baidu_results(parsed: &Value, max_results: usize) -> Vec<WebSearchEntry
         .collect()
 }
 
+fn parse_searxng_results(parsed: &Value, max_results: usize) -> Vec<WebSearchEntry> {
+    parsed
+        .get("results")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flat_map(|arr| arr.iter())
+        .filter_map(|item| {
+            let title = item.get("title").and_then(Value::as_str)?.trim();
+            let url = item.get("url").and_then(Value::as_str)?.trim();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            let snippet = first_non_empty_string(item, &["content", "snippet"]);
+            Some(WebSearchEntry {
+                title: title.to_string(),
+                url: url.to_string(),
+                snippet,
+            })
+        })
+        .take(max_results)
+        .collect()
+}
+
 fn baidu_error_message(parsed: &Value) -> Option<String> {
     let code = parsed
         .get("error_code")
@@ -1526,6 +1623,33 @@ fn duckduckgo_search_url(
     Ok((url.to_string(), host.to_string()))
 }
 
+fn searxng_search_url(base_url: Option<&str>, query: &str) -> Result<(String, String), ToolError> {
+    let raw = configured_search_base_url(base_url).ok_or_else(|| {
+        ToolError::invalid_input(
+            "SearXNG search requires [search] base_url = \"https://your-searxng.example\"; no public instance is used by default.",
+        )
+    })?;
+    let mut url = reqwest::Url::parse(raw).map_err(|err| {
+        ToolError::invalid_input(format!("Invalid SearXNG search base_url: {err}"))
+    })?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| ToolError::invalid_input("SearXNG search base_url must include a host"))?
+        .to_string();
+
+    let path = url.path().trim_end_matches('/');
+    if path.is_empty() {
+        url.set_path("search");
+    } else if path != "/search" && !path.ends_with("/search") {
+        url.set_path(&format!("{path}/search"));
+    }
+    url.query_pairs_mut()
+        .append_pair("q", query)
+        .append_pair("format", "json");
+
+    Ok((url.to_string(), host))
+}
+
 fn configured_search_base_url(base_url: Option<&str>) -> Option<&str> {
     base_url.map(str::trim).filter(|value| !value.is_empty())
 }
@@ -1639,8 +1763,9 @@ mod tests {
         ERROR_BODY_PREVIEW_BYTES, WebSearchEntry, WebSearchTool, baidu_search_payload,
         bocha_error_message, decode_html_entities, duckduckgo_search_url, extract_search_query,
         is_likely_spam_results, normalize_bing_url, optional_search_max_results,
-        parse_baidu_results, parse_bocha_results, parse_sofya_results, root_domain,
-        sanitize_error_body, truncate_error_body, volcengine_extract_text,
+        parse_baidu_results, parse_bocha_results, parse_searxng_results, parse_sofya_results,
+        root_domain, sanitize_error_body, searxng_search_url, truncate_error_body,
+        volcengine_extract_text,
     };
     use serde_json::json;
 
@@ -2362,6 +2487,296 @@ mod tests {
         )));
     }
 
+    #[test]
+    fn searxng_url_uses_search_path_and_json_format() {
+        let (url, host) =
+            searxng_search_url(Some("https://search.example/"), "rust async").expect("searxng url");
+        let parsed = reqwest::Url::parse(&url).expect("valid url");
+        assert_eq!(host, "search.example");
+        assert_eq!(parsed.path(), "/search");
+        assert_eq!(
+            parsed.query_pairs().find(|(key, _)| key == "q").unwrap().1,
+            "rust async"
+        );
+        assert_eq!(
+            parsed
+                .query_pairs()
+                .find(|(key, _)| key == "format")
+                .unwrap()
+                .1,
+            "json"
+        );
+
+        let (subpath_url, _) = searxng_search_url(
+            Some("https://search.example/searxng?language=en"),
+            "codewhale",
+        )
+        .expect("searxng subpath url");
+        let parsed = reqwest::Url::parse(&subpath_url).expect("valid subpath url");
+        assert_eq!(parsed.path(), "/searxng/search");
+        assert_eq!(
+            parsed
+                .query_pairs()
+                .find(|(key, _)| key == "language")
+                .unwrap()
+                .1,
+            "en"
+        );
+
+        let (search_url, _) =
+            searxng_search_url(Some("https://search.example/searxng/search"), "codewhale")
+                .expect("searxng search endpoint");
+        assert_eq!(
+            reqwest::Url::parse(&search_url)
+                .expect("valid search url")
+                .path(),
+            "/searxng/search"
+        );
+    }
+
+    #[test]
+    fn searxng_parser_normalizes_results() {
+        let parsed = json!({
+            "results": [
+                {
+                    "title": " Rust async ",
+                    "url": " https://example.com/rust ",
+                    "content": " Result content "
+                },
+                {
+                    "title": "Empty snippet",
+                    "url": "https://example.com/empty",
+                    "content": "   ",
+                    "snippet": " Fallback snippet "
+                },
+                {
+                    "title": "",
+                    "url": "https://example.com/missing-title",
+                    "content": "ignored"
+                },
+                {
+                    "title": "Missing URL",
+                    "content": "ignored"
+                }
+            ]
+        });
+
+        let results = parse_searxng_results(&parsed, 10);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Rust async");
+        assert_eq!(results[0].url, "https://example.com/rust");
+        assert_eq!(results[0].snippet.as_deref(), Some("Result content"));
+        assert_eq!(results[1].snippet.as_deref(), Some("Fallback snippet"));
+    }
+
+    #[tokio::test]
+    async fn searxng_provider_requires_base_url() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = None;
+
+        let err = WebSearchTool
+            .execute(json!({"query": "rust async"}), &ctx)
+            .await
+            .expect_err("searxng requires explicit base_url");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SearXNG")
+                && msg.contains("base_url")
+                && msg.contains("no public instance"),
+            "got `{msg}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn searxng_search_returns_json_results() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "rust async"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {
+                        "title": "Rust async",
+                        "url": "https://example.com/rust",
+                        "content": "Async Rust result"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = Some(server.uri());
+
+        let result = WebSearchTool
+            .execute(json!({"query": "rust async"}), &ctx)
+            .await
+            .expect("searxng endpoint should return results");
+        let value: serde_json::Value =
+            serde_json::from_str(&result.content).expect("web search json response");
+
+        assert_eq!(value["source"].as_str(), Some("searxng"));
+        assert_eq!(value["count"].as_u64(), Some(1));
+        assert!(
+            value["message"]
+                .as_str()
+                .expect("message")
+                .contains("Backend: searxng at")
+        );
+    }
+
+    #[tokio::test]
+    async fn searxng_empty_results_report_backend() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "empty"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"results": []})))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = Some(server.uri());
+
+        let result = WebSearchTool
+            .execute(json!({"query": "empty"}), &ctx)
+            .await
+            .expect("empty searxng response should still be structured");
+        let value: serde_json::Value =
+            serde_json::from_str(&result.content).expect("web search json response");
+
+        assert_eq!(value["count"].as_u64(), Some(0));
+        assert!(
+            value["message"]
+                .as_str()
+                .expect("message")
+                .contains("Backend: searxng at")
+        );
+    }
+
+    #[tokio::test]
+    async fn searxng_http_errors_are_actionable() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "blocked"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("json disabled"))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = Some(server.uri());
+
+        let err = WebSearchTool
+            .execute(json!({"query": "blocked"}), &ctx)
+            .await
+            .expect_err("403 should be actionable");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HTTP 403")
+                && msg.contains("JSON output")
+                && msg.contains("permits API access"),
+            "got `{msg}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn searxng_rate_limit_error_mentions_configured_instance() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "later"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("too many requests"))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = Some(server.uri());
+
+        let err = WebSearchTool
+            .execute(json!({"query": "later"}), &ctx)
+            .await
+            .expect_err("429 should be actionable");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HTTP 429")
+                && msg.contains("rate-limiting")
+                && msg.contains("trusted/self-hosted instance"),
+            "got `{msg}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn searxng_invalid_json_is_actionable() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "html"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>not json</html>"))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = Some(server.uri());
+
+        let err = WebSearchTool
+            .execute(json!({"query": "html"}), &ctx)
+            .await
+            .expect_err("invalid JSON should be actionable");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Failed to parse SearXNG JSON response")
+                && msg.contains("format=json")
+                && msg.contains("JSON output"),
+            "got `{msg}`"
+        );
+    }
+
     #[tokio::test]
     async fn custom_duckduckgo_results_report_custom_host_source() {
         use crate::config::SearchProvider;
@@ -2458,7 +2873,7 @@ mod tests {
         let msg = err.to_string();
         assert!(
             msg.contains("[search].base_url")
-                && msg.contains("provider = \"duckduckgo\"")
+                && msg.contains("provider = \"duckduckgo\" or \"searxng\"")
                 && msg.contains("tavily"),
             "got `{msg}`"
         );

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1320,8 +1320,8 @@ graduate behind real gated flags.
 `web_search` uses DuckDuckGo by default and does not require an API key. The
 DuckDuckGo path keeps a Bing fallback when DDG returns a bot challenge or no
 parseable results. Bing remains selectable for users who explicitly want it,
-and Tavily, Bocha, Metaso, Baidu, Volcengine, or Sofya can be selected when an
-API-backed provider is preferred.
+and Tavily, Bocha, Metaso, SearXNG, Baidu, Volcengine, or Sofya can be selected
+when an API-backed provider is preferred.
 
 For a private/internal search service that serves DuckDuckGo-compatible HTML,
 keep `provider = "duckduckgo"` and set `base_url`; CodeWhale appends the `q`
@@ -1329,6 +1329,13 @@ query parameter to that endpoint and applies network policy to its host.
 Custom endpoints do not fall back to public Bing. `CODEWHALE_SEARCH_BASE_URL`
 can override this per process; `DEEPSEEK_SEARCH_BASE_URL` remains accepted as
 the legacy alias.
+
+**SearXNG** ([docs](https://docs.searxng.org/dev/search_api.html)) uses the
+configured instance's JSON API. Set `provider = "searxng"` and
+`base_url = "https://your-searxng.example"`; CodeWhale calls
+`/search?q=...&format=json`. CodeWhale does not use a public SearXNG instance
+by default because public instances often disable JSON output or rate-limit API
+traffic.
 
 **Metaso** ([metaso.cn](https://metaso.cn)) has a 100 searches/day free quota;
 set `METASO_API_KEY` or `[search] api_key` for a higher quota.
@@ -1345,9 +1352,9 @@ Sofya model provider.
 
 ```toml
 [search]
-provider = "baidu" # duckduckgo | bing | tavily | bocha | metaso | baidu | volcengine | sofya
-# base_url = "https://search.example/html/" # optional with provider = "duckduckgo"
-# api_key = "YOUR_KEY" # required for tavily, bocha, baidu, volcengine, and sofya; optional for metaso
+provider = "searxng" # duckduckgo | bing | tavily | bocha | metaso | searxng | baidu | volcengine | sofya
+# base_url = "https://search.example/" # optional with provider = "duckduckgo"; required with "searxng"
+# api_key = "YOUR_KEY" # required for tavily, bocha, baidu, volcengine, and sofya; optional for metaso; unused by searxng
 ```
 
 ## Local Media Attachments

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -35,7 +35,7 @@ chosen over the available shell equivalent. Companion to `crates/tui/src/prompts
 |---|---|
 | `grep_files` | Regex search file contents within the workspace; structured matches + context lines. Pure-Rust (`regex` crate), no `rg`/`grep` shell-out. |
 | `file_search` | Fuzzy-match filenames (not contents). Use when you know roughly the name. |
-| `web_search` | DuckDuckGo by default with Bing fallback; Bing, Tavily, Bocha, Metaso, and Baidu are selectable in config. Ranked snippets + `ref_id` for citation. |
+| `web_search` | DuckDuckGo by default with Bing fallback; Bing, Tavily, Bocha, Metaso, SearXNG, Baidu, Volcengine, and Sofya are selectable in config. Ranked snippets + `ref_id` for citation. |
 | `fetch_url` | Direct HTTP GET on a known URL. Faster than `web_search` when the link is already known. HTML stripped to text by default. |
 
 ### Shell


### PR DESCRIPTION
## Goal

Refs #3079. Add a first-class configured SearXNG JSON backend for `web_search` so users can point CodeWhale at a trusted/self-hosted SearXNG instance instead of relying only on HTML scraping or paid API providers.

## Changes

- Adds `SearchProvider::Searxng` with aliases (`searxng`, `searx`, `searx-ng`, `searx_ng`).
- Allows `[search] base_url` for `provider = "searxng"` while keeping other non-DuckDuckGo providers rejected.
- Builds SearXNG requests as `/search?q=...&format=json`, including support for root, subpath, and explicit `/search` base URLs.
- Normalizes SearXNG `results[]` into the existing `WebSearchResponse` shape.
- Returns actionable errors for missing `base_url`, `403`, `429`, invalid JSON/disabled JSON, and includes backend status in empty-result messages.
- Updates `config.example.toml`, `docs/CONFIGURATION.md`, and `docs/TOOL_SURFACE.md` with trusted/self-hosted SearXNG setup notes and the official docs link.

## Verification

Live docs checked:

- https://docs.searxng.org/dev/search_api.html reports `Search API - SearXNG Documentation (2026.6.22+952896d29)` and documents `format=json`.

Commands run:

```sh
cargo fmt
cargo test -p codewhale-tui --bin codewhale-tui --locked searxng
cargo test -p codewhale-tui --bin codewhale-tui --locked search_provider
cargo test -p codewhale-tui --bin codewhale-tui --locked web_search
cargo fmt --all -- --check
```

Results:

- `searxng`: 10 passed
- `search_provider`: 18 passed
- `web_search`: 54 passed
- format check passed

## Risks / Follow-ups

- This intentionally does not select a random public SearXNG instance by default. Users must configure a trusted `base_url`.
- This does not implement ordered fallback providers such as `fallbacks = ["metaso", "duckduckgo"]`; that should remain a separate config/runtime design.
- This improves result messages with backend identity, but the broader Activity/sidebar status requested in #3079 should be a follow-up UI slice.
- SearXNG instances vary in enabled formats and rate limits, so the mock tests pin the contract and the runtime errors point users at JSON/output configuration issues.
