### PR TITLE
test(tui): relax yolo ask-rule event timeout on windows

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -459,6 +459,14 @@ fn file_ask_rule_engine(tool: &str, path: &str) -> codewhale_execpolicy::ExecPol
     ])
 }
 
+fn model_turn_event_timeout() -> Duration {
+    if cfg!(windows) {
+        Duration::from_secs(30)
+    } else {
+        Duration::from_secs(10)
+    }
+}
+
 #[test]
 fn auto_review_policy_forces_prompt_for_publish_like_actions() {
     let (decision, audit) = auto_review_plan_decision(
@@ -2350,7 +2358,7 @@ async fn yolo_mode_does_not_prompt_for_model_driven_typed_ask_rule() {
 
     let mut saw_complete = false;
     let mut rx = handle.rx_event.write().await;
-    while let Some(event) = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+    while let Some(event) = tokio::time::timeout(model_turn_event_timeout(), rx.recv())
         .await
         .expect("timed out waiting for engine event")
     {
@@ -2487,7 +2495,7 @@ async fn yolo_mode_does_not_prompt_for_background_shell_safety_floor() {
 
     let mut saw_complete = false;
     let mut rx = handle.rx_event.write().await;
-    while let Some(event) = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+    while let Some(event) = tokio::time::timeout(model_turn_event_timeout(), rx.recv())
         .await
         .expect("timed out waiting for engine event")
     {


### PR DESCRIPTION
## Summary
- Give model-driven engine-event regression tests a larger timeout on Windows runners.
- Keep the existing 10s timeout on non-Windows platforms.
- Covers the Windows-only full-suite failure seen on main after #3642 and on #3643.

## Validation
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked core::engine::tests::yolo_mode_does_not_prompt_for_model_driven_typed_ask_rule -- --nocapture
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked core::engine::tests::yolo_mode_does_not_prompt_for_background_shell_safety_floor -- --nocapture