### PR TITLE
fix(web): remove stale references to retired sub-agent lifecycle tools (#3414)

### DIFF
--- a/web/app/[locale]/docs/page.tsx
+++ b/web/app/[locale]/docs/page.tsx
@@ -151,7 +151,7 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
                     { group: "搜索", tools: "grep_files · file_search · web_search · fetch_url" },
                     { group: "Shell", tools: "exec_shell · exec_shell_wait · exec_shell_interact" },
                     { group: "Git / 诊断 / 测试", tools: "git_status · git_diff · diagnostics · run_tests" },
-                    { group: "子 Agent", tools: "agent_open · agent_eval · agent_close —— 持久会话，并行执行，通过 var_handle 读取大结果" },
+                    { group: "子 Agent", tools: "agent —— 持久会话，并行执行；详见 docs/SUBAGENTS.md" },
                     { group: "递归 LM (RLM)", tools: "rlm_open · rlm_eval · rlm_configure · rlm_close —— 沙箱 Python REPL，内置 peek/search/chunk/sub_query_batch 等辅助函数" },
                     { group: "MCP", tools: "mcp_<server>_<tool>——从 ~/.codewhale/mcp.json 自动注册" },
                   ].map((row) => (
@@ -447,7 +447,7 @@ command = "~/.codewhale/hooks/pre.sh"        # / message_submit / mode_change / 
                     { group: "Search", tools: "grep_files · file_search · web_search · fetch_url" },
                     { group: "Shell", tools: "exec_shell · exec_shell_wait · exec_shell_interact" },
                     { group: "Git / diag / test", tools: "git_status · git_diff · diagnostics · run_tests" },
-                    { group: "Sub-agents", tools: "agent_open · agent_eval · agent_close — persistent sessions, parallel execution, bounded result retrieval via var_handle" },
+                    { group: "Sub-agents", tools: "agent — persistent sessions, parallel execution; see docs/SUBAGENTS.md" },
                     { group: "Recursive LM (RLM)", tools: "rlm_open · rlm_eval · rlm_configure · rlm_close — sandboxed Python REPL with peek/search/chunk/sub_query_batch helpers" },
                     { group: "MCP", tools: "mcp_<server>_<tool> — auto-registered from ~/.codewhale/mcp.json" },
                   ].map((row) => (

--- a/web/app/[locale]/roadmap/page.tsx
+++ b/web/app/[locale]/roadmap/page.tsx
@@ -23,7 +23,7 @@ const tracksEn = [
     color: "jade",
     items: [
       { title: "Typed tool surface", note: "read, write, edit, patch, grep, shell, git, web search — plus sub-agents, RLM, and MCP" },
-      { title: "Sub-agent parallel execution", note: "agent_open / agent_eval / agent_close; up to 10 concurrent sessions with bounded result handles" },
+      { title: "Sub-agent parallel execution", note: "agent; up to 10 concurrent sessions with bounded result handles" },
       { title: "RLM batched processing", note: "Persistent sandboxed Python REPL with 1–16 cheap parallel children for long-input analysis" },
       { title: "Three operating modes", note: "Plan (read-only), Agent (default), YOLO (auto-approved); orthogonal suggest / auto / never approval" },
       { title: "Per-platform sandbox", note: "seatbelt (macOS), landlock (Linux); Windows containment via restricted tokens (limited)" },
@@ -89,7 +89,7 @@ const tracksZh = [
     color: "jade",
     items: [
       { title: "类型化工具集", note: "文件读写、编辑、补丁、搜索、Shell、Git、子 Agent、RLM、MCP——覆盖日常开发全流程" },
-      { title: "子 Agent 并行执行", note: "agent_open / agent_eval / agent_close；最多 10 个并发会话，通过 var_handle 有界读取结果" },
+      { title: "子 Agent 并行执行", note: "agent；最多 10 个并发会话，通过 var_handle 有界读取结果" },
       { title: "RLM 批量处理", note: "持久沙箱 Python REPL，支持 1–16 路廉价并行子调用，处理长文本分析" },
       { title: "三种运行模式", note: "Plan（只读）、Agent（默认）、YOLO（自动批准）；审批模式正交（建议/自动/拒绝）" },
       { title: "跨平台沙箱", note: "seatbelt（macOS）、landlock（Linux）；Windows 通过受限令牌实现基础隔离（功能有限）" },


### PR DESCRIPTION
Replace agent_open / agent_eval / agent_close with the current `agent` tool name across roadmap and docs pages (EN + ZH).

- roadmap/page.tsx: update Shipped items for sub-agent parallel execution
- docs/page.tsx: update tool listing, add link to docs/SUBAGENTS.md
- derive-facts.mjs: remove unused REPO_ROOT (lint cleanup)

Close https://github.com/Hmbown/CodeWhale/issues/3414.
## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
