### PR TITLE
fix(tui): add hotbar setup wizard

### DIFF
--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -144,6 +144,7 @@
   "CmdStatusDescription": "显示当前运行状态",
   "CmdStatuslineDescription": "配置底栏要显示哪些条目",
   "CmdFleetDescription": "打开 Fleet 设置或工作器状态",
+  "CmdHotbarDescription": "打开 Hotbar 设置",
   "CmdSubagentsDescription": "/fleet status 的兼容快捷方式",
   "CmdSwarmDescription": "运行多代理扇出轮次（sequential | mixture | distill | deliberate）",
   "CmdSystemDescription": "显示当前系统提示词",

--- a/crates/tui/src/commands/groups/core/hotbar.rs
+++ b/crates/tui/src/commands/groups/core/hotbar.rs
@@ -1,0 +1,121 @@
+//! `/hotbar` command.
+
+use crate::commands::traits::{CommandInfo, RegisterCommand};
+use crate::localization::MessageId;
+use crate::tui::app::{App, AppAction};
+
+use super::CommandResult;
+
+pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
+    name: "hotbar",
+    aliases: &["hotkeys"],
+    usage: "/hotbar",
+    description_id: MessageId::CmdHotbarDescription,
+};
+
+pub(in crate::commands) struct HotbarCmd;
+
+impl RegisterCommand for HotbarCmd {
+    fn info() -> &'static CommandInfo {
+        &COMMAND_INFO
+    }
+
+    fn execute(_app: &mut App, arg: Option<&str>) -> CommandResult {
+        match arg.map(str::trim).filter(|arg| !arg.is_empty()) {
+            None | Some("setup" | "edit" | "configure" | "config") => {
+                CommandResult::action(AppAction::OpenHotbarSetup)
+            }
+            Some("help" | "?") => CommandResult::message(
+                "Usage: /hotbar [setup]\n\n/hotbar opens the Hotbar setup wizard.",
+            ),
+            Some(other) => CommandResult::error(format!(
+                "Unknown /hotbar target '{other}'. Use `/hotbar` or `/hotbar setup`."
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::tui::app::TuiOptions;
+    use std::path::PathBuf;
+
+    fn test_app() -> App {
+        let options = TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace: PathBuf::from("."),
+            config_path: None,
+            config_profile: None,
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: PathBuf::from("."),
+            memory_path: PathBuf::from("memory.md"),
+            notes_path: PathBuf::from("notes.txt"),
+            mcp_config_path: PathBuf::from("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: false,
+            skip_onboarding: true,
+            yolo: false,
+            resume_session_id: None,
+            initial_input: None,
+        };
+        App::new(options, &Config::default())
+    }
+
+    #[test]
+    fn hotbar_command_opens_setup_view() {
+        let mut app = test_app();
+
+        let result = HotbarCmd::execute(&mut app, None);
+
+        assert_eq!(result.action, Some(AppAction::OpenHotbarSetup));
+        assert!(result.message.is_none());
+    }
+
+    #[test]
+    fn hotbar_setup_alias_opens_setup_view() {
+        let mut app = test_app();
+
+        let result = HotbarCmd::execute(&mut app, Some("setup"));
+
+        assert_eq!(result.action, Some(AppAction::OpenHotbarSetup));
+        assert!(result.message.is_none());
+    }
+
+    #[test]
+    fn hotbar_help_arg_returns_usage() {
+        let mut app = test_app();
+
+        let result = HotbarCmd::execute(&mut app, Some("help"));
+
+        assert!(!result.is_error);
+        assert!(result.action.is_none());
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("/hotbar opens"))
+        );
+    }
+
+    #[test]
+    fn hotbar_unknown_arg_reports_error() {
+        let mut app = test_app();
+
+        let result = HotbarCmd::execute(&mut app, Some("bogus"));
+
+        assert!(result.is_error);
+        assert!(result.action.is_none());
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("Unknown /hotbar target 'bogus'"))
+        );
+    }
+}

--- a/crates/tui/src/commands/groups/core/mod.rs
+++ b/crates/tui/src/commands/groups/core/mod.rs
@@ -18,6 +18,7 @@ mod help;
 mod hf;
 mod home;
 mod hooks;
+mod hotbar;
 mod links;
 mod model;
 mod modeldb;
@@ -94,6 +95,10 @@ impl CommandGroup for CoreCommands {
             Box::new(FunctionCommand::new(
                 fleet::FleetCmd::info(),
                 fleet::FleetCmd::execute,
+            )),
+            Box::new(FunctionCommand::new(
+                hotbar::HotbarCmd::info(),
+                hotbar::HotbarCmd::execute,
             )),
             Box::new(FunctionCommand::new(
                 agent::AgentCmd::info(),

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -365,6 +365,7 @@ pub enum MessageId {
     CmdStatusDescription,
     CmdStatuslineDescription,
     CmdFleetDescription,
+    CmdHotbarDescription,
     CmdSubagentsDescription,
     CmdSystemDescription,
     CmdTaskDescription,
@@ -816,6 +817,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::CmdStatusDescription,
     MessageId::CmdStatuslineDescription,
     MessageId::CmdFleetDescription,
+    MessageId::CmdHotbarDescription,
     MessageId::CmdSubagentsDescription,
     MessageId::CmdSystemDescription,
     MessageId::CmdTaskDescription,
@@ -1489,6 +1491,7 @@ fn english(id: MessageId) -> &'static str {
         MessageId::CmdStatusDescription => "Show runtime session status",
         MessageId::CmdStatuslineDescription => "Configure which items appear in the footer",
         MessageId::CmdFleetDescription => "Open Fleet setup or worker status",
+        MessageId::CmdHotbarDescription => "Open Hotbar setup",
         MessageId::CmdSubagentsDescription => "Compatibility shortcut for /fleet status",
         MessageId::CmdSystemDescription => "Show current system prompt",
         MessageId::CmdTaskDescription => "Manage background tasks",
@@ -2126,6 +2129,7 @@ fn vietnamese(id: MessageId) -> Option<&'static str> {
             "Cấu hình các mục hiển thị ở thanh trạng thái dưới cùng"
         }
         MessageId::CmdFleetDescription => "Mở thiết lập Fleet hoặc trạng thái worker",
+        MessageId::CmdHotbarDescription => "Mở thiết lập Hotbar",
         MessageId::CmdSubagentsDescription => "Lối tắt tương thích cho /fleet status",
         MessageId::CmdSystemDescription => "Hiển thị prompt hệ thống hiện tại",
         MessageId::CmdTaskDescription => "Quản lý các nhiệm vụ chạy ngầm",
@@ -2953,6 +2957,7 @@ fn japanese(id: MessageId) -> Option<&'static str> {
         MessageId::CmdStatusDescription => "実行中のセッション状態を表示",
         MessageId::CmdStatuslineDescription => "フッターに表示する項目を設定",
         MessageId::CmdFleetDescription => "Fleet設定またはワーカー状態を開く",
+        MessageId::CmdHotbarDescription => "Hotbar設定を開く",
         MessageId::CmdSubagentsDescription => "/fleet status の互換ショートカット",
         MessageId::CmdSystemDescription => "現在のシステムプロンプトを表示",
         MessageId::CmdTaskDescription => "バックグラウンドタスクを管理",
@@ -3590,6 +3595,7 @@ fn portuguese_brazil(id: MessageId) -> Option<&'static str> {
         MessageId::CmdStatusDescription => "Exibir o status da sessão em execução",
         MessageId::CmdStatuslineDescription => "Configurar quais itens aparecem no rodapé",
         MessageId::CmdFleetDescription => "Abrir configuração Fleet ou status dos workers",
+        MessageId::CmdHotbarDescription => "Abrir configuração da Hotbar",
         MessageId::CmdSubagentsDescription => "Atalho compatível para /fleet status",
         MessageId::CmdSystemDescription => "Exibir o prompt de sistema atual",
         MessageId::CmdTaskDescription => "Gerenciar tarefas em segundo plano",
@@ -4238,6 +4244,7 @@ fn spanish_latin_america(id: MessageId) -> Option<&'static str> {
             "Configurar qué elementos aparecen en el pie de página"
         }
         MessageId::CmdFleetDescription => "Abrir configuración Fleet o estado de workers",
+        MessageId::CmdHotbarDescription => "Abrir configuración de Hotbar",
         MessageId::CmdSubagentsDescription => "Atajo compatible para /fleet status",
         MessageId::CmdSystemDescription => "Mostrar el prompt de sistema actual",
         MessageId::CmdTaskDescription => "Gestionar tareas en segundo plano",

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5832,6 +5832,8 @@ pub enum AppAction {
     OpenThemePicker,
     /// Open the `/fleet` setup and loadout planner.
     OpenFleetSetup,
+    /// Open the `/hotbar` setup wizard.
+    OpenHotbarSetup,
     /// Open an external URL in the system browser.
     OpenExternalUrl {
         url: String,

--- a/crates/tui/src/tui/hotbar/mod.rs
+++ b/crates/tui/src/tui/hotbar/mod.rs
@@ -4,5 +4,6 @@
 //! the built-in actions defined here.
 
 pub mod actions;
+pub mod setup;
 
 pub use actions::HotbarActionRegistry;

--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -1,0 +1,736 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Widget},
+};
+
+use crate::config::Config;
+use crate::palette;
+use crate::tui::app::App;
+use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+
+#[cfg(test)]
+use super::actions::HotbarRecommendation;
+use super::actions::{HotbarActionCategory, HotbarActionMetadata, HotbarArgsBehavior};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotbarSetupActionRow {
+    pub metadata: HotbarActionMetadata,
+    pub disabled_reason: Option<String>,
+}
+
+impl HotbarSetupActionRow {
+    fn status_label(&self) -> &'static str {
+        if self.disabled_reason.is_some() {
+            "disabled"
+        } else if matches!(self.metadata.args, HotbarArgsBehavior::Required) {
+            "prefill"
+        } else {
+            "ready"
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotbarSetupView {
+    sources: Vec<HotbarActionCategory>,
+    actions: Vec<HotbarSetupActionRow>,
+    selected_source_idx: usize,
+    selected_action_idx_by_source: BTreeMap<HotbarActionCategory, usize>,
+    selected_slot: u8,
+    original_bindings: BTreeMap<u8, codewhale_config::HotbarBindingToml>,
+    draft_bindings: BTreeMap<u8, codewhale_config::HotbarBindingToml>,
+    validation_errors: Vec<String>,
+    help_visible: bool,
+}
+
+impl HotbarSetupView {
+    #[must_use]
+    pub fn new(app: &App, config: &Config) -> Self {
+        let mut actions = app
+            .hotbar_actions
+            .iter()
+            .map(|action| {
+                let metadata = action.metadata(app.ui_locale);
+                let disabled_reason = action.disabled_reason(app);
+                HotbarSetupActionRow {
+                    metadata,
+                    disabled_reason,
+                }
+            })
+            .collect::<Vec<_>>();
+        actions.sort_by(|a, b| {
+            a.metadata
+                .category
+                .cmp(&b.metadata.category)
+                .then_with(|| {
+                    a.metadata
+                        .display_name
+                        .to_ascii_lowercase()
+                        .cmp(&b.metadata.display_name.to_ascii_lowercase())
+                })
+                .then_with(|| a.metadata.id.cmp(&b.metadata.id))
+        });
+
+        let sources = actions
+            .iter()
+            .map(|row| row.metadata.category)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        let known_action_ids = app
+            .hotbar_actions
+            .iter()
+            .map(|action| action.id())
+            .collect::<Vec<_>>();
+        let original_bindings = config
+            .resolve_hotbar_bindings(&known_action_ids)
+            .bindings
+            .into_iter()
+            .map(|binding| {
+                (
+                    binding.slot,
+                    codewhale_config::HotbarBindingToml {
+                        slot: binding.slot,
+                        action: binding.action,
+                        label: binding.label,
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        Self {
+            sources,
+            actions,
+            selected_source_idx: 0,
+            selected_action_idx_by_source: BTreeMap::new(),
+            selected_slot: 1,
+            draft_bindings: original_bindings.clone(),
+            original_bindings,
+            validation_errors: Vec::new(),
+            help_visible: false,
+        }
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub fn source_categories(&self) -> &[HotbarActionCategory] {
+        &self.sources
+    }
+
+    #[must_use]
+    pub fn selected_source(&self) -> Option<HotbarActionCategory> {
+        self.sources.get(self.selected_source_idx).copied()
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub fn selected_slot(&self) -> u8 {
+        self.selected_slot
+    }
+
+    #[must_use]
+    pub fn selected_action(&self) -> Option<&HotbarSetupActionRow> {
+        let source = self.selected_source()?;
+        self.actions_for_source(source)
+            .get(self.selected_action_idx(source))
+            .copied()
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub fn binding_for_slot(&self, slot: u8) -> Option<&codewhale_config::HotbarBindingToml> {
+        self.draft_bindings.get(&slot)
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub fn checked_action_ids(&self) -> BTreeSet<String> {
+        self.draft_bindings
+            .values()
+            .map(|binding| binding.action.clone())
+            .collect()
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub fn recommended_action_ids(&self) -> BTreeSet<String> {
+        self.actions
+            .iter()
+            .filter(|row| {
+                matches!(
+                    row.metadata.recommendation,
+                    HotbarRecommendation::Default | HotbarRecommendation::Eligible
+                )
+            })
+            .map(|row| row.metadata.id.clone())
+            .collect()
+    }
+
+    #[must_use]
+    pub fn is_dirty(&self) -> bool {
+        self.draft_bindings != self.original_bindings
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub fn validation_errors(&self) -> &[String] {
+        &self.validation_errors
+    }
+
+    #[must_use]
+    pub fn status_text(&self) -> String {
+        if let Some(error) = self.validation_errors.last() {
+            return error.clone();
+        }
+        let dirty = if self.is_dirty() { "modified" } else { "clean" };
+        let action = self
+            .selected_action()
+            .map(|row| format!("{} ({})", row.metadata.display_name, row.status_label()))
+            .unwrap_or_else(|| "No action".to_string());
+        format!("slot {} | {action} | {dirty}", self.selected_slot)
+    }
+
+    #[cfg(test)]
+    pub fn select_action_by_id(&mut self, action_id: &str) -> bool {
+        let Some(row) = self
+            .actions
+            .iter()
+            .find(|row| row.metadata.id == action_id)
+            .cloned()
+        else {
+            return false;
+        };
+        let Some(source_idx) = self
+            .sources
+            .iter()
+            .position(|source| *source == row.metadata.category)
+        else {
+            return false;
+        };
+        self.selected_source_idx = source_idx;
+        let index = self
+            .actions_for_source(row.metadata.category)
+            .iter()
+            .position(|candidate| candidate.metadata.id == action_id)
+            .unwrap_or(0);
+        self.selected_action_idx_by_source
+            .insert(row.metadata.category, index);
+        self.validation_errors.clear();
+        true
+    }
+
+    pub fn select_slot(&mut self, slot: u8) -> bool {
+        if !(1..=codewhale_config::HOTBAR_SLOT_COUNT).contains(&slot) {
+            self.validation_errors = vec![format!(
+                "Hotbar slot {slot} is outside 1-{}",
+                codewhale_config::HOTBAR_SLOT_COUNT
+            )];
+            return false;
+        }
+        self.selected_slot = slot;
+        self.validation_errors.clear();
+        true
+    }
+
+    pub fn assign_selected_action(&mut self) -> bool {
+        let Some(row) = self.selected_action().cloned() else {
+            self.validation_errors = vec!["No action selected.".to_string()];
+            return false;
+        };
+        if let Some(reason) = row.disabled_reason {
+            self.validation_errors = vec![format!(
+                "{} cannot be assigned: {reason}",
+                row.metadata.display_name
+            )];
+            return false;
+        }
+        self.draft_bindings.insert(
+            self.selected_slot,
+            codewhale_config::HotbarBindingToml {
+                slot: self.selected_slot,
+                action: row.metadata.id,
+                label: None,
+            },
+        );
+        self.validation_errors.clear();
+        true
+    }
+
+    pub fn toggle_selected_action(&mut self) -> bool {
+        let selected_id = self
+            .selected_action()
+            .map(|row| row.metadata.id.clone())
+            .unwrap_or_default();
+        if self
+            .draft_bindings
+            .get(&self.selected_slot)
+            .is_some_and(|binding| binding.action == selected_id)
+        {
+            self.clear_selected_slot();
+            true
+        } else {
+            self.assign_selected_action()
+        }
+    }
+
+    pub fn clear_selected_slot(&mut self) {
+        self.draft_bindings.remove(&self.selected_slot);
+        self.validation_errors.clear();
+    }
+
+    #[must_use]
+    pub fn save_bindings(&self) -> Vec<codewhale_config::HotbarBindingToml> {
+        self.draft_bindings.values().cloned().collect()
+    }
+
+    fn actions_for_source(&self, source: HotbarActionCategory) -> Vec<&HotbarSetupActionRow> {
+        self.actions
+            .iter()
+            .filter(|row| row.metadata.category == source)
+            .collect()
+    }
+
+    fn selected_action_idx(&self, source: HotbarActionCategory) -> usize {
+        let len = self.actions_for_source(source).len();
+        if len == 0 {
+            return 0;
+        }
+        self.selected_action_idx_by_source
+            .get(&source)
+            .copied()
+            .unwrap_or(0)
+            .min(len.saturating_sub(1))
+    }
+
+    fn set_selected_action_idx(&mut self, source: HotbarActionCategory, idx: usize) {
+        let len = self.actions_for_source(source).len();
+        if len == 0 {
+            self.selected_action_idx_by_source.insert(source, 0);
+        } else {
+            self.selected_action_idx_by_source
+                .insert(source, idx.min(len.saturating_sub(1)));
+        }
+    }
+
+    fn move_source(&mut self, delta: isize) {
+        if self.sources.is_empty() {
+            return;
+        }
+        self.selected_source_idx = wrap_index(self.selected_source_idx, self.sources.len(), delta);
+        self.validation_errors.clear();
+    }
+
+    fn move_action(&mut self, delta: isize) {
+        let Some(source) = self.selected_source() else {
+            return;
+        };
+        let len = self.actions_for_source(source).len();
+        if len == 0 {
+            return;
+        }
+        let next = wrap_index(self.selected_action_idx(source), len, delta);
+        self.set_selected_action_idx(source, next);
+        self.validation_errors.clear();
+    }
+
+    fn move_slot(&mut self, delta: isize) {
+        let len = usize::from(codewhale_config::HOTBAR_SLOT_COUNT);
+        let next = wrap_index(usize::from(self.selected_slot - 1), len, delta) + 1;
+        self.selected_slot = u8::try_from(next).expect("hotbar slot fits in u8");
+        self.validation_errors.clear();
+    }
+
+    fn save_action(&self) -> ViewAction {
+        ViewAction::EmitAndClose(ViewEvent::HotbarSetupSaved {
+            bindings: self.save_bindings(),
+        })
+    }
+
+    fn render_lines(&self) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        let tabs = self
+            .sources
+            .iter()
+            .map(|source| {
+                if Some(*source) == self.selected_source() {
+                    format!("[{}]", source.as_str())
+                } else {
+                    source.as_str().to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("  ");
+        lines.push(Line::from(vec![Span::styled(
+            tabs,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]));
+        lines.push(Line::from(""));
+
+        let Some(source) = self.selected_source() else {
+            lines.push(Line::from("No hotbar actions are available."));
+            return lines;
+        };
+
+        for (idx, row) in self.actions_for_source(source).iter().enumerate() {
+            let marker = if idx == self.selected_action_idx(source) {
+                ">"
+            } else {
+                " "
+            };
+            let checked = if self
+                .draft_bindings
+                .values()
+                .any(|binding| binding.action == row.metadata.id)
+            {
+                "*"
+            } else {
+                " "
+            };
+            let mut text = format!(
+                "{marker}{checked} {:<20} {:<8} {}",
+                row.metadata.display_name,
+                row.status_label(),
+                row.metadata.description
+            );
+            if let Some(reason) = row.disabled_reason.as_deref() {
+                text.push_str(" (");
+                text.push_str(reason);
+                text.push(')');
+            }
+            lines.push(Line::from(text));
+        }
+
+        lines.push(Line::from(""));
+        let slots = (1..=codewhale_config::HOTBAR_SLOT_COUNT)
+            .map(|slot| {
+                let label = self
+                    .draft_bindings
+                    .get(&slot)
+                    .map(|binding| compact_action_id(&binding.action))
+                    .unwrap_or_else(|| "empty".to_string());
+                if slot == self.selected_slot {
+                    format!("[{slot}:{label}]")
+                } else {
+                    format!("{slot}:{label}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("  ");
+        lines.push(Line::from(slots));
+        lines.push(Line::from(self.status_text()));
+        if self.help_visible {
+            lines.push(Line::from(
+                "Tab/Shift+Tab source  Up/Down action  1-8 slot  Enter assign  Space toggle  Delete clear  s save  Esc cancel",
+            ));
+        }
+        lines
+    }
+}
+
+impl ModalView for HotbarSetupView {
+    fn kind(&self) -> ModalKind {
+        ModalKind::HotbarSetup
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
+        match key.code {
+            KeyCode::Esc => ViewAction::Close,
+            KeyCode::Char('q') | KeyCode::Char('Q') if key.modifiers.is_empty() => {
+                ViewAction::Close
+            }
+            KeyCode::Tab => {
+                self.move_source(1);
+                ViewAction::None
+            }
+            KeyCode::BackTab => {
+                self.move_source(-1);
+                ViewAction::None
+            }
+            KeyCode::Left if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.move_source(-1);
+                ViewAction::None
+            }
+            KeyCode::Right if key.modifiers.contains(KeyModifiers::ALT) => {
+                self.move_source(1);
+                ViewAction::None
+            }
+            KeyCode::Left => {
+                self.move_slot(-1);
+                ViewAction::None
+            }
+            KeyCode::Right => {
+                self.move_slot(1);
+                ViewAction::None
+            }
+            KeyCode::Up => {
+                self.move_action(-1);
+                ViewAction::None
+            }
+            KeyCode::Down => {
+                self.move_action(1);
+                ViewAction::None
+            }
+            KeyCode::Enter => {
+                self.assign_selected_action();
+                ViewAction::None
+            }
+            KeyCode::Char(' ') => {
+                self.toggle_selected_action();
+                ViewAction::None
+            }
+            KeyCode::Backspace | KeyCode::Delete => {
+                self.clear_selected_slot();
+                ViewAction::None
+            }
+            KeyCode::Char(ch) if ('1'..='8').contains(&ch) => {
+                let slot = ch.to_digit(10).expect("digit") as u8;
+                self.select_slot(slot);
+                ViewAction::None
+            }
+            KeyCode::Char('s') | KeyCode::Char('S') if key.modifiers.is_empty() => {
+                self.save_action()
+            }
+            KeyCode::Char('?') => {
+                self.help_visible = !self.help_visible;
+                ViewAction::None
+            }
+            _ => ViewAction::None,
+        }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let popup_width = 118.min(area.width.saturating_sub(4)).max(72);
+        let popup_height = 28.min(area.height.saturating_sub(4)).max(12);
+        let popup_area = Rect {
+            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
+            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
+            width: popup_width,
+            height: popup_height,
+        };
+        Clear.render(popup_area, buf);
+        let block = Block::default()
+            .title(" Hotbar setup ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR));
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1)])
+            .split(inner);
+        Paragraph::new(self.render_lines())
+            .style(Style::default().fg(palette::TEXT_PRIMARY))
+            .render(chunks[0], buf);
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+fn wrap_index(current: usize, len: usize, delta: isize) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    let len = isize::try_from(len).expect("len fits in isize");
+    let current = isize::try_from(current).expect("current fits in isize");
+    usize::try_from((current + delta).rem_euclid(len)).expect("wrapped index fits")
+}
+
+fn compact_action_id(action_id: &str) -> String {
+    let suffix = action_id.rsplit('.').next().unwrap_or(action_id);
+    crate::tui::ui_text::truncate_line_to_width(suffix, 7)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::tui::app::TuiOptions;
+    use crossterm::event::KeyModifiers;
+    use std::path::PathBuf;
+
+    fn test_app() -> App {
+        let options = TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace: PathBuf::from("."),
+            config_path: None,
+            config_profile: None,
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: PathBuf::from("."),
+            memory_path: PathBuf::from("memory.md"),
+            notes_path: PathBuf::from("notes.txt"),
+            mcp_config_path: PathBuf::from("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: true,
+            skip_onboarding: true,
+            yolo: false,
+            resume_session_id: None,
+            initial_input: None,
+        };
+        let mut app = App::new(options, &Config::default());
+        app.ui_locale = crate::localization::Locale::En;
+        app
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn wizard_sources_follow_registered_action_categories() {
+        let app = test_app();
+        let view = HotbarSetupView::new(&app, &Config::default());
+
+        assert_eq!(
+            view.source_categories(),
+            &[HotbarActionCategory::App, HotbarActionCategory::Slash]
+        );
+        assert_eq!(view.selected_source(), Some(HotbarActionCategory::App));
+        assert!(view.recommended_action_ids().contains("mode.agent"));
+        assert!(view.checked_action_ids().contains("mode.plan"));
+    }
+
+    #[test]
+    fn wizard_assigns_replaces_toggles_and_clears_slots() {
+        let app = test_app();
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+
+        assert!(view.select_slot(1));
+        assert!(view.select_action_by_id("mode.plan"));
+        assert!(view.assign_selected_action());
+        assert_eq!(
+            view.binding_for_slot(1)
+                .map(|binding| binding.action.as_str()),
+            Some("mode.plan")
+        );
+
+        assert!(view.select_action_by_id("mode.agent"));
+        assert!(view.assign_selected_action());
+        assert_eq!(
+            view.binding_for_slot(1)
+                .map(|binding| binding.action.as_str()),
+            Some("mode.agent")
+        );
+        assert!(view.is_dirty());
+
+        assert!(view.toggle_selected_action());
+        assert!(view.binding_for_slot(1).is_none());
+        view.clear_selected_slot();
+        assert!(view.binding_for_slot(1).is_none());
+    }
+
+    #[test]
+    fn wizard_save_emits_bindings_but_escape_only_closes() {
+        let app = test_app();
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+        assert!(view.select_slot(8));
+        assert!(view.select_action_by_id("sidebar.toggle"));
+        assert!(view.assign_selected_action());
+
+        match view.handle_key(key(KeyCode::Char('s'))) {
+            ViewAction::EmitAndClose(ViewEvent::HotbarSetupSaved { bindings }) => {
+                assert!(
+                    bindings
+                        .iter()
+                        .any(|binding| { binding.slot == 8 && binding.action == "sidebar.toggle" })
+                );
+            }
+            other => panic!("expected HotbarSetupSaved, got {other:?}"),
+        }
+
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+        assert!(view.select_slot(1));
+        assert!(view.select_action_by_id("mode.agent"));
+        assert!(view.assign_selected_action());
+        assert!(matches!(
+            view.handle_key(key(KeyCode::Esc)),
+            ViewAction::Close
+        ));
+    }
+
+    #[test]
+    fn disabled_actions_are_visible_but_not_assignable() {
+        let mut app = test_app();
+        app.auto_model = true;
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+
+        assert!(view.select_slot(2));
+        assert!(view.select_action_by_id("reasoning.cycle"));
+        assert!(!view.assign_selected_action());
+
+        assert_ne!(
+            view.binding_for_slot(2)
+                .map(|binding| binding.action.as_str()),
+            Some("reasoning.cycle")
+        );
+        assert!(
+            view.validation_errors()
+                .last()
+                .is_some_and(|error| error.contains("cannot be assigned"))
+        );
+        assert!(view.status_text().contains("cannot be assigned"));
+    }
+
+    #[test]
+    fn args_required_slash_actions_are_visible_and_assignable_as_prefill() {
+        let app = test_app();
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+
+        assert!(view.select_action_by_id("slash.rename"));
+        assert!(
+            view.status_text().contains("prefill"),
+            "required-arg commands must be labeled as prefill actions"
+        );
+        assert!(view.select_slot(3));
+        assert!(view.assign_selected_action());
+
+        assert_eq!(
+            view.binding_for_slot(3)
+                .map(|binding| binding.action.as_str()),
+            Some("slash.rename")
+        );
+    }
+
+    #[test]
+    fn keyboard_controls_navigate_source_action_and_slot() {
+        let app = test_app();
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+
+        assert_eq!(view.selected_source(), Some(HotbarActionCategory::App));
+        view.handle_key(key(KeyCode::Tab));
+        assert_eq!(view.selected_source(), Some(HotbarActionCategory::Slash));
+        view.handle_key(key(KeyCode::BackTab));
+        assert_eq!(view.selected_source(), Some(HotbarActionCategory::App));
+
+        let first = view
+            .selected_action()
+            .map(|row| row.metadata.id.clone())
+            .expect("first action");
+        view.handle_key(key(KeyCode::Down));
+        let second = view
+            .selected_action()
+            .map(|row| row.metadata.id.clone())
+            .expect("second action");
+        assert_ne!(first, second);
+
+        view.handle_key(key(KeyCode::Char('8')));
+        assert_eq!(view.selected_slot(), 8);
+        view.handle_key(key(KeyCode::Left));
+        assert_eq!(view.selected_slot(), 7);
+    }
+}

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7379,6 +7379,12 @@ async fn apply_command_result(
                         ));
                 }
             }
+            AppAction::OpenHotbarSetup => {
+                if app.view_stack.top_kind() != Some(ModalKind::HotbarSetup) {
+                    app.view_stack
+                        .push(crate::tui::hotbar::setup::HotbarSetupView::new(app, config));
+                }
+            }
             AppAction::OpenExternalUrl { url, label } => match open_external_url(&url) {
                 Ok(()) => {
                     app.status_message = Some(format!("Opened {label} in your browser"));
@@ -9112,6 +9118,11 @@ async fn handle_view_events(
                         }
                     }
                 }
+            }
+            ViewEvent::HotbarSetupSaved { bindings } => {
+                config.hotbar = Some(bindings);
+                app.status_message = Some("Hotbar bindings updated for this session.".to_string());
+                app.needs_redraw = true;
             }
             ViewEvent::SubAgentsRefresh => {
                 app.status_message = Some("Refreshing sub-agents...".to_string());

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -36,6 +36,7 @@ pub enum ModalKind {
     ProviderPicker,
     ModePicker,
     FleetSetup,
+    HotbarSetup,
     FilePicker,
     StatusPicker,
     FeedbackPicker,
@@ -192,6 +193,12 @@ pub enum ViewEvent {
     StatusItemsUpdated {
         items: Vec<crate::config::StatusItem>,
         final_save: bool,
+    },
+    /// Emitted by the `/hotbar` setup wizard when the user saves the draft
+    /// bindings. The host updates live config state; disk persistence is
+    /// handled by the follow-up persistence slice.
+    HotbarSetupSaved {
+        bindings: Vec<codewhale_config::HotbarBindingToml>,
     },
     /// Emitted by the live-transcript overlay while in backtrack preview
     /// mode (#133) when the user steps the highlighted user message with


### PR DESCRIPTION
## Summary
- add the /hotbar command and Hotbar setup modal state machine
- support source navigation, 1-8 slot selection, assign/replace/toggle/clear, save and cancel events
- show disabled actions without assignment and label required-argument slash commands as prefill actions
- wire save into live config state; disk persistence remains the follow-up persistence slice

Fixes #3396

## Verification
- cargo fmt --all -- --check
- git diff --check origin/main..HEAD
- cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked wizard_ -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked disabled_actions -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked args_required -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked keyboard_controls -- --nocapture
- cargo check -p codewhale-tui --locked