### PR TITLE
fix(tui): gate unsafe hotbar dispatch paths

### DIFF
--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -194,41 +194,79 @@ pub enum HotbarSourceDispatchBoundary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HotbarSourceSafetyMode {
+    /// Pressing the bound hotbar slot directly fires the existing action path.
+    DirectFire,
+    /// Pressing the bound hotbar slot opens/prefills the composer for arguments.
+    ComposerPrefill,
+    /// The source must not register bindable actions until its gates are wired.
+    Disabled,
+    /// The source may dispatch only through an approval/trust-enforced path.
+    ApprovalGated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HotbarSourceDescriptor {
     pub category: HotbarActionCategory,
     pub boundary: HotbarSourceDispatchBoundary,
+    pub safety_modes: &'static [HotbarSourceSafetyMode],
     pub dispatch_path: &'static str,
     pub status: &'static str,
 }
+
+impl HotbarSourceDescriptor {
+    #[must_use]
+    pub fn registers_dispatchable_actions(self) -> bool {
+        self.boundary != HotbarSourceDispatchBoundary::Deferred
+            && !self
+                .safety_modes
+                .contains(&HotbarSourceSafetyMode::Disabled)
+    }
+}
+
+const HOTBAR_DIRECT_APP_SAFETY: &[HotbarSourceSafetyMode] = &[HotbarSourceSafetyMode::DirectFire];
+const HOTBAR_SLASH_SAFETY: &[HotbarSourceSafetyMode] = &[
+    HotbarSourceSafetyMode::DirectFire,
+    HotbarSourceSafetyMode::ComposerPrefill,
+];
+const HOTBAR_DEFERRED_SAFETY: &[HotbarSourceSafetyMode] = &[
+    HotbarSourceSafetyMode::Disabled,
+    HotbarSourceSafetyMode::ApprovalGated,
+];
 
 const HOTBAR_SOURCE_DESCRIPTORS: &[HotbarSourceDescriptor] = &[
     HotbarSourceDescriptor {
         category: HotbarActionCategory::App,
         boundary: HotbarSourceDispatchBoundary::DirectApp,
+        safety_modes: HOTBAR_DIRECT_APP_SAFETY,
         dispatch_path: "AppHotbarAction::dispatch",
         status: "dispatchable",
     },
     HotbarSourceDescriptor {
         category: HotbarActionCategory::Slash,
         boundary: HotbarSourceDispatchBoundary::SlashCommand,
+        safety_modes: HOTBAR_SLASH_SAFETY,
         dispatch_path: "commands::execute or composer prefill for required arguments",
         status: "dispatchable",
     },
     HotbarSourceDescriptor {
         category: HotbarActionCategory::Mcp,
         boundary: HotbarSourceDispatchBoundary::Deferred,
+        safety_modes: HOTBAR_DEFERRED_SAFETY,
         dispatch_path: "command palette / MCP manager until tool args and approvals are wired",
         status: "exploratory",
     },
     HotbarSourceDescriptor {
         category: HotbarActionCategory::Skill,
         boundary: HotbarSourceDispatchBoundary::Deferred,
+        safety_modes: HOTBAR_DEFERRED_SAFETY,
         dispatch_path: "command palette / skill command until activation receipts are wired",
         status: "exploratory",
     },
     HotbarSourceDescriptor {
         category: HotbarActionCategory::Plugin,
         boundary: HotbarSourceDispatchBoundary::Deferred,
+        safety_modes: HOTBAR_DEFERRED_SAFETY,
         dispatch_path: "plugin command/tool registry until plugin approval gates are wired",
         status: "exploratory",
     },
@@ -409,7 +447,17 @@ impl HotbarActionRegistry {
         );
         debug_assert!(!descriptor.dispatch_path.trim().is_empty());
         debug_assert!(!descriptor.status.trim().is_empty());
+        debug_assert!(!descriptor.safety_modes.is_empty());
+        let before = self.actions.len();
         source.register_actions(self);
+        if !descriptor.registers_dispatchable_actions() {
+            assert_eq!(
+                self.actions.len(),
+                before,
+                "deferred hotbar source {:?} must not register dispatchable actions before safety gates are wired",
+                descriptor.category
+            );
+        }
     }
 
     pub(crate) fn register_builtins(&mut self) {
@@ -951,6 +999,24 @@ mod tests {
         }
     }
 
+    struct DeferredTestHotbarSource;
+
+    impl HotbarActionSource for DeferredTestHotbarSource {
+        fn descriptor(&self) -> HotbarSourceDescriptor {
+            HOTBAR_SOURCE_DESCRIPTORS
+                .iter()
+                .copied()
+                .find(|descriptor| descriptor.category == HotbarActionCategory::Mcp)
+                .expect("mcp descriptor exists")
+        }
+
+        fn register_actions(&self, registry: &mut HotbarActionRegistry) {
+            registry.register(TestHotbarAction {
+                id: "mcp.deferred-test",
+            });
+        }
+    }
+
     #[test]
     #[should_panic(expected = "duplicate hotbar action id duplicate.action")]
     fn registry_rejects_duplicate_action_ids() {
@@ -1028,15 +1094,31 @@ mod tests {
             descriptors
                 .iter()
                 .find(|descriptor| descriptor.category == HotbarActionCategory::App)
-                .map(|descriptor| descriptor.boundary),
-            Some(HotbarSourceDispatchBoundary::DirectApp)
+                .map(|descriptor| (
+                    descriptor.boundary,
+                    descriptor.safety_modes,
+                    descriptor.registers_dispatchable_actions()
+                )),
+            Some((
+                HotbarSourceDispatchBoundary::DirectApp,
+                HOTBAR_DIRECT_APP_SAFETY,
+                true
+            ))
         );
         assert_eq!(
             descriptors
                 .iter()
                 .find(|descriptor| descriptor.category == HotbarActionCategory::Slash)
-                .map(|descriptor| descriptor.boundary),
-            Some(HotbarSourceDispatchBoundary::SlashCommand)
+                .map(|descriptor| (
+                    descriptor.boundary,
+                    descriptor.safety_modes,
+                    descriptor.registers_dispatchable_actions()
+                )),
+            Some((
+                HotbarSourceDispatchBoundary::SlashCommand,
+                HOTBAR_SLASH_SAFETY,
+                true
+            ))
         );
         for category in [
             HotbarActionCategory::Mcp,
@@ -1048,8 +1130,20 @@ mod tests {
                 .find(|descriptor| descriptor.category == category)
                 .unwrap_or_else(|| panic!("missing descriptor for {category:?}"));
             assert_eq!(descriptor.boundary, HotbarSourceDispatchBoundary::Deferred);
+            assert_eq!(descriptor.safety_modes, HOTBAR_DEFERRED_SAFETY);
             assert_eq!(descriptor.status, "exploratory");
+            assert!(
+                !descriptor.registers_dispatchable_actions(),
+                "deferred {category:?} source must not be dispatchable"
+            );
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "deferred hotbar source Mcp must not register dispatchable actions")]
+    fn deferred_sources_cannot_register_dispatchable_actions() {
+        let mut registry = HotbarActionRegistry::new();
+        registry.register_source(&DeferredTestHotbarSource);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5007,6 +5007,14 @@ fn dispatch_hotbar_slot(
         return Ok(Some(HotbarDispatch::Handled));
     };
 
+    if let Some(reason) = action.disabled_reason(app) {
+        app.status_message = Some(format!(
+            "Hotbar slot {slot} action is not available: {reason}"
+        ));
+        app.needs_redraw = true;
+        return Ok(Some(HotbarDispatch::Handled));
+    }
+
     action.dispatch(app).map(Some)
 }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -6,7 +6,7 @@ use crate::config::{
 use crate::config_ui::{self, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::mock_engine_handle;
 use crate::tui::active_cell::ActiveCell;
-use crate::tui::app::{SidebarHoverRow, SidebarHoverSection, ToolDetailRecord};
+use crate::tui::app::{ReasoningEffort, SidebarHoverRow, SidebarHoverSection, ToolDetailRecord};
 use crate::tui::file_mention::{
     apply_mention_menu_selection, find_file_mention_completions, partial_file_mention_at_cursor,
     try_autocomplete_file_mention, user_request_with_file_mentions, visible_mention_menu_entries,
@@ -4072,6 +4072,36 @@ fn hotbar_dispatches_slash_command_slot() {
         Some(HotbarDispatch::AppAction(AppAction::OpenModePicker))
     );
     assert!(app.input.is_empty());
+}
+
+#[test]
+fn hotbar_bound_disabled_action_reports_reason_without_dispatching() {
+    let mut app = create_test_app();
+    app.onboarding = OnboardingState::None;
+    app.auto_model = true;
+    app.reasoning_effort = ReasoningEffort::Off;
+    app.needs_redraw = false;
+    let config = Config {
+        hotbar: Some(vec![codewhale_config::HotbarBindingToml {
+            slot: 1,
+            label: Some("reason".to_string()),
+            action: "reasoning.cycle".to_string(),
+        }]),
+        ..Config::default()
+    };
+
+    assert_eq!(
+        dispatch_hotbar_slot(&mut app, &config, 1).expect("disabled slot dispatch"),
+        Some(HotbarDispatch::Handled)
+    );
+    assert_eq!(app.reasoning_effort, ReasoningEffort::Off);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some(
+            "Hotbar slot 1 action is not available: Reasoning effort is controlled by auto model routing."
+        )
+    );
+    assert!(app.needs_redraw);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add explicit hotbar source safety modes for direct-fire, composer-prefill, disabled, and approval-gated behavior
- enforce that deferred MCP/skill/plugin sources cannot register bindable actions before their safety path is wired
- block manually bound disabled actions at hotbar dispatch time with a visible status reason
- add tests for app/slash/deferred-source contracts and disabled bound-slot behavior

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar::actions -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar_bound_disabled_action -- --nocapture`
- `cargo check -p codewhale-tui --locked`
- `cargo clippy --workspace --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`

Closes #3400
