### PR TITLE
test(tui): add token cache report fixtures

### DIFF
--- a/crates/tui/src/commands/groups/debug/debug.rs
+++ b/crates/tui/src/commands/groups/debug/debug.rs
@@ -1384,6 +1384,40 @@ mod tests {
     }
 
     #[test]
+    fn cache_command_replays_reported_1177_low_hit_fixture() {
+        let mut app = create_test_app();
+        let now = Instant::now();
+        // Fixture from #1177 / douglarek's 2026-05-10 `/cache` report.
+        // It captures a real low-hit sequence with one 56.8% tail turn.
+        for (input, output, hit, miss) in [
+            (25_839, 12, 4_608, 21_231),
+            (25_906, 288, 25_728, 178),
+            (264_500, 2_528, 235_648, 28_852),
+            (202_230, 3_191, 193_536, 8_694),
+            (45_982, 294, 26_112, 19_870),
+        ] {
+            app.push_turn_cache_record(TurnCacheRecord {
+                input_tokens: input,
+                output_tokens: output,
+                cache_hit_tokens: Some(hit),
+                cache_miss_tokens: Some(miss),
+                reasoning_replay_tokens: None,
+                recorded_at: now,
+            });
+        }
+
+        let result = cache(&mut app, None);
+        let msg = result.message.expect("cache produces a message");
+
+        assert!(msg.contains("last 5 of 5 turn(s)"), "got: {msg}");
+        assert!(msg.contains("56.8%"), "got: {msg}");
+        assert!(msg.contains("Σ in: 564457"), "got: {msg}");
+        assert!(msg.contains("Σ hit: 485632"), "got: {msg}");
+        assert!(msg.contains("Σ miss: 78825"), "got: {msg}");
+        assert!(msg.contains("avg hit ratio: 86.0%"), "got: {msg}");
+    }
+
+    #[test]
     fn cache_command_count_argument_clamps_to_history() {
         let mut app = create_test_app();
         for _ in 0..3 {
@@ -2132,6 +2166,37 @@ mod tests {
         assert!(
             msg.contains("cache hit rate is low"),
             "should show low-hit-rate advisory, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn cache_stats_flags_reported_1747_low_hit_fixture() {
+        let mut app = create_test_app();
+        app.prefix_stability_pct = Some(100);
+        app.prefix_checks_total = 1;
+        app.last_pinned_prefix_hash =
+            Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
+
+        // Fixture from #1747 / Amund's DeepSeek-TUI session aggregate:
+        // hit=21,356,928, miss=8,470,281, output=165,624.
+        app.push_turn_cache_record(TurnCacheRecord {
+            input_tokens: 29_827_209,
+            output_tokens: 165_624,
+            cache_hit_tokens: Some(21_356_928),
+            cache_miss_tokens: Some(8_470_281),
+            reasoning_replay_tokens: None,
+            recorded_at: Instant::now(),
+        });
+
+        let result = cache(&mut app, Some("stats"));
+        let msg = result.message.expect("cache stats produces a message");
+
+        assert!(msg.contains("71.6%"), "got: {msg}");
+        assert!(msg.contains("Cache hit tokens:  21.4M"), "got: {msg}");
+        assert!(msg.contains("Cache miss tokens: 8.5M"), "got: {msg}");
+        assert!(
+            msg.contains("cache hit rate is low"),
+            "reported #1747 fixture should remain below the advisory threshold: {msg}"
         );
     }
 

--- a/docs/evidence/token-cache-report-fixtures.md
+++ b/docs/evidence/token-cache-report-fixtures.md
@@ -1,0 +1,37 @@
+# Token/cache report fixture matrix
+
+This matrix supports #3390 by tying user token/cache reports to concrete
+fixtures or next actions. It is intentionally evidence-focused: reports without
+provider/model/transcript detail stay open for fresh data instead of being
+treated as proven regressions.
+
+## Fixture Coverage
+
+| Source | Reporter / helper | Report shape | Fixture |
+| --- | --- | --- | --- |
+| #1177 | @douglarek | Five-turn `/cache` table with one low 56.8% tail turn and 86.0% aggregate hit ratio | `cache_command_replays_reported_1177_low_hit_fixture` |
+| #1747 | @Amund | DeepSeek-TUI aggregate: 21,356,928 hit, 8,470,281 miss, 165,624 output, clearly below desired 90%+ cache hit target | `cache_stats_flags_reported_1747_low_hit_fixture` |
+
+## Related Report Triage
+
+| Issue | Disposition | Next action |
+| --- | --- | --- |
+| #743 | Needs fresh reporter data | Original report mixed high spend, old versions, UI freeze, and macOS color readability. Keep asking for current version, provider/model, dashboard token counts, and cache hit/miss totals. |
+| #1120 | Repro direction identified | Use existing prompt-inspect/tool-catalog stability tests plus the #1177/#1747 cache fixtures. Further closure needs provider-request snapshots or paired same-task runs. |
+| #1177 | Fixture linked | Use the five-turn table fixture as the reproducible cache-history smoke case; keep broader cache-architecture work open. |
+| #1747 | Fixture linked | Use the aggregate low-hit stats fixture as the regression smoke case; exact first-differing-byte diagnosis still needs request snapshots. |
+| #1818 | Needs reporter data | Screenshots show high daily spend but comments note 96.6-98.3% hit rate and no transcript/task detail. Ask for task shape, large-file reads, compaction state, and provider/model. |
+| #1863 | Duplicate / moved | Already closed as duplicate of #3275 for model self-questioning loop behavior. Track there, not under cache-hit fixtures. |
+| #2953 | Separate prompt-size lane | Needs before/after prompt-size comparison and prompt-layer audit; not closed by cache-history fixtures. |
+| #2956 | Separate transcript-growth lane | Needs per-turn input growth analysis and benchmark/exec transcript fixtures; not closed by cache-history fixtures. |
+| #2958 | Partially covered elsewhere | Prompt-mode matrix work exists in #3611 but remains policy-blocked from merging; leave issue open until that PR lands. |
+| #2961 | Resolved prerequisite | Usage normalization was marked resolved for v0.8.65 via #3509/#3544, so #3390 can consume normalized cache telemetry instead of reparsing provider payloads. |
+
+## Remaining Gaps
+
+- Request-body snapshot fixtures are still needed for first-differing-byte
+  diagnosis when a user reports a low hit rate with two consecutive requests.
+- Benchmark-harness fixtures are still needed for #2956-style repeated
+  transcript growth and large tool-output replay.
+- Cost per completed task and quota-style telemetry remain outside this slice;
+  they belong to provider usage/pricing display work.


### PR DESCRIPTION
## Summary

Closes #3390.

- Add a #1177-derived /cache history fixture for the reported low-hit tail turn and 86.0% aggregate hit ratio.
- Add a #1747-derived /cache stats fixture for the reported DeepSeek-TUI aggregate cache telemetry.
- Document related high-token/cache issue triage in docs/evidence/token-cache-report-fixtures.md.

## Testing

- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] cargo test -p codewhale-tui --bin codewhale-tui --locked reported_ -- --nocapture
- [x] cargo test -p codewhale-tui --bin codewhale-tui --locked cache_ -- --nocapture
- [x] cargo check -p codewhale-tui --bin codewhale-tui --locked
- [ ] cargo clippy --workspace --all-targets --all-features
- [ ] cargo test --workspace --all-features

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (N/A; tests/docs only)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A)