### PR TITLE
refactor(config): extract ProviderKind into a provider_kind module (#3311)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4,8 +4,10 @@ pub mod models_dev;
 pub mod pricing;
 pub mod provider;
 mod provider_defaults;
+mod provider_kind;
 pub mod route;
 pub(crate) use provider_defaults::*;
+pub use provider_kind::ProviderKind;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
@@ -30,165 +32,6 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const PERMISSIONS_FILE_NAME: &str = "permissions.toml";
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "kebab-case")]
-pub enum ProviderKind {
-    #[default]
-    #[serde(
-        alias = "deepseek-cn",
-        alias = "deepseek_china",
-        alias = "deepseekcn",
-        alias = "deepseek-china"
-    )]
-    Deepseek,
-    #[serde(
-        alias = "deepseek-anthropic",
-        alias = "deepseek_anthropic",
-        alias = "deepseek-claude",
-        alias = "deepseek_claude"
-    )]
-    DeepseekAnthropic,
-    NvidiaNim,
-    #[serde(alias = "open-ai")]
-    Openai,
-    Atlascloud,
-    #[serde(
-        alias = "wanjie",
-        alias = "wanjie_ark",
-        alias = "ark-wanjie",
-        alias = "ark_wanjie",
-        alias = "wanjie-maas",
-        alias = "wanjie_maas"
-    )]
-    WanjieArk,
-    #[serde(alias = "volcengine-ark", alias = "volcengine_ark", alias = "ark")]
-    Volcengine,
-    Openrouter,
-    #[serde(alias = "mimo", alias = "xiaomi", alias = "xiaomi_mimo")]
-    XiaomiMimo,
-    Novita,
-    Fireworks,
-    #[serde(alias = "silicon-flow", alias = "silicon_flow")]
-    Siliconflow,
-    #[serde(alias = "arcee-ai", alias = "arcee_ai")]
-    Arcee,
-    #[serde(alias = "siliconflow-cn", alias = "siliconflow-CN")]
-    SiliconflowCN,
-    Moonshot,
-    Sglang,
-    Vllm,
-    Ollama,
-    #[serde(alias = "hugging-face", alias = "hugging_face", alias = "hf")]
-    Huggingface,
-    #[serde(alias = "together-ai", alias = "together_ai")]
-    Together,
-    #[serde(alias = "baidu-qianfan", alias = "baidu_qianfan", alias = "baidu")]
-    Qianfan,
-    #[serde(
-        alias = "openai-codex",
-        alias = "openai_codex",
-        alias = "codex",
-        alias = "chatgpt",
-        alias = "chatgpt-codex",
-        alias = "chatgpt_codex"
-    )]
-    OpenaiCodex,
-    #[serde(alias = "claude")]
-    Anthropic,
-    #[serde(alias = "z-ai", alias = "z_ai", alias = "z.ai")]
-    Zai,
-    #[serde(
-        alias = "step-fun",
-        alias = "step_fun",
-        alias = "stepfun",
-        alias = "stepflash",
-        alias = "step-flash",
-        alias = "step_flash"
-    )]
-    Stepfun,
-    #[serde(alias = "mini-max", alias = "mini_max", alias = "minimax")]
-    Minimax,
-    #[serde(alias = "deep-infra", alias = "deep_infra")]
-    Deepinfra,
-}
-
-impl ProviderKind {
-    pub const ALL: [Self; 27] = [
-        Self::Deepseek,
-        Self::DeepseekAnthropic,
-        Self::NvidiaNim,
-        Self::Openai,
-        Self::Atlascloud,
-        Self::WanjieArk,
-        Self::Volcengine,
-        Self::Openrouter,
-        Self::XiaomiMimo,
-        Self::Novita,
-        Self::Fireworks,
-        Self::Siliconflow,
-        Self::Arcee,
-        Self::SiliconflowCN,
-        Self::Moonshot,
-        Self::Sglang,
-        Self::Vllm,
-        Self::Ollama,
-        Self::Huggingface,
-        Self::Together,
-        Self::Qianfan,
-        Self::OpenaiCodex,
-        Self::Anthropic,
-        Self::Zai,
-        Self::Stepfun,
-        Self::Minimax,
-        Self::Deepinfra,
-    ];
-
-    #[must_use]
-    pub fn all() -> &'static [Self] {
-        &Self::ALL
-    }
-
-    #[must_use]
-    pub fn names_hint() -> String {
-        Self::all()
-            .iter()
-            .map(|provider| provider.as_str())
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-
-    #[must_use]
-    pub fn as_str(self) -> &'static str {
-        self.provider().id()
-    }
-
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        let trimmed = value.trim();
-        provider::all_providers()
-            .iter()
-            .find(|p| {
-                trimmed.eq_ignore_ascii_case(p.id())
-                    || p.aliases().iter().any(|a| trimmed.eq_ignore_ascii_case(a))
-            })
-            .map(|p| p.kind())
-    }
-
-    #[must_use]
-    pub fn is_siliconflow(self) -> bool {
-        matches!(self, Self::Siliconflow | Self::SiliconflowCN)
-    }
-
-    /// Return the built-in metadata entry for this provider.
-    ///
-    /// This is a metadata foundation only; runtime routing still resolves
-    /// through [`ConfigToml::resolve_runtime_options`].
-    #[must_use]
-    pub fn provider(self) -> &'static dyn provider::Provider {
-        provider::provider_for_kind(self)
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProviderConfigToml {

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -160,7 +160,7 @@ impl ProviderKind {
     /// Return the built-in metadata entry for this provider.
     ///
     /// This is a metadata foundation only; runtime routing still resolves
-    /// through [`ConfigToml::resolve_runtime_options`].
+    /// through [`crate::ConfigToml::resolve_runtime_options`].
     #[must_use]
     pub fn provider(self) -> &'static dyn provider::Provider {
         provider::provider_for_kind(self)

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -1,0 +1,168 @@
+//! The canonical [`ProviderKind`] enum (#3311): the set of built-in provider
+//! kinds, their serde aliases, and identity helpers (`all`, `as_str`, `parse`,
+//! `provider`). Extracted verbatim from `lib.rs` to separate provider identity
+//! from config schema/loading; re-exported at the crate root so
+//! `codewhale_config::ProviderKind` is unchanged. Behavior is identical.
+
+use serde::{Deserialize, Serialize};
+
+use crate::provider;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderKind {
+    #[default]
+    #[serde(
+        alias = "deepseek-cn",
+        alias = "deepseek_china",
+        alias = "deepseekcn",
+        alias = "deepseek-china"
+    )]
+    Deepseek,
+    #[serde(
+        alias = "deepseek-anthropic",
+        alias = "deepseek_anthropic",
+        alias = "deepseek-claude",
+        alias = "deepseek_claude"
+    )]
+    DeepseekAnthropic,
+    NvidiaNim,
+    #[serde(alias = "open-ai")]
+    Openai,
+    Atlascloud,
+    #[serde(
+        alias = "wanjie",
+        alias = "wanjie_ark",
+        alias = "ark-wanjie",
+        alias = "ark_wanjie",
+        alias = "wanjie-maas",
+        alias = "wanjie_maas"
+    )]
+    WanjieArk,
+    #[serde(alias = "volcengine-ark", alias = "volcengine_ark", alias = "ark")]
+    Volcengine,
+    Openrouter,
+    #[serde(alias = "mimo", alias = "xiaomi", alias = "xiaomi_mimo")]
+    XiaomiMimo,
+    Novita,
+    Fireworks,
+    #[serde(alias = "silicon-flow", alias = "silicon_flow")]
+    Siliconflow,
+    #[serde(alias = "arcee-ai", alias = "arcee_ai")]
+    Arcee,
+    #[serde(alias = "siliconflow-cn", alias = "siliconflow-CN")]
+    SiliconflowCN,
+    Moonshot,
+    Sglang,
+    Vllm,
+    Ollama,
+    #[serde(alias = "hugging-face", alias = "hugging_face", alias = "hf")]
+    Huggingface,
+    #[serde(alias = "together-ai", alias = "together_ai")]
+    Together,
+    #[serde(alias = "baidu-qianfan", alias = "baidu_qianfan", alias = "baidu")]
+    Qianfan,
+    #[serde(
+        alias = "openai-codex",
+        alias = "openai_codex",
+        alias = "codex",
+        alias = "chatgpt",
+        alias = "chatgpt-codex",
+        alias = "chatgpt_codex"
+    )]
+    OpenaiCodex,
+    #[serde(alias = "claude")]
+    Anthropic,
+    #[serde(alias = "z-ai", alias = "z_ai", alias = "z.ai")]
+    Zai,
+    #[serde(
+        alias = "step-fun",
+        alias = "step_fun",
+        alias = "stepfun",
+        alias = "stepflash",
+        alias = "step-flash",
+        alias = "step_flash"
+    )]
+    Stepfun,
+    #[serde(alias = "mini-max", alias = "mini_max", alias = "minimax")]
+    Minimax,
+    #[serde(alias = "deep-infra", alias = "deep_infra")]
+    Deepinfra,
+}
+
+impl ProviderKind {
+    pub const ALL: [Self; 27] = [
+        Self::Deepseek,
+        Self::DeepseekAnthropic,
+        Self::NvidiaNim,
+        Self::Openai,
+        Self::Atlascloud,
+        Self::WanjieArk,
+        Self::Volcengine,
+        Self::Openrouter,
+        Self::XiaomiMimo,
+        Self::Novita,
+        Self::Fireworks,
+        Self::Siliconflow,
+        Self::Arcee,
+        Self::SiliconflowCN,
+        Self::Moonshot,
+        Self::Sglang,
+        Self::Vllm,
+        Self::Ollama,
+        Self::Huggingface,
+        Self::Together,
+        Self::Qianfan,
+        Self::OpenaiCodex,
+        Self::Anthropic,
+        Self::Zai,
+        Self::Stepfun,
+        Self::Minimax,
+        Self::Deepinfra,
+    ];
+
+    #[must_use]
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
+    #[must_use]
+    pub fn names_hint() -> String {
+        Self::all()
+            .iter()
+            .map(|provider| provider.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        self.provider().id()
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        let trimmed = value.trim();
+        provider::all_providers()
+            .iter()
+            .find(|p| {
+                trimmed.eq_ignore_ascii_case(p.id())
+                    || p.aliases().iter().any(|a| trimmed.eq_ignore_ascii_case(a))
+            })
+            .map(|p| p.kind())
+    }
+
+    #[must_use]
+    pub fn is_siliconflow(self) -> bool {
+        matches!(self, Self::Siliconflow | Self::SiliconflowCN)
+    }
+
+    /// Return the built-in metadata entry for this provider.
+    ///
+    /// This is a metadata foundation only; runtime routing still resolves
+    /// through [`ConfigToml::resolve_runtime_options`].
+    #[must_use]
+    pub fn provider(self) -> &'static dyn provider::Provider {
+        provider::provider_for_kind(self)
+    }
+}

--- a/scripts/check-provider-registry.py
+++ b/scripts/check-provider-registry.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG_RS = ROOT / "crates" / "config" / "src" / "lib.rs"
+# ProviderKind's enum + identity impl were split out of lib.rs into this module.
+PROVIDER_KIND_RS = ROOT / "crates" / "config" / "src" / "provider_kind.rs"
 PROVIDER_RS = ROOT / "crates" / "config" / "src" / "provider.rs"
 TUI_CONFIG_RS = ROOT / "crates" / "tui" / "src" / "config.rs"
 AGENT_RS = ROOT / "crates" / "agent" / "src" / "lib.rs"
@@ -91,6 +93,12 @@ def extract_match_block(
 
 
 def parse_aliases_for_variant(source: str, enum_name: str, variant: str, context: str) -> set[str]:
+    # `ProviderKind`'s enum + identity impl (incl. `parse`) live in
+    # provider_kind.rs after the config module split; read the impl from there
+    # regardless of the file the caller passed for other lookups.
+    if enum_name == "ProviderKind":
+        source = read(PROVIDER_KIND_RS)
+        context = "crates/config/src/provider_kind.rs"
     impl_start = require_index(source, f"impl {enum_name}", context)
     block = extract_match_block(
         source,


### PR DESCRIPTION
## Summary

Second mechanical, behavior-preserving slice of the config module split (#3311), continuing from #3503. Config **crate** only — collision-free with the TUI `config.rs` work.

Moves the `ProviderKind` enum (with its serde aliases) and its identity `impl` (`ALL` / `all` / `names_hint` / `as_str` / `parse` / `is_siliconflow` / `provider`) verbatim out of `lib.rs` into a focused `provider_kind` module, re-exported `pub use provider_kind::ProviderKind` at the crate root.

- **`codewhale_config::ProviderKind` and every `crate::ProviderKind` path are unchanged** — only the definition site moved; the re-export preserves the public API, so all dependent crates (tui, cli, core, …) are unaffected.
- The module depends only on `crate::provider`; **no values, aliases, or logic changed** (extracted as a contiguous block, not retyped).
- `lib.rs` shrinks by ~158 lines (now ~4.38k), continuing to separate provider **identity** from config schema/loading per #3311 / #2608.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p codewhale-config --all-targets` (clean)
- `cargo test -p codewhale-config` → **251 passed (unchanged)** — existing alias / parse / round-trip tests prove `ProviderKind` behavior is identical.

Stacked on #3503 (merged); rebased onto `main` so the diff is the `ProviderKind` move only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX

---
_Generated by [Claude Code](https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX)_