### PR TITLE
chore(credit): reconcile machine credit for six harvested contributors

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -127,3 +127,16 @@ tiger-dog = tiger-dog <63037740+tiger-dog@users.noreply.github.com>
 Jianfengwu2024 = Jianfengwu2024 <186297054+Jianfengwu2024@users.noreply.github.com>
 wplll = wplll <106327929+wplll@users.noreply.github.com>
 buko = buko <12692585+buko@users.noreply.github.com>
+
+# Machine-credit reconciliation follow-up: contributors credited in prose or
+# harvested by handle but missing from AUTHOR_MAP. Logins/IDs verified against
+# the GitHub user API.
+1Git2Clone = 1Git2Clone <171241044+1Git2Clone@users.noreply.github.com>
+jieshu666 = jieshu666 <272788222+jieshu666@users.noreply.github.com>
+rockeverm3m = rockeverm3m <280319705+rockeverm3m@users.noreply.github.com>
+wfxqws65hc@privaterelay.appleid.com = rockeverm3m <280319705+rockeverm3m@users.noreply.github.com>
+wavezhang = wavezhang <832911+wavezhang@users.noreply.github.com>
+hxy91819 = hxy91819 <8814856+hxy91819@users.noreply.github.com>
+hxy91819@gmail.com = hxy91819 <8814856+hxy91819@users.noreply.github.com>
+heloanc = heloanc <61081755+heloanc@users.noreply.github.com>
+heloanc@users.noreply.github.com = heloanc <61081755+heloanc@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all seven shipped locales (model-facing mode labels stay English). Harvested
   from #2239 by @gordonlu.
 
+### Changed
+
+- **Restored contributor credit.** Threaded machine-readable credit
+  (`docs/CONTRIBUTORS.md` + `.github/AUTHOR_MAP`) for earlier merged work that
+  shipped without it, including the `/jobs cancel-all` action and the npm
+  retry-timeout hint (#1538) by @jieshu666, and the community ACP adapter
+  reference by @rockeverm3m.
+
 ## [0.8.64] - 2026-06-22
 
 ### Added

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all seven shipped locales (model-facing mode labels stay English). Harvested
   from #2239 by @gordonlu.
 
+### Changed
+
+- **Restored contributor credit.** Threaded machine-readable credit
+  (`docs/CONTRIBUTORS.md` + `.github/AUTHOR_MAP`) for earlier merged work that
+  shipped without it, including the `/jobs cancel-all` action and the npm
+  retry-timeout hint (#1538) by @jieshu666, and the community ACP adapter
+  reference by @rockeverm3m.
+
 ## [0.8.64] - 2026-06-22
 
 ### Added

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -379,6 +379,15 @@ was dropped. Restoring them here — every one shipped real code:_
 Additional harvested PRs from the same audit, credited to contributors already
 listed above: **[axobase001](https://github.com/axobase001)** (#2400, #2405, #2406, #2407, #2408, #2415), **[cyq1017](https://github.com/cyq1017)** (#2516, #2534, #2540), **[Oliver-ZPLiu](https://github.com/Oliver-ZPLiu)** (#1451, #1456), **[reidliu41](https://github.com/reidliu41)** (#1444, #1493), **[lucaszhu-hue](https://github.com/lucaszhu-hue)** (#1436, #2343), **[h3c-hexin](https://github.com/h3c-hexin)** (#1480), **[Duducoco](https://github.com/Duducoco)** (#1345), **[zhuangbiaowei](https://github.com/zhuangbiaowei)** (#1416), **[wdw8276](https://github.com/wdw8276)** (#1498), and **[buko](https://github.com/buko)** (#2377).
 
+_A further machine-credit pass restored these contributors, missing from both the
+list above and the contribution graph (AUTHOR_MAP entries added; logins/IDs
+verified against the GitHub user API) — every one shipped real code:_
+
+- **[1Git2Clone](https://github.com/1Git2Clone)** — `Ctrl+P`/`Ctrl+N` slash-menu navigation
+- **[rockeverm3m](https://github.com/rockeverm3m)** — community ACP adapter reference in the docs
+- **[hxy91819](https://github.com/hxy91819)** — stable MCP tool ordering for prefix-cache stability (#1319)
+- **[heloanc](https://github.com/heloanc)** — Home/End keys moving the cursor in the input box (#1246)
+
 </details>
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to #3517. I ran the co-author credit gate (`scripts/check-coauthor-trailers.py`) over **all of `main`'s history** to find contributor credit dropped in earlier harvests.

Most of the ~191 historical findings are *already-credited* contributors whose old commits used a raw/non-canonical trailer (credit was restored in prose; history isn't rewritten) — **not** lost credit. After verifying each candidate against `origin/main`'s real AUTHOR_MAP/CONTRIBUTORS (the working branch carried a **stale AUTHOR_MAP** that produced false positives, e.g. NorethSea/tiger-dog looked "missing" but #3517 already added them) and against the **GitHub user API**, six contributors had genuinely-missing machine credit:

| Contributor | Contribution | In CONTRIBUTORS? | In AUTHOR_MAP? |
|---|---|---|---|
| 1Git2Clone | Ctrl+P/N slash-menu nav | no → added | no → added |
| rockeverm3m | community ACP adapter docs | no → added | no → added |
| hxy91819 | stable MCP tool ordering (#1319) | no → added | no → added |
| heloanc | Home/End cursor (#1246) | no → added | no → added |
| jieshu666 | (already listed) | yes | no → added |
| wavezhang | (already listed) | yes | no → added |

Per the #3517 model, history isn't rewritten — credit is restored on the manual surfaces so the contribution graph and future references resolve canonically.

## Deliberately NOT credited

- **bengao168** — an older harvest line says `@bengao168`, but that maps to `bengao168@msn.com` → **@gaord**, already in AUTHOR_MAP. Not a separate account (the bare login 404s).
- A broader set of historical co-author trailers use raw third-party emails where the GitHub login can't be confirmed from the trailer alone (e.g. "Stephen Xu", "kitty", "lei", "Zhao Xiaohong", "Jason"). I left those out rather than guess a login — mis-crediting is worse than the gap. Happy to extend once you confirm logins (same GitHub-API method).

Docs/metadata only; no code change. **Rebase-merge, not squash.**
