### PR TITLE
Harden local storage path boundaries

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3239,14 +3239,21 @@ pub const LEGACY_APP_DIR: &str = ".deepseek";
 /// `$CODEWHALE_HOME` takes precedence when set. Otherwise defaults to
 /// `$HOME/.codewhale`. This is the write target for new product state.
 pub fn codewhale_home() -> Result<PathBuf> {
-    if let Ok(val) = std::env::var("CODEWHALE_HOME") {
-        let trimmed = val.trim();
-        if !trimmed.is_empty() {
-            return Ok(PathBuf::from(trimmed));
-        }
+    if let Some(path) = codewhale_home_env_override() {
+        return Ok(path);
     }
     let home = effective_home_dir().context("failed to resolve home directory")?;
     Ok(home.join(CODEWHALE_APP_DIR))
+}
+
+fn codewhale_home_env_override() -> Option<PathBuf> {
+    let val = std::env::var("CODEWHALE_HOME").ok()?;
+    let trimmed = val.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
 }
 
 /// Resolve the legacy DeepSeek home directory (`$HOME/.deepseek`).
@@ -3304,8 +3311,9 @@ fn ensure_safe_state_subdir(subdir: &str) -> Result<()> {
 /// from the legacy path for users who haven't migrated yet.
 pub fn resolve_state_dir(subdir: &str) -> Result<PathBuf> {
     ensure_safe_state_subdir(subdir)?;
+    let explicit_codewhale_home = codewhale_home_env_override().is_some();
     let primary = codewhale_home()?.join(subdir);
-    if primary.exists() {
+    if explicit_codewhale_home || primary.exists() {
         return Ok(primary);
     }
     let legacy = legacy_deepseek_home()?.join(subdir);
@@ -3327,8 +3335,11 @@ pub fn resolve_state_dir(subdir: &str) -> Result<PathBuf> {
 /// data in the primary location; the read resolver itself is unchanged.
 pub fn ensure_state_dir(subdir: &str) -> Result<PathBuf> {
     ensure_safe_state_subdir(subdir)?;
+    let explicit_codewhale_home = codewhale_home_env_override().is_some();
     let dir = codewhale_home()?.join(subdir);
-    migrate_legacy_state_dir(&dir, subdir)?;
+    if !explicit_codewhale_home {
+        migrate_legacy_state_dir(&dir, subdir)?;
+    }
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("failed to create {}/", dir.display()))?;
     Ok(dir)

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -1962,9 +1962,9 @@ impl Drop for StateEnvRestore {
     }
 }
 
-/// Points `HOME`/`USERPROFILE`/`CODEWHALE_HOME` at a fresh temp tree so
-/// `codewhale_home()` -> `<home>/.codewhale` and `legacy_deepseek_home()`
-/// -> `<home>/.deepseek`. Env is restored on drop.
+/// Points `HOME`/`USERPROFILE` at a fresh temp tree and clears
+/// `CODEWHALE_HOME` so `codewhale_home()` -> `<home>/.codewhale` and
+/// `legacy_deepseek_home()` -> `<home>/.deepseek`. Env is restored on drop.
 struct StateDirEnv {
     home: PathBuf,
     _restore: StateEnvRestore,
@@ -1985,7 +1985,7 @@ impl StateDirEnv {
         unsafe {
             env::set_var("HOME", &home);
             env::set_var("USERPROFILE", &home);
-            env::set_var("CODEWHALE_HOME", home.join(CODEWHALE_APP_DIR));
+            env::remove_var("CODEWHALE_HOME");
         }
         Self {
             home,
@@ -2083,6 +2083,42 @@ fn resolve_state_dir_still_finds_legacy_for_backfill() {
     assert_eq!(
         resolve_state_dir("catalog").expect("resolve after migrate"),
         state_env.primary("catalog")
+    );
+    let _ = fs::remove_dir_all(&state_env.home);
+}
+
+#[test]
+fn explicit_codewhale_home_bypasses_legacy_state_fallback_and_migration() {
+    let _lock = env_lock();
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let state_env = StateDirEnv::install(unique);
+    let explicit_home = state_env.home.join("isolated-codewhale");
+    // Safety: test-only environment mutation is serialized by env_lock().
+    unsafe {
+        env::set_var("CODEWHALE_HOME", &explicit_home);
+    }
+    fs::create_dir_all(state_env.legacy("catalog")).expect("legacy dir");
+    fs::write(state_env.legacy("catalog").join("legacy.json"), b"legacy").expect("legacy file");
+
+    let primary = explicit_home.join("catalog");
+    assert_eq!(
+        resolve_state_dir("catalog").expect("resolve"),
+        primary,
+        "explicit CODEWHALE_HOME must not read ambient legacy state"
+    );
+
+    let ensured = ensure_state_dir("catalog").expect("ensure");
+    assert_eq!(ensured, primary);
+    assert!(
+        state_env.legacy("catalog").join("legacy.json").exists(),
+        "explicit CODEWHALE_HOME must not migrate ambient legacy state"
+    );
+    assert!(
+        !primary.join("legacy.json").exists(),
+        "legacy contents must not be copied into an explicit CODEWHALE_HOME"
     );
     let _ = fs::remove_dir_all(&state_env.home);
 }

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -480,7 +480,7 @@ impl FileKeyringStore {
             }
         }
         let body = serde_json::to_string_pretty(blob)?;
-        fs::write(&self.path, body)?;
+        write_private_file(&self.path, body.as_bytes())?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -498,6 +498,28 @@ impl FileKeyringStore {
         }
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn write_private_file(path: &Path, body: &[u8]) -> Result<(), SecretsError> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(body)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_private_file(path: &Path, body: &[u8]) -> Result<(), SecretsError> {
+    fs::write(path, body)?;
+    Ok(())
 }
 
 impl KeyringStore for FileKeyringStore {

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -305,8 +305,16 @@ impl StateStore {
     }
 
     fn conn(&self) -> Result<Connection> {
-        Connection::open(&self.db_path)
-            .with_context(|| format!("failed to open state db {}", self.db_path.display()))
+        let conn = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open state db {}", self.db_path.display()))?;
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .with_context(|| {
+                format!(
+                    "failed to enable foreign keys for {}",
+                    self.db_path.display()
+                )
+            })?;
+        Ok(conn)
     }
 
     fn init_schema(&self) -> Result<()> {
@@ -1865,6 +1873,50 @@ mod tests {
             .upsert_thread_goal(&test_goal("missing-thread", "nope"))
             .expect_err("goal without a thread should fail");
         assert!(err.to_string().contains("thread missing-thread not found"));
+    }
+
+    #[test]
+    fn delete_thread_cascades_child_rows() {
+        let store = temp_state_store("thread-delete-cascade");
+        store
+            .upsert_thread(&test_thread("thread-1"))
+            .expect("upsert thread");
+        store
+            .append_message("thread-1", "user", "hello", None)
+            .expect("append message");
+        store
+            .save_checkpoint("thread-1", "checkpoint-1", &serde_json::json!({"ok": true}))
+            .expect("save checkpoint");
+        store
+            .persist_dynamic_tools(
+                "thread-1",
+                &[DynamicToolRecord {
+                    position: 0,
+                    name: "test_tool".to_string(),
+                    description: Some("test".to_string()),
+                    input_schema: serde_json::json!({"type": "object"}),
+                }],
+            )
+            .expect("persist dynamic tools");
+        store
+            .upsert_thread_goal(&test_goal("thread-1", "Ship v0.8.67"))
+            .expect("upsert goal");
+
+        store.delete_thread("thread-1").expect("delete thread");
+
+        let conn = store.conn().expect("conn");
+        for table in [
+            "messages",
+            "checkpoints",
+            "thread_dynamic_tools",
+            "thread_goals",
+        ] {
+            let sql = format!("SELECT COUNT(*) FROM {table} WHERE thread_id = ?1");
+            let count: i64 = conn
+                .query_row(&sql, params!["thread-1"], |row| row.get(0))
+                .expect("count child rows");
+            assert_eq!(count, 0, "{table} row survived thread deletion");
+        }
     }
 
     #[test]

--- a/crates/tui/src/automation_manager.rs
+++ b/crates/tui/src/automation_manager.rs
@@ -319,17 +319,21 @@ impl AutomationManager {
         Self::open(default_automations_dir())
     }
 
-    fn automation_path(&self, id: &str) -> PathBuf {
-        self.automations_dir.join(format!("{id}.json"))
+    fn automation_path(&self, id: &str) -> Result<PathBuf> {
+        ensure_safe_storage_id("automation id", id)?;
+        Ok(self.automations_dir.join(format!("{id}.json")))
     }
 
-    fn runs_dir_for(&self, automation_id: &str) -> PathBuf {
-        self.runs_dir.join(automation_id)
+    fn runs_dir_for(&self, automation_id: &str) -> Result<PathBuf> {
+        ensure_safe_storage_id("automation id", automation_id)?;
+        Ok(self.runs_dir.join(automation_id))
     }
 
-    fn run_path(&self, automation_id: &str, run_id: &str) -> PathBuf {
-        self.runs_dir_for(automation_id)
-            .join(format!("{run_id}.json"))
+    fn run_path(&self, automation_id: &str, run_id: &str) -> Result<PathBuf> {
+        ensure_safe_storage_id("run id", run_id)?;
+        Ok(self
+            .runs_dir_for(automation_id)?
+            .join(format!("{run_id}.json")))
     }
 
     pub fn create_automation(&self, req: CreateAutomationRequest) -> Result<AutomationRecord> {
@@ -362,7 +366,7 @@ impl AutomationManager {
     }
 
     pub fn get_automation(&self, id: &str) -> Result<AutomationRecord> {
-        let path = self.automation_path(id);
+        let path = self.automation_path(id)?;
         let raw = fs::read_to_string(&path)
             .with_context(|| format!("Failed to read automation {}", path.display()))?;
         let record: AutomationRecord = serde_json::from_str(&raw)
@@ -378,7 +382,7 @@ impl AutomationManager {
     }
 
     pub fn save_automation(&self, record: &AutomationRecord) -> Result<()> {
-        write_json_atomic(&self.automation_path(&record.id), record)
+        write_json_atomic(&self.automation_path(&record.id)?, record)
     }
 
     pub fn list_automations(&self) -> Result<Vec<AutomationRecord>> {
@@ -476,11 +480,11 @@ impl AutomationManager {
 
     pub fn delete_automation(&self, id: &str) -> Result<AutomationRecord> {
         let existing = self.get_automation(id)?;
-        let path = self.automation_path(id);
+        let path = self.automation_path(id)?;
         fs::remove_file(&path)
             .with_context(|| format!("Failed to delete automation {}", path.display()))?;
 
-        let runs_dir = self.runs_dir_for(id);
+        let runs_dir = self.runs_dir_for(id)?;
         if runs_dir.exists() {
             fs::remove_dir_all(&runs_dir).with_context(|| {
                 format!("Failed to delete automation runs {}", runs_dir.display())
@@ -495,7 +499,7 @@ impl AutomationManager {
         automation_id: &str,
         limit: Option<usize>,
     ) -> Result<Vec<AutomationRunRecord>> {
-        let dir = self.runs_dir_for(automation_id);
+        let dir = self.runs_dir_for(automation_id)?;
         if !dir.exists() {
             return Ok(Vec::new());
         }
@@ -531,9 +535,9 @@ impl AutomationManager {
     }
 
     fn save_run(&self, run: &AutomationRunRecord) -> Result<()> {
-        let dir = self.runs_dir_for(&run.automation_id);
+        let dir = self.runs_dir_for(&run.automation_id)?;
         fs::create_dir_all(&dir).with_context(|| format!("Failed to create {}", dir.display()))?;
-        write_json_atomic(&self.run_path(&run.automation_id, &run.id), run)
+        write_json_atomic(&self.run_path(&run.automation_id, &run.id)?, run)
     }
 
     async fn enqueue_run_task(
@@ -759,6 +763,17 @@ impl AutomationManager {
     }
 }
 
+fn ensure_safe_storage_id(kind: &str, value: &str) -> Result<()> {
+    let mut components = Path::new(value).components();
+    let Some(component) = components.next() else {
+        bail!("{kind} must not be empty");
+    };
+    if components.next().is_some() || !matches!(component, std::path::Component::Normal(_)) {
+        bail!("{kind} must be a single path component");
+    }
+    Ok(())
+}
+
 fn validate_name_and_prompt(name: &str, prompt: &str) -> Result<()> {
     if name.trim().is_empty() {
         bail!("Automation name is required");
@@ -941,14 +956,64 @@ mod tests {
             error: None,
         };
         manager.save_run(&run).expect("save run");
-        assert!(manager.runs_dir_for(&created.id).exists());
+        assert!(
+            manager
+                .runs_dir_for(&created.id)
+                .expect("runs dir")
+                .exists()
+        );
 
         manager
             .delete_automation(&created.id)
             .expect("delete automation");
 
         assert!(manager.get_automation(&created.id).is_err());
-        assert!(!manager.runs_dir_for(&created.id).exists());
+        assert!(
+            !manager
+                .runs_dir_for(&created.id)
+                .expect("runs dir")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn automation_storage_rejects_traversal_ids() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let manager = AutomationManager::open(tempdir.path().join("root")).expect("manager");
+        let escaped_file = tempdir.path().join("escape.json");
+        let escaped_runs = tempdir.path().join("escape-runs");
+
+        let err = manager
+            .get_automation("../escape")
+            .expect_err("traversal automation ids must be rejected");
+        assert!(err.to_string().contains("single path component"));
+        assert!(!escaped_file.exists());
+
+        let err = manager
+            .list_runs("../escape-runs", None)
+            .expect_err("traversal run dirs must be rejected");
+        assert!(err.to_string().contains("single path component"));
+        assert!(!escaped_runs.exists());
+
+        let run = AutomationRunRecord {
+            schema_version: CURRENT_RUN_SCHEMA_VERSION,
+            id: "../escape-run".to_string(),
+            automation_id: Uuid::new_v4().to_string(),
+            scheduled_for: Utc::now(),
+            status: AutomationRunStatus::Queued,
+            created_at: Utc::now(),
+            started_at: None,
+            ended_at: None,
+            task_id: None,
+            thread_id: None,
+            turn_id: None,
+            error: None,
+        };
+        let err = manager
+            .save_run(&run)
+            .expect_err("traversal run ids must be rejected");
+        assert!(err.to_string().contains("single path component"));
+        assert!(!tempdir.path().join("escape-run.json").exists());
     }
 
     #[test]

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -1361,6 +1361,7 @@ impl TaskManager {
     }
 
     fn write_artifact(&self, task_id: &str, label: &str, content: &str) -> Result<PathBuf> {
+        ensure_safe_storage_id("task id", task_id)?;
         let artifact_dir = self.artifacts_dir.join(task_id);
         fs::create_dir_all(&artifact_dir)
             .with_context(|| format!("Failed to create artifact dir {}", artifact_dir.display()))?;
@@ -1622,6 +1623,17 @@ fn summarize_text(text: &str, limit: usize) -> String {
         count += 1;
     }
     out
+}
+
+fn ensure_safe_storage_id(kind: &str, value: &str) -> Result<()> {
+    let mut components = Path::new(value).components();
+    let Some(component) = components.next() else {
+        bail!("{kind} must not be empty");
+    };
+    if components.next().is_some() || !matches!(component, std::path::Component::Normal(_)) {
+        bail!("{kind} must be a single path component");
+    }
+    Ok(())
 }
 
 fn sanitize_filename(input: &str) -> String {
@@ -1959,6 +1971,24 @@ mod tests {
 
         assert_eq!(updated.gates.len(), 1);
         assert_eq!(updated.gates[0].classification, "passed");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn write_task_artifact_rejects_traversal_task_id() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("tasks-root");
+        let escaped = temp.path().join("escape");
+        let manager =
+            TaskManager::start_with_executor(test_config(root.clone()), Arc::new(MockExecutor))
+                .await?;
+
+        let err = manager
+            .write_task_artifact("../escape", "result", "artifact body")
+            .expect_err("traversal task ids must be rejected");
+
+        assert!(err.to_string().contains("single path component"));
+        assert!(!escaped.exists(), "artifact write escaped the task root");
         Ok(())
     }
 


### PR DESCRIPTION
## Goal

Tighten local storage boundaries for the v0.8.67 hardening lane so caller-controlled identifiers and explicit state roots cannot redirect reads or writes outside their intended directories.

## Changes

- Validate task artifact IDs before writing artifacts under the task artifact root.
- Validate automation IDs and run IDs before resolving automation definition and run-history paths.
- Enable SQLite foreign-key enforcement on every state-store connection so thread deletion cascades to child rows.
- Create file-backed secret stores with private Unix file mode at first write, then keep the existing compatibility chmod pass.
- Keep explicit `CODEWHALE_HOME` state reads/writes isolated from ambient legacy `.deepseek` fallback or migration.

## Verification

Passed:

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked write_task_artifact_rejects_traversal_task_id`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked automation_storage_rejects_traversal_ids`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked deletes_automation_and_runs`
- `cargo test -p codewhale-state --locked delete_thread_cascades_child_rows`
- `cargo test -p codewhale-state --locked`
- `cargo test -p codewhale-secrets --locked file_store_round_trips_with_secure_perms`
- `cargo test -p codewhale-secrets --locked`
- `cargo test -p codewhale-config --locked explicit_codewhale_home_bypasses_legacy_state_fallback_and_migration`
- `cargo test -p codewhale-config --locked state_dir`
- `git diff --check`

## Risks

- The task artifact helper still permits arbitrary safe single-component task IDs; this PR constrains the filesystem boundary without adding task-existence coupling to that public helper.
- Explicit `CODEWHALE_HOME` no longer reads or migrates legacy state. That is intentional for isolated homes, while default-home legacy migration remains covered by existing tests.

## Tracking

- v0.8.67 local storage hardening slice.
