### PR TITLE
docs(readme): correct stale version comment to 0.8.64 (en/vi/zh-CN/ja-JP)

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -17,7 +17,7 @@ Rust 製の TUI と CLI、25 のプロバイダ。DeepSeek、OpenRouter、Huggin
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.63
+codewhale --version   # 0.8.64
 ```
 
 npm wrapper（Node 18+）は GitHub Releases から SHA-256 検証済みのバイナリをダウンロードし、`codewhale`、`codew`、`codewhale-tui` をインストールします。ソースからビルドしたい場合は cargo（Rust 1.88+）で:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ there's a model, endpoint, or feature you don't see that you want, open an issue
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.63
+codewhale --version   # 0.8.64
 ```
 
 The npm wrapper (Node 18+) downloads SHA-256-verified binaries from GitHub

--- a/README.vi.md
+++ b/README.vi.md
@@ -21,7 +21,7 @@ bằng `/restore` cho mọi lượt.
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.63
+codewhale --version   # 0.8.64
 ```
 
 Wrapper npm (Node 18+) tải binary đã xác minh SHA-256 từ GitHub Releases và

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@ DeepInfra 以及本地 vLLM/SGLang/Ollama 都是一等路由；当你手里是 A
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.63
+codewhale --version   # 0.8.64
 ```
 
 npm wrapper（Node 18+）会从 GitHub Releases 下载经 SHA-256 校验的二进制，并安装


### PR DESCRIPTION
## Summary

Fixes a stale version on the front-page install instructions. The `codewhale --version` snippet printed `# 0.8.63` in all four README variants, while:

- the workspace is at **0.8.64** (`Cargo.toml` `[workspace.package]`), and
- the same READMEs' CNB-mirror install lines already reference `v0.8.64`.

Synced en / vi / zh-CN / ja-JP so the install block is internally consistent and current. Comment-only, 4 lines, no behavior change.

## Scope note (re #3087)

#3087 asks for the full v0.8.65 README end-cap "after the provider/model/Fleet architecture is stable enough to describe accurately." The current README already covers the deepseek-tui → CodeWhale history, the shipped provider list, the nested-constitution differentiator, modes, rollback, and OS sandboxing (bwrap/Landlock/Seatbelt/seccomp — verified as real backends) accurately.

The remaining end-cap items — a Fleet body section and a provider/model graph generated from descriptors — depend on still-open work (#3167 Fleet profiles, #3205 Fleet model classes / loadout-auto, #3384 ReadyRouteCandidate). In particular, #3087's `strong`/`balanced`/`fast` model-class taxonomy does **not** match the shipped `FleetLoadout` token set (`inherit`/`fast`/`balanced`/`deep-reasoning`/`code`/`review`/`tool-heavy`), so describing it now would be premature. This PR lands the safe, verifiable subset; the larger end-cap should follow once that architecture merges.

Refs #3087.
