### PR TITLE
fix(tui): warn on unknown exec tool surface

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -386,7 +386,14 @@ enum ExecToolSurface {
 fn exec_tool_surface_from_env() -> Option<ExecToolSurface> {
     std::env::var(CODEWHALE_TOOL_SURFACE_ENV)
         .ok()
-        .and_then(|value| parse_exec_tool_surface(&value))
+        .and_then(|value| {
+            if should_warn_unknown_exec_tool_surface(&value) {
+                eprintln!(
+                    "warning: unrecognized {CODEWHALE_TOOL_SURFACE_ENV}; leaving exec tool surface unchanged. Use `shell-only`, `full`, or `native-tools`."
+                );
+            }
+            parse_exec_tool_surface(&value)
+        })
 }
 
 fn parse_exec_tool_surface(value: &str) -> Option<ExecToolSurface> {
@@ -395,6 +402,14 @@ fn parse_exec_tool_surface(value: &str) -> Option<ExecToolSurface> {
         "full" | "native-tools" | "native_tools" | "" => None,
         _ => None,
     }
+}
+
+fn should_warn_unknown_exec_tool_surface(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    !matches!(
+        normalized.as_str(),
+        "" | "shell-only" | "shell_only" | "shell" | "full" | "native-tools" | "native_tools"
+    )
 }
 
 fn normalize_exec_tool_names(tools: &[String]) -> Vec<String> {
@@ -7763,6 +7778,16 @@ mod terminal_mode_tests {
             resolve_exec_allowed_tools(None, exec_tool_surface_from_env()),
             None
         );
+    }
+
+    #[test]
+    fn exec_unknown_tool_surface_env_warns_without_allowlist() {
+        assert!(should_warn_unknown_exec_tool_surface("shell_onyl"));
+        assert!(!should_warn_unknown_exec_tool_surface("shell-only"));
+        assert!(!should_warn_unknown_exec_tool_surface("native-tools"));
+        assert!(!should_warn_unknown_exec_tool_surface("full"));
+        assert!(!should_warn_unknown_exec_tool_surface(" "));
+        assert_eq!(parse_exec_tool_surface("shell_onyl"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- warn when `CODEWHALE_TOOL_SURFACE` is set to an unrecognized value instead of silently treating the typo as a full/native tool surface
- keep known no-op values (`full`, `native-tools`, empty) unchanged
- add regression coverage for the typo path alongside the landed shell-only allowlist behavior

Refs #2954.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked exec_unknown_tool_surface_env_warns_without_allowlist -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked exec_shell_only_tool_surface_env_sets_shell_allowlist -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tool_catalog_shell_only_benchmark_surface_hides_native_tools -- --nocapture`
- `cargo check -p codewhale-tui --bin codewhale-tui --locked`

## Note

This is a follow-up to #3593. I still have not rerun the Harbor `cancel-async-tasks` benchmark/token comparison because the referenced `scripts/benchmark/harbor_agents/codewhale.py` harness is not present in this checkout, so this intentionally references #2954 without closing it.