### PR TITLE
feat(tui): mouse-wheel scrolling for pickers + provider type-ahead (z → Z.ai)

### DIFF
--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -760,6 +760,15 @@ impl ModalView for CommandPaletteView {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
+        match mouse.kind {
+            MouseEventKind::ScrollUp => self.move_selection(-1),
+            MouseEventKind::ScrollDown => self.move_selection(1),
+            _ => {}
+        }
+        ViewAction::None
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -17,7 +17,7 @@
 //! Pressing Esc backs out: from key entry returns to the list; from the
 //! list closes the modal without changes.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
@@ -468,6 +468,28 @@ impl ProviderPickerView {
         }
     }
 
+    /// Type-ahead: move the selection to the next provider whose display name
+    /// starts with the given character (case-insensitive), wrapping so repeated
+    /// presses cycle through matches — e.g. pressing `z` jumps to "Z.ai".
+    fn jump_to_letter(&mut self, c: char) {
+        let count = self.rows.len();
+        if count == 0 {
+            return;
+        }
+        let target = c.to_ascii_lowercase();
+        for offset in 1..=count {
+            let idx = (self.selected_idx + offset) % count;
+            if self.rows[idx]
+                .display_name
+                .to_ascii_lowercase()
+                .starts_with(target)
+            {
+                self.selected_idx = idx;
+                return;
+            }
+        }
+    }
+
     fn selected_provider(&self) -> ApiProvider {
         self.rows[self.selected_idx].provider
     }
@@ -523,6 +545,8 @@ impl ProviderPickerView {
             .title_bottom(Line::from(vec![
                 Span::styled(" ↑↓ ", Style::default().fg(palette::TEXT_MUTED)),
                 Span::raw("move "),
+                Span::styled(" a-z ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::raw("jump "),
                 Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
                 Span::raw(format!("{enter_action} ")),
                 Span::styled(" R ", Style::default().fg(palette::TEXT_MUTED)),
@@ -727,6 +751,12 @@ impl ModalView for ProviderPickerView {
                     self.enter_key_entry();
                     ViewAction::None
                 }
+                // Type-ahead: any other letter jumps to the next provider whose
+                // name starts with it (e.g. `z` -> "Z.ai").
+                KeyCode::Char(c) if key.modifiers.is_empty() && c.is_ascii_alphabetic() => {
+                    self.jump_to_letter(c);
+                    ViewAction::None
+                }
                 _ => ViewAction::None,
             },
             Stage::KeyEntry => match key.code {
@@ -768,6 +798,17 @@ impl ModalView for ProviderPickerView {
                 _ => ViewAction::None,
             },
         }
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
+        if self.stage == Stage::List {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => self.move_up(),
+                MouseEventKind::ScrollDown => self.move_down(),
+                _ => {}
+            }
+        }
+        ViewAction::None
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
@@ -858,6 +899,32 @@ mod tests {
             .map(|y| (0..width).map(|x| buf[(x, y)].symbol()).collect::<String>())
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn type_ahead_jumps_to_provider_by_first_letter() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        // `z` is unique to Z.ai among provider display names.
+        picker.handle_key(key(KeyCode::Char('z')));
+        assert_eq!(picker.selected_provider(), ApiProvider::Zai);
+    }
+
+    #[test]
+    fn mouse_scroll_moves_selection_in_list_stage() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let before = picker.selected_idx;
+        picker.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        });
+        assert_ne!(
+            picker.selected_idx, before,
+            "scroll down should advance the selection"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Local};
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
@@ -399,6 +399,15 @@ impl ModalView for SessionPickerView {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
+        match mouse.kind {
+            MouseEventKind::ScrollUp => self.move_selection(-1),
+            MouseEventKind::ScrollDown => self.move_selection(1),
+            _ => {}
+        }
+        ViewAction::None
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -9,7 +9,7 @@
 //!   `ConfigUpdated{persist:false}` to restore the original theme name
 //!   that was active when the picker opened.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -105,6 +105,15 @@ impl ModalView for ThemePickerView {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
+        match mouse.kind {
+            MouseEventKind::ScrollUp => self.move_up(),
+            MouseEventKind::ScrollDown => self.move_down(),
+            _ => {}
+        }
+        ViewAction::None
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -12,7 +12,7 @@
 //! ten rows, `Home`/`End` jump to ends, and `Esc` closes. Pressing `?` again
 //! at the call-site (`tui::ui`) also toggles the overlay closed.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -295,6 +295,17 @@ impl ModalView for HelpView {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
+        // Scroll clamps at the ends (keyboard Up/Down wrap); wheel-wrapping
+        // reads as disorienting.
+        match mouse.kind {
+            MouseEventKind::ScrollUp => self.move_selection(-1),
+            MouseEventKind::ScrollDown => self.move_selection(1),
+            _ => {}
+        }
+        ViewAction::None
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {


### PR DESCRIPTION
Adds the two navigation behaviors users keep reaching for in the modal pickers.

**Mouse-wheel scrolling** — `handle_mouse` (ScrollUp/ScrollDown → the view's existing selection movement) added to the **provider picker, help view, session picker, command palette, and theme picker**. The model picker and pager already had it; this brings the rest in line. Routed through the existing `ViewStack::handle_mouse`.

**Provider type-ahead** — in the provider picker, pressing a letter jumps to the next provider whose display name starts with it (e.g. `z` → "Z.ai"), wrapping on repeat. `r` remains the key-entry shortcut; the model picker keeps its richer substring filter (unchanged).

Tests: `z` selects Z.ai; a scroll event advances the provider selection. `cargo test -p codewhale-tui provider_picker` passes; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX

---
_Generated by [Claude Code](https://claude.ai/code/session_01991fnUqBbWSgiUFw33L8XX)_