### PR TITLE
fix(tools): make js_execution fetch honor proxy env vars (#3273)

### DIFF
--- a/crates/tui/src/tools/js_execution.rs
+++ b/crates/tui/src/tools/js_execution.rs
@@ -89,6 +89,17 @@ pub async fn execute_js_execution_tool(
     })?;
     cmd.arg(&script_path).current_dir(workspace);
 
+    // #3273: Node's built-in `fetch` (undici) ignores HTTP(S)_PROXY env vars
+    // unless `NODE_USE_ENV_PROXY` is set (Node >= 24). This child already
+    // inherits CodeWhale's proxy environment, so enabling the flag lets
+    // `js_execution`'s `fetch()` reach the network through the same proxy/VPN
+    // as the rest of the app and honor `NO_PROXY`. Only default it on when the
+    // user hasn't chosen a value, so an explicit opt-out (`NODE_USE_ENV_PROXY=0`)
+    // still wins. No-op on Node < 24, which ignores the unknown variable.
+    if std::env::var_os("NODE_USE_ENV_PROXY").is_none() {
+        cmd.env("NODE_USE_ENV_PROXY", "1");
+    }
+
     let output = tokio::time::timeout(Duration::from_secs(120), cmd.output())
         .await
         .map_err(|_| ToolError::Timeout { seconds: 120 })
@@ -183,6 +194,31 @@ mod tests {
         assert!(
             result.content.contains("intentional fail"),
             "stderr payload must surface the error message; got {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_js_enables_env_proxy_so_fetch_honors_proxy_vars() {
+        if !node_present() {
+            return;
+        }
+        // The tool defers to an explicit caller choice; only assert the
+        // default-on behavior when the surrounding env hasn't set it.
+        if std::env::var_os("NODE_USE_ENV_PROXY").is_some() {
+            return;
+        }
+        let tmp = tempdir().expect("tempdir");
+        let result = execute_js_execution_tool(
+            &json!({ "code": "process.stdout.write(String(process.env.NODE_USE_ENV_PROXY))" }),
+            tmp.path(),
+        )
+        .await
+        .expect("execute");
+        assert!(
+            result.content.contains("\"stdout\":\"1\""),
+            "#3273: js_execution must default NODE_USE_ENV_PROXY=1 so Node's fetch \
+             routes through HTTP(S)_PROXY; got {}",
             result.content
         );
     }


### PR DESCRIPTION
## Problem

Fixes #3273 — on a host with a local proxy/VPN, `js_execution` can't reach the network even though CodeWhale config and the shell both have `HTTP_PROXY`/`HTTPS_PROXY` set. `fetch()` times out with an Undici connect error, while the shell tools reach the same URL fine.

## Root cause

Node's built-in `fetch` (undici) **ignores** `HTTP_PROXY`/`HTTPS_PROXY` environment variables by default. It only honors them when `NODE_USE_ENV_PROXY` is set (equivalent to `--use-env-proxy`, Node ≥ 24). `js_execution` spawns `node script.js` inheriting CodeWhale's environment — so the proxy variables *are* present in the child, but Node's `fetch` never consults them.

Verified locally (Node 26):

```
# proxy env honored only with the flag → connection goes to the (dead) proxy port
$ HTTPS_PROXY=http://127.0.0.1:9 NODE_USE_ENV_PROXY=1 node -e "fetch('https://example.com').catch(e=>console.log(e.cause.code, e.cause.port))"
ECONNREFUSED 9
# without it → fetch ignores the proxy and connects directly
$ HTTPS_PROXY=http://127.0.0.1:9 node -e "fetch('https://example.com').then(r=>console.log(r.status))"
200
```

## Fix

Default `NODE_USE_ENV_PROXY=1` on the `js_execution` Node child so its `fetch()` uses the same `HTTP(S)_PROXY` (and honors `NO_PROXY`) as the rest of CodeWhale. Only defaulted when the variable is unset, so an explicit `NODE_USE_ENV_PROXY=0` opt-out still wins. It's a no-op on Node < 24 (the variable is simply ignored), so it's safe across versions — the proper fix for the reporter's Node 22 would be upgrading to Node ≥ 24, but this removes the CodeWhale-side gap for every Node that supports it.

## Testing

- New test `execute_js_enables_env_proxy_so_fetch_honors_proxy_vars` spawns the Node child and asserts it sees `NODE_USE_ENV_PROXY=1` (skipped when Node is absent or the caller already set the variable).
- `cargo clippy -p codewhale-tui --all-features` clean; `cargo test -p codewhale-tui --all-features js_execution` green.
