### PR TITLE
refactor(web): promote repo docs into structured website documentation (#3417)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -42,6 +42,10 @@ jobs:
         # differ from the workspace sources). Catches mechanical drift before
         # deploy so the website never serves wrong version/provider data.
         run: npm run check:facts
+      - name: Check docs parity
+        # Fails CI when docs-map.ts references non-existent repo files or
+        # when website version / command snippets are stale.
+        run: npm run check:docs
       - name: Run ESLint
         run: npm run lint
       - name: TypeScript type check

--- a/web/app/[locale]/docs/constitution/page.tsx
+++ b/web/app/[locale]/docs/constitution/page.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return {
+    title: isZh ? "嵌套宪法 · CodeWhale 文档" : "Constitution · CodeWhale Docs",
+    description: isZh
+      ? "Agent 自我模型、嵌套权威系统和证据规则。"
+      : "Agent identity, nested authority system, and evidence rules.",
+  };
+}
+
+export default async function ConstitutionPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">
+          {isZh ? "嵌套宪法" : "Constitution"}{" "}
+          <span className="font-cjk text-indigo text-2xl ml-2">
+            {isZh ? "Constitution" : "嵌套宪法"}
+          </span>
+        </h2>
+        {isZh ? (
+          <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
+            CodeWhale 先给 Agent 一个可追责的地址，再给上下文冲突一套法律。全局 Constitution 处理
+            truth、user agency、行动和验证；仓库可以通过{" "}
+            <code className="inline">.codewhale/constitution.json</code> 增加本地 law；runtime
+            policy 再把模式、审批、沙箱、成本和工具边界落到代码里。
+          </p>
+        ) : (
+          <p className="text-ink-soft mt-3 leading-relaxed">
+            CodeWhale gives the agent an accountable address, then a legal system for
+            context conflicts. The global Constitution handles truth, user agency,
+            action, and verification; repos can add local law via{" "}
+            <code className="inline">.codewhale/constitution.json</code>; runtime policy
+            encodes modes, approval, sandbox, cost, and tool boundaries.
+          </p>
+        )}
+        <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
+          {[
+            {
+              name: "Identity",
+              cn: "自我",
+              en: "The agent is an instance in this terminal, workspace, and session; accountability starts with an address.",
+              zh: "Agent 是当前终端、工作区和会话里的实例；责任先有地址。",
+            },
+            {
+              name: "Authority",
+              cn: "权威",
+              en: "User request, runtime policy, repo local law, live evidence, and memory each have a rank.",
+              zh: "当前用户请求、运行时规则、仓库本地 law、实时证据、记忆各有顺位。",
+            },
+            {
+              name: "Evidence",
+              cn: "证据",
+              en: "Tool output, file contents, test results, and diagnostic feedback are the source of truth; no claim of success without evidence.",
+              zh: "工具输出、文件内容、测试结果和诊断反馈是事实来源；没有证据就不声明完成。",
+            },
+          ].map((row) => (
+            <div key={row.name} className="p-5">
+              <div className="font-display text-lg text-indigo mb-1">
+                {row.name} <span className="font-cjk text-sm ml-1.5">{row.cn}</span>
+              </div>
+              <p className={`text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
+                {isZh ? row.zh : row.en}
+              </p>
+            </div>
+          ))}
+        </div>
+        <p className={`mt-4 text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
+          {isZh
+            ? "普通项目说明仍放在 AGENTS.md；CodeWhale 专属的冲突解决和验证策略放在 .codewhale/constitution.json。详见 "
+            : "Standard project instructions still live in AGENTS.md; CodeWhale-specific conflict resolution and verification policies go in .codewhale/constitution.json. See "}
+          <Link
+            href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#project-instructions--repo-authority"
+            className="body-link"
+          >
+            {isZh ? "repo authority docs" : "repo authority docs"}
+          </Link>
+          {isZh ? "。" : "."}
+        </p>
+      </section>
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/ARCHITECTURE.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/ARCHITECTURE.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/layout.tsx
+++ b/web/app/[locale]/docs/layout.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+import { Seal } from "@/components/seal";
+import { getTopicsByCategory, REPO_DOCS_BASE, type DocTopic } from "@/lib/docs-map";
+
+/* ------------------------------------------------------------------ */
+/*  Locale-aware category heading labels                               */
+/* ------------------------------------------------------------------ */
+
+const CATEGORY_LABELS: Record<string, { en: string; zh: string }> = {
+  "getting-started": { en: "Getting started", zh: "入门" },
+  "core-concepts": { en: "Core concepts", zh: "核心概念" },
+  reference: { en: "Reference", zh: "参考" },
+  extending: { en: "Extending", zh: "扩展" },
+  operations: { en: "Operations", zh: "运维" },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Link resolution helpers                                            */
+/* ------------------------------------------------------------------ */
+
+function topicHref(topic: DocTopic, locale: string): string {
+  if (topic.hasPage) {
+    return `/${locale}/docs/${topic.slug}`;
+  }
+  const src = Array.isArray(topic.repoSource) ? topic.repoSource[0] : topic.repoSource;
+  return `${REPO_DOCS_BASE}/${src}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sidebar                                                            */
+/* ------------------------------------------------------------------ */
+
+function DocsSidebar({ locale, currentId }: { locale: string; currentId?: string }) {
+  const isZh = locale === "zh";
+  const byCategory = getTopicsByCategory();
+
+  return (
+    <aside className="lg:col-span-3 min-w-0">
+      <div className="lg:sticky lg:top-32">
+        <div className="eyebrow mb-3">{isZh ? "文档目录" : "Docs index"}</div>
+        <nav className="hairline-t hairline-b py-3 space-y-4">
+          {[...byCategory.entries()].map(([cat, topics]) => (
+            <div key={cat}>
+              <div className="font-mono text-[0.62rem] uppercase tracking-widest text-ink-mute mb-1.5 px-0.5">
+                {isZh ? CATEGORY_LABELS[cat]?.zh ?? cat : CATEGORY_LABELS[cat]?.en ?? cat}
+              </div>
+              <ul className="space-y-0.5">
+                {topics.map((t) => {
+                  const href = topicHref(t, locale);
+                  const isCurrent = t.id === currentId;
+                  return (
+                    <li key={t.id}>
+                      <Link
+                        href={href}
+                        target={t.hasPage ? undefined : "_blank"}
+                        className={`block py-0.5 px-0.5 text-sm transition-colors ${
+                          isCurrent ? "text-indigo font-semibold" : "text-ink-soft hover:text-indigo"
+                        }`}
+                      >
+                        <span className="font-mono text-[0.7rem] text-ink-mute mr-1.5 tabular">
+                          {t.hasPage ? "§" : "↗"}
+                        </span>
+                        {isZh ? t.label.zh : t.label.en}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Layout (Next.js App Router)                                        */
+/* ------------------------------------------------------------------ */
+
+export default async function DocsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+
+  return (
+    <section className="mx-auto max-w-[1400px] px-6 pt-12 pb-8">
+      <div className="flex items-baseline gap-4 mb-3">
+        <Seal char="文" />
+        <div className="eyebrow">{isZh ? "Section 02 · 文档" : "Section 02 · Docs"}</div>
+      </div>
+      <h1 className="font-display tracking-crisp">
+        {isZh ? (
+          <>
+            文档 <span className="font-cjk text-indigo text-5xl ml-2">Documentation</span>
+          </>
+        ) : (
+          <>
+            Documentation <span className="font-cjk text-indigo text-5xl ml-2">文档</span>
+          </>
+        )}
+      </h1>
+      <p className="mt-5 max-w-3xl text-ink-soft text-lg leading-[1.9] tracking-wide">
+        {isZh
+          ? "工作原理简述：先有 Agent 自我模型，再有嵌套权威系统，最后才是模式、工具和 provider。完整的架构讲解请参阅仓库中的 "
+          : "How CodeWhale works: ego, conflict law, evidence, modes, tools, sandbox, MCP, config, hooks. The full architecture walkthrough is in "}
+        <Link
+          href="https://github.com/Hmbown/CodeWhale/blob/main/docs/ARCHITECTURE.md"
+          className="body-link mx-1"
+        >
+          docs/ARCHITECTURE.md
+        </Link>
+        。
+      </p>
+
+      <div className="mt-10 grid lg:grid-cols-12 gap-10 min-w-0">
+        <DocsSidebar locale={locale} />
+        <article className="lg:col-span-9 min-w-0">{children}</article>
+      </div>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/modes/page.tsx
+++ b/web/app/[locale]/docs/modes/page.tsx
@@ -1,0 +1,135 @@
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return {
+    title: isZh ? "模式 · CodeWhale 文档" : "Modes · CodeWhale Docs",
+    description: isZh
+      ? "Plan、Agent、YOLO 三种运行模式与正交审批策略。"
+      : "Plan, Agent, YOLO operating modes and orthogonal approval policies.",
+  };
+}
+
+export default async function ModesPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">
+          {isZh ? "模式" : "Modes"}{" "}
+          <span className="font-cjk text-indigo text-2xl ml-2">
+            {isZh ? "Modes" : "模式"}
+          </span>
+        </h2>
+        {isZh ? (
+          <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
+            三种运行模式——与审批系统正交。按{" "}
+            <kbd className="font-mono text-xs px-1.5 py-0.5 hairline-t hairline-b hairline-l hairline-r">
+              Tab
+            </kbd>{" "}
+            切换。
+          </p>
+        ) : (
+          <p className="text-ink-soft mt-3 leading-relaxed">
+            Three operating modes — orthogonal to the approval system. Press{" "}
+            <kbd className="font-mono text-xs px-1.5 py-0.5 hairline-t hairline-b hairline-l hairline-r">
+              Tab
+            </kbd>{" "}
+            to cycle.
+          </p>
+        )}
+        <div className="grid md:grid-cols-3 gap-0 col-rule hairline-t hairline-b mt-6">
+          {[
+            {
+              name: "Plan",
+              cn: "计划",
+              color: "text-cobalt",
+              en: "Read-only investigation. Grep, read files, list directories, fetch URLs — cannot write or execute shell.",
+              zh: "只读调查。可以 grep、读文件、列目录、抓取 URL——不能写入或执行 shell。",
+            },
+            {
+              name: "Agent",
+              cn: "代理",
+              color: "text-jade",
+              en: "Default mode. Multi-step tool use. Shell and side-effect tools require approval per approval_mode.",
+              zh: "默认模式。多步工具调用。Shell 和有副作用的工具需按 approval_mode 设置审批。",
+            },
+            {
+              name: "YOLO",
+              cn: "全权",
+              color: "text-indigo",
+              en: "Auto-approve all actions and enable trust mode. Workspace boundary lifted. Use carefully.",
+              zh: "自动批准所有操作并启用信任模式。工作区边界解除。请谨慎使用。",
+            },
+          ].map((m) => (
+            <div key={m.name} className="p-5">
+              <div className={`font-display text-xl ${m.color} mb-1`}>
+                {m.name} <span className="font-cjk text-base ml-1.5">{m.cn}</span>
+              </div>
+              <p className={`text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
+                {isZh ? m.zh : m.en}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="approval" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "审批策略" : "Approval Policies"}
+        </h2>
+        {isZh ? (
+          <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
+            模式与审批是两个独立的维度。通过 <code className="inline">/config</code> 设置。
+          </p>
+        ) : (
+          <p className="text-ink-soft mt-3 leading-relaxed">
+            Modes and approval are independent dimensions. Set via{" "}
+            <code className="inline">/config</code>.
+          </p>
+        )}
+        <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
+          {[
+            {
+              name: "suggest",
+              cn: "建议",
+              en: "Default — follow mode rules. Ask before dangerous operations.",
+              zh: "默认——按模式规则执行。危险操作前询问。",
+            },
+            {
+              name: "auto",
+              cn: "自动",
+              en: "Auto-approve all tool calls. Equivalent to YOLO without trust.",
+              zh: "自动批准所有工具调用。等同于无信任的 YOLO。",
+            },
+            {
+              name: "never",
+              cn: "拒绝",
+              en: "Block any non-safe / non-read-only action. Investigation only.",
+              zh: "阻止任何非安全/非只读操作。仅限调查。",
+            },
+          ].map((a) => (
+            <div key={a.name} className="p-5">
+              <div className="font-mono text-sm text-indigo uppercase tracking-wider">
+                {a.name} ·{" "}
+                <span className="font-cjk normal-case tracking-normal">{a.cn}</span>
+              </div>
+              <p className={`text-sm text-ink-soft mt-2 ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
+                {isZh ? a.zh : a.en}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/MODES.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/MODES.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/page.tsx
+++ b/web/app/[locale]/docs/page.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link";
-import { Seal } from "@/components/seal";
-import { getFacts } from "@/lib/facts";
+import {
+  getTopicsByCategory,
+  REPO_DOCS_BASE,
+  type DocTopic,
+} from "@/lib/docs-map";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
@@ -8,633 +11,99 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: isZh ? "文档 · CodeWhale" : "Docs · CodeWhale",
     description: isZh
-      ? "CodeWhale 的工作原理：嵌套宪法、模式、工具、沙箱、MCP、配置、钩子。"
-      : "How CodeWhale works: ego, conflict law, evidence, modes, tools, sandbox, MCP, config, hooks.",
+      ? "CodeWhale 文档：安装、使用指南、配置、提供商、核心概念、工具、MCP、技能、沙箱、运行时 API、排障。"
+      : "CodeWhale documentation: install, user guide, configuration, providers, core concepts, tools, MCP, skills, sandbox, runtime API, troubleshooting.",
   };
 }
 
-const sectionsEn = [
-  { id: "constitution", label: "Constitution" },
-  { id: "modes", label: "Modes" },
-  { id: "tools", label: "Tools" },
-  { id: "approval", label: "Approval & Sandbox" },
-  { id: "config", label: "Configuration" },
-  { id: "mcp", label: "MCP" },
-  { id: "skills", label: "Skills" },
-  { id: "providers", label: "Providers" },
-  { id: "fin", label: "Fin" },
-  { id: "shortcuts", label: "Shortcuts" },
-];
+/* ------------------------------------------------------------------ */
+/*  Locale-aware strings                                              */
+/* ------------------------------------------------------------------ */
 
-const sectionsZh = [
-  { id: "constitution", label: "宪法" },
-  { id: "modes", label: "模式" },
-  { id: "tools", label: "工具" },
-  { id: "approval", label: "审批与沙箱" },
-  { id: "config", label: "配置" },
-  { id: "mcp", label: "MCP" },
-  { id: "skills", label: "技能" },
-  { id: "providers", label: "提供商" },
-  { id: "fin", label: "Fin" },
-  { id: "shortcuts", label: "快捷键" },
-];
+const CATEGORY_LABELS: Record<string, { en: string; zh: string }> = {
+  "getting-started": { en: "Getting started", zh: "入门" },
+  "core-concepts": { en: "Core concepts", zh: "核心概念" },
+  reference: { en: "Reference", zh: "参考" },
+  extending: { en: "Extending", zh: "扩展" },
+  operations: { en: "Operations & community", zh: "运维与社区" },
+};
 
-export default async function DocsPage({ params }: { params: Promise<{ locale: string }> }) {
+/* ------------------------------------------------------------------ */
+
+function topicHref(topic: DocTopic, locale: string): string {
+  if (topic.hasPage) {
+    return `/${locale}/docs/${topic.slug}`;
+  }
+  const src = Array.isArray(topic.repoSource) ? topic.repoSource[0] : topic.repoSource;
+  return `${REPO_DOCS_BASE}/${src}`;
+}
+
+function topicSources(topic: DocTopic): string[] {
+  return Array.isArray(topic.repoSource) ? topic.repoSource : [topic.repoSource];
+}
+
+/* ------------------------------------------------------------------ */
+
+export default async function DocsHubPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const isZh = locale === "zh";
-  const sections = isZh ? sectionsZh : sectionsEn;
-  const facts = await getFacts();
+  const byCategory = getTopicsByCategory();
 
-  return (
-    <>
-      {isZh ? (
-        <>
-          <section className="mx-auto max-w-[1400px] px-6 pt-12 pb-8">
-            <div className="flex items-baseline gap-4 mb-3">
-              <Seal char="文" />
-              <div className="eyebrow">Section 02 · 文档</div>
-            </div>
-            <h1 className="font-display tracking-crisp">
-              文档 <span className="font-cjk text-indigo text-5xl ml-2">Documentation</span>
-            </h1>
-            <p className="mt-5 max-w-3xl text-ink-soft text-lg leading-[1.9] tracking-wide">
-              工作原理简述：先有 Agent 自我模型，再有嵌套权威系统，最后才是模式、工具和 provider。
-              完整的架构讲解请参阅仓库中的
-              <Link href="https://github.com/Hmbown/CodeWhale/blob/main/docs/ARCHITECTURE.md" className="body-link mx-1">docs/ARCHITECTURE.md</Link>。
-            </p>
-          </section>
+  const body = (
+    <div className="space-y-12">
+      {[...byCategory.entries()].map(([cat, topics]) => (
+        <section key={cat} id={cat}>
+          <h2 className="font-display text-2xl mb-1">
+            {isZh ? CATEGORY_LABELS[cat]?.zh ?? cat : CATEGORY_LABELS[cat]?.en ?? cat}
+          </h2>
+          <div className="grid sm:grid-cols-2 gap-4 mt-4">
+            {topics.map((t) => {
+              const href = topicHref(t, locale);
+              const sources = topicSources(t);
+              const isExternal = !t.hasPage;
+              return (
+                <Link
+                  key={t.id}
+                  href={href}
+                  target={isExternal ? "_blank" : undefined}
+                  className="hairline-t hairline-b hairline-l hairline-r p-4 hover:bg-paper-deep transition-colors group block"
+                >
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <span className="font-mono text-[0.62rem] uppercase tracking-widest text-ink-mute">
+                      {isZh ? t.label.zh : t.label.en}
+                    </span>
+                    {isExternal && (
+                      <span className="font-mono text-[0.6rem] text-ink-mute">↗</span>
+                    )}
+                  </div>
+                  <p className="text-sm text-ink-soft leading-relaxed">
+                    {isZh ? t.description.zh : t.description.en}
+                  </p>
+                  <div className="mt-2 font-mono text-[0.62rem] text-ink-mute truncate">
+                    {sources.map((s, i) => (
+                      <span key={s}>
+                        {i > 0 && ", "}
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      ))}
 
-          <section className="mx-auto max-w-[1400px] px-6 pb-16 grid lg:grid-cols-12 gap-10 min-w-0">
-            <aside className="lg:col-span-3 min-w-0">
-              <div className="lg:sticky lg:top-32">
-                <div className="eyebrow mb-3">本页目录 · On this page</div>
-                <ul className="space-y-1.5 hairline-t hairline-b py-3">
-                  {sections.map((s) => (
-                    <li key={s.id}>
-                      <a href={`#${s.id}`} className="text-sm hover:text-indigo block py-0.5">
-                        <span className="font-mono text-[0.7rem] text-ink-mute mr-2 tabular">§</span>
-                        {s.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </aside>
-
-            <article className="lg:col-span-9 space-y-14 min-w-0">
-
-              {/* 宪法 */}
-              <section id="constitution" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  嵌套宪法 <span className="font-cjk text-indigo text-2xl ml-2">Constitution</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  CodeWhale 先给 Agent 一个可追责的地址，再给上下文冲突一套法律。全局 Constitution 处理 truth、user agency、行动和验证；
-                  仓库可以通过 <code className="inline">.codewhale/constitution.json</code> 增加本地 law；
-                  runtime policy 再把模式、审批、沙箱、成本和工具边界落到代码里。
-                </p>
-                <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
-                  {[
-                    { name: "Identity", cn: "自我", desc: "Agent 是当前终端、工作区和会话里的实例；责任先有地址。" },
-                    { name: "Authority", cn: "权威", desc: "当前用户请求、运行时规则、仓库本地 law、实时证据、记忆、个性和旧交接各有顺位。" },
-                    { name: "Evidence", cn: "证据", desc: "工具输出、文件内容、测试结果和诊断反馈是事实来源；没有证据就不声明完成。" },
-                  ].map((row) => (
-                    <div key={row.name} className="p-5">
-                      <div className="font-display text-lg text-indigo mb-1">{row.name} <span className="font-cjk text-sm ml-1.5">{row.cn}</span></div>
-                      <p className="text-sm text-ink-soft leading-[1.9] tracking-wide">{row.desc}</p>
-                    </div>
-                  ))}
-                </div>
-                <p className="mt-4 text-sm text-ink-soft leading-[1.9] tracking-wide">
-                  普通项目说明仍放在 <code className="inline">AGENTS.md</code>；CodeWhale 专属的冲突解决和验证策略放在
-                  <code className="inline">.codewhale/constitution.json</code>。详见
-                  <Link href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#project-instructions--repo-authority" className="body-link mx-1">repo authority docs</Link>。
-                </p>
-              </section>
-
-              {/* 模式 */}
-              <section id="modes" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  模式 <span className="font-cjk text-indigo text-2xl ml-2">Modes</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  三种运行模式——与审批系统正交。按{" "}
-                  <kbd className="font-mono text-xs px-1.5 py-0.5 hairline-t hairline-b hairline-l hairline-r">Tab</kbd> 切换。
-                </p>
-                <div className="grid md:grid-cols-3 gap-0 col-rule hairline-t hairline-b mt-6">
-                  {[
-                    { name: "Plan", cn: "计划", color: "text-cobalt", desc: "只读调查。可以 grep、读文件、列目录、抓取 URL——不能写入或执行 shell。" },
-                    { name: "Agent", cn: "代理", color: "text-jade", desc: "默认模式。多步工具调用。Shell 和有副作用的工具需按 approval_mode 设置审批。" },
-                    { name: "YOLO", cn: "全权", color: "text-indigo", desc: "自动批准所有操作并启用信任模式。工作区边界解除。请谨慎使用。" },
-                  ].map((m) => (
-                    <div key={m.name} className="p-5">
-                      <div className={`font-display text-xl ${m.color} mb-1`}>
-                        {m.name} <span className="font-cjk text-base ml-1.5">{m.cn}</span>
-                      </div>
-                      <p className="text-sm text-ink-soft leading-[1.9] tracking-wide">{m.desc}</p>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              {/* 工具 */}
-              <section id="tools" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  工具 <span className="font-cjk text-indigo text-2xl ml-2">Tools</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  精选工具集——设计思路详见 <code className="inline">docs/TOOL_SURFACE.md</code>。
-                </p>
-                <div className="hairline-t hairline-b mt-6">
-                  {[
-                    { group: "文件操作", tools: "read_file · list_dir · write_file · edit_file · apply_patch" },
-                    { group: "搜索", tools: "grep_files · file_search · web_search · fetch_url" },
-                    { group: "Shell", tools: "exec_shell · exec_shell_wait · exec_shell_interact" },
-                    { group: "Git / 诊断 / 测试", tools: "git_status · git_diff · diagnostics · run_tests" },
-                    { group: "子 Agent", tools: "agent —— 持久会话，并行执行；详见 docs/SUBAGENTS.md" },
-                    { group: "递归 LM (RLM)", tools: "rlm_open · rlm_eval · rlm_configure · rlm_close —— 沙箱 Python REPL，内置 peek/search/chunk/sub_query_batch 等辅助函数" },
-                    { group: "MCP", tools: "mcp_<server>_<tool>——从 ~/.codewhale/mcp.json 自动注册" },
-                  ].map((row) => (
-                    <div key={row.group} className="grid md:grid-cols-12 gap-0 hairline-t py-3 px-4 hover:bg-paper-deep transition-colors min-w-0">
-                      <div className="md:col-span-3 font-display text-sm font-semibold">{row.group}</div>
-                      <div className="md:col-span-9 font-mono text-[0.78rem] text-ink-soft leading-relaxed break-words min-w-0">{row.tools}</div>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              {/* 审批 */}
-              <section id="approval" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  审批与沙箱 <span className="font-cjk text-indigo text-2xl ml-2">Approval</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  模式与审批是两个独立的维度。通过 <code className="inline">/config</code> 设置。
-                </p>
-                <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
-                  {[
-                    { name: "suggest", cn: "建议", desc: "默认——按模式规则执行。危险操作前询问。" },
-                    { name: "auto", cn: "自动", desc: "自动批准所有工具调用。等同于无信任的 YOLO。" },
-                    { name: "never", cn: "拒绝", desc: "阻止任何非安全/非只读操作。仅限调查。" },
-                  ].map((a) => (
-                    <div key={a.name} className="p-5">
-                      <div className="font-mono text-sm text-indigo uppercase tracking-wider">{a.name} · <span className="font-cjk normal-case tracking-normal">{a.cn}</span></div>
-                      <p className="text-sm text-ink-soft mt-2 leading-[1.9] tracking-wide">{a.desc}</p>
-                    </div>
-                  ))}
-                </div>
-                <p className="mt-5 text-ink-soft leading-[1.9] tracking-wide">
-                  沙箱：{facts.sandboxBackends.join("、")}。工作区边界默认为 <code className="inline">--workspace</code>。
-                  <code className="inline">/trust</code> 可解除边界限制。
-                </p>
-              </section>
-
-              {/* 配置 */}
-              <section id="config" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  配置 <span className="font-cjk text-indigo text-2xl ml-2">Configuration</span>
-                </h2>
-                <pre className="code-block mt-5">
-{`# ~/.codewhale/config.toml
-api_key = "sk-..."
-base_url = "https://api.deepseek.com"
-default_text_model = "${facts.defaultModel ?? "deepseek-v4-pro"}"  # 默认模型；deepseek-v4-flash 用于快速 / 子智能体
-
-[ui]
-default_mode = "agent"                      # plan | agent | yolo
-approval_mode = "suggest"                   # suggest | auto | never
-reasoning_effort = "high"                   # off | low | medium | high | max
-
-[hooks]
-enabled = true
-default_timeout_secs = 30
-
-[[hooks.hooks]]
-event = "session_start"                     # 也支持: tool_call_before / tool_call_after
-command = "~/.codewhale/hooks/pre.sh"        # / message_submit / mode_change / on_error / shell_env`}
-                </pre>
-                <p className="mt-4 text-sm text-ink-soft">
-                  完整参考：<Link className="body-link" href="https://github.com/Hmbown/CodeWhale/blob/main/config.example.toml">config.example.toml</Link>。
-                </p>
-                <p className="mt-3 text-sm text-ink-soft leading-[1.9]">
-                  Hooks v2（0.8.58）：<code className="inline">tool_call_before</code> 钩子可以在 stdout 输出 JSON 决策——
-                  <code className="inline">{'{"decision": "allow" | "deny" | "ask"}'}</code>，并可附带原因说明；多个钩子命中同一调用时，
-                  优先级为 deny &gt; ask &gt; allow。退出码 <code className="inline">2</code> 仍作为旧式硬性拒绝生效。
-                  钩子支持 glob 匹配器按工具或路径筛选，仓库也可以通过项目级的
-                  <code className="inline">.codewhale/hooks.toml</code> 随代码一起分发钩子。
-                </p>
-                <p className="mt-3 text-sm text-ink-soft leading-[1.9]">
-                  <code className="inline">message_submit</code> hooks run before a user message is sent to the model. A non-background hook can print
-                  <code className="inline">{'{"text":"replacement"}'}</code> on stdout to replace the message; <code className="inline">text</code> must be non-empty. Exit with code <code className="inline">2</code> to block the submission.
-                  <code className="inline">shell_env</code> keeps its existing <code className="inline">KEY=VALUE</code> stdout contract.
-                </p>
-              </section>
-
-              {/* MCP */}
-              <section id="mcp" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  MCP 服务器 <span className="font-cjk text-indigo text-2xl ml-2">MCP</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  <code className="inline">codewhale</code> 双向支持模型上下文协议（Model Context Protocol）：作为客户端从
-                  <code className="inline">~/.codewhale/mcp.json</code> 加载服务器，同时也可作为服务器暴露工具
-                  （<code className="inline">codewhale mcp</code>）。工具以 <code className="inline">mcp_&lt;server&gt;_&lt;tool&gt;</code> 形式呈现。
-                </p>
-                <pre className="code-block mt-5">
-{`{
-  "mcpServers": {
-    "filesystem": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me"]
-    },
-    "sqlite": {
-      "command": "uvx",
-      "args": ["mcp-server-sqlite", "--db-path", "./data.db"]
-    }
-  }
-}`}
-                </pre>
-              </section>
-
-              {/* 技能 */}
-              <section id="skills" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  技能 <span className="font-cjk text-indigo text-2xl ml-2">Skills</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  技能是 <code className="inline">~/.codewhale/skills/&lt;name&gt;/</code> 下的一个文件夹，
-                  根目录包含 <code className="inline">SKILL.md</code>。Agent 启动时加载技能名称和描述，
-                  在需要时通过 Skill 工具拉取完整内容。
-                </p>
-              </section>
-
-              {/* Fin */}
-              <section id="fin" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Fin 智能路由 <span className="font-cjk text-indigo text-2xl ml-2">Fin</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  Fin 是 CodeWhale 的模型自动路由层。它会分析每个任务的特征——复杂度、上下文大小、工具需求——然后自动将请求分发到最合适的模型后端。
-                </p>
-                <div className="hairline-t hairline-b mt-6 grid md:grid-cols-2 col-rule">
-                  {[
-                    { name: "Fast lane", cn: "快速通道", desc: "轻量任务（文件查找、fetch、简单 shell 命令）自动路由到 flash 级模型，降低延迟与成本。" },
-                    { name: "Deep lane", cn: "深度通道", desc: "复杂推理、大型重构、多步规划自动升级到全尺寸推理模型。" },
-                  ].map((l) => (
-                    <div key={l.name} className="p-5">
-                      <div className="font-display text-lg text-indigo mb-1">{l.name} <span className="font-cjk text-sm ml-1.5">{l.cn}</span></div>
-                      <p className="text-sm text-ink-soft leading-[1.9] tracking-wide">{l.desc}</p>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              {/* 提供商 */}
-              <section id="providers" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  提供商 <span className="font-cjk text-indigo text-2xl ml-2">Providers</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-[1.9] tracking-wide">
-                  使用 <code className="inline">codewhale auth set --provider &lt;id&gt;</code> 切换。下表为
-                  <code className="inline">crates/tui/src/config.rs</code> 中 <code className="inline">ApiProvider</code> 枚举的实时投影
-                  ，目前共 {facts.providers.length} 个。
-                </p>
-                <div className="hairline-t hairline-b mt-5">
-                  {facts.providers.map((p) => (
-                    <div key={p.id} className="grid md:grid-cols-12 gap-0 hairline-t py-3 px-4 hover:bg-paper-deep min-w-0">
-                      <div className="md:col-span-3 font-display font-semibold">{p.label}</div>
-                      <div className="md:col-span-3 font-mono text-[0.78rem] text-ink-soft break-words min-w-0">{p.id}</div>
-                      <div className="md:col-span-6 font-mono text-[0.78rem] text-ink-soft break-words min-w-0">{p.env}</div>
-                    </div>
-                  ))}
-                </div>
-                <p className="mt-5 text-ink-soft leading-[1.9] tracking-wide">
-                  <strong>OpenRouter</strong>、<strong>Hugging Face</strong>（Inference Providers）以及自托管的
-                  <strong> vLLM / SGLang / Ollama</strong> 端点都已是正式可用的路由。闭源提供商同样是原生接入而非兼容垫片：
-                  <code className="inline">anthropic</code> 通过专用适配器直连 Anthropic Messages API，
-                  <code className="inline">openai-codex</code> 复用已有的 ChatGPT/Codex CLI 登录。
-                  接下来的方向是模型发现——Model Lab 将带来 Hub 浏览、模型卡片和数据集。
-                </p>
-              </section>
-
-              {/* 快捷键 */}
-              <section id="shortcuts" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  快捷键 <span className="font-cjk text-indigo text-2xl ml-2">Shortcuts</span>
-                </h2>
-                <div className="hairline-t hairline-b mt-5 grid md:grid-cols-2 col-rule">
-                  {[
-                    { k: "Tab", v: "切换模式（Plan / Agent / YOLO）" },
-                    { k: "Shift+Tab", v: "切换推理强度" },
-                    { k: "Ctrl+L", v: "清屏，保留会话" },
-                    { k: "Ctrl+C", v: "取消当前轮次" },
-                    { k: "Ctrl+D", v: "退出" },
-                    { k: "/help", v: "斜杠命令面板" },
-                    { k: "/config", v: "交互式编辑配置" },
-                    { k: "/trust", v: "解除本会话的工作区边界" },
-                  ].map((s) => (
-                    <div key={s.k} className="p-4 flex items-center gap-4 hairline-t">
-                      <kbd className="font-mono text-xs px-2 py-1 hairline-t hairline-b hairline-l hairline-r bg-paper-deep min-w-[5rem] text-center">{s.k}</kbd>
-                      <span className="text-sm text-ink-soft">{s.v}</span>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-            </article>
-          </section>
-        </>
-      ) : (
-        <>
-          <section className="mx-auto max-w-[1400px] px-6 pt-12 pb-8">
-            <div className="flex items-baseline gap-4 mb-3">
-              <Seal char="文" />
-              <div className="eyebrow">Section 02 · 文档</div>
-            </div>
-            <h1 className="font-display tracking-crisp">
-              Documentation <span className="font-cjk text-indigo text-5xl ml-2">文档</span>
-            </h1>
-            <p className="mt-5 max-w-3xl text-ink-soft text-lg leading-relaxed">
-              The short version of how it works: identity first, nested authority next, then modes, tools, and providers.
-              For the full architecture walk-through, see
-              <Link href="https://github.com/Hmbown/CodeWhale/blob/main/docs/ARCHITECTURE.md" className="body-link mx-1">docs/ARCHITECTURE.md</Link>
-              in the repo.
-            </p>
-          </section>
-
-          <section className="mx-auto max-w-[1400px] px-6 pb-16 grid lg:grid-cols-12 gap-10 min-w-0">
-            <aside className="lg:col-span-3 min-w-0">
-              <div className="lg:sticky lg:top-32">
-                <div className="eyebrow mb-3">On this page · 目录</div>
-                <ul className="space-y-1.5 hairline-t hairline-b py-3">
-                  {sections.map((s) => (
-                    <li key={s.id}>
-                      <a href={`#${s.id}`} className="text-sm hover:text-indigo block py-0.5">
-                        <span className="font-mono text-[0.7rem] text-ink-mute mr-2 tabular">§</span>
-                        {s.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </aside>
-
-            <article className="lg:col-span-9 space-y-14 min-w-0">
-
-              <section id="constitution" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Nested Constitution <span className="font-cjk text-indigo text-2xl ml-2">宪法</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  CodeWhale gives the agent an accountable address before it hands over the tool list. The global Constitution handles truth,
-                  user agency, action, and verification. Repositories can add local law through
-                  <code className="inline">.codewhale/constitution.json</code>. Runtime policy then turns modes, approvals,
-                  sandboxing, cost limits, and tool boundaries into code.
-                </p>
-                <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
-                  {[
-                    { name: "Identity", cn: "自我", desc: "The agent is an instance in this terminal, workspace, and session. Responsibility gets an address first." },
-                    { name: "Authority", cn: "权威", desc: "Current user request, runtime statutes, repo-local law, live evidence, memory, personality, and old handoffs each have a rank." },
-                    { name: "Evidence", cn: "证据", desc: "Tool output, file contents, tests, and diagnostics are fact sources. Without evidence, the task is not done." },
-                  ].map((row) => (
-                    <div key={row.name} className="p-5">
-                      <div className="font-display text-lg text-indigo mb-1">{row.name} <span className="font-cjk text-sm ml-1.5">{row.cn}</span></div>
-                      <p className="text-sm text-ink-soft leading-relaxed">{row.desc}</p>
-                    </div>
-                  ))}
-                </div>
-                <p className="mt-4 text-sm text-ink-soft leading-relaxed">
-                  Put ordinary project instructions in <code className="inline">AGENTS.md</code>. Put CodeWhale-specific conflict
-                  resolution and verification policy in <code className="inline">.codewhale/constitution.json</code>. See the
-                  <Link href="https://github.com/Hmbown/CodeWhale/blob/main/docs/CONFIGURATION.md#project-instructions--repo-authority" className="body-link mx-1">repo authority docs</Link>.
-                </p>
-              </section>
-
-              <section id="modes" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Modes <span className="font-cjk text-indigo text-2xl ml-2">模式</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  Three operating modes — orthogonal to the approval system. Cycle with{" "}
-                  <kbd className="font-mono text-xs px-1.5 py-0.5 hairline-t hairline-b hairline-l hairline-r">Tab</kbd>.
-                </p>
-                <div className="grid md:grid-cols-3 gap-0 col-rule hairline-t hairline-b mt-6">
-                  {[
-                    { name: "Plan", cn: "计划", color: "text-cobalt", desc: "Read-only investigation. The agent can grep, read files, list dirs, fetch URLs — never write or shell out." },
-                    { name: "Agent", cn: "代理", color: "text-jade", desc: "Default. Multi-step tool use. Shell and side-effectful tools require approval per `approval_mode` setting." },
-                    { name: "YOLO", cn: "全权", color: "text-indigo", desc: "Auto-approve everything + enable trust mode. Workspace boundary lifts. Use carefully." },
-                  ].map((m) => (
-                    <div key={m.name} className="p-5">
-                      <div className={`font-display text-xl ${m.color} mb-1`}>
-                        {m.name} <span className="font-cjk text-base ml-1.5">{m.cn}</span>
-                      </div>
-                      <p className="text-sm text-ink-soft leading-relaxed">{m.desc}</p>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section id="tools" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Tools <span className="font-cjk text-indigo text-2xl ml-2">工具</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  Curated surface — see <code className="inline">docs/TOOL_SURFACE.md</code> for design rationale.
-                </p>
-                <div className="hairline-t hairline-b mt-6">
-                  {[
-                    { group: "File ops", tools: "read_file · list_dir · write_file · edit_file · apply_patch" },
-                    { group: "Search", tools: "grep_files · file_search · web_search · fetch_url" },
-                    { group: "Shell", tools: "exec_shell · exec_shell_wait · exec_shell_interact" },
-                    { group: "Git / diag / test", tools: "git_status · git_diff · diagnostics · run_tests" },
-                    { group: "Sub-agents", tools: "agent — persistent sessions, parallel execution; see docs/SUBAGENTS.md" },
-                    { group: "Recursive LM (RLM)", tools: "rlm_open · rlm_eval · rlm_configure · rlm_close — sandboxed Python REPL with peek/search/chunk/sub_query_batch helpers" },
-                    { group: "MCP", tools: "mcp_<server>_<tool> — auto-registered from ~/.codewhale/mcp.json" },
-                  ].map((row) => (
-                    <div key={row.group} className="grid md:grid-cols-12 gap-0 hairline-t py-3 px-4 hover:bg-paper-deep transition-colors min-w-0">
-                      <div className="md:col-span-3 font-display text-sm font-semibold">{row.group}</div>
-                      <div className="md:col-span-9 font-mono text-[0.78rem] text-ink-soft leading-relaxed break-words min-w-0">{row.tools}</div>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section id="approval" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Approval & Sandbox <span className="font-cjk text-indigo text-2xl ml-2">审批</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  Mode and approval are independent axes. Set via <code className="inline">/config</code>.
-                </p>
-                <div className="hairline-t hairline-b mt-6 grid md:grid-cols-3 col-rule">
-                  {[
-                    { name: "suggest", cn: "建议", desc: "Default — uses per-mode rules. Asks before risky ops." },
-                    { name: "auto", cn: "自动", desc: "Auto-approve all tool calls. Equivalent to YOLO without trust." },
-                    { name: "never", cn: "拒绝", desc: "Block anything not safe/read-only. Investigation only." },
-                  ].map((a) => (
-                    <div key={a.name} className="p-5">
-                      <div className="font-mono text-sm text-indigo uppercase tracking-wider">{a.name} · <span className="font-cjk normal-case tracking-normal">{a.cn}</span></div>
-                      <p className="text-sm text-ink-soft mt-2 leading-relaxed">{a.desc}</p>
-                    </div>
-                  ))}
-                </div>
-                <p className="mt-5 text-ink-soft leading-relaxed">
-                  Sandbox: {facts.sandboxBackends.join(", ")}. Workspace boundary defaults to{" "}
-                  <code className="inline">--workspace</code>. <code className="inline">/trust</code> lifts the boundary.
-                </p>
-              </section>
-
-              <section id="config" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Configuration <span className="font-cjk text-indigo text-2xl ml-2">配置</span>
-                </h2>
-                <pre className="code-block mt-5">
-{`# ~/.codewhale/config.toml
-api_key = "sk-..."
-base_url = "https://api.deepseek.com"
-default_text_model = "${facts.defaultModel ?? "deepseek-v4-pro"}"  # default; deepseek-v4-flash is the fast / sub-agent option
-
-[ui]
-default_mode = "agent"                      # plan | agent | yolo
-approval_mode = "suggest"                   # suggest | auto | never
-reasoning_effort = "high"                   # off | low | medium | high | max
-
-[hooks]
-enabled = true
-default_timeout_secs = 30
-
-[[hooks.hooks]]
-event = "session_start"                     # or: tool_call_before / tool_call_after
-command = "~/.codewhale/hooks/pre.sh"        # / message_submit / mode_change / on_error / shell_env`}
-                </pre>
-                <p className="mt-4 text-sm text-ink-soft">
-                  Full reference: <Link className="body-link" href="https://github.com/Hmbown/CodeWhale/blob/main/config.example.toml">config.example.toml</Link>.
-                </p>
-                <p className="mt-3 text-sm text-ink-soft leading-relaxed">
-                  Hooks v2 (0.8.58): a <code className="inline">tool_call_before</code> hook can print a JSON decision on stdout —
-                  <code className="inline">{'{"decision": "allow" | "deny" | "ask"}'}</code>, with an optional reason. When multiple hooks
-                  match the same call, precedence is deny &gt; ask &gt; allow. Exit code <code className="inline">2</code> still works as the
-                  legacy hard deny. Hooks can be scoped with glob matchers on tool or path, and repos can ship project-local hooks
-                  in <code className="inline">.codewhale/hooks.toml</code>.
-                </p>
-                <p className="mt-3 text-sm text-ink-soft leading-relaxed">
-                  <code className="inline">message_submit</code> hooks run before a user message is sent to the model. A non-background hook can print
-                  <code className="inline">{'{"text":"replacement"}'}</code> on stdout to replace the message; <code className="inline">text</code> must be non-empty. Exit with code <code className="inline">2</code> to block the submission.
-                  <code className="inline">shell_env</code> keeps its existing <code className="inline">KEY=VALUE</code> stdout contract.
-                </p>
-              </section>
-
-              <section id="mcp" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  MCP Servers <span className="font-cjk text-indigo text-2xl ml-2">MCP</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  <code className="inline">codewhale</code> speaks the Model Context Protocol both ways: as a client (loads
-                  servers from <code className="inline">~/.codewhale/mcp.json</code>) and as a server
-                  (<code className="inline">codewhale mcp</code>). Tools surface as <code className="inline">mcp_&lt;server&gt;_&lt;tool&gt;</code>.
-                </p>
-                <pre className="code-block mt-5">
-{`{
-  "mcpServers": {
-    "filesystem": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me"]
-    },
-    "sqlite": {
-      "command": "uvx",
-      "args": ["mcp-server-sqlite", "--db-path", "./data.db"]
-    }
-  }
-}`}
-                </pre>
-              </section>
-
-              <section id="skills" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Skills <span className="font-cjk text-indigo text-2xl ml-2">技能</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  A skill is a folder under <code className="inline">~/.codewhale/skills/&lt;name&gt;/</code>
-                  with a <code className="inline">SKILL.md</code> at the root. The agent loads skill names + descriptions on
-                  startup and can pull in the full body via the Skill tool when relevant.
-                </p>
-              </section>
-
-              {/* Fin */}
-              <section id="fin" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Fin <span className="font-cjk text-indigo text-2xl ml-2">智能路由</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  Fin is CodeWhale's model auto-routing layer. It analyses each task's profile — complexity, context size, tool needs — and dispatches to the best model backend automatically.
-                </p>
-                <div className="hairline-t hairline-b mt-6 grid md:grid-cols-2 col-rule">
-                  {[
-                    { name: "Fast lane", cn: "快速通道", desc: "Lightweight tasks (file ops, fetch, simple shell) auto-route to flash-tier models for lower latency and cost." },
-                    { name: "Deep lane", cn: "深度通道", desc: "Complex reasoning, large refactors, multi-step plans auto-upgrade to full-size reasoning models." },
-                  ].map((l) => (
-                    <div key={l.name} className="p-5">
-                      <div className="font-display text-lg text-indigo mb-1">{l.name} <span className="font-cjk text-sm ml-1.5">{l.cn}</span></div>
-                      <p className="text-sm text-ink-soft leading-relaxed">{l.desc}</p>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section id="providers" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Providers <span className="font-cjk text-indigo text-2xl ml-2">提供商</span>
-                </h2>
-                <p className="text-ink-soft mt-3 leading-relaxed">
-                  Switch with <code className="inline">codewhale auth set --provider &lt;id&gt;</code>. The
-                  table below is a live projection of the <code className="inline">ApiProvider</code> enum
-                  in <code className="inline">crates/tui/src/config.rs</code> — currently {facts.providers.length} providers.
-                </p>
-                <div className="hairline-t hairline-b mt-5">
-                  {facts.providers.map((p) => (
-                    <div key={p.id} className="grid md:grid-cols-12 gap-0 hairline-t py-3 px-4 hover:bg-paper-deep min-w-0">
-                      <div className="md:col-span-3 font-display font-semibold">{p.label}</div>
-                      <div className="md:col-span-3 font-mono text-[0.78rem] text-ink-soft break-words min-w-0">{p.id}</div>
-                      <div className="md:col-span-6 font-mono text-[0.78rem] text-ink-soft break-words min-w-0">{p.env}</div>
-                    </div>
-                  ))}
-                </div>
-                <p className="mt-5 text-ink-soft leading-relaxed">
-                  <strong>OpenRouter</strong>, <strong>Hugging Face</strong> (Inference Providers), and self-hosted
-                  <strong> vLLM / SGLang / Ollama</strong> endpoints are all shipped routes today. Closed providers are
-                  native, not shims: <code className="inline">anthropic</code> speaks the Anthropic Messages API through a
-                  dedicated adapter, and <code className="inline">openai-codex</code> reuses an existing ChatGPT/Codex CLI
-                  login. What is ahead is discovery — Model Lab for Hub browsing, model cards, and datasets.
-                </p>
-              </section>
-
-              <section id="shortcuts" className="scroll-mt-32">
-                <h2 className="font-display text-3xl mb-1">
-                  Shortcuts <span className="font-cjk text-indigo text-2xl ml-2">快捷键</span>
-                </h2>
-                <div className="hairline-t hairline-b mt-5 grid md:grid-cols-2 col-rule">
-                  {[
-                    { k: "Tab", v: "Cycle mode (Plan / Agent / YOLO)" },
-                    { k: "Shift+Tab", v: "Cycle reasoning effort" },
-                    { k: "Ctrl+L", v: "Clear screen, keep session" },
-                    { k: "Ctrl+C", v: "Cancel current turn" },
-                    { k: "Ctrl+D", v: "Exit" },
-                    { k: "/help", v: "Slash command palette" },
-                    { k: "/config", v: "Edit config interactively" },
-                    { k: "/trust", v: "Lift workspace boundary for session" },
-                  ].map((s) => (
-                    <div key={s.k} className="p-4 flex items-center gap-4 hairline-t">
-                      <kbd className="font-mono text-xs px-2 py-1 hairline-t hairline-b hairline-l hairline-r bg-paper-deep min-w-[5rem] text-center">{s.k}</kbd>
-                      <span className="text-sm text-ink-soft">{s.v}</span>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-            </article>
-          </section>
-        </>
-      )}
-    </>
+      {/* Parapgraph about the docs approach */}
+      <section className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute leading-relaxed max-w-2xl">
+          {isZh
+            ? "§ 标记的条目在 CodeWhale 网站上有独立页面；↗ 标记的条目链接到 GitHub 仓库中的源文档。所有内容来源于 docs/ 目录下的 40+ 篇 Markdown 文档，通过 docs-map.ts 注册表维护。"
+            : "Entries marked § have dedicated pages on codewhale.net; entries marked ↗ link to source documents in the GitHub repository. All content is sourced from 40+ Markdown documents in the docs/ directory, maintained through the docs-map.ts registry."}
+        </p>
+      </section>
+    </div>
   );
+
+  return body;
 }

--- a/web/app/[locale]/docs/tools/page.tsx
+++ b/web/app/[locale]/docs/tools/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return {
+    title: isZh ? "工具 · CodeWhale 文档" : "Tools · CodeWhale Docs",
+    description: isZh
+      ? "类型化工具集、工具生命周期和精选工具目录。"
+      : "Typed tool surface, tool lifecycle, and the curated tool catalog.",
+  };
+}
+
+export default async function ToolsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">
+          {isZh ? "工具" : "Tools"}{" "}
+          <span className="font-cjk text-indigo text-2xl ml-2">
+            {isZh ? "Tools" : "工具"}
+          </span>
+        </h2>
+        <p className={`text-ink-soft mt-3 ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
+          {isZh
+            ? "精选工具集——设计思路详见 "
+            : "Curated surface — see "}
+          <Link
+            href="https://github.com/Hmbown/CodeWhale/blob/main/docs/TOOL_SURFACE.md"
+            className="body-link"
+          >
+            docs/TOOL_SURFACE.md
+          </Link>
+          {isZh ? "。" : " for design rationale."}
+        </p>
+        <div className="hairline-t hairline-b mt-6">
+          {[
+            {
+              group: isZh ? "文件操作" : "File ops",
+              tools: "read_file · list_dir · write_file · edit_file · apply_patch",
+            },
+            {
+              group: isZh ? "搜索" : "Search",
+              tools: "grep_files · file_search · web_search · fetch_url",
+            },
+            {
+              group: "Shell",
+              tools: "exec_shell · exec_shell_wait · exec_shell_interact",
+            },
+            {
+              group: isZh ? "Git / 诊断 / 测试" : "Git / diag / test",
+              tools: "git_status · git_diff · diagnostics · run_tests",
+            },
+            {
+              group: isZh ? "子 Agent" : "Sub-agents",
+              tools: isZh
+                ? "agent —— 持久会话，并行执行；详见 docs/SUBAGENTS.md"
+                : "agent — persistent sessions, parallel execution; see docs/SUBAGENTS.md",
+            },
+            {
+              group: isZh ? "递归 LM (RLM)" : "Recursive LM (RLM)",
+              tools: isZh
+                ? "rlm_open · rlm_eval · rlm_configure · rlm_close —— 沙箱 Python REPL，内置 peek/search/chunk/sub_query_batch 等辅助函数"
+                : "rlm_open · rlm_eval · rlm_configure · rlm_close — sandboxed Python REPL with peek/search/chunk/sub_query_batch helpers",
+            },
+            {
+              group: "MCP",
+              tools: isZh
+                ? "mcp_<server>_<tool>——从 ~/.codewhale/mcp.json 自动注册"
+                : "mcp_<server>_<tool> — auto-registered from ~/.codewhale/mcp.json",
+            },
+          ].map((row) => (
+            <div
+              key={row.group}
+              className="grid md:grid-cols-12 gap-0 hairline-t py-3 px-4 hover:bg-paper-deep transition-colors min-w-0"
+            >
+              <div className="md:col-span-3 font-display text-sm font-semibold">
+                {row.group}
+              </div>
+              <div className="md:col-span-9 font-mono text-[0.78rem] text-ink-soft leading-relaxed break-words min-w-0">
+                {row.tools}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="lifecycle" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "工具生命周期" : "Tool Lifecycle"}
+        </h2>
+        <p className={`text-ink-soft mt-3 ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
+          {isZh
+            ? "工具注册、发现、弃用和稳定的完整流程详见仓库文档。"
+            : "Full lifecycle for tool registration, discovery, deprecation, and stabilization is documented in the repo."}
+        </p>
+        <Link
+          href="https://github.com/Hmbown/CodeWhale/blob/main/docs/TOOL_LIFECYCLE.md"
+          className="inline-block mt-3 font-mono text-xs uppercase tracking-wider text-indigo hover:underline"
+        >
+          docs/TOOL_LIFECYCLE.md →
+        </Link>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/TOOL_SURFACE.md, docs/TOOL_LIFECYCLE.md · 更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/TOOL_SURFACE.md, docs/TOOL_LIFECYCLE.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -1,0 +1,248 @@
+/**
+ * docs-map.ts — canonical documentation registry for codewhale.net.
+ *
+ * Maps every first-class documentation topic area to its repo source file(s)
+ * and website route. This is the single source of truth for the docs hub
+ * sidebar, breadcrumbs, and drift/parity checks.
+ *
+ * EXTENSION PATH FOR NEW LOCALES:
+ *   Labels are keyed by locale. Add a new locale column and update the page
+ *   components that consume this map. The topic IDs, slugs, and repo sources
+ *   are locale-agnostic.
+ */
+
+export interface DocTopic {
+  /** Stable identifier used in routes and anchors. */
+  id: string;
+  /** URL slug for the docs sub-route (e.g. "install"). */
+  slug: string;
+  /** Label per locale. */
+  label: { en: string; zh: string };
+  /** Short description per locale. */
+  description: { en: string; zh: string };
+  /** Repo source file(s) — the canonical markdown doc in the repo. */
+  repoSource: string | string[];
+  /** Whether this topic has a dedicated website page (vs. linking out). */
+  hasPage: boolean;
+  /** Category for grouping in the sidebar. */
+  category: "getting-started" | "core-concepts" | "reference" | "extending" | "operations";
+}
+
+export const DOC_TOPICS: DocTopic[] = [
+  {
+    id: "install",
+    slug: "install",
+    label: { en: "Install", zh: "安装" },
+    description: {
+      en: "npm, Cargo, Homebrew, Docker, Nix, Scoop, CNB mirror, and platform-specific notes.",
+      zh: "npm、Cargo、Homebrew、Docker、Nix、Scoop、CNB 镜像及平台说明。",
+    },
+    repoSource: "docs/INSTALL.md",
+    hasPage: false,
+    category: "getting-started",
+  },
+  {
+    id: "guide",
+    slug: "guide",
+    label: { en: "User Guide", zh: "使用指南" },
+    description: {
+      en: "First run, sessions, commands, keyboard shortcuts, and everyday workflows.",
+      zh: "首次运行、会话、命令、快捷键和日常使用流程。",
+    },
+    repoSource: ["docs/GUIDE.md", "docs/KEYBINDINGS.md"],
+    hasPage: false,
+    category: "getting-started",
+  },
+  {
+    id: "configuration",
+    slug: "configuration",
+    label: { en: "Configuration", zh: "配置" },
+    description: {
+      en: "config.toml reference, environment variables, project overrides, and legacy paths.",
+      zh: "config.toml 参考、环境变量、项目覆盖和旧版路径。",
+    },
+    repoSource: ["docs/CONFIGURATION.md", "docs/LEGACY_PATHS.md"],
+    hasPage: false,
+    category: "getting-started",
+  },
+  {
+    id: "providers",
+    slug: "providers",
+    label: { en: "Providers & Models", zh: "提供商与模型" },
+    description: {
+      en: "Supported providers, model switching, local runtimes (vLLM, Ollama, SGLang), and Model Lab.",
+      zh: "支持的提供商、模型切换、本地运行时（vLLM、Ollama、SGLang）和模型实验室。",
+    },
+    repoSource: ["docs/PROVIDERS.md", "docs/MODEL_LAB.md"],
+    hasPage: false,
+    category: "reference",
+  },
+  {
+    id: "constitution",
+    slug: "constitution",
+    label: { en: "Constitution", zh: "嵌套宪法" },
+    description: {
+      en: "Agent identity, authority hierarchy, evidence rules, and the nested law system.",
+      zh: "Agent 自我模型、权威层次、证据规则和嵌套法律系统。",
+    },
+    repoSource: "docs/ARCHITECTURE.md",
+    hasPage: true,
+    category: "core-concepts",
+  },
+  {
+    id: "modes",
+    slug: "modes",
+    label: { en: "Modes", zh: "模式" },
+    description: {
+      en: "Plan, Agent, YOLO modes and orthogonal approval policies.",
+      zh: "Plan、Agent、YOLO 三种模式与正交审批策略。",
+    },
+    repoSource: "docs/MODES.md",
+    hasPage: true,
+    category: "core-concepts",
+  },
+  {
+    id: "tools",
+    slug: "tools",
+    label: { en: "Tools", zh: "工具" },
+    description: {
+      en: "Typed tool surface, tool lifecycle, and the curated tool catalog.",
+      zh: "类型化工具集、工具生命周期和精选工具目录。",
+    },
+    repoSource: ["docs/TOOL_SURFACE.md", "docs/TOOL_LIFECYCLE.md"],
+    hasPage: true,
+    category: "core-concepts",
+  },
+  {
+    id: "subagents",
+    slug: "subagents",
+    label: { en: "Sub-Agents", zh: "子 Agent" },
+    description: {
+      en: "Parallel execution, role types, transcript handles, and nesting.",
+      zh: "并行执行、角色类型、transcript 句柄和嵌套。",
+    },
+    repoSource: "docs/SUBAGENTS.md",
+    hasPage: false,
+    category: "core-concepts",
+  },
+  {
+    id: "mcp",
+    slug: "mcp",
+    label: { en: "MCP", zh: "MCP" },
+    description: {
+      en: "Model Context Protocol — consuming and exposing tools via stdio and HTTP/SSE.",
+      zh: "Model Context Protocol — 通过 stdio 和 HTTP/SSE 消费和暴露工具。",
+    },
+    repoSource: "docs/MCP.md",
+    hasPage: false,
+    category: "extending",
+  },
+  {
+    id: "skills",
+    slug: "skills",
+    label: { en: "Skills", zh: "技能" },
+    description: {
+      en: "Skill loading, invocation design, and the community skill ecosystem.",
+      zh: "技能加载、调用设计和社区技能生态。",
+    },
+    repoSource: ["docs/SKILL_INVOCATION_DESIGN.md"],
+    hasPage: false,
+    category: "extending",
+  },
+  {
+    id: "hooks",
+    slug: "hooks",
+    label: { en: "Hooks", zh: "钩子" },
+    description: {
+      en: "Lifecycle hooks for pre/post tool execution, mode changes, and session events.",
+      zh: "工具执行前后、模式切换和会话事件的生命周期钩子。",
+    },
+    repoSource: "docs/rfcs/1364-hooks-lifecycle.md",
+    hasPage: false,
+    category: "extending",
+  },
+  {
+    id: "sandbox",
+    slug: "sandbox",
+    label: { en: "Sandbox & Approval", zh: "沙箱与审批" },
+    description: {
+      en: "seatbelt (macOS), landlock (Linux), Windows containment, and approval policies.",
+      zh: "seatbelt（macOS）、landlock（Linux）、Windows 隔离和审批策略。",
+    },
+    repoSource: "docs/SANDBOX.md",
+    hasPage: false,
+    category: "core-concepts",
+  },
+  {
+    id: "runtime-api",
+    slug: "runtime-api",
+    label: { en: "Runtime API", zh: "运行时 API" },
+    description: {
+      en: "Public HTTP API for integrations, bridges, and automation.",
+      zh: "用于集成、桥接和自动化的公开 HTTP API。",
+    },
+    repoSource: "docs/RUNTIME_API.md",
+    hasPage: false,
+    category: "extending",
+  },
+  {
+    id: "fleet",
+    slug: "fleet",
+    label: { en: "Fleet / WhaleFlow", zh: "Fleet / WhaleFlow" },
+    description: {
+      en: "Durable task execution, fleet management, and WhaleFlow authoring.",
+      zh: "持久任务执行、Fleet 管理和 WhaleFlow 编写。",
+    },
+    repoSource: ["docs/FLEET.md", "docs/WHALEFLOW_AUTHORING.md"],
+    hasPage: false,
+    category: "operations",
+  },
+  {
+    id: "troubleshooting",
+    slug: "troubleshooting",
+    label: { en: "Troubleshooting", zh: "排障" },
+    description: {
+      en: "Common issues, diagnostics, operations runbook, and Docker notes.",
+      zh: "常见问题、诊断、运维手册和 Docker 说明。",
+    },
+    repoSource: ["docs/OPERATIONS_RUNBOOK.md", "docs/DOCKER.md"],
+    hasPage: false,
+    category: "operations",
+  },
+  {
+    id: "contribution",
+    slug: "contribution",
+    label: { en: "Contribution", zh: "贡献" },
+    description: {
+      en: "Contributing guide, agent ethos, contributor credits, and release process.",
+      zh: "贡献指南、Agent 伦理、贡献者致谢和发布流程。",
+    },
+    repoSource: [
+      "CONTRIBUTING.md",
+      "docs/AGENT_ETHOS.md",
+      "docs/CONTRIBUTORS.md",
+      "docs/RELEASE_CHECKLIST.md",
+    ],
+    hasPage: false,
+    category: "operations",
+  },
+];
+
+/** Convenience lookup. */
+export function getTopic(id: string): DocTopic | undefined {
+  return DOC_TOPICS.find((t) => t.id === id);
+}
+
+/** Group topics by category for sidebar rendering. */
+export function getTopicsByCategory(): Map<string, DocTopic[]> {
+  const map = new Map<string, DocTopic[]>();
+  for (const t of DOC_TOPICS) {
+    const group = map.get(t.category) ?? [];
+    group.push(t);
+    map.set(t.category, group);
+  }
+  return map;
+}
+
+/** Repo source base URL for generating direct links. */
+export const REPO_DOCS_BASE = "https://github.com/Hmbown/CodeWhale/blob/main";

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "start": "next start",
     "test": "vitest run",
     "check:facts": "node scripts/check-facts.mjs",
+    "check:docs": "node scripts/check-docs.mjs",
     "lint": "eslint .",
     "preview": "opennextjs-cloudflare preview",
     "predeploy": "node scripts/check-kv-id.mjs",

--- a/web/scripts/check-docs.mjs
+++ b/web/scripts/check-docs.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * check-docs.mjs — drift / parity gate for website documentation.
+ *
+ * Verifies that:
+ *   1. Every doc topic in docs-map.ts points to a real repo source file.
+ *   2. Version, command snippets, and tool names referenced on the website
+ *      match the current workspace state.
+ *
+ * Usage:
+ *   cd web && npm run check:docs
+ *
+ * Relies on facts-lib.mjs for version / provider / tool derivation.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = resolve(__dirname, "..");
+const REPO_ROOT = resolve(WEB_DIR, "..");
+
+/* ------------------------------------------------------------------ */
+/*  Parse docs-map.ts (regex — avoids ts-node dependency)              */
+/* ------------------------------------------------------------------ */
+
+function parseDocsMap() {
+  const path = resolve(WEB_DIR, "lib", "docs-map.ts");
+  if (!existsSync(path)) {
+    console.error(`[check-docs] ERROR: docs-map.ts not found at ${path}`);
+    process.exit(1);
+  }
+  const src = readFileSync(path, "utf-8");
+
+  const topics = [];
+  const re =
+    /\{\s*id:\s*"(\w[^"]*)",\s*slug:\s*"(\w[^"]*)",[\s\S]*?repoSource:\s*(\[[^\]]+\]|"[^"]+")/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const id = m[1];
+    const slug = m[2];
+    let rawSource = m[3];
+    const sources = rawSource.startsWith("[")
+      ? rawSource.match(/"([^"]+)"/g)?.map((s) => s.slice(1, -1)) ?? []
+      : [rawSource.slice(1, -1)];
+    topics.push({ id, slug, repoSource: sources });
+  }
+  return topics;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Check 1: every repo source file exists                             */
+/* ------------------------------------------------------------------ */
+
+function checkSourcesExist(topics) {
+  const missing = [];
+  for (const t of topics) {
+    for (const src of t.repoSource) {
+      const p = resolve(REPO_ROOT, src);
+      if (!existsSync(p)) {
+        missing.push({ topic: t.id, source: src, expected: p });
+      }
+    }
+  }
+  return missing;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Check 2: version matches Cargo.toml                                 */
+/* ------------------------------------------------------------------ */
+
+function deriveVersion() {
+  const cargoPath = resolve(REPO_ROOT, "Cargo.toml");
+  if (!existsSync(cargoPath)) return null;
+  const cargo = readFileSync(cargoPath, "utf-8");
+  const m = cargo.match(/^version\s*=\s*"([^"]+)"/m);
+  return m ? m[1] : null;
+}
+
+function checkVersion() {
+  const version = deriveVersion();
+  return { version, ok: version != null };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Check 3: command snippet freshness (install commands)               */
+/* ------------------------------------------------------------------ */
+
+function checkInstallSnippets() {
+  const version = deriveVersion();
+  if (!version) return { ok: false, note: "could not derive version" };
+
+  const installPath = resolve(WEB_DIR, "app", "[locale]", "install", "page.tsx");
+  if (!existsSync(installPath)) return { ok: true, note: "install page not found" };
+
+  const src = readFileSync(installPath, "utf-8");
+  const versionRefs = [...src.matchAll(/codewhale.*?([\d]+\.[\d]+\.[\d]+)/g)];
+  const stale = [];
+  for (const ref of versionRefs) {
+    const v = ref[1];
+    if (v !== version) {
+      stale.push({ found: v, expected: version, context: ref[0].slice(0, 60) });
+    }
+  }
+  return { ok: stale.length === 0, stale };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                                */
+/* ------------------------------------------------------------------ */
+
+function main() {
+  const topics = parseDocsMap();
+  if (topics.length === 0) {
+    console.error("[check-docs] ERROR: no topics parsed from docs-map.ts");
+    process.exit(1);
+  }
+  console.log(`[check-docs] parsed ${topics.length} doc topics`);
+
+  // Check 1: sources exist
+  const missingSources = checkSourcesExist(topics);
+  if (missingSources.length > 0) {
+    console.error("[check-docs] FAIL — missing repo source files:");
+    for (const m of missingSources) {
+      console.error(`  ${m.topic}: ${m.source} → ${m.expected} (not found)`);
+    }
+    process.exit(1);
+  }
+  console.log("[check-docs] OK — all repo source files exist");
+
+  // Check 2: version
+  const ver = checkVersion();
+  if (!ver.ok) {
+    console.error("[check-docs] FAIL — could not derive version from workspace");
+    process.exit(1);
+  }
+  console.log(`[check-docs] OK — version=${ver.version}`);
+
+  // Check 3: install snippets
+  const install = checkInstallSnippets();
+  if (!install.ok && !install.note) {
+    console.error("[check-docs] FAIL — stale version in install snippets:");
+    for (const s of install.stale) {
+      console.error(`  found "${s.found}", expected "${s.expected}" in: ${s.context}`);
+    }
+  } else {
+    console.log(`[check-docs] OK — install snippets${install.note ? ` (${install.note})` : ""}`);
+  }
+
+  console.log("[check-docs] PASS");
+}
+
+try {
+  main();
+} catch (e) {
+  console.error("[check-docs] ERROR:", e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Replace the single monolithic Docs page with a hub-and-spoke structure backed by a canonical docs-map.ts registry.

- web/lib/docs-map.ts: canonical doc registry mapping 16 topic areas to repo source files, with locale-aware labels and category groups
- web/app/[locale]/docs/layout.tsx: shared sidebar nav layout for all docs sub-pages with categorized topic links (§ for pages, ↗ for repo)
- web/app/[locale]/docs/page.tsx: rewritten from 640-line monolith into a hub index with categorized topic cards and source attribution
- web/app/[locale]/docs/constitution/page.tsx: standalone page preserving existing EN+ZH inline content
- web/app/[locale]/docs/modes/page.tsx: standalone modes + approval page
- web/app/[locale]/docs/tools/page.tsx: standalone tools catalog page
- web/scripts/check-docs.mjs: drift/parity gate verifying repo source files exist, version matches workspace, and install snippets are fresh
- web/package.json: add npm run check:docs
- .github/workflows/web.yml: run check:docs after prebuild in lint job

Close https://github.com/Hmbown/CodeWhale/issues/3417.
## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
