### PR TITLE
[codex] preserve Windows SDK env roots for shell

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -100,4 +100,4 @@ objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSDictionary", "NSError", "NSObject", "NSString", "NSURL"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Media_Audio", "Win32_Security", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Media_Audio", "Win32_Security", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_Environment", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }

--- a/crates/tui/src/child_env.rs
+++ b/crates/tui/src/child_env.rs
@@ -3,6 +3,20 @@
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 
+#[cfg(windows)]
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+#[cfg(windows)]
+use windows::Win32::Foundation::{ERROR_MORE_DATA, ERROR_NO_MORE_ITEMS, ERROR_SUCCESS};
+#[cfg(windows)]
+use windows::Win32::System::Environment::ExpandEnvironmentStringsW;
+#[cfg(windows)]
+use windows::Win32::System::Registry::{
+    HKEY, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ, REG_EXPAND_SZ, REG_SZ, REG_VALUE_TYPE,
+    RegCloseKey, RegEnumValueW, RegOpenKeyExW,
+};
+#[cfg(windows)]
+use windows::core::{PCWSTR, PWSTR};
+
 /// Convert a string env map into owned OS strings for child env helpers.
 pub fn string_map_env(
     env: &HashMap<String, String>,
@@ -23,10 +37,10 @@ where
     V: AsRef<OsStr>,
 {
     let mut env = Vec::new();
+    #[cfg(windows)]
+    append_sanitized_child_env_candidates(&mut env, windows_registry_env_vars());
     for (key, value) in std::env::vars_os() {
-        if is_allowed_parent_env_key(&key) {
-            upsert_env(&mut env, key, value);
-        }
+        append_sanitized_child_env_candidate(&mut env, key, value);
     }
     for (key, value) in overrides {
         upsert_env(
@@ -205,6 +219,43 @@ fn is_allowed_parent_env_key(key: &OsStr) -> bool {
         // DOTNET_NOLOGO, DOTNET_CLI_TELEMETRY_OPTOUT, …). Paths and flags
         // only — no secret-shaped values (#1857).
         || normalized.starts_with("DOTNET_")
+        || is_allowed_platform_path_like_child_env_key(&normalized)
+}
+
+#[cfg(windows)]
+fn is_allowed_platform_path_like_child_env_key(normalized: &str) -> bool {
+    is_allowed_path_like_child_env_key(normalized)
+}
+
+#[cfg(not(windows))]
+fn is_allowed_platform_path_like_child_env_key(_normalized: &str) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn is_allowed_path_like_child_env_key(normalized: &str) -> bool {
+    if is_secret_like_child_env_key(normalized) {
+        return false;
+    }
+    normalized.ends_with("_ROOT")
+        || normalized.ends_with("_DIR")
+        || normalized.ends_with("_HOME")
+        || normalized.ends_with("_PATH")
+        || normalized.ends_with("_PATHS")
+        || normalized.ends_with("SDKROOT")
+}
+
+#[cfg(windows)]
+fn is_secret_like_child_env_key(normalized: &str) -> bool {
+    normalized.contains("SECRET")
+        || normalized.contains("TOKEN")
+        || normalized.contains("PASSWORD")
+        || normalized.contains("PASSWD")
+        || normalized.contains("CREDENTIAL")
+        || normalized.contains("API_KEY")
+        || normalized.contains("ACCESS_KEY")
+        || normalized.contains("PRIVATE_KEY")
+        || normalized.ends_with("_KEY")
 }
 
 /// Allowlist for MCP stdio launches. Strict superset of
@@ -265,10 +316,173 @@ fn is_allowed_mcp_env_key(key: &OsStr) -> bool {
     false
 }
 
+#[cfg(windows)]
+fn append_sanitized_child_env_candidates<I, K, V>(
+    env: &mut Vec<(OsString, OsString)>,
+    candidates: I,
+) where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<OsString>,
+    V: Into<OsString>,
+{
+    for (key, value) in candidates {
+        append_sanitized_child_env_candidate(env, key.into(), value.into());
+    }
+}
+
+fn append_sanitized_child_env_candidate(
+    env: &mut Vec<(OsString, OsString)>,
+    key: OsString,
+    value: OsString,
+) {
+    if is_allowed_parent_env_key(&key) {
+        upsert_env(env, key, value);
+    }
+}
+
 fn upsert_env(env: &mut Vec<(OsString, OsString)>, key: OsString, value: OsString) {
     let normalized = normalize_key(&key);
     env.retain(|(existing, _)| normalize_key(existing) != normalized);
     env.push((key, value));
+}
+
+#[cfg(windows)]
+fn windows_registry_env_vars() -> Vec<(OsString, OsString)> {
+    let mut env = Vec::new();
+    append_windows_registry_env_key(
+        &mut env,
+        HKEY_LOCAL_MACHINE,
+        r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+    );
+    append_windows_registry_env_key(&mut env, HKEY_CURRENT_USER, "Environment");
+    env
+}
+
+#[cfg(windows)]
+fn append_windows_registry_env_key(env: &mut Vec<(OsString, OsString)>, root: HKEY, subkey: &str) {
+    let mut key = HKEY::default();
+    let subkey_wide = windows_wide_null(OsStr::new(subkey));
+    let open =
+        unsafe { RegOpenKeyExW(root, PCWSTR(subkey_wide.as_ptr()), None, KEY_READ, &mut key) };
+    if open != ERROR_SUCCESS {
+        return;
+    }
+
+    let mut index = 0;
+    loop {
+        match read_windows_registry_env_value(key, index) {
+            RegistryEnvValue::Value(name, value) => {
+                upsert_env(env, name, value);
+                index += 1;
+            }
+            RegistryEnvValue::Skip => {
+                index += 1;
+            }
+            RegistryEnvValue::Done => break,
+        }
+    }
+
+    let _ = unsafe { RegCloseKey(key) };
+}
+
+#[cfg(windows)]
+enum RegistryEnvValue {
+    Value(OsString, OsString),
+    Skip,
+    Done,
+}
+
+#[cfg(windows)]
+fn read_windows_registry_env_value(key: HKEY, index: u32) -> RegistryEnvValue {
+    let mut name = vec![0u16; 32_767];
+    let mut data = vec![0u8; 65_536];
+
+    loop {
+        let mut name_len = name.len() as u32;
+        let mut data_len = data.len() as u32;
+        let mut value_type = 0u32;
+        let status = unsafe {
+            RegEnumValueW(
+                key,
+                index,
+                Some(PWSTR(name.as_mut_ptr())),
+                &mut name_len,
+                None,
+                Some(&mut value_type),
+                Some(data.as_mut_ptr()),
+                Some(&mut data_len),
+            )
+        };
+
+        if status == ERROR_NO_MORE_ITEMS {
+            return RegistryEnvValue::Done;
+        }
+        if status == ERROR_MORE_DATA && resize_registry_data_buffer(&mut data, data_len) {
+            continue;
+        }
+        if status != ERROR_SUCCESS {
+            return RegistryEnvValue::Skip;
+        }
+        if value_type != REG_SZ.0 && value_type != REG_EXPAND_SZ.0 {
+            return RegistryEnvValue::Skip;
+        }
+
+        let name = OsString::from_wide(&name[..name_len as usize]);
+        let value = registry_utf16_value_from_bytes(&data[..data_len as usize]);
+        let value = if REG_VALUE_TYPE(value_type) == REG_EXPAND_SZ {
+            expand_windows_env_string(&value).unwrap_or(value)
+        } else {
+            value
+        };
+        return RegistryEnvValue::Value(name, value);
+    }
+}
+
+#[cfg(windows)]
+fn resize_registry_data_buffer(data: &mut Vec<u8>, required_len: u32) -> bool {
+    let Ok(required_len) = usize::try_from(required_len) else {
+        return false;
+    };
+    if required_len <= data.len() {
+        return false;
+    }
+    data.resize(required_len, 0);
+    true
+}
+
+#[cfg(windows)]
+fn registry_utf16_value_from_bytes(data: &[u8]) -> OsString {
+    let mut wide = data
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect::<Vec<_>>();
+    while wide.last() == Some(&0) {
+        wide.pop();
+    }
+    OsString::from_wide(&wide)
+}
+
+#[cfg(windows)]
+fn expand_windows_env_string(value: &OsStr) -> Option<OsString> {
+    let src = windows_wide_null(value);
+    let required_len = unsafe { ExpandEnvironmentStringsW(PCWSTR(src.as_ptr()), None) };
+    if required_len == 0 {
+        return None;
+    }
+
+    let mut expanded = vec![0u16; required_len as usize];
+    let written = unsafe { ExpandEnvironmentStringsW(PCWSTR(src.as_ptr()), Some(&mut expanded)) };
+    if written == 0 || written > required_len {
+        return None;
+    }
+
+    let len = usize::try_from(written).ok()?.saturating_sub(1);
+    Some(OsString::from_wide(&expanded[..len]))
+}
+
+#[cfg(windows)]
+fn windows_wide_null(value: &OsStr) -> Vec<u16> {
+    value.encode_wide().chain(std::iter::once(0)).collect()
 }
 
 #[cfg(any(windows, test))]
@@ -434,6 +648,125 @@ mod tests {
             !is_allowed_parent_env_key(OsStr::new("NuGetPackageSourceCredentials_feed")),
             "NuGet credential vars must not be exported to child processes"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn child_env_allowlist_includes_custom_path_like_vars_without_secrets() {
+        // #3572: SDK/toolchain roots created through Windows Environment
+        // Variables are often project-specific and cannot be exhaustively
+        // named in the static allowlist.
+        for key in [
+            "BIMRV_SDK_ROOT",
+            "ACME_TOOLCHAIN_HOME",
+            "PROJECT_SDK_DIR",
+            "CMAKE_PREFIX_PATH",
+            "ANDROID_SDKROOT",
+        ] {
+            assert!(
+                is_allowed_parent_env_key(OsStr::new(key)),
+                "child env allowlist should include path-like key {key}"
+            );
+        }
+
+        for key in [
+            "OPENAI_API_KEY",
+            "GITHUB_TOKEN",
+            "MY_SECRET_ROOT",
+            "SERVICE_PASSWORD_DIR",
+            "AWS_ACCESS_KEY_ID",
+            "PRIVATE_KEY_PATH",
+            "NuGetPackageSourceCredentials_feed",
+        ] {
+            assert!(
+                !is_allowed_parent_env_key(OsStr::new(key)),
+                "secret-like key {key} must not be exported to child processes"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sanitized_child_env_preserves_custom_sdk_root_vars() {
+        let _guard = env_lock().lock().expect("env lock");
+        let previous_sdk = std::env::var_os("BIMRV_SDK_ROOT");
+        let previous_secret = std::env::var_os("MY_SECRET_ROOT");
+        unsafe {
+            std::env::set_var("BIMRV_SDK_ROOT", r"F:\Lib\BimRv27.5");
+            std::env::set_var("MY_SECRET_ROOT", r"F:\Secrets");
+        }
+
+        let env = sanitized_child_env(std::iter::empty::<(OsString, OsString)>());
+
+        unsafe {
+            match previous_sdk {
+                Some(value) => std::env::set_var("BIMRV_SDK_ROOT", value),
+                None => std::env::remove_var("BIMRV_SDK_ROOT"),
+            }
+            match previous_secret {
+                Some(value) => std::env::set_var("MY_SECRET_ROOT", value),
+                None => std::env::remove_var("MY_SECRET_ROOT"),
+            }
+        }
+
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == "BIMRV_SDK_ROOT" && value == r"F:\Lib\BimRv27.5"),
+            "child env should preserve custom SDK roots"
+        );
+        assert!(
+            env.iter().all(|(key, _)| key != "MY_SECRET_ROOT"),
+            "secret-like path vars must still be dropped"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_registry_env_candidates_preserve_custom_sdk_roots() {
+        use windows::Win32::System::Registry::{
+            HKEY_CURRENT_USER, REG_SZ, RegCreateKeyW, RegDeleteTreeW, RegSetValueExW,
+        };
+
+        let subkey = format!(r"Software\CodeWhaleTest\child_env_{}", std::process::id());
+        let subkey_wide = windows_wide_null(OsStr::new(&subkey));
+        let mut key = HKEY::default();
+        let created =
+            unsafe { RegCreateKeyW(HKEY_CURRENT_USER, PCWSTR(subkey_wide.as_ptr()), &mut key) };
+        assert_eq!(created, ERROR_SUCCESS);
+
+        set_registry_string_value(key, "BIMRV_SDK_ROOT", r"F:\Lib\BimRv27.5");
+        set_registry_string_value(key, "MY_SECRET_ROOT", r"F:\Secrets");
+        let _ = unsafe { RegCloseKey(key) };
+
+        let mut candidates = Vec::new();
+        append_windows_registry_env_key(&mut candidates, HKEY_CURRENT_USER, &subkey);
+        let mut env = Vec::new();
+        append_sanitized_child_env_candidates(&mut env, candidates);
+
+        let _ = unsafe { RegDeleteTreeW(HKEY_CURRENT_USER, PCWSTR(subkey_wide.as_ptr())) };
+
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == "BIMRV_SDK_ROOT" && value == r"F:\Lib\BimRv27.5"),
+            "registry child env should preserve custom SDK roots"
+        );
+        assert!(
+            env.iter().all(|(key, _)| key != "MY_SECRET_ROOT"),
+            "secret-like registry vars must still be dropped"
+        );
+
+        fn set_registry_string_value(key: HKEY, name: &str, value: &str) {
+            let name_wide = windows_wide_null(OsStr::new(name));
+            let data = value
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .flat_map(u16::to_le_bytes)
+                .collect::<Vec<_>>();
+            let status = unsafe {
+                RegSetValueExW(key, PCWSTR(name_wide.as_ptr()), None, REG_SZ, Some(&data))
+            };
+            assert_eq!(status, ERROR_SUCCESS);
+        }
     }
 
     #[test]

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -9,13 +9,11 @@ use windows::Win32::Foundation::{DUPLICATE_HANDLE_OPTIONS, DuplicateHandle, HAND
 #[cfg(windows)]
 use windows::Win32::System::Threading::GetCurrentProcess;
 
-// `env_lock` exists only to serialize Unix-only env-mutating tests.
-// Windows builds gate that test out, so the helper would be dead code
-// under `-Dwarnings` if the import + helper were unconditional.
-#[cfg(unix)]
+// `env_lock` serializes tests that mutate the process environment.
+#[cfg(any(unix, windows))]
 use std::sync::{Mutex, OnceLock};
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -459,6 +457,58 @@ fn shell_execution_scrubs_parent_env_and_keeps_explicit_env() {
 
     assert_eq!(result.status, ShellStatus::Completed);
     assert_eq!(result.stdout, "unset\nexplicit-value\n");
+}
+
+#[test]
+#[cfg(windows)]
+fn shell_execution_preserves_custom_windows_sdk_root_env() {
+    let _guard = env_lock().lock().expect("env lock");
+    let previous_sdk = std::env::var_os("BIMRV_SDK_ROOT");
+    let previous_secret = std::env::var_os("MY_SECRET_ROOT");
+    unsafe {
+        std::env::set_var("BIMRV_SDK_ROOT", r"F:\Lib\BimRv27.5");
+        std::env::set_var("MY_SECRET_ROOT", r"F:\Secrets");
+    }
+
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = ShellManager::new(tmp.path().to_path_buf());
+    let command = if crate::shell_dispatcher::global_dispatcher()
+        .kind()
+        .is_powershell()
+    {
+        r#"[Console]::WriteLine($env:BIMRV_SDK_ROOT); if ($null -eq $env:MY_SECRET_ROOT) { [Console]::WriteLine("secret-unset") } else { [Console]::WriteLine("secret-set") }"#
+            .to_string()
+    } else {
+        r#"echo %BIMRV_SDK_ROOT% & if defined MY_SECRET_ROOT (echo secret-set) else (echo secret-unset)"#
+            .to_string()
+    };
+
+    let result = manager
+        .execute(&command, None, 5000, false)
+        .expect("execute");
+
+    unsafe {
+        match previous_sdk {
+            Some(value) => std::env::set_var("BIMRV_SDK_ROOT", value),
+            None => std::env::remove_var("BIMRV_SDK_ROOT"),
+        }
+        match previous_secret {
+            Some(value) => std::env::set_var("MY_SECRET_ROOT", value),
+            None => std::env::remove_var("MY_SECRET_ROOT"),
+        }
+    }
+
+    assert_eq!(result.status, ShellStatus::Completed);
+    assert!(
+        result.stdout.contains(r"F:\Lib\BimRv27.5"),
+        "custom SDK root should reach exec_shell stdout: {:?}",
+        result
+    );
+    assert!(
+        result.stdout.contains("secret-unset"),
+        "secret-like env should stay scrubbed: {:?}",
+        result
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #3572 by making Windows `exec_shell` child environments recover safe SDK/toolchain path variables from the Windows User/Machine environment registry before shell launch.

The shell environment still goes through the existing sanitizer. This only adds Windows path-like keys such as `BIMRV_SDK_ROOT`, `*_DIR`, `*_HOME`, `*_PATH`, and `*SDKROOT`, while rejecting secret-shaped names such as token/key/password/credential variables. Parent process environment values and explicit `shell_env` hook overrides still win over registry values.

Thanks @xsyww for the detailed Windows repro and registry-vs-process-env evidence.

## Validation

- `cargo fmt`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked child_env`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked shell_execution_preserves_custom_windows_sdk_root_env`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tools::shell::tests`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked`
- `cargo test --workspace --locked`
- `cargo build --release -p codewhale-cli -p codewhale-tui --locked`

Fixes #3572