### PR TITLE
fix(telegram): debounce turn sequence writes

### DIFF
--- a/integrations/telegram-bridge/src/index.mjs
+++ b/integrations/telegram-bridge/src/index.mjs
@@ -28,6 +28,7 @@ import { ThreadStore as CoreThreadStore } from "../../bridge-core/src/lib.mjs";
 
 const TYPING_INTERVAL_MS = 2000;
 const TYPING_TIMEOUT_MS = 1500;
+const LAST_SEQ_FLUSH_INTERVAL_MS = 2000;
 
 class ThreadStore extends CoreThreadStore {
   constructor(filePath) {
@@ -547,9 +548,19 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
   }
   let responseText = "";
   let latestSeq = sinceSeq;
+  let flushedSeq = sinceSeq;
+  let lastSeqFlushAt = 0;
   let sentProgressAt = Date.now();
   let typingPaused = false;
   let typingInFlight = false;
+
+  async function flushLastSeq(force = false) {
+    if (latestSeq <= flushedSeq) return;
+    if (!force && Date.now() - lastSeqFlushAt < LAST_SEQ_FLUSH_INTERVAL_MS) return;
+    await threadStore.patchChat(chatId, { lastSeq: latestSeq });
+    flushedSeq = latestSeq;
+    lastSeqFlushAt = Date.now();
+  }
 
   const tickTyping = async () => {
     if (stopping || typingPaused || typingInFlight) return;
@@ -585,7 +596,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
       if (!event.data) continue;
       const record = JSON.parse(event.data);
       latestSeq = Math.max(latestSeq, Number(record.seq || 0));
-      await threadStore.patchChat(chatId, { lastSeq: latestSeq });
+      await flushLastSeq(false);
 
       if (turnId && record.turn_id && record.turn_id !== turnId) continue;
       const lifecycleStatus =
@@ -690,6 +701,7 @@ async function streamTurnEvents(chatId, threadId, turnId, sinceSeq, options = {}
     clearInterval(typingTimer);
     clearTimeout(timeout);
     options.signal?.removeEventListener("abort", abortFromCaller);
+    await flushLastSeq(true);
   }
 }
 

--- a/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
+++ b/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
@@ -146,3 +146,22 @@ test("turn streams keep Telegram typing visible and pause while waiting for appr
   assert.match(sendTypingAction, /setTimeout\(\(\) => controller\.abort\(\), TYPING_TIMEOUT_MS\)/);
   assert.match(telegramApiOnce, /signal: options\.signal/);
 });
+
+test("turn streams debounce last-seq writes and flush before exit", async () => {
+  const source = await readBridgeSource();
+  const streamTurnEvents = extractFunction(source, "streamTurnEvents");
+  const flushLastSeq = extractFunction(source, "flushLastSeq");
+  const streamWithoutFlushHelper = streamTurnEvents.replace(flushLastSeq, "");
+
+  assert.match(source, /const LAST_SEQ_FLUSH_INTERVAL_MS = 2000;/);
+  assert.doesNotMatch(
+    streamWithoutFlushHelper,
+    /await threadStore\.patchChat\(chatId, \{ lastSeq: latestSeq \}\);/
+  );
+  assert.match(streamTurnEvents, /await flushLastSeq\(false\);/);
+  assert.match(streamTurnEvents, /await flushLastSeq\(true\);/);
+  assert.match(flushLastSeq, /if \(latestSeq <= flushedSeq\) return;/);
+  assert.match(flushLastSeq, /Date\.now\(\) - lastSeqFlushAt < LAST_SEQ_FLUSH_INTERVAL_MS/);
+  assert.match(flushLastSeq, /await threadStore\.patchChat\(chatId, \{ lastSeq: latestSeq \}\);/);
+  assert.match(flushLastSeq, /flushedSeq = latestSeq;/);
+});


### PR DESCRIPTION
Part of #2967.

## Summary
- debounce Telegram turn-stream `lastSeq` writes instead of saving on every SSE event
- force a final `lastSeq` flush when the stream exits so reattach can resume from the latest observed event
- cover the stream state-write behavior in the dispatch concurrency regression test

## Verification
- `npm test`
- `npm run check`
- `git diff --check upstream/main...HEAD`