### PR TITLE
feat(exec): report visible final answer size

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6426,6 +6426,7 @@ struct ExecStreamMeta {
     input_tokens: u32,
     output_tokens: u32,
     input_analysis: ExecStreamInputAnalysis,
+    visible_final_answer_chars: usize,
     session_id: String,
     resume_command: String,
     workspace: String,
@@ -7142,6 +7143,7 @@ async fn run_exec_agent(
                                 &latest_messages,
                                 latest_system_prompt.as_ref(),
                             ),
+                            visible_final_answer_chars: summary.output.chars().count(),
                             resume_command: saved_session_id
                                 .as_deref()
                                 .map(exec_stream_resume_hint)
@@ -7993,6 +7995,7 @@ mod terminal_mode_tests {
                 input_tokens: 123,
                 output_tokens: 45,
                 input_analysis: ExecStreamInputAnalysis::default(),
+                visible_final_answer_chars: 17,
                 session_id: exec_stream_session_ref(raw_session_id),
                 resume_command: exec_stream_resume_hint(raw_session_id),
                 workspace: "/tmp/work".to_string(),
@@ -8019,6 +8022,7 @@ mod terminal_mode_tests {
         );
         assert_eq!(parsed["meta"]["workspace"], "/tmp/work");
         assert_eq!(parsed["meta"]["message_count"], 4);
+        assert_eq!(parsed["meta"]["visible_final_answer_chars"], 17);
 
         let capture = ExecStreamEvent::SessionCapture {
             content: exec_stream_session_ref(raw_session_id),


### PR DESCRIPTION
## Summary

- add `visible_final_answer_chars` to `codewhale exec --output-format stream-json` metadata
- compute it from the accumulated visible answer text, separate from provider `output_tokens`
- keep interactive TUI behavior unchanged and preserve existing concise verbosity wiring

Refs #2957.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked exec_stream_metadata_redacts_resume_breadcrumbs -- --nocapture`
- `cargo check -p codewhale-tui --bin codewhale-tui --locked`

## Note

This covers the benchmark reporting slice of #2957. The issue should stay open until the harness reruns at least two passing paired tasks and records whether output tokens move closer to Codex while preserving reward.