### PR TITLE
docs(config): document saved ask rules from approvals

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1011,8 +1011,13 @@ If you are upgrading from older releases:
   `[[rules]]` entries with `tool` plus optional `command` or `path` fields.
   Loaded rules feed the execution policy engine and force approval in approval
   modes that can ask; under `approval_policy = "never"`, matching ask rules are
-  rejected because no prompt can be shown. This intentionally does not accept
-  typed allow/deny records, glob expansion, or approval UI persistence yet.
+  rejected because no prompt can be shown. In an `exec_shell` approval card,
+  press `S` to approve the request once and save an ask rule containing that
+  command to this file. Only `exec_shell` cards support this shortcut; saved
+  command rules use existing arity-aware prefix matching. File-path ask rules
+  can be added manually and are matched at runtime, but the approval UI does
+  not save file rules yet. This intentionally does not accept typed allow/deny
+  records or glob expansion.
 - `[auto_review]` (table, optional): deterministic tool-call review policy.
   This layer sits on top of existing approval modes; it can force a prompt or
   block a tool call, but it is not an auto-push, auto-merge, or hosted review

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -76,7 +76,11 @@ ask records are currently a narrow foundation: when one matches under
 ask the user; existing allow/deny behavior is otherwise unchanged. The TUI
 runtime loads ask-only records from the sibling `permissions.toml` file and
 applies matching `exec_shell` command ask-rules and explicit file-path ask-rules
-before Auto/session approval shortcuts.
+before Auto/session approval shortcuts. In an `exec_shell` approval card, `S`
+approves once and saves an ask rule containing that command; only `exec_shell`
+cards support the shortcut, and saved command rules use existing arity-aware
+prefix matching. File-path ask rules can be authored in `permissions.toml` and
+matched at runtime, but cannot yet be saved from the approval UI.
 
 ### MCP manager and palette discovery
 


### PR DESCRIPTION
## Summary

Document the current persistence behavior for ask rules created from approval cards.

## Scope

- Replace the stale statement that approval UI persistence is unsupported.
- Document that `S` is available only in `exec_shell` approval cards.
- Clarify that `S` approves once and persists an ask rule containing the approved command.
- Document that saved command rules use the existing arity-aware prefix matching.
- Clarify that file-path ask rules can be authored in `permissions.toml` and matched at runtime, but cannot yet be saved through the approval UI.

## Not in this slice

- Typed allow/deny rules.
- Glob expansion.
- File-rule creation from the approval UI.
- Changes to runtime approval or persistence behavior.

## Builds on

- The landed ask-only `permissions.toml` schema and runtime wiring.
- The landed approval-card persistence for `exec_shell` ask rules.

## Issues

Refs #1186 (partial)  
Refs #2242 (partial)

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`