### PR TITLE
docs(rfc): Tailscale-first remote setup design (Track D5)

### DIFF
--- a/docs/rfcs/REMOTE_SETUP_DESIGN.md
+++ b/docs/rfcs/REMOTE_SETUP_DESIGN.md
@@ -1,264 +1,734 @@
-# `codewhale remote-setup` — Design & Implementation Plan
+# `codewhale remote-setup` - Tailscale-first design
 
-Status: **design** (do not implement against the 0.8.48 release wrap; land on a
-branch or after 0.8.48 ships). Author handoff doc, mirrors the style of
-`REFACTOR_HANDOFF.md`.
+Status: **design / revision**. This RFC revises the earlier cloud-first
+`remote-setup` plan. Keep the accurate implementation work already present:
+`codewhale remote-setup` exists today as a generate-only bundle wizard for
+cloud plus chat bridge deployments, and `--apply` is still not implemented.
 
 ## Goal
 
-One command — `codewhale remote-setup` — that guides a user through standing up
-a remote CodeWhale agent they can talk to from a phone chat app, across:
+Give users a guided, education-forward way to reach a local-first CodeWhale
+runtime from another surface without accidentally publishing their agent.
 
-- **Cloud target:** Tencent Lighthouse **or** Azure (extensible to GCP/Hetzner/bare).
-- **Chat bridge:** Feishu/Lark **or** Telegram (extensible to Slack/Discord).
-- **Model provider:** any entry in the existing `PROVIDERS` registry
-  (DeepSeek, OpenAI, NVIDIA NIM, Atlascloud, WanjieArk, OpenRouter, Novita,
-  Fireworks, Moonshot, SGLang, vLLM, Ollama, Xiaomi).
+Default posture:
 
-Decisions locked with the user:
-- **Form:** native Rust subcommand in-binary (touches `crates/cli` + `crates/tui`).
-- **Scope:** generate the deploy bundle **and** optionally auto-provision via the
-  cloud CLI (`az` / CNB), behind a confirmation gate.
+1. **Local-first by default.**
+2. **Tailnet-private when remote.**
+3. **Public only when explicitly chosen.**
 
-## Prior art: Hermes Agent (reference only — do not copy)
+The wizard should ask:
 
-Nous Research's Hermes Agent (Python) solves the
-same problem and **validates this design**. Use it for ideas; keep CodeWhale's
-style (Rust core, zero-dep Node bridges, plain-text replies).
+> How do you want to reach CodeWhale?
 
-- Its `gateway/platform_registry.py` is exactly the table-driven approach here: a
-  `PlatformEntry { name, label, adapter_factory, check_fn, validate_config,
-  required_env, install_hint, setup_fn, source }`. That maps 1:1 onto our
-  `BridgeSpec`/`CloudTarget` rows, and its per-platform `setup_fn` + `required_env`
-  are what our wizard reads to prompt. A single gateway process fans out to many
-  platforms — the model we want.
-- Its `gateway/pairing.py` mirrors our allowlist/first-pairing flow.
+and offer these paths, in this order:
 
-### Telegram hardening checklist (mined from `gateway/platforms/telegram.py`)
+1. This machine only (localhost)
+2. Private devices with Tailscale (**Recommended**)
+3. Telegram bot
+4. Feishu/Lark bot
+5. Weixin personal bridge
+6. Public webhook / Funnel (**Advanced**)
 
-That adapter is battle-tested; its method names enumerate edge cases our MVP
-bridge should handle. Status against `integrations/telegram-bridge`:
+The recommended remote answer is Tailscale Serve with the backend still bound
+to `127.0.0.1`. Tailscale supplies device identity and encrypted transport.
+Tailscale Funnel is public internet exposure and must stay advanced.
 
-| Edge case | In Hermes | In our bridge |
+## Current implementation checkpoint
+
+Verified against the codebase:
+
+- `codewhale app-server --http` is the canonical HTTP/SSE runtime API entrypoint.
+  It delegates to the mature `serve --http` implementation.
+- `codewhale app-server --mobile` is real and serves the phone control page at
+  `/mobile`.
+- `--host`, `--port`, `--workers`, `--auth-token`, `--insecure-no-auth`, and
+  repeatable `--cors-origin` exist on `app-server --http` / `--mobile`.
+- `--mobile` without `--host` binds to `0.0.0.0` by design. Use
+  `--host 127.0.0.1` when putting Tailscale in front of the runtime.
+- `/health` and `/v1/runtime/info` are public bootstrap/supervision endpoints.
+  `/v1/*` control routes require the runtime bearer token unless auth is
+  explicitly disabled on a trusted loopback bind.
+- `codewhale doctor --json` exists as the machine-readable local diagnostic.
+- `codewhale remote-setup` exists, but today it is generate-only. Its current
+  matrix is cloud target (`lighthouse`, `azure`, `digitalocean`) x bridge
+  (`feishu`, `telegram`) x provider registry. It does **not** yet model
+  localhost, Tailscale, Weixin, or Funnel as first-class choices.
+- Telegram and Feishu bridge validators exist as `npm run validate:config`.
+  Weixin currently has `npm run check`, but no validate-config script.
+
+Accuracy note for the Tailscale recommendation: the requested setup uses
+`app-server --http`, but the current runtime serves `/mobile` only in mobile
+mode. This RFC keeps the target command shape for the recommended loopback
+runtime, and documents the verified current-binary variant when the mobile page
+is required:
+
+```bash
+# Runtime API only, verified:
+codewhale app-server --http --host 127.0.0.1 --port 7878 --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+
+# Runtime API plus /mobile, verified:
+codewhale app-server --mobile --host 127.0.0.1 --port 7878 --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+```
+
+## Common runtime base
+
+Every path starts from the same local runtime trust boundary.
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --http \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+```
+
+For the current binary, use `--mobile --host 127.0.0.1` instead of `--http` if
+the path needs the built-in `/mobile` page.
+
+Doctor-style local validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+curl -fsS \
+  -H "Authorization: Bearer $CODEWHALE_RUNTIME_TOKEN" \
+  http://127.0.0.1:7878/v1/runtime/info
+```
+
+Runtime mental model:
+
+- Exposed by CodeWhale: only the address it binds. The recommended bind is
+  `127.0.0.1:7878`.
+- Auth token: `CODEWHALE_RUNTIME_TOKEN`, passed as `Authorization: Bearer ...`
+  by clients and bridges. Legacy `DEEPSEEK_RUNTIME_TOKEN` remains a fallback.
+- Provider secrets: stay in runtime configuration, not in bridge env files.
+- Bridge secrets: stay in transport-specific env files.
+
+## Guided flow
+
+### 1. This machine only (localhost)
+
+Use this when the TUI, SDK, browser, or local script runs on the same machine as
+CodeWhale.
+
+Setup:
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --http \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+```
+
+Env template:
+
+```env
+CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878
+CODEWHALE_RUNTIME_TOKEN=<same value used to start app-server>
+```
+
+Validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+curl -fsS \
+  -H "Authorization: Bearer $CODEWHALE_RUNTIME_TOKEN" \
+  http://127.0.0.1:7878/v1/runtime/info
+```
+
+Trust boundary:
+
+- Exposed: loopback only.
+- Not exposed: LAN, tailnet, or public internet.
+- Token used: `CODEWHALE_RUNTIME_TOKEN` for control routes; local `/health` and
+  `/v1/runtime/info` are public bootstrap endpoints.
+
+### 2. Private devices with Tailscale (Recommended)
+
+Use this to reach CodeWhale from your phone or laptop without opening a LAN or
+public port. Tailscale authenticates devices in your tailnet; CodeWhale still
+binds to localhost.
+
+Target setup to feature in the wizard:
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --http \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+
+tailscale serve --bg --https=443 localhost:7878
+```
+
+Then open the Tailscale Serve URL from a phone or laptop in the same tailnet.
+For the current binary's mobile page, start CodeWhale with the verified mobile
+variant:
+
+```bash
+codewhale app-server --mobile \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+```
+
+Then open (put the token in the URL **fragment**, not a query param — the
+`/mobile` page reads it from `location.hash`, and a fragment is never sent to
+the Tailscale serving layer or to any proxy log):
+
+```text
+https://<machine>.<tailnet>.ts.net/mobile#token=<CODEWHALE_RUNTIME_TOKEN>
+```
+
+Env template:
+
+```env
+CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878
+CODEWHALE_RUNTIME_TOKEN=<openssl-rand-hex-32>
+TAILSCALE_SERVE_TARGET=localhost:7878
+TAILSCALE_SERVE_URL=https://<machine>.<tailnet>.ts.net
+```
+
+Validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+curl -fsS https://<machine>.<tailnet>.ts.net/health
+curl -fsS \
+  -H "Authorization: Bearer $CODEWHALE_RUNTIME_TOKEN" \
+  https://<machine>.<tailnet>.ts.net/v1/runtime/info
+tailscale serve status
+```
+
+Trust boundary:
+
+- Exposed: an HTTPS endpoint reachable by devices authorized in your tailnet.
+- Not exposed: the raw CodeWhale listener; it stays on `127.0.0.1`.
+- Token used: Tailscale identity gates network reachability; CodeWhale still
+  uses `CODEWHALE_RUNTIME_TOKEN` for runtime control.
+- Caveat: Tailscale Serve is private to the tailnet. Tailscale Funnel is public
+  internet exposure and belongs only in the advanced path below.
+
+### 3. Telegram bot
+
+Use this when a Telegram DM should control a local CodeWhale runtime. The bridge
+uses Telegram Bot API long polling, so it does not require a public webhook URL
+or inbound port.
+
+Setup:
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --http \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+
+cd integrations/telegram-bridge
+npm install --omit=dev
+cp .env.example .env
+$EDITOR .env
+npm run validate:config -- \
+  --env .env \
+  --workspace-root "$PWD/../.." \
+  --check-filesystem
+npm start
+```
+
+Env template:
+
+```env
+TELEGRAM_BOT_TOKEN=replace-with-botfather-token
+
+CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878
+CODEWHALE_RUNTIME_TOKEN=<same value used to start app-server>
+CODEWHALE_WORKSPACE=/path/to/workspace
+# Optional override; leave blank to inherit the runtime's configured provider/model.
+CODEWHALE_MODEL=
+CODEWHALE_MODE=agent
+CODEWHALE_ALLOW_SHELL=true     # grants shell execution from the bridge; set false for text-only chat
+CODEWHALE_TRUST_MODE=false
+CODEWHALE_AUTO_APPROVE=false
+
+TELEGRAM_CHAT_ALLOWLIST=
+TELEGRAM_ALLOW_UNLISTED=false
+TELEGRAM_ALLOW_GROUPS=false
+```
+
+First pairing:
+
+```bash
+# Temporarily in .env:
+TELEGRAM_ALLOW_UNLISTED=true
+```
+
+DM the bot `/status`, copy the returned `chat_id` or `user_id` into
+`TELEGRAM_CHAT_ALLOWLIST`, then set `TELEGRAM_ALLOW_UNLISTED=false` and restart
+the bridge.
+
+Validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+npm run validate:config -- \
+  --env .env \
+  --workspace-root "$PWD/../.." \
+  --check-filesystem
+```
+
+Trust boundary:
+
+- Exposed: no inbound CodeWhale port. Telegram sees messages sent to the bot.
+- Not exposed: CodeWhale remains on `127.0.0.1`; provider keys stay in the
+  runtime env, not the Telegram env.
+- Tokens used: `TELEGRAM_BOT_TOKEN` for Telegram, `CODEWHALE_RUNTIME_TOKEN` for
+  bridge-to-runtime calls, and `TELEGRAM_CHAT_ALLOWLIST` for user/chat gating.
+- Caveat: direct messages are the intended MVP control surface. Group control is
+  off unless `TELEGRAM_ALLOW_GROUPS=true`.
+
+### 4. Feishu/Lark bot
+
+Use this when a Feishu or Lark chat should control the local runtime. The bridge
+uses the Lark/Feishu long-connection SDK, so the first version does not need a
+public webhook URL.
+
+Setup:
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --http \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+
+cd integrations/feishu-bridge
+npm install --omit=dev
+cp .env.example .env
+$EDITOR .env
+npm run validate:config -- \
+  --env .env \
+  --workspace-root "$PWD/../.." \
+  --check-filesystem
+npm start
+```
+
+Env template:
+
+```env
+FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxx
+FEISHU_APP_SECRET=replace-with-app-secret
+FEISHU_DOMAIN=feishu               # international Lark users: set to "lark"
+
+CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878
+CODEWHALE_RUNTIME_TOKEN=<same value used to start app-server>
+CODEWHALE_WORKSPACE=/path/to/workspace
+# Optional override; leave blank to inherit the runtime's configured provider/model.
+CODEWHALE_MODEL=
+CODEWHALE_MODE=agent
+CODEWHALE_ALLOW_SHELL=true     # grants shell execution from the bridge; set false for text-only chat
+CODEWHALE_TRUST_MODE=false
+CODEWHALE_AUTO_APPROVE=false
+
+CODEWHALE_CHAT_ALLOWLIST=
+CODEWHALE_ALLOW_UNLISTED=false
+FEISHU_ALLOW_GROUPS=false
+```
+
+First pairing:
+
+Temporarily set `CODEWHALE_ALLOW_UNLISTED=true`, message the app once, copy the
+logged open id into `CODEWHALE_CHAT_ALLOWLIST`, then set
+`CODEWHALE_ALLOW_UNLISTED=false` and restart the bridge.
+
+Validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+npm run validate:config -- \
+  --env .env \
+  --workspace-root "$PWD/../.." \
+  --check-filesystem
+```
+
+Trust boundary:
+
+- Exposed: no inbound CodeWhale port. Feishu/Lark sees messages sent to the app.
+- Not exposed: CodeWhale remains on `127.0.0.1`; provider keys stay in runtime
+  config.
+- Tokens used: `FEISHU_APP_ID` / `FEISHU_APP_SECRET` for the platform,
+  `CODEWHALE_RUNTIME_TOKEN` for bridge-to-runtime calls, and
+  `CODEWHALE_CHAT_ALLOWLIST` for chat gating.
+- Caveat: group control is off unless explicitly enabled.
+
+### 5. Weixin personal bridge
+
+Use this when a personal Weixin account should control the local runtime by QR
+login. This is not a public account webhook. The bridge initiates long polling
+and does not need a public port.
+
+Setup:
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --http \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+
+cd integrations/weixin-bridge
+npm install --omit=dev
+cp .env.example .env
+$EDITOR .env
+npm run check
+npm start
+```
+
+Env template:
+
+```env
+CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878
+CODEWHALE_RUNTIME_TOKEN=<same value used to start app-server>
+CODEWHALE_WORKSPACE=/path/to/workspace
+# Optional override; leave blank to inherit the runtime's configured provider/model.
+CODEWHALE_MODEL=
+CODEWHALE_MODE=agent
+CODEWHALE_ALLOW_SHELL=true     # grants shell execution from the bridge; set false for text-only chat
+CODEWHALE_TRUST_MODE=false
+CODEWHALE_AUTO_APPROVE=false
+
+WEXIN_CHAT_ALLOWLIST=
+WEXIN_ALLOW_UNLISTED=false
+WEXIN_STATE_DIR=/var/lib/codewhale-weixin-bot-bridge
+```
+
+First pairing:
+
+Set `WEXIN_ALLOW_UNLISTED=true`, start the bridge, scan the QR code, send
+`/status`, copy the returned `user_id` into `WEXIN_CHAT_ALLOWLIST`, then set
+`WEXIN_ALLOW_UNLISTED=false` and restart the bridge.
+
+Validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+npm run check
+```
+
+Trust boundary:
+
+- Exposed: no inbound CodeWhale port. The personal Weixin session and the
+  bridge state directory become sensitive local state.
+- Not exposed: CodeWhale remains on `127.0.0.1`; provider keys stay in runtime
+  config.
+- Tokens used: the scanned Weixin login/session state for platform access,
+  `CODEWHALE_RUNTIME_TOKEN` for bridge-to-runtime calls, and
+  `WEXIN_CHAT_ALLOWLIST` for user gating.
+- Caveat: this is a personal-account bridge. Treat the host and state directory
+  like a logged-in phone session.
+
+### 6. Public webhook / Funnel (Advanced)
+
+Use this only when the user explicitly chooses public internet reachability,
+understands that the URL can be reached outside the tailnet, and has a reason
+that Tailscale Serve or long polling cannot satisfy.
+
+Preferred advanced pattern:
+
+```bash
+CODEWHALE_RUNTIME_TOKEN="$(openssl rand -hex 32)"
+export CODEWHALE_RUNTIME_TOKEN
+
+codewhale app-server --mobile \
+  --host 127.0.0.1 \
+  --port 7878 \
+  --auth-token "$CODEWHALE_RUNTIME_TOKEN"
+
+tailscale funnel --bg --https=443 localhost:7878
+```
+
+Env template:
+
+```env
+CODEWHALE_RUNTIME_URL=https://<public-name>
+CODEWHALE_RUNTIME_TOKEN=<openssl-rand-hex-32>
+PUBLIC_EXPOSURE_ACK=true
+```
+
+Validation:
+
+```bash
+codewhale doctor --json
+curl -fsS http://127.0.0.1:7878/health
+curl -fsS https://<public-name>/health
+curl -fsS \
+  -H "Authorization: Bearer $CODEWHALE_RUNTIME_TOKEN" \
+  https://<public-name>/v1/runtime/info
+tailscale funnel status
+```
+
+Trust boundary:
+
+- Exposed: a public HTTPS endpoint, not just your tailnet.
+- Not exposed by CodeWhale directly: the backend still binds to `127.0.0.1`,
+  but the fronting layer makes selected routes reachable from the internet.
+- Token used: `CODEWHALE_RUNTIME_TOKEN` remains mandatory for control routes.
+- Caveat: public does not mean safe. Do not use `--insecure-no-auth`, do not bind
+  CodeWhale to `0.0.0.0`, and do not call this the default.
+
+## Cloud/VPS posture
+
+Cloud/VPS is a placement choice, not a trust model. The old RFC's cloud work is
+still useful, but it should sit behind the same reachability choices:
+
+- A VPS can run the runtime bound to `127.0.0.1`.
+- Recommended remote access from personal devices is still Tailscale Serve.
+- Bot bridges should use long polling / long connection where available, keeping
+  the runtime localhost-only on the host.
+- SSH tunnels remain acceptable for ad hoc validation:
+
+```bash
+ssh -L 7878:127.0.0.1:7878 <host>
+```
+
+Public inbound listeners, public webhooks, and Tailscale Funnel are advanced
+choices, not the default cloud path.
+
+## Prior art: Hermes Agent (reference only - do not copy)
+
+Nous Research's Hermes Agent validates the table-driven part of this design.
+Use it for ideas; keep CodeWhale's style: Rust core, local runtime, zero-dep
+Node bridges where possible, and plain-text replies.
+
+- `gateway/platform_registry.py` maps to our `BridgeSpec` / access-path
+  registry: one row per platform, with setup hints, required env, validation,
+  and adapter factory.
+- `gateway/pairing.py` maps to our allowlist / first-pairing flow.
+
+Telegram hardening carried forward from the original RFC:
+
+| Edge case | In Hermes | In our Telegram bridge |
 |---|---|---|
-| 409 polling conflict (two `getUpdates`) | `_looks_like_polling_conflict` | **done** — poll loop backs off 10s + warns |
-| 429 `retry_after` | rate-limit handling | **done** — `telegramApi` honors `parameters.retry_after` |
-| Forum "General topic = 1" send/typing asymmetry | `_message_thread_id_for_send` vs `_for_typing` | **done** — omit `message_thread_id` when id is 1 on send |
-| "message to be replied not found" after restart | `_send_with_dm_topic_reply_anchor_retry` | **sidestepped** — we never set `reply_to_message_id` |
-| Network/connect-timeout retry | `_looks_like_network_error` | partial — generic 3s backoff in poll loop |
-| Text batching + progress-edit (edit one msg vs spam) | `test_telegram_text_batching` | **deferred** — we send a chunk every 15s |
-| MarkdownV2 escaping + table rendering | `_escape_mdv2`, `_wrap_markdown_tables` | **deferred** — plain text (safe; tables look plain) |
-| Webhook mode as an alternative to long polling | `_webhook_mode` | out of scope — long-poll only (no inbound ports) |
-
-Deferred items are deliberate: progress-edit and MarkdownV2 add real UX polish
-but also complexity and (for MDV2) a whole class of parser-escaping bugs. Revisit
-after `remote-setup` lands.
+| 409 polling conflict | `_looks_like_polling_conflict` | done - poll loop backs off and warns |
+| 429 `retry_after` | rate-limit handling | done - `telegramApi` honors `parameters.retry_after` |
+| Forum General topic id handling | send/typing split | done - omit `message_thread_id` when id is 1 on send |
+| Stale reply anchor after restart | retry without anchor | sidestepped - no `reply_to_message_id` |
+| Network/connect timeout retry | network error detection | partial - generic poll-loop backoff |
+| Text batching / progress edit | progress-edit tests | deferred - plain periodic chunks |
+| MarkdownV2 escaping | escaping helpers | deferred - plain text |
+| Webhook mode | webhook adapter | out of default scope - long polling first |
 
 ## Design principle: table-driven, like `ProviderSpec`
 
-The provider registry (`crates/config/src/lib.rs::PROVIDERS`) is the model to
-copy: "adding a provider is one row." Apply the same to clouds and bridges so
-the matrix grows by data, not by new control flow.
+The provider registry is the model to preserve: adding a provider is one row.
+Apply the same idea to access paths, bridges, and cloud placements so the matrix
+grows by data.
 
-```
-        CloudTarget  ×  BridgeSpec   +  ProviderSpec (existing registry)
-        ───────────     ──────────      ────────────────────────────────
-        lighthouse      feishu          deepseek / openai / nvidia-nim / …
-        azure           telegram        (wizard reads PROVIDERS, prompts for
-        (future…)       (future…)        that provider's env_keys[0])
-```
-
-Clean separation that the architecture already implies:
-- **Provider = a `runtime.env` concern.** The runtime resolves the provider from
-  `CODEWHALE_PROVIDER` and the provider's own key var. The bridge never needs to
-  know which provider is behind the runtime — it only forwards `model` to
-  `/v1/threads`. So "multi-provider" only touches `runtime.env` generation.
-- **Cloud = where it runs + where secrets live.**
-- **Bridge = pure transport** between a chat app and `127.0.0.1:7878`.
-
-## Command surface
-
-New variant in `crates/cli/src/lib.rs` `Commands`:
-
-```rust
-/// Provision and configure a remote CodeWhale agent (cloud + chat bridge).
-RemoteSetup(RemoteSetupArgs),
+```text
+AccessPath x Placement x BridgeSpec + ProviderSpec
+----------   ---------   ----------   ------------
+localhost    local       none         deepseek / openai / ...
+tailscale    local/vps   none         provider lives in runtime.env
+telegram     local/vps   telegram     bridge is pure transport
+feishu       local/vps   feishu       bridge is pure transport
+weixin       local/vps   weixin       bridge is pure transport
+funnel       local/vps   optional     explicit public exposure
 ```
 
-`RemoteSetupArgs` (clap):
+Clean separation:
+
+- **Provider = runtime env.** The runtime resolves provider/model/API key from
+  `CODEWHALE_PROVIDER`, provider key vars, and the provider registry. Bridges do
+  not need provider keys.
+- **Access path = reachability.** Localhost, Tailscale Serve, chat long polling,
+  and Funnel are separate choices with different trust boundaries.
+- **Bridge = transport.** A chat bridge forwards allowed chat messages to
+  `http://127.0.0.1:7878` with `CODEWHALE_RUNTIME_TOKEN`.
+- **Cloud = where it runs and where secrets live.** It is not permission to
+  open port 7878.
+
+## Proposed command surface
+
+Current flags are verified for the generate-only cloud/bridge wizard:
+
+| Flag | Current status |
+|---|---|
+| `--cloud <lighthouse|azure|digitalocean>` | verified |
+| `--bridge <telegram|feishu>` | verified |
+| `--provider <slug>` | verified, provider registry-backed |
+| `--out <dir>` | verified |
+| `--generate-only` | verified |
+| `--apply` | verified flag, but not implemented |
+| `--yes` | verified flag |
+| `--non-interactive` | verified flag |
+
+Proposed Tailscale-first revision:
 
 | Flag | Meaning |
 |---|---|
-| `--cloud <azure\|lighthouse>` | Skip the cloud prompt. |
-| `--bridge <telegram\|feishu>` | Skip the bridge prompt. |
-| `--provider <slug>` | Provider slug; validated against `PROVIDERS`. |
-| `--out <dir>` | Bundle output dir (default `./codewhale-deploy/<cloud>-<bridge>`). |
-| `--generate-only` | Emit the bundle, do not provision (default). |
-| `--apply` | Run the cloud CLI to actually provision (the auto-provision path). |
-| `--yes` | Skip the final confirmation gate (CI/non-interactive). |
-| `--non-interactive` | Fail instead of prompting if any required value is missing. |
+| `--access <localhost|tailscale|telegram|feishu|weixin|funnel>` | Skip the reachability prompt. |
+| `--placement <local|vps|lighthouse|azure|digitalocean>` | Where the runtime runs; default local. |
+| `--bridge <telegram|feishu|weixin>` | Optional when `--access` implies a bridge. |
+| `--provider <slug>` | Provider slug; validated against the existing provider registry. |
+| `--out <dir>` | Bundle output dir. |
+| `--generate-only` | Emit commands/env/runbook, do not provision. Default. |
+| `--apply` | Future cloud CLI provisioning, behind confirmation. Still not implemented. |
+| `--yes` | Skip final confirmation gates where safe for CI/non-interactive use. |
+| `--non-interactive` | Fail instead of prompting for missing required values. |
 
-CLI delegates to the TUI binary exactly like `Serve`/`Setup` do
-(`delegate_to_tui(&cli, &resolved_runtime, tui_args("remote-setup", args))`).
-The implementation lives next to `run_setup` in `crates/tui/src/`.
-
-## Code layout
-
-New module `crates/tui/src/remote_setup/`:
-
-```
-remote_setup/
-  mod.rs          # run_remote_setup(): wizard orchestration + dispatch
-  registry.rs     # CloudTarget + BridgeSpec tables (the matrix)
-  prompt.rs       # thin stdin prompt helpers (reuse existing patterns)
-  bundle.rs       # render env files / systemd units / RUNBOOK.md to --out
-  provision/
-    mod.rs        # Provisioner trait + confirmation gate + dry-run printer
-    azure.rs      # az preflight, RG, VM+cloud-init, Key Vault, NSG, start
-    lighthouse.rs # cnb.yml + tag_deploy.yml generation, CNB guidance
-  templates/      # runtime.env, <bridge>.env, *.service, cloud-init.yaml.tmpl
-```
-
-### Registry types
-
-```rust
-pub struct BridgeSpec {
-    pub slug: &'static str,            // "telegram"
-    pub display: &'static str,         // "Telegram"
-    pub package_dir: &'static str,     // "integrations/telegram-bridge"
-    pub service_unit: &'static str,    // "codewhale-telegram-bridge.service"
-    pub env_template: &'static str,    // templates/telegram.env
-    /// Bridge-specific secret env keys to prompt for (token, etc.).
-    pub secret_keys: &'static [&'static str], // ["TELEGRAM_BOT_TOKEN"]
-    /// One-liner shown before prompting (e.g. "Create a bot with @BotFather").
-    pub setup_hint: &'static str,
-}
-
-pub struct CloudTarget {
-    pub slug: &'static str,            // "azure"
-    pub display: &'static str,         // "Azure VM"
-    pub secret_store: SecretStore,     // KeyVault | EnvFile
-    pub install: InstallMethod,        // Docker | NativeSystemd
-    /// Builds the ordered list of provisioning steps as (description, command).
-    /// Commands are returned as data so they can be dry-run printed, gated,
-    /// and only then executed.
-    pub plan: fn(&DeployInputs) -> Vec<ProvisionStep>,
-}
-```
-
-A `ProvisionStep { description, program, args, secret_args }` is *data*, never a
-shell string — so the confirmation gate can print every command, secrets are fed
-via stdin/temp files (never argv/`history`), and `--apply` just executes the
-already-printed plan.
-
-## Wizard flow
-
-1. **Cloud** — pick from `CLOUD_TARGETS` (or `--cloud`).
-2. **Bridge** — pick from `BRIDGES` (or `--bridge`); print `setup_hint`.
-3. **Provider** — list `PROVIDERS` (canonical names), pick (or `--provider`).
-   Look up `spec.env_keys[0]` as the key var to prompt for.
-4. **Secrets** — prompt for: provider API key, bridge token(s) from
-   `secret_keys`, allowlist (chat ids). Generate a random `CODEWHALE_RUNTIME_TOKEN`.
-5. **Mode** — generate-only vs `--apply`.
-6. **Render bundle** to `--out` (always, even with `--apply`).
-7. **Confirm + provision** (only if `--apply`): print the full ordered command
-   plan, require `y` (unless `--yes`), then execute step by step with progress.
-8. **Print RUNBOOK.md** path and the remaining manual steps.
+The first prompt should be the reachability question, not the cloud question.
+Tailscale should be visually marked as recommended.
 
 ## Generated bundle
 
-Written to `./codewhale-deploy/<cloud>-<bridge>/`:
+The current bundle model stays useful. Extend it so the generated runbook is
+access-path-first.
 
-- `runtime.env` — **provider config lives here**:
-  ```
+Files:
+
+- `runtime.env` - provider and runtime config:
+
+  ```env
   CODEWHALE_PROVIDER=openai
-  OPENAI_API_KEY=…              # the provider's own key var, from registry
-  CODEWHALE_MODEL=auto
+  OPENAI_API_KEY=replace-with-provider-key
+  # Optional override; leave blank to inherit the runtime's configured provider/model.
+CODEWHALE_MODEL=
   CODEWHALE_RUNTIME_TOKEN=<random>
   CODEWHALE_RUNTIME_PORT=7878
   CODEWHALE_RUNTIME_WORKERS=2
   RUST_LOG=info
   ```
-- `<bridge>.env` — transport only: `CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878`,
-  matching `CODEWHALE_RUNTIME_TOKEN`, allowlist, `TELEGRAM_BOT_TOKEN` (or Feishu
-  app id/secret), `CODEWHALE_WORKSPACE`, `CODEWHALE_MODEL`.
-- `codewhale-runtime.service`, `codewhale-<bridge>.service`.
-- Cloud artifact: `cloud-init.yaml` + `provision.sh` (Azure) or `cnb.yml` +
-  `tag_deploy.yml` (Lighthouse).
-- `RUNBOOK.md` — the exact remaining commands + first-pairing steps.
+
+- `<bridge>.env` - transport only when a bridge is selected:
+
+  ```env
+  CODEWHALE_RUNTIME_URL=http://127.0.0.1:7878
+  CODEWHALE_RUNTIME_TOKEN=<same random token>
+  CODEWHALE_WORKSPACE=/opt/whalebro
+  # Optional override; leave blank to inherit the runtime's configured provider/model.
+CODEWHALE_MODEL=
+  CODEWHALE_MODE=agent
+  CODEWHALE_ALLOW_SHELL=true     # grants shell execution from the bridge; set false for text-only chat
+  CODEWHALE_TRUST_MODE=false
+  CODEWHALE_AUTO_APPROVE=false
+  ```
+
+- `codewhale-runtime.service`
+- optional `codewhale-<bridge>.service`
+- optional cloud artifacts: `cloud-init.yaml`, `provision.sh`, `cnb.yml`, or
+  cloud-specific runbook steps
+- `RUNBOOK.md` with:
+  - exact setup commands
+  - env template
+  - doctor-style validation
+  - first-pairing steps for bridges
+  - trust-boundary summary
+  - explicit "public exposure acknowledged" section for Funnel/webhook modes
 
 ## Auto-provision
 
-### Azure (`--apply --cloud azure`)
-Preflight: `az account show` (fail with "run `az login`" if absent). Then the
-`plan()` emits, in order:
-1. `az group create` (region prompted; default `eastus`).
-2. `az keyvault create` + `az keyvault secret set` for the provider key and the
-   runtime token (secrets via stdin, not argv).
-3. `az vm create` with `--custom-data cloud-init.yaml` and a **system-assigned
-   managed identity**; cloud-init pulls `ghcr.io/hmbown/codewhale:latest`, reads
-   the secrets from Key Vault via the identity, writes `/etc/codewhale/*.env`,
-   installs both systemd units, `enable --now`.
-4. NSG: SSH (22) only, scoped to the caller's IP; **7878 stays on `127.0.0.1`**.
-5. Print the SSH tunnel command for `/status` from a laptop if desired.
+Preserve the original safety model:
 
-### Lighthouse (`--apply --cloud lighthouse`)
-Reuse the existing `deploy/tencent-lighthouse/cnb/*.example` pipeline: render
-`cnb.yml` + `tag_deploy.yml` from inputs and walk the user through the CNB
-trigger (CNB does the VM-side work). Systemd units mirror the existing
-`codewhale-runtime.service`.
+- `--generate-only` is the default.
+- `--apply` is explicit and is not implemented today.
+- Every command is rendered before execution.
+- Secrets are not passed through shell history or argv.
+- Cloud CLIs are placement helpers, not permission to open runtime ports.
 
-Safety (matches the harness rules for outward-facing actions):
-- Every command printed before execution; `y` gate unless `--yes`.
-- Secrets never in argv or shell history.
-- `--generate-only` is the default; `--apply` is explicit.
+Existing cloud target design remains accurate:
 
-## Namespace migration: `DEEPSEEK_*` → `CODEWHALE_*`
+- Tencent Lighthouse: native plus systemd, env-file secrets, CNB-oriented plan.
+- Azure VM: Docker image plus Key Vault, managed identity at boot.
+- DigitalOcean Droplet: native plus systemd, env-file secrets, `doctl` plan.
 
-Follow the convention already in `crates/config/src/lib.rs`: **read
-`CODEWHALE_X` first, fall back to `DEEPSEEK_X`.** Nothing breaks for existing
-deployments.
+All cloud plans should bind CodeWhale to `127.0.0.1` and then layer one of the
+reachability paths above.
 
-Touch list:
-1. **Bridges** (`integrations/feishu-bridge`, `integrations/telegram-bridge`):
-   in `lib.mjs`/`index.mjs`, read `process.env.CODEWHALE_X ?? process.env.DEEPSEEK_X`
-   for `RUNTIME_URL`, `RUNTIME_TOKEN`, `WORKSPACE`, `MODEL`, `MODE`, `ALLOW_SHELL`,
-   `TRUST_MODE`, `AUTO_APPROVE`, `CHAT_ALLOWLIST`, `ALLOW_UNLISTED`, `TURN_TIMEOUT_MS`.
-   Validators accept either; templates emit `CODEWHALE_*`.
-2. **Deploy units** (`deploy/tencent-lighthouse/systemd/*`,
-   `integrations/*/deploy/*`): `DEEPSEEK_RUNTIME_*` → `CODEWHALE_RUNTIME_*`,
-   env file paths `/etc/deepseek/` → `/etc/codewhale/` (keep reading the old path
-   if present).
-3. **`.env.example` files + `config.example.toml`**: lead with `CODEWHALE_*`,
-   document `DEEPSEEK_*` as legacy aliases.
-4. **Drop DeepSeek-shaped defaults** in the bridge: no hardcoded
-   `DEEPSEEK_MODEL=auto`; the provider lives in `runtime.env` via
-   `CODEWHALE_PROVIDER` + the registry's key var.
+## Namespace migration: `DEEPSEEK_*` to `CODEWHALE_*`
 
-Note: items 1–3 touch **tracked** files, so they are part of the same
-"don't ship during 0.8.48" hold. The brand-new (untracked) Telegram bridge can
-be converted to `CODEWHALE_*` first as the reference implementation.
+Carry forward the convention already used in code: read `CODEWHALE_X` first,
+fall back to `DEEPSEEK_X` where compatibility is needed.
+
+Touch list from the original RFC remains valid:
+
+1. Bridges: read `CODEWHALE_X ?? DEEPSEEK_X` for runtime URL/token, workspace,
+   model, mode, shell/trust/approval flags, allowlists, and timeouts. Templates
+   should emit `CODEWHALE_*`.
+2. Deploy units: prefer `/etc/codewhale/*.env`; keep legacy path reads only for
+   compatibility where needed.
+3. `.env.example` files and `config.example.toml`: lead with `CODEWHALE_*`,
+   document legacy aliases.
+4. Drop DeepSeek-shaped defaults in bridge templates except where DeepSeek is
+   explicitly the chosen provider. Provider choice belongs in `runtime.env`.
 
 ## Tests
 
-- `registry.rs`: every `CloudTarget`/`BridgeSpec` slug is unique; each bridge's
-  `package_dir`/`service_unit`/`env_template` exists.
-- `bundle.rs`: rendering a bundle for each cloud×bridge×provider triple produces
-  files with `CODEWHALE_*` keys, a matching runtime/bridge token, and a non-empty
-  RUNBOOK.
-- `provision`: `plan()` returns the expected ordered steps; **commands are built
-  but never executed** in tests (assert on program+args, secrets redacted).
+Existing bundle tests should stay:
 
-## Extensibility check
+- Every cloud / bridge / provider triple renders.
+- Runtime and bridge env files share the same `CODEWHALE_RUNTIME_TOKEN`.
+- Env files lead with `CODEWHALE_*`.
+- Generated runbooks are non-empty and list the provision plan.
+- Provision plans are command data and are not executed in tests.
 
-- Add **GCP**: one `CloudTarget` row + a `provision/gcp.rs` + a cloud-init reuse.
-- Add **Slack**: one `BridgeSpec` row + `integrations/slack-bridge` + template.
-No changes to the wizard control flow — it iterates the registries.
+New tests for this revision:
 
-## Suggested sequencing (given the 0.8.48 freeze)
+- Every `AccessPath` row has setup commands, env template, validation commands,
+  and trust-boundary copy.
+- Tailscale is the recommended remote path in prompt ordering.
+- Funnel/webhook mode requires an explicit advanced/public acknowledgement.
+- `/mobile` docs use `app-server --mobile --host 127.0.0.1` for current binary
+  behavior, or clearly mark any `--http` plus `/mobile` path as proposed.
+- Weixin can be documented before it is in the `remote-setup` registry, but the
+  wizard must mark it proposed until a `BridgeSpec` row and validation story
+  exist.
 
-1. **Now (safe, untracked):** convert the new Telegram bridge to `CODEWHALE_* ??
-   DEEPSEEK_*`; finalize this design.
-2. **Post-0.8.48, branch:** namespace migration on tracked bridges + deploy units.
-3. **Then:** implement `remote-setup` (registry → bundle → Azure provisioner →
-   Lighthouse provisioner), generate-only first, `--apply` second.
+## Suggested sequencing
+
+1. Revise the RFC and runbook copy to be Tailscale-first.
+2. Add an access-path registry above the existing cloud/bridge/provider tables.
+3. Add localhost and Tailscale generate-only bundles.
+4. Add Weixin as a `BridgeSpec` row or explicitly hide it behind "proposed" in
+   the wizard until registry and validation support land.
+5. Rework cloud bundles so placement is second and reachability is first.
+6. Add Funnel/webhook only as an advanced path with explicit public-exposure
+   acknowledgement.
+7. Implement `--apply` last, after generate-only output is reviewed.
+
+## Command verification ledger
+
+Verified against CodeWhale code/docs in this worktree:
+
+- `codewhale app-server --http --host 127.0.0.1 --port 7878 --auth-token TOKEN`
+- `codewhale app-server --mobile --host 127.0.0.1 --port 7878 --auth-token TOKEN`
+- `codewhale doctor --json`
+- `curl /health` and authenticated `curl /v1/runtime/info`
+- `npm run validate:config` for Telegram and Feishu bridges
+- `npm run check` for the Weixin bridge
+- Existing `remote-setup` generate-only flags listed above
+
+Marked proposed or external:
+
+- `codewhale remote-setup --access ...` and access-path registry
+- first-class Tailscale, localhost, Weixin, and Funnel choices in the wizard
+- `--apply` execution
+- Tailscale CLI commands (`tailscale serve ...`, `tailscale funnel ...`) are
+  external Tailscale commands. They are the intended RFC examples, but they are
+  not CodeWhale CLI flags.


### PR DESCRIPTION
## What
Track D5: revise `docs/rfcs/REMOTE_SETUP_DESIGN.md` around **Tailscale-first** ("local-first by default, tailnet-private when remote, public only when explicitly chosen"). Adds a guided "How do you want to reach CodeWhale?" flow with, per path, setup commands + env templates + a `doctor`-style validation check + a trust-boundary mental model:
1. This machine only · 2. **Tailscale (recommended)** · 3. Telegram · 4. Feishu/Lark · 5. Weixin · 6. public Funnel (advanced, last)

Cloud/VPS reframed as *placement*, not a trust model. Prior RFC material (registry design, auto-provision safety, namespace migration, tests, sequencing) preserved.

## Honesty about commands
Each command is labeled: **verified** (`codewhale app-server --http/--mobile`, `--auth-token`, `doctor --json`, bridge `validate:config`), **proposed** (the `remote-setup` wizard / access-path registry — forward-looking RFC design), or **external** (`tailscale serve/funnel` examples — the Tailscale binary couldn't load prefs in the sandbox, so they're framed as external examples, not CodeWhale-verified flags). Trust caveats kept explicit (Tailscale = your tailnet only; Funnel = public internet; `--mobile`/gateway never implied "safe" without the auth/TLS caveat).

Docs-only (an RFC). Drafted by a Codex sub-agent, orchestrator-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)