### PR TITLE
fix(web): serve install script before app fallback

### DIFF
--- a/web/lib/static-installer.test.ts
+++ b/web/lib/static-installer.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchWithStaticInstaller } from "./static-installer";
 
-function ctx(): ExecutionContext {
+function ctx(): unknown {
   return {
     waitUntil: vi.fn(),
     passThroughOnException: vi.fn(),
-  } as unknown as ExecutionContext;
+  };
 }
 
 describe("static installer route", () => {

--- a/web/lib/static-installer.test.ts
+++ b/web/lib/static-installer.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithStaticInstaller } from "./static-installer";
+
+function ctx(): ExecutionContext {
+  return {
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+  } as unknown as ExecutionContext;
+}
+
+describe("static installer route", () => {
+  const fallbackFetch = vi.fn(async () => new Response("fallback", { status: 200 }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serves /install.sh from the static asset binding before OpenNext fallback", async () => {
+    const assetFetch = vi.fn(async () =>
+      new Response("#!/bin/sh\necho codewhale\n", {
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const response = await fetchWithStaticInstaller(
+      new Request("https://codewhale.net/install.sh"),
+      { ASSETS: { fetch: assetFetch } },
+      ctx(),
+      fallbackFetch,
+    );
+
+    expect(assetFetch).toHaveBeenCalledOnce();
+    expect(fallbackFetch).not.toHaveBeenCalled();
+    expect(response.headers.get("content-type")).toBe("text/x-shellscript; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300");
+    expect(await response.text()).toContain("echo codewhale");
+  });
+
+  it("delegates non-installer paths to the OpenNext handler", async () => {
+    const assetFetch = vi.fn();
+
+    const response = await fetchWithStaticInstaller(
+      new Request("https://codewhale.net/install"),
+      { ASSETS: { fetch: assetFetch } },
+      ctx(),
+      fallbackFetch,
+    );
+
+    expect(assetFetch).not.toHaveBeenCalled();
+    expect(fallbackFetch).toHaveBeenCalledOnce();
+    expect(await response.text()).toBe("fallback");
+  });
+});

--- a/web/lib/static-installer.ts
+++ b/web/lib/static-installer.ts
@@ -1,0 +1,37 @@
+type AssetBinding = {
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+};
+
+type FallbackFetch = (
+  request: Request,
+  env: Record<string, unknown>,
+  ctx: unknown,
+) => Response | Promise<Response>;
+
+const INSTALL_SCRIPT_PATH = "/install.sh";
+
+export async function fetchWithStaticInstaller(
+  request: Request,
+  env: Record<string, unknown>,
+  ctx: unknown,
+  fallbackFetch: FallbackFetch,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const assets = (env as { ASSETS?: AssetBinding }).ASSETS;
+
+  if (url.pathname === INSTALL_SCRIPT_PATH && assets) {
+    const assetResponse = await assets.fetch(request);
+    if (assetResponse.status !== 404) {
+      const headers = new Headers(assetResponse.headers);
+      headers.set("content-type", "text/x-shellscript; charset=utf-8");
+      headers.set("cache-control", "public, max-age=300");
+      return new Response(assetResponse.body, {
+        status: assetResponse.status,
+        statusText: assetResponse.statusText,
+        headers,
+      });
+    }
+  }
+
+  return fallbackFetch(request, env, ctx);
+}

--- a/web/worker.ts
+++ b/web/worker.ts
@@ -10,9 +10,17 @@ import {
 } from "./lib/community-agent-tasks";
 import { runFactsDrift } from "./lib/facts-drift";
 import { runLinkCheck, runSemanticDrift } from "./lib/content-watch";
+import { fetchWithStaticInstaller } from "./lib/static-installer";
 
 export default {
-  fetch: handler.fetch,
+  fetch(request, env, ctx) {
+    return fetchWithStaticInstaller(
+      request,
+      env,
+      ctx,
+      (nextRequest, nextEnv, nextCtx) => handler.fetch(nextRequest, nextEnv, nextCtx),
+    );
+  },
   async scheduled(event: ScheduledEvent, env: Record<string, unknown>, ctx: ExecutionContext) {
     const expr = event.cron;
     ctx.waitUntil((async () => {


### PR DESCRIPTION
## Summary

- Fixes #3582 by serving `/install.sh` from the Cloudflare static `ASSETS` binding before the OpenNext app fallback.
- Preserves existing OpenNext handling for every other route.
- Credit: thanks @noaft for the live production report and repro.

## Testing

- [x] `npm --prefix web test`
- [x] `npm --prefix web run lint`
- [x] `(cd web && npx tsc --noEmit)`
- [x] `npm --prefix web run build && (cd web && npx opennextjs-cloudflare build) && test -f web/.open-next/assets/install.sh && head -3 web/.open-next/assets/install.sh`
- [x] `git diff --check`
- [ ] `cargo fmt --all -- --check` (not run; web-only change)
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; web-only change)
- [ ] `cargo test --workspace --all-features` (not run; web-only change)

## Checklist

- [x] Updated docs or comments as needed (no docs change needed for worker routing)
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (N/A, no TUI change)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A, no harvest)
