### PR TITLE
feat(tui): #3478 /config preset calm — beautiful/calm transcript preset

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -67,12 +67,15 @@ pub fn config_command(app: &mut App, arg: Option<&str>) -> CommandResult {
         return config_editability_audit(app);
     }
     let mut raw_words = raw.splitn(2, char::is_whitespace);
-    if raw_words
-        .next()
-        .is_some_and(|token| token.eq_ignore_ascii_case("subagents"))
-    {
+    let first_word = raw_words.next();
+    if first_word.is_some_and(|token| token.eq_ignore_ascii_case("subagents")) {
         let rest = raw_words.next().unwrap_or("").trim();
         return subagents_config_command(app, rest);
+    }
+    // `/config preset <name> [--save|-s]` — apply a bundled settings preset (#3478).
+    if first_word.is_some_and(|token| token.eq_ignore_ascii_case("preset")) {
+        let rest = raw_words.next().unwrap_or("").trim();
+        return config_preset_command(app, rest);
     }
     let parts: Vec<&str> = raw.splitn(2, ' ').collect();
     if parts.len() == 1 {
@@ -100,6 +103,63 @@ pub fn config_command(app: &mut App, arg: Option<&str>) -> CommandResult {
         };
         set_config_value(app, parts[0], value, persist)
     }
+}
+
+/// Apply a bundled settings preset, e.g. `/config preset calm [--save]` (#3478).
+///
+/// The preset is applied to the live session through the same per-key setter a
+/// single `/config <key> <value>` uses, so app state mirroring and (with
+/// `--save`) persistence stay consistent. The preset name is validated before
+/// any field is touched.
+fn config_preset_command(app: &mut App, rest: &str) -> CommandResult {
+    let tokens: Vec<&str> = rest.split_whitespace().collect();
+    let persist = matches!(tokens.last(), Some(&"--save") | Some(&"-s"));
+    let name = tokens.first().copied().unwrap_or("");
+    if name.is_empty() {
+        return CommandResult::message(
+            "Usage: /config preset <name> [--save]. Available presets: calm.",
+        );
+    }
+
+    let Some(fields) = crate::settings::preset_fields(name) else {
+        return CommandResult::error(format!("Unknown preset '{name}'. Available presets: calm."));
+    };
+
+    // Persist the whole bundle atomically when requested (one load/apply/save),
+    // validating the preset before touching anything on disk.
+    if persist {
+        match Settings::load() {
+            Ok(mut settings) => {
+                if let Err(e) = settings.apply_preset(name) {
+                    return CommandResult::error(format!("{e}"));
+                }
+                settings.apply_env_overrides();
+                if let Err(e) = settings.save() {
+                    return CommandResult::error(format!("Failed to save settings: {e}"));
+                }
+            }
+            Err(e) => return CommandResult::error(format!("Failed to load settings: {e}")),
+        }
+    }
+
+    // Mirror the bundle into the live session via the per-key setter (the
+    // persisted write, if any, already happened atomically above, so this pass
+    // is session-only).
+    let mut applied = Vec::with_capacity(fields.len());
+    for (key, value) in fields {
+        let _ = set_config_value(app, key, value, false);
+        applied.push(format!("{key}={value}"));
+    }
+
+    let suffix = if persist {
+        " (saved)"
+    } else {
+        " (session only — add --save to persist)"
+    };
+    CommandResult::message(format!(
+        "Applied '{name}' transcript preset{suffix}: {}. Thinking stays visible and tool runs stay expandable.",
+        applied.join(", ")
+    ))
 }
 
 /// Show the current value of a single setting.
@@ -1971,6 +2031,48 @@ mod tests {
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
         app
+    }
+
+    #[test]
+    fn config_preset_calm_applies_bundle_to_session_and_keeps_evidence() {
+        let mut app = create_test_app();
+        app.calm_mode = false;
+        app.show_thinking = true;
+        app.show_tool_details = true;
+        app.fancy_animations = true;
+
+        let result = config_command(&mut app, Some("preset calm"));
+        let message = result.message.unwrap_or_default();
+        assert!(
+            message.contains("calm"),
+            "summary should name the preset: {message}"
+        );
+
+        assert!(app.calm_mode);
+        assert!(!app.show_tool_details);
+        assert!(app.low_motion);
+        assert!(!app.fancy_animations);
+        assert_eq!(
+            app.tool_collapse_mode,
+            crate::tui::app::ToolCollapseMode::Calm
+        );
+        assert_eq!(
+            app.transcript_spacing,
+            crate::tui::app::TranscriptSpacing::Comfortable
+        );
+        // Evidence preserved: thinking is not hidden by the preset.
+        assert!(app.show_thinking, "calm preset must not hide thinking");
+    }
+
+    #[test]
+    fn config_preset_unknown_name_reports_error() {
+        let mut app = create_test_app();
+        let result = config_command(&mut app, Some("preset turbo"));
+        let message = result.message.unwrap_or_default();
+        assert!(
+            message.to_lowercase().contains("unknown preset"),
+            "expected unknown-preset error, got: {message}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -115,7 +115,7 @@ fn config_preset_command(app: &mut App, rest: &str) -> CommandResult {
     let tokens: Vec<&str> = rest.split_whitespace().collect();
     let persist = matches!(tokens.last(), Some(&"--save") | Some(&"-s"));
     let name = tokens.first().copied().unwrap_or("");
-    if name.is_empty() {
+    if name.is_empty() || name.starts_with('-') {
         return CommandResult::message(
             "Usage: /config preset <name> [--save]. Available presets: calm.",
         );
@@ -147,7 +147,15 @@ fn config_preset_command(app: &mut App, rest: &str) -> CommandResult {
     // is session-only).
     let mut applied = Vec::with_capacity(fields.len());
     for (key, value) in fields {
-        let _ = set_config_value(app, key, value, false);
+        let result = set_config_value(app, key, value, false);
+        if result.is_error {
+            let message = result
+                .message
+                .unwrap_or_else(|| "unknown apply error".to_string());
+            return CommandResult::error(format!(
+                "Failed to apply preset field {key}={value}: {message}"
+            ));
+        }
         applied.push(format!("{key}={value}"));
     }
 
@@ -2073,6 +2081,18 @@ mod tests {
             message.to_lowercase().contains("unknown preset"),
             "expected unknown-preset error, got: {message}"
         );
+    }
+
+    #[test]
+    fn config_preset_save_without_name_reports_usage() {
+        let mut app = create_test_app();
+        let result = config_command(&mut app, Some("preset --save"));
+        let message = result.message.unwrap_or_default();
+        assert!(
+            message.contains("Usage: /config preset"),
+            "expected usage hint, got: {message}"
+        );
+        assert!(!result.is_error);
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -398,6 +398,32 @@ impl Default for Settings {
     }
 }
 
+/// The `calm` transcript preset (#3478): a coherent "beautiful/calm" bundle that
+/// favors a quiet, readable transcript over debug-dense output. Presentation
+/// only, and evidence-preserving — `show_thinking` is deliberately left untouched
+/// (thinking stays visible) and tool runs only have their inline detail
+/// collapsed, never hidden. Keyed by [`Settings::set`] names so the preset and a
+/// single-key `/config` set share one validation path.
+pub const CALM_PRESET_FIELDS: &[(&str, &str)] = &[
+    ("calm_mode", "true"),
+    ("tool_collapse", "calm"),
+    ("transcript_spacing", "comfortable"),
+    ("low_motion", "true"),
+    ("fancy_animations", "false"),
+    ("show_tool_details", "false"),
+];
+
+/// The `(key, value)` fields a named preset applies, or `None` for an unknown
+/// name. Single source of truth shared by [`Settings::apply_preset`] and the
+/// `/config preset` command so the bundle is never defined twice.
+#[must_use]
+pub fn preset_fields(name: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "calm" => Some(CALM_PRESET_FIELDS),
+        _ => None,
+    }
+}
+
 impl Settings {
     /// Get the canonical settings file path.
     ///
@@ -839,6 +865,30 @@ impl Settings {
             }
         }
         Ok(())
+    }
+
+    /// Apply a named settings preset (#3478).
+    ///
+    /// Presets are the first bundled-settings mechanism: a single name applies a
+    /// coherent group of presentation knobs. `calm` is the "beautiful/calm
+    /// transcript" preset — it quiets motion and verbose tool output while
+    /// **keeping evidence reachable**: thinking stays visible and tool runs stay
+    /// expandable (only their inline detail is collapsed), so maintainer/release
+    /// work is never blind to failures. Presentation only — no model, provider,
+    /// routing, or safety setting is touched. Reuses [`Settings::set`] so each
+    /// field goes through the same validation as a single-key set.
+    ///
+    /// Returns the keys changed, or an error for an unknown preset.
+    pub fn apply_preset(&mut self, name: &str) -> Result<Vec<&'static str>> {
+        let Some(bundle) = preset_fields(name) else {
+            anyhow::bail!("Unknown preset '{}'. Available presets: calm", name.trim());
+        };
+        let mut changed = Vec::with_capacity(bundle.len());
+        for (key, value) in bundle {
+            self.set(key, value)?;
+            changed.push(*key);
+        }
+        Ok(changed)
     }
 
     /// Get all settings as a displayable string
@@ -1442,6 +1492,45 @@ fn env_truthy(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apply_preset_calm_sets_bundle_and_preserves_evidence() {
+        let mut settings = Settings::default();
+        // Defaults are the debug-visible posture.
+        assert!(!settings.calm_mode);
+        assert!(settings.show_thinking);
+
+        let changed = settings.apply_preset("CALM").expect("calm preset applies");
+        assert_eq!(
+            changed,
+            CALM_PRESET_FIELDS
+                .iter()
+                .map(|(k, _)| *k)
+                .collect::<Vec<_>>()
+        );
+
+        assert!(settings.calm_mode);
+        assert_eq!(settings.tool_collapse_mode, "calm");
+        assert_eq!(settings.transcript_spacing, "comfortable");
+        assert!(settings.low_motion);
+        assert!(!settings.fancy_animations);
+        assert!(!settings.show_tool_details);
+        // Evidence preserved: the calm preset must NOT hide thinking — it only
+        // quiets motion and verbose tool detail.
+        assert!(
+            settings.show_thinking,
+            "calm preset must keep thinking visible"
+        );
+    }
+
+    #[test]
+    fn apply_preset_rejects_unknown_name() {
+        let mut settings = Settings::default();
+        let err = settings.apply_preset("turbo").expect_err("unknown preset");
+        assert!(err.to_string().contains("Unknown preset"));
+        assert!(preset_fields("calm").is_some());
+        assert!(preset_fields("turbo").is_none());
+    }
 
     #[test]
     fn default_settings_keep_auto_compact_as_unset_fallback() {


### PR DESCRIPTION
Advances #3478 (the calm-preset deliverable). #3478 is framed as an ongoing UI/UX polish *lane*, not a one-off; this lands its headline product item.

## What this delivers
The issue's explicit product ask: *"Provide a clear 'beautiful/calm transcript' preset separate from power-user debug settings."* No settings-preset mechanism existed — this adds the first one.

- **`Settings::apply_preset(name)`** + a shared **`preset_fields()`** lookup (single source of truth for the bundle), reusing `Settings::set` so each field gets the same validation as a single-key `/config` set.
- **`/config preset <name> [--save]`** — persists the bundle **atomically** (one load/apply/save) with `--save`, and mirrors it into the live session via the existing per-key setter.

**The `calm` bundle:** `calm_mode=true, tool_collapse=calm, transcript_spacing=comfortable, low_motion=true, fancy_animations=false, show_tool_details=false`.

**Evidence-preserving by design:** `show_thinking` is deliberately left untouched (thinking stays visible) and tool runs only have their inline detail collapsed — never hidden — so maintainer/release work is never blind to failures. This is the "separate from power-user debug settings" line the issue draws.

## Tests
- `apply_preset_calm_sets_bundle_and_preserves_evidence` (pure) — bundle applied; thinking stays visible.
- `apply_preset_rejects_unknown_name` + `preset_fields` lookup.
- `config_preset_calm_applies_bundle_to_session_and_keeps_evidence` — the live command mirrors the bundle into app state (calm_mode, tool_collapse=Calm, spacing=Comfortable, low_motion, fancy_animations off, show_tool_details off) and keeps `show_thinking`.
- `config_preset_unknown_name_reports_error`.

## Scope note / remaining lane (for Hunter)
The issue also lists diffuse polish — streaming-pacing continuity, quieter *rendering* of thinking blocks, markdown/paragraph rhythm, lighter pinned sidebar, card re-anchor. It explicitly says this *"should become an ongoing small-details UX lane, not a one-off."* I scoped those out: they're hard to pin with deterministic tests and are the lane's continuing work. The dormant `calm_mode` flag is now reachable as a clean preset entry point for that rendering work to build on. **Question for Hunter:** close #3478 on this preset and open a fresh tracking issue for the ongoing polish lane, or keep #3478 open as the lane tracker?

## Verification
- `cargo fmt`; `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo test -p codewhale-tui -- apply_preset config_preset preset_fields settings:: config::` — green.
- Full `codewhale-tui` bin suite: **5275 passed**; only the known environmental papercuts failed (`config_command_allow_shell_*`, `run_verifiers_background_*`, `run_tests_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)