### PR TITLE
feat(tui): save apply_patch ask rules from validated touched files

### DIFF
--- a/crates/tui/src/tools/apply_patch.rs
+++ b/crates/tui/src/tools/apply_patch.rs
@@ -558,6 +558,7 @@ fn resolve_diff_paths(
 }
 
 fn normalize_diff_path(raw: &str) -> Option<String> {
+    let raw = raw.split_once('\t').map_or(raw, |(path, _timestamp)| path);
     let raw = raw.trim();
     if raw.is_empty() {
         return None;
@@ -670,10 +671,22 @@ fn inspect_patch_shape(patch: &str) -> PatchShape {
     let mut shape = PatchShape::default();
     let mut seen = HashSet::new();
     let mut old_path: Option<String> = None;
+    let mut hunk_old_remaining = 0usize;
+    let mut hunk_new_remaining = 0usize;
 
     for line in patch.lines() {
         if line.starts_with("@@") {
             shape.has_hunks = true;
+            if let Some((old_count, new_count)) = hunk_line_counts_for_shape(line) {
+                hunk_old_remaining = old_count;
+                hunk_new_remaining = new_count;
+            }
+            continue;
+        }
+
+        if hunk_old_remaining > 0 || hunk_new_remaining > 0 {
+            advance_hunk_shape_counts(line, &mut hunk_old_remaining, &mut hunk_new_remaining);
+            continue;
         }
 
         if let Some(stripped) = line.strip_prefix("--- ") {
@@ -694,6 +707,30 @@ fn inspect_patch_shape(patch: &str) -> PatchShape {
     }
 
     shape
+}
+
+fn hunk_line_counts_for_shape(header: &str) -> Option<(usize, usize)> {
+    let parts: Vec<&str> = header.split_whitespace().collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let (_, old_count) = parse_range(parts[1].trim_start_matches('-')).ok()?;
+    let (_, new_count) = parse_range(parts[2].trim_start_matches('+')).ok()?;
+    Some((old_count, new_count))
+}
+
+fn advance_hunk_shape_counts(line: &str, old_remaining: &mut usize, new_remaining: &mut usize) {
+    if line.starts_with('\\') {
+        return;
+    }
+    if line.starts_with('+') {
+        *new_remaining = new_remaining.saturating_sub(1);
+    } else if line.starts_with('-') {
+        *old_remaining = old_remaining.saturating_sub(1);
+    } else {
+        *old_remaining = old_remaining.saturating_sub(1);
+        *new_remaining = new_remaining.saturating_sub(1);
+    }
 }
 
 fn validate_patch_shape(shape: &PatchShape, path_override: Option<&str>) -> Result<(), ToolError> {
@@ -1260,6 +1297,43 @@ diff --git a/old.rs b/old.rs
         assert_eq!(preflight.hunks_total, 2);
         assert_eq!(preflight.creates, vec!["new.rs"]);
         assert_eq!(preflight.deletes, vec!["old.rs"]);
+    }
+
+    #[test]
+    fn test_preflight_apply_patch_timestamp_headers_strip_metadata() {
+        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n\
+--- a/src/lib.rs\t2026-06-26 10:00:00 +0000\n\
++++ b/src/lib.rs\t2026-06-26 10:01:00 +0000\n\
+@@ -1,1 +1,1 @@\n\
+-old\n\
++new\n";
+
+        let preflight = preflight_apply_patch(&json!({ "patch": patch })).expect("preflight");
+
+        assert_eq!(preflight.touched_files, vec!["src/lib.rs"]);
+        assert_eq!(preflight.files_total, 1);
+        assert_eq!(preflight.hunks_total, 1);
+    }
+
+    #[test]
+    fn test_preflight_apply_patch_ignores_forged_headers_inside_hunk_shape() {
+        let patch = r"--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ line1
+--- a/forged.rs
++++ b/forged.rs
+ line3
+";
+
+        let preflight = preflight_apply_patch(&json!({
+            "path": "src/lib.rs",
+            "patch": patch
+        }))
+        .expect("preflight");
+
+        assert_eq!(preflight.touched_files, vec!["src/lib.rs"]);
+        assert_eq!(preflight.header_path_mismatch, None);
     }
 
     #[test]

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -276,6 +276,7 @@ fn build_persistent_ask_rules(
         // edit/write of the same file is matched. read_file stays out: this
         // boundary is about persisting *write* approvals only.
         "write_file" | "edit_file" => build_file_write_ask_rules(tool_name, params, workspace),
+        "apply_patch" => build_apply_patch_ask_rules(params, workspace),
         _ => Vec::new(),
     }
 }
@@ -320,6 +321,30 @@ fn build_file_write_ask_rules(
         return Vec::new();
     };
     vec![ToolAskRule::file_path(tool_name, relative)]
+}
+
+#[must_use]
+fn build_apply_patch_ask_rules(params: &Value, workspace: &Path) -> Vec<ToolAskRule> {
+    let Ok(preflight) = crate::tools::apply_patch::preflight_apply_patch(params) else {
+        return Vec::new();
+    };
+    let workspace = workspace.to_string_lossy();
+    let mut rules = Vec::new();
+
+    for path in preflight.touched_files {
+        let Some(relative) =
+            codewhale_execpolicy::normalize_workspace_relative_path(&path, workspace.as_ref())
+                .filter(|relative| !relative.is_empty())
+        else {
+            return Vec::new();
+        };
+        let rule = ToolAskRule::file_path("apply_patch", relative);
+        if !rules.contains(&rule) {
+            rules.push(rule);
+        }
+    }
+
+    rules
 }
 
 /// Get the category for a tool by name
@@ -1930,6 +1955,142 @@ mod tests {
             assert!(!request.can_save_ask_rule());
             assert_eq!(request.ask_rule_preview(), None);
         }
+    }
+
+    #[test]
+    fn apply_patch_ask_rules_saved_for_multi_file_patch() {
+        let patch = r"diff --git a/src/a.rs b/src/a.rs
+--- a/src/a.rs
++++ b/src/a.rs
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/src/b.rs b/src/b.rs
+--- a/src/b.rs
++++ b/src/b.rs
+@@ -1,1 +1,1 @@
+-old
++new
+";
+
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({"patch": patch}),
+            "tool:apply_patch",
+        );
+
+        assert_eq!(
+            request.persistent_ask_rules,
+            vec![
+                ToolAskRule::file_path("apply_patch", "src/a.rs"),
+                ToolAskRule::file_path("apply_patch", "src/b.rs"),
+            ]
+        );
+        assert!(request.can_save_ask_rule());
+    }
+
+    #[test]
+    fn apply_patch_ask_rules_dedupe_targets_after_normalization() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({
+                "changes": [
+                    { "path": "src/a.rs", "content": "one" },
+                    { "path": "/workspace/src/a.rs", "content": "two" }
+                ]
+            }),
+            "tool:apply_patch",
+        );
+
+        assert_eq!(
+            request.persistent_ask_rules,
+            vec![ToolAskRule::file_path("apply_patch", "src/a.rs")]
+        );
+    }
+
+    #[test]
+    fn apply_patch_ask_rule_handles_timestamp_headers() {
+        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n\
+--- a/src/lib.rs\t2026-06-26 10:00:00 +0000\n\
++++ b/src/lib.rs\t2026-06-26 10:01:00 +0000\n\
+@@ -1,1 +1,1 @@\n\
+-old\n\
++new\n";
+
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({"patch": patch}),
+            "tool:apply_patch",
+        );
+
+        assert_eq!(
+            request.persistent_ask_rules,
+            vec![ToolAskRule::file_path("apply_patch", "src/lib.rs")]
+        );
+    }
+
+    #[test]
+    fn apply_patch_ask_rule_ignores_forged_headers_inside_hunk() {
+        let patch = r"--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ line1
+--- a/forged.rs
++++ b/forged.rs
+ line3
+";
+
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({"path": "src/lib.rs", "patch": patch}),
+            "tool:apply_patch",
+        );
+
+        assert_eq!(
+            request.persistent_ask_rules,
+            vec![ToolAskRule::file_path("apply_patch", "src/lib.rs")]
+        );
+    }
+
+    #[test]
+    fn apply_patch_ask_rule_skipped_when_any_target_traverses_workspace() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({
+                "changes": [
+                    { "path": "src/a.rs", "content": "safe" },
+                    { "path": "../escape.rs", "content": "unsafe" }
+                ]
+            }),
+            "tool:apply_patch",
+        );
+
+        assert!(request.persistent_ask_rules.is_empty());
+        assert!(!request.can_save_ask_rule());
+    }
+
+    #[test]
+    fn apply_patch_ask_rule_skipped_on_preflight_failure() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({"patch": "@@ -1 +1 @@\n-old\n+new\n"}),
+            "tool:apply_patch",
+        );
+
+        assert!(request.persistent_ask_rules.is_empty());
+        assert_eq!(request.ask_rule_preview(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Save ask-only `apply_patch` rules from `preflight_apply_patch(input)?.touched_files`.
- Show/enable the `S` save shortcut only when preflight succeeds and every touched file safely normalizes to a workspace-relative path.
- Persist one exact `tool = "apply_patch"` + `path = ...` rule per touched file, with duplicate normalized targets collapsed.
- Harden shared apply_patch preflight path extraction for timestamped diff headers and header-looking lines inside hunks.

## Scope
- In scope: approval UI rule construction for `apply_patch`, using shared preflight results only.
- Out of scope: UI editing/deleting rules, allow/deny policy, glob rules, or parsing patch diffs inside approval UI.

## Builds on
- Builds on #3547.

## Issues
- Refs #1186 (partial)
- Refs #2242 (partial)

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked apply_patch_ask_rule`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked preflight_apply_patch`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked file_ask_rule`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked apply_patch`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked approval`
- `cargo test -p codewhale-config --locked permissions`
- `./scripts/release/check-versions.sh`