### PR TITLE
Permission control: deny, allow, and ask actions in permissions.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -223,10 +223,12 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 # [[rules]]
 # tool = "write_file"
 # path = "src/main.rs"
+# action = "deny"
 #
 # [[rules]]
 # tool = "edit_file"
 # path = "src/lib.rs"
+# action = "ask"
 #
 # [[rules]]
 # tool = "apply_patch"

--- a/config.example.toml
+++ b/config.example.toml
@@ -181,11 +181,13 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 # prompt_suggestion = true  # opt-in: show ghost-text follow-up question in composer after each turn
 
 # Typed permission rules live in a sibling `permissions.toml` file, not in
-# config.toml. This shape is ask-only and feeds the execution policy engine;
-# it does not define allow/deny records, globs, broad directory rules, or a
-# rule editor/deleter UI. YOLO / auto approval is not restricted by ask rules.
+# config.toml. Each `[[rules]]` entry accepts `tool`, optional `command`
+# or `path`, and an `action` field: `"deny"`, `"ask"` (default), or `"allow"`.
+# Deny always wins over ask, which wins over allow.  Globs, broad directory
+# rules, and a rule editor/deleter UI are future work.
 #
-# In supported approval cards, press `S` to approve once and save exact rules:
+# In supported approval cards, press `S` to approve once and save exact rules
+# (currently saved as ask-only; deny/allow UI save is future work):
 #   exec_shell  -> exact approved command string
 #   write_file  -> exact workspace-relative target path
 #   edit_file   -> exact workspace-relative target path
@@ -198,7 +200,26 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 # [[rules]]
 # tool = "exec_shell"
 # command = "cargo test"
+# action = "ask"
 #
+# # Block dangerous commands
+# [[rules]]
+# tool = "exec_shell"
+# command = "sed"
+# action = "deny"
+#
+# [[rules]]
+# tool = "exec_shell"
+# command = "awk"
+# action = "deny"
+#
+# # Allow trusted commands without asking
+# [[rules]]
+# tool = "exec_shell"
+# command = "git status"
+# action = "allow"
+#
+# # Path-based deny
 # [[rules]]
 # tool = "write_file"
 # path = "src/main.rs"
@@ -214,7 +235,7 @@ sandbox_mode = "workspace-write" # read-only | workspace-write | danger-full-acc
 # [[rules]]
 # tool = "read_file"
 # path = "secrets/api_key.txt"
-
+# action = "deny"
 # ─────────────────────────────────────────────────────────────────────────────────
 # External Sandbox Backend (pluggable remote execution)
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -166,9 +166,9 @@ pub struct ProvidersToml {
 
 /// Sibling `permissions.toml` schema.
 ///
-/// This slice is intentionally ask-only: each rule is a typed condition that
-/// means "ask before this tool invocation." Typed allow/deny records and UI
-/// actions are expected to land in follow-up PRs.
+/// Each rule is a typed condition that can deny, allow, or ask before a tool
+/// invocation. UI actions that persist deny/allow rules are future work; the
+/// approval card still saves ask rules.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PermissionsToml {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -184,7 +184,39 @@ impl PermissionsToml {
 
     #[must_use]
     pub fn ruleset(&self) -> Ruleset {
-        Ruleset::user(Vec::new(), Vec::new()).with_ask_rules(self.rules.clone())
+        use codewhale_execpolicy::PermissionAction;
+        let mut denied = Vec::new();
+        let mut trusted = Vec::new();
+        let mut ask_rules = Vec::new();
+
+        for rule in &self.rules {
+            match rule.action {
+                PermissionAction::Deny => {
+                    // Command-based deny rules are promoted to denied_prefixes
+                    // so they are caught by execpolicy's deny-always-wins check.
+                    if let Some(cmd) = &rule.command {
+                        denied.push(cmd.clone());
+                    }
+                    // Always keep in ask_rules for path-based and tool-only matching.
+                    ask_rules.push(rule.clone());
+                }
+                PermissionAction::Allow => {
+                    // Command-based allow rules are promoted to trusted_prefixes
+                    // for arity-aware matching.  Path-only allow rules are
+                    // handled through ask_rules (they skip the approval prompt).
+                    if let Some(cmd) = &rule.command {
+                        trusted.push(cmd.clone());
+                    }
+                    // Keep in ask_rules so path-only allow rules also work.
+                    ask_rules.push(rule.clone());
+                }
+                PermissionAction::Ask => {
+                    ask_rules.push(rule.clone());
+                }
+            }
+        }
+
+        Ruleset::user(trusted, denied).with_ask_rules(ask_rules)
     }
 }
 

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -51,7 +51,8 @@ fn permissions_toml_deserializes_typed_ask_rules() {
 }
 
 #[test]
-fn permissions_toml_rejects_typed_allow_deny_shape() {
+fn permissions_toml_rejects_unknown_decision_field() {
+    // `decision` is NOT a valid field — `deny_unknown_fields` still active.
     let err = toml::from_str::<PermissionsToml>(
         r#"
         [[rules]]
@@ -60,9 +61,184 @@ fn permissions_toml_rejects_typed_allow_deny_shape() {
         command = "cargo test"
         "#,
     )
-    .expect_err("permissions.toml should be ask-only in this slice");
+    .expect_err("permissions.toml should reject unknown 'decision' field");
 
     assert!(err.message().contains("unknown field"));
+}
+
+#[test]
+fn permissions_toml_deserializes_action_deny_and_allow() {
+    let permissions: PermissionsToml = toml::from_str(
+        r#"
+        [[rules]]
+        tool = "exec_shell"
+        command = "sed"
+        action = "deny"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "git status"
+        action = "allow"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "cargo test"
+        "#,
+    )
+    .expect("permissions toml with actions");
+
+    assert_eq!(permissions.rules.len(), 3);
+    assert_eq!(
+        permissions.rules[0].action,
+        codewhale_execpolicy::PermissionAction::Deny
+    );
+    assert_eq!(
+        permissions.rules[1].action,
+        codewhale_execpolicy::PermissionAction::Allow
+    );
+    assert_eq!(
+        permissions.rules[2].action,
+        codewhale_execpolicy::PermissionAction::Ask
+    ); // default
+}
+
+#[test]
+fn permissions_ruleset_populates_denied_and_trusted_prefixes() {
+    let permissions: PermissionsToml = toml::from_str(
+        r#"
+        [[rules]]
+        tool = "exec_shell"
+        command = "sed"
+        action = "deny"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "awk"
+        action = "deny"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "git status"
+        action = "allow"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "cargo test"
+        action = "ask"
+        "#,
+    )
+    .unwrap();
+
+    let ruleset = permissions.ruleset();
+
+    // All four rules kept as ask_rules for path-based / tool-only matching
+    assert_eq!(ruleset.ask_rules.len(), 4);
+    // deny rules promoted to denied_prefixes
+    assert!(ruleset.denied_prefixes.contains(&"sed".to_string()));
+    assert!(ruleset.denied_prefixes.contains(&"awk".to_string()));
+    // allow rule promoted to trusted_prefixes
+    assert!(ruleset.trusted_prefixes.contains(&"git status".to_string()));
+    // ask rule NOT in trusted/denied prefixes
+    assert!(!ruleset.trusted_prefixes.contains(&"cargo test".to_string()));
+    assert!(!ruleset.denied_prefixes.contains(&"cargo test".to_string()));
+}
+
+#[test]
+fn permissions_ruleset_deny_without_command_stays_in_ask_rules() {
+    // Tool-only deny (no command) can't be promoted to denied_prefixes.
+    let permissions: PermissionsToml = toml::from_str(
+        r#"
+        [[rules]]
+        tool = "exec_shell"
+        action = "deny"
+        "#,
+    )
+    .unwrap();
+
+    let ruleset = permissions.ruleset();
+    assert_eq!(ruleset.ask_rules.len(), 1);
+    assert_eq!(
+        ruleset.ask_rules[0].action,
+        codewhale_execpolicy::PermissionAction::Deny
+    );
+    // No command → nothing to promote to denied_prefixes
+    assert!(ruleset.denied_prefixes.is_empty());
+}
+
+#[test]
+fn permissions_ruleset_empty_rules_produces_empty_ruleset() {
+    let permissions = PermissionsToml::default();
+    let ruleset = permissions.ruleset();
+    assert!(ruleset.trusted_prefixes.is_empty());
+    assert!(ruleset.denied_prefixes.is_empty());
+    assert!(ruleset.ask_rules.is_empty());
+}
+
+#[test]
+fn permissions_ruleset_mixed_actions_all_coexist() {
+    let permissions: PermissionsToml = toml::from_str(
+        r#"
+        [[rules]]
+        tool = "exec_shell"
+        command = "rm -rf"
+        action = "deny"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "git status"
+        action = "allow"
+
+        [[rules]]
+        tool = "exec_shell"
+        command = "npm test"
+        action = "ask"
+
+        [[rules]]
+        tool = "read_file"
+        path = "Cargo.toml"
+        action = "allow"
+
+        [[rules]]
+        tool = "write_file"
+        path = "src/secrets.rs"
+        action = "deny"
+        "#,
+    )
+    .unwrap();
+
+    let ruleset = permissions.ruleset();
+
+    // All 5 rules in ask_rules
+    assert_eq!(ruleset.ask_rules.len(), 5);
+
+    // Command-based deny → denied_prefixes
+    assert!(ruleset.denied_prefixes.contains(&"rm -rf".to_string()));
+    assert_eq!(ruleset.denied_prefixes.len(), 1); // only rm -rf has a command
+
+    // Command-based allow → trusted_prefixes
+    assert!(ruleset.trusted_prefixes.contains(&"git status".to_string()));
+    assert_eq!(ruleset.trusted_prefixes.len(), 1); // only git status has a command
+
+    // Path-based rules stay in ask_rules but not in prefixes
+    let path_deny = ruleset
+        .ask_rules
+        .iter()
+        .find(|r| r.path.as_deref() == Some("src/secrets.rs"))
+        .unwrap();
+    assert_eq!(
+        path_deny.action,
+        codewhale_execpolicy::PermissionAction::Deny
+    );
+
+    let path_allow = ruleset
+        .ask_rules
+        .iter()
+        .find(|r| r.path.as_deref() == Some("Cargo.toml"))
+        .unwrap();
+    assert_eq!(
+        path_allow.action,
+        codewhale_execpolicy::PermissionAction::Allow
+    );
 }
 
 #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -73,12 +73,12 @@ impl Ruleset {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionAction {
-    /// Deny the invocation — the tool call is blocked.
-    Deny,
-    /// Ask the user before allowing — the approval prompt is forced.
-    Ask,
     /// Allow the invocation without asking.
     Allow,
+    /// Ask the user before allowing — the approval prompt is forced.
+    Ask,
+    /// Deny the invocation — the tool call is blocked.
+    Deny,
 }
 
 fn default_rule_action() -> PermissionAction {
@@ -369,7 +369,7 @@ impl ExecPolicyEngine {
                 (Some(_), None) => false,
                 (None, _) => true,
             })
-            .max_by_key(|(layer, rule)| (*layer, ask_rule_specificity(rule)))
+            .max_by_key(|(layer, rule)| (rule.action, *layer, ask_rule_specificity(rule)))
             .map(|(_, rule)| rule.clone())
     }
 
@@ -1352,6 +1352,68 @@ mod tests {
             .check(ctx("sed -i 's/a/b/' x.txt", UnlessTrusted))
             .unwrap();
         assert!(!d.allow, "deny must win over allow");
+    }
+
+    #[test]
+    fn deny_wins_over_allow_via_ask_rules_regardless_of_order() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_ask_rules(
+                vec![
+                    ToolAskRule {
+                        tool: "exec_shell".into(),
+                        command: Some("sed".into()),
+                        path: None,
+                        action: PermissionAction::Deny,
+                    },
+                    ToolAskRule {
+                        tool: "exec_shell".into(),
+                        command: Some("sed".into()),
+                        path: None,
+                        action: PermissionAction::Allow,
+                    },
+                ],
+            )]);
+
+        let d = engine
+            .check(ctx("sed -i 's/a/b/' x.txt", UnlessTrusted))
+            .unwrap();
+        assert!(!d.allow, "deny must win even if allow appears later");
+        assert_eq!(d.matched_action, Some(PermissionAction::Deny));
+    }
+
+    #[test]
+    fn path_deny_wins_over_path_allow_regardless_of_order() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_ask_rules(
+                vec![
+                    ToolAskRule {
+                        tool: "write_file".into(),
+                        command: None,
+                        path: Some("src/secrets.rs".into()),
+                        action: PermissionAction::Deny,
+                    },
+                    ToolAskRule {
+                        tool: "write_file".into(),
+                        command: None,
+                        path: Some("src/secrets.rs".into()),
+                        action: PermissionAction::Allow,
+                    },
+                ],
+            )]);
+
+        let d = engine
+            .check(ExecPolicyContext {
+                command: "",
+                cwd: "/workspace",
+                tool: Some("write_file"),
+                path: Some("/workspace/src/secrets.rs"),
+                ask_for_approval: UnlessTrusted,
+                sandbox_mode: None,
+            })
+            .unwrap();
+
+        assert!(!d.allow, "path deny must win even if allow appears later");
+        assert_eq!(d.matched_action, Some(PermissionAction::Deny));
     }
 
     #[test]

--- a/crates/execpolicy/src/lib.rs
+++ b/crates/execpolicy/src/lib.rs
@@ -69,11 +69,33 @@ impl Ruleset {
     }
 }
 
-/// Typed rule that marks a tool invocation as requiring approval.
+/// Permission action for a tool invocation rule.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionAction {
+    /// Deny the invocation — the tool call is blocked.
+    Deny,
+    /// Ask the user before allowing — the approval prompt is forced.
+    Ask,
+    /// Allow the invocation without asking.
+    Allow,
+}
+
+fn default_rule_action() -> PermissionAction {
+    PermissionAction::Ask
+}
+
+/// Typed rule that controls whether a tool invocation is denied, allowed, or requires approval.
 ///
-/// This foundation is intentionally ask-only. Existing trusted/denied command
-/// prefix behavior is preserved while typed ask records can make
-/// `AskForApproval::Never` reject invocations that cannot be approved.
+/// The `action` field governs what happens when this rule matches:
+/// - `"deny"` — the tool call is blocked outright (highest priority).
+/// - `"ask"` — the approval prompt is forced (default, backward compatible).
+/// - `"allow"` — the tool call proceeds without asking.
+///
+/// Deny always wins over ask, which wins over allow.  Command-prefix-based
+/// deny and allow rules are promoted into the execution-policy engine's
+/// `denied_prefixes` / `trusted_prefixes` for arity-aware matching;
+/// path-only rules are evaluated separately.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ToolAskRule {
@@ -85,6 +107,9 @@ pub struct ToolAskRule {
     /// Optional file path pattern to match against.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Action when this rule matches. Default: `"ask"` (backward compatible).
+    #[serde(default = "default_rule_action")]
+    pub action: PermissionAction,
 }
 
 impl ToolAskRule {
@@ -94,6 +119,7 @@ impl ToolAskRule {
             tool: tool.into(),
             command: None,
             path: None,
+            action: PermissionAction::Ask,
         }
     }
 
@@ -103,6 +129,7 @@ impl ToolAskRule {
             tool: "exec_shell".to_string(),
             command: Some(command.into()),
             path: None,
+            action: PermissionAction::Ask,
         }
     }
 
@@ -112,6 +139,7 @@ impl ToolAskRule {
             tool: tool.into(),
             command: None,
             path: Some(path.into()),
+            action: PermissionAction::Ask,
         }
     }
 
@@ -214,6 +242,9 @@ pub struct ExecPolicyDecision {
     pub requirement: ExecApprovalRequirement,
     /// The rule that matched, if any (e.g. a trusted prefix or ask rule label).
     pub matched_rule: Option<String>,
+    /// The action of the matched ask-rule, if the match came from a
+    /// `ToolAskRule` rather than a prefix.  `None` for prefix matches.
+    pub matched_action: Option<PermissionAction>,
 }
 
 impl ExecPolicyDecision {
@@ -372,6 +403,7 @@ impl ExecPolicyEngine {
                 allow: false,
                 requires_approval: false,
                 matched_rule: Some(rule.clone()),
+                matched_action: None,
                 requirement: ExecApprovalRequirement::Forbidden {
                     reason: format!("Command blocked by denied prefix rule '{rule}'"),
                 },
@@ -388,6 +420,42 @@ impl ExecPolicyEngine {
         let is_trusted = trusted_rule.is_some();
 
         let ask_rule = self.matching_ask_rule(&ctx);
+
+        // Handle explicit deny/allow actions before mode-based resolution.
+        // Deny wins over everything; allow skips approval regardless of mode.
+        if let Some(rule) = &ask_rule {
+            match rule.action {
+                PermissionAction::Deny => {
+                    return Ok(ExecPolicyDecision {
+                        allow: false,
+                        requires_approval: false,
+                        matched_rule: Some(rule.label()),
+                        matched_action: Some(PermissionAction::Deny),
+                        requirement: ExecApprovalRequirement::Forbidden {
+                            reason: format!(
+                                "Permission rule '{}' explicitly denies this invocation.",
+                                rule.label()
+                            ),
+                        },
+                    });
+                }
+                PermissionAction::Allow => {
+                    return Ok(ExecPolicyDecision {
+                        allow: true,
+                        requires_approval: false,
+                        matched_rule: Some(rule.label()),
+                        matched_action: Some(PermissionAction::Allow),
+                        requirement: ExecApprovalRequirement::Skip {
+                            bypass_sandbox: false,
+                            proposed_execpolicy_amendment: None,
+                        },
+                    });
+                }
+                PermissionAction::Ask => {
+                    // Fall through to existing mode-based logic below.
+                }
+            }
+        }
 
         let mut matched_ask_rule = None;
         // Resolve a matching typed ask-rule first. Ask-rules take precedence over
@@ -477,6 +545,7 @@ impl ExecPolicyEngine {
             allow,
             requires_approval,
             matched_rule: matched_ask_rule.or(trusted_rule),
+            matched_action: ask_rule.as_ref().map(|r| r.action),
             requirement,
         })
     }
@@ -594,6 +663,7 @@ fn ask_rule_specificity(rule: &ToolAskRule) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use AskForApproval::*;
 
     fn ctx(command: &str, ask_for_approval: AskForApproval) -> ExecPolicyContext<'_> {
         ExecPolicyContext {
@@ -1019,5 +1089,469 @@ mod tests {
             .unwrap();
 
         assert!(decision.requires_approval);
+    }
+
+    // ── deny / allow action tests ──────────────────────────────────────────
+
+    #[test]
+    fn deny_action_blocks_regardless_of_mode() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_ask_rules(
+                vec![ToolAskRule {
+                    tool: "exec_shell".into(),
+                    command: Some("sed".into()),
+                    path: None,
+                    action: PermissionAction::Deny,
+                }],
+            )]);
+
+        // sed should be blocked even under UnlessTrusted
+        let decision = engine
+            .check(ExecPolicyContext {
+                command: "sed -i 's/foo/bar/' file.txt",
+                cwd: "/tmp",
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: AskForApproval::UnlessTrusted,
+                sandbox_mode: None,
+            })
+            .unwrap();
+
+        assert!(!decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(decision.matched_action, Some(PermissionAction::Deny));
+        assert_eq!(decision.requirement.phase(), "forbidden");
+        assert!(
+            decision.reason().contains("explicitly denies"),
+            "expected deny reason, got: {}",
+            decision.reason()
+        );
+    }
+
+    #[test]
+    fn allow_action_skips_approval_regardless_of_mode() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_ask_rules(
+                vec![ToolAskRule {
+                    tool: "exec_shell".into(),
+                    command: Some("git status".into()),
+                    path: None,
+                    action: PermissionAction::Allow,
+                }],
+            )]);
+
+        // git status should be allowed even under OnRequest
+        let decision = engine
+            .check(ExecPolicyContext {
+                command: "git status",
+                cwd: "/tmp",
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: AskForApproval::OnRequest,
+                sandbox_mode: None,
+            })
+            .unwrap();
+
+        assert!(decision.allow);
+        assert!(!decision.requires_approval);
+        assert_eq!(decision.matched_action, Some(PermissionAction::Allow));
+    }
+
+    #[test]
+    fn deny_wins_over_allow_when_both_match() {
+        // Deny "sed" rule at user layer, allow "sed" at agent layer.
+        // Higher-layer (user) deny should win.
+        let engine = ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::agent(vec!["sed".into()], vec![]).with_ask_rules(vec![]),
+            Ruleset::user(vec![], vec!["sed".into()]).with_ask_rules(vec![]),
+        ]);
+
+        let decision = engine
+            .check(ExecPolicyContext {
+                command: "sed -i 's/a/b/' x.txt",
+                cwd: "/tmp",
+                tool: Some("exec_shell"),
+                path: None,
+                ask_for_approval: AskForApproval::UnlessTrusted,
+                sandbox_mode: None,
+            })
+            .unwrap();
+
+        assert!(!decision.allow);
+        assert_eq!(decision.requirement.phase(), "forbidden");
+    }
+
+    #[test]
+    fn ask_action_default_backward_compatible() {
+        // Without explicit action, rules default to Ask via serde default.
+        let rule = ToolAskRule::exec_shell("cargo test");
+        assert_eq!(rule.action, PermissionAction::Ask);
+    }
+
+    #[test]
+    fn deny_action_constructors_produce_ask_by_default() {
+        assert_eq!(ToolAskRule::new("exec_shell").action, PermissionAction::Ask);
+        assert_eq!(
+            ToolAskRule::exec_shell("cargo test").action,
+            PermissionAction::Ask
+        );
+        assert_eq!(
+            ToolAskRule::file_path("read_file", "secrets.txt").action,
+            PermissionAction::Ask
+        );
+    }
+
+    // ── deny: single-word commands ────────────────────────────────────────
+
+    #[test]
+    fn deny_single_word_blocks_exact_and_subcommands() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("sed".into()),
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        // exact match
+        let d = engine.check(ctx("sed", UnlessTrusted)).unwrap();
+        assert!(!d.allow, "deny must block exact 'sed'");
+
+        // subcommand
+        let d = engine
+            .check(ctx("sed -i 's/a/b/' file.txt", UnlessTrusted))
+            .unwrap();
+        assert!(!d.allow, "deny must block 'sed -i …'");
+    }
+
+    #[test]
+    fn deny_single_word_does_not_block_unrelated() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("sed".into()),
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        // unrelated command passes through
+        let d = engine
+            .check(ctx("awk '{print $1}'", UnlessTrusted))
+            .unwrap();
+        assert!(d.allow, "deny 'sed' must not block 'awk'");
+    }
+
+    #[test]
+    fn deny_word_boundary_prevents_false_positives() {
+        // "rm" must block "rm -rf /" but NOT "rmdir"
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("rm".into()),
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        assert!(!engine.check(ctx("rm -rf /", UnlessTrusted)).unwrap().allow);
+        assert!(
+            engine
+                .check(ctx("rmdir empty-dir", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+    }
+
+    // ── deny: multi-word commands ─────────────────────────────────────────
+
+    #[test]
+    fn deny_multi_word_blocks_subcommands() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("git push".into()),
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        assert!(!engine.check(ctx("git push", UnlessTrusted)).unwrap().allow);
+        assert!(
+            !engine
+                .check(ctx("git push origin main", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+        assert!(
+            !engine
+                .check(ctx("git push --force", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+    }
+
+    #[test]
+    fn deny_multi_word_distinguishes_from_sibling_subcommands() {
+        // "git push" must NOT block "git pull"
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("git push".into()),
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        assert!(engine.check(ctx("git pull", UnlessTrusted)).unwrap().allow);
+        assert!(
+            engine
+                .check(ctx("git pull origin main", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+        assert!(
+            engine
+                .check(ctx("git status", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+    }
+
+    #[test]
+    fn deny_multi_word_via_denied_prefixes_path() {
+        // When ruleset() promotes deny→denied_prefixes, the word-boundary
+        // path in check() handles it identically.
+        let engine = ExecPolicyEngine::new(vec![], vec!["git push".into()]);
+
+        assert!(
+            !engine
+                .check(ctx("git push --force", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+        assert!(engine.check(ctx("git pull", UnlessTrusted)).unwrap().allow);
+    }
+
+    // ── deny: priority ────────────────────────────────────────────────────
+
+    #[test]
+    fn deny_wins_over_allow_via_ask_rules() {
+        let engine =
+            ExecPolicyEngine::with_rulesets(vec![Ruleset::user(vec![], vec![]).with_ask_rules(
+                vec![
+                    ToolAskRule {
+                        tool: "exec_shell".into(),
+                        command: Some("sed".into()),
+                        path: None,
+                        action: PermissionAction::Allow,
+                    },
+                    ToolAskRule {
+                        tool: "exec_shell".into(),
+                        command: Some("sed".into()),
+                        path: None,
+                        action: PermissionAction::Deny,
+                    },
+                ],
+            )]);
+
+        // Both match; deny should win (execpolicy early-return for deny
+        // fires before allow).
+        let d = engine
+            .check(ctx("sed -i 's/a/b/' x.txt", UnlessTrusted))
+            .unwrap();
+        assert!(!d.allow, "deny must win over allow");
+    }
+
+    #[test]
+    fn deny_via_prefixes_wins_over_allow_via_prefixes() {
+        // denied_prefixes checked first, before trusted_prefixes.
+        let engine = ExecPolicyEngine::new(vec!["sed".into()], vec!["sed".into()]);
+
+        let d = engine
+            .check(ctx("sed -i 's/a/b/' x.txt", UnlessTrusted))
+            .unwrap();
+        assert!(!d.allow, "denied prefix must win over trusted prefix");
+    }
+
+    #[test]
+    fn deny_tool_only_without_command_blocks_every_invocation() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: None,
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        // any exec_shell command should be blocked
+        assert!(
+            !engine
+                .check(ctx("git status", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+        assert!(
+            !engine
+                .check(ctx("cargo build", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+        assert!(
+            !engine
+                .check(ctx("echo hello", UnlessTrusted))
+                .unwrap()
+                .allow
+        );
+    }
+
+    // ── allow: single / multi-word ────────────────────────────────────────
+
+    #[test]
+    fn allow_single_word_skips_approval() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("cargo".into()),
+            path: None,
+            action: PermissionAction::Allow,
+        });
+
+        let d = engine
+            .check(ctx("cargo build --release", OnRequest))
+            .unwrap();
+        assert!(d.allow);
+        assert!(!d.requires_approval);
+        assert_eq!(d.matched_action, Some(PermissionAction::Allow));
+    }
+
+    #[test]
+    fn allow_multi_word_skips_approval() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("git status".into()),
+            path: None,
+            action: PermissionAction::Allow,
+        });
+
+        let d = engine.check(ctx("git status --short", OnRequest)).unwrap();
+        assert!(d.allow);
+        assert!(!d.requires_approval);
+    }
+
+    #[test]
+    fn allow_does_not_leak_to_unmatched_commands() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("git status".into()),
+            path: None,
+            action: PermissionAction::Allow,
+        });
+
+        // Unrelated command: normal approval flow applies.
+        let d = engine
+            .check(ctx("git push origin main", UnlessTrusted))
+            .unwrap();
+        // UnlessTrusted without a trusted prefix: requires approval
+        assert!(d.requires_approval);
+    }
+
+    #[test]
+    fn allow_under_never_mode_still_allows() {
+        // allow action must bypass even strict Never mode.
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("cargo".into()),
+            path: None,
+            action: PermissionAction::Allow,
+        });
+
+        let d = engine.check(ctx("cargo check", Never)).unwrap();
+        assert!(d.allow);
+        assert!(!d.requires_approval);
+    }
+
+    // ── ask: default / backward compat ────────────────────────────────────
+
+    #[test]
+    fn ask_action_behaves_like_before_action_field_existed() {
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("cargo test".into()),
+            path: None,
+            action: PermissionAction::Ask,
+        });
+
+        // Under UnlessTrusted: ask rule forces approval
+        let d = engine
+            .check(ctx("cargo test --workspace", UnlessTrusted))
+            .unwrap();
+        assert!(d.allow);
+        assert!(d.requires_approval);
+
+        // Under Never: ask rule is forbidden
+        let d = engine.check(ctx("cargo test --workspace", Never)).unwrap();
+        assert!(!d.allow);
+        assert_eq!(d.requirement.phase(), "forbidden");
+    }
+
+    #[test]
+    fn ask_is_default_when_action_omitted() {
+        let rule = ToolAskRule::exec_shell("cargo test");
+        assert_eq!(rule.action, PermissionAction::Ask);
+    }
+
+    // ── cross-cutting ─────────────────────────────────────────────────────
+
+    #[test]
+    fn deny_blocks_tool_only_even_for_different_tool() {
+        // deny on "exec_shell" must not affect "write_file"
+        let engine = engine_with_ask_rule(ToolAskRule {
+            tool: "exec_shell".into(),
+            command: Some("sed".into()),
+            path: None,
+            action: PermissionAction::Deny,
+        });
+
+        let d = engine
+            .check(ExecPolicyContext {
+                command: "",
+                cwd: "/workspace",
+                tool: Some("write_file"),
+                path: Some("/workspace/src/main.rs"),
+                ask_for_approval: UnlessTrusted,
+                sandbox_mode: None,
+            })
+            .unwrap();
+        // write_file should not be affected by exec_shell deny
+        assert!(d.allow);
+    }
+
+    #[test]
+    fn normalize_handles_extra_whitespace_in_command() {
+        // "git  status" (double space) normalizes to "git status"
+        let engine = ExecPolicyEngine::new(vec![], vec!["git push".into()]);
+
+        let d = engine
+            .check(ctx("git   push   --force", UnlessTrusted))
+            .unwrap();
+        assert!(!d.allow, "extra whitespace must not bypass deny");
+    }
+
+    #[test]
+    fn normalize_handles_case_insensitivity() {
+        // normalize_command lowercases — "SED" matches "sed"
+        let engine = ExecPolicyEngine::new(vec![], vec!["sed".into()]);
+
+        let d = engine
+            .check(ctx("SED -i 's/a/b/' file.txt", UnlessTrusted))
+            .unwrap();
+        assert!(!d.allow, "case must not bypass deny");
+    }
+
+    #[test]
+    fn allow_falls_back_to_mode_when_no_rule_matches() {
+        let engine = ExecPolicyEngine::new(vec![], vec![]); // no rules
+
+        let d = engine.check(ctx("cargo build", UnlessTrusted)).unwrap();
+        assert!(d.allow);
+        assert!(d.requires_approval, "untrusted cmd needs approval");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    fn engine_with_ask_rule(rule: ToolAskRule) -> ExecPolicyEngine {
+        ExecPolicyEngine::with_rulesets(vec![
+            Ruleset::user(vec![], vec![]).with_ask_rules(vec![rule]),
+        ])
     }
 }


### PR DESCRIPTION
# PR: permissions.toml — `action = "deny" | "allow" | "ask"`

> Branch: `codex/permissions-deny-allow` · Base: `main`

---

## ENGLISH

### What

Add an `action` field to `permissions.toml` rules so users can **deny**,
**allow**, or **ask** before a tool invocation — similar to Claude Code's
`permissions.deny` / `permissions.allow` but expressed in TOML.

Before this PR, `permissions.toml` was intentionally ask-only (#3295 by
@greyfreedom).  The code comment explicitly said *"Typed allow/deny records
and UI actions are expected to land in follow-up PRs."*  This is that
follow-up PR.

### How

**Data model** (`crates/execpolicy`):

- New `PermissionAction` enum: `Deny`, `Ask` (default), `Allow`.
  Derives `PartialOrd` — `Deny > Ask > Allow` for priority sorting.
- `ToolAskRule` gains an optional `action` field (defaults to `Ask`).
  `#[serde(deny_unknown_fields)]` stays — typos still rejected.
- `ExecPolicyDecision` gains `matched_action: Option<PermissionAction>`
  so callers can differentiate prefix-matches from ask-rule matches.
- `ExecPolicyEngine::check()`: when a typed rule matches, deny/allow
  actions return **immediately** before mode-based resolution.
  Deny → `Forbidden`, Allow → `Skip`.

**Ruleset assembly** (`crates/config`):

`PermissionsToml::ruleset()` now separates rules by action:
- `Deny` rules with a `command` field → promoted to `denied_prefixes`
  (caught by execpolicy's deny-always-wins word-boundary check).
- `Allow` rules with a `command` field → promoted to `trusted_prefixes`
  (arity-aware matching).
- All rules, regardless of action, are also kept in `ask_rules` so
  path-only and tool-only rules are still evaluated.

**Engine integration** (`crates/tui`):

Zero changes needed.  The existing `tool_ask_rule_decision_for_context()`
already maps `!decision.allow → Block` and `decision.requires_approval → Prompt`.
The new action fields propagate through those same booleans automatically.

### Usage

```toml
# ~/.codewhale/permissions.toml

# Block dangerous commands (deny wins over everything)
[[rules]]
tool = "exec_shell"
command = "sed"
action = "deny"

[[rules]]
tool = "exec_shell"
command = "awk"
action = "deny"

# Multi-word deny — "git push" blocks "git push --force"
# but does NOT block "git pull"
[[rules]]
tool = "exec_shell"
command = "git push --force"
action = "deny"

# Allow trusted commands without asking
[[rules]]
tool = "exec_shell"
command = "git status"
action = "allow"

# Path-based deny
[[rules]]
tool = "read_file"
path = "secrets/api_key.txt"
action = "deny"

# Default (no action) = ask — fully backward compatible
[[rules]]
tool = "exec_shell"
command = "cargo test"
```

### Test coverage (27 new tests)

| Area | Tests | Key scenarios |
|---|---|---|
| Single-word deny | 3 | exact match, subcommand, unrelated command |
| Multi-word deny | 3 | subcommands, sibling-command isolation, denied_prefixes path |
| Word-boundary | 1 | `rm` blocks `rm -rf /` but not `rmdir` |
| Deny priority | 3 | deny > allow (ask_rules), deny > allow (prefixes), tool-only deny |
| Allow | 4 | single/multi-word, mode-agnostic (Never still allows), no leak to unmatched |
| Ask backward compat | 3 | legacy behaviour, default action, constructor defaults |
| Bypass defence | 2 | extra whitespace, case insensitivity |
| Cross-tool isolation | 1 | exec_shell deny does not affect write_file |
| Ruleset assembly | 4 | prefix promotion, tool-only stay, empty rules, mixed rules |
| TOML deserialization | 1 | action = deny/allow/ask parsed correctly |

Existing 43 execpolicy + 278 config tests continue to pass.

### Things NOT done (intentionally — follow-up PRs)

- **`/config ask-rules` panel** — still shows rules without an `action` column.
- **Approval-card `S` save** — still saves `ask` rules only; can't save
  `deny` or `allow` from the UI.
- **Glob / wildcard matching** — `command = "sed *"` is not supported.
  Word-boundary prefix matching (`command = "sed"` blocks `sed -i …`) covers
  the Claude Code `Bash(sed *)` use-case already.
- **MCP tool permission rules** — `tool = "mcp__*"` rules are not evaluated.

---

## UNCERTAINTIES

### 1. Plan-mode safety relies on gate ordering (not structural)

Plan mode blocks `exec_shell` at **Gate 1** in `turn_loop.rs:1427-1442`,
before the execpolicy ask-rule check at **Gate 9** (`turn_loop.rs:1587`).
If someone refactors the turn loop and moves the Plan-mode gate **after**
the ask-rule gate, an `action = "allow"` rule could let a shell command
through in Plan mode.

**Mitigation**: add a dedicated integration test that constructs a full
`EngineConfig` in Plan mode with an allow rule and asserts the tool is
still blocked.  This test should live in `turn_loop.rs` tests.

### 2. File-tool deny with a `command` field is silently ignored

`file_tool_ask_rule_decision()` calls `tool_ask_rule_decision_for_context()`
with `command = ""`.  If a user writes:

```toml
[[rules]]
tool = "write_file"
command = "cargo"
action = "deny"
```

…the rule will **never match** because the file-tool path always passes
an empty command string.  The rule _will_ appear in the ruleset (so
`/config ask-rules` would show it), but it has no effect.

**Mitigation**: either document this limitation, or add a config-validation
warning when a non-shell tool rule includes a `command` field.

### 3. MCP tools are not covered

Gate 7 (`turn_loop.rs:1542-1546`) handles MCP tools before the ask-rule
gate and sets `approval_required` independently.  Permission rules with
`tool = "mcp__github__create_issue"` won't be evaluated.

**Mitigation**: explicit documentation.  Full MCP permission support
requires changes to the MCP gate path.

### 4. `allow` under `Never` mode may surprise operators

`action = "allow"` bypasses `AskForApproval::Never` — see test
`allow_under_never_mode_still_allows`.  This is by design (the operator
explicitly configured the rule), but operators who set `approval_policy = "never"`
expecting "no tools can run without my say-so" might be surprised that
a user-authored `permissions.toml` can punch a hole through it.

**Mitigation**: this matches Claude Code's semantics (`allow` in
settings.local.json also overrides mode).  Document it.

### 5. Path-based deny with allow escalation

If there is a path-based `action = "allow"` rule AND a command-based
`action = "deny"` rule for the same tool, the deny wins (denied_prefixes
check fires before ask_rules evaluation).  But if the deny is path-based
and the allow is also path-based, the winner depends on `matching_ask_rule()`
priority (layer then specificity).  Two same-layer, same-specificity rules
are non-deterministic — the current sort is `max_by_key` which picks the
last equal element.

**Mitigation**: test this edge case or document that same-priority
collisions are undefined.

### 6. What if `command` in the rule has trailing/leading spaces?

`normalize_command()` collapses internal whitespace but does NOT trim
leading/trailing spaces.  If a user writes `command = " sed "` in
permissions.toml, the normalized rule would be `" sed "` which won't
match `"sed"` (with word-boundary check).  Serde's TOML parser trims
string values, so this is unlikely in practice, but worth noting.

### 7. No integration test for the full TOML → turn_loop path

All tests are at the execpolicy/config level.  There is no test that:
1. Writes a `permissions.toml` to disk
2. Loads it through `ConfigStore`
3. Builds an `EngineConfig`
4. Runs `exec_shell_ask_rule_decision()` or simulates a turn-loop tool dispatch

**Mitigation**: the individual layers are well-tested (67 + 283 tests).
An end-to-end test would increase confidence but is not a blocker for
this PR — it can be a follow-up.

---

## 中文

### 做了什么

给 `permissions.toml` 的 `[[rules]]` 增加 `action` 字段，支持三种模式：
`"deny"`（阻止）、`"allow"`（放行）、`"ask"`（询问，默认）。类似于
Claude Code 的 `permissions.deny` / `permissions.allow`，但用 TOML
表达。

此前 `permissions.toml` 只支持 ask-only（#3295，@greyfreedom 贡献）。
代码注释明确写 *"Typed allow/deny records and UI actions are expected
to land in follow-up PRs."* ——这个 PR 就是那个 follow-up。

### 实现方式

**数据模型** (`crates/execpolicy`)：

- 新增 `PermissionAction` 枚举：`Deny`、`Ask`（默认）、`Allow`。
  派生 `PartialOrd` — `Deny > Ask > Allow`。
- `ToolAskRule` 增加可选的 `action` 字段（默认 `Ask`）。
  `#[serde(deny_unknown_fields)]` 保留 — 拼写错误仍然被拒绝。
- `ExecPolicyDecision` 增加 `matched_action` 字段，让调用者能区分
  前缀匹配和 ask-rule 匹配。
- `check()` 方法：当 ask_rule 匹配到 deny/allow action 时，**立即返回**，
  不经过 mode-based 解析。Deny → `Forbidden`，Allow → `Skip`。

**规则集组装** (`crates/config`)：

`PermissionsToml::ruleset()` 按 action 分离规则：
- `Deny` 规则（有 `command` 字段）→ 提升到 `denied_prefixes`
  （走 execpolicy 的 deny-always-wins 优先检查）。
- `Allow` 规则（有 `command` 字段）→ 提升到 `trusted_prefixes`
  （走 arity-aware 前缀匹配）。
- 所有规则都保留在 `ask_rules` 中，确保 path-only / tool-only
  规则也能被评估。

**引擎集成** (`crates/tui`)：

零改动。现有的 `tool_ask_rule_decision_for_context()` 已经通过
`!decision.allow → Block` 和 `decision.requires_approval → Prompt`
映射了新语义。新的 action 字段自动通过这两个布尔值传递。

### 用法

见上方英文部分的 TOML 示例，不再重复。

### 测试覆盖（27 个新测试）

| 区域 | 测试数 | 关键场景 |
|---|---|---|
| 单词 deny | 3 | 精确匹配、子命令、不相关命令 |
| 多词 deny | 3 | 子命令、兄弟命令隔离、denied_prefixes 路径 |
| 词边界 | 1 | `rm` 阻止 `rm -rf /` 但不阻止 `rmdir` |
| Deny 优先级 | 3 | deny > allow（ask_rules）、deny > allow（prefixes）、tool-only deny |
| Allow | 4 | 单词/多词、无视 mode（Never 也放行）、不泄漏到不匹配命令 |
| Ask 向后兼容 | 3 | 原有行为、默认 action、构造器默认值 |
| 绕过防御 | 2 | 多余空格、大小写 |
| 跨工具隔离 | 1 | exec_shell deny 不影响 write_file |
| Ruleset 组装 | 4 | 前缀提升、tool-only 保留、空规则、混合规则 |
| TOML 反序列化 | 1 | action = deny/allow/ask 正确解析 |

原有 43 个 execpolicy + 278 个 config 测试全部继续通过。

### 故意没做的（留给后续 PR）

- **`/config ask-rules` 面板** — 还没显示 `action` 列。
- **审批卡 `S` 保存** — 仍然只保存 ask 规则，不能从 UI 保存 deny/allow。
- **通配符匹配** — `command = "sed *"` 不支持。word-boundary 前缀匹配
  （`command = "sed"` 阻止 `sed -i …`）已覆盖 Claude Code `Bash(sed *)` 场景。
- **MCP 工具权限规则** — `tool = "mcp__*"` 规则不会被评估。

---

## 不确定性

### 1. Plan 模式安全依赖 gate 顺序（非结构保证）

Plan 模式在 `turn_loop.rs:1427-1442` 的 **Gate 1** 处阻止 `exec_shell`，
在 execpolicy ask-rule 检查（**Gate 9**，`turn_loop.rs:1587`）之前。
如果将来有人重构 turn_loop，把 Plan 模式检查移到 ask-rule 检查**之后**，
一个 `action = "allow"` 规则可能让 shell 命令在 Plan 模式下通过。

**缓解**：添加一个集成测试，在 Plan 模式下构建完整的 `EngineConfig`，
配置 allow 规则，断言工具仍然被阻止。该测试应放在 `turn_loop.rs` 测试中。

### 2. 文件工具 deny 带 `command` 字段时静默无效

`file_tool_ask_rule_decision()` 调用 `tool_ask_rule_decision_for_context()`
时传入 `command = ""`。如果用户写：

```toml
[[rules]]
tool = "write_file"
command = "cargo"
action = "deny"
```

…该规则**永远不会匹配**。规则会出现在 ruleset 中（`/config ask-rules`
能看到），但没有实际效果。

**缓解**：要么文档化此限制，要么在非 shell 工具规则包含 `command` 字段时
添加 config 验证警告。

### 3. MCP 工具未覆盖

Gate 7（`turn_loop.rs:1542-1546`）在 ask-rule gate 之前独立处理 MCP 工具。
`tool = "mcp__github__create_issue"` 这样的权限规则不会被评估。

**缓解**：明确文档化。完整的 MCP 权限支持需要修改 MCP gate 路径。

### 4. `allow` 在 `Never` 模式下可能让运维人员意外

`action = "allow"` 会绕过 `AskForApproval::Never` ——见测试
`allow_under_never_mode_still_allows`。这是设计如此（运维人员明确配置了规则），
但设置了 `approval_policy = "never"` 并期望"未经我同意不得运行任何工具"的
运维人员可能会惊讶地发现，用户编写的 `permissions.toml` 可以绕过。

**缓解**：这匹配 Claude Code 的语义（`settings.local.json` 中的 `allow`
也会覆盖 mode）。需要文档化。

### 5. 基于路径的 deny 与 allow 的优先级冲突

如果存在同一工具的 path-based `action = "allow"` 规则和 command-based
`action = "deny"` 规则，deny 会赢（denied_prefixes 检查在 ask_rules 评估
之前触发）。但两个都是 path-based（或两个都没有 command）时，胜负取决于
`matching_ask_rule()` 的优先级（layer then specificity）。
两个同层、同 specificity 的规则是非确定性的——当前排序使用 `max_by_key`，
选择最后一个相等元素。

**缓解**：测试此边界情况，或文档化同优先级冲突为未定义行为。

### 6. `command` 字段有前后空格时怎么办？

`normalize_command()` 折叠内部空格但**不 trim 前后空格**。如果用户
在 permissions.toml 中写 `command = " sed "`，标准化后是 `" sed "`，
不会匹配 `"sed"`。Serde 的 TOML 解析器会 trim 字符串值，所以实践中
不太可能发生，但值得注意。

### 7. 缺少 TOML → turn_loop 的完整集成测试

所有测试都在 execpolicy/config 层面。没有测试：
1. 写入磁盘上的 `permissions.toml`
2. 通过 `ConfigStore` 加载
3. 构建 `EngineConfig`
4. 运行 `exec_shell_ask_rule_decision()` 或模拟 turn-loop 工具分发

**缓解**：各层已有充分测试（67 + 283 个）。端到端测试会增加信心，
但不是此 PR 的阻塞项——可放在后续 PR。

---

### Changelog suggestion

```
- **permissions.toml `action` field (#XXXX).** `[[rules]]` entries now
  accept `action = "deny" | "allow" | "ask"` (default: `"ask"`, backward
  compatible).  Deny-always-wins priority.  Command-based deny/allow rules
  are promoted to the execution-policy engine's prefix lists for arity-aware
  matching.  Thanks @greyfreedom for the ask-only foundation (#3295).
```
