### PR TITLE
test(tui): add terminal visual matrix guardrails

### DIFF
--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -1033,6 +1033,17 @@ mod tests {
             .find(|&y| buffer_row_text(buf, area, y).contains(needle))
     }
 
+    fn buffer_text(buf: &Buffer, area: Rect) -> String {
+        let mut out = String::new();
+        for y in area.y..area.y.saturating_add(area.height) {
+            for x in area.x..area.x.saturating_add(area.width) {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
     #[test]
     fn workspace_scope_filters_sessions_to_current_project() {
         // #1395 reproduction: Ctrl+R in project B must not surface sessions
@@ -1172,6 +1183,78 @@ mod tests {
                 .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY),
             "selected /sessions row should not use the bright accent background"
         );
+    }
+
+    #[test]
+    fn session_picker_visual_matrix_covers_narrow_and_medium_rendering() {
+        let base_time = DateTime::parse_from_rfc3339("2026-06-25T10:30:00Z")
+            .expect("visual matrix timestamp")
+            .with_timezone(&Utc);
+        let sessions = (0..12)
+            .map(|idx| {
+                let title = if idx == 6 {
+                    "selected visual matrix target with 中文内容 and suffix that must truncate"
+                } else {
+                    "A very long terminal visual regression session title with 中文内容 and suffix that must truncate"
+                };
+                let mut session = test_session(idx, title);
+                session.id = format!("visual-matrix-{idx:02}");
+                session.created_at = base_time - chrono::Duration::seconds(idx as i64);
+                session.updated_at = session.created_at;
+                session
+            })
+            .collect::<Vec<_>>();
+        let mut view = picker_with(sessions, None);
+        view.selected = view
+            .filtered
+            .iter()
+            .position(|session| session.id == "visual-matrix-06")
+            .expect("visual matrix target session should be filtered");
+        view.ensure_selected_visible();
+        view.current_preview = vec![
+            "Title: terminal visual matrix".to_string(),
+            "Updated: 2026-06-25 10:30".to_string(),
+            "Messages: 3 | Model: deepseek-v4-pro".to_string(),
+            String::new(),
+            "USER: narrow panes should keep long CJK text readable 中文中文中文".to_string(),
+            "ASSISTANT: overlays should keep borders and truncate rows predictably".to_string(),
+        ];
+
+        for (width, height, label) in [(72, 20, "narrow"), (120, 28, "medium")] {
+            let area = Rect::new(0, 0, width, height);
+            let mut buf = Buffer::empty(area);
+
+            view.render(area, &mut buf);
+
+            let dump = buffer_text(&buf, area);
+            assert!(
+                dump.contains("Sessions"),
+                "{label} sessions pane missing:\n{dump}"
+            );
+            assert!(
+                dump.contains("History"),
+                "{label} history pane missing:\n{dump}"
+            );
+            assert!(dump.contains('┌'), "{label} top border missing:\n{dump}");
+            assert!(dump.contains('┘'), "{label} bottom border missing:\n{dump}");
+            assert!(
+                !dump.contains("suffix that must truncate"),
+                "{label} long title tail leaked instead of truncating:\n{dump}"
+            );
+            assert!(
+                dump.contains("..."),
+                "{label} should show an explicit ellipsis for truncated rows:\n{dump}"
+            );
+            assert!(
+                !dump.contains('\u{fffd}'),
+                "{label} render emitted replacement characters:\n{dump}"
+            );
+
+            assert!(
+                row_containing(&buf, area, "selected visual").is_some(),
+                "{label} selected session row missing:\n{dump}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/tests/palette_audit.rs
+++ b/crates/tui/tests/palette_audit.rs
@@ -140,4 +140,34 @@ fn contrast_guardrails_for_key_ui_pairs() {
         palette::DEEPSEEK_INK,
         min_readable,
     );
+    assert_min_contrast(
+        "SELECTION_TEXT on SELECTION_BG",
+        palette::SELECTION_TEXT,
+        palette::SELECTION_BG,
+        min_readable,
+    );
+    assert_min_contrast(
+        "TEXT_PRIMARY on SURFACE_ELEVATED",
+        palette::TEXT_PRIMARY,
+        palette::SURFACE_ELEVATED,
+        min_readable,
+    );
+    assert_min_contrast(
+        "LIGHT_TEXT_BODY on LIGHT_SURFACE",
+        palette::LIGHT_TEXT_BODY,
+        palette::LIGHT_SURFACE,
+        min_readable,
+    );
+    assert_min_contrast(
+        "LIGHT_TEXT_MUTED on LIGHT_SURFACE",
+        palette::LIGHT_TEXT_MUTED,
+        palette::LIGHT_SURFACE,
+        min_readable,
+    );
+    assert_min_contrast(
+        "LIGHT_TEXT_BODY on LIGHT_SELECTION_BG",
+        palette::LIGHT_TEXT_BODY,
+        palette::LIGHT_SELECTION_BG,
+        min_readable,
+    );
 }

--- a/docs/evidence/terminal-visual-regression-matrix.md
+++ b/docs/evidence/terminal-visual-regression-matrix.md
@@ -1,0 +1,31 @@
+# Terminal Visual Regression Matrix
+
+Issue: #3487
+
+This matrix tracks deterministic terminal UI fixtures that should stay legible without provider or network access. It is intentionally focused on objective failures: unreadable contrast, broken borders, clipped key labels, missing panes, replacement characters, and long-row truncation.
+
+## Gate Commands
+
+```sh
+cargo test -p codewhale-tui --test palette_audit --locked
+cargo test -p codewhale-tui --bin codewhale-tui --locked visual_matrix -- --nocapture
+cargo test -p codewhale-tui --bin codewhale-tui --locked selected_provider_row_uses_strong_highlight -- --nocapture
+cargo test -p codewhale-tui --bin codewhale-tui --locked config_view_selected_row_uses_muted_selection_highlight -- --nocapture
+```
+
+## Matrix
+
+| Surface | Widths | Fixture | Guardrails |
+|---------|--------|---------|------------|
+| Palette contrast | dark, light | `crates/tui/tests/palette_audit.rs::contrast_guardrails_for_key_ui_pairs` | body, muted, warning, error, selected row, elevated row, and light-palette text pairs meet 4.5:1 contrast |
+| `/model` provider selector | narrow-ish, medium | `provider_picker::tests::small_list_render_keeps_selected_provider_visible_after_down_navigation`, `selected_provider_row_uses_strong_highlight` | selected provider remains visible after scroll, selection background is continuous and avoids bright accent backgrounds |
+| `/sessions` selector | 72x20, 120x28 | `session_picker::tests::session_picker_visual_matrix_covers_narrow_and_medium_rendering`, `session_picker_selected_row_renders_readable_selection_contrast` | both panes render, borders survive, long CJK titles truncate with ellipsis, no replacement characters, selected row stays visible and keeps readable contrast |
+| Settings/config modal | 60x18, 100x24 | `views::tests::localized_config_view_renders_at_narrow_width`, `config_view_selected_row_uses_muted_selection_highlight`, `config_view_keeps_scope_column_aligned_for_long_keys` | localized title survives narrow width, selected row uses muted highlight, long labels and CJK scope column remain aligned |
+| Sidebar hotbar/task rows | sidebar unit widths | `sidebar::tests::hotbar_panel_lines_keep_two_fixed_rows_and_hover_status`, `hotbar_panel_slots_handle_empty_partial_and_unknown_config` | fixed rows do not resize, empty/unknown slots render explicit states |
+| Transcript/live overlay | 40x10, 48x10, 60x16 | `live_transcript::tests::backtrack_preview_opens_near_latest_user_not_transcript_start`, `cache_reuses_unchanged_cells_across_renders` | overlay renders without provider access, recent turns stay visible, unchanged cells reuse wrap cache |
+
+## Deferred Rows
+
+- Full sub-agent/Fleet progress overlay screenshots remain under #3480 because the current tests assert model rows and live fanout membership but do not yet render a complete narrow terminal shell.
+- Approval modal destructive-review semantics are tracked under #3466; visual checks should be added there once the permission copy is finalized.
+- Hotbar end-to-end source coverage is tracked under #3401 after MCP, skill, and plugin source adapters land.


### PR DESCRIPTION
## Summary
- add a terminal visual regression matrix document for contrast, selectors, sessions, config, sidebar, and transcript surfaces
- extend palette contrast guardrails for selected rows, elevated surfaces, and light-palette pairs
- add a deterministic /sessions render fixture for narrow and medium terminal widths with long CJK titles, border checks, truncation checks, and selected-row visibility

Fixes #3487

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p codewhale-tui --test palette_audit --locked
- cargo test -p codewhale-tui --bin codewhale-tui --locked visual_matrix -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked session_picker -- --nocapture