### PR TITLE
ci: add advisory Claude PR review workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # Default owner for everything in the repo.
 * @Hmbown
+
+# AI code review is advisory and not wired through CODEOWNERS: GitHub CODEOWNERS
+# only accepts users and teams, not bots. @Hmbown stays the human code owner.
+#   - Claude: .github/workflows/claude-review.yml (GitHub Actions).
+#   - Codex/ChatGPT: the ChatGPT Codex cloud integration (chatgpt.com/codex ->
+#     connect GitHub -> enable Code review), authed by the ChatGPT subscription.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,81 @@
+name: Claude PR Review
+
+# Advisory AI code review by Claude (anthropics/claude-code-action) on every
+# non-draft PR. CODEOWNERS (@Hmbown) stays the human owner — this review posts
+# alongside it, it does not replace approval.
+#
+# Setup: add a CLAUDE_CODE_OAUTH_TOKEN repository secret
+#   1. Run `claude setup-token` locally (Pro/Max subscription) to mint a token.
+#   2. Settings -> Secrets and variables -> Actions -> New repository secret.
+# Until the secret exists the job no-ops with a notice (stays green), so this
+# workflow is safe to merge before the token is configured.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [master, main]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    name: Claude review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    env:
+      HAS_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Skip when token is unset
+        if: env.HAS_OAUTH != 'true'
+        run: echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not set — skipping Claude review. Add the secret to enable it."
+
+      - name: Checkout repository
+        if: env.HAS_OAUTH == 'true'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Claude code review
+        if: env.HAS_OAUTH == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a pull request against CodeWhale, a Rust workspace
+            (an agentic coding TUI/runtime). The PR branch is already checked out
+            in the current working directory.
+
+            Review the diff and report findings in this priority order:
+            1. Correctness bugs: logic errors, panics, unwrap/expect on fallible
+               paths, race conditions, incorrect error handling, off-by-one, and
+               non-exhaustive matches that could break compilation.
+            2. Provider/model/route safety (v0.8.65 EPIC #2608 invariant): a
+               provider-prefixed model string (e.g. `deepseek-ai/`, `deepseek/`,
+               `anthropic/`, `openai/`, `qwen/`) is a wire id or namespace hint,
+               never proof of provider selection. Flag any code that infers a
+               provider/model switch from such a prefix or from freeform prompt
+               text rather than from explicit user choice, config, Fleet policy,
+               capability requirements, or fallback policy.
+            3. Reuse and simplification: duplicated logic, dead code, needless
+               allocation/cloning, or reimplementing something the workspace
+               already provides.
+            4. Tests: missing coverage for new behavior and edge cases.
+            5. Security: secret handling, shell/exec policy, input validation.
+
+            Be specific and concise. Use inline comments for line-specific issues
+            and one top-level comment for the summary. Note genuinely good choices
+            briefly. Do not nitpick style that `cargo fmt` / `clippy` already
+            enforce.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*)"


### PR DESCRIPTION
## What

Adds an advisory **Claude code review** GitHub Action that runs on every non-draft PR, per Hunter's request to add AI reviewers.

- `.github/workflows/claude-review.yml` — `anthropics/claude-code-action@v1` (review mode, `track_progress`), authed by the **`CLAUDE_CODE_OAUTH_TOKEN`** repo secret (already added).
- `.github/CODEOWNERS` — comment documenting that AI review is advisory and not wired through CODEOWNERS (which only accepts users/teams, not bots); **`@Hmbown` stays the human owner**.

## Codex / ChatGPT review — handled out-of-repo

Per Hunter's choice, Codex review runs via the **ChatGPT Codex cloud integration** (chatgpt.com/codex → connect GitHub → enable Code review), authed by the ChatGPT subscription — so there's **no OpenAI workflow file or repo secret** here. (An earlier revision of this PR included a `codex-review.yml` using `OPENAI_API_KEY`; it was dropped in favor of the cloud integration to avoid duplicate Codex comments.)

## Why a workflow, not CODEOWNERS

CODEOWNERS can only list real GitHub users/teams — a bot like `claude[bot]` can't be a code owner. So Claude review is a `pull_request` Action that posts review comments. It's **advisory**; it doesn't gate merge or replace `@Hmbown`.

## Notes

- Triggers: `opened, synchronize, reopened, ready_for_review` on `[master, main]`; drafts skipped; `concurrency` cancels superseded runs.
- The job **no-ops with a notice (stays green)** if the secret is ever unset, so it's safe to merge.
- The review prompt guards the **v0.8.65 EPIC #2608 routing invariant** (provider-prefixed model strings like `deepseek-ai/`, `deepseek/`, `anthropic/` are wire ids/hints, never provider-selection proof).
- ⚠️ Base `main` currently fails to compile (`error[E0004]` in `doctor_api_key_source_label`, fixed by #3453). This PR only adds workflow YAML; its own CI goes green once #3453 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)