### PR TITLE
fix(tui): surface mode policy in turn metadata

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -656,6 +656,15 @@ fn subagent_mailbox_best_effort_send_permitted(
 }
 
 impl Engine {
+    fn mode_runtime_instructions(mode: AppMode) -> &'static str {
+        match mode {
+            AppMode::Agent => prompts::AGENT_MODE,
+            AppMode::Plan => prompts::PLAN_MODE,
+            AppMode::Yolo => prompts::YOLO_MODE,
+        }
+        .trim()
+    }
+
     pub(super) async fn emit_compaction_started(
         &mut self,
         id: String,
@@ -1886,6 +1895,12 @@ impl Engine {
             // `render_environment_block` for the prefix-cache rationale).
             format!("Current workspace: {}", self.config.workspace.display()),
             format!("Current model: {routed_model}"),
+            format!("Current mode: {}", self.current_mode.as_setting()),
+            "Current mode policy source: runtime".to_string(),
+            format!(
+                "Current mode policy:\n{}",
+                Self::mode_runtime_instructions(self.current_mode)
+            ),
             format!("Input provenance: {}", provenance.as_str()),
             format!(
                 "Input authority: {}",

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -4027,32 +4027,40 @@ fn review_only_external_input_keeps_explicit_mode_with_advisory_hint() {
 }
 
 #[test]
-fn turn_metadata_omits_mode_policy() {
+fn turn_metadata_includes_plan_mode_policy() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
         workspace: tmp.path().to_path_buf(),
         ..Default::default()
     };
-    let (engine, _handle) = Engine::new(config, &Config::default());
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.current_mode = AppMode::Plan;
 
     let user_msg = engine.user_text_message_with_turn_metadata_for_route(
-        "test mode metadata".to_string(),
+        "explain the refactor plan before editing".to_string(),
         "deepseek-v4-flash",
         false,
         None,
         false,
     );
-    // turn_meta was relocated to the tail of the user message in #2517
-    // to keep the leading bytes (user input) stable across date / model
-    // route / working-set changes.
     let last_block = user_msg.content.last().expect("turn metadata block");
     let ContentBlock::Text { text, .. } = last_block else {
         panic!("expected text metadata block");
     };
 
+    assert!(text.contains("Current mode: plan"), "got: {text}");
     assert!(
-        !text.contains("Current mode:"),
-        "turn metadata should leave runtime policy to the capability tag, got: {text}"
+        text.contains("Current mode policy source: runtime"),
+        "got: {text}"
+    );
+    assert!(text.contains("##### Mode: Plan"), "got: {text}");
+    assert!(
+        text.contains("All writes and patches are blocked"),
+        "got: {text}"
+    );
+    assert!(
+        text.contains("Shell and code execution are unavailable"),
+        "got: {text}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add the active mode and canonical mode-policy delta to each user turn's `<turn_meta>` block.
- Reuse the existing Plan/Agent/YOLO prompt snippets instead of duplicating new policy copy.
- Replace the old omit-mode-policy assertion with a Plan-mode regression covering the #3568 failure shape.

## Why

#3568 includes a DeepSeek V4-pro thinking trace where a Plan-mode turn still reasoned through edit/patch/write fallbacks. The request path already strips write/exec tools in Plan mode, but the model-facing prompt no longer carried an explicit mode delta, so the reduced catalog alone was too weak. This keeps the stable system prefix unchanged and puts the active runtime policy at the tail of the current user message.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked turn_metadata_includes_plan_mode_policy -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked plan_mode -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked`

Refs #3568.