### PR TITLE
feat(web): publish install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ docs/*.pdf
 *.cmd
 !scripts/**
 !.github/scripts/**
+!web/public/install.sh
 test.txt
 TODO*.md
 todo*.md

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,6 +8,16 @@ If you just want the short version, see the
 [main README](../README.md#install) or
 [简体中文 README](../README.zh-CN.md#安装).
 
+On macOS and Linux, the website installer is the shortest install/update path:
+
+```bash
+curl -fsSL https://codewhale.net/install.sh | sh
+```
+
+It downloads the matching `codewhale` and `codewhale-tui` release binaries,
+verifies them against `codewhale-artifacts-sha256.txt`, installs to
+`~/.local/bin` by default, and creates the `codew` convenience alias.
+
 ---
 
 ## 1. Supported platforms
@@ -117,11 +127,11 @@ a download sourced from an impersonating repository or mirror.
 ## 3. Install via npm
 
 npm is the recommended install path. The `codewhale` wrapper is published at
-v0.8.63 (Node 18+; wrapper available for v0.8.56 and later).
+v0.8.64 (Node 18+; wrapper available for v0.8.56 and later).
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.63
+codewhale --version   # 0.8.64
 ```
 
 `postinstall` downloads the right pair of binaries from the matching GitHub

--- a/web/app/[locale]/install/page.tsx
+++ b/web/app/[locale]/install/page.tsx
@@ -13,11 +13,13 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     locale,
     title: isZh ? "安装 · CodeWhale" : "Install · CodeWhale",
     description: isZh
-      ? "一行 npm install -g codewhale 安装 CodeWhale，也支持 Cargo、GitHub Releases、CNB 镜像、Homebrew、预编译二进制、Docker 和源码编译。"
-      : "Install CodeWhale with npm install -g codewhale — or via cargo, GitHub Releases, the CNB mirror, Homebrew, prebuilt binaries, Docker, or from source.",
+      ? "一行 curl -fsSL https://codewhale.net/install.sh | sh 安装或更新 CodeWhale，也支持 npm、Cargo、GitHub Releases、CNB 镜像、Homebrew、预编译二进制、Docker 和源码编译。"
+      : "Install or update CodeWhale with curl -fsSL https://codewhale.net/install.sh | sh, or via npm, cargo, GitHub Releases, the CNB mirror, Homebrew, prebuilt binaries, Docker, or from source.",
   });
 }
 
+const SHELL_INSTALL = `curl -fsSL https://codewhale.net/install.sh | sh`;
+const SHELL_INSPECT = `curl -fsSL https://codewhale.net/install.sh`;
 const NPM_INSTALL = `npm install -g codewhale`;
 const CARGO_INSTALL = `cargo install codewhale-cli --locked
 cargo install codewhale-tui --locked`;
@@ -52,7 +54,7 @@ docker run --rm -it \\
   ghcr.io/hmbown/codewhale:latest`;
 
 const FROM_SOURCE = `git clone https://github.com/Hmbown/CodeWhale
-cd codewhale
+cd CodeWhale
 cargo build --release --locked
 
 # Install both binaries from the local checkout
@@ -107,27 +109,30 @@ codewhale doctor`;
         </h1>
 
         <div className="space-y-3">
-          <InstallCodeBlock cmd={NPM_INSTALL} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+          <InstallCodeBlock cmd={SHELL_INSTALL} copyLabel={copyLabel} copiedLabel={copiedLabel} />
           <InstallCodeBlock cmd={FIRST_RUN} copyLabel={copyLabel} copiedLabel={copiedLabel} />
         </div>
 
         <p className="mt-4 text-sm text-ink-soft leading-relaxed max-w-2xl">
           {isZh ? (
             <>
-              npm wrapper（Node 18+）会从 GitHub Releases 下载经 SHA-256 校验的二进制，并安装{" "}
+              macOS / Linux 安装脚本会从 GitHub Releases 下载经 SHA-256 校验的二进制，
+              默认安装到 <code className="inline">~/.local/bin</code>，并安装{" "}
               <code className="inline">codewhale</code>、<code className="inline">codew</code> 和{" "}
-              <code className="inline">codewhale-tui</code> 三个命令。
-              下方「其他安装方式」列出 Cargo、GitHub Releases、CNB、国内镜像、Homebrew、预编译二进制和 Docker。
+              <code className="inline">codewhale-tui</code>。先审阅脚本可运行{" "}
+              <code className="inline">{SHELL_INSPECT}</code>。下方「其他安装方式」列出 npm、Cargo、GitHub Releases、
+              CNB、国内镜像、Homebrew、预编译二进制和 Docker。
             </>
           ) : (
             <>
-              The npm wrapper (Node 18+) downloads SHA-256-verified binaries from GitHub Releases
-              and installs <code className="inline">codewhale</code>,{" "}
-              <code className="inline">codew</code>, and{" "}
-              <code className="inline">codewhale-tui</code>. See{" "}
+              The macOS / Linux installer downloads SHA-256-verified binaries from GitHub Releases,
+              installs to <code className="inline">~/.local/bin</code> by default, and exposes{" "}
+              <code className="inline">codewhale</code>, <code className="inline">codew</code>, and{" "}
+              <code className="inline">codewhale-tui</code>. To inspect it first, run{" "}
+              <code className="inline">{SHELL_INSPECT}</code>. See{" "}
               <a href="#other-ways" className="body-link">Other ways to install</a> below for
-              cargo, GitHub Releases, CNB, Homebrew, prebuilt binaries, Docker, or mainland China
-              mirrors.
+              npm, cargo, GitHub Releases, CNB, Homebrew, prebuilt binaries, Docker, or mainland
+              China mirrors.
             </>
           )}
         </p>
@@ -146,14 +151,14 @@ codewhale doctor`;
           {isZh ? (
             <>
               <code className="inline">codewhale doctor</code> 检查 API 密钥、网络、沙箱可用性、
-              MCP 服务器，并将完整报告写入{" "}
-              <code className="inline">~/.codewhale/doctor.log</code>。
+              MCP 服务器，并在终端输出修复建议；需要结构化输出时可加{" "}
+              <code className="inline">--json</code>。
             </>
           ) : (
             <>
               <code className="inline">codewhale doctor</code> checks your API key, network,
-              sandbox availability, and MCP servers. Full report is written to{" "}
-              <code className="inline">~/.codewhale/doctor.log</code>.
+              sandbox availability, and MCP servers, then prints remediation guidance. Add{" "}
+              <code className="inline">--json</code> when you need structured output.
             </>
           )}
         </p>
@@ -167,11 +172,16 @@ codewhale doctor`;
         </div>
 
         <InstallCodeBlock cmd={UPDATE} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+        <div className="mt-3">
+          <InstallCodeBlock cmd={SHELL_INSTALL} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+        </div>
 
         <p className="mt-4 text-sm text-ink-soft leading-relaxed max-w-2xl">
           {isZh ? (
             <>
               检查 GitHub Releases 是否有新版本并就地替换二进制。
+              通过 <code className="inline">install.sh</code> 安装的用户也可以重跑同一条{" "}
+              <code className="inline">curl</code> 命令覆盖更新。
               通过包管理器安装的话，用包管理器升级更稳：npm 安装的运行{" "}
               <code className="inline">npm update -g codewhale</code>；
               Cargo 安装的重跑两个 <code className="inline">cargo install</code> 命令并加{" "}
@@ -181,7 +191,9 @@ codewhale doctor`;
           ) : (
             <>
               Checks GitHub Releases for a newer version and replaces the binary in place. If you
-              installed via a package manager, prefer it instead: npm users run{" "}
+              installed with <code className="inline">install.sh</code>, re-run the same{" "}
+              <code className="inline">curl</code> command to overwrite the binaries.
+              If you installed via a package manager, prefer it instead: npm users run{" "}
               <code className="inline">npm update -g codewhale</code>; cargo users re-run both{" "}
               <code className="inline">cargo install</code> commands with{" "}
               <code className="inline">--force</code>; the legacy Homebrew tap updates with{" "}
@@ -274,11 +286,38 @@ codewhale doctor`;
           </h2>
           <p className="text-sm text-ink-soft max-w-2xl mb-10">
             {isZh
-              ? "如果上面的 npm 路径不适合你，从下面找到匹配你情况的一条。每条都安装同一组 codewhale / codewhale-tui 二进制。"
-              : "If the npm path above doesn't fit your setup, pick the row that matches your situation. Every path installs the same codewhale / codewhale-tui binary pair."}
+              ? "如果上面的脚本路径不适合你，从下面找到匹配你情况的一条。每条都安装同一组 codewhale / codewhale-tui 二进制。"
+              : "If the script above doesn't fit your setup, pick the row that matches your situation. Every path installs the same codewhale / codewhale-tui binary pair."}
           </p>
 
           <div className="space-y-10">
+            {/* npm */}
+            <div>
+              <div className="eyebrow mb-2 text-indigo">
+                npm{" "}
+                <span className="text-ink-mute font-mono normal-case tracking-normal">
+                  {isZh ? "· Node 18+" : "· Node 18+"}
+                </span>
+              </div>
+              <InstallCodeBlock cmd={NPM_INSTALL} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+              <p className="mt-3 text-sm text-ink-soft leading-relaxed max-w-2xl">
+                {isZh ? (
+                  <>
+                    npm wrapper 会从 GitHub Releases 下载经 SHA-256 校验的二进制，并安装{" "}
+                    <code className="inline">codewhale</code>、<code className="inline">codew</code> 和{" "}
+                    <code className="inline">codewhale-tui</code> 三个命令。
+                  </>
+                ) : (
+                  <>
+                    The npm wrapper downloads SHA-256-verified binaries from GitHub Releases and
+                    installs <code className="inline">codewhale</code>,{" "}
+                    <code className="inline">codew</code>, and{" "}
+                    <code className="inline">codewhale-tui</code>.
+                  </>
+                )}
+              </p>
+            </div>
+
             {/* Cargo */}
             <div>
               <div className="eyebrow mb-2 text-indigo">
@@ -289,7 +328,9 @@ codewhale doctor`;
                 {isZh ? (
                   <>
                     编译并安装 <code className="inline">codewhale</code> 和 <code className="inline">codewhale-tui</code> 到 <code className="inline">~/.cargo/bin</code>。
-                    需要 Rust 1.88+；如未安装可访问 <a href="https://rustup.rs" className="body-link">rustup.rs</a>。
+                    需要 Rust 1.88+；Linux 用户先安装 <code className="inline">pkg-config</code> 和{" "}
+                    <code className="inline">libdbus-1-dev</code> 等构建依赖。如未安装 Rust，可访问{" "}
+                    <a href="https://rustup.rs" className="body-link">rustup.rs</a>。
                   </>
                 ) : (
                   <>
@@ -297,6 +338,9 @@ codewhale doctor`;
                     <code className="inline">codewhale-tui</code> to{" "}
                     <code className="inline">~/.cargo/bin</code>. Requires Rust 1.88+; install via{" "}
                     <a href="https://rustup.rs" className="body-link">rustup.rs</a> if you don&apos;t have it.
+                    On Linux, install build dependencies such as{" "}
+                    <code className="inline">pkg-config</code> and{" "}
+                    <code className="inline">libdbus-1-dev</code> first.
                   </>
                 )}
               </p>
@@ -485,13 +529,13 @@ codewhale doctor`;
                 {isZh ? (
                   <>
                     面向无法稳定访问 GitHub 的用户，提供 CNB 镜像（
-                    <Link href="/docs#cnb-mirror" className="body-link">docs/CNB_MIRROR.md</Link>
+                    <a href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CNB_MIRROR.md" className="body-link">docs/CNB_MIRROR.md</a>
                     ）。镜像仓库由社区成员维护，发布延迟可能为几小时。
                   </>
                 ) : (
                   <>
                     A CNB mirror is available for users who cannot reliably reach GitHub (
-                    <Link href="/docs#cnb-mirror" className="body-link">docs/CNB_MIRROR.md</Link>
+                    <a href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CNB_MIRROR.md" className="body-link">docs/CNB_MIRROR.md</a>
                     ). The mirror is maintained by community members; release latency may be a few hours.
                   </>
                 )}
@@ -526,7 +570,7 @@ codewhale doctor`;
           </div>
           <div className="grid md:grid-cols-3 gap-0 col-rule hairline-t hairline-b">
             <Link
-              href={isZh ? "/zh/docs" : "/docs"}
+              href={isZh ? "/zh/docs" : "/en/docs"}
               className="p-6 hover:bg-paper-deep transition-colors"
             >
               <div className="font-display text-xl mb-2">Docs</div>

--- a/web/components/install-binary.tsx
+++ b/web/components/install-binary.tsx
@@ -3,39 +3,56 @@
 import { useEffect, useState } from "react";
 import { InstallCodeBlock } from "./install-code-block";
 
-type Arch = "macos-arm64" | "macos-x64" | "linux-x64" | "linux-arm64" | "windows-x64";
+type Arch = "macos-arm64" | "macos-x64" | "linux-x64" | "linux-arm64" | "linux-riscv64" | "windows-x64";
 
 const SNIPPETS: Record<Arch, string> = {
-  "macos-arm64": `curl -fsSL -o codewhale \\
+  "macos-arm64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-macos-arm64
 curl -fsSL -o codewhale-tui \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-macos-arm64
+grep -E ' (codewhale|codewhale-tui)-macos-arm64$' codewhale-artifacts-sha256.txt | shasum -a 256 -c -
 chmod +x codewhale codewhale-tui
 xattr -d com.apple.quarantine codewhale codewhale-tui 2>/dev/null || true
 sudo mv codewhale codewhale-tui /usr/local/bin/`,
-  "macos-x64": `curl -fsSL -o codewhale \\
+  "macos-x64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-macos-x64
 curl -fsSL -o codewhale-tui \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-macos-x64
+grep -E ' (codewhale|codewhale-tui)-macos-x64$' codewhale-artifacts-sha256.txt | shasum -a 256 -c -
 chmod +x codewhale codewhale-tui
 xattr -d com.apple.quarantine codewhale codewhale-tui 2>/dev/null || true
 sudo mv codewhale codewhale-tui /usr/local/bin/`,
-  "linux-x64": `curl -fsSL -o codewhale \\
+  "linux-x64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-linux-x64
 curl -fsSL -o codewhale-tui \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-linux-x64
+grep -E ' (codewhale|codewhale-tui)-linux-x64$' codewhale-artifacts-sha256.txt | sha256sum -c -
 chmod +x codewhale codewhale-tui
 sudo mv codewhale codewhale-tui /usr/local/bin/`,
-  "linux-arm64": `curl -fsSL -o codewhale \\
+  "linux-arm64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+curl -fsSL -o codewhale \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-linux-arm64
 curl -fsSL -o codewhale-tui \\
   https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-linux-arm64
+grep -E ' (codewhale|codewhale-tui)-linux-arm64$' codewhale-artifacts-sha256.txt | sha256sum -c -
+chmod +x codewhale codewhale-tui
+sudo mv codewhale codewhale-tui /usr/local/bin/`,
+  "linux-riscv64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+curl -fsSL -o codewhale \\
+  https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-linux-riscv64
+curl -fsSL -o codewhale-tui \\
+  https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-linux-riscv64
+grep -E ' (codewhale|codewhale-tui)-linux-riscv64$' codewhale-artifacts-sha256.txt | sha256sum -c -
 chmod +x codewhale codewhale-tui
 sudo mv codewhale codewhale-tui /usr/local/bin/`,
   "windows-x64": `# PowerShell
 $ErrorActionPreference = "Stop"
 $dest = "$Env:USERPROFILE\\bin"
 New-Item -ItemType Directory -Force $dest | Out-Null
+$manifest = Invoke-WebRequest https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
 
 Invoke-WebRequest \`
   -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-windows-x64.exe \`
@@ -44,21 +61,32 @@ Invoke-WebRequest \`
   -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-windows-x64.exe \`
   -OutFile "$dest\\codewhale-tui.exe"
 
+$expected = @{}
+$manifest.Content -split "\`n" | ForEach-Object {
+  $parts = $_.Trim() -split "\\s+"
+  if ($parts.Length -ge 2) { $expected[$parts[1]] = $parts[0].ToUpperInvariant() }
+}
+if ((Get-FileHash "$dest\\codewhale.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-windows-x64.exe"]) { throw "codewhale.exe checksum mismatch" }
+if ((Get-FileHash "$dest\\codewhale-tui.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-tui-windows-x64.exe"]) { throw "codewhale-tui.exe checksum mismatch" }
+
 $Env:Path = "$dest;$Env:Path"`,
 };
 
 const VERIFY: Record<Arch, string> = {
-  "macos-arm64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
-shasum -a 256 -c codewhale-artifacts-sha256.txt --ignore-missing`,
-  "macos-x64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
-shasum -a 256 -c codewhale-artifacts-sha256.txt --ignore-missing`,
-  "linux-x64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
-sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing`,
-  "linux-arm64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
-sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing`,
+  "macos-arm64": `grep -E ' (codewhale|codewhale-tui)-macos-arm64$' codewhale-artifacts-sha256.txt | shasum -a 256 -c -`,
+  "macos-x64": `grep -E ' (codewhale|codewhale-tui)-macos-x64$' codewhale-artifacts-sha256.txt | shasum -a 256 -c -`,
+  "linux-x64": `grep -E ' (codewhale|codewhale-tui)-linux-x64$' codewhale-artifacts-sha256.txt | sha256sum -c -`,
+  "linux-arm64": `grep -E ' (codewhale|codewhale-tui)-linux-arm64$' codewhale-artifacts-sha256.txt | sha256sum -c -`,
+  "linux-riscv64": `grep -E ' (codewhale|codewhale-tui)-linux-riscv64$' codewhale-artifacts-sha256.txt | sha256sum -c -`,
   "windows-x64": `# PowerShell
-Get-FileHash "$Env:USERPROFILE\\bin\\codewhale.exe" -Algorithm SHA256
-Get-FileHash "$Env:USERPROFILE\\bin\\codewhale-tui.exe" -Algorithm SHA256`,
+$manifest = Invoke-WebRequest https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+$expected = @{}
+$manifest.Content -split "\`n" | ForEach-Object {
+  $parts = $_.Trim() -split "\\s+"
+  if ($parts.Length -ge 2) { $expected[$parts[1]] = $parts[0].ToUpperInvariant() }
+}
+if ((Get-FileHash "$Env:USERPROFILE\\bin\\codewhale.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-windows-x64.exe"]) { throw "codewhale.exe checksum mismatch" }
+if ((Get-FileHash "$Env:USERPROFILE\\bin\\codewhale-tui.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-tui-windows-x64.exe"]) { throw "codewhale-tui.exe checksum mismatch" }`,
 };
 
 const LABELS: Record<Arch, string> = {
@@ -66,6 +94,7 @@ const LABELS: Record<Arch, string> = {
   "macos-x64": "macOS · Intel",
   "linux-x64": "Linux · x64",
   "linux-arm64": "Linux · arm64",
+  "linux-riscv64": "Linux · riscv64",
   "windows-x64": "Windows · x64",
 };
 

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -1,0 +1,264 @@
+#!/bin/sh
+set -eu
+
+repo="Hmbown/CodeWhale"
+version="${CODEWHALE_VERSION:-latest}"
+release_base="${CODEWHALE_RELEASE_BASE_URL:-${DEEPSEEK_TUI_RELEASE_BASE_URL:-}}"
+
+usage() {
+  cat <<'USAGE'
+CodeWhale installer for macOS and Linux.
+
+Usage:
+  curl -fsSL https://codewhale.net/install.sh | sh
+
+Environment:
+  CODEWHALE_INSTALL_DIR    Install directory. Default: $HOME/.local/bin
+  CODEWHALE_VERSION        Release tag to install, for example v0.8.64. Default: latest
+  CODEWHALE_RELEASE_BASE_URL
+                           Custom release asset base URL ending in /download
+  CODEWHALE_SKIP_GLIBC_CHECK=1
+                           Skip Linux arm64/riscv64 glibc compatibility preflight
+
+Examples:
+  curl -fsSL https://codewhale.net/install.sh | CODEWHALE_INSTALL_DIR=/usr/local/bin sh
+  curl -fsSL https://codewhale.net/install.sh | CODEWHALE_VERSION=v0.8.64 sh
+USAGE
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+say() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'codewhale install: %s\n' "$*" >&2
+  exit 1
+}
+
+if [ -n "${CODEWHALE_INSTALL_DIR:-}" ]; then
+  install_dir="$CODEWHALE_INSTALL_DIR"
+else
+  [ -n "${HOME:-}" ] || fail "HOME is not set; set CODEWHALE_INSTALL_DIR"
+  install_dir="$HOME/.local/bin"
+fi
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+download() {
+  url="$1"
+  out="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$out"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$out"
+  else
+    fail "curl or wget is required"
+  fi
+}
+
+sha256_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    fail "sha256sum or shasum is required to verify downloads"
+  fi
+}
+
+verify_asset() {
+  asset="$1"
+  file="$2"
+  manifest="$3"
+  expected="$(
+    awk -v name="$asset" '
+      {
+        digest = tolower($1)
+        file = $2
+        sub(/^\*/, "", file)
+        if (file == name && digest ~ /^[0-9a-f]{64}$/) {
+          print digest
+          exit
+        }
+      }
+    ' "$manifest"
+  )"
+  [ -n "$expected" ] || fail "checksum not found for $asset"
+  actual="$(sha256_file "$file" | tr '[:upper:]' '[:lower:]')"
+  [ "$actual" = "$expected" ] || fail "checksum mismatch for $asset"
+}
+
+glibc_version() {
+  if command -v getconf >/dev/null 2>&1; then
+    getconf GNU_LIBC_VERSION 2>/dev/null | awk '{ print $NF; exit }'
+    return
+  fi
+  if command -v ldd >/dev/null 2>&1; then
+    ldd --version 2>/dev/null | awk 'NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^[0-9]+\.[0-9]+/) {
+          print $i
+          exit
+        }
+      }
+    }'
+  fi
+}
+
+version_at_least() {
+  have="$1"
+  need="$2"
+  awk -v have="$have" -v need="$need" '
+    BEGIN {
+      split(have, h, ".")
+      split(need, n, ".")
+      for (i = 1; i <= 3; i++) {
+        hv = h[i] + 0
+        nv = n[i] + 0
+        if (hv > nv) exit 0
+        if (hv < nv) exit 1
+      }
+      exit 0
+    }
+  '
+}
+
+check_glibc() {
+  case "$target" in
+    linux-arm64|linux-riscv64) ;;
+    *) return ;;
+  esac
+
+  [ "${CODEWHALE_SKIP_GLIBC_CHECK:-}" = "1" ] && return
+  [ "${DEEPSEEK_TUI_SKIP_GLIBC_CHECK:-}" = "1" ] && return
+  [ "${DEEPSEEK_SKIP_GLIBC_CHECK:-}" = "1" ] && return
+
+  required="2.39"
+  host="$(glibc_version || true)"
+  if [ -z "$host" ] || ! version_at_least "$host" "$required"; then
+    cat >&2 <<EOF
+codewhale install: prebuilt CodeWhale $target assets require glibc $required or newer.
+This system reports glibc ${host:-unavailable}.
+
+Linux x64 uses a static musl build. Linux arm64 and riscv64 release assets are
+GNU libc builds from Ubuntu 24.04. Build from source with Cargo or set
+CODEWHALE_SKIP_GLIBC_CHECK=1 to bypass this check at your own risk.
+EOF
+    exit 1
+  fi
+}
+
+detect_platform() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Darwin) platform="macos" ;;
+    Linux) platform="linux" ;;
+    *) fail "unsupported OS: $os. Use npm, Cargo, or the GitHub Releases page." ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64) cpu="x64" ;;
+    arm64|aarch64) cpu="arm64" ;;
+    riscv64) cpu="riscv64" ;;
+    *) fail "unsupported CPU architecture: $arch. Use Cargo or build from source." ;;
+  esac
+
+  if [ "$platform" = "macos" ] && [ "$cpu" = "riscv64" ]; then
+    fail "macOS riscv64 is not a supported release target"
+  fi
+
+  printf '%s-%s' "$platform" "$cpu"
+}
+
+if [ -z "$release_base" ]; then
+  if [ "$version" = "latest" ]; then
+    release_base="https://github.com/$repo/releases/latest/download"
+  else
+    release_base="https://github.com/$repo/releases/download/$version"
+  fi
+fi
+
+target="$(detect_platform)"
+check_glibc
+cli_asset="codewhale-$target"
+tui_asset="codewhale-tui-$target"
+manifest_asset="codewhale-artifacts-sha256.txt"
+
+tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t codewhale-install)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+say "Installing CodeWhale for $target"
+say "Release assets: $release_base"
+say "Install dir: $install_dir"
+
+download "$release_base/$manifest_asset" "$tmpdir/$manifest_asset"
+download "$release_base/$cli_asset" "$tmpdir/codewhale"
+download "$release_base/$tui_asset" "$tmpdir/codewhale-tui"
+
+verify_asset "$cli_asset" "$tmpdir/codewhale" "$tmpdir/$manifest_asset"
+verify_asset "$tui_asset" "$tmpdir/codewhale-tui" "$tmpdir/$manifest_asset"
+say "Checksums verified"
+
+chmod 755 "$tmpdir/codewhale" "$tmpdir/codewhale-tui"
+if command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "$tmpdir/codewhale" "$tmpdir/codewhale-tui" 2>/dev/null || true
+fi
+
+sudo_cmd=""
+if [ -d "$install_dir" ]; then
+  if [ ! -w "$install_dir" ] ||
+    { [ -e "$install_dir/codewhale" ] && [ ! -w "$install_dir/codewhale" ]; } ||
+    { [ -e "$install_dir/codewhale-tui" ] && [ ! -w "$install_dir/codewhale-tui" ]; } ||
+    { [ -e "$install_dir/codew" ] && [ ! -w "$install_dir/codew" ]; }; then
+    need_cmd sudo
+    sudo_cmd="sudo"
+  fi
+else
+  if ! mkdir -p "$install_dir" 2>/dev/null; then
+    need_cmd sudo
+    sudo mkdir -p "$install_dir"
+    sudo_cmd="sudo"
+  fi
+fi
+
+stage_cli="$install_dir/.codewhale.$$"
+stage_tui="$install_dir/.codewhale-tui.$$"
+trap 'rm -rf "$tmpdir"; rm -f "$stage_cli" "$stage_tui" 2>/dev/null || true' EXIT INT TERM
+
+$sudo_cmd cp "$tmpdir/codewhale" "$stage_cli"
+$sudo_cmd cp "$tmpdir/codewhale-tui" "$stage_tui"
+$sudo_cmd chmod 755 "$stage_cli" "$stage_tui"
+$sudo_cmd mv "$stage_cli" "$install_dir/codewhale"
+$sudo_cmd mv "$stage_tui" "$install_dir/codewhale-tui"
+
+$sudo_cmd rm -f "$install_dir/codew"
+if ! $sudo_cmd ln -s codewhale "$install_dir/codew"; then
+  say "Installed binaries, but could not create $install_dir/codew alias"
+fi
+
+say "Installed:"
+"$install_dir/codewhale" --version || true
+"$install_dir/codewhale-tui" --version || true
+
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *)
+    say ""
+    say "Add $install_dir to PATH to run codewhale from any terminal."
+    ;;
+esac
+
+say ""
+say "Run: codewhale"


### PR DESCRIPTION
## Summary
- add tracked public web installer at web/public/install.sh for macOS/Linux
- update install docs and website install page to make install.sh the primary macOS/Linux install/update path
- harden installer checksum parsing, Linux glibc preflight, staged binary replacement, and visible codew alias behavior
- fix install-page review issues: source checkout directory, doctor output copy, CNB docs link, Cargo Linux dependency note, manual checksum snippets, and Linux riscv64 selector

Closes #3477.

## Verification
- sh -n web/public/install.sh
- npm run lint (passes; existing #3476 digest unused Link warning on main)
- npm run build (passes; existing metadataBase warnings and #3476 digest lint warning)
- local fake-release smoke with CODEWHALE_RELEASE_BASE_URL=file://... and CODEWHALE_INSTALL_DIR=/tmp/... verified manifest, installed both fake binaries, and created codew symlink

## Notes
- This does not bump version, tag, publish artifacts, or deploy codewhale.net.
- Deployed /install.sh verification remains a post-merge website deploy gate.