### PR TITLE
fix(tui): throttle per-agent sub-agent mailbox telemetry to cut UI lag

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -617,6 +617,29 @@ fn subagent_mailbox_message_is_best_effort(message: &MailboxMessage) -> bool {
     )
 }
 
+const SUBAGENT_MAILBOX_BEST_EFFORT_MIN_INTERVAL: Duration = Duration::from_millis(100);
+
+fn subagent_mailbox_best_effort_send_permitted(
+    last_sent_at: &mut HashMap<String, Instant>,
+    message: &MailboxMessage,
+    now: Instant,
+) -> bool {
+    if !subagent_mailbox_message_is_best_effort(message) {
+        return true;
+    }
+
+    let agent_id = message.agent_id().to_string();
+    if last_sent_at
+        .get(&agent_id)
+        .is_some_and(|last| now.duration_since(*last) < SUBAGENT_MAILBOX_BEST_EFFORT_MIN_INTERVAL)
+    {
+        return false;
+    }
+
+    last_sent_at.insert(agent_id, now);
+    true
+}
+
 impl Engine {
     pub(super) async fn emit_compaction_started(
         &mut self,
@@ -2210,6 +2233,7 @@ impl Engine {
                 "subagent-mailbox-drainer",
                 std::panic::Location::caller(),
                 async move {
+                    let mut best_effort_sent_at: HashMap<String, Instant> = HashMap::new();
                     while let Some(envelope) = receiver.recv().await {
                         let event = Event::SubAgentMailbox {
                             seq: envelope.seq,
@@ -2218,6 +2242,13 @@ impl Engine {
                         if let Event::SubAgentMailbox { message, .. } = &event
                             && subagent_mailbox_message_is_best_effort(message)
                         {
+                            if !subagent_mailbox_best_effort_send_permitted(
+                                &mut best_effort_sent_at,
+                                message,
+                                Instant::now(),
+                            ) {
+                                continue;
+                            }
                             match tx_event_clone.try_send(event) {
                                 Ok(()) => continue,
                                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => continue,

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
 
 const WORKING_SET_SUMMARY_MARKER: &str = "## Repo Working Set";
@@ -63,6 +63,93 @@ fn subagent_mailbox_keeps_lifecycle_events_reliable() {
             model: "model".to_string(),
             usage: Usage::default(),
         }
+    ));
+}
+
+#[test]
+fn subagent_mailbox_samples_best_effort_events_per_agent() {
+    use crate::tools::subagent::MailboxMessage;
+
+    let mut last_sent_at = HashMap::new();
+    let start = Instant::now();
+    let first = MailboxMessage::ToolCallStarted {
+        agent_id: "agent_a".to_string(),
+        tool_name: "exec_shell".to_string(),
+        step: 1,
+    };
+    let second = MailboxMessage::ToolCallCompleted {
+        agent_id: "agent_a".to_string(),
+        tool_name: "exec_shell".to_string(),
+        step: 1,
+        ok: true,
+    };
+    let other_agent = MailboxMessage::ToolCallCompleted {
+        agent_id: "agent_b".to_string(),
+        tool_name: "exec_shell".to_string(),
+        step: 1,
+        ok: true,
+    };
+
+    assert!(subagent_mailbox_best_effort_send_permitted(
+        &mut last_sent_at,
+        &first,
+        start,
+    ));
+    assert!(
+        !subagent_mailbox_best_effort_send_permitted(
+            &mut last_sent_at,
+            &second,
+            start + Duration::from_millis(10),
+        ),
+        "same-agent telemetry inside the sampling window is dropped"
+    );
+    assert!(
+        subagent_mailbox_best_effort_send_permitted(
+            &mut last_sent_at,
+            &other_agent,
+            start + Duration::from_millis(10),
+        ),
+        "sampling is per agent, so one busy child cannot hide another"
+    );
+    assert!(
+        subagent_mailbox_best_effort_send_permitted(
+            &mut last_sent_at,
+            &second,
+            start + SUBAGENT_MAILBOX_BEST_EFFORT_MIN_INTERVAL,
+        ),
+        "the next same-agent update is allowed after the interval"
+    );
+}
+
+#[test]
+fn subagent_mailbox_never_samples_lifecycle_or_usage_events() {
+    use crate::models::Usage;
+    use crate::tools::subagent::{MailboxMessage, SubAgentType};
+
+    let mut last_sent_at = HashMap::new();
+    let start = Instant::now();
+
+    assert!(subagent_mailbox_best_effort_send_permitted(
+        &mut last_sent_at,
+        &MailboxMessage::started("agent_a", SubAgentType::Explore),
+        start,
+    ));
+    assert!(subagent_mailbox_best_effort_send_permitted(
+        &mut last_sent_at,
+        &MailboxMessage::Completed {
+            agent_id: "agent_a".to_string(),
+            summary: "done".to_string(),
+        },
+        start,
+    ));
+    assert!(subagent_mailbox_best_effort_send_permitted(
+        &mut last_sent_at,
+        &MailboxMessage::TokenUsage {
+            agent_id: "agent_a".to_string(),
+            model: "model".to_string(),
+            usage: Usage::default(),
+        },
+        start,
     ));
 }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3675,9 +3675,11 @@ fn doctor_xiaomi_mimo_base_url_uses_token_plan(base_url: &str) -> bool {
 
 fn doctor_api_key_source_label(source: ApiKeySource) -> &'static str {
     match source {
+        ApiKeySource::Command => "command",
         ApiKeySource::Env => "env",
         ApiKeySource::Config => "config",
         ApiKeySource::Keyring => "keyring",
+        ApiKeySource::Secret => "secret",
         ApiKeySource::Missing => "missing",
     }
 }

--- a/crates/tui/src/tools/subagent/mailbox.rs
+++ b/crates/tui/src/tools/subagent/mailbox.rs
@@ -5,18 +5,14 @@
 //! independently; close-as-cancel lets a single signal both stop new mail and
 //! propagate cancellation through nested children.
 
-// Some surface here is producer-only inside this crate today and consumed by
-// #128's UI cards in a follow-up; suppress the dead-code warnings until then
-// rather than deleting capabilities the design depends on.
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(test)]
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::models::Usage;
@@ -145,6 +141,7 @@ struct MailboxInner {
     next_seq: AtomicU64,
     seq_tx: watch::Sender<u64>,
     closed: AtomicBool,
+    #[cfg(test)]
     cancel_token: CancellationToken,
 }
 
@@ -163,6 +160,8 @@ impl Mailbox {
     /// background `agent` sessions use their own runtime token.
     #[must_use]
     pub fn new(cancel_token: CancellationToken) -> (Self, MailboxReceiver) {
+        #[cfg(not(test))]
+        let _ = cancel_token;
         let (tx, rx) = mpsc::unbounded_channel();
         let (seq_tx, _) = watch::channel(0);
         let inner = MailboxInner {
@@ -170,6 +169,7 @@ impl Mailbox {
             next_seq: AtomicU64::new(0),
             seq_tx,
             closed: AtomicBool::new(false),
+            #[cfg(test)]
             cancel_token,
         };
         (
@@ -187,6 +187,7 @@ impl Mailbox {
     /// sequence counter advances, signaling new mail without copying it —
     /// the consumer then calls `drain` (or `recv_one` on its own receiver).
     /// Multiple subscribers may exist; this is the fanout primitive.
+    #[cfg(test)]
     #[must_use]
     pub fn subscribe(&self) -> watch::Receiver<u64> {
         self.inner.seq_tx.subscribe()
@@ -209,6 +210,7 @@ impl Mailbox {
     }
 
     /// Whether the mailbox has been closed.
+    #[cfg(test)]
     #[must_use]
     pub fn is_closed(&self) -> bool {
         self.inner.closed.load(Ordering::Acquire)
@@ -221,6 +223,7 @@ impl Mailbox {
     /// Closing cancels the bound token; directly derived `child_runtime()`
     /// children observe it, while detached `agent` sessions rely on their
     /// own explicit cancellation.
+    #[cfg(test)]
     pub fn close(&self) {
         if !self.inner.closed.swap(true, Ordering::AcqRel) {
             self.inner.cancel_token.cancel();
@@ -229,6 +232,7 @@ impl Mailbox {
 }
 
 impl MailboxReceiver {
+    #[cfg(test)]
     fn sync_pending(&mut self) {
         while let Ok(env) = self.rx.try_recv() {
             self.pending.push_back(env);
@@ -236,12 +240,14 @@ impl MailboxReceiver {
     }
 
     /// Whether any envelopes are buffered (or arrived since last check).
+    #[cfg(test)]
     pub fn has_pending(&mut self) -> bool {
         self.sync_pending();
         !self.pending.is_empty()
     }
 
     /// Drain all currently available envelopes, in delivery order.
+    #[cfg(test)]
     pub fn drain(&mut self) -> Vec<MailboxEnvelope> {
         self.sync_pending();
         self.pending.drain(..).collect()
@@ -257,7 +263,7 @@ impl MailboxReceiver {
     }
 
     /// Awaits the next envelope with a timeout. Useful in tests.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub async fn recv_timeout(&mut self, timeout: Duration) -> Option<MailboxEnvelope> {
         tokio::time::timeout(timeout, self.recv())
             .await
@@ -265,10 +271,6 @@ impl MailboxReceiver {
             .flatten()
     }
 }
-
-/// Convenience handle: a mailbox + the matching cancellation token, ready to
-/// hand to a runtime. The receiver lives on the spawning side.
-pub type SharedMailbox = Arc<Mutex<Option<MailboxReceiver>>>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -7,7 +7,6 @@
 //! The model-facing surface is the single `agent` tool. Older lifecycle
 //! structs and manager helpers remain executable for persisted records and
 //! internal recovery while the durable runtime is reused by the new surface.
-#![allow(dead_code)]
 
 use std::collections::{HashMap, VecDeque};
 use std::fs;
@@ -107,8 +106,6 @@ const SUBAGENT_TRANSIENT_PROVIDER_INITIAL_BACKOFF: Duration = Duration::from_mil
 /// default; production runtimes set the field explicitly (#1806, #1808).
 const DEFAULT_STEP_API_TIMEOUT: Duration =
     Duration::from_secs(crate::config::DEFAULT_SUBAGENT_API_TIMEOUT_SECS);
-const DEFAULT_RESULT_TIMEOUT_MS: u64 = 30_000;
-const MAX_RESULT_TIMEOUT_MS: u64 = 3_600_000;
 const COMPLETED_AGENT_RETENTION: Duration = Duration::from_secs(60 * 60);
 const MAX_AGENT_WORKER_RECORDS: usize = 256;
 const MAX_AGENT_WORKER_EVENTS_PER_RECORD: usize = 128;
@@ -158,11 +155,6 @@ const SUBAGENT_TYPE_DESCRIPTION: &str = "Sub-agent type. Accepted vocabulary: ge
      explore (aliases: exploration, explorer), plan (aliases: planning, planner, awaiter), \
      review (aliases: code-review, code_review, reviewer), implementer (aliases: implement, implementation, builder), \
      verifier (aliases: verify, verification, validator, tester), custom.";
-const SUBAGENT_ROLE_DESCRIPTION: &str = "Role alias. Accepted vocabulary: default; worker (aliases: general, general-purpose, general_purpose); \
-     explorer (aliases: explore, exploration); awaiter (aliases: plan, planning, planner); \
-     reviewer (aliases: review, code-review, code_review); implementer (aliases: implement, implementation, builder); \
-     verifier (aliases: verify, verification, validator, tester); custom. \
-     Must match `type` if both are given.";
 /// Whale species used as friendly names for sub-agents in the UI. The full
 /// Cetacea infraorder — baleen whales (Mysticeti), toothed whales
 /// (Odontoceti), plus select dolphin species (family Delphinidae) that
@@ -322,71 +314,6 @@ pub fn assign_unique_whale_name(
     }
     // Fallback (should never reach here)
     format!("{base} ({})", id.get(..4).unwrap_or("?"))
-}
-
-/// Removal version for deprecated tool aliases.
-const DEPRECATION_REMOVAL_VERSION: &str = "0.8.0";
-
-#[must_use]
-pub fn whale_nickname_for_index(index: usize) -> String {
-    let base = WHALE_NICKNAMES[index % WHALE_NICKNAMES.len()];
-    if index < WHALE_NICKNAMES.len() {
-        base.to_string()
-    } else {
-        format!("{base} {}", index / WHALE_NICKNAMES.len() + 1)
-    }
-}
-
-// === Deprecation helpers ===
-
-/// Wrap a `ToolResult` with a `_deprecation` block in its metadata.
-///
-/// Applied exclusively on alias paths (not on canonical tool names) so the
-/// model can detect and migrate away from the old name before removal in
-/// v`DEPRECATION_REMOVAL_VERSION`.
-///
-/// The `_deprecation` key is merged into any existing metadata so other
-/// metadata (e.g. `status`, `timed_out`) is preserved unchanged.
-fn wrap_with_deprecation_notice(
-    mut result: ToolResult,
-    this_tool: &str,
-    use_instead: &str,
-) -> ToolResult {
-    tracing::warn!(
-        "Deprecated tool '{}' invoked — use '{}' instead (removal: v{})",
-        this_tool,
-        use_instead,
-        DEPRECATION_REMOVAL_VERSION,
-    );
-
-    let notice = json!({
-        "_deprecation": {
-            "this_tool": this_tool,
-            "use_instead": use_instead,
-            "removed_in": DEPRECATION_REMOVAL_VERSION,
-            "message": format!(
-                "Tool '{}' is deprecated; switch to '{}' before v{}.",
-                this_tool, use_instead, DEPRECATION_REMOVAL_VERSION
-            )
-        }
-    });
-
-    result.metadata = Some(match result.metadata.take() {
-        Some(Value::Object(mut map)) => {
-            if let Value::Object(notice_map) = notice {
-                map.extend(notice_map);
-            }
-            Value::Object(map)
-        }
-        Some(other) => {
-            // Existing metadata was not an object — keep it as-is and add
-            // the deprecation notice as a sibling under a wrapper.
-            json!({ "_deprecation": notice["_deprecation"].clone(), "_original_metadata": other })
-        }
-        None => notice,
-    });
-
-    result
 }
 
 // === Types ===
@@ -1110,15 +1037,6 @@ fn default_subagent_artifacts(run_id: &str) -> Vec<AgentRunArtifactRef> {
                 .to_string(),
         },
     ]
-}
-
-fn message_preview(text: &str) -> String {
-    const MAX_PREVIEW_CHARS: usize = 120;
-    let mut preview: String = text.chars().take(MAX_PREVIEW_CHARS).collect();
-    if text.chars().count() > MAX_PREVIEW_CHARS {
-        preview.push_str("...");
-    }
-    preview
 }
 
 fn normalize_worker_spec(mut spec: AgentWorkerSpec) -> AgentWorkerSpec {
@@ -2442,33 +2360,6 @@ impl SubAgentManager {
         }
     }
 
-    fn record_follow_up_delivery(
-        &mut self,
-        worker_id: &str,
-        delivered: bool,
-        message: Option<&str>,
-        reason: Option<&str>,
-        interrupt: bool,
-        continued_from_checkpoint: bool,
-    ) {
-        let Some(record) = self.worker_records.get_mut(worker_id) else {
-            return;
-        };
-        let now_ms = epoch_millis_now();
-        record.updated_at_ms = now_ms;
-        record.follow_up.latest_delivery = Some(AgentRunFollowUpDelivery {
-            delivered,
-            timestamp_ms: now_ms,
-            message_preview: message.map(message_preview),
-            reason: reason.map(str::to_string),
-            interrupt,
-            continued_from_checkpoint,
-        });
-        if delivered {
-            record.latest_message = Some("follow-up delivered".to_string());
-        }
-    }
-
     fn fail_worker(&mut self, worker_id: &str, error: String) {
         self.record_worker_event(
             worker_id,
@@ -3051,56 +2942,6 @@ impl SubAgentManager {
         self.persist_state_best_effort();
         Ok(snapshot)
     }
-
-    fn continue_checkpointed(
-        &mut self,
-        agent_id: &str,
-        message: Option<String>,
-        interrupt: bool,
-    ) -> Result<SubAgentResult> {
-        let snapshot = {
-            let agent = self
-                .agents
-                .get_mut(agent_id)
-                .ok_or_else(|| anyhow!("Agent {agent_id} not found"))?;
-            if !matches!(agent.status, SubAgentStatus::Interrupted(_)) {
-                return Err(anyhow!(
-                    "Agent {agent_id} is not interrupted; checkpoint continuation is only available for interrupted sessions"
-                ));
-            }
-            let checkpoint = agent
-                .checkpoint
-                .as_ref()
-                .ok_or_else(|| anyhow!("Agent {agent_id} has no checkpoint to continue"))?;
-            if !checkpoint.continuable || checkpoint.messages.is_empty() {
-                return Err(anyhow!("Agent {agent_id} checkpoint is not continuable"));
-            }
-            let tx = agent.input_tx.as_ref().ok_or_else(|| {
-                anyhow!(
-                    "Agent {agent_id} checkpoint is persisted, but no live child task is available to continue"
-                )
-            })?;
-            tx.send(SubAgentInput {
-                text: message.unwrap_or_default(),
-                interrupt,
-            })
-            .map_err(|_| anyhow!("Failed to continue checkpointed agent {agent_id}"))?;
-
-            agent.status = SubAgentStatus::Running;
-            agent.result = None;
-            agent.last_activity_at = Instant::now();
-            agent.snapshot()
-        };
-        self.record_worker_event(
-            agent_id,
-            AgentWorkerStatus::Running,
-            Some("continued from checkpoint".to_string()),
-            Some(snapshot.steps_taken),
-            None,
-        );
-        self.persist_state_best_effort();
-        Ok(snapshot)
-    }
 }
 
 /// Thread-safe wrapper for `SubAgentManager`.
@@ -3475,6 +3316,7 @@ fn write_json_atomic<T: Serialize>(workspace: &Path, path: &Path, value: &T) -> 
 }
 
 /// Create a shared sub-agent manager with a configurable limit.
+#[cfg(test)]
 #[must_use]
 pub fn new_shared_subagent_manager(workspace: PathBuf, max_agents: usize) -> SharedSubAgentManager {
     new_shared_subagent_manager_with_timeout(
@@ -4192,12 +4034,17 @@ async fn record_queued_launch_progress(task: &SubAgentTask) {
     }
     emit_agent_progress(
         task.runtime.event_tx.as_ref(),
-        task.runtime.mailbox.as_ref(),
         &task.agent_id,
         SUBAGENT_QUEUED_LAUNCH_REASON.to_string(),
         task.runtime.parent_agent_id.clone(),
         task.runtime.spawn_depth,
     );
+    if let Some(mailbox) = task.runtime.mailbox.as_ref() {
+        let _ = mailbox.send(MailboxMessage::progress(
+            &task.agent_id,
+            SUBAGENT_QUEUED_LAUNCH_REASON,
+        ));
+    }
 }
 
 /// Notify this runtime's immediate parent that the child finished (issue
@@ -4510,7 +4357,6 @@ fn record_agent_progress(runtime: &SubAgentRuntime, agent_id: &str, message: imp
     }
     emit_agent_progress(
         runtime.event_tx.as_ref(),
-        runtime.mailbox.as_ref(),
         agent_id,
         message,
         runtime.parent_agent_id.clone(),
@@ -5567,6 +5413,7 @@ fn parse_optional_positive_u64(input: &Value, names: &[&str]) -> Result<Option<u
     Ok(None)
 }
 
+#[cfg(test)]
 fn with_default_fork_context(mut input: Value, default: bool) -> Value {
     let Some(object) = input.as_object_mut() else {
         return input;
@@ -5663,10 +5510,6 @@ impl SubAgentResolvedRoute {
             tuning,
         }
     }
-
-    fn refresh_tuning(&mut self) {
-        self.tuning = subagent_request_tuning(self.reasoning_effort.as_deref());
-    }
 }
 
 pub(crate) async fn resolve_subagent_assignment_route(
@@ -5714,6 +5557,7 @@ fn subagent_router_candidates(runtime: &SubAgentRuntime) -> crate::model_routing
     crate::model_routing::provider_router_candidates(runtime.client.api_provider(), &runtime.model)
 }
 
+#[cfg(test)]
 fn fallback_subagent_assignment_route(
     runtime: &SubAgentRuntime,
     configured_model: Option<String>,
@@ -6290,15 +6134,11 @@ fn subagent_progress_tool_display_name(name: &str) -> &str {
 
 fn emit_agent_progress(
     event_tx: Option<&mpsc::Sender<Event>>,
-    mailbox: Option<&Mailbox>,
     agent_id: &str,
     status: String,
     parent_run_id: Option<String>,
     spawn_depth: u32,
 ) {
-    if let Some(mb) = mailbox {
-        let _ = mb.send(MailboxMessage::progress(agent_id, status.clone()));
-    }
     if let Some(event_tx) = event_tx {
         let _ = event_tx.try_send(Event::AgentProgress {
             id: agent_id.to_string(),
@@ -6368,6 +6208,7 @@ struct SubAgentToolRegistry {
 }
 
 impl SubAgentToolRegistry {
+    #[cfg(test)]
     fn new(
         runtime: SubAgentRuntime,
         agent_type: SubAgentType,


### PR DESCRIPTION
## Problem

The sub-agent mailbox drainer forwarded **every** best-effort telemetry event (tool-call started/completed) to the engine event channel unconditionally. A chatty child agent could flood the bounded channel faster than the UI drained it — starving lifecycle/usage events and producing visible sub-agent lag.

## Fix

1. **Per-agent sampling** — the drainer now keeps a `last_sent_at` map per agent id and drops same-agent best-effort telemetry inside a **100ms** sampling window (`SUBAGENT_MAILBOX_BEST_EFFORT_MIN_INTERVAL`). Lifecycle (`started`/`completed`) and token-usage events are **never** sampled, so completion and cost display stay reliable. Sampling is per agent so one busy child cannot hide another's updates.
2. **Removed redundant mailbox progress send** from `emit_agent_progress` — progress already flows through `event_tx`, so the mailbox send was duplicate work that added load.
3. **Dead-code cleanup** — removed `#![allow(dead_code)]` from `subagent/mod.rs` and `mailbox.rs` that was masking unused surface; gated test-only items with `#[cfg(test)]`; deleted genuinely dead constants/functions (`DEFAULT_RESULT_TIMEOUT_MS`, `MAX_RESULT_TIMEOUT_MS`, `SUBAGENT_ROLE_DESCRIPTION`, `DEPRECATION_REMOVAL_VERSION`, `whale_nickname_for_index`, `refresh_tuning`, `SharedMailbox` alias).

## Tests

Two new tests cover the sampling window behavior:
- `subagent_mailbox_samples_best_effort_events_per_agent` — same-agent telemetry dropped inside window, other agents unaffected, re-allowed after interval.
- `subagent_mailbox_never_samples_lifecycle_or_usage_events` — lifecycle/usage events always pass through.

## Verification

- `cargo check -p codewhale-tui` — clean.
- `cargo clippy -p codewhale-tui` with CI allow-flags — clean.
- 18 mailbox tests pass (including the 2 new ones).

## Stacking note

This branch includes the broken-main fix from **#3453** (`doctor_api_key_source_label` E0004) as its base commit so it compiles for verification. Once #3453 lands on `main`, that commit drops out of this PR's diff automatically (GitHub recognizes the shared commit), leaving only the sub-agent changes. No conflict expected.