### PR TITLE
fix: prevent ordinary prompt text from being interpreted as a mode switch

### DIFF
--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2026,7 +2026,15 @@ impl RuntimeThreadManager {
             touch_lru(&mut active.lru, thread_id);
         }
 
-        let mode = parse_mode(req.mode.as_deref().unwrap_or(&thread.mode));
+        // A requested mode override only takes effect when it is an explicit,
+        // recognized mode token. An unrecognized override (e.g. a stray prompt
+        // fragment) must NOT silently change the mode: fall back to the
+        // thread's persisted mode rather than coercing to Agent (#3387).
+        let mode = req
+            .mode
+            .as_deref()
+            .and_then(parse_mode_opt)
+            .unwrap_or_else(|| parse_mode(&thread.mode));
         let requested_model = req.model.unwrap_or_else(|| thread.model.clone());
         let auto_model = requested_model.trim().eq_ignore_ascii_case("auto");
         let (provider, model, reasoning_effort) = if auto_model {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3740,12 +3740,22 @@ fn enforce_lru_capacity(
     evicted
 }
 
-fn parse_mode(mode: &str) -> AppMode {
+/// Resolves only explicit mode tokens to an app mode. Free-form prompt text is
+/// never a valid mode token: `parse_mode_opt` returns `None` unless the input is
+/// exactly `agent`/`plan`/`yolo` or the numeric aliases `1`/`2`/`3`. Mode
+/// changes originate from the Tab cycle, `/mode`, the mode picker, or
+/// config/startup defaults, not from submitted natural-language prompt text.
+fn parse_mode_opt(mode: &str) -> Option<AppMode> {
     match mode.trim().to_ascii_lowercase().as_str() {
-        "plan" => AppMode::Plan,
-        "yolo" => AppMode::Yolo,
-        _ => AppMode::Agent,
+        "agent" | "1" => Some(AppMode::Agent),
+        "plan" | "2" => Some(AppMode::Plan),
+        "yolo" | "3" => Some(AppMode::Yolo),
+        _ => None,
     }
+}
+
+fn parse_mode(mode: &str) -> AppMode {
+    parse_mode_opt(mode).unwrap_or(AppMode::Agent)
 }
 
 fn tool_kind_for_name(name: &str) -> TurnItemKind {

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2466,6 +2466,38 @@ fn parse_mode_defaults_to_agent() {
     assert_eq!(parse_mode("plan"), AppMode::Plan);
 }
 
+#[test]
+fn parse_mode_opt_resolves_explicit_tokens_and_aliases() {
+    assert_eq!(parse_mode_opt("agent"), Some(AppMode::Agent));
+    assert_eq!(parse_mode_opt("1"), Some(AppMode::Agent));
+    assert_eq!(parse_mode_opt("plan"), Some(AppMode::Plan));
+    assert_eq!(parse_mode_opt("2"), Some(AppMode::Plan));
+    assert_eq!(parse_mode_opt("yolo"), Some(AppMode::Yolo));
+    assert_eq!(parse_mode_opt("3"), Some(AppMode::Yolo));
+    assert_eq!(parse_mode_opt(" PLAN "), Some(AppMode::Plan));
+}
+
+#[test]
+fn parse_mode_opt_rejects_prompt_fragments() {
+    for input in [
+        "plan a trip to Tokyo",
+        "switch the agent on",
+        "enter yolo mode",
+        "agent of chaos",
+        "mode",
+    ] {
+        assert_eq!(parse_mode_opt(input), None);
+    }
+}
+
+#[test]
+fn parse_mode_wrapper_defaults_and_resolves_numeric_aliases() {
+    assert_eq!(parse_mode("plan a trip to Tokyo"), AppMode::Agent);
+    assert_eq!(parse_mode("1"), AppMode::Agent);
+    assert_eq!(parse_mode("2"), AppMode::Plan);
+    assert_eq!(parse_mode("3"), AppMode::Yolo);
+}
+
 fn rebind_event(event: &str, agent_id: &str, seq: u64) -> RuntimeEventRecord {
     RuntimeEventRecord {
         schema_version: CURRENT_RUNTIME_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

Mode changes were able to leak from ordinary prompt text. On the runtime turn-start path, `parse_mode` resolved a mode string with a broad catch-all (`_ => AppMode::Agent`), so any unrecognized value silently became a valid mode instead of being rejected. Because `start_turn` prefers `StartTurnRequest.mode` over the thread's persisted mode, a stray prompt-like override (e.g. `enter yolo mode`) that should be ignored was coerced into `Agent`, silently changing a Plan/YOLO thread's mode without an explicit request (#3387).

This draws a clear boundary between prompt-submission text and mode-command parsing:

- Adds a strict `parse_mode_opt(mode) -> Option<AppMode>` that resolves **only** the explicit mode tokens, matching the `/mode` command's own accepted set: `agent`/`plan`/`yolo` plus the numeric aliases `1`/`2`/`3`. Anything else returns `None`.
- `parse_mode` stays an infallible wrapper (`parse_mode_opt(..).unwrap_or(AppMode::Agent)`), so the persisted/default mode path is unchanged (`AppMode::as_setting()` always yields a recognized token).
- At the `start_turn` call site, an unrecognized per-turn override now falls back to the thread's persisted mode rather than coercing to `Agent`, so an invalid override never crosses the mode boundary.

Mode transitions continue to originate only from explicit sources: the Tab cycle, `/mode`, the mode picker, and config/startup defaults. The composer/submit path (`looks_like_slash_command_input`, which requires a leading `/`) was already strict and is left untouched.

## Why this matters

Root cause: the lone runtime mode resolver treated every non-token string as a valid mode, and the turn-start call preferred the request override unconditionally, so free-form prompt text could silently change approval/sandbox/trust posture.

The failing case now fixed: starting a turn on a Plan or YOLO thread with a request mode such as `enter yolo mode` (or any non-token fragment) no longer flips the thread to `Agent`; the unrecognized override is ignored and the persisted mode is preserved. Regression tests assert that prompt fragments (`plan a trip to Tokyo`, `switch the agent on`, `enter yolo mode`, `agent of chaos`, `mode`) never resolve to a mode, while exact tokens and numeric aliases still do.

## Testing

- [x] `cargo fmt` clean on the changed crate
- [x] `cargo test -p codewhale-tui parse_mode` — all `parse_mode` / `parse_mode_opt` regression tests pass

(Note: the full `cargo test --workspace` build currently fails before reaching these tests due to a pre-existing non-exhaustive match in `crates/tui/src/main.rs` `doctor_api_key_source_label` — `ApiKeySource::Command` / `ApiKeySource::Secret` are uncovered on `main`, unrelated to this change. The `parse_mode` tests were verified passing under a local workaround for that build error.)

Fixes #3387

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] No UI changes (runtime mode-resolver logic only); no manual TUI verification needed
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address
