### PR TITLE
v0.8.65: passive MCP tool discovery (#3461) + configured custom provider rows (#1519)

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5319,6 +5319,21 @@ enum McpServerDoctorStatus {
     Error(String),
 }
 
+fn is_relative_stdio_path_arg(value: &str) -> bool {
+    if value.is_empty() || value.starts_with('-') || value.contains("://") || value.starts_with('~')
+    {
+        return false;
+    }
+    let looks_like_path = value.contains('/') || value.contains('\\');
+    if !looks_like_path {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    let windows_absolute = value.starts_with("\\\\")
+        || (bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/'));
+    !Path::new(value).is_absolute() && !windows_absolute
+}
+
 /// Check an MCP server config entry for common issues.
 fn doctor_check_mcp_server(server: &McpServerConfig) -> McpServerDoctorStatus {
     // No command or URL — incomplete entry.
@@ -5344,6 +5359,23 @@ fn doctor_check_mcp_server(server: &McpServerConfig) -> McpServerDoctorStatus {
 
     if is_absolute && !cmd_path.exists() {
         return McpServerDoctorStatus::Error(format!("command not found: {cmd}"));
+    }
+
+    if server.cwd.is_none() {
+        if is_relative_stdio_path_arg(cmd) {
+            return McpServerDoctorStatus::Warning(format!(
+                "stdio server uses relative command \"{cmd}\" without cwd; set cwd so headless exec and UI status checks resolve the same path"
+            ));
+        }
+        if let Some(arg) = server
+            .args
+            .iter()
+            .find(|arg| is_relative_stdio_path_arg(arg))
+        {
+            return McpServerDoctorStatus::Warning(format!(
+                "stdio server uses relative path argument \"{arg}\" without cwd; set cwd so headless exec and UI status checks resolve the same path"
+            ));
+        }
     }
 
     // Detect self-hosted DeepSeek server entries.
@@ -8632,6 +8664,28 @@ mod doctor_mcp_tests {
         match doctor_check_mcp_server(&server) {
             McpServerDoctorStatus::Ok(detail) => assert!(detail.contains("stdio")),
             other => panic!("Expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_relative_stdio_path_arg_without_cwd_warns() {
+        let server = make_server(Some("python"), &["server/mcp_server.py"], None);
+        match doctor_check_mcp_server(&server) {
+            McpServerDoctorStatus::Warning(detail) => {
+                assert!(detail.contains("relative path argument"));
+                assert!(detail.contains("cwd"));
+            }
+            other => panic!("Expected Warning for relative path argument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_relative_stdio_path_arg_with_cwd_is_ok() {
+        let mut server = make_server(Some("python"), &["server/mcp_server.py"], None);
+        server.cwd = Some(PathBuf::from("/tmp/codewhale-project"));
+        match doctor_check_mcp_server(&server) {
+            McpServerDoctorStatus::Ok(detail) => assert!(detail.contains("stdio")),
+            other => panic!("Expected Ok when cwd anchors relative path, got {other:?}"),
         }
     }
 

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -82,10 +82,9 @@ pub struct RuntimeApiState {
     bind_host: String,
     bind_port: u16,
     mobile_enabled: bool,
-    /// Shared McpPool reused across HTTP API calls so each call does not
-    /// spawn a duplicate set of MCP server processes. The engine maintains
-    /// its own separate pool; this one is for read-only tool discovery via
-    /// the API.
+    /// Shared McpPool reused for explicit live MCP discovery. Passive API
+    /// calls do not initialize this pool so dashboards cannot accidentally
+    /// become a second stdio-process owner.
     mcp_pool: Arc<Mutex<Option<McpPool>>>,
 }
 
@@ -457,6 +456,8 @@ struct McpServersResponse {
 #[derive(Debug, Deserialize)]
 struct McpToolsQuery {
     server: Option<String>,
+    #[serde(default)]
+    connect: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -2200,14 +2201,22 @@ async fn list_mcp_tools(
     Query(query): Query<McpToolsQuery>,
 ) -> Result<Json<McpToolsResponse>, ApiError> {
     let mut pool_guard = state.mcp_pool.lock().await;
-    if pool_guard.is_none() {
+    if query.connect && pool_guard.is_none() {
         let new_pool =
             McpPool::from_config_path_with_workspace(&state.mcp_config_path, &state.workspace)
                 .map_err(|e| ApiError::internal(format!("Failed to load MCP config: {e}")))?;
         pool_guard.replace(new_pool);
     }
-    let pool = pool_guard.as_mut().unwrap();
-    let _errors = pool.connect_all().await;
+
+    if query.connect {
+        if let Some(pool) = pool_guard.as_mut() {
+            let _errors = pool.connect_all().await;
+        }
+    }
+
+    let Some(pool) = pool_guard.as_ref() else {
+        return Ok(Json(McpToolsResponse { tools: Vec::new() }));
+    };
 
     let mut tools = Vec::new();
     for (prefixed_name, tool) in pool.all_tools() {

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -739,6 +739,74 @@ async fn health_and_tasks_endpoints_work() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn mcp_tools_endpoint_is_passive_until_connect_requested() -> Result<()> {
+    let root = std::env::temp_dir().join(format!("codewhale-mcp-tools-api-{}", Uuid::new_v4()));
+    let sessions_dir = root.join("sessions");
+    fs::create_dir_all(&root)?;
+    let sentinel = root.join("mcp-spawned");
+    fs::write(
+        root.join("mcp.json"),
+        serde_json::json!({
+            "servers": {
+                "sentinel": {
+                    "command": "sh",
+                    "args": [
+                        "-c",
+                        "printf spawned > \"$1\"",
+                        "sh",
+                        sentinel
+                    ]
+                }
+            }
+        })
+        .to_string(),
+    )?;
+
+    let Some((addr, _runtime_threads, handle)) =
+        spawn_test_server_with_root(root.clone(), sessions_dir).await?
+    else {
+        return Ok(());
+    };
+    let client = crate::tls::reqwest_client();
+
+    let passive: serde_json::Value = client
+        .get(format!("http://{addr}/v1/apps/mcp/tools"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(passive["tools"].as_array().map(Vec::len), Some(0));
+    assert!(
+        !sentinel.exists(),
+        "passive MCP tool listing must not spawn stdio servers"
+    );
+
+    let _live: serde_json::Value = client
+        .get(format!("http://{addr}/v1/apps/mcp/tools?connect=true"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    for _ in 0..20 {
+        if sentinel.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(
+        sentinel.exists(),
+        "explicit MCP connect should spawn configured stdio servers"
+    );
+
+    handle.abort();
+    Ok(())
+}
+
 #[tokio::test]
 async fn runtime_token_guard_protects_v1_routes() -> Result<()> {
     let root = std::env::temp_dir().join(format!("deepseek-runtime-api-{}", Uuid::new_v4()));

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -1470,6 +1470,24 @@ mod tests {
     }
 
     #[test]
+    fn picker_exposes_active_custom_provider_model_row() {
+        let (mut app, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Custom;
+        app.model_ids_passthrough = true;
+        app.model = "vendor/custom-model-v1".to_string();
+        app.auto_model = false;
+
+        let view = ModelPickerView::new(&app);
+
+        assert!(view.show_custom_model_row);
+        assert_eq!(view.resolved_model(), "vendor/custom-model-v1");
+        assert_eq!(
+            view.resolved_provider(),
+            Some(crate::config::ApiProvider::Custom)
+        );
+    }
+
+    #[test]
     fn picker_exposes_saved_model_for_active_provider() {
         let (mut app, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::XiaomiMimo;

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -266,7 +266,21 @@ pub enum ProviderReasoningStreamVisibility {
 
 impl ProviderDashboardRow {
     fn from_config(provider: ApiProvider, active: ApiProvider, config: &Config) -> Self {
-        let has_key = has_api_key_for(config, provider);
+        Self::from_config_with_provider_id(provider, active, config, None)
+    }
+
+    fn from_custom_config(provider_id: &str, active: ApiProvider, config: &Config) -> Self {
+        let mut scoped = config.clone();
+        scoped.provider = Some(provider_id.to_string());
+        Self::from_config_with_provider_id(ApiProvider::Custom, active, &scoped, Some(provider_id))
+    }
+
+    fn from_config_with_provider_id(
+        provider: ApiProvider,
+        active: ApiProvider,
+        config: &Config,
+        provider_id_override: Option<&str>,
+    ) -> Self {
         let configured = config.provider_config_for(provider);
         let configured_base_url = configured
             .and_then(|entry| entry.base_url.as_deref())
@@ -280,14 +294,34 @@ impl ProviderDashboardRow {
             .map(str::to_string);
         let has_configured_model = configured_model.is_some();
         let model_origin = ProviderModelOrigin::for_provider(provider, has_configured_model);
+        let has_key = if provider == ApiProvider::Custom {
+            custom_provider_has_auth(configured)
+        } else {
+            has_api_key_for(config, provider)
+        };
         let auth_status = auth_status_for(provider, has_key, configured);
         let usage_meter = usage_meter_for(provider);
+        let provider_id = provider_id_override
+            .map(str::to_string)
+            .unwrap_or_else(|| provider.as_str().to_string());
+        let display_name = provider_id_override
+            .map(|id| format!("{id} (custom)"))
+            .unwrap_or_else(|| provider.display_name().to_string());
+        let is_active = if provider == ApiProvider::Custom {
+            active == ApiProvider::Custom
+                && match provider_id_override {
+                    Some(id) => config.provider.as_deref() == Some(id),
+                    None => true,
+                }
+        } else {
+            provider == active
+        };
 
         let Some(kind) = provider.kind() else {
             return Self {
                 provider,
-                provider_id: provider.as_str().to_string(),
-                display_name: provider.display_name().to_string(),
+                provider_id,
+                display_name,
                 kind: "legacy".to_string(),
                 base_url: configured_base_url
                     .unwrap_or_else(|| provider.default_base_url().to_string()),
@@ -310,7 +344,7 @@ impl ProviderDashboardRow {
                     "legacy DeepSeek China alias; routing maps through DeepSeek compatibility"
                         .to_string(),
                 ],
-                is_active: provider == active,
+                is_active,
                 has_key,
             };
         };
@@ -376,7 +410,7 @@ impl ProviderDashboardRow {
             auth_status,
             ProviderAuthStatus::Missing | ProviderAuthStatus::OAuthMissing
         ) {
-            messages.push(format!("missing {}", provider.env_vars_label()));
+            messages.push(missing_auth_message(provider, configured, &provider_id));
         }
         if catalog_status == ProviderCatalogStatus::DefaultOnly {
             messages.push("catalog snapshot missing; using provider default".to_string());
@@ -388,9 +422,13 @@ impl ProviderDashboardRow {
 
         Self {
             provider,
-            provider_id: kind.as_str().to_string(),
-            display_name: provider.display_name().to_string(),
-            kind: format!("{kind:?}"),
+            provider_id,
+            display_name,
+            kind: configured
+                .and_then(|entry| entry.kind.as_deref())
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{kind:?}")),
             base_url,
             auth_status,
             catalog_status,
@@ -404,7 +442,7 @@ impl ProviderDashboardRow {
             readiness,
             maturity: ProviderMaturity::for_provider(provider),
             messages,
-            is_active: provider == active,
+            is_active,
             has_key,
         }
     }
@@ -710,6 +748,15 @@ fn auth_status_for(
             ProviderAuthStatus::Optional
         };
     }
+    if provider == ApiProvider::Custom {
+        return if custom_provider_auth_is_optional(configured) {
+            ProviderAuthStatus::Optional
+        } else if has_key {
+            ProviderAuthStatus::Configured
+        } else {
+            ProviderAuthStatus::Missing
+        };
+    }
     if provider == ApiProvider::Moonshot && configured.is_some_and(config_uses_kimi_oauth) {
         return if has_key {
             ProviderAuthStatus::OAuthReady
@@ -749,6 +796,92 @@ fn has_explicit_credential(
                     .as_ref()
                     .is_some_and(|auth| auth.validate().is_ok())
         })
+}
+
+fn custom_provider_has_auth(configured: Option<&crate::config::ProviderConfig>) -> bool {
+    if custom_provider_auth_is_optional(configured) {
+        return true;
+    }
+    configured.is_some_and(|entry| {
+        entry
+            .api_key
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || entry
+                .api_key_env
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .is_some_and(|name| std::env::var(name).is_ok_and(|value| !value.trim().is_empty()))
+            || entry
+                .auth
+                .as_ref()
+                .is_some_and(|auth| auth.validate().is_ok())
+    })
+}
+
+fn custom_provider_auth_is_optional(configured: Option<&crate::config::ProviderConfig>) -> bool {
+    configured.is_some_and(|entry| {
+        entry
+            .auth_mode
+            .as_deref()
+            .is_some_and(auth_mode_disables_api_key)
+            || entry
+                .base_url
+                .as_deref()
+                .is_some_and(base_url_uses_local_host)
+    })
+}
+
+fn auth_mode_disables_api_key(mode: &str) -> bool {
+    matches!(
+        mode.trim()
+            .to_ascii_lowercase()
+            .replace(['-', ' '], "_")
+            .as_str(),
+        "none" | "off" | "disabled" | "no_auth" | "noapi" | "no_api_key" | "anonymous"
+    )
+}
+
+fn base_url_uses_local_host(base_url: &str) -> bool {
+    let without_scheme = base_url
+        .split_once("://")
+        .map_or(base_url, |(_, rest)| rest);
+    let authority = without_scheme.split('/').next().unwrap_or_default();
+    let host = authority
+        .rsplit('@')
+        .next()
+        .unwrap_or(authority)
+        .trim_start_matches('[')
+        .split(']')
+        .next()
+        .unwrap_or(authority)
+        .split(':')
+        .next()
+        .unwrap_or(authority)
+        .to_ascii_lowercase();
+    matches!(host.as_str(), "localhost" | "0.0.0.0")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|addr| addr.is_loopback() || addr.is_unspecified())
+}
+
+fn missing_auth_message(
+    provider: ApiProvider,
+    configured: Option<&crate::config::ProviderConfig>,
+    provider_id: &str,
+) -> String {
+    if provider == ApiProvider::Custom {
+        if let Some(env_name) = configured
+            .and_then(|entry| entry.api_key_env.as_deref())
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            return format!("missing {env_name} for custom provider {provider_id}");
+        }
+        return format!("missing custom provider auth for {provider_id}");
+    }
+    format!("missing {}", provider.env_vars_label())
 }
 
 fn config_uses_kimi_oauth(config: &crate::config::ProviderConfig) -> bool {
@@ -847,13 +980,23 @@ impl ProviderPickerView {
         // Present providers in the shared metadata display order (#3076). The
         // active provider is highlighted via `selected_idx` below, so it is
         // never lost in the list.
-        let rows: Vec<ProviderDashboardRow> = ApiProvider::sorted_for_display()
+        let custom_rows = custom_provider_dashboard_rows(active, config);
+        let mut rows: Vec<ProviderDashboardRow> = ApiProvider::sorted_for_display()
             .into_iter()
+            .filter(|provider| *provider != ApiProvider::Custom || custom_rows.is_empty())
             .map(|p| ProviderDashboardRow::from_config(p, active, config))
             .collect();
+        rows.extend(custom_rows);
+        rows.sort_by(|a, b| {
+            a.display_name
+                .to_ascii_lowercase()
+                .cmp(&b.display_name.to_ascii_lowercase())
+                .then_with(|| a.provider_id.cmp(&b.provider_id))
+        });
         let selected_idx = rows
             .iter()
-            .position(|row| row.provider == active)
+            .position(|row| row.is_active)
+            .or_else(|| rows.iter().position(|row| row.provider == active))
             .unwrap_or(0);
         Self {
             rows,
@@ -922,6 +1065,23 @@ impl ProviderPickerView {
 
     fn env_var_for(provider: ApiProvider) -> String {
         provider.env_vars_label()
+    }
+
+    fn env_var_for_selected_row(&self) -> String {
+        let row = &self.rows[self.selected_idx];
+        if row.provider == ApiProvider::Custom {
+            return row
+                .messages
+                .iter()
+                .find_map(|message| {
+                    message
+                        .strip_prefix("missing ")
+                        .and_then(|rest| rest.split_once(" for custom provider"))
+                        .map(|(env_name, _)| env_name.to_string())
+                })
+                .unwrap_or_else(|| format!("[providers.{}] api_key", row.provider_id));
+        }
+        Self::env_var_for(row.provider)
     }
 
     fn visible_start(&self, visible_rows: usize) -> usize {
@@ -1042,10 +1202,10 @@ impl ProviderPickerView {
     }
 
     fn render_key_entry(&self, area: Rect, buf: &mut Buffer) {
-        let provider = self.selected_provider();
+        let row = &self.rows[self.selected_idx];
         let outer = Block::default()
             .title(Line::from(Span::styled(
-                format!(" API key — {} ", provider.display_name()),
+                format!(" API key — {} ", row.display_name),
                 Style::default()
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
@@ -1090,7 +1250,7 @@ impl ProviderPickerView {
 
         let hint = format!(
             "Or set the {} environment variable and re-open /provider.",
-            Self::env_var_for(provider),
+            self.env_var_for_selected_row(),
         );
         Paragraph::new(Line::from(Span::styled(
             hint,
@@ -1261,6 +1421,25 @@ impl ModalView for ProviderPickerView {
     }
 }
 
+fn custom_provider_dashboard_rows(
+    active: ApiProvider,
+    config: &Config,
+) -> Vec<ProviderDashboardRow> {
+    let Some(providers) = config.providers.as_ref() else {
+        return Vec::new();
+    };
+    let mut ids: Vec<_> = providers.custom.keys().cloned().collect();
+    ids.sort_by_key(|id| id.to_ascii_lowercase());
+    ids.into_iter()
+        .filter(|id| {
+            providers
+                .custom_provider_config(id)
+                .is_some_and(|entry| entry.is_openai_compatible_custom())
+        })
+        .map(|id| ProviderDashboardRow::from_custom_config(&id, active, config))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1284,6 +1463,17 @@ mod tests {
             // this module can concurrently mutate/read this provider key.
             unsafe {
                 env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: provider-picker tests that mutate environment variables
+            // hold ENV_LOCK for the whole guard lifetime, so no sibling test in
+            // this module can concurrently mutate/read this provider key.
+            unsafe {
+                env::set_var(key, value);
             }
             Self { key, previous }
         }
@@ -1679,6 +1869,101 @@ mod tests {
         assert_eq!(row.default_route.logical_model, "custom-model");
         assert_eq!(row.default_route.wire_model, "custom-model");
         assert_eq!(row.supported_protocols, vec!["chat".to_string()]);
+    }
+
+    #[test]
+    fn provider_picker_lists_configured_custom_provider_readiness() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let _example_key = EnvVarGuard::remove("EXAMPLE_API_KEY");
+        let mut custom = std::collections::HashMap::new();
+        custom.insert(
+            "my_thing".to_string(),
+            crate::config::ProviderConfig {
+                kind: Some("openai-compatible".to_string()),
+                base_url: Some("https://api.example.com/v1".to_string()),
+                model: Some("vendor/custom-model-v1".to_string()),
+                api_key_env: Some("EXAMPLE_API_KEY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = Config {
+            provider: Some("my_thing".to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                custom,
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        let picker = ProviderPickerView::new(ApiProvider::Custom, &config);
+        let row = picker
+            .rows
+            .iter()
+            .find(|row| row.provider_id == "my_thing")
+            .expect("configured custom provider row");
+
+        assert_eq!(row.provider, ApiProvider::Custom);
+        assert_eq!(row.display_name, "my_thing (custom)");
+        assert_eq!(row.kind, "openai-compatible");
+        assert!(row.is_active);
+        assert_eq!(row.auth_status, ProviderAuthStatus::Missing);
+        assert_eq!(row.readiness, ProviderReadiness::NeedsAuth);
+        assert_eq!(row.base_url, "https://api.example.com/v1");
+        assert_eq!(row.supported_protocols, vec!["chat".to_string()]);
+        assert_eq!(row.default_route.logical_model, "vendor/custom-model-v1");
+        assert_eq!(row.default_route.wire_model, "vendor/custom-model-v1");
+        assert_eq!(row.model_origin, ProviderModelOrigin::Saved);
+        assert!(
+            row.messages
+                .iter()
+                .any(|message| message.contains("EXAMPLE_API_KEY")),
+            "custom row should name the configured auth env var: {:?}",
+            row.messages
+        );
+        assert_eq!(picker.rows[picker.selected_idx].provider_id, "my_thing");
+    }
+
+    #[test]
+    fn provider_picker_marks_custom_provider_ready_when_env_auth_is_set() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let _example_key = EnvVarGuard::set("EXAMPLE_API_KEY", "sk-test");
+        let mut custom = std::collections::HashMap::new();
+        custom.insert(
+            "my_thing".to_string(),
+            crate::config::ProviderConfig {
+                kind: Some("openai-compatible".to_string()),
+                base_url: Some("https://api.example.com/v1".to_string()),
+                model: Some("custom-model-v1".to_string()),
+                api_key_env: Some("EXAMPLE_API_KEY".to_string()),
+                ..Default::default()
+            },
+        );
+        let config = Config {
+            provider: Some("my_thing".to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                custom,
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        let picker = ProviderPickerView::new(ApiProvider::Custom, &config);
+        let row = picker
+            .rows
+            .iter()
+            .find(|row| row.provider_id == "my_thing")
+            .expect("configured custom provider row");
+
+        assert_eq!(row.auth_status, ProviderAuthStatus::Configured);
+        assert_eq!(row.readiness, ProviderReadiness::Ready);
+        assert!(row.has_key);
+        assert!(
+            !row.messages
+                .iter()
+                .any(|message| message.contains("EXAMPLE_API_KEY")),
+            "configured custom auth should not report missing env var: {:?}",
+            row.messages
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two verified, independent v0.8.65 fixes off a clean `main`. Each is one focused commit; happy to split into two PRs if a reviewer prefers smaller units.

## #3461 — MCP tool discovery passive by default (`9f9f0f1`)
Avoid spawning runtime API-owned stdio MCP processes from passive `GET /v1/apps/mcp/tools` requests. Live discovery remains available through `?connect=true`, which keeps headless exec/tool execution as the explicit process-owner path and prevents dashboard/status calls from becoming duplicate lifecycle owners.

Doctor now warns when stdio MCP entries use relative-path commands or script args without `cwd`, matching the duplicate / no-log Windows report pattern.

Tests:
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mcp_tools_endpoint_is_passive_until_connect_requested`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked doctor_mcp_tests`

## #1519 — surface configured custom provider rows (`e94cc3a`)
List concrete `[providers.<name>]` OpenAI-compatible entries in the provider picker instead of only the generic custom placeholder. Each row carries the configured provider id, endpoint, auth readiness, wire protocol, and current model from the route resolver.

Custom provider auth readiness now honors per-entry `api_key`, `api_key_env`, `auth` metadata, explicit no-auth mode, and loopback endpoints. The model picker also gains direct coverage for the active custom pass-through row.

Tests:
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_dashboard`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_picker`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked model_picker`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked custom_provider`

Closes #3461
Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013aXMdQizAJRUCPmdhWFeGh)_