### PR TITLE
feat(config): EPIC #2608 route foundation — canonical types + ReadyRouteCandidate/RouteResolver (#3084, #3384)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth_source;
 pub mod provider;
+pub mod route;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -24,7 +24,8 @@ use super::{
 };
 
 /// Wire protocol spoken by a provider.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum WireFormat {
     /// OpenAI-compatible `/v1/chat/completions` style payloads.
     ChatCompletions,

--- a/crates/config/src/route/candidate.rs
+++ b/crates/config/src/route/candidate.rs
@@ -5,10 +5,13 @@
 //! > Execution requires a `ReadyRouteCandidate`.
 //! > A `ReadyRouteCandidate` can only be produced by `RouteResolver`.
 //!
-//! All fields are pub-read, but the ONLY constructor is
-//! [`ReadyRouteCandidate::new`], which is `pub(super)`. Only
-//! [`super::resolver`] (the [`super::resolver::RouteResolver`]) can mint one;
-//! no other code in or out of the crate can fabricate a candidate.
+//! Fields are pub-*read*, but the type cannot be *constructed* outside this
+//! crate: the struct is `#[non_exhaustive]` (no other crate can build it via a
+//! struct literal) and deliberately does not derive `Deserialize` (so it cannot
+//! be fabricated from JSON either). The only constructor is
+//! [`ReadyRouteCandidate::new`]
+//! (`pub(super)`), and [`super::resolver::RouteResolver::resolve`] is its sole
+//! caller. A candidate's existence is therefore proof it passed the resolver.
 //!
 //! DEFERRED: #3384's full sketch also carried `capabilities: CapabilityProfile`
 //! and `config_snapshot: Config`. Both are intentionally omitted here: pulling
@@ -98,9 +101,11 @@ pub struct ValidationReport {
 
 /// A runtime-resolved, executable route.
 ///
-/// All fields are read-only to callers. The only constructor is
+/// Fields are read-only to callers; the type cannot be constructed outside this
+/// crate (`#[non_exhaustive]` + no `Deserialize`). The only constructor is
 /// [`Self::new`], which is `pub(super)`; see module docs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct ReadyRouteCandidate {
     /// Resolved provider id.
     pub provider_id: ProviderId,

--- a/crates/config/src/route/candidate.rs
+++ b/crates/config/src/route/candidate.rs
@@ -1,0 +1,156 @@
+//! The runtime-resolved executable route (#3384).
+//!
+//! A [`ReadyRouteCandidate`] is the concrete form of the #2608 contract:
+//!
+//! > Execution requires a `ReadyRouteCandidate`.
+//! > A `ReadyRouteCandidate` can only be produced by `RouteResolver`.
+//!
+//! All fields are pub-read, but the ONLY constructor is
+//! [`ReadyRouteCandidate::new`], which is `pub(super)`. Only
+//! [`super::resolver`] (the [`super::resolver::RouteResolver`]) can mint one;
+//! no other code in or out of the crate can fabricate a candidate.
+//!
+//! DEFERRED: #3384's full sketch also carried `capabilities: CapabilityProfile`
+//! and `config_snapshot: Config`. Both are intentionally omitted here: pulling
+//! `CapabilityProfile` into `crates/config` would force a `tui -> config` type
+//! move, and embedding `Config` would couple the candidate to the full config
+//! model. They will be added when those types have a home in this crate.
+
+use serde::{Deserialize, Serialize};
+
+use super::RequestProtocol;
+use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
+use crate::ProviderKind;
+
+/// A concrete, resolved endpoint the route will talk to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedEndpoint {
+    /// Resolved base URL (after any override).
+    pub base_url: String,
+    /// Endpoint key (e.g. `"chat"`, `"responses"`).
+    pub endpoint_key: String,
+    /// Wire protocol spoken at this endpoint.
+    pub protocol: RequestProtocol,
+}
+
+/// The CLASS of auth source resolved for the route.
+///
+/// This records only *where* a credential comes from, never the credential
+/// value itself. There is intentionally no field that could hold a secret.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolvedAuthSource {
+    /// Supplied via CLI flag/argument.
+    Cli,
+    /// Read from a config file.
+    ConfigFile,
+    /// Read from the OS keyring.
+    Keyring,
+    /// Read from an environment variable.
+    Env,
+    /// Produced by running a command.
+    Command,
+    /// Resolved from a named secret.
+    Secret,
+    /// No credential resolved.
+    Missing,
+}
+
+/// Pricing/quota class for the resolved route.
+///
+/// Carries only coarse, non-sensitive shape; never secrets or account ids.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PricingSku {
+    /// Per-token pricing.
+    Token {
+        /// Input price per million tokens, if known.
+        input_per_mtok: Option<f64>,
+        /// Output price per million tokens, if known.
+        output_per_mtok: Option<f64>,
+    },
+    /// Subscription quota usage.
+    SubscriptionQuota {
+        /// Percent of quota used, if known.
+        used_pct: Option<f32>,
+        /// When the quota resets, if known.
+        resets_at: Option<String>,
+    },
+    /// Prepaid account credits.
+    AccountCredits {
+        /// Remaining balance, if known.
+        balance: Option<f64>,
+    },
+    /// Local or otherwise not billed.
+    LocalOrNotApplicable,
+    /// Pricing unknown or stale.
+    UnknownOrStale,
+}
+
+/// Outcome of route validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationReport {
+    /// Whether the route passed validation.
+    pub ok: bool,
+    /// Human-readable diagnostics (advisory; secret-free).
+    pub messages: Vec<String>,
+}
+
+/// A runtime-resolved, executable route.
+///
+/// All fields are read-only to callers. The only constructor is
+/// [`Self::new`], which is `pub(super)`; see module docs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadyRouteCandidate {
+    /// Resolved provider id.
+    pub provider_id: ProviderId,
+    /// Resolved provider kind.
+    pub provider_kind: ProviderKind,
+    /// The selector the user/route requested.
+    pub logical_model: LogicalModelRef,
+    /// Canonical model identity, if one was resolved.
+    pub canonical_model: Option<ModelId>,
+    /// Provider-owned wire id put on the request.
+    pub wire_model_id: WireModelId,
+    /// Resolved endpoint transport facts.
+    pub endpoint: ResolvedEndpoint,
+    /// Resolved auth source CLASS (never a secret value).
+    pub auth: ResolvedAuthSource,
+    /// Selected wire protocol.
+    pub protocol: RequestProtocol,
+    /// Pricing/quota class, if known.
+    pub pricing: Option<PricingSku>,
+    /// Validation outcome.
+    pub validation: ValidationReport,
+}
+
+impl ReadyRouteCandidate {
+    /// Mint a candidate. Restricted to [`super::resolver`] so the resolver is
+    /// the sole producer of executable routes (the #2608 mutation gate).
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        provider_id: ProviderId,
+        provider_kind: ProviderKind,
+        logical_model: LogicalModelRef,
+        canonical_model: Option<ModelId>,
+        wire_model_id: WireModelId,
+        endpoint: ResolvedEndpoint,
+        auth: ResolvedAuthSource,
+        protocol: RequestProtocol,
+        pricing: Option<PricingSku>,
+        validation: ValidationReport,
+    ) -> Self {
+        Self {
+            provider_id,
+            provider_kind,
+            logical_model,
+            canonical_model,
+            wire_model_id,
+            endpoint,
+            auth,
+            protocol,
+            pricing,
+            validation,
+        }
+    }
+}

--- a/crates/config/src/route/descriptor.rs
+++ b/crates/config/src/route/descriptor.rs
@@ -1,0 +1,94 @@
+//! Provider descriptors over the existing built-in provider registry (#3084).
+//!
+//! A [`ProviderDescriptor`] is a thin, route-facing view over the static
+//! [`provider::Provider`] trait objects already in [`crate::provider`]. It
+//! surfaces only the transport facts route resolution needs (id, base URL,
+//! default wire model, env vars, protocol) without duplicating the registry.
+//!
+//! Because a descriptor holds a `&'static dyn Provider`, it is intentionally
+//! NOT `Serialize`/`PartialEq`-derivable. Never embed a [`ProviderDescriptor`]
+//! inside a `Serialize` struct; serialize the resolved facts instead.
+
+use crate::ProviderKind;
+use crate::provider::{self, Provider};
+
+use super::RequestProtocol;
+use super::ids::{ProviderId, WireModelId};
+
+/// Route-facing view of a built-in provider's transport facts.
+///
+/// Holds a trait object, so it is deliberately not serializable/comparable.
+#[derive(Clone, Copy)]
+pub struct ProviderDescriptor {
+    /// The provider kind this descriptor describes.
+    pub kind: ProviderKind,
+    /// Backing static provider metadata entry.
+    pub inner: &'static dyn Provider,
+}
+
+impl ProviderDescriptor {
+    /// Build a descriptor for a known provider kind.
+    #[must_use]
+    pub fn for_kind(kind: ProviderKind) -> Self {
+        Self {
+            kind,
+            inner: provider::provider_for_kind(kind),
+        }
+    }
+
+    /// Canonical provider id.
+    #[must_use]
+    pub fn id(&self) -> ProviderId {
+        ProviderId::from(self.inner.id())
+    }
+
+    /// Default base URL when no override is present.
+    #[must_use]
+    pub fn default_base_url(&self) -> &'static str {
+        self.inner.default_base_url()
+    }
+
+    /// Default wire model id when no model is selected.
+    #[must_use]
+    pub fn default_wire_model(&self) -> WireModelId {
+        WireModelId::from(self.inner.default_model())
+    }
+
+    /// Environment variable candidates for this provider's API key.
+    #[must_use]
+    pub fn env_vars(&self) -> &'static [&'static str] {
+        self.inner.env_vars()
+    }
+
+    /// Selected wire protocol for this provider.
+    #[must_use]
+    pub fn protocol(&self) -> RequestProtocol {
+        self.inner.wire()
+    }
+}
+
+impl std::fmt::Debug for ProviderDescriptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderDescriptor")
+            .field("kind", &self.kind)
+            .field("id", &self.inner.id())
+            .field("protocol", &self.inner.wire())
+            .finish()
+    }
+}
+
+/// A concrete endpoint's transport facts.
+///
+/// Unlike [`ProviderDescriptor`], this owns plain data and is safe to embed in
+/// serializable route output (see [`super::candidate::ResolvedEndpoint`]).
+#[derive(Debug, Clone)]
+pub struct EndpointDescriptor {
+    /// Stable endpoint key (e.g. `"chat"`, `"responses"`).
+    pub endpoint_key: String,
+    /// Wire protocol spoken at this endpoint.
+    pub protocol: RequestProtocol,
+    /// Default base URL for this endpoint.
+    pub default_base_url: String,
+    /// Whether streaming is supported.
+    pub streaming: bool,
+}

--- a/crates/config/src/route/errors.rs
+++ b/crates/config/src/route/errors.rs
@@ -1,0 +1,50 @@
+//! Route resolution errors (#3384).
+//!
+//! `thiserror` is not a dependency of this crate, so [`Display`] and
+//! [`std::error::Error`] are hand-implemented. No new dependency is added.
+
+use std::fmt;
+
+use super::ids::ProviderId;
+
+/// Why a [`super::resolver::RouteResolver`] could not produce a candidate.
+#[derive(Debug, Clone)]
+pub enum RouteError {
+    /// The requested model selector was empty.
+    EmptyModel,
+    /// The named provider could not be resolved.
+    InvalidProvider(String),
+    /// A model matched multiple providers; the caller must disambiguate.
+    AmbiguousModel(Vec<ProviderId>),
+    /// A clearly-foreign model was requested for a strict direct provider.
+    ForeignModelForDirectProvider {
+        /// The strict direct provider that rejected the model.
+        provider: ProviderId,
+        /// The foreign model selector that was rejected.
+        model: String,
+    },
+}
+
+impl fmt::Display for RouteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyModel => write!(f, "model selector was empty"),
+            Self::InvalidProvider(name) => write!(f, "invalid provider: {name}"),
+            Self::AmbiguousModel(providers) => {
+                let names: Vec<&str> = providers.iter().map(ProviderId::as_str).collect();
+                write!(
+                    f,
+                    "model matches multiple providers ({}); specify a provider",
+                    names.join(", ")
+                )
+            }
+            Self::ForeignModelForDirectProvider { provider, model } => write!(
+                f,
+                "model {model:?} is not served by direct provider {}",
+                provider.as_str()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RouteError {}

--- a/crates/config/src/route/ids.rs
+++ b/crates/config/src/route/ids.rs
@@ -1,0 +1,165 @@
+//! Transparent string newtypes for provider/model/route identities.
+//!
+//! These types make the distinct *meanings* of route strings unmistakable at
+//! the type level so callers can no longer mix:
+//!
+//! - [`ProviderId`] — a provider's canonical id (e.g. `"deepseek"`).
+//! - [`ModelId`] — a canonical, provider-agnostic logical model id.
+//! - [`WireModelId`] — a provider-owned wire id sent on the request
+//!   (e.g. `"deepseek-ai/DeepSeek-V4-Pro"` on Together).
+//! - [`LogicalModelRef`] — a user/selector reference to a model, which may be
+//!   `"auto"`, a bare model, or an aggregator-prefixed string.
+//!
+//! [`ModelId`] and [`WireModelId`] are deliberately DISTINCT types and are
+//! never interchangeable: a canonical model identity is not the same thing as
+//! the provider-specific string put on the wire.
+//!
+//! INVARIANT (load-bearing for #2608): a namespace prefix can NEVER become a
+//! provider. There is intentionally NO `From`/`Into` conversion from
+//! [`LogicalModelRef`] or [`NamespaceHint`] to [`ProviderId`]. A prefix like
+//! `deepseek-ai/` is a catalog/namespace hint only; it is not proof of
+//! provider ownership. Do not add such a conversion.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ProviderKind;
+
+macro_rules! string_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Borrow the inner string slice.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_string())
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+string_newtype!(
+    /// A provider's canonical identifier (e.g. `"deepseek"`, `"openrouter"`).
+    ProviderId
+);
+
+string_newtype!(
+    /// A canonical, provider-agnostic logical model identity.
+    ///
+    /// Distinct from [`WireModelId`]: this is "what the model is", not "what
+    /// string a provider expects on the wire".
+    ModelId
+);
+
+string_newtype!(
+    /// A provider-owned wire model id sent verbatim on the request.
+    ///
+    /// Distinct from [`ModelId`]: aggregator-prefixed strings such as
+    /// `"deepseek-ai/DeepSeek-V4-Pro"` are wire ids, not canonical identities.
+    WireModelId
+);
+
+string_newtype!(
+    /// A user/selector reference to a model.
+    ///
+    /// May be the `"auto"` sentinel, a bare model name, or an
+    /// aggregator-prefixed string. A [`LogicalModelRef`] carries no provider
+    /// authority by itself; see [`Self::namespace_hint`].
+    LogicalModelRef
+);
+
+impl ProviderId {
+    /// Build a [`ProviderId`] from a [`ProviderKind`] using its canonical id.
+    #[must_use]
+    pub fn from_kind(kind: ProviderKind) -> Self {
+        Self(kind.as_str().to_string())
+    }
+}
+
+/// A leading namespace/organization prefix carried by a [`LogicalModelRef`].
+///
+/// A namespace hint is a *catalog* hint only. It is NEVER convertible to a
+/// [`ProviderId`]; an aggregator may serve `deepseek-ai/...` without being
+/// DeepSeek, and a custom endpoint may legitimately use a look-alike string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NamespaceHint {
+    /// `deepseek-ai/` prefix.
+    DeepseekAi,
+    /// `deepseek/` prefix.
+    Deepseek,
+    /// `anthropic/` prefix.
+    Anthropic,
+    /// `openai/` prefix.
+    Openai,
+    /// `qwen/` prefix.
+    Qwen,
+}
+
+impl LogicalModelRef {
+    /// Borrow the raw selector string.
+    #[must_use]
+    pub fn raw(&self) -> &str {
+        self.as_str()
+    }
+
+    /// Whether this selector is the explicit `auto` router sentinel.
+    ///
+    /// `auto` is an opt-in router sentinel, never a literal model id.
+    #[must_use]
+    pub fn is_auto(&self) -> bool {
+        self.raw() == "auto"
+    }
+
+    /// Parse the leading namespace prefix, if any.
+    ///
+    /// Returns `Some` only for the curated aggregator/organization prefixes.
+    /// This is a hint about catalog namespace and does NOT identify a provider.
+    #[must_use]
+    pub fn namespace_hint(&self) -> Option<NamespaceHint> {
+        let raw = self.raw();
+        // Order matters: `deepseek-ai/` must be matched before `deepseek/`.
+        if raw.starts_with("deepseek-ai/") {
+            Some(NamespaceHint::DeepseekAi)
+        } else if raw.starts_with("deepseek/") {
+            Some(NamespaceHint::Deepseek)
+        } else if raw.starts_with("anthropic/") {
+            Some(NamespaceHint::Anthropic)
+        } else if raw.starts_with("openai/") {
+            Some(NamespaceHint::Openai)
+        } else if raw.starts_with("qwen/") {
+            Some(NamespaceHint::Qwen)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -12,6 +12,7 @@
 //! - [`offering`] — provider/model offering seam (wire-id binding).
 //! - [`candidate`] — the runtime-resolved executable route + its parts.
 //! - [`errors`] — route resolution errors.
+//! - [`resolver`] — the sole producer of [`candidate::ReadyRouteCandidate`].
 //!
 //! Naming: the request/response wire shape is spelled [`RequestProtocol`],
 //! which is a re-export alias of [`crate::provider::WireFormat`] rather than a
@@ -30,6 +31,7 @@ pub mod descriptor;
 pub mod errors;
 pub mod ids;
 pub mod offering;
+pub mod resolver;
 
 pub use candidate::{
     PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint, ValidationReport,
@@ -38,6 +40,7 @@ pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
 pub use errors::RouteError;
 pub use ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
 pub use offering::{ProviderModelOffering, bundled_offerings};
+pub use resolver::{RouteRequest, RouteResolver};
 
 #[cfg(test)]
 mod tests;

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -8,6 +8,8 @@
 //!
 //! Layering:
 //! - [`ids`] — provider/model/wire string newtypes + namespace hints.
+//! - [`descriptor`] — route-facing view over the static provider registry.
+//! - [`offering`] — provider/model offering seam (wire-id binding).
 //!
 //! Naming: the request/response wire shape is spelled [`RequestProtocol`],
 //! which is a re-export alias of [`crate::provider::WireFormat`] rather than a
@@ -21,9 +23,13 @@
 /// avoid introducing yet another protocol synonym.
 pub use crate::provider::WireFormat as RequestProtocol;
 
+pub mod descriptor;
 pub mod ids;
+pub mod offering;
 
+pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
 pub use ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
+pub use offering::{ProviderModelOffering, bundled_offerings};
 
 #[cfg(test)]
 mod tests;

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -1,0 +1,29 @@
+//! Route foundation: additive, runtime-unwired types for EPIC #2608.
+//!
+//! This module tree introduces the canonical identity newtypes (#3084) and the
+//! `ReadyRouteCandidate` / `RouteResolver` contract (#3384) without touching
+//! any runtime routing path. Nothing here is consumed by `config.rs`, the TUI,
+//! the client, or the engine yet; it is a self-contained seam that later
+//! tracks will wire in.
+//!
+//! Layering:
+//! - [`ids`] — provider/model/wire string newtypes + namespace hints.
+//!
+//! Naming: the request/response wire shape is spelled [`RequestProtocol`],
+//! which is a re-export alias of [`crate::provider::WireFormat`] rather than a
+//! fourth protocol synonym.
+
+#![allow(dead_code)]
+
+/// The selected endpoint's request/response wire shape.
+///
+/// Alias of [`crate::provider::WireFormat`]; intentionally NOT a new enum, to
+/// avoid introducing yet another protocol synonym.
+pub use crate::provider::WireFormat as RequestProtocol;
+
+pub mod ids;
+
+pub use ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
+
+#[cfg(test)]
+mod tests;

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -10,6 +10,8 @@
 //! - [`ids`] — provider/model/wire string newtypes + namespace hints.
 //! - [`descriptor`] — route-facing view over the static provider registry.
 //! - [`offering`] — provider/model offering seam (wire-id binding).
+//! - [`candidate`] — the runtime-resolved executable route + its parts.
+//! - [`errors`] — route resolution errors.
 //!
 //! Naming: the request/response wire shape is spelled [`RequestProtocol`],
 //! which is a re-export alias of [`crate::provider::WireFormat`] rather than a
@@ -23,11 +25,17 @@
 /// avoid introducing yet another protocol synonym.
 pub use crate::provider::WireFormat as RequestProtocol;
 
+pub mod candidate;
 pub mod descriptor;
+pub mod errors;
 pub mod ids;
 pub mod offering;
 
+pub use candidate::{
+    PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint, ValidationReport,
+};
 pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
+pub use errors::RouteError;
 pub use ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
 pub use offering::{ProviderModelOffering, bundled_offerings};
 

--- a/crates/config/src/route/offering.rs
+++ b/crates/config/src/route/offering.rs
@@ -1,0 +1,93 @@
+//! Provider model offerings (#3084).
+//!
+//! A [`ProviderModelOffering`] binds a provider to a canonical model, the
+//! provider-owned wire id that serves it, and the endpoint key. This is the
+//! seam that proves the #2608 invariant: the SAME canonical model can be served
+//! by multiple providers under DIFFERENT wire ids (some aggregator-prefixed),
+//! and a prefix never implies provider ownership.
+//!
+//! [`BUNDLED_OFFERINGS`] is intentionally tiny: a couple DeepSeek-native rows
+//! plus a couple aggregator rows (Together / OpenRouter) whose wire ids carry
+//! prefixes such as `deepseek-ai/DeepSeek-V4-Pro`. It exists to exercise the
+//! seam, not to be the eventual catalog.
+
+use super::ids::{ModelId, ProviderId, WireModelId};
+
+/// One provider's way of serving a (possibly canonical) model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderModelOffering {
+    /// Provider serving this offering.
+    pub provider: ProviderId,
+    /// Canonical model identity, if this offering maps to one.
+    pub canonical_model: Option<ModelId>,
+    /// Provider-owned wire id sent on the request (verbatim).
+    pub wire_model_id: WireModelId,
+    /// Endpoint key the offering is served on.
+    pub endpoint_key: String,
+    /// Whether this is the provider's default offering.
+    pub default_for_provider: bool,
+}
+
+/// A static, lazily-materialized seam catalog.
+///
+/// Each row binds a provider id, an optional canonical model id, the wire id
+/// it is served under, the endpoint key, and whether it is the provider
+/// default. Aggregator rows demonstrate prefixed wire ids.
+struct OfferingSeed {
+    provider: &'static str,
+    canonical_model: Option<&'static str>,
+    wire_model_id: &'static str,
+    endpoint_key: &'static str,
+    default_for_provider: bool,
+}
+
+const OFFERING_SEEDS: &[OfferingSeed] = &[
+    // DeepSeek-native: wire id equals the bare model name, no prefix.
+    OfferingSeed {
+        provider: "deepseek",
+        canonical_model: Some("deepseek-v4-pro"),
+        wire_model_id: "deepseek-v4-pro",
+        endpoint_key: "chat",
+        default_for_provider: true,
+    },
+    OfferingSeed {
+        provider: "deepseek",
+        canonical_model: Some("deepseek-v4-flash"),
+        wire_model_id: "deepseek-v4-flash",
+        endpoint_key: "chat",
+        default_for_provider: false,
+    },
+    // Together aggregator: same canonical model, prefixed wire id.
+    OfferingSeed {
+        provider: "together",
+        canonical_model: Some("deepseek-v4-pro"),
+        wire_model_id: "deepseek-ai/DeepSeek-V4-Pro",
+        endpoint_key: "chat",
+        default_for_provider: true,
+    },
+    // OpenRouter aggregator: same canonical model, different prefixed wire id.
+    OfferingSeed {
+        provider: "openrouter",
+        canonical_model: Some("deepseek-v4-pro"),
+        wire_model_id: "deepseek/deepseek-v4-pro",
+        endpoint_key: "chat",
+        default_for_provider: true,
+    },
+];
+
+/// Return the bundled offering seam as owned [`ProviderModelOffering`] rows.
+///
+/// Owned because the newtypes wrap `String`; the seed table stays `&'static`.
+#[must_use]
+pub fn bundled_offerings() -> Vec<ProviderModelOffering> {
+    OFFERING_SEEDS
+        .iter()
+        .map(|seed| ProviderModelOffering {
+            provider: ProviderId::from(seed.provider),
+            canonical_model: seed.canonical_model.map(ModelId::from),
+            wire_model_id: WireModelId::from(seed.wire_model_id),
+            endpoint_key: seed.endpoint_key.to_string(),
+            default_for_provider: seed.default_for_provider,
+        })
+        .collect()
+}

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -73,14 +73,10 @@ impl RouteResolver {
         let descriptor = ProviderDescriptor::for_kind(provider_kind);
         let provider_id = descriptor.id();
 
-        // 2. Determine the logical selector + reject empties up front.
+        // 2. Determine the logical selector from explicit choice, then the
+        //    saved-model fallback, then the provider default.
         let logical_model = match &req.model_selector {
-            Some(selector) => {
-                if selector.raw().is_empty() {
-                    return Err(RouteError::EmptyModel);
-                }
-                selector.clone()
-            }
+            Some(selector) => selector.clone(),
             None => {
                 // No selector: fall back to saved wire model, then provider
                 // default. Both stay in the resolved provider's scope.
@@ -92,6 +88,12 @@ impl RouteResolver {
                 LogicalModelRef::from(raw)
             }
         };
+
+        // Reject an empty selector from ANY source (explicit, saved, or a
+        // degenerate default), not just an empty explicit selector.
+        if logical_model.raw().is_empty() {
+            return Err(RouteError::EmptyModel);
+        }
 
         // 3. `auto` is an opt-in sentinel: resolve to the provider default wire
         //    id without treating "auto" as a literal model name.

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -1,0 +1,218 @@
+//! The sole producer of [`ReadyRouteCandidate`] (#3384).
+//!
+//! [`RouteResolver::resolve`] is the ONLY caller of
+//! [`ReadyRouteCandidate::new`]. It resolves a [`RouteRequest`] into an
+//! executable route using:
+//!
+//! 1. provider from `explicit_provider` ONLY (no base-URL / prefix sniffing);
+//!    when absent, the workspace default provider scope is used. The provider
+//!    is NEVER inferred from a model prefix.
+//! 2. the model selector, interpreted STRICTLY within that provider's scope
+//!    against [`bundled_offerings`] plus the provider default. Prefixed
+//!    selectors are preserved verbatim as the [`WireModelId`].
+//! 3. `auto` => the [`LogicalModelRef::is_auto`] sentinel, never a literal
+//!    model.
+//!
+//! It encodes its OWN minimal direct/aggregator/local classification because
+//! the tui helpers (`provider_passes_model_through` /
+//! `accepts_custom_model_ids`) are not reachable from `crates/config`. The
+//! classification here is deliberately NARROWER than tui's `validate_route`:
+//! it only rejects [`RouteError::ForeignModelForDirectProvider`] for a small
+//! set of strict direct providers given a clearly-foreign selector;
+//! aggregators, local, and custom endpoints pass through `Ok` with
+//! `validation.ok == true`.
+//!
+//! There is deliberately no prompt-text / freeform field on [`RouteRequest`],
+//! which structurally bars prompt-content routing.
+
+use super::candidate::{
+    PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint, ValidationReport,
+};
+use super::descriptor::ProviderDescriptor;
+use super::errors::RouteError;
+use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
+use super::offering::bundled_offerings;
+use crate::ProviderKind;
+
+/// A request to resolve into an executable route.
+///
+/// Note the absence of any prompt-text/freeform field: the resolver cannot see
+/// prompt content, so it cannot silently route on it.
+#[derive(Debug, Clone, Default)]
+pub struct RouteRequest {
+    /// Explicit provider choice. The ONLY source of provider identity.
+    pub explicit_provider: Option<ProviderKind>,
+    /// The model the caller selected (may be `auto` or prefixed).
+    pub model_selector: Option<LogicalModelRef>,
+    /// A previously-saved provider wire model id, used as scope fallback.
+    pub saved_provider_model: Option<WireModelId>,
+    /// An explicit base URL override for the endpoint.
+    pub base_url_override: Option<String>,
+}
+
+/// Resolves [`RouteRequest`]s into [`ReadyRouteCandidate`]s.
+#[derive(Debug, Clone, Default)]
+pub struct RouteResolver;
+
+impl RouteResolver {
+    /// Construct a resolver.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Resolve a request into an executable route candidate.
+    ///
+    /// # Errors
+    /// Returns [`RouteError`] when the model is empty, the provider is invalid,
+    /// or a clearly-foreign model is requested for a strict direct provider.
+    pub fn resolve(&self, req: &RouteRequest) -> Result<ReadyRouteCandidate, RouteError> {
+        // 1. Provider scope from explicit choice only; default otherwise.
+        //    The provider is NEVER inferred from a model prefix.
+        let provider_kind = req.explicit_provider.unwrap_or_default();
+        let descriptor = ProviderDescriptor::for_kind(provider_kind);
+        let provider_id = descriptor.id();
+
+        // 2. Determine the logical selector + reject empties up front.
+        let logical_model = match &req.model_selector {
+            Some(selector) => {
+                if selector.raw().is_empty() {
+                    return Err(RouteError::EmptyModel);
+                }
+                selector.clone()
+            }
+            None => {
+                // No selector: fall back to saved wire model, then provider
+                // default. Both stay in the resolved provider's scope.
+                let raw = req
+                    .saved_provider_model
+                    .as_ref()
+                    .map(|w| w.as_str().to_string())
+                    .unwrap_or_else(|| descriptor.default_wire_model().as_str().to_string());
+                LogicalModelRef::from(raw)
+            }
+        };
+
+        // 3. `auto` is an opt-in sentinel: resolve to the provider default wire
+        //    id without treating "auto" as a literal model name.
+        let is_auto = logical_model.is_auto();
+
+        // 4. Map the selector to a wire id within provider scope.
+        //    Prefixed selectors are preserved VERBATIM as the wire id.
+        let class = classify(provider_kind);
+        let (wire_model_id, canonical_model) = if is_auto {
+            (descriptor.default_wire_model(), None)
+        } else {
+            self.scope_selector(provider_kind, &provider_id, &logical_model, class)?
+        };
+
+        let endpoint = ResolvedEndpoint {
+            base_url: req
+                .base_url_override
+                .clone()
+                .unwrap_or_else(|| descriptor.default_base_url().to_string()),
+            endpoint_key: "chat".to_string(),
+            protocol: descriptor.protocol(),
+        };
+
+        let validation = ValidationReport {
+            ok: true,
+            messages: Vec::new(),
+        };
+
+        Ok(ReadyRouteCandidate::new(
+            provider_id,
+            provider_kind,
+            logical_model,
+            canonical_model,
+            wire_model_id,
+            endpoint,
+            ResolvedAuthSource::Missing,
+            descriptor.protocol(),
+            Some(PricingSku::UnknownOrStale),
+            validation,
+        ))
+    }
+
+    /// Interpret a concrete (non-auto) selector strictly within provider scope.
+    fn scope_selector(
+        &self,
+        provider_kind: ProviderKind,
+        provider_id: &ProviderId,
+        logical_model: &LogicalModelRef,
+        class: ProviderClass,
+    ) -> Result<(WireModelId, Option<ModelId>), RouteError> {
+        let raw = logical_model.raw();
+
+        // Try to match a bundled offering owned by THIS provider, either by
+        // canonical model id or by exact wire id. This keeps interpretation
+        // inside provider scope; offerings from other providers are ignored.
+        for offering in bundled_offerings() {
+            if offering.provider != *provider_id {
+                continue;
+            }
+            let matches_canonical = offering
+                .canonical_model
+                .as_ref()
+                .is_some_and(|m| m.as_str() == raw);
+            let matches_wire = offering.wire_model_id.as_str() == raw;
+            if matches_canonical || matches_wire {
+                return Ok((offering.wire_model_id, offering.canonical_model));
+            }
+        }
+
+        // No catalog match. Apply class-specific pass-through rules.
+        match class {
+            ProviderClass::StrictDirect => {
+                // A clearly-foreign selector for a strict direct provider is
+                // rejected. "Clearly foreign" = it carries an aggregator/org
+                // namespace prefix, which a direct provider never expects.
+                if logical_model.namespace_hint().is_some() {
+                    return Err(RouteError::ForeignModelForDirectProvider {
+                        provider: provider_id.clone(),
+                        model: raw.to_string(),
+                    });
+                }
+                // A bare, unknown model on a strict direct provider is passed
+                // through verbatim (the provider validates it server-side).
+                Ok((WireModelId::from(raw), None))
+            }
+            // Aggregators, local runtimes, and custom OpenAI-compatible
+            // endpoints legitimately accept arbitrary / prefixed ids verbatim.
+            ProviderClass::Aggregator | ProviderClass::LocalOrCustom => {
+                let _ = provider_kind;
+                Ok((WireModelId::from(raw), None))
+            }
+        }
+    }
+}
+
+/// The resolver's minimal route classification.
+///
+/// Intentionally narrower than tui's `validate_route`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderClass {
+    /// Strict direct provider: rejects clearly-foreign (prefixed) selectors.
+    StrictDirect,
+    /// Aggregator: serves many catalogs under prefixed wire ids.
+    Aggregator,
+    /// Local runtime or custom OpenAI-compatible endpoint: pass-through.
+    LocalOrCustom,
+}
+
+/// Classify a provider kind for resolver pass-through rules.
+///
+/// Only a SMALL set of providers are strict-direct. Everything else passes
+/// through, so the resolver stays permissive by default.
+fn classify(kind: ProviderKind) -> ProviderClass {
+    match kind {
+        // Strict first-party direct providers.
+        ProviderKind::Deepseek | ProviderKind::Zai => ProviderClass::StrictDirect,
+        // Local runtimes / custom OpenAI-compatible endpoints.
+        ProviderKind::Ollama | ProviderKind::Vllm | ProviderKind::Sglang | ProviderKind::Openai => {
+            ProviderClass::LocalOrCustom
+        }
+        // Everything else is treated as an aggregator-style pass-through.
+        _ => ProviderClass::Aggregator,
+    }
+}

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -2,8 +2,20 @@
 
 use super::RequestProtocol;
 use super::descriptor::ProviderDescriptor;
+use super::errors::RouteError;
 use super::ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
+use super::resolver::{RouteRequest, RouteResolver};
 use crate::ProviderKind;
+
+/// Build a request with only an explicit provider + a model selector string.
+fn req(provider: Option<ProviderKind>, model: Option<&str>) -> RouteRequest {
+    RouteRequest {
+        explicit_provider: provider,
+        model_selector: model.map(LogicalModelRef::from),
+        saved_provider_model: None,
+        base_url_override: None,
+    }
+}
 
 #[test]
 fn provider_id_from_kind_uses_canonical_id() {
@@ -115,4 +127,134 @@ fn descriptor_protocol_matches_provider_wire() {
         };
         assert_eq!(d.protocol(), expected, "{kind:?} protocol mismatch");
     }
+}
+
+#[test]
+fn resolver_explicit_provider_scoped_model_maps_to_wire_id() {
+    let r = RouteResolver::new();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
+        .expect("should resolve");
+    assert_eq!(out.provider_kind, ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id.as_str(), "deepseek-v4-pro");
+    assert_eq!(
+        out.canonical_model.as_ref().map(ModelId::as_str),
+        Some("deepseek-v4-pro")
+    );
+}
+
+#[test]
+fn resolver_aggregator_preserves_prefixed_wire_id_without_inferring_deepseek() {
+    let r = RouteResolver::new();
+    let out = r
+        .resolve(&req(
+            Some(ProviderKind::Together),
+            Some("deepseek-ai/DeepSeek-V4-Pro"),
+        ))
+        .expect("aggregator should resolve");
+    // Provider stays Together, NOT Deepseek, despite the deepseek-ai/ prefix.
+    assert_eq!(out.provider_kind, ProviderKind::Together);
+    assert_ne!(out.provider_kind, ProviderKind::Deepseek);
+    // Wire id preserved verbatim.
+    assert_eq!(out.wire_model_id.as_str(), "deepseek-ai/DeepSeek-V4-Pro");
+}
+
+#[test]
+fn resolver_openrouter_keeps_provider_for_every_namespace_prefix() {
+    let r = RouteResolver::new();
+    let prefixes = [
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "deepseek/deepseek-v4-pro",
+        "anthropic/claude-foo",
+        "openai/gpt-foo",
+        "qwen/qwen-foo",
+    ];
+    for raw in prefixes {
+        let selector = LogicalModelRef::from(raw);
+        // The selector DOES carry a namespace hint...
+        assert!(
+            selector.namespace_hint().is_some(),
+            "{raw} should have a namespace hint"
+        );
+        let out = r
+            .resolve(&req(Some(ProviderKind::Openrouter), Some(raw)))
+            .unwrap_or_else(|e| panic!("{raw} should resolve on openrouter: {e}"));
+        // ...but the provider stays Openrouter regardless.
+        assert_eq!(
+            out.provider_kind,
+            ProviderKind::Openrouter,
+            "{raw} must not change provider"
+        );
+        assert_eq!(out.wire_model_id.as_str(), raw, "{raw} wire id verbatim");
+    }
+}
+
+#[test]
+fn resolver_no_explicit_provider_does_not_infer_deepseek_from_prefix() {
+    let r = RouteResolver::new();
+    // explicit_provider=None => default scope (Deepseek). A prefixed selector
+    // is foreign for the strict-direct default, so it ERRORS rather than being
+    // silently accepted as a deepseek model: the prefix never *selects* it.
+    let out = r.resolve(&req(None, Some("deepseek/deepseek-v4-pro")));
+    match out {
+        Err(RouteError::ForeignModelForDirectProvider { provider, model }) => {
+            assert_eq!(provider.as_str(), "deepseek");
+            assert_eq!(model, "deepseek/deepseek-v4-pro");
+        }
+        other => panic!("expected ForeignModelForDirectProvider, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolver_auto_is_sentinel_not_literal_model() {
+    let r = RouteResolver::new();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Deepseek), Some("auto")))
+        .expect("auto should resolve");
+    // The logical selector is the auto sentinel...
+    assert!(out.logical_model.is_auto());
+    // ...and "auto" is NOT put on the wire as a literal model.
+    assert_ne!(out.wire_model_id.as_str(), "auto");
+    assert_eq!(out.wire_model_id.as_str(), "deepseek-v4-pro");
+}
+
+#[test]
+fn resolver_strict_direct_rejects_clearly_foreign_selector() {
+    let r = RouteResolver::new();
+    let out = r.resolve(&req(Some(ProviderKind::Zai), Some("anthropic/claude-foo")));
+    match out {
+        Err(RouteError::ForeignModelForDirectProvider { provider, model }) => {
+            assert_eq!(provider.as_str(), "zai");
+            assert_eq!(model, "anthropic/claude-foo");
+        }
+        other => panic!("expected ForeignModelForDirectProvider, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolver_deepseek_none_selector_uses_default_wire_id() {
+    let r = RouteResolver::new();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Deepseek), None))
+        .expect("none selector should use provider default");
+    assert_eq!(out.provider_kind, ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id.as_str(), "deepseek-v4-pro");
+}
+
+#[test]
+fn resolver_empty_string_selector_is_empty_model_error() {
+    let r = RouteResolver::new();
+    let out = r.resolve(&req(Some(ProviderKind::Deepseek), Some("")));
+    assert!(matches!(out, Err(RouteError::EmptyModel)));
+}
+
+#[test]
+fn resolver_passthrough_provider_preserves_custom_id_verbatim() {
+    let r = RouteResolver::new();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Ollama), Some("my-local:7b")))
+        .expect("local passthrough should resolve");
+    assert_eq!(out.provider_kind, ProviderKind::Ollama);
+    assert_eq!(out.wire_model_id.as_str(), "my-local:7b");
+    assert!(out.validation.ok);
 }

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -249,6 +249,20 @@ fn resolver_empty_string_selector_is_empty_model_error() {
 }
 
 #[test]
+fn resolver_empty_saved_provider_model_is_empty_model_error() {
+    // An empty selector from the saved-model fallback must be rejected too, not
+    // just an empty explicit selector (the guard covers every selector source).
+    let r = RouteResolver::new();
+    let request = RouteRequest {
+        explicit_provider: Some(ProviderKind::Deepseek),
+        model_selector: None,
+        saved_provider_model: Some(WireModelId::from("")),
+        base_url_override: None,
+    };
+    assert!(matches!(r.resolve(&request), Err(RouteError::EmptyModel)));
+}
+
+#[test]
 fn resolver_passthrough_provider_preserves_custom_id_verbatim() {
     let r = RouteResolver::new();
     let out = r

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -258,3 +258,64 @@ fn resolver_passthrough_provider_preserves_custom_id_verbatim() {
     assert_eq!(out.wire_model_id.as_str(), "my-local:7b");
     assert!(out.validation.ok);
 }
+
+#[test]
+fn resolved_candidate_serializes_secret_free() {
+    let r = RouteResolver::new();
+    // Cover a direct, an aggregator, and a local/passthrough route.
+    let candidates = [
+        r.resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
+            .expect("direct resolves"),
+        r.resolve(&req(
+            Some(ProviderKind::Together),
+            Some("deepseek-ai/DeepSeek-V4-Pro"),
+        ))
+        .expect("aggregator resolves"),
+        r.resolve(&req(Some(ProviderKind::Ollama), Some("my-local:7b")))
+            .expect("local resolves"),
+    ];
+    for out in candidates {
+        let json = serde_json::to_string(&out).expect("candidate serializes");
+        // Carries provider/model/wire/protocol/auth-source class.
+        assert!(json.contains("provider_id"), "{json}");
+        assert!(json.contains("provider_kind"), "{json}");
+        assert!(json.contains("wire_model_id"), "{json}");
+        assert!(json.contains("protocol"), "{json}");
+        assert!(json.contains("auth"), "{json}");
+        // Never any secret/api-key material.
+        let lower = json.to_lowercase();
+        assert!(!lower.contains("api_key"), "leaked api_key: {json}");
+        assert!(!lower.contains("apikey"), "leaked apikey: {json}");
+        assert!(!lower.contains("secret_id"), "leaked secret_id: {json}");
+        assert!(!lower.contains("password"), "leaked password: {json}");
+        assert!(!lower.contains("bearer"), "leaked bearer: {json}");
+        assert!(
+            !lower.contains("authorization"),
+            "leaked authorization: {json}"
+        );
+    }
+}
+
+#[test]
+fn resolver_protocol_matches_descriptor_for_every_provider() {
+    let r = RouteResolver::new();
+    for kind in ProviderKind::ALL {
+        // Use each provider's own default wire id as the selector so strict
+        // direct providers do not reject; this exercises the resolver across
+        // the whole provider set.
+        let default_wire = ProviderDescriptor::for_kind(kind).default_wire_model();
+        let request = req(Some(kind), Some(default_wire.as_str()));
+        let out = r
+            .resolve(&request)
+            .unwrap_or_else(|e| panic!("{kind:?} should resolve its own default: {e}"));
+        assert_eq!(
+            out.protocol,
+            ProviderDescriptor::for_kind(kind).protocol(),
+            "{kind:?} candidate protocol must match descriptor"
+        );
+        assert_eq!(
+            out.endpoint.protocol, out.protocol,
+            "{kind:?} endpoint protocol"
+        );
+    }
+}

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -1,5 +1,7 @@
 //! Behavior tests for the route foundation (#2608 / #3084 / #3384).
 
+use super::RequestProtocol;
+use super::descriptor::ProviderDescriptor;
 use super::ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
 use crate::ProviderKind;
 
@@ -77,4 +79,40 @@ fn newtypes_serialize_transparently() {
         serde_json::to_string(&wire).unwrap(),
         "\"deepseek-ai/DeepSeek-V4-Pro\""
     );
+}
+
+#[test]
+fn descriptor_for_every_kind_has_nonempty_transport_facts() {
+    for kind in ProviderKind::ALL {
+        let d = ProviderDescriptor::for_kind(kind);
+        assert!(!d.id().as_str().is_empty(), "{kind:?} id empty");
+        assert!(
+            !d.default_base_url().is_empty(),
+            "{kind:?} default_base_url empty"
+        );
+        assert!(
+            !d.default_wire_model().as_str().is_empty(),
+            "{kind:?} default_wire_model empty"
+        );
+        // protocol() always yields a RequestProtocol; calling it must not panic.
+        let _: RequestProtocol = d.protocol();
+    }
+}
+
+#[test]
+fn descriptor_protocol_matches_provider_wire() {
+    for kind in ProviderKind::ALL {
+        let d = ProviderDescriptor::for_kind(kind);
+        assert_eq!(
+            d.protocol(),
+            kind.provider().wire(),
+            "{kind:?} protocol must equal provider().wire()"
+        );
+        let expected = match kind {
+            ProviderKind::OpenaiCodex => RequestProtocol::Responses,
+            ProviderKind::Anthropic => RequestProtocol::AnthropicMessages,
+            _ => RequestProtocol::ChatCompletions,
+        };
+        assert_eq!(d.protocol(), expected, "{kind:?} protocol mismatch");
+    }
 }

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -1,0 +1,80 @@
+//! Behavior tests for the route foundation (#2608 / #3084 / #3384).
+
+use super::ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
+use crate::ProviderKind;
+
+#[test]
+fn provider_id_from_kind_uses_canonical_id() {
+    assert_eq!(
+        ProviderId::from_kind(ProviderKind::Deepseek).as_str(),
+        "deepseek"
+    );
+    assert_eq!(
+        ProviderId::from_kind(ProviderKind::Openrouter).as_str(),
+        "openrouter"
+    );
+}
+
+#[test]
+fn model_id_and_wire_model_id_are_distinct_types() {
+    // This test asserts the values; the *type* distinction is enforced by the
+    // compiler: a function taking `WireModelId` rejects a `ModelId` argument.
+    let canonical = ModelId::from("deepseek-v4-pro");
+    let wire = WireModelId::from("deepseek-ai/DeepSeek-V4-Pro");
+    assert_eq!(canonical.as_str(), "deepseek-v4-pro");
+    assert_eq!(wire.as_str(), "deepseek-ai/DeepSeek-V4-Pro");
+}
+
+#[test]
+fn logical_model_ref_auto_is_sentinel() {
+    assert!(LogicalModelRef::from("auto").is_auto());
+    assert!(!LogicalModelRef::from("deepseek-v4-pro").is_auto());
+}
+
+#[test]
+fn logical_model_ref_namespace_hint_parses_curated_prefixes() {
+    let cases = [
+        ("deepseek-ai/DeepSeek-V4-Pro", NamespaceHint::DeepseekAi),
+        ("deepseek/deepseek-v4-pro", NamespaceHint::Deepseek),
+        ("anthropic/claude-foo", NamespaceHint::Anthropic),
+        ("openai/gpt-foo", NamespaceHint::Openai),
+        ("qwen/qwen-foo", NamespaceHint::Qwen),
+    ];
+    for (raw, expected) in cases {
+        assert_eq!(
+            LogicalModelRef::from(raw).namespace_hint(),
+            Some(expected),
+            "{raw} should parse to {expected:?}"
+        );
+    }
+    assert_eq!(LogicalModelRef::from("plain-model").namespace_hint(), None);
+    assert_eq!(LogicalModelRef::from("auto").namespace_hint(), None);
+}
+
+/// By construction there is NO path from a namespace prefix to a provider.
+///
+/// This is enforced by the *absence* of any `From<NamespaceHint>` /
+/// `From<LogicalModelRef>` for `ProviderId`. The following lines are the
+/// canonical way to mint a `ProviderId` and demonstrate the only supported
+/// source is an explicit `ProviderKind`, never a parsed prefix.
+#[test]
+fn no_namespace_hint_or_logical_ref_to_provider_id_conversion() {
+    let hint = LogicalModelRef::from("deepseek-ai/DeepSeek-V4-Pro").namespace_hint();
+    assert_eq!(hint, Some(NamespaceHint::DeepseekAi));
+    // A ProviderId may ONLY be built from an explicit ProviderKind or string,
+    // never derived from the hint above. (If a `From<NamespaceHint>` for
+    // `ProviderId` were ever added, this seam would silently break #2608.)
+    let provider = ProviderId::from_kind(ProviderKind::Together);
+    assert_eq!(provider.as_str(), "together");
+}
+
+#[test]
+fn newtypes_serialize_transparently() {
+    let id = ProviderId::from("deepseek");
+    assert_eq!(serde_json::to_string(&id).unwrap(), "\"deepseek\"");
+    let wire = WireModelId::from("deepseek-ai/DeepSeek-V4-Pro");
+    assert_eq!(
+        serde_json::to_string(&wire).unwrap(),
+        "\"deepseek-ai/DeepSeek-V4-Pro\""
+    );
+}


### PR DESCRIPTION
## What

The **backbone of the v0.8.65 EPIC #2608** provider/model/route rework: a new, **additive, runtime-unwired** `crates/config/src/route/` module that gives the whole codebase one place to resolve routes. Implements the type layer of **#3084** and the `ReadyRouteCandidate`/`RouteResolver` mutation gate of **#3384**.

This is slice 1 (types + resolver). It is wired into **nothing** yet — no call site changes — so it lands green and the route consumers (#3383/#3075/#3083/#3086/#3085/#2574/#1519/#3222) and Fleet (#3154) rebase onto it next.

## The #2608 invariant, enforced structurally (not just documented)

> A model string alone is never enough to select a route. Execution requires a `ReadyRouteCandidate`, which only `RouteResolver` can produce.

- **`LogicalModelRef`** parses provider/org prefixes (`deepseek-ai/`, `deepseek/`, `anthropic/`, `openai/`, `qwen/`) only into an advisory `namespace_hint()` — there is **deliberately no `From<NamespaceHint>`/`From<LogicalModelRef>` for `ProviderId`**, so a prefix can never become a provider selection (compiler-enforced).
- **`RouteRequest` has no prompt-text field** — the resolver physically cannot route on freeform content.
- **`ReadyRouteCandidate` is `#[non_exhaustive]` and does not derive `Deserialize`** — no other crate can fabricate one via struct literal or serde; the only constructor is `pub(super) fn new`, and `RouteResolver::resolve` is its sole caller. A candidate's existence is proof it passed the resolver.
- The resolver interprets a prefixed selector **only within the already-chosen provider scope** (e.g. `deepseek-ai/…` under `Together` stays Together, wire id preserved verbatim).

## Types (all new, in `crates/config`)

`ProviderId` · `ModelId` · `WireModelId` · `LogicalModelRef` (#3084 newtypes) · `ProviderDescriptor`/`EndpointDescriptor`/`ProviderModelOffering` (thin views over the existing `Provider`/`PROVIDER_REGISTRY`/`WireFormat` — no duplicated provider facts) · `ReadyRouteCandidate` + `ResolvedEndpoint`/`ResolvedAuthSource`/`PricingSku`/`ValidationReport` · `RouteResolver`/`RouteRequest`/`RouteError`. `RequestProtocol` is a `pub use` **alias** of the existing `WireFormat` (no 4th protocol synonym).

## Reuse, not duplication
- Wraps the existing `Provider` trait + `PROVIDER_REGISTRY` + `WireFormat` + `ProviderKind`. The only change to existing code is `+pub mod route;` in `lib.rs` and adding `#[derive(Serialize, Deserialize)]` to `WireFormat` (additive).
- `ModelProfile`/`CapabilityProfile` (#3365, already on main) are **not** duplicated — `ReadyRouteCandidate` defers the `capabilities`/`config_snapshot` fields to a later slice to avoid a `tui→config` type move.

## Verification
- `cargo test -p codewhale-config` → **201 passed / 0 failed** (181 baseline + 20 new `route::` tests incl. resolver behavior + descriptor conformance + secret-free candidate serialization).
- `cargo clippy -p codewhale-config` (CI allow-flags, `-D warnings`) → clean.
- `cargo fmt --check` → clean.
- Built/verified with TDD; an adversarial 3-lens review (Rust soundness · #2608 invariant · CI greenness) ran and its findings (forgeable candidate, empty-model guard gap) are fixed in the final commit.
- **No new dependency**, `Cargo.lock` unchanged. Nothing outside `crates/config` touched (`config.rs`/`ui.rs`/`client.rs`/`engine.rs`/`app-server`/`agent` and the `ProviderKind::ALL`/`PROVIDER_REGISTRY` arrays are untouched).

## Notes for the reviewer
- Based on `origin/main`; the diff is **config-only**. ⚠️ Full-workspace CI is red until **#3453** (the broken-`main` `doctor_api_key_source_label` `E0004`) lands — unrelated to this PR; `crates/config` doesn't depend on `crates/tui`, hence the isolated `-p codewhale-config` verification.
- 🚩 Unrelated but worth flagging: **#2963 and #3357 both bump `ProviderKind::ALL` to `[Self; 26]`** off a 25-base → landing both = 27 elements, no merge conflict → silent compile break. The descriptor foundation here is the path to making those arrays data-driven later.
- `RouteError::{AmbiguousModel, InvalidProvider}` are reserved for the future global-search path (resolver doesn't produce them yet; covered by the module `#![allow(dead_code)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)