### PR TITLE
fix(telegram): bound polling conflict retries

### DIFF
--- a/integrations/telegram-bridge/src/index.mjs
+++ b/integrations/telegram-bridge/src/index.mjs
@@ -21,6 +21,7 @@ import {
   stripGroupPrefix,
   threadListKeyboard,
   telegramIdentity,
+  telegramPollingConflictDelayMs,
   telegramRetryDelayMs,
   telegramSendRetryDelayMs
 } from "./lib.mjs";
@@ -111,6 +112,7 @@ async function configureBotCommands() {
 }
 
 async function pollTelegram() {
+  let pollingConflictAttempts = 0;
   while (!stopping) {
     try {
       const updates = await telegramApi("getUpdates", {
@@ -118,6 +120,7 @@ async function pollTelegram() {
         timeout: config.pollTimeoutSeconds,
         allowed_updates: ["message", "callback_query"]
       });
+      pollingConflictAttempts = 0;
       for (const update of updates || []) {
         try {
           await handleIncomingUpdate(update);
@@ -129,10 +132,20 @@ async function pollTelegram() {
       }
     } catch (error) {
       if (looksLikePollingConflict(error)) {
-        console.warn("Telegram getUpdates conflict; another bridge is polling this bot. Retrying in 10s.");
-        await delay(10000);
+        const waitMs = telegramPollingConflictDelayMs(pollingConflictAttempts);
+        pollingConflictAttempts += 1;
+        if (waitMs == null) {
+          throw new Error(
+            "Telegram getUpdates conflict; another bridge is polling this bot token. Stop the other bridge process or use a different token."
+          );
+        }
+        console.warn(
+          `Telegram getUpdates conflict; another bridge is polling this bot. Retrying in ${Math.round(waitMs / 1000)}s.`
+        );
+        await delay(waitMs);
         continue;
       }
+      pollingConflictAttempts = 0;
       const waitMs = telegramRetryDelayMs(error);
       console.error(`Telegram poll failed: ${error.message}. Retrying in ${Math.round(waitMs / 1000)}s.`);
       await delay(waitMs);

--- a/integrations/telegram-bridge/src/lib.mjs
+++ b/integrations/telegram-bridge/src/lib.mjs
@@ -179,6 +179,13 @@ export function telegramRetryDelayMs(error, fallbackMs = 3000) {
   return fallbackMs;
 }
 
+const POLLING_CONFLICT_DELAYS_MS = [15000, 25000, 35000, 45000, 55000];
+
+export function telegramPollingConflictDelayMs(attempt = 0) {
+  const index = Math.max(0, Math.floor(Number(attempt) || 0));
+  return POLLING_CONFLICT_DELAYS_MS[index] ?? null;
+}
+
 export function telegramSendRetryDelayMs(error, attempt = 0) {
   const retryAfter = Number(error?.parameters?.retry_after || 0);
   if (error?.errorCode === 429 && attempt < 3) {

--- a/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
+++ b/integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
@@ -82,6 +82,19 @@ test("polling persists offsets only after successful update handling", async () 
   assert.match(markUpdateHandled, /await threadStore\.setCursor\("telegram\.update_offset", updateOffset\);/);
 });
 
+test("polling conflicts use bounded escalation instead of a flat retry loop", async () => {
+  const source = await readBridgeSource();
+  const pollTelegram = extractFunction(source, "pollTelegram");
+
+  assert.match(source, /telegramPollingConflictDelayMs/);
+  assert.match(pollTelegram, /let pollingConflictAttempts = 0;/);
+  assert.match(pollTelegram, /telegramPollingConflictDelayMs\(pollingConflictAttempts\)/);
+  assert.match(pollTelegram, /pollingConflictAttempts \+= 1;/);
+  assert.match(pollTelegram, /throw new Error\(/);
+  assert.doesNotMatch(pollTelegram, /Retrying in 10s/);
+  assert.doesNotMatch(pollTelegram, /await delay\(10000\)/);
+});
+
 test("callback replay is ignored before modal dispatch", async () => {
   const source = await readBridgeSource();
   const incomingHandler = extractFunction(source, "handleIncomingUpdate");

--- a/integrations/telegram-bridge/test/lib.test.mjs
+++ b/integrations/telegram-bridge/test/lib.test.mjs
@@ -22,6 +22,7 @@ import {
   stripGroupPrefix,
   threadListKeyboard,
   telegramIdentity,
+  telegramPollingConflictDelayMs,
   telegramRetryDelayMs,
   telegramSendRetryDelayMs,
   looksLikePollingConflict,
@@ -248,6 +249,13 @@ test("splitMessage chunks long text without splitting surrogate pairs", () => {
 
 test("telegramRetryDelayMs honors retry_after", () => {
   assert.equal(telegramRetryDelayMs({ parameters: { retry_after: 2 } }), 2000);
+});
+
+test("telegramPollingConflictDelayMs escalates before going fatal", () => {
+  assert.deepEqual(
+    [0, 1, 2, 3, 4, 5].map((attempt) => telegramPollingConflictDelayMs(attempt)),
+    [15000, 25000, 35000, 45000, 55000, null]
+  );
 });
 
 test("telegramSendRetryDelayMs retries only safe send failures", () => {


### PR DESCRIPTION
Summary
- replace the flat 10s Telegram getUpdates conflict retry with a bounded 15/25/35/45/55s ladder
- fail with a clear operator message when another bridge keeps owning the bot token
- add tests for the conflict delay helper and poll loop behavior

Verification
- node --test integrations/telegram-bridge/test/lib.test.mjs integrations/telegram-bridge/test/dispatch-concurrency.test.mjs
- npm test --prefix integrations/telegram-bridge
- npm run check --prefix integrations/telegram-bridge
- git diff --check

Refs #2967