### PR TITLE
fix(tui): keep failed tool output expanded

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -283,7 +283,7 @@ impl HistoryCell {
                 folded ^ !options.verbose,
                 options.low_motion,
             ),
-            HistoryCell::Tool(cell) if !options.show_tool_details => {
+            HistoryCell::Tool(cell) if !options.show_tool_details && !cell.is_failed() => {
                 let mut lines = cell.lines_with_motion(width, options.low_motion);
                 if lines.len() > 2 {
                     lines.truncate(2);
@@ -294,7 +294,7 @@ impl HistoryCell {
                 }
                 lines
             }
-            HistoryCell::Tool(cell) if options.calm_mode => {
+            HistoryCell::Tool(cell) if options.calm_mode && !cell.is_failed() => {
                 let mut lines = cell.lines_with_motion(width, options.low_motion);
                 if lines.len() > TOOL_CARD_SUMMARY_LINES {
                     lines.truncate(TOOL_CARD_SUMMARY_LINES);

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -2016,6 +2016,70 @@ fn generic_tool_failed_output_live_renders_card_rail() {
 }
 
 #[test]
+fn hidden_tool_details_keeps_failed_generic_output_expanded() {
+    let output = (0..30usize)
+        .map(|i| format!("row {i:02}: payload"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let cell = HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+        name: "read_file".to_string(),
+        status: ToolStatus::Failed,
+        input_summary: Some("command: noisy".to_string()),
+        output: Some(output),
+        prompts: None,
+        spillover_path: None,
+        output_summary: None,
+        is_diff: false,
+    }));
+
+    let live_text = lines_text(&cell.lines_with_options(
+        80,
+        TranscriptRenderOptions {
+            show_tool_details: false,
+            ..TranscriptRenderOptions::default()
+        },
+    ));
+
+    assert!(
+        !live_text.contains("lines omitted") && !live_text.contains("details"),
+        "failed output must not be hidden behind a details affordance: {live_text}"
+    );
+    assert!(live_text.contains("row 29"), "{live_text}");
+}
+
+#[test]
+fn calm_mode_keeps_failed_generic_output_expanded() {
+    let output = (0..30usize)
+        .map(|i| format!("row {i:02}: payload"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let cell = HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+        name: "read_file".to_string(),
+        status: ToolStatus::Failed,
+        input_summary: Some("command: noisy".to_string()),
+        output: Some(output),
+        prompts: None,
+        spillover_path: None,
+        output_summary: None,
+        is_diff: false,
+    }));
+
+    let live_text = lines_text(&cell.lines_with_options(
+        80,
+        TranscriptRenderOptions {
+            calm_mode: true,
+            ..TranscriptRenderOptions::default()
+        },
+    ));
+
+    assert!(
+        !live_text.contains("lines omitted") && !live_text.contains("details"),
+        "failed output must not be hidden behind a details affordance: {live_text}"
+    );
+    assert!(live_text.contains("row 29"), "{live_text}");
+}
+
+#[test]
 fn generic_tool_success_live_collapses_output_transcript_keeps_it() {
     let output = (0..24usize)
         .map(|i| format!("row {i:02}: payload"))


### PR DESCRIPTION
## Summary
- Refs #3256. Fix a compact/calm rendering gap where failed tool cards were still truncated by the outer transcript detail filters.
- Skip those outer truncation paths for failed tools while preserving compact collapsing for non-failed tool cards.
- Add regressions for failed generic tool output with hidden details and calm mode.

## Verification
- cargo fmt --all --check
- cargo test -p codewhale-tui --bin codewhale-tui keeps_failed_generic_output_expanded --locked
- cargo test -p codewhale-tui --bin codewhale-tui generic_tool --locked
- cargo test -p codewhale-tui --bin codewhale-tui generic_tool_success_live_collapses_output_transcript_keeps_it --locked
- cargo test -p codewhale-tui --bin codewhale-tui generic_tool_cell_expands_failed_multi_line_output_in_live --locked
- git diff --check upstream/main...HEAD