### PR TITLE
fix(tui): harden picker selection contrast

### DIFF
--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -383,9 +383,9 @@ fn picker_row_spans<'a>(
     let label_width = width.saturating_sub(prefix_width);
     let label = fit_text(label, label_width);
     let mut spans = vec![
-        Span::raw(" "),
+        Span::styled(" ", label_style),
         Span::styled(marker, label_style),
-        Span::raw(" "),
+        Span::styled(" ", label_style),
         Span::styled(label, label_style),
     ];
 
@@ -974,6 +974,17 @@ mod tests {
                 crossterm::event::KeyModifiers::NONE,
             ));
         }
+    }
+
+    fn buffer_row_text(buf: &Buffer, area: Rect, y: u16) -> String {
+        (area.x..area.x.saturating_add(area.width))
+            .map(|x| buf[(x, y)].symbol())
+            .collect()
+    }
+
+    fn row_containing(buf: &Buffer, area: Rect, needle: &str) -> Option<u16> {
+        (area.y..area.y.saturating_add(area.height))
+            .find(|&y| buffer_row_text(buf, area, y).contains(needle))
     }
 
     #[test]
@@ -1698,6 +1709,39 @@ mod tests {
         assert_eq!(view.focus, Pane::Model);
         assert_eq!(view.resolved_model(), "deepseek-v4-flash");
         assert_eq!(view.resolved_effort(), ReasoningEffort::Max);
+    }
+
+    #[test]
+    fn model_picker_selected_row_renders_readable_selection_contrast() {
+        let (mut app, _lock) = create_test_app();
+        app.model = "deepseek-v4-flash".to_string();
+        app.auto_model = false;
+        let view = ModelPickerView::new(&app);
+        let area = Rect::new(0, 0, 100, 28);
+        let mut buf = Buffer::empty(area);
+
+        view.render(area, &mut buf);
+
+        let y = row_containing(&buf, area, "deepseek-v4-flash")
+            .expect("selected model row should render");
+        let highlighted_cells = (area.x..area.x.saturating_add(area.width))
+            .filter(|&x| {
+                let cell = &buf[(x, y)];
+                !cell.symbol().trim().is_empty()
+                    && cell.bg == palette::SELECTION_BG
+                    && cell.fg == palette::SELECTION_TEXT
+            })
+            .count();
+
+        assert!(
+            highlighted_cells >= "deepseek-v4-flash".len(),
+            "selected /model row should use readable selection text"
+        );
+        assert!(
+            !(area.x..area.x.saturating_add(area.width))
+                .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY),
+            "selected /model row should not use the bright accent background"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -1013,6 +1013,17 @@ mod tests {
         view
     }
 
+    fn buffer_row_text(buf: &Buffer, area: Rect, y: u16) -> String {
+        (area.x..area.x.saturating_add(area.width))
+            .map(|x| buf[(x, y)].symbol())
+            .collect()
+    }
+
+    fn row_containing(buf: &Buffer, area: Rect, needle: &str) -> Option<u16> {
+        (area.y..area.y.saturating_add(area.height))
+            .find(|&y| buffer_row_text(buf, area, y).contains(needle))
+    }
+
     #[test]
     fn workspace_scope_filters_sessions_to_current_project() {
         // #1395 reproduction: Ctrl+R in project B must not surface sessions
@@ -1112,6 +1123,46 @@ mod tests {
         assert_eq!(span.style.bg, Some(palette::SELECTION_BG));
         assert_ne!(span.style.bg, Some(palette::WHALE_ACCENT_PRIMARY));
         assert!(span.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn session_picker_selected_row_renders_readable_selection_contrast() {
+        let mut first = test_session(1, "first contrast fixture");
+        first.id = "alpha-contrast-fixture".to_string();
+        let mut second = test_session(2, "second contrast fixture");
+        second.id = "bravo-contrast-fixture".to_string();
+        let sessions = vec![first, second];
+        let mut view = picker_with(sessions, None);
+        view.selected = 1;
+        view.ensure_selected_visible();
+        view.current_preview = vec!["preview".to_string()];
+        let selected_id = crate::session_manager::truncate_id(&view.filtered[view.selected].id);
+        let area = Rect::new(0, 0, 120, 28);
+        let mut buf = Buffer::empty(area);
+
+        view.render(area, &mut buf);
+
+        let y =
+            row_containing(&buf, area, &selected_id).expect("selected session row should render");
+        let rendered_row = buffer_row_text(&buf, area, y);
+        let highlighted_cells = (area.x..area.x.saturating_add(area.width))
+            .filter(|&x| {
+                let cell = &buf[(x, y)];
+                !cell.symbol().trim().is_empty()
+                    && cell.bg == palette::SELECTION_BG
+                    && cell.fg == palette::SELECTION_TEXT
+            })
+            .count();
+
+        assert!(
+            highlighted_cells >= 4,
+            "selected /sessions row should use readable selection text; got {highlighted_cells} highlighted cells on {rendered_row:?}"
+        );
+        assert!(
+            !(area.x..area.x.saturating_add(area.width))
+                .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY),
+            "selected /sessions row should not use the bright accent background"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Style the `/model` selected-row marker and spacing with the same muted selection colors as the row text.
- Add render-buffer regression coverage for `/model` and `/sessions` selected rows so they keep `SELECTION_TEXT` on `SELECTION_BG` and avoid the bright accent background.

Closes #3474.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; narrow TUI contrast slice)
- [ ] `cargo test --workspace --all-features` (not run; narrow TUI contrast slice)
- [x] `cargo check -p codewhale-tui --bin codewhale-tui --tests --locked`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked selected_row_renders_readable_selection_contrast`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::model_picker::tests`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::session_picker::tests`

## Checklist

- [ ] Updated docs or comments as needed (not needed)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (covered by render-buffer tests)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable)
