### PR TITLE
docs: bump stale 0.8.64 version references to 0.8.65 (#3087)

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -17,7 +17,7 @@ Rust 製の TUI と CLI、25 のプロバイダ。DeepSeek、OpenRouter、Huggin
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.64
+codewhale --version   # 0.8.65
 ```
 
 npm wrapper（Node 18+）は GitHub Releases から SHA-256 検証済みのバイナリをダウンロードし、`codewhale`、`codew`、`codewhale-tui` をインストールします。ソースからビルドしたい場合は cargo（Rust 1.88+）で:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ open an issue — that's how the project grows.
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.64
+codewhale --version   # 0.8.65
 ```
 
 The npm wrapper (Node 18+) downloads SHA-256-verified binaries from GitHub

--- a/README.vi.md
+++ b/README.vi.md
@@ -21,7 +21,7 @@ bằng `/restore` cho mọi lượt.
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.64
+codewhale --version   # 0.8.65
 ```
 
 Wrapper npm (Node 18+) tải binary đã xác minh SHA-256 từ GitHub Releases và

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@ DeepInfra 以及本地 vLLM/SGLang/Ollama 都是一等路由；当你手里是 A
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.64
+codewhale --version   # 0.8.65
 ```
 
 npm wrapper（Node 18+）会从 GitHub Releases 下载经 SHA-256 校验的二进制，并安装

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1082,7 +1082,7 @@ If you are upgrading from older releases:
   `unknown`; invalid names fail config validation instead of becoming broad
   rules. `natural_language_guidance` is recorded on the runtime policy and audit
   event, but deterministic rules and the built-in safety floor are the enforced
-  behavior in v0.8.64.
+  behavior in v0.8.65.
 
   Auto-review decisions emit `tool.auto_review_decision` audit events when tool
   audit logging is enabled. Future PreToolUse/PostToolUse hooks can add

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -127,11 +127,11 @@ a download sourced from an impersonating repository or mirror.
 ## 3. Install via npm
 
 npm is the recommended install path. The `codewhale` wrapper is published at
-v0.8.64 (Node 18+; wrapper available for v0.8.56 and later).
+v0.8.65 (Node 18+; wrapper available for v0.8.56 and later).
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.64
+codewhale --version   # 0.8.65
 ```
 
 `postinstall` downloads the right pair of binaries from the matching GitHub


### PR DESCRIPTION
## Summary

The README install example-output comments (all four locales) and the CONFIGURATION.md auto_review section still named v0.8.64 as the current release after the v0.8.65 bump. #3528 corrected a stale Cargo comment but missed these user-facing docs.

- `README.md` / `README.ja-JP.md` / `README.vi.md` / `README.zh-CN.md`: example `codewhale --version` output comment `0.8.64` → `0.8.65`
- `docs/CONFIGURATION.md`: auto_review "enforced behavior in v0.8.64" → `v0.8.65`

Found during the v0.8.65 release-completeness audit (clean worktree at tag `v0.8.65`, verified against `origin/main`).

## Verification

- [x] `./scripts/release/check-versions.sh` → `Version state OK: workspace=0.8.65, npm=0.8.65, lockfile in sync`
- [x] `git grep -n "0\.8\.64" -- README*.md docs/CONFIGURATION.md` → no remaining stale refs

## Notes

- Docs-only; no runtime/test impact.
- The remaining `0.8.64` mentions in `CHANGELOG.md` are legitimate historical entries (the previous release) and are correctly retained.

Closes #3087 (docs portion).