### PR TITLE
fix(tui): preserve mode when editing a turn

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1649,7 +1649,7 @@ impl Engine {
                         }
                         // Now dispatch the new message as a normal send,
                         // reusing the engine's stored mode/model config.
-                        let mode = AppMode::Agent; // default fallback
+                        let mode = self.current_mode;
                         self.handle_send_message(
                             new_message,
                             mode,

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3141,6 +3141,74 @@ async fn change_mode_op_updates_current_mode_and_emits_status() {
     run.abort();
 }
 
+#[tokio::test]
+async fn edit_last_turn_preserves_current_mode() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &Config::default());
+
+    let run = tokio::spawn(engine.run());
+    let seeded_messages = vec![
+        Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "draft the plan".to_string(),
+                cache_control: None,
+            }],
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "initial response".to_string(),
+                cache_control: None,
+            }],
+        },
+    ];
+    handle
+        .send(Op::SyncSession {
+            session_id: Some("edit-mode-test".to_string()),
+            messages: seeded_messages,
+            system_prompt: None,
+            system_prompt_override: false,
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmp.path().to_path_buf(),
+        })
+        .await
+        .expect("sync session");
+    handle
+        .send(Op::ChangeMode {
+            mode: AppMode::Plan,
+        })
+        .await
+        .expect("send plan mode");
+    handle
+        .send(Op::EditLastTurn {
+            new_message: "revise this in plan mode".to_string(),
+        })
+        .await
+        .expect("send edit");
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(tx))),
+        })
+        .await
+        .expect("request snapshot");
+    let snapshot = tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("snapshot response")
+        .expect("snapshot");
+
+    assert_eq!(snapshot.mode, "plan");
+
+    run.abort();
+}
+
 #[test]
 fn detects_context_length_errors_from_provider_payloads() {
     let msg = r#"SSE stream request failed: HTTP 400 Bad Request: {"error":{"message":"This model's maximum context length is 131072 tokens. However, you requested 153056 tokens (148960 in the messages, 4096 in the completion).","type":"invalid_request_error"}}"#;


### PR DESCRIPTION
## Summary

- Refs #3568 by fixing a concrete stale-mode resend path: `/edit` now redispatches the edited turn using the engine current mode instead of forcing Agent mode.
- Adds a regression that seeds a session, switches the engine to Plan, runs `EditLastTurn`, and verifies the snapshot remains `plan`.
- Credit: thanks @DracheTek for the report, and @orz0219 / @yekern for confirming related mode-desync symptoms. This PR is a narrow mitigation, not a full closure of every reported mode-state path.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target-v0865 cargo test -p codewhale-tui --bin codewhale-tui --locked edit_last_turn_preserves_current_mode`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target-v0865 cargo test -p codewhale-tui --bin codewhale-tui --locked change_mode_op_updates_current_mode_and_emits_status`
- [x] `git diff --check`
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; targeted TUI engine regression)
- [ ] `cargo test --workspace --all-features` (not run; targeted TUI engine regression)

## Checklist

- [x] Updated docs or comments as needed (N/A, behavior fix)
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (covered by engine op regression; no renderer change)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A, no harvest)
