### PR TITLE
feat: surface the weekly community digest in sitemap and navigation

### DIFF
--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from "@/lib/page-meta";
 
 // Public, indexable routes (locale-prefixed). /admin and /api are
 // intentionally excluded; see app/robots.ts.
-const PATHS = ["", "/install", "/runtime", "/docs", "/faq", "/roadmap", "/feed", "/contribute"];
+const PATHS = ["", "/install", "/runtime", "/docs", "/faq", "/roadmap", "/feed", "/digest", "/contribute"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();

--- a/web/components/mobile-menu.tsx
+++ b/web/components/mobile-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 type MobileLink = { href: string; label: string; cn?: string };
@@ -15,6 +16,7 @@ export function MobileMenu({
   installLabel: string;
 }) {
   const [open, setOpen] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!open) return;
@@ -60,21 +62,25 @@ export function MobileMenu({
         >
           <nav className="px-6 py-4">
             <ul className="divide-y divide-[rgba(14,14,16,0.18)]">
-              {links.map((l) => (
-                <li key={l.href}>
-                  <Link
-                    href={l.href}
-                    onClick={() => setOpen(false)}
-                    className="flex items-baseline gap-3 py-4 hover:text-indigo transition-colors"
-                  >
-                    <span className="font-display text-lg">{l.label}</span>
-                    {l.cn && (
-                      <span className="font-cjk text-sm text-ink-mute">{l.cn}</span>
-                    )}
-                    <span className="ml-auto font-mono text-xs text-ink-mute">→</span>
-                  </Link>
-                </li>
-              ))}
+              {links.map((l) => {
+                const isActive = pathname === l.href || pathname.startsWith(`${l.href}/`);
+                return (
+                  <li key={l.href}>
+                    <Link
+                      href={l.href}
+                      onClick={() => setOpen(false)}
+                      className={`flex items-baseline gap-3 py-4 hover:text-indigo transition-colors ${isActive ? "text-indigo" : ""}`}
+                      aria-current={isActive ? "page" : undefined}
+                    >
+                      <span className="font-display text-lg">{l.label}</span>
+                      {l.cn && (
+                        <span className="font-cjk text-sm text-ink-mute">{l.cn}</span>
+                      )}
+                      <span className="ml-auto font-mono text-xs text-ink-mute">→</span>
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
 
             <Link

--- a/web/components/nav-links.tsx
+++ b/web/components/nav-links.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type NavLink = { href: string; label: string; cn?: string };
+
+export function NavLinks({ links, isZh }: { links: NavLink[]; isZh: boolean }) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="hidden md:flex items-center gap-7">
+      {links.map((l) => {
+        const isActive = pathname === l.href || pathname.startsWith(`${l.href}/`);
+        return (
+          <Link key={l.href} href={l.href} className="nav-link group" aria-current={isActive ? "page" : undefined}>
+            <span>{l.label}</span>
+            {!isZh && l.cn && (
+              <span className="font-cjk text-[0.66rem] ml-1.5 text-ink-mute">{l.cn}</span>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import type { Locale } from "@/lib/i18n/config";
 import { Seal } from "./seal";
 import { Whale } from "./whale";
@@ -10,8 +13,7 @@ const EN_LINKS = [
   { href: "/en/runtime", label: "Runtime", cn: "集成" },
   { href: "/en/docs", label: "Docs", cn: "文档" },
   { href: "/en/feed", label: "Activity", cn: "动态" },
-  /* ADDED NEW DIGEST ARCHIVE LINK HERE */
-  { href: "/en/digest", label: "Digest", cn: "摘要" },
+  { href: "/en/digest", label: "Community Digest", cn: "社区摘要" },
   { href: "/en/roadmap", label: "Roadmap", cn: "路线" },
   { href: "/en/faq", label: "FAQ", cn: "问答" },
   { href: "/en/contribute", label: "Contribute", cn: "参与" },
@@ -22,8 +24,7 @@ const ZH_LINKS = [
   { href: "/zh/runtime", label: "集成", cn: "" },
   { href: "/zh/docs", label: "文档", cn: "" },
   { href: "/zh/feed", label: "动态", cn: "" },
-  /* ADDED NEW ZH DIGEST ARCHIVE LINK HERE */
-  { href: "/zh/digest", label: "每周摘要", cn: "" },
+  { href: "/zh/digest", label: "社区摘要", cn: "" },
   { href: "/zh/roadmap", label: "路线图", cn: "" },
   { href: "/zh/faq", label: "常见问题", cn: "" },
   { href: "/zh/contribute", label: "参与贡献", cn: "" },
@@ -32,6 +33,7 @@ const ZH_LINKS = [
 export function Nav({ locale = "en" }: { locale?: Locale }) {
   const isZh = locale === "zh";
   const links = isZh ? ZH_LINKS : EN_LINKS;
+  const pathname = usePathname();
 
   return (
     <header className="hairline-b bg-paper/85 backdrop-blur sticky top-0 z-30">
@@ -65,14 +67,17 @@ export function Nav({ locale = "en" }: { locale?: Locale }) {
         </Link>
 
         <nav className="hidden md:flex items-center gap-7">
-          {links.map((l) => (
-            <Link key={l.href} href={l.href} className="nav-link group">
-              <span>{l.label}</span>
-              {!isZh && "cn" in l && l.cn && (
-                <span className="font-cjk text-[0.66rem] ml-1.5 text-ink-mute">{l.cn}</span>
-              )}
-            </Link>
-          ))}
+          {links.map((l) => {
+            const isActive = pathname === l.href || pathname.startsWith(`${l.href}/`);
+            return (
+              <Link key={l.href} href={l.href} className="nav-link group" aria-current={isActive ? "page" : undefined}>
+                <span>{l.label}</span>
+                {!isZh && "cn" in l && l.cn && (
+                  <span className="font-cjk text-[0.66rem] ml-1.5 text-ink-mute">{l.cn}</span>
+                )}
+              </Link>
+            );
+          })}
         </nav>
 
         <div className="flex items-center gap-2 sm:gap-3">

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -1,12 +1,10 @@
-"use client";
-
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import type { Locale } from "@/lib/i18n/config";
 import { Seal } from "./seal";
 import { Whale } from "./whale";
 import { LocaleSwitcher } from "./locale-switcher";
 import { MobileMenu } from "./mobile-menu";
+import { NavLinks } from "./nav-links";
 
 const EN_LINKS = [
   { href: "/en/install", label: "Install", cn: "安装" },
@@ -33,7 +31,6 @@ const ZH_LINKS = [
 export function Nav({ locale = "en" }: { locale?: Locale }) {
   const isZh = locale === "zh";
   const links = isZh ? ZH_LINKS : EN_LINKS;
-  const pathname = usePathname();
 
   return (
     <header className="hairline-b bg-paper/85 backdrop-blur sticky top-0 z-30">
@@ -66,19 +63,7 @@ export function Nav({ locale = "en" }: { locale?: Locale }) {
           </div>
         </Link>
 
-        <nav className="hidden md:flex items-center gap-7">
-          {links.map((l) => {
-            const isActive = pathname === l.href || pathname.startsWith(`${l.href}/`);
-            return (
-              <Link key={l.href} href={l.href} className="nav-link group" aria-current={isActive ? "page" : undefined}>
-                <span>{l.label}</span>
-                {!isZh && "cn" in l && l.cn && (
-                  <span className="font-cjk text-[0.66rem] ml-1.5 text-ink-mute">{l.cn}</span>
-                )}
-              </Link>
-            );
-          })}
-        </nav>
+        <NavLinks links={links} isZh={isZh} />
 
         <div className="flex items-center gap-2 sm:gap-3">
           <LocaleSwitcher current={locale} />


### PR DESCRIPTION
## Summary

The website agent already generates a bilingual weekly community digest and persists it, and a `/digest` route exists to render it, but nothing pointed users at that page. It was missing from the sitemap (so search engines never found it) and absent from both the desktop and mobile navigation (so visitors couldn't either). This wires up those entry points so the digest the agent already produces becomes reachable.

The sitemap now includes the localized `/digest` path, and the desktop nav and mobile menu both gain a localized "Community Digest" / "社区摘要" link with active-state highlighting. To keep that highlighting from regressing the layout, the active-link logic lives in a small dedicated client component rather than converting the whole header to a client component. That matters because the header also renders a date: making the entire nav client-side would re-run the date on hydration and diverge from the server-rendered HTML for prerendered pages and visitors in other timezones, producing a hydration mismatch. Keeping the header server-rendered avoids that.

## Testing

Rust checks are not applicable; this change only touches the `web/` Next.js app. Web checks were run locally and all pass: `npm --prefix web run lint` (eslint clean), `npm --prefix web test` (3 files, 23 tests), and `npm --prefix web run build`, whose output confirms the localized `/en/digest` and `/zh/digest` routes are generated.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant (no new behavioral logic; route reachability is exercised by the existing build/route-generation tests)
- [x] Verified TUI behavior manually if UI changes (confirmed the build emits both localized digest routes and the nav links resolve to them)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address

Fixes #3420
