### PR TITLE
ci: run rlm cache workflow tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       heavy: ${{ steps.detect.outputs.heavy }}
+      whaleflow: ${{ steps.detect.outputs.whaleflow }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -42,6 +43,7 @@ jobs:
 
           if [[ "${EVENT_NAME}" == "schedule" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "heavy=true" >> "${GITHUB_OUTPUT}"
+            echo "whaleflow=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -55,11 +57,13 @@ jobs:
 
           if [[ -z "${base}" ]]; then
             echo "heavy=true" >> "${GITHUB_OUTPUT}"
+            echo "whaleflow=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
           mapfile -t changed < <(git diff --name-only "${base}" "${GITHUB_SHA}" | sort)
           heavy=false
+          whaleflow=false
           for path in "${changed[@]}"; do
             case "${path}" in
               docs/*|*.md|.github/PULL_REQUEST_TEMPLATE.md|.github/ISSUE_TEMPLATE/*|.github/workflows/auto-tag.yml|.github/workflows/stale.yml|.github/workflows/triage.yml)
@@ -68,11 +72,18 @@ jobs:
                 heavy=true
                 ;;
             esac
+            case "${path}" in
+              crates/whaleflow/*|workflows/rlm_cache_change.star|.github/workflows/ci.yml)
+                whaleflow=true
+                ;;
+            esac
           done
 
           echo "heavy=${heavy}" >> "${GITHUB_OUTPUT}"
+          echo "whaleflow=${whaleflow}" >> "${GITHUB_OUTPUT}"
 
           echo "Heavy Rust CI required: ${heavy}"
+          echo "WhaleFlow RLM cache CI required: ${whaleflow}"
           printf 'Changed files:\n'
           printf '  %s\n' "${changed[@]}"
 
@@ -151,6 +162,26 @@ jobs:
             --check-authors
       - name: Linux clippy location
         run: echo "Linux clippy/test gates run on CNB for mirrored fix/*, rebrand/*, work/v*, and main branches."
+
+  whaleflow-rlm-cache:
+    name: WhaleFlow RLM cache workflow
+    needs: changes
+    if: needs.changes.outputs.whaleflow == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Enable sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - name: Run RLM cache workflow mock/replay tests
+        run: cargo test -p codewhale-whaleflow --locked rlm_cache_change
 
   test:
     name: Test


### PR DESCRIPTION
## Problem

#2980 asks for CI coverage that runs `workflows/rlm_cache_change.star` against the mock provider so the WhaleFlow authoring, IR, execution, and trace path stays deterministic.

## Change

- Add a `whaleflow` change-detection output to CI.
- Run a focused `WhaleFlow RLM cache workflow` job when WhaleFlow crate files, `workflows/rlm_cache_change.star`, or `ci.yml` change.
- Reuse the existing `rlm_cache_change` mock/replay tests instead of adding a new execution path.

## Verification

- `cargo test -p codewhale-whaleflow --locked rlm_cache_change -- --nocapture`
- `cargo test -p codewhale-whaleflow --locked`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `git diff --check upstream/main...HEAD`
