### PR TITLE
fix(hash): support sha2 0.11 digest hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -1034,7 +1034,7 @@ dependencies = [
  "schemaui",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "shellexpand",
  "shlex",
  "similar",
@@ -1068,7 +1068,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "starlark",
  "thiserror 2.0.18",
 ]
@@ -1150,6 +1150,12 @@ dependencies = [
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -1585,6 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid",
  "crypto-common 0.2.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tempfile = "3.27"
 tokio = { version = "1.50.0", features = ["full"] }
 toml = "1.0.6"
 toml_edit = "0.23.10"
-sha2 = "0.10"
+sha2 = "0.11"
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -751,7 +751,17 @@ fn download_url_once(url: &str, proxy: Option<&Proxy>) -> Result<(reqwest::Statu
 fn sha256_hex(data: &[u8]) -> String {
     use sha2::Digest;
     let hash = sha2::Sha256::digest(data);
-    format!("{hash:x}")
+    hex_bytes(hash)
+}
+
+fn hex_bytes(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -78,7 +78,7 @@ parking_lot = "0.12"
 pdf-extract = "0.10"
 tar = "0.4"
 flate2 = "1.1"
-sha2 = "0.10"
+sha2 = "0.11"
 rust-i18n = "4.1.0"
 
 [dev-dependencies]

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 use tokio::time::timeout as tokio_timeout;
 
 use crate::config::wire_model_for_provider;
@@ -1204,9 +1203,7 @@ fn prompt_layer(
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 /// Persist a SHA-addressed copy of `content` to

--- a/crates/tui/src/fleet/task_spec.rs
+++ b/crates/tui/src/fleet/task_spec.rs
@@ -11,7 +11,6 @@ use codewhale_protocol::fleet::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 
 use super::ledger::FleetLedger;
 
@@ -215,11 +214,10 @@ pub fn write_fleet_artifact_ref(
     }
     std::fs::write(&abs_path, contents)
         .with_context(|| format!("writing fleet artifact {}", abs_path.display()))?;
-    let digest = Sha256::digest(contents);
     Ok(FleetArtifactRef {
         kind,
         path: rel_path,
-        checksum: Some(format!("sha256:{digest:x}")),
+        checksum: Some(format!("sha256:{}", crate::hashing::sha256_hex(contents))),
         mime_type: mime_type.map(str::to_string),
         size_bytes: Some(contents.len() as u64),
     })

--- a/crates/tui/src/hashing.rs
+++ b/crates/tui/src/hashing.rs
@@ -1,0 +1,15 @@
+use sha2::{Digest, Sha256};
+
+pub(crate) fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
+    hex_bytes(Sha256::digest(bytes.as_ref()))
+}
+
+pub(crate) fn hex_bytes(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -46,6 +46,7 @@ mod execpolicy;
 mod features;
 mod fleet;
 mod goal_loop;
+mod hashing;
 mod hooks;
 mod llm_client;
 mod llm_response_cache;

--- a/crates/tui/src/prefix_cache.rs
+++ b/crates/tui/src/prefix_cache.rs
@@ -35,7 +35,6 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::models::{SystemPrompt, Tool};
 
@@ -578,9 +577,7 @@ fn tool_to_api_json(tool: &Tool) -> Option<String> {
 
 /// Compute the SHA-256 hex digest of a byte slice.
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 /// Extract the system prompt text from an optional SystemPrompt,

--- a/crates/tui/src/prompt_zones.rs
+++ b/crates/tui/src/prompt_zones.rs
@@ -22,15 +22,11 @@
 //! for future phases — not yet wired into the request path.
 
 use crate::models::{Message, SystemPrompt, Tool};
-use sha2::{Digest, Sha256};
-
 // ── helpers ────────────────────────────────────────────────────────────
 
 #[allow(dead_code)]
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 #[allow(dead_code)]

--- a/crates/tui/src/rlm/session.rs
+++ b/crates/tui/src/rlm/session.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -451,9 +450,7 @@ pub fn derive_session_name(source_hint: Option<&str>) -> String {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 #[cfg(test)]

--- a/crates/tui/src/skills/install.rs
+++ b/crates/tui/src/skills/install.rs
@@ -315,9 +315,7 @@ pub async fn install_with_registry(
 
     // Compute a checksum before unpacking so [`update`] can detect upstream
     // no-op changes without redoing the extract.
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let checksum = format!("{:x}", hasher.finalize());
+    let checksum = sha256_hex(&bytes);
 
     let staged = stage_tarball(&bytes, skills_dir, max_size)?;
 
@@ -434,9 +432,7 @@ pub async fn update_with_registry(
         DownloadOutcome::Denied(host) => return Ok(UpdateResult::NetworkDenied(host)),
     };
 
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let checksum = format!("{:x}", hasher.finalize());
+    let checksum = sha256_hex(&bytes);
     if checksum == marker.checksum {
         return Ok(UpdateResult::NoChange);
     }
@@ -746,9 +742,7 @@ async fn sync_one_skill(
         }
 
         // Compute SHA-256 of the downloaded bytes.
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let sha256 = format!("{:x}", hasher.finalize());
+        let sha256 = sha256_hex(&bytes);
 
         // Short-circuit: if the hash matches the cached one, we're fresh even
         // without a 304 (some CDNs strip ETags on redirects).
@@ -1487,6 +1481,20 @@ fn source_spec_string(source: &InstallSource) -> String {
         InstallSource::DirectUrl(url) => url.clone(),
         InstallSource::Registry(name) => name.clone(),
     }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex_bytes(Sha256::digest(bytes))
+}
+
+fn hex_bytes(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/tui/src/tool_output_receipts.rs
+++ b/crates/tui/src/tool_output_receipts.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::artifacts::{ArtifactKind, ArtifactRecord, format_artifact_relative_path};
 use crate::models::{ContentBlock, Message};
@@ -336,9 +335,7 @@ fn summarize_text(text: &str, max_chars: usize) -> String {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 fn approx_tokens(chars: usize) -> usize {

--- a/crates/tui/src/tools/handle.rs
+++ b/crates/tui/src/tools/handle.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
 use crate::tools::spec::{
@@ -763,9 +762,7 @@ fn truncate_chars(text: &str, max_chars: usize) -> String {
 
 #[allow(dead_code)] // Used when producer tools register handle payloads.
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 fn json_type(value: &Value) -> &'static str {

--- a/crates/tui/src/tools/review.rs
+++ b/crates/tui/src/tools/review.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 
 use crate::client::DeepSeekClient;
 use crate::dependencies::ExternalTool;
@@ -407,9 +406,7 @@ fn review_receipt_check_status_passes(status: &str) -> bool {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::hashing::sha256_hex(bytes)
 }
 
 pub struct ReviewTool {

--- a/crates/tui/src/tools/tool_result_retrieval.rs
+++ b/crates/tui/src/tools/tool_result_retrieval.rs
@@ -808,12 +808,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let _guard = set_spillover_root(tmp.path().join("tool_outputs"));
         let body = "checking crate ... error[E0425]: cannot find value\n".repeat(80);
-        let sha = {
-            use sha2::{Digest, Sha256};
-            let mut hasher = Sha256::new();
-            hasher.update(body.as_bytes());
-            format!("{:x}", hasher.finalize())
-        };
+        let sha = crate::hashing::sha256_hex(body.as_bytes());
         crate::tools::truncate::write_sha_spillover(&sha, &body).unwrap();
 
         // Form: `sha:<hex>`

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -1788,8 +1788,10 @@ fn hotbar_setup_save_error_leaves_live_config_and_file_unchanged() {
         action: "mode.plan".to_string(),
         label: None,
     }];
-    let mut config = Config::default();
-    config.hotbar = Some(original_bindings.clone());
+    let mut config = Config {
+        hotbar: Some(original_bindings.clone()),
+        ..Default::default()
+    };
     let attempted_bindings = vec![codewhale_config::HotbarBindingToml {
         slot: 1,
         action: "mode.agent".to_string(),

--- a/crates/whaleflow/src/replay.rs
+++ b/crates/whaleflow/src/replay.rs
@@ -435,7 +435,17 @@ pub fn compute_leaf_input_hash(
         reason: error.to_string(),
     })?;
     let digest = Sha256::digest(bytes);
-    Ok(format!("{digest:x}"))
+    Ok(hex_bytes(digest))
+}
+
+fn hex_bytes(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- carries Dependabot's `sha2` 0.11 upgrade from #3672 on top of current `main`
- replaces direct `LowerHex` formatting of SHA-256 digest outputs with explicit byte-to-hex helpers
- keeps existing SHA-256 strings stable across CLI, TUI, skills, Fleet, RLM, tool receipts, and WhaleFlow replay paths
- cleans up one test initializer surfaced by targeted clippy

## Validation
- `cargo fmt`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo check -p codewhale-cli -p codewhale-tui -p codewhale-whaleflow --locked`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo test -p codewhale-cli --locked test_sha256_hex`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo test -p codewhale-whaleflow --locked replay`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo test -p codewhale-tui --bin codewhale-tui --locked sha256`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo test -p codewhale-tui --bin codewhale-tui --locked prompt_zones::tests`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo test -p codewhale-tui --bin codewhale-tui --locked prefix_cache::tests`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo clippy -p codewhale-cli -p codewhale-tui -p codewhale-whaleflow --all-targets --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale/target cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar_setup_save_error_leaves_live_config_and_file_unchanged`

Replacement for red Dependabot PR #3672.