### PR TITLE
[codex] Address context window review feedback

### DIFF
--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -75,6 +75,7 @@ pub(super) fn effective_max_output_tokens_for_route(
     };
     u32::try_from(ContextBudget::new(u64::from(window), 0, u64::from(cap)).output_cap_tokens)
         .unwrap_or(cap)
+        .max(1)
 }
 /// Keep this many most recent messages when emergency trimming is required.
 pub(super) const MIN_RECENT_MESSAGES_TO_KEEP: usize = 4;

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3231,6 +3231,21 @@ fn effective_max_output_tokens_for_route_caps_to_context_window() {
 }
 
 #[test]
+fn effective_max_output_tokens_for_route_keeps_tiny_window_positive() {
+    let _lock = lock_test_env();
+    let limits = codewhale_config::route::RouteLimits {
+        context_tokens: Some(2_048),
+        input_tokens: None,
+        output_tokens: None,
+    };
+
+    assert_eq!(
+        effective_max_output_tokens_for_route("deepseek-v4-pro", Some(limits)),
+        1
+    );
+}
+
+#[test]
 fn effective_max_output_tokens_caps_api_request_for_large_window_models() {
     // Serialize with other tests that mutate DEEPSEEK_MAX_OUTPUT_TOKENS so
     // v4_cap and flash_cap below see the same env state.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1508,6 +1508,7 @@ pub(crate) struct PendingProviderSwitch {
     pub previous_model: String,
     pub previous_model_ids_passthrough: bool,
     pub previous_route_limits: Option<RouteLimits>,
+    pub previous_context_window_override: Option<u32>,
     pub previous_config: Config,
     pub previous_onboarding: OnboardingState,
     pub previous_onboarding_needs_api_key: bool,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5511,6 +5511,7 @@ fn rollback_provider_after_auth_failure(app: &mut App, config: &mut Config) -> O
         previous_model,
         previous_model_ids_passthrough,
         previous_route_limits,
+        previous_context_window_override,
         previous_config,
         previous_onboarding,
         previous_onboarding_needs_api_key,
@@ -5523,6 +5524,7 @@ fn rollback_provider_after_auth_failure(app: &mut App, config: &mut Config) -> O
     app.provider_models
         .insert(previous_provider.as_str().to_string(), previous_model);
     app.model_ids_passthrough = previous_model_ids_passthrough;
+    app.active_context_window_override = previous_context_window_override;
     app.active_route_limits = previous_route_limits;
     app.update_model_compaction_budget();
     app.clear_model_scoped_telemetry();
@@ -6715,6 +6717,7 @@ async fn switch_provider(
         previous_model: previous_model.clone(),
         previous_model_ids_passthrough,
         previous_route_limits: app.active_route_limits,
+        previous_context_window_override: app.active_context_window_override,
         previous_config: previous_config.clone(),
         previous_onboarding: app.onboarding,
         previous_onboarding_needs_api_key: app.onboarding_needs_api_key,

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -9287,6 +9287,7 @@ async fn provider_switch_auth_error_restores_previous_provider_and_model() {
     app.onboarding = OnboardingState::None;
     app.onboarding_needs_api_key = false;
     app.api_key_env_only = true;
+    app.active_context_window_override = Some(1_000_000);
     let mut engine = mock_engine_handle();
     let mut config = Config {
         provider: Some("deepseek".to_string()),
@@ -9295,10 +9296,12 @@ async fn provider_switch_auth_error_restores_previous_provider_and_model() {
         providers: Some(ProvidersConfig {
             deepseek: ProviderConfig {
                 api_key: Some("deepseek-key".to_string()),
+                context_window: Some(1_000_000),
                 ..Default::default()
             },
             moonshot: ProviderConfig {
                 api_key: Some("kimi-key".to_string()),
+                context_window: Some(262_144),
                 ..Default::default()
             },
             ..Default::default()
@@ -9315,6 +9318,7 @@ async fn provider_switch_auth_error_restores_previous_provider_and_model() {
     )
     .await;
     assert_eq!(app.api_provider, ApiProvider::Moonshot);
+    assert_eq!(app.active_context_window_override, Some(262_144));
     assert_eq!(config.provider.as_deref(), Some("moonshot"));
     assert!(app.pending_provider_switch.is_some());
 
@@ -9327,6 +9331,7 @@ async fn provider_switch_auth_error_restores_previous_provider_and_model() {
 
     assert_eq!(app.api_provider, ApiProvider::Deepseek);
     assert_eq!(app.model, "deepseek-v4-pro");
+    assert_eq!(app.active_context_window_override, Some(1_000_000));
     assert!(!app.model_ids_passthrough);
     assert!(!app.offline_mode);
     assert_eq!(app.onboarding, OnboardingState::None);


### PR DESCRIPTION
## Summary

Follow-up to #3573 after Codex cloud review found two edge cases:

- keep route-derived `max_tokens` positive when a configured context window is tiny enough for `ContextBudget` to clamp output to zero
- restore `active_context_window_override` when provider-switch auth rollback restores the previous provider and route limits

The original provider `context_window` feature for #3545 was already merged in #3573; this PR carries only the cloud-review fixes that landed locally after that PR was merged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked effective_max_output_tokens_for_route`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_switch_auth_error_restores_previous_provider_and_model`
- `cargo test --workspace --locked`
- `git diff --check`

## Review feedback addressed

- Resolved #3573 Codex thread: keep tiny context overrides from sending zero `max_tokens`
- Resolved #3573 Codex thread: restore context override on provider rollback