### PR TITLE
fix(telegram): retry transient send failures

### DIFF
--- a/integrations/telegram-bridge/src/index.mjs
+++ b/integrations/telegram-bridge/src/index.mjs
@@ -21,7 +21,8 @@ import {
   stripGroupPrefix,
   threadListKeyboard,
   telegramIdentity,
-  telegramRetryDelayMs
+  telegramRetryDelayMs,
+  telegramSendRetryDelayMs
 } from "./lib.mjs";
 import { ThreadStore as CoreThreadStore } from "../../bridge-core/src/lib.mjs";
 
@@ -463,7 +464,7 @@ async function runPrompt(chatId, prompt, options = {}) {
     lastSeq: sinceSeq,
     updatedAt: new Date().toISOString()
   });
-  await sendText(chatId, `Started turn ${turnId || "(unknown)"}`, {
+  await sendTurnText(chatId, `Started turn ${turnId || "(unknown)"}`, {
     replyMarkup: activeTurnKeyboard()
   });
 
@@ -498,7 +499,7 @@ async function reattachActiveTurns() {
       activeTurnId: turnId,
       updatedAt: new Date().toISOString()
     });
-    await sendText(
+    await sendTurnText(
       chatId,
       `Bridge restarted. Reattaching to active turn ${turnId} from seq ${sinceSeq}.`
     );
@@ -548,7 +549,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
         responseText += record.payload.delta || "";
         const now = Date.now();
         if (responseText.length > config.maxReplyChars && now - sentProgressAt > 15000) {
-          await sendText(chatId, responseText.slice(0, config.maxReplyChars));
+          await sendTurnText(chatId, responseText.slice(0, config.maxReplyChars));
           responseText = responseText.slice(config.maxReplyChars);
           sentProgressAt = now;
         }
@@ -558,7 +559,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
         const approval = record.payload || {};
         const approvalId = approval.approval_id || approval.id;
         if (!approvalId) {
-          await sendText(
+          await sendTurnText(
             chatId,
             [
               "Approval required",
@@ -577,7 +578,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
           kind: "approval",
           approvalId
         });
-        await sendText(
+        await sendTurnText(
           chatId,
           [
             "Approval required",
@@ -599,11 +600,11 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
         const status = turn.status || "completed";
         const error = turn.error ? `\n${turn.error}` : "";
         if (status !== "completed") {
-          await sendText(chatId, `Turn ${status}.${error}`.trim(), {
+          await sendTurnText(chatId, `Turn ${status}.${error}`.trim(), {
             replyMarkup: controlKeyboard()
           });
         } else {
-          await sendText(chatId, responseText.trim() || "Turn completed.", {
+          await sendTurnText(chatId, responseText.trim() || "Turn completed.", {
             replyMarkup: controlKeyboard()
           });
         }
@@ -613,7 +614,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
       if (record.event === "turn.lifecycle") {
         const status = record.payload?.turn?.status || record.payload?.status;
         if (["failed", "canceled", "interrupted"].includes(status)) {
-          await sendText(chatId, `Turn ${status}.`, { replyMarkup: controlKeyboard() });
+          await sendTurnText(chatId, `Turn ${status}.`, { replyMarkup: controlKeyboard() });
           return;
         }
       }
@@ -621,9 +622,9 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
   } catch (error) {
     if (error.name === "AbortError") {
       if (timedOut) {
-        await sendText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
+        await sendTurnText(chatId, `Turn timed out after ${Math.round(config.turnTimeoutMs / 1000)}s.`);
       } else if (!stopping) {
-        await sendText(chatId, "Turn stream aborted.");
+        await sendTurnText(chatId, "Turn stream aborted.");
       }
       return;
     }
@@ -789,6 +790,14 @@ async function sendText(chatId, text, options = {}) {
   }
 }
 
+async function sendTurnText(chatId, text, options = {}) {
+  try {
+    await sendText(chatId, text, options);
+  } catch (error) {
+    console.error("failed to send Telegram turn update", error);
+  }
+}
+
 async function answerCallback(callbackQueryId, text = "") {
   await telegramApi("answerCallbackQuery", {
     callback_query_id: callbackQueryId,
@@ -806,6 +815,21 @@ async function editMessageReplyMarkup(chatId, messageId, replyMarkup) {
 }
 
 async function telegramApi(method, body = {}) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await telegramApiOnce(method, body);
+    } catch (error) {
+      const retryMs = method === "sendMessage" ? telegramSendRetryDelayMs(error, attempt) : null;
+      if (retryMs == null) throw error;
+      console.warn(
+        `Telegram ${method} failed: ${error.message}. Retrying in ${Math.round(retryMs / 1000)}s.`
+      );
+      await delay(retryMs);
+    }
+  }
+}
+
+async function telegramApiOnce(method, body = {}) {
   const response = await fetch(`${config.apiBase}/bot${config.botToken}/${method}`, {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/integrations/telegram-bridge/src/lib.mjs
+++ b/integrations/telegram-bridge/src/lib.mjs
@@ -179,6 +179,39 @@ export function telegramRetryDelayMs(error, fallbackMs = 3000) {
   return fallbackMs;
 }
 
+export function telegramSendRetryDelayMs(error, attempt = 0) {
+  const retryAfter = Number(error?.parameters?.retry_after || 0);
+  if (error?.errorCode === 429 && attempt < 3) {
+    if (Number.isFinite(retryAfter) && retryAfter > 0) {
+      return Math.min(retryAfter * 1000, 60000);
+    }
+    return 3000;
+  }
+  if (isTransientTelegramSendError(error) && attempt < 2) {
+    return attempt === 0 ? 1000 : 2000;
+  }
+  return null;
+}
+
+function isTransientTelegramSendError(error) {
+  if (!error || error.errorCode) return false;
+  const name = String(error.name || "");
+  if (name === "AbortError" || name === "TimeoutError") return false;
+  if (error instanceof TypeError) return true;
+
+  const code = String(error.code || error.cause?.code || "");
+  if (["ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "ETIMEDOUT"].includes(code)) {
+    return true;
+  }
+
+  const message = String(error.message || "").toLowerCase();
+  return (
+    message.includes("fetch failed") ||
+    message.includes("network") ||
+    message.includes("socket hang up")
+  );
+}
+
 export function looksLikePollingConflict(error) {
   const text = String(error?.description || error?.message || "").toLowerCase();
   return error?.errorCode === 409 || text.includes("terminated by other getupdates request");

--- a/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
+++ b/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
@@ -72,3 +72,15 @@ test("reattached streams are detached and shutdown preserves active turn state",
   const trackedStream = extractFunction(source, "startTrackedTurnStream");
   assert.match(trackedStream, /if \(!stopping\) {\s*await clearActiveTurn\(chatId\);\s*}/);
 });
+
+test("turn update sends retry without ending the stream", async () => {
+  const source = await readBridgeSource();
+  const streamTurnEvents = extractFunction(source, "streamTurnEvents");
+  const sendTurnText = extractFunction(source, "sendTurnText");
+  const telegramApi = extractFunction(source, "telegramApi");
+
+  assert.doesNotMatch(streamTurnEvents, /await\s+sendText\(/);
+  assert.match(streamTurnEvents, /await\s+sendTurnText\(/);
+  assert.match(sendTurnText, /catch \(error\) {\s*console\.error\("failed to send Telegram turn update"/);
+  assert.match(telegramApi, /method === "sendMessage" \? telegramSendRetryDelayMs\(error, attempt\) : null/);
+});

--- a/integrations/telegram-bridge/test/lib.test.mjs
+++ b/integrations/telegram-bridge/test/lib.test.mjs
@@ -23,6 +23,7 @@ import {
   threadListKeyboard,
   telegramIdentity,
   telegramRetryDelayMs,
+  telegramSendRetryDelayMs,
   looksLikePollingConflict,
   validateBridgeConfig
 } from "../src/lib.mjs";
@@ -247,6 +248,22 @@ test("splitMessage chunks long text without splitting surrogate pairs", () => {
 
 test("telegramRetryDelayMs honors retry_after", () => {
   assert.equal(telegramRetryDelayMs({ parameters: { retry_after: 2 } }), 2000);
+});
+
+test("telegramSendRetryDelayMs retries only safe send failures", () => {
+  assert.equal(
+    telegramSendRetryDelayMs({ errorCode: 429, parameters: { retry_after: 3 } }, 0),
+    3000
+  );
+  assert.equal(
+    telegramSendRetryDelayMs({ errorCode: 429, parameters: { retry_after: 3 } }, 3),
+    null
+  );
+  assert.equal(telegramSendRetryDelayMs(new TypeError("fetch failed"), 0), 1000);
+  assert.equal(telegramSendRetryDelayMs(new TypeError("fetch failed"), 1), 2000);
+  assert.equal(telegramSendRetryDelayMs(new TypeError("fetch failed"), 2), null);
+  assert.equal(telegramSendRetryDelayMs({ name: "AbortError" }, 0), null);
+  assert.equal(telegramSendRetryDelayMs({ errorCode: 500 }, 0), null);
 });
 
 test("looksLikePollingConflict detects Telegram 409 conflicts", () => {


### PR DESCRIPTION
Refs #2967

Problem:
- Telegram sendMessage calls throw immediately on 429 or transient network failures.
- A failed turn update can stop the bridge stream even though the runtime turn is still active.

Change:
- Add bounded retry delays for sendMessage on 429 retry_after and short transient network failures.
- Keep non-send Telegram methods unchanged.
- Log turn update send failures after retries instead of ending the stream.

Verification:
- node --test test/*.test.mjs (integrations/telegram-bridge)
- npm run check (integrations/telegram-bridge)
- git diff --check