### PR TITLE
test(tui): #2574 fallback acceptance coverage + local/private guardrail

### DIFF
--- a/crates/tui/src/commands/groups/core/provider.rs
+++ b/crates/tui/src/commands/groups/core/provider.rs
@@ -597,6 +597,42 @@ mod tests {
         ));
     }
 
+    /// #2574: `/provider fallback reset` returns to the *primary* (chain entry
+    /// 0), not to whatever fallback is currently active. The resolved
+    /// `SwitchProvider` action is the canonical restore path — it re-seats
+    /// `api_provider` and rebuilds the chain at position 0 (see
+    /// `switch_provider`), so a bare `ProviderChain::reset()` is not needed here.
+    #[test]
+    fn provider_fallback_reset_targets_primary_even_when_on_fallback() {
+        let mut app = create_test_app();
+        app.api_provider = ApiProvider::Deepseek;
+        app.provider_chain = Some(codewhale_config::ProviderChain::new(
+            codewhale_config::ProviderKind::Deepseek,
+            &[codewhale_config::ProviderKind::Openrouter],
+        ));
+        // Simulate having already fallen back to the secondary provider.
+        // (Openrouter is treated as ready by default — no readiness snapshot.)
+        let advanced = app.advance_fallback("recoverable error");
+        assert_eq!(advanced, Some(ApiProvider::Openrouter));
+        assert_eq!(app.api_provider, ApiProvider::Openrouter);
+
+        let reset = provider(&mut app, Some("fallback reset"));
+        assert!(
+            reset
+                .message
+                .as_deref()
+                .unwrap_or("")
+                .contains("primary provider: deepseek")
+        );
+        assert!(matches!(
+            reset.action,
+            Some(AppAction::SwitchProvider {
+                provider: ApiProvider::Deepseek,
+                model: None
+            })
+        ));
+    }
+
     #[test]
     fn aggregator_passes_unrecognized_model_through() {
         // Equal treatment: a non-DeepSeek id on a DeepSeek-hosting aggregator is

--- a/crates/tui/src/commands/groups/core/provider.rs
+++ b/crates/tui/src/commands/groups/core/provider.rs
@@ -179,6 +179,7 @@ fn expand_model_alias_for_provider(provider: ApiProvider, name: &str) -> String 
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::test_support::lock_test_env;
     use crate::tui::app::TuiOptions;
     use std::path::PathBuf;
 
@@ -604,6 +605,7 @@ mod tests {
     /// `switch_provider`), so a bare `ProviderChain::reset()` is not needed here.
     #[test]
     fn provider_fallback_reset_targets_primary_even_when_on_fallback() {
+        let _lock = lock_test_env();
         let mut app = create_test_app();
         app.api_provider = ApiProvider::Deepseek;
         app.provider_chain = Some(codewhale_config::ProviderChain::new(

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -296,7 +296,8 @@ impl ApiProvider {
     /// own infrastructure, so they carry a local/private posture. Used by the
     /// fallback chain to avoid silently routing a local/private primary out to
     /// a cloud provider (#2574) and by the `/provider` dashboard's self-hosted
-    /// hint (#3083).
+    /// hint (#3083). Update this list whenever adding a provider whose runtime
+    /// is hosted on the user's own infrastructure.
     #[must_use]
     pub fn is_self_hosted(self) -> bool {
         matches!(self, Self::Sglang | Self::Vllm | Self::Ollama)

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -289,6 +289,18 @@ impl ApiProvider {
     pub fn from_kind(kind: codewhale_config::ProviderKind) -> Self {
         Self::FROM_KIND_LOOKUP[kind as usize]
     }
+
+    /// Whether this provider is a self-hosted / local runtime.
+    ///
+    /// These run without hosted authentication and keep traffic on the user's
+    /// own infrastructure, so they carry a local/private posture. Used by the
+    /// fallback chain to avoid silently routing a local/private primary out to
+    /// a cloud provider (#2574) and by the `/provider` dashboard's self-hosted
+    /// hint (#3083).
+    #[must_use]
+    pub fn is_self_hosted(self) -> bool {
+        matches!(self, Self::Sglang | Self::Vllm | Self::Ollama)
+    }
 }
 
 fn normalize_subagent_provider_key(value: &str) -> String {
@@ -5962,10 +5974,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     }
 
     // Self-hosted providers typically run without authentication.
-    if matches!(
-        provider,
-        ApiProvider::Sglang | ApiProvider::Vllm | ApiProvider::Ollama
-    ) {
+    if provider.is_self_hosted() {
         return true;
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5673,7 +5673,9 @@ impl App {
     /// Local/private policy (#2574): when the chain's primary provider is a
     /// self-hosted / local runtime, cloud candidates are skipped with a clear
     /// note so a local/private route never silently falls back out to a hosted
-    /// provider. Self-hosted siblings remain eligible.
+    /// provider. Self-hosted siblings remain eligible. The policy is anchored
+    /// to the original primary; a cloud primary may still hop through a local
+    /// runtime and then back to another cloud fallback.
     pub fn advance_fallback(&mut self, reason: impl Into<String>) -> Option<ApiProvider> {
         let reason = reason.into();
         self.provider_chain.as_ref()?;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5669,9 +5669,21 @@ impl App {
     /// Note: auth-rejection (401) failures never reach this path; the caller
     /// excludes them from fallback so a bad key does not silently rotate
     /// providers (see `apply_engine_error_to_app`).
+    ///
+    /// Local/private policy (#2574): when the chain's primary provider is a
+    /// self-hosted / local runtime, cloud candidates are skipped with a clear
+    /// note so a local/private route never silently falls back out to a hosted
+    /// provider. Self-hosted siblings remain eligible.
     pub fn advance_fallback(&mut self, reason: impl Into<String>) -> Option<ApiProvider> {
         let reason = reason.into();
         self.provider_chain.as_ref()?;
+
+        let origin_is_local = self
+            .provider_chain
+            .as_ref()
+            .and_then(|chain| chain.providers().first().copied())
+            .map(ApiProvider::from_kind)
+            .is_some_and(ApiProvider::is_self_hosted);
 
         let mut skip_notes: Vec<String> = Vec::new();
         let mut chosen: Option<ApiProvider> = None;
@@ -5681,6 +5693,13 @@ impl App {
             .and_then(ProviderChain::advance)
         {
             let candidate = ApiProvider::from_kind(next_kind);
+            if origin_is_local && !candidate.is_self_hosted() {
+                skip_notes.push(format!(
+                    "skipped {}: local/private policy (no local->cloud fallback)",
+                    candidate.as_str()
+                ));
+                continue;
+            }
             if self.fallback_provider_is_ready(candidate) {
                 chosen = Some(candidate);
                 break;

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -3178,3 +3178,38 @@ fn advance_fallback_local_primary_may_fall_back_to_local_sibling() {
     let reason = app.last_fallback_reason.as_deref().unwrap_or_default();
     assert!(reason.contains("Fell back to vllm"), "{reason}");
 }
+
+#[test]
+fn advance_fallback_cloud_primary_can_hop_cloud_to_local_to_cloud() {
+    let _lock = lock_test_env();
+    let _openai = EnvVarGuard::remove("OPENAI_API_KEY");
+    let _deepseek = EnvVarGuard::remove("DEEPSEEK_API_KEY");
+
+    // The local/private guard is origin-based. A cloud primary may route to a
+    // local fallback and then to another cloud fallback if the cloud candidate
+    // is otherwise ready; only local/private primaries are blocked from leaking
+    // out to cloud.
+    let mut app = app_with_fallback_chain(
+        ApiProvider::Openai,
+        &[
+            codewhale_config::ProviderKind::Ollama,
+            codewhale_config::ProviderKind::Deepseek,
+        ],
+        &[ApiProvider::Openai, ApiProvider::Deepseek],
+    );
+
+    let local = app.advance_fallback("cloud provider timed out");
+    assert_eq!(local, Some(ApiProvider::Ollama));
+    assert_eq!(app.api_provider, ApiProvider::Ollama);
+
+    let cloud = app.advance_fallback("local runtime unavailable");
+    assert_eq!(cloud, Some(ApiProvider::Deepseek));
+    assert_eq!(app.api_provider, ApiProvider::Deepseek);
+
+    let reason = app.last_fallback_reason.as_deref().unwrap_or_default();
+    assert!(reason.contains("Fell back to deepseek"), "{reason}");
+    assert!(
+        !reason.contains("local/private policy"),
+        "cloud-primary chains should not trigger local/private blocking: {reason}"
+    );
+}

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -3007,6 +3007,7 @@ fn app_with_fallback_chain(
             ..Default::default()
         };
         match provider {
+            ApiProvider::Deepseek => providers.deepseek = entry,
             ApiProvider::Openai => providers.openai = entry,
             ApiProvider::Openrouter => providers.openrouter = entry,
             ApiProvider::Together => providers.together = entry,
@@ -3123,4 +3124,57 @@ fn advance_fallback_all_unready_exhausts_with_clear_reason() {
             && reason.contains("skipped together: needs auth"),
         "reason should note every skipped provider: {reason}"
     );
+}
+
+#[test]
+fn advance_fallback_local_primary_does_not_fall_back_to_cloud() {
+    let _lock = lock_test_env();
+    let _openai = EnvVarGuard::remove("OPENAI_API_KEY");
+    let _deepseek = EnvVarGuard::remove("DEEPSEEK_API_KEY");
+
+    // Local primary (Ollama) -> cloud fallback (DeepSeek, fully keyed). The
+    // cloud entry is policy-blocked even though it is otherwise ready, so the
+    // chain exhausts rather than leaking a local/private route out to cloud.
+    let mut app = app_with_fallback_chain(
+        ApiProvider::Ollama,
+        &[codewhale_config::ProviderKind::Deepseek],
+        &[ApiProvider::Deepseek],
+    );
+
+    let next = app.advance_fallback("local runtime unavailable");
+    assert_eq!(next, None, "local->cloud fallback must be blocked");
+    assert_eq!(app.api_provider, ApiProvider::Ollama);
+
+    let reason = app.last_fallback_reason.as_deref().unwrap_or_default();
+    assert!(
+        reason.contains("local/private policy"),
+        "block reason must be visible and specific: {reason}"
+    );
+    assert!(
+        !reason.contains("needs auth"),
+        "the block is policy, not missing auth: {reason}"
+    );
+}
+
+#[test]
+fn advance_fallback_local_primary_may_fall_back_to_local_sibling() {
+    let _lock = lock_test_env();
+
+    // Local primary (Ollama) -> local sibling (vLLM). Both are self-hosted, so
+    // the local/private posture is preserved and the fallback is allowed.
+    let mut app = app_with_fallback_chain(
+        ApiProvider::Ollama,
+        &[codewhale_config::ProviderKind::Vllm],
+        &[],
+    );
+
+    let next = app.advance_fallback("local runtime unavailable");
+    assert_eq!(
+        next,
+        Some(ApiProvider::Vllm),
+        "local->local fallback stays within the private posture"
+    );
+    assert_eq!(app.api_provider, ApiProvider::Vllm);
+    let reason = app.last_fallback_reason.as_deref().unwrap_or_default();
+    assert!(reason.contains("Fell back to vllm"), "{reason}");
 }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -9169,6 +9169,88 @@ fn recoverable_provider_error_advances_fallback_chain() {
     );
 }
 
+/// #2574 acceptance: auth (401) errors must never trigger provider fallback,
+/// even when marked recoverable — the exclusion is by error *category*, not
+/// recoverability (the gate lives at this call site, not inside the chain
+/// walk). A bad key requires user intervention, not a silent rotation.
+#[test]
+fn auth_error_does_not_trigger_provider_fallback() {
+    use crate::error_taxonomy::{ErrorCategory, ErrorEnvelope, ErrorSeverity};
+
+    let mut app = create_test_app();
+    app.api_provider = ApiProvider::Deepseek;
+    // Not env-only, so we exercise the category gate rather than the env-key
+    // onboarding early-return.
+    app.api_key_env_only = false;
+    app.provider_chain = Some(codewhale_config::ProviderChain::new(
+        codewhale_config::ProviderKind::Deepseek,
+        &[codewhale_config::ProviderKind::Openrouter],
+    ));
+
+    apply_engine_error_to_app(
+        &mut app,
+        ErrorEnvelope::new(
+            ErrorCategory::Authentication,
+            ErrorSeverity::Critical,
+            // Deliberately recoverable to prove the *category* is what excludes
+            // fallback, not the recoverable flag.
+            true,
+            "authentication",
+            "provider returned 401",
+        ),
+    );
+
+    assert_eq!(
+        app.api_provider,
+        ApiProvider::Deepseek,
+        "auth failure must not rotate providers"
+    );
+    assert!(!app.is_fallback_active());
+    assert_eq!(app.fallback_chain_position(), Some(0));
+    assert!(
+        app.last_fallback_reason.is_none(),
+        "no fallback should have been attempted on an auth error"
+    );
+}
+
+/// #2574 acceptance: the route switch is visible to the user with a 1-based
+/// position and the failure cause (regression guard against off-by-one position
+/// indexing in the fallback status).
+#[test]
+fn fallback_switch_status_shows_one_based_position_and_reason() {
+    use crate::error_taxonomy::{ErrorCategory, ErrorEnvelope, ErrorSeverity};
+
+    let mut app = create_test_app();
+    app.api_provider = ApiProvider::Deepseek;
+    app.provider_chain = Some(codewhale_config::ProviderChain::new(
+        codewhale_config::ProviderKind::Deepseek,
+        &[codewhale_config::ProviderKind::Openrouter],
+    ));
+
+    apply_engine_error_to_app(
+        &mut app,
+        ErrorEnvelope::new(
+            ErrorCategory::RateLimit,
+            ErrorSeverity::Warning,
+            true,
+            "rate_limit",
+            "provider returned 429",
+        ),
+    );
+
+    assert_eq!(app.api_provider, ApiProvider::Openrouter);
+    assert_eq!(
+        app.fallback_chain_position(),
+        Some(1),
+        "first fallback sits at 1-based position 1"
+    );
+    let status = app.status_message.as_deref().unwrap_or_default();
+    assert!(
+        status.contains("Switched to openrouter") && status.contains("(fallback 1/"),
+        "visible status must show the destination and 1-based position: {status}"
+    );
+}
+
 #[tokio::test]
 async fn provider_switch_auth_error_restores_previous_provider_and_model() {
     use crate::error_taxonomy::ErrorEnvelope;


### PR DESCRIPTION
Closes #2574

## Summary
The capability-aware provider fallback chain (#2574) shipped its runtime to `main` (`advance_fallback`, `/provider fallback`, footer/status indicators, auth-error exclusion). This PR completes the issue's **acceptance criteria** — the test coverage gap — and closes the one genuinely-missing guardrail.

## What shipped already (verified on main, not re-touched)
- `App::advance_fallback` walks the chain, skips unready providers with recorded notes, returns first ready or `None` with an exhaustion reason.
- 401/auth failures are excluded from fallback at the `apply_engine_error_to_app` call site (by error *category*).
- `/provider fallback [status|reset]` command + 1-based footer/status indicator.
- Pre-existing app-level tests already covered **success/advance**, **all-fallbacks-failed exhaustion**, **readiness-mismatch skip+note**, and **local-eligible-without-key** (`crates/tui/src/tui/app/tests.rs`).

## What this PR adds
**Guardrail (genuinely missing — `feat` commit):** the issue requires *"do not fallback from local/private routes to cloud routes unless policy explicitly permits it,"* but `advance_fallback` would happily route a local/private primary out to a keyed cloud provider. Added a minimal, **visible** block: when the chain's primary is self-hosted (Ollama/vLLM/SGLang), cloud candidates are skipped with a clear note (`local/private policy (no local->cloud fallback)`); local→local fallback stays allowed. Introduced `ApiProvider::is_self_hosted()` as the single source of truth (also reused by `has_api_key_for`).

**Test hardening (`test` commit):** the remaining acceptance cases not previously pinned —
- **auth (401) does not fall back** — exercised through `apply_engine_error_to_app` with a *recoverable* auth envelope, proving the **category** (not recoverability) is the gate;
- **visible route metadata** — status shows `Switched to <provider> (fallback 1/N)` with a 1-based position (off-by-one regression guard);
- **`/provider fallback reset` returns to primary** even when a fallback is active.

## Open question resolved
The handoff asked whether `/provider fallback reset` should restore the *primary* into `api_provider`. **It already does, by design:** the command emits `SwitchProvider { provider: primary }`, and `switch_provider` re-seats `api_provider`, rebuilds the chain at position 0, and clears `last_fallback_reason`. A bare `ProviderChain::reset()` (which has no production callers) is not needed. Pinned with `provider_fallback_reset_targets_primary_even_when_on_fallback`.

## Scope note
The issue's "recorded in run/session metadata" is satisfied at the session level (`last_fallback_reason` + visible status). **Fleet/subagent ledger route fields** (provider/wire_model/reasoning/route_source) are deliberately left to **#3205**, which owns the ledger schema change per the release plan.

## Verification
- `cargo fmt`
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test -p codewhale-tui --bin codewhale-tui -- fallback provider_chain route_resolver provider has_api_key_for` — green
- Full `codewhale-tui` bin suite: **5276 passed**; only the known environmental/flaky papercuts failed (`config_command_allow_shell_*`, `run_verifiers_background_*`, `run_tests_succeeds_on_fresh_project`) — reproduced identically on pristine `main`, not caused by this PR.

New tests: `advance_fallback_local_primary_does_not_fall_back_to_cloud`, `advance_fallback_local_primary_may_fall_back_to_local_sibling`, `auth_error_does_not_trigger_provider_fallback`, `fallback_switch_status_shows_one_based_position_and_reason`, `provider_fallback_reset_targets_primary_even_when_on_fallback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)