### PR TITLE
fix(tui): keep review intent from overriding explicit mode

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2404,6 +2404,7 @@ impl Engine {
             tools,
             input_policy.mode,
             force_update_plan_first,
+            input_policy.dynamic_active_tools,
         ))
         .catch_unwind()
         .await;
@@ -3269,6 +3270,7 @@ struct EffectiveInputPolicy {
     trust_mode: bool,
     auto_approve: bool,
     approval_mode: crate::tui::approval::ApprovalMode,
+    dynamic_active_tools: Vec<&'static str>,
     status: Option<String>,
 }
 
@@ -3285,6 +3287,7 @@ fn effective_input_policy(
     let mut trust_mode = trust_mode;
     let mut auto_approve = auto_approve;
     let mut approval_mode = approval_mode;
+    let mut dynamic_active_tools = Vec::new();
     let mut status = None;
 
     if !provenance.can_authorize_work() {
@@ -3307,14 +3310,12 @@ fn effective_input_policy(
             ));
         }
     } else if is_review_only_user_intent(content) {
-        mode = AppMode::Plan;
-        trust_mode = false;
-        auto_approve = false;
-        if matches!(approval_mode, crate::tui::approval::ApprovalMode::Auto) {
-            approval_mode = crate::tui::approval::ApprovalMode::Suggest;
-        }
+        // Advisory only: never silently override an explicitly chosen mode
+        // or strip its tools. Surface the question modal dynamically so the
+        // model can ask focused follow-ups without inflating every tool prompt.
+        dynamic_active_tools.push(REQUEST_USER_INPUT_NAME);
         status = Some(
-            "Review/inspection request detected; using read-only Plan tools for this turn. Add an explicit fix/edit/commit instruction to allow writes.".to_string(),
+            "Review/inspection request detected; keeping the current mode and exposing request_user_input for focused follow-up questions.".to_string(),
         );
     }
 
@@ -3324,6 +3325,7 @@ fn effective_input_policy(
         trust_mode,
         auto_approve,
         approval_mode,
+        dynamic_active_tools,
         status,
     }
 }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1290,6 +1290,10 @@ fn non_yolo_mode_retains_default_defer_policy() {
     ));
     assert!(!should_default_defer_tool("web_search", &always_load));
     assert!(!should_default_defer_tool("write_file", &always_load));
+    assert!(should_default_defer_tool(
+        REQUEST_USER_INPUT_NAME,
+        &always_load
+    ));
     assert!(should_default_defer_tool("task_shell_start", &always_load));
     assert!(should_default_defer_tool("task_shell_wait", &always_load));
     assert!(should_default_defer_tool("git_blame", &always_load));
@@ -1764,6 +1768,37 @@ fn model_tool_catalog_defers_non_core_native_tools_in_yolo_mode() {
     assert_eq!(defer_loading("read_file"), Some(false));
     assert_eq!(defer_loading("project_map"), Some(true));
     assert_eq!(defer_loading("mcp_server_write"), Some(false));
+}
+
+#[test]
+fn request_user_input_stays_deferred_but_can_be_dynamically_activated() {
+    let always_load = HashSet::new();
+    let catalog = build_model_tool_catalog(
+        vec![api_tool("read_file"), api_tool(REQUEST_USER_INPUT_NAME)],
+        Vec::new(),
+        AppMode::Agent,
+        &always_load,
+    );
+
+    assert_eq!(
+        catalog
+            .iter()
+            .find(|tool| tool.name == REQUEST_USER_INPUT_NAME)
+            .and_then(|tool| tool.defer_loading),
+        Some(true)
+    );
+
+    let mut active = initial_active_tools(&catalog);
+    assert!(!active.contains(REQUEST_USER_INPUT_NAME));
+    active.insert(REQUEST_USER_INPUT_NAME.to_string());
+
+    let active_tools = active_tools_for_step(&catalog, &active, false);
+    assert!(
+        active_tools
+            .iter()
+            .any(|tool| tool.name == REQUEST_USER_INPUT_NAME),
+        "dynamic active tools should expose the question modal without making it eager by default"
+    );
 }
 
 #[test]
@@ -3354,7 +3389,12 @@ fn self_generated_fake_approvals_cannot_authorize_work() {
 }
 
 #[test]
-fn review_only_external_input_gets_read_only_policy_until_write_is_explicit() {
+fn review_only_external_input_keeps_explicit_mode_with_advisory_hint() {
+    // Review-only wording must NEVER silently override an explicitly chosen
+    // mode or strip its tools. The heuristic only activates the existing
+    // request_user_input modal tool so the model can ask focused follow-ups.
+
+    // Agent-mode request: the requested mode/tools must be preserved unchanged.
     let agent = effective_input_policy(
         UserInputProvenance::ExternalUser,
         AppMode::Agent,
@@ -3364,18 +3404,21 @@ fn review_only_external_input_gets_read_only_policy_until_write_is_explicit() {
         true,
         crate::tui::approval::ApprovalMode::Auto,
     );
-    assert_eq!(agent.mode, AppMode::Plan);
+    assert_eq!(agent.mode, AppMode::Agent);
     assert!(agent.allow_shell);
-    assert!(!agent.trust_mode);
-    assert!(!agent.auto_approve);
+    assert!(agent.trust_mode);
+    assert!(agent.auto_approve);
     assert!(matches!(
         agent.approval_mode,
-        crate::tui::approval::ApprovalMode::Suggest
+        crate::tui::approval::ApprovalMode::Auto
     ));
+    assert_eq!(agent.dynamic_active_tools, vec![REQUEST_USER_INPUT_NAME]);
     assert!(agent.status.as_deref().is_some_and(|status| {
-        status.contains("read-only Plan tools") && status.contains("explicit fix/edit/commit")
+        status.contains("keeping the current mode") && status.contains("request_user_input")
     }));
 
+    // Yolo-mode request: previously this was silently downgraded to Plan and
+    // exec_shell/write_file/etc. were stripped. It must now stay as requested.
     let yolo = effective_input_policy(
         UserInputProvenance::ExternalUser,
         AppMode::Yolo,
@@ -3385,16 +3428,17 @@ fn review_only_external_input_gets_read_only_policy_until_write_is_explicit() {
         true,
         crate::tui::approval::ApprovalMode::Auto,
     );
-    assert_eq!(yolo.mode, AppMode::Plan);
+    assert_eq!(yolo.mode, AppMode::Yolo);
     assert!(yolo.allow_shell);
-    assert!(!yolo.trust_mode);
-    assert!(!yolo.auto_approve);
+    assert!(yolo.trust_mode);
+    assert!(yolo.auto_approve);
     assert!(matches!(
         yolo.approval_mode,
-        crate::tui::approval::ApprovalMode::Suggest
+        crate::tui::approval::ApprovalMode::Auto
     ));
+    assert_eq!(yolo.dynamic_active_tools, vec![REQUEST_USER_INPUT_NAME]);
     assert!(yolo.status.as_deref().is_some_and(|status| {
-        status.contains("read-only Plan tools") && status.contains("explicit fix/edit/commit")
+        status.contains("keeping the current mode") && status.contains("request_user_input")
     }));
 
     let explicit_write = effective_input_policy(
@@ -3407,6 +3451,7 @@ fn review_only_external_input_gets_read_only_policy_until_write_is_explicit() {
         crate::tui::approval::ApprovalMode::Suggest,
     );
     assert_eq!(explicit_write.mode, AppMode::Agent);
+    assert!(explicit_write.dynamic_active_tools.is_empty());
     assert!(explicit_write.status.is_none());
 }
 
@@ -3881,6 +3926,32 @@ fn tool_search_activates_discovered_deferred_tools() {
     .expect("search succeeds");
     assert!(result.success);
     assert!(active.contains("read_file"));
+}
+
+#[test]
+fn tool_search_can_discover_request_user_input_modal_tool() {
+    let always_load = HashSet::new();
+    let mut catalog = build_model_tool_catalog(
+        vec![api_tool(REQUEST_USER_INPUT_NAME)],
+        Vec::new(),
+        AppMode::Agent,
+        &always_load,
+    );
+    ensure_advanced_tooling(&mut catalog, AppMode::Agent, &always_load);
+
+    let mut active = initial_active_tools(&catalog);
+    assert!(!active.contains(REQUEST_USER_INPUT_NAME));
+
+    let result = execute_tool_search(
+        TOOL_SEARCH_NAME,
+        &json!({"query":"ask user question"}),
+        &catalog,
+        &mut active,
+    )
+    .expect("search succeeds");
+
+    assert!(result.success);
+    assert!(active.contains(REQUEST_USER_INPUT_NAME));
 }
 
 fn tool_search_catalog_with_matches(count: usize) -> Vec<Tool> {

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -110,6 +110,7 @@ impl Engine {
         tools: Option<Vec<Tool>>,
         mode: AppMode,
         force_update_plan_first: bool,
+        dynamic_active_tools: Vec<&'static str>,
     ) -> (TurnOutcomeStatus, Option<String>) {
         // Signal to the terminal / taskbar that a turn is in progress
         // (OSC 9 ; 4 indeterminate progress + title spinner).
@@ -139,6 +140,11 @@ impl Engine {
             }
         }
         let mut active_tool_names = initial_active_tools(&tool_catalog);
+        active_tool_names.extend(
+            dynamic_active_tools
+                .into_iter()
+                .map(std::string::ToString::to_string),
+        );
         let mut goal_continuations_this_turn = 0u32;
 
         // Outer stream-retry counter: when the chunked-transfer connection

--- a/crates/tui/src/prompts/constitution.md
+++ b/crates/tui/src/prompts/constitution.md
@@ -620,7 +620,7 @@ survive compaction. Think once, reference many times.
 - **Recursive LM (long inputs / parallel reasoning)**: `rlm_open`, `rlm_eval`, `rlm_configure`, `rlm_close` — open a named Python REPL over a file/string/URL, run deterministic and semantic analysis, return compact results or `var_handle`s, then close when done.
 - **Large symbolic outputs**: `handle_read` — read bounded slices, counts, ranges, or JSONPath projections from returned `var_handle`s without replaying the whole payload.
 - **Skills**: `load_skill` (#434) — when the user names a skill or the task matches one in the `## Skills` section above, call this with the skill id to pull its `SKILL.md` body and companion-file list into context in one tool call. Faster than `read_file` + `list_dir`.
-- **Other**: `code_execution` (Python sandbox), `validate_data` (JSON/TOML), `request_user_input`, `finance` (market quotes), `tool_search_tool_regex`, `tool_search_tool_bm25` (deferred tool discovery).
+- **Other**: `code_execution` (Python sandbox), `validate_data` (JSON/TOML), `request_user_input` (ask the user through the modal UX), `finance` (market quotes), `tool_search` (`match: "bm25"` by default, or `"regex"` for pattern discovery of deferred tools).
 
 Multiple `tool_calls` in one turn run in parallel. `web_search` returns `ref_id`s — cite as `(ref_id)`.
 


### PR DESCRIPTION
## Summary
- stop review/check/inspection wording from silently downgrading explicit Agent or YOLO turns into Plan mode
- preserve the selected approval posture, then dynamically activate `request_user_input` for that turn so the model can ask focused follow-up questions through the modal UX
- keep `request_user_input` deferred/searchable by default and refresh constitution wording for the folded `tool_search` surface

Refs #3386.

## Testing
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked review_only_external_input_keeps_explicit_mode_with_advisory_hint -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked request_user_input_stays_deferred_but_can_be_dynamically_activated -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked tool_search_can_discover_request_user_input_modal_tool -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked tool_search -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked prompt -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked mode -- --nocapture`
