### PR TITLE
docs(bridge): rebrand Feishu/WeCom bridge READMEs to CodeWhale + trust-boundary notes (Track D3)

### DIFF
--- a/integrations/feishu-bridge/README.md
+++ b/integrations/feishu-bridge/README.md
@@ -7,20 +7,24 @@ mode, so the first version does not need a public webhook URL.
 Security model:
 
 - `codewhale serve --http` stays bound to `127.0.0.1`.
-- `/v1/*` runtime calls use `DEEPSEEK_RUNTIME_TOKEN`.
-- Feishu/Lark chats must be allowlisted unless `DEEPSEEK_ALLOW_UNLISTED=true`
+- `/v1/*` runtime calls use `CODEWHALE_RUNTIME_TOKEN`.
+- Feishu/Lark chats must be allowlisted in `CODEWHALE_CHAT_ALLOWLIST` unless
+  `CODEWHALE_ALLOW_UNLISTED=true`
   is set for first pairing.
 - Direct messages are the intended MVP control surface. Group chat control is
   disabled unless `FEISHU_ALLOW_GROUPS=true`.
 - Tool approvals are text commands: `/allow <approval_id>` or `/deny <approval_id>`.
+- Feishu/Lark only sees the prompts, status, thread summaries, and approval
+  messages the bridge sends. The workspace, shell, and runtime HTTP listener
+  stay local behind the CodeWhale runtime token.
 
 ## Setup
 
 ```bash
-cd /opt/codewhale/bridge
+cd /opt/codewhale/feishu-bridge
 npm install --omit=dev
-cp .env.example /etc/deepseek/feishu-bridge.env
-sudoedit /etc/deepseek/feishu-bridge.env
+cp .env.example /etc/codewhale/feishu-bridge.env
+sudoedit /etc/codewhale/feishu-bridge.env
 node src/index.mjs
 ```
 
@@ -28,11 +32,15 @@ Validate the env files before starting the service:
 
 ```bash
 npm run validate:config -- \
-  --env /etc/deepseek/feishu-bridge.env \
-  --runtime-env /etc/deepseek/runtime.env \
+  --env /etc/codewhale/feishu-bridge.env \
+  --runtime-env /etc/codewhale/runtime.env \
   --workspace-root /opt/whalebro \
   --check-filesystem
 ```
+
+For first pairing, temporarily set `CODEWHALE_ALLOW_UNLISTED=true`, send the
+bot `/status`, copy the returned `chat_id`, `open_id`, or `union_id` into
+`CODEWHALE_CHAT_ALLOWLIST`, then turn `CODEWHALE_ALLOW_UNLISTED=false`.
 
 For a Tencent Lighthouse deployment, use:
 
@@ -47,14 +55,15 @@ sudo journalctl -u codewhale-feishu-bridge -f
 - `/threads`
 - `/new`
 - `/resume <thread_id>`
+- `/model <name|default>`
 - `/interrupt`
 - `/compact`
 - `/allow <approval_id> [remember]`
 - `/deny <approval_id>`
 
 Anything else is sent as a prompt. If group control is explicitly enabled,
-messages must start with `/ds` by default, for example:
+messages should start with the CodeWhale prefix `/cw`, for example:
 
 ```text
-/ds check git status and tell me what is dirty
+/cw check git status and tell me what is dirty
 ```

--- a/integrations/wecom-bridge/README.md
+++ b/integrations/wecom-bridge/README.md
@@ -11,9 +11,11 @@
 - `codewhale serve --http` 绑定于 `127.0.0.1`。
 - `/v1/*` runtime 调用使用 `CODEWHALE_RUNTIME_TOKEN`。
 - 企业微信用户必须加入白名单（`WECOM_CHAT_ALLOWLIST`），除非首次配对时设置 `WECOM_ALLOW_UNLISTED=true`。
-- 支持私聊和群聊（群聊需要前缀 `/ds`）。
+- 支持私聊和群聊（群聊需要前缀 `/cw`）。
 - 工具审批通过文本命令：`/allow <approval_id>` 或 `/deny <approval_id>`。
 - 长连接模式无需公网端口。
+- 企业微信只会看到 bridge 发送的提示、状态、线程摘要和审批消息；工作区、shell 和 runtime HTTP
+  监听仍留在本机，并由 `CODEWHALE_RUNTIME_TOKEN` 保护。
 
 ## 前提
 
@@ -49,7 +51,7 @@ node src/index.mjs
 | `/allow <approval_id> [remember]` | 批准待处理的工具调用 |
 | `/deny <approval_id>` | 拒绝待处理的工具调用 |
 
-其他所有内容均作为 CodeWhale 提示发送。群聊中需要在消息前加 `/ds` 前缀。
+其他所有内容均作为 CodeWhale 提示发送。群聊中需要在消息前加 `/cw` 前缀。
 
 ## 首次配对
 


### PR DESCRIPTION
## What
Track D3 docs cleanup: removes DeepSeek-era residue from the Feishu/Lark and WeCom bridge READMEs and aligns them with the branded Telegram bridge, plus adds a concise per-bridge trust-boundary note (education-forward operator posture).

- `DEEPSEEK_RUNTIME_TOKEN` → `CODEWHALE_RUNTIME_TOKEN`, `DEEPSEEK_ALLOW_UNLISTED` → `CODEWHALE_ALLOW_UNLISTED`, `/etc/deepseek` → `/etc/codewhale`, `/ds` → `/cw`.
- Names the allowlist var (`CODEWHALE_CHAT_ALLOWLIST` for Feishu, `WECOM_CHAT_ALLOWLIST` for WeCom) and documents the first-pairing flow.
- Trust-boundary note per bridge: the chat platform only sees prompts/status/approvals; workspace, shell, and the runtime HTTP listener stay on localhost behind the runtime token.

## Verification
Docs-only. Every env var + command was **verified against the bridge source** (not invented): `feishu-bridge/src/index.mjs` reads `CODEWHALE_CHAT_ALLOWLIST`/`CODEWHALE_ALLOW_UNLISTED` (with `DEEPSEEK_*` compat fallback), and `/model`/`/cw` are real bridge commands. Weixin left unchanged (already branded). The only remaining `DEEPSEEK_*` mention in the bridge READMEs is Telegram's intentional compatibility-fallback note.

Drafted by a Codex sub-agent, verified against the code by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)