### PR TITLE
fix(tui): cover all ApiKeySource variants in doctor label match (broken main)

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3675,9 +3675,11 @@ fn doctor_xiaomi_mimo_base_url_uses_token_plan(base_url: &str) -> bool {
 
 fn doctor_api_key_source_label(source: ApiKeySource) -> &'static str {
     match source {
+        ApiKeySource::Command => "command",
         ApiKeySource::Env => "env",
         ApiKeySource::Config => "config",
         ApiKeySource::Keyring => "keyring",
+        ApiKeySource::Secret => "secret",
         ApiKeySource::Missing => "missing",
     }
 }


### PR DESCRIPTION
## Problem

`origin/main` does **not compile**. Commit ad13292d3 (#3427, "test(provider): pin SiliconFlow TokenHub route diagnostics") added `doctor_api_key_source_label` at `crates/tui/src/main.rs` with a non-exhaustive match:

```rust
fn doctor_api_key_source_label(source: ApiKeySource) -> &'static str {
    match source {
        ApiKeySource::Env => "env",
        ApiKeySource::Config => "config",
        ApiKeySource::Keyring => "keyring",
        ApiKeySource::Missing => "missing",
    }   // ← ApiKeySource::Command and ::Secret not covered
}
```

This raises `error[E0004]: non-exhaustive patterns`, which fails `cargo check`/`build`/`test` for `codewhale-tui` outright — breaking main's CI and the CI of **every** open PR that rebases onto it.

## Fix

Add the two missing arms (`Command`, `Secret`), matching the complete pattern already used by the `api_key_state` match elsewhere in doctor output.

```rust
match source {
    ApiKeySource::Command => "command",
    ApiKeySource::Env => "env",
    ApiKeySource::Config => "config",
    ApiKeySource::Keyring => "keyring",
    ApiKeySource::Secret => "secret",
    ApiKeySource::Missing => "missing",
}
```

## Verification

- `cargo check -p codewhale-tui` — now passes (was: `error[E0004]`).
- `cargo clippy -p codewhale-tui` with CI allow-flags (`-A clippy::too_many_arguments` etc.) — clean.
- 25 `doctor` tests pass.

This is a tiny, isolated, two-line fix that unblocks main and the entire PR queue. Recommend fast review/merge.