### PR TITLE
fix(tui): surface provider concurrency status

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -61,7 +61,9 @@ use crate::worker_profile::ModelRoute;
 use crate::working_set::WorkingSet;
 
 use super::events::{Event, TurnOutcomeStatus};
-use super::ops::{Op, SessionSnapshot, USER_SHELL_TOOL_ID_PREFIX, UserInputProvenance};
+use super::ops::{
+    Op, ProviderRuntimeStatus, SessionSnapshot, USER_SHELL_TOOL_ID_PREFIX, UserInputProvenance,
+};
 use super::session::Session;
 use super::tool_parser;
 use super::turn::{TurnContext, post_turn_snapshot, pre_turn_snapshot};
@@ -1625,6 +1627,28 @@ impl Engine {
                         };
                         if let Some(tx) = tx.lock().ok().and_then(|mut g| g.take()) {
                             let _ = tx.send(snapshot);
+                        }
+                    }
+                    Op::GetProviderRuntimeStatus { tx } => {
+                        let status = if let Some(client) = self.deepseek_client.as_ref() {
+                            ProviderRuntimeStatus {
+                                provider: client.api_provider(),
+                                request_concurrency_limit: client
+                                    .provider_request_concurrency_limit(),
+                                active_provider_requests: client.active_provider_requests(),
+                            }
+                        } else {
+                            let provider = self.api_config.api_provider();
+                            ProviderRuntimeStatus {
+                                provider,
+                                request_concurrency_limit: self
+                                    .api_config
+                                    .provider_max_concurrency(provider),
+                                active_provider_requests: 0,
+                            }
+                        };
+                        if let Some(tx) = tx.lock().ok().and_then(|mut g| g.take()) {
+                            let _ = tx.send(status);
                         }
                     }
                     Op::PurgeContext => {

--- a/crates/tui/src/core/engine/handle.rs
+++ b/crates/tui/src/core/engine/handle.rs
@@ -139,4 +139,15 @@ impl EngineHandle {
         rx.await
             .map_err(|_| anyhow::anyhow!("Engine dropped session snapshot oneshot"))
     }
+
+    /// Request active provider request concurrency state.
+    pub async fn get_provider_runtime_status(
+        &self,
+    ) -> Result<crate::core::ops::ProviderRuntimeStatus> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let tx = std::sync::Arc::new(std::sync::Mutex::new(Some(tx)));
+        self.send(Op::GetProviderRuntimeStatus { tx }).await?;
+        rx.await
+            .map_err(|_| anyhow::anyhow!("Engine dropped provider runtime status oneshot"))
+    }
 }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -4,7 +4,7 @@ use super::context::{COMPACTION_SUMMARY_MARKER, TURN_MAX_OUTPUT_TOKENS};
 use super::turn_loop::registered_tool_approval_required;
 use crate::config::ApiProvider;
 use crate::models::SystemBlock;
-use crate::test_support::lock_test_env;
+use crate::test_support::{EnvVarGuard, lock_test_env};
 use crate::tools::plan::{PlanItemArg, PlanSnapshot, StepStatus};
 use crate::tools::spec::ToolCapability;
 use crate::tools::todo::{TodoItem, TodoListSnapshot, TodoStatus};
@@ -3232,6 +3232,35 @@ async fn edit_last_turn_preserves_current_mode() {
         .expect("snapshot");
 
     assert_eq!(snapshot.mode, "plan");
+
+    run.abort();
+}
+
+#[tokio::test]
+async fn provider_runtime_status_reports_configured_zai_cap_without_client() {
+    let (engine, handle) = {
+        let _lock = lock_test_env();
+        let _zai_key = EnvVarGuard::remove("ZAI_API_KEY");
+        let _zai_alt_key = EnvVarGuard::remove("Z_AI_API_KEY");
+        let api_config = Config {
+            provider: Some("zai".to_string()),
+            ..Config::default()
+        };
+        Engine::new(EngineConfig::default(), &api_config)
+    };
+
+    let run = tokio::spawn(engine.run());
+    let status = tokio::time::timeout(Duration::from_secs(2), handle.get_provider_runtime_status())
+        .await
+        .expect("provider runtime status response")
+        .expect("provider runtime status");
+
+    assert_eq!(status.provider, ApiProvider::Zai);
+    assert_eq!(
+        status.request_concurrency_limit,
+        Some(crate::config::DEFAULT_ZAI_PROVIDER_MAX_CONCURRENCY)
+    );
+    assert_eq!(status.active_provider_requests, 0);
 
     run.abort();
 }

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -27,6 +27,15 @@ pub struct SessionSnapshot {
     pub mode: String,
 }
 
+/// Provider request runtime state surfaced by `/provider`.
+/// Returned by `Op::GetProviderRuntimeStatus` via a oneshot channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderRuntimeStatus {
+    pub provider: ApiProvider,
+    pub request_concurrency_limit: Option<usize>,
+    pub active_provider_requests: usize,
+}
+
 /// Origin of text being introduced as a user-role turn.
 ///
 /// Chat providers force several runtime/control-plane signals through
@@ -194,6 +203,13 @@ pub enum Op {
     /// the caller doesn't have to compete with the SSE event stream.
     GetSessionSnapshot {
         tx: std::sync::Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<SessionSnapshot>>>>,
+    },
+
+    /// Get active provider request concurrency state for readiness surfaces.
+    GetProviderRuntimeStatus {
+        tx: std::sync::Arc<
+            std::sync::Mutex<Option<tokio::sync::oneshot::Sender<ProviderRuntimeStatus>>>,
+        >,
     },
 
     /// Run agent-driven context purging.

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -27,6 +27,7 @@ use ratatui::{
 };
 
 use crate::config::{ApiProvider, Config, has_api_key_for, kimi_cli_credentials_present};
+use crate::core::ops::ProviderRuntimeStatus;
 use crate::model_profile::{SupportState, resolved_capability_profile};
 use crate::palette;
 use crate::tui::app::ReasoningEffort;
@@ -64,6 +65,7 @@ pub struct ProviderDashboardRow {
     pub supported_protocols: Vec<String>,
     pub available_model_count: usize,
     pub default_route: ProviderDefaultRoute,
+    pub request_concurrency: ProviderRequestConcurrencySummary,
     pub usage_meter: String,
     pub reasoning: ProviderReasoningSummary,
     pub capabilities: ProviderCapabilityBadges,
@@ -97,6 +99,12 @@ pub enum ProviderCatalogStatus {
 pub struct ProviderDefaultRoute {
     pub logical_model: String,
     pub wire_model: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderRequestConcurrencySummary {
+    pub limit: Option<usize>,
+    pub active: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -265,14 +273,35 @@ pub enum ProviderReasoningStreamVisibility {
 }
 
 impl ProviderDashboardRow {
+    #[cfg(test)]
     fn from_config(provider: ApiProvider, active: ApiProvider, config: &Config) -> Self {
-        Self::from_config_with_provider_id(provider, active, config, None)
+        Self::from_config_with_runtime_status(provider, active, config, None)
     }
 
-    fn from_custom_config(provider_id: &str, active: ApiProvider, config: &Config) -> Self {
+    fn from_config_with_runtime_status(
+        provider: ApiProvider,
+        active: ApiProvider,
+        config: &Config,
+        runtime_status: Option<&ProviderRuntimeStatus>,
+    ) -> Self {
+        Self::from_config_with_provider_id(provider, active, config, None, runtime_status)
+    }
+
+    fn from_custom_config_with_runtime_status(
+        provider_id: &str,
+        active: ApiProvider,
+        config: &Config,
+        runtime_status: Option<&ProviderRuntimeStatus>,
+    ) -> Self {
         let mut scoped = config.clone();
         scoped.provider = Some(provider_id.to_string());
-        Self::from_config_with_provider_id(ApiProvider::Custom, active, &scoped, Some(provider_id))
+        Self::from_config_with_provider_id(
+            ApiProvider::Custom,
+            active,
+            &scoped,
+            Some(provider_id),
+            runtime_status,
+        )
     }
 
     fn from_config_with_provider_id(
@@ -280,6 +309,7 @@ impl ProviderDashboardRow {
         active: ApiProvider,
         config: &Config,
         provider_id_override: Option<&str>,
+        runtime_status: Option<&ProviderRuntimeStatus>,
     ) -> Self {
         let configured = config.provider_config_for(provider);
         let configured_base_url = configured
@@ -316,6 +346,8 @@ impl ProviderDashboardRow {
         } else {
             provider == active
         };
+        let request_concurrency =
+            ProviderRequestConcurrencySummary::for_row(provider, config, runtime_status, is_active);
 
         let Some(kind) = provider.kind() else {
             return Self {
@@ -334,6 +366,7 @@ impl ProviderDashboardRow {
                         .unwrap_or_else(|| "deepseek-v4-pro".to_string()),
                     wire_model: "legacy alias".to_string(),
                 },
+                request_concurrency,
                 usage_meter,
                 reasoning: ProviderReasoningSummary::unknown(provider, config),
                 capabilities: ProviderCapabilityBadges::unknown(),
@@ -435,6 +468,7 @@ impl ProviderDashboardRow {
             supported_protocols,
             available_model_count,
             default_route,
+            request_concurrency,
             usage_meter: resolved_pricing,
             reasoning,
             capabilities,
@@ -458,8 +492,13 @@ impl ProviderDashboardRow {
         } else {
             ""
         };
+        let request_concurrency = self
+            .request_concurrency
+            .label()
+            .map(|label| format!(" | {label}"))
+            .unwrap_or_default();
         format!(
-            "{} | auth:{} | {} | {} | base:{}{} | route:{}{} origin:{} | {} | {} | catalog:{}{}",
+            "{} | auth:{} | {} | {} | base:{}{} | route:{}{} origin:{} | {} | {}{} | catalog:{}{}",
             self.readiness.label(),
             self.auth_status.label(),
             self.usage_meter,
@@ -471,6 +510,7 @@ impl ProviderDashboardRow {
             self.model_origin.label(),
             self.capabilities.label(),
             self.reasoning.label(),
+            request_concurrency,
             self.catalog_label(),
             // Only experimental integrations add a tag; supported ones stay
             // noise-free (#2984).
@@ -486,6 +526,37 @@ impl ProviderDashboardRow {
             ProviderCatalogStatus::Bundled => format!("{} bundled", self.available_model_count),
             ProviderCatalogStatus::DefaultOnly => "default-only".to_string(),
             ProviderCatalogStatus::Legacy => "legacy".to_string(),
+        }
+    }
+}
+
+impl ProviderRequestConcurrencySummary {
+    fn for_row(
+        provider: ApiProvider,
+        config: &Config,
+        runtime_status: Option<&ProviderRuntimeStatus>,
+        is_active: bool,
+    ) -> Self {
+        let mut summary = Self {
+            limit: config.provider_max_concurrency(provider),
+            active: None,
+        };
+        if is_active
+            && let Some(status) = runtime_status
+            && status.provider == provider
+        {
+            summary.limit = status.request_concurrency_limit;
+            summary.active = Some(status.active_provider_requests);
+        }
+        summary
+    }
+
+    fn label(self) -> Option<String> {
+        match (self.limit, self.active) {
+            (Some(limit), Some(active)) => Some(format!("req:{active}/{limit}")),
+            (Some(limit), None) => Some(format!("req:cap {limit}")),
+            (None, Some(active)) if active > 0 => Some(format!("req:{active}/uncapped")),
+            _ => None,
         }
     }
 }
@@ -975,16 +1046,34 @@ fn compact_base_url(base_url: &str) -> String {
 }
 
 impl ProviderPickerView {
+    #[cfg(test)]
     #[must_use]
     pub fn new(active: ApiProvider, config: &Config) -> Self {
+        Self::new_with_runtime_status(active, config, None)
+    }
+
+    #[must_use]
+    pub fn new_with_runtime_status(
+        active: ApiProvider,
+        config: &Config,
+        runtime_status: Option<ProviderRuntimeStatus>,
+    ) -> Self {
         // Present providers in the shared metadata display order (#3076). The
         // active provider is highlighted via `selected_idx` below, so it is
         // never lost in the list.
-        let custom_rows = custom_provider_dashboard_rows(active, config);
+        let runtime_status = runtime_status.as_ref();
+        let custom_rows = custom_provider_dashboard_rows(active, config, runtime_status);
         let mut rows: Vec<ProviderDashboardRow> = ApiProvider::sorted_for_display()
             .into_iter()
             .filter(|provider| *provider != ApiProvider::Custom || custom_rows.is_empty())
-            .map(|p| ProviderDashboardRow::from_config(p, active, config))
+            .map(|p| {
+                ProviderDashboardRow::from_config_with_runtime_status(
+                    p,
+                    active,
+                    config,
+                    runtime_status,
+                )
+            })
             .collect();
         rows.extend(custom_rows);
         rows.sort_by(|a, b| {
@@ -1424,6 +1513,7 @@ impl ModalView for ProviderPickerView {
 fn custom_provider_dashboard_rows(
     active: ApiProvider,
     config: &Config,
+    runtime_status: Option<&ProviderRuntimeStatus>,
 ) -> Vec<ProviderDashboardRow> {
     let Some(providers) = config.providers.as_ref() else {
         return Vec::new();
@@ -1436,7 +1526,14 @@ fn custom_provider_dashboard_rows(
                 .custom_provider_config(id)
                 .is_some_and(|entry| entry.is_openai_compatible_custom())
         })
-        .map(|id| ProviderDashboardRow::from_custom_config(&id, active, config))
+        .map(|id| {
+            ProviderDashboardRow::from_custom_config_with_runtime_status(
+                &id,
+                active,
+                config,
+                runtime_status,
+            )
+        })
         .collect()
 }
 
@@ -1678,6 +1775,53 @@ mod tests {
         assert_eq!(row.reasoning.selected_control.as_deref(), Some("max"));
         assert!(row.compact_hint().contains("reasoning:high/max"));
         assert!(row.compact_hint().contains("stream:structured"));
+    }
+
+    #[test]
+    fn provider_dashboard_row_surfaces_zai_concurrency_cap() {
+        let config = Config::default();
+        let row =
+            ProviderDashboardRow::from_config(ApiProvider::Zai, ApiProvider::Deepseek, &config);
+
+        assert_eq!(
+            row.request_concurrency.limit,
+            Some(crate::config::DEFAULT_ZAI_PROVIDER_MAX_CONCURRENCY)
+        );
+        assert_eq!(row.request_concurrency.active, None);
+        assert!(
+            row.compact_hint().contains("req:cap 3"),
+            "Z.ai's effective default cap must surface in /provider, got {:?}",
+            row.compact_hint()
+        );
+    }
+
+    #[test]
+    fn provider_dashboard_row_surfaces_active_provider_requests() {
+        let config = Config::default();
+        let runtime_status = ProviderRuntimeStatus {
+            provider: ApiProvider::Zai,
+            request_concurrency_limit: Some(crate::config::DEFAULT_ZAI_PROVIDER_MAX_CONCURRENCY),
+            active_provider_requests: 2,
+        };
+        let mut picker = ProviderPickerView::new_with_runtime_status(
+            ApiProvider::Zai,
+            &config,
+            Some(runtime_status),
+        );
+
+        move_to_provider(&mut picker, ApiProvider::Zai);
+        let row = &picker.rows[picker.selected_idx];
+
+        assert_eq!(
+            row.request_concurrency.limit,
+            Some(crate::config::DEFAULT_ZAI_PROVIDER_MAX_CONCURRENCY)
+        );
+        assert_eq!(row.request_concurrency.active, Some(2));
+        assert!(
+            row.compact_hint().contains("req:2/3"),
+            "active runtime concurrency must surface in /provider, got {:?}",
+            row.compact_hint()
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -55,7 +55,7 @@ use crate::config::{
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::Event as EngineEvent;
-use crate::core::ops::{Op, USER_SHELL_TOOL_ID_PREFIX};
+use crate::core::ops::{Op, ProviderRuntimeStatus, USER_SHELL_TOOL_ID_PREFIX};
 use crate::hooks::{HookEvent, HookExecutor, TurnEndPayloadInput, TurnEndTotals};
 use crate::llm_client::LlmClient;
 use crate::localization::{MessageId, tr};
@@ -6980,6 +6980,18 @@ fn provider_picker_model_override(app: &App, provider: ApiProvider) -> Option<St
     (app.api_provider == provider).then(|| app.model.clone())
 }
 
+async fn query_provider_runtime_status(
+    engine_handle: &EngineHandle,
+) -> Option<ProviderRuntimeStatus> {
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        engine_handle.get_provider_runtime_status(),
+    )
+    .await
+    .ok()
+    .and_then(|result| result.ok())
+}
+
 fn open_text_pager(app: &mut App, title: String, content: String) {
     let width = app
         .viewport
@@ -7313,11 +7325,14 @@ async fn apply_command_result(
             }
             AppAction::OpenProviderPicker => {
                 if app.view_stack.top_kind() != Some(ModalKind::ProviderPicker) {
-                    app.view_stack
-                        .push(crate::tui::provider_picker::ProviderPickerView::new(
+                    let runtime_status = query_provider_runtime_status(engine_handle).await;
+                    app.view_stack.push(
+                        crate::tui::provider_picker::ProviderPickerView::new_with_runtime_status(
                             app.api_provider,
                             config,
-                        ));
+                            runtime_status,
+                        ),
+                    );
                 }
             }
             AppAction::OpenModePicker => {


### PR DESCRIPTION
## Summary
- add a read-only engine provider runtime snapshot for the active provider request cap and in-flight request count
- show Z.ai/GLM effective request caps in `/provider`, using config-derived caps for inactive rows and live active counts for the active provider when available
- keep `/provider` responsive with a short timeout around the runtime query, falling back to config-only readiness data if the engine is busy

Fixes #3496.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_dashboard_row_surfaces -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_request_concurrency -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_runtime_status_reports_configured_zai_cap_without_client -- --nocapture`
- `cargo check -p codewhale-tui --locked`