### PR TITLE
tui: restore saved session mode on sync

### DIFF
--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -66,6 +66,7 @@ pub fn clear(app: &mut App) -> CommandResult {
             system_prompt: None,
             model: app.model.clone(),
             workspace: app.workspace.clone(),
+            mode: app.mode,
         },
     )
 }

--- a/crates/tui/src/commands/groups/debug/debug.rs
+++ b/crates/tui/src/commands/groups/debug/debug.rs
@@ -2442,6 +2442,7 @@ pub fn patch_undo(app: &mut App) -> CommandResult {
             system_prompt: app.system_prompt.clone(),
             model: app.model.clone(),
             workspace: app.workspace.clone(),
+            mode: app.mode,
         },
     )
 }

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use crate::session_manager::{
     create_saved_session_with_id_and_mode, create_saved_session_with_mode,
 };
-use crate::tui::app::{App, AppAction};
+use crate::tui::app::{App, AppAction, AppMode};
 use crate::tui::history::{HistoryCell, history_cells_from_message};
 use crate::tui::session_picker::SessionPickerView;
 
@@ -129,6 +129,7 @@ pub fn fork(app: &mut App) -> CommandResult {
             system_prompt: app.system_prompt.clone(),
             model: app.model.clone(),
             workspace: app.workspace.clone(),
+            mode: app.mode,
         },
     )
 }
@@ -176,6 +177,7 @@ pub fn new_session(app: &mut App, arg: Option<&str>) -> CommandResult {
             system_prompt: None,
             model: app.model.clone(),
             workspace: app.workspace.clone(),
+            mode: app.mode,
         },
     )
 }
@@ -239,6 +241,9 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     app.set_model_selection(session.metadata.model.clone());
     app.update_model_compaction_budget();
     app.workspace.clone_from(&session.metadata.workspace);
+    if let Some(mode) = session.metadata.mode.as_deref().and_then(AppMode::parse) {
+        app.set_mode(mode);
+    }
     app.session.total_tokens = u32::try_from(session.metadata.total_tokens).unwrap_or(u32::MAX);
     app.session.total_conversation_tokens = app.session.total_tokens;
     // Accumulated token breakdown is per-runtime-session; zero on load.
@@ -277,6 +282,7 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
             system_prompt: app.system_prompt.clone(),
             model: app.model.clone(),
             workspace: app.workspace.clone(),
+            mode: app.mode,
         },
     )
 }
@@ -443,7 +449,7 @@ mod tests {
     use super::*;
     use crate::config::{Config, DEFAULT_TEXT_MODEL};
     use crate::test_support::EnvVarGuard;
-    use crate::tui::app::{App, ReasoningEffort, TuiOptions, TurnCacheRecord};
+    use crate::tui::app::{App, AppMode, ReasoningEffort, TuiOptions, TurnCacheRecord};
     use std::time::Instant;
     use tempfile::TempDir;
 
@@ -747,6 +753,7 @@ mod tests {
             }],
         });
         app1.session.total_tokens = 500;
+        app1.set_mode(AppMode::Plan);
         let save_path = tmpdir.path().join("test.json");
         save(&mut app1, Some(save_path.to_str().unwrap()));
 
@@ -760,8 +767,15 @@ mod tests {
         assert!(msg.contains("messages"));
         assert_eq!(app2.api_messages.len(), 1);
         assert_eq!(app2.session.total_tokens, 500);
+        assert_eq!(app2.mode, AppMode::Plan);
         assert!(app2.current_session_id.is_some());
-        assert!(matches!(result.action, Some(AppAction::SyncSession { .. })));
+        assert!(matches!(
+            result.action,
+            Some(AppAction::SyncSession {
+                mode: AppMode::Plan,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1587,6 +1587,7 @@ impl Engine {
                         system_prompt_override,
                         model,
                         workspace,
+                        mode,
                     } => {
                         if let Some(session_id) = session_id {
                             self.session.id = session_id;
@@ -1606,6 +1607,7 @@ impl Engine {
                         self.session.auto_model = model.trim().eq_ignore_ascii_case("auto");
                         self.session.model = model;
                         self.session.workspace = workspace.clone();
+                        self.current_mode = mode;
                         self.config.model.clone_from(&self.session.model);
                         self.config.workspace = workspace.clone();
                         let ctx =

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3177,6 +3177,47 @@ async fn change_mode_op_updates_current_mode_and_emits_status() {
 }
 
 #[tokio::test]
+async fn sync_session_restores_current_mode() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &Config::default());
+
+    let run = tokio::spawn(engine.run());
+    handle
+        .send(Op::SyncSession {
+            session_id: Some("plan-session".to_string()),
+            messages: Vec::new(),
+            system_prompt: None,
+            system_prompt_override: false,
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmp.path().to_path_buf(),
+            mode: AppMode::Plan,
+        })
+        .await
+        .expect("sync session");
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(tx))),
+        })
+        .await
+        .expect("request snapshot");
+    let snapshot = tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("snapshot response")
+        .expect("snapshot");
+
+    assert_eq!(snapshot.mode, "plan");
+
+    run.abort();
+}
+
+#[tokio::test]
 async fn edit_last_turn_preserves_current_mode() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
@@ -3211,6 +3252,7 @@ async fn edit_last_turn_preserves_current_mode() {
             system_prompt_override: false,
             model: "deepseek-v4-pro".to_string(),
             workspace: tmp.path().to_path_buf(),
+            mode: AppMode::Agent,
         })
         .await
         .expect("sync session");

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -193,6 +193,7 @@ pub enum Op {
         system_prompt_override: bool,
         model: String,
         workspace: PathBuf,
+        mode: AppMode,
     },
 
     /// Run context compaction immediately.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6866,6 +6866,7 @@ async fn run_exec_agent(
                 system_prompt_override: false,
                 model: saved.metadata.model,
                 workspace: saved.metadata.workspace,
+                mode,
             })
             .await?;
         loaded_session_id = Some(saved_id.clone());

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2552,6 +2552,7 @@ impl RuntimeThreadManager {
                     system_prompt_override: thread.system_prompt.is_some(),
                     model: thread.model.clone(),
                     workspace: thread.workspace.clone(),
+                    mode: parse_mode(&thread.mode),
                 })
                 .await
                 .map_err(|e| anyhow!("Failed to sync thread session: {e}"))?;

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -5813,6 +5813,7 @@ pub enum AppAction {
         system_prompt: Option<SystemPrompt>,
         model: String,
         workspace: PathBuf,
+        mode: AppMode,
     },
     OpenConfigEditor(ConfigUiMode),
     OpenConfigView,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -819,6 +819,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
                 system_prompt_override: false,
                 model: app.model.clone(),
                 workspace: app.workspace.clone(),
+                mode: app.mode,
             })
             .await;
     }
@@ -2986,6 +2987,7 @@ async fn run_event_loop(
                         system_prompt_override: false,
                         model: app.model.clone(),
                         workspace: app.workspace.clone(),
+                        mode: app.mode,
                     })
                     .await;
             }
@@ -3593,6 +3595,7 @@ async fn run_event_loop(
                                                 system_prompt_override: false,
                                                 model: app.model.clone(),
                                                 workspace: app.workspace.clone(),
+                                                mode: app.mode,
                                             })
                                             .await;
                                     }
@@ -4659,6 +4662,7 @@ async fn run_event_loop(
                                         system_prompt_override: false,
                                         model: app.model.clone(),
                                         workspace: app.workspace.clone(),
+                                        mode: app.mode,
                                     })
                                     .await;
                             }
@@ -6818,6 +6822,7 @@ async fn switch_provider(
                 system_prompt_override: false,
                 model: app.model.clone(),
                 workspace: app.workspace.clone(),
+                mode: app.mode,
             })
             .await;
     }
@@ -6946,6 +6951,7 @@ async fn apply_provider_fallback_switch(
                 system_prompt_override: false,
                 model: app.model.clone(),
                 workspace: app.workspace.clone(),
+                mode: app.mode,
             })
             .await;
     }
@@ -7066,6 +7072,7 @@ async fn apply_command_result(
                 system_prompt,
                 model,
                 workspace,
+                mode,
             } => {
                 let mut session_id = session_id;
                 let is_full_reset = messages.is_empty() && system_prompt.is_none();
@@ -7082,6 +7089,7 @@ async fn apply_command_result(
                         system_prompt_override: false,
                         model,
                         workspace,
+                        mode,
                     })
                     .await;
                 let _ = engine_handle
@@ -7538,6 +7546,7 @@ async fn apply_command_result(
                                     system_prompt_override: false,
                                     model: app.model.clone(),
                                     workspace: app.workspace.clone(),
+                                    mode: app.mode,
                                 })
                                 .await;
                         }
@@ -7662,6 +7671,7 @@ async fn switch_workspace(
                 system_prompt_override: false,
                 model: app.model.clone(),
                 workspace: workspace.clone(),
+                mode: app.mode,
             })
             .await;
     }
@@ -9039,6 +9049,7 @@ async fn handle_view_events(
                                 system_prompt_override: false,
                                 model: app.model.clone(),
                                 workspace: app.workspace.clone(),
+                                mode: app.mode,
                             })
                             .await;
                         let _ = engine_handle
@@ -9252,6 +9263,7 @@ async fn handle_view_events(
                             system_prompt_override: false,
                             model: app.model.clone(),
                             workspace: app.workspace.clone(),
+                            mode: app.mode,
                         })
                         .await;
                 }
@@ -9765,6 +9777,9 @@ fn apply_loaded_session(app: &mut App, config: &Config, session: &SavedSession) 
     app.set_model_selection(session.metadata.model.clone());
     app.update_model_compaction_budget();
     apply_workspace_runtime_state(app, config, session.metadata.workspace.clone());
+    if let Some(mode) = session.metadata.mode.as_deref().and_then(AppMode::parse) {
+        app.set_mode(mode);
+    }
     app.session.total_tokens = u32::try_from(session.metadata.total_tokens).unwrap_or(u32::MAX);
     app.session.total_conversation_tokens = app.session.total_tokens;
     app.session.session_cost = session.metadata.cost.session_cost_usd;

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -8145,6 +8145,24 @@ fn apply_loaded_session_restores_auto_model_mode() {
 }
 
 #[test]
+fn apply_loaded_session_restores_saved_mode() {
+    let mut app = create_test_app();
+    app.set_mode(crate::tui::app::AppMode::Agent);
+    let mut session = saved_session_with_messages(vec![
+        text_message("user", "draft a plan"),
+        text_message("assistant", "plan response"),
+    ]);
+    session.metadata.mode = Some("plan".to_string());
+
+    let recovered = apply_loaded_session(&mut app, &Config::default(), &session);
+
+    assert!(!recovered);
+    assert_eq!(app.mode, crate::tui::app::AppMode::Plan);
+    assert!(!app.allow_shell);
+    assert!(!app.trust_mode);
+}
+
+#[test]
 fn app_new_restores_saved_model_and_reasoning_effort() {
     let _guard = ConfigPathEnvGuard::new();
     let settings = crate::settings::Settings {


### PR DESCRIPTION
Refs #3568

## Summary
- restore saved session mode metadata when loading sessions
- carry the active AppMode through SyncSession so respawned engines keep UI/session mode in sync
- cover /load, UI session restore, and engine sync paths with regressions

## Verification
- cargo test -p codewhale-tui --bin codewhale-tui apply_loaded_session_restores_saved_mode --locked
- cargo test -p codewhale-tui --bin codewhale-tui sync_session_restores_current_mode --locked
- cargo test -p codewhale-tui --bin codewhale-tui test_load_valid_session_restores_state --locked
- cargo check -p codewhale-tui --locked
- cargo fmt --check
- git diff --check