### PR TITLE
feat(config): add Models.dev catalog route foundation

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth_source;
+pub mod models_dev;
 pub mod provider;
 pub mod route;
 

--- a/crates/config/src/models_dev.rs
+++ b/crates/config/src/models_dev.rs
@@ -1,0 +1,503 @@
+//! Models.dev catalog schema and helpers.
+//!
+//! Models.dev is the upstream taxonomy CodeWhale should use for model facts,
+//! provider offerings, pricing, limits, and capabilities. This module is
+//! intentionally network-free: callers provide JSON from a bundled snapshot,
+//! live refresh, or tests. Runtime fetch/cache policy belongs above this layer.
+//!
+//! The important boundary is the same one Models.dev uses:
+//! - `models` are provider-agnostic model facts.
+//! - `providers.*.models` are provider-scoped wire offerings.
+//!
+//! A provider row may inline inherited facts without exposing a canonical
+//! `base_model` link. CodeWhale must preserve that distinction instead of
+//! inferring canonical ownership from wire IDs or namespace prefixes.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::route::{ModelId, ProviderId, ProviderModelOffering, WireModelId};
+
+/// Provider catalog endpoint used by Models.dev.
+pub const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
+/// Provider-agnostic model metadata endpoint used by Models.dev.
+pub const MODELS_DEV_MODELS_URL: &str = "https://models.dev/models.json";
+/// Combined `{ models, providers }` endpoint used by Models.dev.
+pub const MODELS_DEV_CATALOG_URL: &str = "https://models.dev/catalog.json";
+
+/// Combined Models.dev catalog payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ModelsDevCatalog {
+    /// Provider-agnostic model facts, keyed by canonical model id.
+    #[serde(default)]
+    pub models: BTreeMap<String, ModelsDevModel>,
+    /// Provider-scoped catalogs, keyed by provider id.
+    #[serde(default)]
+    pub providers: BTreeMap<String, ModelsDevProvider>,
+}
+
+impl ModelsDevCatalog {
+    /// Parse a Models.dev combined catalog JSON payload.
+    ///
+    /// # Errors
+    /// Returns a serde error when the input is not valid Models.dev JSON.
+    pub fn parse_json(raw: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(raw)
+    }
+
+    /// Look up provider-agnostic model facts by canonical model id.
+    #[must_use]
+    pub fn model(&self, model_id: &str) -> Option<&ModelsDevModel> {
+        self.models.get(model_id.trim())
+    }
+
+    /// Look up a provider catalog by provider id.
+    #[must_use]
+    pub fn provider(&self, provider_id: &str) -> Option<&ModelsDevProvider> {
+        self.providers.get(provider_id.trim())
+    }
+
+    /// Look up a provider-scoped wire model row.
+    #[must_use]
+    pub fn provider_model(
+        &self,
+        provider_id: &str,
+        wire_model_id: &str,
+    ) -> Option<&ModelsDevProviderModel> {
+        self.provider(provider_id)?.models.get(wire_model_id.trim())
+    }
+
+    /// Build a route offering from a provider-scoped Models.dev row.
+    ///
+    /// The canonical model is set only when the row carries an explicit
+    /// `base_model` id. Generated Models.dev JSON often inlines inherited facts
+    /// without that link, so callers must not guess one from a prefix.
+    #[must_use]
+    pub fn provider_offering(
+        &self,
+        provider_id: &str,
+        wire_model_id: &str,
+    ) -> Option<ProviderModelOffering> {
+        let provider_key = provider_id.trim();
+        let provider = self.provider(provider_id)?;
+        let model = provider.models.get(wire_model_id.trim())?;
+        let provider_id = if provider.id.trim().is_empty() {
+            provider_key.to_string()
+        } else {
+            provider.id.trim().to_string()
+        };
+        Some(ProviderModelOffering {
+            provider: ProviderId::from(provider_id),
+            canonical_model: model.base_model.clone().map(ModelId::from),
+            wire_model_id: WireModelId::from(model.id.clone()),
+            endpoint_key: "chat".to_string(),
+            default_for_provider: model.default_for_provider,
+        })
+    }
+
+    /// Build route offerings for every normal text-chat model served by a
+    /// provider.
+    ///
+    /// Non-chat rows (for example TTS/audio-only offerings) stay in the parsed
+    /// catalog but are excluded from route resolution lists.
+    #[must_use]
+    pub fn provider_offerings(&self, provider_id: &str) -> Option<Vec<ProviderModelOffering>> {
+        let provider_key = provider_id.trim();
+        let provider = self.provider(provider_key)?;
+        let provider_id = if provider.id.trim().is_empty() {
+            provider_key.to_string()
+        } else {
+            provider.id.trim().to_string()
+        };
+        Some(
+            provider
+                .models
+                .values()
+                .filter(|model| model.supports_text_chat())
+                .map(|model| ProviderModelOffering {
+                    provider: ProviderId::from(provider_id.clone()),
+                    canonical_model: model.base_model.clone().map(ModelId::from),
+                    wire_model_id: WireModelId::from(model.id.clone()),
+                    endpoint_key: "chat".to_string(),
+                    default_for_provider: model.default_for_provider,
+                })
+                .collect(),
+        )
+    }
+}
+
+/// Provider-agnostic model facts from `models.json` / `catalog.models`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ModelsDevModel {
+    /// Canonical Models.dev model id, such as `zhipuai/glm-5.2`.
+    #[serde(default)]
+    pub id: String,
+    /// Human-friendly model name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Model family, such as `glm`, `gpt`, or `claude`.
+    #[serde(default)]
+    pub family: Option<String>,
+    /// Whether attachments are accepted.
+    #[serde(default)]
+    pub attachment: Option<bool>,
+    /// Whether the model supports reasoning.
+    #[serde(default)]
+    pub reasoning: Option<bool>,
+    /// Whether tool calling is supported.
+    #[serde(default)]
+    pub tool_call: Option<bool>,
+    /// Whether structured output is supported.
+    #[serde(default)]
+    pub structured_output: Option<bool>,
+    /// Whether temperature is supported.
+    #[serde(default)]
+    pub temperature: Option<bool>,
+    /// Whether weights are open.
+    #[serde(default)]
+    pub open_weights: Option<bool>,
+    /// Token limits.
+    #[serde(default)]
+    pub limit: Option<ModelsDevLimit>,
+    /// Input/output modalities.
+    #[serde(default)]
+    pub modalities: Option<ModelsDevModalities>,
+}
+
+impl ModelsDevModel {
+    /// True when the model can be used for normal text chat.
+    #[must_use]
+    pub fn supports_text_chat(&self) -> bool {
+        supports_text_chat(self.modalities.as_ref())
+    }
+}
+
+/// Provider-scoped model row from `api.json` / `catalog.providers.*.models`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ModelsDevProviderModel {
+    /// Provider wire model id.
+    #[serde(default)]
+    pub id: String,
+    /// Optional explicit canonical model link from source TOML.
+    #[serde(default)]
+    pub base_model: Option<String>,
+    /// Human-friendly model name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Model family as exposed for this provider row.
+    #[serde(default)]
+    pub family: Option<String>,
+    /// Whether this is the provider's default model in a CodeWhale snapshot.
+    #[serde(default, alias = "default")]
+    pub default_for_provider: bool,
+    /// Whether attachments are accepted.
+    #[serde(default)]
+    pub attachment: Option<bool>,
+    /// Whether the model supports reasoning.
+    #[serde(default)]
+    pub reasoning: Option<bool>,
+    /// Flexible reasoning-control metadata.
+    #[serde(default)]
+    pub reasoning_options: Vec<serde_json::Value>,
+    /// Whether tool calling is supported.
+    #[serde(default)]
+    pub tool_call: Option<bool>,
+    /// Whether structured output is supported.
+    #[serde(default)]
+    pub structured_output: Option<bool>,
+    /// Whether temperature is supported.
+    #[serde(default)]
+    pub temperature: Option<bool>,
+    /// Whether weights are open through this offering.
+    #[serde(default)]
+    pub open_weights: Option<bool>,
+    /// Token limits for this provider offering.
+    #[serde(default)]
+    pub limit: Option<ModelsDevLimit>,
+    /// Input/output modalities for this provider offering.
+    #[serde(default)]
+    pub modalities: Option<ModelsDevModalities>,
+    /// Provider-scoped pricing.
+    #[serde(default)]
+    pub cost: Option<ModelsDevCost>,
+    /// Interleaved reasoning field hints.
+    #[serde(default)]
+    pub interleaved: Option<ModelsDevInterleaved>,
+}
+
+impl ModelsDevProviderModel {
+    /// True when the provider offering can be used for normal text chat.
+    #[must_use]
+    pub fn supports_text_chat(&self) -> bool {
+        supports_text_chat(self.modalities.as_ref())
+    }
+}
+
+/// Provider row from Models.dev.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ModelsDevProvider {
+    /// Provider id, such as `zai`, `zhipuai`, or `openrouter`.
+    #[serde(default)]
+    pub id: String,
+    /// Human-friendly provider name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Default API base URL, if published.
+    #[serde(default)]
+    pub api: Option<String>,
+    /// AI SDK package identifier, useful as a protocol hint.
+    #[serde(default)]
+    pub npm: Option<String>,
+    /// Documentation URL, if published.
+    #[serde(default)]
+    pub doc: Option<String>,
+    /// Environment variable names for credentials.
+    #[serde(default)]
+    pub env: Vec<String>,
+    /// Provider-scoped wire model rows.
+    #[serde(default)]
+    pub models: BTreeMap<String, ModelsDevProviderModel>,
+}
+
+/// Token limits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ModelsDevLimit {
+    #[serde(default)]
+    pub context: Option<u64>,
+    #[serde(default)]
+    pub input: Option<u64>,
+    #[serde(default)]
+    pub output: Option<u64>,
+}
+
+/// Input/output modalities.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ModelsDevModalities {
+    #[serde(default)]
+    pub input: Vec<String>,
+    #[serde(default)]
+    pub output: Vec<String>,
+}
+
+/// Provider-scoped cost fields. Values are per million tokens unless a future
+/// Models.dev row specifies a richer tiering object in fields CodeWhale does
+/// not yet model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ModelsDevCost {
+    #[serde(default)]
+    pub input: Option<f64>,
+    #[serde(default)]
+    pub output: Option<f64>,
+    #[serde(default)]
+    pub cache_read: Option<f64>,
+    #[serde(default)]
+    pub cache_write: Option<f64>,
+}
+
+/// Interleaved reasoning field metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ModelsDevInterleaved {
+    #[serde(default)]
+    pub field: Option<String>,
+}
+
+fn supports_text_chat(modalities: Option<&ModelsDevModalities>) -> bool {
+    let Some(modalities) = modalities else {
+        return true;
+    };
+    modalities
+        .input
+        .iter()
+        .any(|modality| modality.eq_ignore_ascii_case("text"))
+        && modalities
+            .output
+            .iter()
+            .any(|modality| modality.eq_ignore_ascii_case("text"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GLM_FIXTURE: &str = r#"{
+      "models": {
+        "zhipuai/glm-5.2": {
+          "id": "zhipuai/glm-5.2",
+          "name": "GLM-5.2",
+          "family": "glm",
+          "reasoning": true,
+          "tool_call": true,
+          "structured_output": true,
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "limit": { "context": 1000000, "output": 131072 },
+          "open_weights": true
+        }
+      },
+      "providers": {
+        "zhipuai": {
+          "id": "zhipuai",
+          "name": "Zhipu AI",
+          "api": "https://open.bigmodel.cn/api/paas/v4",
+          "npm": "@ai-sdk/openai-compatible",
+          "env": ["ZHIPU_API_KEY"],
+          "models": {
+            "glm-5.2": {
+              "id": "glm-5.2",
+              "name": "GLM-5.2",
+              "family": "glm",
+              "reasoning": true,
+              "reasoning_options": [{ "type": "effort", "values": ["high", "max"] }],
+              "tool_call": true,
+              "structured_output": true,
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 1000000, "output": 131072 },
+              "cost": { "input": 1.4, "output": 4.4, "cache_read": 0.26 }
+            }
+          }
+        },
+        "zai": {
+          "id": "zai",
+          "name": "Z.AI",
+          "api": "https://api.z.ai/api/paas/v4",
+          "npm": "@ai-sdk/openai-compatible",
+          "env": ["ZHIPU_API_KEY"],
+          "models": {
+            "glm-5.2": {
+              "id": "glm-5.2",
+              "family": "glm",
+              "reasoning": true,
+              "tool_call": true,
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "cost": { "input": 1.4, "output": 4.4 }
+            }
+          }
+        }
+      }
+    }"#;
+
+    #[test]
+    fn parses_models_dev_catalog_layers_without_joining_by_prefix() {
+        let catalog = ModelsDevCatalog::parse_json(GLM_FIXTURE).expect("fixture parses");
+
+        let canonical = catalog.model("zhipuai/glm-5.2").expect("canonical model");
+        assert_eq!(canonical.family.as_deref(), Some("glm"));
+        assert_eq!(
+            canonical.limit.as_ref().and_then(|limit| limit.context),
+            Some(1_000_000)
+        );
+        assert!(canonical.supports_text_chat());
+
+        let provider = catalog.provider("zhipuai").expect("provider");
+        assert_eq!(
+            provider.api.as_deref(),
+            Some("https://open.bigmodel.cn/api/paas/v4")
+        );
+        assert_eq!(provider.npm.as_deref(), Some("@ai-sdk/openai-compatible"));
+        assert_eq!(provider.env, ["ZHIPU_API_KEY"]);
+
+        let offering = catalog
+            .provider_model("zhipuai", "glm-5.2")
+            .expect("provider model");
+        assert_eq!(offering.id, "glm-5.2");
+        assert_eq!(offering.reasoning, Some(true));
+        assert_eq!(
+            offering.cost.as_ref().and_then(|cost| cost.cache_read),
+            Some(0.26)
+        );
+        assert!(offering.supports_text_chat());
+        assert_eq!(
+            offering.base_model, None,
+            "generated JSON does not prove a canonical join"
+        );
+    }
+
+    #[test]
+    fn provider_offering_preserves_wire_id_without_inferred_canonical_model() {
+        let catalog = ModelsDevCatalog::parse_json(GLM_FIXTURE).expect("fixture parses");
+        let offering = catalog
+            .provider_offering("zai", "glm-5.2")
+            .expect("offering");
+
+        assert_eq!(offering.provider.as_str(), "zai");
+        assert_eq!(offering.wire_model_id.as_str(), "glm-5.2");
+        assert_eq!(offering.canonical_model, None);
+        assert_eq!(offering.endpoint_key, "chat");
+    }
+
+    #[test]
+    fn provider_offering_uses_explicit_base_model_when_present() {
+        let raw = r#"{
+          "providers": {
+            "openrouter": {
+              "id": "openrouter",
+              "models": {
+                "z-ai/glm-5.2": {
+                  "id": "z-ai/glm-5.2",
+                  "base_model": "zhipuai/glm-5.2"
+                }
+              }
+            }
+          }
+        }"#;
+        let catalog = ModelsDevCatalog::parse_json(raw).expect("fixture parses");
+        let offering = catalog
+            .provider_offering("openrouter", "z-ai/glm-5.2")
+            .expect("offering");
+
+        assert_eq!(
+            offering.canonical_model.as_ref().map(ModelId::as_str),
+            Some("zhipuai/glm-5.2")
+        );
+        assert_eq!(offering.wire_model_id.as_str(), "z-ai/glm-5.2");
+    }
+
+    #[test]
+    fn provider_offerings_emit_chat_rows_and_skip_non_text_outputs() {
+        let raw = r#"{
+          "providers": {
+            "zai": {
+              "models": {
+                "glm-5.2": {
+                  "id": "glm-5.2",
+                  "base_model": "zhipuai/glm-5.2",
+                  "default": true,
+                  "modalities": { "input": ["text"], "output": ["text"] }
+                },
+                "glm-voice": {
+                  "id": "glm-voice",
+                  "modalities": { "input": ["text"], "output": ["audio"] }
+                }
+              }
+            }
+          }
+        }"#;
+        let catalog = ModelsDevCatalog::parse_json(raw).expect("fixture parses");
+        let offerings = catalog
+            .provider_offerings("zai")
+            .expect("provider offerings");
+
+        assert_eq!(offerings.len(), 1);
+        assert_eq!(offerings[0].provider.as_str(), "zai");
+        assert_eq!(offerings[0].wire_model_id.as_str(), "glm-5.2");
+        assert_eq!(
+            offerings[0].canonical_model.as_ref().map(ModelId::as_str),
+            Some("zhipuai/glm-5.2")
+        );
+        assert!(offerings[0].default_for_provider);
+    }
+
+    #[test]
+    fn non_text_output_is_not_a_chat_model() {
+        let model = ModelsDevProviderModel {
+            id: "mimo-v2.5-tts".to_string(),
+            modalities: Some(ModelsDevModalities {
+                input: vec!["text".to_string()],
+                output: vec!["audio".to_string()],
+            }),
+            ..Default::default()
+        };
+
+        assert!(!model.supports_text_chat());
+    }
+}

--- a/crates/config/src/models_dev.rs
+++ b/crates/config/src/models_dev.rs
@@ -80,13 +80,9 @@ impl ModelsDevCatalog {
         wire_model_id: &str,
     ) -> Option<ProviderModelOffering> {
         let provider_key = provider_id.trim();
-        let provider = self.provider(provider_id)?;
+        let provider = self.provider(provider_key)?;
         let model = provider.models.get(wire_model_id.trim())?;
-        let provider_id = if provider.id.trim().is_empty() {
-            provider_key.to_string()
-        } else {
-            provider.id.trim().to_string()
-        };
+        let provider_id = provider.effective_id(provider_key);
         Some(ProviderModelOffering {
             provider: ProviderId::from(provider_id),
             canonical_model: model.base_model.clone().map(ModelId::from),
@@ -105,11 +101,7 @@ impl ModelsDevCatalog {
     pub fn provider_offerings(&self, provider_id: &str) -> Option<Vec<ProviderModelOffering>> {
         let provider_key = provider_id.trim();
         let provider = self.provider(provider_key)?;
-        let provider_id = if provider.id.trim().is_empty() {
-            provider_key.to_string()
-        } else {
-            provider.id.trim().to_string()
-        };
+        let provider_id = provider.effective_id(provider_key);
         Some(
             provider
                 .models
@@ -260,6 +252,22 @@ pub struct ModelsDevProvider {
     pub models: BTreeMap<String, ModelsDevProviderModel>,
 }
 
+impl ModelsDevProvider {
+    /// Resolve the effective provider id for this row.
+    ///
+    /// Models.dev snapshots usually repeat the catalog key in the `id` field,
+    /// but generated JSON can omit it. Fall back to the catalog key so callers
+    /// never emit an empty [`ProviderId`].
+    #[must_use]
+    fn effective_id(&self, provider_key: &str) -> String {
+        if self.id.trim().is_empty() {
+            provider_key.to_string()
+        } else {
+            self.id.trim().to_string()
+        }
+    }
+}
+
 /// Token limits.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ModelsDevLimit {
@@ -306,14 +314,23 @@ fn supports_text_chat(modalities: Option<&ModelsDevModalities>) -> bool {
     let Some(modalities) = modalities else {
         return true;
     };
-    modalities
-        .input
-        .iter()
-        .any(|modality| modality.eq_ignore_ascii_case("text"))
-        && modalities
+    // Treat an empty modality list the same as absent metadata. An incomplete
+    // catalog snapshot can deserialize to `Some({ input: [], output: [] })`,
+    // and `Iterator::any` over an empty slice is `false` — without this guard
+    // such rows would be silently dropped from chat offerings even though the
+    // `None` branch above defaults them to chat-capable. Only an explicitly
+    // populated, non-text list excludes the row.
+    let input_ok = modalities.input.is_empty()
+        || modalities
+            .input
+            .iter()
+            .any(|modality| modality.eq_ignore_ascii_case("text"));
+    let output_ok = modalities.output.is_empty()
+        || modalities
             .output
             .iter()
-            .any(|modality| modality.eq_ignore_ascii_case("text"))
+            .any(|modality| modality.eq_ignore_ascii_case("text"));
+    input_ok && output_ok
 }
 
 #[cfg(test)]
@@ -499,5 +516,58 @@ mod tests {
         };
 
         assert!(!model.supports_text_chat());
+    }
+
+    #[test]
+    fn empty_modalities_struct_is_chat_capable() {
+        // `"modalities": {}` deserializes to Some(empty); it must default to
+        // chat-capable just like absent modality metadata (the None branch),
+        // otherwise rows from incomplete snapshots are silently dropped.
+        let provider_model = ModelsDevProviderModel {
+            modalities: Some(ModelsDevModalities::default()),
+            ..Default::default()
+        };
+        assert!(provider_model.supports_text_chat());
+
+        let canonical = ModelsDevModel {
+            modalities: Some(ModelsDevModalities::default()),
+            ..Default::default()
+        };
+        assert!(canonical.supports_text_chat());
+
+        // A list populated with only non-text entries still excludes the row.
+        let audio_only = ModelsDevProviderModel {
+            modalities: Some(ModelsDevModalities {
+                input: vec!["text".to_string()],
+                output: vec!["audio".to_string()],
+            }),
+            ..Default::default()
+        };
+        assert!(!audio_only.supports_text_chat());
+    }
+
+    #[test]
+    fn provider_offerings_keep_rows_with_empty_modalities_object() {
+        // End-to-end guard for the empty-modalities case at the offering layer:
+        // a custom/local provider row with `"modalities": {}` must still emit a
+        // chat offering rather than being filtered out of route resolution.
+        let raw = r#"{
+          "providers": {
+            "custom": {
+              "models": {
+                "house-model": { "id": "house-model", "modalities": {} }
+              }
+            }
+          }
+        }"#;
+        let catalog = ModelsDevCatalog::parse_json(raw).expect("fixture parses");
+        let offerings = catalog
+            .provider_offerings("custom")
+            .expect("provider offerings");
+
+        assert_eq!(offerings.len(), 1);
+        assert_eq!(offerings[0].wire_model_id.as_str(), "house-model");
+        // `id` was omitted on the provider row → effective id is the catalog key.
+        assert_eq!(offerings[0].provider.as_str(), "custom");
     }
 }

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -8,8 +8,10 @@
 //!    when absent, the workspace default provider scope is used. The provider
 //!    is NEVER inferred from a model prefix.
 //! 2. the model selector, interpreted STRICTLY within that provider's scope
-//!    against [`bundled_offerings`] plus the provider default. Prefixed
-//!    selectors are preserved verbatim as the [`WireModelId`].
+//!    against resolver-provided offerings plus the provider default. The default
+//!    resolver uses [`bundled_offerings`], while tests or snapshot loaders can
+//!    inject Models.dev-derived rows. Prefixed selectors are preserved verbatim
+//!    as the [`WireModelId`].
 //! 3. `auto` => the [`LogicalModelRef::is_auto`] sentinel, never a literal
 //!    model.
 //!
@@ -31,7 +33,7 @@ use super::candidate::{
 use super::descriptor::ProviderDescriptor;
 use super::errors::RouteError;
 use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
-use super::offering::bundled_offerings;
+use super::offering::{ProviderModelOffering, bundled_offerings};
 use crate::ProviderKind;
 
 /// A request to resolve into an executable route.
@@ -51,14 +53,32 @@ pub struct RouteRequest {
 }
 
 /// Resolves [`RouteRequest`]s into [`ReadyRouteCandidate`]s.
-#[derive(Debug, Clone, Default)]
-pub struct RouteResolver;
+#[derive(Debug, Clone)]
+pub struct RouteResolver {
+    offerings: Vec<ProviderModelOffering>,
+}
+
+impl Default for RouteResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl RouteResolver {
-    /// Construct a resolver.
+    /// Construct a resolver with CodeWhale's bundled offline offerings.
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self::from_offerings(bundled_offerings())
+    }
+
+    /// Construct a resolver from a provider-scoped offering catalog.
+    ///
+    /// This is the bridge for Models.dev snapshots: callers parse a catalog,
+    /// emit provider offerings, then hand those rows to the resolver without
+    /// changing route-resolution semantics.
+    #[must_use]
+    pub fn from_offerings(offerings: Vec<ProviderModelOffering>) -> Self {
+        Self { offerings }
     }
 
     /// Resolve a request into an executable route candidate.
@@ -72,6 +92,7 @@ impl RouteResolver {
         let provider_kind = req.explicit_provider.unwrap_or_default();
         let descriptor = ProviderDescriptor::for_kind(provider_kind);
         let provider_id = descriptor.id();
+        let default_offering = self.default_offering(&provider_id);
 
         // 2. Determine the logical selector from explicit choice, then the
         //    saved-model fallback, then the provider default.
@@ -84,7 +105,12 @@ impl RouteResolver {
                     .saved_provider_model
                     .as_ref()
                     .map(|w| w.as_str().to_string())
-                    .unwrap_or_else(|| descriptor.default_wire_model().as_str().to_string());
+                    .unwrap_or_else(|| {
+                        default_offering.map_or_else(
+                            || descriptor.default_wire_model().as_str().to_string(),
+                            |offering| offering.wire_model_id.as_str().to_string(),
+                        )
+                    });
                 LogicalModelRef::from(raw)
             }
         };
@@ -102,8 +128,17 @@ impl RouteResolver {
         // 4. Map the selector to a wire id within provider scope.
         //    Prefixed selectors are preserved VERBATIM as the wire id.
         let class = classify(provider_kind);
-        let (wire_model_id, canonical_model) = if is_auto {
-            (descriptor.default_wire_model(), None)
+        let (wire_model_id, canonical_model, endpoint_key) = if is_auto {
+            default_offering.map_or_else(
+                || (descriptor.default_wire_model(), None, "chat".to_string()),
+                |offering| {
+                    (
+                        offering.wire_model_id.clone(),
+                        offering.canonical_model.clone(),
+                        offering.endpoint_key.clone(),
+                    )
+                },
+            )
         } else {
             self.scope_selector(provider_kind, &provider_id, &logical_model, class)?
         };
@@ -113,7 +148,7 @@ impl RouteResolver {
                 .base_url_override
                 .clone()
                 .unwrap_or_else(|| descriptor.default_base_url().to_string()),
-            endpoint_key: "chat".to_string(),
+            endpoint_key,
             protocol: descriptor.protocol(),
         };
 
@@ -143,13 +178,13 @@ impl RouteResolver {
         provider_id: &ProviderId,
         logical_model: &LogicalModelRef,
         class: ProviderClass,
-    ) -> Result<(WireModelId, Option<ModelId>), RouteError> {
+    ) -> Result<(WireModelId, Option<ModelId>, String), RouteError> {
         let raw = logical_model.raw();
 
-        // Try to match a bundled offering owned by THIS provider, either by
+        // Try to match a catalog offering owned by THIS provider, either by
         // canonical model id or by exact wire id. This keeps interpretation
         // inside provider scope; offerings from other providers are ignored.
-        for offering in bundled_offerings() {
+        for offering in &self.offerings {
             if offering.provider != *provider_id {
                 continue;
             }
@@ -159,13 +194,23 @@ impl RouteResolver {
                 .is_some_and(|m| m.as_str() == raw);
             let matches_wire = offering.wire_model_id.as_str() == raw;
             if matches_canonical || matches_wire {
-                return Ok((offering.wire_model_id, offering.canonical_model));
+                return Ok((
+                    offering.wire_model_id.clone(),
+                    offering.canonical_model.clone(),
+                    offering.endpoint_key.clone(),
+                ));
             }
         }
 
         // No catalog match. Apply class-specific pass-through rules.
         match class {
             ProviderClass::StrictDirect => {
+                if self.selector_matches_other_provider_offering(provider_id, raw) {
+                    return Err(RouteError::ForeignModelForDirectProvider {
+                        provider: provider_id.clone(),
+                        model: raw.to_string(),
+                    });
+                }
                 // A clearly-foreign selector for a strict direct provider is
                 // rejected. "Clearly foreign" = it carries an aggregator/org
                 // namespace prefix, which a direct provider never expects.
@@ -177,15 +222,36 @@ impl RouteResolver {
                 }
                 // A bare, unknown model on a strict direct provider is passed
                 // through verbatim (the provider validates it server-side).
-                Ok((WireModelId::from(raw), None))
+                Ok((WireModelId::from(raw), None, "chat".to_string()))
             }
             // Aggregators, local runtimes, and custom OpenAI-compatible
             // endpoints legitimately accept arbitrary / prefixed ids verbatim.
             ProviderClass::Aggregator | ProviderClass::LocalOrCustom => {
                 let _ = provider_kind;
-                Ok((WireModelId::from(raw), None))
+                Ok((WireModelId::from(raw), None, "chat".to_string()))
             }
         }
+    }
+
+    fn default_offering(&self, provider_id: &ProviderId) -> Option<&ProviderModelOffering> {
+        self.offerings
+            .iter()
+            .find(|offering| offering.provider == *provider_id && offering.default_for_provider)
+    }
+
+    fn selector_matches_other_provider_offering(
+        &self,
+        provider_id: &ProviderId,
+        raw: &str,
+    ) -> bool {
+        self.offerings.iter().any(|offering| {
+            offering.provider != *provider_id
+                && (offering.wire_model_id.as_str() == raw
+                    || offering
+                        .canonical_model
+                        .as_ref()
+                        .is_some_and(|model| model.as_str() == raw))
+        })
     }
 }
 

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -239,6 +239,16 @@ impl RouteResolver {
             .find(|offering| offering.provider == *provider_id && offering.default_for_provider)
     }
 
+    /// True when `raw` names an offering that lives on a *different* provider.
+    ///
+    /// The `wire_model_id` arm catches the common case (a bare id another
+    /// provider serves). The `canonical_model` arm covers catalog rows whose
+    /// canonical id is slash-free: Models.dev canonical ids normally contain a
+    /// namespace (`zhipuai/glm-5.2`) and are already caught by the
+    /// `namespace_hint()` guard at the call site, but a bare canonical id (or a
+    /// hand-authored offering) would slip through wire-id matching alone. It is
+    /// kept deliberately so a bare canonical selector cannot masquerade as a
+    /// pass-through model on the wrong provider.
     fn selector_matches_other_provider_offering(
         &self,
         provider_id: &ProviderId,

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -293,6 +293,45 @@ fn resolver_auto_uses_models_dev_default_offering_when_available() {
 }
 
 #[test]
+fn resolver_auto_falls_back_to_descriptor_default_without_catalog_default() {
+    // Z.ai offerings exist in the catalog snapshot but none is marked
+    // `default: true`. `auto` must then fall back to the provider descriptor's
+    // built-in default wire model rather than picking an arbitrary catalog row.
+    let raw = r#"{
+      "providers": {
+        "zai": {
+          "models": {
+            "glm-5-turbo": {
+              "id": "glm-5-turbo",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        }
+      }
+    }"#;
+    let catalog = ModelsDevCatalog::parse_json(raw).expect("Models.dev fixture parses");
+    let offerings = catalog
+        .provider_offerings("zai")
+        .expect("zai provider offerings");
+    let r = RouteResolver::from_offerings(offerings);
+
+    let out = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("auto")))
+        .expect("auto should resolve to the descriptor default");
+
+    assert!(out.logical_model.is_auto());
+    assert_eq!(
+        out.wire_model_id.as_str(),
+        "GLM-5.2",
+        "no catalog default → descriptor built-in default wins"
+    );
+    assert_eq!(
+        out.canonical_model, None,
+        "descriptor fallback carries no catalog canonical link"
+    );
+}
+
+#[test]
 fn resolver_models_dev_prefixed_wire_id_stays_inside_provider_scope() {
     let r = models_dev_route_resolver();
     let out = r

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -6,6 +6,7 @@ use super::errors::RouteError;
 use super::ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
 use super::resolver::{RouteRequest, RouteResolver};
 use crate::ProviderKind;
+use crate::models_dev::ModelsDevCatalog;
 
 /// Build a request with only an explicit provider + a model selector string.
 fn req(provider: Option<ProviderKind>, model: Option<&str>) -> RouteRequest {
@@ -15,6 +16,42 @@ fn req(provider: Option<ProviderKind>, model: Option<&str>) -> RouteRequest {
         saved_provider_model: None,
         base_url_override: None,
     }
+}
+
+fn models_dev_route_resolver() -> RouteResolver {
+    let raw = r#"{
+      "providers": {
+        "zai": {
+          "models": {
+            "glm-5.2": {
+              "id": "glm-5.2",
+              "base_model": "zhipuai/glm-5.2",
+              "default": true,
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        },
+        "openrouter": {
+          "models": {
+            "z-ai/glm-5.2": {
+              "id": "z-ai/glm-5.2",
+              "base_model": "zhipuai/glm-5.2",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        }
+      }
+    }"#;
+    let catalog = ModelsDevCatalog::parse_json(raw).expect("Models.dev fixture parses");
+    let mut offerings = catalog
+        .provider_offerings("zai")
+        .expect("zai provider offerings");
+    offerings.extend(
+        catalog
+            .provider_offerings("openrouter")
+            .expect("openrouter provider offerings"),
+    );
+    RouteResolver::from_offerings(offerings)
 }
 
 #[test]
@@ -221,6 +258,57 @@ fn resolver_auto_is_sentinel_not_literal_model() {
 }
 
 #[test]
+fn resolver_can_use_models_dev_offering_for_provider_scoped_route() {
+    let r = models_dev_route_resolver();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.2")))
+        .expect("Models.dev-backed Z.ai route should resolve");
+
+    assert_eq!(out.provider_kind, ProviderKind::Zai);
+    assert_eq!(out.provider_id.as_str(), "zai");
+    assert_eq!(out.wire_model_id.as_str(), "glm-5.2");
+    assert_eq!(
+        out.canonical_model.as_ref().map(ModelId::as_str),
+        Some("zhipuai/glm-5.2")
+    );
+}
+
+#[test]
+fn resolver_auto_uses_models_dev_default_offering_when_available() {
+    let r = models_dev_route_resolver();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("auto")))
+        .expect("auto should resolve through catalog default");
+
+    assert!(out.logical_model.is_auto());
+    assert_eq!(
+        out.wire_model_id.as_str(),
+        "glm-5.2",
+        "catalog default should win over the built-in Z.ai spelling"
+    );
+    assert_eq!(
+        out.canonical_model.as_ref().map(ModelId::as_str),
+        Some("zhipuai/glm-5.2")
+    );
+}
+
+#[test]
+fn resolver_models_dev_prefixed_wire_id_stays_inside_provider_scope() {
+    let r = models_dev_route_resolver();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Openrouter), Some("z-ai/glm-5.2")))
+        .expect("OpenRouter Models.dev row should resolve");
+
+    assert_eq!(out.provider_kind, ProviderKind::Openrouter);
+    assert_ne!(out.provider_kind, ProviderKind::Zai);
+    assert_eq!(out.wire_model_id.as_str(), "z-ai/glm-5.2");
+    assert_eq!(
+        out.canonical_model.as_ref().map(ModelId::as_str),
+        Some("zhipuai/glm-5.2")
+    );
+}
+
+#[test]
 fn resolver_strict_direct_rejects_clearly_foreign_selector() {
     let r = RouteResolver::new();
     let out = r.resolve(&req(Some(ProviderKind::Zai), Some("anthropic/claude-foo")));
@@ -228,6 +316,32 @@ fn resolver_strict_direct_rejects_clearly_foreign_selector() {
         Err(RouteError::ForeignModelForDirectProvider { provider, model }) => {
             assert_eq!(provider.as_str(), "zai");
             assert_eq!(model, "anthropic/claude-foo");
+        }
+        other => panic!("expected ForeignModelForDirectProvider, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolver_strict_direct_rejects_other_provider_known_bare_offering() {
+    let r = RouteResolver::new();
+    let out = r.resolve(&req(Some(ProviderKind::Zai), Some("deepseek-v4-pro")));
+    match out {
+        Err(RouteError::ForeignModelForDirectProvider { provider, model }) => {
+            assert_eq!(provider.as_str(), "zai");
+            assert_eq!(model, "deepseek-v4-pro");
+        }
+        other => panic!("expected ForeignModelForDirectProvider, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolver_strict_direct_rejects_models_dev_offering_from_another_provider() {
+    let r = models_dev_route_resolver();
+    let out = r.resolve(&req(Some(ProviderKind::Deepseek), Some("glm-5.2")));
+    match out {
+        Err(RouteError::ForeignModelForDirectProvider { provider, model }) => {
+            assert_eq!(provider.as_str(), "deepseek");
+            assert_eq!(model, "glm-5.2");
         }
         other => panic!("expected ForeignModelForDirectProvider, got {other:?}"),
     }


### PR DESCRIPTION
## Summary
- add a network-free `codewhale_config::models_dev` parser for Models.dev combined catalog JSON
- preserve provider-agnostic model facts separately from provider-scoped wire offerings
- emit chat-capable `ProviderModelOffering` rows from Models.dev provider data
- let `RouteResolver` consume injected offering rows and prefer catalog defaults for `auto` / no-model resolution

## Why
Models.dev gives CodeWhale the provider/model/pricing/capability taxonomy we need without growing DeepSeek-shaped or provider-specific match tables. This keeps namespace-prefixed wire IDs scoped to the provider that serves them and avoids treating prefixes as global model ownership proof.

## Verification
- `cargo fmt`
- `cargo fmt --all -- --check`
- `cargo test -p codewhale-config --locked models_dev`
- `cargo test -p codewhale-config --locked route`
- `cargo test -p codewhale-config --locked`