### PR TITLE
v0.8.65: factual model reference database + /modeldb browse (#3205, #2300)

### DIFF
--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -34,7 +34,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::models_dev::{ModelsDevCatalog, ModelsDevCost, ModelsDevLimit};
+use crate::models_dev::{ModelsDevCatalog, ModelsDevCost, ModelsDevLimit, ModelsDevModalities};
 use crate::route::{ModelId, ProviderId, ProviderModelOffering, RouteLimits, WireModelId};
 
 /// Provenance of a catalog row. Drives layer precedence and UI provenance.
@@ -84,6 +84,12 @@ pub struct CatalogOffering {
     /// Provider-scoped pricing, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<ModelsDevCost>,
+    /// Input/output modalities for this offering, when known. Carried as the
+    /// raw Models.dev shape so a factual `text` vs `multimodal` label can be
+    /// derived without guessing; `None` means the layer did not state it (an
+    /// unknown, not "text-only").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modalities: Option<ModelsDevModalities>,
     /// Whether this offering supports reasoning, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
@@ -202,6 +208,7 @@ pub fn bundled_offerings_from_models_dev(catalog: &ModelsDevCatalog) -> Vec<Cata
                 family: model.family.clone(),
                 limit: model.limit.clone(),
                 cost: model.cost.clone(),
+                modalities: model.modalities.clone(),
                 reasoning: model.reasoning,
                 reasoning_options: model.reasoning_options.clone(),
                 source: CatalogSource::Bundled,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth_source;
 pub mod catalog;
 mod harness;
+pub mod model_reference;
 pub mod models_dev;
 pub mod pricing;
 pub mod provider;
@@ -11,6 +12,7 @@ pub use harness::{
     HarnessCompactionStrategy, HarnessPosture, HarnessPostureKind, HarnessProfile,
     HarnessSafetyPosture, HarnessToolSurface, built_in_harness_profiles,
 };
+pub use model_reference::{Modality, ModelReferenceCard, ModelReferenceDatabase};
 pub(crate) use provider_defaults::*;
 pub use provider_kind::ProviderKind;
 

--- a/crates/config/src/model_reference.rs
+++ b/crates/config/src/model_reference.rs
@@ -1,0 +1,534 @@
+//! Factual model reference database (#3205, #2300).
+//!
+//! A browsable, read-only projection of the compiled catalog into per-offering
+//! "fact cards": the model id as-is, the serving provider and its kind, the
+//! context window, the price, and the modality (text vs multimodal). It exists
+//! to answer "what are this model's stated attributes?", nothing more.
+//!
+//! This layer is **labels only**. It performs no selection, routing, tiering,
+//! or ranking — it never decides which model to use, and it carries no
+//! `strong`/`balanced`/`fast` or role concept. It is a superset-free view over
+//! [`crate::catalog::CatalogOffering`] rows.
+//!
+//! Honesty rule (shared with #2608 / #3085): an attribute the catalog layer did
+//! not state is reported as **unknown**, never guessed. A local/custom endpoint
+//! with no catalog facts yields `Unknown` modality, `None` context window, and
+//! an unknown price — its model id is still preserved verbatim. Nothing here is
+//! inferred from a model-id prefix.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::ProviderKind;
+use crate::catalog::{CatalogOffering, CatalogSnapshot, CatalogSource, bundled_catalog_offerings};
+use crate::models_dev::ModelsDevModalities;
+use crate::pricing::{Currency, OfferingPricing};
+
+/// Coarse, factual input/output modality label for a model.
+///
+/// `text` vs `multimodal` is derived from the union of stated input/output
+/// modalities. Absent modality metadata is [`Modality::Unknown`], distinct from
+/// a stated text-only model — "we were not told" is not "text only".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Modality {
+    /// Every stated modality is text.
+    Text,
+    /// At least one stated modality is non-text (image/audio/video/…).
+    Multimodal,
+    /// No modality metadata was stated for this row.
+    #[default]
+    Unknown,
+}
+
+impl Modality {
+    /// Classify the modality from a Models.dev-shaped modality block.
+    ///
+    /// Returns [`Modality::Unknown`] for absent metadata or an empty list,
+    /// [`Modality::Multimodal`] when any stated input/output modality is not
+    /// `text`, and [`Modality::Text`] when the only stated modalities are text.
+    #[must_use]
+    pub fn from_modalities(modalities: Option<&ModelsDevModalities>) -> Self {
+        let Some(modalities) = modalities else {
+            return Self::Unknown;
+        };
+        let mut saw_any = false;
+        for modality in modalities.input.iter().chain(modalities.output.iter()) {
+            let trimmed = modality.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            saw_any = true;
+            if !trimmed.eq_ignore_ascii_case("text") {
+                return Self::Multimodal;
+            }
+        }
+        if saw_any { Self::Text } else { Self::Unknown }
+    }
+
+    /// Stable lowercase label.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Multimodal => "multimodal",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// A factual reference card for one provider offering.
+///
+/// Every field is either a stated fact or an explicit unknown. This is a
+/// labels-only projection: it carries no routing, tier, or selection concept.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModelReferenceCard {
+    /// Provider id serving this offering, exactly as the catalog row states it.
+    pub provider: String,
+    /// Resolved built-in provider kind, when the provider id maps to one.
+    ///
+    /// `None` for an unrecognized / user-named custom provider — an unknown
+    /// kind, not a guess.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<ProviderKind>,
+    /// The provider wire model id, verbatim. Never normalized or prefixed.
+    pub model_id: String,
+    /// Canonical model identity, only when the row carried an explicit join.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_model: Option<String>,
+    /// Model family / series, when stated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    /// Context-window tokens, when stated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
+    /// Max-output tokens, when stated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output: Option<u64>,
+    /// Text vs multimodal, or unknown.
+    pub modality: Modality,
+    /// Per-token pricing facts, when priced. `None` is unknown, never free.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pricing: Option<OfferingPricing>,
+    /// Provenance of the underlying catalog row (bundled / live / override).
+    pub source: CatalogSource,
+}
+
+impl ModelReferenceCard {
+    /// Project a catalog offering into its factual reference card.
+    #[must_use]
+    pub fn from_offering(offering: &CatalogOffering) -> Self {
+        Self {
+            provider: offering.provider.clone(),
+            provider_kind: ProviderKind::parse(&offering.provider),
+            model_id: offering.wire_model_id.clone(),
+            canonical_model: offering.canonical_model.clone(),
+            family: offering.family.clone(),
+            context_window: offering.limit.as_ref().and_then(|limit| limit.context),
+            max_output: offering.limit.as_ref().and_then(|limit| limit.output),
+            modality: Modality::from_modalities(offering.modalities.as_ref()),
+            pricing: OfferingPricing::from_catalog_offering(offering),
+            source: offering.source.clone(),
+        }
+    }
+
+    /// Label for the resolved provider kind, or `"unknown"`.
+    #[must_use]
+    pub fn provider_kind_label(&self) -> &'static str {
+        self.provider_kind.map_or("unknown", ProviderKind::as_str)
+    }
+
+    /// Human context-window label such as `"1M"`, `"131K"`, `"512"`, or
+    /// `"unknown"`. The exact token count remains on [`Self::context_window`].
+    #[must_use]
+    pub fn context_window_label(&self) -> String {
+        humanize_tokens(self.context_window)
+    }
+
+    /// Human max-output label, same shape as [`Self::context_window_label`].
+    #[must_use]
+    pub fn max_output_label(&self) -> String {
+        humanize_tokens(self.max_output)
+    }
+
+    /// Short factual price label, e.g. `"$0.30 / $1.20 per Mtok"`, or
+    /// `"unknown"` when no per-token input/output rate is sourced.
+    ///
+    /// A `?` in one slot means that single rate is unknown while the other is
+    /// stated; a fully unknown price collapses to `"unknown"` rather than a
+    /// fabricated zero.
+    #[must_use]
+    pub fn price_label(&self) -> String {
+        let Some(pricing) = self.pricing.as_ref() else {
+            return "unknown".to_string();
+        };
+        if pricing.input_per_million.is_none() && pricing.output_per_million.is_none() {
+            return "unknown".to_string();
+        }
+        let symbol = currency_symbol(&pricing.currency);
+        let render = |value: Option<f64>| match value {
+            Some(rate) => format!("{symbol}{rate:.2}"),
+            None => "?".to_string(),
+        };
+        let suffix = currency_suffix(&pricing.currency);
+        format!(
+            "{} / {} per Mtok{suffix}",
+            render(pricing.input_per_million),
+            render(pricing.output_per_million),
+        )
+    }
+}
+
+/// A browsable, read-only factual reference database of model offerings.
+///
+/// Cards are sorted by `(provider, model id)` and de-duplicated on that
+/// identity, so the database is deterministic regardless of input order.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ModelReferenceDatabase {
+    cards: Vec<ModelReferenceCard>,
+}
+
+impl ModelReferenceDatabase {
+    /// Build from raw catalog offerings.
+    ///
+    /// Rows are keyed by `(provider, model id)`; a later row with the same
+    /// identity replaces an earlier one, matching catalog merge semantics.
+    #[must_use]
+    pub fn from_offerings(offerings: &[CatalogOffering]) -> Self {
+        let mut by_identity: BTreeMap<(String, String), ModelReferenceCard> = BTreeMap::new();
+        for offering in offerings {
+            let card = ModelReferenceCard::from_offering(offering);
+            by_identity.insert((card.provider.clone(), card.model_id.clone()), card);
+        }
+        Self {
+            cards: by_identity.into_values().collect(),
+        }
+    }
+
+    /// Build from a compiled catalog snapshot (bundled < live < overrides).
+    #[must_use]
+    pub fn from_snapshot(snapshot: &CatalogSnapshot) -> Self {
+        Self::from_offerings(&snapshot.offerings)
+    }
+
+    /// Build from CodeWhale's bundled, network-free catalog snapshot.
+    ///
+    /// This is the curated reference set every install carries; it needs no
+    /// credentials or network and is always available.
+    #[must_use]
+    pub fn bundled() -> Self {
+        Self::from_offerings(&bundled_catalog_offerings())
+    }
+
+    /// All cards, in stable `(provider, model id)` order.
+    #[must_use]
+    pub fn cards(&self) -> &[ModelReferenceCard] {
+        &self.cards
+    }
+
+    /// Number of cards.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.cards.len()
+    }
+
+    /// Whether the database is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.cards.is_empty()
+    }
+
+    /// Distinct provider ids present, sorted.
+    #[must_use]
+    pub fn providers(&self) -> Vec<&str> {
+        self.cards
+            .iter()
+            .map(|card| card.provider.as_str())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    /// All cards served by one provider id.
+    #[must_use]
+    pub fn for_provider(&self, provider: &str) -> Vec<&ModelReferenceCard> {
+        self.cards
+            .iter()
+            .filter(|card| card.provider == provider)
+            .collect()
+    }
+
+    /// Find a card by `(provider, model id)`.
+    #[must_use]
+    pub fn find(&self, provider: &str, model_id: &str) -> Option<&ModelReferenceCard> {
+        self.cards
+            .iter()
+            .find(|card| card.provider == provider && card.model_id == model_id)
+    }
+}
+
+/// Round a token count to a short human label (`"1M"`, `"203K"`, `"512"`), or
+/// `"unknown"` for an absent count. Used for display only; callers needing the
+/// exact value read the `Option<u64>` field directly.
+fn humanize_tokens(tokens: Option<u64>) -> String {
+    let Some(tokens) = tokens else {
+        return "unknown".to_string();
+    };
+    if tokens >= 1_000_000 {
+        let millions = tokens as f64 / 1_000_000.0;
+        let rendered = format!("{millions:.2}");
+        let trimmed = rendered.trim_end_matches('0').trim_end_matches('.');
+        format!("{trimmed}M")
+    } else if tokens >= 1_000 {
+        format!("{}K", (tokens as f64 / 1_000.0).round() as u64)
+    } else {
+        tokens.to_string()
+    }
+}
+
+fn currency_symbol(currency: &Currency) -> &'static str {
+    match currency {
+        Currency::Usd => "$",
+        Currency::Cny => "¥",
+        Currency::Other(_) => "",
+    }
+}
+
+fn currency_suffix(currency: &Currency) -> String {
+    match currency {
+        Currency::Usd | Currency::Cny => String::new(),
+        Currency::Other(code) => format!(" {code}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models_dev::{ModelsDevCost, ModelsDevLimit};
+
+    fn offering(provider: &str, wire: &str) -> CatalogOffering {
+        CatalogOffering {
+            provider: provider.to_string(),
+            wire_model_id: wire.to_string(),
+            endpoint_key: "chat".to_string(),
+            source: CatalogSource::Bundled,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn modality_text_multimodal_and_unknown() {
+        assert_eq!(Modality::from_modalities(None), Modality::Unknown);
+        assert_eq!(
+            Modality::from_modalities(Some(&ModelsDevModalities::default())),
+            Modality::Unknown,
+            "an empty modality block is unknown, not text-only"
+        );
+        assert_eq!(
+            Modality::from_modalities(Some(&ModelsDevModalities {
+                input: vec!["text".to_string()],
+                output: vec!["text".to_string()],
+            })),
+            Modality::Text
+        );
+        assert_eq!(
+            Modality::from_modalities(Some(&ModelsDevModalities {
+                input: vec!["text".to_string(), "image".to_string()],
+                output: vec!["text".to_string()],
+            })),
+            Modality::Multimodal
+        );
+        // Case-insensitive and tolerant of an output-only non-text modality.
+        assert_eq!(
+            Modality::from_modalities(Some(&ModelsDevModalities {
+                input: vec!["TEXT".to_string()],
+                output: vec!["Audio".to_string()],
+            })),
+            Modality::Multimodal
+        );
+    }
+
+    #[test]
+    fn card_projects_stated_facts() {
+        let row = CatalogOffering {
+            family: Some("deepseek".to_string()),
+            limit: Some(ModelsDevLimit {
+                context: Some(1_000_000),
+                input: None,
+                output: Some(384_000),
+            }),
+            cost: Some(ModelsDevCost {
+                input: Some(0.3),
+                output: Some(1.2),
+                cache_read: Some(0.06),
+                cache_write: None,
+            }),
+            modalities: Some(ModelsDevModalities {
+                input: vec!["text".to_string()],
+                output: vec!["text".to_string()],
+            }),
+            ..offering("deepseek", "deepseek-v4-pro")
+        };
+        let card = ModelReferenceCard::from_offering(&row);
+
+        assert_eq!(card.provider, "deepseek");
+        assert_eq!(card.provider_kind, Some(ProviderKind::Deepseek));
+        assert_eq!(card.provider_kind_label(), "deepseek");
+        assert_eq!(card.model_id, "deepseek-v4-pro");
+        assert_eq!(card.family.as_deref(), Some("deepseek"));
+        assert_eq!(card.context_window, Some(1_000_000));
+        assert_eq!(card.context_window_label(), "1M");
+        assert_eq!(card.max_output, Some(384_000));
+        assert_eq!(card.max_output_label(), "384K");
+        assert_eq!(card.modality, Modality::Text);
+        assert_eq!(card.price_label(), "$0.30 / $1.20 per Mtok");
+    }
+
+    #[test]
+    fn custom_local_row_is_all_unknown_but_keeps_model_id_verbatim() {
+        // A user-named custom endpoint with no catalog facts: provider kind,
+        // context window, modality, and price are all unknown — never guessed —
+        // and the model id is preserved exactly.
+        let row = CatalogOffering {
+            source: CatalogSource::UserOverride,
+            ..offering("my-local-llm", "Vendor/Custom-Model_v1")
+        };
+        let card = ModelReferenceCard::from_offering(&row);
+
+        assert_eq!(card.provider_kind, None);
+        assert_eq!(card.provider_kind_label(), "unknown");
+        assert_eq!(card.model_id, "Vendor/Custom-Model_v1");
+        assert_eq!(card.context_window, None);
+        assert_eq!(card.context_window_label(), "unknown");
+        assert_eq!(card.max_output_label(), "unknown");
+        assert_eq!(card.modality, Modality::Unknown);
+        assert_eq!(card.price_label(), "unknown");
+    }
+
+    #[test]
+    fn unpriced_and_cache_only_rows_report_unknown_price_never_zero() {
+        // No cost block at all.
+        let unpriced = ModelReferenceCard::from_offering(&offering("deepseek", "deepseek-v4-pro"));
+        assert_eq!(unpriced.price_label(), "unknown");
+        assert!(unpriced.pricing.is_none());
+
+        // A cost object priced only on cache classes is still unknown for the
+        // headline input/output rate label.
+        let cache_only = CatalogOffering {
+            cost: Some(ModelsDevCost {
+                input: None,
+                output: None,
+                cache_read: Some(0.05),
+                cache_write: None,
+            }),
+            ..offering("acme", "house-model")
+        };
+        assert_eq!(
+            ModelReferenceCard::from_offering(&cache_only).price_label(),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn partial_price_renders_known_rate_and_marks_the_other_unknown() {
+        let row = CatalogOffering {
+            cost: Some(ModelsDevCost {
+                input: Some(5.0),
+                output: None,
+                cache_read: None,
+                cache_write: None,
+            }),
+            ..offering("openai", "gpt-5.5")
+        };
+        assert_eq!(
+            ModelReferenceCard::from_offering(&row).price_label(),
+            "$5.00 / ? per Mtok"
+        );
+    }
+
+    #[test]
+    fn database_is_sorted_deduped_and_queryable() {
+        let rows = vec![
+            CatalogOffering {
+                limit: Some(ModelsDevLimit {
+                    context: Some(1),
+                    input: None,
+                    output: None,
+                }),
+                ..offering("zai", "GLM-5.2")
+            },
+            offering("deepseek", "deepseek-v4-pro"),
+            // Duplicate identity with a higher context wins (last-write).
+            CatalogOffering {
+                limit: Some(ModelsDevLimit {
+                    context: Some(1_000_000),
+                    input: None,
+                    output: None,
+                }),
+                ..offering("zai", "GLM-5.2")
+            },
+        ];
+        let db = ModelReferenceDatabase::from_offerings(&rows);
+
+        assert_eq!(db.len(), 2, "duplicate (provider, model) collapses to one");
+        // Sorted by (provider, model id): deepseek before zai.
+        assert_eq!(db.cards()[0].provider, "deepseek");
+        assert_eq!(db.cards()[1].provider, "zai");
+        assert_eq!(db.providers(), vec!["deepseek", "zai"]);
+        assert_eq!(db.for_provider("zai").len(), 1);
+        assert_eq!(
+            db.find("zai", "GLM-5.2")
+                .and_then(|card| card.context_window),
+            Some(1_000_000),
+            "last-write-wins kept the richer row"
+        );
+        assert!(db.find("zai", "missing").is_none());
+    }
+
+    #[test]
+    fn bundled_database_is_nonempty_and_honest() {
+        let db = ModelReferenceDatabase::bundled();
+        assert!(!db.is_empty());
+        assert!(
+            db.len() >= 20,
+            "bundled snapshot should carry the curated offerings, got {}",
+            db.len()
+        );
+
+        // Every card preserves a non-empty model id and resolves a known kind
+        // for the bundled (first-class) providers.
+        for card in db.cards() {
+            assert!(!card.model_id.is_empty());
+            assert!(
+                card.provider_kind.is_some(),
+                "bundled provider {} should map to a known kind",
+                card.provider
+            );
+        }
+
+        // A DeepSeek-native row: context window known, price honestly unknown
+        // (the bundled snapshot omits DeepSeek-native per-token pricing).
+        let deepseek = db
+            .find("deepseek", "deepseek-v4-pro")
+            .expect("bundled deepseek row");
+        assert_eq!(deepseek.context_window, Some(1_000_000));
+        assert_eq!(deepseek.modality, Modality::Text);
+        assert_eq!(deepseek.price_label(), "unknown");
+
+        // A priced row surfaces its stated per-token rate.
+        let minimax = db
+            .find("minimax", "MiniMax-M3")
+            .expect("bundled minimax row");
+        assert_eq!(minimax.price_label(), "$0.30 / $1.20 per Mtok");
+    }
+
+    #[test]
+    fn humanize_tokens_shapes() {
+        assert_eq!(humanize_tokens(None), "unknown");
+        assert_eq!(humanize_tokens(Some(512)), "512");
+        assert_eq!(humanize_tokens(Some(131_072)), "131K");
+        assert_eq!(humanize_tokens(Some(1_000_000)), "1M");
+        assert_eq!(humanize_tokens(Some(1_050_000)), "1.05M");
+    }
+}

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -104,6 +104,7 @@
   "CmdModeDescription": "切换运行模式或打开选择器：/mode [agent|plan|yolo|1|2|3]",
   "CmdModelDescription": "切换或查看当前模型",
   "CmdModelsDescription": "列出 API 中可用的模型",
+  "CmdModelDbDescription": "浏览内置的模型参考数据库",
   "CmdNetworkDescription": "管理网络允许和拒绝规则",
   "CmdNoteDescription": "添加、列出、编辑或删除工作区笔记",
   "CmdThemeDescription": "切换主题：深色、浅色、灰度或系统",

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1119,6 +1119,10 @@ impl DeepSeekClient {
                 family: None,
                 limit: None,
                 cost: None,
+                // The chat-model listing endpoint does not state modalities; a
+                // future per-provider catalog adapter can fill this in. Left
+                // unknown rather than assumed text-only.
+                modalities: None,
                 reasoning: None,
                 reasoning_options: Vec::new(),
                 source: CatalogSource::Live {

--- a/crates/tui/src/commands/groups/core/mod.rs
+++ b/crates/tui/src/commands/groups/core/mod.rs
@@ -20,6 +20,7 @@ mod home;
 mod hooks;
 mod links;
 mod model;
+mod modeldb;
 mod models;
 mod profile;
 mod provider;
@@ -66,6 +67,10 @@ impl CommandGroup for CoreCommands {
             Box::new(FunctionCommand::new(
                 models::ModelsCmd::info(),
                 models::ModelsCmd::execute,
+            )),
+            Box::new(FunctionCommand::new(
+                modeldb::ModelDbCmd::info(),
+                modeldb::ModelDbCmd::execute,
             )),
             Box::new(FunctionCommand::new(
                 provider::ProviderCmd::info(),

--- a/crates/tui/src/commands/groups/core/modeldb.rs
+++ b/crates/tui/src/commands/groups/core/modeldb.rs
@@ -1,0 +1,211 @@
+//! `/modeldb` command — browse the factual model reference database.
+//!
+//! Opens a read-only pager listing each catalog model's stated attributes:
+//! provider + kind, the model id verbatim, context window, max output,
+//! modality (text vs multimodal), and price. This is labels only — it never
+//! selects, routes, or tiers a model (#3205, #2300). Attributes the catalog
+//! does not state render as `unknown`, never guessed.
+
+use codewhale_config::model_reference::ModelReferenceDatabase;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+
+use crate::commands::traits::{CommandInfo, RegisterCommand};
+use crate::localization::MessageId;
+use crate::tui::app::App;
+use crate::tui::pager::PagerView;
+
+use super::CommandResult;
+
+pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+    name: "modeldb",
+    aliases: &["model-reference", "modelref"],
+    usage: "/modeldb",
+    description_id: MessageId::CmdModelDbDescription,
+};
+
+pub(in crate::commands) struct ModelDbCmd;
+
+impl RegisterCommand for ModelDbCmd {
+    fn info() -> &'static CommandInfo {
+        &COMMAND_INFO
+    }
+
+    fn execute(app: &mut App, _arg: Option<&str>) -> CommandResult {
+        let db = ModelReferenceDatabase::bundled();
+        let title = format!(
+            "Model Reference — {} offerings · {} providers",
+            db.len(),
+            db.providers().len()
+        );
+        app.view_stack
+            .push(PagerView::new(title, reference_lines(&db)));
+        CommandResult::ok()
+    }
+}
+
+/// Render the reference database as aligned, browsable pager lines.
+///
+/// Cards are grouped under a provider/kind header (the database is already
+/// sorted by `(provider, model id)`), so each row only needs the model-scoped
+/// columns. Column widths are computed across the whole table for stable
+/// alignment.
+fn reference_lines(db: &ModelReferenceDatabase) -> Vec<Line<'static>> {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+    let dim = Style::default().add_modifier(Modifier::DIM);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::styled(
+        "Bundled curated model reference catalog.".to_string(),
+        bold,
+    ));
+    lines.push(Line::styled(
+        "Attributes are stated facts; \"unknown\" means the catalog did not state it (never guessed)."
+            .to_string(),
+        dim,
+    ));
+    lines.push(Line::from(String::new()));
+
+    if db.is_empty() {
+        lines.push(Line::from("(no models in catalog)".to_string()));
+        return lines;
+    }
+
+    let cards = db.cards();
+    let id_w = cards
+        .iter()
+        .map(|card| card.model_id.chars().count())
+        .chain(std::iter::once("MODEL ID".len()))
+        .max()
+        .unwrap_or(8)
+        .clamp(8, 46);
+    let ctx_w = cards
+        .iter()
+        .map(|card| card.context_window_label().chars().count())
+        .chain(std::iter::once("CTX".len()))
+        .max()
+        .unwrap_or(3);
+    let out_w = cards
+        .iter()
+        .map(|card| card.max_output_label().chars().count())
+        .chain(std::iter::once("MAX OUT".len()))
+        .max()
+        .unwrap_or(7);
+    // "multimodal" (10) is the widest possible label and exceeds "MODALITY".
+    let mod_w = "multimodal".len();
+
+    lines.push(Line::styled(
+        format!(
+            "  {}  {}  {}  {}  {}",
+            pad("MODEL ID", id_w),
+            pad("CTX", ctx_w),
+            pad("MAX OUT", out_w),
+            pad("MODALITY", mod_w),
+            "PRICE (USD/Mtok)"
+        ),
+        bold,
+    ));
+
+    let mut current_provider: Option<&str> = None;
+    for card in cards {
+        if current_provider != Some(card.provider.as_str()) {
+            lines.push(Line::from(String::new()));
+            lines.push(Line::styled(
+                format!(
+                    "{}   ·   kind: {}",
+                    card.provider,
+                    card.provider_kind_label()
+                ),
+                bold,
+            ));
+            current_provider = Some(card.provider.as_str());
+        }
+        lines.push(Line::from(format!(
+            "  {}  {}  {}  {}  {}",
+            pad(&truncate_to(&card.model_id, id_w), id_w),
+            pad(&card.context_window_label(), ctx_w),
+            pad(&card.max_output_label(), out_w),
+            pad(card.modality.as_str(), mod_w),
+            card.price_label(),
+        )));
+    }
+
+    lines
+}
+
+/// Left-justify `s` to `width` display columns (counted by `char`).
+fn pad(s: &str, width: usize) -> String {
+    let len = s.chars().count();
+    if len >= width {
+        s.to_string()
+    } else {
+        format!("{s}{}", " ".repeat(width - len))
+    }
+}
+
+/// Truncate `s` to at most `width` chars, marking elision with `…`.
+fn truncate_to(s: &str, width: usize) -> String {
+    let count = s.chars().count();
+    if count <= width {
+        return s.to_string();
+    }
+    if width <= 1 {
+        return s.chars().take(width).collect();
+    }
+    let mut truncated: String = s.chars().take(width - 1).collect();
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rendered(db: &ModelReferenceDatabase) -> Vec<String> {
+        reference_lines(db)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn bundled_reference_lists_models_with_factual_columns() {
+        let db = ModelReferenceDatabase::bundled();
+        let text = rendered(&db).join("\n");
+
+        // Legend states the honesty contract.
+        assert!(text.contains("never guessed"));
+        // Column key present.
+        assert!(text.contains("MODEL ID"));
+        assert!(text.contains("MODALITY"));
+        assert!(text.contains("PRICE (USD/Mtok)"));
+        // A provider header and a verbatim model id row.
+        assert!(text.contains("kind: deepseek"));
+        assert!(text.contains("deepseek-v4-pro"));
+        // Stated modality and an honest unknown price both appear.
+        assert!(text.contains("text"));
+        assert!(text.contains("unknown"));
+        // A priced row surfaces a concrete rate.
+        assert!(text.contains("$0.30 / $1.20 per Mtok"));
+    }
+
+    #[test]
+    fn empty_database_renders_placeholder_not_a_crash() {
+        let db = ModelReferenceDatabase::from_offerings(&[]);
+        let text = rendered(&db).join("\n");
+        assert!(text.contains("(no models in catalog)"));
+    }
+
+    #[test]
+    fn pad_and_truncate_are_width_safe() {
+        assert_eq!(pad("ab", 5), "ab   ");
+        assert_eq!(pad("abcde", 3), "abcde");
+        assert_eq!(truncate_to("short", 10), "short");
+        assert_eq!(truncate_to("abcdefghij", 5), "abcd…");
+    }
+}

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -325,6 +325,7 @@ pub enum MessageId {
     CmdModeDescription,
     CmdModelDescription,
     CmdModelsDescription,
+    CmdModelDbDescription,
     CmdNetworkDescription,
     CmdNoteDescription,
     CmdThemeDescription,
@@ -778,6 +779,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdModeDescription,
     MessageId::CmdModelDescription,
     MessageId::CmdModelsDescription,
+    MessageId::CmdModelDbDescription,
     MessageId::CmdNetworkDescription,
     MessageId::CmdNoteDescription,
     MessageId::CmdProviderDescription,
@@ -1435,6 +1437,7 @@ fn english(id: MessageId) -> &'static str {
         }
         MessageId::CmdModelDescription => "Switch or view current model",
         MessageId::CmdModelsDescription => "List available models from API",
+        MessageId::CmdModelDbDescription => "Browse the bundled model reference database",
         MessageId::CmdNetworkDescription => "Manage network allow and deny rules",
         MessageId::CmdNoteDescription => "Add, list, edit, or remove workspace notes",
         MessageId::CmdThemeDescription => "Switch theme or open the theme picker",
@@ -2062,6 +2065,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdModelDescription => "Chuyển đổi hoặc xem mô hình AI hiện tại",
         MessageId::CmdModelsDescription => "Liệt kê các mô hình khả dụng từ API",
+        MessageId::CmdModelDbDescription => "Duyệt cơ sở dữ liệu tham chiếu mô hình tích hợp",
         MessageId::CmdNetworkDescription => "Quản lý các quy tắc cho phép và từ chối mạng",
         MessageId::CmdNoteDescription => {
             "Thêm, liệt kê, sửa hoặc xóa ghi chú trong không gian làm việc"
@@ -2899,6 +2903,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdModelDescription => "現在のモデルを切り替え・確認",
         MessageId::CmdModelsDescription => "API から利用可能なモデルを一覧表示",
+        MessageId::CmdModelDbDescription => "内蔵のモデルリファレンスデータベースを閲覧",
         MessageId::CmdNetworkDescription => "ネットワーク許可・拒否ルールを管理",
         MessageId::CmdNoteDescription => "ワークスペースノートの追加、一覧、編集、削除",
         MessageId::CmdThemeDescription => {
@@ -3532,6 +3537,9 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdModelDescription => "Trocar ou exibir o modelo atual",
         MessageId::CmdModelsDescription => "Listar os modelos disponíveis pela API",
+        MessageId::CmdModelDbDescription => {
+            "Navegar pelo banco de dados de referência de modelos integrado"
+        }
         MessageId::CmdNetworkDescription => "Gerenciar regras de rede permitidas e bloqueadas",
         MessageId::CmdNoteDescription => "Adicionar, listar, editar ou remover notas do workspace",
         MessageId::CmdThemeDescription => "Alternar tema: escuro, claro, tons de cinza ou sistema",
@@ -4176,6 +4184,9 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
         }
         MessageId::CmdModelDescription => "Cambiar o mostrar el modelo actual",
         MessageId::CmdModelsDescription => "Listar los modelos disponibles por la API",
+        MessageId::CmdModelDbDescription => {
+            "Explorar la base de datos de referencia de modelos integrada"
+        }
         MessageId::CmdNetworkDescription => "Gestionar reglas de red permitidas y bloqueadas",
         MessageId::CmdNoteDescription => {
             "Agregar nota al archivo persistente (.codewhale/notes.md)"


### PR DESCRIPTION
## Scope: labeling only

This is the **narrowed v0.8.65 slice** for #3205 / #2300 agreed in the latest handoff comments: give each model its **factual attributes** — context window, price, modality (text vs multimodal), provider/kind, and the model id as-is — and store them as a **reference database users can browse**. **No selection, no routing, no tiers** — just accurate labels. For local/custom providers, anything we can't know is marked `unknown` instead of guessed.

It deliberately does **not** implement the Fleet loadout-auto / semantic-route-role half of those epics. Per the handoff (`#3205` comment, `#2300` comment), those issues stay **open**; this PR does not close them.

## What's in it

**`crates/config` — the reference database (data layer)**
- Carry `modalities` onto `CatalogOffering`. It was already parsed from the Models.dev layer but dropped at projection, so a text-vs-multimodal label couldn't be derived. Live `/models` ingestion leaves it `None` (unknown) rather than assuming text-only.
- New `model_reference` module:
  - `Modality` — `Text` / `Multimodal` / `Unknown`, derived from stated input+output modalities. Absent metadata is `Unknown` (not "text-only").
  - `ModelReferenceCard` — one offering's stated facts: provider, resolved `ProviderKind`, wire model id verbatim, canonical model, family, context window, max output, modality, and per-token pricing.
  - `ModelReferenceDatabase` — a browsable, sorted, de-duplicated projection from a `CatalogSnapshot` (or the bundled snapshot).
- **Honesty:** every unstated attribute is `unknown`. An unpriced row stays unknown (never a fabricated zero, reusing the existing `OfferingPricing` honesty rule), and a user-named custom/local endpoint keeps its model id verbatim with unknown kind/context/price/modality.

**`crates/tui` — the browse surface**
- New read-only `/modeldb` command (aliases `model-reference`, `modelref`) opens a pager listing the catalog grouped by provider/kind, with aligned context-window, max-output, modality, and price columns. Long ids are preserved and only truncated for display. Description localized across all shipped locales.

This is intentionally separate from `/models` (which does a live fetch from the active endpoint) — `/modeldb` is the curated, network-free reference.

## Not in scope (still tracked by #3205 / #2300)
- Automatic loadout / model-class / route-role selection
- Any routing or provider/model switching behavior
- Merging the user's live-configured custom providers into the browse view (this slice shows the bundled curated catalog; the custom-provider merge is a follow-up that needs careful no-clobber + custom-naming handling)

## Tests
- `cargo test -p codewhale-config` — 275 passed (incl. 8 new `model_reference` cases: modality classification, unknown-not-zero pricing, custom/local all-unknown, sorted/deduped DB, bundled honesty)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked modeldb` — 3 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked localization` — green (`shipped_first_pack_has_no_missing_core_messages` incl. the new id)
- `cargo fmt --all --check` clean; `cargo clippy` clean on the changed code

Part of #3205
Part of #2300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013aXMdQizAJRUCPmdhWFeGh)_