### PR TITLE
fix(bridge): keep Telegram chunks readable

### DIFF
--- a/integrations/bridge-core/src/lib.mjs
+++ b/integrations/bridge-core/src/lib.mjs
@@ -291,15 +291,76 @@ export function preservedChatStateFields(state = {}, fields = ["model"]) {
 
 export function splitMessage(text, maxChars = 3500) {
   const value = String(text || "");
+  const limit = Math.max(1, Math.floor(Number(maxChars) || 3500));
   const chars = Array.from(value);
-  if (chars.length <= maxChars) return value ? [value] : [];
+  if (chars.length <= limit) return value ? [value] : [];
   const chunks = [];
-  let cursor = 0;
-  while (cursor < chars.length) {
-    chunks.push(chars.slice(cursor, cursor + maxChars).join(""));
-    cursor += maxChars;
+  let remaining = value;
+  let openFence = null;
+  while (remaining) {
+    const next = takeRenderedSplitMessageChunk(remaining, limit, openFence);
+    chunks.push(next.chunk);
+    remaining = next.remaining;
+    openFence = next.openFence;
   }
   return chunks;
+}
+
+function takeRenderedSplitMessageChunk(text, maxChars, openFence) {
+  const prefix = openFence !== null ? `\`\`\`${openFence}\n` : "";
+  let payloadLimit = Math.max(1, maxChars - charLength(prefix));
+
+  while (true) {
+    const next = takeSplitMessageChunk(text, payloadLimit);
+    const body = `${prefix}${next.chunk}`;
+    const nextOpenFence = updateCodeFenceState(openFence, next.chunk);
+    const suffix = nextOpenFence !== null && next.remaining ? (body.endsWith("\n") ? "```" : "\n```") : "";
+    const chunk = `${body}${suffix}`;
+    const overflow = charLength(chunk) - maxChars;
+    if (overflow <= 0 || payloadLimit === 1) {
+      return { chunk, remaining: next.remaining, openFence: nextOpenFence };
+    }
+    payloadLimit = Math.max(1, payloadLimit - overflow);
+  }
+}
+
+function takeSplitMessageChunk(text, maxChars) {
+  const chars = Array.from(text);
+  if (chars.length <= maxChars) {
+    return { chunk: text, remaining: "" };
+  }
+  const splitAt = preferredSplitIndex(chars, maxChars);
+  return {
+    chunk: chars.slice(0, splitAt).join(""),
+    remaining: chars.slice(splitAt).join("")
+  };
+}
+
+function preferredSplitIndex(chars, maxChars) {
+  const limit = Math.min(chars.length, maxChars);
+  for (let i = limit - 1; i > 0; i -= 1) {
+    if (chars[i] === "\n") return i + 1;
+  }
+  for (let i = limit - 1; i > 0; i -= 1) {
+    if (/\s/u.test(chars[i])) return i + 1;
+  }
+  return limit;
+}
+
+function charLength(text) {
+  return Array.from(text).length;
+}
+
+function updateCodeFenceState(openFence, text) {
+  let current = openFence;
+  for (const match of text.matchAll(/^```([^\n`]*)\s*$/gm)) {
+    if (current === null) {
+      current = match[1]?.trim() || "";
+    } else {
+      current = null;
+    }
+  }
+  return current;
 }
 
 export function compactRuntimeError(status, body) {

--- a/integrations/bridge-core/test/lib.test.mjs
+++ b/integrations/bridge-core/test/lib.test.mjs
@@ -79,6 +79,16 @@ test("state/message/runtime helpers preserve bridge behavior", () => {
     { model: "m", replyToMessageId: "r" }
   );
   assert.deepEqual(splitMessage("a🧪b", 2), ["a🧪", "b"]);
+  assert.deepEqual(splitMessage("alpha beta gamma", 12), ["alpha beta ", "gamma"]);
+  const fenced = splitMessage("```js\nconst first = 1;\nconst second = 2;\n```\nDone", 24);
+  assert.ok(fenced.length > 1);
+  assert.equal(fenced[0].endsWith("\n```"), true);
+  assert.equal(fenced[1].startsWith("```js\n"), true);
+  assert.equal(fenced.at(-1).includes("Done"), true);
+  for (const chunk of fenced) {
+    assert.ok(Array.from(chunk).length <= 24);
+    assert.equal((chunk.match(/```/g) || []).length % 2, 0);
+  }
   assert.deepEqual(activeTurnBlock({ turns: [{ id: "t1", status: "queued" }] }), {
     turnId: "t1",
     message: "Thread already has active turn t1. Wait for it to finish or send /interrupt."


### PR DESCRIPTION
Refs #2967

Problem:
- Long bridge replies were split at fixed character boundaries, which could split words and leave fenced code blocks unreadable across Telegram chunks.

Change:
- Prefer newline/whitespace split points before hard splitting.
- Close and reopen fenced code blocks across chunks while keeping each rendered chunk within the configured limit.
- Keep surrogate-pair handling covered.

Verification:
- node --test test/*.test.mjs (integrations/bridge-core)
- node --test test/*.test.mjs (integrations/telegram-bridge)
- node --test test/*.test.mjs (integrations/feishu-bridge)
- node --test test/*.test.mjs (integrations/wecom-bridge)
- node --test test/*.test.mjs (integrations/weixin-bridge)
- npm run check (integrations/bridge-core, telegram-bridge, feishu-bridge, wecom-bridge, weixin-bridge)
- git diff --check