### PR TITLE
WIP: Record unscored Fleet exits as partial

### DIFF
--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -109,6 +109,7 @@ pub struct FleetWorkerInspection {
     pub latest_heartbeat_at: Option<String>,
     pub latest_event: Option<FleetWorkerEvent>,
     pub artifacts: Vec<FleetArtifactRef>,
+    pub receipt_summary: Option<String>,
     pub last_error: Option<String>,
     pub alert_state: Option<String>,
     /// Lightweight projection from the sub-agent worker runtime.
@@ -421,6 +422,7 @@ impl FleetManager {
                     .flat_map(|receipt| receipt.artifacts.clone()),
             )
             .collect();
+        let receipt_summary = latest_receipt_for_worker(&state, worker_id).map(receipt_summary);
         let last_error = latest_error_for_worker(&state, worker_id);
         let status = state
             .workers
@@ -464,6 +466,7 @@ impl FleetManager {
             latest_heartbeat_at,
             latest_event,
             artifacts,
+            receipt_summary,
             last_error,
             alert_state,
             runtime_state,
@@ -802,6 +805,8 @@ impl FleetManager {
 
         let (receipt_result, failure_kind, exit_code) =
             task_receipt_outcome(&terminal.payload, terminal.exit_code);
+        let terminal_completed =
+            matches!(&terminal.payload, FleetWorkerEventPayload::Completed { .. });
         self.append_worker_event(
             &task.entry.run_id,
             &task.worker_id,
@@ -842,6 +847,17 @@ impl FleetManager {
                     FleetTaskLedgerStatus::Failed,
                 )?;
             }
+            return Ok(true);
+        }
+        if terminal_completed {
+            let verification =
+                verify_task_result(&self.workspace, &task.task_spec, &verification_input);
+            record_verification_receipt(
+                &self.ledger,
+                &self.workspace,
+                &verification_input,
+                verification,
+            )?;
             return Ok(true);
         }
         self.ledger.record_receipt(FleetReceipt {
@@ -1230,6 +1246,45 @@ fn latest_alert_for_worker(state: &FleetLedgerState, worker_id: &str) -> Option<
         .map(|(_, message)| message)
 }
 
+fn latest_receipt_for_worker<'a>(
+    state: &'a FleetLedgerState,
+    worker_id: &str,
+) -> Option<&'a FleetReceipt> {
+    state
+        .receipts
+        .values()
+        .filter(|receipt| receipt.worker_id == worker_id)
+        .max_by_key(|receipt| &receipt.completed_at)
+}
+
+fn receipt_summary(receipt: &FleetReceipt) -> String {
+    let result = match receipt.result {
+        FleetTaskResult::Pass => "pass",
+        FleetTaskResult::Partial => "partial",
+        FleetTaskResult::Fail => "fail",
+        FleetTaskResult::Skip => "skip",
+        FleetTaskResult::Timeout => "timeout",
+    };
+    let mut summary = format!("result={result}");
+    if let Some(kind) = &receipt.failure_kind {
+        let kind = match kind {
+            FleetTaskFailureKind::Transport => "transport",
+            FleetTaskFailureKind::Task => "task",
+            FleetTaskFailureKind::Verifier => "verifier",
+        };
+        summary.push_str(&format!(" failure_kind={kind}"));
+    }
+    if let Some(notes) = receipt
+        .score
+        .as_ref()
+        .and_then(|score| score.notes.as_deref())
+        .filter(|notes| !notes.trim().is_empty())
+    {
+        summary.push_str(&format!(" notes={notes}"));
+    }
+    summary
+}
+
 fn latest_error_for_worker(state: &FleetLedgerState, worker_id: &str) -> Option<String> {
     state
         .latest_events
@@ -1585,6 +1640,78 @@ exit 0
                 .iter()
                 .any(|artifact| matches!(artifact.kind, FleetArtifactKind::Receipt))
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fleet_task_spec_unscored_zero_exit_records_partial_receipt() {
+        let tmp = TempDir::new().unwrap();
+        let manager = FleetManager::open(tmp.path()).unwrap();
+        let path = task_spec_file(&tmp, vec![task("task-a")]);
+        let fake = fake_codewhale(
+            &tmp,
+            r#"#!/bin/sh
+printf '{"type":"done"}\n'
+exit 0
+"#,
+        );
+
+        let report = manager.create_run_from_task_spec_path(&path, 1).unwrap();
+        let worker_id = report.worker_ids[0].clone();
+        let status = complete_with_fake_codewhale(&manager, &report.run_id, 1, &fake);
+
+        assert_eq!(status.completed, 1);
+        assert_eq!(status.partial, 1);
+        assert_eq!(status.failed, 0);
+        let state = manager.ledger.rebuild_state().unwrap();
+        let receipt = &state.receipts[&format!("{}:task-a", report.run_id.0)];
+        assert_eq!(receipt.result, FleetTaskResult::Partial);
+        assert_eq!(receipt.failure_kind, None);
+        assert!(
+            receipt
+                .score
+                .as_ref()
+                .and_then(|score| score.notes.as_deref())
+                .unwrap_or_default()
+                .contains("no verifiable output")
+        );
+        assert!(
+            receipt
+                .artifacts
+                .iter()
+                .any(|artifact| matches!(artifact.kind, FleetArtifactKind::Receipt))
+        );
+        let inspection = manager.inspect_worker(&worker_id).unwrap();
+        let summary = inspection.receipt_summary.as_deref().unwrap_or_default();
+        assert!(summary.contains("result=partial"));
+        assert!(summary.contains("no verifiable output"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fleet_task_spec_unscored_worker_error_records_failed_receipt() {
+        let tmp = TempDir::new().unwrap();
+        let manager = FleetManager::open(tmp.path()).unwrap();
+        let path = task_spec_file(&tmp, vec![task("task-a")]);
+        let fake = fake_codewhale(
+            &tmp,
+            r#"#!/bin/sh
+printf '{"type":"error","error":"tool failed"}\n'
+exit 7
+"#,
+        );
+
+        let report = manager.create_run_from_task_spec_path(&path, 1).unwrap();
+        let status = complete_with_fake_codewhale(&manager, &report.run_id, 1, &fake);
+
+        assert_eq!(status.completed, 0);
+        assert_eq!(status.partial, 0);
+        assert_eq!(status.failed, 1);
+        assert_eq!(status.task_failed, 1);
+        let state = manager.ledger.rebuild_state().unwrap();
+        let receipt = &state.receipts[&format!("{}:task-a", report.run_id.0)];
+        assert_eq!(receipt.result, FleetTaskResult::Fail);
+        assert_eq!(receipt.failure_kind, Some(FleetTaskFailureKind::Task));
     }
 
     #[cfg(unix)]

--- a/crates/tui/src/fleet/task_spec.rs
+++ b/crates/tui/src/fleet/task_spec.rs
@@ -193,6 +193,10 @@ pub fn verify_task_result(
             "manual scorer configured",
             "manual verification is required to finalize this receipt",
         ),
+        None if !has_verifiable_artifact(input) => partial(
+            "no scorer configured and no verifiable artifacts recorded",
+            "worker exited successfully but produced no verifiable output",
+        ),
         None => partial(
             "no scorer configured",
             "task has artifacts but no deterministic scorer",
@@ -439,6 +443,15 @@ fn fail(
     }
 }
 
+fn has_verifiable_artifact(input: &FleetTaskVerificationInput) -> bool {
+    input.artifacts.iter().any(|artifact| {
+        !matches!(
+            artifact.kind,
+            FleetArtifactKind::Log | FleetArtifactKind::Receipt
+        )
+    })
+}
+
 #[derive(Debug)]
 struct EvidenceReadError {
     failure_kind: FleetTaskFailureKind,
@@ -676,6 +689,17 @@ mod tests {
             &input,
         );
         assert_eq!(manual.result, FleetTaskResult::Partial);
+
+        let no_scorer_empty = verify_task_result(tmp.path(), &task("unscored", None), &input);
+        assert_eq!(no_scorer_empty.result, FleetTaskResult::Partial);
+        assert!(
+            no_scorer_empty
+                .score
+                .notes
+                .as_deref()
+                .unwrap_or_default()
+                .contains("no verifiable output")
+        );
 
         let failed = verify_task_result(
             tmp.path(),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1506,6 +1506,9 @@ async fn run_fleet_command(workspace: &Path, config: &Config, args: FleetArgs) -
                 );
             }
         }
+        if let Some(receipt) = &inspection.receipt_summary {
+            println!("receipt: {receipt}");
+        }
         if let Some(error) = &inspection.last_error {
             println!("last_error: {error}");
         }


### PR DESCRIPTION
## Summary

Refs #2989.

This is the Fleet receipt/status slice for the Ollama/qwen premature-completed report. It does not close the full issue because provider-route telemetry, timeout/context diagnostics, and user-facing Ollama guidance still need follow-up work.

Changes:
- Record clean worker exits with no scorer and no verifiable non-log artifacts as `partial` receipts instead of pass-like unscored completions.
- Keep deterministic scored success unchanged: `scorer = exit_code` and exit 0 still records `Pass`.
- Preserve worker/tool errors as failed receipts for unscored tasks.
- Add `receipt_summary` to `fleet inspect` output so operators can see `result=partial ... no verifiable output` without opening receipt JSON.
- Add regression tests for unscored zero-exit/empty-output, unscored worker error, existing scored pass, and failure-source status accounting.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

Focused verification run:
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_task_spec_unscored_zero_exit_records_partial_receipt`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_task_spec_unscored_worker_error_records_failed_receipt`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_task_spec_local_scorer_records_receipt_artifact`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_task_spec_status_distinguishes_failure_sources`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked exit_classification`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked stream_line_maps_done_and_error`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_manager_can_record_completed_local_smoke_tasks`
- [x] `git diff --check`

## Risks

- Ledger task lifecycle status remains `completed` for successful worker transport; the task truth is now carried by the receipt (`partial`) and surfaced in status/inspect. That preserves transport semantics while avoiding a false verified-pass receipt.
- This intentionally treats log-only output as not verifiable evidence for unscored tasks. Non-log artifacts still produce the existing partial/no-deterministic-scorer receipt.
- Full #2989 still needs local provider finish-reason/timeout/context diagnostics and user guidance.

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
