### PR TITLE
fix(release): gate registry publish on fresh assets

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -172,6 +172,15 @@ release anxiety: contributors cannot tell whether their work merged.
       `git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
 - [ ] The `release.yml` workflow has built and uploaded artifacts to the
       GitHub release for this tag.
+- [ ] The public GitHub Release assets are proven to match the tag commit
+      before publishing Cargo or npm:
+      ```
+      ./scripts/release/verify-release-assets.sh X.Y.Z
+      ```
+      This checks the local tag, remote tag, successful Release workflow SHA,
+      npm-facing assets, and `codewhale-artifacts-sha256.txt` manifest. If it
+      fails, rerun or repair the GitHub Release workflow before touching any
+      registry.
 - [ ] The live GitHub Release body has its own `## Contributors` or
       `## Credits` section; do not rely on "see CHANGELOG" alone. Verify with:
       ```
@@ -185,6 +194,10 @@ release anxiety: contributors cannot tell whether their work merged.
 - [ ] `crates.io` has the new version (or the `publish-crates.sh` job has
       pushed it).
 - [ ] `ghcr.io/hmbown/codewhale:vX.Y.Z` and `:latest` are updated.
+- [ ] The final registry verification passes:
+      ```
+      ./scripts/release/check-published.sh X.Y.Z
+      ```
 
 ## 8. Post-tag
 

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -213,17 +213,31 @@ The publish helper is idempotent for reruns: already-published crate versions ar
 
 `.github/workflows/release.yml` builds these binaries:
 
-- `codewhale-linux-x64`
-- `codewhale-macos-x64`
-- `codewhale-macos-arm64`
-- `codewhale-windows-x64.exe`
-- `codewhale-tui-linux-x64`
-- `codewhale-tui-macos-x64`
-- `codewhale-tui-macos-arm64`
-- `codewhale-tui-windows-x64.exe`
+- `codewhale-*` CLI binaries for Linux x64/arm64/riscv64, macOS x64/arm64,
+  and Windows x64
+- `codewhale-tui-*` TUI binaries for the same target matrix
+- `codew-*` shortcut binaries for the same target matrix
+- `codewhale.bat` for the Windows npm launcher
 
 The release job also uploads `codewhale-artifacts-sha256.txt`. The npm installer and
-release verification script both depend on that checksum manifest.
+release verification script both depend on that checksum manifest. The
+authoritative npm-facing asset list lives in
+`npm/codewhale/scripts/artifacts.js`.
+
+Before any Cargo or npm publish, prove that the public GitHub Release assets
+belong to the tag commit you are publishing:
+
+```bash
+./scripts/release/verify-release-assets.sh X.Y.Z
+```
+
+That gate compares the local and remote `vX.Y.Z` tag SHAs, confirms a
+successful `Release` workflow run used that SHA, then runs the npm wrapper's
+release check against the public GitHub asset URLs. The npm check fails if the
+release is missing an npm-facing asset, the checksum manifest omits a required
+binary, or the assets predate the matching release workflow run. If the command
+fails, rerun or repair `release.yml`; do not publish Cargo or npm against stale
+assets.
 
 ## npm Wrapper Release
 
@@ -240,14 +254,47 @@ on a workstation with `npm login` and an authenticator app.
 3. Push the version bump to `main`. After the release source is frozen, create
    the matching `vX.Y.Z` tag from `main`; `release.yml` then builds the binary
    matrix and drafts the GitHub Release.
-4. **Wait for the GitHub Release to finalize** with all eight signed binaries plus `codewhale-artifacts-sha256.txt`. The npm `prepublishOnly` hook (`scripts/verify-release-assets.js`) requires every asset to be present.
-5. From a developer machine, publish the npm wrapper manually:
+4. **Wait for the GitHub Release to finalize** with the full npm-facing binary
+   matrix plus `codewhale-artifacts-sha256.txt`. The npm `prepublishOnly` hook
+   (`scripts/verify-release-assets.js`) requires every asset to be present.
+5. Run the public asset freshness gate from the repo root:
 
 ```bash
+./scripts/release/verify-release-assets.sh X.Y.Z
+```
+
+For a rare packaging-only npm release where the npm package version intentionally
+points at older Rust binaries, add `--allow-npm-binary-mismatch` and keep the
+release notes explicit that no new binary version shipped.
+
+6. From a developer machine, confirm npm auth and publish the wrapper manually:
+
+```bash
+npm whoami
 cd npm/codewhale
 npm publish --access public
 # (you will be prompted for the npm OTP from your authenticator)
+npm view codewhale@X.Y.Z version codewhaleBinaryVersion --json
+cd ../..
+./scripts/release/check-published.sh X.Y.Z
 ```
+
+If `npm whoami` or `npm publish` reports `E401`, `ENEEDAUTH`, or an OTP/login
+failure, do not edit package contents. Run:
+
+```bash
+npm login
+npm whoami
+cd npm/codewhale
+npm publish --access public
+```
+
+Rerun the same `npm publish --access public` command after completing the login
+or OTP prompt. The package's `prepublishOnly` hook reruns the release-asset
+gate before each publish attempt, so an auth failure cannot accidentally skip
+asset verification on retry.
+
+Do not publish `npm/deepseek-tui`; it is deprecated compatibility metadata only.
 
 ### Why not automated?
 

--- a/npm/codewhale/README.md
+++ b/npm/codewhale/README.md
@@ -103,6 +103,10 @@ offline installs, set `DEEPSEEK_TUI_DISABLE_INSTALL=1` or point
 
 - `npm publish` runs a release-asset check to ensure all required binary assets
   exist for the target GitHub release before publishing.
+- For the default GitHub Release source, `npm run release:check` also verifies
+  that the npm-facing assets were updated by a successful `release.yml` run for
+  the tag commit. When `CODEWHALE_RELEASE_BASE_URL` or a legacy mirror override
+  is set, it checks the mirror asset URLs and checksum manifest instead.
 - Install-time downloads are verified against the release checksum manifest before
   the wrapper marks them executable.
 

--- a/npm/codewhale/scripts/verify-release-assets.js
+++ b/npm/codewhale/scripts/verify-release-assets.js
@@ -22,6 +22,35 @@ function resolveRepo() {
   return process.env.DEEPSEEK_TUI_GITHUB_REPO || process.env.DEEPSEEK_GITHUB_REPO || "Hmbown/CodeWhale";
 }
 
+function hasReleaseBaseOverride() {
+  return Boolean(
+    process.env.CODEWHALE_RELEASE_BASE_URL ||
+      process.env.DEEPSEEK_TUI_RELEASE_BASE_URL ||
+      process.env.DEEPSEEK_RELEASE_BASE_URL ||
+      process.env.CODEWHALE_USE_CNB_MIRROR,
+  );
+}
+
+function packageVersionMatchesBinaryVersion(version) {
+  return String(pkg.version).trim() === version;
+}
+
+function assertPackageVersionMatchesBinaryVersion(version) {
+  if (packageVersionMatchesBinaryVersion(version)) {
+    return;
+  }
+  if (process.env.CODEWHALE_ALLOW_NPM_BINARY_MISMATCH === "1") {
+    console.log(
+      `npm package version ${pkg.version} points at binary release ${version} (allowed packaging-only mismatch).`,
+    );
+    return;
+  }
+  throw new Error(
+    `npm package version ${pkg.version} does not match codewhaleBinaryVersion ${version}. ` +
+      "Set CODEWHALE_ALLOW_NPM_BINARY_MISMATCH=1 only for an intentional packaging-only npm release.",
+  );
+}
+
 function requestStatus(url, method = "HEAD", redirects = 0) {
   if (redirects > 10) {
     throw new Error(`Too many redirects while checking ${url}`);
@@ -96,6 +125,141 @@ async function downloadText(url) {
   });
 }
 
+async function downloadJson(url) {
+  const client = url.startsWith("https:") ? https : http;
+  return new Promise((resolve, reject) => {
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "codewhale-npm-release-check",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    client
+      .get(url, { headers }, (res) => {
+        const status = res.statusCode || 0;
+        if (status >= 300 && status < 400 && res.headers.location) {
+          const next = new URL(res.headers.location, url).toString();
+          resolve(downloadJson(next));
+          return;
+        }
+        const chunks = [];
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          const body = chunks.join("");
+          let parsed;
+          try {
+            parsed = body ? JSON.parse(body) : {};
+          } catch (error) {
+            reject(new Error(`Invalid JSON from ${url}: ${error.message}`));
+            return;
+          }
+          if (status < 200 || status >= 300) {
+            const message = parsed.message ? `: ${parsed.message}` : "";
+            reject(new Error(`GitHub API request failed with status ${status}${message} (${url})`));
+            return;
+          }
+          resolve(parsed);
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+function githubApiUrl(repo, path) {
+  return `https://api.github.com/repos/${repo}${path}`;
+}
+
+async function githubApi(repo, path) {
+  return downloadJson(githubApiUrl(repo, path));
+}
+
+async function resolveTagCommitSha(repo, tag) {
+  const ref = await githubApi(repo, `/git/ref/tags/${encodeURIComponent(tag)}`);
+  if (!ref.object || !ref.object.sha || !ref.object.type) {
+    throw new Error(`GitHub tag ref ${tag} did not include an object SHA`);
+  }
+  if (ref.object.type === "commit") {
+    return ref.object.sha;
+  }
+  if (ref.object.type !== "tag") {
+    throw new Error(`GitHub tag ref ${tag} points at ${ref.object.type}, not a commit or annotated tag`);
+  }
+  const tagObject = await githubApi(repo, `/git/tags/${ref.object.sha}`);
+  if (!tagObject.object || tagObject.object.type !== "commit" || !tagObject.object.sha) {
+    throw new Error(`Annotated tag ${tag} did not peel to a commit SHA`);
+  }
+  return tagObject.object.sha;
+}
+
+async function findReleaseWorkflowRun(repo, tag, tagSha) {
+  const runs = await githubApi(repo, "/actions/workflows/release.yml/runs?per_page=100");
+  const matches = (runs.workflow_runs || [])
+    .filter((run) => run.head_sha === tagSha)
+    .filter((run) => run.conclusion === "success")
+    .filter((run) => run.event === "push" || run.event === "workflow_dispatch")
+    .sort((a, b) => String(b.updated_at).localeCompare(String(a.updated_at)));
+  const tagBranchMatch = matches.find((run) => run.head_branch === tag);
+  const match = tagBranchMatch || matches[0];
+  if (!match) {
+    throw new Error(
+      `No successful release.yml workflow run found for ${tag} at ${tagSha}. ` +
+        "Rerun the Release workflow before publishing npm.",
+    );
+  }
+  return match;
+}
+
+function parseGitHubTime(value, label) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`GitHub ${label} timestamp is invalid: ${value}`);
+  }
+  return timestamp;
+}
+
+function assertReleaseAssetsFresh(release, expectedAssets, run) {
+  const assetsByName = new Map((release.assets || []).map((asset) => [asset.name, asset]));
+  const missing = expectedAssets.filter((asset) => !assetsByName.has(asset));
+  if (missing.length > 0) {
+    throw new Error(`GitHub Release is missing required npm-facing asset(s): ${missing.join(", ")}`);
+  }
+
+  const runStartedAt = parseGitHubTime(run.run_started_at || run.created_at, "workflow run start");
+  const stale = [];
+  for (const expected of expectedAssets) {
+    const asset = assetsByName.get(expected);
+    if (asset.state && asset.state !== "uploaded") {
+      stale.push(`${expected} has state ${asset.state}`);
+      continue;
+    }
+    const updatedAt = parseGitHubTime(asset.updated_at || asset.created_at, `${expected} update`);
+    if (updatedAt < runStartedAt) {
+      stale.push(`${expected} updated at ${asset.updated_at || asset.created_at}`);
+    }
+  }
+
+  if (stale.length > 0) {
+    throw new Error(
+      `GitHub Release asset set is stale for workflow run ${run.database_id || run.id}: ${stale.join("; ")}`,
+    );
+  }
+}
+
+async function verifyGitHubReleaseFreshness(repo, version, expectedAssets) {
+  const tag = `v${version}`;
+  const tagSha = await resolveTagCommitSha(repo, tag);
+  const release = await githubApi(repo, `/releases/tags/${encodeURIComponent(tag)}`);
+  const run = await findReleaseWorkflowRun(repo, tag, tagSha);
+  assertReleaseAssetsFresh(release, expectedAssets, run);
+  console.log(
+    `GitHub release asset freshness OK: ${expectedAssets.length} npm-facing assets for ${tag} were produced by run ${run.database_id || run.id} at ${tagSha.slice(0, 12)}.`,
+  );
+}
+
 function parseChecksumManifest(text) {
   const checksums = new Map();
   for (const line of text.split(/\r?\n/)) {
@@ -117,7 +281,14 @@ async function run() {
   const repo = resolveRepo();
   const assets = allReleaseAssetNames();
 
+  assertPackageVersionMatchesBinaryVersion(version);
+
   console.log(`Verifying ${assets.length} release assets for ${repo}@v${version}...`);
+  if (hasReleaseBaseOverride()) {
+    console.log("Skipping GitHub workflow freshness check because a release asset mirror/base URL override is set.");
+  } else {
+    await verifyGitHubReleaseFreshness(repo, version, assets);
+  }
   for (const asset of assets) {
     const url = releaseAssetUrl(asset, version, repo);
     await verifyAsset(url, asset);
@@ -134,7 +305,16 @@ async function run() {
   console.log("Release assets verified.");
 }
 
-run().catch((error) => {
-  console.error("Release asset verification failed:", error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  run().catch((error) => {
+    console.error("Release asset verification failed:", error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  assertPackageVersionMatchesBinaryVersion,
+  assertReleaseAssetsFresh,
+  hasReleaseBaseOverride,
+  parseChecksumManifest,
+};

--- a/npm/codewhale/scripts/verify-release-assets.js
+++ b/npm/codewhale/scripts/verify-release-assets.js
@@ -92,7 +92,10 @@ async function verifyAsset(url, label) {
   }
 }
 
-async function downloadText(url) {
+async function downloadText(url, redirects = 0) {
+  if (redirects > 10) {
+    throw new Error(`Too many redirects while downloading ${url}`);
+  }
   const client = url.startsWith("https:") ? https : http;
   return new Promise((resolve, reject) => {
     client
@@ -107,7 +110,8 @@ async function downloadText(url) {
           const status = res.statusCode || 0;
           if (status >= 300 && status < 400 && res.headers.location) {
             const next = new URL(res.headers.location, url).toString();
-            resolve(downloadText(next));
+            res.resume();
+            resolve(downloadText(next, redirects + 1));
             return;
           }
           if (status !== 200) {
@@ -125,7 +129,10 @@ async function downloadText(url) {
   });
 }
 
-async function downloadJson(url) {
+async function downloadJson(url, redirects = 0) {
+  if (redirects > 10) {
+    throw new Error(`Too many redirects while downloading ${url}`);
+  }
   const client = url.startsWith("https:") ? https : http;
   return new Promise((resolve, reject) => {
     const headers = {
@@ -142,7 +149,8 @@ async function downloadJson(url) {
         const status = res.statusCode || 0;
         if (status >= 300 && status < 400 && res.headers.location) {
           const next = new URL(res.headers.location, url).toString();
-          resolve(downloadJson(next));
+          res.resume();
+          resolve(downloadJson(next, redirects + 1));
           return;
         }
         const chunks = [];
@@ -207,7 +215,7 @@ async function findReleaseWorkflowRun(repo, tag, tagSha) {
   if (!match) {
     throw new Error(
       `No successful release.yml workflow run found for ${tag} at ${tagSha}. ` +
-        "Rerun the Release workflow before publishing npm.",
+        "Rerun the Release workflow before publishing npm, or increase the verifier's last-100-runs search window.",
     );
   }
   return match;

--- a/npm/codewhale/test/release-assets.test.js
+++ b/npm/codewhale/test/release-assets.test.js
@@ -1,0 +1,82 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const pkg = require("../package.json");
+const {
+  assertPackageVersionMatchesBinaryVersion,
+  assertReleaseAssetsFresh,
+  parseChecksumManifest,
+} = require("../scripts/verify-release-assets");
+
+test("parseChecksumManifest accepts GNU and BSD filename forms", () => {
+  const manifest = parseChecksumManifest(
+    [
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  codewhale-linux-x64",
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *codewhale-windows-x64.exe",
+    ].join("\n"),
+  );
+
+  assert.equal(manifest.get("codewhale-linux-x64"), "a".repeat(64));
+  assert.equal(manifest.get("codewhale-windows-x64.exe"), "b".repeat(64));
+});
+
+test("parseChecksumManifest rejects malformed checksum rows", () => {
+  assert.throws(
+    () => parseChecksumManifest("not-a-sha  codewhale-linux-x64"),
+    /Invalid checksum manifest line/,
+  );
+});
+
+test("assertReleaseAssetsFresh rejects missing npm-facing assets", () => {
+  assert.throws(
+    () =>
+      assertReleaseAssetsFresh(
+        { assets: [{ name: "codewhale-linux-x64", state: "uploaded", updated_at: "2026-06-26T00:10:00Z" }] },
+        ["codewhale-linux-x64", "codewhale-artifacts-sha256.txt"],
+        { database_id: 123, created_at: "2026-06-26T00:00:00Z" },
+      ),
+    /missing required npm-facing asset/,
+  );
+});
+
+test("assertReleaseAssetsFresh rejects assets older than the release workflow run", () => {
+  assert.throws(
+    () =>
+      assertReleaseAssetsFresh(
+        { assets: [{ name: "codewhale-linux-x64", state: "uploaded", updated_at: "2026-06-25T23:59:59Z" }] },
+        ["codewhale-linux-x64"],
+        { database_id: 123, created_at: "2026-06-26T00:00:00Z" },
+      ),
+    /asset set is stale/,
+  );
+});
+
+test("assertReleaseAssetsFresh accepts assets updated by the release workflow run", () => {
+  assert.doesNotThrow(() =>
+    assertReleaseAssetsFresh(
+      { assets: [{ name: "codewhale-linux-x64", state: "uploaded", updated_at: "2026-06-26T00:10:00Z" }] },
+      ["codewhale-linux-x64"],
+      { database_id: 123, created_at: "2026-06-26T00:00:00Z" },
+    ),
+  );
+});
+
+test("assertPackageVersionMatchesBinaryVersion allows packaging-only releases only with an explicit override", () => {
+  assert.doesNotThrow(() => assertPackageVersionMatchesBinaryVersion(pkg.version));
+  assert.throws(
+    () => assertPackageVersionMatchesBinaryVersion("0.0.0-packaging-test"),
+    /does not match codewhaleBinaryVersion/,
+  );
+
+  const previous = process.env.CODEWHALE_ALLOW_NPM_BINARY_MISMATCH;
+  process.env.CODEWHALE_ALLOW_NPM_BINARY_MISMATCH = "1";
+  try {
+    assert.doesNotThrow(() => assertPackageVersionMatchesBinaryVersion("0.0.0-packaging-test"));
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CODEWHALE_ALLOW_NPM_BINARY_MISMATCH;
+    } else {
+      process.env.CODEWHALE_ALLOW_NPM_BINARY_MISMATCH = previous;
+    }
+  }
+});

--- a/npm/codewhale/test/release-assets.test.js
+++ b/npm/codewhale/test/release-assets.test.js
@@ -51,6 +51,18 @@ test("assertReleaseAssetsFresh rejects assets older than the release workflow ru
   );
 });
 
+test("assertReleaseAssetsFresh rejects non-uploaded assets", () => {
+  assert.throws(
+    () =>
+      assertReleaseAssetsFresh(
+        { assets: [{ name: "codewhale-linux-x64", state: "new", updated_at: "2026-06-26T00:10:00Z" }] },
+        ["codewhale-linux-x64"],
+        { database_id: 123, created_at: "2026-06-26T00:00:00Z" },
+      ),
+    /asset set is stale/,
+  );
+});
+
 test("assertReleaseAssetsFresh accepts assets updated by the release workflow run", () => {
   assert.doesNotThrow(() =>
     assertReleaseAssetsFresh(

--- a/scripts/release/verify-release-assets.sh
+++ b/scripts/release/verify-release-assets.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/release/verify-release-assets.sh [--allow-npm-binary-mismatch] [VERSION]
+
+Proves the public GitHub Release assets for VERSION were built from the same
+tag commit that will be published to Cargo/npm.
+
+Checks:
+  - local tag vVERSION exists
+  - remote tag vVERSION resolves to the same commit SHA
+  - GitHub Release vVERSION exists
+  - a successful Release workflow run used that SHA
+  - npm/codewhale release:check sees fresh npm-facing assets and checksum rows
+
+Set GH_BIN=/path/to/gh to choose a GitHub CLI binary. Set
+CODEWHALE_GITHUB_REPO=owner/repo or CODEWHALE_RELEASE_REMOTE=remote to override
+the default Hmbown/CodeWhale origin check.
+EOF
+}
+
+allow_npm_binary_mismatch=0
+version=""
+
+while (($# > 0)); do
+  case "$1" in
+    --allow-npm-binary-mismatch)
+      allow_npm_binary_mismatch=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "${version}" ]]; then
+        usage >&2
+        exit 2
+      fi
+      version="$1"
+      ;;
+  esac
+  shift
+done
+
+cd "${repo_root}"
+
+if [[ -z "${version}" ]]; then
+  version="$(grep -E '^version = "' Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)".*/\1/')"
+fi
+version="${version#v}"
+tag="v${version}"
+
+if [[ -z "${version}" ]]; then
+  echo "Could not determine release version." >&2
+  exit 1
+fi
+
+repo="${CODEWHALE_GITHUB_REPO:-Hmbown/CodeWhale}"
+remote="${CODEWHALE_RELEASE_REMOTE:-origin}"
+gh_bin="${GH_BIN:-gh}"
+
+if ! command -v "${gh_bin}" >/dev/null 2>&1; then
+  echo "GitHub CLI not found: ${gh_bin}" >&2
+  echo "Install gh or set GH_BIN=/path/to/gh." >&2
+  exit 1
+fi
+
+local_sha="$(git rev-list -n 1 "${tag}" 2>/dev/null || true)"
+if [[ -z "${local_sha}" ]]; then
+  echo "Local tag ${tag} does not exist." >&2
+  exit 1
+fi
+
+remote_sha="$(git ls-remote --tags "${remote}" "refs/tags/${tag}^{}" | awk 'NR == 1 {print $1}')"
+if [[ -z "${remote_sha}" ]]; then
+  remote_sha="$(git ls-remote --tags "${remote}" "refs/tags/${tag}" | awk 'NR == 1 {print $1}')"
+fi
+if [[ -z "${remote_sha}" ]]; then
+  echo "Remote tag ${tag} does not exist on ${remote}." >&2
+  exit 1
+fi
+if [[ "${local_sha}" != "${remote_sha}" ]]; then
+  echo "Tag SHA mismatch for ${tag}:" >&2
+  echo "  local : ${local_sha}" >&2
+  echo "  remote: ${remote_sha}" >&2
+  exit 1
+fi
+echo "Tag check OK: ${tag} -> ${local_sha}"
+
+release_url="$("${gh_bin}" release view "${tag}" --repo "${repo}" --json url --jq '.url')"
+if [[ -z "${release_url}" ]]; then
+  echo "GitHub Release ${tag} was not found in ${repo}." >&2
+  exit 1
+fi
+echo "GitHub Release OK: ${release_url}"
+
+run_summary="$(
+  TAG_SHA="${local_sha}" "${gh_bin}" run list \
+    --repo "${repo}" \
+    --workflow "Release" \
+    --limit 100 \
+    --json databaseId,headSha,headBranch,event,conclusion,status,createdAt,updatedAt,url \
+    --jq 'map(select(.headSha == env.TAG_SHA and .conclusion == "success" and (.event == "push" or .event == "workflow_dispatch"))) | sort_by(.updatedAt) | last | if . == null then empty else "\(.databaseId)\t\(.headBranch)\t\(.event)\t\(.url)" end'
+)"
+if [[ -z "${run_summary}" ]]; then
+  echo "No successful Release workflow run found for ${tag} at ${local_sha}." >&2
+  echo "Rerun the Release workflow before publishing Cargo/npm." >&2
+  exit 1
+fi
+printf 'Release workflow OK: %s\n' "${run_summary}"
+
+npm_package_version="$(node -p "require('./npm/codewhale/package.json').version")"
+npm_binary_version="$(
+  node -p "const p=require('./npm/codewhale/package.json'); p.codewhaleBinaryVersion || p.deepseekBinaryVersion || p.version"
+)"
+if [[ "${npm_package_version}" != "${version}" ]]; then
+  echo "npm/codewhale package version ${npm_package_version} does not match ${version}." >&2
+  exit 1
+fi
+if [[ "${npm_binary_version}" != "${version}" && "${allow_npm_binary_mismatch}" != "1" ]]; then
+  echo "npm/codewhale codewhaleBinaryVersion ${npm_binary_version} does not match ${version}." >&2
+  echo "Use --allow-npm-binary-mismatch only for an intentional packaging-only npm release." >&2
+  exit 1
+fi
+
+(
+  cd npm/codewhale
+  env \
+    -u CODEWHALE_RELEASE_BASE_URL \
+    -u DEEPSEEK_TUI_RELEASE_BASE_URL \
+    -u DEEPSEEK_RELEASE_BASE_URL \
+    -u CODEWHALE_USE_CNB_MIRROR \
+    DEEPSEEK_TUI_VERSION="${version}" \
+    DEEPSEEK_TUI_GITHUB_REPO="${repo}" \
+    CODEWHALE_ALLOW_NPM_BINARY_MISMATCH="${allow_npm_binary_mismatch}" \
+    npm run release:check
+)
+
+echo "Release asset gate OK: ${tag} assets match ${local_sha} and npm/codewhale is ready for publish."

--- a/scripts/release/verify-release-assets.sh
+++ b/scripts/release/verify-release-assets.sh
@@ -108,7 +108,7 @@ run_summary="$(
     --jq 'map(select(.headSha == env.TAG_SHA and .conclusion == "success" and (.event == "push" or .event == "workflow_dispatch"))) | sort_by(.updatedAt) | last | if . == null then empty else "\(.databaseId)\t\(.headBranch)\t\(.event)\t\(.url)" end'
 )"
 if [[ -z "${run_summary}" ]]; then
-  echo "No successful Release workflow run found for ${tag} at ${local_sha}." >&2
+  echo "No successful Release workflow run found in the last 100 Release runs for ${tag} at ${local_sha}." >&2
   echo "Rerun the Release workflow before publishing Cargo/npm." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- add `scripts/release/verify-release-assets.sh` to compare local/remote tag SHAs, confirm the matching successful Release workflow run, and run the npm asset verifier against public GitHub Release assets
- strengthen `npm run release:check` so default GitHub releases fail on stale/incomplete npm-facing assets while local/mirror overrides still use URL + checksum checks
- document the pre-registry asset gate, npm auth/OTP retry commands, final published-state check, and the legacy `deepseek-tui` no-republish rule

Closes #2642.
Closes #2643.

## Verification
- `cargo fmt --all -- --check`
- `npm --prefix npm/codewhale test`
- `bash -n scripts/release/verify-release-assets.sh`
- `node --check npm/codewhale/scripts/verify-release-assets.js`
- `git diff --check`
- `GH_BIN=/opt/homebrew/bin/gh scripts/release/verify-release-assets.sh 0.8.65`
  - confirmed `v0.8.65` local/remote tag SHA `21df7bc0da7a1bb9bf04bd37731e53bc7c26ef4e`
  - confirmed Release workflow run `28195635316` used that SHA
  - verified 20 npm-facing assets plus checksum manifest for the public GitHub Release

## Notes
- `shellcheck` is not installed in this environment, so shell lint was skipped after `bash -n` passed.
- This does not publish npm; it only hardens the gate and runbook before the next publish attempt.