### PR TITLE
docs: update ask-rule persistence docs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -182,14 +182,34 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 
 # Typed permission rules live in a sibling `permissions.toml` file, not in
 # config.toml. This shape is ask-only and feeds the execution policy engine;
-# allow/deny records, glob expansion, and UI persistence are intentionally out
-# of scope here.
+# it does not define allow/deny records, globs, broad directory rules, or a
+# rule editor/deleter UI. YOLO / auto approval is not restricted by ask rules.
+#
+# In supported approval cards, press `S` to approve once and save exact rules:
+#   exec_shell  -> exact approved command string
+#   write_file  -> exact workspace-relative target path
+#   edit_file   -> exact workspace-relative target path
+#   apply_patch -> one exact workspace-relative path per validated touched file
+# `read_file` rules can be written manually, but the approval UI does not save
+# them.
 #
 # Example ~/.codewhale/permissions.toml:
 #
 # [[rules]]
 # tool = "exec_shell"
 # command = "cargo test"
+#
+# [[rules]]
+# tool = "write_file"
+# path = "src/main.rs"
+#
+# [[rules]]
+# tool = "edit_file"
+# path = "src/lib.rs"
+#
+# [[rules]]
+# tool = "apply_patch"
+# path = "src/patch-target.rs"
 #
 # [[rules]]
 # tool = "read_file"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1047,15 +1047,26 @@ If you are upgrading from older releases:
   records loaded next to `config.toml`, for example
   `~/.codewhale/permissions.toml`. This schema foundation accepts
   `[[rules]]` entries with `tool` plus optional `command` or `path` fields.
-  Loaded rules feed the execution policy engine and force approval in approval
-  modes that can ask; under `approval_policy = "never"`, matching ask rules are
-  rejected because no prompt can be shown. In an `exec_shell` approval card,
-  press `S` to approve the request once and save an ask rule containing that
-  command to this file. Only `exec_shell` cards support this shortcut; saved
-  command rules use existing arity-aware prefix matching. File-path ask rules
-  can be added manually and are matched at runtime, but the approval UI does
-  not save file rules yet. This intentionally does not accept typed allow/deny
-  records or glob expansion.
+  Loaded rules feed the execution policy engine and force approval in
+  non-YOLO approval modes that can ask; under `approval_policy = "never"`,
+  matching ask rules are rejected because no prompt can be shown. YOLO / auto
+  approval retains complete freedom: ask rules do not downgrade YOLO into
+  prompting or blocking.
+
+  In a supported approval card, press `S` to approve the request once and
+  append exact ask rules to this file. Supported saves are intentionally narrow:
+  `exec_shell` stores the exact approved command string; `write_file` and
+  `edit_file` store the exact workspace-relative file path; `apply_patch`
+  stores one exact workspace-relative `path` rule per validated touched file
+  from apply-patch preflight. Existing exec command matching remains
+  arity-aware, and file paths are normalized to the same workspace-relative
+  form used by runtime matching.
+
+  `read_file` rules can still be authored manually when you want future reads
+  of a specific path to ask, but the approval UI does not save `read_file`
+  rules. This schema still does not accept typed allow/deny records, glob
+  expansion, broad directory/recursive rules, or UI editing/deleting of saved
+  rules.
 - `[[hotbar]]` (array of tables, optional): user-owned 1-8 slot bindings for
   the TUI hotbar. Each entry has `slot`, `action`, and optional `label`.
   Omitting `hotbar` uses the built-in default eight slots. Setting

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -71,16 +71,27 @@ stale rather than presented as live processes.
 Shell permission policy is evaluated by `crates/execpolicy`. Deny prefixes are
 checked before trusted prefixes and block matching commands regardless of layer.
 Trusted prefixes only skip approval in modes that permit trust shortcuts. Typed
-ask records are currently a narrow foundation: when one matches under
+ask records are an ask-only layer: when one matches under
 `AskForApproval::Never`, the invocation is rejected because the runtime cannot
-ask the user; existing allow/deny behavior is otherwise unchanged. The TUI
-runtime loads ask-only records from the sibling `permissions.toml` file and
-applies matching `exec_shell` command ask-rules and explicit file-path ask-rules
-before Auto/session approval shortcuts. In an `exec_shell` approval card, `S`
-approves once and saves an ask rule containing that command; only `exec_shell`
-cards support the shortcut, and saved command rules use existing arity-aware
-prefix matching. File-path ask rules can be authored in `permissions.toml` and
-matched at runtime, but cannot yet be saved from the approval UI.
+ask the user; YOLO / auto approval keeps complete freedom and is not limited by
+ask rules. Existing allow/deny behavior is otherwise unchanged.
+
+The TUI runtime loads ask-only records from the sibling `permissions.toml` file
+and applies matching `exec_shell` command ask-rules and explicit file-path
+ask-rules in modes that can ask. In supported approval cards, `S` approves once
+and appends persistent ask rules:
+
+- `exec_shell`: the exact approved command string (matched by the existing
+  arity-aware command matcher).
+- `write_file`: the exact workspace-relative target path.
+- `edit_file`: the exact workspace-relative target path.
+- `apply_patch`: one exact workspace-relative path rule per validated touched
+  file reported by apply-patch preflight.
+
+`read_file` path ask rules can be authored in `permissions.toml` and matched at
+runtime, but the approval UI does not save `read_file` rules. This is still not
+a policy editor: no typed allow/deny records, glob expansion, broad directory
+rules, or UI edit/delete flow exist for saved ask rules.
 
 ### MCP manager and palette discovery
 


### PR DESCRIPTION
## Summary
- Update ask-only `permissions.toml` docs to match current `S` persistence behavior.
- Document supported `S` saves for `exec_shell`, `write_file`, `edit_file`, and `apply_patch`.
- Clarify that `read_file` rules remain manual-only.
- Clarify that ask rules do not restrict YOLO / auto approval.
- Clarify that allow/deny records, globs, broad directory rules, and edit/delete UI remain out of scope.

## Scope
- Documentation-only update in `docs/CONFIGURATION.md`, `docs/TOOL_SURFACE.md`, and `config.example.toml`.
- No runtime behavior changes.

## Builds on
- Builds on the landed ask-rule persistence slices for shell, file writes, and apply_patch touched files.

## Issues
- Refs #1186 (partial)
- Refs #2242 (partial)

## Validation
- `cargo fmt --all`
- `git diff --check`
- `./scripts/release/check-versions.sh`