### PR TITLE
refactor(web): extract release credits into durable data source (#3416)

### DIFF
--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -18,76 +18,7 @@ const FALLBACK_STATS: RepoStats = {
   fetchedAt: new Date().toISOString(),
 };
 
-const RELEASE_CONTRIBUTORS = [
-  "@1Git2Clone",
-  "@cy2311",
-  "@LING71671",
-  "@axobase001",
-  "@dzyuan",
-  "@mvanhorn",
-  "@malsony",
-  "@manaskarra",
-  "@gaord",
-  "@yuanchenglu",
-  "@idling11",
-  "@h3c-hexin",
-  "@AdityaVG13",
-  "@Sskift",
-  "@cyq1017",
-  "@HUQIANTAO",
-  "@New2Niu",
-  "@AiurArtanis",
-  "@Lee-take",
-  "@nightt5879",
-  "@AresNing",
-  "@AccMoment",
-  "@reidliu41",
-  "@aboimpinto",
-  "@zhuangbiaowei",
-  "@donglovejava",
-  "@hongqitai",
-  "@zlh124",
-  "@encyc",
-  "@Implementist",
-  "@lihuan215",
-  "@LeoAlex0",
-  "@jimmyzhuu",
-  "@rockyzhang",
-  "@mo-vic",
-  "@hufanexplore",
-  "@hoclaptrinh33",
-  "@quentin-lian",
-  "@BryonGo",
-];
-
-const RELEASE_HELPERS = [
-  "@buko",
-  "@yyyCode",
-  "@gaslebinh-glitch",
-  "@Dr3259",
-  "@lpeng1711694086-lang",
-  "@VerrPower",
-  "@yan-zay",
-  "@jretz",
-  "@Neo-millunnium",
-  "@caeserchen",
-  "@cmyyy",
-  "@djairjr",
-  "@F1LT3R",
-  "@Final527",
-  "@Geallier",
-  "@k0tran",
-  "@lordwedggie",
-  "@T-Phuong-Nguyen",
-  "@xfy6238",
-  "@zhyuzhyu",
-  "@0gl20shk0sbt36",
-  "@hatakes",
-  "@goodvecn-dev",
-  "@bevis-wong",
-  "@PurplePulse",
-  "@nbiish",
-];
+import { RELEASE_CONTRIBUTORS, RELEASE_HELPERS } from "@/lib/release-credits";
 
 const FALLBACK_DISPATCH_EN: CuratedDispatch = {
   generatedAt: new Date().toISOString(),
@@ -424,9 +355,20 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
                 ? "这一版合并和吸收了来自社区的大量工作。完整条目在 CHANGELOG 中；这里保留最新发布的公开致谢入口。"
                 : "This release merged and harvested a large community tranche. The full notes live in the changelog; this keeps the latest public credit surface easy to find."}
             </p>
-            <Link href="https://github.com/Hmbown/CodeWhale/blob/main/CHANGELOG.md" className="inline-block mt-4 font-mono text-xs uppercase tracking-wider text-indigo hover:underline">
-              {isZh ? "查看完整 changelog →" : "Full changelog →"}
-            </Link>
+            <div className="flex flex-wrap gap-x-5 gap-y-2 mt-4">
+              <Link href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONTRIBUTORS.md" className="font-mono text-xs uppercase tracking-wider text-indigo hover:underline">
+                {isZh ? "完整贡献者名单 →" : "Full contributor list →"}
+              </Link>
+              <Link href="https://github.com/Hmbown/CodeWhale/blob/main/CHANGELOG.md" className="font-mono text-xs uppercase tracking-wider text-indigo hover:underline">
+                {isZh ? "CHANGELOG →" : "CHANGELOG →"}
+              </Link>
+              <Link href={isZh ? "/zh/contribute" : "/contribute"} className="font-mono text-xs uppercase tracking-wider text-indigo hover:underline">
+                {isZh ? "参与贡献 →" : "Contribute →"}
+              </Link>
+              <Link href="https://github.com/Hmbown/CodeWhale/issues" className="font-mono text-xs uppercase tracking-wider text-indigo hover:underline">
+                {isZh ? "开放议题 →" : "Open issues →"}
+              </Link>
+            </div>
           </div>
           <div className="lg:col-span-7 grid gap-6">
             <div>

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -1,0 +1,92 @@
+/**
+ * release-credits.ts — community credit data for the website.
+ *
+ * CANONICAL SOURCE: docs/CONTRIBUTORS.md
+ *   That file is the full per-PR contributor record in chronological order.
+ *   This module is a snapshot of the latest release's merged/harvested
+ *   contributors and issue helpers, kept in sync by the release process.
+ *   When cutting a release, update both docs/CONTRIBUTORS.md AND this file.
+ *
+ * EXTENSION PATH FOR NEW LOCALES:
+ *   The arrays below are locale-agnostic (GitHub handles). Locale-specific
+ *   section labels and descriptions live in the page component. To add a
+ *   new locale, update the page copy — no data changes needed here.
+ *
+ * See also:
+ *   - .github/AUTHOR_MAP for identity mapping
+ *   - CHANGELOG.md for the full release narrative
+ *   - https://github.com/Hmbown/CodeWhale/graphs/contributors for the live list
+ */
+
+/** Contributors whose PRs were merged or harvested into this release. */
+export const RELEASE_CONTRIBUTORS: string[] = [
+  "@1Git2Clone",
+  "@cy2311",
+  "@LING71671",
+  "@axobase001",
+  "@dzyuan",
+  "@mvanhorn",
+  "@malsony",
+  "@manaskarra",
+  "@gaord",
+  "@yuanchenglu",
+  "@idling11",
+  "@h3c-hexin",
+  "@AdityaVG13",
+  "@Sskift",
+  "@cyq1017",
+  "@HUQIANTAO",
+  "@New2Niu",
+  "@AiurArtanis",
+  "@Lee-take",
+  "@nightt5879",
+  "@AresNing",
+  "@AccMoment",
+  "@reidliu41",
+  "@aboimpinto",
+  "@zhuangbiaowei",
+  "@donglovejava",
+  "@hongqitai",
+  "@zlh124",
+  "@encyc",
+  "@Implementist",
+  "@lihuan215",
+  "@LeoAlex0",
+  "@jimmyzhuu",
+  "@rockyzhang",
+  "@mo-vic",
+  "@hufanexplore",
+  "@hoclaptrinh33",
+  "@quentin-lian",
+  "@BryonGo",
+];
+
+/** Contributors who helped with reports, reproductions, and verification. */
+export const RELEASE_HELPERS: string[] = [
+  "@buko",
+  "@yyyCode",
+  "@gaslebinh-glitch",
+  "@Dr3259",
+  "@lpeng1711694086-lang",
+  "@VerrPower",
+  "@yan-zay",
+  "@jretz",
+  "@Neo-millunnium",
+  "@caeserchen",
+  "@cmyyy",
+  "@djairjr",
+  "@F1LT3R",
+  "@Final527",
+  "@Geallier",
+  "@k0tran",
+  "@lordwedggie",
+  "@T-Phuong-Nguyen",
+  "@xfy6238",
+  "@zhyuzhyu",
+  "@0gl20shk0sbt36",
+  "@hatakes",
+  "@goodvecn-dev",
+  "@bevis-wong",
+  "@PurplePulse",
+  "@nbiish",
+];


### PR DESCRIPTION
Move the hard-coded RELEASE_CONTRIBUTORS and RELEASE_HELPERS arrays out of the homepage route into web/lib/release-credits.ts with documented provenance pointing to docs/CONTRIBUTORS.md as the canonical source. Add cross-links in the credits section to CONTRIBUTORS.md, the contribute page, open issues, and the CHANGELOG.

- web/lib/release-credits.ts: documented data source with extension path for future locales (locale-agnostic arrays, labels in page)
- web/app/[locale]/page.tsx: import from data source instead of inline arrays; cross-links for contribution docs, issues, changelog

Close https://github.com/Hmbown/CodeWhale/issues/3416.
## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
