### PR TITLE
Add provider readiness dashboard rows

### DIFF
--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -29,6 +29,10 @@ use ratatui::{
 use crate::config::{ApiProvider, Config, has_api_key_for, kimi_cli_credentials_present};
 use crate::palette;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use codewhale_config::provider::WireFormat;
+use codewhale_config::route::{
+    LogicalModelRef, PricingSku, RequestProtocol, RouteRequest, RouteResolver, bundled_offerings,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Stage {
@@ -37,11 +41,387 @@ enum Stage {
 }
 
 pub struct ProviderPickerView {
-    providers: Vec<(ApiProvider, bool)>,
-    active_provider: ApiProvider,
+    rows: Vec<ProviderDashboardRow>,
     selected_idx: usize,
     stage: Stage,
     api_key_input: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderDashboardRow {
+    pub provider: ApiProvider,
+    pub provider_id: String,
+    pub display_name: String,
+    pub kind: String,
+    pub base_url: String,
+    pub auth_status: ProviderAuthStatus,
+    pub catalog_status: ProviderCatalogStatus,
+    pub supported_protocols: Vec<String>,
+    pub available_model_count: usize,
+    pub default_route: ProviderDefaultRoute,
+    pub usage_meter: String,
+    pub readiness: ProviderReadiness,
+    pub messages: Vec<String>,
+    pub is_active: bool,
+    has_key: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderAuthStatus {
+    Configured,
+    Missing,
+    Optional,
+    OAuthReady,
+    OAuthMissing,
+    Local,
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderCatalogStatus {
+    Bundled,
+    DefaultOnly,
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderDefaultRoute {
+    pub logical_model: String,
+    pub wire_model: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderReadiness {
+    Ready,
+    NeedsAuth,
+    LocalReady,
+    Legacy,
+    Invalid,
+}
+
+impl ProviderDashboardRow {
+    fn from_config(provider: ApiProvider, active: ApiProvider, config: &Config) -> Self {
+        let has_key = has_api_key_for(config, provider);
+        let configured = config.provider_config_for(provider);
+        let configured_base_url = configured
+            .and_then(|entry| entry.base_url.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let configured_model = configured
+            .and_then(|entry| entry.model.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let auth_status = auth_status_for(provider, has_key, configured);
+        let usage_meter = usage_meter_for(provider);
+
+        let Some(kind) = provider.kind() else {
+            return Self {
+                provider,
+                provider_id: provider.as_str().to_string(),
+                display_name: provider.display_name().to_string(),
+                kind: "legacy".to_string(),
+                base_url: configured_base_url
+                    .unwrap_or_else(|| provider.default_base_url().to_string()),
+                auth_status: ProviderAuthStatus::Legacy,
+                catalog_status: ProviderCatalogStatus::Legacy,
+                supported_protocols: vec![protocol_label(WireFormat::ChatCompletions).to_string()],
+                available_model_count: 0,
+                default_route: ProviderDefaultRoute {
+                    logical_model: configured_model
+                        .unwrap_or_else(|| "deepseek-v4-pro".to_string()),
+                    wire_model: "legacy alias".to_string(),
+                },
+                usage_meter,
+                readiness: ProviderReadiness::Legacy,
+                messages: vec![
+                    "legacy DeepSeek China alias; routing maps through DeepSeek compatibility"
+                        .to_string(),
+                ],
+                is_active: provider == active,
+                has_key,
+            };
+        };
+
+        let available_model_count = bundled_offerings()
+            .iter()
+            .filter(|offering| offering.provider.as_str() == kind.as_str())
+            .count();
+        let catalog_status = if available_model_count == 0 {
+            ProviderCatalogStatus::DefaultOnly
+        } else {
+            ProviderCatalogStatus::Bundled
+        };
+        let route_request = RouteRequest {
+            explicit_provider: Some(kind),
+            model_selector: configured_model.clone().map(LogicalModelRef::from),
+            saved_provider_model: None,
+            base_url_override: configured_base_url.clone(),
+        };
+
+        let mut messages = Vec::new();
+        let route = RouteResolver::new().resolve(&route_request);
+        let (base_url, supported_protocols, default_route, resolved_pricing, route_ok) = match route
+        {
+            Ok(candidate) => {
+                if !candidate.validation.messages.is_empty() {
+                    messages.extend(candidate.validation.messages.clone());
+                }
+                (
+                    candidate.endpoint.base_url,
+                    vec![protocol_label(candidate.protocol).to_string()],
+                    ProviderDefaultRoute {
+                        logical_model: candidate.logical_model.raw().to_string(),
+                        wire_model: candidate.wire_model_id.as_str().to_string(),
+                    },
+                    pricing_label(provider, candidate.pricing.as_ref()),
+                    candidate.validation.ok,
+                )
+            }
+            Err(error) => {
+                messages.push(format!("route validation failed: {error}"));
+                (
+                    configured_base_url.unwrap_or_else(|| provider.default_base_url().to_string()),
+                    vec![
+                        provider
+                            .metadata()
+                            .map(|metadata| protocol_label(metadata.wire()).to_string())
+                            .unwrap_or_else(|| {
+                                protocol_label(WireFormat::ChatCompletions).to_string()
+                            }),
+                    ],
+                    ProviderDefaultRoute {
+                        logical_model: configured_model.unwrap_or_else(|| "invalid".to_string()),
+                        wire_model: "unresolved".to_string(),
+                    },
+                    usage_meter.clone(),
+                    false,
+                )
+            }
+        };
+
+        if matches!(
+            auth_status,
+            ProviderAuthStatus::Missing | ProviderAuthStatus::OAuthMissing
+        ) {
+            messages.push(format!("missing {}", provider.env_vars_label()));
+        }
+        if catalog_status == ProviderCatalogStatus::DefaultOnly {
+            messages.push("catalog snapshot missing; using provider default".to_string());
+        }
+
+        let readiness = readiness_for(provider, auth_status, route_ok);
+
+        Self {
+            provider,
+            provider_id: kind.as_str().to_string(),
+            display_name: provider.display_name().to_string(),
+            kind: format!("{kind:?}"),
+            base_url,
+            auth_status,
+            catalog_status,
+            supported_protocols,
+            available_model_count,
+            default_route,
+            usage_meter: resolved_pricing,
+            readiness,
+            messages,
+            is_active: provider == active,
+            has_key,
+        }
+    }
+
+    fn compact_hint(&self) -> String {
+        format!(
+            "{} | auth:{} | {} | {} | base:{} | route:{}{} | catalog:{}",
+            self.readiness.label(),
+            self.auth_status.label(),
+            self.usage_meter,
+            self.supported_protocols.join("+"),
+            compact_base_url(&self.base_url),
+            self.default_route.logical_model,
+            route_wire_suffix(&self.default_route),
+            self.catalog_label()
+        )
+    }
+
+    fn catalog_label(&self) -> String {
+        match self.catalog_status {
+            ProviderCatalogStatus::Bundled => format!("{} bundled", self.available_model_count),
+            ProviderCatalogStatus::DefaultOnly => "default-only".to_string(),
+            ProviderCatalogStatus::Legacy => "legacy".to_string(),
+        }
+    }
+}
+
+impl ProviderAuthStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Configured => "configured",
+            Self::Missing => "missing",
+            Self::Optional => "optional",
+            Self::OAuthReady => "oauth-ready",
+            Self::OAuthMissing => "oauth-missing",
+            Self::Local => "local",
+            Self::Legacy => "legacy",
+        }
+    }
+}
+
+impl ProviderReadiness {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::NeedsAuth => "needs-auth",
+            Self::LocalReady => "local-ready",
+            Self::Legacy => "legacy",
+            Self::Invalid => "invalid",
+        }
+    }
+}
+
+fn auth_status_for(
+    provider: ApiProvider,
+    has_key: bool,
+    configured: Option<&crate::config::ProviderConfig>,
+) -> ProviderAuthStatus {
+    if matches!(provider, ApiProvider::Ollama) {
+        return ProviderAuthStatus::Local;
+    }
+    if matches!(provider, ApiProvider::Sglang | ApiProvider::Vllm) {
+        return if has_explicit_credential(provider, configured) {
+            ProviderAuthStatus::Configured
+        } else {
+            ProviderAuthStatus::Optional
+        };
+    }
+    if provider == ApiProvider::Moonshot && configured.is_some_and(config_uses_kimi_oauth) {
+        return if has_key {
+            ProviderAuthStatus::OAuthReady
+        } else {
+            ProviderAuthStatus::OAuthMissing
+        };
+    }
+    if provider == ApiProvider::OpenaiCodex {
+        return if has_key {
+            ProviderAuthStatus::OAuthReady
+        } else {
+            ProviderAuthStatus::OAuthMissing
+        };
+    }
+    if has_key {
+        ProviderAuthStatus::Configured
+    } else {
+        ProviderAuthStatus::Missing
+    }
+}
+
+fn has_explicit_credential(
+    provider: ApiProvider,
+    configured: Option<&crate::config::ProviderConfig>,
+) -> bool {
+    provider
+        .env_vars()
+        .iter()
+        .any(|var| std::env::var(var).is_ok_and(|value| !value.trim().is_empty()))
+        || configured.is_some_and(|entry| {
+            entry
+                .api_key
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+                || entry
+                    .auth
+                    .as_ref()
+                    .is_some_and(|auth| auth.validate().is_ok())
+        })
+}
+
+fn config_uses_kimi_oauth(config: &crate::config::ProviderConfig) -> bool {
+    config.auth_mode.as_deref().is_some_and(|mode| {
+        let normalized = mode.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+        matches!(normalized.as_str(), "kimi_oauth" | "kimi_cli" | "kimi_code")
+    })
+}
+
+fn readiness_for(
+    provider: ApiProvider,
+    auth_status: ProviderAuthStatus,
+    route_ok: bool,
+) -> ProviderReadiness {
+    if provider.kind().is_none() {
+        return ProviderReadiness::Legacy;
+    }
+    if !route_ok {
+        return ProviderReadiness::Invalid;
+    }
+    match auth_status {
+        ProviderAuthStatus::Local | ProviderAuthStatus::Optional => ProviderReadiness::LocalReady,
+        ProviderAuthStatus::Configured | ProviderAuthStatus::OAuthReady => ProviderReadiness::Ready,
+        ProviderAuthStatus::Legacy => ProviderReadiness::Legacy,
+        ProviderAuthStatus::Missing | ProviderAuthStatus::OAuthMissing => {
+            ProviderReadiness::NeedsAuth
+        }
+    }
+}
+
+fn usage_meter_for(provider: ApiProvider) -> String {
+    match provider {
+        ApiProvider::Ollama | ApiProvider::Sglang | ApiProvider::Vllm => "cost: local".to_string(),
+        ApiProvider::OpenaiCodex => "usage: Codex OAuth quota".to_string(),
+        ApiProvider::Moonshot if kimi_cli_credentials_present() => {
+            "usage: Kimi OAuth quota".to_string()
+        }
+        ApiProvider::XiaomiMimo => "cost: token-plan".to_string(),
+        _ => "cost: unknown".to_string(),
+    }
+}
+
+fn pricing_label(provider: ApiProvider, pricing: Option<&PricingSku>) -> String {
+    match pricing {
+        Some(PricingSku::Token {
+            input_per_mtok,
+            output_per_mtok,
+        }) => match (input_per_mtok, output_per_mtok) {
+            (Some(input), Some(output)) => format!("cost: ${input:.2}/${output:.2} mtok"),
+            _ => "cost: token".to_string(),
+        },
+        Some(PricingSku::SubscriptionQuota { used_pct, .. }) => used_pct.map_or_else(
+            || "usage: subscription quota".to_string(),
+            |pct| format!("usage: subscription {pct:.0}%"),
+        ),
+        Some(PricingSku::AccountCredits { balance }) => balance.map_or_else(
+            || "usage: account credits".to_string(),
+            |balance| format!("usage: ${balance:.2} credits"),
+        ),
+        Some(PricingSku::LocalOrNotApplicable) => "cost: local".to_string(),
+        Some(PricingSku::UnknownOrStale) | None => usage_meter_for(provider),
+    }
+}
+
+fn protocol_label(protocol: RequestProtocol) -> &'static str {
+    match protocol {
+        WireFormat::ChatCompletions => "chat",
+        WireFormat::Responses => "responses",
+        WireFormat::AnthropicMessages => "anthropic",
+    }
+}
+
+fn route_wire_suffix(route: &ProviderDefaultRoute) -> String {
+    if route.logical_model == route.wire_model {
+        String::new()
+    } else {
+        format!(" -> {}", route.wire_model)
+    }
+}
+
+fn compact_base_url(base_url: &str) -> String {
+    base_url
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .to_string()
 }
 
 impl ProviderPickerView {
@@ -50,17 +430,16 @@ impl ProviderPickerView {
         // Present providers in the shared metadata display order (#3076). The
         // active provider is highlighted via `selected_idx` below, so it is
         // never lost in the list.
-        let providers: Vec<(ApiProvider, bool)> = ApiProvider::sorted_for_display()
+        let rows: Vec<ProviderDashboardRow> = ApiProvider::sorted_for_display()
             .into_iter()
-            .map(|p| (p, has_api_key_for(config, p)))
+            .map(|p| ProviderDashboardRow::from_config(p, active, config))
             .collect();
-        let selected_idx = providers
+        let selected_idx = rows
             .iter()
-            .position(|(p, _)| *p == active)
+            .position(|row| row.provider == active)
             .unwrap_or(0);
         Self {
-            providers,
-            active_provider: active,
+            rows,
             selected_idx,
             stage: Stage::List,
             api_key_input: String::new(),
@@ -68,21 +447,21 @@ impl ProviderPickerView {
     }
 
     fn move_up(&mut self) {
-        if self.providers.is_empty() {
+        if self.rows.is_empty() {
             return;
         }
         if self.selected_idx == 0 {
-            self.selected_idx = self.providers.len() - 1;
+            self.selected_idx = self.rows.len() - 1;
         } else {
             self.selected_idx -= 1;
         }
     }
 
     fn move_down(&mut self) {
-        if self.providers.is_empty() {
+        if self.rows.is_empty() {
             return;
         }
-        if self.selected_idx + 1 == self.providers.len() {
+        if self.selected_idx + 1 == self.rows.len() {
             self.selected_idx = 0;
         } else {
             self.selected_idx += 1;
@@ -90,11 +469,11 @@ impl ProviderPickerView {
     }
 
     fn selected_provider(&self) -> ApiProvider {
-        self.providers[self.selected_idx].0
+        self.rows[self.selected_idx].provider
     }
 
     fn selected_has_key(&self) -> bool {
-        self.providers[self.selected_idx].1
+        self.rows[self.selected_idx].has_key
     }
 
     fn enter_key_entry(&mut self) {
@@ -106,32 +485,11 @@ impl ProviderPickerView {
         provider.env_vars_label()
     }
 
-    fn provider_hint(provider: ApiProvider, has_key: bool) -> String {
-        match provider {
-            ApiProvider::Moonshot if kimi_cli_credentials_present() => {
-                "(Kimi CLI OAuth ready)".to_string()
-            }
-            ApiProvider::XiaomiMimo if has_key => "(configured; token-plan endpoint)".to_string(),
-            ApiProvider::XiaomiMimo => {
-                "(needs API key; token-plan endpoint by default)".to_string()
-            }
-            ApiProvider::Ollama => {
-                format!("self-hosted; defaults to {}", provider.default_base_url())
-            }
-            ApiProvider::Sglang | ApiProvider::Vllm if has_key => {
-                "(configured; optional key)".to_string()
-            }
-            ApiProvider::Sglang | ApiProvider::Vllm => "(optional key)".to_string(),
-            _ if has_key => "(configured)".to_string(),
-            _ => "(needs API key)".to_string(),
-        }
-    }
-
     fn visible_start(&self, visible_rows: usize) -> usize {
         if visible_rows == 0 {
             return 0;
         }
-        let max_start = self.providers.len().saturating_sub(visible_rows);
+        let max_start = self.rows.len().saturating_sub(visible_rows);
         self.selected_idx
             .saturating_add(1)
             .saturating_sub(visible_rows)
@@ -181,15 +539,15 @@ impl ProviderPickerView {
         let visible_rows = usize::from(inner.height);
         let visible_start = self.visible_start(visible_rows);
         let mut lines: Vec<Line> = Vec::with_capacity(visible_rows);
-        for (idx, (provider, has_key)) in self
-            .providers
+        for (idx, row) in self
+            .rows
             .iter()
             .enumerate()
             .skip(visible_start)
             .take(visible_rows)
         {
             let is_selected = idx == self.selected_idx;
-            let is_active = *provider == self.active_provider;
+            let is_active = row.is_active;
             let arrow = if is_selected { "▸" } else { " " };
             let active_dot = if is_active { " *" } else { "  " };
             let spacer_style = if is_selected {
@@ -203,23 +561,23 @@ impl ProviderPickerView {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
             let hint_style = if is_selected {
-                let hint_fg = if *has_key {
+                let hint_fg = if row.has_key {
                     palette::TEXT_MUTED
                 } else {
                     palette::STATUS_WARNING
                 };
                 Self::selected_row_style(hint_fg)
-            } else if *has_key {
+            } else if row.has_key {
                 Style::default().fg(palette::TEXT_MUTED)
             } else {
                 Style::default().fg(palette::STATUS_WARNING)
             };
-            let hint = Self::provider_hint(*provider, *has_key);
+            let hint = row.compact_hint();
             let mut line = Line::from(vec![
                 Span::styled(" ", spacer_style),
                 Span::styled(arrow, label_style),
                 Span::styled(" ", spacer_style),
-                Span::styled(provider.display_name().to_string(), label_style),
+                Span::styled(row.display_name.as_str(), label_style),
                 Span::styled(active_dot, label_style),
                 Span::styled("  ", spacer_style),
                 Span::styled(hint, hint_style),
@@ -413,9 +771,9 @@ impl ModalView for ProviderPickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 64.min(area.width.saturating_sub(4)).max(40);
+        let popup_width = 120.min(area.width.saturating_sub(4)).max(64);
         let popup_height = match self.stage {
-            Stage::List => (self.providers.len() as u16).saturating_add(2),
+            Stage::List => (self.rows.len() as u16).saturating_add(2),
             Stage::KeyEntry => 10,
         }
         .min(area.height.saturating_sub(4))
@@ -440,13 +798,49 @@ impl ModalView for ProviderPickerView {
 mod tests {
     use super::*;
     use crossterm::event::{KeyEvent, KeyModifiers};
+    use std::env;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn remove(key: &'static str) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: provider-picker tests that mutate environment variables
+            // hold ENV_LOCK for the whole guard lifetime, so no sibling test in
+            // this module can concurrently mutate/read this provider key.
+            unsafe {
+                env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: EnvVarGuard is used while ENV_LOCK is held; declaration
+            // order in the test drops the guard before releasing the lock.
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
     fn move_to_provider(picker: &mut ProviderPickerView, provider: ApiProvider) {
-        let max_steps = picker.providers.len();
+        let max_steps = picker.rows.len();
         for _ in 0..max_steps {
             if picker.selected_provider() == provider {
                 return;
@@ -471,9 +865,9 @@ mod tests {
         let config = Config::default();
         let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
         let names: Vec<_> = picker
-            .providers
+            .rows
             .iter()
-            .map(|(p, _)| p.display_name())
+            .map(|row| row.display_name.as_str())
             .collect();
 
         // Every built-in provider is present, none dropped (#3076 reorders, it
@@ -502,11 +896,137 @@ mod tests {
     }
 
     #[test]
-    fn ollama_hint_uses_metadata_default_base_url() {
-        assert!(
-            ProviderPickerView::provider_hint(ApiProvider::Ollama, true)
-                .contains(ApiProvider::Ollama.default_base_url())
+    fn provider_dashboard_row_models_local_readiness_without_rendering() {
+        let config = Config::default();
+        let row =
+            ProviderDashboardRow::from_config(ApiProvider::Ollama, ApiProvider::Ollama, &config);
+
+        assert_eq!(row.provider_id, "ollama");
+        assert_eq!(row.auth_status, ProviderAuthStatus::Local);
+        assert_eq!(row.readiness, ProviderReadiness::LocalReady);
+        assert_eq!(row.supported_protocols, vec!["chat".to_string()]);
+        assert_eq!(row.usage_meter, "cost: local");
+        assert!(row.base_url.contains("localhost:11434"));
+        assert!(row.is_active);
+    }
+
+    #[test]
+    fn provider_dashboard_row_uses_route_resolver_for_custom_openai_endpoint() {
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                openai: crate::config::ProviderConfig {
+                    api_key: Some("openai-key".to_string()),
+                    base_url: Some("http://localhost:9000/v1".to_string()),
+                    model: Some("custom-model".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let row =
+            ProviderDashboardRow::from_config(ApiProvider::Openai, ApiProvider::Openai, &config);
+
+        assert_eq!(row.provider_id, "openai");
+        assert_eq!(row.auth_status, ProviderAuthStatus::Configured);
+        assert_eq!(row.readiness, ProviderReadiness::Ready);
+        assert_eq!(row.base_url, "http://localhost:9000/v1");
+        assert_eq!(row.default_route.logical_model, "custom-model");
+        assert_eq!(row.default_route.wire_model, "custom-model");
+        assert_eq!(row.supported_protocols, vec!["chat".to_string()]);
+    }
+
+    #[test]
+    fn provider_dashboard_row_surfaces_anthropic_wire_protocol() {
+        let config = Config::default();
+        let row = ProviderDashboardRow::from_config(
+            ApiProvider::Anthropic,
+            ApiProvider::Deepseek,
+            &config,
         );
+
+        assert_eq!(row.provider_id, "anthropic");
+        assert_eq!(row.supported_protocols, vec!["anthropic".to_string()]);
+        assert_eq!(row.catalog_status, ProviderCatalogStatus::DefaultOnly);
+        assert!(
+            row.messages
+                .iter()
+                .any(|message| message.contains("catalog"))
+        );
+    }
+
+    #[test]
+    fn provider_dashboard_row_marks_missing_hosted_auth_as_needs_auth() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let _openrouter_key = EnvVarGuard::remove("OPENROUTER_API_KEY");
+        let config = Config::default();
+        let row = ProviderDashboardRow::from_config(
+            ApiProvider::Openrouter,
+            ApiProvider::Deepseek,
+            &config,
+        );
+
+        assert_eq!(row.auth_status, ProviderAuthStatus::Missing);
+        assert_eq!(row.readiness, ProviderReadiness::NeedsAuth);
+        assert!(
+            row.messages
+                .iter()
+                .any(|message| message.contains("missing OPENROUTER_API_KEY"))
+        );
+    }
+
+    #[test]
+    fn provider_dashboard_row_marks_route_resolver_errors_as_invalid() {
+        let config = Config {
+            api_key: Some("deepseek-key".to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                deepseek: crate::config::ProviderConfig {
+                    model: Some("anthropic/claude-foreign".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let row = ProviderDashboardRow::from_config(
+            ApiProvider::Deepseek,
+            ApiProvider::Deepseek,
+            &config,
+        );
+
+        assert_eq!(row.auth_status, ProviderAuthStatus::Configured);
+        assert_eq!(row.readiness, ProviderReadiness::Invalid);
+        assert_eq!(row.default_route.wire_model, "unresolved");
+        assert!(
+            row.messages
+                .iter()
+                .any(|message| message.contains("route validation failed"))
+        );
+    }
+
+    #[test]
+    fn provider_dashboard_render_includes_route_protocol_usage_and_base_url() {
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                openai: crate::config::ProviderConfig {
+                    api_key: Some("openai-key".to_string()),
+                    base_url: Some("http://localhost:9000/v1".to_string()),
+                    model: Some("custom-model".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let picker = ProviderPickerView::new(ApiProvider::Openai, &config);
+
+        let rendered = render_text(&picker, 124, 18);
+
+        assert!(rendered.contains("auth:configured"));
+        assert!(rendered.contains("route:custom-model"));
+        assert!(rendered.contains("chat"));
+        assert!(rendered.contains("cost: unknown"));
+        assert!(rendered.contains("localhost:9000/v1"));
     }
 
     #[test]
@@ -530,15 +1050,15 @@ mod tests {
         let config = Config::default();
         let picker = ProviderPickerView::new(ApiProvider::Openrouter, &config);
         assert_eq!(picker.selected_provider(), ApiProvider::Openrouter);
-        assert_eq!(picker.active_provider, ApiProvider::Openrouter);
+        assert!(picker.rows[picker.selected_idx].is_active);
     }
 
     #[test]
     fn list_navigation_wraps_between_first_and_last_provider() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
-        let first = picker.providers.first().expect("non-empty list").0;
-        let last = picker.providers.last().expect("non-empty list").0;
+        let first = picker.rows.first().expect("non-empty list").provider;
+        let last = picker.rows.last().expect("non-empty list").provider;
 
         // Order-independent: jump to the first entry, wrap up to the last, back down.
         picker.selected_idx = 0;


### PR DESCRIPTION
## Summary

Refs #3083.

- Replaces the /provider picker backing tuple list with a testable ProviderDashboardRow projection.
- Surfaces provider id/kind, auth/readiness, catalog status, protocol, default route, usage/cost class, and base URL in the compact picker row.
- Keeps existing provider switch and API-key entry behavior intact; no live network I/O is added.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target-v0865 cargo test -p codewhale-tui --bin codewhale-tui --locked provider_picker`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target-v0865 cargo test -p codewhale-config --locked route::tests`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target-v0865 cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::assertions_on_constants`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
