### PR TITLE
[codex] feat(tui): feed route limits into context budgets

### DIFF
--- a/crates/tui/src/commands/groups/config/status.rs
+++ b/crates/tui/src/commands/groups/config/status.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 use super::CommandResult;
 use crate::compaction::estimate_input_tokens_conservative;
-use crate::config::provider_capability;
 use crate::tui::app::App;
 use crate::utils::{display_path, estimate_message_chars};
 
@@ -166,7 +165,11 @@ fn footer_items(app: &App) -> String {
 }
 
 fn context_usage(app: &App) -> (usize, u32, f64) {
-    let max = provider_capability(app.api_provider, &app.model).context_window;
+    let max = crate::route_budget::route_context_window_tokens(
+        app.api_provider,
+        app.effective_model_for_budget(),
+        app.active_route_limits,
+    );
     let estimated =
         estimate_input_tokens_conservative(&app.api_messages, app.system_prompt.as_ref());
     let total_chars = estimate_message_chars(&app.api_messages);

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -129,6 +129,7 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
             app.last_effective_model = None;
             app.reasoning_effort = ReasoningEffort::Auto;
             app.last_effective_reasoning_effort = None;
+            app.active_route_limits = None;
             app.update_model_compaction_budget();
             if model_changed {
                 app.clear_model_scoped_telemetry();
@@ -173,15 +174,22 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
                 app.api_provider,
                 ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::Zai
             );
-        if !strict_direct_custom_endpoint
-            && let Err(reason) =
-                resolve_route_candidate(app.api_provider, Some(&model_id), None, None)
-        {
-            return CommandResult::error(reason);
-        }
+        let route_limits = if strict_direct_custom_endpoint {
+            None
+        } else {
+            match resolve_route_candidate(app.api_provider, Some(&model_id), None, None) {
+                Ok(candidate) => Some(candidate.limits),
+                Err(reason) => return CommandResult::error(reason),
+            }
+        };
         let old_model = app.model_display_label();
         let model_changed = app.auto_model || app.model != model_id;
         app.set_model_selection(model_id.clone());
+        if let Some(limits) = route_limits {
+            app.set_active_route_limits(limits);
+        } else {
+            app.active_route_limits = None;
+        }
         app.update_model_compaction_budget();
         if model_changed {
             app.clear_model_scoped_telemetry();

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -241,6 +241,9 @@ fn append_plan_list(out: &mut String, label: &str, values: &[String]) {
 pub struct EngineConfig {
     /// Model identifier to use for responses.
     pub model: String,
+    /// Route/offering limits for the active provider+model, when the runtime
+    /// route resolver had concrete catalog facts.
+    pub active_route_limits: Option<codewhale_config::route::RouteLimits>,
     /// Workspace root for tool execution and file operations.
     pub workspace: PathBuf,
     /// Allow shell tool execution when true.
@@ -401,6 +404,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             model: DEFAULT_TEXT_MODEL.to_string(),
+            active_route_limits: None,
             workspace: PathBuf::from("."),
             allow_shell: true,
             trust_mode: false,
@@ -546,6 +550,7 @@ pub struct Engine {
     shell_manager: SharedShellManager,
     mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
     api_provider: ApiProvider,
+    active_route_limits: Option<codewhale_config::route::RouteLimits>,
     rx_op: mpsc::Receiver<Op>,
     /// Clone of the op-channel sender, so the engine can self-dispatch ops
     /// (e.g. a goal-continuation `SendMessage` after a turn completes).
@@ -843,8 +848,11 @@ impl Engine {
                     translation_enabled: config.translation_enabled,
                     model_id: &config.model,
                     context_window_override: Some(
-                        crate::config::provider_capability(api_provider, &config.model)
-                            .context_window,
+                        crate::route_budget::route_context_window_tokens(
+                            api_provider,
+                            &config.model,
+                            config.active_route_limits,
+                        ),
                     ),
                     show_thinking: config.show_thinking,
                     verbosity: config.verbosity.as_deref(),
@@ -941,6 +949,7 @@ impl Engine {
             })
             .map(std::sync::Arc::from);
 
+        let active_route_limits = config.active_route_limits;
         let engine = Engine {
             config,
             api_config: api_config.clone(),
@@ -952,6 +961,7 @@ impl Engine {
             shell_manager,
             mcp_pool: None,
             api_provider,
+            active_route_limits,
             rx_op,
             tx_op: tx_op.clone(),
             rx_approval,
@@ -1467,10 +1477,15 @@ impl Engine {
                             )))
                             .await;
                     }
-                    Op::SetModel { model, mode: _ } => {
+                    Op::SetModel {
+                        model,
+                        mode: _,
+                        route_limits,
+                    } => {
                         self.session.auto_model = model.trim().eq_ignore_ascii_case("auto");
                         self.session.model = model;
                         self.config.model.clone_from(&self.session.model);
+                        self.active_route_limits = route_limits;
                         self.refresh_system_prompt();
                         self.emit_session_updated().await;
                         let _ = self
@@ -2634,7 +2649,7 @@ impl Engine {
             &self.session.messages,
             &self.session.model,
             self.session.reasoning_effort.clone(),
-            effective_max_output_tokens(&self.session.model),
+            effective_max_output_tokens_for_route(&self.session.model, self.active_route_limits),
         )
         .await
         {
@@ -2702,9 +2717,12 @@ impl Engine {
     }
 
     async fn recover_context_overflow(&mut self, client: &DeepSeekClient, reason: &str) -> bool {
-        let Some(target_budget) =
-            context_input_budget_for_provider(self.api_provider, &self.session.model)
-        else {
+        let Some(target_budget) = context_input_budget_for_route(
+            self.api_provider,
+            &self.session.model,
+            self.active_route_limits,
+            0,
+        ) else {
             return false;
         };
 
@@ -3051,10 +3069,11 @@ impl Engine {
                 locale_tag: &self.config.locale_tag,
                 translation_enabled: self.config.translation_enabled,
                 model_id: &self.config.model,
-                context_window_override: Some(
-                    crate::config::provider_capability(self.api_provider, &self.config.model)
-                        .context_window,
-                ),
+                context_window_override: Some(crate::route_budget::route_context_window_tokens(
+                    self.api_provider,
+                    &self.config.model,
+                    self.active_route_limits,
+                )),
                 show_thinking: self.config.show_thinking,
                 verbosity: self.config.verbosity.as_deref(),
                 skills_scan_codewhale_only: self.config.skills_scan_codewhale_only,
@@ -3633,13 +3652,15 @@ mod approval;
 mod context;
 mod handle;
 pub(crate) use context::compact_tool_result_for_context;
-#[cfg(test)]
-use context::route_context_budget_for_provider;
 use context::{
-    MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP, context_input_budget_for_provider,
-    effective_max_output_tokens, extract_compaction_summary_prompt,
+    MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP, context_input_budget_for_route,
+    effective_max_output_tokens_for_route, extract_compaction_summary_prompt,
     is_context_length_error_message, summarize_text,
 };
+#[cfg(test)]
+use context::{context_input_budget_for_provider, effective_max_output_tokens};
+#[cfg(test)]
+use context::{route_context_budget_for_provider, route_context_budget_for_route};
 mod dispatch;
 mod lsp_hooks;
 mod streaming;

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -5,11 +5,12 @@
 //! engine module from accumulating unrelated context-policy details.
 
 use crate::compaction::estimate_tokens;
-use crate::config::{ApiProvider, provider_capability};
+use crate::config::ApiProvider;
 use crate::context_budget::ContextBudget;
 use crate::error_taxonomy::ErrorCategory;
 use crate::models::{Message, SystemPrompt, context_window_for_model};
 use crate::tools::spec::ToolResult;
+use codewhale_config::route::RouteLimits;
 use serde_json::Value;
 
 /// Max output tokens requested for normal agent turns. Generous on purpose:
@@ -56,6 +57,15 @@ pub(super) fn effective_max_output_tokens(model: &str) -> u32 {
         let capped = window / 2;
         capped.min(API_MAX_OUTPUT_TOKENS)
     }
+}
+
+pub(super) fn effective_max_output_tokens_for_route(
+    model: &str,
+    route_limits: Option<RouteLimits>,
+) -> u32 {
+    let cap = effective_max_output_tokens(model);
+    crate::route_budget::route_output_limit_tokens(route_limits)
+        .map_or(cap, |route_cap| cap.min(route_cap))
 }
 /// Keep this many most recent messages when emergency trimming is required.
 pub(super) const MIN_RECENT_MESSAGES_TO_KEEP: usize = 4;
@@ -569,31 +579,58 @@ const INTERNAL_BUDGET_LARGE_WINDOW_THRESHOLD: u32 = 500_000;
 ///     `256K - 262K - 1K`, which underflows `checked_sub` to `None` and
 ///     *silently disables every preflight and emergency recovery path* — the
 ///     session then runs until the provider hard-rejects on context length.
+#[cfg(test)]
 pub(super) fn context_input_budget_for_provider(
     provider: ApiProvider,
     model: &str,
 ) -> Option<usize> {
-    route_context_budget_for_provider(provider, model, 0)
+    context_input_budget_for_route(provider, model, None, 0)
+}
+
+pub(super) fn context_input_budget_for_route(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
+    input_tokens: usize,
+) -> Option<usize> {
+    route_context_budget_for_route(provider, model, route_limits, input_tokens)
         .and_then(|budget| usize::try_from(budget.available_input_tokens).ok())
 }
 
+#[cfg(test)]
 pub(super) fn route_context_budget_for_provider(
     provider: ApiProvider,
     model: &str,
     input_tokens: usize,
 ) -> Option<ContextBudget> {
-    let capability = provider_capability(provider, model);
-    Some(ContextBudget::new(
-        u64::from(capability.context_window),
-        u64::try_from(input_tokens).ok()?,
-        u64::from(route_output_reservation_for_window(
-            model,
-            capability.context_window,
-        )),
-    ))
+    route_context_budget_for_route(provider, model, None, input_tokens)
 }
 
-fn route_output_reservation_for_window(model: &str, window_tokens: u32) -> u32 {
+pub(super) fn route_context_budget_for_route(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
+    input_tokens: usize,
+) -> Option<ContextBudget> {
+    let window = crate::route_budget::route_context_window_tokens(provider, model, route_limits);
+    let output_cap = route_output_reservation_for_window(model, window, route_limits);
+    crate::route_budget::route_context_budget(
+        provider,
+        model,
+        route_limits,
+        input_tokens,
+        output_cap,
+    )
+}
+
+fn route_output_reservation_for_window(
+    model: &str,
+    window_tokens: u32,
+    route_limits: Option<RouteLimits>,
+) -> u32 {
+    if let Some(route_cap) = crate::route_budget::route_output_limit_tokens(route_limits) {
+        return route_cap.min(TURN_MAX_OUTPUT_TOKENS);
+    }
     if window_tokens >= INTERNAL_BUDGET_LARGE_WINDOW_THRESHOLD {
         TURN_MAX_OUTPUT_TOKENS
     } else {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2560,6 +2560,7 @@ async fn set_model_reloads_instruction_sources_and_updates_session_prompt() {
         .send(Op::SetModel {
             model: "deepseek-v4-pro".to_string(),
             mode: AppMode::Agent,
+            route_limits: None,
         })
         .await
         .expect("send set model");
@@ -2797,6 +2798,42 @@ fn route_context_budget_uses_shared_budget_service() {
         crate::context_budget::PressureLevel::Critical
     );
     assert!(!budget.fits_additional(1));
+}
+
+#[test]
+fn route_context_budget_prefers_resolved_route_limits() {
+    let _lock = lock_test_env();
+    let limits = codewhale_config::route::RouteLimits {
+        context_tokens: Some(128_000),
+        input_tokens: None,
+        output_tokens: Some(32_768),
+    };
+    let budget = route_context_budget_for_route(
+        ApiProvider::Openrouter,
+        "deepseek/deepseek-v4-pro",
+        Some(limits),
+        60_000,
+    )
+    .expect("route limits should produce a budget");
+
+    assert_eq!(budget.window_tokens, 128_000);
+    assert_eq!(budget.output_cap_tokens, 32_768);
+    assert_eq!(budget.available_input_tokens, 34_208);
+}
+
+#[test]
+fn effective_max_output_tokens_for_route_caps_to_route_output_limit() {
+    let _lock = lock_test_env();
+    let limits = codewhale_config::route::RouteLimits {
+        context_tokens: Some(1_000_000),
+        input_tokens: None,
+        output_tokens: Some(8_192),
+    };
+
+    assert_eq!(
+        effective_max_output_tokens_for_route("deepseek-v4-pro", Some(limits)),
+        8_192
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -276,9 +276,12 @@ impl Engine {
                 }
             }
 
-            if let Some(input_budget) =
-                context_input_budget_for_provider(self.api_provider, &self.session.model)
-            {
+            if let Some(input_budget) = context_input_budget_for_route(
+                self.api_provider,
+                &self.session.model,
+                self.active_route_limits,
+                0,
+            ) {
                 let estimated_input = self.estimated_input_tokens();
                 if estimated_input > input_budget {
                     if context_recovery_attempts >= MAX_CONTEXT_RECOVERY_ATTEMPTS {
@@ -438,7 +441,10 @@ impl Engine {
             let request = MessageRequest {
                 model: self.session.model.clone(),
                 messages: self.messages_with_turn_metadata(),
-                max_tokens: effective_max_output_tokens(&self.session.model),
+                max_tokens: effective_max_output_tokens_for_route(
+                    &self.session.model,
+                    self.active_route_limits,
+                ),
                 system: self.session.system_prompt.clone(),
                 tools: active_tools.clone(),
                 tool_choice: if active_tools.is_some() {

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -154,7 +154,11 @@ pub enum Op {
 
     /// Update the model being used and refresh stable prompt context.
     #[allow(dead_code)]
-    SetModel { model: String, mode: AppMode },
+    SetModel {
+        model: String,
+        mode: AppMode,
+        route_limits: Option<codewhale_config::route::RouteLimits>,
+    },
 
     /// Update auto-compaction settings
     SetCompaction { config: CompactionConfig },

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -75,6 +75,7 @@ mod request_tuning;
 mod resource_telemetry;
 mod retry_status;
 pub mod rlm;
+mod route_budget;
 mod route_runtime;
 mod runtime_api;
 mod runtime_log;
@@ -6326,6 +6327,7 @@ async fn run_exec_agent(
         .map(crate::config::LspConfigToml::into_runtime);
     let engine_config = EngineConfig {
         model: effective_model.clone(),
+        active_route_limits: None,
         workspace: workspace.clone(),
         allow_shell: auto_approve || execution_config.allow_shell(),
         trust_mode,

--- a/crates/tui/src/route_budget.rs
+++ b/crates/tui/src/route_budget.rs
@@ -1,0 +1,99 @@
+use codewhale_config::route::RouteLimits;
+
+use crate::config::{ApiProvider, provider_capability};
+use crate::context_budget::ContextBudget;
+use crate::models::{
+    DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS, DEFAULT_COMPACTION_TOKEN_THRESHOLD,
+    compaction_threshold_for_model_at_percent,
+};
+
+/// Preserve only route limits that came from a concrete offering.
+#[must_use]
+pub(crate) fn known_route_limits(limits: RouteLimits) -> Option<RouteLimits> {
+    limits.has_known_limit().then_some(limits)
+}
+
+/// Context window for a resolved runtime route.
+///
+/// Route/offering facts win when known; otherwise this falls back to the
+/// existing provider+model capability matrix so startup and custom/local
+/// routes keep their previous conservative behavior.
+#[must_use]
+pub(crate) fn route_context_window_tokens(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
+) -> u32 {
+    route_limits
+        .and_then(|limits| limits.context_tokens)
+        .and_then(|tokens| u32::try_from(tokens).ok())
+        .filter(|tokens| *tokens > 0)
+        .unwrap_or_else(|| provider_capability(provider, model).context_window)
+}
+
+/// Provider/offering output cap, when the resolved route reports one.
+#[must_use]
+pub(crate) fn route_output_limit_tokens(route_limits: Option<RouteLimits>) -> Option<u32> {
+    route_limits
+        .and_then(|limits| limits.output_tokens)
+        .and_then(|tokens| u32::try_from(tokens).ok())
+        .filter(|tokens| *tokens > 0)
+}
+
+#[must_use]
+pub(crate) fn route_context_budget(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
+    input_tokens: usize,
+    configured_output_cap: u32,
+) -> Option<ContextBudget> {
+    let window = route_context_window_tokens(provider, model, route_limits);
+    Some(ContextBudget::new(
+        u64::from(window),
+        u64::try_from(input_tokens).ok()?,
+        u64::from(configured_output_cap),
+    ))
+}
+
+#[must_use]
+pub(crate) fn compaction_threshold_for_route_at_percent(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
+    percent: f64,
+) -> usize {
+    if route_limits
+        .and_then(|limits| limits.context_tokens)
+        .is_some()
+    {
+        let window = route_context_window_tokens(provider, model, route_limits);
+        let percent = percent.clamp(10.0, 100.0);
+        let threshold = (f64::from(window) * percent / 100.0).round();
+        let threshold = if threshold.is_finite() && threshold > 0.0 {
+            threshold as u64
+        } else {
+            return DEFAULT_COMPACTION_TOKEN_THRESHOLD;
+        };
+        return usize::try_from(threshold).unwrap_or(DEFAULT_COMPACTION_TOKEN_THRESHOLD);
+    }
+
+    compaction_threshold_for_model_at_percent(model, percent)
+}
+
+#[must_use]
+pub(crate) fn auto_compact_default_for_route(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
+) -> bool {
+    if route_limits
+        .and_then(|limits| limits.context_tokens)
+        .is_some()
+    {
+        return route_context_window_tokens(provider, model, route_limits)
+            <= DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS;
+    }
+
+    crate::models::auto_compact_default_for_model(model)
+}

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2407,6 +2407,7 @@ impl RuntimeThreadManager {
             .clamp(1, MAX_SUBAGENTS);
         let engine_cfg = EngineConfig {
             model: thread.model.clone(),
+            active_route_limits: None,
             workspace: thread.workspace.clone(),
             allow_shell: thread.allow_shell,
             trust_mode: thread.trust_mode,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-use codewhale_config::ProviderChain;
+use codewhale_config::{ProviderChain, route::RouteLimits};
 
 use crate::artifacts::ArtifactRecord;
 use crate::client::{CacheWarmupKey, PromptInspection};
@@ -1430,6 +1430,7 @@ pub(crate) struct PendingProviderSwitch {
     pub previous_provider: ApiProvider,
     pub previous_model: String,
     pub previous_model_ids_passthrough: bool,
+    pub previous_route_limits: Option<RouteLimits>,
     pub previous_config: Config,
     pub previous_onboarding: OnboardingState,
     pub previous_onboarding_needs_api_key: bool,
@@ -1515,6 +1516,8 @@ pub struct App {
     /// True when the active provider/base URL accepts arbitrary model IDs
     /// verbatim rather than DeepSeek-only aliases.
     pub model_ids_passthrough: bool,
+    /// Resolved provider/model route limits for the active runtime route.
+    pub active_route_limits: Option<RouteLimits>,
     /// Pending provider transition for transactional rollback when the next
     /// auth failure indicates the new provider cannot be used.
     pub pending_provider_switch: Option<PendingProviderSwitch>,
@@ -2425,6 +2428,7 @@ impl App {
             provider_chain,
             last_fallback_reason: None,
             model_ids_passthrough,
+            active_route_limits: None,
             pending_provider_switch: None,
             reasoning_effort,
             last_effective_reasoning_effort: None,
@@ -5415,11 +5419,23 @@ impl App {
 
     pub fn update_model_compaction_budget(&mut self) {
         let model = self.effective_model_for_budget().to_string();
-        self.compact_threshold =
-            compaction_threshold_for_model_at_percent(&model, self.auto_compact_threshold_percent);
+        self.compact_threshold = crate::route_budget::compaction_threshold_for_route_at_percent(
+            self.api_provider,
+            &model,
+            self.active_route_limits,
+            self.auto_compact_threshold_percent,
+        );
         if !self.auto_compact_user_configured {
-            self.auto_compact = auto_compact_default_for_model(&model);
+            self.auto_compact = crate::route_budget::auto_compact_default_for_route(
+                self.api_provider,
+                &model,
+                self.active_route_limits,
+            );
         }
+    }
+
+    pub fn set_active_route_limits(&mut self, limits: RouteLimits) {
+        self.active_route_limits = crate::route_budget::known_route_limits(limits);
     }
 
     pub fn set_model_selection(&mut self, model: String) {

--- a/crates/tui/src/tui/context_inspector.rs
+++ b/crates/tui/src/tui/context_inspector.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use crate::compaction::estimate_input_tokens_conservative;
-use crate::config::provider_capability;
 use crate::localization::{Locale, MessageId, tr};
 use crate::models::SystemPrompt;
 use crate::session_manager::SessionContextReference;
@@ -154,8 +153,11 @@ pub fn build_context_inspector_text(app: &App, locale: Locale) -> String {
 }
 
 fn context_usage(app: &App) -> (usize, u32, f64) {
-    let max =
-        provider_capability(app.api_provider, app.effective_model_for_budget()).context_window;
+    let max = crate::route_budget::route_context_window_tokens(
+        app.api_provider,
+        app.effective_model_for_budget(),
+        app.active_route_limits,
+    );
     let estimated =
         estimate_input_tokens_conservative(&app.api_messages, app.system_prompt.as_ref());
     let total_chars = estimate_message_chars(&app.api_messages);

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -31,7 +31,6 @@ use super::app::{
 use super::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus, summarize_tool_output};
 use super::subagent_routing::active_fanout_counts;
 use super::ui_text::{concise_shell_command_label, truncate_line_to_width};
-use crate::config::provider_capability;
 
 /// Tolerance for floating-point cost comparison in the sidebar breakdown.
 /// Must be large enough that accumulated f64 error across hundreds of turns
@@ -2775,7 +2774,11 @@ fn render_context_panel(f: &mut Frame, area: Rect, app: &mut App) {
 
     // ── Token usage ──────────────────────────────────────────────
     let total_tokens = app.session.total_conversation_tokens;
-    let window = provider_capability(app.api_provider, &app.model).context_window;
+    let window = crate::route_budget::route_context_window_tokens(
+        app.api_provider,
+        app.effective_model_for_budget(),
+        app.active_route_limits,
+    );
     let pct = if window > 0 {
         ((total_tokens as f64 / window as f64) * 100.0).clamp(0.0, 100.0)
     } else {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1117,6 +1117,7 @@ fn build_engine_config(app: &App, config: &Config) -> EngineConfig {
     let max_subagents = app.max_subagents.clamp(1, crate::config::MAX_SUBAGENTS);
     EngineConfig {
         model: app.model.clone(),
+        active_route_limits: app.active_route_limits,
         workspace: app.workspace.clone(),
         allow_shell: app.allow_shell,
         trust_mode: app.trust_mode,
@@ -4398,6 +4399,7 @@ async fn run_event_loop(
                             .send(Op::SetModel {
                                 model: app.model.clone(),
                                 mode: app.mode,
+                                route_limits: app.active_route_limits,
                             })
                             .await;
                     }
@@ -5502,6 +5504,7 @@ fn rollback_provider_after_auth_failure(app: &mut App, config: &mut Config) -> O
         previous_provider,
         previous_model,
         previous_model_ids_passthrough,
+        previous_route_limits,
         previous_config,
         previous_onboarding,
         previous_onboarding_needs_api_key,
@@ -5514,6 +5517,7 @@ fn rollback_provider_after_auth_failure(app: &mut App, config: &mut Config) -> O
     app.provider_models
         .insert(previous_provider.as_str().to_string(), previous_model);
     app.model_ids_passthrough = previous_model_ids_passthrough;
+    app.active_route_limits = previous_route_limits;
     app.update_model_compaction_budget();
     app.clear_model_scoped_telemetry();
     app.offline_mode = false;
@@ -6380,11 +6384,13 @@ async fn apply_model_and_compaction_update(
     engine_handle: &EngineHandle,
     compaction: crate::compaction::CompactionConfig,
     mode: AppMode,
+    route_limits: Option<codewhale_config::route::RouteLimits>,
 ) {
     let _ = engine_handle
         .send(Op::SetModel {
             model: compaction.model.clone(),
             mode,
+            route_limits,
         })
         .await;
     let _ = engine_handle
@@ -6413,6 +6419,7 @@ async fn drain_web_config_events(
                                 engine_handle,
                                 app.compaction_config(),
                                 app.mode,
+                                app.active_route_limits,
                             )
                             .await;
                         }
@@ -6438,6 +6445,7 @@ async fn drain_web_config_events(
                                 engine_handle,
                                 app.compaction_config(),
                                 app.mode,
+                                app.active_route_limits,
                             )
                             .await;
                         }
@@ -6532,12 +6540,15 @@ async fn apply_model_picker_choice(
         ) {
             Ok(candidate) => {
                 resolved_model = candidate.wire_model_id.as_str().to_string();
+                app.set_active_route_limits(candidate.limits);
             }
             Err(reason) => {
                 app.status_message = Some(reason);
                 return;
             }
         }
+    } else if model_changed && model_is_auto {
+        app.active_route_limits = None;
     }
 
     if model_changed {
@@ -6583,7 +6594,13 @@ async fn apply_model_picker_choice(
     }
 
     if model_changed {
-        apply_model_and_compaction_update(engine_handle, app.compaction_config(), app.mode).await;
+        apply_model_and_compaction_update(
+            engine_handle,
+            app.compaction_config(),
+            app.mode,
+            app.active_route_limits,
+        )
+        .await;
     }
 
     let model_summary = if model_is_auto {
@@ -6645,7 +6662,13 @@ async fn apply_picker_effort_choice(
     .err()
     .map(|err| format!(" (not persisted: {err})"));
 
-    apply_model_and_compaction_update(engine_handle, app.compaction_config(), app.mode).await;
+    apply_model_and_compaction_update(
+        engine_handle,
+        app.compaction_config(),
+        app.mode,
+        app.active_route_limits,
+    )
+    .await;
 
     let mut summary = format!(
         "Thinking: {} → {} · model {}",
@@ -6678,6 +6701,7 @@ async fn switch_provider(
         previous_provider,
         previous_model: previous_model.clone(),
         previous_model_ids_passthrough,
+        previous_route_limits: app.active_route_limits,
         previous_config: previous_config.clone(),
         previous_onboarding: app.onboarding,
         previous_onboarding_needs_api_key: app.onboarding_needs_api_key,
@@ -6734,6 +6758,7 @@ async fn switch_provider(
     app.model_ids_passthrough = config.model_ids_pass_through();
     app.reasoning_effort = app.reasoning_effort.normalize_for_provider(target);
     app.set_model_selection(new_model.clone());
+    app.set_active_route_limits(resolved_route.candidate.limits);
     if model_override.is_some() {
         app.provider_models
             .insert(target.as_str().to_string(), new_model.clone());
@@ -6864,6 +6889,7 @@ async fn apply_provider_fallback_switch(
     app.model_ids_passthrough = config.model_ids_pass_through();
     app.reasoning_effort = app.reasoning_effort.normalize_for_provider(target);
     app.set_model_selection(new_model.clone());
+    app.set_active_route_limits(resolved_route.candidate.limits);
     app.update_model_compaction_budget();
     if cache_scope_changed {
         app.clear_model_scoped_telemetry();
@@ -7153,7 +7179,13 @@ async fn apply_command_result(
                 }
             }
             AppAction::UpdateCompaction(compaction) => {
-                apply_model_and_compaction_update(engine_handle, compaction, app.mode).await;
+                apply_model_and_compaction_update(
+                    engine_handle,
+                    compaction,
+                    app.mode,
+                    app.active_route_limits,
+                )
+                .await;
             }
             AppAction::UpdateStreamChunkTimeout(timeout_secs) => {
                 let _ = engine_handle
@@ -7208,6 +7240,7 @@ async fn apply_command_result(
                                     engine_handle,
                                     app.compaction_config(),
                                     app.mode,
+                                    app.active_route_limits,
                                 )
                                 .await;
                             }
@@ -7411,6 +7444,7 @@ async fn apply_command_result(
                         app.api_provider = config.api_provider();
                         let new_model = config.default_model();
                         app.set_model_selection(new_model.clone());
+                        app.active_route_limits = None;
                         app.update_model_compaction_budget();
                         app.session.last_prompt_tokens = None;
                         app.session.last_completion_tokens = None;
@@ -8894,8 +8928,13 @@ async fn handle_view_events(
                 if let Some(action) = result.action {
                     match action {
                         AppAction::UpdateCompaction(compaction) => {
-                            apply_model_and_compaction_update(engine_handle, compaction, app.mode)
-                                .await;
+                            apply_model_and_compaction_update(
+                                engine_handle,
+                                compaction,
+                                app.mode,
+                                app.active_route_limits,
+                            )
+                            .await;
                         }
                         AppAction::UpdateStreamChunkTimeout(timeout_secs) => {
                             let _ = engine_handle
@@ -10147,8 +10186,11 @@ fn estimated_context_tokens(app: &App) -> Option<i64> {
 }
 
 pub(crate) fn context_usage_snapshot(app: &App) -> Option<(i64, u32, f64)> {
-    let max =
-        provider_capability(app.api_provider, app.effective_model_for_budget()).context_window;
+    let max = crate::route_budget::route_context_window_tokens(
+        app.api_provider,
+        app.effective_model_for_budget(),
+        app.active_route_limits,
+    );
     let max_i64 = i64::from(max);
     let reported = app
         .session

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2506,10 +2506,20 @@ async fn model_change_update_syncs_engine_model_before_compaction() {
     let compaction = app.compaction_config();
     let mut engine = crate::core::engine::mock_engine_handle();
 
-    apply_model_and_compaction_update(&engine.handle, compaction, app.mode).await;
+    apply_model_and_compaction_update(
+        &engine.handle,
+        compaction,
+        app.mode,
+        app.active_route_limits,
+    )
+    .await;
 
     match engine.rx_op.recv().await.expect("set model op") {
-        crate::core::ops::Op::SetModel { model, mode } => {
+        crate::core::ops::Op::SetModel {
+            model,
+            mode,
+            route_limits: _,
+        } => {
             assert_eq!(model, "deepseek-v4-flash");
             assert_eq!(mode, app.mode);
         }


### PR DESCRIPTION
## Summary
- Adds a `route_budget` adapter so resolved `RouteLimits` can drive context windows, output caps, compaction thresholds, prompt facts, and visible pressure readouts.
- Threads active route limits through `App`, `EngineConfig`, `SetModel`, provider switches, fallback switches, and `/model` changes.
- Keeps provider/model fallback behavior for startup, unknown, custom, and local routes where the resolver has no concrete offering limits yet.

Refs #3086.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked context_budget -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked route_context_budget -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked effective_max_output_tokens_for_route -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked context_usage_snapshot -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked model_change_update_syncs_engine_model_before_compaction -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked commands::groups::core::core -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked route_runtime -- --nocapture`
