### PR TITLE
docs: require rebase/merge-commit (not squash) for harvested PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,10 @@
   author where possible, add `Co-authored-by` using `.github/AUTHOR_MAP` or
   GitHub numeric noreply identity, and include `Harvested from PR #N by
   @handle` in the commit body so the auto-close workflow can close the PR with
-  credit after it reaches `main`.
+  credit after it reaches `main`. Merge a PR whose commit carries that line
+  with rebase or a merge commit, never squash: a squash can rewrite the body,
+  drop the `Harvested from PR` line, and silently lose both the
+  machine-readable credit and the auto-close.
 - Never add bot/tool `Co-authored-by` trailers (Claude, codex, cursor,
   `noreply@anthropic.com`): `scripts/check-coauthor-trailers.py` rejects them on
   harvest commits — contributor trailers are for humans. Also refresh the manual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,10 @@ dependent layers. For those changes, use this workflow:
    but leaves follow-up work.
 7. Structured commits are fine during review. Maintainers may squash or harvest
    at merge time, with contributor credit preserved through authorship,
-   co-author trailers, changelog entries, or PR/issue comments.
+   co-author trailers, changelog entries, or PR/issue comments. When the merge
+   commit itself carries a `Harvested from PR #N by @author` line, that PR is
+   merged with rebase or a merge commit rather than squashed, so the line
+   reaches `main` intact and the auto-close credit fires.
 
 Before asking for merge review on a layered PR, check that it is:
 


### PR DESCRIPTION
## Summary

Closes the one remaining way contributor credit can silently drop at merge time: a **squash-merge rewrites the commit body**, so it can strip the `Harvested from PR #N by @author` line a harvest commit carries. If that line never reaches `main`, both the machine-readable credit *and* the `auto-close-harvested` workflow silently fail — the exact credit-drop class #3517 had to reconcile after the fact.

The credit gate (`scripts/check-coauthor-trailers.py`) already runs on every PR and every push to `main`, but it can only validate a marker that *survives* — it cannot detect one a squash already deleted. **Merge method is the missing guardrail**, so this documents it in the two canonical places:

- **AGENTS.md** — extend the harvesting-credit rule: merge a harvest-carrying PR with rebase or a merge commit, never squash.
- **CONTRIBUTING.md** — refine the "maintainers may squash or harvest at merge time" note with the same caveat.

## Live precedent

#3529 (harvest of #3524 by @cyq1017) was just rebase-merged for exactly this reason — the trailer reached `main` intact and #3524 auto-closed with credit. This PR writes that rule down so the next harvest doesn't depend on remembering it.

Docs-only; no code or behavior change.
