### PR TITLE
fix(tui): make MCP connection drops explicit

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1949,6 +1949,31 @@ impl McpPool {
         self
     }
 
+    fn drop_connection(&mut self, server_name: &str, reason: &str) {
+        if self.connections.remove(server_name).is_some() {
+            tracing::debug!(
+                target: "mcp",
+                server = %server_name,
+                reason = %reason,
+                "dropped MCP connection"
+            );
+        }
+    }
+
+    fn drop_all_connections(&mut self, reason: &str) {
+        if self.connections.is_empty() {
+            return;
+        }
+        let count = self.connections.len();
+        tracing::debug!(
+            target: "mcp",
+            count,
+            reason = %reason,
+            "dropping MCP connections"
+        );
+        self.connections.clear();
+    }
+
     /// If the source config file's mtime has changed since the last check,
     /// re-read it and (only when the content hash also changed) drop all
     /// existing connections so the next `get_or_connect` reattaches under
@@ -1993,7 +2018,7 @@ impl McpPool {
         }
         // Real content change — drop all live connections so the next
         // get_or_connect picks up the new config (sandbox flags, env, args).
-        self.connections.clear();
+        self.drop_all_connections("config reload");
         self.config = new_config;
         self.config_hash = new_hash;
         Ok(true)
@@ -2020,7 +2045,7 @@ impl McpPool {
                 .ok_or_else(|| anyhow::anyhow!("MCP connection disappeared for {server_name}"));
         }
 
-        self.connections.remove(server_name);
+        self.drop_connection(server_name, "reconnect");
 
         let server_config = self
             .config
@@ -2491,7 +2516,7 @@ impl McpPool {
                     error = %err,
                     "retrying MCP tool call after stale session"
                 );
-                self.connections.remove(server_name);
+                self.drop_connection(server_name, "stale session retry");
                 let conn = self.get_or_connect(server_name).await?;
                 if !conn.config().is_tool_enabled(tool_name) {
                     anyhow::bail!("MCP tool '{tool_name}' is disabled for server '{server_name}'");
@@ -2525,7 +2550,7 @@ impl McpPool {
     /// Disconnect all connections
     #[allow(dead_code)] // Public API for MCP lifecycle management
     pub fn disconnect_all(&mut self) {
-        self.connections.clear();
+        self.drop_all_connections("disconnect all");
     }
 
     /// Graceful shutdown of every connection in the pool: send SIGTERM to

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -2,7 +2,7 @@ use super::headers::{MCP_HTTP_ACCEPT, is_safe_custom_header, with_default_mcp_ht
 use super::*;
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 fn test_http_client() -> reqwest::Client {
@@ -927,6 +927,27 @@ impl McpTransport for HangingValueTransport {
     }
 }
 
+struct DropCountingTransport {
+    drops: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl McpTransport for DropCountingTransport {
+    async fn send(&mut self, _msg: Vec<u8>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> Result<Vec<u8>> {
+        std::future::pending().await
+    }
+}
+
+impl Drop for DropCountingTransport {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, AtomicOrdering::SeqCst);
+    }
+}
+
 fn test_server_config() -> McpServerConfig {
     McpServerConfig {
         command: Some("mock".to_string()),
@@ -1128,6 +1149,48 @@ async fn reload_if_config_changed_swaps_config_on_content_change() {
     assert!(
         names.contains(&"new"),
         "expected new server in pool after reload, got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn reload_if_config_changed_drops_live_connections() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mcp.json");
+    std::fs::write(
+        &path,
+        r#"{"servers":{"local":{"command":"node","args":["server.js"]}}}"#,
+    )
+    .unwrap();
+    let mut pool = McpPool::from_config_path(&path).unwrap();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut conn = test_connection(Box::new(DropCountingTransport {
+        drops: Arc::clone(&drops),
+    }));
+    conn.name = "local".to_string();
+    conn.config = pool.config.servers.get("local").unwrap().clone();
+    pool.connections.insert("local".to_string(), conn);
+
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::fs::write(
+        &path,
+        r#"{"servers":{"local":{"command":"node","args":["server-v2.js"]}}}"#,
+    )
+    .unwrap();
+
+    let reloaded = pool.reload_if_config_changed().await.unwrap();
+    assert!(reloaded, "content-changed config must trigger reload");
+    assert_eq!(
+        drops.load(AtomicOrdering::SeqCst),
+        1,
+        "reload must drop the stale live transport"
+    );
+    assert!(
+        !pool.connections.contains_key("local"),
+        "stale connection must not survive config reload"
+    );
+    assert_eq!(
+        pool.config.servers.get("local").unwrap().args,
+        vec!["server-v2.js".to_string()]
     );
 }
 


### PR DESCRIPTION
Refs #3461

## Summary
- centralize MCP connection removal through lifecycle helpers that log why stale connections are dropped
- use the helpers for config reloads, reconnects, stale-session retries, and disconnect_all
- add a reload regression test that asserts live transports are dropped when config content changes

## Verification
- cargo test -p codewhale-tui --bin codewhale-tui --locked reload_if_config_changed
- cargo fmt --check
- git diff --check