### PR TITLE
fix(tui): emit approval.decided after auto-approve for external clients

### DIFF
--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3178,14 +3178,35 @@ impl RuntimeThreadManager {
                     };
 
                     if auto_approve || trust_mode {
-                        match Self::approval_decision(auto_approve, trust_mode, false) {
-                            RuntimeApprovalDecision::ApproveTool => {
-                                let _ = engine.approve_tool_call(id).await;
-                            }
+                        let auto_decision = Self::approval_decision(auto_approve, trust_mode, false);
+                        let (dec_str, approved) = match auto_decision {
+                            RuntimeApprovalDecision::ApproveTool => ("allow", true),
                             RuntimeApprovalDecision::DenyTool
-                            | RuntimeApprovalDecision::RetryWithFullAccess => {
-                                let _ = engine.deny_tool_call(id).await;
-                            }
+                            | RuntimeApprovalDecision::RetryWithFullAccess => ("deny", false),
+                        };
+                        // Emit approval.decided so external clients (GUI)
+                        // know the approval was resolved automatically and
+                        // can clear any pending approval UI.  Without this
+                        // event the GUI would show a frozen approval dialog
+                        // that never receives approval.decided.
+                        self.emit_event(
+                            &thread_id,
+                            Some(&turn_id),
+                            None,
+                            "approval.decided",
+                            json!({
+                                "approval_id": id,
+                                "decision": dec_str,
+                                "remember": false,
+                                "auto": true,
+                            }),
+                        )
+                        .await
+                        .ok();
+                        if approved {
+                            let _ = engine.approve_tool_call(id).await;
+                        } else {
+                            let _ = engine.deny_tool_call(id).await;
                         }
                         continue;
                     }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3178,7 +3178,8 @@ impl RuntimeThreadManager {
                     };
 
                     if auto_approve || trust_mode {
-                        let auto_decision = Self::approval_decision(auto_approve, trust_mode, false);
+                        let auto_decision =
+                            Self::approval_decision(auto_approve, trust_mode, false);
                         let (dec_str, approved) = match auto_decision {
                             RuntimeApprovalDecision::ApproveTool => ("allow", true),
                             RuntimeApprovalDecision::DenyTool


### PR DESCRIPTION
## Summary

In YOLO / trust mode, the TUI auto-approves tool calls server-side but previously skipped emitting `approval.decided`. External clients (e.g. the CodeWhale GUI VSCode extension) track approval lifecycle via SSE events — `approval.required` opens a confirmation dialog, and `approval.decided` clears it. Without the latter, the GUI dialog can freeze permanently because the resolution signal never arrives.

This change emits `approval.decided` with `auto: true` before calling the engine, so external clients receive the resolution signal and can clear pending approval UI.

### Why the GUI's existing defenses aren't enough

The GUI has three layers of protection, but two have failure windows:

| Layer | Logic | Failure window |
|---|---|---|
| Skip if `currentThread.auto_approve` cache is set | Relies on local cache, which can be stale | |
| Skip if tool call is already `complete` | Race: `approval.required` may arrive before the tool finishes | |
| Clear dialog on `approval.decided` | **Didn't fire in auto-approve path** ← this fix | |

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
