### PR TITLE
fix(tui): count zero-width chars as 0 columns in display-width math (#3488)

### DIFF
--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -209,7 +209,12 @@ fn char_display_width(ch: char) -> usize {
     if ch == '\t' {
         4
     } else {
-        UnicodeWidthChar::width(ch).unwrap_or(0).max(1)
+        // `width()` returns `None` for control/unassigned chars (default them to
+        // one column so layout doesn't collapse) and `Some(0)` for genuinely
+        // zero-width chars — combining marks, ZWJ, zero-width spaces — which must
+        // stay 0 so display-width math (truncation, slicing, overflow, copy)
+        // matches what the terminal actually renders.
+        UnicodeWidthChar::width(ch).unwrap_or(1)
     }
 }
 
@@ -270,6 +275,61 @@ mod tests {
     fn slice_text_truncates_at_end() {
         let text = "ab";
         assert_eq!(slice_text(text, 1, 5), "b");
+    }
+
+    // --- Unicode / CJK / terminal-width QA (issue #3488) -------------------
+    // These exercise the production width helpers directly so the assertions
+    // track the same code path the renderer uses.
+
+    #[test]
+    fn text_display_width_counts_cjk_as_two_columns() {
+        assert_eq!(text_display_width("中文"), 4); // two wide glyphs
+        assert_eq!(text_display_width("Hello世界"), 9); // 5 ASCII + 2×2
+        // Full-width (ambiguous→wide) punctuation is two columns each.
+        assert_eq!(text_display_width("，。！？"), 8);
+    }
+
+    #[test]
+    fn text_display_width_treats_zero_width_marks_as_zero() {
+        // A combining mark adds no column: "e" + U+0301 renders as one cell.
+        // (Regression guard: the old `.max(1)` counted it as 1, over-reporting
+        // width and causing premature truncation / border drift on text with
+        // combining marks or ZWJ emoji sequences.)
+        assert_eq!(text_display_width("e\u{0301}"), 1);
+        assert_eq!(text_display_width("cafe\u{0301}"), 4);
+        // ZWJ joiner itself is zero-width; the two emoji are 2 cols each.
+        assert_eq!(text_display_width("\u{1F469}\u{200D}\u{1F4BB}"), 4);
+    }
+
+    #[test]
+    fn text_display_width_keeps_control_and_tab_widths() {
+        // Control chars still occupy a column (avoid layout collapse); tab = 4.
+        assert_eq!(text_display_width("a\u{0007}b"), 3);
+        assert_eq!(text_display_width("\t"), 4);
+        assert_eq!(text_display_width("\ta"), 5);
+    }
+
+    #[test]
+    fn truncate_line_to_width_respects_display_width_not_byte_len() {
+        // No truncation when the string already fits by display width.
+        assert_eq!(truncate_line_to_width("中文", 10), "中文");
+        // Oversized: reserve 3 cols for the ellipsis, fill the rest by width.
+        let out = truncate_line_to_width("中文测试", 7);
+        assert_eq!(out, "中文...");
+        assert_eq!(text_display_width(&out), 7);
+        // Never split a wide glyph across the boundary, and never emit U+FFFD.
+        let clipped = truncate_line_to_width("界界界界界", 5);
+        assert!(text_display_width(&clipped) <= 5);
+        assert!(!clipped.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn slice_text_slices_cjk_by_display_column() {
+        // Columns:  中=[0,2) 文=[2,4) a=[4,5) b=[5,6)
+        let text = "中文ab";
+        assert_eq!(slice_text(text, 0, 2), "中");
+        assert_eq!(slice_text(text, 2, 4), "文");
+        assert_eq!(slice_text(text, 4, 6), "ab");
     }
 
     #[test]

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2268,7 +2268,10 @@ fn char_display_width(ch: char) -> usize {
     if ch == '\t' {
         4
     } else {
-        UnicodeWidthChar::width(ch).unwrap_or(0).max(1)
+        // `None` (control/unassigned) defaults to one column; `Some(0)` (combining
+        // marks, ZWJ, zero-width spaces) must stay 0 so width math matches what the
+        // terminal renders. Mirrors `ui_text::char_display_width`.
+        UnicodeWidthChar::width(ch).unwrap_or(1)
     }
 }
 


### PR DESCRIPTION
## Summary

Part of the #3488 Unicode/CJK/terminal-width QA lane. Adds Unicode width QA
coverage on the production rendering helpers, and fixes one real defect those
tests surfaced.

**Bug:** `char_display_width` computed `UnicodeWidthChar::width(ch).unwrap_or(0).max(1)`.
The `.max(1)` forces *zero-width* characters — combining marks, ZWJ, zero-width
spaces, which `unicode-width` reports as `Some(0)` — to count as **1 column**.
So `text_display_width` / `slice_text` over-report the width of any string with
combining marks or ZWJ emoji sequences, which drifts truncation, column slicing
(terminal-native copy), and overflow decisions — exactly the border/wrap
artifacts this issue tracks. The helper is duplicated in two modules
(`ui_text` and `widgets`), so both had the bug.

**Fix:** `unwrap_or(1)`. `None` (control / unassigned) still defaults to one
column so layout doesn't collapse; `Some(0)` stays `0` to match what the
terminal actually renders. Behavior changes *only* for zero-width chars.

**Tests** (added to `ui_text`'s module, exercising the production helpers):
CJK = 2 columns, mixed CN/EN, full-width punctuation, combining marks (= 0),
ZWJ emoji, control chars (still 1), tabs (= 4), display-width-aware truncation
(ellipsis budget, no mid-glyph split, no `U+FFFD`), and CJK column slicing. The
combining-mark test fails before the fix (counts 2, expects 1) and passes after.

## Testing

- [x] `cargo test -p codewhale-tui --bin codewhale-tui` — **5470 passed, 1 failed**.
  The single failure (`runtime_api::tests::resolve_skills_dir_rejects_symlink_escaping_workspace`)
  is a **pre-existing full-suite-parallelism flake**: it passes in isolation
  both on base (`git stash`) and with this change, and is unrelated to text
  width (it's a skills-dir symlink test; macOS `/tmp`,`/var` are symlinks).
- [x] Targeted: `ui_text::tests` 14/14; width/wrap/truncate/clip/cjk/unicode
  filters all green.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p codewhale-tui --bin codewhale-tui` — no new warnings in
  touched files.

## Checklist

- [x] Updated docs or comments as needed (explained the `None` vs `Some(0)` contract at both call sites)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — unit-tested at the helper level; no visual change beyond correct width math
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a (single author)

`Refs #3488` (partial — one fix + width QA tests; the lane covers more surfaces).
