### PR TITLE
refactor(tools): trim eager tool surface — task_shell_* + tool_search_* fold (Track C1)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3699,9 +3699,8 @@ use self::tool_catalog::{
 };
 #[cfg(test)]
 use self::tool_catalog::{
-    TOOL_SEARCH_BM25_NAME, TOOL_SEARCH_REGEX_NAME, build_model_tool_catalog,
-    maybe_activate_requested_deferred_tool, preflight_requested_deferred_tool,
-    should_default_defer_tool,
+    TOOL_SEARCH_NAME, build_model_tool_catalog, maybe_activate_requested_deferred_tool,
+    preflight_requested_deferred_tool, should_default_defer_tool,
 };
 use self::tool_execution::emit_tool_audit;
 use self::tool_setup::{sandbox_policy_for_mode, shell_policy_for_mode};

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1272,8 +1272,8 @@ fn non_yolo_mode_retains_default_defer_policy() {
     ));
     assert!(!should_default_defer_tool("web_search", &always_load));
     assert!(!should_default_defer_tool("write_file", &always_load));
-    assert!(!should_default_defer_tool("task_shell_start", &always_load));
-    assert!(!should_default_defer_tool("task_shell_wait", &always_load));
+    assert!(should_default_defer_tool("task_shell_start", &always_load));
+    assert!(should_default_defer_tool("task_shell_wait", &always_load));
     assert!(should_default_defer_tool("git_blame", &always_load));
 }
 
@@ -1318,7 +1318,7 @@ fn capability_compact_surface_defers_nonessential_core_tools() {
             api_tool("grep_files"),
             api_tool("read_file"),
             api_tool("run_tests"),
-            api_tool(TOOL_SEARCH_REGEX_NAME),
+            api_tool(TOOL_SEARCH_NAME),
             api_tool("update_plan"),
             api_tool("web_search"),
             api_tool("write_file"),
@@ -1340,7 +1340,7 @@ fn capability_compact_surface_defers_nonessential_core_tools() {
     assert_eq!(defer_loading("grep_files"), Some(false));
     assert_eq!(defer_loading("update_plan"), Some(false));
     assert_eq!(defer_loading("write_file"), Some(false));
-    assert_eq!(defer_loading(TOOL_SEARCH_REGEX_NAME), Some(false));
+    assert_eq!(defer_loading(TOOL_SEARCH_NAME), Some(false));
     assert_eq!(defer_loading("list_mcp_resources"), Some(false));
     assert_eq!(defer_loading("agent"), Some(true));
     assert_eq!(defer_loading("run_tests"), Some(true));
@@ -1504,7 +1504,7 @@ fn agent_catalog_advertises_and_searches_core_action_tools() {
 
         let mut active = initial_active_tools(&catalog);
         let result = execute_tool_search(
-            TOOL_SEARCH_BM25_NAME,
+            TOOL_SEARCH_NAME,
             &json!({ "query": tool_name }),
             &catalog,
             &mut active,
@@ -1560,7 +1560,7 @@ fn tool_search_reports_known_core_action_tool_when_current_catalog_omits_it() {
     let mut active = initial_active_tools(&catalog);
 
     let result = execute_tool_search(
-        TOOL_SEARCH_BM25_NAME,
+        TOOL_SEARCH_NAME,
         &json!({ "query": "exec_shell" }),
         &catalog,
         &mut active,
@@ -3818,7 +3818,7 @@ fn tool_search_activates_discovered_deferred_tools() {
     ensure_advanced_tooling(&mut catalog, AppMode::Agent, &always_load);
     let mut active = initial_active_tools(&catalog);
     let result = execute_tool_search(
-        TOOL_SEARCH_BM25_NAME,
+        TOOL_SEARCH_NAME,
         &json!({"query":"read file"}),
         &catalog,
         &mut active,
@@ -3860,11 +3860,11 @@ fn tool_search_reference_count(result: &ToolResult) -> usize {
 fn tool_search_defaults_to_twenty_results_for_regex_and_bm25() {
     let catalog = tool_search_catalog_with_matches(25);
 
-    for tool_name in [TOOL_SEARCH_REGEX_NAME, TOOL_SEARCH_BM25_NAME] {
+    for match_kind in ["regex", "bm25"] {
         let mut active = initial_active_tools(&catalog);
         let result = execute_tool_search(
-            tool_name,
-            &json!({"query":"matching"}),
+            TOOL_SEARCH_NAME,
+            &json!({"query":"matching","match":match_kind}),
             &catalog,
             &mut active,
         )
@@ -3880,7 +3880,7 @@ fn tool_search_respects_and_caps_max_results() {
 
     let mut active = initial_active_tools(&catalog);
     let limited = execute_tool_search(
-        TOOL_SEARCH_BM25_NAME,
+        TOOL_SEARCH_NAME,
         &json!({"query":"matching","max_results":7}),
         &catalog,
         &mut active,
@@ -3890,8 +3890,8 @@ fn tool_search_respects_and_caps_max_results() {
 
     let mut active = initial_active_tools(&catalog);
     let capped = execute_tool_search(
-        TOOL_SEARCH_REGEX_NAME,
-        &json!({"query":"matching","max_results":999}),
+        TOOL_SEARCH_NAME,
+        &json!({"query":"matching","match":"regex","max_results":999}),
         &catalog,
         &mut active,
     )
@@ -3905,17 +3905,16 @@ fn tool_search_schema_exposes_max_results_default_and_cap() {
     let always_load = HashSet::new();
     ensure_advanced_tooling(&mut catalog, AppMode::Agent, &always_load);
 
-    for tool_name in [TOOL_SEARCH_REGEX_NAME, TOOL_SEARCH_BM25_NAME] {
-        let tool = catalog
-            .iter()
-            .find(|tool| tool.name == tool_name)
-            .expect("tool search definition exists");
-        let schema = &tool.input_schema["properties"]["max_results"];
+    let tool = catalog
+        .iter()
+        .find(|tool| tool.name == TOOL_SEARCH_NAME)
+        .expect("tool search definition exists");
+    let schema = &tool.input_schema["properties"]["max_results"];
 
-        assert_eq!(schema["default"], 20);
-        assert_eq!(schema["maximum"], 100);
-        assert_eq!(schema["minimum"], 1);
-    }
+    assert_eq!(schema["default"], 20);
+    assert_eq!(schema["maximum"], 100);
+    assert_eq!(schema["minimum"], 1);
+    assert_eq!(tool.input_schema["properties"]["match"]["default"], "bm25");
 }
 
 #[tokio::test]
@@ -4030,7 +4029,7 @@ fn missing_tool_error_message_offers_suggestions() {
     let message = missing_tool_error_message("reed_file", &catalog);
     assert!(message.contains("Did you mean:"));
     assert!(message.contains("read_file"));
-    assert!(message.contains(TOOL_SEARCH_BM25_NAME));
+    assert!(message.contains(TOOL_SEARCH_NAME));
 }
 
 #[test]
@@ -4049,7 +4048,7 @@ fn missing_tool_error_message_includes_discovery_guidance_when_no_match() {
 
     let message = missing_tool_error_message("totally_unknown_tool", &catalog);
     assert!(message.contains("not available in the current tool catalog"));
-    assert!(message.contains(TOOL_SEARCH_BM25_NAME));
+    assert!(message.contains(TOOL_SEARCH_NAME));
 }
 
 #[test]
@@ -4082,10 +4081,7 @@ fn missing_shell_tool_error_message_names_allow_shell_gate() {
         );
         assert!(!message.contains("YOLO"), "{tool_name}: {message}");
         assert!(!message.contains("auto-approve"), "{tool_name}: {message}");
-        assert!(
-            message.contains(TOOL_SEARCH_BM25_NAME),
-            "{tool_name}: {message}"
-        );
+        assert!(message.contains(TOOL_SEARCH_NAME), "{tool_name}: {message}");
     }
 }
 
@@ -4104,7 +4100,7 @@ fn missing_shell_tool_error_message_keeps_allow_shell_hint_with_suggestions() {
     assert!(message.contains("Agent mode"));
     assert!(!message.contains("YOLO"));
     assert!(!message.contains("auto-approve"));
-    assert!(message.contains(TOOL_SEARCH_BM25_NAME));
+    assert!(message.contains(TOOL_SEARCH_NAME));
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -14,7 +14,7 @@ use serde_json::{Value, json};
 use crate::mcp::McpPool;
 use crate::model_profile::ToolSurfaceBudget;
 use crate::models::Tool;
-use crate::tools::spec::{ToolError, ToolResult, optional_u64, required_str};
+use crate::tools::spec::{ToolError, ToolResult, optional_str, optional_u64, required_str};
 use crate::tui::app::AppMode;
 
 use crate::dependencies::ExternalTool;
@@ -24,15 +24,18 @@ pub(super) const REQUEST_USER_INPUT_NAME: &str = "request_user_input";
 pub(super) const CODE_EXECUTION_TOOL_NAME: &str = "code_execution";
 const CODE_EXECUTION_TOOL_TYPE: &str = "code_execution_20250825";
 pub(super) use crate::tools::js_execution::JS_EXECUTION_TOOL_NAME;
-pub(super) const TOOL_SEARCH_REGEX_NAME: &str = "tool_search_tool_regex";
-const TOOL_SEARCH_REGEX_TYPE: &str = "tool_search_tool_regex_20251119";
-pub(super) const TOOL_SEARCH_BM25_NAME: &str = "tool_search_tool_bm25";
-const TOOL_SEARCH_BM25_TYPE: &str = "tool_search_tool_bm25_20251119";
+pub(super) const TOOL_SEARCH_NAME: &str = "tool_search";
+const TOOL_SEARCH_TYPE: &str = "tool_search_20251119";
+const LEGACY_TOOL_SEARCH_REGEX_NAME: &str = "tool_search_tool_regex";
+const LEGACY_TOOL_SEARCH_BM25_NAME: &str = "tool_search_tool_bm25";
 const TOOL_SEARCH_DEFAULT_MAX_RESULTS: usize = 20;
 const TOOL_SEARCH_MAX_RESULTS_LIMIT: usize = 100;
 
 pub(super) fn is_tool_search_tool(name: &str) -> bool {
-    matches!(name, TOOL_SEARCH_REGEX_NAME | TOOL_SEARCH_BM25_NAME)
+    matches!(
+        name,
+        TOOL_SEARCH_NAME | LEGACY_TOOL_SEARCH_REGEX_NAME | LEGACY_TOOL_SEARCH_BM25_NAME
+    )
 }
 
 pub(super) const DEFAULT_ACTIVE_NATIVE_TOOLS: &[&str] = &[
@@ -59,8 +62,6 @@ pub(super) const DEFAULT_ACTIVE_NATIVE_TOOLS: &[&str] = &[
     "task_create",
     "task_list",
     "task_read",
-    "task_shell_start",
-    "task_shell_wait",
     "update_plan",
     "wait_for_dev_server",
     "web_search",
@@ -197,13 +198,7 @@ fn apply_tool_surface_budget(
         }
         if matches!(
             tool.name.as_str(),
-            "agent"
-                | "run_tests"
-                | "run_verifiers"
-                | "task_create"
-                | "task_shell_start"
-                | "task_shell_wait"
-                | "web_search"
+            "agent" | "run_tests" | "run_verifiers" | "task_create" | "web_search"
         ) {
             tool.defer_loading = Some(true);
         }
@@ -262,42 +257,21 @@ pub(super) fn ensure_advanced_tooling(
         catalog.push(tool);
     }
 
-    if !catalog.iter().any(|t| t.name == TOOL_SEARCH_REGEX_NAME) {
+    if !catalog.iter().any(|t| t.name == TOOL_SEARCH_NAME) {
         catalog.push(Tool {
-            tool_type: Some(TOOL_SEARCH_REGEX_TYPE.to_string()),
-            name: TOOL_SEARCH_REGEX_NAME.to_string(),
-            description: "Search deferred tool definitions using a regex query and return matching tool references.".to_string(),
+            tool_type: Some(TOOL_SEARCH_TYPE.to_string()),
+            name: TOOL_SEARCH_NAME.to_string(),
+            description: "Search deferred tool definitions and return matching tool references.".to_string(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "query": { "type": "string", "description": "Regex pattern to search tool names/descriptions/schema." },
-                    "max_results": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": TOOL_SEARCH_MAX_RESULTS_LIMIT,
-                        "default": TOOL_SEARCH_DEFAULT_MAX_RESULTS,
-                        "description": "Maximum number of matching tool references to return."
-                    }
-                },
-                "required": ["query"]
-            }),
-            allowed_callers: Some(vec!["direct".to_string()]),
-            defer_loading: Some(false),
-            input_examples: None,
-            strict: None,
-            cache_control: None,
-        });
-    }
-
-    if !catalog.iter().any(|t| t.name == TOOL_SEARCH_BM25_NAME) {
-        catalog.push(Tool {
-            tool_type: Some(TOOL_SEARCH_BM25_TYPE.to_string()),
-            name: TOOL_SEARCH_BM25_NAME.to_string(),
-            description: "Search deferred tool definitions using natural-language matching and return matching tool references.".to_string(),
-            input_schema: json!({
-                "type": "object",
-                "properties": {
-                    "query": { "type": "string", "description": "Natural language query for tool discovery." },
+                    "query": { "type": "string", "description": "Search query for tool discovery." },
+                    "match": {
+                        "type": "string",
+                        "enum": ["bm25", "regex"],
+                        "default": "bm25",
+                        "description": "Matching algorithm: bm25 for natural-language matching, regex for a regular expression over tool names/descriptions/schema."
+                    },
                     "max_results": {
                         "type": "integer",
                         "minimum": 1,
@@ -651,12 +625,12 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
         if let Some(shell_hint) = shell_hint {
             return format!(
                 "Tool '{tool_name}' is not available in the current tool catalog. \
-                 {shell_hint}, or use {TOOL_SEARCH_BM25_NAME} with a short query."
+                 {shell_hint}, or use {TOOL_SEARCH_NAME} with a short query."
             );
         }
         return format!(
             "Tool '{tool_name}' is not available in the current tool catalog. \
-             Verify mode/feature flags, or use {TOOL_SEARCH_BM25_NAME} with a short query."
+             Verify mode/feature flags, or use {TOOL_SEARCH_NAME} with a short query."
         );
     }
 
@@ -665,13 +639,13 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
         return format!(
             "Tool '{tool_name}' is not available in the current tool catalog. \
              {suggestion_text} {shell_hint}. \
-             You can also use {TOOL_SEARCH_BM25_NAME} to discover tools."
+             You can also use {TOOL_SEARCH_NAME} to discover tools."
         );
     }
 
     format!(
         "Tool '{tool_name}' is not available in the current tool catalog. \
-         {suggestion_text} You can also use {TOOL_SEARCH_BM25_NAME} to discover tools."
+         {suggestion_text} You can also use {TOOL_SEARCH_NAME} to discover tools."
     )
 }
 
@@ -941,6 +915,16 @@ pub(super) fn execute_tool_search(
     active_tools: &mut HashSet<String>,
 ) -> Result<ToolResult, ToolError> {
     let query = required_str(input, "query")?;
+    let match_kind = match tool_name {
+        LEGACY_TOOL_SEARCH_REGEX_NAME => "regex",
+        LEGACY_TOOL_SEARCH_BM25_NAME => "bm25",
+        _ => optional_str(input, "match").unwrap_or("bm25"),
+    };
+    if !matches!(match_kind, "bm25" | "regex") {
+        return Err(ToolError::invalid_input(format!(
+            "Unsupported match algorithm '{match_kind}'. Expected one of: bm25, regex"
+        )));
+    }
     let max_results = usize::try_from(optional_u64(
         input,
         "max_results",
@@ -948,13 +932,13 @@ pub(super) fn execute_tool_search(
     ))
     .unwrap_or(TOOL_SEARCH_DEFAULT_MAX_RESULTS)
     .clamp(1, TOOL_SEARCH_MAX_RESULTS_LIMIT);
-    let discovered = if tool_name == TOOL_SEARCH_REGEX_NAME {
+    let discovered = if match_kind == "regex" {
         discover_tools_with_regex(catalog, query, max_results)?
     } else {
         discover_tools_with_bm25_like(catalog, query, max_results)
     };
     let remaining_results = max_results.saturating_sub(discovered.len());
-    let unavailable = if tool_name == TOOL_SEARCH_REGEX_NAME {
+    let unavailable = if match_kind == "regex" {
         unavailable_core_action_tools_with_regex(catalog, query, remaining_results)?
     } else {
         unavailable_core_action_tools_with_bm25_like(catalog, query, remaining_results)

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -312,8 +312,7 @@ pub fn is_parallel_safe_read_only_tool(tool_name: &str) -> bool {
             | "git_blame"
             | "fetch_url"
             | "web_search"
-            | "tool_search_tool_regex"
-            | "tool_search_tool_bm25"
+            | "tool_search"
     )
 }
 


### PR DESCRIPTION
## What
Track C1 (the safe first cut): shrink the always-on (eager) tool surface, keeping every differentiator.
- Drop `task_shell_start`/`task_shell_wait` from the eager set (registration stays; background work routes through `exec_shell` background + `exec_shell_wait`).
- Fold eager `tool_search_tool_regex` + `tool_search_tool_bm25` → one `tool_search` with `match: bm25|regex` (old names kept as internal legacy aliases).
- **Did NOT cut `run_tests`** — verified it has Cargo-test-specific result/metadata behavior `run_verifiers` doesn't strictly preserve, so it's not a pure subset (conservative call).

KEEP list intact: `goal_*`, `update_plan`, `checklist_*`, `agent`, `run_verifiers`, durable `task_*` core.

## Verification
`cargo build -p codewhale-tui` ✅ · `cargo test -p codewhale-tui --bins` **5158 passed / 0 failed** ✅ · clippy `-D warnings` (CI flags) ✅ · `fmt --check` ✅. Drafted by a Codex sub-agent, independently verified by the orchestrator.

## ⚠️ Merge ordering
Touches `loop_guard.rs`/`turn_loop.rs`/`engine.rs` to update the folded tool name, which **overlaps PR #3462 (Tracks A+B)** that deletes `loop_guard.rs`. **Land #3462 first**, then this rebases onto it (the `loop_guard.rs` ripple drops with the deleted file; `engine.rs`/`turn_loop.rs` tool-name updates re-apply). I'll do that rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)