### PR TITLE
[codex] refactor(tui): centralize AppMode helpers

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -1591,7 +1591,7 @@ pub fn mode(app: &mut App, arg: Option<&str>) -> CommandResult {
     let Some(arg) = arg.filter(|value| !value.trim().is_empty()) else {
         return CommandResult::action(AppAction::OpenModePicker);
     };
-    match parse_mode_arg(arg) {
+    match AppMode::parse(arg) {
         Some(mode) => {
             let (message, changed) = switch_mode_with_status(app, mode);
             if changed {
@@ -1610,32 +1610,9 @@ pub fn switch_mode(app: &mut App, mode: AppMode) -> String {
 
 fn switch_mode_with_status(app: &mut App, mode: AppMode) -> (String, bool) {
     if app.set_mode(mode) {
-        (
-            format!("Switched to {} mode.", mode_display_name(mode)),
-            true,
-        )
+        (format!("Switched to {} mode.", mode.display_name()), true)
     } else {
-        (
-            format!("Already in {} mode.", mode_display_name(mode)),
-            false,
-        )
-    }
-}
-
-fn parse_mode_arg(arg: &str) -> Option<AppMode> {
-    match arg.trim().to_ascii_lowercase().as_str() {
-        "agent" | "1" => Some(AppMode::Agent),
-        "plan" | "2" => Some(AppMode::Plan),
-        "yolo" | "3" => Some(AppMode::Yolo),
-        _ => None,
-    }
-}
-
-fn mode_display_name(mode: AppMode) -> &'static str {
-    match mode {
-        AppMode::Agent => "Agent",
-        AppMode::Plan => "Plan",
-        AppMode::Yolo => "YOLO",
+        (format!("Already in {} mode.", mode.display_name()), false)
     }
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -901,13 +901,25 @@ const MAX_COMPOSER_DISPLAY_CHARS: usize = 4_000;
 const MAX_DRAFT_HISTORY: usize = 50;
 
 impl AppMode {
+    /// Keyboard cycle order: Plan -> Agent -> YOLO -> Plan.
+    pub const CYCLE: [Self; 3] = [Self::Plan, Self::Agent, Self::Yolo];
+
+    /// User-facing picker / numeric command order.
+    pub const CHOICES: [Self; 3] = [Self::Agent, Self::Plan, Self::Yolo];
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "agent" | "1" => Some(Self::Agent),
+            "plan" | "2" => Some(Self::Plan),
+            "yolo" | "3" => Some(Self::Yolo),
+            _ => None,
+        }
+    }
+
     #[must_use]
     pub fn from_setting(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "plan" => Self::Plan,
-            "yolo" => Self::Yolo,
-            _ => Self::Agent,
-        }
+        Self::parse(value).unwrap_or(Self::Agent)
     }
 
     #[must_use]
@@ -928,6 +940,33 @@ impl AppMode {
         }
     }
 
+    #[must_use]
+    pub fn display_name(self) -> &'static str {
+        match self {
+            AppMode::Agent => "Agent",
+            AppMode::Yolo => "YOLO",
+            AppMode::Plan => "Plan",
+        }
+    }
+
+    #[must_use]
+    pub fn number(self) -> char {
+        match self {
+            AppMode::Agent => '1',
+            AppMode::Plan => '2',
+            AppMode::Yolo => '3',
+        }
+    }
+
+    #[must_use]
+    pub fn picker_hint(self) -> &'static str {
+        match self {
+            AppMode::Agent => "Normal execution with approvals",
+            AppMode::Plan => "Plan first before execution",
+            AppMode::Yolo => "Auto-approve; shell enabled",
+        }
+    }
+
     #[allow(dead_code)]
     /// Description shown in help or onboarding text.
     pub fn description(self) -> &'static str {
@@ -936,6 +975,24 @@ impl AppMode {
             AppMode::Yolo => "YOLO mode - full tool access without approvals",
             AppMode::Plan => "Plan mode - design before implementing",
         }
+    }
+
+    #[must_use]
+    pub fn next(self) -> Self {
+        let index = Self::CYCLE
+            .iter()
+            .position(|mode| *mode == self)
+            .unwrap_or(0);
+        Self::CYCLE[(index + 1) % Self::CYCLE.len()]
+    }
+
+    #[must_use]
+    pub fn previous(self) -> Self {
+        let index = Self::CYCLE
+            .iter()
+            .position(|mode| *mode == self)
+            .unwrap_or(0);
+        Self::CYCLE[(index + Self::CYCLE.len() - 1) % Self::CYCLE.len()]
     }
 }
 
@@ -2744,11 +2801,7 @@ impl App {
         if self.reject_setting_change_while_busy("Mode") {
             return;
         }
-        let next = match self.mode {
-            AppMode::Plan => AppMode::Agent,
-            AppMode::Agent => AppMode::Yolo,
-            AppMode::Yolo => AppMode::Plan,
-        };
+        let next = self.mode.next();
         let _ = self.set_mode(next);
     }
 
@@ -2758,11 +2811,7 @@ impl App {
         if self.reject_setting_change_while_busy("Mode") {
             return;
         }
-        let next = match self.mode {
-            AppMode::Agent => AppMode::Plan,
-            AppMode::Yolo => AppMode::Agent,
-            AppMode::Plan => AppMode::Yolo,
-        };
+        let next = self.mode.previous();
         let _ = self.set_mode(next);
     }
 

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1391,6 +1391,34 @@ fn clear_todos_resets_plan_state() {
 }
 
 #[test]
+fn app_mode_helpers_centralize_parse_labels_and_cycle_order() {
+    assert_eq!(AppMode::parse("agent"), Some(AppMode::Agent));
+    assert_eq!(AppMode::parse("2"), Some(AppMode::Plan));
+    assert_eq!(AppMode::parse("YOLO"), Some(AppMode::Yolo));
+    assert_eq!(AppMode::parse("fast"), None);
+
+    assert_eq!(AppMode::Agent.as_setting(), "agent");
+    assert_eq!(AppMode::Plan.display_name(), "Plan");
+    assert_eq!(AppMode::Yolo.label(), "YOLO");
+    assert_eq!(AppMode::Agent.number(), '1');
+    assert_eq!(
+        AppMode::CHOICES,
+        [AppMode::Agent, AppMode::Plan, AppMode::Yolo]
+    );
+    assert_eq!(
+        AppMode::CYCLE,
+        [AppMode::Plan, AppMode::Agent, AppMode::Yolo]
+    );
+
+    assert_eq!(AppMode::Plan.next(), AppMode::Agent);
+    assert_eq!(AppMode::Agent.next(), AppMode::Yolo);
+    assert_eq!(AppMode::Yolo.next(), AppMode::Plan);
+    assert_eq!(AppMode::Plan.previous(), AppMode::Yolo);
+    assert_eq!(AppMode::Agent.previous(), AppMode::Plan);
+    assert_eq!(AppMode::Yolo.previous(), AppMode::Agent);
+}
+
+#[test]
 fn test_cycle_mode_transitions() {
     let mut app = App::new(test_options(false), &Config::default());
     let initial_mode = app.mode;
@@ -1419,21 +1447,9 @@ fn test_cycle_mode_reverse_transitions() {
 #[test]
 fn test_mode_switch_toasts_replace_previous_mode_switch_toast() {
     let mut app = App::new(test_options(false), &Config::default());
-    let first_mode = match app.mode {
-        AppMode::Plan => AppMode::Agent,
-        AppMode::Agent => AppMode::Yolo,
-        AppMode::Yolo => AppMode::Plan,
-    };
-    let second_mode = match first_mode {
-        AppMode::Plan => AppMode::Agent,
-        AppMode::Agent => AppMode::Yolo,
-        AppMode::Yolo => AppMode::Plan,
-    };
-    let third_mode = match second_mode {
-        AppMode::Plan => AppMode::Agent,
-        AppMode::Agent => AppMode::Yolo,
-        AppMode::Yolo => AppMode::Plan,
-    };
+    let first_mode = app.mode.next();
+    let second_mode = first_mode.next();
+    let third_mode = second_mode.next();
 
     app.set_mode(first_mode);
     app.sync_status_message_to_toasts();

--- a/crates/tui/src/tui/views/mode_picker.rs
+++ b/crates/tui/src/tui/views/mode_picker.rs
@@ -13,35 +13,6 @@ use crate::palette;
 use crate::tui::app::AppMode;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
-#[derive(Debug, Clone, Copy)]
-struct ModeRow {
-    mode: AppMode,
-    number: char,
-    name: &'static str,
-    hint: &'static str,
-}
-
-const MODE_ROWS: &[ModeRow] = &[
-    ModeRow {
-        mode: AppMode::Agent,
-        number: '1',
-        name: "Agent",
-        hint: "Normal execution with approvals",
-    },
-    ModeRow {
-        mode: AppMode::Plan,
-        number: '2',
-        name: "Plan",
-        hint: "Plan first before execution",
-    },
-    ModeRow {
-        mode: AppMode::Yolo,
-        number: '3',
-        name: "YOLO",
-        hint: "Auto-approve; shell enabled",
-    },
-];
-
 pub struct ModePickerView {
     cursor: usize,
 }
@@ -49,17 +20,18 @@ pub struct ModePickerView {
 impl ModePickerView {
     #[must_use]
     pub fn new(current: AppMode) -> Self {
-        let cursor = MODE_ROWS
+        let cursor = AppMode::CHOICES
             .iter()
-            .position(|row| row.mode == current)
+            .position(|mode| *mode == current)
             .unwrap_or(0);
         Self { cursor }
     }
 
     fn selected_mode(&self) -> AppMode {
-        MODE_ROWS
+        AppMode::CHOICES
             .get(self.cursor)
-            .map_or(AppMode::Agent, |row| row.mode)
+            .copied()
+            .unwrap_or(AppMode::Agent)
     }
 
     fn move_up(&mut self) {
@@ -69,14 +41,16 @@ impl ModePickerView {
     }
 
     fn move_down(&mut self) {
-        let max = MODE_ROWS.len().saturating_sub(1);
+        let max = AppMode::CHOICES.len().saturating_sub(1);
         if self.cursor < max {
             self.cursor += 1;
         }
     }
 
     fn select_by_number(&mut self, number: char) -> Option<ViewAction> {
-        let idx = MODE_ROWS.iter().position(|row| row.number == number)?;
+        let idx = AppMode::CHOICES
+            .iter()
+            .position(|mode| mode.number() == number)?;
         self.cursor = idx;
         Some(ViewAction::EmitAndClose(ViewEvent::ModeSelected {
             mode: self.selected_mode(),
@@ -147,13 +121,13 @@ impl ModalView for ModePickerView {
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
 
-        let mut lines = Vec::with_capacity(MODE_ROWS.len() + 1);
+        let mut lines = Vec::with_capacity(AppMode::CHOICES.len() + 1);
         lines.push(Line::from(Span::styled(
             "Choose how CodeWhale should operate:",
             Style::default().fg(palette::TEXT_MUTED),
         )));
 
-        for (idx, row) in MODE_ROWS.iter().enumerate() {
+        for (idx, mode) in AppMode::CHOICES.iter().copied().enumerate() {
             let is_cursor = idx == self.cursor;
             let row_style = if is_cursor {
                 Style::default()
@@ -174,10 +148,10 @@ impl ModalView for ModePickerView {
 
             lines.push(Line::from(vec![
                 Span::styled(
-                    format!("{pointer} {}. {:<7}", row.number, row.name),
+                    format!("{pointer} {}. {:<7}", mode.number(), mode.display_name()),
                     row_style,
                 ),
-                Span::styled(row.hint, hint_style),
+                Span::styled(mode.picker_hint(), hint_style),
             ]));
         }
 


### PR DESCRIPTION
## Summary

- Move mode parsing, display names, numeric aliases, picker hints, and cycle transitions onto `AppMode`.
- Replace duplicated `/mode` command parsing/display helpers with the shared `AppMode` helpers.
- Make the mode picker derive row order, numbers, labels, and hints from `AppMode::CHOICES`.
- Preserve existing mode behavior: numeric order remains `1=Agent`, `2=Plan`, `3=YOLO`, while keyboard cycling remains `Plan -> Agent -> YOLO -> Plan`.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mode -- --nocapture`

Refs #3386