### PR TITLE
cleanup(compaction): remove hard compaction dead code (#3490)

### DIFF
--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -60,8 +60,6 @@ impl Default for CompactionConfig {
 }
 
 pub const KEEP_RECENT_MESSAGES: usize = 4;
-#[allow(dead_code)]
-pub const HARD_COMPACT_KEEP_RECENT: usize = 8;
 const RECENT_WORKING_SET_WINDOW: usize = 12;
 const MAX_WORKING_SET_PATHS: usize = 24;
 const MIN_SUMMARIZE_MESSAGES: usize = 6;
@@ -121,29 +119,6 @@ fn summary_input_limits_for_model(model: &str) -> SummaryInputLimits {
 pub struct CompactionPlan {
     pub pinned_indices: BTreeSet<usize>,
     pub summarize_indices: Vec<usize>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
-pub struct HardCompactionConfig {
-    pub enabled: bool,
-    pub keep_recent: usize,
-}
-
-impl Default for HardCompactionConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            keep_recent: HARD_COMPACT_KEEP_RECENT,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
-pub struct HardCompactionPlan {
-    pub summarize_indices: Vec<usize>,
-    pub preserved_indices: Vec<usize>,
 }
 
 fn path_regex() -> &'static Regex {
@@ -476,30 +451,6 @@ pub fn plan_compaction(
 }
 
 #[allow(dead_code)]
-pub fn plan_hard_compaction(
-    messages: &[Message],
-    workspace: Option<&Path>,
-    keep_recent: usize,
-) -> Option<HardCompactionPlan> {
-    if keep_recent == 0 || messages.len() < keep_recent.saturating_add(MIN_SUMMARIZE_MESSAGES) {
-        return None;
-    }
-
-    let soft_plan = plan_compaction(messages, workspace, keep_recent, None, None);
-    if soft_plan.summarize_indices.len() < MIN_SUMMARIZE_MESSAGES {
-        return None;
-    }
-
-    let summarized: BTreeSet<_> = soft_plan.summarize_indices.iter().copied().collect();
-    let preserved_indices = (0..messages.len())
-        .filter(|idx| !summarized.contains(idx))
-        .collect();
-
-    Some(HardCompactionPlan {
-        summarize_indices: soft_plan.summarize_indices,
-        preserved_indices,
-    })
-}
 
 fn enforce_tool_call_pairs(messages: &[Message], pinned_indices: &mut BTreeSet<usize>) {
     if pinned_indices.is_empty() {
@@ -899,6 +850,7 @@ pub struct CompactionResult {
     /// Summary system prompt
     pub summary_prompt: Option<SystemPrompt>,
     /// Messages that were removed from the active window
+    // TODO(v0.8.71): kept for replay compatibility; dead in production, see #3490
     #[allow(dead_code)]
     pub removed_messages: Vec<Message>,
     /// Number of retries used before success
@@ -2150,80 +2102,6 @@ mod tests {
         let plan = plan_compaction(&messages, None, 1, None, None);
         assert!(plan.pinned_indices.contains(&2));
         assert!(plan.pinned_indices.contains(&1));
-    }
-
-    #[test]
-    fn plan_hard_compaction_returns_none_when_too_few_messages() {
-        let messages = vec![
-            msg("user", "hello"),
-            msg("assistant", "hi"),
-            msg("user", "how are you"),
-            msg("assistant", "good"),
-        ];
-
-        assert!(plan_hard_compaction(&messages, None, HARD_COMPACT_KEEP_RECENT).is_none());
-    }
-
-    #[test]
-    fn plan_hard_compaction_preserves_recent_tail() {
-        let messages: Vec<Message> = (0..20)
-            .map(|i| {
-                msg(
-                    if i % 2 == 0 { "user" } else { "assistant" },
-                    &format!("message {i}"),
-                )
-            })
-            .collect();
-
-        let plan =
-            plan_hard_compaction(&messages, None, HARD_COMPACT_KEEP_RECENT).expect("hard plan");
-
-        let expected_recent: Vec<usize> = (20 - HARD_COMPACT_KEEP_RECENT..20).collect();
-        for idx in expected_recent {
-            assert!(plan.preserved_indices.contains(&idx));
-            assert!(!plan.summarize_indices.contains(&idx));
-        }
-        assert_eq!(plan.summarize_indices, (0..12).collect::<Vec<_>>());
-    }
-
-    #[test]
-    fn plan_hard_compaction_keeps_tool_pairs_across_tail_boundary() {
-        let mut messages: Vec<Message> = (0..8)
-            .map(|i| msg("user", &format!("summarizable noise {i}")))
-            .collect();
-        messages.push(Message {
-            role: "assistant".to_string(),
-            content: vec![ContentBlock::ToolUse {
-                id: "tail-call".to_string(),
-                name: "read_file".to_string(),
-                input: json!({"path": "crates/tui/src/compaction.rs"}),
-                caller: None,
-            }],
-        });
-        messages.push(Message {
-            role: "user".to_string(),
-            content: vec![ContentBlock::ToolResult {
-                tool_use_id: "tail-call".to_string(),
-                content: "file contents".to_string(),
-                is_error: None,
-                content_blocks: None,
-            }],
-        });
-
-        let plan = plan_hard_compaction(&messages, None, 1).expect("hard plan");
-
-        assert!(plan.preserved_indices.contains(&8));
-        assert!(plan.preserved_indices.contains(&9));
-        assert!(!plan.summarize_indices.contains(&8));
-        assert!(!plan.summarize_indices.contains(&9));
-    }
-
-    #[test]
-    fn hard_compaction_config_defaults_to_disabled() {
-        let config = HardCompactionConfig::default();
-
-        assert!(!config.enabled);
-        assert_eq!(config.keep_recent, HARD_COMPACT_KEEP_RECENT);
     }
 
     #[test]

--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -451,7 +451,6 @@ pub fn plan_compaction(
 }
 
 #[allow(dead_code)]
-
 fn enforce_tool_call_pairs(messages: &[Message], pinned_indices: &mut BTreeSet<usize>) {
     if pinned_indices.is_empty() {
         return;


### PR DESCRIPTION
Hard compaction (HARD_COMPACT_KEEP_RECENT, HardCompactionConfig, HardCompactionPlan, plan_hard_compaction) was superseded by the soft-seam compression scheme. These symbols were only referenced among themselves and in tests.

- Delete HARD_COMPACT_KEEP_RECENT constant
- Delete HardCompactionConfig struct + Default impl
- Delete HardCompactionPlan struct
- Delete plan_hard_compaction function
- Delete 4 related test functions
- Update removed_messages field with TODO(v0.8.71) + #3490 link

Part of #3490 (v0.8.71 legacy inventory)

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
