### PR TITLE
ci/release: freeze tags and accelerate Rust PR gates

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,24 +1,19 @@
-name: Auto-tag on version bump
+name: Create release tag
 
-# When the workspace version on `main` advances past the latest existing
-# `vX.Y.Z` tag, push the matching tag automatically. The push then triggers
-# `release.yml`, which runs parity, builds binaries, drafts the GitHub
-# Release, and publishes the npm wrapper.
+# Manual helper that creates `vX.Y.Z` from the current `main` workspace
+# version after the release source is frozen. This is intentionally not
+# triggered by every version bump on `main`: release prep can land before the
+# same-version issue/PR queue is truly empty, and an eager tag leaves later
+# same-version work outside the public release anchor.
 #
 # IMPORTANT: tag pushes signed by the default `GITHUB_TOKEN` do NOT trigger
 # downstream `on: push: tags` workflows (GitHub Actions safety rule). For
 # this auto-tag flow to actually fire `release.yml`, store a PAT (or
 # fine-grained token) with `contents: write` on this repo as the
 # `RELEASE_TAG_PAT` secret. Without it, the tag is created but `release.yml`
-# does NOT run automatically — you'd have to push the tag again manually
-# (`git push origin v$VERSION` from a developer machine) to trigger release.
+# does NOT run automatically; run `release.yml` manually for the version.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'Cargo.toml'
-      - 'npm/codewhale/package.json'
   workflow_dispatch:
 
 permissions:
@@ -38,6 +33,13 @@ jobs:
           # Prefer PAT so the resulting tag push triggers release.yml.
           # Falls back to GITHUB_TOKEN, which will tag but NOT trigger.
           token: ${{ secrets.RELEASE_TAG_PAT || github.token }}
+
+      - name: Require main dispatch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::Create release tags from main only; rerun this workflow with ref 'main'." >&2
+            exit 1
+          fi
 
       - name: Read workspace version
         id: ver
@@ -123,5 +125,5 @@ jobs:
           HAS_PAT: ${{ secrets.RELEASE_TAG_PAT != '' }}
         run: |
           if [ "${HAS_PAT}" != "true" ]; then
-            echo "::warning::RELEASE_TAG_PAT secret is not set. The tag was pushed using GITHUB_TOKEN, which does NOT trigger release.yml. Manually re-push the tag from a developer machine, or run 'gh workflow run release.yml --ref ${{ steps.ver.outputs.tag }}'."
+            echo "::warning::RELEASE_TAG_PAT secret is not set. The tag was pushed using GITHUB_TOKEN, which does NOT trigger release.yml. Run 'gh workflow run release.yml --ref main -f version=${{ steps.ver.outputs.version }}' after confirming the tag points at the intended main commit."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RUSTFLAGS: -Dwarnings
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,70 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  changes:
+    name: Change detection
+    runs-on: ubuntu-latest
+    outputs:
+      heavy: ${{ steps.detect.outputs.heavy }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Detect executable changes
+        id: detect
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "schedule" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "heavy=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          base=""
+          if [[ "${EVENT_NAME}" == "pull_request" && -n "${BASE_REF}" ]]; then
+            git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=1
+            base="origin/${BASE_REF}"
+          elif [[ -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            base="${BEFORE_SHA}"
+          fi
+
+          if [[ -z "${base}" ]]; then
+            echo "heavy=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          mapfile -t changed < <(git diff --name-only "${base}" "${GITHUB_SHA}" | sort)
+          heavy=false
+          for path in "${changed[@]}"; do
+            case "${path}" in
+              docs/*|*.md|.github/PULL_REQUEST_TEMPLATE.md|.github/ISSUE_TEMPLATE/*|.github/workflows/auto-tag.yml|.github/workflows/stale.yml|.github/workflows/triage.yml)
+                ;;
+              *)
+                heavy=true
+                ;;
+            esac
+          done
+
+          echo "heavy=${heavy}" >> "${GITHUB_OUTPUT}"
+
+          echo "Heavy Rust CI required: ${heavy}"
+          printf 'Changed files:\n'
+          printf '  %s\n' "${changed[@]}"
+
   versions:
     name: Version drift
     runs-on: ubuntu-latest
@@ -32,6 +91,8 @@ jobs:
 
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.heavy == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -49,6 +110,9 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Run clippy
@@ -82,6 +146,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.heavy == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -112,7 +178,8 @@ jobs:
 
   npm-wrapper-smoke:
     name: npm wrapper smoke
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.heavy == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -142,7 +209,8 @@ jobs:
 
   mobile-smoke:
     name: Mobile runtime smoke
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.heavy == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
         with:
           toolchain: '1.88'
           components: rustfmt, clippy
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - name: Install Linux system dependencies
         run: |
           for i in 1 2 3 4 5; do
@@ -159,6 +165,14 @@ jobs:
         if: runner.os != 'Linux'
       - uses: dtolnay/rust-toolchain@stable
         if: runner.os != 'Linux'
+      - uses: mozilla-actions/sccache-action@v0.0.10
+        if: runner.os != 'Linux'
+      - name: Enable sccache
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - uses: Swatinem/rust-cache@v2
         if: runner.os != 'Linux'
         with:
@@ -189,6 +203,14 @@ jobs:
         if: runner.os != 'Linux'
       - uses: dtolnay/rust-toolchain@stable
         if: runner.os != 'Linux'
+      - uses: mozilla-actions/sccache-action@v0.0.10
+        if: runner.os != 'Linux'
+      - name: Enable sccache
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - uses: actions/setup-node@v6
         if: runner.os != 'Linux'
         with:
@@ -215,6 +237,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - name: Install Linux system dependencies
         run: |
           for i in 1 2 3 4 5; do

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,66 +14,59 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RUSTFLAGS: -Dwarnings
   DEEPSEEK_BUILD_SHA: ${{ github.sha }}
 
 jobs:
   build:
-    name: Build ${{ matrix.artifact_name }}
+    name: Build ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # --- codewhale (cli dispatcher, canonical) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary: codewhale
-            artifact_name: codewhale-linux-x64
+            platform: linux-x64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-x64
+            tui_artifact: codewhale-tui-linux-x64
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            binary: codewhale
-            artifact_name: codewhale-linux-arm64
+            platform: linux-arm64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-arm64
+            tui_artifact: codewhale-tui-linux-arm64
           - os: ubuntu-latest
             target: riscv64gc-unknown-linux-gnu
-            binary: codewhale
-            artifact_name: codewhale-linux-riscv64
+            platform: linux-riscv64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-riscv64
+            tui_artifact: codewhale-tui-linux-riscv64
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary: codewhale
-            artifact_name: codewhale-macos-x64
+            platform: macos-x64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-macos-x64
+            tui_artifact: codewhale-tui-macos-x64
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary: codewhale
-            artifact_name: codewhale-macos-arm64
+            platform: macos-arm64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-macos-arm64
+            tui_artifact: codewhale-tui-macos-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary: codewhale.exe
-            artifact_name: codewhale-windows-x64.exe
-          # --- codewhale-tui (TUI runtime, canonical) ---
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-linux-x64
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-linux-arm64
-          - os: ubuntu-latest
-            target: riscv64gc-unknown-linux-gnu
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-linux-riscv64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-macos-x64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-macos-arm64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            binary: codewhale-tui.exe
-            artifact_name: codewhale-tui-windows-x64.exe
+            platform: windows-x64
+            cli_binary: codewhale.exe
+            tui_binary: codewhale-tui.exe
+            cli_artifact: codewhale-windows-x64.exe
+            tui_artifact: codewhale-tui-windows-x64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -83,6 +76,12 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install Rust target
         run: rustup target add --toolchain 1.88 ${{ matrix.target }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - uses: Swatinem/rust-cache@v2
         with:
           cache-bin: false
@@ -124,7 +123,7 @@ jobs:
           PKG_CONFIG_LIBDIR_riscv64gc_unknown_linux_gnu: /usr/lib/riscv64-linux-gnu/pkgconfig
         run: |
           for attempt in 1 2 3; do
-            if cargo build --release --locked --target ${{ matrix.target }}; then
+            if cargo build --release --locked --target ${{ matrix.target }} -p codewhale-cli -p codewhale-tui; then
               exit 0
             fi
             if [ "${attempt}" -lt 3 ]; then
@@ -139,24 +138,38 @@ jobs:
         shell: bash
         run: |
           short_sha="${GITHUB_SHA::12}"
-          bin_path="target/${{ matrix.target }}/release/${{ matrix.binary }}"
-          if [ ! -f "${bin_path}" ]; then
-            echo "Binary not at ${bin_path}; searching target/ for ${{ matrix.binary }}:"
-            find target -name "${{ matrix.binary }}" -type f
-            exit 1
-          fi
+          stage_one() {
+            local binary="$1"
+            local artifact="$2"
+            local dir="$3"
+            local bin_path="target/${{ matrix.target }}/release/${binary}"
+            if [ ! -f "${bin_path}" ]; then
+              echo "Binary not at ${bin_path}; searching target/ for ${binary}:"
+              find target -name "${binary}" -type f
+              exit 1
+            fi
 
-          mkdir -p nightly
-          cp "${bin_path}" "nightly/${{ matrix.artifact_name }}"
-          cat > nightly/nightly-build-info.txt <<INFO
+            mkdir -p "${dir}"
+            cp "${bin_path}" "${dir}/${artifact}"
+            cat > "${dir}/nightly-build-info.txt" <<INFO
           repository=${GITHUB_REPOSITORY}
           ref=${GITHUB_REF_NAME}
           commit=${GITHUB_SHA}
-          artifact=${{ matrix.artifact_name }}
+          artifact=${artifact}
           INFO
-          echo "name=${{ matrix.artifact_name }}-${short_sha}" >> "${GITHUB_OUTPUT}"
+          }
+
+          stage_one "${{ matrix.cli_binary }}" "${{ matrix.cli_artifact }}" nightly-cli
+          stage_one "${{ matrix.tui_binary }}" "${{ matrix.tui_artifact }}" nightly-tui
+          echo "cli_name=${{ matrix.cli_artifact }}-${short_sha}" >> "${GITHUB_OUTPUT}"
+          echo "tui_name=${{ matrix.tui_artifact }}-${short_sha}" >> "${GITHUB_OUTPUT}"
       - uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.stage.outputs.name }}
-          path: nightly/*
+          name: ${{ steps.stage.outputs.cli_name }}
+          path: nightly-cli/*
+          retention-days: 14
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.stage.outputs.tui_name }}
+          path: nightly-tui/*
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RUSTFLAGS: -Dwarnings
 
 jobs:
@@ -27,6 +28,12 @@ jobs:
         with:
           toolchain: '1.88'
           components: clippy, rustfmt
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -116,56 +123,48 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # --- codewhale (cli dispatcher, canonical) ---
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            binary: codewhale
-            artifact_name: codewhale-linux-x64
+            platform: linux-x64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-x64
+            tui_artifact: codewhale-tui-linux-x64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            binary: codewhale
-            artifact_name: codewhale-linux-arm64
+            platform: linux-arm64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-arm64
+            tui_artifact: codewhale-tui-linux-arm64
           - os: ubuntu-latest
             target: riscv64gc-unknown-linux-gnu
-            binary: codewhale
-            artifact_name: codewhale-linux-riscv64
+            platform: linux-riscv64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-riscv64
+            tui_artifact: codewhale-tui-linux-riscv64
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary: codewhale
-            artifact_name: codewhale-macos-x64
+            platform: macos-x64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-macos-x64
+            tui_artifact: codewhale-tui-macos-x64
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary: codewhale
-            artifact_name: codewhale-macos-arm64
+            platform: macos-arm64
+            cli_binary: codewhale
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-macos-arm64
+            tui_artifact: codewhale-tui-macos-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary: codewhale.exe
-            artifact_name: codewhale-windows-x64.exe
-          # --- codewhale-tui (TUI runtime, canonical) ---
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-linux-x64
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-linux-arm64
-          - os: ubuntu-latest
-            target: riscv64gc-unknown-linux-gnu
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-linux-riscv64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-macos-x64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            binary: codewhale-tui
-            artifact_name: codewhale-tui-macos-arm64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            binary: codewhale-tui.exe
-            artifact_name: codewhale-tui-windows-x64.exe
+            platform: windows-x64
+            cli_binary: codewhale.exe
+            tui_binary: codewhale-tui.exe
+            cli_artifact: codewhale-windows-x64.exe
+            tui_artifact: codewhale-tui-windows-x64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -177,6 +176,12 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install Rust target
         run: rustup target add --toolchain 1.88 ${{ matrix.target }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
       - uses: Swatinem/rust-cache@v2
         with:
           cache-bin: false
@@ -196,7 +201,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
           rustup target add --toolchain 1.88 x86_64-unknown-linux-musl
-          cargo build --release --locked --target x86_64-unknown-linux-musl
+          cargo build --release --locked --target x86_64-unknown-linux-musl -p codewhale-cli -p codewhale-tui
       - name: Install RISC-V cross-compilation toolchain
         if: matrix.target == 'riscv64gc-unknown-linux-gnu'
         run: |
@@ -244,21 +249,32 @@ jobs:
           PKG_CONFIG_ALLOW_CROSS: 1
           PKG_CONFIG_LIBDIR_aarch64_unknown_linux_gnu: /usr/lib/aarch64-linux-gnu/pkgconfig
           PKG_CONFIG_LIBDIR_riscv64gc_unknown_linux_gnu: /usr/lib/riscv64-linux-gnu/pkgconfig
-        run: cargo build --release --locked --target ${{ matrix.target }}
-      - name: Rename binary
+        run: cargo build --release --locked --target ${{ matrix.target }} -p codewhale-cli -p codewhale-tui
+      - name: Stage binaries
         shell: bash
         run: |
-          BIN_PATH="target/${{ matrix.target }}/release/${{ matrix.binary }}"
-          if [ ! -f "${BIN_PATH}" ]; then
-            echo "Binary not at ${BIN_PATH}; searching target/ for ${{ matrix.binary }}:"
-            find target -name "${{ matrix.binary }}" -type f
-            exit 1
-          fi
-          cp "${BIN_PATH}" "${{ matrix.artifact_name }}"
+          stage_binary() {
+            local binary="$1"
+            local artifact="$2"
+            local bin_path="target/${{ matrix.target }}/release/${binary}"
+            if [ ! -f "${bin_path}" ]; then
+              echo "Binary not at ${bin_path}; searching target/ for ${binary}:"
+              find target -name "${binary}" -type f
+              exit 1
+            fi
+            cp "${bin_path}" "${artifact}"
+          }
+
+          stage_binary "${{ matrix.cli_binary }}" "${{ matrix.cli_artifact }}"
+          stage_binary "${{ matrix.tui_binary }}" "${{ matrix.tui_artifact }}"
       - uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.artifact_name }}
+          name: ${{ matrix.cli_artifact }}
+          path: ${{ matrix.cli_artifact }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.tui_artifact }}
+          path: ${{ matrix.tui_artifact }}
 
   bundle:
     needs: [build, resolve]

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,8 +1,8 @@
 # Release Checklist
 
 A pre-tag checklist that the v0.8.21/v0.8.22 CHANGELOG gap proved we needed.
-Step through this in order from a clean worktree on the release branch
-(`work/vX.Y.Z-...`). Treat any unchecked box as a release blocker.
+Step through this in order from a clean worktree on the final release source.
+Treat any unchecked box as a release blocker.
 
 For deeper context on the underlying tools (preflight scripts, npm smoke,
 publish-crates), see [`RELEASE_RUNBOOK.md`](RELEASE_RUNBOOK.md).
@@ -10,6 +10,29 @@ For larger milestone releases, add any version-specific acceptance matrix to
 the release branch before tagging; use it for provider routes, feature gates,
 GUI/runtime smoke, remote-workbench decisions, and credit hygiene that the
 generic checklist does not enumerate.
+
+## 0. Release source is frozen
+
+- [ ] The live milestone and PR queue no longer contain work intended for this
+      version:
+      ```
+      gh issue list --repo Hmbown/CodeWhale --milestone "vX.Y.Z" --state open
+      gh pr list --repo Hmbown/CodeWhale --state open --limit 100
+      ```
+- [ ] Any remaining same-theme work is explicitly retargeted to a later
+      version or called out as a known issue. Do not bump/tag while still
+      planning to merge more same-version fixes.
+- [ ] The release tag does not already point at an older source SHA, or the
+      maintainer has deliberately chosen to publish exactly that older SHA:
+      ```
+      git ls-remote origin refs/heads/main refs/tags/vX.Y.Z
+      gh release view vX.Y.Z --repo Hmbown/CodeWhale
+      ./scripts/release/check-published.sh X.Y.Z
+      ```
+- [ ] If `vX.Y.Z` exists with no GitHub Release/packages and `main` has moved
+      on, stop. Choose one of: publish the existing tag as-is, bump the later
+      work to the next patch version, or explicitly approve deleting/recreating
+      the unpublished tag. Do not silently move tags during PR cleanup.
 
 ## 1. CHANGELOG entry exists for the version
 
@@ -144,8 +167,9 @@ release anxiety: contributors cannot tell whether their work merged.
       `git switch main && git fetch origin main && git merge --ff-only origin/main`
 - [ ] The release source is reachable from `main`:
       `./scripts/release/ensure-release-on-main.sh HEAD`
-- [ ] `git tag -s vX.Y.Z -m "vX.Y.Z"`
-- [ ] `git push origin vX.Y.Z`
+- [ ] Create `vX.Y.Z` from the final `main` SHA using the **Create release tag**
+      workflow, or create and push a signed local tag:
+      `git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
 - [ ] The `release.yml` workflow has built and uploaded artifacts to the
       GitHub release for this tag.
 - [ ] The live GitHub Release body has its own `## Contributors` or

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -38,6 +38,35 @@ Current packaging note:
   - leave `codewhaleBinaryVersion` pinned to the previously released Rust binaries
   - rerun `npm pack` smoke checks before `npm publish`
 
+## Release Source Timing
+
+Freeze the source before creating a public `vX.Y.Z` tag. The version bump is
+not the release; it is the last source-prep commit before the tag. Do not keep
+merging same-version feature/fix PRs after `vX.Y.Z` exists and assume the
+release workflow will pick them up. It will not: the tag is the release anchor.
+
+Before tagging, verify the live queue and existing anchors:
+
+```bash
+gh issue list --repo Hmbown/CodeWhale --milestone "vX.Y.Z" --state open
+gh pr list --repo Hmbown/CodeWhale --state open --limit 100
+git ls-remote origin refs/heads/main refs/tags/vX.Y.Z
+gh release view vX.Y.Z --repo Hmbown/CodeWhale
+./scripts/release/check-published.sh X.Y.Z
+```
+
+If a same-version tag already exists but there is no GitHub Release and nothing
+is published, stop and choose deliberately:
+
+- publish exactly the tagged SHA, leaving later commits for the next patch;
+- bump the later work to the next patch version and tag that later SHA; or
+- with explicit maintainer approval only, delete/recreate the unpublished tag
+  after confirming no package, GitHub Release, mirror, or installer consumer has
+  treated it as public.
+
+Do not delete, move, or recreate a release tag implicitly as part of ordinary
+PR merge or milestone cleanup work.
+
 ## Preflight
 
 Run these from the repository root before cutting a tag:
@@ -143,10 +172,9 @@ configured.
 
 Release commits must land on `main` before any `vX.Y.Z` tag is pushed. Do not
 tag a release-only branch. Open the release PR against `main`, let required
-review and CI finish, merge it, then tag the commit that is reachable from
-`main` or let `auto-tag.yml` create that tag after the version bump reaches
-`main`. This is what lets GitHub process `Closes #N` lines automatically and
-show the release PR as merged. The tag release workflow runs
+review and CI finish, merge it, then explicitly tag the final source commit
+that is reachable from `main`. This is what lets GitHub process `Closes #N`
+lines automatically and show the release PR as merged. The tag release workflow runs
 `scripts/release/ensure-release-on-main.sh` for tag pushes and manual dispatches,
 and fails branch-only release sources before assets are published.
 
@@ -156,10 +184,11 @@ and fails branch-only release sources before assets are published.
    install tags), refreshes the lockfile and generated files, and runs
    `check-versions.sh`.
 2. Run `./scripts/release/publish-crates.sh dry-run` locally; it must be clean.
-3. Merge the release PR into `main` before tagging. The normal path is to push
-   the version bump PR to `main` and let `auto-tag.yml` create `vX.Y.Z` from the
-   main commit; see the npm wrapper release section below for the
-   `RELEASE_TAG_PAT` requirement.
+3. Merge the release PR into `main` before tagging. After the same-version
+   queue is frozen and `main` is at the intended source SHA, create `vX.Y.Z`
+   from `main` with the manual **Create release tag** workflow or with a signed
+   local tag push from a developer machine. See the npm wrapper release section
+   below for the `RELEASE_TAG_PAT` / manual release dispatch caveat.
 4. Publish crates in this order with `./scripts/release/publish-crates.sh publish`:
    - `codewhale-mcp`
    - `codewhale-protocol`
@@ -208,7 +237,9 @@ on a workstation with `npm login` and an authenticator app.
 
 1. Set the npm package version in [npm/codewhale/package.json](../npm/codewhale/package.json) to match the workspace `Cargo.toml`. CI's version-drift guard will catch mismatches before tag.
 2. Set `codewhaleBinaryVersion` to the GitHub release tag that should supply binaries.
-3. Push the version bump to `main`. `auto-tag.yml` creates the matching `vX.Y.Z` tag, and `release.yml` builds the binary matrix and drafts the GitHub Release.
+3. Push the version bump to `main`. After the release source is frozen, create
+   the matching `vX.Y.Z` tag from `main`; `release.yml` then builds the binary
+   matrix and drafts the GitHub Release.
 4. **Wait for the GitHub Release to finalize** with all eight signed binaries plus `codewhale-artifacts-sha256.txt`. The npm `prepublishOnly` hook (`scripts/verify-release-assets.js`) requires every asset to be present.
 5. From a developer machine, publish the npm wrapper manually:
 

--- a/docs/V0865_RELEASE_LEDGER.md
+++ b/docs/V0865_RELEASE_LEDGER.md
@@ -18,9 +18,13 @@ reporter/user-facing items into v0.8.65 after the PR queue was cleared:
 `docs/V0865_REMAINING_AGENT_PROMPT.md` is the focused handoff prompt for the
 next agent.
 
-The release is not publicly shipped from this ledger alone. The latest public
-ship state still has to be verified at release time by Hunter before any tag,
-package publish, GitHub Release, or deploy.
+The release is not publicly shipped from this ledger alone. Live truth on
+2026-06-24: `refs/tags/v0.8.65` exists at `f1f79827128f28489eb852596d5f8df971370f29`,
+but there is no GitHub Release for `v0.8.65`, and `./scripts/release/check-published.sh 0.8.65`
+reports npm plus all `codewhale-*` crates unpublished. `origin/main` has moved
+past that tag. Do not claim a final `0.8.65` public candidate includes post-tag
+commits until Hunter chooses whether to publish the existing tag, retag the
+unpublished release anchor, or move the remaining work to the next patch.
 
 ## PR Queue
 
@@ -29,7 +33,9 @@ package publish, GitHub Release, or deploy.
 | #3559 | Merged | Harvested @cy2311's zh-Hans JSON extraction, completed current localization coverage, moved the visible details shortcut to bare `v`, added the AUTHOR_MAP entry required by the harvest gate, and removed the stale internal `AltV` message id. Merge: `a7285ea5a2743d28d0c4bb4154526d0e727ac2fe`. |
 | #3560 | Merged | Finished the remaining harness-profile split by moving built-in harness seeds and private matching helpers into `crates/config/src/harness.rs` while preserving crate-root exports. Merge: `ec29998cce511047f0a237f2be4d95e9c5108a05`. |
 | #3561 | Merged | Harvested shared `integrations/bridge-core` helpers, patched review findings, and verified bridge-core plus Telegram, Feishu, WeCom, and Weixin checks/tests locally. Merge: `ead5165d433a3422625f55e0934443b50faad165`. |
-| #3493 | Open ledger PR | This document plus the remaining-agent prompt. It is the only open v0.8.65 PR after the non-ledger PR closeout. |
+| #3493 | Merged | Release ledger and remaining-agent prompt landed on `main`. Merge: `370bc45f345030f6a11c441e2a2a45b16fb3f63c`. |
+| #3562 | Open draft | Passive MCP discovery for #3461 plus configured custom provider rows for #1519. CI was green when reviewed on 2026-06-24, but the release-source/tag decision should be resolved before merging more same-version work. |
+| #3563 | Open draft | Factual model reference database and read-only `/modeldb` label browser for #3205/#2300. This is a labeling slice only, not Fleet loadout-auto completion. |
 | #3549 | Merged/auto-associated through #3559 | GitHub marked the original contributor PR merged by the replacement merge commit; final evidence comment posted. |
 | #3506 | Closed by #3560 | Final evidence comment posted. |
 | #3432 | Merged/auto-associated through #3561 | GitHub marked the original draft PR merged by the replacement merge commit; final evidence comment posted. |
@@ -94,12 +100,14 @@ Moved out of v0.8.65:
 
 ## Required Closeout
 
-1. Use `docs/V0865_REMAINING_AGENT_PROMPT.md` to hand the four remaining
-   v0.8.65 issues to the next implementation agent.
-2. Merge #3493 when its docs-only checks are green if the handoff ledger is
-   useful on `main`.
-3. After #3461, #3205, #2300, and #1519 are merged or clearly resolved, update
-   this ledger again with the actual closeout evidence.
+1. Resolve the release-source mismatch before merging more same-version work:
+   `v0.8.65` is already tagged, but `main` has advanced and no public release
+   exists.
+2. Use `docs/V0865_REMAINING_AGENT_PROMPT.md` to hand the four remaining
+   v0.8.65 issues to the next implementation agent only after deciding whether
+   those issues remain in `0.8.65` or move to the next patch.
+3. After #3461, #3205, #2300, and #1519 are merged, retargeted, or clearly
+   resolved, update this ledger again with the actual closeout evidence.
 4. Hunter may perform the separate release-owner actions: final release
    verification, version/tag/package/GitHub Release/publish/deploy decisions.
 


### PR DESCRIPTION
## Summary

- make the release tag helper manual-only instead of auto-tagging every version bump on `main`
- document the source-freeze check before tagging, including what to do when a same-version tag exists but no release/packages are public
- update the v0.8.65 ledger with the live tag/publish mismatch so agents stop treating post-tag commits as already included in the public release anchor
- add CI change detection so docs/process-only diffs keep required check names but skip expensive Rust/macOS/Windows/mobile/npm-smoke gates
- cancel superseded CI runs for the same PR
- add `Swatinem/rust-cache` to the lint job and enable `mozilla-actions/sccache-action` for Rust-heavy PR jobs
- enable sccache for release/nightly Rust builds and disable Cargo incremental compilation in CI for cleaner compiler-output caching
- halve release/nightly Rust build fanout by building `codewhale-cli` and `codewhale-tui` together once per target while preserving the existing public artifact names

## Testing

- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/nightly.yml .github/workflows/auto-tag.yml`
- [x] `./scripts/release/check-versions.sh`
- [ ] `cargo fmt --all -- --check` (not run locally; workflow-only change)
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run locally; CI workflow change is validated by GitHub Actions on this PR)
- [ ] `cargo test --workspace --all-features` (not run locally; CI workflow change is validated by GitHub Actions on this PR)

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant (not applicable; workflow/docs timing and CI routing change)
- [ ] Verified TUI behavior manually if UI changes (not applicable)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable)
