### PR TITLE
feat(settings): accept `collapsed` as alias for default tool-collapse mode (#3256)

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -985,7 +985,7 @@ impl Settings {
             ("calm_mode", "Calmer UI defaults: on/off"),
             (
                 "tool_collapse",
-                "Dense tool-run collapse mode: compact, expanded, calm",
+                "Dense tool-run collapse mode: collapsed (alias compact), expanded, calm",
             ),
             (
                 "low_motion",
@@ -1362,7 +1362,7 @@ fn normalize_transcript_spacing(value: &str) -> &str {
 
 fn normalize_tool_collapse_mode(value: &str) -> &str {
     match value.trim().to_ascii_lowercase().as_str() {
-        "compact" | "default" | "on" | "true" => "compact",
+        "compact" | "collapsed" | "collapse" | "default" | "on" | "true" => "compact",
         "expanded" | "expand" | "off" | "none" | "false" => "expanded",
         "calm" | "calm_mode" | "calm-mode" | "calm_only" | "calm-only" => "calm",
         _ => value,
@@ -1829,6 +1829,18 @@ mod tests {
 
         settings.set("collapse", "off").expect("off alias");
         assert_eq!(settings.tool_collapse_mode, "expanded");
+
+        // Issue #3256 proposes `collapsed` as the default verbosity name;
+        // accept it (and the bare verb) as an alias of the canonical `compact`.
+        settings
+            .set("tool_collapse", "collapsed")
+            .expect("collapsed alias");
+        assert_eq!(settings.tool_collapse_mode, "compact");
+        settings.set("tool_collapse", "expanded").expect("reset");
+        settings
+            .set("tool_collapse", "collapse")
+            .expect("collapse alias");
+        assert_eq!(settings.tool_collapse_mode, "compact");
 
         let err = settings
             .set("tool_collapse", "mystery")

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -436,6 +436,8 @@ impl ToolCollapseMode {
         match value.trim().to_ascii_lowercase().as_str() {
             "expanded" | "off" | "none" => Self::Expanded,
             "calm" | "calm-mode" | "calm_only" | "calm-only" => Self::Calm,
+            // `collapsed`/`collapse` are issue #3256's preferred names for the
+            // default; treat them like the canonical `compact`.
             _ => Self::Compact,
         }
     }


### PR DESCRIPTION
## What

Issue #3256 proposes that the default tool-call verbosity mode be named **`collapsed`** (opposite `expanded`), and made configurable. The collapse/expand behavior, the `tool_collapse` setting, the failure-auto-expand path, and the `Alt+V` removal already shipped — the canonical setting value is `compact`. The one remaining gap: the issue's own proposed name `collapsed` was **not** a recognized value, so `tool_collapse=collapsed` was stored verbatim and only behaved correctly by falling through to the default match arm (never round-tripping to a canonical name, and absent from the help text).

This PR closes that vocabulary gap:

- `normalize_tool_collapse_mode` now accepts `collapsed` / `collapse` as aliases that normalize to the canonical `compact`.
- Settings help text lists `collapsed (alias compact)`.
- `ToolCollapseMode::from_setting` documents the intent.
- Round-trip coverage added to the existing `tool_collapse_mode_is_configurable` test.

Backward compatible — existing `compact`/`expanded`/`calm` configs are unchanged.

## Note on scope

I verified the rest of #3256 is already implemented on `main`:
- collapse-on-success / auto-expand-on-failure: `crates/tui/src/tui/history.rs` (`should_collapse` + the `Failed → Transcript` override).
- configurable verbosity: `tool_collapse` setting + `ToolCollapseMode` (`compact`/`expanded`/`calm`).
- the broken `Alt+V` affordance is already gone (replaced by the bare `v` details key); no dead "Alt+V for details" hint remains.

So this is intentionally a small alignment PR rather than a reimplementation. Happy to also fold in the batched-call rollup from the issue as a follow-up if useful.

## Test

`cargo test -p codewhale-tui --bin codewhale-tui settings::tests::tool_collapse_mode_is_configurable` passes; `cargo fmt --all -- --check` and `cargo clippy -p codewhale-tui --all-features --locked` (CI flags) clean.

Refs #3256