### PR TITLE
fix(tui): preserve yolo for detached destructive tools

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -576,13 +576,13 @@ fn auto_review_run_origin_marks_detached_tools_as_background() {
 }
 
 #[test]
-fn auto_review_policy_holds_background_destructive_auto_approval() {
+fn auto_review_policy_holds_background_destructive_suggest_approval() {
     let (decision, audit) = auto_review_plan_decision(
         &crate::tui::auto_review::AutoReviewPolicy::default(),
         "exec_shell",
         &json!({"command": "cargo test", "background": true}),
         crate::tui::auto_review::RunOrigin::Background,
-        crate::tui::approval::ApprovalMode::Auto,
+        crate::tui::approval::ApprovalMode::Suggest,
         Some("run tests in the background"),
         true,
         false,
@@ -597,6 +597,30 @@ fn auto_review_policy_holds_background_destructive_auto_approval() {
     );
     assert_eq!(audit["run_origin"], "background");
     assert_eq!(audit["decision"], "hold_for_review");
+}
+
+#[test]
+fn auto_review_policy_preserves_yolo_for_detached_destructive_tools() {
+    for run_origin in [
+        crate::tui::auto_review::RunOrigin::Background,
+        crate::tui::auto_review::RunOrigin::Headless,
+    ] {
+        let (decision, audit) = auto_review_plan_decision(
+            &crate::tui::auto_review::AutoReviewPolicy::default(),
+            "exec_shell",
+            &json!({"command": "cargo test", "background": true}),
+            run_origin,
+            crate::tui::approval::ApprovalMode::Auto,
+            Some("run tests in the background"),
+            true,
+            false,
+        );
+
+        assert_eq!(decision, AutoReviewPlanDecision::NoChange);
+        assert_eq!(audit["approval_mode"], "AUTO");
+        assert_eq!(audit["run_origin"], run_origin.as_str());
+        assert_eq!(audit["decision"], "ask_user");
+    }
 }
 
 #[test]

--- a/crates/tui/src/tui/auto_review.rs
+++ b/crates/tui/src/tui/auto_review.rs
@@ -335,7 +335,8 @@ fn safety_floor(ctx: &AutoReviewContext<'_>) -> Option<AutoReviewDecision> {
         ));
     }
 
-    if matches!(ctx.run_origin, RunOrigin::Headless | RunOrigin::Background)
+    if !matches!(ctx.approval_mode, ApprovalMode::Auto)
+        && matches!(ctx.run_origin, RunOrigin::Headless | RunOrigin::Background)
         && matches!(ctx.risk, RiskLevel::Destructive)
     {
         return Some(AutoReviewDecision::new(


### PR DESCRIPTION
Addresses the YOLO auto-approval part of #3466.

## Summary
- allow detached destructive tool calls to keep the normal Auto/YOLO approval shortcut
- keep background/headless destructive calls review-gated outside Auto mode
- keep publish-like actions forced through the durable review path

## Verification
- cargo fmt --all --check
- cargo test -p codewhale-tui auto_review_policy_
- cargo test -p codewhale-tui auto_review
- cargo test -p codewhale-tui forced_approval_prompt