### PR TITLE
docs: reconcile dropped harvest credit (CONTRIBUTORS.md + AUTHOR_MAP)

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -114,3 +114,16 @@ pkeging = pkeging <237035657+pkeging@users.noreply.github.com>
 147567034@qq.com = pkeging <237035657+pkeging@users.noreply.github.com>
 KUK4 = KUK4 <246008043+KUK4@users.noreply.github.com>
 LLL@users.noreply.github.com = KUK4 <246008043+KUK4@users.noreply.github.com>
+
+# Harvest-credit reconciliation: contributors restored to docs/CONTRIBUTORS.md
+# whose harvested work previously lacked a canonical map entry.
+MMMarcinho = MMMarcinho <48539922+MMMarcinho@users.noreply.github.com>
+MeAiRobot = MeAiRobot <283844506+MeAiRobot@users.noreply.github.com>
+NorethSea = NorethSea <39730900+NorethSea@users.noreply.github.com>
+SamhandsomeLee = SamhandsomeLee <135809116+SamhandsomeLee@users.noreply.github.com>
+YaYII = YaYII <6007186+YaYII@users.noreply.github.com>
+sandofree = sandofree <7775605+sandofree@users.noreply.github.com>
+tiger-dog = tiger-dog <63037740+tiger-dog@users.noreply.github.com>
+Jianfengwu2024 = Jianfengwu2024 <186297054+Jianfengwu2024@users.noreply.github.com>
+wplll = wplll <106327929+wplll@users.noreply.github.com>
+buko = buko <12692585+buko@users.noreply.github.com>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@
   GitHub numeric noreply identity, and include `Harvested from PR #N by
   @handle` in the commit body so the auto-close workflow can close the PR with
   credit after it reaches `main`.
+- Never add bot/tool `Co-authored-by` trailers (Claude, codex, cursor,
+  `noreply@anthropic.com`): `scripts/check-coauthor-trailers.py` rejects them on
+  harvest commits — contributor trailers are for humans. Also refresh the manual
+  credit surfaces that do not auto-populate from trailers: `docs/CONTRIBUTORS.md`
+  and `CHANGELOG.md`.
 - Close or update issues and PRs only after verifying the landed commit on the
   relevant branch. If the release branch already contains equivalent behavior,
   leave a clear note linking the commit and describing any remaining delta.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,9 @@ for Claude-based agents working in this repository.
   support and legacy migration care.
 - Preserve contributor credit for harvested work with authorship,
   `Co-authored-by`, `Harvested from PR #N by @handle`, and changelog/release
-  notes where applicable.
+  notes where applicable. Use canonical GitHub-noreply identities from
+  `.github/AUTHOR_MAP`; never add bot/tool `Co-authored-by` trailers (Claude,
+  codex, cursor) — the `check-coauthor-trailers.py` CI gate rejects them.
 
 ## Scratch Integration Branches
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -361,6 +361,24 @@ in the changelog. Restoring them with thanks — every one shipped real code.
 - **[nightfallsad](https://github.com/nightfallsad)** — clearer `/continue` hint copy
 - **[zxyasfas](https://github.com/zxyasfas)** — align Rust MSRV references with the workspace (#739)
 
+_A follow-up audit of harvested commits (work reimplemented onto a maintainer
+branch rather than merged) surfaced contributors whose machine-readable credit
+was dropped. Restoring them here — every one shipped real code:_
+
+- **[CrepuscularIRIS](https://github.com/CrepuscularIRIS)** — OpenHarmony→Linux npm binary mapping, O(1) job-panel refresh, file-mention UTF-8 boundary safety, Kitty keyboard protocol on Windows, and auto low-motion under Termius/SSH (#1479, #1483, #1494, #1495, #1499, #1475)
+- **[MMMarcinho](https://github.com/MMMarcinho)** — `image_analyze` vision tool (#1467)
+- **[MeAiRobot](https://github.com/MeAiRobot)** — toast-stack overlay z-order fix (#1485)
+- **[NorethSea](https://github.com/NorethSea)** — `update` refreshing the sibling TUI binary (#1492)
+- **[SamhandsomeLee](https://github.com/SamhandsomeLee)** — bundled v4-best-practices skill (#1448)
+- **[YaYII](https://github.com/YaYII)** — opt-in `/translate` command (#1462)
+- **[sandofree](https://github.com/sandofree)** — Tavily and Bocha `web_search` backends (#1294)
+- **[tiger-dog](https://github.com/tiger-dog)** — approval one-line banner and Markdown underscore handling (#1455)
+- **[Jianfengwu2024](https://github.com/Jianfengwu2024)** — preserving MSVC toolchain vars in the child environment (#1487)
+- **[wplll](https://github.com/wplll)** — prompt-cache warmup keys, tool-catalog handling, a dedup test, and pack ordering (#2390, #2391, #2392, #2393)
+
+Additional harvested PRs from the same audit, credited to contributors already
+listed above: **[axobase001](https://github.com/axobase001)** (#2400, #2405, #2406, #2407, #2408, #2415), **[cyq1017](https://github.com/cyq1017)** (#2516, #2534, #2540), **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** (#1451, #1456), **[reidliu41](https://github.com/reidliu41)** (#1444, #1493), **[lucaszhu-hue](https://github.com/lucaszhu-hue)** (#1436, #2343), **[h3c-hexin](https://github.com/h3c-hexin)** (#1480), **[Duducoco](https://github.com/Duducoco)** (#1345), **[zhuangbiaowei](https://github.com/zhuangbiaowei)** (#1416), **[wdw8276](https://github.com/wdw8276)** (#1498), and **[buko](https://github.com/buko)** (#2377).
+
 </details>
 
 ---


### PR DESCRIPTION
## Why

An audit of harvested commits on `main` found that when a contributor's PR is **harvested** (reimplemented onto a maintainer branch) rather than **merged**, the machine-readable credit (`Co-authored-by` / canonical author) was sometimes dropped. The CI co-author gate (`scripts/check-coauthor-trailers.py`) only runs over `origin/main..HEAD`, so it never validated existing history — and those commits are already on `main`, so history is **not** rewritten. This restores credit on the curated surfaces, which is where it belongs once the git trailer is missed.

## What

**`docs/CONTRIBUTORS.md`** — a reconciliation block under *Reconciled credits*:
- Contributors who were absent from the file entirely: **CrepuscularIRIS, MMMarcinho, MeAiRobot, NorethSea, SamhandsomeLee, YaYII, sandofree, tiger-dog, Jianfengwu2024, wplll**.
- Additional harvested PRs for contributors already listed: **axobase001, cyq1017, Oliver-ZPLiu, reidliu41, lucaszhu-hue, h3c-hexin, Duducoco, zhuangbiaowei, wdw8276, buko**.

**`.github/AUTHOR_MAP`** — canonical `id+login@users.noreply.github.com` aliases for the ten contributors that lacked a map entry, so any future reference credits them in the contributor graph and passes the co-author check.

## Verified
- Every handle + numeric ID checked against the GitHub user API (each is an exact-login match).
- `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors` → passes.
- Cross-checked the audit against the existing file first, so already-credited contributors (e.g. @AlphaGogoo) were **not** duplicated as "missing."

Note: past commits' GitHub-graph credit can't be recovered without rewriting `main`; this is the non-destructive remediation. A follow-up can broaden the checker to catch non-canonical phrasings ("with thanks to @", "cherry-picked from PR #N by @") and run over full history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX

---
_Generated by [Claude Code](https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX)_