### PR TITLE
  fix(tui): preserve configured instructions in context inspector

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1123,11 +1123,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         mcp_config_path: config.mcp_config_path(),
         skills_dir: app.skills_dir.clone(),
         skills_scan_codewhale_only: app.skills_scan_codewhale_only,
-        instructions: config
-            .instructions_paths()
-            .into_iter()
-            .map(Into::into)
-            .collect(),
+        instructions: configured_instruction_sources(config),
         project_context_pack_enabled: config.project_context_pack_enabled(),
         translation_enabled: app.translation_enabled,
         show_thinking: app.show_thinking,
@@ -1202,6 +1198,38 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
         workspace_follow_symlinks: app.workspace_follow_symlinks,
         exec_policy_engine: config.exec_policy_engine.clone(),
     }
+}
+
+fn configured_instruction_sources(config: &Config) -> Vec<prompts::InstructionSource> {
+    config
+        .instructions_paths()
+        .into_iter()
+        .map(Into::into)
+        .collect()
+}
+
+fn build_app_system_prompt(app: &App, config: &Config) -> SystemPrompt {
+    let instructions = configured_instruction_sources(config);
+    prompts::system_prompt_for_mode_with_context_skills_and_session(
+        &app.workspace,
+        None,
+        None,
+        Some(&instructions),
+        prompts::PromptSessionContext {
+            user_memory_block: None,
+            goal_objective: app.hunt.quarry.as_deref(),
+            project_context_pack_enabled: config.project_context_pack_enabled(),
+            locale_tag: app.ui_locale.tag(),
+            translation_enabled: app.translation_enabled,
+            model_id: &app.model,
+            context_window_override: Some(
+                provider_capability(app.api_provider, &app.model).context_window,
+            ),
+            show_thinking: app.show_thinking,
+            verbosity: app.verbosity.as_deref(),
+            skills_scan_codewhale_only: app.skills_scan_codewhale_only,
+        },
+    )
 }
 
 /// How long after a task finishes it should still appear in the Work
@@ -6135,28 +6163,7 @@ async fn dispatch_user_message(
         .map(|selection| selection.provider)
         .unwrap_or(app.api_provider);
     let message_index = app.api_messages.len();
-    app.system_prompt = Some(
-        prompts::system_prompt_for_mode_with_context_skills_and_session(
-            &app.workspace,
-            None,
-            None,
-            None,
-            prompts::PromptSessionContext {
-                user_memory_block: None,
-                goal_objective: app.hunt.quarry.as_deref(),
-                project_context_pack_enabled: config.project_context_pack_enabled(),
-                locale_tag: app.ui_locale.tag(),
-                translation_enabled: app.translation_enabled,
-                model_id: &app.model,
-                context_window_override: Some(
-                    provider_capability(app.api_provider, &app.model).context_window,
-                ),
-                show_thinking: app.show_thinking,
-                verbosity: app.verbosity.as_deref(),
-                skills_scan_codewhale_only: app.skills_scan_codewhale_only,
-            },
-        ),
-    );
+    app.system_prompt = Some(build_app_system_prompt(app, config));
     app.add_message(HistoryCell::User {
         content: message.display.clone(),
     });

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1692,6 +1692,28 @@ fn create_test_app() -> App {
 }
 
 #[test]
+fn app_system_prompt_includes_configured_instructions() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let instructions = tmp.path().join("extra-instructions.md");
+    std::fs::write(&instructions, "CONFIGURED_INSTRUCTIONS_MARKER").expect("write instructions");
+
+    let mut app = create_test_app();
+    app.workspace = tmp.path().to_path_buf();
+    let config = Config {
+        instructions: Some(vec![instructions.display().to_string()]),
+        ..Config::default()
+    };
+
+    let prompt = match build_app_system_prompt(&app, &config) {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(_) => panic!("expected text system prompt"),
+    };
+
+    assert!(prompt.contains("CONFIGURED_INSTRUCTIONS_MARKER"));
+    assert!(prompt.contains(&instructions.display().to_string()));
+}
+
+#[test]
 fn session_denied_cache_matches_only_approval_key() {
     let mut app = create_test_app();
     app.approval_session_denied.insert("edit_file".to_string());


### PR DESCRIPTION

## Summary

  Fixes #3457.

  When a session has configured `instructions = [...]`, switching models with `/model` can leave the Alt-C context inspector without the `Configured instructions` section. The reported context size also becomes smaller because the inspector estimates usage from `app.system_prompt`.

 This keeps the TUI-side system prompt rebuild aligned with the engine config path by including configured instruction sources when rebuilding `app.system_prompt`.


## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
