### PR TITLE
feat(providers): fold Zhipu into Z.ai, finish equal-treatment model normalization

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -119,7 +119,16 @@ pub struct ProvidersToml {
     pub openai_codex: ProviderConfigToml,
     #[serde(default)]
     pub anthropic: ProviderConfigToml,
-    #[serde(default, alias = "z-ai", alias = "z_ai", alias = "z.ai")]
+    #[serde(
+        default,
+        alias = "z-ai",
+        alias = "z_ai",
+        alias = "z.ai",
+        alias = "zhipu",
+        alias = "zhipuai",
+        alias = "bigmodel",
+        alias = "big-model"
+    )]
     pub zai: ProviderConfigToml,
     #[serde(
         default,
@@ -4134,10 +4143,17 @@ impl EnvRuntimeOverrides {
                 .filter(|v| !v.trim().is_empty()),
             zai_base_url: std::env::var("ZAI_BASE_URL")
                 .or_else(|_| std::env::var("Z_AI_BASE_URL"))
+                .or_else(|_| std::env::var("ZHIPU_BASE_URL"))
+                .or_else(|_| std::env::var("ZHIPUAI_BASE_URL"))
+                .or_else(|_| std::env::var("BIGMODEL_BASE_URL"))
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             zai_model: std::env::var("ZAI_MODEL")
                 .or_else(|_| std::env::var("Z_AI_MODEL"))
+                .or_else(|_| std::env::var("ZHIPU_MODEL"))
+                .or_else(|_| std::env::var("ZHIPUAI_MODEL"))
+                .or_else(|_| std::env::var("BIGMODEL_MODEL"))
+                .or_else(|_| std::env::var("GLM_MODEL"))
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
             stepfun_base_url: std::env::var("STEPFUN_BASE_URL")

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -496,12 +496,12 @@ provider!(
     Zai,
     Zai,
     "zai",
-    "Z.ai (GLM Coding)",
+    "Zhipu AI / Z.ai",
     DEFAULT_ZAI_BASE_URL,
     DEFAULT_ZAI_MODEL,
-    ["ZAI_API_KEY", "Z_AI_API_KEY"],
+    ["ZAI_API_KEY", "Z_AI_API_KEY", "ZHIPU_API_KEY", "GLM_API_KEY"],
     "zai",
-    aliases: ["z-ai", "z_ai", "z.ai"]
+    aliases: ["z-ai", "z_ai", "z.ai", "zhipu", "zhipuai", "bigmodel", "big-model"]
 );
 
 provider!(

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -73,7 +73,15 @@ pub enum ProviderKind {
     OpenaiCodex,
     #[serde(alias = "claude")]
     Anthropic,
-    #[serde(alias = "z-ai", alias = "z_ai", alias = "z.ai")]
+    #[serde(
+        alias = "z-ai",
+        alias = "z_ai",
+        alias = "z.ai",
+        alias = "zhipu",
+        alias = "zhipuai",
+        alias = "bigmodel",
+        alias = "big-model"
+    )]
     Zai,
     #[serde(
         alias = "step-fun",

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -598,8 +598,19 @@ struct EnvGuard {
     kimi_model_name: Option<OsString>,
     zai_api_key: Option<OsString>,
     z_ai_api_key: Option<OsString>,
+    zhipu_api_key: Option<OsString>,
+    glm_api_key: Option<OsString>,
     zai_base_url: Option<OsString>,
+    z_ai_base_url: Option<OsString>,
+    zhipu_base_url: Option<OsString>,
+    zhipuai_base_url: Option<OsString>,
+    bigmodel_base_url: Option<OsString>,
     zai_model: Option<OsString>,
+    z_ai_model: Option<OsString>,
+    zhipu_model: Option<OsString>,
+    zhipuai_model: Option<OsString>,
+    bigmodel_model: Option<OsString>,
+    glm_model: Option<OsString>,
     stepfun_api_key: Option<OsString>,
     step_api_key: Option<OsString>,
     stepfun_base_url: Option<OsString>,
@@ -694,8 +705,19 @@ impl EnvGuard {
             kimi_model_name: env::var_os("KIMI_MODEL_NAME"),
             zai_api_key: env::var_os("ZAI_API_KEY"),
             z_ai_api_key: env::var_os("Z_AI_API_KEY"),
+            zhipu_api_key: env::var_os("ZHIPU_API_KEY"),
+            glm_api_key: env::var_os("GLM_API_KEY"),
             zai_base_url: env::var_os("ZAI_BASE_URL"),
+            z_ai_base_url: env::var_os("Z_AI_BASE_URL"),
+            zhipu_base_url: env::var_os("ZHIPU_BASE_URL"),
+            zhipuai_base_url: env::var_os("ZHIPUAI_BASE_URL"),
+            bigmodel_base_url: env::var_os("BIGMODEL_BASE_URL"),
             zai_model: env::var_os("ZAI_MODEL"),
+            z_ai_model: env::var_os("Z_AI_MODEL"),
+            zhipu_model: env::var_os("ZHIPU_MODEL"),
+            zhipuai_model: env::var_os("ZHIPUAI_MODEL"),
+            bigmodel_model: env::var_os("BIGMODEL_MODEL"),
+            glm_model: env::var_os("GLM_MODEL"),
             stepfun_api_key: env::var_os("STEPFUN_API_KEY"),
             step_api_key: env::var_os("STEP_API_KEY"),
             stepfun_base_url: env::var_os("STEPFUN_BASE_URL"),
@@ -785,8 +807,19 @@ impl EnvGuard {
             env::remove_var("KIMI_MODEL_NAME");
             env::remove_var("ZAI_API_KEY");
             env::remove_var("Z_AI_API_KEY");
+            env::remove_var("ZHIPU_API_KEY");
+            env::remove_var("GLM_API_KEY");
             env::remove_var("ZAI_BASE_URL");
+            env::remove_var("Z_AI_BASE_URL");
+            env::remove_var("ZHIPU_BASE_URL");
+            env::remove_var("ZHIPUAI_BASE_URL");
+            env::remove_var("BIGMODEL_BASE_URL");
             env::remove_var("ZAI_MODEL");
+            env::remove_var("Z_AI_MODEL");
+            env::remove_var("ZHIPU_MODEL");
+            env::remove_var("ZHIPUAI_MODEL");
+            env::remove_var("BIGMODEL_MODEL");
+            env::remove_var("GLM_MODEL");
             env::remove_var("STEPFUN_API_KEY");
             env::remove_var("STEP_API_KEY");
             env::remove_var("STEPFUN_BASE_URL");
@@ -908,8 +941,19 @@ impl Drop for EnvGuard {
             Self::restore_var("KIMI_MODEL_NAME", self.kimi_model_name.take());
             Self::restore_var("ZAI_API_KEY", self.zai_api_key.take());
             Self::restore_var("Z_AI_API_KEY", self.z_ai_api_key.take());
+            Self::restore_var("ZHIPU_API_KEY", self.zhipu_api_key.take());
+            Self::restore_var("GLM_API_KEY", self.glm_api_key.take());
             Self::restore_var("ZAI_BASE_URL", self.zai_base_url.take());
+            Self::restore_var("Z_AI_BASE_URL", self.z_ai_base_url.take());
+            Self::restore_var("ZHIPU_BASE_URL", self.zhipu_base_url.take());
+            Self::restore_var("ZHIPUAI_BASE_URL", self.zhipuai_base_url.take());
+            Self::restore_var("BIGMODEL_BASE_URL", self.bigmodel_base_url.take());
             Self::restore_var("ZAI_MODEL", self.zai_model.take());
+            Self::restore_var("Z_AI_MODEL", self.z_ai_model.take());
+            Self::restore_var("ZHIPU_MODEL", self.zhipu_model.take());
+            Self::restore_var("ZHIPUAI_MODEL", self.zhipuai_model.take());
+            Self::restore_var("BIGMODEL_MODEL", self.bigmodel_model.take());
+            Self::restore_var("GLM_MODEL", self.glm_model.take());
             Self::restore_var("STEPFUN_API_KEY", self.stepfun_api_key.take());
             Self::restore_var("STEP_API_KEY", self.step_api_key.take());
             Self::restore_var("STEPFUN_BASE_URL", self.stepfun_base_url.take());
@@ -3127,6 +3171,42 @@ fn zai_aliases_resolve_to_canonical_models() {
     assert_eq!(
         normalize_model_for_provider(ProviderKind::Zai, "custom-glm-preview"),
         "custom-glm-preview"
+    );
+}
+
+#[test]
+fn zhipu_aliases_fold_into_zai_provider() {
+    // Zhipu AI and Z.ai are the same vendor; `zhipu`/`zhipuai`/`bigmodel`
+    // resolve to the single Zai provider rather than a separate one.
+    assert_eq!(ProviderKind::parse("zhipu"), Some(ProviderKind::Zai));
+    assert_eq!(ProviderKind::parse("zhipuai"), Some(ProviderKind::Zai));
+    assert_eq!(ProviderKind::parse("bigmodel"), Some(ProviderKind::Zai));
+    assert_eq!(ProviderKind::parse("big-model"), Some(ProviderKind::Zai));
+
+    // A `[providers.zhipu]` table (BigModel China endpoint) merges into the Zai
+    // provider config through the serde alias.
+    let parsed: ConfigToml = toml::from_str(
+        r#"
+        [providers.zhipu]
+        api_key = "$ZHIPU_API_KEY"
+        base_url = "https://open.bigmodel.cn/api/paas/v4/"
+        model = "glm-5-2"
+        "#,
+    )
+    .expect("zhipu provider table parses");
+
+    let provider = parsed.providers.for_provider(ProviderKind::Zai);
+    assert_eq!(provider.api_key.as_deref(), Some("$ZHIPU_API_KEY"));
+    assert_eq!(
+        provider.base_url.as_deref(),
+        Some("https://open.bigmodel.cn/api/paas/v4/")
+    );
+    assert_eq!(provider.model.as_deref(), Some("glm-5-2"));
+
+    // GLM aliases canonicalize under the Zai umbrella.
+    assert_eq!(
+        normalize_model_for_provider(ProviderKind::Zai, "glm-5-2"),
+        DEFAULT_ZAI_MODEL
     );
 }
 

--- a/crates/tui/src/commands/groups/core/provider.rs
+++ b/crates/tui/src/commands/groups/core/provider.rs
@@ -5,10 +5,7 @@
 //! keeps the v0.6.6 CLI form for muscle-memory + scripted use.
 
 use crate::commands::traits::{CommandInfo, RegisterCommand};
-use crate::config::{
-    ApiProvider, normalize_model_name, normalize_model_name_for_provider,
-    provider_passes_model_through,
-};
+use crate::config::{ApiProvider, canonical_model_id_for_provider, provider_passes_model_through};
 use crate::localization::MessageId;
 use crate::tui::app::{App, AppAction};
 
@@ -62,27 +59,26 @@ pub fn provider(app: &mut App, args: Option<&str>) -> CommandResult {
 
     let model = match model_arg {
         None => None,
-        Some(raw) if matches!(target, ApiProvider::XiaomiMimo) => {
-            let expanded = expand_model_alias_for_provider(target, raw);
-            Some(normalize_model_name_for_provider(target, &expanded).unwrap_or(expanded))
-        }
-        Some(raw) if provider_passes_model_through(target) => Some(raw.trim().to_string()),
         Some(raw) => {
+            // Expand provider shorthands (flash/pro, Xiaomi MiMo tts/omni, …)
+            // uniformly, then either keep the id verbatim for providers that take
+            // opaque/custom model tags, or resolve it to the canonical family id.
+            // Families are treated equally: each resolves through its own
+            // canonical map (DeepSeek, GLM via Z.ai/Zhipu, Kimi, MiniMax, …) and
+            // an id matching none passes through unchanged — the upstream API is
+            // the authority. Wire-id translation is deferred to the route
+            // resolver at request time, so `/provider` stores canonical names.
             let expanded = expand_model_alias_for_provider(target, raw);
-            let normalized = if matches!(
-                target,
-                ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::Together
-            ) {
-                normalize_model_name_for_provider(target, &expanded)
+            if provider_passes_model_through(target) {
+                Some(expanded)
             } else {
-                normalize_model_name(&expanded)
-            };
-            match normalized {
-                Some(normalized) => Some(normalized),
-                None => {
-                    return CommandResult::error(format!(
-                        "Invalid model '{raw}'. Try: flash, pro, deepseek-v4-flash, deepseek-v4-pro, or xiaomi-mimo omni."
-                    ));
+                match canonical_model_id_for_provider(target, &expanded) {
+                    Some(canonical) => Some(canonical),
+                    None => {
+                        return CommandResult::error(format!(
+                            "Invalid model '{raw}'. Provide a non-empty model id."
+                        ));
+                    }
                 }
             }
         }
@@ -150,7 +146,8 @@ fn provider_fallback(app: &mut App, subcommand: Option<&str>) -> CommandResult {
 }
 
 fn expand_model_alias_for_provider(provider: ApiProvider, name: &str) -> String {
-    let lower = name.trim().to_ascii_lowercase();
+    let trimmed = name.trim();
+    let lower = trimmed.to_ascii_lowercase();
     if matches!(provider, ApiProvider::XiaomiMimo) {
         return match lower.as_str() {
             "pro" | "mimo" => "mimo-v2.5-pro".to_string(),
@@ -163,21 +160,25 @@ fn expand_model_alias_for_provider(provider: ApiProvider, name: &str) -> String 
             "voiceclone" | "voice-clone" | "mimo-voice-clone" => {
                 "mimo-v2.5-tts-voiceclone".to_string()
             }
-            other => other.to_string(),
+            // Not a shorthand: keep the id as typed (case preserved for custom
+            // token-plan model ids).
+            _ => trimmed.to_string(),
         };
     }
 
     match lower.as_str() {
         "pro" | "v4-pro" => "deepseek-v4-pro".to_string(),
         "flash" | "v4-flash" => "deepseek-v4-flash".to_string(),
-        other => other.to_string(),
+        // Not a shorthand: keep the id as typed (case preserved for opaque
+        // model tags on passthrough providers like Ollama/HuggingFace).
+        _ => trimmed.to_string(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, DEFAULT_TOGETHER_FLASH_MODEL, DEFAULT_TOGETHER_MODEL};
+    use crate::config::Config;
     use crate::tui::app::TuiOptions;
     use std::path::PathBuf;
 
@@ -352,6 +353,31 @@ mod tests {
     }
 
     #[test]
+    fn zhipu_aliases_fold_into_zai_and_canonicalize_glm() {
+        // Zhipu AI and Z.ai are the same vendor: `zhipu`/`zhipuai` select the
+        // single Zai provider and store the canonical GLM family id in Z.ai's own
+        // casing (`glm-5.2` → `GLM-5.2`).
+        let mut app = create_test_app();
+        let result = provider(&mut app, Some("zhipu glm-5.2"));
+        match result.action {
+            Some(AppAction::SwitchProvider { provider, model }) => {
+                assert_eq!(provider, ApiProvider::Zai);
+                assert_eq!(model.as_deref(), Some("GLM-5.2"));
+            }
+            other => panic!("expected SwitchProvider, got {other:?}"),
+        }
+
+        let result = provider(&mut app, Some("zhipuai glm-5-1"));
+        match result.action {
+            Some(AppAction::SwitchProvider { provider, model }) => {
+                assert_eq!(provider, ApiProvider::Zai);
+                assert_eq!(model.as_deref(), Some("GLM-5.1"));
+            }
+            other => panic!("expected SwitchProvider, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn switch_to_novita_emits_action() {
         let mut app = create_test_app();
         let result = provider(&mut app, Some("novita"));
@@ -404,13 +430,17 @@ mod tests {
     }
 
     #[test]
-    fn switch_to_together_accepts_provider_owned_deepseek_aliases() {
+    fn switch_to_together_canonicalizes_deepseek_aliases() {
+        // Together is symmetric with the other DeepSeek-hosting routes: the
+        // canonical family id is stored and the route resolver performs the
+        // wire-id translation (deepseek-v4-pro → Together's catalog slug) at
+        // request time, rather than the command storing a wire slug.
         let mut app = create_test_app();
         let result = provider(&mut app, Some("together deepseek-v4-pro"));
         match result.action {
             Some(AppAction::SwitchProvider { provider, model }) => {
                 assert_eq!(provider, ApiProvider::Together);
-                assert_eq!(model.as_deref(), Some(DEFAULT_TOGETHER_MODEL));
+                assert_eq!(model.as_deref(), Some("deepseek-v4-pro"));
             }
             other => panic!("expected SwitchProvider, got {other:?}"),
         }
@@ -419,7 +449,7 @@ mod tests {
         match result.action {
             Some(AppAction::SwitchProvider { provider, model }) => {
                 assert_eq!(provider, ApiProvider::Together);
-                assert_eq!(model.as_deref(), Some(DEFAULT_TOGETHER_FLASH_MODEL));
+                assert_eq!(model.as_deref(), Some("deepseek-v4-flash"));
             }
             other => panic!("expected SwitchProvider, got {other:?}"),
         }
@@ -568,11 +598,19 @@ mod tests {
     }
 
     #[test]
-    fn invalid_model_returns_error() {
+    fn aggregator_passes_unrecognized_model_through() {
+        // Equal treatment: a non-DeepSeek id on a DeepSeek-hosting aggregator is
+        // not rejected — it passes through so the upstream API stays the
+        // authority on what it can serve.
         let mut app = create_test_app();
         let result = provider(&mut app, Some("nim gpt-4"));
-        let msg = result.message.expect("expected error message");
-        assert!(msg.contains("Invalid model"));
-        assert!(result.action.is_none());
+        assert!(result.message.is_none());
+        match result.action {
+            Some(AppAction::SwitchProvider { provider, model }) => {
+                assert_eq!(provider, ApiProvider::NvidiaNim);
+                assert_eq!(model.as_deref(), Some("gpt-4"));
+            }
+            other => panic!("expected SwitchProvider action, got {other:?}"),
+        }
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -521,7 +521,16 @@ fn subagent_provider_key_matches(key: &str, provider: ApiProvider) -> bool {
         }
         ApiProvider::Zai => matches!(
             normalized.as_str(),
-            "zai" | "z_ai" | "glm" | "zai_glm" | "z_glm"
+            "zai"
+                | "z_ai"
+                | "glm"
+                | "zai_glm"
+                | "z_glm"
+                | "zhipu"
+                | "zhipuai"
+                | "bigmodel"
+                | "big_model"
+                | "zhipu_glm"
         ),
         _ => false,
     }
@@ -1116,93 +1125,114 @@ fn canonical_minimax_model_id(model: &str) -> Option<&'static str> {
     }
 }
 
-/// Normalize a model selected through the TUI for the active provider.
+/// Resolve a user-entered model id to the canonical family id a provider
+/// understands, without any wire-id translation.
 ///
-/// Official DeepSeek endpoints require bare model IDs. Provider-prefixed
-/// aliases are valid for some compatible backends, but sending them to
-/// DeepSeek's own API causes a 400. Keep the generic normalizer permissive for
-/// config/back-compat, and canonicalize only when the active provider is known.
+/// Model families are treated equally: every provider-owned family (GLM via
+/// Z.ai/Zhipu, Kimi, Xiaomi MiMo, MiniMax, Arcee, OpenRouter slugs, …)
+/// resolves through the same "apply the family's canonical map, else pass the
+/// input through" path. Nothing is rejected just because it is not a
+/// DeepSeek id — the upstream API remains the final authority, mirroring how
+/// the models.dev catalog (the route resolver's source of truth) carries one
+/// authoritative id per offering regardless of vendor.
 ///
-/// Preserves the caller's casing when the model is already a recognised
-/// DeepSeek id (e.g. `DeepSeek-V4-Flash` stays as-is). Only rewrites compact
-/// aliases like `deepseek-v4pro` → `deepseek-v4-pro`.
+/// This is the canonicalization half of what [`normalize_model_name_for_provider`]
+/// used to fuse together. Wire-id translation (e.g. `deepseek-v4-pro` → an
+/// aggregator's `accounts/…/deepseek-v4-pro` slug) belongs to the route
+/// resolver at request time, not to a name typed into `/provider`, so it is
+/// deliberately kept out of here.
+///
+/// Returns `None` only for empty or control-character input; every other id
+/// passes through so a custom/self-hosted endpoint is never wrongly rejected.
 #[must_use]
-pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> Option<String> {
-    if matches!(provider, ApiProvider::Openrouter)
-        && let Some(canonical) = canonical_openrouter_recent_model_id(model)
-    {
+pub fn canonical_model_id_for_provider(provider: ApiProvider, model: &str) -> Option<String> {
+    let trimmed = model.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_control) {
+        return None;
+    }
+
+    // Provider-owned model families resolve through their own canonical map,
+    // which defines the authoritative casing (`glm-5.1` → `GLM-5.1`,
+    // `minimax-m2.7` → `MiniMax-M2.7`). Each map recognizes only *its own*
+    // aliases, so an unknown id falls through to passthrough — no family acts
+    // as a gate against any other.
+    let family_canonical: Option<&'static str> = match provider {
+        ApiProvider::Openrouter => canonical_openrouter_recent_model_id(trimmed),
+        ApiProvider::XiaomiMimo => canonical_xiaomi_mimo_model_id(trimmed),
+        ApiProvider::Arcee => canonical_arcee_model_id(trimmed),
+        ApiProvider::Moonshot => canonical_moonshot_model_id(trimmed),
+        ApiProvider::Zai => canonical_zai_model_id(trimmed),
+        ApiProvider::Minimax => canonical_minimax_model_id(trimmed),
+        _ => None,
+    };
+    if let Some(canonical) = family_canonical {
         return Some(canonical.to_string());
     }
 
-    if matches!(provider, ApiProvider::XiaomiMimo)
-        && let Some(canonical) = canonical_xiaomi_mimo_model_id(model)
-    {
-        return Some(canonical.to_string());
-    }
-
-    if matches!(provider, ApiProvider::Arcee) {
-        return canonical_arcee_model_id(model)
-            .map(ToString::to_string)
-            .or_else(|| normalize_custom_model_id(model));
-    }
-
-    if matches!(provider, ApiProvider::Moonshot) {
-        return canonical_moonshot_model_id(model)
-            .map(ToString::to_string)
-            .or_else(|| normalize_custom_model_id(model));
-    }
-
-    if matches!(provider, ApiProvider::Zai) {
-        return canonical_zai_model_id(model)
-            .map(ToString::to_string)
-            .or_else(|| normalize_custom_model_id(model));
-    }
-
-    if matches!(provider, ApiProvider::Minimax) {
-        return canonical_minimax_model_id(model)
-            .map(ToString::to_string)
-            .or_else(|| normalize_custom_model_id(model));
-    }
-
-    if matches!(provider, ApiProvider::Huggingface) {
-        return normalize_custom_model_id(model);
-    }
-
-    let normalized = normalize_model_name(model)?;
-    if matches!(provider, ApiProvider::Together) {
-        let provider_model = model_for_provider(provider, normalized.clone());
-        if provider_model != normalized {
-            return Some(provider_model);
-        }
-    }
+    // The official DeepSeek API is the one legitimate per-family gate: it serves
+    // only its own ids (and 400s anything else), so reject an id it does not
+    // recognize. Compact aliases are rewritten (deepseek-v4pro → deepseek-v4-pro)
+    // and the caller's casing is kept for an already-valid id (`DeepSeek-V4-Flash`
+    // stays as-is). Custom/self-hosted DeepSeek endpoints take the
+    // accepts-custom-model-ids path, so they never reach this gate.
     if matches!(
         provider,
         ApiProvider::Deepseek | ApiProvider::DeepseekCN | ApiProvider::DeepseekAnthropic
-    ) && let Some(canonical) = canonical_official_deepseek_model_id(&normalized)
-    {
-        // When the user's input already matches a known model id
-        // case-insensitively, keep their original casing; only rewrite
-        // compact aliases (e.g. v4pro → v4-pro).
-        if canonical.eq_ignore_ascii_case(&normalized)
-            || normalized.to_ascii_lowercase() == canonical
-        {
-            return Some(normalized);
+    ) {
+        let normalized = normalize_model_name(trimmed)?;
+        if let Some(canonical) = canonical_official_deepseek_model_id(&normalized) {
+            if canonical.eq_ignore_ascii_case(&normalized)
+                || normalized.to_ascii_lowercase() == canonical
+            {
+                return Some(normalized);
+            }
+            return Some(canonical.to_string());
         }
-        return Some(canonical.to_string());
+        return Some(normalized);
     }
+
+    // Aggregators that host DeepSeek (NIM, Novita, Fireworks, SiliconFlow, SGLang,
+    // vLLM, DeepInfra, Wanjie Ark, Volcengine) canonicalize recognized DeepSeek
+    // ids but pass everything else through — they serve more than DeepSeek, so
+    // the upstream API stays the authority. A name is never rejected here.
     if matches!(
         provider,
-        ApiProvider::Siliconflow | ApiProvider::SiliconflowCn
+        ApiProvider::NvidiaNim
+            | ApiProvider::Novita
+            | ApiProvider::Fireworks
+            | ApiProvider::Siliconflow
+            | ApiProvider::SiliconflowCn
+            | ApiProvider::Sglang
+            | ApiProvider::Vllm
+            | ApiProvider::Deepinfra
+            | ApiProvider::WanjieArk
+            | ApiProvider::Volcengine
+    ) && let Some(canonical) = canonical_official_deepseek_model_id(
+        &normalize_model_name(trimmed).unwrap_or_else(|| trimmed.to_string()),
     ) {
-        let provider_model = model_for_provider(provider, normalized.clone());
-        if provider_model != normalized {
-            return Some(provider_model);
-        }
+        return Some(canonical.to_string());
     }
-    if let Some(canonical) = canonical_official_deepseek_model_id(&normalized) {
-        return Some(model_for_provider(provider, canonical.to_string()));
-    }
-    Some(normalized)
+
+    // Everything else (HuggingFace, OpenAI-compatible, Qianfan, StepFun, Codex,
+    // Anthropic) owns no canonical map — the id the user typed is authoritative.
+    Some(trimmed.to_string())
+}
+
+/// Normalize a model selected through the TUI for the active provider, applying
+/// the provider's wire-slug translation on top of the canonical family id.
+///
+/// This is the wire-id half of the split (canonicalization lives in
+/// [`canonical_model_id_for_provider`]). Used by config-file normalization,
+/// where vendor-prefixed ids (e.g. `deepseek-ai/DeepSeek-V4-Pro` on SiliconFlow)
+/// are the stored form. `/provider` deliberately uses the canonical half instead.
+#[must_use]
+pub fn normalize_model_name_for_provider(provider: ApiProvider, model: &str) -> Option<String> {
+    let canonical = canonical_model_id_for_provider(provider, model)?;
+    // Translate the canonical family id to the provider's wire slug when the
+    // provider's API uses vendor-prefixed ids (Together, Siliconflow, NIM, …).
+    // `model_for_provider` is a no-op for providers without a wire-slug map, so
+    // this is one uniform layer over the equal-treatment canonical resolver.
+    Some(model_for_provider(provider, canonical))
 }
 
 #[must_use]
@@ -2735,7 +2765,13 @@ pub struct ProvidersConfig {
     pub openai_codex: ProviderConfig,
     #[serde(default, alias = "claude")]
     pub anthropic: ProviderConfig,
-    #[serde(default)]
+    #[serde(
+        default,
+        alias = "zhipu",
+        alias = "zhipuai",
+        alias = "bigmodel",
+        alias = "big-model"
+    )]
     pub zai: ProviderConfig,
     #[serde(default)]
     pub stepfun: ProviderConfig,

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -99,7 +99,7 @@ fn deepseek_api_key_reads_metadata_env_vars_for_newer_providers() -> Result<()> 
 fn missing_provider_api_key_message_uses_provider_metadata() -> Result<()> {
     let message = missing_provider_api_key_message(ApiProvider::Zai)?;
 
-    assert!(message.contains("Z.ai (GLM Coding) API key not found"));
+    assert!(message.contains("Zhipu AI / Z.ai API key not found"));
     assert!(message.contains("https://z.ai/model-api"));
     assert!(message.contains("ZAI_API_KEY / Z_AI_API_KEY"));
     assert!(message.contains("[providers.zai] api_key"));


### PR DESCRIPTION
## Summary

Closes #3439.

This folds Zhipu/BigModel into the existing Z.ai provider instead of adding a duplicate provider kind. Current public Z.AI docs list GLM-5.2 as live, with the OpenAI-compatible coding endpoint at `https://api.z.ai/api/coding/paas/v4` and model id `glm-5.2`; Models.dev also lists `zhipuai/glm-5.2` with Z.AI and Zhipu AI provider rows. So this is not forward-versioned or speculative provider wiring.

Changes:

- Adds `zhipu`, `zhipuai`, `bigmodel`, and `big-model` aliases for the existing `zai` provider/config table.
- Relabels the provider as `Zhipu AI / Z.ai` and accepts `ZHIPU_API_KEY` / `GLM_API_KEY` in addition to `ZAI_API_KEY` / `Z_AI_API_KEY`.
- Accepts Zhipu/BigModel env aliases for base URL/model overrides while keeping one Z.ai/Zhipu provider slot.
- Keeps GLM canonicalization on current real models: `GLM-5.2`, `GLM-5.1`, and `GLM-5-Turbo`; no `glm-5.2-flash` tier is added.
- Splits provider model canonicalization from wire-id translation so `/provider` stores canonical family names and config normalization can still emit provider wire slugs.
- Hardens config tests so new Zhipu/GLM/BigModel env aliases do not leak in from the developer shell.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-config --locked zhipu -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked zhipu -- --nocapture`
- [x] `cargo test -p codewhale-config --locked provider_kind -- --nocapture`
- [x] `cargo test -p codewhale-config --locked provider -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked provider -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked model_routing -- --nocapture`
- [x] `cargo clippy --workspace --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::assertions_on_constants`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually - not needed; this is provider/config/model normalization plumbing
- [x] No bot/tool co-author trailers
