### PR TITLE
docs: update public security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Check the [releases page](https://github.com/Hmbown/CodeWhale/releases) for the 
 Report privately via one of:
 
 - **GitHub private advisory**: [github.com/Hmbown/CodeWhale/security/advisories/new](https://github.com/Hmbown/CodeWhale/security/advisories/new)
-- **Email**: [security@codewhale.net](mailto:security@codewhale.net) — include `[SECURITY]` in the subject line
+- **Email**: [hmbown@gmail.com](mailto:hmbown@gmail.com) — include `[SECURITY]` in the subject line
 
 Include in your report:
 

--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -141,13 +141,13 @@ if [[ -n "${previous_tag}" ]]; then
 fi
 
 # 7) Security contact guard.
-security_email="security@codewhale.net"
+security_email="hmbown@gmail.com"
 if ! grep -qF "${security_email}" SECURITY.md; then
   echo "::error::SECURITY.md must list ${security_email} as the security contact." >&2
   fail=1
 fi
 if grep -qF "hmbown.dev@gmail.com" SECURITY.md; then
-  echo "::error::SECURITY.md must not use the personal fallback email; use ${security_email}." >&2
+  echo "::error::SECURITY.md must not use the alternate personal fallback email; use ${security_email}." >&2
   fail=1
 fi
 

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -143,7 +143,7 @@ export function Footer({ locale = "en" }: { locale?: Locale }) {
         <div className="mx-auto max-w-[1400px] px-6 py-4 flex flex-col gap-2 text-[0.78rem] text-ink-soft">
           <div>
             {isZh ? "安全报告、负责任披露、漏洞协调 — " : "For security reports, responsible disclosure, or vulnerability coordination — "}
-            <a href="mailto:security@codewhale.net" className="font-mono text-ink hover:text-indigo">security@codewhale.net</a>
+            <a href="mailto:hmbown@gmail.com" className="font-mono text-ink hover:text-indigo">hmbown@gmail.com</a>
           </div>
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 font-mono text-[0.7rem] text-ink-mute uppercase tracking-widest">
             <span>© {new Date().getFullYear()} · CodeWhale · Hmbown</span>


### PR DESCRIPTION
## Summary

- Point public vulnerability-reporting contact surfaces at hmbown@gmail.com after the codewhale.net security mailbox bounced.
- Update the release version guard so CI enforces the corrected SECURITY.md contact.
- Keep the website footer aligned with SECURITY.md.

No vulnerability details are included here.

## Verification

- 
- Version state OK: workspace=0.8.65, npm=0.8.65, lockfile in sync.