### PR TITLE
fix(tui): show proposed file changes in approvals

### DIFF
--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -254,7 +254,7 @@ impl ApprovalRequest {
     /// Extract the most important params for the approval card.
     #[must_use]
     pub fn prominent_detail_items(&self, locale: Locale) -> Vec<ApprovalDetail> {
-        build_prominent_details(self.category, &self.params)
+        build_prominent_details(&self.tool_name, self.category, &self.params)
             .into_iter()
             .map(|mut detail| {
                 detail.label = localize_detail_label(&detail.label, locale).to_string();
@@ -580,7 +580,11 @@ fn build_impact_summary_zh_hans(
     }
 }
 
-fn build_prominent_details(category: ToolCategory, params: &Value) -> Vec<ApprovalDetail> {
+fn build_prominent_details(
+    tool_name: &str,
+    category: ToolCategory,
+    params: &Value,
+) -> Vec<ApprovalDetail> {
     let mut details = Vec::new();
     match category {
         ToolCategory::Shell => {
@@ -605,6 +609,13 @@ fn build_prominent_details(category: ToolCategory, params: &Value) -> Vec<Approv
                     label: "File".to_string(),
                     value: path,
                     shell_lines: None,
+                });
+            }
+            if let Some(preview_lines) = file_write_preview_lines(tool_name, params) {
+                details.push(ApprovalDetail {
+                    label: "Preview".to_string(),
+                    value: preview_lines.join("\n"),
+                    shell_lines: Some(preview_lines),
                 });
             }
         }
@@ -645,6 +656,121 @@ fn build_prominent_details(category: ToolCategory, params: &Value) -> Vec<Approv
     details
 }
 
+fn file_write_preview_lines(tool_name: &str, params: &Value) -> Option<Vec<String>> {
+    match tool_name {
+        "write_file" => {
+            let content = param_text(params, &["content"])?;
+            Some(prefixed_preview_lines(
+                "proposed content",
+                "+ ",
+                &content,
+                5,
+            ))
+        }
+        "edit_file" => {
+            let search = param_text(params, &["search"])?;
+            let replace = param_text(params, &["replace"])?;
+            let mut lines = Vec::new();
+            lines.extend(prefixed_preview_lines("replace this", "- ", &search, 3));
+            lines.extend(prefixed_preview_lines("with this", "+ ", &replace, 3));
+            Some(lines)
+        }
+        "apply_patch" => params
+            .get("patch")
+            .and_then(Value::as_str)
+            .and_then(apply_patch_preview_lines)
+            .or_else(|| {
+                params
+                    .get("changes")
+                    .and_then(Value::as_array)
+                    .and_then(|changes| changes_preview_lines(changes))
+            }),
+        _ => None,
+    }
+    .filter(|lines| !lines.is_empty())
+}
+
+fn prefixed_preview_lines(
+    header: &str,
+    prefix: &str,
+    content: &str,
+    max_lines: usize,
+) -> Vec<String> {
+    let mut lines = vec![header.to_string()];
+    if content.is_empty() {
+        lines.push(format!("{prefix}<empty>"));
+        return lines;
+    }
+
+    let total = content.lines().count();
+    for line in content.lines().take(max_lines) {
+        lines.push(format!("{prefix}{line}"));
+    }
+    if total > max_lines {
+        lines.push(format!("... (+{} more lines)", total - max_lines));
+    }
+    lines
+}
+
+fn apply_patch_preview_lines(patch: &str) -> Option<Vec<String>> {
+    let mut lines = Vec::new();
+    let mut omitted = 0usize;
+    for line in patch.lines().filter(|line| !line.trim().is_empty()) {
+        let is_diff_header = line.starts_with("diff --git ")
+            || line.starts_with("--- ")
+            || line.starts_with("+++ ")
+            || line.starts_with("@@");
+        let is_change_line = (line.starts_with('+') && !line.starts_with("+++"))
+            || (line.starts_with('-') && !line.starts_with("---"));
+        if is_diff_header || is_change_line {
+            if lines.len() < 7 {
+                lines.push(line.to_string());
+            } else {
+                omitted += 1;
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        for line in patch.lines().filter(|line| !line.trim().is_empty()).take(7) {
+            lines.push(line.to_string());
+        }
+    }
+
+    if omitted > 0 {
+        lines.push(format!("... (+{omitted} more diff lines)"));
+    }
+    if lines.is_empty() { None } else { Some(lines) }
+}
+
+fn changes_preview_lines(changes: &[Value]) -> Option<Vec<String>> {
+    let mut lines = Vec::new();
+    for (idx, change) in changes.iter().take(2).enumerate() {
+        let path = change
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or("<file>");
+        let content = change.get("content").and_then(Value::as_str).unwrap_or("");
+        if idx > 0 {
+            lines.push(String::new());
+        }
+        lines.push(format!("file: {path}"));
+        let remaining = 7usize.saturating_sub(lines.len()).max(1);
+        lines.extend(
+            prefixed_preview_lines("replacement content", "+ ", content, remaining)
+                .into_iter()
+                .skip(1),
+        );
+        if lines.len() >= 7 {
+            break;
+        }
+    }
+    if changes.len() > 2 {
+        lines.push(format!("... (+{} more files)", changes.len() - 2));
+    }
+    if lines.is_empty() { None } else { Some(lines) }
+}
+
 fn param_text(params: &Value, keys: &[&str]) -> Option<String> {
     let Value::Object(map) = params else {
         return None;
@@ -671,6 +797,7 @@ fn localize_detail_label(label: &str, locale: Locale) -> &str {
             "Command" => "命令",
             "Dir" => "目录",
             "File" => "文件",
+            "Preview" => "预览",
             "Path" => "路径",
             "Target" => "目标",
             "Input" => "输入",
@@ -1636,6 +1763,63 @@ mod tests {
         assert_eq!(details[0].label, "File");
         assert_eq!(details[0].value, "src/main.rs");
         assert!(details[0].shell_lines.is_none());
+        assert_eq!(details[1].label, "Preview");
+        let preview = details[1].shell_lines.as_ref().expect("preview lines");
+        assert!(preview.iter().any(|line| line == "+ fn main() {}"));
+    }
+
+    #[test]
+    fn prominent_details_edit_file_includes_search_replace_preview() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "edit_file",
+            "Edit a file on disk",
+            &json!({
+                "path": "src/lib.rs",
+                "search": "old_call();",
+                "replace": "new_call();"
+            }),
+            "tool:edit_file",
+        );
+
+        let details = request.prominent_detail_items(Locale::En);
+        let preview = details
+            .iter()
+            .find(|detail| detail.label == "Preview")
+            .and_then(|detail| detail.shell_lines.as_ref())
+            .expect("edit preview");
+
+        assert!(preview.iter().any(|line| line == "- old_call();"));
+        assert!(preview.iter().any(|line| line == "+ new_call();"));
+    }
+
+    #[test]
+    fn prominent_details_apply_patch_includes_diff_preview() {
+        let patch = r#"diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,2 +1,2 @@
+-old
++new
+"#;
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({"patch": patch}),
+            "tool:apply_patch",
+        );
+
+        let details = request.prominent_detail_items(Locale::En);
+        let preview = details
+            .iter()
+            .find(|detail| detail.label == "Preview")
+            .and_then(|detail| detail.shell_lines.as_ref())
+            .expect("patch preview");
+
+        assert!(preview.iter().any(|line| line.starts_with("@@")));
+        assert!(preview.iter().any(|line| line == "-old"));
+        assert!(preview.iter().any(|line| line == "+new"));
     }
 
     #[test]

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1337,39 +1337,44 @@ impl Renderable for ApprovalWidget<'_> {
         }
         let details = self.request.prominent_detail_items(locale);
         if details.is_empty() {
-            let params_str = self.request.params_display();
-            let params_width = card_area.width.saturating_sub(14) as usize;
-            let params_truncated =
-                crate::utils::truncate_with_ellipsis(&params_str, params_width.max(20), "...");
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(
-                    label_params(locale),
-                    Style::default().fg(palette::TEXT_HINT),
-                ),
-                Span::styled(
-                    params_truncated,
-                    Style::default().fg(palette::TEXT_SECONDARY),
-                ),
-            ]));
+            push_params_detail_line(&mut lines, self.request, locale, card_area.width);
         } else {
             let detail_limit = if compact_vertical { 2 } else { 4 };
+            let mut rendered_detail = false;
             for detail in details.iter().take(detail_limit) {
-                if self.request.category == ToolCategory::Shell
-                    && matches!(detail.label.as_str(), "Command" | "命令")
-                    && let Some(shell_lines) = detail.shell_lines.as_deref()
-                {
+                let multiline_preview = detail.shell_lines.as_deref();
+                let is_command_detail = matches!(detail.label.as_str(), "Command" | "命令");
+                let is_change_preview = matches!(detail.label.as_str(), "Preview" | "预览");
+                if compact_vertical && is_change_preview {
+                    continue;
+                }
+                if let Some(shell_lines) = multiline_preview {
                     let command_width = card_area.width.saturating_sub(10) as usize;
+                    let max_rows = if is_change_preview {
+                        if self.request.intent_summary.is_some() {
+                            Some(3)
+                        } else {
+                            Some(5)
+                        }
+                    } else if compact_vertical && is_command_detail {
+                        Some(3)
+                    } else {
+                        None
+                    };
                     push_shell_command_lines(
                         &mut lines,
                         &detail.label,
                         shell_lines,
                         command_width.max(20),
-                        if compact_vertical { Some(3) } else { None },
+                        max_rows,
                     );
                 } else {
                     push_detail_line(&mut lines, &detail.label, &detail.value);
                 }
+                rendered_detail = true;
+            }
+            if !rendered_detail {
+                push_params_detail_line(&mut lines, self.request, locale, card_area.width);
             }
         }
 
@@ -1626,6 +1631,29 @@ fn push_detail_line(lines: &mut Vec<Line<'static>>, label: &str, value: &str) {
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(value.to_string(), Style::default().fg(palette::TEXT_BODY)),
+    ]));
+}
+
+fn push_params_detail_line(
+    lines: &mut Vec<Line<'static>>,
+    request: &ApprovalRequest,
+    locale: Locale,
+    card_width: u16,
+) {
+    let params_str = request.params_display();
+    let params_width = card_width.saturating_sub(14) as usize;
+    let params_truncated =
+        crate::utils::truncate_with_ellipsis(&params_str, params_width.max(20), "...");
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            label_params(locale),
+            Style::default().fg(palette::TEXT_HINT),
+        ),
+        Span::styled(
+            params_truncated,
+            Style::default().fg(palette::TEXT_SECONDARY),
+        ),
     ]));
 }
 
@@ -4799,6 +4827,59 @@ mod tests {
         assert!(rendered.contains("beta"), "{rendered}");
         assert!(rendered.contains("Dir"), "{rendered}");
         assert!(rendered.contains("/tmp/project"), "{rendered}");
+    }
+
+    #[test]
+    fn approval_file_write_modal_renders_proposed_change_preview() {
+        let request = crate::tui::approval::ApprovalRequest::new(
+            "approval-1",
+            "write_file",
+            "Write a file",
+            &serde_json::json!({
+                "path": "src/main.rs",
+                "content": "fn main() {\n    println!(\"visible before approval\");\n}\n",
+            }),
+            "write_file:src/main.rs",
+        );
+        let view = crate::tui::approval::ApprovalView::new(request.clone());
+        let widget = ApprovalWidget::new(&request, &view);
+        let area = Rect::new(0, 0, 120, 34);
+        let mut buf = Buffer::empty(area);
+
+        widget.render(area, &mut buf);
+        let rendered = buffer_text(&buf, area);
+
+        assert!(rendered.contains("Preview:"), "{rendered}");
+        assert!(rendered.contains("+ fn main() {"), "{rendered}");
+        assert!(
+            rendered.contains("visible before approval"),
+            "approval modal should show proposed file content before approval:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn compact_apply_patch_approval_falls_back_to_params_when_preview_is_hidden() {
+        let request = crate::tui::approval::ApprovalRequest::new(
+            "approval-1",
+            "apply_patch",
+            "Apply a patch",
+            &serde_json::json!({
+                "patch": "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+            }),
+            "apply_patch:src/lib.rs",
+        );
+        let view = crate::tui::approval::ApprovalView::new(request.clone());
+        let widget = ApprovalWidget::new(&request, &view);
+        let area = Rect::new(0, 0, 80, 20);
+        let mut buf = Buffer::empty(area);
+
+        widget.render(area, &mut buf);
+        let rendered = buffer_text(&buf, area);
+
+        assert!(rendered.contains("Params:"), "{rendered}");
+        assert!(rendered.contains("patch"), "{rendered}");
+        assert!(rendered.contains("[y]"), "{rendered}");
+        assert!(rendered.contains("[d]"), "{rendered}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1846.

- Show bounded proposed-change previews inside expanded approval cards for write_file, edit_file, and apply_patch.
- Keep compact approval cards focused on controls; if a preview is hidden there, fall back to truncated params so the card is never blank.
- Add approval extraction and render coverage for proposed file content before approval.

## Testing

- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] cargo test -p codewhale-tui --bin codewhale-tui --locked prominent_details -- --nocapture
- [x] cargo test -p codewhale-tui --bin codewhale-tui --locked approval_file_write_modal_renders_proposed_change_preview -- --nocapture
- [x] cargo test -p codewhale-tui --bin codewhale-tui --locked approval_ -- --nocapture
- [x] cargo check -p codewhale-tui --bin codewhale-tui --locked
- [ ] cargo clippy --workspace --all-targets --all-features
- [ ] cargo test --workspace --all-features

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (buffer-render regression tests)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A)