### PR TITLE
ci: retry OHOS dependency graph probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the OHOS dependency drift check against transient Cargo registry EOFs
+  by retrying the dependency graph probe before failing CI.
 - Updated the `/links` provider fallback to the current CodeWhale docs URL and
   added a Baidu Qianfan docs link. Harvested from #3621 by @noaft.
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Hardened the OHOS dependency drift check against transient Cargo registry EOFs
+  by retrying the dependency graph probe before failing CI.
 - Updated the `/links` provider fallback to the current CodeWhale docs URL and
   added a Baidu Qianfan docs link. Harvested from #3621 by @noaft.
 

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -12,15 +12,44 @@ cd "$(dirname "$0")/../.."
 target="${1:-aarch64-unknown-linux-ohos}"
 package="${CODEWHALE_OHOS_DEP_PACKAGE:-codewhale-tui}"
 
-tree="$(
-  cargo tree \
-    --locked \
-    --package "${package}" \
-    --all-features \
-    --target "${target}" \
-    --prefix none \
-    --no-dedupe
-)"
+cargo_tree_with_retry() {
+  local attempt
+  local max_attempts="${CODEWHALE_OHOS_DEP_RETRIES:-3}"
+  local delay_seconds="${CODEWHALE_OHOS_DEP_RETRY_DELAY_SECONDS:-10}"
+  local err_file
+  local output
+  local status
+
+  err_file="$(mktemp)"
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if output="$(
+      cargo tree \
+        --locked \
+        --package "${package}" \
+        --all-features \
+        --target "${target}" \
+        --prefix none \
+        --no-dedupe \
+        2>"${err_file}"
+    )"; then
+      rm -f "${err_file}"
+      printf '%s\n' "${output}"
+      return 0
+    else
+      status=$?
+    fi
+
+    cat "${err_file}" >&2
+    if ((attempt >= max_attempts)); then
+      rm -f "${err_file}"
+      return "${status}"
+    fi
+    echo "cargo tree for OHOS dependency graph failed (attempt ${attempt}/${max_attempts}); retrying in ${delay_seconds}s..." >&2
+    sleep "${delay_seconds}"
+  done
+}
+
+tree="$(cargo_tree_with_retry)"
 
 disallowed="$(
   grep -E '^(nix v0\.(28|29)\.|portable-pty v|starlark v|arboard v|keyring v)' <<<"${tree}" || true

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -20,6 +20,11 @@ cargo_tree_with_retry() {
   local output
   local status
 
+  if ! [[ "${max_attempts}" =~ ^[0-9]+$ ]] || ((max_attempts < 1)); then
+    echo "CODEWHALE_OHOS_DEP_RETRIES must be an integer greater than or equal to 1." >&2
+    return 1
+  fi
+
   err_file="$(mktemp)"
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if output="$(


### PR DESCRIPTION
## Summary
- retry the OHOS `cargo tree` dependency graph probe before failing the release drift check
- preserve the final nonzero `cargo tree` status for real dependency or package errors
- document the CI hardening in the root and TUI changelogs

## Why
The Version drift workflow failed once after the version check passed because Cargo hit a transient registry EOF while resolving `serde` for the OHOS dependency graph. Local rerun of the same script passed, so this keeps the useful drift gate while making it less brittle to one-off registry/network drops.

## Verification
- `bash -n scripts/release/check-ohos-deps.sh`
- `./scripts/release/check-ohos-deps.sh`
- forced retry path with `CODEWHALE_OHOS_DEP_PACKAGE=definitely-not-a-real-package CODEWHALE_OHOS_DEP_RETRIES=2 CODEWHALE_OHOS_DEP_RETRY_DELAY_SECONDS=0 ./scripts/release/check-ohos-deps.sh`
- `./scripts/release/check-versions.sh`
- `git diff --check`
- `cargo fmt --all -- --check`