### PR TITLE
WIP: Add model capability profiles

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2314,11 +2314,16 @@ impl Engine {
             Vec::new()
         };
         let tools = tool_registry.as_ref().map(|registry| {
-            let mut catalog = build_model_tool_catalog(
+            let capability = crate::model_profile::resolved_capability_profile(
+                self.api_config.api_provider(),
+                &self.config.model,
+            );
+            let mut catalog = build_model_tool_catalog_with_surface(
                 registry.to_api_tools_with_cache(true),
                 mcp_tools,
                 input_policy.mode,
                 &self.config.tools_always_load,
+                capability.tool_surface_budget,
             );
             for tool in &mut catalog {
                 if plugin_tool_names.contains(&tool.name) {
@@ -3653,15 +3658,16 @@ use self::streaming::{
 };
 use self::tool_catalog::{
     CODE_EXECUTION_TOOL_NAME, JS_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME,
-    REQUEST_USER_INPUT_NAME, active_tools_for_step, build_model_tool_catalog,
+    REQUEST_USER_INPUT_NAME, active_tools_for_step, build_model_tool_catalog_with_surface,
     ensure_advanced_tooling, execute_code_execution_tool, execute_tool_search,
     initial_active_tools, is_tool_search_tool, maybe_hydrate_requested_deferred_tool,
     missing_tool_error_message, tool_catalog_consistency_issues,
 };
 #[cfg(test)]
 use self::tool_catalog::{
-    TOOL_SEARCH_BM25_NAME, TOOL_SEARCH_REGEX_NAME, maybe_activate_requested_deferred_tool,
-    preflight_requested_deferred_tool, should_default_defer_tool,
+    TOOL_SEARCH_BM25_NAME, TOOL_SEARCH_REGEX_NAME, build_model_tool_catalog,
+    maybe_activate_requested_deferred_tool, preflight_requested_deferred_tool,
+    should_default_defer_tool,
 };
 use self::tool_execution::emit_tool_audit;
 use self::tool_setup::{sandbox_policy_for_mode, shell_policy_for_mode};

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1182,6 +1182,72 @@ fn model_tool_catalog_applies_native_and_mcp_deferral() {
 }
 
 #[test]
+fn capability_compact_surface_defers_nonessential_core_tools() {
+    let always_load = HashSet::new();
+    let catalog = build_model_tool_catalog_with_surface(
+        vec![
+            api_tool("agent"),
+            api_tool("grep_files"),
+            api_tool("read_file"),
+            api_tool("run_tests"),
+            api_tool(TOOL_SEARCH_REGEX_NAME),
+            api_tool("update_plan"),
+            api_tool("web_search"),
+            api_tool("write_file"),
+        ],
+        vec![api_tool("list_mcp_resources"), api_tool("mcp_server_write")],
+        AppMode::Agent,
+        &always_load,
+        crate::model_profile::ToolSurfaceBudget::Compact,
+    );
+
+    let defer_loading = |name: &str| {
+        catalog
+            .iter()
+            .find(|tool| tool.name == name)
+            .and_then(|tool| tool.defer_loading)
+    };
+
+    assert_eq!(defer_loading("read_file"), Some(false));
+    assert_eq!(defer_loading("grep_files"), Some(false));
+    assert_eq!(defer_loading("update_plan"), Some(false));
+    assert_eq!(defer_loading("write_file"), Some(false));
+    assert_eq!(defer_loading(TOOL_SEARCH_REGEX_NAME), Some(false));
+    assert_eq!(defer_loading("list_mcp_resources"), Some(false));
+    assert_eq!(defer_loading("agent"), Some(true));
+    assert_eq!(defer_loading("run_tests"), Some(true));
+    assert_eq!(defer_loading("web_search"), Some(true));
+    assert_eq!(defer_loading("mcp_server_write"), Some(true));
+}
+
+#[test]
+fn capability_full_surface_preserves_default_core_tools() {
+    let always_load = HashSet::new();
+    let catalog = build_model_tool_catalog_with_surface(
+        vec![
+            api_tool("agent"),
+            api_tool("read_file"),
+            api_tool("run_tests"),
+        ],
+        Vec::new(),
+        AppMode::Agent,
+        &always_load,
+        crate::model_profile::ToolSurfaceBudget::Full,
+    );
+
+    for name in ["agent", "read_file", "run_tests"] {
+        assert_eq!(
+            catalog
+                .iter()
+                .find(|tool| tool.name == name)
+                .and_then(|tool| tool.defer_loading),
+            Some(false),
+            "{name} should stay eager on full tool surfaces"
+        );
+    }
+}
+
+#[test]
 fn plugin_or_benchmark_tools_marked_loaded_stay_active() {
     let always_load = HashSet::new();
     let mut catalog = build_model_tool_catalog(

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 
 use crate::mcp::McpPool;
+use crate::model_profile::ToolSurfaceBudget;
 use crate::models::Tool;
 use crate::tools::spec::{ToolError, ToolResult, optional_u64, required_str};
 use crate::tui::app::AppMode;
@@ -143,14 +144,33 @@ pub(super) fn apply_mcp_tool_deferral(catalog: &mut [Tool], mode: AppMode) {
 /// head. This invariant is critical for DeepSeek's KV prefix cache:
 /// the tools array is part of the immutable prefix, and any byte-level
 /// change in the head forces a full re-prefill on the next turn.
+#[cfg(test)]
 pub(super) fn build_model_tool_catalog(
+    native_tools: Vec<Tool>,
+    mcp_tools: Vec<Tool>,
+    mode: AppMode,
+    always_load: &HashSet<String>,
+) -> Vec<Tool> {
+    build_model_tool_catalog_with_surface(
+        native_tools,
+        mcp_tools,
+        mode,
+        always_load,
+        ToolSurfaceBudget::Standard,
+    )
+}
+
+pub(super) fn build_model_tool_catalog_with_surface(
     mut native_tools: Vec<Tool>,
     mut mcp_tools: Vec<Tool>,
     mode: AppMode,
     always_load: &HashSet<String>,
+    surface_budget: ToolSurfaceBudget,
 ) -> Vec<Tool> {
     apply_native_tool_deferral(&mut native_tools, always_load);
     apply_mcp_tool_deferral(&mut mcp_tools, mode);
+    apply_tool_surface_budget(&mut native_tools, surface_budget, always_load);
+    apply_tool_surface_budget(&mut mcp_tools, surface_budget, always_load);
     // Sort each partition by name for prefix-cache stability (#263). The
     // upstream `to_api_tools()` already sorts the registry's HashMap output;
     // this catalog is built from caller-supplied Vecs which the test harness
@@ -161,6 +181,33 @@ pub(super) fn build_model_tool_catalog(
     mcp_tools.sort_by(|a, b| a.name.cmp(&b.name));
     native_tools.extend(mcp_tools);
     native_tools
+}
+
+fn apply_tool_surface_budget(
+    catalog: &mut [Tool],
+    surface_budget: ToolSurfaceBudget,
+    always_load: &HashSet<String>,
+) {
+    if !matches!(surface_budget, ToolSurfaceBudget::Compact) {
+        return;
+    }
+    for tool in catalog {
+        if always_load.contains(&tool.name) {
+            continue;
+        }
+        if matches!(
+            tool.name.as_str(),
+            "agent"
+                | "run_tests"
+                | "run_verifiers"
+                | "task_create"
+                | "task_shell_start"
+                | "task_shell_wait"
+                | "web_search"
+        ) {
+            tool.defer_loading = Some(true);
+        }
+    }
 }
 
 pub(super) fn ensure_advanced_tooling(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -54,6 +54,7 @@ mod mcp_server;
 mod memory;
 mod model_catalog;
 mod model_inventory;
+mod model_profile;
 mod model_registry;
 mod model_routing;
 mod models;

--- a/crates/tui/src/model_profile.rs
+++ b/crates/tui/src/model_profile.rs
@@ -1,0 +1,384 @@
+//! Typed model and resolved-route capability descriptors (#3365).
+//!
+//! This module bridges the additive [`crate::model_registry`] facts and the
+//! provider+model capability matrix in [`crate::config::provider_capability`].
+//! It intentionally keeps intrinsic model facts separate from resolved route
+//! facts so future route resolution can combine catalog offerings, user
+//! overrides, live hints, and auth readiness without scattering provider/model
+//! string checks through prompt, tool, and Fleet code.
+#![allow(dead_code)]
+
+use crate::config::{ApiProvider, RequestPayloadMode, provider_capability};
+use crate::model_registry::{self, ModelProvider};
+
+/// Three-state support facts. Unknown is distinct from unsupported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupportState {
+    Supported,
+    Unsupported,
+    Unknown,
+}
+
+impl SupportState {
+    #[must_use]
+    pub const fn from_bool(value: bool) -> Self {
+        if value {
+            Self::Supported
+        } else {
+            Self::Unsupported
+        }
+    }
+
+    #[must_use]
+    pub const fn is_supported(self) -> bool {
+        matches!(self, Self::Supported)
+    }
+}
+
+/// Coarse tool-catalog budget for the selected route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolSurfaceBudget {
+    /// Keep only the most essential turn-one tool surface eager.
+    Compact,
+    /// Current default surface: core tools eager, long tail deferred.
+    Standard,
+    /// Large-window/full-capability routes can afford the standard full head.
+    Full,
+}
+
+/// Fact provenance for diagnostics and route explanations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactProvenance {
+    SeededModelRegistry,
+    LegacyModelHeuristics,
+    ConservativeUnknownFallback,
+    ProviderCapabilityMatrix,
+    UserOverride,
+}
+
+/// Provider-agnostic facts owned by the model identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntrinsicCapabilityProfile {
+    pub context_window: Option<u32>,
+    pub max_output: Option<u32>,
+    pub reasoning: SupportState,
+    pub native_tool_calls: SupportState,
+    pub parallel_tool_calls: SupportState,
+    pub structured_output: SupportState,
+    pub streaming: SupportState,
+    pub prompt_caching: SupportState,
+    pub tool_surface_budget: ToolSurfaceBudget,
+}
+
+/// A model-owned profile. This does not imply a provider route is ready.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelProfile {
+    pub canonical_id: String,
+    pub display_name: String,
+    pub aliases: Vec<String>,
+    pub family: Option<ModelProvider>,
+    pub capabilities: IntrinsicCapabilityProfile,
+    pub provenance: FactProvenance,
+}
+
+/// Optional capability overrides layered after provider capability facts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CapabilityOverride {
+    pub context_window: Option<u32>,
+    pub max_output: Option<u32>,
+    pub reasoning: Option<SupportState>,
+    pub native_tool_calls: Option<SupportState>,
+    pub parallel_tool_calls: Option<SupportState>,
+    pub structured_output: Option<SupportState>,
+    pub streaming: Option<SupportState>,
+    pub prompt_caching: Option<SupportState>,
+    pub tool_surface_budget: Option<ToolSurfaceBudget>,
+}
+
+/// Capabilities after provider route facts and user overrides are applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityProfile {
+    pub provider: ApiProvider,
+    pub canonical_model: Option<String>,
+    pub wire_model_id: String,
+    pub request_payload_mode: RequestPayloadMode,
+    pub context_window: Option<u32>,
+    pub max_output: Option<u32>,
+    pub reasoning: SupportState,
+    pub native_tool_calls: SupportState,
+    pub parallel_tool_calls: SupportState,
+    pub structured_output: SupportState,
+    pub streaming: SupportState,
+    pub prompt_caching: SupportState,
+    pub tool_surface_budget: ToolSurfaceBudget,
+    pub provenance: Vec<FactProvenance>,
+}
+
+impl CapabilityProfile {
+    #[must_use]
+    pub fn supports_reasoning(&self) -> bool {
+        self.reasoning.is_supported()
+    }
+
+    #[must_use]
+    pub fn has_large_context(&self) -> bool {
+        self.context_window.is_some_and(|window| window >= 400_000)
+    }
+
+    #[must_use]
+    pub fn prefers_full_tool_surface(&self) -> bool {
+        matches!(self.tool_surface_budget, ToolSurfaceBudget::Full)
+    }
+
+    #[must_use]
+    pub fn suitable_for_broad_fleet_worker(&self) -> bool {
+        self.has_large_context()
+            && !matches!(self.native_tool_calls, SupportState::Unsupported)
+            && matches!(
+                self.tool_surface_budget,
+                ToolSurfaceBudget::Standard | ToolSurfaceBudget::Full
+            )
+    }
+}
+
+/// Build an intrinsic profile for any model string.
+#[must_use]
+pub fn model_profile(model: &str) -> ModelProfile {
+    let trimmed = model.trim();
+    let display_name = display_name(trimmed);
+    match model_registry::lookup(trimmed) {
+        Some(meta) => {
+            let canonical_id = if meta.id.is_empty() {
+                trimmed.to_string()
+            } else {
+                meta.id.to_string()
+            };
+            let provenance = if meta.id.is_empty() {
+                FactProvenance::LegacyModelHeuristics
+            } else {
+                FactProvenance::SeededModelRegistry
+            };
+            ModelProfile {
+                canonical_id,
+                display_name,
+                aliases: Vec::new(),
+                family: Some(meta.provider),
+                capabilities: IntrinsicCapabilityProfile {
+                    context_window: meta.context_window,
+                    max_output: meta.max_output,
+                    reasoning: SupportState::from_bool(meta.supports_reasoning),
+                    native_tool_calls: SupportState::Unknown,
+                    parallel_tool_calls: SupportState::Unknown,
+                    structured_output: SupportState::Unknown,
+                    streaming: SupportState::Supported,
+                    prompt_caching: SupportState::Unknown,
+                    tool_surface_budget: tool_surface_for_window(meta.context_window),
+                },
+                provenance,
+            }
+        }
+        None => ModelProfile {
+            canonical_id: trimmed.to_string(),
+            display_name,
+            aliases: Vec::new(),
+            family: None,
+            capabilities: IntrinsicCapabilityProfile {
+                context_window: None,
+                max_output: None,
+                reasoning: SupportState::Unknown,
+                native_tool_calls: SupportState::Unknown,
+                parallel_tool_calls: SupportState::Unknown,
+                structured_output: SupportState::Unknown,
+                streaming: SupportState::Unknown,
+                prompt_caching: SupportState::Unknown,
+                tool_surface_budget: ToolSurfaceBudget::Compact,
+            },
+            provenance: FactProvenance::ConservativeUnknownFallback,
+        },
+    }
+}
+
+/// Resolve route capabilities from intrinsic model facts plus provider facts.
+#[must_use]
+pub fn resolved_capability_profile(
+    provider: ApiProvider,
+    wire_model_id: &str,
+) -> CapabilityProfile {
+    resolved_capability_profile_with_overrides(
+        provider,
+        wire_model_id,
+        CapabilityOverride::default(),
+    )
+}
+
+/// Resolve route capabilities and apply explicit user/config overrides last.
+#[must_use]
+pub fn resolved_capability_profile_with_overrides(
+    provider: ApiProvider,
+    wire_model_id: &str,
+    overrides: CapabilityOverride,
+) -> CapabilityProfile {
+    let model = model_profile(wire_model_id);
+    let provider_cap = provider_capability(provider, wire_model_id);
+    let request_payload_mode = provider_cap.request_payload_mode;
+    let context_window = Some(
+        overrides
+            .context_window
+            .unwrap_or(provider_cap.context_window),
+    );
+    let max_output = Some(overrides.max_output.unwrap_or(provider_cap.max_output));
+    let reasoning = overrides
+        .reasoning
+        .unwrap_or_else(|| SupportState::from_bool(provider_cap.thinking_supported));
+    let prompt_caching = overrides
+        .prompt_caching
+        .unwrap_or_else(|| SupportState::from_bool(provider_cap.cache_telemetry_supported));
+    let native_tool_calls = overrides
+        .native_tool_calls
+        .unwrap_or_else(|| native_tool_support_for_payload(request_payload_mode));
+    let structured_output = overrides
+        .structured_output
+        .unwrap_or(model.capabilities.structured_output);
+    let streaming = overrides.streaming.unwrap_or(SupportState::Supported);
+    let parallel_tool_calls = overrides
+        .parallel_tool_calls
+        .unwrap_or(model.capabilities.parallel_tool_calls);
+    let tool_surface_budget = overrides
+        .tool_surface_budget
+        .unwrap_or_else(|| tool_surface_for_window(context_window));
+
+    let mut provenance = vec![model.provenance, FactProvenance::ProviderCapabilityMatrix];
+    if overrides != CapabilityOverride::default() {
+        provenance.push(FactProvenance::UserOverride);
+    }
+
+    CapabilityProfile {
+        provider,
+        canonical_model: Some(model.canonical_id),
+        wire_model_id: wire_model_id.to_string(),
+        request_payload_mode,
+        context_window,
+        max_output,
+        reasoning,
+        native_tool_calls,
+        parallel_tool_calls,
+        structured_output,
+        streaming,
+        prompt_caching,
+        tool_surface_budget,
+        provenance,
+    }
+}
+
+#[must_use]
+pub fn tool_surface_for_window(context_window: Option<u32>) -> ToolSurfaceBudget {
+    match context_window {
+        Some(window) if window >= 400_000 => ToolSurfaceBudget::Full,
+        Some(window) if window >= 128_000 => ToolSurfaceBudget::Standard,
+        _ => ToolSurfaceBudget::Compact,
+    }
+}
+
+fn native_tool_support_for_payload(mode: RequestPayloadMode) -> SupportState {
+    match mode {
+        RequestPayloadMode::ChatCompletions
+        | RequestPayloadMode::Responses
+        | RequestPayloadMode::AnthropicMessages => SupportState::Supported,
+    }
+}
+
+fn display_name(model: &str) -> String {
+    model
+        .rsplit(['/', ':'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or(model)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_profile_known_lookup_uses_seeded_model_facts() {
+        let profile = model_profile("deepseek-v4-pro");
+
+        assert_eq!(profile.canonical_id, "deepseek-v4-pro");
+        assert_eq!(profile.family, Some(ModelProvider::DeepSeek));
+        assert_eq!(profile.capabilities.context_window, Some(1_000_000));
+        assert_eq!(profile.capabilities.max_output, Some(384_000));
+        assert_eq!(profile.capabilities.reasoning, SupportState::Supported);
+        assert_eq!(
+            profile.capabilities.tool_surface_budget,
+            ToolSurfaceBudget::Full
+        );
+        assert_eq!(profile.provenance, FactProvenance::SeededModelRegistry);
+    }
+
+    #[test]
+    fn model_profile_unknown_fallback_is_conservative() {
+        let profile = model_profile("custom-local-model");
+
+        assert_eq!(profile.canonical_id, "custom-local-model");
+        assert_eq!(profile.family, None);
+        assert_eq!(profile.capabilities.context_window, None);
+        assert_eq!(profile.capabilities.reasoning, SupportState::Unknown);
+        assert_eq!(
+            profile.capabilities.native_tool_calls,
+            SupportState::Unknown
+        );
+        assert_eq!(
+            profile.capabilities.tool_surface_budget,
+            ToolSurfaceBudget::Compact
+        );
+        assert_eq!(
+            profile.provenance,
+            FactProvenance::ConservativeUnknownFallback
+        );
+    }
+
+    #[test]
+    fn resolved_capability_profile_merges_provider_facts_and_overrides() {
+        let profile = resolved_capability_profile_with_overrides(
+            ApiProvider::OpenaiCodex,
+            "gpt-5-codex",
+            CapabilityOverride {
+                context_window: Some(123_456),
+                reasoning: Some(SupportState::Unsupported),
+                tool_surface_budget: Some(ToolSurfaceBudget::Compact),
+                ..CapabilityOverride::default()
+            },
+        );
+
+        assert_eq!(profile.provider, ApiProvider::OpenaiCodex);
+        assert_eq!(profile.request_payload_mode, RequestPayloadMode::Responses);
+        assert_eq!(profile.context_window, Some(123_456));
+        assert_eq!(profile.reasoning, SupportState::Unsupported);
+        assert_eq!(profile.native_tool_calls, SupportState::Supported);
+        assert_eq!(profile.tool_surface_budget, ToolSurfaceBudget::Compact);
+        assert!(profile.provenance.contains(&FactProvenance::UserOverride));
+    }
+
+    #[test]
+    fn capability_predicates_are_not_provider_string_checks() {
+        let broad = resolved_capability_profile(ApiProvider::Deepseek, "deepseek-v4-pro");
+        let compact = resolved_capability_profile_with_overrides(
+            ApiProvider::Openrouter,
+            "unknown-small-model",
+            CapabilityOverride {
+                context_window: Some(32_000),
+                native_tool_calls: Some(SupportState::Unknown),
+                tool_surface_budget: Some(ToolSurfaceBudget::Compact),
+                ..CapabilityOverride::default()
+            },
+        );
+
+        assert!(broad.has_large_context());
+        assert!(broad.prefers_full_tool_surface());
+        assert!(broad.suitable_for_broad_fleet_worker());
+        assert!(!compact.has_large_context());
+        assert!(!compact.prefers_full_tool_surface());
+        assert!(!compact.suitable_for_broad_fleet_worker());
+    }
+}


### PR DESCRIPTION
## Goal

Refs #3365. Add a typed descriptor layer for model and resolved provider-route capabilities so prompt sizing, tool-surface selection, Fleet loadouts, and future route ranking can consume shared capability facts instead of scattered provider/model string checks.

## Changes

- Added `model_profile` with intrinsic `ModelProfile`, resolved `CapabilityProfile`, tri-state support facts, provenance, override layering, and conservative unknown-model fallback.
- Derived route capabilities from the existing provider capability matrix while keeping user/config overrides as the final layer.
- Wired the resolved profile into the engine tool catalog path so compact routes defer heavier nonessential tools while standard/full routes preserve the existing eager surface.
- Added focused descriptor and tool-catalog regression tests.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked model_profile`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked capability_`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked model_tool_catalog`
- `cargo check -p codewhale-tui --bin codewhale-tui --locked`

## Risks

- This is intentionally a first consumer slice: it does not replace the full route resolver, Fleet semantic router, or prompt-density migration yet.
- Compact surface policy currently defers a small explicit list of heavier tools; future provider/model facts may want a richer policy table.
- The descriptor module starts additive and has some future-facing fields that are not all consumed yet.
