### PR TITLE
feat(config): offering pricing projection with provenance (#3085)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth_source;
 pub mod catalog;
 pub mod models_dev;
+pub mod pricing;
 pub mod provider;
 pub mod route;
 

--- a/crates/config/src/pricing.rs
+++ b/crates/config/src/pricing.rs
@@ -1,0 +1,222 @@
+//! Provider/offering-scoped pricing projection with provenance (#3085).
+//!
+//! Network-free. Maps Models.dev offering `cost` (and live / user-override
+//! rows) into pricing rows that carry explicit **provenance**, **currency**, and
+//! **effective-at** metadata, plus a pure cost estimator over normalized token
+//! usage. UI display (`CostDisplay`) and provider usage-payload parsing live
+//! above this layer and are out of scope here.
+//!
+//! Boundary with the route layer: this models *pricing* — offering-owned,
+//! per-token unit prices. The coarse route-facing meter shape already exists as
+//! [`crate::route::PricingSku`]
+//! (`Token` / `SubscriptionQuota` / `AccountCredits` / `LocalOrNotApplicable` /
+//! `UnknownOrStale`); [`OfferingPricing::to_route_sku`] and
+//! [`route_pricing_sku`] bridge to it.
+//!
+//! Honesty rule (#2608 / #3085): pricing is never assumed. A route with no
+//! sourced price yields `None` here and `UnknownOrStale` at the route layer —
+//! never a fabricated token price, and never an implicit "free" for
+//! local/custom/subscription routes.
+
+use serde::{Deserialize, Serialize};
+
+use crate::catalog::{CatalogOffering, CatalogSource};
+use crate::route::PricingSku;
+
+/// Billing currency for a pricing row. Models.dev publishes USD per-million
+/// costs; other currencies arrive via provider docs or user overrides.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Currency {
+    #[default]
+    Usd,
+    Cny,
+    /// An ISO-4217-style code CodeWhale does not special-case.
+    Other(String),
+}
+
+/// Where a pricing row came from. Retained so the UI can show provenance and so
+/// stale/unknown prices are never silently treated as authoritative.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum PricingProvenance {
+    /// Seeded from a bundled Models.dev catalog snapshot.
+    ModelsDevBundled,
+    /// From a provider live `/models` (or pricing) refresh.
+    ProviderLive,
+    /// From provider documentation / a hand-sourced seed.
+    ProviderDocs,
+    /// User-supplied override (custom endpoint, enterprise terms, local route).
+    UserOverride,
+    /// No sourced price.
+    Unknown,
+}
+
+/// Normalized token usage for a single turn, in canonical billable classes.
+///
+/// Producing this from provider-specific usage payloads (Chat Completions,
+/// Responses, Anthropic) is a separate concern; this layer only consumes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TokenUsage {
+    /// Non-cached input (prompt) tokens.
+    pub input: u64,
+    /// Output (completion) tokens, including reasoning output.
+    pub output: u64,
+    /// Cache-read (cache-hit) input tokens, billed at the cache-read rate.
+    pub cache_read: u64,
+    /// Cache-write (cache-creation) tokens, billed at the cache-write rate.
+    pub cache_write: u64,
+}
+
+/// A provider/offering-scoped pricing row.
+///
+/// Prices are per million tokens in [`Currency`]. Any field may be unknown
+/// (`None`); [`OfferingPricing::estimate_cost`] refuses to invent a number for a
+/// used class whose price is unknown.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OfferingPricing {
+    /// Provider id serving the offering.
+    pub provider: String,
+    /// Provider-owned wire id the price applies to.
+    pub wire_model_id: String,
+    /// Canonical model identity, when the offering carries one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_model: Option<String>,
+    /// Billing currency.
+    pub currency: Currency,
+    /// Input price per million tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_per_million: Option<f64>,
+    /// Output price per million tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_per_million: Option<f64>,
+    /// Cache-read price per million tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_per_million: Option<f64>,
+    /// Cache-write price per million tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_per_million: Option<f64>,
+    /// Where the price came from.
+    pub provenance: PricingProvenance,
+    /// Unix seconds the price was fetched / became effective, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_at: Option<u64>,
+}
+
+impl OfferingPricing {
+    /// Derive a pricing row from a catalog offering's `cost`, when priced.
+    ///
+    /// Returns `None` when the offering carries no cost, or a cost object with
+    /// no concrete price field — those routes are *unknown*, not free, and the
+    /// caller should render them as such (see [`route_pricing_sku`]).
+    ///
+    /// Models.dev `cost` values are USD per million tokens, so the currency is
+    /// [`Currency::Usd`]; provenance and `effective_at` follow the offering's
+    /// [`CatalogSource`].
+    #[must_use]
+    pub fn from_catalog_offering(offering: &CatalogOffering) -> Option<Self> {
+        let cost = offering.cost.as_ref()?;
+        if cost.input.is_none()
+            && cost.output.is_none()
+            && cost.cache_read.is_none()
+            && cost.cache_write.is_none()
+        {
+            return None;
+        }
+        Some(Self {
+            provider: offering.provider.clone(),
+            wire_model_id: offering.wire_model_id.clone(),
+            canonical_model: offering.canonical_model.clone(),
+            currency: Currency::Usd,
+            input_per_million: cost.input,
+            output_per_million: cost.output,
+            cache_read_per_million: cost.cache_read,
+            cache_write_per_million: cost.cache_write,
+            provenance: provenance_from_source(&offering.source),
+            effective_at: effective_at_from_source(&offering.source),
+        })
+    }
+
+    /// Whether any per-token price is known.
+    #[must_use]
+    pub fn has_any_price(&self) -> bool {
+        self.input_per_million.is_some()
+            || self.output_per_million.is_some()
+            || self.cache_read_per_million.is_some()
+            || self.cache_write_per_million.is_some()
+    }
+
+    /// Whether this price is older than `max_age_secs` at `now_unix`.
+    ///
+    /// Rows without an `effective_at` (bundled snapshot / user override) carry
+    /// no fetch clock and are not considered age-stale here; live rows are.
+    #[must_use]
+    pub fn is_stale(&self, now_unix: u64, max_age_secs: u64) -> bool {
+        match self.effective_at {
+            Some(t) => now_unix.saturating_sub(t) >= max_age_secs,
+            None => false,
+        }
+    }
+
+    /// Estimate the cost of `usage` in this row's [`Currency`].
+    ///
+    /// Returns `None` if any usage class with a non-zero token count has an
+    /// unknown price — the estimate would otherwise silently under-report. With
+    /// all-zero usage the cost is `Some(0.0)`.
+    #[must_use]
+    pub fn estimate_cost(&self, usage: &TokenUsage) -> Option<f64> {
+        let mut total = 0.0_f64;
+        for (tokens, price) in [
+            (usage.input, self.input_per_million),
+            (usage.output, self.output_per_million),
+            (usage.cache_read, self.cache_read_per_million),
+            (usage.cache_write, self.cache_write_per_million),
+        ] {
+            if tokens > 0 {
+                let price = price?;
+                total += (tokens as f64 / 1_000_000.0) * price;
+            }
+        }
+        Some(total)
+    }
+
+    /// Project to the coarse route-facing meter shape.
+    #[must_use]
+    pub fn to_route_sku(&self) -> PricingSku {
+        PricingSku::Token {
+            input_per_mtok: self.input_per_million,
+            output_per_mtok: self.output_per_million,
+        }
+    }
+}
+
+/// The honest route-facing pricing meter for a catalog offering.
+///
+/// Priced offerings become [`PricingSku::Token`]; everything else (no cost, or a
+/// cost object with no concrete price) becomes [`PricingSku::UnknownOrStale`]
+/// rather than a fabricated zero price.
+#[must_use]
+pub fn route_pricing_sku(offering: &CatalogOffering) -> PricingSku {
+    match OfferingPricing::from_catalog_offering(offering) {
+        Some(pricing) if pricing.has_any_price() => pricing.to_route_sku(),
+        _ => PricingSku::UnknownOrStale,
+    }
+}
+
+fn provenance_from_source(source: &CatalogSource) -> PricingProvenance {
+    match source {
+        CatalogSource::Bundled => PricingProvenance::ModelsDevBundled,
+        CatalogSource::Live { .. } => PricingProvenance::ProviderLive,
+        CatalogSource::UserOverride => PricingProvenance::UserOverride,
+    }
+}
+
+fn effective_at_from_source(source: &CatalogSource) -> Option<u64> {
+    match source {
+        CatalogSource::Live { fetched_at, .. } => Some(*fetched_at),
+        CatalogSource::Bundled | CatalogSource::UserOverride => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/config/src/pricing.rs
+++ b/crates/config/src/pricing.rs
@@ -44,7 +44,9 @@ pub enum PricingProvenance {
     ModelsDevBundled,
     /// From a provider live `/models` (or pricing) refresh.
     ProviderLive,
-    /// From provider documentation / a hand-sourced seed.
+    /// From provider documentation / a hand-sourced seed. Set only by callers
+    /// constructing rows directly; `from_catalog_offering` never produces this
+    /// (Models.dev-sourced rows map to `ModelsDevBundled` / `ProviderLive`).
     ProviderDocs,
     /// User-supplied override (custom endpoint, enterprise terms, local route).
     UserOverride,
@@ -174,6 +176,8 @@ impl OfferingPricing {
         ] {
             if tokens > 0 {
                 let price = price?;
+                // Per-turn token counts are far below 2^53, so this cast is
+                // exact; revisit if TokenUsage ever aggregates across sessions.
                 total += (tokens as f64 / 1_000_000.0) * price;
             }
         }
@@ -181,8 +185,18 @@ impl OfferingPricing {
     }
 
     /// Project to the coarse route-facing meter shape.
+    ///
+    /// Returns [`PricingSku::Token`] only when an input or output rate is known.
+    /// The route-layer `Token` shape carries only input/output rates, so a row
+    /// priced *only* on cache classes would become a `Token` with no visible
+    /// rates — misleading at the route layer. Such rows degrade to
+    /// [`PricingSku::UnknownOrStale`] here while their cache rates remain usable
+    /// through [`OfferingPricing::estimate_cost`].
     #[must_use]
     pub fn to_route_sku(&self) -> PricingSku {
+        if self.input_per_million.is_none() && self.output_per_million.is_none() {
+            return PricingSku::UnknownOrStale;
+        }
         PricingSku::Token {
             input_per_mtok: self.input_per_million,
             output_per_mtok: self.output_per_million,
@@ -192,15 +206,15 @@ impl OfferingPricing {
 
 /// The honest route-facing pricing meter for a catalog offering.
 ///
-/// Priced offerings become [`PricingSku::Token`]; everything else (no cost, or a
-/// cost object with no concrete price) becomes [`PricingSku::UnknownOrStale`]
-/// rather than a fabricated zero price.
+/// An offering with a usable input/output rate becomes [`PricingSku::Token`];
+/// everything else — no cost, a cost object with no concrete price, or a
+/// cache-only price — becomes [`PricingSku::UnknownOrStale`] rather than a
+/// fabricated zero price. (`from_catalog_offering` collapses the unpriced case
+/// to `None`; `to_route_sku` collapses the cache-only case.)
 #[must_use]
 pub fn route_pricing_sku(offering: &CatalogOffering) -> PricingSku {
-    match OfferingPricing::from_catalog_offering(offering) {
-        Some(pricing) if pricing.has_any_price() => pricing.to_route_sku(),
-        _ => PricingSku::UnknownOrStale,
-    }
+    OfferingPricing::from_catalog_offering(offering)
+        .map_or(PricingSku::UnknownOrStale, |pricing| pricing.to_route_sku())
 }
 
 fn provenance_from_source(source: &CatalogSource) -> PricingProvenance {

--- a/crates/config/src/pricing/tests.rs
+++ b/crates/config/src/pricing/tests.rs
@@ -201,3 +201,54 @@ fn pricing_flows_from_the_models_dev_parser() {
     assert_eq!(pricing.cache_read_per_million, Some(0.26));
     assert_eq!(pricing.provenance, PricingProvenance::ModelsDevBundled);
 }
+
+#[test]
+fn cache_only_offering_is_unknown_at_the_route_layer() {
+    // Priced only on cache classes (no input/output): the route Token badge
+    // would have no visible rates, so route_pricing_sku degrades to
+    // UnknownOrStale — yet the cache rate is still usable for estimate_cost.
+    let mut offering = priced(CatalogSource::Bundled);
+    offering.cost = Some(ModelsDevCost {
+        input: None,
+        output: None,
+        cache_read: Some(0.028),
+        cache_write: None,
+    });
+
+    assert!(matches!(
+        route_pricing_sku(&offering),
+        PricingSku::UnknownOrStale
+    ));
+
+    let pricing =
+        OfferingPricing::from_catalog_offering(&offering).expect("cache-only row is still priced");
+    assert!(pricing.has_any_price());
+    let usage = TokenUsage {
+        cache_read: 1_000_000,
+        ..Default::default()
+    };
+    assert_eq!(pricing.estimate_cost(&usage), Some(0.028));
+}
+
+#[test]
+fn user_override_source_maps_through_from_catalog_offering() {
+    // Exercises provenance_from_source / effective_at_from_source for the
+    // override arm via the hydration path (not direct construction).
+    let pricing = OfferingPricing::from_catalog_offering(&priced(CatalogSource::UserOverride))
+        .expect("priced");
+    assert_eq!(pricing.provenance, PricingProvenance::UserOverride);
+    assert_eq!(pricing.effective_at, None);
+}
+
+#[test]
+fn staleness_is_inclusive_at_the_ttl_boundary() {
+    let live = CatalogSource::Live {
+        base_url_fingerprint: "fp".into(),
+        fetched_at: 1_000,
+    };
+    let p = OfferingPricing::from_catalog_offering(&priced(live)).unwrap();
+    // age == max_age_secs counts as stale (`>=` semantics)...
+    assert!(p.is_stale(1_100, 100));
+    // ...one second younger is still fresh.
+    assert!(!p.is_stale(1_099, 100));
+}

--- a/crates/config/src/pricing/tests.rs
+++ b/crates/config/src/pricing/tests.rs
@@ -1,0 +1,203 @@
+//! Behavior tests for the offering pricing projection (#3085).
+
+use super::*;
+use crate::catalog::{CatalogOffering, CatalogSource, bundled_offerings_from_models_dev};
+use crate::models_dev::{ModelsDevCatalog, ModelsDevCost};
+use crate::route::PricingSku;
+
+/// A DeepSeek-shaped priced offering (input/output/cache-read known,
+/// cache-write deliberately unknown) tagged with the given provenance source.
+fn priced(source: CatalogSource) -> CatalogOffering {
+    CatalogOffering {
+        provider: "deepseek".into(),
+        wire_model_id: "deepseek-v4-pro".into(),
+        canonical_model: Some("deepseek-v4-pro".into()),
+        endpoint_key: "chat".into(),
+        cost: Some(ModelsDevCost {
+            input: Some(0.28),
+            output: Some(0.42),
+            cache_read: Some(0.028),
+            cache_write: None,
+        }),
+        source,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn maps_models_dev_cost_with_bundled_provenance_in_usd() {
+    let p =
+        OfferingPricing::from_catalog_offering(&priced(CatalogSource::Bundled)).expect("priced");
+    assert_eq!(p.currency, Currency::Usd);
+    assert_eq!(p.input_per_million, Some(0.28));
+    assert_eq!(p.output_per_million, Some(0.42));
+    assert_eq!(p.cache_read_per_million, Some(0.028));
+    assert_eq!(p.cache_write_per_million, None);
+    assert_eq!(p.provenance, PricingProvenance::ModelsDevBundled);
+    assert_eq!(p.effective_at, None);
+    assert!(p.has_any_price());
+}
+
+#[test]
+fn live_source_carries_provider_live_provenance_and_effective_at() {
+    let src = CatalogSource::Live {
+        base_url_fingerprint: "fp".into(),
+        fetched_at: 1_700,
+    };
+    let p = OfferingPricing::from_catalog_offering(&priced(src)).expect("priced");
+    assert_eq!(p.provenance, PricingProvenance::ProviderLive);
+    assert_eq!(p.effective_at, Some(1_700));
+}
+
+#[test]
+fn no_cost_or_empty_cost_object_is_unknown() {
+    let mut offering = priced(CatalogSource::Bundled);
+    offering.cost = None;
+    assert!(
+        OfferingPricing::from_catalog_offering(&offering).is_none(),
+        "absent cost is unknown, not free"
+    );
+
+    // A cost object present but with no concrete price is still unknown.
+    offering.cost = Some(ModelsDevCost::default());
+    assert!(OfferingPricing::from_catalog_offering(&offering).is_none());
+}
+
+#[test]
+fn estimate_cost_sums_priced_classes() {
+    let p = OfferingPricing::from_catalog_offering(&priced(CatalogSource::Bundled)).unwrap();
+    // 1M input @0.28 + 0.5M output @0.42 + 2M cache_read @0.028 = 0.546
+    let usage = TokenUsage {
+        input: 1_000_000,
+        output: 500_000,
+        cache_read: 2_000_000,
+        cache_write: 0,
+    };
+    let cost = p.estimate_cost(&usage).expect("priced classes estimate");
+    assert!((cost - 0.546).abs() < 1e-9, "got {cost}");
+}
+
+#[test]
+fn estimate_cost_is_none_when_a_used_class_is_unpriced() {
+    // cache_write price is unknown; charging cache-write tokens cannot be
+    // estimated honestly, so the whole estimate is None rather than under-reported.
+    let p = OfferingPricing::from_catalog_offering(&priced(CatalogSource::Bundled)).unwrap();
+    let usage = TokenUsage {
+        input: 100,
+        output: 0,
+        cache_read: 0,
+        cache_write: 10,
+    };
+    assert!(p.estimate_cost(&usage).is_none());
+}
+
+#[test]
+fn estimate_cost_with_zero_usage_is_zero() {
+    let p = OfferingPricing::from_catalog_offering(&priced(CatalogSource::Bundled)).unwrap();
+    assert_eq!(p.estimate_cost(&TokenUsage::default()), Some(0.0));
+}
+
+#[test]
+fn route_pricing_sku_is_token_when_priced_and_unknown_otherwise() {
+    match route_pricing_sku(&priced(CatalogSource::Bundled)) {
+        PricingSku::Token {
+            input_per_mtok,
+            output_per_mtok,
+        } => {
+            assert_eq!(input_per_mtok, Some(0.28));
+            assert_eq!(output_per_mtok, Some(0.42));
+        }
+        other => panic!("expected Token, got {other:?}"),
+    }
+
+    // No cost → honest UnknownOrStale, never a fabricated zero price.
+    let mut unpriced = priced(CatalogSource::Bundled);
+    unpriced.cost = None;
+    assert!(matches!(
+        route_pricing_sku(&unpriced),
+        PricingSku::UnknownOrStale
+    ));
+}
+
+#[test]
+fn currency_round_trips_including_other() {
+    for currency in [Currency::Usd, Currency::Cny, Currency::Other("eur".into())] {
+        let json = serde_json::to_string(&currency).expect("serialize");
+        let back: Currency = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(currency, back);
+    }
+}
+
+#[test]
+fn user_override_pricing_round_trips_and_carries_no_secrets() {
+    let pricing = OfferingPricing {
+        provider: "custom".into(),
+        wire_model_id: "house-model".into(),
+        canonical_model: None,
+        currency: Currency::Cny,
+        input_per_million: Some(8.0),
+        output_per_million: Some(16.0),
+        cache_read_per_million: None,
+        cache_write_per_million: None,
+        provenance: PricingProvenance::UserOverride,
+        effective_at: None,
+    };
+    let json = serde_json::to_string_pretty(&pricing).expect("serialize");
+    let back: OfferingPricing = serde_json::from_str(&json).expect("round-trip");
+    assert_eq!(pricing, back);
+
+    let lower = json.to_lowercase();
+    for needle in [
+        "api_key",
+        "apikey",
+        "authorization",
+        "secret",
+        "password",
+        "bearer",
+        "access_token",
+    ] {
+        assert!(!lower.contains(needle), "pricing JSON contains `{needle}`");
+    }
+}
+
+#[test]
+fn staleness_applies_to_live_rows_only() {
+    let live = CatalogSource::Live {
+        base_url_fingerprint: "fp".into(),
+        fetched_at: 1_000,
+    };
+    let live_price = OfferingPricing::from_catalog_offering(&priced(live)).unwrap();
+    assert!(!live_price.is_stale(1_500, 3_600), "within TTL");
+    assert!(live_price.is_stale(5_000, 3_600), "past TTL");
+
+    // A bundled price has no fetch clock and is not age-stale.
+    let bundled = OfferingPricing::from_catalog_offering(&priced(CatalogSource::Bundled)).unwrap();
+    assert!(!bundled.is_stale(u64::MAX, 1));
+}
+
+#[test]
+fn pricing_flows_from_the_models_dev_parser() {
+    let raw = r#"{
+      "providers": {
+        "zai": {
+          "models": {
+            "glm-5.2": {
+              "id": "glm-5.2",
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "cost": { "input": 1.4, "output": 4.4, "cache_read": 0.26 }
+            }
+          }
+        }
+      }
+    }"#;
+    let catalog = ModelsDevCatalog::parse_json(raw).expect("fixture parses");
+    let rows = bundled_offerings_from_models_dev(&catalog);
+    let pricing = OfferingPricing::from_catalog_offering(&rows[0]).expect("zai glm-5.2 is priced");
+
+    assert_eq!(pricing.provider, "zai");
+    assert_eq!(pricing.wire_model_id, "glm-5.2");
+    assert_eq!(pricing.input_per_million, Some(1.4));
+    assert_eq!(pricing.output_per_million, Some(4.4));
+    assert_eq!(pricing.cache_read_per_million, Some(0.26));
+    assert_eq!(pricing.provenance, PricingProvenance::ModelsDevBundled);
+}


### PR DESCRIPTION
## Summary

Network-free `codewhale_config::pricing` — the config-layer slice of #3085. Maps the catalog offerings from #3498 into provider/offering-scoped pricing rows with explicit provenance, so pricing stops being DeepSeek-shaped and a route's price is owned by its **offering**, not its model string.

- **`OfferingPricing`** — per-million `input` / `output` / `cache_read` / `cache_write` prices in a `Currency` (Usd / Cny / Other), with `PricingProvenance` (`ModelsDevBundled` / `ProviderLive` / `ProviderDocs` / `UserOverride` / `Unknown`) and an `effective_at` timestamp.
- **`from_catalog_offering()`** — seeds USD pricing from Models.dev `cost`; provenance and `effective_at` follow the offering's `CatalogSource`. Absent cost — or a cost object with no concrete price — yields `None` (**unknown, not free**).
- **`estimate_cost(TokenUsage)`** — pure per-class arithmetic that returns `None` if any *used* class has an unknown price, so a cost is never silently under-reported; all-zero usage → `Some(0.0)`.
- **`route_pricing_sku()` / `to_route_sku()`** — bridge to the existing `route::PricingSku`, mapping unpriced routes to `UnknownOrStale` rather than a fabricated zero price.
- **`is_stale()`** — age staleness for live (timestamped) rows only; bundled/override prices carry no fetch clock.

## Honesty invariants (from #2608 / #3085)
- Pricing lookup is keyed by provider + offering, not a bare model string.
- Unknown / local / custom / subscription routes are represented honestly — never implied free, never a fabricated token price.
- The coarse `SubscriptionQuota` / `AccountCredits` / `LocalOrNotApplicable` meter shapes already live in `route::PricingSku`; this layer feeds the token-pricing case and leaves the others to the route/UI layer.

## Deliberately out of this slice (separate surfaces)
- Provider usage-payload normalization in the client parsers (Chat Completions / Responses / Anthropic).
- `CostDisplay` UI wiring: `/provider`, `/model`, sidebar cost/usage, session metadata, `doctor --json`. (Left for whoever owns the TUI surface, to avoid collision.)

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p codewhale-config --all-targets` (clean)
- `cargo test -p codewhale-config` → **245 passed** (11 new `pricing` tests: Models.dev→USD mapping + provenance, live provenance/effective-at, unknown/empty-cost, cache-aware cost estimation, unpriced-class → `None`, honest `route_pricing_sku`, currency round-trips, user-override + no-secrets guard, staleness).

Builds on #3497 + #3498 (both merged); rebased onto `main` so the diff is the pricing layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX

---
_Generated by [Claude Code](https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX)_