### PR TITLE
Guard exec against misplaced global flags

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -703,6 +703,7 @@ fn run() -> Result<()> {
             delegate_to_tui(&cli, &resolved_runtime, remote_setup_tui_args(args))
         }
         Some(Commands::Exec(args)) => {
+            reject_exec_global_flags(&args.args)?;
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("exec", args))
         }
@@ -854,6 +855,24 @@ fn tui_args(command: &str, args: TuiPassthroughArgs) -> Vec<String> {
     forwarded.push(command.to_string());
     forwarded.extend(args.args);
     forwarded
+}
+
+fn reject_exec_global_flags(args: &[String]) -> Result<()> {
+    const GLOBAL_ONLY_FLAGS: &[&str] = &["--provider", "--model", "--api-key", "--base-url"];
+
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        let flag = arg.split_once('=').map_or(arg.as_str(), |(flag, _)| flag);
+        if GLOBAL_ONLY_FLAGS.contains(&flag) {
+            bail!(
+                "{flag} must be placed before `exec`.\n\nUse:\n  codewhale {flag} <value> exec \"<prompt>\""
+            );
+        }
+    }
+
+    Ok(())
 }
 
 fn run_login_command(store: &mut ConfigStore, args: LoginArgs) -> Result<()> {
@@ -2910,6 +2929,81 @@ mod tests {
             Some(Commands::Fleet(TuiPassthroughArgs { ref args }))
                 if args == &["run", "tasks.json", "--max-workers", "2"]
         ));
+    }
+
+    #[test]
+    fn exec_keeps_global_looking_flags_as_passthrough_args() {
+        let cli = parse_ok(&[
+            "codewhale",
+            "exec",
+            "--provider",
+            "definitely-not-a-provider",
+            "Reply OK",
+        ]);
+
+        let Some(Commands::Exec(args)) = cli.command else {
+            panic!("expected exec command");
+        };
+
+        assert_eq!(
+            args.args,
+            vec![
+                "--provider".to_string(),
+                "definitely-not-a-provider".to_string(),
+                "Reply OK".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn exec_rejects_provider_after_subcommand() {
+        let args = vec![
+            "--provider".to_string(),
+            "definitely-not-a-provider".to_string(),
+            "Reply OK".to_string(),
+        ];
+
+        let err = reject_exec_global_flags(&args).expect_err("provider after exec should fail");
+
+        assert!(
+            err.to_string()
+                .contains("--provider must be placed before `exec`")
+        );
+    }
+
+    #[test]
+    fn exec_rejects_equals_form_provider_after_subcommand() {
+        let args = vec!["--provider=openmodel".to_string(), "Reply OK".to_string()];
+
+        let err = reject_exec_global_flags(&args).expect_err("provider after exec should fail");
+
+        assert!(
+            err.to_string()
+                .contains("--provider must be placed before `exec`")
+        );
+    }
+
+    #[test]
+    fn exec_allows_documented_forwarded_flags() {
+        let args = vec![
+            "--auto".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "fix tests".to_string(),
+        ];
+
+        reject_exec_global_flags(&args).expect("documented exec flags should pass");
+    }
+
+    #[test]
+    fn exec_allows_literal_prompt_flags_after_separator() {
+        let args = vec![
+            "--".to_string(),
+            "--provider".to_string(),
+            "is literal prompt text".to_string(),
+        ];
+
+        reject_exec_global_flags(&args).expect("separator should stop global flag validation");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`codewhale exec` accepts passthrough arguments, so global runtime flags placed
after the `exec` subcommand can be treated as prompt text instead of CLI
configuration.

For example:

```bash
codewhale exec --provider definitely-not-a-provider "Reply with exactly OK"
```

Before this change, that command could still run with the configured/default
provider because `--provider` was swallowed by the exec passthrough parser.

This PR adds a narrow guard for `exec` so routing/auth globals fail fast when
placed after `exec`:

- `--provider`
- `--model`
- `--api-key`
- `--base-url`

The supported form remains:

```bash
codewhale --provider <value> exec "<prompt>"
```

## Verification

```bash
cargo +1.88 fmt -- --check
CARGO_INCREMENTAL=0 cargo +1.88 test -p codewhale-cli --locked
cargo +1.88 build --release --locked -p codewhale-cli -p codewhale-tui
```

Manual smoke test:

```bash
./target/debug/codewhale --config /dev/null exec --provider definitely-not-a-provider "Reply with exactly OK"
```

Now returns:

```text
error: --provider must be placed before `exec`.

Use:
  codewhale --provider <value> exec "<prompt>"
```

I also ran:

```bash
CARGO_INCREMENTAL=0 cargo +1.88 test --workspace --locked
```

That reached the workspace suite but hit the existing verifier background test
failure:

```text
tools::verifier::tests::run_verifiers_background_starts_shell_jobs_and_returns_task_ids
```

I reproduced the same isolated failure from `origin/main` in a separate worktree,
so this is not caused by this CLI-only change.
