### PR TITLE
docs(tui): add prompt mode audit matrix

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -2558,6 +2558,69 @@ mod tests {
     }
 
     #[test]
+    fn mode_prompts_remain_small_deltas_not_base_policy_copies() {
+        for (name, prompt) in [
+            ("agent", AGENT_MODE),
+            ("plan", PLAN_MODE),
+            ("yolo", YOLO_MODE),
+        ] {
+            let word_count = prompt.split_whitespace().count();
+            let estimated_tokens = crate::compaction::estimate_text_tokens_conservative(prompt);
+
+            assert!(
+                word_count <= 350,
+                "{name} mode prompt should remain a delta, got {word_count} words"
+            );
+            assert!(
+                estimated_tokens <= 700,
+                "{name} mode prompt should remain compact, got {estimated_tokens} estimated tokens"
+            );
+            for forbidden in [
+                "## CONSTITUTION OF CODEWHALE",
+                "## STATUTES (Tier 2)",
+                "## REGULATIONS (Tier 3)",
+                "## EVIDENCE (Tier 6)",
+                "## Context Management",
+                "## Runtime Policy Reference",
+            ] {
+                assert!(
+                    !prompt.contains(forbidden),
+                    "{name} mode prompt duplicated shared base section {forbidden:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mode_prompts_do_not_inline_full_approval_policy_overlays() {
+        for (name, mode_prompt) in [
+            ("agent", AGENT_MODE),
+            ("plan", PLAN_MODE),
+            ("yolo", YOLO_MODE),
+        ] {
+            for (approval_name, approval_prompt) in [
+                ("auto", AUTO_APPROVAL),
+                ("suggest", SUGGEST_APPROVAL),
+                ("never", NEVER_APPROVAL),
+            ] {
+                assert!(
+                    !mode_prompt.contains(approval_prompt.trim()),
+                    "{name} mode prompt must not inline the full {approval_name} approval overlay"
+                );
+            }
+        }
+
+        assert!(
+            PLAN_MODE.contains("All writes and patches are blocked"),
+            "Plan may summarize the user-facing mode delta"
+        );
+        assert!(
+            NEVER_APPROVAL.contains("This approval policy is a Tier 2 Statute"),
+            "the approval overlay keeps the policy authority explanation"
+        );
+    }
+
+    #[test]
     fn approval_policy_no_longer_inlined_in_base_prompt() {
         let prompt = compose_prompt(Personality::Calm);
         assert!(!prompt.contains("Mode: Agent"));

--- a/docs/PROMPT_MODE_MATRIX.md
+++ b/docs/PROMPT_MODE_MATRIX.md
@@ -1,0 +1,48 @@
+# Prompt Mode Matrix
+
+This note records the v0.8.66 prompt-mode audit for #2958. The current
+contract is:
+
+- `crates/tui/src/prompts/constitution.md` is the single shared base prompt.
+- `crates/tui/src/prompts/modes/*.md` are mode deltas only.
+- `crates/tui/src/prompts/approvals/*.md` describe approval policy overlays.
+- Plan write blocking is enforced by runtime policy and tool registry setup,
+  not by trusting prompt prose.
+
+## Mode Matrix
+
+| Mode | Runtime authority | Shell policy | Approval surface | Model-visible delta |
+| --- | --- | --- | --- | --- |
+| Agent | User's durable Agent baseline | From Agent baseline | From Agent baseline | Autonomous execution, approval batching, checklist discipline, session longevity |
+| Plan | Read-only investigation | None | Suggest UI, with writes blocked by mode/runtime | Investigation first, `update_plan` as handoff, no shell/code execution |
+| YOLO | Full authority | Full | Auto | Auto-approved execution plus destructive-action caution |
+
+Runtime anchors:
+
+- `base_policy_for_mode` in `crates/tui/src/tui/app.rs` derives the live
+  permission mirrors for Plan, Agent, and YOLO.
+- `sandbox_policy_for_mode` and `shell_policy_for_mode` in
+  `crates/tui/src/core/engine/tool_setup.rs` keep Plan in a read-only sandbox
+  and remove shell tools from Plan turns.
+- `Engine::send_user_shell_command` still rejects `exec_shell` directly when
+  the active mode is Plan.
+
+## Size Snapshot
+
+Measured on 2026-06-25 with `wc -l -w -c`. Estimated tokens use the existing
+conservative rule in `compaction::estimate_text_tokens_conservative`
+(`chars / 3`, rounded up); these are not provider-tokenizer exact counts.
+
+| Layer | Lines | Words | Bytes | Est. tokens |
+| --- | ---: | ---: | ---: | ---: |
+| `constitution.md` | 667 | 5728 | 37301 | 12434 |
+| `modes/agent.md` | 33 | 314 | 2059 | 687 |
+| `modes/plan.md` | 21 | 216 | 1389 | 463 |
+| `modes/yolo.md` | 13 | 120 | 775 | 259 |
+| `approvals/suggest.md` | 12 | 131 | 843 | 281 |
+| `approvals/never.md` | 12 | 162 | 1022 | 341 |
+| `approvals/auto.md` | 11 | 127 | 806 | 269 |
+
+The important audit result is that mode prompts stay under 6 percent of the
+base prompt by word count, and approval overlays stay separate. Future prompt
+changes should update this table when they intentionally change the contract.


### PR DESCRIPTION
## Summary
- document the current Agent/Plan/YOLO prompt-mode matrix and runtime enforcement anchors
- record the v0.8.66 prompt size snapshot for base, mode, and approval layers
- add prompt tests that keep mode prompts compact and prevent full approval overlays/base sections from being inlined

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mode_prompts -- --nocapture`
- `cargo check -p codewhale-tui --locked`

Refs #2958
