### PR TITLE
ci: add DCO (Developer Certificate of Origin) check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,46 @@
+name: DCO
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  dco:
+    name: Check Signed-off-by
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commits for Signed-off-by
+        shell: bash
+        run: |
+          set -euo pipefail
+          bad=()
+          while IFS= read -r commit; do
+            msg=$(git log --format=%B -n1 "$commit")
+            if ! echo "$msg" | grep -qi "^Signed-off-by:"; then
+              bad+=("$commit")
+            fi
+          done < <(git rev-list origin/main..HEAD 2>/dev/null || git rev-list HEAD~0..HEAD)
+
+          if [ ${#bad[@]} -gt 0 ]; then
+            echo "❌ The following commit(s) are missing Signed-off-by:"
+            for c in "${bad[@]}"; do
+              echo "  • $c $(git log --format=%s -n1 "$c")"
+            done
+            echo ""
+            echo "Please amend each commit with:"
+            echo "  git commit --amend -s   (for the most recent commit)"
+            echo "or use git rebase to add -s to older commits."
+            echo ""
+            echo "See CONTRIBUTING.md for details."
+            exit 1
+          fi
+
+          echo "✅ All commits have Signed-off-by."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,6 +384,43 @@ Be respectful and inclusive. We welcome contributors of all backgrounds and
 experience levels. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the full
 code of conduct.
 
+
+## Developer Certificate of Origin (DCO)
+
+This project uses the **Developer Certificate of Origin** — a lightweight
+mechanism confirming that you have the right to submit your contribution
+under the MIT license.
+
+To accept the DCO, add a `Signed-off-by` line to your commit messages:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Use `git commit -s` to append it automatically:
+
+```bash
+git commit -s -m "feat: your change description"
+```
+
+If you forget, amend the most recent commit:
+
+```bash
+git commit --amend -s
+```
+
+For older commits in an open PR, use interactive rebase:
+
+```bash
+git rebase -i HEAD~N
+# replace "pick" with "edit" for each commit
+git commit --amend -s
+git rebase --continue
+```
+
+All commits in a pull request must include `Signed-off-by` or the DCO
+check will fail. The check runs automatically when you open or update a PR.
+
 ## License
 
 By contributing to codewhale, you agree that your contributions will be licensed under the MIT License.


### PR DESCRIPTION
- Add dco.yml workflow to verify Signed-off-by on all PR commits
- Add DCO section to CONTRIBUTING.md with usage instructions
- Uses pull_request_target for safe contributor PR handling

Ref: developer-certificate-of-origin (DCO)

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
