### PR TITLE
[codex] feat(fleet): resolve agent profiles into worker runtime

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1217,6 +1217,7 @@ impl<'de> Deserialize<'de> for FleetSlot {
 pub enum FleetLoadout {
     #[default]
     Inherit,
+    Strong,
     Fast,
     Balanced,
     DeepReasoning,
@@ -1231,6 +1232,7 @@ impl FleetLoadout {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Inherit => "inherit",
+            Self::Strong => "strong",
             Self::Fast => "fast",
             Self::Balanced => "balanced",
             Self::DeepReasoning => "deep-reasoning",
@@ -1245,6 +1247,7 @@ impl FleetLoadout {
     pub fn from_name(value: &str) -> Self {
         match value.trim() {
             "inherit" | "default" | "auto" | "" => Self::Inherit,
+            "strong" => Self::Strong,
             "fast" => Self::Fast,
             "balanced" => Self::Balanced,
             "deep-reasoning" | "deep_reasoning" | "reasoning" => Self::DeepReasoning,

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -4695,6 +4695,14 @@ concurrency = 3
 }
 
 #[test]
+fn fleet_loadout_accepts_default_model_classes() {
+    assert_eq!(FleetLoadout::from_name("strong"), FleetLoadout::Strong);
+    assert_eq!(FleetLoadout::from_name("balanced"), FleetLoadout::Balanced);
+    assert_eq!(FleetLoadout::from_name("fast"), FleetLoadout::Fast);
+    assert_eq!(FleetLoadout::Strong.as_str(), "strong");
+}
+
+#[test]
 fn fallback_providers_do_not_change_runtime_resolution() {
     let _lock = env_lock();
     let _env = EnvGuard::without_deepseek_runtime_overrides();

--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -20,11 +20,13 @@
 
 #![allow(dead_code)]
 
+use anyhow::Result;
 use codewhale_config::FleetExecConfig;
 use codewhale_protocol::fleet::{FleetHostSpec, FleetTaskSpec, FleetWorkerEventPayload};
 
 use super::host::{FleetHostAdapter, FleetWorkerCommand};
-use super::worker_runtime::fleet_task_prompt;
+use super::profile::AgentProfile;
+use super::worker_runtime::{fleet_task_prompt, fleet_task_prompt_with_profiles};
 
 /// Build the `codewhale exec` argv that runs a fleet task headlessly.
 ///
@@ -40,6 +42,36 @@ use super::worker_runtime::fleet_task_prompt;
 pub fn build_worker_exec_command(
     codewhale_binary: &str,
     task_spec: &FleetTaskSpec,
+    exec_config: &FleetExecConfig,
+    model: Option<&str>,
+) -> FleetWorkerCommand {
+    build_worker_exec_command_from_prompt(
+        codewhale_binary,
+        fleet_task_prompt(task_spec),
+        exec_config,
+        model,
+    )
+}
+
+/// Build a worker command after resolving workspace Fleet profile input.
+pub fn build_worker_exec_command_with_profiles(
+    codewhale_binary: &str,
+    task_spec: &FleetTaskSpec,
+    exec_config: &FleetExecConfig,
+    model: Option<&str>,
+    agent_profiles: &[AgentProfile],
+) -> Result<FleetWorkerCommand> {
+    Ok(build_worker_exec_command_from_prompt(
+        codewhale_binary,
+        fleet_task_prompt_with_profiles(task_spec, agent_profiles)?,
+        exec_config,
+        model,
+    ))
+}
+
+fn build_worker_exec_command_from_prompt(
+    codewhale_binary: &str,
+    task_prompt: String,
     exec_config: &FleetExecConfig,
     model: Option<&str>,
 ) -> FleetWorkerCommand {
@@ -73,7 +105,7 @@ pub fn build_worker_exec_command(
     }
 
     // The composed task prompt is the final positional argument.
-    args.push(fleet_task_prompt(task_spec));
+    args.push(task_prompt);
 
     FleetWorkerCommand::new(codewhale_binary.to_string(), args)
 }
@@ -353,6 +385,10 @@ impl FleetExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codewhale_config::{
+        FleetDelegationHints, FleetLoadout, FleetProfile, FleetProfilePermissions, FleetRole,
+        FleetSlot,
+    };
     use codewhale_protocol::fleet::{FleetTaskSpec, FleetTaskWorkerProfile};
     use std::collections::BTreeMap;
 
@@ -386,6 +422,26 @@ mod tests {
         }
     }
 
+    fn agent_profile(id: &str, role: &str, instructions: &str) -> AgentProfile {
+        AgentProfile {
+            id: id.to_string(),
+            display_name: Some(format!("{role} profile")),
+            description: Some(format!("{role} description")),
+            profile: FleetProfile {
+                slot: FleetSlot::from_name(role),
+                role: FleetRole {
+                    name: role.to_string(),
+                    description: None,
+                    instructions: Some(instructions.to_string()),
+                },
+                loadout: FleetLoadout::Balanced,
+                permissions: FleetProfilePermissions::default(),
+                delegation: FleetDelegationHints::default(),
+            },
+            source: std::path::PathBuf::from(format!("{id}.toml")),
+        }
+    }
+
     #[test]
     fn worker_command_is_a_headless_codewhale_exec_run() {
         let exec = FleetExecConfig::default();
@@ -416,6 +472,28 @@ mod tests {
         assert!(joined.contains("--disallowed-tools exec_shell"));
         assert!(joined.contains("--max-turns 40"));
         assert!(cmd.args.iter().any(|a| a == "never push to main"));
+    }
+
+    #[test]
+    fn worker_command_threads_agent_profile_prompt() {
+        let mut task = task("audit");
+        task.worker.as_mut().unwrap().agent_profile = Some("reviewer".to_string());
+        let cmd = build_worker_exec_command_with_profiles(
+            "codewhale",
+            &task,
+            &FleetExecConfig::default(),
+            None,
+            &[agent_profile(
+                "reviewer",
+                "reviewer",
+                "Focus on defects, regressions, and missing tests.",
+            )],
+        )
+        .unwrap();
+        let prompt = cmd.args.last().unwrap();
+
+        assert!(prompt.contains("Fleet profile: reviewer"));
+        assert!(prompt.contains("Focus on defects, regressions, and missing tests."));
     }
 
     #[test]

--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -16,7 +16,9 @@ use codewhale_protocol::fleet::*;
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::executor::{FleetExecutor, FleetWorkerTerminalEvent, build_worker_exec_command};
+use super::executor::{
+    FleetExecutor, FleetWorkerTerminalEvent, build_worker_exec_command_with_profiles,
+};
 use super::host::FleetHostErrorKind;
 use super::ledger::{FleetLedger, FleetLedgerState, FleetTaskLedgerStatus, FleetTaskState};
 use super::task_spec::{
@@ -205,6 +207,8 @@ impl FleetManager {
         max_workers: usize,
     ) -> Result<FleetRunReport> {
         validate_task_spec_document(&doc)?;
+        let agent_profiles = super::profile::load_workspace_agent_profiles(&self.workspace)?;
+        worker_runtime::validate_task_agent_profiles(&doc.tasks, &agent_profiles)?;
         let max_workers = max_workers.clamp(1, 128);
         let run_id = FleetRunId::from(format!(
             "fleet-{}",
@@ -621,6 +625,42 @@ impl FleetManager {
         entry: &FleetInboxEntry,
         task_spec: &FleetTaskSpec,
     ) -> Result<()> {
+        let sub_agent_worker = if self.sub_agent_manager.is_some() {
+            let run = self
+                .ledger
+                .rebuild_state()
+                .ok()
+                .and_then(|state| state.runs.get(&entry.run_id.0).cloned());
+            let worker_spec = run
+                .as_ref()
+                .and_then(|r| r.worker_specs.iter().find(|w| w.id == worker_id).cloned())
+                .unwrap_or_else(|| FleetWorkerSpec {
+                    id: worker_id.to_string(),
+                    name: worker_id.to_string(),
+                    host: FleetHostSpec::Local,
+                    trust_level: Some(FleetTrustLevel::Local),
+                    labels: BTreeMap::new(),
+                    capabilities: vec![],
+                    max_concurrent_tasks: Some(1),
+                });
+            let agent_profiles = super::profile::load_workspace_agent_profiles(&self.workspace)?;
+            let worker = worker_runtime::fleet_task_to_worker_spec_with_profiles(
+                worker_id,
+                &entry.run_id.0,
+                task_spec,
+                &worker_spec,
+                "auto",
+                &self.workspace,
+                &agent_profiles,
+                None,
+            )?;
+            Some(worker_runtime::apply_exec_hardening(
+                worker,
+                &self.exec_config,
+            ))
+        } else {
+            None
+        };
         let now = timestamp();
         self.ledger
             .lease_task(&entry.run_id, &entry.task_id, worker_id, &now, None)?;
@@ -656,39 +696,10 @@ impl FleetManager {
         // Register with the sub-agent manager for headless worker tracking.
         // The engine's agent path handles actual sub-agent spawning.
         if let Some(ref mgr) = self.sub_agent_manager
-            && let Ok(guard) = mgr.try_write()
+            && let Some(worker) = sub_agent_worker
+            && let Ok(mut guard) = mgr.try_write()
         {
-            let run = self
-                .ledger
-                .rebuild_state()
-                .ok()
-                .and_then(|state| state.runs.get(&entry.run_id.0).cloned());
-            let worker_spec = run
-                .as_ref()
-                .and_then(|r| r.worker_specs.iter().find(|w| w.id == worker_id).cloned())
-                .unwrap_or_else(|| FleetWorkerSpec {
-                    id: worker_id.to_string(),
-                    name: worker_id.to_string(),
-                    host: FleetHostSpec::Local,
-                    trust_level: Some(FleetTrustLevel::Local),
-                    labels: BTreeMap::new(),
-                    capabilities: vec![],
-                    max_concurrent_tasks: Some(1),
-                });
-            let worker = worker_runtime::fleet_task_to_worker_spec(
-                worker_id,
-                &entry.run_id.0,
-                task_spec,
-                &worker_spec,
-                "auto",
-                &self.workspace,
-            );
-            let worker = worker_runtime::apply_exec_hardening(worker, &self.exec_config);
-            // drop guard after registering so we don't hold the write lock
-            drop(guard);
-            if let Ok(mut guard) = mgr.try_write() {
-                guard.register_worker(worker);
-            }
+            guard.register_worker(worker);
         }
 
         Ok(())
@@ -707,6 +718,7 @@ impl FleetManager {
             .get(&run_id.0)
             .cloned()
             .ok_or_else(|| anyhow!("fleet run {} does not exist", run_id.0))?;
+        let agent_profiles = super::profile::load_workspace_agent_profiles(&self.workspace)?;
         let mut started = 0usize;
         for task in active_tasks_for_run(&state, run_id) {
             let Some(worker_id) = task.leased_to.as_deref() else {
@@ -729,8 +741,13 @@ impl FleetManager {
                 .find(|worker| worker.id == worker_id)
                 .cloned()
                 .unwrap_or_else(|| default_local_worker(worker_id));
-            let command =
-                build_worker_exec_command(codewhale_binary, &task_spec, &self.exec_config, model);
+            let command = build_worker_exec_command_with_profiles(
+                codewhale_binary,
+                &task_spec,
+                &self.exec_config,
+                model,
+                &agent_profiles,
+            )?;
             let cwd = resolve_task_cwd(&self.workspace, &task_spec);
             match executor.start_worker_on_host(worker_id, &worker_spec.host, command, Some(cwd)) {
                 Ok(handle) => {
@@ -1495,6 +1512,39 @@ mod tests {
         assert_eq!(status.queued, 1);
         assert_eq!(status.running, 2);
         assert_eq!(status.completed, 0);
+    }
+
+    #[test]
+    fn fleet_manager_rejects_unknown_agent_profile_before_run_creation() {
+        let tmp = TempDir::new().unwrap();
+        let manager = FleetManager::open(tmp.path()).unwrap();
+        let mut task = task("task-a");
+        task.worker = Some(FleetTaskWorkerProfile {
+            role: None,
+            agent_profile: Some("missing".to_string()),
+            loadout: None,
+            model_class: None,
+            tool_profile: None,
+            tools: Vec::new(),
+            capabilities: Vec::new(),
+        });
+        let doc = FleetTaskSpecDocument {
+            name: Some("profile guard".to_string()),
+            labels: BTreeMap::new(),
+            security_policy: None,
+            workers: Vec::new(),
+            tasks: vec![task],
+        };
+
+        let err = manager
+            .create_run(doc, 1)
+            .expect_err("unknown agent profile must reject the run");
+
+        assert!(
+            err.to_string()
+                .contains("references unknown agent profile \"missing\"")
+        );
+        assert!(manager.ledger.rebuild_state().unwrap().runs.is_empty());
     }
 
     #[test]

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -13,11 +13,13 @@
 
 #![allow(dead_code)]
 
+use anyhow::{Result, bail};
 use codewhale_protocol::fleet::{
     FleetHostSpec, FleetTaskSpec, FleetTaskWorkerProfile, FleetWorkerEventPayload, FleetWorkerSpec,
 };
 
 use super::host::FleetHostKind;
+use super::profile::AgentProfile;
 use crate::tools::subagent::{
     AgentWorkerSpec, AgentWorkerStatus, AgentWorkerToolProfile, SubAgentType,
 };
@@ -88,7 +90,103 @@ pub fn fleet_task_to_worker_spec(
     }
 }
 
+/// Validate that every task referencing a workspace agent profile can resolve it.
+///
+/// This is intended to run at Fleet run creation time, before leasing any
+/// worker or appending lifecycle events.
+pub fn validate_task_agent_profiles(
+    tasks: &[FleetTaskSpec],
+    agent_profiles: &[AgentProfile],
+) -> Result<()> {
+    for task in tasks {
+        resolve_task_agent_profile(task, agent_profiles)?;
+    }
+    Ok(())
+}
+
+/// Build a sub-agent worker spec after resolving workspace Fleet profile input.
+///
+/// This keeps Fleet and sub-agents on the same runtime substrate: profile files
+/// and task-level role/loadout intent are composed into the existing
+/// `AgentWorkerSpec` / `WorkerRuntimeProfile` pair, then optionally intersected
+/// with a parent profile when the caller has one.
+#[allow(clippy::too_many_arguments)]
+pub fn fleet_task_to_worker_spec_with_profiles(
+    worker_id: &str,
+    run_id: &str,
+    task_spec: &FleetTaskSpec,
+    _worker_spec: &FleetWorkerSpec,
+    model: &str,
+    workspace: &std::path::Path,
+    agent_profiles: &[AgentProfile],
+    parent_runtime_profile: Option<&WorkerRuntimeProfile>,
+) -> Result<AgentWorkerSpec> {
+    let agent_profile = resolve_task_agent_profile(task_spec, agent_profiles)?;
+    let worker_profile = task_spec.worker.as_ref();
+    let role = effective_fleet_role(worker_profile, agent_profile);
+    let agent_type = fleet_role_to_agent_type(role.as_deref());
+    let tool_profile = fleet_tool_profile(worker_profile);
+    let objective = fleet_task_prompt_with_profile(task_spec, agent_profile);
+    let max_spawn_depth = codewhale_config::FleetExecConfig::default().max_spawn_depth;
+    let loadout = effective_fleet_loadout(worker_profile, agent_profile);
+    let mut requested_runtime = fleet_worker_runtime_profile_for_loadout(
+        &agent_type,
+        &tool_profile,
+        model,
+        0,
+        max_spawn_depth,
+        &loadout,
+    );
+    if let Some(agent_profile) = agent_profile
+        && let Some(profile_depth) = agent_profile.profile.delegation.max_spawn_depth
+    {
+        requested_runtime.max_spawn_depth = requested_runtime.max_spawn_depth.min(profile_depth);
+    }
+    let runtime_profile = parent_runtime_profile
+        .map(|parent| parent.derive_child(&requested_runtime))
+        .unwrap_or(requested_runtime);
+
+    Ok(AgentWorkerSpec {
+        worker_id: worker_id.to_string(),
+        run_id: run_id.to_string(),
+        parent_run_id: None,
+        session_name: Some(format!("fleet-{}-{}", worker_id, task_spec.id)),
+        objective,
+        role,
+        agent_type,
+        model: model.to_string(),
+        workspace: workspace.to_path_buf(),
+        git_branch: None,
+        context_mode: "fresh".to_string(),
+        fork_context: false,
+        tool_profile,
+        runtime_profile: runtime_profile.clone(),
+        max_steps: task_spec
+            .budget
+            .as_ref()
+            .and_then(|b| b.max_tool_calls)
+            .unwrap_or(u32::MAX),
+        spawn_depth: 0,
+        max_spawn_depth: runtime_profile.max_spawn_depth,
+    })
+}
+
 pub(crate) fn fleet_task_prompt(task_spec: &FleetTaskSpec) -> String {
+    fleet_task_prompt_with_profile(task_spec, None)
+}
+
+pub(crate) fn fleet_task_prompt_with_profiles(
+    task_spec: &FleetTaskSpec,
+    agent_profiles: &[AgentProfile],
+) -> Result<String> {
+    let agent_profile = resolve_task_agent_profile(task_spec, agent_profiles)?;
+    Ok(fleet_task_prompt_with_profile(task_spec, agent_profile))
+}
+
+fn fleet_task_prompt_with_profile(
+    task_spec: &FleetTaskSpec,
+    agent_profile: Option<&AgentProfile>,
+) -> String {
     let mut prompt = String::new();
     prompt.push_str("Fleet task: ");
     prompt.push_str(&task_spec.name);
@@ -122,7 +220,77 @@ pub(crate) fn fleet_task_prompt(task_spec: &FleetTaskSpec) -> String {
         }
     }
 
+    if let Some(agent_profile) = agent_profile {
+        prompt.push_str("\nFleet profile: ");
+        prompt.push_str(&agent_profile.id);
+        if let Some(display_name) = agent_profile.display_name.as_deref() {
+            prompt.push_str(" (");
+            prompt.push_str(display_name);
+            prompt.push(')');
+        }
+        if let Some(description) = agent_profile.description.as_deref() {
+            prompt.push_str("\nProfile description:\n");
+            prompt.push_str(description);
+        }
+        if let Some(instructions) = agent_profile.profile.role.instructions.as_deref() {
+            prompt.push_str("\nProfile instructions:\n");
+            prompt.push_str(instructions);
+        }
+    }
+
     prompt
+}
+
+fn resolve_task_agent_profile<'a>(
+    task_spec: &FleetTaskSpec,
+    agent_profiles: &'a [AgentProfile],
+) -> Result<Option<&'a AgentProfile>> {
+    let Some(profile_id) = task_spec
+        .worker
+        .as_ref()
+        .and_then(|worker| worker.agent_profile.as_deref())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let Some(profile) = agent_profiles
+        .iter()
+        .find(|profile| profile.id == profile_id)
+    else {
+        bail!(
+            "fleet task {} references unknown agent profile {profile_id:?}",
+            task_spec.id
+        );
+    };
+    Ok(Some(profile))
+}
+
+fn effective_fleet_role(
+    worker_profile: Option<&FleetTaskWorkerProfile>,
+    agent_profile: Option<&AgentProfile>,
+) -> Option<String> {
+    worker_profile
+        .and_then(|worker| worker.role.as_deref())
+        .map(str::trim)
+        .filter(|role| !role.is_empty())
+        .map(str::to_string)
+        .or_else(|| agent_profile.map(|profile| profile.profile.role.name.clone()))
+}
+
+fn effective_fleet_loadout(
+    worker_profile: Option<&FleetTaskWorkerProfile>,
+    agent_profile: Option<&AgentProfile>,
+) -> codewhale_config::FleetLoadout {
+    worker_profile
+        .and_then(|worker| worker.model_class.as_deref().or(worker.loadout.as_deref()))
+        .map(codewhale_config::FleetLoadout::from_name)
+        .or_else(|| {
+            agent_profile
+                .map(|profile| profile.profile.loadout.clone())
+                .filter(|loadout| *loadout != codewhale_config::FleetLoadout::Inherit)
+        })
+        .unwrap_or_default()
 }
 
 /// Map a fleet role name to a `SubAgentType`. Unknown roles default to `General`.
@@ -172,6 +340,46 @@ fn fleet_worker_runtime_profile(
     profile.max_spawn_depth = max_spawn_depth.saturating_sub(spawn_depth);
     profile.background = true;
     profile
+}
+
+fn fleet_worker_runtime_profile_for_loadout(
+    agent_type: &SubAgentType,
+    tool_profile: &AgentWorkerToolProfile,
+    model: &str,
+    spawn_depth: u32,
+    max_spawn_depth: u32,
+    loadout: &codewhale_config::FleetLoadout,
+) -> WorkerRuntimeProfile {
+    let mut profile = fleet_worker_runtime_profile(
+        agent_type,
+        tool_profile,
+        model,
+        spawn_depth,
+        max_spawn_depth,
+    );
+    profile.model = fleet_model_route_for_loadout(model, loadout);
+    profile
+}
+
+fn fleet_model_route_for_loadout(
+    model: &str,
+    loadout: &codewhale_config::FleetLoadout,
+) -> ModelRoute {
+    let model = model.trim();
+    if !model.is_empty() && !model.eq_ignore_ascii_case("auto") {
+        return ModelRoute::Fixed(model.to_string());
+    }
+    match loadout {
+        codewhale_config::FleetLoadout::Inherit => ModelRoute::Inherit,
+        codewhale_config::FleetLoadout::Fast => ModelRoute::Faster,
+        codewhale_config::FleetLoadout::Strong
+        | codewhale_config::FleetLoadout::Balanced
+        | codewhale_config::FleetLoadout::DeepReasoning
+        | codewhale_config::FleetLoadout::Code
+        | codewhale_config::FleetLoadout::Review
+        | codewhale_config::FleetLoadout::ToolHeavy
+        | codewhale_config::FleetLoadout::Custom(_) => ModelRoute::Auto,
+    }
 }
 
 /// Create a fleet artifact ref from a worker output.
@@ -320,6 +528,71 @@ pub fn is_parallel_safe_read_only_tool(tool_name: &str) -> bool {
 mod tests {
     use super::*;
 
+    fn fleet_task(id: &str, worker: Option<FleetTaskWorkerProfile>) -> FleetTaskSpec {
+        FleetTaskSpec {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            objective: Some(format!("Complete {id}")),
+            instructions: format!("do {id}"),
+            worker,
+            workspace: None,
+            input_files: Vec::new(),
+            context: Vec::new(),
+            budget: None,
+            tags: Vec::new(),
+            expected_artifacts: Vec::new(),
+            scorer: None,
+            retry_policy: None,
+            alert_policy: None,
+            timeout_seconds: None,
+            metadata: Default::default(),
+        }
+    }
+
+    fn worker_profile(
+        agent_profile: Option<&str>,
+        role: Option<&str>,
+        loadout: Option<&str>,
+        model_class: Option<&str>,
+        tools: Vec<&str>,
+    ) -> FleetTaskWorkerProfile {
+        FleetTaskWorkerProfile {
+            agent_profile: agent_profile.map(str::to_string),
+            role: role.map(str::to_string),
+            loadout: loadout.map(str::to_string),
+            model_class: model_class.map(str::to_string),
+            tool_profile: None,
+            tools: tools.into_iter().map(str::to_string).collect(),
+            capabilities: Vec::new(),
+        }
+    }
+
+    fn agent_profile(
+        id: &str,
+        role: &str,
+        instructions: Option<&str>,
+        loadout: codewhale_config::FleetLoadout,
+    ) -> AgentProfile {
+        AgentProfile {
+            id: id.to_string(),
+            display_name: Some(format!("{role} profile")),
+            description: Some(format!("{role} description")),
+            profile: codewhale_config::FleetProfile {
+                slot: codewhale_config::FleetSlot::from_name(role),
+                role: codewhale_config::FleetRole {
+                    name: role.to_string(),
+                    description: Some(format!("{role} role")),
+                    instructions: instructions.map(str::to_string),
+                },
+                loadout,
+                permissions: codewhale_config::FleetProfilePermissions::default(),
+                delegation: codewhale_config::FleetDelegationHints::default(),
+            },
+            source: std::path::PathBuf::from(format!("{id}.toml")),
+        }
+    }
+
     #[test]
     fn fleet_role_smoke_runner_maps_to_verifier() {
         assert_eq!(
@@ -428,6 +701,119 @@ mod tests {
         assert!(prompt.contains("Read the fleet protocol and report issues."));
         assert!(prompt.contains("Keep the report concise."));
         assert!(prompt.contains("crates/protocol/src/fleet.rs"));
+    }
+
+    #[test]
+    fn fleet_worker_spec_resolves_agent_profile_role_prompt_and_loadout() {
+        let profile = agent_profile(
+            "reviewer",
+            "reviewer",
+            Some("Focus on regressions and missing tests."),
+            codewhale_config::FleetLoadout::Balanced,
+        );
+        let task = fleet_task(
+            "review",
+            Some(worker_profile(Some("reviewer"), None, None, None, vec![])),
+        );
+        let worker = FleetWorkerSpec {
+            id: "worker-1".to_string(),
+            name: "Worker".to_string(),
+            host: FleetHostSpec::Local,
+            trust_level: None,
+            labels: Default::default(),
+            capabilities: vec![],
+            max_concurrent_tasks: None,
+        };
+
+        let spec = fleet_task_to_worker_spec_with_profiles(
+            "worker-1",
+            "run-1",
+            &task,
+            &worker,
+            "auto",
+            std::path::Path::new("/tmp"),
+            &[profile],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(spec.role.as_deref(), Some("reviewer"));
+        assert_eq!(spec.agent_type, SubAgentType::Review);
+        assert!(spec.objective.contains("Fleet profile: reviewer"));
+        assert!(
+            spec.objective
+                .contains("Focus on regressions and missing tests.")
+        );
+        assert_eq!(spec.runtime_profile.role, SubAgentType::Review);
+        assert_eq!(spec.runtime_profile.model, ModelRoute::Auto);
+    }
+
+    #[test]
+    fn fleet_worker_spec_rejects_unknown_agent_profile_before_spawn() {
+        let task = fleet_task(
+            "review",
+            Some(worker_profile(Some("missing"), None, None, None, vec![])),
+        );
+
+        let err = validate_task_agent_profiles(&[task], &[])
+            .expect_err("unknown agent profile must fail validation");
+
+        assert!(
+            err.to_string()
+                .contains("references unknown agent profile \"missing\"")
+        );
+    }
+
+    #[test]
+    fn fleet_worker_spec_intersects_task_tools_with_parent_runtime_profile() {
+        let task = fleet_task(
+            "build",
+            Some(worker_profile(
+                None,
+                Some("builder"),
+                None,
+                Some("fast"),
+                vec!["read_file", "apply_patch"],
+            )),
+        );
+        let worker = FleetWorkerSpec {
+            id: "worker-1".to_string(),
+            name: "Worker".to_string(),
+            host: FleetHostSpec::Local,
+            trust_level: None,
+            labels: Default::default(),
+            capabilities: vec![],
+            max_concurrent_tasks: None,
+        };
+        let mut parent = WorkerRuntimeProfile::for_role(SubAgentType::Explore);
+        parent.tools = ToolScope::Explicit(vec!["read_file".to_string()]);
+        parent.max_spawn_depth = 2;
+
+        let spec = fleet_task_to_worker_spec_with_profiles(
+            "worker-1",
+            "run-1",
+            &task,
+            &worker,
+            "auto",
+            std::path::Path::new("/tmp"),
+            &[],
+            Some(&parent),
+        )
+        .unwrap();
+
+        assert_eq!(spec.agent_type, SubAgentType::Implementer);
+        assert!(!spec.runtime_profile.permissions.write);
+        assert!(!spec.runtime_profile.permissions.network);
+        assert_eq!(
+            spec.runtime_profile.shell,
+            crate::worker_profile::ShellPolicy::ReadOnly
+        );
+        assert_eq!(
+            spec.runtime_profile.tools,
+            ToolScope::Explicit(vec!["read_file".to_string()])
+        );
+        assert_eq!(spec.runtime_profile.model, ModelRoute::Faster);
+        assert_eq!(spec.max_spawn_depth, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve Fleet task agent_profile references against workspace .codewhale/agents profiles before run creation
- compose selected profile instructions into both sub-agent worker specs and codewhale exec subprocess prompts
- map Fleet role/loadout intent into the existing AgentWorkerSpec / WorkerRuntimeProfile path, with parent authority narrowing support and strong/balanced/fast loadout vocabulary

## Stack note
This is intentionally stacked on #3513 until the profile loader lands. After #3513 merges, rebase this branch onto main so the PR shows only the resolver commit.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p codewhale-config --locked fleet_loadout_accepts_default_model_classes -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::worker_runtime -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::executor -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::manager -- --nocapture

Refs #3167, #3367, #3154