### PR TITLE
Polish composer panel title chrome

### DIFF
--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -3945,6 +3945,20 @@ mod tests {
             height: 5,
         };
 
+        let mut normal_app = create_test_app();
+        normal_app.composer_density = ComposerDensity::Comfortable;
+        let normal_widget =
+            ComposerWidget::new(&normal_app, 5, &slash_menu_entries, &mention_menu_entries);
+        let mut normal_buf = Buffer::empty(area);
+        normal_widget.render(area, &mut normal_buf);
+        let normal_rendered = buffer_text(&normal_buf, area);
+        assert!(!normal_rendered.contains("Composer"));
+        assert!(!normal_rendered.contains("Draft"));
+        assert!(
+            !normal_rendered
+                .contains(&normal_app.tr(crate::localization::MessageId::HistorySearchTitle))
+        );
+
         let mut draft_app = create_test_app();
         draft_app.composer_density = ComposerDensity::Comfortable;
         draft_app.insert_str("first line\nsecond line");

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -740,20 +740,20 @@ impl Renderable for ComposerWidget<'_> {
             };
 
             let mut block = Block::default()
-                .title(Line::from(Span::styled(
-                    if self.app.is_history_search_active() {
-                        self.app
-                            .tr(crate::localization::MessageId::HistorySearchTitle)
-                    } else if is_draft_mode {
-                        "Draft"
-                    } else {
-                        "Composer"
-                    },
-                    Style::default().fg(palette::TEXT_MUTED),
-                )))
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(border_color))
                 .style(background);
+            if self.app.is_history_search_active() || is_draft_mode {
+                block = block.title(Line::from(Span::styled(
+                    if self.app.is_history_search_active() {
+                        self.app
+                            .tr(crate::localization::MessageId::HistorySearchTitle)
+                    } else {
+                        "Draft"
+                    },
+                    Style::default().fg(palette::TEXT_MUTED),
+                )));
+            }
             // Top-right corner: editor state plus transient turn receipts.
             // Receipts are lifecycle chrome, not transcript content; they
             // should appear briefly without displacing conversation rows.
@@ -3906,7 +3906,7 @@ mod tests {
         widget.render(area, &mut buf);
         let rendered = buffer_text(&buf, area);
 
-        assert!(rendered.contains("Composer"));
+        assert!(!rendered.contains("Composer"));
         assert!(rendered.contains("my-session"));
     }
 
@@ -3929,9 +3929,42 @@ mod tests {
         widget.render(area, &mut buf);
         let rendered = buffer_text(&buf, area);
 
-        assert!(rendered.contains("Composer"));
+        assert!(!rendered.contains("Composer"));
         assert!(rendered.contains("turn completed"));
         assert!(rendered.contains("tool(s) used"));
+    }
+
+    #[test]
+    fn composer_border_keeps_mode_titles_contextual() {
+        let slash_menu_entries = Vec::<SlashMenuEntry>::new();
+        let mention_menu_entries = Vec::<String>::new();
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 96,
+            height: 5,
+        };
+
+        let mut draft_app = create_test_app();
+        draft_app.composer_density = ComposerDensity::Comfortable;
+        draft_app.insert_str("first line\nsecond line");
+        let draft_widget =
+            ComposerWidget::new(&draft_app, 5, &slash_menu_entries, &mention_menu_entries);
+        let mut draft_buf = Buffer::empty(area);
+        draft_widget.render(area, &mut draft_buf);
+        assert!(buffer_text(&draft_buf, area).contains("Draft"));
+
+        let mut search_app = create_test_app();
+        search_app.composer_density = ComposerDensity::Comfortable;
+        search_app.start_history_search();
+        let search_widget =
+            ComposerWidget::new(&search_app, 5, &slash_menu_entries, &mention_menu_entries);
+        let mut search_buf = Buffer::empty(area);
+        search_widget.render(area, &mut search_buf);
+        assert!(
+            buffer_text(&search_buf, area)
+                .contains(&search_app.tr(crate::localization::MessageId::HistorySearchTitle))
+        );
     }
 
     #[test]

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -21,6 +21,7 @@ use qa_harness::keys;
 
 const BOOT_TIMEOUT: Duration = Duration::from_secs(15);
 const KEY_TIMEOUT: Duration = Duration::from_secs(5);
+const COMPOSER_READY_TEXT: &str = "Write a task";
 static QA_PTY_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn qa_pty_test_lock() -> MutexGuard<'static, ()> {
@@ -107,8 +108,7 @@ fn smoke_boot_paints_composer() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let (_ws, mut h) = boot_minimal()?;
 
-    // The composer panel border is labelled "Composer" — wait for it.
-    h.wait_for_text("Composer", BOOT_TIMEOUT)?;
+    h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
 
     let f = h.frame();
     assert!(
@@ -182,7 +182,7 @@ web_search = true
 fn viewport_origin_stays_row_zero_after_failed_turn() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let (_ws, mut h) = boot_minimal_without_retry()?;
-    h.wait_for_text("Composer", BOOT_TIMEOUT)?;
+    h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
     assert_viewport_starts_at_top(h.frame());
 
     h.send(keys::key::text("trigger a failed turn"))?;
@@ -210,7 +210,7 @@ fn viewport_origin_stays_row_zero_after_failed_turn() -> anyhow::Result<()> {
 fn smoke_keystroke_reaches_composer() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let (_ws, mut h) = boot_minimal()?;
-    h.wait_for_text("Composer", BOOT_TIMEOUT)?;
+    h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
 
     h.send(keys::key::text("hello-from-pty"))?;
     h.wait_for_text("hello-from-pty", KEY_TIMEOUT)?;
@@ -249,7 +249,7 @@ fn skills_menu_shows_local_and_global_skills() -> anyhow::Result<()> {
         .size(40, 140)
         .spawn()?;
 
-    h.wait_for_text("Composer", BOOT_TIMEOUT)?;
+    h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
     h.send(keys::key::text("/skills"))?;
     h.wait_for_text("/skills", KEY_TIMEOUT)?;
     h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(2))?;
@@ -282,7 +282,7 @@ fn skills_menu_shows_local_and_global_skills() -> anyhow::Result<()> {
 fn paste_bracketed_with_trailing_newline_does_not_autosubmit() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let (_ws, mut h) = boot_minimal()?;
-    h.wait_for_text("Composer", BOOT_TIMEOUT)?;
+    h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
 
     // ~200 chars matching the original report. Trailing newline is the
     // payload that historically triggered the auto-submit.
@@ -323,7 +323,7 @@ fn paste_bracketed_with_trailing_newline_does_not_autosubmit() -> anyhow::Result
 fn paste_unbracketed_with_trailing_newline_does_not_autosubmit() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let (_ws, mut h) = boot_minimal()?;
-    h.wait_for_text("Composer", BOOT_TIMEOUT)?;
+    h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
     // Let the boot fully settle so input handling is wired up.
     h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(3))?;
 


### PR DESCRIPTION
## Summary

- Removes the default `Composer` border title so the normal composer panel renders without label chrome.
- Preserves contextual composer titles for draft mode and history search.
- Updates unit and PTY QA readiness checks to assert against the current prompt/contexts instead of the removed title.
- Adds explicit normal-mode coverage that no contextual title leaks into the untitled composer chrome.

## Testing

- [x] `cargo fmt`
- [x] `cargo +1.88.0-x86_64-pc-windows-gnu test -p codewhale-tui --bin codewhale-tui --locked`
- [x] `cargo +1.88.0-x86_64-pc-windows-gnu test -p codewhale-tui --test qa_pty --locked` (Windows host: `cfg(unix)`, 0 tests; macOS CI exercises these)
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

Link to Devin session: https://app.devin.ai/sessions/efceeec2274347859797add10986368c