### PR TITLE
feat(skills): locale-aware skill descriptions to save tokens (#3354)

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -1130,11 +1130,13 @@ pub fn system_prompt_for_mode_with_context_skills_session_and_approval(
                 workspace,
                 dir,
                 skill_discovery_mode,
+                session_context.locale_tag,
             )
         }
         None => crate::skills::render_available_skills_context_for_workspace_with_mode(
             workspace,
             skill_discovery_mode,
+            session_context.locale_tag,
         ),
     };
     if let Some(block) = skills_block {

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -3650,12 +3650,14 @@ fn skill_entry_is_bundled_requires_configured_bundle_path() {
     let bundled_skill = crate::skills::Skill {
         name: "delegate".to_string(),
         description: String::new(),
+        localized_descriptions: std::collections::HashMap::new(),
         body: String::new(),
         path: bundled_skill_path,
     };
     let override_skill = crate::skills::Skill {
         name: "delegate".to_string(),
         description: String::new(),
+        localized_descriptions: std::collections::HashMap::new(),
         body: String::new(),
         path: override_skill_path,
     };

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -87,10 +87,15 @@ impl Skill {
     /// Pick the best description for a session `locale_tag`, falling back to the
     /// default `description` when no localized variant matches.
     ///
-    /// Matching is conservative on purpose: an exact (lowercased) tag match
-    /// first, then the primary language subtag (e.g. `zh-cn` → `zh`). We do not
-    /// fold e.g. `zh-hant` into `zh`, since Traditional and Simplified are
-    /// authored separately — an author keys each variant by the tag they mean.
+    /// Order: exact (lowercased) tag match, then the primary language subtag
+    /// (so `en-us` → `en`, `pt-br` → `pt`, `zh-cn` → `zh`), then default.
+    ///
+    /// Chinese is the one place where the primary-subtag fallback would be
+    /// *wrong*: Traditional and Simplified are written differently, so a
+    /// Traditional tag (`zh-hant`, or the Traditional regions `zh-tw` / `zh-hk`
+    /// / `zh-mo`) must NOT borrow a Simplified `description_zh`. Those match only
+    /// an exact `description_zh-hant`-style key, else the default. Simplified
+    /// tags (`zh`, `zh-hans`, `zh-cn`, …) still fold to `description_zh`.
     #[must_use]
     pub fn description_for_locale(&self, locale_tag: &str) -> &str {
         if self.localized_descriptions.is_empty() {
@@ -101,8 +106,17 @@ impl Skill {
             return desc;
         }
         if let Some((primary, _)) = normalized.split_once('-') {
-            if let Some(desc) = self.localized_descriptions.get(primary) {
-                return desc;
+            // Don't let a Traditional-Chinese session fall back to a Simplified
+            // (`zh`) description — different written form, not just a region.
+            let traditional_chinese = primary == "zh"
+                && (normalized.contains("hant")
+                    || normalized.ends_with("-tw")
+                    || normalized.ends_with("-hk")
+                    || normalized.ends_with("-mo"));
+            if !traditional_chinese {
+                if let Some(desc) = self.localized_descriptions.get(primary) {
+                    return desc;
+                }
             }
         }
         &self.description
@@ -1110,10 +1124,39 @@ body";
 
         assert_eq!(skill.description_for_locale("zh"), "中文描述"); // exact
         assert_eq!(skill.description_for_locale("ZH"), "中文描述"); // case-insensitive
-        assert_eq!(skill.description_for_locale("zh-CN"), "中文描述"); // primary subtag
+        assert_eq!(skill.description_for_locale("zh-CN"), "中文描述"); // Simplified region → zh
+        assert_eq!(skill.description_for_locale("zh-Hans"), "中文描述"); // Simplified script → zh
         assert_eq!(skill.description_for_locale("ja"), "日本語の説明");
         assert_eq!(skill.description_for_locale("fr"), "English description"); // fallback
         assert_eq!(skill.description_for_locale("en"), "English description");
+
+        // Traditional Chinese must NOT borrow the Simplified `zh` description:
+        // with no exact zh-hant key authored, it falls back to the default.
+        assert_eq!(
+            skill.description_for_locale("zh-Hant"),
+            "English description"
+        );
+        assert_eq!(skill.description_for_locale("zh-TW"), "English description");
+        assert_eq!(skill.description_for_locale("zh-HK"), "English description");
+    }
+
+    #[test]
+    fn description_for_locale_uses_exact_traditional_key_when_authored() {
+        let mut localized = std::collections::HashMap::new();
+        localized.insert("zh".to_string(), "简体描述".to_string());
+        localized.insert("zh-hant".to_string(), "繁體描述".to_string());
+        let skill = super::Skill {
+            name: "demo".to_string(),
+            description: "English".to_string(),
+            localized_descriptions: localized,
+            body: String::new(),
+            path: std::path::PathBuf::new(),
+        };
+        // Exact Traditional key wins for a Traditional session.
+        assert_eq!(skill.description_for_locale("zh-Hant"), "繁體描述");
+        // Simplified session still gets the Simplified description.
+        assert_eq!(skill.description_for_locale("zh-Hans"), "简体描述");
+        assert_eq!(skill.description_for_locale("zh"), "简体描述");
     }
 
     #[test]

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -68,13 +68,45 @@ impl SkillDiscoveryMode {
 #[derive(Debug, Clone)]
 pub struct Skill {
     pub name: String,
+    /// Default (language-neutral, usually English) description.
     pub description: String,
+    /// Optional locale-specific descriptions, keyed by lowercased locale tag
+    /// (e.g. `zh`, `zh-hant`, `ja`). Populated from `description_<tag>:`
+    /// frontmatter keys so a skill author can ship a shorter, native-language
+    /// description for non-English sessions (saves prompt tokens; see #3354).
+    pub localized_descriptions: HashMap<String, String>,
     pub body: String,
     /// On-disk path to the `SKILL.md` this was loaded from. The directory
     /// name can differ from the frontmatter `name` for community installs
     /// or manually-placed skills, so callers must use this rather than
     /// reconstructing `<dir>/<name>/SKILL.md`.
     pub path: PathBuf,
+}
+
+impl Skill {
+    /// Pick the best description for a session `locale_tag`, falling back to the
+    /// default `description` when no localized variant matches.
+    ///
+    /// Matching is conservative on purpose: an exact (lowercased) tag match
+    /// first, then the primary language subtag (e.g. `zh-cn` → `zh`). We do not
+    /// fold e.g. `zh-hant` into `zh`, since Traditional and Simplified are
+    /// authored separately — an author keys each variant by the tag they mean.
+    #[must_use]
+    pub fn description_for_locale(&self, locale_tag: &str) -> &str {
+        if self.localized_descriptions.is_empty() {
+            return &self.description;
+        }
+        let normalized = locale_tag.trim().to_ascii_lowercase();
+        if let Some(desc) = self.localized_descriptions.get(&normalized) {
+            return desc;
+        }
+        if let Some((primary, _)) = normalized.split_once('-') {
+            if let Some(desc) = self.localized_descriptions.get(primary) {
+                return desc;
+            }
+        }
+        &self.description
+    }
 }
 
 /// Collection of discovered skills.
@@ -396,9 +428,21 @@ impl SkillRegistry {
 
             let description = metadata.get("description").cloned().unwrap_or_default();
 
+            // Collect `description_<tag>:` frontmatter keys (already lowercased
+            // above) into locale-specific descriptions, e.g. `description_zh`.
+            let localized_descriptions = metadata
+                .iter()
+                .filter_map(|(key, value)| {
+                    key.strip_prefix("description_")
+                        .filter(|tag| !tag.is_empty())
+                        .map(|tag| (tag.to_string(), value.clone()))
+                })
+                .collect();
+
             return Ok(Skill {
                 name,
                 description,
+                localized_descriptions,
                 body: body.trim().to_string(),
                 // Filled in by `discover` after parse succeeds; default to an
                 // empty path so direct constructors (e.g. tests) compile.
@@ -421,6 +465,7 @@ impl SkillRegistry {
         Ok(Skill {
             name,
             description: String::new(),
+            localized_descriptions: HashMap::new(),
             body: content.trim().to_string(),
             path: PathBuf::new(),
         })
@@ -686,16 +731,17 @@ pub(crate) fn discover_for_workspace_and_dir_with_home_and_mode(
 #[must_use]
 pub fn render_available_skills_context_for_workspace(workspace: &Path) -> Option<String> {
     let registry = discover_in_workspace(workspace);
-    render_skills_block(&registry)
+    render_skills_block(&registry, "en")
 }
 
 #[must_use]
 pub fn render_available_skills_context_for_workspace_with_mode(
     workspace: &Path,
     mode: SkillDiscoveryMode,
+    locale: &str,
 ) -> Option<String> {
     let registry = discover_in_workspace_with_mode(workspace, mode);
-    render_skills_block(&registry)
+    render_skills_block(&registry, locale)
 }
 
 /// Codex's progressive-disclosure contract: the model sees skill names,
@@ -709,7 +755,7 @@ pub fn render_available_skills_context_for_workspace_with_mode(
 #[must_use]
 fn render_available_skills_context(skills_dir: &Path) -> Option<String> {
     let registry = SkillRegistry::discover(skills_dir);
-    render_skills_block(&registry)
+    render_skills_block(&registry, "en")
 }
 
 /// Union variant: merge skills discovered in the `workspace` (cross-tool skill
@@ -723,6 +769,7 @@ pub fn render_available_skills_context_for_workspace_and_dir(
         workspace,
         skills_dir,
         SkillDiscoveryMode::Compatible,
+        "en",
     )
 }
 
@@ -731,12 +778,13 @@ pub fn render_available_skills_context_for_workspace_and_dir_with_mode(
     workspace: &Path,
     skills_dir: &Path,
     mode: SkillDiscoveryMode,
+    locale: &str,
 ) -> Option<String> {
     let registry = discover_for_workspace_and_dir_with_mode(workspace, skills_dir, mode);
-    render_skills_block(&registry)
+    render_skills_block(&registry, locale)
 }
 
-fn render_skills_block(registry: &SkillRegistry) -> Option<String> {
+fn render_skills_block(registry: &SkillRegistry, locale: &str) -> Option<String> {
     if registry.is_empty() {
         return None;
     }
@@ -757,7 +805,10 @@ instructions when using a specific skill.\n\n",
         // name can differ from the frontmatter `name` for community
         // installs, in which case `<dir>/<name>/SKILL.md` would not exist
         // and the model would fail to open it.
-        let description = truncate_for_prompt(&skill.description, MAX_SKILL_DESCRIPTION_CHARS);
+        let description = truncate_for_prompt(
+            skill.description_for_locale(locale),
+            MAX_SKILL_DESCRIPTION_CHARS,
+        );
         let line = if description.is_empty() {
             format!("- {}: (file: {})\n", skill.name, skill.path.display())
         } else {
@@ -979,6 +1030,7 @@ mod tests {
         registry.skills.push(super::Skill {
             name: "workspace-priority".to_string(),
             description: "must survive truncation".to_string(),
+            localized_descriptions: std::collections::HashMap::new(),
             body: "body".to_string(),
             path: tmpdir
                 .path()
@@ -993,6 +1045,7 @@ mod tests {
             registry.skills.push(super::Skill {
                 name: format!("aaa-global-{i:03}"),
                 description: big_desc.clone(),
+                localized_descriptions: std::collections::HashMap::new(),
                 body: "body".to_string(),
                 path: tmpdir
                     .path()
@@ -1003,7 +1056,7 @@ mod tests {
             });
         }
 
-        let rendered = super::render_skills_block(&registry).expect("skill context");
+        let rendered = super::render_skills_block(&registry, "en").expect("skill context");
         assert!(
             rendered.contains("workspace-priority"),
             "higher-precedence workspace skills must not be reordered behind globals:\n{rendered}"
@@ -1011,6 +1064,94 @@ mod tests {
         assert!(
             rendered.contains("additional skills omitted from this prompt budget"),
             "fixture should exceed prompt budget"
+        );
+    }
+
+    // --- Localized skill descriptions (#3354) ------------------------------
+
+    #[test]
+    fn parse_skill_collects_localized_description_frontmatter() {
+        let content = "---\n\
+name: demo\n\
+description: A demo skill\n\
+description_zh: 一个演示技能\n\
+description_zh-Hant: 一個示範技能\n\
+---\n\
+body";
+        let skill = super::SkillRegistry::parse_skill(std::path::Path::new("SKILL.md"), content)
+            .expect("parse should succeed");
+        assert_eq!(skill.description, "A demo skill");
+        assert_eq!(
+            skill.localized_descriptions.get("zh").map(String::as_str),
+            Some("一个演示技能")
+        );
+        // Frontmatter keys are lowercased, so zh-Hant is stored as zh-hant.
+        assert_eq!(
+            skill
+                .localized_descriptions
+                .get("zh-hant")
+                .map(String::as_str),
+            Some("一個示範技能")
+        );
+    }
+
+    #[test]
+    fn description_for_locale_matches_exact_then_primary_then_falls_back() {
+        let mut localized = std::collections::HashMap::new();
+        localized.insert("zh".to_string(), "中文描述".to_string());
+        localized.insert("ja".to_string(), "日本語の説明".to_string());
+        let skill = super::Skill {
+            name: "demo".to_string(),
+            description: "English description".to_string(),
+            localized_descriptions: localized,
+            body: String::new(),
+            path: std::path::PathBuf::new(),
+        };
+
+        assert_eq!(skill.description_for_locale("zh"), "中文描述"); // exact
+        assert_eq!(skill.description_for_locale("ZH"), "中文描述"); // case-insensitive
+        assert_eq!(skill.description_for_locale("zh-CN"), "中文描述"); // primary subtag
+        assert_eq!(skill.description_for_locale("ja"), "日本語の説明");
+        assert_eq!(skill.description_for_locale("fr"), "English description"); // fallback
+        assert_eq!(skill.description_for_locale("en"), "English description");
+    }
+
+    #[test]
+    fn description_for_locale_uses_default_when_no_localized_variants() {
+        let skill = super::Skill {
+            name: "demo".to_string(),
+            description: "only english".to_string(),
+            localized_descriptions: std::collections::HashMap::new(),
+            body: String::new(),
+            path: std::path::PathBuf::new(),
+        };
+        assert_eq!(skill.description_for_locale("zh"), "only english");
+    }
+
+    #[test]
+    fn render_skills_block_selects_description_by_locale() {
+        let mut registry = super::SkillRegistry::default();
+        let mut localized = std::collections::HashMap::new();
+        localized.insert("zh".to_string(), "压缩日志的技能".to_string());
+        registry.skills.push(super::Skill {
+            name: "compress".to_string(),
+            description: "Compress logs to save space".to_string(),
+            localized_descriptions: localized,
+            body: "body".to_string(),
+            path: std::path::PathBuf::from("/skills/compress/SKILL.md"),
+        });
+
+        let zh = super::render_skills_block(&registry, "zh-Hans").expect("zh block");
+        assert!(
+            zh.contains("压缩日志的技能"),
+            "zh session should get the zh description:\n{zh}"
+        );
+        assert!(!zh.contains("Compress logs to save space"));
+
+        let en = super::render_skills_block(&registry, "en").expect("en block");
+        assert!(
+            en.contains("Compress logs to save space"),
+            "en session keeps default:\n{en}"
         );
     }
 


### PR DESCRIPTION
## Summary

`Refs #3354` (Chinese environment: provide/load Chinese skills to save tokens).

Skills inject their **name + description** into every session's system prompt
(progressive disclosure). In a non-English session the model is instructed to
respond in e.g. Chinese, yet every skill description stays English — that wastes
prompt tokens and hands the model mixed-language context.

This lets a `SKILL.md` ship native-language descriptions via locale-suffixed
frontmatter keys, selected by the session locale with an English fallback:

```yaml
---
name: demo
description: A demo skill            # default / fallback (unchanged behavior)
description_zh: 一个演示技能          # used when the session locale is zh*
description_zh-Hant: 一個示範技能
---
```

### How it works
- `Skill` gains `localized_descriptions: HashMap<lowercased-tag, String>`,
  populated from `description_<tag>:` keys. The frontmatter parser already
  collects every key into a map, so this is a small extraction — no parser
  rewrite.
- `Skill::description_for_locale(tag)`: exact (lowercased) match → primary
  language subtag (`zh-cn` → `zh`) → default `description`. It deliberately does
  **not** fold `zh-hant` into `zh` (Traditional/Simplified are authored
  separately; each is keyed by the tag the author means).
- `render_skills_block` selects per the session `locale_tag`, threaded from
  `PromptSessionContext`. The no-locale public render wrappers pass `"en"`.

**Fully backward compatible:** skills without localized variants render exactly
as today.

## Testing

- [x] `cargo test -p codewhale-tui --bin codewhale-tui` — **5481 passed, 0 failed**.
- [x] New unit tests: `parse_skill_collects_localized_description_frontmatter`,
  `description_for_locale_matches_exact_then_primary_then_falls_back`,
  `description_for_locale_uses_default_when_no_localized_variants`,
  `render_skills_block_selects_description_by_locale`.
- [x] `prompts::` suite green (touched the skills-block call site).
- [x] `cargo fmt --all -- --check` clean; `cargo clippy` — no new warnings in touched files.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — n/a (prompt-text/data change; unit-tested at the render-helper level)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a (single author)

Note: the `description_<tag>` frontmatter convention is a proposal — happy to
adjust to whatever shape you prefer for the v0.8.67 skills work.
