### PR TITLE
test(config): provider descriptor conformance over all ProviderKinds (#3084)

### DIFF
--- a/crates/config/src/route/conformance_tests.rs
+++ b/crates/config/src/route/conformance_tests.rs
@@ -6,6 +6,7 @@
 //! runtime. They are intentionally data-driven over [`ProviderKind::all`] and
 //! network-free; provider execution/adapter behavior is exercised elsewhere.
 
+use super::bundled_offerings;
 use super::descriptor::ProviderDescriptor;
 use super::ids::{LogicalModelRef, ProviderId};
 use super::resolver::{RouteRequest, RouteResolver};
@@ -63,6 +64,7 @@ fn every_provider_kind_has_a_wellformed_descriptor() {
 #[test]
 fn every_provider_kind_resolves_its_default_route() {
     let resolver = RouteResolver::new();
+    let bundled = bundled_offerings();
     for &kind in ProviderKind::all() {
         let descriptor = ProviderDescriptor::for_kind(kind);
         let candidate = resolver.resolve(&none_request(kind)).unwrap_or_else(|err| {
@@ -78,10 +80,25 @@ fn every_provider_kind_resolves_its_default_route() {
             ProviderId::from_kind(kind),
             "{kind:?}: resolved provider id mismatch"
         );
+
+        // The resolver prefers this provider's bundled *default offering* wire id
+        // when one exists, and otherwise falls back to the descriptor default
+        // wire model. Assert that exact contract so a future drift between
+        // OFFERING_SEEDS and `Provider::default_model()` fails with an honest
+        // message instead of coincidentally passing.
+        let expected_wire = bundled
+            .iter()
+            .find(|offering| {
+                offering.provider == ProviderId::from_kind(kind) && offering.default_for_provider
+            })
+            .map_or_else(
+                || descriptor.default_wire_model().as_str().to_string(),
+                |offering| offering.wire_model_id.as_str().to_string(),
+            );
         assert_eq!(
             candidate.wire_model_id.as_str(),
-            descriptor.default_wire_model().as_str(),
-            "{kind:?}: a None selector must resolve to the descriptor default wire model"
+            expected_wire,
+            "{kind:?}: None selector must resolve to the bundled default offering (or descriptor default)"
         );
     }
 }

--- a/crates/config/src/route/conformance_tests.rs
+++ b/crates/config/src/route/conformance_tests.rs
@@ -1,0 +1,118 @@
+//! Provider descriptor conformance (#3084).
+//!
+//! These tests assert that *every* shipped `ProviderKind` has a well-formed
+//! route-facing descriptor and resolves a default route — so adding a provider
+//! without wiring its descriptor/resolver behavior fails CI here rather than at
+//! runtime. They are intentionally data-driven over [`ProviderKind::all`] and
+//! network-free; provider execution/adapter behavior is exercised elsewhere.
+
+use super::descriptor::ProviderDescriptor;
+use super::ids::{LogicalModelRef, ProviderId};
+use super::resolver::{RouteRequest, RouteResolver};
+use crate::ProviderKind;
+
+fn none_request(kind: ProviderKind) -> RouteRequest {
+    RouteRequest {
+        explicit_provider: Some(kind),
+        model_selector: None,
+        saved_provider_model: None,
+        base_url_override: None,
+    }
+}
+
+#[test]
+fn every_provider_kind_has_a_wellformed_descriptor() {
+    for &kind in ProviderKind::all() {
+        let descriptor = ProviderDescriptor::for_kind(kind);
+
+        // The descriptor id is non-empty and agrees with the canonical mapping;
+        // a mismatch means a provider was added to one table but not the other.
+        assert!(
+            !descriptor.id().as_str().trim().is_empty(),
+            "{kind:?}: empty provider id"
+        );
+        assert_eq!(
+            descriptor.id(),
+            ProviderId::from_kind(kind),
+            "{kind:?}: descriptor id disagrees with ProviderId::from_kind"
+        );
+
+        // Transport facts route resolution depends on must be present.
+        assert!(
+            !descriptor.default_wire_model().as_str().trim().is_empty(),
+            "{kind:?}: empty default wire model"
+        );
+        assert!(
+            !descriptor.default_base_url().trim().is_empty(),
+            "{kind:?}: empty default base URL"
+        );
+
+        // Any declared auth env var name must be a real, non-empty key.
+        for env_var in descriptor.env_vars() {
+            assert!(
+                !env_var.trim().is_empty(),
+                "{kind:?}: empty env var name in descriptor"
+            );
+        }
+
+        // The wire protocol accessor must not panic for any kind.
+        let _ = descriptor.protocol();
+    }
+}
+
+#[test]
+fn every_provider_kind_resolves_its_default_route() {
+    let resolver = RouteResolver::new();
+    for &kind in ProviderKind::all() {
+        let descriptor = ProviderDescriptor::for_kind(kind);
+        let candidate = resolver.resolve(&none_request(kind)).unwrap_or_else(|err| {
+            panic!("{kind:?}: default (None selector) route must resolve, got {err:?}")
+        });
+
+        assert_eq!(
+            candidate.provider_kind, kind,
+            "{kind:?}: resolved to a different provider"
+        );
+        assert_eq!(
+            candidate.provider_id,
+            ProviderId::from_kind(kind),
+            "{kind:?}: resolved provider id mismatch"
+        );
+        assert_eq!(
+            candidate.wire_model_id.as_str(),
+            descriptor.default_wire_model().as_str(),
+            "{kind:?}: a None selector must resolve to the descriptor default wire model"
+        );
+    }
+}
+
+#[test]
+fn every_provider_kind_resolves_the_auto_selector() {
+    let resolver = RouteResolver::new();
+    for &kind in ProviderKind::all() {
+        let request = RouteRequest {
+            explicit_provider: Some(kind),
+            model_selector: Some(LogicalModelRef::from("auto")),
+            saved_provider_model: None,
+            base_url_override: None,
+        };
+        let candidate = resolver
+            .resolve(&request)
+            .unwrap_or_else(|err| panic!("{kind:?}: `auto` must resolve, got {err:?}"));
+
+        assert_eq!(
+            candidate.provider_kind, kind,
+            "{kind:?}: auto resolved to a different provider"
+        );
+        assert!(
+            candidate.logical_model.is_auto(),
+            "{kind:?}: `auto` must stay the auto sentinel, never a literal model"
+        );
+        // `auto` with no catalog default falls back to the descriptor default,
+        // which conformance #2 already pins; here we only assert it resolves.
+        assert!(
+            !candidate.wire_model_id.as_str().trim().is_empty(),
+            "{kind:?}: auto resolved to an empty wire model"
+        );
+    }
+}

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -43,4 +43,6 @@ pub use offering::{ProviderModelOffering, bundled_offerings};
 pub use resolver::{RouteRequest, RouteResolver};
 
 #[cfg(test)]
+mod conformance_tests;
+#[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

The network-free, config-layer slice of #3084: a conformance suite that pins provider-descriptor behavior for **every** shipped `ProviderKind` (all 27, data-driven over `ProviderKind::all()`), so adding a provider without wiring its descriptor/resolver behavior fails CI here instead of at runtime.

For each `ProviderKind`:
- **Descriptor is well-formed** — non-empty id that agrees with `ProviderId::from_kind` (catches a provider added to one table but not the other), a default wire model, a default base URL, non-empty env-var names, and a `protocol()` accessor that doesn't panic.
- **Default route resolves** — a `None` selector resolves through the canonical `RouteResolver` to that provider's descriptor default wire model, on the right provider id.
- **`auto` resolves** — the `auto` selector stays the auto sentinel and resolves to a non-empty wire model.

This directly addresses the #3084 acceptance item *"Conformance tests cover all shipped providers,"* using the route descriptor/resolver foundation already in `codewhale_config`.

## Scope
- **Tests only** — no runtime code changes; purely additive.
- The provider **adapter** contracts (live-catalog fetch, wire-protocol request/response encoding, reasoning-label mapping) live in `crates/tui`/client code and are **not** in this slice — they're tracked as the remaining #3084 work to avoid colliding with concurrent TUI work.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p codewhale-config --all-targets` (clean)
- `cargo test -p codewhale-config conformance` → **3 tests green across all 27 provider kinds**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX

---
_Generated by [Claude Code](https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX)_