### PR TITLE
Expand links command to provider token directory

### DIFF
--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -339,20 +339,203 @@ fn expand_workspace_path(path: &str) -> Result<PathBuf, String> {
     Ok(PathBuf::from(path))
 }
 
-/// Show `DeepSeek` dashboard and docs links
+struct ProviderLinkInfo {
+    key_url: Option<&'static str>,
+    docs_url: &'static str,
+    note: &'static str,
+}
+
+fn provider_link_info(provider_id: &str) -> ProviderLinkInfo {
+    match provider_id {
+        "deepseek" => ProviderLinkInfo {
+            key_url: Some("https://platform.deepseek.com/api_keys"),
+            docs_url: "https://api-docs.deepseek.com/",
+            note: "Create an API key in the DeepSeek platform console.",
+        },
+        "nvidia-nim" => ProviderLinkInfo {
+            key_url: Some("https://build.nvidia.com/settings/api-keys"),
+            docs_url: "https://build.nvidia.com/explore/discover",
+            note: "NVIDIA NIM keys are managed from the NVIDIA build console.",
+        },
+        "openai" => ProviderLinkInfo {
+            key_url: Some("https://platform.openai.com/api-keys"),
+            docs_url: "https://platform.openai.com/docs/api-reference",
+            note: "Use this for OpenAI or compatible endpoints that share OpenAI-style auth.",
+        },
+        "atlascloud" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://atlascloud.ai/docs/en/api-keys",
+            note: "Atlas Cloud documents API key creation in its API Keys guide.",
+        },
+        "wanjie-ark" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://platform.lingyiwanwu.com/docs",
+            note: "Use the Wanjie/01.AI platform console for provider credentials.",
+        },
+        "volcengine" => ProviderLinkInfo {
+            key_url: Some("https://console.volcengine.com/ark/apiKey"),
+            docs_url: "https://www.volcengine.com/docs/82379/1541594",
+            note: "Volcengine Ark API keys are managed in the Ark console.",
+        },
+        "openrouter" => ProviderLinkInfo {
+            key_url: Some("https://openrouter.ai/settings/keys"),
+            docs_url: "https://openrouter.ai/docs/api/reference/authentication",
+            note: "OpenRouter keys can include app credit limits and model routing controls.",
+        },
+        "xiaomi-mimo" => ProviderLinkInfo {
+            key_url: Some("https://platform.xiaomimimo.com/token-plan"),
+            docs_url: "https://mimo.mi.com/docs/en-US/tokenplan/Token%20Plan/subscription",
+            note: "Token Plan keys use the base URL shown on the Xiaomi MiMo Token Plan page.",
+        },
+        "novita" => ProviderLinkInfo {
+            key_url: Some("https://novita.ai/en/settings/key-management"),
+            docs_url: "https://novita.ai/docs/guides/quickstart",
+            note: "Novita keys are managed from Key Management in account settings.",
+        },
+        "fireworks" => ProviderLinkInfo {
+            key_url: Some("https://fireworks.ai/api-keys"),
+            docs_url: "https://docs.fireworks.ai/getting-started/quickstart",
+            note: "Create a Fireworks API key before exporting FIREWORKS_API_KEY.",
+        },
+        "siliconflow" => ProviderLinkInfo {
+            key_url: Some("https://cloud.siliconflow.com/account/ak"),
+            docs_url: "https://docs.siliconflow.com/en/userguide/quickstart",
+            note: "Use the global SiliconFlow console unless your route is the China endpoint.",
+        },
+        "siliconflow-CN" => ProviderLinkInfo {
+            key_url: Some("https://cloud.siliconflow.cn/account/ak"),
+            docs_url: "https://docs.siliconflow.cn/en/userguide/quickstart",
+            note: "Use the China SiliconFlow console for the China endpoint.",
+        },
+        "arcee" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://docs.arcee.ai/other/create-your-first-api-key",
+            note: "Arcee documents key creation from the platform API Keys page.",
+        },
+        "moonshot" => ProviderLinkInfo {
+            key_url: Some("https://platform.kimi.ai/console/api-keys"),
+            docs_url: "https://platform.kimi.ai/docs/api/overview",
+            note: "Moonshot/Kimi keys are managed in the Kimi Open Platform console.",
+        },
+        "sglang" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://docs.sglang.ai/",
+            note: "Self-hosted SGLang usually needs a local base URL, not a hosted token.",
+        },
+        "vllm" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://docs.vllm.ai/en/stable/serving/openai_compatible_server/",
+            note: "Self-hosted vLLM usually needs a local base URL, not a hosted token.",
+        },
+        "ollama" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://docs.ollama.com/api",
+            note: "Local Ollama does not require an API key by default.",
+        },
+        "huggingface" => ProviderLinkInfo {
+            key_url: Some("https://huggingface.co/settings/tokens"),
+            docs_url: "https://huggingface.co/docs/hub/en/security-tokens",
+            note: "Use a scoped Hugging Face access token.",
+        },
+        "together" => ProviderLinkInfo {
+            key_url: Some("https://api.together.ai/settings/api-keys"),
+            docs_url: "https://docs.together.ai/docs/api-keys-authentication",
+            note: "Together API keys are project-scoped.",
+        },
+        "openai-codex" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://developers.openai.com/codex/",
+            note: "This route uses Codex/ChatGPT auth instead of a normal provider API key.",
+        },
+        "anthropic" => ProviderLinkInfo {
+            key_url: Some("https://console.anthropic.com/settings/keys"),
+            docs_url: "https://docs.anthropic.com/en/api/overview",
+            note: "Create Claude API keys from the Anthropic Console.",
+        },
+        "zai" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://docs.z.ai/api-reference/introduction",
+            note: "Create or manage Z.ai API keys from the API Keys page linked in the docs.",
+        },
+        "stepfun" => ProviderLinkInfo {
+            key_url: Some("https://platform.stepfun.ai/"),
+            docs_url: "https://platform.stepfun.ai/docs/en/quickstart/overview",
+            note: "Open Account Management > Interface Keys in the StepFun console.",
+        },
+        "minimax" => ProviderLinkInfo {
+            key_url: Some(
+                "https://platform.minimax.io/user-center/basic-information/interface-key",
+            ),
+            docs_url: "https://platform.minimax.io/docs/api-reference/api-overview",
+            note: "MiniMax has separate pay-as-you-go API keys and Token Plan subscription keys.",
+        },
+        "deepinfra" => ProviderLinkInfo {
+            key_url: Some("https://deepinfra.com/dash/api_keys"),
+            docs_url: "https://docs.deepinfra.com/quickstart",
+            note: "Create DeepInfra API keys from the dashboard.",
+        },
+        _ => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://codewhale.dev/docs/providers",
+            note: "Use the provider console for credentials, then configure the matching env var.",
+        },
+    }
+}
+
+/// Show provider dashboard, token, and docs links.
 pub fn deepseek_links(app: &mut App) -> CommandResult {
     let locale = app.ui_locale;
-    CommandResult::message(format!(
-        "{}\n\
-─────────────────────────────\n\
-{} https://platform.deepseek.com\n\
-{}      https://platform.deepseek.com/docs\n\n\
-{}",
-        tr(locale, MessageId::LinksTitle),
-        tr(locale, MessageId::LinksDashboard),
-        tr(locale, MessageId::LinksDocs),
-        tr(locale, MessageId::LinksTip),
-    ))
+    let active_provider = app.api_provider.as_str();
+    let mut message = format!(
+        "{}\n─────────────────────────────\n",
+        tr(locale, MessageId::LinksTitle)
+    );
+
+    for provider in codewhale_config::provider::providers_sorted_for_display() {
+        let links = provider_link_info(provider.id());
+        let active_marker = if provider.id() == active_provider {
+            " <- current"
+        } else {
+            ""
+        };
+        let _ = writeln!(
+            message,
+            "\n{} ({}){}",
+            provider.display_name(),
+            provider.id(),
+            active_marker
+        );
+        if let Some(key_url) = links.key_url {
+            let _ = writeln!(
+                message,
+                "{} {}",
+                tr(locale, MessageId::LinksDashboard),
+                key_url
+            );
+        } else {
+            let _ = writeln!(
+                message,
+                "{} {}",
+                tr(locale, MessageId::LinksDashboard),
+                links.note
+            );
+        }
+        let _ = writeln!(
+            message,
+            "{}      {}",
+            tr(locale, MessageId::LinksDocs),
+            links.docs_url
+        );
+        let env_vars = provider.env_vars();
+        if env_vars.is_empty() {
+            let _ = writeln!(message, "Env: none");
+        } else {
+            let _ = writeln!(message, "Env: {}", env_vars.join(", "));
+        }
+    }
+
+    let _ = writeln!(message, "\n{}", tr(locale, MessageId::LinksTip));
+    CommandResult::message(message)
 }
 
 /// Show home dashboard with stats and quick actions
@@ -598,7 +781,7 @@ mod tests {
         let result = help(&mut app, Some("links"));
         let msg = result.message.expect("help topic should return message");
         assert!(msg.contains("links"));
-        assert!(msg.contains("Show DeepSeek dashboard and docs links"));
+        assert!(msg.contains("Show provider token, dashboard, and docs links"));
         assert!(msg.contains("Usage: /links"));
         assert!(msg.contains("Aliases: dashboard, api"));
     }
@@ -1126,8 +1309,13 @@ mod tests {
         let result = deepseek_links(&mut app);
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
-        assert!(msg.contains("DeepSeek Links"));
-        assert!(msg.contains("https://platform.deepseek.com"));
+        assert!(msg.contains("Provider Links"));
+        assert!(msg.contains("DeepSeek (deepseek) <- current"));
+        assert!(msg.contains("https://platform.deepseek.com/api_keys"));
+        assert!(msg.contains("Xiaomi MiMo (xiaomi-mimo)"));
+        assert!(msg.contains("https://platform.xiaomimimo.com/token-plan"));
+        assert!(msg.contains("OPENAI_API_KEY"));
+        assert!(msg.contains("XIAOMI_MIMO_TOKEN_PLAN_API_KEY"));
         assert!(result.action.is_none());
     }
 

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1393,7 +1393,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdLspDescription => "Toggle LSP diagnostics on or off",
         MessageId::CmdShareDescription => "Export current session as a shareable web URL",
         MessageId::CmdJobsDescription => "Inspect and control background Bash jobs",
-        MessageId::CmdLinksDescription => "Show DeepSeek dashboard and docs links",
+        MessageId::CmdLinksDescription => "Show provider token, dashboard, and docs links",
         MessageId::CmdLoadDescription => "Load session from file",
         MessageId::CmdLogoutDescription => "Clear API key and return to setup",
         MessageId::CmdMcpDescription => "Open or manage MCP servers",
@@ -1614,10 +1614,12 @@ fn english(id: MessageId) -> &'static str {
             "Conversation cleared (plan state busy; run /clear again if needed)"
         }
         MessageId::ModelChanged => "Model changed: {old} \u{2192} {new}",
-        MessageId::LinksTitle => "DeepSeek Links:",
+        MessageId::LinksTitle => "Provider Links:",
         MessageId::LinksDashboard => "Dashboard:",
         MessageId::LinksDocs => "Docs:",
-        MessageId::LinksTip => "Tip: API keys are available in the dashboard console.",
+        MessageId::LinksTip => {
+            "Tip: Use the env var shown for your provider, or save the key with `codewhale auth set --provider <id>`."
+        }
         MessageId::SubagentsFetching => "Fetching sub-agent status...",
         MessageId::HelpUnknownCommand => "Unknown command: {topic}",
         MessageId::HomeDashboardTitle => "codewhale Home Dashboard",
@@ -2006,7 +2008,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdJobsDescription => "Kiểm tra và kiểm soát các lệnh chạy ngầm",
         MessageId::CmdLinksDescription => {
-            "Hiển thị các liên kết đến bảng điều khiển và tài liệu của DeepSeek"
+            "Hiển thị liên kết token, bảng điều khiển và tài liệu của nhà cung cấp"
         }
         MessageId::CmdLoadDescription => "Tải phiên làm việc từ tệp",
         MessageId::CmdLogoutDescription => "Xóa khóa API và quay lại bước thiết lập",
@@ -2247,10 +2249,12 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
             "Đã xóa cuộc trò chuyện (trạng thái plan đang bận; chạy lại /clear nếu cần)"
         }
         MessageId::ModelChanged => "Đã thay đổi mô hình: {old} \u{2192} {new}",
-        MessageId::LinksTitle => "Liên kết DeepSeek:",
+        MessageId::LinksTitle => "Liên kết nhà cung cấp:",
         MessageId::LinksDashboard => "Bảng điều khiển:",
         MessageId::LinksDocs => "Tài liệu:",
-        MessageId::LinksTip => "Mẹo: Mã khóa API có sẵn trong bảng điều khiển console.",
+        MessageId::LinksTip => {
+            "Mẹo: Dùng biến môi trường được hiển thị cho nhà cung cấp, hoặc lưu khóa bằng `codewhale auth set --provider <id>`."
+        }
         MessageId::SubagentsFetching => "Đang lấy trạng thái của các sub-agent...",
         MessageId::HelpUnknownCommand => "Lệnh không xác định: {topic}",
         MessageId::HomeDashboardTitle => "Bảng Điều Khiển Trang Chủ codewhale",
@@ -2815,7 +2819,9 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdLspDescription => "LSP 診断のオン・オフを切り替え",
         MessageId::CmdShareDescription => "現在のセッションを共有可能な Web URL としてエクスポート",
         MessageId::CmdJobsDescription => "バックグラウンドのシェルジョブを確認・制御",
-        MessageId::CmdLinksDescription => "DeepSeek ダッシュボードとドキュメントへのリンクを表示",
+        MessageId::CmdLinksDescription => {
+            "プロバイダーのトークン、ダッシュボード、ドキュメントのリンクを表示"
+        }
         MessageId::CmdLoadDescription => "ファイルからセッションを読み込み",
         MessageId::CmdLogoutDescription => "API キーを消去してセットアップに戻る",
         MessageId::CmdMcpDescription => "MCP サーバを開く・管理する",
@@ -3037,10 +3043,12 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "会話履歴をクリアしました（plan 状態が忙しい；必要なら /clear を再度実行）"
         }
         MessageId::ModelChanged => "モデルを変更しました: {old} → {new}",
-        MessageId::LinksTitle => "DeepSeek リンク：",
+        MessageId::LinksTitle => "プロバイダーリンク：",
         MessageId::LinksDashboard => "ダッシュボード：",
         MessageId::LinksDocs => "ドキュメント：",
-        MessageId::LinksTip => "ヒント: API キーはダッシュボードコンソールで取得できます。",
+        MessageId::LinksTip => {
+            "ヒント: 表示されたプロバイダー用の環境変数を使うか、`codewhale auth set --provider <id>` でキーを保存してください。"
+        }
         MessageId::SubagentsFetching => "サブエージェントの状態を取得中...",
         MessageId::HelpUnknownCommand => "不明なコマンド: {topic}",
         MessageId::HomeDashboardTitle => "codewhale ホームダッシュボード",
@@ -3400,7 +3408,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CmdLspDescription => "切换 LSP 诊断的开启或关闭",
         MessageId::CmdShareDescription => "将当前会话导出为可共享的 Web URL",
         MessageId::CmdJobsDescription => "查看并管理后台 shell 作业",
-        MessageId::CmdLinksDescription => "显示 DeepSeek 控制台与文档链接",
+        MessageId::CmdLinksDescription => "显示服务商令牌、控制台与文档链接",
         MessageId::CmdLoadDescription => "从文件加载会话",
         MessageId::CmdLogoutDescription => "清除 API 密钥并返回设置",
         MessageId::CmdMcpDescription => "打开或管理 MCP 服务器",
@@ -3592,10 +3600,12 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
             "对话已清空（Plan 状态忙碌；如需再次清空请运行 /clear）"
         }
         MessageId::ModelChanged => "模型已切换：{old} \u{2192} {new}",
-        MessageId::LinksTitle => "DeepSeek 链接：",
+        MessageId::LinksTitle => "服务商链接：",
         MessageId::LinksDashboard => "控制台：",
         MessageId::LinksDocs => "文档：",
-        MessageId::LinksTip => "提示：API 密钥可在控制台中获取。",
+        MessageId::LinksTip => {
+            "提示：使用所显示服务商的环境变量，或通过 `codewhale auth set --provider <id>` 保存密钥。"
+        }
         MessageId::SubagentsFetching => "正在获取子代理状态...",
         MessageId::HelpUnknownCommand => "未知命令：{topic}",
         MessageId::HomeDashboardTitle => "codewhale 主面板",
@@ -3945,7 +3955,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdLspDescription => "Alternar diagnóstico LSP ligado ou desligado",
         MessageId::CmdShareDescription => "Exportar a sessão atual como uma URL web compartilhável",
         MessageId::CmdJobsDescription => "Inspecionar e controlar jobs de shell em segundo plano",
-        MessageId::CmdLinksDescription => "Exibir links do painel e da documentação do DeepSeek",
+        MessageId::CmdLinksDescription => {
+            "Exibir links de tokens, painéis e documentação dos provedores"
+        }
         MessageId::CmdLoadDescription => "Carregar a sessão de um arquivo",
         MessageId::CmdLogoutDescription => "Limpar a chave de API e voltar à configuração",
         MessageId::CmdMcpDescription => "Abrir ou gerenciar servidores MCP",
@@ -4181,10 +4193,12 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
             "Conversa limpa (estado do plano ocupado; execute /clear novamente se necessário)"
         }
         MessageId::ModelChanged => "Modelo alterado: {old} \u{2192} {new}",
-        MessageId::LinksTitle => "Links do DeepSeek:",
+        MessageId::LinksTitle => "Links dos provedores:",
         MessageId::LinksDashboard => "Painel:",
         MessageId::LinksDocs => "Documentação:",
-        MessageId::LinksTip => "Dica: chaves de API estão disponíveis no console do painel.",
+        MessageId::LinksTip => {
+            "Dica: use a variável de ambiente mostrada para seu provedor ou salve a chave com `codewhale auth set --provider <id>`."
+        }
         MessageId::SubagentsFetching => "Buscando status dos sub-agentes...",
         MessageId::HelpUnknownCommand => "Comando desconhecido: {topic}",
         MessageId::HomeDashboardTitle => "Painel Inicial do codewhale",
@@ -4572,7 +4586,9 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::CmdJobsDescription => {
             "Inspeccionar y controlar trabajos de shell en segundo plano"
         }
-        MessageId::CmdLinksDescription => "Mostrar enlaces del panel y documentación de DeepSeek",
+        MessageId::CmdLinksDescription => {
+            "Mostrar enlaces de tokens, paneles y documentación de proveedores"
+        }
         MessageId::CmdLoadDescription => "Cargar la sesión desde un archivo",
         MessageId::CmdLogoutDescription => "Limpiar la clave de API y volver a la configuración",
         MessageId::CmdMcpDescription => "Abrir o gestionar servidores MCP",
@@ -4816,10 +4832,12 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
             "Conversación limpia (estado del plan ocupado; ejecuta /clear de nuevo si es necesario)"
         }
         MessageId::ModelChanged => "Modelo cambiado: {old} \u{2192} {new}",
-        MessageId::LinksTitle => "Enlaces de DeepSeek:",
+        MessageId::LinksTitle => "Enlaces de proveedores:",
         MessageId::LinksDashboard => "Panel:",
         MessageId::LinksDocs => "Documentación:",
-        MessageId::LinksTip => "Tip: las claves de API están disponibles en la consola del panel.",
+        MessageId::LinksTip => {
+            "Tip: usa la variable de entorno mostrada para tu proveedor o guarda la clave con `codewhale auth set --provider <id>`."
+        }
         MessageId::SubagentsFetching => "Obteniendo estado de los sub-agentes...",
         MessageId::HelpUnknownCommand => "Comando desconocido: {topic}",
         MessageId::HomeDashboardTitle => "Panel Inicial de codewhale",


### PR DESCRIPTION
## Goal

Make `/links` useful for provider-aware setup by giving users token/dashboard, docs, and environment-variable guidance for every built-in provider.

## Changes

- Replace the DeepSeek-only `/links` output with a provider directory generated from the built-in provider registry.
- Include credential/dashboard links where stable, docs links for every provider, and provider-specific env var names.
- Mark the current provider in the output.
- Refresh localized `/links` title/description/tip copy so help text no longer describes DeepSeek-only behavior.

## Verification

- cargo fmt --all -- --check
- cargo test -p codewhale-tui --bin codewhale-tui --locked test_deepseek_links
- cargo test -p codewhale-tui --bin codewhale-tui --locked test_help_links_topic_shows_aliases
- git diff --check

## Notes

This is a small setup-hub foundation slice. It does not implement the full setup wizard or provider auth resolver; it gives the existing command and future setup surface a provider-aware link catalog.