### PR TITLE
Pin SiliconFlow DSML regression fixtures

### DIFF
--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2891,6 +2891,14 @@ fn wire_model_for_provider_matches_active_provider_shape() {
         wire_model_for_provider(ApiProvider::Openrouter, OPENROUTER_MINIMAX_M3_MODEL),
         OPENROUTER_MINIMAX_M3_MODEL
     );
+    assert_eq!(
+        wire_model_for_provider(ApiProvider::SiliconflowCn, DEFAULT_SILICONFLOW_MODEL),
+        DEFAULT_SILICONFLOW_MODEL
+    );
+    assert_eq!(
+        wire_model_for_provider(ApiProvider::SiliconflowCn, "deepseek-v4-pro"),
+        DEFAULT_SILICONFLOW_MODEL
+    );
 }
 
 #[test]
@@ -4985,6 +4993,47 @@ model = "deepseek-reasoner"
     assert_eq!(config.deepseek_base_url(), DEFAULT_SILICONFLOW_CN_BASE_URL);
     assert_eq!(config.default_model(), DEFAULT_SILICONFLOW_MODEL);
     assert!(has_api_key_for(&config, ApiProvider::SiliconflowCn));
+    Ok(())
+}
+
+#[test]
+fn siliconflow_cn_preserves_reported_deepseek_prefixed_v4_route() -> Result<()> {
+    let _lock = lock_test_env();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_root = env::temp_dir().join(format!(
+        "codewhale-tui-siliconflow-cn-v4-report-{}-{}",
+        std::process::id(),
+        nanos
+    ));
+    fs::create_dir_all(&temp_root)?;
+    let _guard = EnvGuard::new(&temp_root);
+
+    let config_path = temp_root.join(".deepseek").join("config.toml");
+    ensure_parent_dir(&config_path)?;
+    fs::write(
+        &config_path,
+        r#"provider = "siliconflow-CN"
+
+[providers.siliconflow-CN]
+api_key = "sf-cn-table-key"
+base_url = "https://api.siliconflow.cn/v1"
+model = "deepseek-ai/DeepSeek-V4-Pro"
+"#,
+    )?;
+
+    let config = Config::load(None, None)?;
+    assert_eq!(config.api_provider(), ApiProvider::SiliconflowCn);
+    assert_ne!(config.api_provider(), ApiProvider::Deepseek);
+    assert_eq!(config.deepseek_api_key()?, "sf-cn-table-key");
+    assert_eq!(config.deepseek_base_url(), DEFAULT_SILICONFLOW_CN_BASE_URL);
+    assert_eq!(config.default_model(), DEFAULT_SILICONFLOW_MODEL);
+    assert_eq!(
+        wire_model_for_provider(config.api_provider(), &config.default_model()),
+        DEFAULT_SILICONFLOW_MODEL
+    );
     Ok(())
 }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3989,6 +3989,27 @@ fn filter_tool_call_delta_strips_function_calls_marker() {
 }
 
 #[test]
+fn filter_tool_call_delta_strips_siliconflow_v4_dsml_content_fixture() {
+    // #2900: a SiliconFlow CN `deepseek-ai/DeepSeek-V4-Pro` stream can leak
+    // DSML/function-call markup through the ordinary content channel. Keep it
+    // out of visible assistant text; do not reinterpret `<function_calls>` as
+    // an executable legacy text tool call.
+    let mut in_block = false;
+    let visible_a = filter_tool_call_delta(
+        "visible prefix <function_calls>\n{\"name\":\"exec_shell\",\"arguments\":{\"cmd\":\"echo leaked\"}}",
+        &mut in_block,
+    );
+    assert!(in_block);
+    assert_eq!(visible_a, "visible prefix ");
+
+    let visible_b = filter_tool_call_delta("\n</function_calls> visible suffix", &mut in_block);
+    assert!(!in_block);
+    assert_eq!(visible_b, " visible suffix");
+    assert!(!visible_b.contains("exec_shell"));
+    assert!(!visible_b.contains("<function_calls>"));
+}
+
+#[test]
 fn filter_tool_call_delta_handles_chunk_split_marker() {
     let mut in_block = false;
     // First chunk opens the wrapper but does not close it.


### PR DESCRIPTION
## Goal

Refs #2900. Preserve the reported SiliconFlow CN + `deepseek-ai/DeepSeek-V4-Pro` DSML/tool-call streaming regression as explicit fixtures, without broadening text-based tool execution.

## Changes

- Adds a config fixture for the reported route:
  - `provider = "siliconflow-CN"`
  - CN base URL remains `https://api.siliconflow.cn/v1`
  - model remains `deepseek-ai/DeepSeek-V4-Pro`
  - selected provider remains `ApiProvider::SiliconflowCn`, not official DeepSeek.
- Extends the provider wire-model test so SiliconFlow CN maps `deepseek-v4-pro` to the provider-owned `deepseek-ai/DeepSeek-V4-Pro` wire id.
- Adds a stream filtering fixture for DSML/function-call markup leaked through ordinary content:
  - visible assistant text keeps only the surrounding prose
  - leaked `exec_shell`/`<function_calls>` content is stripped
  - this does not make `<function_calls>` executable through the legacy text parser.

## Verification

```sh
cargo fmt
cargo test -p codewhale-tui --bin codewhale-tui --locked siliconflow
cargo test -p codewhale-tui --test protocol_recovery --locked
cargo test -p codewhale-tui --bin codewhale-tui --locked filter_tool_call_delta
cargo test -p codewhale-tui --bin codewhale-tui --locked decoder_emits_tool_use_block_for_tool_call_delta
cargo fmt --all -- --check
```

Results:

- `siliconflow`: 12 passed
- `protocol_recovery`: 14 passed
- `filter_tool_call_delta`: 9 passed
- `decoder_emits_tool_use_block_for_tool_call_delta`: 1 passed
- format check passed

## Risks / Follow-ups

- This is intentionally a fixture/guardrail slice. It does not infer executable tool calls from `<function_calls>` text, because existing protocol-recovery tests treat that wrapper as forged/non-API text.
- If we get the literal original DSML payload from the Windows report screenshot/logs, we should add it as a second recorded fixture.
- Broader metadata plumbing for provider/model/finish reason/debug outcome remains separate from this small regression pin.
