### PR TITLE
[codex] feat(route): gate runtime switches on RouteResolver

### DIFF
--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -127,7 +127,11 @@ impl RouteResolver {
 
         // 4. Map the selector to a wire id within provider scope.
         //    Prefixed selectors are preserved VERBATIM as the wire id.
-        let class = classify(provider_kind);
+        let class = if request_uses_custom_endpoint(&descriptor, req.base_url_override.as_deref()) {
+            ProviderClass::LocalOrCustom
+        } else {
+            classify(provider_kind)
+        };
         let (wire_model_id, canonical_model, endpoint_key, limits) = if is_auto {
             default_offering.map_or_else(
                 || {
@@ -313,4 +317,36 @@ fn classify(kind: ProviderKind) -> ProviderClass {
         // Everything else is treated as an aggregator-style pass-through.
         _ => ProviderClass::Aggregator,
     }
+}
+
+fn request_uses_custom_endpoint(
+    descriptor: &ProviderDescriptor,
+    base_url_override: Option<&str>,
+) -> bool {
+    base_url_override.is_some_and(|base_url| {
+        normalize_route_base_url(base_url)
+            != normalize_route_base_url(descriptor.default_base_url())
+    })
+}
+
+fn normalize_route_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    let deepseek_domains = ["api.deepseek.com", "api.deepseeki.com"];
+    if deepseek_domains
+        .iter()
+        .any(|domain| trimmed.to_ascii_lowercase().contains(domain))
+    {
+        return trimmed.trim_end_matches("/v1").to_string();
+    }
+    if let Some(idx) = trimmed.find("://") {
+        let (scheme, rest) = trimmed.split_at(idx);
+        let scheme = scheme.to_ascii_lowercase();
+        let rest = &rest[3..];
+        let (authority, path) = match rest.find('/') {
+            Some(p) => (&rest[..p], &rest[p..]),
+            None => (rest, ""),
+        };
+        return format!("{scheme}://{}{path}", authority.to_ascii_lowercase());
+    }
+    trimmed.to_ascii_lowercase()
 }

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -408,6 +408,23 @@ fn resolver_strict_direct_rejects_other_provider_known_bare_offering() {
 }
 
 #[test]
+fn resolver_custom_endpoint_allows_namespaced_selector_for_strict_provider() {
+    let r = RouteResolver::new();
+    let request = RouteRequest {
+        explicit_provider: Some(ProviderKind::Deepseek),
+        model_selector: Some(LogicalModelRef::from("vendor/custom-coder")),
+        saved_provider_model: None,
+        base_url_override: Some("https://example.local/v1".to_string()),
+    };
+    let out = r
+        .resolve(&request)
+        .expect("custom endpoint should defer model validation upstream");
+    assert_eq!(out.provider_kind, ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id.as_str(), "vendor/custom-coder");
+    assert_eq!(out.endpoint.base_url, "https://example.local/v1");
+}
+
+#[test]
 fn resolver_strict_direct_rejects_models_dev_offering_from_another_provider() {
     let r = models_dev_route_resolver();
     let out = r.resolve(&req(Some(ProviderKind::Deepseek), Some("glm-5.2")));

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -8,6 +8,7 @@ use crate::config::{
     normalize_model_name_for_provider,
 };
 use crate::localization::{MessageId, tr};
+use crate::route_runtime::resolve_route_candidate;
 use crate::tui::app::{App, AppAction, AppMode, ReasoningEffort};
 use crate::tui::views::{HelpView, ModalKind, SubAgentsView, subagent_view_agents};
 
@@ -167,14 +168,14 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
             };
             model_id
         };
-        // Reject a model that is incompatible with the active provider locally,
-        // before it can be persisted or sent and bounced as `400 Unknown Model`
-        // (#3227). The route stays atomic: provider unchanged, model unchanged.
-        // Skip the strict check when the app accepts custom model ids (a
-        // pass-through provider or a custom DeepSeek-compatible base URL), where
-        // any id is a deliberate choice and the upstream is the authority.
-        if !app.accepts_custom_model_ids()
-            && let Err(reason) = crate::config::validate_route(app.api_provider, &model_id)
+        let strict_direct_custom_endpoint = app.accepts_custom_model_ids()
+            && matches!(
+                app.api_provider,
+                ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::Zai
+            );
+        if !strict_direct_custom_endpoint
+            && let Err(reason) =
+                resolve_route_candidate(app.api_provider, Some(&model_id), None, None)
         {
             return CommandResult::error(reason);
         }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -833,6 +833,7 @@ pub fn requested_model_for_provider(provider: ApiProvider, model: &str) -> Optio
 ///
 /// Returns `Ok(())` for any tuple we cannot confidently reject (the provider
 /// API remains the final authority for those).
+#[cfg(test)]
 pub fn validate_route(provider: ApiProvider, model: &str) -> Result<(), String> {
     let trimmed = model.trim();
     if trimmed.is_empty() {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -40,6 +40,7 @@ use crate::models::{
 };
 use crate::prompts;
 use crate::purge::{emit_purge_completed, emit_purge_failed, emit_purge_started, run_purge};
+use crate::route_runtime::resolve_runtime_route;
 use crate::seam_manager::{SeamConfig, SeamManager};
 use crate::tools::goal::{GoalSnapshot, GoalStatus, SharedGoalState, new_shared_goal_state};
 use crate::tools::plan::{PlanSnapshot, SharedPlanState, new_shared_plan_state};
@@ -738,16 +739,6 @@ impl Engine {
         format!("{message}\n\n{hint}")
     }
 
-    fn config_for_runtime_route(&self, provider: ApiProvider, model: &str) -> Config {
-        let mut config = self.api_config.clone();
-        config.provider = Some(provider.as_str().to_string());
-        config.provider_config_for_mut(provider).model = Some(model.to_string());
-        if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
-            config.default_text_model = Some(model.to_string());
-        }
-        config
-    }
-
     fn activate_runtime_route(&mut self, provider: ApiProvider, model: &str) -> Result<(), String> {
         if self.api_provider == provider
             && self
@@ -758,7 +749,15 @@ impl Engine {
             return Ok(());
         }
 
-        let route_config = self.config_for_runtime_route(provider, model);
+        let route =
+            resolve_runtime_route(&self.api_config, provider, Some(model)).map_err(|reason| {
+                format!(
+                    "Failed to resolve provider route {} / {}: {reason}",
+                    provider.as_str(),
+                    model
+                )
+            })?;
+        let route_config = route.config;
         match DeepSeekClient::new(&route_config) {
             Ok(client) => {
                 self.api_provider = provider;

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -75,6 +75,7 @@ mod request_tuning;
 mod resource_telemetry;
 mod retry_status;
 pub mod rlm;
+mod route_runtime;
 mod runtime_api;
 mod runtime_log;
 mod runtime_threads;

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -1,0 +1,178 @@
+use codewhale_config::route::{
+    LogicalModelRef, ReadyRouteCandidate, RouteRequest, RouteResolver, WireModelId,
+};
+
+use crate::config::{ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedRuntimeRoute {
+    pub(crate) candidate: ReadyRouteCandidate,
+    pub(crate) config: Config,
+    pub(crate) model: String,
+}
+
+pub(crate) fn resolve_route_candidate(
+    provider: ApiProvider,
+    model_selector: Option<&str>,
+    saved_provider_model: Option<&str>,
+    base_url_override: Option<String>,
+) -> Result<ReadyRouteCandidate, String> {
+    let route_request = RouteRequest {
+        explicit_provider: provider.kind(),
+        model_selector: model_selector.map(|model| LogicalModelRef::from(model.to_string())),
+        saved_provider_model: saved_provider_model
+            .map(|model| WireModelId::from(model.to_string())),
+        base_url_override,
+    };
+    RouteResolver::new()
+        .resolve(&route_request)
+        .map_err(|err| err.to_string())
+}
+
+pub(crate) fn resolve_runtime_route(
+    config: &Config,
+    provider: ApiProvider,
+    model_selector: Option<&str>,
+) -> Result<ResolvedRuntimeRoute, String> {
+    let mut route_config = prepared_route_config(config, provider, model_selector);
+    let saved_provider_model = route_config
+        .provider_config_for(provider)
+        .and_then(|provider| provider.model.as_deref());
+    let candidate = resolve_route_candidate(
+        provider,
+        model_selector,
+        saved_provider_model,
+        Some(route_config.deepseek_base_url()),
+    )?;
+    let model = candidate.wire_model_id.as_str().to_string();
+    route_config.provider_config_for_mut(provider).model = Some(model.clone());
+
+    Ok(ResolvedRuntimeRoute {
+        candidate,
+        config: route_config,
+        model,
+    })
+}
+
+fn prepared_route_config(
+    config: &Config,
+    provider: ApiProvider,
+    model_selector: Option<&str>,
+) -> Config {
+    let mut route_config = config.clone();
+    route_config.provider = Some(provider.as_str().to_string());
+    if matches!(provider, ApiProvider::NvidiaNim)
+        && route_config
+            .base_url
+            .as_deref()
+            .map(|base| !base.contains("integrate.api.nvidia.com"))
+            .unwrap_or(true)
+    {
+        route_config.base_url = Some(DEFAULT_NVIDIA_NIM_BASE_URL.to_string());
+    }
+    if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
+        && route_config
+            .base_url
+            .as_deref()
+            .map(root_base_url_belongs_to_non_deepseek_provider)
+            .unwrap_or(false)
+    {
+        route_config.base_url = None;
+    }
+    if let Some(model) = model_selector {
+        route_config.provider_config_for_mut(provider).model = Some(model.to_string());
+    }
+    route_config
+}
+
+fn root_base_url_belongs_to_non_deepseek_provider(base_url: &str) -> bool {
+    let lower = base_url.to_ascii_lowercase();
+    [
+        "integrate.api.nvidia.com",
+        "api.openai.com",
+        "api.atlascloud.ai",
+        "maas-openapi.wanjiedata.com",
+        "volces.com",
+        "openrouter.ai",
+        "xiaomimimo.com",
+        "novita.ai",
+        "fireworks.ai",
+        "siliconflow",
+        "arcee.ai",
+        "moonshot.ai",
+        "api.kimi.com",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DEFAULT_TEXT_MODEL, DEFAULT_ZAI_MODEL, ProviderConfig, ProvidersConfig};
+
+    #[test]
+    fn runtime_route_without_model_uses_target_provider_default() {
+        let config = Config {
+            provider: Some("openrouter".to_string()),
+            providers: Some(ProvidersConfig {
+                openrouter: ProviderConfig {
+                    model: Some("deepseek/deepseek-v4-pro".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let route = resolve_runtime_route(&config, ApiProvider::Zai, None)
+            .expect("target provider default should resolve");
+
+        assert_eq!(route.model, DEFAULT_ZAI_MODEL);
+        assert_eq!(route.config.provider.as_deref(), Some("zai"));
+        assert_eq!(
+            route
+                .config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.zai.model.as_deref()),
+            Some(DEFAULT_ZAI_MODEL)
+        );
+        assert_eq!(
+            route
+                .config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.openrouter.model.as_deref()),
+            Some("deepseek/deepseek-v4-pro")
+        );
+    }
+
+    #[test]
+    fn runtime_route_rejects_foreign_direct_model_before_config_snapshot() {
+        let config = Config {
+            provider: Some("deepseek".to_string()),
+            providers: Some(ProvidersConfig {
+                deepseek: ProviderConfig {
+                    model: Some(DEFAULT_TEXT_MODEL.to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let err = resolve_runtime_route(&config, ApiProvider::Zai, Some("deepseek-v4-pro"))
+            .expect_err("foreign direct-provider model should reject");
+
+        assert!(err.contains("not served by direct provider zai"));
+        assert_eq!(config.provider.as_deref(), Some("deepseek"));
+        assert_eq!(
+            config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.zai.model.as_deref()),
+            None
+        );
+    }
+}

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -49,8 +49,8 @@ use crate::client::{
 use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::config::{
-    ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL, ProviderConfig, ProvidersConfig, StatusItem,
-    UpdateConfig, provider_capability, save_provider_auth_mode_for,
+    ApiProvider, Config, ProviderConfig, ProvidersConfig, StatusItem, UpdateConfig,
+    provider_capability, save_provider_auth_mode_for,
 };
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
@@ -62,6 +62,7 @@ use crate::localization::{MessageId, tr};
 use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt, Usage};
 use crate::palette;
 use crate::prompts;
+use crate::route_runtime::{resolve_route_candidate, resolve_runtime_route};
 use crate::session_manager::{
     OfflineQueueState, QueuedSessionMessage, SavedSession, SessionManager,
     create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session,
@@ -6518,25 +6519,33 @@ async fn apply_model_picker_choice(
         return;
     }
 
-    // Reject a model that does not belong to the active provider before we
-    // mutate session state or persist it (#3227/#3383). The provider-scoped
-    // picker should only emit active-provider rows; keep this guard as the
-    // in-session safety net. Explicit cross-provider route switches go through
-    // `switch_provider`, which validates the route atomically. Skip the strict
-    // check when the app accepts custom ids (pass-through provider or custom
-    // DeepSeek-compatible base URL) — the upstream is the authority there.
-    if model_changed
-        && !app.accepts_custom_model_ids()
-        && let Err(reason) = crate::config::validate_route(app.api_provider, &model)
-    {
-        app.status_message = Some(reason);
-        return;
+    let mut resolved_model = model.clone();
+    if model_changed && !model_is_auto {
+        let saved_provider_model = config
+            .provider_config_for(app.api_provider)
+            .and_then(|provider| provider.model.as_deref());
+        match resolve_route_candidate(
+            app.api_provider,
+            Some(&model),
+            saved_provider_model,
+            Some(config.deepseek_base_url()),
+        ) {
+            Ok(candidate) => {
+                resolved_model = candidate.wire_model_id.as_str().to_string();
+            }
+            Err(reason) => {
+                app.status_message = Some(reason);
+                return;
+            }
+        }
     }
 
     if model_changed {
-        app.set_model_selection(model.clone());
-        app.provider_models
-            .insert(app.api_provider.as_str().to_string(), model.clone());
+        app.set_model_selection(resolved_model.clone());
+        app.provider_models.insert(
+            app.api_provider.as_str().to_string(),
+            resolved_model.clone(),
+        );
         app.clear_model_scoped_telemetry();
     }
     if effort_changed {
@@ -6557,9 +6566,9 @@ async fn apply_model_picker_choice(
                 app.api_provider,
                 ApiProvider::Deepseek | ApiProvider::DeepseekCN
             ) {
-                settings.set("default_model", &model)?;
+                settings.set("default_model", &resolved_model)?;
             }
-            settings.set_model_for_provider(app.api_provider.as_str(), &model);
+            settings.set_model_for_provider(app.api_provider.as_str(), &resolved_model);
         }
         if effort_changed {
             settings.set(
@@ -6580,7 +6589,7 @@ async fn apply_model_picker_choice(
     let model_summary = if model_is_auto {
         "auto (per-turn model)".to_string()
     } else {
-        model.clone()
+        resolved_model.clone()
     };
     let previous_effort_summary = previous_effort.display_label_for_provider(app.api_provider);
     let effort_summary = if effort == ReasoningEffort::Auto {
@@ -6650,11 +6659,10 @@ async fn apply_picker_effort_choice(
     app.status_message = Some(summary);
 }
 
-/// Apply a `/provider` switch by mutating the in-memory config, validating
-/// that credentials exist for the new provider, then respawning the engine
-/// so the API client picks up the new base URL/key. When `model_override`
-/// is set, it replaces the active model post-switch (already normalized,
-/// will be provider-prefixed by `Config::default_model`).
+/// Apply a `/provider` switch by resolving a complete route candidate before
+/// mutating state, then respawning the engine so the API client picks up the
+/// new base URL/key. When `model_override` is set, it replaces the active
+/// model post-switch after provider-scoped normalization.
 async fn switch_provider(
     app: &mut App,
     engine_handle: &mut EngineHandle,
@@ -6676,32 +6684,30 @@ async fn switch_provider(
         previous_api_key_env_only: app.api_key_env_only,
     });
 
-    config.provider = Some(target.as_str().to_string());
-    if matches!(target, ApiProvider::NvidiaNim)
-        && config
-            .base_url
-            .as_deref()
-            .map(|base| !base.contains("integrate.api.nvidia.com"))
-            .unwrap_or(true)
-    {
-        config.base_url = Some(DEFAULT_NVIDIA_NIM_BASE_URL.to_string());
-    }
-    if matches!(target, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
-        && config
-            .base_url
-            .as_deref()
-            .map(root_base_url_belongs_to_non_deepseek_provider)
-            .unwrap_or(false)
-    {
-        config.base_url = None;
-    }
-    if let Some(ref model) = model_override {
-        config.provider_config_for_mut(target).model = Some(model.clone());
-    }
+    let resolved_route = match resolve_runtime_route(config, target, model_override.as_deref()) {
+        Ok(route) => route,
+        Err(reason) => {
+            app.pending_provider_switch = None;
+            app.add_message(HistoryCell::System {
+                content: format!(
+                    "Cannot switch to {}: {reason}\nProvider unchanged ({}).",
+                    target.as_str(),
+                    previous_provider.as_str()
+                ),
+            });
+            app.status_message = Some(format!(
+                "Route rejected before provider switch: {}.",
+                target.as_str()
+            ));
+            return;
+        }
+    };
+    let resolved_endpoint = resolved_route.candidate.endpoint.base_url.clone();
+    let next_config = resolved_route.config;
+    let new_model = resolved_route.model;
 
-    if let Err(err) = DeepSeekClient::new(config) {
+    if let Err(err) = DeepSeekClient::new(&next_config) {
         app.pending_provider_switch = None;
-        *config = previous_config;
         app.add_message(HistoryCell::System {
             content: format!(
                 "Failed to switch provider to {}: {err}\nProvider unchanged ({}).",
@@ -6711,35 +6717,9 @@ async fn switch_provider(
         });
         return;
     }
+    *config = next_config;
 
-    let new_model = config.default_model();
-    // Validate the resolved (provider, model) tuple as one atomic unit before
-    // we tear down the engine or persist anything (#3227). This catches a
-    // contaminated route — e.g. provider `zai` paired with `deepseek-v4-pro` —
-    // locally with a precise diagnostic instead of a `400 Unknown Model`. On
-    // failure we leave the provider, model, and config exactly as they were.
-    // Pass-through routes (OpenAI-compatible, custom DeepSeek base URLs, …)
-    // skip the strict check; the upstream service is the authority there.
-    if !config.model_ids_pass_through()
-        && let Err(reason) = crate::config::validate_route(target, &new_model)
-    {
-        app.pending_provider_switch = None;
-        *config = previous_config;
-        app.add_message(HistoryCell::System {
-            content: format!(
-                "Cannot switch to {}: {reason}\nProvider unchanged ({}).",
-                target.as_str(),
-                previous_provider.as_str()
-            ),
-        });
-        app.status_message = Some(format!(
-            "Route rejected: {} is not compatible with {}.",
-            new_model,
-            target.as_str()
-        ));
-        return;
-    }
-    let new_base_url = config.deepseek_base_url();
+    let new_base_url = resolved_endpoint;
     let new_endpoint = display_base_url_host(&new_base_url);
     let cache_scope_changed = previous_provider != target || previous_model != new_model;
     app.api_provider = target;
@@ -6841,31 +6821,29 @@ async fn apply_provider_fallback_switch(
     previous_provider: ApiProvider,
 ) {
     let target = app.api_provider;
-    let previous_config = config.clone();
     let previous_model = app.model.clone();
 
-    config.provider = Some(target.as_str().to_string());
-    if matches!(target, ApiProvider::NvidiaNim)
-        && config
-            .base_url
-            .as_deref()
-            .map(|base| !base.contains("integrate.api.nvidia.com"))
-            .unwrap_or(true)
-    {
-        config.base_url = Some(DEFAULT_NVIDIA_NIM_BASE_URL.to_string());
-    }
-    if matches!(target, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
-        && config
-            .base_url
-            .as_deref()
-            .map(root_base_url_belongs_to_non_deepseek_provider)
-            .unwrap_or(false)
-    {
-        config.base_url = None;
-    }
+    let resolved_route = match resolve_runtime_route(config, target, None) {
+        Ok(route) => route,
+        Err(reason) => {
+            app.api_provider = previous_provider;
+            app.last_fallback_reason = Some(format!(
+                "Fallback provider {} route was rejected: {reason}",
+                target.as_str()
+            ));
+            app.status_message = Some(format!(
+                "Fallback provider {} rejected; provider remains {}.",
+                target.as_str(),
+                previous_provider.as_str()
+            ));
+            return;
+        }
+    };
+    let resolved_endpoint = resolved_route.candidate.endpoint.base_url.clone();
+    let next_config = resolved_route.config;
+    let new_model = resolved_route.model;
 
-    if let Err(err) = DeepSeekClient::new(config) {
-        *config = previous_config;
+    if let Err(err) = DeepSeekClient::new(&next_config) {
         app.api_provider = previous_provider;
         app.last_fallback_reason = Some(format!(
             "Fallback provider {} was unavailable: {err}",
@@ -6878,9 +6856,9 @@ async fn apply_provider_fallback_switch(
         ));
         return;
     }
+    *config = next_config;
 
-    let new_model = config.default_model();
-    let new_base_url = config.deepseek_base_url();
+    let new_base_url = resolved_endpoint;
     let new_endpoint = display_base_url_host(&new_base_url);
     let cache_scope_changed = previous_provider != target || previous_model != new_model;
     app.model_ids_passthrough = config.model_ids_pass_through();
@@ -6932,27 +6910,6 @@ async fn apply_provider_fallback_switch(
         target.as_str(),
         new_endpoint
     ));
-}
-
-fn root_base_url_belongs_to_non_deepseek_provider(base_url: &str) -> bool {
-    let lower = base_url.to_ascii_lowercase();
-    [
-        "integrate.api.nvidia.com",
-        "api.openai.com",
-        "api.atlascloud.ai",
-        "maas-openapi.wanjiedata.com",
-        "volces.com",
-        "openrouter.ai",
-        "xiaomimimo.com",
-        "novita.ai",
-        "fireworks.ai",
-        "siliconflow",
-        "arcee.ai",
-        "moonshot.ai",
-        "api.kimi.com",
-    ]
-    .iter()
-    .any(|needle| lower.contains(needle))
 }
 
 fn display_base_url_host(base_url: &str) -> String {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::{
-    ApiProvider, Config, DEFAULT_OPENROUTER_MODEL, DEFAULT_TEXT_MODEL, ProviderConfig,
-    ProvidersConfig,
+    ApiProvider, Config, DEFAULT_OPENROUTER_MODEL, DEFAULT_TEXT_MODEL, DEFAULT_ZAI_MODEL,
+    ProviderConfig, ProvidersConfig,
 };
 use crate::config_ui::{self, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::mock_engine_handle;
@@ -2833,6 +2833,113 @@ async fn provider_switch_model_override_updates_target_provider_model_slot() {
             .as_ref()
             .and_then(|providers| providers.xiaomi_mimo.model.as_deref()),
         Some("mimo-v2.5-pro")
+    );
+}
+
+#[tokio::test]
+async fn provider_switch_without_model_uses_target_default_not_previous_provider_model() {
+    let _home = SettingsHomeGuard::new();
+    let mut app = create_test_app();
+    app.api_provider = ApiProvider::Openrouter;
+    app.model = "deepseek/deepseek-v4-pro".to_string();
+    app.model_ids_passthrough = true;
+    let mut engine = mock_engine_handle();
+    let mut config = Config {
+        provider: Some("openrouter".to_string()),
+        api_key: Some("deepseek-key".to_string()),
+        providers: Some(ProvidersConfig {
+            openrouter: ProviderConfig {
+                api_key: Some("openrouter-key".to_string()),
+                model: Some("deepseek/deepseek-v4-pro".to_string()),
+                ..Default::default()
+            },
+            zai: ProviderConfig {
+                api_key: Some("zai-key".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    switch_provider(
+        &mut app,
+        &mut engine.handle,
+        &mut config,
+        ApiProvider::Zai,
+        None,
+    )
+    .await;
+
+    assert_eq!(app.api_provider, ApiProvider::Zai);
+    assert_eq!(app.model, DEFAULT_ZAI_MODEL);
+    assert_eq!(config.provider.as_deref(), Some("zai"));
+    assert_eq!(
+        config
+            .providers
+            .as_ref()
+            .and_then(|providers| providers.zai.model.as_deref()),
+        Some(DEFAULT_ZAI_MODEL)
+    );
+    assert_eq!(
+        config
+            .providers
+            .as_ref()
+            .and_then(|providers| providers.openrouter.model.as_deref()),
+        Some("deepseek/deepseek-v4-pro")
+    );
+}
+
+#[tokio::test]
+async fn provider_switch_foreign_direct_model_rejected_before_mutation() {
+    let _home = SettingsHomeGuard::new();
+    let mut app = create_test_app();
+    app.api_provider = ApiProvider::Deepseek;
+    app.model = DEFAULT_TEXT_MODEL.to_string();
+    let mut engine = mock_engine_handle();
+    let mut config = Config {
+        provider: Some("deepseek".to_string()),
+        api_key: Some("deepseek-key".to_string()),
+        providers: Some(ProvidersConfig {
+            deepseek: ProviderConfig {
+                api_key: Some("deepseek-key".to_string()),
+                model: Some(DEFAULT_TEXT_MODEL.to_string()),
+                ..Default::default()
+            },
+            zai: ProviderConfig {
+                api_key: Some("zai-key".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    switch_provider(
+        &mut app,
+        &mut engine.handle,
+        &mut config,
+        ApiProvider::Zai,
+        Some("deepseek-v4-pro".to_string()),
+    )
+    .await;
+
+    assert_eq!(app.api_provider, ApiProvider::Deepseek);
+    assert_eq!(app.model, DEFAULT_TEXT_MODEL);
+    assert_eq!(config.provider.as_deref(), Some("deepseek"));
+    assert_eq!(
+        config
+            .providers
+            .as_ref()
+            .and_then(|providers| providers.zai.model.as_deref()),
+        None
+    );
+    assert!(app.pending_provider_switch.is_none());
+    assert!(
+        app.status_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Route rejected before provider switch")
     );
 }
 


### PR DESCRIPTION
## Summary
- add a TUI runtime-route adapter around codewhale_config::route::RouteResolver so provider/model choices produce a ReadyRouteCandidate before state mutation
- route /provider, model picker, slash /model, provider fallback, and engine runtime activation through that candidate gate
- preserve custom endpoint pass-through behavior in the config resolver while keeping strict direct-provider foreign-model rejection
- add regressions for stale previous-provider models, direct-provider rejection before mutation, runtime route snapshots, and custom endpoint route resolution
- keep the retired validate_route helper test-only so release/mobile builds stay clean under -D warnings

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo build --release -p codewhale-tui --locked
- cargo test -p codewhale-config --locked route:: -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked route_runtime -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked provider_switch -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked commands::groups::core::core -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked commands::groups::core::provider -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked tui::model_picker -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked fallback -- --nocapture

Refs #3384