### PR TITLE
fix(tui): surface resource usage in turn metadata

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -40,6 +40,7 @@ use crate::models::{
 };
 use crate::prompts;
 use crate::purge::{emit_purge_completed, emit_purge_failed, emit_purge_started, run_purge};
+use crate::resource_telemetry::ResourceTelemetry;
 use crate::route_runtime::resolve_runtime_route;
 use crate::seam_manager::{SeamConfig, SeamManager};
 use crate::tools::goal::{GoalSnapshot, GoalStatus, SharedGoalState, new_shared_goal_state};
@@ -1769,6 +1770,92 @@ impl Engine {
         }
     }
 
+    fn active_input_tokens_with_current_text(&self, current_text: &str) -> usize {
+        let mut messages: Vec<Message> = self.session.messages.clone().into();
+        if !current_text.trim().is_empty() {
+            messages.push(Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: current_text.to_string(),
+                    cache_control: None,
+                }],
+            });
+        }
+        estimate_input_tokens_conservative(&messages, self.session.system_prompt.as_ref())
+    }
+
+    fn append_resource_metadata_lines(
+        &self,
+        lines: &mut Vec<String>,
+        routed_model: &str,
+        current_text: &str,
+    ) {
+        let input_tokens = self.active_input_tokens_with_current_text(current_text);
+        if let Some(budget) = route_context_budget_for_route(
+            self.api_provider,
+            routed_model,
+            self.active_route_limits,
+            input_tokens,
+        ) {
+            lines.push(format!(
+                "Context pressure: {} ({:.1}% used, {} / {} tokens; {} input tokens available)",
+                budget.pressure.label(),
+                budget.usage_percent(),
+                budget.input_tokens,
+                budget.window_tokens,
+                budget.available_input_tokens,
+            ));
+        }
+
+        if let Some(line) = self.session_token_usage_line() {
+            lines.push(line);
+        }
+        if let Some(line) = self.active_goal_resource_line() {
+            lines.push(line);
+        }
+    }
+
+    fn session_token_usage_line(&self) -> Option<String> {
+        let usage = &self.session.total_usage;
+        let total = usage.input_tokens.saturating_add(usage.output_tokens);
+        if total == 0 {
+            return None;
+        }
+
+        let mut line = format!(
+            "Session token usage: {total} total ({} input, {} output)",
+            usage.input_tokens, usage.output_tokens,
+        );
+        if let Some(hit_tokens) = usage.cache_read_input_tokens {
+            line.push_str(&format!(", cache hits {hit_tokens}"));
+        }
+        if let Some(miss_tokens) = usage.cache_creation_input_tokens {
+            line.push_str(&format!(", cache misses {miss_tokens}"));
+        }
+        Some(line)
+    }
+
+    fn active_goal_resource_line(&self) -> Option<String> {
+        let snapshot = self.config.goal_state.lock().ok()?.snapshot();
+        if !snapshot.is_active() {
+            return None;
+        }
+
+        let mut telemetry =
+            ResourceTelemetry::new(snapshot.tokens_used, snapshot.time_used_seconds);
+        if let Some(token_budget) = snapshot.token_budget {
+            telemetry = telemetry.with_token_budget(u64::from(token_budget));
+        }
+
+        let mut line = format!("Active goal resource usage: {}", telemetry.human_summary());
+        if snapshot.tokens_used > 0 && snapshot.time_used_seconds > 0 {
+            let rate = snapshot.tokens_used as f64 / snapshot.time_used_seconds as f64;
+            line.push_str(&format!("; {rate:.1} tok/s"));
+        }
+        line.push_str(&format!("; {} continuations", snapshot.continuation_count));
+        Some(line)
+    }
+
     async fn add_session_message(&mut self, message: Message) {
         self.session.add_message(message);
         self.emit_session_updated().await;
@@ -1781,6 +1868,7 @@ impl Engine {
         reasoning_effort: Option<&str>,
         reasoning_effort_auto: bool,
         provenance: UserInputProvenance,
+        current_text: &str,
     ) -> ContentBlock {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
         let working_set_summary = self
@@ -1813,6 +1901,7 @@ impl Engine {
         if reasoning_effort_auto && let Some(reasoning_effort) = reasoning_effort {
             lines.push(format!("Auto reasoning effort: {reasoning_effort}"));
         }
+        self.append_resource_metadata_lines(&mut lines, routed_model, current_text);
         if let Some(working_set_summary) = working_set_summary {
             lines.push(working_set_summary);
         }
@@ -1884,6 +1973,14 @@ impl Engine {
         // message prefix is invalidated at every date boundary. Moving it
         // to the tail preserves the user-input prefix and limits cache
         // invalidation to the trailing metadata block.
+        let turn_metadata = self.turn_metadata_block(
+            routed_model,
+            auto_model,
+            reasoning_effort,
+            reasoning_effort_auto,
+            provenance,
+            &text,
+        );
         Message {
             role: "user".to_string(),
             content: vec![
@@ -1891,13 +1988,7 @@ impl Engine {
                     text,
                     cache_control: None,
                 },
-                self.turn_metadata_block(
-                    routed_model,
-                    auto_model,
-                    reasoning_effort,
-                    reasoning_effort_auto,
-                    provenance,
-                ),
+                turn_metadata,
             ],
         }
     }
@@ -3689,15 +3780,16 @@ mod approval;
 mod context;
 mod handle;
 pub(crate) use context::compact_tool_result_for_context;
+#[cfg(test)]
+use context::route_context_budget_for_provider;
 use context::{
     MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP, context_input_budget_for_route,
-    effective_max_output_tokens_for_route, extract_compaction_summary_prompt,
-    is_context_length_error_message, summarize_text,
+    effective_max_output_tokens_for_route, estimate_input_tokens_conservative,
+    extract_compaction_summary_prompt, is_context_length_error_message,
+    route_context_budget_for_route, summarize_text,
 };
 #[cfg(test)]
 use context::{context_input_budget_for_provider, effective_max_output_tokens};
-#[cfg(test)]
-use context::{route_context_budget_for_provider, route_context_budget_for_route};
 mod dispatch;
 mod lsp_hooks;
 mod streaming;

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use super::context::{COMPACTION_SUMMARY_MARKER, TURN_MAX_OUTPUT_TOKENS};
 use super::turn_loop::registered_tool_approval_required;
 use crate::config::ApiProvider;
-use crate::models::SystemBlock;
+use crate::models::{SystemBlock, Usage};
 use crate::test_support::{EnvVarGuard, lock_test_env};
 use crate::tools::plan::{PlanItemArg, PlanSnapshot, StepStatus};
 use crate::tools::spec::ToolCapability;
@@ -3791,6 +3791,55 @@ fn turn_metadata_includes_current_local_date_without_working_set() {
     assert!(text.contains("Current model: deepseek-v4-flash"));
     assert!(text.contains("Input provenance: external_user"));
     assert!(text.contains("Input authority: external_current_turn"));
+}
+
+#[test]
+fn turn_metadata_surfaces_context_and_resource_usage() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        model: "deepseek-v4-flash".to_string(),
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.session.total_usage.add(&Usage {
+        input_tokens: 1_200,
+        output_tokens: 300,
+        prompt_cache_hit_tokens: Some(800),
+        prompt_cache_miss_tokens: Some(400),
+        ..Default::default()
+    });
+    {
+        let mut goal = engine.config.goal_state.lock().expect("goal lock");
+        goal.create("Finish telemetry visibility".to_string(), Some(2_000));
+        goal.record_usage(1_000, 100);
+    }
+
+    let user_msg = engine
+        .user_text_message_with_turn_metadata("continue the long-running release task".to_string());
+    let last_block = user_msg.content.last().expect("turn metadata block");
+    let ContentBlock::Text { text, .. } = last_block else {
+        panic!("expected text metadata block");
+    };
+
+    assert!(text.contains("Context pressure:"), "got: {text}");
+    assert!(text.contains("tokens;"), "got: {text}");
+    assert!(
+        text.contains("input tokens available"),
+        "context headroom should be model-visible: {text}"
+    );
+    assert!(
+        text.contains("Session token usage: 1500 total (1200 input, 300 output"),
+        "session usage should be model-visible: {text}"
+    );
+    assert!(text.contains("cache hits 800"), "got: {text}");
+    assert!(text.contains("cache misses 400"), "got: {text}");
+    assert!(
+        text.contains("Active goal resource usage:"),
+        "active goal resource usage should be model-visible: {text}"
+    );
+    assert!(text.contains("50% budget"), "got: {text}");
+    assert!(text.contains("10.0 tok/s"), "got: {text}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Closes #2666.
- Adds model-visible context pressure to each `<turn_meta>` block using the route-effective context budget and the current user text estimate.
- Adds session token totals/cache totals and active `/goal` resource usage, including token budget percentage and tokens-per-second, to the same volatile turn metadata tail.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; targeted runtime slice)
- [ ] `cargo test --workspace --all-features` (not run; targeted runtime slice)
- [x] `git diff --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked turn_metadata_surfaces_context_and_resource_usage -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked turn_metadata -- --nocapture`
- [x] `cargo check -p codewhale-tui --bin codewhale-tui --locked`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (model-visible metadata path only; covered by engine test)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (not a harvested change)
