### PR TITLE
fix(command-safety): make python -m arity entries reachable in classify_command

### DIFF
--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -209,8 +209,13 @@ pub static COMMAND_ARITY: &[(&str, u8)] = &[
     ("pip3 uninstall", 2),
     ("pip3 list", 2),
     ("pip3 show", 2),
-    ("python -m", 3),
-    ("python3 -m", 3),
+    // Keyed on the bare interpreter (not `python -m`): `classify_command`
+    // strips flags such as `-m` before matching, so a `"python -m"` key could
+    // never fire. Arity 2 captures the module/script word that follows, so
+    // `python -m http.server` classifies to `python http.server` (distinct from
+    // `python -m pip` → `python pip`) and `python manage.py` → `python manage.py`.
+    ("python", 2),
+    ("python3", 2),
     // ── make / cmake ─────────────────────────────────────────────────────────
     ("make", 1),
     // ── gh (GitHub CLI) ──────────────────────────────────────────────────────
@@ -1453,6 +1458,31 @@ mod tests {
     #[test]
     fn classify_npm_test() {
         assert_eq!(classify("npm test"), "npm test");
+    }
+
+    // ── python (interpreter, arity 2) ─────────────────────────────────────────
+
+    #[test]
+    fn classify_python_module_captures_module_word() {
+        // `-m` is a flag and is stripped before arity lookup, so the canonical
+        // prefix must still capture the module that follows. Regression guard:
+        // a `"python -m"` arity key can never match (the flag is gone), which
+        // collapsed `python -m http.server` to just `python`.
+        assert_eq!(classify("python -m http.server"), "python http.server");
+        assert_eq!(
+            classify("python -m http.server --bind 0.0.0.0"),
+            "python http.server"
+        );
+        assert_eq!(classify("python3 -m venv env"), "python3 venv");
+        // Different modules classify distinctly so an allow rule for one does
+        // not leak to another.
+        assert_eq!(classify("python -m pip install x"), "python pip");
+    }
+
+    #[test]
+    fn classify_python_script_arity_2() {
+        assert_eq!(classify("python manage.py runserver"), "python manage.py");
+        assert_eq!(classify("python3 setup.py install"), "python3 setup.py");
     }
 
     // ── docker ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
The `COMMAND_ARITY` entries `("python -m", 3)` and `("python3 -m", 3)` are dead — they can never match.

`classify_command` strips flag tokens (anything starting with `-`) *before* doing the arity lookup, so `-m` is gone by the time the key is compared. `python -m http.server` therefore collapses to the bare `python` prefix, losing the module-level granularity those entries were meant to provide and making `python -m http.server` indistinguishable from `python -m pip`.

### Fix
Key the entries on the bare interpreter instead — matching the upstream opencode port these were ported from (`python: 2  // python -m venv env`). Arity 2 captures the module/script word that follows the stripped flag:

| command | before | after |
|---|---|---|
| `python -m http.server` | `python` | `python http.server` |
| `python -m pip install x` | `python` | `python pip` |
| `python manage.py runserver` | `python` | `python manage.py` |

### Tests
Added `classify_python_module_captures_module_word` and `classify_python_script_arity_2`. Both fail on `main` (`left: "python"`) and pass with the fix. Full `command_safety` suite (57 tests) stays green.