### PR TITLE
test(tui): lock approval key badges

### DIFF
--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -2547,12 +2547,22 @@ mod tests {
         lines.join("\n").replace(' ', "")
     }
 
+    fn assert_approval_key_badges_visible(joined: &str) {
+        for badge in ["[1 / y]", "[2 / a]", "[3 / d / n]", "[Esc]"] {
+            assert!(
+                joined.contains(badge),
+                "missing key badge {badge}:\n{joined}"
+            );
+        }
+    }
+
     #[test]
     fn render_benign_includes_review_badge_and_selection_hint() {
         let view = ApprovalView::new(benign_request());
         let lines = render_lines(&view, 100, 40);
         let joined = lines.join("\n");
         assert!(joined.contains("REVIEW"), "missing REVIEW badge:\n{joined}");
+        assert_approval_key_badges_visible(&joined);
         assert!(joined.contains("Choose"), "benign hint missing:\n{joined}");
         assert!(
             joined.contains("Enter selected option"),
@@ -2570,6 +2580,7 @@ mod tests {
             joined.contains("DESTRUCTIVE"),
             "missing DESTRUCTIVE badge:\n{joined}"
         );
+        assert_approval_key_badges_visible(&joined);
         assert!(
             joined.contains("Enter selected option"),
             "destructive hint missing:\n{joined}"


### PR DESCRIPTION
## Summary

- add render-test assertions that the approval modal shows explicit key badges for approve once, approve always, deny, and abort
- cover both benign and destructive approval variants so the #3380 UX acceptance stays locked
- no runtime behavior change; current option rows already render the visible badges

Closes #3380

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked render_benign_includes_review_badge_and_selection_hint -- --nocapture`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked render_destructive_shows_warning_badge_and_one_step_hint -- --nocapture`
- [x] `git diff --check`

## Checklist

- [ ] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address