### PR TITLE
feat(bridge): support natural-language approval responses

### DIFF
--- a/integrations/wecom-bridge/src/index.mjs
+++ b/integrations/wecom-bridge/src/index.mjs
@@ -13,12 +13,24 @@ import {
   parseCommand,
   parseList,
   parseApprovalDecisionArgs,
+  isApprovalResponse,
+  isDenyResponse,
   preservedChatStateFields,
   requiredEnv,
   splitMessage,
   stripGroupPrefix,
   ThreadStore
 } from "./lib.mjs";
+
+/** Map of chatId -> latest pending approval info for natural-language approval. */
+const pendingApprovals = new Map();
+// Clean up stale approvals every 2 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [chatId, approval] of pendingApprovals) {
+    if (now - approval.timestamp > 300_000) pendingApprovals.delete(chatId);
+  }
+}, 120_000);
 
 const config = {
   botId: requiredEnv("WECOM_BOT_ID"),
@@ -35,7 +47,8 @@ const config = {
   allowUnlisted: parseBool(process.env.WECOM_ALLOW_UNLISTED, false),
   threadMapPath: process.env.WECOM_THREAD_MAP_PATH || "/var/lib/codewhale-wecom-bridge/thread-map.json",
   maxReplyChars: Number(process.env.WECOM_MAX_REPLY_CHARS || 3500),
-  turnTimeoutMs: Number(process.env.CODEWHALE_TURN_TIMEOUT_MS || 900000)
+  turnTimeoutMs: Number(process.env.CODEWHALE_TURN_TIMEOUT_MS || 900000),
+  approvalTimeoutMs: Number(process.env.CODEWHALE_APPROVAL_TIMEOUT_MS || 300000)
 };
 
 const threadStore = await ThreadStore.open(config.threadMapPath);
@@ -168,6 +181,24 @@ async function handleCommand(chatId, command, frame) {
       await setChatModel(chatId, action.modelName, frame);
       return;
     case "prompt":
+      // Check if this is a natural-language approval/deny response
+      if (pendingApprovals.has(chatId)) {
+        const pending = pendingApprovals.get(chatId);
+        if (Date.now() - pending.timestamp < config.approvalTimeoutMs) {
+          if (isApprovalResponse(action.prompt)) {
+            const action2 = { kind: "approval", decision: "allow", approvalId: pending.approvalId };
+            await decideApproval(chatId, action2, frame);
+            pendingApprovals.delete(chatId);
+            return;
+          }
+          if (isDenyResponse(action.prompt)) {
+            const action2 = { kind: "approval", decision: "deny", approvalId: pending.approvalId };
+            await decideApproval(chatId, action2, frame);
+            pendingApprovals.delete(chatId);
+            return;
+          }
+        }
+      }
       await runPrompt(chatId, action.prompt, frame);
       return;
     default:
@@ -304,16 +335,27 @@ async function streamTurnEvents(chatId, frame, threadId, turnId, sinceSeq) {
 
       if (record.event === "approval.required") {
         const approval = record.payload || {};
+        const approvalId = approval.approval_id || approval.id;
+        // Track latest pending approval per chat for natural-language responses
+        if (approvalId) {
+          pendingApprovals.set(chatId, {
+            approvalId,
+            toolName: approval.tool_name || "unknown",
+            description: approval.description || "",
+            timestamp: Date.now()
+          });
+        }
         await replyText(
           frame,
           [
             "审批请求",
             `tool=${approval.tool_name || "unknown"}`,
-            `approval_id=${approval.approval_id || approval.id}`,
+            `approval_id=${approvalId}`,
             approval.description || "",
             "",
-            `回复 /allow ${approval.approval_id || approval.id}`,
-            `回复 /deny ${approval.approval_id || approval.id}`
+            `回复 /allow ${approvalId}`,
+            `回复 /deny ${approvalId}`,
+            "也可以直接回复「允许」或「拒绝」"
           ]
             .filter(Boolean)
             .join("\n")

--- a/integrations/wecom-bridge/src/lib.mjs
+++ b/integrations/wecom-bridge/src/lib.mjs
@@ -108,6 +108,24 @@ export function parseApprovalDecisionArgs(args) {
   };
 }
 
+/** Check if text is a natural-language approval response (Chinese or English). */
+export function isApprovalResponse(text) {
+  const t = String(text || "").trim().toLowerCase();
+  // Single-word approvals
+  if (["允许", "可以", "好", "同意", "批准", "yes", "ok", "y", "approve", "allow"].includes(t)) return true;
+  // Two-char approvals
+  if (["好的", "可以", "没问题", "批准了", "同意"].includes(t)) return true;
+  return false;
+}
+
+/** Check if text is a natural-language deny response. */
+export function isDenyResponse(text) {
+  const t = String(text || "").trim().toLowerCase();
+  if (["拒绝", "不行", "不要", "no", "n", "deny", "reject", "取消", "stop", "否"].includes(t)) return true;
+  if (["不可以", "不同意", "不要执行"].includes(t)) return true;
+  return false;
+}
+
 export function commandAction(command) {
   switch (command.name) {
     case "help":

--- a/integrations/wecom-bridge/test/lib.test.mjs
+++ b/integrations/wecom-bridge/test/lib.test.mjs
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { ThreadStore, validateBridgeConfig } from "../src/lib.mjs";
+import { ThreadStore, validateBridgeConfig, isApprovalResponse, isDenyResponse } from "../src/lib.mjs";
+
+// ─── ThreadStore ─────────────────────────────────────────────────
 
 test("ThreadStore writes private state files", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "codewhale-wecom-"));
@@ -30,6 +32,8 @@ test("ThreadStore writes private state files", async () => {
   }
 });
 
+// ─── Config validation ──────────────────────────────────────────
+
 test("validateBridgeConfig rejects placeholder secrets", () => {
   const result = validateBridgeConfig({
     WECOM_BOT_ID: "your-bot-id",
@@ -43,4 +47,103 @@ test("validateBridgeConfig rejects placeholder secrets", () => {
     result.errors.map((item) => item.code),
     ["placeholder_runtime_token"]
   );
+});
+
+// ─── isApprovalResponse ─────────────────────────────────────────
+
+test("isApprovalResponse: single-word Chinese keywords", () => {
+  for (const kw of ["允许", "可以", "好", "同意", "批准"]) {
+    assert.equal(isApprovalResponse(kw), true, `"${kw}" should be approval`);
+  }
+});
+
+test("isApprovalResponse: single-word English keywords", () => {
+  for (const kw of ["yes", "ok", "y", "approve", "allow"]) {
+    assert.equal(isApprovalResponse(kw), true, `"${kw}" should be approval`);
+  }
+});
+
+test("isApprovalResponse: two-character Chinese keywords", () => {
+  for (const kw of ["好的", "可以", "没问题", "批准了", "同意"]) {
+    assert.equal(isApprovalResponse(kw), true, `"${kw}" should be approval`);
+  }
+});
+
+test("isApprovalResponse: case-insensitive", () => {
+  assert.equal(isApprovalResponse("YES"), true);
+  assert.equal(isApprovalResponse("Ok"), true);
+  assert.equal(isApprovalResponse("Allow"), true);
+});
+
+test("isApprovalResponse: trims whitespace", () => {
+  assert.equal(isApprovalResponse("  允许  "), true);
+  assert.equal(isApprovalResponse("  yes  "), true);
+});
+
+test("isApprovalResponse: rejects non-approval text", () => {
+  assert.equal(isApprovalResponse("帮我查一下"), false);
+  assert.equal(isApprovalResponse("/allow abc123"), false);
+  assert.equal(isApprovalResponse("run prompt"), false);
+});
+
+test("isApprovalResponse: handles null/empty/undefined", () => {
+  assert.equal(isApprovalResponse(null), false);
+  assert.equal(isApprovalResponse(""), false);
+  assert.equal(isApprovalResponse(undefined), false);
+});
+
+// ─── isDenyResponse ─────────────────────────────────────────────
+
+test("isDenyResponse: single-word Chinese keywords", () => {
+  for (const kw of ["拒绝", "不行", "不要", "取消", "否"]) {
+    assert.equal(isDenyResponse(kw), true, `"${kw}" should be denial`);
+  }
+});
+
+test("isDenyResponse: single-word English keywords", () => {
+  for (const kw of ["no", "n", "deny", "reject", "stop"]) {
+    assert.equal(isDenyResponse(kw), true, `"${kw}" should be denial`);
+  }
+});
+
+test("isDenyResponse: two-character Chinese keywords", () => {
+  for (const kw of ["不可以", "不同意", "不要执行"]) {
+    assert.equal(isDenyResponse(kw), true, `"${kw}" should be denial`);
+  }
+});
+
+test("isDenyResponse: case-insensitive and trims whitespace", () => {
+  assert.equal(isDenyResponse("  NO  "), true);
+  assert.equal(isDenyResponse("No"), true);
+});
+
+test("isDenyResponse: rejects non-denial text", () => {
+  assert.equal(isDenyResponse("让我想想"), false);
+  assert.equal(isDenyResponse("/deny abc123"), false);
+  assert.equal(isDenyResponse("继续"), false);
+});
+
+test("isDenyResponse: handles null/empty/undefined", () => {
+  assert.equal(isDenyResponse(null), false);
+  assert.equal(isDenyResponse(""), false);
+  assert.equal(isDenyResponse(undefined), false);
+});
+
+// ─── Mutual exclusivity ─────────────────────────────────────────
+
+test("no keyword is both approval and denial", () => {
+  const all = [
+    "允许", "可以", "好", "同意", "批准",
+    "好的", "没问题", "批准了",
+    "yes", "ok", "y", "approve", "allow",
+    "拒绝", "不行", "不要", "取消", "否",
+    "不可以", "不同意", "不要执行",
+    "no", "n", "deny", "reject", "stop"
+  ];
+  for (const kw of all) {
+    assert.notEqual(
+      isApprovalResponse(kw), isDenyResponse(kw),
+      `"${kw}" should not be both approval and denial`
+    );
+  }
 });


### PR DESCRIPTION
Users can now reply with Chinese/English approval keywords (e.g. "允许", "可以", "好", "ok", "yes") instead of
copying the approval_id from the prompt.

- Add isApprovalResponse / isDenyResponse helpers to lib.mjs
- Track latest pending approval per chat in a Map
- Intercept prompt messages that match approval/deny keywords
- Add approvalTimeoutMs config (env CODEWHALE_APPROVAL_TIMEOUT_MS)
- Update approval prompt with natural-language hint

Ref: #2967 (WeCom bridge resilience hardening)

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
