### PR TITLE
Canonicalize model-visible work tracking

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -7,6 +7,7 @@ use crate::models::SystemBlock;
 use crate::test_support::lock_test_env;
 use crate::tools::plan::{PlanItemArg, PlanSnapshot, StepStatus};
 use crate::tools::spec::ToolCapability;
+use crate::tools::todo::{TodoItem, TodoListSnapshot, TodoStatus};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
@@ -170,6 +171,46 @@ fn structured_state_block_includes_rich_plan_artifact() {
     assert!(block.contains("Verification plan: Run focused tests"));
     assert!(block.contains("Handoff packet: Next agent should inspect replay"));
     assert!(block.contains("- [~] Render rich artifact"));
+}
+
+#[test]
+fn structured_state_block_uses_checklist_as_work_surface() {
+    let state = StructuredState {
+        mode_label: "Agent".to_string(),
+        workspace: PathBuf::from("/workspace/codewhale"),
+        cwd: Some(PathBuf::from("/workspace/codewhale")),
+        working_set_summary: None,
+        todo_snapshot: Some(TodoListSnapshot {
+            items: vec![
+                TodoItem {
+                    id: 1,
+                    content: "Wire Fleet progress projection".to_string(),
+                    status: TodoStatus::InProgress,
+                },
+                TodoItem {
+                    id: 2,
+                    content: "Run focused gates".to_string(),
+                    status: TodoStatus::Pending,
+                },
+            ],
+            completion_pct: 0,
+            in_progress_id: Some(1),
+        }),
+        plan_snapshot: Some(PlanSnapshot {
+            objective: Some("Keep strategy separate".to_string()),
+            ..PlanSnapshot::default()
+        }),
+        subagent_snapshots: Vec::new(),
+    };
+
+    let block = state.to_system_block().expect("fork state block");
+
+    assert!(block.contains("### Work"));
+    assert!(block.contains("Checklist (0% complete)"));
+    assert!(block.contains("- [~] Wire Fleet progress projection"));
+    assert!(block.contains("Strategy metadata"));
+    assert!(block.contains("Objective: Keep strategy separate"));
+    assert!(!block.contains("Todo list"));
 }
 
 #[test]

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -646,6 +646,16 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn update_plan_description_keeps_checklist_as_primary_work_progress() {
+        let tool = UpdatePlanTool::new(new_shared_plan_state());
+        let description = tool.description();
+
+        assert!(description.contains("Use checklist_write for primary Work progress"));
+        assert!(description.contains("not duplicate checklist items"));
+        assert!(description.contains("high-level strategy metadata"));
+    }
+
+    #[test]
     fn plan_state_treats_every_artifact_field_as_non_empty() {
         let cases = vec![
             UpdatePlanArgs {

--- a/crates/tui/src/tools/todo.rs
+++ b/crates/tui/src/tools/todo.rs
@@ -176,6 +176,8 @@ pub fn new_shared_todo_list() -> SharedTodoList {
 
 const TODO_ALIAS_FIRST_DEPRECATED_VERSION: &str = "0.8.53";
 const TODO_ALIAS_REMOVAL_VERSION: &str = "0.9.0";
+const CANONICAL_WORK_SURFACE: &str = "checklist";
+const DURABLE_WORK_OWNER: &str = "fleet_whaleflow_ledger";
 
 fn is_compat_alias(tool_name: &str) -> bool {
     tool_name.starts_with("todo_")
@@ -596,6 +598,12 @@ fn checklist_metadata(snapshot: &TodoListSnapshot, tool_name: &str) -> serde_jso
     let mut metadata = json!({
         "canonical_tool": canonical_tool,
         "compat_alias": compat_alias,
+        "work_surface": {
+            "canonical": CANONICAL_WORK_SURFACE,
+            "model_visible": !compat_alias,
+            "durable_owner": DURABLE_WORK_OWNER,
+            "progress_key": "task_updates.checklist"
+        },
         "task_updates": {
             "checklist": {
                 "items": items,
@@ -646,6 +654,16 @@ mod tests {
         let metadata = result.metadata.expect("metadata");
         assert_eq!(metadata["canonical_tool"], "checklist_write");
         assert_eq!(metadata["compat_alias"], false);
+        assert_eq!(metadata["work_surface"]["canonical"], "checklist");
+        assert_eq!(metadata["work_surface"]["model_visible"], true);
+        assert_eq!(
+            metadata["work_surface"]["durable_owner"],
+            "fleet_whaleflow_ledger"
+        );
+        assert_eq!(
+            metadata["work_surface"]["progress_key"],
+            "task_updates.checklist"
+        );
         assert_eq!(
             metadata["task_updates"]["checklist"]["in_progress_id"],
             json!(1)
@@ -676,6 +694,15 @@ mod tests {
         assert_eq!(tool.name(), "todo_write");
         assert_eq!(metadata["canonical_tool"], "checklist_write");
         assert_eq!(metadata["compat_alias"], true);
+        assert_eq!(metadata["work_surface"]["canonical"], "checklist");
+        assert_eq!(
+            metadata["work_surface"]["progress_key"],
+            "task_updates.checklist"
+        );
+        assert_eq!(
+            metadata["task_updates"]["checklist"]["items"][0]["content"],
+            "legacy caller"
+        );
         assert_eq!(metadata["_deprecation"]["this_tool"], "todo_write");
         assert_eq!(metadata["_deprecation"]["use_instead"], "checklist_write");
         assert_eq!(metadata["_deprecation"]["removed_in"], "0.9.0");
@@ -697,6 +724,7 @@ mod tests {
             .expect("todo add succeeds");
         let add_metadata = add_result.metadata.expect("add metadata");
         assert_eq!(add_metadata["canonical_tool"], "checklist_add");
+        assert_eq!(add_metadata["work_surface"]["canonical"], "checklist");
         assert_eq!(add_metadata["_deprecation"]["use_instead"], "checklist_add");
         assert!(!add.model_visible());
 
@@ -707,6 +735,7 @@ mod tests {
             .expect("todo update succeeds");
         let update_metadata = update_result.metadata.expect("update metadata");
         assert_eq!(update_metadata["canonical_tool"], "checklist_update");
+        assert_eq!(update_metadata["work_surface"]["canonical"], "checklist");
         assert_eq!(
             update_metadata["_deprecation"]["use_instead"],
             "checklist_update"
@@ -720,6 +749,7 @@ mod tests {
             .expect("todo list succeeds");
         let list_metadata = list_result.metadata.expect("list metadata");
         assert_eq!(list_metadata["canonical_tool"], "checklist_list");
+        assert_eq!(list_metadata["work_surface"]["canonical"], "checklist");
         assert_eq!(
             list_metadata["_deprecation"]["use_instead"],
             "checklist_list"

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -80,6 +80,12 @@ Use fresh sessions for independent exploration. Use forked sessions when the
 task depends on decisions, files, todos, or plan state already in the parent
 transcript.
 
+Forked state renders concrete Work progress through the canonical
+`checklist_*` surface. The durable task/Fleet ledger owns lifecycle state;
+checklist entries are the model-visible progress projection. Use `update_plan`
+only for strategy metadata that helps a parent or later worker understand the
+approach.
+
 ## Worktree isolation
 
 For parallel edit lanes, launch the child with `worktree: true`. CodeWhale

--- a/docs/TOOL_LIFECYCLE.md
+++ b/docs/TOOL_LIFECYCLE.md
@@ -47,6 +47,26 @@ The lifecycle policy exists to **shrink and discipline the model-visible
 surface** without ever breaking the ability to replay an old transcript that
 referenced a now-retired name.
 
+### Canonical work-tracking surface for v0.8.65
+
+The model-visible progress surface is `checklist_*`:
+`checklist_write`, `checklist_add`, `checklist_update`, and `checklist_list`.
+Agents and Fleet workers use that surface for concrete Work progress under the
+active runtime thread or durable task.
+
+`task_*` and the Fleet/WhaleFlow ledger remain the durable lifecycle owners.
+Checklist metadata is the model-visible projection of progress:
+`task_updates.checklist` carries the current items, completion percentage, and
+in-progress item. `update_plan` is optional high-level strategy metadata for
+complex initiatives; it must not duplicate checklist items or become a parallel
+progress store.
+
+The legacy `todo_*` names are deprecated hidden compatibility aliases. They
+remain registered and dispatchable against the same checklist state so old
+transcripts replay without data loss, but they are not advertised to the model
+catalog and their result metadata points callers to the corresponding
+`checklist_*` tool.
+
 ---
 
 ## 2. The five lifecycle states


### PR DESCRIPTION
## Summary
- formalizes `checklist_*` as the canonical model-visible Work progress surface
- keeps `todo_*` dispatchable as hidden compatibility aliases over the same checklist state, with replacement metadata
- pins `update_plan` as strategy metadata and adds fork-state coverage for checklist progress under Work
- documents the Fleet/WhaleFlow durable-owner split from the checklist progress projection

Refs #3366

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked checklist`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked todo`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked structured_state_block`
- `git diff --check`

## Risk
- Metadata shape adds a new `work_surface` object; existing callers reading only `task_updates.checklist` remain compatible.
