### PR TITLE
docs(contributing): fix stale file paths in PR exemplars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,13 +332,13 @@ these crates, including the bottom-up build order.
 
 A well-structured PR follows a consistent pattern. Recent exemplars include:
 
-- **#386** — `/init` command: new `crates/tui/src/commands/init.rs` module, project-type detection,
+- **#386** — `/init` command: new `crates/tui/src/commands/groups/project/init.rs` module, project-type detection,
   AGENTS.md generation, command registration in `commands/mod.rs`, localization strings.
 - **#389** — Inline LSP diagnostics: LSP subsystem in `crates/tui/src/lsp/`, engine hooks in
-  `core/engine/lsp_hooks.rs`, config toggle, test coverage.
+  `crates/tui/src/core/engine/lsp_hooks.rs`, config toggle, test coverage.
 - **#387** — Self-update: new `crates/cli/src/update.rs` module, CLI subcommand registration,
   HTTP download + SHA256 verification + atomic binary replacement.
-- **#393** — `/share` session URL: new `crates/tui/src/commands/share.rs`, HTML rendering,
+- **#393** — `/share` session URL: new `crates/tui/src/commands/groups/project/share.rs`, HTML rendering,
   `gh gist create` integration, command registration.
 - **#343/#346** — (v0.8.5) Runtime thread/turn timeline and durable task manager refactors.
 


### PR DESCRIPTION
## Summary

Fixes three stale file paths in the **"Shape of a Typical PR"** exemplars in
`CONTRIBUTING.md`. The grouped commands have since moved under
`commands/groups/project/`, and one path was missing its crate prefix. New
contributors clicking through these examples currently land on non-existent
paths.

| Exemplar | Before | After |
| --- | --- | --- |
| #386 `/init` | `crates/tui/src/commands/init.rs` | `crates/tui/src/commands/groups/project/init.rs` |
| #389 LSP | `core/engine/lsp_hooks.rs` | `crates/tui/src/core/engine/lsp_hooks.rs` |
| #393 `/share` | `crates/tui/src/commands/share.rs` | `crates/tui/src/commands/groups/project/share.rs` |

Each new path was verified against the current tree. The
`crates/tui/src/lsp/` and `crates/cli/src/update.rs` references in the same
block are already correct and were intentionally left unchanged.

## Testing

Docs-only change (no Rust sources touched), so the build/lint/test gate is
not applicable here:

- [ ] `cargo fmt --all -- --check` — n/a (no `.rs` changes)
- [ ] `cargo clippy --workspace --all-targets --all-features` — n/a
- [ ] `cargo test --workspace --all-features` — n/a

Verification performed instead:

- `find . -name init.rs -path '*commands*'` → `crates/tui/src/commands/groups/project/init.rs`
- `find . -name lsp_hooks.rs` → `crates/tui/src/core/engine/lsp_hooks.rs`
- `find . -name share.rs -path '*commands*'` → `crates/tui/src/commands/groups/project/share.rs`

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant — n/a (docs only)
- [ ] Verified TUI behavior manually if UI changes — n/a (docs only)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a
