### PR TITLE
feat(web): add provenance and mirror trust copy to codewhale.net (#3421)

### DIFF
--- a/web/app/[locale]/faq/page.tsx
+++ b/web/app/[locale]/faq/page.tsx
@@ -269,6 +269,35 @@ registry = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"`}
     sources: ["README.md", "#1914", "docs/CNB_MIRROR.md"],
   },
   {
+    q: "Is codewhale.net the official site? What about mirrors?",
+    a: (
+      <>
+        <p className="mb-2">
+          <strong>codewhale.net</strong> and <strong>www.codewhale.net</strong> are the
+          official CodeWhale sites, deployed on Cloudflare. The website source is open
+          and lives under <code className="inline">web/</code> in the{" "}
+          <code className="inline">Hmbown/CodeWhale</code> repository — anyone can
+          self-deploy it as a mirror.
+        </p>
+        <p className="mb-2">
+          All official releases and SHA-256 checksums are distributed exclusively through{" "}
+          <a href="https://github.com/Hmbown/CodeWhale/releases" className="body-link">GitHub Releases</a>.
+          The npm package downloads verified binaries from GitHub Releases.
+        </p>
+        <p className="mb-2">
+          A CNB mirror is maintained for users who cannot reliably reach GitHub
+          (<Link href="/docs#cnb-mirror" className="body-link">docs/CNB_MIRROR.md</Link>).
+          Cargo users can use the TUNA mirror for faster downloads in China.
+        </p>
+        <p>
+          Self-deployed website copies, mirror sites, and third-party packages are not
+          controlled by the CodeWhale project. Verify download sources and checksums.
+        </p>
+      </>
+    ),
+    sources: ["#2624", "#3421", "docs/CNB_MIRROR.md"],
+  },
+  {
     q: "My API key was rejected or I get auth errors on first run.",
     a: (
       <>
@@ -581,6 +610,34 @@ registry = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"`}
       </>
     ),
     sources: ["README.md", "#1914", "docs/CNB_MIRROR.md"],
+  },
+  {
+    q: "codewhale.net 是官方网站吗？镜像站点呢？",
+    a: (
+      <>
+        <p className="mb-2">
+          <strong>codewhale.net</strong> 和 <strong>www.codewhale.net</strong> 是
+          CodeWhale 的官方站点，部署在 Cloudflare 上。网站源码存放于{" "}
+          <code className="inline">Hmbown/CodeWhale</code> 仓库的{" "}
+          <code className="inline">web/</code> 目录下，任何人都可自行部署为镜像。
+        </p>
+        <p className="mb-2">
+          所有正式发布和 SHA-256 校验文件仅通过{" "}
+          <a href="https://github.com/Hmbown/CodeWhale/releases" className="body-link">GitHub Releases</a> 分发。
+          npm 包从 GitHub Releases 下载经校验的二进制。
+        </p>
+        <p className="mb-2">
+          面向无法稳定访问 GitHub 的用户，提供 CNB 镜像（
+          <Link href="/docs#cnb-mirror" className="body-link">docs/CNB_MIRROR.md</Link>）。
+          Cargo 用户可使用 TUNA 镜像在国内加速下载。
+        </p>
+        <p>
+          自行部署的网站副本、镜像站和第三方包不受 CodeWhale 项目控制。
+          请验证下载来源和校验和。
+        </p>
+      </>
+    ),
+    sources: ["#2624", "#3421", "docs/CNB_MIRROR.md"],
   },
   {
     q: "首次运行时提示 API 密钥被拒绝或认证错误？",

--- a/web/app/[locale]/install/page.tsx
+++ b/web/app/[locale]/install/page.tsx
@@ -441,12 +441,88 @@ codewhale doctor`;
         </p>
       </section>
 
-      {/* ⑦ NEXT STEPS */}
+      {/* ⑦ PROVENANCE */}
+      <section className="mx-auto max-w-[1100px] px-6 py-12 hairline-t">
+        <div className="flex items-baseline gap-4 mb-5">
+          <Seal char="源" />
+          <div className="eyebrow">{isZh ? "07 · 来源与镜像" : "07 · Provenance & mirrors"}</div>
+        </div>
+
+        <div className="space-y-4 text-sm text-ink-soft leading-relaxed max-w-2xl">
+          <p>
+            {isZh ? (
+              <>
+                <strong className="text-ink">codewhale.net</strong> 和{" "}
+                <strong className="text-ink">www.codewhale.net</strong> 是 CodeWhale 的官方站点，
+                部署在 Cloudflare 上。网站源码位于{" "}
+                <code className="inline">Hmbown/CodeWhale</code> 仓库的{" "}
+                <code className="inline">web/</code> 目录下，任何人都可自行部署为镜像。
+              </>
+            ) : (
+              <>
+                <strong className="text-ink">codewhale.net</strong> and{" "}
+                <strong className="text-ink">www.codewhale.net</strong> are the official CodeWhale
+                sites, deployed on Cloudflare. The website source lives under{" "}
+                <code className="inline">web/</code> in the{" "}
+                <code className="inline">Hmbown/CodeWhale</code> repository — anyone can
+                self-deploy it as a mirror.
+              </>
+            )}
+          </p>
+
+          <div className="grid sm:grid-cols-2 gap-4 mt-4">
+            <div>
+              <div className="eyebrow mb-1 text-indigo">{isZh ? "官方发布" : "Official releases"}</div>
+              <p>
+                {isZh
+                  ? "所有正式发布和 SHA-256 校验文件仅通过 GitHub Releases 分发。npm 包从 GitHub Releases 下载经校验的二进制。"
+                  : "All official releases and SHA-256 checksums are distributed exclusively through GitHub Releases. The npm package downloads verified binaries from GitHub Releases."}
+              </p>
+            </div>
+            <div>
+              <div className="eyebrow mb-1 text-indigo">{isZh ? "CNB 镜像" : "CNB mirror"}</div>
+              <p>
+                {isZh ? (
+                  <>
+                    面向无法稳定访问 GitHub 的用户，提供 CNB 镜像（
+                    <Link href="/docs#cnb-mirror" className="body-link">docs/CNB_MIRROR.md</Link>
+                    ）。镜像仓库由社区成员维护，发布延迟可能为几小时。
+                  </>
+                ) : (
+                  <>
+                    A CNB mirror is available for users who cannot reliably reach GitHub (
+                    <Link href="/docs#cnb-mirror" className="body-link">docs/CNB_MIRROR.md</Link>
+                    ). The mirror is maintained by community members; release latency may be a few hours.
+                  </>
+                )}
+              </p>
+            </div>
+            <div>
+              <div className="eyebrow mb-1 text-indigo">{isZh ? "TUNA / 包镜像" : "TUNA / package mirrors"}</div>
+              <p>
+                {isZh
+                  ? "Cargo 用户可通过 TUNA（清华大学开源镜像站）加速下载。这些镜像由第三方维护，CodeWhale 项目不控制镜像内容。"
+                  : "Cargo users can accelerate downloads via TUNA (Tsinghua University Open Source Mirror). These mirrors are maintained by third parties; the CodeWhale project does not control mirror content."}
+              </p>
+            </div>
+            <div>
+              <div className="eyebrow mb-1 text-indigo">{isZh ? "自行部署" : "Self-deployed"}</div>
+              <p>
+                {isZh
+                  ? "自行部署的网站副本、镜像站和第三方包不受 CodeWhale 项目控制。请验证下载来源和校验和。"
+                  : "Self-deployed website copies, mirror sites, and third-party packages are not controlled by the CodeWhale project. Verify download sources and checksums."}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ⑧ NEXT STEPS */}
       <section className="bg-paper-deep hairline-t hairline-b">
         <div className="mx-auto max-w-[1100px] px-6 py-12">
           <div className="flex items-baseline gap-4 mb-5">
             <Seal char="续" />
-            <div className="eyebrow">{isZh ? "07 · 下一步" : "07 · Next steps"}</div>
+            <div className="eyebrow">{isZh ? "08 · 下一步" : "08 · Next steps"}</div>
           </div>
           <div className="grid md:grid-cols-3 gap-0 col-rule hairline-t hairline-b">
             <Link

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -139,6 +139,7 @@ export function Footer({ locale = "en" }: { locale?: Locale }) {
           </div>
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 font-mono text-[0.7rem] text-ink-mute uppercase tracking-widest">
             <span>© {new Date().getFullYear()} · CodeWhale · Hmbown</span>
+            <span>codewhale.net — {isZh ? "唯一官方站点" : "the only official site"}</span>
             <span className="font-cjk normal-case tracking-normal">
               {isZh ? "本网站由 DeepSeek V4-Flash 协助维护" : "Maintained with DeepSeek V4-Flash"}
             </span>


### PR DESCRIPTION
Adds official-site provenance information across three surfaces:

- Install page: new 'Provenance & mirrors' section (§07) covering official sites, GitHub Releases, CNB mirror, TUNA mirrors, and self-deployed copies

- FAQ: new EN+ZH entry 'Is codewhale.net the official site?' with mirror trust boundaries

- Footer: 'codewhale.net — the only official site' provenance line

Bilingual EN/ZH copy throughout.

Close https://github.com/Hmbown/CodeWhale/issues/3421.

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
