### PR TITLE
feat(fleet): durable manager resume from ledger + route-parity proof

### DIFF
--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -21,6 +21,7 @@ use super::executor::{
 };
 use super::host::FleetHostErrorKind;
 use super::ledger::{FleetLedger, FleetLedgerState, FleetTaskLedgerStatus, FleetTaskState};
+use super::scheduler::{FleetScheduler, FleetSchedulerPolicy};
 use super::task_spec::{
     FleetTaskSpecDocument, FleetTaskVerificationInput, load_task_spec_document,
     record_verification_receipt, validate_task_spec_document, verify_task_result,
@@ -97,6 +98,24 @@ pub struct FleetStatusSnapshot {
     pub cancelled: usize,
     pub stale: usize,
     pub workers: BTreeMap<String, FleetWorkerStatus>,
+}
+
+/// Outcome of resuming a fleet run from durable ledger state after a manager
+/// restart. The counts reflect the reconciliation pass; `status` is the
+/// post-resume inspectable snapshot.
+#[derive(Debug, Clone)]
+pub struct FleetResumeReport {
+    pub run_id: FleetRunId,
+    /// Orphaned in-flight leases detected as stale and reclaimed.
+    pub reclaimed_stale: usize,
+    /// Stale leases retried within their retry budget.
+    pub restarted: usize,
+    /// Stale leases that exhausted their retry budget and were failed.
+    pub failed: usize,
+    /// Escalation alerts emitted for exhausted tasks.
+    pub escalated: usize,
+    /// Inspectable run status after the resume pass.
+    pub status: FleetStatusSnapshot,
 }
 
 #[derive(Debug, Clone)]
@@ -318,6 +337,49 @@ impl FleetManager {
     pub fn run_has_open_work(&self, run_id: &FleetRunId) -> Result<bool> {
         let status = self.run_status(run_id)?;
         Ok(status.queued + status.running + status.stale > 0)
+    }
+
+    /// Resume a run from durable ledger state after a manager restart.
+    ///
+    /// A crashed or detached manager can leave in-flight tasks `Leased` to
+    /// workers whose processes are gone. Resume rebuilds run state from the
+    /// ledger, reconciles those orphaned/stale leases through the shared
+    /// scheduler recovery semantics (retry within budget, else fail and
+    /// escalate), records every decision durably, and returns an inspectable
+    /// status. It launches no new work and does not re-process tasks that
+    /// already reached a terminal state, so it is safe to call repeatedly.
+    pub fn resume_run(&self, run_id: &FleetRunId) -> Result<FleetResumeReport> {
+        self.resume_run_at(run_id, Utc::now())
+    }
+
+    /// Resume reconciliation at an explicit instant. This is the deterministic
+    /// seam behind [`resume_run`]'s wall clock: stale detection compares the
+    /// last heartbeat against `now`.
+    pub(crate) fn resume_run_at(
+        &self,
+        run_id: &FleetRunId,
+        now: DateTime<Utc>,
+    ) -> Result<FleetResumeReport> {
+        // Reuse the shared scheduler recovery engine over the same ledger so
+        // resume and steady-state supervision converge on one store and one
+        // retry/escalation policy. The manager's `stale_after` becomes the
+        // scheduler's heartbeat timeout so both surfaces agree on staleness.
+        let policy = FleetSchedulerPolicy {
+            heartbeat_timeout: self.stale_after,
+            ..FleetSchedulerPolicy::default()
+        };
+        let mut scheduler = FleetScheduler::open(&self.workspace, policy)?;
+        scheduler.set_now(now);
+        let report = scheduler.resume_run(run_id)?;
+        let status = self.run_status(run_id)?;
+        Ok(FleetResumeReport {
+            run_id: run_id.clone(),
+            reclaimed_stale: report.marked_stale,
+            restarted: report.restarted,
+            failed: report.failed,
+            escalated: report.alerts,
+            status,
+        })
     }
 
     pub async fn run_to_completion(
@@ -1494,6 +1556,314 @@ mod tests {
                 .await
                 .unwrap()
         })
+    }
+
+    const RESUME_T0: &str = "2026-06-13T01:00:00Z";
+
+    fn role_task_with_retry(id: &str, role: &str, max_attempts: u32) -> FleetTaskSpec {
+        let mut spec = task(id);
+        spec.worker = Some(FleetTaskWorkerProfile {
+            agent_profile: None,
+            role: Some(role.to_string()),
+            loadout: None,
+            model_class: None,
+            tool_profile: None,
+            tools: Vec::new(),
+            capabilities: Vec::new(),
+        });
+        spec.retry_policy = Some(FleetRetryPolicy {
+            max_attempts,
+            ..FleetRetryPolicy::default()
+        });
+        spec
+    }
+
+    fn resume_worker_spec(id: &str) -> FleetWorkerSpec {
+        FleetWorkerSpec {
+            id: id.to_string(),
+            name: id.to_string(),
+            host: FleetHostSpec::Local,
+            trust_level: Some(FleetTrustLevel::Local),
+            labels: BTreeMap::new(),
+            capabilities: vec!["local".to_string()],
+            max_concurrent_tasks: Some(1),
+        }
+    }
+
+    fn resume_now(offset_secs: i64) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(RESUME_T0)
+            .unwrap()
+            .with_timezone(&Utc)
+            + chrono::Duration::seconds(offset_secs)
+    }
+
+    /// Seed the durable ledger with the state a crashed manager would leave: a
+    /// running run whose `completed` task ids finished with receipts, and whose
+    /// `orphaned` (task_id, worker_id) pairs are still `Leased` to workers that
+    /// last heartbeat at `heartbeat_ts` — stale once the resume clock advances
+    /// past `stale_after`.
+    fn seed_crashed_run(
+        ledger: &FleetLedger,
+        run_id: &FleetRunId,
+        tasks: &[FleetTaskSpec],
+        workers: &[FleetWorkerSpec],
+        completed: &[&str],
+        orphaned: &[(&str, &str)],
+        heartbeat_ts: &str,
+    ) {
+        ledger
+            .create_run(&FleetRun {
+                id: run_id.clone(),
+                name: "resume smoke".to_string(),
+                status: FleetRunStatus::Running,
+                task_specs: tasks.to_vec(),
+                worker_specs: workers.to_vec(),
+                labels: BTreeMap::new(),
+                security_policy: None,
+                created_at: heartbeat_ts.to_string(),
+                updated_at: Some(heartbeat_ts.to_string()),
+                completed_at: None,
+            })
+            .unwrap();
+        for spec in tasks {
+            ledger
+                .enqueue(FleetInboxEntry {
+                    run_id: run_id.clone(),
+                    task_id: spec.id.clone(),
+                    priority: 0,
+                    enqueued_at: heartbeat_ts.to_string(),
+                    lease_deadline: None,
+                    attempts: 0,
+                })
+                .unwrap();
+        }
+        for (idx, &task_id) in completed.iter().enumerate() {
+            let worker_id = format!("done-worker-{idx}");
+            ledger
+                .lease_task(run_id, task_id, &worker_id, heartbeat_ts, None)
+                .unwrap();
+            ledger
+                .mark_task_terminal_status(
+                    run_id,
+                    task_id,
+                    Some(worker_id.as_str()),
+                    heartbeat_ts,
+                    FleetTaskLedgerStatus::Completed,
+                )
+                .unwrap();
+            ledger
+                .record_receipt(FleetReceipt {
+                    run_id: run_id.clone(),
+                    task_id: task_id.to_string(),
+                    worker_id,
+                    completed_at: heartbeat_ts.to_string(),
+                    result: FleetTaskResult::Pass,
+                    failure_kind: None,
+                    artifacts: Vec::new(),
+                    score: None,
+                })
+                .unwrap();
+        }
+        for &(task_id, worker_id) in orphaned {
+            ledger
+                .lease_task(run_id, task_id, worker_id, heartbeat_ts, None)
+                .unwrap();
+            ledger
+                .heartbeat(worker_id, heartbeat_ts, None, None)
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn fleet_resume_reconciles_orphaned_lease_and_retries_within_budget() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = FleetLedger::open(tmp.path()).unwrap();
+        let run_id = FleetRunId::from("resume-run");
+        // Three roles, three workers; scout and verifier finished, builder is
+        // orphaned mid-flight (its worker stopped heartbeating at the crash).
+        let tasks = vec![
+            role_task_with_retry("scout-1", "read-only", 3),
+            role_task_with_retry("build-1", "builder", 3),
+            role_task_with_retry("verify-1", "smoke-runner", 3),
+        ];
+        let workers = vec![
+            resume_worker_spec("w-scout"),
+            resume_worker_spec("w-build"),
+            resume_worker_spec("w-verify"),
+        ];
+        seed_crashed_run(
+            &ledger,
+            &run_id,
+            &tasks,
+            &workers,
+            &["scout-1", "verify-1"],
+            &[("build-1", "w-build")],
+            RESUME_T0,
+        );
+
+        // Restart: a fresh manager over the same workspace resumes from ledger.
+        let manager = FleetManager::open(tmp.path())
+            .unwrap()
+            .with_stale_after(Duration::from_secs(5));
+        let outcome = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
+
+        assert_eq!(
+            outcome.reclaimed_stale, 1,
+            "orphaned builder lease detected stale"
+        );
+        assert_eq!(outcome.restarted, 1, "builder retried within budget");
+        assert_eq!(outcome.failed, 0);
+        assert_eq!(outcome.escalated, 0);
+        assert_eq!(
+            outcome.status.completed, 2,
+            "pre-crash completions preserved"
+        );
+        assert_eq!(outcome.status.restarted, 1);
+
+        let state = manager.rebuild_state().unwrap();
+        assert_eq!(state.receipts.len(), 2, "pre-crash receipts survive resume");
+        let builder = &state.tasks["resume-run:build-1"];
+        assert_eq!(builder.status, FleetTaskLedgerStatus::Leased);
+        assert_eq!(builder.entry.attempts, 2, "retry leased a second attempt");
+
+        let text = std::fs::read_to_string(manager.ledger_path()).unwrap();
+        assert!(
+            text.contains("\"state\":\"stale\""),
+            "stale event durably recorded"
+        );
+        assert!(
+            text.contains("\"state\":\"restarted\""),
+            "restart durably recorded"
+        );
+    }
+
+    #[test]
+    fn fleet_resume_exhausted_retry_fails_and_escalates_idempotently() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = FleetLedger::open(tmp.path()).unwrap();
+        let run_id = FleetRunId::from("resume-run");
+        let mut builder = role_task_with_retry("build-1", "builder", 1);
+        builder.alert_policy = Some(FleetAlertPolicy {
+            events: vec![FleetAlertEventClass::RestartExhausted],
+            channels: vec![FleetAlertChannel::Slack {
+                webhook: FleetAlertEndpoint::inline("https://hooks.slack.invalid/secret"),
+            }],
+            after_attempts: Some(1),
+            after_minutes_stale: Some(1),
+        });
+        let tasks = vec![builder];
+        let workers = vec![resume_worker_spec("w-build")];
+        seed_crashed_run(
+            &ledger,
+            &run_id,
+            &tasks,
+            &workers,
+            &[],
+            &[("build-1", "w-build")],
+            RESUME_T0,
+        );
+
+        let manager = FleetManager::open(tmp.path())
+            .unwrap()
+            .with_stale_after(Duration::from_secs(5));
+        let outcome = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
+
+        assert_eq!(outcome.reclaimed_stale, 1);
+        assert_eq!(outcome.restarted, 0);
+        assert_eq!(outcome.failed, 1, "exhausted retry budget fails the task");
+        assert_eq!(
+            outcome.escalated, 1,
+            "exhaustion escalates per alert policy"
+        );
+        assert_eq!(outcome.status.failed, 1);
+        assert_eq!(outcome.status.escalated, 1);
+
+        let text = std::fs::read_to_string(manager.ledger_path()).unwrap();
+        assert!(text.contains("\"state\":\"failed\""));
+        assert!(text.contains("\"state\":\"escalated\""));
+        assert!(text.contains("\"record\":\"alert_sent\""));
+        assert!(
+            !text.contains("hooks.slack.invalid/secret"),
+            "secret webhook redacted in ledger"
+        );
+
+        // Resuming again must not resurrect or re-escalate a terminal failure.
+        let again = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
+        assert_eq!(again.reclaimed_stale, 0);
+        assert_eq!(again.failed, 0);
+        assert_eq!(again.escalated, 0);
+        assert_eq!(
+            manager.run_status(&run_id).unwrap().escalated,
+            1,
+            "no duplicate escalation across resumes"
+        );
+    }
+
+    #[test]
+    fn fleet_resume_retry_is_idempotent_at_same_instant() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = FleetLedger::open(tmp.path()).unwrap();
+        let run_id = FleetRunId::from("resume-run");
+        let tasks = vec![role_task_with_retry("build-1", "builder", 3)];
+        let workers = vec![resume_worker_spec("w-build")];
+        seed_crashed_run(
+            &ledger,
+            &run_id,
+            &tasks,
+            &workers,
+            &[],
+            &[("build-1", "w-build")],
+            RESUME_T0,
+        );
+
+        let manager = FleetManager::open(tmp.path())
+            .unwrap()
+            .with_stale_after(Duration::from_secs(5));
+        let first = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
+        assert_eq!(first.restarted, 1);
+
+        // Re-leased at the resume instant, the task is no longer stale, so a
+        // second resume at the same instant is a no-op (no double retry).
+        let second = manager.resume_run_at(&run_id, resume_now(30)).unwrap();
+        assert_eq!(second.reclaimed_stale, 0);
+        assert_eq!(second.restarted, 0);
+        assert_eq!(
+            manager.rebuild_state().unwrap().tasks["resume-run:build-1"]
+                .entry
+                .attempts,
+            2,
+            "attempts did not double on the second resume"
+        );
+    }
+
+    #[test]
+    fn fleet_resume_uses_wall_clock_for_stale_detection() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = FleetLedger::open(tmp.path()).unwrap();
+        let run_id = FleetRunId::from("resume-run");
+        let tasks = vec![role_task_with_retry("build-1", "builder", 3)];
+        let workers = vec![resume_worker_spec("w-build")];
+        // Heartbeat an hour in the past so it is reliably stale under the real
+        // wall clock used by the production `resume_run` entrypoint.
+        let stale_ts = (Utc::now() - chrono::Duration::seconds(3600))
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        seed_crashed_run(
+            &ledger,
+            &run_id,
+            &tasks,
+            &workers,
+            &[],
+            &[("build-1", "w-build")],
+            &stale_ts,
+        );
+
+        let manager = FleetManager::open(tmp.path())
+            .unwrap()
+            .with_stale_after(Duration::from_secs(5));
+        let outcome = manager.resume_run(&run_id).unwrap();
+
+        assert_eq!(outcome.reclaimed_stale, 1);
+        assert_eq!(outcome.restarted, 1);
     }
 
     #[test]

--- a/crates/tui/src/fleet/scheduler.rs
+++ b/crates/tui/src/fleet/scheduler.rs
@@ -73,6 +73,22 @@ impl FleetScheduler {
         Ok(report)
     }
 
+    /// Resume reconciliation after a manager restart: detect orphaned/stale
+    /// in-flight leases left by a prior process and apply retry/escalation
+    /// policy, then recompute run status.
+    ///
+    /// Unlike [`tick_run`], this launches no new queued work and does not
+    /// re-process tasks that already reached a terminal state, so it is safe
+    /// and idempotent to call on a fresh process: a task re-leased by an
+    /// earlier resume is no longer stale at the same instant, and a terminally
+    /// failed task is never failed or escalated twice.
+    pub fn resume_run(&self, run_id: &FleetRunId) -> Result<FleetSchedulerReport> {
+        let mut report = FleetSchedulerReport::default();
+        self.reconcile_stale_leases(run_id, &mut report)?;
+        self.refresh_run_status(run_id)?;
+        Ok(report)
+    }
+
     pub fn cancel_run(&self, run_id: &FleetRunId, reason: &str) -> Result<FleetSchedulerReport> {
         let state = self.ledger.rebuild_state()?;
         let mut report = FleetSchedulerReport::default();
@@ -167,6 +183,52 @@ impl FleetScheduler {
                 }
                 _ => {}
             }
+        }
+        Ok(())
+    }
+
+    /// Reconcile only orphaned/stale in-flight leases (the restart-recovery
+    /// subset of [`recover_unhealthy_work`]): a `Leased` task whose worker has
+    /// stopped heartbeating is marked stale and routed through the shared
+    /// retry/escalation budget. Terminal and healthy tasks are left untouched,
+    /// which keeps [`resume_run`] idempotent.
+    fn reconcile_stale_leases(
+        &self,
+        run_id: &FleetRunId,
+        report: &mut FleetSchedulerReport,
+    ) -> Result<()> {
+        let state = self.ledger.rebuild_state()?;
+        for task in state
+            .tasks
+            .values()
+            .filter(|task| task.entry.run_id == *run_id)
+        {
+            if !matches!(task.status, FleetTaskLedgerStatus::Leased)
+                || !self.task_is_stale(task, &state)
+            {
+                continue;
+            }
+            let Some(task_spec) = task_spec_for(&state, task) else {
+                continue;
+            };
+            let worker_id = task
+                .leased_to
+                .clone()
+                .unwrap_or_else(|| "fleet-scheduler".to_string());
+            self.append_worker_event(
+                &task.entry.run_id,
+                &worker_id,
+                &task.entry.task_id,
+                FleetWorkerEventPayload::Stale {
+                    last_heartbeat_at: state
+                        .heartbeats
+                        .get(&worker_id)
+                        .map(|heartbeat| heartbeat.timestamp.clone()),
+                },
+            )?;
+            report.marked_stale += 1;
+            self.retry_or_fail(task, &task_spec, &worker_id, report)
+                .with_context(|| format!("resuming stale task {}", task.entry.task_id))?;
         }
         Ok(())
     }

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -993,6 +993,77 @@ mod tests {
     }
 
     #[test]
+    fn fleet_route_parity_uses_shared_router_candidates() {
+        use crate::config::ApiProvider;
+        use crate::model_routing::{RouterCandidates, provider_router_candidates};
+
+        // Fleet emits the SAME `ModelRoute` seam the sub-agent assignment path
+        // consumes (`SubAgentModelStrength::model_route`: fast -> Faster,
+        // same/inherit -> Inherit). No fleet-specific provider/model table is
+        // involved — only the shared enum.
+        assert_eq!(
+            fleet_model_route_for_loadout("auto", &codewhale_config::FleetLoadout::Fast),
+            ModelRoute::Faster,
+        );
+        assert_eq!(
+            fleet_model_route_for_loadout("auto", &codewhale_config::FleetLoadout::Inherit),
+            ModelRoute::Inherit,
+        );
+        assert_eq!(
+            fleet_model_route_for_loadout("auto", &codewhale_config::FleetLoadout::Strong),
+            ModelRoute::Auto,
+        );
+        // An explicit model always pins to a Fixed route, regardless of loadout.
+        assert_eq!(
+            fleet_model_route_for_loadout(
+                "deepseek-v4-flash",
+                &codewhale_config::FleetLoadout::Strong
+            ),
+            ModelRoute::Fixed("deepseek-v4-flash".to_string()),
+        );
+
+        // The sub-agent runtime resolves a `ModelRoute` to a concrete model via
+        // `provider_router_candidates` (see `worker_profile_subagent_assignment_route`):
+        //   Fixed(m)      -> m
+        //   Faster | Auto -> candidates.cheap (else parent)
+        //   Inherit       -> parent
+        // A fleet worker hands its `ModelRoute` to that same resolution, so a
+        // fleet "fast" loadout lands on the provider's cheap sibling.
+        let parent = "deepseek-v4-pro";
+        let resolve = |route: &ModelRoute, candidates: &RouterCandidates| match route {
+            ModelRoute::Fixed(model) => model.clone(),
+            ModelRoute::Faster | ModelRoute::Auto => candidates
+                .cheap
+                .clone()
+                .unwrap_or_else(|| parent.to_string()),
+            ModelRoute::Inherit => parent.to_string(),
+        };
+
+        let deepseek = provider_router_candidates(ApiProvider::Deepseek, parent);
+        assert_eq!(
+            resolve(
+                &fleet_model_route_for_loadout("auto", &codewhale_config::FleetLoadout::Fast),
+                &deepseek,
+            ),
+            "deepseek-v4-flash",
+            "fleet fast loadout resolves to the provider cheap sibling via the shared router",
+        );
+
+        // A provider with no known fast sibling must keep children on the parent
+        // model rather than fabricating a cloud id (#3166 route assertion).
+        let no_sibling = provider_router_candidates(ApiProvider::Anthropic, parent);
+        assert_eq!(no_sibling.cheap, None);
+        assert_eq!(
+            resolve(
+                &fleet_model_route_for_loadout("auto", &codewhale_config::FleetLoadout::Fast),
+                &no_sibling,
+            ),
+            parent,
+            "fast with no provider sibling stays on the parent/default model",
+        );
+    }
+
+    #[test]
     fn exec_hardening_caps_max_steps_to_max_turns() {
         let spec = AgentWorkerSpec {
             worker_id: "w1".to_string(),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -410,6 +410,14 @@ enum FleetCommand {
         /// Worker id printed by `codewhale fleet run`
         worker_id: String,
     },
+    /// Resume a run from durable ledger state, reconciling orphaned/stale leases
+    Resume {
+        /// Run id printed by `codewhale fleet run`
+        run_id: String,
+        /// Seconds without heartbeat before a leased task is treated as stale
+        #[arg(long, default_value_t = 300)]
+        stale_after_seconds: u64,
+    },
     /// Stop all queued and running fleet work
     Stop {
         /// Confirm stopping all queued and running fleet tasks
@@ -1694,6 +1702,23 @@ async fn run_fleet_command(workspace: &Path, config: &Config, args: FleetArgs) -
         FleetCommand::Restart { worker_id } => {
             let inspection = manager.restart_worker(&worker_id)?;
             print_inspection(&inspection);
+            Ok(())
+        }
+        FleetCommand::Resume {
+            run_id,
+            stale_after_seconds,
+        } => {
+            let manager = manager.with_stale_after(Duration::from_secs(stale_after_seconds.max(1)));
+            let report = manager.resume_run(&FleetRunId::from(run_id))?;
+            println!(
+                "fleet resume: {} reclaimed_stale={} restarted={} failed={} escalated={}",
+                report.run_id.0,
+                report.reclaimed_stale,
+                report.restarted,
+                report.failed,
+                report.escalated
+            );
+            print_status(&report.status);
             Ok(())
         }
         FleetCommand::Stop { all } => {

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -21,8 +21,16 @@ codewhale fleet logs <worker-id>
 codewhale fleet artifacts <worker-id>
 codewhale fleet interrupt <worker-id>
 codewhale fleet restart <worker-id>
+codewhale fleet resume <run-id>
 codewhale fleet stop --all
 ```
+
+`codewhale fleet resume <run-id>` is the restart-recovery verb: it replays the
+ledger, reconciles any in-flight lease whose worker stopped heartbeating
+(retrying within the task's budget, else failing and escalating per the alert
+policy), and prints the post-resume status. It launches no new work and is
+idempotent, so it is safe to run after a manager exit, laptop sleep, or runtime
+restart.
 
 Fleet state is stored under the workspace in `.codewhale/fleet.jsonl`. Worker
 logs and adapter logs are stored under `.codewhale/fleet/` and


### PR DESCRIPTION
## Summary

Lands the durable **resume-from-ledger** entrypoint for Agent Fleet and proves it deterministically. `FleetScheduler` already owned tested stale/retry/escalation recovery over the ledger, but nothing wired it into a restart path and `FleetManager` had no `resume()` — so a crashed/detached manager left in-flight tasks `Leased` to dead workers with nothing to reconcile them.

The fix **reuses the scheduler instead of adding a second store** — one ledger, one retry/escalation policy:

- **`FleetScheduler::resume_run`** — restart-recovery sweep: `reconcile_stale_leases` → `retry_or_fail`, then recompute run status. Launches no new work and never re-processes terminal failures, so it is **idempotent** across repeated restarts.
- **`FleetManager::resume_run`** (wall clock) / **`resume_run_at(now)`** (deterministic seam) — open a scheduler over the same workspace with `heartbeat_timeout = stale_after`, run recovery, return an inspectable `FleetResumeReport`.
- **`codewhale fleet resume <run-id>`** CLI verb + `docs/FLEET.md`.
- **`fleet_route_parity_uses_shared_router_candidates`** — regression test locking fleet route resolution to the shared `ModelRoute` seam + `model_routing::provider_router_candidates` the sub-agent assignment path uses.

## Tests (deterministic, cross-platform)

`fleet_resume_*` seed the durable ledger state a crashed manager would leave, then resume from it:

| Test | Proves |
|---|---|
| `fleet_resume_reconciles_orphaned_lease_and_retries_within_budget` | 3 roles / 3 workers; 2 completed-with-receipts + 1 orphaned stale lease → detects stale, retries within budget, **preserves pre-crash receipts**, durably records `stale` + `restarted` |
| `fleet_resume_exhausted_retry_fails_and_escalates_idempotently` | `max_attempts=1` → fail + escalate (secret webhook redacted in ledger); a second resume does **not** resurrect or re-escalate the terminal failure |
| `fleet_resume_retry_is_idempotent_at_same_instant` | a re-leased task is not stale at the same instant → no double retry |
| `fleet_resume_uses_wall_clock_for_stale_detection` | the production `resume_run()` entrypoint over the real clock |
| `fleet_route_parity_uses_shared_router_candidates` | fleet emits the same `ModelRoute` seam and resolves via the shared `provider_router_candidates`; a provider with no fast sibling stays on the parent model (no fabricated id) |

## Acceptance criteria

**Covered** (toward #3154 / #3166):
- #3154 verification **"Resume/replay test from persisted ledger state"** — landed (did not previously exist).
- #3154 "A stuck worker is detected and either restarted, stopped, or escalated according to policy" — proven across a simulated restart.
- #3154 "Fleet state is visible from CLI … replayable enough for handoff" — `fleet resume` + inspectable `FleetResumeReport` / `status`.
- #3166 "Force at least one manager restart/resume from ledger state" — the resume tests do exactly this, deterministically.
- #3154 verification "Fleet worker route parity with subagent route resolution" — **partial**: proven at the shared `ModelRoute` / `provider_router_candidates` seam.

**Remaining** (explicitly *not* claimed complete):
- #3154 "Resolved route details recorded in the ledger for every worker" (provider / canonical / wire-model / reasoning / source / class / slot) — needs route-detail recording; deferred.
- Full convergence of fleet + subagent onto the atomic `RouteResolver` / `ReadyRouteCandidate` (#3384) — deferred; both still share `ModelRoute` + `provider_router_candidates`, not `RouteResolver`.
- #3166 full endurance / continuation / SSH soak smoke — separate, larger lane.

Fleet is **not** complete; this narrowly lands the durable resume/replay proof + a route-parity regression guard.

## Testing
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked -- fleet` (127 passed incl. 4 `fleet_resume_*` + parity; no regressions, rebased on current `main`)
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked -- model_routing`
- [ ] `cargo clippy --workspace` (not run; focused fleet slice — CI Lint covers)

Refs #3154, #3166, #3167, #3205. Does not close any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
