### PR TITLE
fix(tui): reconcile stale subagents before status

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -114,7 +114,8 @@ impl StructuredState {
         };
 
         let subagent_snapshots = if let Some(handle) = subagents {
-            let guard = handle.read().await;
+            let mut guard = handle.write().await;
+            guard.cleanup(Duration::from_secs(60 * 60));
             guard
                 .list()
                 .into_iter()

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3578,7 +3578,8 @@ async fn inspect_agent_from_input(
 
     if let Some(agent_ref) = parse_agent_ref(input) {
         let (snapshot, worker_record) = {
-            let manager = manager.read().await;
+            let mut manager = manager.write().await;
+            manager.cleanup(COMPLETED_AGENT_RETENTION);
             let snapshot = manager
                 .get_result_by_ref(&agent_ref)
                 .map_err(|err| ToolError::invalid_input(err.to_string()))?;
@@ -3599,7 +3600,8 @@ async fn inspect_agent_from_input(
     }
 
     let snapshots = {
-        let manager = manager.read().await;
+        let mut manager = manager.write().await;
+        manager.cleanup(COMPLETED_AGENT_RETENTION);
         manager
             .list_filtered(include_archived)
             .into_iter()

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -2378,6 +2378,55 @@ async fn cleanup_auto_cancels_stale_running_agent_and_releases_slot() {
 }
 
 #[tokio::test]
+async fn status_projection_reconciles_stale_running_agent() {
+    let mut inner = SubAgentManager::new(PathBuf::from("."), 1)
+        .with_running_heartbeat_timeout(Duration::from_millis(1));
+    let current_boot = inner.session_boot_id().to_string();
+    let (input_tx, _input_rx) = mpsc::unbounded_channel();
+    let mut agent = SubAgent::new(
+        "test_agent_status_stale".to_string(),
+        SubAgentType::Explore,
+        "prompt".to_string(),
+        make_assignment(),
+        "deepseek-v4-flash".to_string(),
+        Some("Blue".to_string()),
+        Some(vec!["read_file".to_string()]),
+        input_tx,
+        PathBuf::from("."),
+        current_boot,
+    );
+    agent.task_handle = Some(tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }));
+    inner.agents.insert(agent.id.clone(), agent);
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let manager = Arc::new(RwLock::new(inner));
+    let context = ToolContext::new(".");
+    let result = inspect_agent_from_input(&json!({"action": "status"}), manager, &context, false)
+        .await
+        .expect("status projection should succeed");
+    let payload: serde_json::Value =
+        serde_json::from_str(&result.content).expect("status payload should be json");
+    let agent = payload["agents"]
+        .as_array()
+        .and_then(|agents| agents.first())
+        .expect("stale current-session agent should remain inspectable");
+
+    assert_eq!(payload["count"], 1);
+    assert_eq!(agent["agent_id"], "test_agent_status_stale");
+    assert_eq!(agent["status"], "cancelled");
+    assert_eq!(agent["terminal"], true);
+    assert_eq!(agent["snapshot"]["status"], "Cancelled");
+    assert!(
+        agent["snapshot"]["result"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Auto-cancelled")
+    );
+}
+
+#[tokio::test]
 async fn cleanup_keeps_recent_running_agent() {
     let mut manager = SubAgentManager::new(PathBuf::from("."), 1)
         .with_running_heartbeat_timeout(Duration::from_secs(300));


### PR DESCRIPTION
## Summary

- Runs stale sub-agent cleanup before parent structured-state capture injects running child state into the next turn.
- Runs the same cleanup before model-facing `agent` status/peek projections, so heartbeat-expired workers surface as terminal instead of lingering as running.
- Adds a regression for a stale current-session agent projecting as `cancelled` and terminal.

Refs #1679.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked status_projection_reconciles_stale_running_agent -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked cleanup_auto_cancels_stale_running_agent_and_releases_slot -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked test_running_count_counts_only_agents_with_live_task_handles -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked touch_refreshes_stale_running_agent_heartbeat -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked subagent -- --nocapture`
- [x] `cargo check -p codewhale-tui --bin codewhale-tui --locked`
- [x] Post-rebase: `git diff --check origin/main..HEAD`
- [x] Post-rebase: `cargo test -p codewhale-tui --bin codewhale-tui --locked status_projection_reconciles_stale_running_agent -- --nocapture`
- [x] Post-rebase: `cargo check -p codewhale-tui --bin codewhale-tui --locked`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address