### PR TITLE
fix(tui): reuse live auto approval for follow-up paths

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2911,8 +2911,8 @@ async fn run_event_loop(
                         blocked_network,
                         blocked_write,
                     } => {
-                        // In YOLO mode, auto-elevate to full access
-                        if app.approval_mode == ApprovalMode::Auto {
+                        // Auto-approved modes may retry denied tools without another prompt.
+                        if app_auto_approve_enabled(app) {
                             log_sensitive_event(
                                 "tool.sandbox.auto_elevate",
                                 serde_json::json!({
@@ -7428,7 +7428,7 @@ async fn apply_command_result(
                     mode: Some(task_mode_label(app.mode).to_string()),
                     allow_shell: Some(app.allow_shell),
                     trust_mode: Some(app.trust_mode),
-                    auto_approve: Some(app.approval_mode == ApprovalMode::Auto),
+                    auto_approve: Some(app_auto_approve_enabled(app)),
                 };
                 match task_manager.add_task(request).await {
                     Ok(task) => {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1919,6 +1919,21 @@ fn non_forced_approval_request_keeps_existing_auto_shortcuts() {
     ));
 }
 
+#[test]
+fn app_auto_approval_helper_covers_yolo_and_live_auto_mode() {
+    let mut app = create_test_app();
+    app.mode = AppMode::Agent;
+    app.approval_mode = ApprovalMode::Suggest;
+    assert!(!app_auto_approve_enabled(&app));
+
+    app.approval_mode = ApprovalMode::Auto;
+    assert!(app_auto_approve_enabled(&app));
+
+    app.approval_mode = ApprovalMode::Suggest;
+    app.mode = AppMode::Yolo;
+    assert!(app_auto_approve_enabled(&app));
+}
+
 fn create_test_options() -> TuiOptions {
     TuiOptions {
         model: "deepseek-v4-pro".to_string(),


### PR DESCRIPTION
## Summary
- completes the live auto-approval wiring from #3613
- routes sandbox elevation retry and queued task creation through `app_auto_approve_enabled(app)`
- adds regression coverage for the helper so YOLO and explicit `ApprovalMode::Auto` stay aligned

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked auto_approval_helper -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked live_auto_approval_mode -- --nocapture`
- `cargo check -p codewhale-tui --locked`

Follow-up to #3613.