### PR TITLE
fix(tui): expand failed tool output live

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1357,7 +1357,8 @@ impl GenericToolCell {
                 ));
             }
         } else {
-            let show_args = matches!(self.status, ToolStatus::Running) || self.output.is_none();
+            let show_args = matches!(self.status, ToolStatus::Running | ToolStatus::Failed)
+                || self.output.is_none();
             if show_args && let Some(summary) = self.input_summary.as_ref() {
                 lines.extend(render_compact_kv(
                     "args",
@@ -1381,11 +1382,17 @@ impl GenericToolCell {
                 ));
                 lines.extend(diff_render::render_diff(output, width));
             } else {
+                let output_mode =
+                    if matches!(mode, RenderMode::Live) && self.status == ToolStatus::Failed {
+                        RenderMode::Transcript
+                    } else {
+                        mode
+                    };
                 lines.extend(render_tool_output_mode(
                     output,
                     width,
                     TOOL_OUTPUT_LINE_LIMIT,
-                    mode,
+                    output_mode,
                 ));
             }
 

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -1952,9 +1952,9 @@ fn generic_tool_cell_preserves_multi_line_output_in_transcript() {
 }
 
 #[test]
-fn generic_tool_cell_caps_failed_multi_line_output_in_live_with_affordance() {
-    // Failed tools keep error output visible in live mode, capped at
-    // TOOL_OUTPUT_LINE_LIMIT (=6) with an omission marker.
+fn generic_tool_cell_expands_failed_multi_line_output_in_live() {
+    // Failed tools should auto-expand in live mode so the command/input summary
+    // and full error output remain immediately visible.
     let total = 30usize;
     let output = (0..total)
         .map(|i| format!("row {i:02}: payload"))
@@ -1974,20 +1974,16 @@ fn generic_tool_cell_caps_failed_multi_line_output_in_live_with_affordance() {
 
     let live = cell.lines_with_options(80, TranscriptRenderOptions::default());
     let transcript = cell.transcript_lines(80);
-
-    assert!(
-        live.len() < transcript.len(),
-        "live generic-tool output must be shorter than transcript (live={}, transcript={})",
-        live.len(),
-        transcript.len(),
-    );
     let live_text = lines_text(&live);
-    assert!(
-        live_text.contains("lines omitted"),
-        "live view must show the omission marker: {live_text}"
-    );
     let transcript_text = lines_text(&transcript);
+
+    assert!(live_text.contains("command: ls"), "{live_text}");
+    assert!(
+        !live_text.contains("lines omitted"),
+        "failed output must not be hidden behind an omission marker: {live_text}"
+    );
     assert!(transcript_text.contains("row 29"));
+    assert!(live_text.contains("row 29"));
 }
 
 #[test]
@@ -2014,7 +2010,7 @@ fn generic_tool_failed_output_live_renders_card_rail() {
         live_text.starts_with('\u{256D}'),
         "live view must start with card-rail top glyph ╭: {live_text}"
     );
-    assert!(live_text.contains("lines omitted"));
+    assert!(!live_text.contains("lines omitted"), "{live_text}");
     assert!(live_text.contains("line 00"));
     assert!(live_text.contains("line 23"));
 }
@@ -2078,16 +2074,15 @@ fn tool_output_live_preserves_error_card_rail() {
 
     let live_text = lines_text(&cell.lines_with_options(80, TranscriptRenderOptions::default()));
 
-    // Live mode: one-line summary + omission marker.
     assert!(
-        live_text.contains("lines omitted"),
-        "live view must show the omission marker: {live_text}"
+        !live_text.contains("lines omitted"),
+        "failed output must not be hidden behind an omission marker: {live_text}"
     );
-    // The pre-computed summary captures the first meaningful content.
     assert!(
         live_text.contains("Error:") || live_text.contains("fatal:"),
         "live summary should capture error text: {live_text}"
     );
+    assert!(live_text.contains("final line"), "{live_text}");
 }
 
 // === ErrorEnvelope severity → cell color tests (#66) ===


### PR DESCRIPTION
## Summary
- expand failed generic tool output in the live transcript instead of hiding lines behind the omission marker
- show the failed tool input summary so the failing command/path remains visible
- keep successful generic tool collapse and exec shell output behavior unchanged

## Verification
- cargo fmt --check
- cargo test -p codewhale-tui --bin codewhale-tui tui::history::tests::
- cargo test -p codewhale-tui --bin codewhale-tui chat_widget_
- git diff --check

Part of #3256.