### PR TITLE
[codex] feat(fleet): expose worker runtime through Runtime API

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -38,7 +38,9 @@ use crate::automation_manager::{
 };
 use crate::config::{Config, DEFAULT_TEXT_MODEL};
 use crate::fleet::ledger::{FleetLedgerState, FleetTaskLedgerStatus};
-use crate::fleet::manager::{FleetManager, FleetStatusSnapshot, FleetWorkerInspection};
+use crate::fleet::manager::{
+    FleetManager, FleetStatusSnapshot, FleetWorkerInspection, FleetWorkerRuntimeProjection,
+};
 use crate::mcp::McpPool;
 use crate::models::{ContentBlock, Message};
 use crate::runtime_threads::{
@@ -55,7 +57,10 @@ use crate::skill_state::SkillStateStore;
 use crate::task_manager::{
     NewTaskRequest, SharedTaskManager, TaskManager, TaskManagerConfig, TaskRecord, TaskSummary,
 };
-use crate::tools::subagent::{AgentWorkerRecord, load_persisted_agent_worker_records};
+use crate::tools::subagent::{
+    AgentWorkerRecord, SharedSubAgentManager, load_persisted_agent_worker_records,
+    new_shared_subagent_manager_with_timeout,
+};
 use codewhale_protocol::fleet::{
     FleetArtifactKind, FleetRun, FleetRunId, FleetWorkerEventPayload, FleetWorkerStatus,
 };
@@ -70,6 +75,7 @@ pub struct RuntimeApiState {
     sessions_dir: PathBuf,
     mcp_config_path: PathBuf,
     automations: SharedAutomationManager,
+    sub_agent_manager: SharedSubAgentManager,
     runtime_token: Option<String>,
     skill_state: Arc<Mutex<SkillStateStore>>,
     auth_required: bool,
@@ -410,8 +416,20 @@ fn default_runtime_capabilities() -> RuntimeCapabilities {
         event_replay: true,
         external_tools: true,
         environments: false,
-        worker_runtime: false,
+        worker_runtime: true,
     }
+}
+
+fn runtime_api_sub_agent_manager(workspace: &FsPath, workers: usize) -> SharedSubAgentManager {
+    let max_agents = workers.max(1);
+    new_shared_subagent_manager_with_timeout(
+        workspace.to_path_buf(),
+        max_agents,
+        max_agents,
+        Duration::from_secs(crate::config::DEFAULT_SUBAGENT_HEARTBEAT_TIMEOUT_SECS),
+        max_agents,
+        None,
+    )
 }
 
 #[derive(Debug, Serialize)]
@@ -523,6 +541,7 @@ pub async fn run_http_server(
         );
         SkillStateStore::default()
     });
+    let sub_agent_manager = runtime_api_sub_agent_manager(&workspace, options.workers);
     let state = RuntimeApiState {
         config: config.clone(),
         workspace,
@@ -532,6 +551,7 @@ pub async fn run_http_server(
         sessions_dir,
         mcp_config_path: config.mcp_config_path(),
         automations,
+        sub_agent_manager,
         runtime_token: runtime_token.clone(),
         skill_state: Arc::new(Mutex::new(skill_state)),
         auth_required: auth_enabled,
@@ -1781,7 +1801,18 @@ async fn stop_fleet_run(
 }
 
 fn open_fleet_manager(state: &RuntimeApiState) -> Result<FleetManager, ApiError> {
+    let exec_config = state
+        .config
+        .fleet
+        .as_ref()
+        .map(|fleet| fleet.exec.clone())
+        .unwrap_or_default();
     FleetManager::open(&state.workspace)
+        .map(|manager| {
+            manager
+                .with_exec_config(exec_config)
+                .with_sub_agent_manager(state.sub_agent_manager.clone())
+        })
         .map_err(|err| ApiError::internal(format!("Failed to open fleet manager: {err}")))
 }
 
@@ -1875,6 +1906,18 @@ fn fleet_worker_json(inspection: &FleetWorkerInspection) -> Value {
         "artifacts": inspection.artifacts.iter().map(fleet_artifact_json).collect::<Vec<_>>(),
         "last_error": inspection.last_error.clone(),
         "alert_state": inspection.alert_state.clone(),
+        "runtime_state": inspection.runtime_state.as_ref().map(fleet_worker_runtime_json),
+    })
+}
+
+fn fleet_worker_runtime_json(runtime: &FleetWorkerRuntimeProjection) -> Value {
+    json!({
+        "agent_status": runtime.agent_status.clone(),
+        "steps_taken": runtime.steps_taken,
+        "latest_message": runtime.latest_message.clone(),
+        "error": runtime.error.clone(),
+        "result_summary": runtime.result_summary.clone(),
+        "has_session": runtime.has_session,
     })
 }
 

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -472,6 +472,31 @@ async fn spawn_test_server_with_root_token_mobile_workspace(
         tokio::task::JoinHandle<()>,
     )>,
 > {
+    spawn_test_server_with_root_token_mobile_workspace_and_subagents(
+        root,
+        sessions_dir,
+        runtime_token,
+        mobile_enabled,
+        workspace,
+        None,
+    )
+    .await
+}
+
+async fn spawn_test_server_with_root_token_mobile_workspace_and_subagents(
+    root: PathBuf,
+    sessions_dir: PathBuf,
+    runtime_token: Option<String>,
+    mobile_enabled: bool,
+    workspace: PathBuf,
+    sub_agent_manager: Option<SharedSubAgentManager>,
+) -> Result<
+    Option<(
+        SocketAddr,
+        SharedRuntimeThreadManager,
+        tokio::task::JoinHandle<()>,
+    )>,
+> {
     let _ = rustls::crypto::ring::default_provider().install_default();
     fs::create_dir_all(&sessions_dir)?;
     fs::create_dir_all(&workspace)?;
@@ -501,6 +526,8 @@ async fn spawn_test_server_with_root_token_mobile_workspace(
     runtime_threads.attach_automation_manager(automations.clone());
 
     let auth_required = runtime_token.is_some();
+    let sub_agent_manager =
+        sub_agent_manager.unwrap_or_else(|| runtime_api_sub_agent_manager(&workspace, 2));
     let state = RuntimeApiState {
         config: Config::default(),
         workspace,
@@ -510,6 +537,7 @@ async fn spawn_test_server_with_root_token_mobile_workspace(
         sessions_dir,
         mcp_config_path: root.join("mcp.json"),
         automations,
+        sub_agent_manager,
         runtime_token,
         skill_state: Arc::new(Mutex::new(
             SkillStateStore::load_from(root.join("skills_state.toml")).unwrap_or_default(),
@@ -1013,6 +1041,9 @@ async fn workspace_and_automation_endpoints_work() -> Result<()> {
 
 #[tokio::test]
 async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
+    use crate::tools::subagent::{AgentWorkerSpec, AgentWorkerToolProfile, SubAgentType};
+    use crate::worker_profile::WorkerRuntimeProfile;
+
     let root = std::env::temp_dir().join(format!("codewhale-fleet-api-{}", Uuid::new_v4()));
     let workspace = root.join("workspace");
     fs::create_dir_all(&workspace)?;
@@ -1056,13 +1087,37 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
     )?;
     let worker_id = report.worker_ids[0].clone();
     let sessions_dir = root.join("sessions");
+    let sub_agent_manager = runtime_api_sub_agent_manager(&workspace, 2);
+    {
+        let mut guard = sub_agent_manager.write().await;
+        guard.register_worker(AgentWorkerSpec {
+            worker_id: worker_id.clone(),
+            run_id: report.run_id.0.clone(),
+            parent_run_id: None,
+            session_name: Some("runtime-api-fleet-worker".to_string()),
+            objective: "Inspect fleet status through Runtime API".to_string(),
+            role: Some("status-reviewer".to_string()),
+            agent_type: SubAgentType::Review,
+            model: "auto".to_string(),
+            workspace: workspace.clone(),
+            git_branch: None,
+            context_mode: "fresh".to_string(),
+            fork_context: false,
+            tool_profile: AgentWorkerToolProfile::Explicit(vec!["rg".to_string()]),
+            runtime_profile: WorkerRuntimeProfile::for_role(SubAgentType::Review),
+            max_steps: 8,
+            spawn_depth: 0,
+            max_spawn_depth: codewhale_config::DEFAULT_SPAWN_DEPTH,
+        });
+    }
     let Some((addr, _runtime_threads, handle)) =
-        spawn_test_server_with_root_token_mobile_workspace(
+        spawn_test_server_with_root_token_mobile_workspace_and_subagents(
             root.clone(),
             sessions_dir,
             None,
             false,
             workspace,
+            Some(sub_agent_manager),
         )
         .await?
     else {
@@ -1094,6 +1149,9 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
     assert_eq!(worker["role"], "status-reviewer");
     assert_eq!(worker["host"], "local");
     assert_eq!(worker["artifacts"][0]["kind"], "log");
+    assert_eq!(worker["runtime_state"]["agent_status"], "starting");
+    assert_eq!(worker["runtime_state"]["steps_taken"], 0);
+    assert_eq!(worker["runtime_state"]["has_session"], true);
 
     let interrupted: serde_json::Value = client
         .post(format!(
@@ -1135,6 +1193,40 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
 
     handle.abort();
     Ok(())
+}
+
+#[test]
+fn fleet_worker_json_includes_runtime_state_projection() {
+    let inspection = FleetWorkerInspection {
+        worker_id: "fleet-worker-1".to_string(),
+        status: FleetWorkerStatus::Busy,
+        current_run_id: Some(FleetRunId::from("fleet-run-1")),
+        current_task_id: Some("task-a".to_string()),
+        objective: Some("Inspect runtime projection".to_string()),
+        role: Some("reviewer".to_string()),
+        host: Some("local".to_string()),
+        latest_heartbeat_at: None,
+        latest_event: None,
+        artifacts: Vec::new(),
+        receipt_summary: None,
+        last_error: None,
+        alert_state: None,
+        runtime_state: Some(FleetWorkerRuntimeProjection {
+            agent_status: "running".to_string(),
+            steps_taken: 3,
+            latest_message: Some("reading files".to_string()),
+            error: None,
+            result_summary: None,
+            has_session: true,
+        }),
+    };
+
+    let worker = fleet_worker_json(&inspection);
+
+    assert_eq!(worker["runtime_state"]["agent_status"], "running");
+    assert_eq!(worker["runtime_state"]["steps_taken"], 3);
+    assert_eq!(worker["runtime_state"]["latest_message"], "reading files");
+    assert_eq!(worker["runtime_state"]["has_session"], true);
 }
 
 #[tokio::test]
@@ -3037,6 +3129,7 @@ async fn runtime_info_reports_bind_state() -> Result<()> {
     assert_eq!(info["transports"], json!(["http", "sse"]));
     assert_eq!(info["capabilities"]["threads"], true);
     assert_eq!(info["capabilities"]["external_tools"], true);
+    assert_eq!(info["capabilities"]["worker_runtime"], true);
     assert!(info["experimental"].is_object());
 
     handle.abort();


### PR DESCRIPTION
## Summary
- attach Runtime API Fleet managers to the shared sub-agent manager
- thread configured [fleet.exec] policy through Runtime API Fleet manager opens
- advertise worker_runtime capability and include Fleet worker runtime_state projections in API JSON

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_status_runtime_api_exposes_state_and_actions -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_worker_json_includes_runtime_state_projection -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_info_reports_bind_state -- --nocapture

Refs #3154, #3167