### PR TITLE
refactor(runtime-api): extract workspace status helpers

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -31,6 +31,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
 
+#[cfg(test)]
 use crate::dependencies::ExternalTool;
 
 use crate::automation_manager::{
@@ -70,6 +71,7 @@ use codewhale_protocol::fleet::{
 
 mod auth;
 mod sessions;
+mod workspace;
 #[cfg(test)]
 use self::auth::{ResolvedRuntimeAuth, token_from_cookie_header};
 use self::auth::{require_runtime_token, resolve_runtime_auth, runtime_auth_status_lines};
@@ -79,6 +81,9 @@ use self::sessions::{
 };
 #[cfg(test)]
 use self::sessions::{messages_from_thread_detail, session_to_detail};
+#[cfg(test)]
+use self::workspace::collect_workspace_status;
+use self::workspace::{collect_workspace_git_metadata, workspace_status};
 
 #[derive(Clone)]
 pub struct RuntimeApiState {
@@ -218,27 +223,6 @@ struct ThreadSummary {
     updated_at: chrono::DateTime<Utc>,
     latest_turn_id: Option<String>,
     latest_turn_status: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct WorkspaceStatusResponse {
-    workspace: PathBuf,
-    git_repo: bool,
-    branch: Option<String>,
-    head: Option<String>,
-    dirty: bool,
-    staged: usize,
-    unstaged: usize,
-    untracked: usize,
-    ahead: Option<u32>,
-    behind: Option<u32>,
-}
-
-#[derive(Debug, Default)]
-struct WorkspaceGitMetadata {
-    branch: Option<String>,
-    head: Option<String>,
-    dirty: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -873,12 +857,6 @@ async fn list_threads_summary(
     }
 
     Ok(Json(summaries))
-}
-
-async fn workspace_status(
-    State(state): State<RuntimeApiState>,
-) -> Result<Json<WorkspaceStatusResponse>, ApiError> {
-    Ok(Json(collect_workspace_status(&state.workspace)))
 }
 
 async fn list_agent_runs(
@@ -2276,113 +2254,6 @@ fn truncate_text(text: &str, max_chars: usize) -> String {
     }
     let truncated: String = text.chars().take(max_chars.saturating_sub(3)).collect();
     format!("{truncated}...")
-}
-
-fn collect_workspace_status(workspace: &std::path::Path) -> WorkspaceStatusResponse {
-    let mut status = WorkspaceStatusResponse {
-        workspace: workspace.to_path_buf(),
-        git_repo: false,
-        branch: None,
-        head: None,
-        dirty: false,
-        staged: 0,
-        unstaged: 0,
-        untracked: 0,
-        ahead: None,
-        behind: None,
-    };
-
-    let Some(repo_check) = run_git(workspace, &["rev-parse", "--is-inside-work-tree"]) else {
-        return status;
-    };
-    if repo_check.trim() != "true" {
-        return status;
-    }
-
-    status.git_repo = true;
-    let metadata = collect_workspace_git_metadata(workspace);
-    status.branch = metadata.branch;
-    status.head = metadata.head;
-    status.dirty = metadata.dirty;
-
-    if let Some(porcelain) = run_git(workspace, &["status", "--porcelain=v1"]) {
-        for line in porcelain.lines() {
-            if line.starts_with("??") {
-                status.untracked += 1;
-                continue;
-            }
-            let chars: Vec<char> = line.chars().collect();
-            if chars.len() >= 2 {
-                if chars[0] != ' ' {
-                    status.staged += 1;
-                }
-                if chars[1] != ' ' {
-                    status.unstaged += 1;
-                }
-            }
-        }
-    }
-
-    if let Some(counts) = run_git(
-        workspace,
-        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
-    ) {
-        let mut parts = counts.split_whitespace();
-        if let (Some(behind), Some(ahead)) = (parts.next(), parts.next()) {
-            status.behind = behind.parse::<u32>().ok();
-            status.ahead = ahead.parse::<u32>().ok();
-        }
-    }
-
-    status
-}
-
-fn collect_workspace_git_metadata(workspace: &std::path::Path) -> WorkspaceGitMetadata {
-    let Some(repo_check) = run_git(workspace, &["rev-parse", "--is-inside-work-tree"]) else {
-        return WorkspaceGitMetadata::default();
-    };
-    if repo_check.trim() != "true" {
-        return WorkspaceGitMetadata::default();
-    }
-
-    WorkspaceGitMetadata {
-        branch: current_git_branch(workspace),
-        head: current_git_head(workspace),
-        dirty: run_git(workspace, &["status", "--porcelain=v1"])
-            .is_some_and(|porcelain| !porcelain.trim().is_empty()),
-    }
-}
-
-fn run_git(workspace: &std::path::Path, args: &[&str]) -> Option<String> {
-    let output = crate::dependencies::Git::output(args, workspace).ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8(output.stdout).ok()
-}
-
-fn current_git_branch(workspace: &std::path::Path) -> Option<String> {
-    let repo_check = run_git(workspace, &["rev-parse", "--is-inside-work-tree"])?;
-    if repo_check.trim() != "true" {
-        return None;
-    }
-    let branch = run_git(workspace, &["rev-parse", "--abbrev-ref", "HEAD"])?;
-    let branch = branch.trim();
-    if branch.is_empty() {
-        return None;
-    }
-    if branch != "HEAD" {
-        return Some(branch.to_string());
-    }
-    let short_hash = run_git(workspace, &["rev-parse", "--short", "HEAD"])?;
-    let short_hash = short_hash.trim();
-    (!short_hash.is_empty()).then(|| format!("detached@{short_hash}"))
-}
-
-fn current_git_head(workspace: &std::path::Path) -> Option<String> {
-    let head = run_git(workspace, &["rev-parse", "--short", "HEAD"])?;
-    let head = head.trim();
-    (!head.is_empty()).then(|| head.to_string())
 }
 
 fn resolve_skills_dir(config: &Config, workspace: &std::path::Path) -> PathBuf {

--- a/crates/tui/src/runtime_api/workspace.rs
+++ b/crates/tui/src/runtime_api/workspace.rs
@@ -1,0 +1,143 @@
+use std::path::{Path as FsPath, PathBuf};
+
+use axum::Json;
+use axum::extract::State;
+use serde::Serialize;
+
+use crate::dependencies::{ExternalTool as _, Git};
+
+use super::{ApiError, RuntimeApiState};
+
+#[derive(Debug, Serialize)]
+pub(super) struct WorkspaceStatusResponse {
+    pub(super) workspace: PathBuf,
+    pub(super) git_repo: bool,
+    pub(super) branch: Option<String>,
+    pub(super) head: Option<String>,
+    pub(super) dirty: bool,
+    pub(super) staged: usize,
+    pub(super) unstaged: usize,
+    pub(super) untracked: usize,
+    pub(super) ahead: Option<u32>,
+    pub(super) behind: Option<u32>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct WorkspaceGitMetadata {
+    pub(super) branch: Option<String>,
+    pub(super) head: Option<String>,
+    pub(super) dirty: bool,
+}
+
+pub(super) async fn workspace_status(
+    State(state): State<RuntimeApiState>,
+) -> Result<Json<WorkspaceStatusResponse>, ApiError> {
+    Ok(Json(collect_workspace_status(&state.workspace)))
+}
+
+pub(super) fn collect_workspace_status(workspace: &FsPath) -> WorkspaceStatusResponse {
+    let mut status = WorkspaceStatusResponse {
+        workspace: workspace.to_path_buf(),
+        git_repo: false,
+        branch: None,
+        head: None,
+        dirty: false,
+        staged: 0,
+        unstaged: 0,
+        untracked: 0,
+        ahead: None,
+        behind: None,
+    };
+
+    let Some(repo_check) = run_git(workspace, &["rev-parse", "--is-inside-work-tree"]) else {
+        return status;
+    };
+    if repo_check.trim() != "true" {
+        return status;
+    }
+
+    status.git_repo = true;
+    let metadata = collect_workspace_git_metadata(workspace);
+    status.branch = metadata.branch;
+    status.head = metadata.head;
+    status.dirty = metadata.dirty;
+
+    if let Some(porcelain) = run_git(workspace, &["status", "--porcelain=v1"]) {
+        for line in porcelain.lines() {
+            if line.starts_with("??") {
+                status.untracked += 1;
+                continue;
+            }
+            let chars: Vec<char> = line.chars().collect();
+            if chars.len() >= 2 {
+                if chars[0] != ' ' {
+                    status.staged += 1;
+                }
+                if chars[1] != ' ' {
+                    status.unstaged += 1;
+                }
+            }
+        }
+    }
+
+    if let Some(counts) = run_git(
+        workspace,
+        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
+    ) {
+        let mut parts = counts.split_whitespace();
+        if let (Some(behind), Some(ahead)) = (parts.next(), parts.next()) {
+            status.behind = behind.parse::<u32>().ok();
+            status.ahead = ahead.parse::<u32>().ok();
+        }
+    }
+
+    status
+}
+
+pub(super) fn collect_workspace_git_metadata(workspace: &FsPath) -> WorkspaceGitMetadata {
+    let Some(repo_check) = run_git(workspace, &["rev-parse", "--is-inside-work-tree"]) else {
+        return WorkspaceGitMetadata::default();
+    };
+    if repo_check.trim() != "true" {
+        return WorkspaceGitMetadata::default();
+    }
+
+    WorkspaceGitMetadata {
+        branch: current_git_branch(workspace),
+        head: current_git_head(workspace),
+        dirty: run_git(workspace, &["status", "--porcelain=v1"])
+            .is_some_and(|porcelain| !porcelain.trim().is_empty()),
+    }
+}
+
+fn run_git(workspace: &FsPath, args: &[&str]) -> Option<String> {
+    let output = Git::output(args, workspace).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+fn current_git_branch(workspace: &FsPath) -> Option<String> {
+    let repo_check = run_git(workspace, &["rev-parse", "--is-inside-work-tree"])?;
+    if repo_check.trim() != "true" {
+        return None;
+    }
+    let branch = run_git(workspace, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return None;
+    }
+    if branch != "HEAD" {
+        return Some(branch.to_string());
+    }
+    let short_hash = run_git(workspace, &["rev-parse", "--short", "HEAD"])?;
+    let short_hash = short_hash.trim();
+    (!short_hash.is_empty()).then(|| format!("detached@{short_hash}"))
+}
+
+fn current_git_head(workspace: &FsPath) -> Option<String> {
+    let head = run_git(workspace, &["rev-parse", "--short", "HEAD"])?;
+    let head = head.trim();
+    (!head.is_empty()).then(|| head.to_string())
+}


### PR DESCRIPTION
## Summary
- Move workspace status response/types and git metadata helpers into runtime_api/workspace.rs
- Keep runtime_api.rs focused on route registration and thread-summary call sites
- Continue the #3306 runtime API monolith split with a small behavior-preserving slice

## Verification
- cargo test -p codewhale-tui --bin codewhale-tui --locked workspace_status_reports_head_and_dirty_counts -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked workspace_and_automation_endpoints_work -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked thread_summary_includes_workspace_branch_metadata -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_api -- --nocapture
- cargo check -p codewhale-tui --bin codewhale-tui --locked
- cargo fmt --all -- --check
- cargo test -p codewhale-tui --bin codewhale-tui --locked workspace -- --nocapture
- git diff --check

Refs #3306