### PR TITLE
fix: prevent ordinary prompt text from being interpreted as a mode switch (#3387)

### DIFF
--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2026,7 +2026,15 @@ impl RuntimeThreadManager {
             touch_lru(&mut active.lru, thread_id);
         }
 
-        let mode = parse_mode(req.mode.as_deref().unwrap_or(&thread.mode));
+        // A requested mode override only takes effect when it is an explicit,
+        // recognized mode token. An unrecognized override (e.g. a stray prompt
+        // fragment) must NOT silently change the mode: fall back to the
+        // thread's persisted mode rather than coercing to Agent (#3387).
+        let mode = req
+            .mode
+            .as_deref()
+            .and_then(parse_mode_opt)
+            .unwrap_or_else(|| parse_mode(&thread.mode));
         let requested_model = req.model.unwrap_or_else(|| thread.model.clone());
         let auto_model = requested_model.trim().eq_ignore_ascii_case("auto");
         let (provider, model, reasoning_effort) = if auto_model {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3748,12 +3748,22 @@ fn enforce_lru_capacity(
     evicted
 }
 
-fn parse_mode(mode: &str) -> AppMode {
+/// Resolves only explicit mode tokens to an app mode. Free-form prompt text is
+/// never a valid mode token: `parse_mode_opt` returns `None` unless the input is
+/// exactly `agent`/`plan`/`yolo` or the numeric aliases `1`/`2`/`3`. Mode
+/// changes originate from the Tab cycle, `/mode`, the mode picker, or
+/// config/startup defaults, not from submitted natural-language prompt text.
+fn parse_mode_opt(mode: &str) -> Option<AppMode> {
     match mode.trim().to_ascii_lowercase().as_str() {
-        "plan" => AppMode::Plan,
-        "yolo" => AppMode::Yolo,
-        _ => AppMode::Agent,
+        "agent" | "1" => Some(AppMode::Agent),
+        "plan" | "2" => Some(AppMode::Plan),
+        "yolo" | "3" => Some(AppMode::Yolo),
+        _ => None,
     }
+}
+
+fn parse_mode(mode: &str) -> AppMode {
+    parse_mode_opt(mode).unwrap_or(AppMode::Agent)
 }
 
 fn tool_kind_for_name(name: &str) -> TurnItemKind {

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2466,6 +2466,38 @@ fn parse_mode_defaults_to_agent() {
     assert_eq!(parse_mode("plan"), AppMode::Plan);
 }
 
+#[test]
+fn parse_mode_opt_resolves_explicit_tokens_and_aliases() {
+    assert_eq!(parse_mode_opt("agent"), Some(AppMode::Agent));
+    assert_eq!(parse_mode_opt("1"), Some(AppMode::Agent));
+    assert_eq!(parse_mode_opt("plan"), Some(AppMode::Plan));
+    assert_eq!(parse_mode_opt("2"), Some(AppMode::Plan));
+    assert_eq!(parse_mode_opt("yolo"), Some(AppMode::Yolo));
+    assert_eq!(parse_mode_opt("3"), Some(AppMode::Yolo));
+    assert_eq!(parse_mode_opt(" PLAN "), Some(AppMode::Plan));
+}
+
+#[test]
+fn parse_mode_opt_rejects_prompt_fragments() {
+    for input in [
+        "plan a trip to Tokyo",
+        "switch the agent on",
+        "enter yolo mode",
+        "agent of chaos",
+        "mode",
+    ] {
+        assert_eq!(parse_mode_opt(input), None);
+    }
+}
+
+#[test]
+fn parse_mode_wrapper_defaults_and_resolves_numeric_aliases() {
+    assert_eq!(parse_mode("plan a trip to Tokyo"), AppMode::Agent);
+    assert_eq!(parse_mode("1"), AppMode::Agent);
+    assert_eq!(parse_mode("2"), AppMode::Plan);
+    assert_eq!(parse_mode("3"), AppMode::Yolo);
+}
+
 fn rebind_event(event: &str, agent_id: &str, seq: u64) -> RuntimeEventRecord {
     RuntimeEventRecord {
         schema_version: CURRENT_RUNTIME_SCHEMA_VERSION,


### PR DESCRIPTION
Rebased, credit-preserving replacement for #3455 (which was red only due to a stale base; the diff itself is clean). Cherry-picked @mvanhorn's two commits onto current `main` so CI runs against the live tree.

Closes #3387.

## What
`RuntimeThreadManager` previously coerced any unrecognized per-turn mode override to `Agent` via `parse_mode`. A stray prompt fragment in the mode slot could silently flip the thread's mode. This splits resolution:
- `parse_mode_opt` resolves **only** explicit tokens (`agent`/`plan`/`yolo`) and numeric aliases (`1`/`2`/`3`); anything else returns `None`.
- An unrecognized override now falls back to the thread's **persisted** mode instead of coercing to Agent.

This aligns with AGENTS.md: route/mode changes must come from explicit user choice, not from interpreting raw prompt text.

## Testing
- `cargo fmt -p codewhale-tui -- --check` ✅
- `cargo test -p codewhale-tui --bin codewhale-tui -- parse_mode` → 6 passed ✅ (incl. new `parse_mode_opt_resolves_explicit_tokens_and_aliases`, `parse_mode_opt_rejects_prompt_fragments`, `parse_mode_wrapper_defaults_and_resolves_numeric_aliases`)

Harvested from #3455.

Co-authored-by: Matt Van Horn <455140+mvanhorn@users.noreply.github.com>