### PR TITLE
[codex] feat(config): carry route limits through resolver

### DIFF
--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::models_dev::{ModelsDevCatalog, ModelsDevCost, ModelsDevLimit};
-use crate::route::{ModelId, ProviderId, ProviderModelOffering, WireModelId};
+use crate::route::{ModelId, ProviderId, ProviderModelOffering, RouteLimits, WireModelId};
 
 /// Provenance of a catalog row. Drives layer precedence and UI provenance.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -121,6 +121,11 @@ impl CatalogOffering {
             wire_model_id: self.wire_id(),
             endpoint_key: self.endpoint_key.clone(),
             default_for_provider: self.default_for_provider,
+            limits: self
+                .limit
+                .as_ref()
+                .map(RouteLimits::from)
+                .unwrap_or_default(),
         }
     }
 

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -99,17 +99,16 @@ fn hosted_offering_keeps_prefixed_wire_id_and_explicit_canonical_join() {
 }
 
 #[test]
-fn to_offering_projects_minimal_routing_identity() {
+fn to_offering_projects_routing_identity_and_limits() {
     let rows = bundled_offerings_from_models_dev(&fixture());
-    let hosted = find(&rows, "together", "deepseek-ai/DeepSeek-V4-Pro").to_offering();
+    let glm = find(&rows, "zhipuai", "glm-5.2").to_offering();
 
-    assert_eq!(hosted.provider.as_str(), "together");
-    assert_eq!(hosted.wire_model_id.as_str(), "deepseek-ai/DeepSeek-V4-Pro");
-    assert_eq!(
-        hosted.canonical_model.as_ref().map(ModelId::as_str),
-        Some("deepseek-v4-pro")
-    );
-    assert_eq!(hosted.endpoint_key, "chat");
+    assert_eq!(glm.provider.as_str(), "zhipuai");
+    assert_eq!(glm.wire_model_id.as_str(), "glm-5.2");
+    assert_eq!(glm.canonical_model, None);
+    assert_eq!(glm.endpoint_key, "chat");
+    assert_eq!(glm.limits.context_tokens, Some(1_000_000));
+    assert_eq!(glm.limits.output_tokens, Some(131_072));
 }
 
 #[test]
@@ -507,11 +506,12 @@ fn snapshot_feeds_route_resolver_offerings() {
     let snapshot = CatalogCompiler::new().with_models_dev(&fixture()).compile();
     let offerings = snapshot.to_offerings();
 
-    assert!(
-        offerings
-            .iter()
-            .any(|o| o.provider.as_str() == "zhipuai" && o.wire_model_id.as_str() == "glm-5.2")
-    );
+    let glm = offerings
+        .iter()
+        .find(|o| o.provider.as_str() == "zhipuai" && o.wire_model_id.as_str() == "glm-5.2")
+        .expect("GLM offering reaches the route resolver seam");
+    assert_eq!(glm.limits.context_tokens, Some(1_000_000));
+    assert_eq!(glm.limits.output_tokens, Some(131_072));
     // Audio-only row never becomes a routing offering.
     assert!(
         !offerings

--- a/crates/config/src/models_dev.rs
+++ b/crates/config/src/models_dev.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::route::{ModelId, ProviderId, ProviderModelOffering, WireModelId};
+use crate::route::{ModelId, ProviderId, ProviderModelOffering, RouteLimits, WireModelId};
 
 /// Provider catalog endpoint used by Models.dev.
 pub const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
@@ -89,6 +89,11 @@ impl ModelsDevCatalog {
             wire_model_id: WireModelId::from(model.id.clone()),
             endpoint_key: "chat".to_string(),
             default_for_provider: model.default_for_provider,
+            limits: model
+                .limit
+                .as_ref()
+                .map(RouteLimits::from)
+                .unwrap_or_default(),
         })
     }
 
@@ -113,6 +118,11 @@ impl ModelsDevCatalog {
                     wire_model_id: WireModelId::from(model.id.clone()),
                     endpoint_key: "chat".to_string(),
                     default_for_provider: model.default_for_provider,
+                    limits: model
+                        .limit
+                        .as_ref()
+                        .map(RouteLimits::from)
+                        .unwrap_or_default(),
                 })
                 .collect(),
         )
@@ -279,6 +289,16 @@ pub struct ModelsDevLimit {
     pub output: Option<u64>,
 }
 
+impl From<&ModelsDevLimit> for RouteLimits {
+    fn from(limit: &ModelsDevLimit) -> Self {
+        Self {
+            context_tokens: limit.context,
+            input_tokens: limit.input,
+            output_tokens: limit.output,
+        }
+    }
+}
+
 /// Input/output modalities.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ModelsDevModalities {
@@ -427,6 +447,12 @@ mod tests {
             offering.base_model, None,
             "generated JSON does not prove a canonical join"
         );
+
+        let route_offering = catalog
+            .provider_offering("zhipuai", "glm-5.2")
+            .expect("route offering");
+        assert_eq!(route_offering.limits.context_tokens, Some(1_000_000));
+        assert_eq!(route_offering.limits.output_tokens, Some(131_072));
     }
 
     #[test]

--- a/crates/config/src/route/candidate.rs
+++ b/crates/config/src/route/candidate.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use super::RequestProtocol;
 use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
+use super::offering::RouteLimits;
 use crate::ProviderKind;
 
 /// A concrete, resolved endpoint the route will talk to.
@@ -123,6 +124,8 @@ pub struct ReadyRouteCandidate {
     pub auth: ResolvedAuthSource,
     /// Selected wire protocol.
     pub protocol: RequestProtocol,
+    /// Route/offering-scoped token limits, when known.
+    pub limits: RouteLimits,
     /// Pricing/quota class, if known.
     pub pricing: Option<PricingSku>,
     /// Validation outcome.
@@ -142,6 +145,7 @@ impl ReadyRouteCandidate {
         endpoint: ResolvedEndpoint,
         auth: ResolvedAuthSource,
         protocol: RequestProtocol,
+        limits: RouteLimits,
         pricing: Option<PricingSku>,
         validation: ValidationReport,
     ) -> Self {
@@ -154,6 +158,7 @@ impl ReadyRouteCandidate {
             endpoint,
             auth,
             protocol,
+            limits,
             pricing,
             validation,
         }

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -39,7 +39,7 @@ pub use candidate::{
 pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
 pub use errors::RouteError;
 pub use ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
-pub use offering::{ProviderModelOffering, bundled_offerings};
+pub use offering::{ProviderModelOffering, RouteLimits, bundled_offerings};
 pub use resolver::{RouteRequest, RouteResolver};
 
 #[cfg(test)]

--- a/crates/config/src/route/offering.rs
+++ b/crates/config/src/route/offering.rs
@@ -11,7 +11,35 @@
 //! prefixes such as `deepseek-ai/DeepSeek-V4-Pro`. It exists to exercise the
 //! seam, not to be the eventual catalog.
 
+use serde::{Deserialize, Serialize};
+
 use super::ids::{ModelId, ProviderId, WireModelId};
+
+/// Token limits for one resolved route/offering.
+///
+/// These are optional because hosted catalogs, local runtimes, and custom
+/// endpoints can legitimately omit some or all limit facts. Callers should
+/// treat `None` as unknown, not zero.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteLimits {
+    /// Total context window (input + output), in tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_tokens: Option<u64>,
+    /// Input-token limit, when the provider reports it separately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    /// Output-token cap for the route/offering, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+}
+
+impl RouteLimits {
+    /// Whether at least one limit fact is known.
+    #[must_use]
+    pub const fn has_known_limit(self) -> bool {
+        self.context_tokens.is_some() || self.input_tokens.is_some() || self.output_tokens.is_some()
+    }
+}
 
 /// One provider's way of serving a (possibly canonical) model.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,6 +54,8 @@ pub struct ProviderModelOffering {
     pub endpoint_key: String,
     /// Whether this is the provider's default offering.
     pub default_for_provider: bool,
+    /// Provider/offering-scoped token limits, when known.
+    pub limits: RouteLimits,
 }
 
 /// A static, lazily-materialized seam catalog.
@@ -88,6 +118,7 @@ pub fn bundled_offerings() -> Vec<ProviderModelOffering> {
             wire_model_id: WireModelId::from(seed.wire_model_id),
             endpoint_key: seed.endpoint_key.to_string(),
             default_for_provider: seed.default_for_provider,
+            limits: RouteLimits::default(),
         })
         .collect()
 }

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -33,7 +33,7 @@ use super::candidate::{
 use super::descriptor::ProviderDescriptor;
 use super::errors::RouteError;
 use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
-use super::offering::{ProviderModelOffering, bundled_offerings};
+use super::offering::{ProviderModelOffering, RouteLimits, bundled_offerings};
 use crate::ProviderKind;
 
 /// A request to resolve into an executable route.
@@ -128,14 +128,22 @@ impl RouteResolver {
         // 4. Map the selector to a wire id within provider scope.
         //    Prefixed selectors are preserved VERBATIM as the wire id.
         let class = classify(provider_kind);
-        let (wire_model_id, canonical_model, endpoint_key) = if is_auto {
+        let (wire_model_id, canonical_model, endpoint_key, limits) = if is_auto {
             default_offering.map_or_else(
-                || (descriptor.default_wire_model(), None, "chat".to_string()),
+                || {
+                    (
+                        descriptor.default_wire_model(),
+                        None,
+                        "chat".to_string(),
+                        RouteLimits::default(),
+                    )
+                },
                 |offering| {
                     (
                         offering.wire_model_id.clone(),
                         offering.canonical_model.clone(),
                         offering.endpoint_key.clone(),
+                        offering.limits,
                     )
                 },
             )
@@ -166,6 +174,7 @@ impl RouteResolver {
             endpoint,
             ResolvedAuthSource::Missing,
             descriptor.protocol(),
+            limits,
             Some(PricingSku::UnknownOrStale),
             validation,
         ))
@@ -178,7 +187,7 @@ impl RouteResolver {
         provider_id: &ProviderId,
         logical_model: &LogicalModelRef,
         class: ProviderClass,
-    ) -> Result<(WireModelId, Option<ModelId>, String), RouteError> {
+    ) -> Result<(WireModelId, Option<ModelId>, String, RouteLimits), RouteError> {
         let raw = logical_model.raw();
 
         // Try to match a catalog offering owned by THIS provider, either by
@@ -198,6 +207,7 @@ impl RouteResolver {
                     offering.wire_model_id.clone(),
                     offering.canonical_model.clone(),
                     offering.endpoint_key.clone(),
+                    offering.limits,
                 ));
             }
         }
@@ -222,13 +232,23 @@ impl RouteResolver {
                 }
                 // A bare, unknown model on a strict direct provider is passed
                 // through verbatim (the provider validates it server-side).
-                Ok((WireModelId::from(raw), None, "chat".to_string()))
+                Ok((
+                    WireModelId::from(raw),
+                    None,
+                    "chat".to_string(),
+                    RouteLimits::default(),
+                ))
             }
             // Aggregators, local runtimes, and custom OpenAI-compatible
             // endpoints legitimately accept arbitrary / prefixed ids verbatim.
             ProviderClass::Aggregator | ProviderClass::LocalOrCustom => {
                 let _ = provider_kind;
-                Ok((WireModelId::from(raw), None, "chat".to_string()))
+                Ok((
+                    WireModelId::from(raw),
+                    None,
+                    "chat".to_string(),
+                    RouteLimits::default(),
+                ))
             }
         }
     }

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -27,7 +27,8 @@ fn models_dev_route_resolver() -> RouteResolver {
               "id": "glm-5.2",
               "base_model": "zhipuai/glm-5.2",
               "default": true,
-              "modalities": { "input": ["text"], "output": ["text"] }
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 1000000, "input": 900000, "output": 131072 }
             }
           }
         },
@@ -36,7 +37,8 @@ fn models_dev_route_resolver() -> RouteResolver {
             "z-ai/glm-5.2": {
               "id": "z-ai/glm-5.2",
               "base_model": "zhipuai/glm-5.2",
-              "modalities": { "input": ["text"], "output": ["text"] }
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 128000, "output": 32768 }
             }
           }
         }
@@ -348,6 +350,38 @@ fn resolver_models_dev_prefixed_wire_id_stays_inside_provider_scope() {
 }
 
 #[test]
+fn resolver_carries_models_dev_limits_into_ready_candidate() {
+    let r = models_dev_route_resolver();
+    let out = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.2")))
+        .expect("Z.AI Models.dev row should resolve");
+
+    assert_eq!(out.limits.context_tokens, Some(1_000_000));
+    assert_eq!(out.limits.input_tokens, Some(900_000));
+    assert_eq!(out.limits.output_tokens, Some(131_072));
+    assert!(out.limits.has_known_limit());
+}
+
+#[test]
+fn resolver_keeps_limits_provider_scoped_for_same_canonical_model() {
+    let r = models_dev_route_resolver();
+    let direct = r
+        .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.2")))
+        .expect("direct Z.AI route should resolve");
+    let hosted = r
+        .resolve(&req(Some(ProviderKind::Openrouter), Some("z-ai/glm-5.2")))
+        .expect("hosted OpenRouter route should resolve");
+
+    assert_eq!(
+        direct.canonical_model.as_ref().map(ModelId::as_str),
+        hosted.canonical_model.as_ref().map(ModelId::as_str)
+    );
+    assert_eq!(direct.limits.context_tokens, Some(1_000_000));
+    assert_eq!(hosted.limits.context_tokens, Some(128_000));
+    assert_eq!(hosted.limits.output_tokens, Some(32_768));
+}
+
+#[test]
 fn resolver_strict_direct_rejects_clearly_foreign_selector() {
     let r = RouteResolver::new();
     let out = r.resolve(&req(Some(ProviderKind::Zai), Some("anthropic/claude-foo")));
@@ -425,6 +459,7 @@ fn resolver_passthrough_provider_preserves_custom_id_verbatim() {
         .expect("local passthrough should resolve");
     assert_eq!(out.provider_kind, ProviderKind::Ollama);
     assert_eq!(out.wire_model_id.as_str(), "my-local:7b");
+    assert_eq!(out.limits, Default::default());
     assert!(out.validation.ok);
 }
 


### PR DESCRIPTION
## Summary

- Add a `RouteLimits` route seam for context/input/output token limits.
- Preserve Models.dev `limit` facts when projecting `CatalogOffering` / `ModelsDevCatalog` rows into `ProviderModelOffering`.
- Copy offering limits into `ReadyRouteCandidate`, while leaving custom/pass-through routes explicitly unknown.
- Add resolver/catalog tests proving provider-scoped GLM/Zhipu-style routes can share a canonical model while retaining different context/output caps.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-config --locked route -- --nocapture`
- `cargo test -p codewhale-config --locked catalog -- --nocapture`
- `cargo test -p codewhale-config --locked`
- `cargo clippy -p codewhale-config --all-targets --locked`

Refs #3086