### PR TITLE
Clarify tool details shortcut hints

### DIFF
--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -3618,6 +3618,19 @@ fn nvidia_nim_provider_normalizes_deepseek_v4_pro_alias() -> Result<()> {
 
 #[test]
 fn nvidia_nim_provider_normalizes_deepseek_v4_flash_alias() -> Result<()> {
+    let _lock = lock_test_env();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_root = env::temp_dir().join(format!(
+        "codewhale-tui-nim-flash-model-alias-test-{}-{}",
+        std::process::id(),
+        nanos
+    ));
+    fs::create_dir_all(&temp_root)?;
+    let _guard = EnvGuard::new(&temp_root);
+
     let config = Config {
         provider: Some("nvidia-nim".to_string()),
         default_text_model: Some("deepseek-v4-flash".to_string()),

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -431,7 +431,6 @@ pub enum MessageId {
     KbFuzzyFilePicker,
     KbCompactInspector,
     KbLastMessagePager,
-    KbSelectedDetails,
     KbToolDetailsPager,
     KbThinkingPager,
     KbLiveTranscript,
@@ -887,7 +886,6 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::KbFuzzyFilePicker,
     MessageId::KbCompactInspector,
     MessageId::KbLastMessagePager,
-    MessageId::KbSelectedDetails,
     MessageId::KbToolDetailsPager,
     MessageId::KbThinkingPager,
     MessageId::KbLiveTranscript,
@@ -1603,9 +1601,6 @@ fn english(id: MessageId) -> &'static str {
         MessageId::KbFuzzyFilePicker => "Open the fuzzy file picker (insert @path on Enter)",
         MessageId::KbCompactInspector => "Open compact session context inspector",
         MessageId::KbLastMessagePager => "Open pager for the last message (when input is empty)",
-        MessageId::KbSelectedDetails => {
-            "Open details for the selected tool or message (when input is empty)"
-        }
         MessageId::KbToolDetailsPager => "Open tool-details pager",
         MessageId::KbThinkingPager => "Open Activity Detail",
         MessageId::KbLiveTranscript => "Open live transcript overlay (sticky-tail auto-scroll)",
@@ -1847,9 +1842,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CtxInspNoSystemPrompt => "No system prompt set.",
         MessageId::CtxInspNoReferences => "No file, directory, or media references recorded yet.",
         MessageId::CtxInspNoToolActivity => "No tool activity recorded yet.",
-        MessageId::CtxInspAltVHint => {
-            "Open the matching card and press Alt+V (or v) for full details."
-        }
+        MessageId::CtxInspAltVHint => "Open the matching card and press Alt+V for full details.",
         MessageId::CtxInspCells => "cells",
         MessageId::CtxInspApiMessages => "API messages",
         MessageId::CtxInspActive => "active",
@@ -2249,9 +2242,6 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::KbLastMessagePager => {
             "Mở trang xem cho tin nhắn cuối cùng (khi khung nhập trống)"
         }
-        MessageId::KbSelectedDetails => {
-            "Mở chi tiết cho công cụ hoặc tin nhắn được chọn (khi khung nhập trống)"
-        }
         MessageId::KbToolDetailsPager => "Mở trang xem chi tiết công cụ",
         MessageId::KbThinkingPager => "Mở Chi Tiết Hoạt Động (Activity Detail)",
         MessageId::KbLiveTranscript => "Mở lớp phủ bản ghi trực tiếp (tự động cuộn theo đuôi)",
@@ -2502,7 +2492,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspNoSystemPrompt => "Chưa có lời nhắc hệ thống.",
         MessageId::CtxInspNoReferences => "Chưa có tham chiếu tệp, thư mục hoặc phương tiện nào.",
         MessageId::CtxInspNoToolActivity => "Chưa có hoạt động công cụ nào.",
-        MessageId::CtxInspAltVHint => "Mở thẻ phù hợp và nhấn Alt+V (hoặc v) để biết chi tiết.",
+        MessageId::CtxInspAltVHint => "Mở thẻ phù hợp và nhấn Alt+V để biết chi tiết.",
         MessageId::CtxInspCells => "ô",
         MessageId::CtxInspApiMessages => "tin nhắn API",
         MessageId::CtxInspActive => "đang hoạt động",
@@ -2671,7 +2661,7 @@ fn traditional_chinese(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspNoSystemPrompt => "未設定系統提示。",
         MessageId::CtxInspNoReferences => "尚未記錄任何檔案、目錄或媒體引用。",
         MessageId::CtxInspNoToolActivity => "尚未記錄任何工具活動。",
-        MessageId::CtxInspAltVHint => "開啟對應的卡片並按 Alt+V（或 v）檢視詳細資訊。",
+        MessageId::CtxInspAltVHint => "開啟對應的卡片並按 Alt+V 檢視詳細資訊。",
         MessageId::CtxInspCells => "儲存格",
         MessageId::CtxInspApiMessages => "API 訊息",
         MessageId::CtxInspActive => "作用中",
@@ -3068,9 +3058,6 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::KbFuzzyFilePicker => "ファジーファイルピッカーを開く（Enter で @path を挿入）",
         MessageId::KbCompactInspector => "コンパクトなセッションコンテキスト検査ツールを開く",
         MessageId::KbLastMessagePager => "最後のメッセージのページャーを開く（入力が空の時）",
-        MessageId::KbSelectedDetails => {
-            "選択中のツールまたはメッセージの詳細を開く（入力が空の時）"
-        }
         MessageId::KbToolDetailsPager => "ツール詳細のページャーを開く",
         MessageId::KbThinkingPager => "Activity Detail を開く",
         MessageId::KbLiveTranscript => "ライブ会話履歴オーバーレイを開く（自動追尾スクロール）",
@@ -3315,9 +3302,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
             "ファイル、ディレクトリ、メディアの参照はまだ記録されていません。"
         }
         MessageId::CtxInspNoToolActivity => "ツールアクティビティはまだ記録されていません。",
-        MessageId::CtxInspAltVHint => {
-            "該当するカードを開き、Alt+V（または v）を押すと詳細が表示されます。"
-        }
+        MessageId::CtxInspAltVHint => "該当するカードを開き、Alt+V を押すと詳細が表示されます。",
         MessageId::CtxInspCells => "セル",
         MessageId::CtxInspApiMessages => "API メッセージ",
         MessageId::CtxInspActive => "アクティブ",
@@ -3648,7 +3633,6 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::KbFuzzyFilePicker => "打开模糊文件选择器（按 Enter 插入 @path）",
         MessageId::KbCompactInspector => "打开紧凑会话上下文检查器",
         MessageId::KbLastMessagePager => "打开最后一条消息的分页器（输入框为空时）",
-        MessageId::KbSelectedDetails => "打开选中工具或消息的详情（输入框为空时）",
         MessageId::KbToolDetailsPager => "打开工具详情分页器",
         MessageId::KbThinkingPager => "打开 Activity Detail",
         MessageId::KbLiveTranscript => "打开实时对话覆盖层（自动滚动尾随）",
@@ -3865,7 +3849,7 @@ fn chinese_simplified(id: MessageId) -> Option<&'static str> {
         MessageId::CtxInspNoSystemPrompt => "未设置系统提示。",
         MessageId::CtxInspNoReferences => "尚未记录任何文件、目录或媒体引用。",
         MessageId::CtxInspNoToolActivity => "尚未记录任何工具活动。",
-        MessageId::CtxInspAltVHint => "打开对应的卡片并按 Alt+V（或 v）查看详细信息。",
+        MessageId::CtxInspAltVHint => "打开对应的卡片并按 Alt+V 查看详细信息。",
         MessageId::CtxInspCells => "单元格",
         MessageId::CtxInspApiMessages => "API 消息",
         MessageId::CtxInspActive => "活动中",
@@ -4246,9 +4230,6 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::KbLastMessagePager => {
             "Abrir paginador para última mensagem (quando entrada vazia)"
         }
-        MessageId::KbSelectedDetails => {
-            "Abrir detalhes da ferramenta ou mensagem selecionada (quando entrada vazia)"
-        }
         MessageId::KbToolDetailsPager => "Abrir paginador de detalhes da ferramenta",
         MessageId::KbThinkingPager => "Abrir Activity Detail",
         MessageId::KbLiveTranscript => "Abrir sobreposição de transcrição ao vivo (auto-scroll)",
@@ -4500,7 +4481,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CtxInspNoToolActivity => "Nenhuma atividade de ferramenta registrada ainda.",
         MessageId::CtxInspAltVHint => {
-            "Abra o cartão correspondente e pressione Alt+V (ou v) para detalhes completos."
+            "Abra o cartão correspondente e pressione Alt+V para detalhes completos."
         }
         MessageId::CtxInspCells => "células",
         MessageId::CtxInspApiMessages => "mensagens da API",
@@ -4896,9 +4877,6 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         MessageId::KbLastMessagePager => {
             "Abrir paginador para el último mensaje (cuando la entrada está vacía)"
         }
-        MessageId::KbSelectedDetails => {
-            "Abrir detalles de la herramienta o mensaje seleccionado (cuando la entrada está vacía)"
-        }
         MessageId::KbToolDetailsPager => "Abrir paginador de detalles de la herramienta",
         MessageId::KbThinkingPager => "Abrir paginador de razonamiento",
         MessageId::KbLiveTranscript => "Abrir superposición de transcripción en vivo (auto-scroll)",
@@ -5148,7 +5126,7 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CtxInspNoToolActivity => "Aún no se ha registrado actividad de herramientas.",
         MessageId::CtxInspAltVHint => {
-            "Abra la tarjeta correspondiente y presione Alt+V (o v) para ver los detalles completos."
+            "Abra la tarjeta correspondiente y presione Alt+V para ver los detalles completos."
         }
         MessageId::CtxInspCells => "celdas",
         MessageId::CtxInspApiMessages => "mensajes de API",

--- a/crates/tui/src/tools/truncate.rs
+++ b/crates/tui/src/tools/truncate.rs
@@ -31,8 +31,7 @@
 //! UI-side rendering of the inline `full output: <path>` annotation
 //! is owned by `tui/history.rs::render_spillover_annotation`. The
 //! tool-details pager opens the spillover file when the user
-//! presses `Alt+V` (or plain `v` with empty composer) on a spilled
-//! tool cell.
+//! presses the tool-details shortcut on a spilled tool cell.
 
 use std::fs;
 use std::io;

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -574,7 +574,7 @@ pub(crate) fn active_tool_status_label(app: &App) -> Option<String> {
     if active_foreground_shell_running(app) {
         parts.push("Ctrl+B shell".to_string());
     }
-    parts.push(key_shortcuts::tool_details_shortcut_hint_label().to_string());
+    parts.push(key_shortcuts::tool_details_shortcut_action_hint("details"));
     Some(parts.join(" \u{00B7} "))
 }
 

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -70,7 +70,7 @@ use std::process::Command;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RenderMode {
     /// Live in-stream view: thinking is collapsed to a summary, tool output is
-    /// truncated with a "Alt+V for details" affordance.
+    /// truncated with a visible details-pager affordance.
     Live,
     /// Full transcript view: every line of reasoning and tool output is
     /// emitted, no caps, no affordance.
@@ -286,7 +286,7 @@ impl HistoryCell {
                 if lines.len() > 2 {
                     lines.truncate(2);
                     lines.push(details_affordance_line(
-                        "details hidden",
+                        &crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details"),
                         Style::default().fg(palette::TEXT_MUTED).italic(),
                     ));
                 }
@@ -297,7 +297,7 @@ impl HistoryCell {
                 if lines.len() > TOOL_CARD_SUMMARY_LINES {
                     lines.truncate(TOOL_CARD_SUMMARY_LINES);
                     lines.push(details_affordance_line(
-                        "details hidden",
+                        &crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details"),
                         Style::default().fg(palette::TEXT_MUTED).italic(),
                     ));
                 }
@@ -360,7 +360,7 @@ impl HistoryCell {
     }
 
     /// Render the cell in transcript mode: full content, no caps, no
-    /// "Alt+V for details" affordances.
+    /// visible details-pager affordances.
     ///
     /// Use this for full-detail pagers, clipboard exports, and any
     /// surface that wants the complete body rather than the live summary.
@@ -598,7 +598,7 @@ impl ToolCell {
     }
 
     /// Full-content rendering for the pager / clipboard. Tool output that
-    /// would be capped + suffixed with "Alt+V for details" in the live view
+    /// would be capped + suffixed with a details-pager hint in the live view
     /// is emitted in full here.
     pub fn transcript_lines(&self, width: u16) -> Vec<Line<'static>> {
         self.render(width, /*low_motion*/ false, RenderMode::Transcript)
@@ -1477,7 +1477,7 @@ fn render_command_mode(command: &str, width: u16, mode: RenderMode) -> Vec<Line<
     {
         if count >= cap {
             lines.push(details_affordance_line(
-                "command clipped",
+                &crate::tui::key_shortcuts::tool_details_shortcut_action_hint("full command"),
                 Style::default().fg(palette::TEXT_MUTED),
             ));
             break;

--- a/crates/tui/src/tui/history/checklist.rs
+++ b/crates/tui/src/tui/history/checklist.rs
@@ -126,7 +126,7 @@ pub(super) fn parse_update_prefix(output: &str) -> Option<ChecklistChange> {
 /// Render a compact one-line state-change card for `todo_update` /
 /// `checklist_update` calls (#403). Shows the changed item's marker,
 /// title, and old -> new status, with a `M/N · pct%` progress summary
-/// in the header. The full list is still available via Alt+V on the
+/// in the header. The full list is still available through the tool
 /// detail record.
 pub(super) fn render_checklist_change_card(
     name: &str,
@@ -196,9 +196,10 @@ pub(super) fn render_checklist_change_card(
     lines.push(render_card_detail_line_single(
         None,
         &format!(
-            "{} item{} (Alt+V for full list)",
+            "{} item{}; {}",
             snapshot.total,
-            if snapshot.total == 1 { "" } else { "s" }
+            if snapshot.total == 1 { "" } else { "s" },
+            crate::tui::key_shortcuts::tool_details_shortcut_action_hint("full list")
         ),
         Style::default().fg(palette::TEXT_MUTED),
     ));
@@ -283,7 +284,10 @@ pub(super) fn render_checklist_card(
     if omitted > 0 {
         lines.push(render_card_detail_line_single(
             None,
-            &format!("+{omitted} more (Alt+V for full list)"),
+            &format!(
+                "+{omitted} more; {}",
+                crate::tui::key_shortcuts::tool_details_shortcut_action_hint("full list")
+            ),
             Style::default().fg(palette::TEXT_DIM),
         ));
     }

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -398,10 +398,8 @@ fn render_checklist_change_card_shows_only_changed_item() {
         .map(|s| s.content.as_ref())
         .collect();
     assert!(summary_line.contains("3 items"), "{summary_line:?}");
-    assert!(
-        summary_line.contains("Alt+V opens full list"),
-        "{summary_line:?}"
-    );
+    let expected_hint = crate::tui::key_shortcuts::tool_details_shortcut_action_hint("full list");
+    assert!(summary_line.contains(&expected_hint), "{summary_line:?}");
 }
 
 #[test]

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -389,7 +389,7 @@ fn render_checklist_change_card_shows_only_changed_item() {
         "should not show other items: {change_line:?}"
     );
 
-    // The summary line carries the count + Alt+V hint.
+    // The summary line carries the count + explicit details-pager hint.
     let summary_line: String = lines
         .last()
         .unwrap()
@@ -398,7 +398,10 @@ fn render_checklist_change_card_shows_only_changed_item() {
         .map(|s| s.content.as_ref())
         .collect();
     assert!(summary_line.contains("3 items"), "{summary_line:?}");
-    assert!(summary_line.contains("Alt+V"), "{summary_line:?}");
+    assert!(
+        summary_line.contains("Alt+V opens full list"),
+        "{summary_line:?}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/tui/history/tool_output.rs
+++ b/crates/tui/src/tui/history/tool_output.rs
@@ -370,7 +370,10 @@ fn render_preserved_output_mode(
             let omitted = idx.saturating_sub(prev + 1);
             if omitted > 0 {
                 lines.push(details_affordance_line(
-                    &format!("{omitted} lines omitted"),
+                    &format!(
+                        "{omitted} lines omitted; {}",
+                        crate::tui::key_shortcuts::tool_details_shortcut_action_hint("full output")
+                    ),
                     Style::default().fg(palette::TEXT_MUTED),
                 ));
             }

--- a/crates/tui/src/tui/key_shortcuts.rs
+++ b/crates/tui/src/tui/key_shortcuts.rs
@@ -58,17 +58,14 @@ pub(super) fn is_file_tree_toggle_shortcut(key: &KeyEvent) -> bool {
 
 pub(super) fn tool_details_shortcut_label() -> &'static str {
     if cfg!(target_os = "macos") {
-        "\u{2325}+V"
+        "Option+V"
     } else {
         "Alt+V"
     }
 }
 
-pub(super) fn tool_details_shortcut_hint_label() -> &'static str {
-    match tool_details_shortcut_label() {
-        "\u{2325}+V" => "\u{2325}+V/v",
-        _ => "Alt+V/v",
-    }
+pub(super) fn tool_details_shortcut_action_hint(noun: &str) -> String {
+    format!("{} opens {noun}", tool_details_shortcut_label())
 }
 
 pub(super) fn activity_shortcut_label() -> &'static str {

--- a/crates/tui/src/tui/keybindings.rs
+++ b/crates/tui/src/tui/keybindings.rs
@@ -211,11 +211,6 @@ pub const KEYBINDINGS: &[KeybindingEntry] = &[
         section: KeybindingSection::Submission,
     },
     KeybindingEntry {
-        chord: "v",
-        description_id: crate::localization::MessageId::KbSelectedDetails,
-        section: KeybindingSection::Submission,
-    },
-    KeybindingEntry {
         chord: "Alt+V",
         description_id: crate::localization::MessageId::KbToolDetailsPager,
         section: KeybindingSection::Submission,
@@ -367,6 +362,19 @@ mod tests {
             ctrl_x_tasks.description_id,
             crate::localization::MessageId::KbCancelBackgroundShellJobs
         );
+    }
+
+    #[test]
+    fn tool_details_help_documents_alt_v_without_bare_v() {
+        let details = KEYBINDINGS
+            .iter()
+            .filter(|entry| {
+                entry.description_id == crate::localization::MessageId::KbToolDetailsPager
+            })
+            .map(|entry| entry.chord)
+            .collect::<Vec<_>>();
+
+        assert_eq!(details, vec!["Alt+V"]);
     }
 
     #[test]

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1717,8 +1717,8 @@ fn shell_summary_for_sidebar(
 ) -> String {
     if status == ToolStatus::Failed && looks_like_pending_ci(command, output_summary, output) {
         return format!(
-            "Waiting for CI \u{00B7} {} details",
-            crate::tui::key_shortcuts::tool_details_shortcut_hint_label()
+            "Waiting for CI \u{00B7} {}",
+            crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details")
         );
     }
 
@@ -1764,10 +1764,7 @@ fn looks_like_pending_ci(
 }
 
 fn failure_summary_with_hint(summary: &str) -> String {
-    let hint = format!(
-        "inspect details with {}",
-        crate::tui::key_shortcuts::tool_details_shortcut_hint_label()
-    );
+    let hint = crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details");
     if summary.trim().is_empty() {
         hint
     } else if summary.contains(&hint) {
@@ -2008,8 +2005,8 @@ fn editorial_tool_rows(
             let command = row.name.clone();
             row.name = "Waiting for CI".to_string();
             row.summary = format!(
-                "{command} \u{00B7} {count} polls collapsed \u{00B7} {} details",
-                crate::tui::key_shortcuts::tool_details_shortcut_hint_label()
+                "{command} \u{00B7} {count} polls collapsed \u{00B7} {}",
+                crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details")
             );
             row.status = ToolStatus::Running;
         }
@@ -4727,10 +4724,9 @@ mod tests {
             "failed shell command should keep its concise label: {text:?}"
         );
         assert!(
-            text.iter().any(|line| line.contains(&format!(
-                "inspect details with {}",
-                crate::tui::key_shortcuts::tool_details_shortcut_hint_label()
-            ))),
+            text.iter().any(|line| line.contains(
+                &crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details")
+            )),
             "failed row should include the next action: {text:?}"
         );
     }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -11078,11 +11078,11 @@ pub(crate) fn selected_detail_footer_label(app: &App) -> Option<String> {
         let noun = if matches!(cell, HistoryCell::SubAgent(_)) {
             "details"
         } else {
-            "raw"
+            "raw details"
         };
         format!(
-            " · {} {noun}",
-            key_shortcuts::tool_details_shortcut_hint_label()
+            " · {}",
+            key_shortcuts::tool_details_shortcut_action_hint(noun)
         )
     } else {
         String::new()

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2232,7 +2232,7 @@ fn active_tool_status_label_summarizes_live_tool_group() {
     assert!(label.contains("1 active"));
     assert!(label.contains("1 done"));
     assert!(label.contains(crate::tui::key_shortcuts::tool_details_shortcut_label()));
-    assert!(label.contains("/v"));
+    assert!(label.contains("opens details"));
 }
 
 #[test]
@@ -6811,9 +6811,9 @@ fn detail_target_prefers_visible_tool_card() {
 
     assert_eq!(detail_target_cell_index(&app), Some(1));
     let expected = format!(
-        "{} Activity: find · {} raw",
+        "{} Activity: find · {}",
         crate::tui::key_shortcuts::activity_shortcut_label(),
-        crate::tui::key_shortcuts::tool_details_shortcut_hint_label()
+        crate::tui::key_shortcuts::tool_details_shortcut_action_hint("raw details")
     );
     assert_eq!(
         selected_detail_footer_label(&app).as_deref(),
@@ -6866,9 +6866,9 @@ fn activity_footer_hint_uses_details_for_subagent_cards() {
     app.viewport.last_transcript_visible = 4;
 
     let expected = format!(
-        "{} Activity: sub-agent · {} details",
+        "{} Activity: sub-agent · {}",
         crate::tui::key_shortcuts::activity_shortcut_label(),
-        crate::tui::key_shortcuts::tool_details_shortcut_hint_label()
+        crate::tui::key_shortcuts::tool_details_shortcut_action_hint("details")
     );
     assert_eq!(
         selected_detail_footer_label(&app).as_deref(),

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -18,6 +18,7 @@ Bindings are not (yet) user-configurable — tracked for a future release (#436,
 | `Ctrl-R`             | Open the resume-session picker                                 |
 | `Ctrl-L`             | Refresh / clear the screen                                     |
 | `Ctrl-O`             | Open Activity Detail for selected/live/recent tool work, or the full reasoning timeline for thinking blocks when the composer is empty |
+| `Alt-V` / `Option-V` (macOS) | Open the details pager for the selected, visible, or most recent tool/sub-agent card; terminals that emit the legacy Option-V glyph are also handled |
 | `Ctrl-Shift-E` / `Cmd-Shift-E` | Toggle the file-tree sidebar                          |
 | `Alt-G`              | Scroll transcript to top when the composer is empty             |
 | `Alt-!` / `Alt-@` / `Alt-#` / `Alt-$` / `Alt-0` | Focus Pinned / Tasks / Agents / Context / Auto sidebar |


### PR DESCRIPTION
## Summary
- Replace ambiguous `Alt+V/v` tool-details hints with explicit action copy such as `Alt+V opens details`, `full output`, or `full list`.
- Keep macOS legacy Option-V glyph input support while presenting user-facing labels as `Option+V`.
- Remove the stale bare-`v` details-pager help entry and add a keybinding catalog regression test.
- Isolate the NVIDIA NIM flash alias config test after the full workspace gate exposed process-env bleed.

Closes #3194.

## Validation
- `cargo fmt`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked keybindings`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked nvidia_nim_provider_normalizes_deepseek_v4_flash_alias`
- `cargo test --workspace --locked`

## Self-review
- Searched for stale `Alt+V/v`, `(or v)`, and removed `KbSelectedDetails` references after implementation.
- Split the hermetic test fix from the UI/help-copy fix so each commit has one concern.