### PR TITLE
fix(tui): surface repo constitution drift

### DIFF
--- a/.codewhale/constitution.json
+++ b/.codewhale/constitution.json
@@ -14,7 +14,7 @@
     "Stable Rust only (edition 2024); no nightly features.",
     "Keep the codewhale CLI dispatcher and the codewhale-tui binary in sync when crates/tui changes."
   ],
-  "branch_policy": "v0.8.53 work targets the codex/v0.8.53 integration branch, not main. One PR per logical workstream; do not mix unrelated fixes.",
+  "branch_policy": "Start from live branch and handoff truth. Never commit directly to main; use the active integration branch or a fresh codex/... branch/worktree for isolated work, and open reviewable PRs into main. One PR per logical workstream; do not mix unrelated fixes.",
   "verification_policy": {
     "before_claiming_done": [
       "run the focused tests for the changed crate (cargo test -p <crate>), then cargo check/clippy as appropriate",

--- a/crates/tui/src/context_report.rs
+++ b/crates/tui/src/context_report.rs
@@ -103,13 +103,36 @@ impl SourceEntry {
             truncation_reason: Some(reason.into()),
         }
     }
+
+    fn diagnostic(
+        source_kind: SourceKind,
+        label: impl Into<String>,
+        source_path: Option<String>,
+        activation_reason: ActivationReason,
+        detail: impl Into<String>,
+        estimated_tokens: usize,
+        authority_tier: Option<u8>,
+    ) -> Self {
+        Self {
+            source_kind,
+            label: label.into(),
+            source_path,
+            activation_reason,
+            estimated_tokens,
+            counting_confidence: CountingConfidence::High,
+            authority_tier,
+            truncation_reason: Some(detail.into()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceKind {
     Constitution,
+    RepoConstitution,
     ProjectContext,
+    ProjectContextWarning,
     ProjectContextPack,
     SkillsBlock,
     ContextManagement,
@@ -283,23 +306,63 @@ fn base_source_entries(model: &str, workspace: &Path, skills_dir: Option<&Path>)
     ));
 
     let project_context = crate::project_context::load_project_context_with_parents(workspace);
-    if let Some(block) = project_context.as_system_block() {
+    if let Some(block) = project_context.constitution_block.as_deref() {
+        builder.push(SourceEntry::text(
+            SourceKind::RepoConstitution,
+            "Repository constitution",
+            project_context
+                .constitution_source_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            ActivationReason::FilePresent,
+            block,
+            CountingConfidence::High,
+            Some(4),
+        ));
+    }
+
+    if let Some(content) = project_context.instructions.as_deref() {
+        let source = project_context
+            .source_path
+            .as_ref()
+            .map_or_else(|| "project".to_string(), |p| p.display().to_string());
+        let block = format!(
+            "<project_instructions source=\"{source}\">\n{content}\n</project_instructions>"
+        );
         builder.push(SourceEntry::text(
             SourceKind::ProjectContext,
-            "Project context and repository instructions",
-            Some(workspace.display().to_string()),
+            "Project instructions",
+            project_context
+                .source_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
             ActivationReason::FilePresent,
             &block,
             CountingConfidence::High,
             Some(5),
         ));
-    } else {
+    }
+
+    if project_context.constitution_block.is_none() && project_context.instructions.is_none() {
         builder.push(SourceEntry::omitted(
             SourceKind::ProjectContext,
             "Project context and repository instructions",
             Some(workspace.display().to_string()),
             Some(5),
             "no project context block available",
+        ));
+    }
+    if !project_context.warnings.is_empty() {
+        let warnings = project_context.warnings.join("\n");
+        let estimated_tokens = estimate_text_tokens_conservative(&warnings);
+        builder.push(SourceEntry::diagnostic(
+            SourceKind::ProjectContextWarning,
+            "Project context warnings",
+            Some(workspace.display().to_string()),
+            ActivationReason::RuntimeState,
+            warnings,
+            estimated_tokens,
+            Some(4),
         ));
     }
 
@@ -688,7 +751,10 @@ pub fn context_report_json(report: &PromptSourceMap) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
     use crate::models::Tool;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn context_report_json_contains_sources_and_tool_results() {
@@ -726,6 +792,54 @@ mod tests {
 
         assert!(json.contains("\"source_kind\": \"tool_result\""));
         assert!(json.contains("\"active_context_estimated_tokens\": 123"));
+    }
+
+    #[test]
+    fn context_report_surfaces_repo_constitution_source_and_warnings() {
+        let tmp = tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("mkdir .git");
+        fs::create_dir(tmp.path().join(".codewhale")).expect("mkdir .codewhale");
+        fs::write(
+            tmp.path().join(".codewhale").join("constitution.json"),
+            r#"{
+                "schema_version": 1,
+                "authority": ["current user request"],
+                "branch_policy": "v0.8.53 work targets the codex/v0.8.53 integration branch, not main"
+            }"#,
+        )
+        .expect("write constitution");
+
+        let report = build_headless_context_report(&Config::default(), tmp.path());
+        assert!(
+            report.entries.iter().any(|entry| {
+                entry.source_kind == SourceKind::RepoConstitution
+                    && entry.source_path.as_deref().is_some_and(|path| {
+                        path.replace('\\', "/")
+                            .ends_with(".codewhale/constitution.json")
+                    })
+            }),
+            "repo constitution source should be an explicit source-map entry: {:?}",
+            report.entries
+        );
+        assert!(
+            report.entries.iter().any(|entry| {
+                entry.source_kind == SourceKind::ProjectContextWarning
+                    && entry
+                        .truncation_reason
+                        .as_deref()
+                        .is_some_and(|reason| reason.contains("branch_policy appears stale"))
+                    && entry.estimated_tokens > 0
+            }),
+            "repo constitution warnings should be explicit source-map entries: {:?}",
+            report.entries
+        );
+
+        let formatted = format_context_report(&report);
+        assert!(formatted.contains("Repository constitution"));
+        assert!(formatted.contains("Project context warnings"));
+        let json = context_report_json(&report);
+        assert!(json.contains("\"repo_constitution\""));
+        assert!(json.contains("branch_policy appears stale"));
     }
 
     #[test]

--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -143,6 +143,8 @@ pub struct ProjectContext {
     /// CodeWhale-specific repo authority/prioritization policy — distinct from
     /// the cross-agent prose in `instructions`.
     pub constitution_block: Option<String>,
+    /// Path to the repo constitution file that produced `constitution_block`.
+    pub constitution_source_path: Option<PathBuf>,
     /// Project root directory
     #[allow(dead_code)] // Part of ProjectContext public interface
     pub project_root: PathBuf,
@@ -158,6 +160,7 @@ impl ProjectContext {
             source_path: None,
             warnings: Vec::new(),
             constitution_block: None,
+            constitution_source_path: None,
             project_root,
             is_trusted: false,
         }
@@ -290,12 +293,51 @@ impl RepoConstitution {
             body.trim_end()
         )
     }
+
+    fn policy_warnings(&self, source: &Path) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if let Some(policy) = self.branch_policy.as_deref()
+            && branch_policy_looks_stale(policy)
+        {
+            warnings.push(format!(
+                "{} branch_policy appears stale: hard-coded release branch guidance (`{}`). Use live branch/handoff truth and AGENTS.md instead of versioned integration-lane text.",
+                source.display(),
+                policy.trim()
+            ));
+        }
+        warnings
+    }
+}
+
+fn branch_policy_looks_stale(policy: &str) -> bool {
+    let lower = policy.to_ascii_lowercase();
+    lower.contains("codex/v")
+        || ((lower.contains("integration branch") || lower.contains("not main"))
+            && contains_release_version_token(policy))
+}
+
+fn contains_release_version_token(value: &str) -> bool {
+    value
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '.'))
+        .any(|token| {
+            let token = token.trim_start_matches(['v', 'V']);
+            let mut parts = token.split('.');
+            matches!(
+                (parts.next(), parts.next(), parts.next(), parts.next()),
+                (Some(major), Some(minor), Some(patch), None)
+                    if major.chars().all(|ch| ch.is_ascii_digit())
+                        && minor.chars().all(|ch| ch.is_ascii_digit())
+                        && patch.chars().all(|ch| ch.is_ascii_digit())
+            )
+        })
 }
 
 /// Discover and render `.codewhale/constitution.json` from `workspace` or, if
 /// absent, its parent directories up to the git root. Returns the rendered
 /// authority block plus any parse warnings.
-fn load_repo_constitution_block(workspace: &Path) -> (Option<String>, Vec<String>) {
+fn load_repo_constitution_block(
+    workspace: &Path,
+) -> (Option<String>, Option<PathBuf>, Vec<String>) {
     let mut warnings = Vec::new();
     let git_root = crate::project_doc::find_git_root(workspace);
     let mut current = workspace.to_path_buf();
@@ -316,23 +358,24 @@ fn load_repo_constitution_block(workspace: &Path) -> (Option<String>, Vec<String
                                 path.display()
                             ));
                         }
-                        return (Some(constitution.render_block(&path)), warnings);
+                        warnings.extend(constitution.policy_warnings(&path));
+                        return (Some(constitution.render_block(&path)), Some(path), warnings);
                     }
                     Ok(_) => {
                         warnings.push(format!(
                             "{} has no authority/verification policy; ignoring.",
                             path.display()
                         ));
-                        return (None, warnings);
+                        return (None, None, warnings);
                     }
                     Err(e) => {
                         warnings.push(format!("Failed to parse {}: {e}", path.display()));
-                        return (None, warnings);
+                        return (None, None, warnings);
                     }
                 },
                 Err(e) => {
                     warnings.push(format!("Failed to read {}: {e}", path.display()));
-                    return (None, warnings);
+                    return (None, None, warnings);
                 }
             }
         }
@@ -346,7 +389,7 @@ fn load_repo_constitution_block(workspace: &Path) -> (Option<String>, Vec<String
             _ => break,
         }
     }
-    (None, warnings)
+    (None, None, warnings)
 }
 
 #[derive(Debug, Serialize)]
@@ -768,9 +811,11 @@ fn load_project_context_with_parents_and_home(
     // an AGENTS.md. When present it takes precedence over a legacy WHALE.md.
     // Loaded last so the auto-generate fallback above (which rebuilds `ctx`)
     // cannot clobber it.
-    let (constitution_block, constitution_warnings) = load_repo_constitution_block(workspace);
+    let (constitution_block, constitution_source_path, constitution_warnings) =
+        load_repo_constitution_block(workspace);
     ctx.warnings.extend(constitution_warnings);
     ctx.constitution_block = constitution_block;
+    ctx.constitution_source_path = constitution_source_path;
 
     ctx
 }
@@ -1386,7 +1431,7 @@ mod tests {
                 "schema_version": 1,
                 "authority": ["current user request", "live code and tests", "AGENTS.md"],
                 "protected_invariants": ["keep the tool-catalog head byte-stable"],
-                "branch_policy": "PRs target codex/v0.8.53, not main",
+                "branch_policy": "Start from live branch truth; open PRs into main",
                 "verification_policy": { "before_claiming_done": ["run focused tests"] },
                 "escalate_when": ["a destructive action was not authorized"]
             }"#,
@@ -1402,14 +1447,67 @@ mod tests {
         assert!(block.contains("current user request"));
         assert!(block.contains("run focused tests"));
         assert!(block.contains("keep the tool-catalog head byte-stable"));
-        assert!(block.contains("PRs target codex/v0.8.53"));
+        assert!(block.contains("Start from live branch truth"));
         assert!(block.contains("a destructive action was not authorized"));
         assert!(block.contains("takes precedence over a legacy WHALE.md"));
+        assert!(
+            ctx.constitution_source_path
+                .as_ref()
+                .is_some_and(|path| path.ends_with(".codewhale/constitution.json")),
+            "constitution source path should be visible: {:?}",
+            ctx.constitution_source_path
+        );
         // It also surfaces through the system block.
         assert!(
             ctx.as_system_block()
                 .expect("system block")
                 .contains("codewhale_repo_constitution")
+        );
+    }
+
+    #[test]
+    fn stale_constitution_branch_policy_warns() {
+        let tmp = tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("mkdir .git");
+        fs::create_dir(tmp.path().join(".codewhale")).expect("mkdir .codewhale");
+        fs::write(
+            tmp.path().join(".codewhale").join("constitution.json"),
+            r#"{
+                "schema_version": 1,
+                "authority": ["current user request"],
+                "branch_policy": "v0.8.53 work targets the codex/v0.8.53 integration branch, not main"
+            }"#,
+        )
+        .expect("write constitution");
+
+        let ctx = load_project_context_with_parents(tmp.path());
+        assert!(
+            ctx.constitution_block.is_some(),
+            "stale policy should warn but still render"
+        );
+        assert!(
+            ctx.warnings
+                .iter()
+                .any(|warning| warning.contains("branch_policy appears stale")),
+            "expected stale branch_policy warning, got {:?}",
+            ctx.warnings
+        );
+    }
+
+    #[test]
+    fn repository_constitution_avoids_hard_coded_release_lane_policy() {
+        let repo_constitution = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join(".codewhale")
+            .join("constitution.json");
+        let raw = fs::read_to_string(&repo_constitution).expect("read repo constitution");
+        let constitution: RepoConstitution =
+            serde_json::from_str(&raw).expect("parse repo constitution");
+        let warnings = constitution.policy_warnings(&repo_constitution);
+        assert!(
+            warnings.is_empty(),
+            "repo constitution should not carry stale release-lane policy: {:?}",
+            warnings
         );
     }
 


### PR DESCRIPTION
Refs #3486.

## Summary
- Replace the stale v0.8.53 branch policy in `.codewhale/constitution.json` with live branch/handoff guidance aligned with `AGENTS.md`.
- Warn when repo constitution `branch_policy` hard-codes versioned integration-lane guidance such as `codex/v0.8.x` or `not main` release targets.
- Split repository constitution and project-context warnings into explicit `/context report` source-map entries so the source path and warning detail are inspectable in text and JSON reports.

## Verification
- `cargo test -p codewhale-tui --bin codewhale-tui --locked stale_constitution_branch_policy_warns`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked repository_constitution_avoids_hard_coded_release_lane_policy`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked context_report_surfaces_repo_constitution_source_and_warnings`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked constitution_json`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked context_report_json_contains_sources_and_tool_results`
- `cargo check -p codewhale-tui --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
