### PR TITLE
ci(web): preflight Cloudflare deploy environment

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -71,6 +71,8 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Check Cloudflare deploy environment
+        run: npm run check:deploy-env
       - name: Build OpenNext bundle
         run: npm run build && npx opennextjs-cloudflare build
       - name: Deploy

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "check:facts": "node scripts/check-facts.mjs",
     "check:docs": "node scripts/check-docs.mjs",
+    "check:deploy-env": "node scripts/check-cloudflare-deploy-env.mjs",
     "lint": "eslint .",
     "preview": "opennextjs-cloudflare preview",
     "predeploy": "node scripts/check-kv-id.mjs",

--- a/web/scripts/check-cloudflare-deploy-env.mjs
+++ b/web/scripts/check-cloudflare-deploy-env.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * check-cloudflare-deploy-env.mjs - fail fast when the GitHub deploy job is
+ * missing Cloudflare credentials.
+ *
+ * The actual deploy still belongs to Wrangler/OpenNext. This script only makes
+ * the common GitHub Actions failure mode obvious before the expensive build
+ * starts.
+ */
+
+const required = [
+  {
+    name: "CLOUDFLARE_ACCOUNT_ID",
+    source: "repository variable",
+    expected: "Settings > Secrets and variables > Actions > Variables",
+    validate(value) {
+      return /^[a-f0-9]{32}$/i.test(value);
+    },
+    detail: "expected the 32-character Cloudflare account id",
+  },
+  {
+    name: "CLOUDFLARE_API_TOKEN",
+    source: "repository secret",
+    expected: "Settings > Secrets and variables > Actions > Secrets",
+    validate(value) {
+      return value.length >= 20;
+    },
+    detail: "expected a non-empty Cloudflare API token",
+  },
+];
+
+const placeholderPattern = /^(changeme|replace(_with)?|todo|example|dummy|null|undefined)$/i;
+const failures = [];
+
+for (const item of required) {
+  const value = (process.env[item.name] ?? "").trim();
+  if (!value || placeholderPattern.test(value)) {
+    failures.push({
+      item,
+      reason: `${item.name} is not set`,
+    });
+    continue;
+  }
+
+  if (!item.validate(value)) {
+    failures.push({
+      item,
+      reason: `${item.name} is set but does not look valid`,
+    });
+  }
+}
+
+if (failures.length > 0) {
+  console.error("[check-cloudflare-deploy-env] FAIL - Cloudflare deploy configuration is incomplete.");
+  for (const failure of failures) {
+    const { item, reason } = failure;
+    console.error("");
+    console.error(`- ${reason}`);
+    console.error(`  Configure ${item.name} as a GitHub ${item.source}.`);
+    console.error(`  Location: ${item.expected}.`);
+    console.error(`  Hint: ${item.detail}.`);
+  }
+  console.error("");
+  console.error("Wrangler deploy was not started.");
+  process.exit(1);
+}
+
+console.log("[check-cloudflare-deploy-env] OK - Cloudflare deploy environment is present.");


### PR DESCRIPTION
## Summary
- add a website deploy preflight that checks the Cloudflare account variable and API token secret before OpenNext builds
- wire it into the manual Cloudflare deploy workflow before the expensive build/deploy steps
- keep Wrangler/OpenNext as the actual deploy authority; this only makes missing config fail clearly

## Verification
- npm run check:deploy-env (expected failure without env)
- env CLOUDFLARE_ACCOUNT_ID=cf50f793171d7cb3b2ce23368b69cdcb CLOUDFLARE_API_TOKEN=abcdefghijklmnopqrstuvwxyz npm run check:deploy-env
- npm run check:facts
- npm run check:docs
- npm run lint
- git diff --check