### PR TITLE
feat(tui): remote MCP OAuth login with bearer/header auth precedence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
  "codewhale-protocol",
  "codewhale-state",
  "codewhale-tools",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
  "codewhale-state",
  "dirs",
  "libc",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -894,7 +894,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "codewhale-protocol",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -924,7 +924,7 @@ name = "codewhale-release"
 version = "0.8.64"
 dependencies = [
  "anyhow",
- "reqwest",
+ "reqwest 0.13.4",
  "semver",
  "serde",
  "serde_json",
@@ -1001,6 +1001,7 @@ dependencies = [
  "libc",
  "lru 0.18.0",
  "multimap",
+ "oauth2",
  "objc2",
  "objc2-foundation",
  "parking_lot",
@@ -1010,7 +1011,8 @@ dependencies = [
  "qrcode",
  "ratatui",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
+ "rmcp",
  "rustls",
  "schemars",
  "schemaui",
@@ -1033,9 +1035,11 @@ dependencies = [
  "tracing-subscriber",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+ "urlencoding",
  "uuid",
  "vt100",
  "wait-timeout",
+ "webbrowser",
  "windows",
  "wiremock",
 ]
@@ -2146,8 +2150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2418,6 +2424,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2765,7 +2772,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2773,10 +2780,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
@@ -3058,6 +3114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3271,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -3402,6 +3470,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.16",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -3911,6 +3999,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,6 +4342,44 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4255,6 +4436,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "oauth2",
+ "pin-project-lite",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,6 +4470,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4335,6 +4544,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4346,7 +4556,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -4814,6 +5024,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -5405,6 +5631,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5755,6 +5992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5976,10 +6219,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -40,9 +40,11 @@ dotenvy = "0.15.7"
 dirs = "6.0.0"
 fd-lock = "4.0.4"
 futures-util = "0.3.31"
+oauth2 = "5"
 ratatui = "0.30"
 regex = "1.11"
 reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "json", "stream", "multipart", "form", "rustls-no-provider", "http2", "gzip", "brotli"] }
+rmcp = { version = "1.7.0", default-features = false, features = ["auth", "client"] }
 rustls.workspace = true
 qrcode = { version = "0.14", default-features = false }
 similar = "3"
@@ -55,6 +57,7 @@ tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = { version = "0.7.16", features = ["io"] }
 unicode-width = "0.2"
 unicode-segmentation = "1.12"
+urlencoding = "2.1"
 uuid = { version = "1.11", features = ["v4"] }
 chrono.workspace = true
 tempfile.workspace = true
@@ -63,6 +66,7 @@ tracing = "0.1"
 tracing-subscriber = { workspace = true }
 tower-http = { version = "0.6", features = ["cors"] }
 wait-timeout = "0.2"
+webbrowser = "1.0"
 multimap = "0.10.0"
 shlex = "1.3.0"
 tiny_http = "0.12"

--- a/crates/tui/src/commands/groups/utility/mcp.rs
+++ b/crates/tui/src/commands/groups/utility/mcp.rs
@@ -29,10 +29,21 @@ pub fn mcp(_app: &mut App, args: Option<&str>) -> CommandResult {
             Ok(name) => CommandResult::action(AppAction::Mcp(McpUiAction::Remove { name })),
             Err(msg) => CommandResult::error(msg),
         },
+        "login" => match parse_name(parts.next(), "Usage: /mcp login <name> [--scope scope]") {
+            Ok(name) => CommandResult::action(AppAction::Mcp(McpUiAction::Login {
+                name,
+                scopes: parse_scopes(parts.collect()),
+            })),
+            Err(msg) => CommandResult::error(msg),
+        },
+        "logout" => match parse_name(parts.next(), "Usage: /mcp logout <name>") {
+            Ok(name) => CommandResult::action(AppAction::Mcp(McpUiAction::Logout { name })),
+            Err(msg) => CommandResult::error(msg),
+        },
         "validate" => CommandResult::action(AppAction::Mcp(McpUiAction::Validate)),
         "reload" | "reconnect" => CommandResult::action(AppAction::Mcp(McpUiAction::Reload)),
         _ => CommandResult::error(
-            "Usage: /mcp [init|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|validate|reload]",
+            "Usage: /mcp [init|add stdio <name> <command> [args...]|add http <name> <url>|enable <name>|disable <name>|remove <name>|login <name>|logout <name>|validate|reload]",
         ),
     }
 }
@@ -70,6 +81,42 @@ fn parse_add(parts: Vec<&str>) -> CommandResult {
             "Usage: /mcp add stdio <name> <command> [args...] OR /mcp add http <name> <url>",
         ),
     }
+}
+
+fn parse_scopes(parts: Vec<&str>) -> Vec<String> {
+    let mut scopes = Vec::new();
+    let mut iter = parts.into_iter();
+    while let Some(part) = iter.next() {
+        if part == "--scope" {
+            let Some(value) = iter.next() else {
+                continue;
+            };
+            for scope in value.split(',') {
+                let scope = scope.trim();
+                if !scope.is_empty() {
+                    scopes.push(scope.to_string());
+                }
+            }
+            continue;
+        }
+        let value = part.strip_prefix("--scope=");
+        let Some(value) = value else {
+            for scope in part.split(',') {
+                let scope = scope.trim();
+                if !scope.is_empty() {
+                    scopes.push(scope.to_string());
+                }
+            }
+            continue;
+        };
+        for scope in value.split(',') {
+            let scope = scope.trim();
+            if !scope.is_empty() {
+                scopes.push(scope.to_string());
+            }
+        }
+    }
+    scopes
 }
 
 #[cfg(test)]
@@ -120,6 +167,17 @@ mod tests {
         assert!(matches!(
             validate.action,
             Some(AppAction::Mcp(McpUiAction::Validate))
+        ));
+
+        let login = mcp(
+            &mut app,
+            Some("login remote --scope tools/read,tools/write"),
+        );
+        assert!(matches!(
+            login.action,
+            Some(AppAction::Mcp(McpUiAction::Login { name, scopes }))
+                if name == "remote"
+                    && scopes == vec!["tools/read".to_string(), "tools/write".to_string()]
         ));
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2091,6 +2091,8 @@ pub struct Config {
     pub tools: Option<ToolsConfig>,
     pub skills_dir: Option<String>,
     pub mcp_config_path: Option<String>,
+    pub mcp_oauth_callback_port: Option<u16>,
+    pub mcp_oauth_callback_url: Option<String>,
     pub notes_path: Option<String>,
     pub memory_path: Option<String>,
     /// When true, set `tool_choice: "required"` and opt compatible function
@@ -5533,6 +5535,12 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         tools: override_cfg.tools.or(base.tools),
         skills_dir: override_cfg.skills_dir.or(base.skills_dir),
         mcp_config_path: override_cfg.mcp_config_path.or(base.mcp_config_path),
+        mcp_oauth_callback_port: override_cfg
+            .mcp_oauth_callback_port
+            .or(base.mcp_oauth_callback_port),
+        mcp_oauth_callback_url: override_cfg
+            .mcp_oauth_callback_url
+            .or(base.mcp_oauth_callback_url),
         notes_path: override_cfg.notes_path.or(base.notes_path),
         memory_path: override_cfg.memory_path.or(base.memory_path),
         vision_model: override_cfg.vision_model.or(base.vision_model),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -107,7 +107,7 @@ use crate::config::{Config, DEFAULT_TEXT_MODEL, MAX_SUBAGENTS, effective_home_di
 use crate::eval::{EvalHarness, EvalHarnessConfig, ScenarioStepKind};
 use crate::features::{Feature, render_feature_table};
 use crate::llm_client::LlmClient;
-use crate::mcp::{McpConfig, McpPool, McpServerConfig};
+use crate::mcp::{McpConfig, McpPool, McpServerConfig, McpServerOAuthConfig};
 use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt};
 use crate::session_manager::{SessionManager, create_saved_session, truncate_id};
 use crate::tui::history::{summarize_tool_args, summarize_tool_output};
@@ -878,9 +878,34 @@ enum McpCommand {
         /// Explicit URL transport override. Use "sse" for legacy SSE endpoints.
         #[arg(long, requires = "url")]
         transport: Option<String>,
+        /// Environment variable containing a bearer token for URL-based servers
+        #[arg(long, requires = "url")]
+        bearer_token_env_var: Option<String>,
+        /// OAuth client ID for servers that do not support dynamic registration
+        #[arg(long, requires = "url")]
+        oauth_client_id: Option<String>,
+        /// OAuth resource parameter to append to the authorization URL
+        #[arg(long, requires = "url")]
+        oauth_resource: Option<String>,
+        /// OAuth scope to request during login. Repeat or comma-separate.
+        #[arg(long = "scope", requires = "url", value_delimiter = ',')]
+        scopes: Vec<String>,
         /// Arguments for command-based servers
         #[arg(long = "arg")]
         args: Vec<String>,
+    },
+    /// Authenticate to a URL-based MCP server using OAuth
+    Login {
+        /// Server name
+        name: String,
+        /// OAuth scope to request. Repeat or comma-separate; defaults to config/discovery.
+        #[arg(long = "scope", value_delimiter = ',')]
+        scopes: Vec<String>,
+    },
+    /// Delete stored OAuth credentials for a URL-based MCP server
+    Logout {
+        /// Server name
+        name: String,
     },
     /// Remove an MCP server entry
     Remove {
@@ -1786,6 +1811,11 @@ fn mcp_template_json() -> Result<String> {
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: std::collections::HashMap::new(),
+            env_headers: std::collections::HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         },
     );
     serde_json::to_string_pretty(&cfg)
@@ -4954,6 +4984,18 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
                 } else {
                     "disabled"
                 };
+                let auth_status = crate::mcp::oauth::auth_status_for_server(&name, &server).await;
+                let auth = if auth_status == crate::mcp::oauth::McpAuthStatus::Unsupported {
+                    String::new()
+                } else {
+                    format!(
+                        " auth={}",
+                        auth_status
+                            .to_string()
+                            .to_ascii_lowercase()
+                            .replace(' ', "-")
+                    )
+                };
                 let args = if server.args.is_empty() {
                     "".to_string()
                 } else {
@@ -4967,7 +5009,7 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
                     "unknown".to_string()
                 };
                 let required = if server.required { " required" } else { "" };
-                println!("  - {name} [{status}{required}] {cmd_str}");
+                println!("  - {name} [{status}{required}{auth}] {cmd_str}");
             }
             Ok(())
         }
@@ -5031,6 +5073,10 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
             command,
             url,
             transport,
+            bearer_token_env_var,
+            oauth_client_id,
+            oauth_resource,
+            scopes,
             args,
         } => {
             if command.is_none() && url.is_none() {
@@ -5041,29 +5087,84 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
             {
                 bail!("Unsupported MCP transport '{transport}'. Supported values: sse");
             }
+            let added_server = McpServerConfig {
+                command,
+                args,
+                env: std::collections::HashMap::new(),
+                cwd: None,
+                url,
+                transport,
+                connect_timeout: None,
+                execute_timeout: None,
+                read_timeout: None,
+                disabled: false,
+                enabled: true,
+                required: false,
+                enabled_tools: Vec::new(),
+                disabled_tools: Vec::new(),
+                headers: std::collections::HashMap::new(),
+                env_headers: std::collections::HashMap::new(),
+                bearer_token_env_var,
+                scopes,
+                oauth: oauth_client_id.map(|client_id| McpServerOAuthConfig {
+                    client_id: Some(client_id),
+                }),
+                oauth_resource,
+            };
+            let can_suggest_oauth = added_server.url.is_some()
+                && added_server.bearer_token_env_var.is_none()
+                && added_server
+                    .headers
+                    .keys()
+                    .all(|key| !key.trim().eq_ignore_ascii_case("authorization"))
+                && added_server
+                    .env_headers
+                    .keys()
+                    .all(|key| !key.trim().eq_ignore_ascii_case("authorization"));
             let mut cfg = load_mcp_config(&config_path)?;
-            cfg.servers.insert(
-                name.clone(),
-                McpServerConfig {
-                    command,
-                    args,
-                    env: std::collections::HashMap::new(),
-                    cwd: None,
-                    url,
-                    transport,
-                    connect_timeout: None,
-                    execute_timeout: None,
-                    read_timeout: None,
-                    disabled: false,
-                    enabled: true,
-                    required: false,
-                    enabled_tools: Vec::new(),
-                    disabled_tools: Vec::new(),
-                    headers: std::collections::HashMap::new(),
-                },
-            );
+            cfg.servers.insert(name.clone(), added_server.clone());
             save_mcp_config(&config_path, &cfg)?;
             println!("Added MCP server '{name}' in {}", config_path.display());
+            if can_suggest_oauth
+                && crate::mcp::oauth::oauth_login_support(&added_server)
+                    .await
+                    .is_ok_and(|support| support.is_some())
+            {
+                println!(
+                    "OAuth is available for '{name}'. Run `codewhale mcp login {name}` to authenticate."
+                );
+            }
+            Ok(())
+        }
+        McpCommand::Login { name, scopes } => {
+            let cfg = crate::mcp::load_config_with_workspace(&config_path, workspace)?;
+            let server = cfg
+                .servers
+                .get(&name)
+                .ok_or_else(|| anyhow!("MCP server '{name}' not found"))?;
+            let explicit_scopes = (!scopes.is_empty()).then_some(scopes);
+            crate::mcp::oauth::perform_oauth_login_for_server(
+                &name,
+                server,
+                explicit_scopes,
+                config.mcp_oauth_callback_port,
+                config.mcp_oauth_callback_url.as_deref(),
+            )
+            .await?;
+            println!("Stored OAuth credentials for MCP server '{name}'.");
+            Ok(())
+        }
+        McpCommand::Logout { name } => {
+            let cfg = crate::mcp::load_config_with_workspace(&config_path, workspace)?;
+            let server = cfg
+                .servers
+                .get(&name)
+                .ok_or_else(|| anyhow!("MCP server '{name}' not found"))?;
+            if crate::mcp::oauth::delete_oauth_tokens_for_server(&name, server)? {
+                println!("Deleted stored OAuth credentials for MCP server '{name}'.");
+            } else {
+                println!("No stored OAuth credentials found for MCP server '{name}'.");
+            }
             Ok(())
         }
         McpCommand::Remove { name } => {
@@ -5148,6 +5249,11 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
                     enabled_tools: Vec::new(),
                     disabled_tools: Vec::new(),
                     headers: std::collections::HashMap::new(),
+                    env_headers: std::collections::HashMap::new(),
+                    bearer_token_env_var: None,
+                    scopes: Vec::new(),
+                    oauth: None,
+                    oauth_resource: None,
                 },
             );
             save_mcp_config(&config_path, &cfg)?;
@@ -5627,13 +5733,22 @@ fn merge_project_config(config: &mut Config, workspace: &Path) {
     //   target host with project-controlled values.
     // * `mcp_config_path` — point the loader at an MCP config that
     //   spawns arbitrary stdio servers under the user's identity.
+    // * `mcp_oauth_callback_*` — choose local OAuth redirect listener
+    //   behavior for user-owned MCP credentials.
     //
     // The overlay path is non-interactive; users can't visually
     // confirm a rogue project config is hijacking these. We surface
     // a stderr warning on first encounter so a user who *did* expect
     // the override has a chance to notice the deny instead of silent
     // discard.
-    const DENY_AT_PROJECT_SCOPE: &[&str] = &["api_key", "base_url", "provider", "mcp_config_path"];
+    const DENY_AT_PROJECT_SCOPE: &[&str] = &[
+        "api_key",
+        "base_url",
+        "provider",
+        "mcp_config_path",
+        "mcp_oauth_callback_port",
+        "mcp_oauth_callback_url",
+    ];
     for key in DENY_AT_PROJECT_SCOPE {
         if table.contains_key(*key) {
             eprintln!(
@@ -7970,19 +8085,24 @@ model = "deepseek-ai/deepseek-v4-pro"
     #[test]
     fn project_overlay_denies_dangerous_credentials_and_redirects() {
         // #417: `api_key` / `base_url` / `provider` / `mcp_config_path`
-        // are all on the deny-list. A malicious project must not be
-        // able to redirect prompts or hijack MCP servers via these.
+        // and MCP OAuth callback settings are all on the deny-list. A
+        // malicious project must not be able to redirect prompts, hijack MCP
+        // servers, or influence OAuth callback behavior via these.
         let tmp = workspace_with_project_config(
             r#"
 api_key = "ATTACKER_KEY"
 base_url = "https://evil.example.com"
 provider = "nvidia-nim"
 mcp_config_path = "/tmp/attacker-mcp.json"
+mcp_oauth_callback_port = 9999
+mcp_oauth_callback_url = "http://evil.example.com/callback"
 "#,
         );
         let mut config = Config {
             api_key: Some("USER_KEY".to_string()),
             base_url: Some("https://api.deepseek.com".to_string()),
+            mcp_oauth_callback_port: Some(1455),
+            mcp_oauth_callback_url: Some("http://127.0.0.1:1455/callback".to_string()),
             ..Config::default()
         };
         merge_project_config(&mut config, tmp.path());
@@ -8003,6 +8123,16 @@ mcp_config_path = "/tmp/attacker-mcp.json"
         assert_eq!(
             config.mcp_config_path, None,
             "project-scope mcp_config_path must be denied"
+        );
+        assert_eq!(
+            config.mcp_oauth_callback_port,
+            Some(1455),
+            "project-scope mcp_oauth_callback_port must be denied"
+        );
+        assert_eq!(
+            config.mcp_oauth_callback_url.as_deref(),
+            Some("http://127.0.0.1:1455/callback"),
+            "project-scope mcp_oauth_callback_url must be denied"
         );
     }
 
@@ -8443,6 +8573,11 @@ mod doctor_mcp_tests {
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: std::collections::HashMap::new(),
+            env_headers: std::collections::HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         }
     }
 

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -22,6 +22,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio::sync::Mutex as TokioMutex;
 
 mod headers;
+pub mod oauth;
 
 use self::headers::{apply_safe_custom_headers, with_default_mcp_http_headers};
 use crate::child_env;
@@ -260,6 +261,36 @@ pub struct McpServerConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub headers: HashMap<String, String>,
+    /// HTTP headers whose values are read from environment variables at request
+    /// time. This keeps common bearer/API-token integrations out of mcp.json.
+    #[serde(default, alias = "env_http_headers")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub env_headers: HashMap<String, String>,
+    /// Environment variable containing a bearer token. When present and set,
+    /// CodeWhale sends `Authorization: Bearer <value>` for URL-based servers.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bearer_token_env_var: Option<String>,
+    /// OAuth scopes requested during `codewhale mcp login`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    /// OAuth client override for MCP servers that require a pre-registered
+    /// public client instead of dynamic registration.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<McpServerOAuthConfig>,
+    /// Optional RFC 8707 resource parameter appended to the authorization URL.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth_resource: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct McpServerOAuthConfig {
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
 }
 
 fn default_enabled() -> bool {
@@ -527,7 +558,7 @@ impl Drop for StdioTransport {
 pub struct SseTransport {
     client: reqwest::Client,
     base_url: String,
-    headers: HashMap<String, String>,
+    auth: McpHttpAuth,
     endpoint_url: Option<String>,
     receiver: tokio::sync::mpsc::UnboundedReceiver<SseInbound>,
     pending_messages: VecDeque<Vec<u8>>,
@@ -544,7 +575,7 @@ struct HttpTransport {
     mode: HttpTransportMode,
     client: reqwest::Client,
     base_url: String,
-    headers: HashMap<String, String>,
+    auth: McpHttpAuth,
     cancel_token: tokio_util::sync::CancellationToken,
     endpoint_timeout: Duration,
 }
@@ -557,11 +588,8 @@ enum HttpTransportMode {
 struct StreamableHttpTransport {
     client: reqwest::Client,
     url: String,
-    /// Extra headers applied to every outbound POST. Populated from
-    /// [`McpServerConfig::headers`]; an empty map is the no-auth
-    /// default. See `apply_custom_headers` for the filtering pass that
-    /// runs before each request.
-    headers: HashMap<String, String>,
+    /// Request-time auth and custom header resolver for outbound POSTs.
+    auth: McpHttpAuth,
     pending_messages: VecDeque<Vec<u8>>,
     /// Per-spec MCP session identifier returned by the server in the
     /// first response (typically the `initialize` response). Attached
@@ -569,6 +597,58 @@ struct StreamableHttpTransport {
     /// request so the server can correlate messages within the same
     /// session.
     session_id: Option<String>,
+}
+
+#[derive(Clone, Default)]
+struct McpHttpAuth {
+    headers: HashMap<String, String>,
+    env_headers: HashMap<String, String>,
+    bearer_token_env_var: Option<String>,
+    oauth: Option<oauth::McpOAuthRuntime>,
+}
+
+impl McpHttpAuth {
+    fn from_config(config: &McpServerConfig, oauth: Option<oauth::McpOAuthRuntime>) -> Self {
+        Self {
+            headers: config.headers.clone(),
+            env_headers: config.env_headers.clone(),
+            bearer_token_env_var: config.bearer_token_env_var.clone(),
+            oauth,
+        }
+    }
+
+    async fn resolved_headers(&self) -> Result<HashMap<String, String>> {
+        let mut headers = self.headers.clone();
+        for (name, env_var) in &self.env_headers {
+            if let Ok(value) = std::env::var(env_var)
+                && !value.trim().is_empty()
+            {
+                headers.insert(name.clone(), value);
+            }
+        }
+        if !mcp_headers_have_authorization(&headers)
+            && let Some(env_var) = self.bearer_token_env_var.as_deref()
+            && let Ok(token) = std::env::var(env_var)
+        {
+            let token = token.trim();
+            if !token.is_empty() {
+                headers.insert("Authorization".to_string(), format!("Bearer {token}"));
+            }
+        }
+        if !mcp_headers_have_authorization(&headers)
+            && let Some(oauth) = &self.oauth
+            && let Some(value) = oauth.authorization_header().await?
+        {
+            headers.insert("Authorization".to_string(), value);
+        }
+        Ok(headers)
+    }
+}
+
+fn mcp_headers_have_authorization(headers: &HashMap<String, String>) -> bool {
+    headers
+        .keys()
+        .any(|key| key.trim().eq_ignore_ascii_case("authorization"))
 }
 
 #[derive(Debug)]
@@ -579,17 +659,17 @@ enum StreamableSendError {
 }
 
 impl SseTransport {
-    pub async fn connect(
+    async fn connect(
         client: reqwest::Client,
         url: String,
-        headers: HashMap<String, String>,
+        auth: McpHttpAuth,
         cancel_token: tokio_util::sync::CancellationToken,
         endpoint_timeout: Duration,
     ) -> Result<Self> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let client_clone = client.clone();
         let url_clone = url.clone();
-        let headers_clone = headers.clone();
+        let auth_clone = auth.clone();
         let wait_cancel_token = cancel_token.clone();
 
         let sse_task = tokio::spawn(async move {
@@ -600,7 +680,7 @@ impl SseTransport {
             let result = std::panic::AssertUnwindSafe(Self::run_sse_loop(
                 client_clone,
                 url_clone,
-                headers_clone,
+                auth_clone,
                 tx,
                 cancel_token,
             ))
@@ -627,7 +707,7 @@ impl SseTransport {
         let mut transport = Self {
             client,
             base_url: url,
-            headers,
+            auth,
             endpoint_url: None,
             receiver: rx,
             pending_messages: VecDeque::new(),
@@ -642,10 +722,11 @@ impl SseTransport {
     async fn run_sse_loop(
         client: reqwest::Client,
         url: String,
-        headers: HashMap<String, String>,
+        auth: McpHttpAuth,
         tx: tokio::sync::mpsc::UnboundedSender<SseInbound>,
         cancel_token: tokio_util::sync::CancellationToken,
     ) -> Result<()> {
+        let headers = auth.resolved_headers().await?;
         let response = apply_safe_custom_headers(
             with_default_mcp_http_headers(client.get(&url), false),
             &headers,
@@ -779,7 +860,7 @@ impl HttpTransport {
     fn new(
         client: reqwest::Client,
         url: String,
-        headers: HashMap<String, String>,
+        auth: McpHttpAuth,
         cancel_token: tokio_util::sync::CancellationToken,
         endpoint_timeout: Duration,
     ) -> Self {
@@ -787,11 +868,11 @@ impl HttpTransport {
             mode: HttpTransportMode::Streamable(StreamableHttpTransport::new(
                 client.clone(),
                 url.clone(),
-                headers.clone(),
+                auth.clone(),
             )),
             client,
             base_url: url,
-            headers,
+            auth,
             cancel_token,
             endpoint_timeout,
         }
@@ -801,7 +882,7 @@ impl HttpTransport {
         let mut sse = SseTransport::connect(
             self.client.clone(),
             self.base_url.clone(),
-            self.headers.clone(),
+            self.auth.clone(),
             self.cancel_token.clone(),
             self.endpoint_timeout,
         )
@@ -842,9 +923,10 @@ impl HttpTransport {
             HttpTransportMode::Sse(_) => return Ok(()),
         };
 
+        let headers = transport.auth.resolved_headers().await?;
         let request = apply_safe_custom_headers(
             with_default_mcp_http_headers(transport.client.get(&transport.url), false),
-            &transport.headers,
+            &headers,
         );
         let response = tokio::time::timeout(Duration::from_secs(5), request.send())
             .await
@@ -923,11 +1005,11 @@ impl McpTransport for HttpTransport {
 }
 
 impl StreamableHttpTransport {
-    fn new(client: reqwest::Client, url: String, headers: HashMap<String, String>) -> Self {
+    fn new(client: reqwest::Client, url: String, auth: McpHttpAuth) -> Self {
         Self {
             client,
             url,
-            headers,
+            auth,
             pending_messages: VecDeque::new(),
             session_id: None,
         }
@@ -936,9 +1018,14 @@ impl StreamableHttpTransport {
     async fn send(&mut self, msg: Vec<u8>) -> std::result::Result<(), StreamableSendError> {
         // Apply user-configured custom headers after protocol framing so
         // reserved Accept / Content-Type overrides can be filtered out.
+        let headers = self
+            .auth
+            .resolved_headers()
+            .await
+            .map_err(StreamableSendError::Other)?;
         let mut request = apply_safe_custom_headers(
             with_default_mcp_http_headers(self.client.post(&self.url), true),
-            &self.headers,
+            &headers,
         );
         // Attach any previously captured session ID per the Streamable
         // HTTP spec so the server can correlate this request to the
@@ -1159,10 +1246,12 @@ impl McpTransport for SseTransport {
         let endpoint = self
             .endpoint_url
             .as_ref()
-            .context("SSE endpoint not yet discovered")?;
+            .context("SSE endpoint not yet discovered")?
+            .clone();
+        let headers = self.auth.resolved_headers().await?;
         let response = apply_safe_custom_headers(
-            with_default_mcp_http_headers(self.client.post(endpoint), true),
-            &self.headers,
+            with_default_mcp_http_headers(self.client.post(&endpoint), true),
+            &headers,
         )
         .body(msg)
         .send()
@@ -1170,7 +1259,7 @@ impl McpTransport for SseTransport {
         .with_context(|| {
             format!(
                 "MCP SSE POST send failed (transport=sse endpoint={})",
-                mask_url_secrets(endpoint)
+                mask_url_secrets(&endpoint)
             )
         })?;
         let status = response.status();
@@ -1179,14 +1268,14 @@ impl McpTransport for SseTransport {
             if is_mcp_stale_session_body(&body_excerpt) {
                 anyhow::bail!(
                     "MCP session expired (transport=sse endpoint={} status={}): {}",
-                    mask_url_secrets(endpoint),
+                    mask_url_secrets(&endpoint),
                     status,
                     body_excerpt
                 );
             }
             anyhow::bail!(
                 "MCP SSE POST rejected (transport=sse endpoint={} status={}): {}",
-                mask_url_secrets(endpoint),
+                mask_url_secrets(&endpoint),
                 status,
                 body_excerpt
             );
@@ -1304,12 +1393,45 @@ impl McpConnection {
                 }
             }
             let client = client_builder.build()?;
+            let oauth_runtime = match oauth::build_default_headers(
+                &config.headers,
+                &config.env_headers,
+            ) {
+                Ok(default_headers) => match oauth::McpOAuthRuntime::from_server_config(
+                    &name,
+                    &config,
+                    default_headers,
+                )
+                .await
+                {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "mcp",
+                            server = %name,
+                            error = %err,
+                            "failed to prepare MCP OAuth runtime; continuing without stored OAuth token"
+                        );
+                        None
+                    }
+                },
+                Err(err) => {
+                    tracing::warn!(
+                        target: "mcp",
+                        server = %name,
+                        error = %err,
+                        "failed to prepare MCP OAuth default headers; continuing without stored OAuth token"
+                    );
+                    None
+                }
+            };
+            let http_auth = McpHttpAuth::from_config(&config, oauth_runtime);
             if is_legacy_sse_transport(&config) {
                 Box::new(
                     SseTransport::connect(
                         client,
                         url.clone(),
-                        config.headers.clone(),
+                        http_auth,
                         cancel_token.clone(),
                         Duration::from_secs(connect_timeout_secs),
                     )
@@ -1319,7 +1441,7 @@ impl McpConnection {
                 let mut http = HttpTransport::new(
                     client,
                     url.clone(),
-                    config.headers.clone(),
+                    http_auth,
                     cancel_token.clone(),
                     Duration::from_secs(connect_timeout_secs),
                 );
@@ -2840,6 +2962,11 @@ fn mcp_template_json() -> Result<String> {
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: HashMap::new(),
+            env_headers: HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         },
     );
     serde_json::to_string_pretty(&cfg).context("Failed to render MCP template JSON")
@@ -2897,6 +3024,11 @@ pub fn add_server_config(
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: HashMap::new(),
+            env_headers: HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         },
     );
     save_config(path, &cfg)

--- a/crates/tui/src/mcp/headers.rs
+++ b/crates/tui/src/mcp/headers.rs
@@ -35,7 +35,7 @@ pub(super) fn with_default_mcp_http_headers(
 ///
 /// Returning `false` means "skip this header"; the rest of the
 /// request still goes out.
-pub(super) fn is_safe_custom_header(key: &str, value: &str) -> bool {
+pub(crate) fn is_safe_custom_header(key: &str, value: &str) -> bool {
     let trimmed = key.trim();
     if trimmed.is_empty() {
         return false;

--- a/crates/tui/src/mcp/oauth.rs
+++ b/crates/tui/src/mcp/oauth.rs
@@ -1,0 +1,1011 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use oauth2::TokenResponse;
+use reqwest::Url;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use rmcp::transport::AuthorizationManager;
+use rmcp::transport::AuthorizationSession;
+use rmcp::transport::auth::{AuthError, OAuthClientConfig, OAuthState, OAuthTokenResponse};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tiny_http::{Response, Server};
+use tokio::sync::{Mutex, oneshot};
+use tokio::time::timeout;
+use urlencoding::decode;
+
+use super::McpServerConfig;
+
+const REFRESH_SKEW_MILLIS: u64 = 30_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAuthStatus {
+    Unsupported,
+    NotLoggedIn,
+    BearerToken,
+    OAuth,
+}
+
+impl std::fmt::Display for McpAuthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let text = match self {
+            Self::Unsupported => "Unsupported",
+            Self::NotLoggedIn => "Not logged in",
+            Self::BearerToken => "Bearer token",
+            Self::OAuth => "OAuth",
+        };
+        f.write_str(text)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StoredMcpOAuthTokens {
+    pub server_name: String,
+    pub url: String,
+    pub client_id: String,
+    pub token_response: WrappedOAuthTokenResponse,
+    #[serde(default)]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WrappedOAuthTokenResponse(pub OAuthTokenResponse);
+
+impl PartialEq for WrappedOAuthTokenResponse {
+    fn eq(&self, other: &Self) -> bool {
+        match (serde_json::to_string(self), serde_json::to_string(other)) {
+            (Ok(left), Ok(right)) => left == right,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct McpOAuthRuntime {
+    inner: Arc<McpOAuthRuntimeInner>,
+}
+
+struct McpOAuthRuntimeInner {
+    server_name: String,
+    url: String,
+    manager: Arc<Mutex<AuthorizationManager>>,
+    last_tokens: Mutex<Option<StoredMcpOAuthTokens>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpOAuthDiscovery {
+    pub scopes_supported: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedMcpOAuthScopes {
+    pub scopes: Vec<String>,
+    pub source: McpOAuthScopesSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpOAuthScopesSource {
+    Explicit,
+    Configured,
+    Discovered,
+    Empty,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthProviderError {
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+impl OAuthProviderError {
+    fn new(error: Option<String>, error_description: Option<String>) -> Self {
+        Self {
+            error,
+            error_description,
+        }
+    }
+}
+
+impl std::fmt::Display for OAuthProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.error.as_deref(), self.error_description.as_deref()) {
+            (Some(error), Some(description)) => {
+                write!(f, "OAuth provider returned `{error}`: {description}")
+            }
+            (Some(error), None) => write!(f, "OAuth provider returned `{error}`"),
+            (None, Some(description)) => write!(f, "OAuth error: {description}"),
+            (None, None) => write!(f, "OAuth provider returned an error"),
+        }
+    }
+}
+
+impl std::error::Error for OAuthProviderError {}
+
+impl McpOAuthRuntime {
+    pub async fn from_server_config(
+        server_name: &str,
+        server: &McpServerConfig,
+        default_headers: HeaderMap,
+    ) -> Result<Option<Self>> {
+        let Some(url) = server.url.as_deref() else {
+            return Ok(None);
+        };
+        if server_has_manual_authorization(server) {
+            return Ok(None);
+        }
+        let Some(tokens) = load_oauth_tokens(server_name, url)? else {
+            return Ok(None);
+        };
+        Self::from_stored_tokens(server_name, url, tokens, default_headers)
+            .await
+            .map(Some)
+    }
+
+    async fn from_stored_tokens(
+        server_name: &str,
+        url: &str,
+        mut tokens: StoredMcpOAuthTokens,
+        default_headers: HeaderMap,
+    ) -> Result<Self> {
+        refresh_expires_in_from_timestamp(&mut tokens);
+        let client = apply_default_headers(crate::tls::reqwest_client_builder(), &default_headers)
+            .build()
+            .context("building MCP OAuth metadata client")?;
+        let mut state = OAuthState::new(url.to_string(), Some(client)).await?;
+        state
+            .set_credentials(&tokens.client_id, tokens.token_response.0.clone())
+            .await
+            .context("installing stored MCP OAuth credentials")?;
+
+        let manager = match state {
+            OAuthState::Authorized(manager) | OAuthState::Unauthorized(manager) => manager,
+            _ => bail!("unexpected MCP OAuth state while preparing stored credentials"),
+        };
+
+        Ok(Self {
+            inner: Arc::new(McpOAuthRuntimeInner {
+                server_name: server_name.to_string(),
+                url: url.to_string(),
+                manager: Arc::new(Mutex::new(manager)),
+                last_tokens: Mutex::new(Some(tokens)),
+            }),
+        })
+    }
+
+    pub async fn authorization_header(&self) -> Result<Option<String>> {
+        self.refresh_if_needed().await?;
+        let credentials = {
+            let guard = self.inner.manager.lock().await;
+            let (_client_id, credentials) = guard
+                .get_credentials()
+                .await
+                .context("reading MCP OAuth credentials")?;
+            credentials
+        };
+        let Some(credentials) = credentials else {
+            return Ok(None);
+        };
+        let token = credentials.access_token().secret().trim();
+        if token.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(format!("Bearer {token}")))
+        }
+    }
+
+    async fn refresh_if_needed(&self) -> Result<()> {
+        let expires_at = {
+            let guard = self.inner.last_tokens.lock().await;
+            guard.as_ref().and_then(|tokens| tokens.expires_at)
+        };
+        if !token_needs_refresh(expires_at) {
+            return Ok(());
+        }
+
+        {
+            let guard = self.inner.manager.lock().await;
+            guard.refresh_token().await.with_context(|| {
+                format!(
+                    "refreshing MCP OAuth token for server {}",
+                    self.inner.server_name
+                )
+            })?;
+        }
+        self.persist_if_needed().await
+    }
+
+    async fn persist_if_needed(&self) -> Result<()> {
+        let (client_id, credentials) = {
+            let guard = self.inner.manager.lock().await;
+            guard
+                .get_credentials()
+                .await
+                .context("reading refreshed MCP OAuth credentials")?
+        };
+        let Some(credentials) = credentials else {
+            let mut last = self.inner.last_tokens.lock().await;
+            if last.take().is_some() {
+                delete_oauth_tokens(&self.inner.server_name, &self.inner.url)?;
+            }
+            return Ok(());
+        };
+
+        let new_response = WrappedOAuthTokenResponse(credentials.clone());
+        let mut last = self.inner.last_tokens.lock().await;
+        let same_token = last
+            .as_ref()
+            .map(|previous| previous.token_response == new_response)
+            .unwrap_or(false);
+        let expires_at = if same_token {
+            last.as_ref().and_then(|previous| previous.expires_at)
+        } else {
+            compute_expires_at_millis(&credentials)
+        };
+        let stored = StoredMcpOAuthTokens {
+            server_name: self.inner.server_name.clone(),
+            url: self.inner.url.clone(),
+            client_id,
+            token_response: new_response,
+            expires_at,
+        };
+        if last.as_ref() != Some(&stored) {
+            save_oauth_tokens(&stored)?;
+            *last = Some(stored);
+        }
+        Ok(())
+    }
+}
+
+pub async fn auth_status_for_server(name: &str, server: &McpServerConfig) -> McpAuthStatus {
+    if !server.is_enabled() || server.url.is_none() {
+        return McpAuthStatus::Unsupported;
+    }
+    if server_has_manual_authorization(server) {
+        return McpAuthStatus::BearerToken;
+    }
+    let Some(url) = server.url.as_deref() else {
+        return McpAuthStatus::Unsupported;
+    };
+    match load_oauth_tokens(name, url) {
+        Ok(Some(tokens)) if oauth_tokens_are_usable(&tokens) => return McpAuthStatus::OAuth,
+        Ok(Some(_)) => return McpAuthStatus::NotLoggedIn,
+        Ok(None) => {}
+        Err(err) => {
+            tracing::warn!(target: "mcp", server = %name, error = %err, "failed to read MCP OAuth tokens");
+        }
+    }
+
+    let headers = match build_default_headers(&server.headers, &server.env_headers) {
+        Ok(headers) => headers,
+        Err(err) => {
+            tracing::warn!(target: "mcp", server = %name, error = %err, "failed to build MCP OAuth discovery headers");
+            return McpAuthStatus::Unsupported;
+        }
+    };
+    match discover_streamable_http_oauth_with_headers(url, headers).await {
+        Ok(Some(_)) => McpAuthStatus::NotLoggedIn,
+        Ok(None) => McpAuthStatus::Unsupported,
+        Err(err) => {
+            tracing::debug!(target: "mcp", server = %name, error = %err, "MCP OAuth discovery failed");
+            McpAuthStatus::Unsupported
+        }
+    }
+}
+
+pub async fn oauth_login_support(server: &McpServerConfig) -> Result<Option<McpOAuthDiscovery>> {
+    let Some(url) = server.url.as_deref() else {
+        return Ok(None);
+    };
+    if server_has_manual_authorization(server) {
+        return Ok(None);
+    }
+    discover_streamable_http_oauth(url, server.headers.clone(), server.env_headers.clone()).await
+}
+
+pub async fn discover_streamable_http_oauth(
+    url: &str,
+    http_headers: HashMap<String, String>,
+    env_headers: HashMap<String, String>,
+) -> Result<Option<McpOAuthDiscovery>> {
+    let headers = build_default_headers(&http_headers, &env_headers)?;
+    discover_streamable_http_oauth_with_headers(url, headers).await
+}
+
+async fn discover_streamable_http_oauth_with_headers(
+    url: &str,
+    default_headers: HeaderMap,
+) -> Result<Option<McpOAuthDiscovery>> {
+    let client = apply_default_headers(crate::tls::reqwest_client_builder(), &default_headers)
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("building MCP OAuth discovery client")?;
+    let mut manager = AuthorizationManager::new(url).await?;
+    manager.with_client(client)?;
+    match manager.discover_metadata().await {
+        Ok(metadata) => Ok(Some(McpOAuthDiscovery {
+            scopes_supported: normalize_scopes(metadata.scopes_supported),
+        })),
+        Err(AuthError::NoAuthorizationSupport) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+pub fn resolve_oauth_scopes(
+    explicit_scopes: Option<Vec<String>>,
+    configured_scopes: Vec<String>,
+    discovered_scopes: Option<Vec<String>>,
+) -> ResolvedMcpOAuthScopes {
+    if let Some(scopes) = explicit_scopes {
+        return ResolvedMcpOAuthScopes {
+            scopes,
+            source: McpOAuthScopesSource::Explicit,
+        };
+    }
+    if !configured_scopes.is_empty() {
+        return ResolvedMcpOAuthScopes {
+            scopes: configured_scopes,
+            source: McpOAuthScopesSource::Configured,
+        };
+    }
+    if let Some(scopes) = discovered_scopes
+        && !scopes.is_empty()
+    {
+        return ResolvedMcpOAuthScopes {
+            scopes,
+            source: McpOAuthScopesSource::Discovered,
+        };
+    }
+    ResolvedMcpOAuthScopes {
+        scopes: Vec::new(),
+        source: McpOAuthScopesSource::Empty,
+    }
+}
+
+pub async fn perform_oauth_login_for_server(
+    name: &str,
+    server: &McpServerConfig,
+    explicit_scopes: Option<Vec<String>>,
+    callback_port: Option<u16>,
+    callback_url: Option<&str>,
+) -> Result<()> {
+    let Some(url) = server.url.as_deref() else {
+        bail!("OAuth login is only supported for URL-based MCP servers");
+    };
+    if server_has_manual_authorization(server) {
+        bail!("MCP server '{name}' already has bearer/static Authorization configured");
+    }
+
+    let discovery = if explicit_scopes.is_none() && server.scopes.is_empty() {
+        oauth_login_support(server).await?
+    } else {
+        None
+    };
+    let resolved_scopes = resolve_oauth_scopes(
+        explicit_scopes,
+        server.scopes.clone(),
+        discovery.and_then(|discovery| discovery.scopes_supported),
+    );
+
+    match perform_oauth_login(
+        name,
+        url,
+        server.headers.clone(),
+        server.env_headers.clone(),
+        &resolved_scopes.scopes,
+        server.oauth_client_id(),
+        server.oauth_resource.as_deref(),
+        callback_port,
+        callback_url,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(err)
+            if resolved_scopes.source == McpOAuthScopesSource::Discovered
+                && err.downcast_ref::<OAuthProviderError>().is_some() =>
+        {
+            println!("OAuth provider rejected discovered scopes. Retrying without scopes...");
+            perform_oauth_login(
+                name,
+                url,
+                server.headers.clone(),
+                server.env_headers.clone(),
+                &[],
+                server.oauth_client_id(),
+                server.oauth_resource.as_deref(),
+                callback_port,
+                callback_url,
+            )
+            .await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn perform_oauth_login(
+    server_name: &str,
+    server_url: &str,
+    http_headers: HashMap<String, String>,
+    env_headers: HashMap<String, String>,
+    scopes: &[String],
+    oauth_client_id: Option<&str>,
+    oauth_resource: Option<&str>,
+    callback_port: Option<u16>,
+    callback_url: Option<&str>,
+) -> Result<()> {
+    OauthLoginFlow::new(
+        server_name,
+        server_url,
+        http_headers,
+        env_headers,
+        scopes,
+        oauth_client_id,
+        oauth_resource,
+        callback_port,
+        callback_url,
+    )
+    .await?
+    .finish()
+    .await
+}
+
+pub fn delete_oauth_tokens_for_server(name: &str, server: &McpServerConfig) -> Result<bool> {
+    let Some(url) = server.url.as_deref() else {
+        bail!("OAuth logout is only supported for URL-based MCP servers");
+    };
+    delete_oauth_tokens(name, url)
+}
+
+fn server_has_manual_authorization(server: &McpServerConfig) -> bool {
+    server.bearer_token_env_var.is_some()
+        || contains_authorization_header(&server.headers)
+        || contains_authorization_header(&server.env_headers)
+}
+
+pub fn build_default_headers(
+    http_headers: &HashMap<String, String>,
+    env_headers: &HashMap<String, String>,
+) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in http_headers {
+        insert_header(&mut headers, name, value)?;
+    }
+    for (name, env_var) in env_headers {
+        if let Ok(value) = std::env::var(env_var)
+            && !value.trim().is_empty()
+        {
+            insert_header(&mut headers, name, &value)?;
+        }
+    }
+    Ok(headers)
+}
+
+fn insert_header(headers: &mut HeaderMap, name: &str, value: &str) -> Result<()> {
+    if !super::headers::is_safe_custom_header(name, value) {
+        bail!("unsafe MCP HTTP header '{name}'");
+    }
+    let name = HeaderName::from_bytes(name.as_bytes())
+        .with_context(|| format!("invalid MCP HTTP header name '{name}'"))?;
+    let value = HeaderValue::from_str(value).with_context(|| "invalid MCP HTTP header value")?;
+    headers.insert(name, value);
+    Ok(())
+}
+
+pub fn apply_default_headers(
+    builder: reqwest::ClientBuilder,
+    headers: &HeaderMap,
+) -> reqwest::ClientBuilder {
+    if headers.is_empty() {
+        builder
+    } else {
+        builder.default_headers(headers.clone())
+    }
+}
+
+fn contains_authorization_header(headers: &HashMap<String, String>) -> bool {
+    headers
+        .keys()
+        .any(|key| key.trim().eq_ignore_ascii_case("authorization"))
+}
+
+fn normalize_scopes(scopes_supported: Option<Vec<String>>) -> Option<Vec<String>> {
+    let scopes_supported = scopes_supported?;
+    let mut normalized = Vec::new();
+    for scope in scopes_supported {
+        let scope = scope.trim();
+        if scope.is_empty() {
+            continue;
+        }
+        let scope = scope.to_string();
+        if !normalized.contains(&scope) {
+            normalized.push(scope);
+        }
+    }
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn load_oauth_tokens(server_name: &str, url: &str) -> Result<Option<StoredMcpOAuthTokens>> {
+    let secrets = codewhale_secrets::Secrets::auto_detect();
+    let key = store_key(server_name, url);
+    let Some(serialized) = secrets
+        .get(&key)
+        .with_context(|| format!("reading MCP OAuth token for '{server_name}'"))?
+    else {
+        return Ok(None);
+    };
+    let mut tokens: StoredMcpOAuthTokens = serde_json::from_str(&serialized)
+        .with_context(|| format!("parsing stored MCP OAuth token for '{server_name}'"))?;
+    refresh_expires_in_from_timestamp(&mut tokens);
+    Ok(Some(tokens))
+}
+
+fn save_oauth_tokens(tokens: &StoredMcpOAuthTokens) -> Result<()> {
+    let secrets = codewhale_secrets::Secrets::auto_detect();
+    let key = store_key(&tokens.server_name, &tokens.url);
+    let serialized = serde_json::to_string(tokens).context("serializing MCP OAuth token")?;
+    secrets
+        .set(&key, &serialized)
+        .with_context(|| format!("saving MCP OAuth token for '{}'", tokens.server_name))
+}
+
+fn delete_oauth_tokens(server_name: &str, url: &str) -> Result<bool> {
+    let secrets = codewhale_secrets::Secrets::auto_detect();
+    let key = store_key(server_name, url);
+    let existed = secrets
+        .get(&key)
+        .with_context(|| format!("reading MCP OAuth token for '{server_name}'"))?
+        .is_some();
+    secrets
+        .delete(&key)
+        .with_context(|| format!("deleting MCP OAuth token for '{server_name}'"))?;
+    Ok(existed)
+}
+
+fn store_key(server_name: &str, url: &str) -> String {
+    let mut payload = Vec::with_capacity(server_name.len() + url.len() + 1);
+    payload.extend_from_slice(server_name.as_bytes());
+    payload.push(0);
+    payload.extend_from_slice(url.as_bytes());
+    let digest = Sha256::digest(&payload);
+    format!("mcp_oauth_{}", URL_SAFE_NO_PAD.encode(digest))
+}
+
+fn oauth_tokens_are_usable(tokens: &StoredMcpOAuthTokens) -> bool {
+    if tokens.client_id.trim().is_empty() {
+        return false;
+    }
+    let response = &tokens.token_response.0;
+    if token_needs_refresh(tokens.expires_at) {
+        return response
+            .refresh_token()
+            .is_some_and(|token| !token.secret().trim().is_empty());
+    }
+    !response.access_token().secret().trim().is_empty()
+}
+
+fn refresh_expires_in_from_timestamp(tokens: &mut StoredMcpOAuthTokens) {
+    let Some(expires_at) = tokens.expires_at else {
+        return;
+    };
+    match expires_in_from_timestamp(expires_at) {
+        Some(seconds) => {
+            let duration = Duration::from_secs(seconds);
+            tokens.token_response.0.set_expires_in(Some(&duration));
+        }
+        None => {
+            tokens
+                .token_response
+                .0
+                .set_expires_in(Some(&Duration::ZERO));
+        }
+    }
+}
+
+fn compute_expires_at_millis(response: &OAuthTokenResponse) -> Option<u64> {
+    let expires = response.expires_in()?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis() as u64;
+    Some(now.saturating_add(expires.as_millis() as u64))
+}
+
+fn expires_in_from_timestamp(expires_at: u64) -> Option<u64> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis() as u64;
+    if expires_at <= now {
+        return None;
+    }
+    Some((expires_at - now) / 1000)
+}
+
+fn token_needs_refresh(expires_at: Option<u64>) -> bool {
+    let Some(expires_at) = expires_at else {
+        return false;
+    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0);
+    now.saturating_add(REFRESH_SKEW_MILLIS) >= expires_at
+}
+
+struct CallbackServerGuard {
+    server: Arc<Server>,
+}
+
+impl Drop for CallbackServerGuard {
+    fn drop(&mut self) {
+        self.server.unblock();
+    }
+}
+
+struct OauthLoginFlow {
+    auth_url: String,
+    oauth_state: OAuthState,
+    rx: oneshot::Receiver<CallbackResult>,
+    guard: CallbackServerGuard,
+    server_name: String,
+    server_url: String,
+}
+
+impl OauthLoginFlow {
+    #[allow(clippy::too_many_arguments)]
+    async fn new(
+        server_name: &str,
+        server_url: &str,
+        http_headers: HashMap<String, String>,
+        env_headers: HashMap<String, String>,
+        scopes: &[String],
+        oauth_client_id: Option<&str>,
+        oauth_resource: Option<&str>,
+        callback_port: Option<u16>,
+        callback_url: Option<&str>,
+    ) -> Result<Self> {
+        let bind_host = callback_bind_host(callback_url);
+        let bind_addr = match callback_port {
+            Some(0) => bail!("invalid MCP OAuth callback port 0"),
+            Some(port) => format!("{bind_host}:{port}"),
+            None => format!("{bind_host}:0"),
+        };
+        let server = Arc::new(Server::http(&bind_addr).map_err(|err| anyhow!(err))?);
+        let guard = CallbackServerGuard {
+            server: Arc::clone(&server),
+        };
+        let redirect_uri = resolve_redirect_uri(&server, callback_url)?;
+        let callback_id = callback_id_from_server_url(server_url)?;
+        let redirect_uri = append_callback_id_to_redirect_uri(&redirect_uri, &callback_id)?;
+        let callback_path = callback_path_from_redirect_uri(&redirect_uri)?;
+
+        let (tx, rx) = oneshot::channel();
+        spawn_callback_server(server, tx, callback_path);
+
+        let headers = build_default_headers(&http_headers, &env_headers)?;
+        let client = apply_default_headers(crate::tls::reqwest_client_builder(), &headers)
+            .build()
+            .context("building MCP OAuth login client")?;
+        let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
+        let oauth_state = start_authorization(
+            server_url,
+            client,
+            &scope_refs,
+            &redirect_uri,
+            oauth_client_id,
+        )
+        .await?;
+        let auth_url = append_query_param(
+            &oauth_state.get_authorization_url().await?,
+            "resource",
+            oauth_resource,
+        );
+
+        Ok(Self {
+            auth_url,
+            oauth_state,
+            rx,
+            guard,
+            server_name: server_name.to_string(),
+            server_url: server_url.to_string(),
+        })
+    }
+
+    async fn finish(mut self) -> Result<()> {
+        println!(
+            "Authorize `{}` by opening this URL in your browser:\n{}\n",
+            self.server_name, self.auth_url
+        );
+        if webbrowser::open(&self.auth_url).is_err() {
+            eprintln!("Browser launch failed; copy the URL above manually.");
+        }
+
+        let result = async {
+            let callback = timeout(Duration::from_secs(300), &mut self.rx)
+                .await
+                .context("timed out waiting for OAuth callback")?
+                .context("OAuth callback was cancelled")?;
+            let OauthCallbackResult { code, state } = match callback {
+                CallbackResult::Success(callback) => callback,
+                CallbackResult::Error(error) => return Err(anyhow!(error)),
+            };
+
+            self.oauth_state
+                .handle_callback(&code, &state)
+                .await
+                .context("handling MCP OAuth callback")?;
+
+            let (client_id, credentials) = self
+                .oauth_state
+                .get_credentials()
+                .await
+                .context("reading MCP OAuth credentials")?;
+            let credentials =
+                credentials.ok_or_else(|| anyhow!("OAuth provider did not return credentials"))?;
+            let stored = StoredMcpOAuthTokens {
+                server_name: self.server_name.clone(),
+                url: self.server_url.clone(),
+                client_id,
+                expires_at: compute_expires_at_millis(&credentials),
+                token_response: WrappedOAuthTokenResponse(credentials),
+            };
+            save_oauth_tokens(&stored)
+        }
+        .await;
+
+        drop(self.guard);
+        result
+    }
+}
+
+async fn start_authorization(
+    server_url: &str,
+    client: reqwest::Client,
+    scopes: &[&str],
+    redirect_uri: &str,
+    oauth_client_id: Option<&str>,
+) -> Result<OAuthState> {
+    let Some(client_id) = oauth_client_id.filter(|client_id| !client_id.trim().is_empty()) else {
+        let mut oauth_state = OAuthState::new(server_url, Some(client)).await?;
+        oauth_state
+            .start_authorization(scopes, redirect_uri, Some("CodeWhale"))
+            .await?;
+        return Ok(oauth_state);
+    };
+
+    let mut manager = AuthorizationManager::new(server_url).await?;
+    manager.with_client(client)?;
+    let metadata = manager.discover_metadata().await?;
+    manager.set_metadata(metadata);
+    manager.configure_client(
+        OAuthClientConfig::new(client_id, redirect_uri)
+            .with_scopes(scopes.iter().map(|scope| (*scope).to_string()).collect()),
+    )?;
+    let auth_url = manager.get_authorization_url(scopes).await?;
+    Ok(OAuthState::Session(
+        AuthorizationSession::for_scope_upgrade(manager, auth_url, redirect_uri),
+    ))
+}
+
+fn spawn_callback_server(
+    server: Arc<Server>,
+    tx: oneshot::Sender<CallbackResult>,
+    expected_callback_path: String,
+) {
+    tokio::task::spawn_blocking(move || {
+        while let Ok(request) = server.recv() {
+            let path = request.url().to_string();
+            match parse_oauth_callback(&path, &expected_callback_path) {
+                CallbackOutcome::Success(callback) => {
+                    let response = Response::from_string(
+                        "Authentication complete. You may close this window.",
+                    );
+                    let _ = request.respond(response);
+                    let _ = tx.send(CallbackResult::Success(callback));
+                    break;
+                }
+                CallbackOutcome::Error(error) => {
+                    let response = Response::from_string(error.to_string()).with_status_code(400);
+                    let _ = request.respond(response);
+                    let _ = tx.send(CallbackResult::Error(error));
+                    break;
+                }
+                CallbackOutcome::Invalid => {
+                    let response =
+                        Response::from_string("Invalid OAuth callback").with_status_code(400);
+                    let _ = request.respond(response);
+                }
+            }
+        }
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OauthCallbackResult {
+    code: String,
+    state: String,
+}
+
+enum CallbackResult {
+    Success(OauthCallbackResult),
+    Error(OAuthProviderError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CallbackOutcome {
+    Success(OauthCallbackResult),
+    Error(OAuthProviderError),
+    Invalid,
+}
+
+fn parse_oauth_callback(path: &str, expected_callback_path: &str) -> CallbackOutcome {
+    let Some((route, query)) = path.split_once('?') else {
+        return CallbackOutcome::Invalid;
+    };
+    if route != expected_callback_path {
+        return CallbackOutcome::Invalid;
+    }
+
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    let mut error_description = None;
+    for pair in query.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        let Ok(decoded) = decode(value) else {
+            continue;
+        };
+        let decoded = decoded.into_owned();
+        match key {
+            "code" => code = Some(decoded),
+            "state" => state = Some(decoded),
+            "error" => error = Some(decoded),
+            "error_description" => error_description = Some(decoded),
+            _ => {}
+        }
+    }
+
+    if let (Some(code), Some(state)) = (code, state) {
+        return CallbackOutcome::Success(OauthCallbackResult { code, state });
+    }
+    if error.is_some() || error_description.is_some() {
+        return CallbackOutcome::Error(OAuthProviderError::new(error, error_description));
+    }
+    CallbackOutcome::Invalid
+}
+
+fn local_redirect_uri(server: &Server) -> Result<String> {
+    match server.server_addr() {
+        tiny_http::ListenAddr::IP(std::net::SocketAddr::V4(addr)) => {
+            Ok(format!("http://{}:{}/callback", addr.ip(), addr.port()))
+        }
+        tiny_http::ListenAddr::IP(std::net::SocketAddr::V6(addr)) => {
+            Ok(format!("http://[{}]:{}/callback", addr.ip(), addr.port()))
+        }
+        #[cfg(not(target_os = "windows"))]
+        _ => Err(anyhow!("unable to determine callback address")),
+    }
+}
+
+fn resolve_redirect_uri(server: &Server, callback_url: Option<&str>) -> Result<String> {
+    let Some(callback_url) = callback_url else {
+        return local_redirect_uri(server);
+    };
+    Url::parse(callback_url)
+        .with_context(|| format!("invalid MCP OAuth callback URL '{callback_url}'"))?;
+    Ok(callback_url.to_string())
+}
+
+fn callback_bind_host(callback_url: Option<&str>) -> &'static str {
+    let Some(callback_url) = callback_url else {
+        return "127.0.0.1";
+    };
+    let Ok(parsed) = Url::parse(callback_url) else {
+        return "127.0.0.1";
+    };
+    match parsed.host_str() {
+        Some("localhost" | "127.0.0.1" | "::1") | None => "127.0.0.1",
+        Some(_) => "0.0.0.0",
+    }
+}
+
+fn callback_id_from_server_url(server_url: &str) -> Result<String> {
+    let mut parsed =
+        Url::parse(server_url).with_context(|| format!("invalid MCP server URL '{server_url}'"))?;
+    parsed
+        .host_str()
+        .ok_or_else(|| anyhow!("MCP server URL '{server_url}' must include a host"))?;
+    parsed.set_fragment(None);
+    let digest = Sha256::digest(parsed.as_str().as_bytes());
+    Ok(URL_SAFE_NO_PAD.encode(&digest[..9]))
+}
+
+fn append_callback_id_to_redirect_uri(redirect_uri: &str, callback_id: &str) -> Result<String> {
+    let mut parsed = Url::parse(redirect_uri)
+        .with_context(|| format!("invalid redirect URI '{redirect_uri}'"))?;
+    let path = parsed.path();
+    let new_path = if path.ends_with('/') {
+        format!("{path}{callback_id}")
+    } else {
+        format!("{path}/{callback_id}")
+    };
+    parsed.set_path(&new_path);
+    Ok(parsed.to_string())
+}
+
+fn callback_path_from_redirect_uri(redirect_uri: &str) -> Result<String> {
+    let parsed = Url::parse(redirect_uri)
+        .with_context(|| format!("invalid redirect URI '{redirect_uri}'"))?;
+    Ok(parsed.path().to_string())
+}
+
+fn append_query_param(url: &str, key: &str, value: Option<&str>) -> String {
+    let Some(value) = value else {
+        return url.to_string();
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return url.to_string();
+    }
+    if let Ok(mut parsed) = Url::parse(url) {
+        parsed.query_pairs_mut().append_pair(key, value);
+        return parsed.to_string();
+    }
+    let separator = if url.contains('?') { "&" } else { "?" };
+    format!("{url}{separator}{key}={}", urlencoding::encode(value))
+}
+
+impl McpServerConfig {
+    pub fn oauth_client_id(&self) -> Option<&str> {
+        self.oauth
+            .as_ref()
+            .and_then(|oauth| oauth.client_id.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_oauth_scopes_prefers_explicit() {
+        let resolved = resolve_oauth_scopes(
+            Some(vec!["explicit".to_string()]),
+            vec!["configured".to_string()],
+            Some(vec!["discovered".to_string()]),
+        );
+        assert_eq!(resolved.source, McpOAuthScopesSource::Explicit);
+        assert_eq!(resolved.scopes, vec!["explicit"]);
+    }
+
+    #[test]
+    fn parse_oauth_callback_accepts_success() {
+        let parsed = parse_oauth_callback("/callback/id?code=abc&state=xyz", "/callback/id");
+        assert!(matches!(parsed, CallbackOutcome::Success(_)));
+    }
+
+    #[test]
+    fn parse_oauth_callback_accepts_provider_error() {
+        let parsed = parse_oauth_callback(
+            "/callback/id?error=invalid_scope&error_description=nope",
+            "/callback/id",
+        );
+        assert!(matches!(parsed, CallbackOutcome::Error(_)));
+    }
+
+    #[test]
+    fn store_key_does_not_include_raw_url_or_name() {
+        let key = store_key("github", "https://example.com/mcp");
+        assert!(key.starts_with("mcp_oauth_"));
+        assert!(!key.contains("github"));
+        assert!(!key.contains("example.com"));
+    }
+}

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -148,6 +148,42 @@ fn mcp_server_config_parses_custom_headers() {
 }
 
 #[test]
+fn mcp_server_config_parses_remote_auth_fields() {
+    let json = r#"{
+        "servers": {
+            "remote": {
+                "url": "https://example.invalid/mcp",
+                "env_http_headers": {
+                    "X-Api-Key": "REMOTE_MCP_KEY"
+                },
+                "bearer_token_env_var": "REMOTE_MCP_TOKEN",
+                "scopes": ["tools/read", "tools/write"],
+                "oauth": {
+                    "client_id": "client-123"
+                },
+                "oauth_resource": "https://example.invalid"
+            }
+        }
+    }"#;
+    let cfg: McpConfig = serde_json::from_str(json).unwrap();
+    let remote = cfg.servers.get("remote").expect("server present");
+    assert_eq!(
+        remote.env_headers.get("X-Api-Key"),
+        Some(&"REMOTE_MCP_KEY".to_string())
+    );
+    assert_eq!(
+        remote.bearer_token_env_var.as_deref(),
+        Some("REMOTE_MCP_TOKEN")
+    );
+    assert_eq!(remote.scopes, vec!["tools/read", "tools/write"]);
+    assert_eq!(remote.oauth_client_id(), Some("client-123"));
+    assert_eq!(
+        remote.oauth_resource.as_deref(),
+        Some("https://example.invalid")
+    );
+}
+
+#[test]
 fn mcp_server_config_omits_headers_when_empty() {
     // Empty headers map should not appear in the serialized output —
     // older mcp.json files written before v0.8.31 must round-trip
@@ -169,11 +205,61 @@ fn mcp_server_config_omits_headers_when_empty() {
         enabled_tools: Vec::new(),
         disabled_tools: Vec::new(),
         headers: HashMap::new(),
+        env_headers: HashMap::new(),
+        bearer_token_env_var: None,
+        scopes: Vec::new(),
+        oauth: None,
+        oauth_resource: None,
     };
     let serialized = serde_json::to_string(&cfg).unwrap();
     assert!(
         !serialized.contains("\"headers\""),
         "empty headers must be omitted: {serialized}"
+    );
+    assert!(
+        !serialized.contains("\"env_headers\""),
+        "empty env_headers must be omitted: {serialized}"
+    );
+    assert!(
+        !serialized.contains("\"scopes\""),
+        "empty scopes must be omitted: {serialized}"
+    );
+    assert!(
+        !serialized.contains("\"oauth\""),
+        "empty oauth config must be omitted: {serialized}"
+    );
+}
+
+#[tokio::test]
+async fn mcp_http_auth_prefers_static_authorization_over_bearer_env() {
+    let mut headers = HashMap::new();
+    headers.insert("Authorization".to_string(), "Bearer static".to_string());
+    let auth = McpHttpAuth {
+        headers,
+        bearer_token_env_var: Some("PATH".to_string()),
+        ..Default::default()
+    };
+
+    let resolved = auth.resolved_headers().await.unwrap();
+    assert_eq!(
+        resolved.get("Authorization"),
+        Some(&"Bearer static".to_string())
+    );
+}
+
+#[tokio::test]
+async fn mcp_http_auth_uses_bearer_env_when_no_authorization_header() {
+    let auth = McpHttpAuth {
+        bearer_token_env_var: Some("PATH".to_string()),
+        ..Default::default()
+    };
+
+    let resolved = auth.resolved_headers().await.unwrap();
+    assert!(
+        resolved
+            .get("Authorization")
+            .is_some_and(|value| value.starts_with("Bearer ") && value.len() > "Bearer ".len()),
+        "expected PATH-backed bearer header, got {resolved:?}"
     );
 }
 
@@ -260,9 +346,12 @@ fn streamable_http_transport_stores_headers() {
     let transport = StreamableHttpTransport::new(
         client,
         "https://example.invalid/mcp".to_string(),
-        headers.clone(),
+        McpHttpAuth {
+            headers: headers.clone(),
+            ..Default::default()
+        },
     );
-    assert_eq!(transport.headers, headers);
+    assert_eq!(transport.auth.headers, headers);
 }
 
 #[test]
@@ -832,6 +921,11 @@ fn test_server_effective_timeouts() {
         enabled_tools: Vec::new(),
         disabled_tools: Vec::new(),
         headers: HashMap::new(),
+        env_headers: HashMap::new(),
+        bearer_token_env_var: None,
+        scopes: Vec::new(),
+        oauth: None,
+        oauth_resource: None,
     };
 
     assert_eq!(server_with_override.effective_connect_timeout(&global), 20);
@@ -944,6 +1038,11 @@ fn test_server_config() -> McpServerConfig {
         enabled_tools: Vec::new(),
         disabled_tools: Vec::new(),
         headers: HashMap::new(),
+        env_headers: HashMap::new(),
+        bearer_token_env_var: None,
+        scopes: Vec::new(),
+        oauth: None,
+        oauth_resource: None,
     }
 }
 
@@ -1157,6 +1256,11 @@ fn hash_mcp_config_is_stable_and_change_sensitive() {
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: HashMap::new(),
+            env_headers: HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         },
     );
     assert_ne!(
@@ -1690,6 +1794,11 @@ async fn mcp_connection_supports_streamable_http_event_stream_responses() {
         enabled_tools: Vec::new(),
         disabled_tools: Vec::new(),
         headers: HashMap::new(),
+        env_headers: HashMap::new(),
+        bearer_token_env_var: None,
+        scopes: Vec::new(),
+        oauth: None,
+        oauth_resource: None,
     };
 
     let conn = McpConnection::connect_with_policy(
@@ -1971,7 +2080,7 @@ async fn sse_connect_waits_for_endpoint_before_first_send() {
     let mut transport = SseTransport::connect(
         client,
         url,
-        HashMap::new(),
+        McpHttpAuth::default(),
         cancel_token.clone(),
         Duration::from_secs(2),
     )
@@ -2062,7 +2171,7 @@ async fn sse_connect_accepts_crlf_endpoint_events() {
     let mut transport = SseTransport::connect(
         client,
         url,
-        HashMap::new(),
+        McpHttpAuth::default(),
         cancel_token.clone(),
         Duration::from_secs(2),
     )
@@ -2164,7 +2273,10 @@ async fn sse_transport_applies_custom_headers_to_get_and_post() {
     let mut transport = SseTransport::connect(
         client,
         url,
-        headers,
+        McpHttpAuth {
+            headers,
+            ..Default::default()
+        },
         cancel_token.clone(),
         Duration::from_secs(2),
     )
@@ -2251,7 +2363,7 @@ async fn sse_post_error_includes_response_body_excerpt() {
     let mut transport = SseTransport::connect(
         client,
         url,
-        HashMap::new(),
+        McpHttpAuth::default(),
         cancel_token.clone(),
         Duration::from_secs(2),
     )
@@ -2437,6 +2549,11 @@ async fn streamable_http_stale_session_reconnects_and_retries_tool_call() {
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: HashMap::new(),
+            env_headers: HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         },
     );
     let mut pool = McpPool::new(cfg);
@@ -2496,7 +2613,7 @@ async fn legacy_sse_session_expiry_is_marked_stale() {
     let mut transport = SseTransport {
         client: test_http_client(),
         base_url: format!("http://{addr}/sse"),
-        headers: HashMap::new(),
+        auth: McpHttpAuth::default(),
         endpoint_url: Some(format!("http://{addr}/messages")),
         receiver,
         pending_messages: VecDeque::new(),
@@ -2708,6 +2825,11 @@ async fn legacy_sse_closed_stream_reconnects_and_retries_tool_call() {
             enabled_tools: Vec::new(),
             disabled_tools: Vec::new(),
             headers: HashMap::new(),
+            env_headers: HashMap::new(),
+            bearer_token_env_var: None,
+            scopes: Vec::new(),
+            oauth: None,
+            oauth_resource: None,
         },
     );
     let mut pool = McpPool::new(cfg);
@@ -2733,7 +2855,7 @@ fn session_id_starts_none() {
     let transport = StreamableHttpTransport::new(
         test_http_client(),
         "https://example.invalid/mcp".to_string(),
-        HashMap::new(),
+        McpHttpAuth::default(),
     );
     assert!(transport.session_id.is_none());
 }
@@ -2782,7 +2904,7 @@ async fn session_id_captured_from_post_response_and_replayed() {
 
     let client = test_http_client();
     let url = format!("http://{addr}/mcp");
-    let mut transport = StreamableHttpTransport::new(client, url, HashMap::new());
+    let mut transport = StreamableHttpTransport::new(client, url, McpHttpAuth::default());
 
     // First send: server returns Mcp-Session-Id.
     transport
@@ -2853,7 +2975,10 @@ async fn custom_headers_applied_to_get_preflight() {
     let mut transport = HttpTransport::new(
         client,
         url,
-        headers,
+        McpHttpAuth {
+            headers,
+            ..Default::default()
+        },
         tokio_util::sync::CancellationToken::new(),
         Duration::from_secs(10),
     );

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5717,6 +5717,13 @@ pub enum McpUiAction {
     Remove {
         name: String,
     },
+    Login {
+        name: String,
+        scopes: Vec<String>,
+    },
+    Logout {
+        name: String,
+    },
     Validate,
     Reload,
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7631,6 +7631,47 @@ async fn handle_mcp_ui_action(
             mcp::remove_server_config(&path, &name)
                 .map(|()| message = Some(format!("Removed MCP server '{name}'")))
         }
+        crate::tui::app::McpUiAction::Login { name, scopes } => {
+            let result = async {
+                let cfg = mcp::load_config_with_workspace(&path, &app.workspace)?;
+                let server = cfg
+                    .servers
+                    .get(&name)
+                    .ok_or_else(|| anyhow::anyhow!("MCP server '{name}' not found"))?;
+                let explicit_scopes = (!scopes.is_empty()).then_some(scopes);
+                mcp::oauth::perform_oauth_login_for_server(
+                    &name,
+                    server,
+                    explicit_scopes,
+                    config.mcp_oauth_callback_port,
+                    config.mcp_oauth_callback_url.as_deref(),
+                )
+                .await
+            }
+            .await;
+            result.map(|()| {
+                message = Some(format!(
+                    "Stored OAuth credentials for MCP server '{name}'. Restart if the server was already connected."
+                ));
+            })
+        }
+        crate::tui::app::McpUiAction::Logout { name } => {
+            let result = (|| {
+                let cfg = mcp::load_config_with_workspace(&path, &app.workspace)?;
+                let server = cfg
+                    .servers
+                    .get(&name)
+                    .ok_or_else(|| anyhow::anyhow!("MCP server '{name}' not found"))?;
+                mcp::oauth::delete_oauth_tokens_for_server(&name, server)
+            })();
+            result.map(|deleted| {
+                message = Some(if deleted {
+                    format!("Deleted stored OAuth credentials for MCP server '{name}'.")
+                } else {
+                    format!("No stored OAuth credentials found for MCP server '{name}'.")
+                });
+            })
+        }
         crate::tui::app::McpUiAction::Validate | crate::tui::app::McpUiAction::Reload => Ok(()),
     };
 
@@ -7690,6 +7731,8 @@ fn mcp_ui_action_refreshes_discovery(action: &crate::tui::app::McpUiAction) -> b
         crate::tui::app::McpUiAction::Show
             | crate::tui::app::McpUiAction::Validate
             | crate::tui::app::McpUiAction::Reload
+            | crate::tui::app::McpUiAction::Login { .. }
+            | crate::tui::app::McpUiAction::Logout { .. }
     )
 }
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,6 +1,6 @@
 # MCP (External Tool Servers)
 
-codewhale can load additional tools via MCP (Model Context Protocol). MCP servers are local processes that the TUI starts and communicates with over stdio.
+codewhale can load additional tools via MCP (Model Context Protocol). MCP servers can be local stdio processes that the TUI starts, or remote URL-based servers that speak Streamable HTTP with legacy SSE fallback.
 
 Browsing note:
 - `web.run` is the canonical built-in browsing tool.
@@ -29,6 +29,9 @@ codewhale-tui mcp list
 codewhale-tui mcp tools [server]
 codewhale-tui mcp add <name> --command "<cmd>" --arg "<arg>"
 codewhale-tui mcp add <name> --url "http://localhost:3000/mcp"
+codewhale-tui mcp add <name> --url "https://example.com/mcp" --bearer-token-env-var MCP_TOKEN
+codewhale-tui mcp login <name>
+codewhale-tui mcp logout <name>
 codewhale-tui mcp enable <name>
 codewhale-tui mcp disable <name>
 codewhale-tui mcp remove <name>
@@ -49,6 +52,8 @@ Supported in-TUI actions:
 /mcp init --force
 /mcp add stdio <name> <command> [args...]
 /mcp add http <name> <url>
+/mcp login <name> [--scope scope]
+/mcp logout <name>
 /mcp enable <name>
 /mcp disable <name>
 /mcp remove <name>
@@ -60,6 +65,68 @@ Supported in-TUI actions:
 manager snapshot. Config edits made from the TUI are written immediately, but
 the model-visible MCP tool pool is not hot-reloaded; the manager marks this as
 restart-required until the TUI is restarted.
+
+## Remote HTTP Auth
+
+URL-based MCP servers can use static headers, env-derived headers, bearer-token
+env vars, or OAuth. Authorization precedence is conservative:
+
+1. `headers` and `env_headers` are applied first.
+2. `bearer_token_env_var` adds `Authorization: Bearer <env value>` when no
+   Authorization header was already set.
+3. Stored OAuth credentials are used only when no Authorization header exists.
+
+For bearer-token auth, prefer env-backed config:
+
+```json
+{
+  "servers": {
+    "remote": {
+      "url": "https://example.com/mcp",
+      "bearer_token_env_var": "EXAMPLE_MCP_TOKEN"
+    }
+  }
+}
+```
+
+For generic remote MCP OAuth, add the URL server and run login:
+
+```bash
+codewhale-tui mcp add remote --url "https://example.com/mcp"
+codewhale-tui mcp login remote
+```
+
+CodeWhale discovers the server OAuth metadata, opens the authorization URL in
+your browser, listens on a local callback, exchanges the code, and stores the
+token response through the CodeWhale secrets backend. Stored OAuth tokens are
+looked up by server name plus URL and refreshed when possible before requests.
+
+Optional OAuth fields:
+
+```json
+{
+  "servers": {
+    "remote": {
+      "url": "https://example.com/mcp",
+      "scopes": ["tools/read"],
+      "oauth": {
+        "client_id": "public-client-id"
+      },
+      "oauth_resource": "https://example.com"
+    }
+  }
+}
+```
+
+User-level config can set callback behavior when the provider requires a fixed
+redirect:
+
+```toml
+mcp_oauth_callback_port = 1455
+mcp_oauth_callback_url = "http://127.0.0.1:1455/callback"
+```
+
+These callback fields are ignored from project-scope config overlays.
 
 ## Hugging Face MCP
 
@@ -261,12 +328,22 @@ Per-server settings:
 - `required` (bool, optional): startup/connect validation fails if this server cannot initialize.
 - `enabled_tools` (array, optional): allowlist of tool names for this server.
 - `disabled_tools` (array, optional): denylist applied after `enabled_tools`.
+- `url` (string, optional): Streamable HTTP endpoint for a remote MCP server.
+- `transport` (string, optional): set to `"sse"` for legacy SSE endpoints.
+- `headers` (object, optional): literal HTTP headers for URL-based servers.
+- `env_headers` or `env_http_headers` (object, optional): header names mapped to environment variable names.
+- `bearer_token_env_var` (string, optional): environment variable containing a bearer token.
+- `scopes` (array, optional): default OAuth scopes for `mcp login`.
+- `oauth.client_id` (string, optional): pre-registered OAuth client ID.
+- `oauth_resource` (string, optional): resource parameter appended to the authorization URL.
 
 ## Safety Notes
 
 MCP tools now flow through the same tool-approval framework as built-in tools. Read-only MCP helpers (resource/prompt listing and reads) can run without prompts in suggestive approval modes, while side-effectful MCP tools require approval.
 
 You should still only configure MCP servers you trust, and treat MCP server configuration as equivalent to running code on your machine.
+Avoid committing literal `Authorization` headers. Prefer `env_headers`,
+`bearer_token_env_var`, or OAuth login so secrets stay outside the MCP file.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Adds OAuth 2.0 and static/bearer authentication for URL-based (HTTP/SSE) MCP servers, so remote MCP servers that require auth can be used from the CLI and TUI.

This was prepared on a feature branch that had drifted 15 commits behind `main`. It has been **rebased cleanly onto current `main` (1 commit, no conflicts)** and **re-verified against that base** — the core OAuth files do not overlap with any of the intervening commits.

## What's included

- **New `crates/tui/src/mcp/oauth.rs`** — PKCE OAuth login over a local loopback callback server, token persistence via `codewhale-secrets` (store keys are the SHA-256 of name+url, never the raw URL/name), automatic refresh with a skew window, and scope resolution (explicit > configured > discovered, with a no-scope retry when a provider rejects discovered scopes).
- **Request-time auth precedence** (`McpHttpAuth::resolved_headers`): static `headers` and `env_headers` first, then `bearer_token_env_var`, then OAuth — later sources are skipped once an `Authorization` header is present. All header values pass `is_safe_custom_header` (rejects CR/LF and the reserved `Accept`/`Content-Type` framing).
- **Remote-auth config fields** on `McpServerConfig`: `env_headers`, `bearer_token_env_var`, `scopes`, `oauth.client_id`, `oauth_resource`.
- **CLI**: `codewhale mcp login <name> [--scope …]` / `codewhale mcp logout <name>`.
- **TUI**: `/mcp login <name>` / `/mcp logout`.
- **User config**: `mcp_oauth_callback_port` / `mcp_oauth_callback_url`.
- **Docs**: `docs/MCP.md` documents the precedence, OAuth login, callback config, and safety notes.
- **Deps**: `rmcp` (auth+client), `oauth2`, `webbrowser`, `urlencoding`, `tiny_http`, `sha2`, `base64`.

## Security boundary

OAuth callback settings are **user-config only**. `mcp_oauth_callback_port` and `mcp_oauth_callback_url` are top-level `Config` fields on the #417 project-overlay **deny-list**, and the project MCP overlay only extends `servers` — so a cloned repo cannot redirect the OAuth callback or inject credential sources. Project MCP servers remain gated behind `is_workspace_trusted` (the same gate that already governs project stdio servers). Covered by `project_overlay_denies_dangerous_credentials_and_redirects`.

## Verification (rebased branch, against current `main`)

- `cargo fmt --all --check` — clean
- `git diff --check` — clean
- `cargo check -p codewhale-tui --bin codewhale-tui --locked` — ok
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mcp` — **120 passed, 0 failed, 1 ignored**
- `cargo test … project_overlay_denies_dangerous_credentials_and_redirects` — ok
- `Cargo.lock` consistent under `--locked`
