### PR TITLE
fix(api): reuse a shared McpPool across HTTP API calls (#3532)

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2539,6 +2539,7 @@ impl McpPool {
     }
 
     /// Get list of connected server names
+    #[allow(dead_code)] // Public API; the HTTP list endpoint no longer spawns a pool to call it (#3532)
     pub fn connected_servers(&self) -> Vec<&str> {
         self.connections
             .iter()

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1,6 +1,6 @@
 //! Runtime HTTP/SSE API for local CodeWhale automation.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::fs;
 use std::net::{SocketAddr, UdpSocket};
@@ -82,6 +82,11 @@ pub struct RuntimeApiState {
     bind_host: String,
     bind_port: u16,
     mobile_enabled: bool,
+    /// Shared McpPool reused across HTTP API calls so each call does not
+    /// spawn a duplicate set of MCP server processes. The engine maintains
+    /// its own separate pool; this one is for read-only tool discovery via
+    /// the API.
+    mcp_pool: Arc<Mutex<Option<McpPool>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -558,6 +563,7 @@ pub async fn run_http_server(
         bind_host: options.host.clone(),
         bind_port: options.port,
         mobile_enabled: options.mobile,
+        mcp_pool: Arc::new(Mutex::new(None)),
     };
     let app = build_router(state);
 
@@ -2170,13 +2176,6 @@ async fn list_mcp_servers(
 ) -> Result<Json<McpServersResponse>, ApiError> {
     let config = crate::mcp::load_config_with_workspace(&state.mcp_config_path, &state.workspace)
         .map_err(|e| ApiError::internal(format!("Failed to load MCP config: {e}")))?;
-    let mut pool = McpPool::new(config.clone());
-    let _errors = pool.connect_all().await;
-    let connected: HashSet<String> = pool
-        .connected_servers()
-        .into_iter()
-        .map(str::to_string)
-        .collect();
 
     let mut servers = Vec::new();
     for (name, server_cfg) in config.servers {
@@ -2186,7 +2185,7 @@ async fn list_mcp_servers(
             required: server_cfg.required,
             command: server_cfg.command.clone(),
             url: server_cfg.url.clone(),
-            connected: connected.contains(&name),
+            connected: false,
             enabled_tools: server_cfg.enabled_tools.clone(),
             disabled_tools: server_cfg.disabled_tools.clone(),
         });
@@ -2200,9 +2199,14 @@ async fn list_mcp_tools(
     State(state): State<RuntimeApiState>,
     Query(query): Query<McpToolsQuery>,
 ) -> Result<Json<McpToolsResponse>, ApiError> {
-    let mut pool =
-        McpPool::from_config_path_with_workspace(&state.mcp_config_path, &state.workspace)
-            .map_err(|e| ApiError::internal(format!("Failed to load MCP config: {e}")))?;
+    let mut pool_guard = state.mcp_pool.lock().await;
+    if pool_guard.is_none() {
+        let new_pool =
+            McpPool::from_config_path_with_workspace(&state.mcp_config_path, &state.workspace)
+                .map_err(|e| ApiError::internal(format!("Failed to load MCP config: {e}")))?;
+        pool_guard.replace(new_pool);
+    }
+    let pool = pool_guard.as_mut().unwrap();
     let _errors = pool.connect_all().await;
 
     let mut tools = Vec::new();

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -536,6 +536,7 @@ async fn spawn_test_server_with_root_token_mobile_workspace_and_subagents(
         cors_origins: Vec::new(),
         sessions_dir,
         mcp_config_path: root.join("mcp.json"),
+        mcp_pool: Arc::new(Mutex::new(None)),
         automations,
         sub_agent_manager,
         runtime_token,


### PR DESCRIPTION
## Summary

Harvests @pkeging's #3532 onto current `main`, repaired green. Fixes the **root cause of #3461's duplicate MCP server processes**: each HTTP runtime-API tool-discovery call built its own `McpPool` and spawned a fresh set of MCP server processes. Now `RuntimeApiState` holds a lazily-initialized `Arc<Mutex<Option<McpPool>>>` reused across calls; the engine keeps its own separate pool.

Complements #3529 (cyq1017's connection-drop lifecycle visibility) — together they cover #3461's lifecycle *and* the duplicate-spawn root cause.

## Harvest repair

#3532 was CI-red (the contributor's own fmt/test checkboxes were unchecked). Minimal repairs to land green, keeping @pkeging's design:
- `runtime_api/tests.rs`: add the new `mcp_pool` field to the test-only `RuntimeApiState` initializer (the one construction site #3532 missed → the macOS/Windows test compile failure).
- `mcp.rs`: `#[allow(dead_code)]` on `connected_servers` (its sole caller was the removed per-call pool → the Lint failure; matches the existing `disconnect_all` convention).

`list_mcp_servers` now reports `connected = false` (config listing only) — a deliberate tradeoff to avoid the duplicate spawn; live state remains on the tool-discovery path.

## Provenance & credit

Author preserved as @pkeging (canonical identity); the `Harvested from PR #3532 by @pkeging` trailer auto-closes #3532 with credit once this reaches `main`. **Rebase-merge, do not squash** (preserves the trailer + author).

## Verification (current `main`)

- `cargo fmt --all --check` — clean
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings` (CI's `-A` set) — clean
- `cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_api` — **63 passed, 0 failed**
- conflict-free vs `main`; co-author credit gate passes
