### PR TITLE
fix(telegram): persist handled update offsets

### DIFF
--- a/integrations/bridge-core/src/lib.mjs
+++ b/integrations/bridge-core/src/lib.mjs
@@ -3,6 +3,14 @@ import path from "node:path";
 
 const DEFAULT_ACTION_TTL_MS = 24 * 60 * 60 * 1000;
 
+function normalizeCursorValue(value, fallback = 0) {
+  const number = Number(value);
+  if (Number.isFinite(number) && number >= 0) return Math.floor(number);
+  const fallbackNumber = Number(fallback);
+  if (Number.isFinite(fallbackNumber) && fallbackNumber >= 0) return Math.floor(fallbackNumber);
+  return 0;
+}
+
 async function chmodBestEffort(filePath, mode) {
   try {
     await chmod(filePath, mode);
@@ -40,6 +48,9 @@ export class ThreadStore {
     if (this.options.actions && (!this.data.actions || typeof this.data.actions !== "object")) {
       this.data.actions = {};
     }
+    if (this.data.cursors && typeof this.data.cursors !== "object") {
+      this.data.cursors = {};
+    }
   }
 
   async load() {
@@ -60,6 +71,25 @@ export class ThreadStore {
     this.data.messages = this.data.messages.slice(-this.options.messageLimit);
     await this.save();
     return false;
+  }
+
+  getCursor(name, fallback = 0) {
+    if (!name) return normalizeCursorValue(fallback);
+    this.ensureShape();
+    return normalizeCursorValue(this.data.cursors?.[name], fallback);
+  }
+
+  async setCursor(name, value) {
+    if (!name) return normalizeCursorValue(value);
+    this.ensureShape();
+    if (!this.data.cursors || typeof this.data.cursors !== "object") {
+      this.data.cursors = {};
+    }
+    const cursor = normalizeCursorValue(value);
+    if (this.data.cursors[name] === cursor) return cursor;
+    this.data.cursors[name] = cursor;
+    await this.save();
+    return cursor;
   }
 
   async getChat(chatId) {

--- a/integrations/bridge-core/test/lib.test.mjs
+++ b/integrations/bridge-core/test/lib.test.mjs
@@ -130,3 +130,20 @@ test("ThreadStore supports chat state, message dedupe, and action tokens", async
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("ThreadStore persists numeric cursors", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "codewhale-bridge-core-"));
+  try {
+    const statePath = path.join(dir, "thread-map.json");
+    const store = await ThreadStore.open(statePath);
+
+    assert.equal(store.getCursor("telegram.update_offset", 7), 7);
+    assert.equal(await store.setCursor("telegram.update_offset", 42), 42);
+    assert.equal(store.getCursor("telegram.update_offset"), 42);
+
+    const saved = await ThreadStore.open(statePath);
+    assert.equal(saved.getCursor("telegram.update_offset"), 42);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/integrations/telegram-bridge/src/index.mjs
+++ b/integrations/telegram-bridge/src/index.mjs
@@ -67,7 +67,10 @@ const config = {
 const threadStore = await ThreadStore.open(config.threadMapPath);
 const activeTurnTasks = new Map();
 let stopping = false;
-let updateOffset = Number(process.env.TELEGRAM_UPDATE_OFFSET || 0);
+let updateOffset = threadStore.getCursor(
+  "telegram.update_offset",
+  Number(process.env.TELEGRAM_UPDATE_OFFSET || 0)
+);
 
 function requestStop() {
   stopping = true;
@@ -115,10 +118,13 @@ async function pollTelegram() {
         allowed_updates: ["message", "callback_query"]
       });
       for (const update of updates || []) {
-        if (update.update_id != null) updateOffset = Math.max(updateOffset, update.update_id + 1);
-        await handleIncomingUpdate(update).catch((error) => {
+        try {
+          await handleIncomingUpdate(update);
+          await markUpdateHandled(update);
+        } catch (error) {
           console.error("failed to handle incoming Telegram update", error);
-        });
+          break;
+        }
       }
     } catch (error) {
       if (looksLikePollingConflict(error)) {
@@ -133,8 +139,18 @@ async function pollTelegram() {
   }
 }
 
+async function markUpdateHandled(update) {
+  if (update.update_id == null) return;
+  if (!Number.isFinite(Number(update.update_id))) return;
+  const nextOffset = Math.max(updateOffset, Number(update.update_id) + 1);
+  if (nextOffset === updateOffset) return;
+  updateOffset = nextOffset;
+  await threadStore.setCursor("telegram.update_offset", updateOffset);
+}
+
 async function handleIncomingUpdate(update) {
   if (update.callback_query) {
+    if (await isReplayCallbackUpdate(update)) return;
     await handleCallbackQuery(update.callback_query);
     return;
   }
@@ -173,6 +189,11 @@ async function handleIncomingUpdate(update) {
 
   const command = parseCommand(scoped.text);
   await handleCommand(identity.chatId, command);
+}
+
+async function isReplayCallbackUpdate(update) {
+  if (update.update_id == null) return false;
+  return threadStore.recordMessage(`callback:${update.update_id}`);
 }
 
 async function handleCommand(chatId, command) {
@@ -296,6 +317,7 @@ async function handleStoredAction(chatId, action, query = null) {
   }
 
   if (stored.kind === "resume") {
+    await threadStore.takeAction(action.token);
     await resumeThread(chatId, stored.threadId);
     return;
   }

--- a/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
+++ b/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
@@ -59,6 +59,46 @@ test("stale callback acknowledgements cannot skip modal actions", async () => {
   assert.match(callbackHandler, /await handleModalAction\(identity\.chatId, action, query\);/);
 });
 
+test("polling persists offsets only after successful update handling", async () => {
+  const source = await readBridgeSource();
+  const startup = source.slice(
+    source.indexOf("const threadStore = await ThreadStore.open"),
+    source.indexOf("function requestStop")
+  );
+  const pollTelegram = extractFunction(source, "pollTelegram");
+  const markUpdateHandled = extractFunction(source, "markUpdateHandled");
+
+  assert.match(
+    startup,
+    /let updateOffset = threadStore\.getCursor\(\s*"telegram\.update_offset",\s*Number\(process\.env\.TELEGRAM_UPDATE_OFFSET \|\| 0\)\s*\);/
+  );
+  assert.doesNotMatch(pollTelegram, /updateOffset = Math\.max\(updateOffset, update\.update_id \+ 1\)/);
+  assert.match(pollTelegram, /await handleIncomingUpdate\(update\);\s*await markUpdateHandled\(update\);/);
+  assert.match(
+    pollTelegram,
+    /catch \(error\) {\s*console\.error\("failed to handle incoming Telegram update", error\);\s*break;\s*}/
+  );
+  assert.match(markUpdateHandled, /const nextOffset = Math\.max\(updateOffset, Number\(update\.update_id\) \+ 1\);/);
+  assert.match(markUpdateHandled, /await threadStore\.setCursor\("telegram\.update_offset", updateOffset\);/);
+});
+
+test("callback replay is ignored before modal dispatch", async () => {
+  const source = await readBridgeSource();
+  const incomingHandler = extractFunction(source, "handleIncomingUpdate");
+  const replayHelper = extractFunction(source, "isReplayCallbackUpdate");
+  const storedAction = extractFunction(source, "handleStoredAction");
+  const resumeCase = storedAction.slice(storedAction.indexOf('if (stored.kind === "resume")'));
+
+  assert.match(incomingHandler, /if \(await isReplayCallbackUpdate\(update\)\) return;\s*await handleCallbackQuery\(update\.callback_query\);/);
+  assert.match(replayHelper, /if \(update\.update_id == null\) return false;/);
+  assert.match(replayHelper, /return threadStore\.recordMessage\(`callback:\$\{update\.update_id\}`\);/);
+  assert.ok(
+    resumeCase.indexOf("await threadStore.takeAction(action.token);") <
+      resumeCase.indexOf("await resumeThread(chatId, stored.threadId);"),
+    "resume callback actions should be consumed before dispatch"
+  );
+});
+
 test("reattached streams are detached and shutdown preserves active turn state", async () => {
   const source = await readBridgeSource();
   const reattach = extractFunction(source, "reattachActiveTurns");


### PR DESCRIPTION
## Summary
- persist the Telegram getUpdates offset in bridge state and restore it on startup
- advance the offset only after an update is handled successfully
- ignore replayed callback updates by update_id and consume resume action tokens before dispatch

Part of #2967.

## Verification
- npm test (integrations/bridge-core)
- npm run check (integrations/bridge-core)
- npm test (integrations/telegram-bridge)
- npm run check (integrations/telegram-bridge)
- git diff --check upstream/main...HEAD