### PR TITLE
ci(dco): add checkout repository for fork PR support

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,56 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dco:
+    name: Check Signed-off-by
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Report missing Signed-off-by (dry-run advisory)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_rev=$(git merge-base origin/${{ github.base_ref }} HEAD 2>/dev/null || echo "HEAD~1")
+          echo "✅ merge-base: $base_rev"
+          echo ""
+
+          bad=()
+          while IFS= read -r commit; do
+            msg=$(git log --format=%B -n1 "$commit")
+            if ! echo "$msg" | grep -qi "^Signed-off-by:"; then
+              bad+=("$commit")
+            fi
+          done < <(git rev-list "${base_rev}..HEAD")
+
+          if [ ${#bad[@]} -eq 0 ]; then
+            echo "✅ All commits have Signed-off-by."
+            exit 0
+          fi
+
+          echo "⚠️  Advisory — the following commit(s) are missing Signed-off-by:"
+          for c in "${bad[@]}"; do
+            echo "    • $c $(git log --format=%s -n1 "$c")"
+          done
+          echo ""
+          echo "This check is advisory and does not block merging."
+          echo "Please amend commits with:"
+          echo "  git commit --amend -s"
+          echo "See CONTRIBUTING.md for details."
+          echo ""
+          echo "::warning title=DCO: missing Signed-off-by::Some commits are missing Signed-off-by — amend with git commit --amend -s"
+
+          # Dry-run: always pass, but surface the warning
+          exit 0


### PR DESCRIPTION
- Add repository: ${{ github.event.pull_request.head.repo.full_name }} so actions/checkout works for both same-repo and fork PRs

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
