### PR TITLE
[codex] feat(fleet): carry profile loadout intent in task specs

### DIFF
--- a/crates/protocol/src/fleet.rs
+++ b/crates/protocol/src/fleet.rs
@@ -109,8 +109,24 @@ pub struct FleetTaskSpec {
 /// Worker role and tool expectations for a task.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct FleetTaskWorkerProfile {
+    /// Named agent profile/persona posture to layer onto this worker.
+    ///
+    /// `profile` is accepted as a shorter authoring alias. This is an intent
+    /// reference only; profile loading and permission narrowing happen in the
+    /// Fleet runtime layer.
+    #[serde(default, alias = "profile", skip_serializing_if = "Option::is_none")]
+    pub agent_profile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
+    /// Fleet loadout intent such as `auto`, `fast`, or `review`.
+    ///
+    /// This is not a concrete provider/model selection; route resolution owns
+    /// the executable provider/model/wire-model decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loadout: Option<String>,
+    /// Fleet model class hint such as `strong`, `balanced`, or `fast`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_class: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_profile: Option<String>,
     #[serde(default)]
@@ -876,7 +892,10 @@ mod tests {
                 objective: Some("Keep the workspace lint-clean".to_string()),
                 instructions: "run cargo clippy".to_string(),
                 worker: Some(FleetTaskWorkerProfile {
+                    agent_profile: None,
                     role: Some("release-checker".to_string()),
+                    loadout: None,
+                    model_class: None,
                     tool_profile: Some("read-only".to_string()),
                     tools: vec!["cargo".to_string()],
                     capabilities: vec!["rust".to_string()],
@@ -929,6 +948,34 @@ mod tests {
                 .required_files,
             vec![PathBuf::from("Cargo.toml")]
         );
+    }
+
+    #[test]
+    fn worker_profile_carries_agent_profile_and_loadout_intent() {
+        let json = r#"{
+            "profile": "adversarial_reviewer",
+            "role": "reviewer",
+            "loadout": "auto",
+            "model_class": "balanced",
+            "tool_profile": "read-only",
+            "tools": ["read_file"],
+            "capabilities": ["rust"]
+        }"#;
+
+        let profile: FleetTaskWorkerProfile = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            profile.agent_profile.as_deref(),
+            Some("adversarial_reviewer")
+        );
+        assert_eq!(profile.role.as_deref(), Some("reviewer"));
+        assert_eq!(profile.loadout.as_deref(), Some("auto"));
+        assert_eq!(profile.model_class.as_deref(), Some("balanced"));
+        assert_eq!(profile.tool_profile.as_deref(), Some("read-only"));
+
+        let serialized = serde_json::to_value(&profile).unwrap();
+        assert_eq!(serialized["agent_profile"], "adversarial_reviewer");
+        assert!(serialized.get("profile").is_none());
     }
 
     #[test]

--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -364,7 +364,10 @@ mod tests {
             objective: Some("prove it runs".to_string()),
             instructions: instructions.to_string(),
             worker: Some(FleetTaskWorkerProfile {
+                agent_profile: None,
                 role: Some("reviewer".to_string()),
+                loadout: None,
+                model_class: None,
                 tool_profile: Some("read-only".to_string()),
                 tools: vec![],
                 capabilities: vec![],

--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -1807,6 +1807,9 @@ esac
             task.instructions = format!("run deterministic fleet smoke lane {marker}");
             task.worker = Some(FleetTaskWorkerProfile {
                 role: Some(role.to_string()),
+                agent_profile: None,
+                loadout: None,
+                model_class: None,
                 tool_profile: Some("explicit".to_string()),
                 tools: tools.into_iter().map(str::to_string).collect(),
                 capabilities: vec!["local-smoke".to_string()],
@@ -1987,7 +1990,10 @@ esac
         let mut contextual = task("task-a");
         contextual.objective = Some("Review the release ledger".to_string());
         contextual.worker = Some(FleetTaskWorkerProfile {
+            agent_profile: None,
             role: Some("release-reviewer".to_string()),
+            loadout: None,
+            model_class: None,
             tool_profile: Some("read-only".to_string()),
             tools: vec!["git".to_string()],
             capabilities: vec!["rust".to_string()],
@@ -2047,7 +2053,10 @@ esac
                 objective: Some("cargo check".to_string()),
                 instructions: "run cargo check and report result".to_string(),
                 worker: Some(FleetTaskWorkerProfile {
+                    agent_profile: None,
                     role: Some("release-checker".to_string()),
+                    loadout: None,
+                    model_class: None,
                     tool_profile: Some("read-only".to_string()),
                     tools: vec!["cargo".to_string()],
                     capabilities: vec!["rust".to_string()],
@@ -2082,7 +2091,10 @@ esac
                 objective: Some("review source".to_string()),
                 instructions: "read src/lib.rs and report findings".to_string(),
                 worker: Some(FleetTaskWorkerProfile {
+                    agent_profile: None,
                     role: Some("reviewer".to_string()),
+                    loadout: None,
+                    model_class: None,
                     tool_profile: Some("read-only".to_string()),
                     tools: vec!["cargo".to_string()],
                     capabilities: vec!["rust".to_string()],

--- a/crates/tui/src/fleet/task_spec.rs
+++ b/crates/tui/src/fleet/task_spec.rs
@@ -127,10 +127,45 @@ pub fn validate_task_spec_document(doc: &FleetTaskSpecDocument) -> Result<()> {
         {
             bail!("fleet task {} objective cannot be empty", task.id);
         }
+        validate_worker_profile(&task.id, task.worker.as_ref())?;
         validate_tags(&task.id, &task.tags)?;
         validate_workspace_requirements(task)?;
     }
     Ok(())
+}
+
+fn validate_worker_profile(task_id: &str, worker: Option<&FleetTaskWorkerProfile>) -> Result<()> {
+    let Some(worker) = worker else {
+        return Ok(());
+    };
+    validate_worker_token(
+        task_id,
+        "worker.agent_profile",
+        worker.agent_profile.as_deref(),
+    )?;
+    validate_worker_token(task_id, "worker.loadout", worker.loadout.as_deref())?;
+    validate_worker_token(task_id, "worker.model_class", worker.model_class.as_deref())?;
+    Ok(())
+}
+
+fn validate_worker_token(task_id: &str, field: &str, value: Option<&str>) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("fleet task {task_id} {field} cannot be empty");
+    }
+    if trimmed != value || !trimmed.chars().all(is_worker_token_char) {
+        bail!(
+            "fleet task {task_id} {field} must be a simple token, not a path or provider/model id"
+        );
+    }
+    Ok(())
+}
+
+fn is_worker_token_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -553,7 +588,10 @@ mod tests {
             objective: Some(format!("Verify {id}")),
             instructions: format!("do {id}"),
             worker: Some(FleetTaskWorkerProfile {
+                agent_profile: None,
                 role: Some("reviewer".to_string()),
+                loadout: None,
+                model_class: None,
                 tool_profile: Some("read-only".to_string()),
                 tools: vec!["git".to_string()],
                 capabilities: vec!["rust".to_string()],
@@ -611,6 +649,68 @@ mod tests {
             Some("reviewer")
         );
         assert_eq!(parsed.tasks[1].tags, vec!["review"]);
+    }
+
+    #[test]
+    fn fleet_task_spec_document_parses_worker_profile_loadout_intent() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("fleet-profile-task.json");
+        let doc = json!({
+            "name": "profile loadout smoke",
+            "tasks": [{
+                "id": "review",
+                "name": "review",
+                "instructions": "review the patch",
+                "worker": {
+                    "profile": "adversarial_reviewer",
+                    "role": "reviewer",
+                    "loadout": "auto",
+                    "model_class": "balanced",
+                    "tool_profile": "read-only",
+                    "tools": ["read_file", "grep_files"],
+                    "capabilities": ["rust"]
+                }
+            }]
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+
+        let parsed = load_task_spec_document(&path).unwrap();
+        let worker = parsed.tasks[0].worker.as_ref().unwrap();
+
+        assert_eq!(
+            worker.agent_profile.as_deref(),
+            Some("adversarial_reviewer")
+        );
+        assert_eq!(worker.role.as_deref(), Some("reviewer"));
+        assert_eq!(worker.loadout.as_deref(), Some("auto"));
+        assert_eq!(worker.model_class.as_deref(), Some("balanced"));
+        assert_eq!(worker.tool_profile.as_deref(), Some("read-only"));
+    }
+
+    #[test]
+    fn fleet_task_spec_rejects_unsafe_worker_profile_intent_tokens() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("unsafe-profile-task.json");
+        let doc = json!({
+            "tasks": [{
+                "id": "review",
+                "name": "review",
+                "instructions": "review the patch",
+                "worker": {
+                    "profile": "../secrets",
+                    "loadout": "openrouter/deepseek",
+                    "model_class": ""
+                }
+            }]
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+
+        let err = load_task_spec_document(&path).unwrap_err().to_string();
+
+        assert!(
+            err.contains("worker.agent_profile must be a simple token"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -368,7 +368,10 @@ mod tests {
     #[test]
     fn fleet_tool_profile_empty_uses_inherited() {
         let profile = FleetTaskWorkerProfile {
+            agent_profile: None,
             role: None,
+            loadout: None,
+            model_class: None,
             tool_profile: None,
             tools: vec![],
             capabilities: vec![],
@@ -382,7 +385,10 @@ mod tests {
     #[test]
     fn fleet_tool_profile_explicit_passes_tools() {
         let profile = FleetTaskWorkerProfile {
+            agent_profile: None,
             role: None,
+            loadout: None,
+            model_class: None,
             tool_profile: None,
             tools: vec!["cargo".to_string(), "git".to_string()],
             capabilities: vec![],
@@ -541,7 +547,10 @@ mod tests {
                 objective: Some(format!("{role} objective")),
                 instructions: "Complete the assigned fanout lane.".to_string(),
                 worker: Some(FleetTaskWorkerProfile {
+                    agent_profile: None,
                     role: Some(role.to_string()),
+                    loadout: None,
+                    model_class: None,
                     tool_profile: None,
                     tools: match &expected_tools {
                         AgentWorkerToolProfile::Explicit(tools) => tools.clone(),

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -1024,7 +1024,10 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
         objective: Some("Inspect fleet status through Runtime API".to_string()),
         instructions: "Stay running for inspection.".to_string(),
         worker: Some(codewhale_protocol::fleet::FleetTaskWorkerProfile {
+            agent_profile: None,
             role: Some("status-reviewer".to_string()),
+            loadout: None,
+            model_class: None,
             tool_profile: Some("read-only".to_string()),
             tools: vec!["rg".to_string()],
             capabilities: vec!["fleet".to_string()],


### PR DESCRIPTION
## Summary

Adds the first Fleet profile/loadout task-spec schema slice for #3167/#3367/#3205.

What changed:
- `FleetTaskWorkerProfile` now carries optional `agent_profile`, `loadout`, and `model_class` intent fields
- `profile = "..."` is accepted as an authoring alias for `agent_profile`
- task-spec validation rejects empty/path-like/provider-model-like values for those intent tokens
- existing Fleet fixtures are updated for the expanded protocol struct

This intentionally does not resolve provider/model routes or apply profile permissions yet. It gives the loader/runtime follow-up a portable schema contract to consume without embedding provider/model policy in prompts.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-protocol --locked worker_profile_carries_agent_profile_and_loadout_intent -- --nocapture`
- `cargo test -p codewhale-protocol --locked fleet -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_task_spec_document_parses_worker_profile_loadout_intent -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_task_spec_rejects_unsafe_worker_profile_intent_tokens -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::task_spec -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::worker_runtime -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::executor -- --nocapture`

## Queue note

If #3511 lands first, this branch may need a small rebase to add these new optional fields to the new Fleet smoke fixture introduced there.

Refs #3167.
Refs #3367.
Refs #3205.
