### PR TITLE
fix(engine): add fallback hints for transient tool errors

### DIFF
--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -111,7 +111,7 @@ fn mentions_mode_word(lower: &str) -> bool {
 }
 
 pub(super) fn format_tool_error(err: &ToolError, tool_name: &str) -> String {
-    match err {
+    let message = match err {
         ToolError::InvalidInput { message } => {
             format!("Invalid input for tool '{tool_name}': {message}")
         }
@@ -159,7 +159,103 @@ pub(super) fn format_tool_error(err: &ToolError, tool_name: &str) -> String {
                 )
             }
         }
+    };
+
+    with_transient_tool_fallback_hint(message, err, tool_name)
+}
+
+fn with_transient_tool_fallback_hint(message: String, err: &ToolError, tool_name: &str) -> String {
+    if message_already_has_recovery_hint(&message) {
+        return message;
     }
+
+    let Some(hint) = transient_tool_fallback_hint(err, tool_name, &message) else {
+        return message;
+    };
+
+    format!("{message} Fallback: {hint}")
+}
+
+fn message_already_has_recovery_hint(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("recovery:") || lower.contains("fallback:")
+}
+
+fn transient_tool_fallback_hint(
+    err: &ToolError,
+    tool_name: &str,
+    formatted_message: &str,
+) -> Option<&'static str> {
+    if !is_transient_tool_failure(err, formatted_message) {
+        return None;
+    }
+
+    let lower_tool = tool_name.to_ascii_lowercase();
+    if lower_tool.contains("web_search")
+        || lower_tool.contains("web_run")
+        || lower_tool == "web.run"
+    {
+        return Some(
+            "after one retry, switch to a direct URL/open/fetch path or cached context instead of repeating the same search.",
+        );
+    }
+
+    if lower_tool.contains("fetch_url") {
+        return Some(
+            "after one retry, try a narrower URL/source, use search results or cached context, or state the access limit instead of repeating the same request.",
+        );
+    }
+
+    if lower_tool.contains("file_search") || lower_tool.contains("grep") {
+        return Some(
+            "after one retry, narrow the query/path or inspect likely files directly instead of repeating the same search unchanged.",
+        );
+    }
+
+    if lower_tool.contains("exec_shell")
+        || lower_tool.contains("run_tests")
+        || lower_tool.contains("run_verifiers")
+    {
+        return Some(
+            "after one retry, narrow the command/scope, increase timeout only for expected long runs, or switch to file-level evidence.",
+        );
+    }
+
+    if lower_tool.contains("agent") {
+        return Some(
+            "after one retry, reduce delegated scope or continue in the parent context instead of repeatedly spawning the same agent.",
+        );
+    }
+
+    Some(
+        "after one retry, choose a different tool or narrower strategy instead of repeating the same call unchanged.",
+    )
+}
+
+fn is_transient_tool_failure(err: &ToolError, formatted_message: &str) -> bool {
+    if matches!(err, ToolError::Timeout { .. }) {
+        return true;
+    }
+
+    if !matches!(err, ToolError::ExecutionFailed { .. }) {
+        return false;
+    }
+
+    let lower = formatted_message.to_ascii_lowercase();
+    [
+        "timeout",
+        "timed out",
+        "request failed",
+        "connection",
+        "network",
+        "http 429",
+        "rate limit",
+        "http 5",
+        "anti-bot",
+        "captcha",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
 }
 
 // === Streaming-buffer parsing =========================================

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1331,6 +1331,27 @@ fn tool_error_messages_include_actionable_hints() {
 }
 
 #[test]
+fn transient_tool_errors_include_fallback_hint() {
+    let search_error = ToolError::execution_failed("Web search request failed: timeout");
+    let formatted = format_tool_error(&search_error, "web_search");
+
+    assert!(
+        formatted.contains("Fallback: after one retry"),
+        "{formatted}"
+    );
+    assert!(formatted.contains("direct URL"), "{formatted}");
+    assert!(formatted.contains("instead of repeating"), "{formatted}");
+}
+
+#[test]
+fn tool_errors_with_specific_recovery_do_not_get_generic_fallback() {
+    let message = "edit_file search string not found. Recovery: call read_file first.";
+    let formatted = format_tool_error(&ToolError::execution_failed(message), "edit_file");
+
+    assert_eq!(formatted, message);
+}
+
+#[test]
 fn tool_exec_outcome_tracks_duration() {
     let outcome = ToolExecOutcome {
         index: 0,


### PR DESCRIPTION
Refs #1641

## Problem
Transient tool failures currently surface as raw error text, which makes it easy for the agent to repeat the same failing call unchanged.

## Change
- append model-visible fallback guidance for transient timeout/network/request-failure tool errors
- tailor hints for web/search/fetch/shell/agent-style tools
- skip the generic fallback hint when a tool already provides a specific `Recovery:` or `Fallback:` path

## Verification
- `cargo test -p codewhale-tui --bin codewhale-tui tool_error --locked -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check HEAD~1 HEAD`