### PR TITLE
fix(tui): lock hotbar config contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "toml_edit",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -155,6 +155,21 @@ fn hotbar_defaults_when_config_is_absent() {
 }
 
 #[test]
+fn hotbar_empty_array_disables_default_slots() {
+    let config: ConfigToml = toml::from_str("hotbar = []\n").expect("parse empty hotbar array");
+
+    let resolved = config.resolve_hotbar_bindings(&DEFAULT_HOTBAR_ACTIONS);
+
+    assert_eq!(resolved.warnings, Vec::new());
+    assert_eq!(resolved.bindings, Vec::new());
+
+    let serialized = toml::to_string_pretty(&config).expect("serialize config");
+    let round_tripped: ConfigToml =
+        toml::from_str(&serialized).expect("deserialize serialized config");
+    assert_eq!(round_tripped.hotbar, Some(Vec::new()));
+}
+
+#[test]
 fn hotbar_tables_parse_and_round_trip() {
     let config: ConfigToml = toml::from_str(
         r#"
@@ -1877,6 +1892,37 @@ fn project_merge_forwards_all_provider_model_overrides() {
             "provider {key} should merge repo-local model override"
         );
     }
+}
+
+#[test]
+fn project_merge_does_not_replace_user_hotbar_bindings() {
+    let mut base = ConfigToml {
+        hotbar: Some(vec![HotbarBindingToml {
+            slot: 1,
+            action: "mode.plan".to_string(),
+            label: Some("Plan".to_string()),
+        }]),
+        ..ConfigToml::default()
+    };
+    let project = ConfigToml {
+        hotbar: Some(vec![HotbarBindingToml {
+            slot: 1,
+            action: "mode.yolo".to_string(),
+            label: Some("Yolo".to_string()),
+        }]),
+        ..ConfigToml::default()
+    };
+
+    base.merge_project_overrides(project);
+
+    assert_eq!(
+        base.hotbar,
+        Some(vec![HotbarBindingToml {
+            slot: 1,
+            action: "mode.plan".to_string(),
+            label: Some("Plan".to_string()),
+        }])
+    );
 }
 
 #[test]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -53,6 +53,7 @@ serde_json = { version = "1.0.149", features = ["preserve_order"] }
 schemars = { version = "1.2.1", features = ["derive", "preserve_order"] }
 shellexpand = "3"
 toml = "1.0.6"
+toml_edit.workspace = true
 tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = { version = "0.7.16", features = ["io"] }
 unicode-width = "0.2"

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -495,6 +495,84 @@ action = "session.compact"
 }
 
 #[test]
+fn tui_config_empty_hotbar_array_disables_defaults() {
+    let parsed: ConfigFile = toml::from_str("hotbar = []\n").expect("parse empty hotbar");
+
+    let resolved = parsed
+        .base
+        .resolve_hotbar_bindings(&["mode.plan", "session.compact"]);
+
+    assert_eq!(resolved.warnings, Vec::new());
+    assert_eq!(resolved.bindings, Vec::new());
+}
+
+#[test]
+fn profile_hotbar_override_replaces_entire_user_list() {
+    let mut profiles = HashMap::new();
+    profiles.insert(
+        "compact".to_string(),
+        Config {
+            hotbar: Some(vec![codewhale_config::HotbarBindingToml {
+                slot: 2,
+                action: "session.compact".to_string(),
+                label: Some("Compact".to_string()),
+            }]),
+            ..Config::default()
+        },
+    );
+    let config = ConfigFile {
+        base: Config {
+            hotbar: Some(vec![codewhale_config::HotbarBindingToml {
+                slot: 1,
+                action: "mode.plan".to_string(),
+                label: Some("Plan".to_string()),
+            }]),
+            ..Config::default()
+        },
+        profiles: Some(profiles),
+    };
+
+    let merged = apply_profile(config, Some("compact")).expect("profile");
+
+    assert_eq!(
+        merged.hotbar,
+        Some(vec![codewhale_config::HotbarBindingToml {
+            slot: 2,
+            action: "session.compact".to_string(),
+            label: Some("Compact".to_string()),
+        }])
+    );
+}
+
+#[test]
+fn profile_without_hotbar_keeps_base_hotbar() {
+    let mut profiles = HashMap::new();
+    profiles.insert("work".to_string(), Config::default());
+    let config = ConfigFile {
+        base: Config {
+            hotbar: Some(vec![codewhale_config::HotbarBindingToml {
+                slot: 1,
+                action: "mode.plan".to_string(),
+                label: None,
+            }]),
+            ..Config::default()
+        },
+        profiles: Some(profiles),
+    };
+
+    let merged = apply_profile(config, Some("work")).expect("profile");
+
+    assert_eq!(
+        merged.hotbar,
+        Some(vec![codewhale_config::HotbarBindingToml {
+            slot: 1,
+            action: "mode.plan".to_string(),
+            label: None,
+        }])
+    );
+}
+
+#[test]
 fn update_config_defaults_to_enabled_without_uri() {
     let config = Config::default();
     assert_eq!(config.update, None);

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -325,6 +325,61 @@ fn provider_base_url_table_key(provider: ApiProvider) -> anyhow::Result<&'static
     }
 }
 
+#[allow(dead_code)]
+pub(crate) fn persist_hotbar_bindings(
+    config_path: Option<&Path>,
+    bindings: &[codewhale_config::HotbarBindingToml],
+) -> anyhow::Result<PathBuf> {
+    use anyhow::Context;
+    use std::fs;
+
+    let path = config_toml_path(config_path)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create config directory {}", parent.display()))?;
+    }
+
+    let raw = if path.exists() {
+        Some(
+            fs::read_to_string(&path)
+                .with_context(|| format!("failed to read config at {}", path.display()))?,
+        )
+    } else {
+        None
+    };
+    let mut document = match raw.as_deref() {
+        Some(raw) if !raw.trim().is_empty() => raw
+            .parse::<toml_edit::DocumentMut>()
+            .with_context(|| format!("failed to edit config at {}", path.display()))?,
+        _ => toml_edit::DocumentMut::new(),
+    };
+
+    let table = document.as_table_mut();
+    table.remove("hotbar");
+    if bindings.is_empty() {
+        table.insert(
+            "hotbar",
+            toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
+        );
+    } else {
+        let mut hotbar = toml_edit::ArrayOfTables::new();
+        for binding in bindings {
+            let mut table = toml_edit::Table::new();
+            table["slot"] = toml_edit::value(i64::from(binding.slot));
+            table["action"] = toml_edit::value(binding.action.clone());
+            if let Some(label) = binding.label.as_deref() {
+                table["label"] = toml_edit::value(label);
+            }
+            hotbar.push(table);
+        }
+        table.insert("hotbar", toml_edit::Item::ArrayOfTables(hotbar));
+    }
+
+    fs::write(&path, document.to_string())
+        .with_context(|| format!("failed to write config at {}", path.display()))?;
+    Ok(path)
+}
+
 pub(crate) fn config_toml_path(config_path: Option<&Path>) -> anyhow::Result<PathBuf> {
     use anyhow::Context;
 
@@ -608,5 +663,101 @@ mod tests {
             body.contains("allow_shell = true"),
             "new key not written: {body}"
         );
+    }
+
+    #[test]
+    fn persist_hotbar_bindings_writes_primary_config_path_for_fresh_installs() {
+        let temp_root = temp_root("codewhale-hotbar-persist-fresh");
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        unsafe {
+            env::remove_var("DEEPSEEK_CONFIG_PATH");
+        }
+
+        let bindings = vec![codewhale_config::HotbarBindingToml {
+            slot: 1,
+            action: "mode.plan".to_string(),
+            label: Some("Plan".to_string()),
+        }];
+        let path = persist_hotbar_bindings(None, &bindings).expect("persist should succeed");
+
+        assert_eq!(path, temp_root.join(".codewhale").join("config.toml"));
+        let body = fs::read_to_string(&path).expect("written file should be readable");
+        assert!(body.contains("[[hotbar]]"), "hotbar table missing: {body}");
+        let parsed: codewhale_config::ConfigToml =
+            toml::from_str(&body).expect("written hotbar config should parse");
+        assert_eq!(parsed.hotbar, Some(bindings));
+    }
+
+    #[test]
+    fn persist_hotbar_bindings_preserves_comments_and_replaces_existing_tables() {
+        let temp_root = temp_root("codewhale-hotbar-persist-comments");
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        let path = temp_root.join(".codewhale").join("config.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"# model note
+model = "deepseek-v4-flash"
+
+[[hotbar]]
+slot = 1
+action = "mode.plan"
+label = "Plan"
+
+# notification note
+[notifications]
+enabled = true
+"#,
+        )
+        .unwrap();
+
+        let bindings = vec![codewhale_config::HotbarBindingToml {
+            slot: 2,
+            action: "session.compact".to_string(),
+            label: Some("Compact".to_string()),
+        }];
+        let written =
+            persist_hotbar_bindings(Some(&path), &bindings).expect("persist should succeed");
+        let body = fs::read_to_string(&written).expect("written file should be readable");
+
+        assert!(body.contains("# model note"), "prefix comment lost: {body}");
+        assert!(
+            body.contains("# notification note"),
+            "section comment lost: {body}"
+        );
+        assert!(
+            !body.contains("mode.plan"),
+            "old hotbar table was not replaced: {body}"
+        );
+        assert!(body.contains("[[hotbar]]"), "hotbar table missing: {body}");
+        assert!(
+            body.contains("action = \"session.compact\""),
+            "new action missing: {body}"
+        );
+        let parsed: codewhale_config::ConfigToml =
+            toml::from_str(&body).expect("written hotbar config should parse");
+        assert_eq!(parsed.hotbar, Some(bindings));
+    }
+
+    #[test]
+    fn persist_hotbar_bindings_writes_empty_array_to_disable_defaults() {
+        let temp_root = temp_root("codewhale-hotbar-persist-empty");
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        let path = temp_root.join(".codewhale").join("config.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let written = persist_hotbar_bindings(Some(&path), &[]).expect("persist should succeed");
+        let body = fs::read_to_string(&written).expect("written file should be readable");
+
+        assert!(body.contains("hotbar = []"), "empty hotbar missing: {body}");
+        let parsed: codewhale_config::ConfigToml =
+            toml::from_str(&body).expect("written hotbar config should parse");
+        assert_eq!(parsed.hotbar, Some(Vec::new()));
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -137,10 +137,10 @@ Supported keys in the project overlay (top-level fields only):
 The overlay is intentionally narrow — it covers the fields a repo
 maintainer is most likely to want to standardize across contributors.
 Credential, endpoint, provider-selection, MCP config, hooks, skills, capacity,
-retry, and `instructions = [...]` settings stay user-global. If a repo-local
-config declares `api_key`, `base_url`, `provider`, `mcp_config_path`,
-`allow_shell = true`, or `instructions`, CodeWhale ignores that key and keeps
-the user's global setting.
+retry, hotbar bindings, and `instructions = [...]` settings stay user-global.
+If a repo-local config declares `api_key`, `base_url`, `provider`,
+`mcp_config_path`, `hotbar`, `allow_shell = true`, or `instructions`,
+CodeWhale ignores that key and keeps the user's global setting.
 
 The `codewhale` facade and `codewhale-tui` binary share the same config file for
 DeepSeek auth and model defaults. `codewhale auth set --provider deepseek` (and
@@ -1056,6 +1056,30 @@ If you are upgrading from older releases:
   can be added manually and are matched at runtime, but the approval UI does
   not save file rules yet. This intentionally does not accept typed allow/deny
   records or glob expansion.
+- `[[hotbar]]` (array of tables, optional): user-owned 1-8 slot bindings for
+  the TUI hotbar. Each entry has `slot`, `action`, and optional `label`.
+  Omitting `hotbar` uses the built-in default eight slots. Setting
+  `hotbar = []` disables all default slots. When one or more `[[hotbar]]`
+  tables are present, that list replaces the defaults; missing slots stay
+  empty. Invalid slots outside `1..=8` are skipped with a warning, duplicate
+  slots use the later entry, and unknown action IDs are kept so the UI can show
+  a disabled/unknown cell instead of silently deleting user config. Trusted
+  user config, profiles, and managed config replace the whole list; project
+  overlays cannot change hotbar bindings. Setup or wizard flows that persist
+  hotbar bindings write this same schema to the resolved `~/.codewhale/config.toml`
+  path, preserving legacy `~/.deepseek/config.toml` only when that fallback file
+  is already the active config.
+
+  ```toml
+  [[hotbar]]
+  slot = 1
+  action = "mode.plan"
+  label = "Plan"
+
+  [[hotbar]]
+  slot = 2
+  action = "session.compact"
+  ```
 - `[auto_review]` (table, optional): deterministic tool-call review policy.
   This layer sits on top of existing approval modes; it can force a prompt or
   block a tool call, but it is not an auto-push, auto-merge, or hosted review


### PR DESCRIPTION
## Summary
- lock empty-list, duplicate-slot, project-overlay, and trusted-profile hotbar config semantics in tests
- add a comment-preserving hotbar persistence helper that writes the documented `[[hotbar]]` schema to the resolved user config path
- document the hotbar config contract, warnings, default behavior, primary `~/.codewhale/config.toml` path, and project-overlay boundary

Refs #3392.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-config --locked hotbar -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked config_persistence -- --nocapture`
- `cargo check -p codewhale-tui --locked`