### PR TITLE
docs(web): provenance / source-of-truth copy (harvest of #3440 by @donglovejava)

### DIFF
--- a/docs/CNB_MIRROR.md
+++ b/docs/CNB_MIRROR.md
@@ -6,6 +6,24 @@ GitHub repository for users on networks where GitHub is slow or blocked
 `fix/*`, `rebrand/*`, and `work/v*` branch used for first-party release work,
 and every `v*` release tag.
 
+## Provenance
+
+**GitHub is the sole canonical source.** All releases, tags, and source code
+originate at `github.com/Hmbown/CodeWhale`. The CNB mirror is a read-only
+replica maintained by the `Sync to CNB` workflow — it exists solely to serve
+users behind GFW-blocked or slow GitHub connections.
+
+Every CNB release includes `codewhale-artifacts-sha256.txt` — a SHA256 manifest
+of the CNB-built Linux x64 binaries, generated from the same source commit that
+is tagged on GitHub. (CNB builds from source, so these checksums cover the
+CNB-built artifacts, not GitHub's release assets.) Verify a downloaded binary
+against it:
+
+```bash
+# Verify a downloaded CNB binary against the CNB manifest
+sha256sum -c codewhale-artifacts-sha256.txt
+```
+
 ## How it works
 
 The mirror is maintained by the [`Sync to CNB`](../.github/workflows/sync-cnb.yml)

--- a/web/app/[locale]/install/page.tsx
+++ b/web/app/[locale]/install/page.tsx
@@ -366,11 +366,13 @@ codewhale doctor`;
               <p className="text-sm text-ink-soft leading-relaxed max-w-2xl mb-3">
                 {isZh ? (
                   <>
-                    Cargo 经清华 Tuna 镜像——添加到 <code className="inline">~/.cargo/config.toml</code>：
+                    <strong className="text-indigo">官方源：</strong>
+                    GitHub Releases 为唯一官方发布源。Cargo 经清华 Tuna 镜像——添加到 <code className="inline">~/.cargo/config.toml</code>：
                   </>
                 ) : (
                   <>
-                    Cargo via Tsinghua Tuna mirror — add to{" "}
+                    <strong className="text-indigo">Official source:</strong>{" "}
+                    GitHub Releases is the sole canonical release source. Cargo via Tsinghua Tuna mirror — add to{" "}
                     <code className="inline">~/.cargo/config.toml</code>:
                   </>
                 )}

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -98,18 +98,26 @@ export function Footer({ locale = "en" }: { locale?: Locale }) {
           <div className="font-mono text-[0.7rem] text-ink-mute uppercase tracking-widest">
             {isZh ? "用心制作 · Made with care" : "Made with care · 用心制作"}
           </div>
-          {/* Mirror sources — prominent on zh */}
-          {isZh && (
-            <div className="pt-2 border-t border-paper-line/20">
-              <div className="eyebrow mb-2 text-ink-mute">镜像源 / Mirror</div>
-              <div className="flex flex-wrap gap-3 text-xs">
-                {GITEE_ENABLED && <a href="https://gitee.com/Hmbown/CodeWhale" className="text-indigo hover:underline" target="_blank" rel="noopener">Gitee 镜像</a>}
-                <a href="https://cnb.cool/codewhale.net/codewhale" className="text-indigo hover:underline" target="_blank" rel="noopener">CNB 镜像</a>
-                <a href="https://npmmirror.com/package/codewhale" className="text-indigo hover:underline" target="_blank" rel="noopener">npmmirror</a>
-                <a href="https://mirrors.tuna.tsinghua.edu.cn/help/crates.io-index.html" className="text-indigo hover:underline" target="_blank" rel="noopener">Tuna crates.io</a>
-              </div>
+          {/* Provenance / source-of-truth — shown on both locales */}
+          <div className="pt-2 border-t border-paper-line/20">
+            <div className="eyebrow mb-2 text-ink-mute">
+              {isZh ? "来源证明 · Provenance" : "Provenance · 来源证明"}
             </div>
-          )}
+            <p className="text-xs text-ink-soft leading-relaxed mb-2">
+              {isZh
+                ? "GitHub (github.com/Hmbown/CodeWhale) 为唯一官方源码与发布源。下方镜像仅为中国大陆网络加速，内容经自动同步校验，SHA256 清单一致。"
+                : "GitHub (github.com/Hmbown/CodeWhale) is the sole canonical source for code and releases. Mirrors below are China-network accelerators only — content is auto-synced and verified via SHA256 manifests."}
+            </p>
+            <div className="flex flex-wrap gap-3 text-xs">
+              <a href="https://github.com/Hmbown/CodeWhale" className="text-indigo hover:underline font-semibold" target="_blank" rel="noopener">
+                {isZh ? "★ 官方 GitHub" : "★ Official GitHub"}
+              </a>
+              {GITEE_ENABLED && <a href="https://gitee.com/Hmbown/CodeWhale" className="text-ink-soft hover:underline" target="_blank" rel="noopener">{isZh ? "Gitee 镜像" : "Gitee mirror"}</a>}
+              <a href="https://cnb.cool/codewhale.net/codewhale" className="text-ink-soft hover:underline" target="_blank" rel="noopener">{isZh ? "CNB 镜像" : "CNB mirror"}</a>
+              <a href="https://npmmirror.com/package/codewhale" className="text-ink-soft hover:underline" target="_blank" rel="noopener">npmmirror</a>
+              <a href="https://mirrors.tuna.tsinghua.edu.cn/help/crates.io-index.html" className="text-ink-soft hover:underline" target="_blank" rel="noopener">Tuna crates.io</a>
+            </div>
+          </div>
         </div>
 
         {cols.map((c) => (


### PR DESCRIPTION
Harvests the provenance / source-of-truth copy from #3440 (by @donglovejava) onto current `main`.

**What landed**
- `web/components/footer.tsx`: a Provenance section shown on all locales (replaces the zh-only mirror list), starring the official GitHub link; mirrors labelled as SHA256-verified China-network accelerators.
- `web/app/[locale]/install/page.tsx`: an "Official source" label on the Mainland China network section.
- `docs/CNB_MIRROR.md`: a Provenance section with a checksum verification path.

**Dropped from the original branch** (out of scope / would regress main): stray working files, workflow edits, and a `SECURITY.md` contact change that regresses the current address. The current Gitee mirror URL is preserved.

Credit preserved via `Co-authored-by: donglovejava`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX

---
_Generated by [Claude Code](https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX)_