### PR TITLE
Fix provider links docs fallback

### DIFF
--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -440,9 +440,14 @@ fn provider_link_info(provider_id: &str) -> ProviderLinkInfo {
             docs_url: "https://docs.deepinfra.com/quickstart",
             note: "Create DeepInfra API keys from the dashboard.",
         },
+        "qianfan" => ProviderLinkInfo {
+            key_url: None,
+            docs_url: "https://cloud.baidu.com/doc/qianfan/index.html",
+            note: "Create Baidu Qianfan API keys from the Qianfan console.",
+        },
         _ => ProviderLinkInfo {
             key_url: None,
-            docs_url: "https://codewhale.dev/docs/providers",
+            docs_url: "https://codewhale.net/en/docs",
             note: "Use the provider console for credentials, then configure the matching env var.",
         },
     }
@@ -1277,9 +1282,20 @@ mod tests {
         assert!(msg.contains("https://platform.deepseek.com/api_keys"));
         assert!(msg.contains("Xiaomi MiMo (xiaomi-mimo)"));
         assert!(msg.contains("https://platform.xiaomimimo.com/token-plan"));
+        assert!(msg.contains("Baidu Qianfan (qianfan)"));
+        assert!(msg.contains("https://cloud.baidu.com/doc/qianfan/index.html"));
         assert!(msg.contains("OPENAI_API_KEY"));
         assert!(msg.contains("XIAOMI_MIMO_TOKEN_PLAN_API_KEY"));
+        assert!(!msg.contains("https://codewhale.dev/docs/providers"));
         assert!(result.action.is_none());
+    }
+
+    #[test]
+    fn provider_link_fallback_uses_current_codewhale_docs() {
+        let links = provider_link_info("unknown-provider");
+
+        assert_eq!(links.docs_url, "https://codewhale.net/en/docs");
+        assert_eq!(links.key_url, None);
     }
 
     #[test]


### PR DESCRIPTION
# Fix provider links docs fallback

## Summary

- Update the `/links` fallback docs URL from the stale `codewhale.dev/docs/providers` page to the current CodeWhale docs page.
- Add a Qianfan-specific docs link so Qianfan does not fall through to generic CodeWhale docs.
- Add regression coverage for the fallback docs URL.

## Verification

- `cargo fmt`
- `CARGO_INCREMENTAL=0 cargo test -p codewhale-tui --bin codewhale-tui --locked links`
- `CARGO_INCREMENTAL=0 cargo test -p codewhale-tui --bin codewhale-tui --locked provider_link_fallback_uses_current_codewhale_docs`

## Notes

Manual URL checks showed `https://codewhale.dev/docs/providers` returns 404, while `https://codewhale.net/en/docs` is reachable. Baidu Qianfan docs resolve at `https://cloud.baidu.com/doc/qianfan/index.html`.