### PR TITLE
feat(fleet): Fleet profile types + config plumbing (#3167, EPIC #3154)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1338,6 +1338,11 @@ pub struct FleetConfigToml {
     /// available; user-defined roles in config override or extend them.
     #[serde(default)]
     pub roles: BTreeMap<String, FleetRolePreset>,
+    /// Fleet profile vocabulary (#3167). Profiles group role semantics,
+    /// loadout hints, permission defaults, and delegation bounds. They are
+    /// config-only in this slice; executor/model routing wiring lands later.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profiles: BTreeMap<String, FleetProfile>,
     /// Headless worker execution hardening (#3027).
     #[serde(default)]
     pub exec: FleetExecConfig,
@@ -1424,6 +1429,269 @@ impl Default for FleetExecConfig {
     }
 }
 
+/// Fleet org-chart profile.
+///
+/// A profile is an additive config record for future fleet scheduling policy.
+/// Loading one must not grant runtime permissions by itself: shell and trust
+/// escalation default off, and approvals default on.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct FleetProfile {
+    /// Org-chart slot this profile describes.
+    #[serde(default)]
+    pub slot: FleetSlot,
+    /// Semantic role name and optional instruction overlay.
+    #[serde(default)]
+    pub role: FleetRole,
+    /// Model class / route-role hint. This is data only in this slice.
+    #[serde(default)]
+    pub loadout: FleetLoadout,
+    /// Permission defaults requested by the profile.
+    #[serde(default)]
+    pub permissions: FleetProfilePermissions,
+    /// Delegation hints for future manager policy.
+    #[serde(default)]
+    pub delegation: FleetDelegationHints,
+}
+
+/// Semantic role declaration for a fleet profile.
+///
+/// TOML may use either `role = "reviewer"` or a role table with `name` and
+/// `instructions`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FleetRole {
+    /// Stable role name, e.g. `scout`, `implementer`, or `verifier`.
+    pub name: String,
+    /// Optional short description for config UIs and docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional instruction overlay to apply when the role is later consumed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+impl Default for FleetRole {
+    fn default() -> Self {
+        Self {
+            name: "general".to_string(),
+            description: None,
+            instructions: None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for FleetRole {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum FleetRoleWire {
+            Name(String),
+            Full {
+                #[serde(default)]
+                name: Option<String>,
+                #[serde(default)]
+                description: Option<String>,
+                #[serde(default)]
+                instructions: Option<String>,
+            },
+        }
+
+        match FleetRoleWire::deserialize(deserializer)? {
+            FleetRoleWire::Name(name) => Ok(Self {
+                name,
+                ..Self::default()
+            }),
+            FleetRoleWire::Full {
+                name,
+                description,
+                instructions,
+            } => Ok(Self {
+                name: name.unwrap_or_else(|| Self::default().name),
+                description,
+                instructions,
+            }),
+        }
+    }
+}
+
+/// Org-chart slot for grouping fleet profiles.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum FleetSlot {
+    Manager,
+    Scout,
+    Implementer,
+    Reviewer,
+    Verifier,
+    ToolHeavy,
+    Operator,
+    Summarizer,
+    #[default]
+    General,
+    Custom(String),
+}
+
+impl FleetSlot {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Manager => "manager",
+            Self::Scout => "scout",
+            Self::Implementer => "implementer",
+            Self::Reviewer => "reviewer",
+            Self::Verifier => "verifier",
+            Self::ToolHeavy => "tool-heavy",
+            Self::Operator => "operator",
+            Self::Summarizer => "summarizer",
+            Self::General => "general",
+            Self::Custom(value) => value.as_str(),
+        }
+    }
+
+    #[must_use]
+    pub fn from_name(value: &str) -> Self {
+        match value.trim() {
+            "manager" | "coordinator" => Self::Manager,
+            "scout" | "research" | "research-worker" => Self::Scout,
+            "implementer" | "builder" => Self::Implementer,
+            "reviewer" => Self::Reviewer,
+            "verifier" | "tester" => Self::Verifier,
+            "tool-heavy" | "tool_heavy" => Self::ToolHeavy,
+            "operator" | "incident" | "incident-worker" => Self::Operator,
+            "summarizer" | "reducer" => Self::Summarizer,
+            "general" | "" => Self::General,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for FleetSlot {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for FleetSlot {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_name(&value))
+    }
+}
+
+/// Model class or route-role hint for a profile.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum FleetLoadout {
+    #[default]
+    Inherit,
+    Fast,
+    Balanced,
+    DeepReasoning,
+    Code,
+    Review,
+    ToolHeavy,
+    Custom(String),
+}
+
+impl FleetLoadout {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::Fast => "fast",
+            Self::Balanced => "balanced",
+            Self::DeepReasoning => "deep-reasoning",
+            Self::Code => "code",
+            Self::Review => "review",
+            Self::ToolHeavy => "tool-heavy",
+            Self::Custom(value) => value.as_str(),
+        }
+    }
+
+    #[must_use]
+    pub fn from_name(value: &str) -> Self {
+        match value.trim() {
+            "inherit" | "default" | "auto" | "" => Self::Inherit,
+            "fast" => Self::Fast,
+            "balanced" => Self::Balanced,
+            "deep-reasoning" | "deep_reasoning" | "reasoning" => Self::DeepReasoning,
+            "code" | "coding" => Self::Code,
+            "review" | "reviewer" => Self::Review,
+            "tool-heavy" | "tool_heavy" => Self::ToolHeavy,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for FleetLoadout {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for FleetLoadout {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_name(&value))
+    }
+}
+
+/// Safe permission defaults attached to a fleet profile.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetProfilePermissions {
+    /// Permit shell-capable tools for this profile when later consumed.
+    #[serde(default)]
+    pub allow_shell: bool,
+    /// Permit trusted/elevated execution for this profile when later consumed.
+    #[serde(default)]
+    pub trust: bool,
+    /// Require approval by default. This intentionally defaults on.
+    #[serde(default = "default_fleet_profile_approval_required")]
+    pub approval_required: bool,
+}
+
+fn default_fleet_profile_approval_required() -> bool {
+    true
+}
+
+impl Default for FleetProfilePermissions {
+    fn default() -> Self {
+        Self {
+            allow_shell: false,
+            trust: false,
+            approval_required: true,
+        }
+    }
+}
+
+/// Delegation hints for future fleet manager scheduling.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct FleetDelegationHints {
+    /// Optional profile-level child spawn depth. `None` means inherit existing
+    /// fleet/sub-agent config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_spawn_depth: Option<u32>,
+    /// Optional profile-level worker concurrency hint.
+    #[serde(
+        default,
+        alias = "concurrency",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_concurrency: Option<usize>,
+}
+
 /// A named role preset that bundles common worker settings.
 ///
 /// Task specs reference a role name (e.g. `"role": "reviewer"`), and the
@@ -1473,6 +1741,7 @@ impl Default for FleetConfigToml {
             require_identity_verification: default_fleet_require_identity(),
             max_trust_level: default_fleet_max_trust_level_str(),
             roles: BTreeMap::new(),
+            profiles: BTreeMap::new(),
             exec: FleetExecConfig::default(),
         }
     }

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -4501,6 +4501,85 @@ max_spawn_depth = 2
 }
 
 #[test]
+fn fleet_profile_defaults_round_trip_through_config() {
+    let config: ConfigToml = toml::from_str(
+        r#"
+[fleet.profiles.default]
+"#,
+    )
+    .expect("fleet profile config should parse");
+
+    let profile = config
+        .fleet
+        .expect("fleet config")
+        .profiles
+        .get("default")
+        .expect("default profile")
+        .clone();
+
+    assert_eq!(profile, FleetProfile::default());
+    assert!(!profile.permissions.allow_shell);
+    assert!(!profile.permissions.trust);
+    assert!(profile.permissions.approval_required);
+
+    let serialized = toml::to_string_pretty(&profile).expect("profile serializes");
+    let round_tripped: FleetProfile =
+        toml::from_str(&serialized).expect("serialized profile parses");
+    assert_eq!(round_tripped, profile);
+}
+
+#[test]
+fn fleet_profile_explicit_config_parses_role_loadout_permissions() {
+    let config: ConfigToml = toml::from_str(
+        r#"
+[fleet.profiles.verifier]
+slot = "verifier"
+loadout = "review"
+
+[fleet.profiles.verifier.role]
+name = "verifier"
+description = "Read-only verification worker"
+instructions = "Check the patch and report evidence."
+
+[fleet.profiles.verifier.permissions]
+allow_shell = false
+trust = false
+approval_required = true
+
+[fleet.profiles.verifier.delegation]
+max_spawn_depth = 0
+concurrency = 3
+"#,
+    )
+    .expect("fleet profile config should parse");
+
+    let profile = config
+        .fleet
+        .expect("fleet config")
+        .profiles
+        .get("verifier")
+        .expect("verifier profile")
+        .clone();
+
+    assert_eq!(profile.slot, FleetSlot::Verifier);
+    assert_eq!(profile.role.name, "verifier");
+    assert_eq!(
+        profile.role.description.as_deref(),
+        Some("Read-only verification worker")
+    );
+    assert_eq!(
+        profile.role.instructions.as_deref(),
+        Some("Check the patch and report evidence.")
+    );
+    assert_eq!(profile.loadout, FleetLoadout::Review);
+    assert!(!profile.permissions.allow_shell);
+    assert!(!profile.permissions.trust);
+    assert!(profile.permissions.approval_required);
+    assert_eq!(profile.delegation.max_spawn_depth, Some(0));
+    assert_eq!(profile.delegation.max_concurrency, Some(3));
+}
+
+#[test]
 fn fallback_providers_do_not_change_runtime_resolution() {
     let _lock = env_lock();
     let _env = EnvGuard::without_deepseek_runtime_overrides();

--- a/crates/tui/src/fleet/mod.rs
+++ b/crates/tui/src/fleet/mod.rs
@@ -5,6 +5,7 @@ pub mod executor;
 pub mod host;
 pub mod ledger;
 pub mod manager;
+pub mod profile;
 pub mod scheduler;
 pub mod task_spec;
 pub mod worker_runtime;

--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -1,0 +1,83 @@
+//! Fleet profile vocabulary and config-facing type aliases.
+
+#![allow(dead_code)]
+
+#[allow(unused_imports)]
+pub use codewhale_config::{
+    FleetDelegationHints, FleetLoadout, FleetProfile, FleetProfilePermissions, FleetRole, FleetSlot,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fleet_profile_round_trips_through_serde_with_safe_defaults() {
+        let profile = FleetProfile::default();
+
+        let serialized = toml::to_string(&profile).expect("profile serializes");
+        let round_tripped: FleetProfile =
+            toml::from_str(&serialized).expect("profile deserializes");
+
+        assert_eq!(round_tripped, profile);
+        assert_eq!(round_tripped.role.name, "general");
+        assert_eq!(round_tripped.loadout, FleetLoadout::Inherit);
+        assert!(!round_tripped.permissions.allow_shell);
+        assert!(!round_tripped.permissions.trust);
+        assert!(round_tripped.permissions.approval_required);
+        assert_eq!(round_tripped.delegation.max_spawn_depth, None);
+        assert_eq!(round_tripped.delegation.max_concurrency, None);
+    }
+
+    #[test]
+    fn fleet_profile_explicit_toml_parses_role_loadout_permissions() {
+        let profile: FleetProfile = toml::from_str(
+            r#"
+slot = "reviewer"
+loadout = "deep-reasoning"
+
+[role]
+name = "verifier"
+instructions = "Review the patch and produce verification evidence."
+
+[permissions]
+allow_shell = true
+trust = true
+approval_required = false
+
+[delegation]
+max_spawn_depth = 1
+concurrency = 2
+"#,
+        )
+        .expect("explicit fleet profile parses");
+
+        assert_eq!(profile.slot, FleetSlot::Reviewer);
+        assert_eq!(profile.role.name, "verifier");
+        assert_eq!(
+            profile.role.instructions.as_deref(),
+            Some("Review the patch and produce verification evidence.")
+        );
+        assert_eq!(profile.loadout, FleetLoadout::DeepReasoning);
+        assert!(profile.permissions.allow_shell);
+        assert!(profile.permissions.trust);
+        assert!(!profile.permissions.approval_required);
+        assert_eq!(profile.delegation.max_spawn_depth, Some(1));
+        assert_eq!(profile.delegation.max_concurrency, Some(2));
+    }
+
+    #[test]
+    fn fleet_profile_accepts_compact_role_string() {
+        let profile: FleetProfile = toml::from_str(
+            r#"
+role = "scout"
+loadout = "fast"
+"#,
+        )
+        .expect("compact fleet profile parses");
+
+        assert_eq!(profile.role.name, "scout");
+        assert_eq!(profile.loadout, FleetLoadout::Fast);
+        assert_eq!(profile.permissions, FleetProfilePermissions::default());
+    }
+}


### PR DESCRIPTION
## What
Bounded **slice 1** of Fleet profiles (#3167, EPIC #3154 Fleet substrate): the profile vocabulary the issue names, additive only.
- Types: `FleetProfile`, `FleetRole`, `FleetSlot`, `FleetLoadout`, `FleetProfilePermissions`, `FleetDelegationHints` (new `crates/tui/src/fleet/profile.rs`, `#![allow(dead_code)]`).
- `[fleet.profiles]` config loading (serde-optional; defaults preserve today's behavior).
- **Conservative defaults:** `allow_shell=false`, `trust=false`, `approval_required=true`.
- **Deferred** (later slices #3205/#3384): wiring profiles into executor lifecycle, worker role mapping, model routing, permission enforcement.

This is the substrate the Orchestration disposition (separate PR) reaches for — a user preconfigures worker roles/loadouts here.

## Verification
build ✅ · `cargo test -p codewhale-tui --bins fleet` 77 ✅ · `cargo test -p codewhale-config` 203 ✅ · clippy `-D warnings` ✅ · fmt ✅. Codex-drafted, orchestrator-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)