### PR TITLE
fix(tui): suppress typed ask-rule prompts in YOLO mode (#3386)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1087,9 +1087,14 @@ impl Engine {
                 self.session.approval_mode,
             );
             if let Some(ToolAskRuleDecision::Prompt(reason)) = ask_rule_decision.as_ref() {
-                approval_required = true;
-                approval_description = reason.clone();
-                approval_force_prompt = true;
+                // YOLO mode (auto_approve) is the explicit "no approvals"
+                // contract: a typed ask-rule must not pop a modal in YOLO.
+                // A typed deny rule still blocks hard below.
+                if !self.session.auto_approve {
+                    approval_required = true;
+                    approval_description = reason.clone();
+                    approval_force_prompt = true;
+                }
             }
             if let Some(ToolAskRuleDecision::Block(reason)) = ask_rule_decision {
                 Err(ToolError::permission_denied(reason))

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2153,6 +2153,54 @@ async fn run_shell_command_op_skips_approval_when_auto_approved() {
 }
 
 #[tokio::test]
+async fn yolo_mode_does_not_prompt_for_typed_ask_rule() {
+    // #3386: a command matching a typed ask-rule (permissions.toml) must not
+    // surface an approval modal in YOLO mode, even though Yolo resolves to
+    // ApprovalMode::Auto which the execpolicy maps to OnFailure (honors
+    // ask-rules). The auto_review safety floor and typed deny rules still
+    // apply; only the ask-rule Prompt is suppressed in YOLO.
+    let (mut engine, handle) = Engine::new(
+        EngineConfig {
+            exec_policy_engine: ask_rule_engine("echo"),
+            ..EngineConfig::default()
+        },
+        &Config::default(),
+    );
+
+    engine
+        .handle_run_shell_command(
+            "echo yolo-ask-rule".to_string(),
+            AppMode::Yolo,
+            true,
+            true,
+            crate::tui::approval::ApprovalMode::Auto,
+        )
+        .await;
+
+    let mut saw_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Event::ApprovalRequired { .. } => {
+                panic!("YOLO mode must not prompt for a typed ask-rule");
+            }
+            Event::ToolCallComplete { result, .. } => {
+                saw_complete = true;
+                let result = result.expect("shell result");
+                assert!(result.success, "{result:?}");
+            }
+            Event::TurnComplete { status, .. } => {
+                assert_eq!(status, TurnOutcomeStatus::Completed);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_complete);
+}
+
+#[tokio::test]
 async fn run_shell_command_op_preserves_plan_mode_shell_block() {
     let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2188,6 +2188,7 @@ async fn yolo_mode_does_not_prompt_for_typed_ask_rule() {
                 saw_complete = true;
                 let result = result.expect("shell result");
                 assert!(result.success, "{result:?}");
+                assert!(result.content.contains("yolo-ask-rule"), "{result:?}");
             }
             Event::TurnComplete { status, .. } => {
                 assert_eq!(status, TurnOutcomeStatus::Completed);
@@ -2197,6 +2198,133 @@ async fn yolo_mode_does_not_prompt_for_typed_ask_rule() {
         }
     }
 
+    assert!(saw_complete);
+}
+
+#[tokio::test]
+async fn yolo_mode_does_not_prompt_for_model_driven_typed_ask_rule() {
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let _lock = lock_test_env();
+    let workspace = tempdir().expect("tempdir");
+    let server = MockServer::start().await;
+
+    let tool_call_sse = concat!(
+        "data: {\"id\":\"chatcmpl-yolo\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[",
+        "{\"index\":0,\"id\":\"call_yolo\",\"type\":\"function\",\"function\":{\"name\":\"exec_shell\",",
+        "\"arguments\":\"{\\\"command\\\":\\\"echo yolo-model-ask-rule\\\"}\"}}",
+        "]},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-yolo\",\"choices\":[{\"index\":0,\"delta\":{},",
+        "\"finish_reason\":\"tool_calls\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    let done_sse = concat!(
+        "data: {\"id\":\"chatcmpl-done\",\"choices\":[{\"index\":0,",
+        "\"delta\":{\"content\":\"done\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-done\",\"choices\":[{\"index\":0,\"delta\":{},",
+        "\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(body_string_contains("yolo-model-ask-rule"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(done_sse),
+        )
+        .expect(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(tool_call_sse),
+        )
+        .expect(1)
+        .with_priority(2)
+        .mount(&server)
+        .await;
+
+    let api_config = Config {
+        api_key: Some("test-key".to_string()),
+        base_url: Some(server.uri()),
+        ..Config::default()
+    };
+    let (engine, handle) = Engine::new(
+        EngineConfig {
+            model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            workspace: workspace.path().to_path_buf(),
+            snapshots_enabled: false,
+            subagents_enabled: false,
+            exec_policy_engine: ask_rule_engine("echo"),
+            ..EngineConfig::default()
+        },
+        &api_config,
+    );
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::SendMessage {
+            content: "please exercise the shell path".to_string(),
+            mode: AppMode::Yolo,
+            provider: None,
+            model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            goal_objective: None,
+            goal_token_budget: None,
+            goal_status: crate::tools::goal::GoalStatus::Active,
+            reasoning_effort: None,
+            reasoning_effort_auto: false,
+            auto_model: false,
+            allow_shell: true,
+            trust_mode: true,
+            auto_approve: true,
+            approval_mode: crate::tui::approval::ApprovalMode::Auto,
+            translation_enabled: false,
+            show_thinking: true,
+            allowed_tools: None,
+            dynamic_tools: Vec::new(),
+            hook_executor: None,
+            verbosity: None,
+            provenance: UserInputProvenance::ExternalUser,
+        })
+        .await
+        .expect("send model turn");
+
+    let mut saw_complete = false;
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("timed out waiting for engine event")
+    {
+        match event {
+            Event::ApprovalRequired { .. } => {
+                panic!("YOLO mode must not prompt for a model-driven typed ask-rule");
+            }
+            Event::ToolCallComplete { name, result, .. } => {
+                if name == "exec_shell" {
+                    saw_complete = true;
+                    let result = result.expect("shell result");
+                    assert!(result.success, "{result:?}");
+                    assert!(result.content.contains("yolo-model-ask-rule"), "{result:?}");
+                }
+            }
+            Event::TurnComplete { status, .. } => {
+                assert_eq!(status, TurnOutcomeStatus::Completed);
+                break;
+            }
+            _ => {}
+        }
+    }
+    drop(rx);
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
     assert!(saw_complete);
 }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1604,9 +1604,18 @@ impl Engine {
                     if let Some(decision) = ask_rule_decision {
                         match decision {
                             ToolAskRuleDecision::Prompt(reason) => {
-                                approval_required = true;
-                                approval_description = reason;
-                                approval_force_prompt = true;
+                                // YOLO mode (auto_approve) is the explicit
+                                // "no approvals" contract: a typed ask-rule
+                                // must not pop a modal in YOLO. The
+                                // auto_review safety floor below still
+                                // independently holds publish/destructive
+                                // actions, and a typed deny rule still
+                                // blocks hard.
+                                if !self.session.auto_approve {
+                                    approval_required = true;
+                                    approval_description = reason;
+                                    approval_force_prompt = true;
+                                }
                             }
                             ToolAskRuleDecision::Block(reason) => {
                                 approval_required = false;


### PR DESCRIPTION
## Summary

YOLO mode is the explicit "full tool access without approvals" contract, but a shell/file command matching a typed ask-rule (`permissions.toml`) still popped an approval modal in YOLO.

### Root cause

`base_policy_for_mode` resolves Yolo → `ApprovalMode::Auto`, and `ApprovalMode::Auto` is **overloaded** to mean both "Agent auto-policy" and "YOLO no-approvals." The execpolicy maps `Auto` → `OnFailure`, and `OnFailure` honors matching ask-rules → `ToolAskRuleDecision::Prompt` → sets `approval_required = true` regardless of Yolos `auto_approve`. **#3479 only patched the separate `auto_review` publish-classifier** (the `git tag --list` fix); it did not touch this path.

### Fix

At the two `Prompt` consumption sites — the turn-loop model-driven path (`turn_loop.rs`) and the `!` composer path (`engine.rs`) — skip the prompt when `self.session.auto_approve` is set (i.e. YOLO).

`auto_approve` is `true` **only** for Yolo (`Plan` and `Agent` both hard-code it `false` in `base_policy_for_mode`), so it is the unambiguous Yolo signal here. This avoids adding a redundant third way to spell the same fact — the cleaner approach vs. threading `auto_approve` as a new parameter alongside `ApprovalMode`, which would just re-encode `AppMode::Yolo` yet again.

**Safety preserved:**
- The `auto_review` safety floor still independently holds publish-like and destructive actions (e.g. `git push`, `git tag` creation/deletion, destructive background actions).
- A typed **deny** rule still blocks hard (`ToolAskRuleDecision::Block`).
- Only the ask-rule **`Prompt`** (the "ask me" outcome) is suppressed in YOLO.

Agent-mode behavior (`ApprovalMode::Auto` without `auto_approve`) is unchanged: ask-rules still prompt in Agent mode.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked ask_rule` → **13 passed** (incl. new `yolo_mode_does_not_prompt_for_typed_ask_rule`)
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked -- run_shell_command_op yolo auto_review approval` → **167 passed, 0 failed**

The new integration test `yolo_mode_does_not_prompt_for_typed_ask_rule` wires a `permissions.toml` ask-rule (`echo`) into YOLO mode and asserts no `ApprovalRequired` event fires, while the shell still executes successfully.

## Related

- Builds on #3479 (which fixed the auto_review publish-classifier path only).
- Filing against `main`; does not touch the release tag. No version bump, tag, or release action.

Closes #3386.