### PR TITLE
fix(engine): nudge fallback after repeated tool errors

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use super::context::{COMPACTION_SUMMARY_MARKER, TURN_MAX_OUTPUT_TOKENS};
-use super::turn_loop::registered_tool_approval_required;
+use super::turn_loop::{registered_tool_approval_required, tool_error_degradation_runtime_hint};
 use crate::config::ApiProvider;
 use crate::models::{SystemBlock, Usage};
 use crate::test_support::{EnvVarGuard, lock_test_env};
@@ -1349,6 +1349,35 @@ fn tool_errors_with_specific_recovery_do_not_get_generic_fallback() {
     let formatted = format_tool_error(&ToolError::execution_failed(message), "edit_file");
 
     assert_eq!(formatted, message);
+}
+
+#[test]
+fn repeated_tool_errors_wait_until_degradation_threshold() {
+    let tools = vec!["web_search".to_string()];
+
+    assert!(tool_error_degradation_runtime_hint(1, &tools, &[ErrorCategory::Tool]).is_none());
+}
+
+#[test]
+fn repeated_tool_errors_emit_model_visible_degradation_hint() {
+    let tools = vec!["web_search".to_string(), "web_search".to_string()];
+    let hint = tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Tool])
+        .expect("second consecutive tool-error step should emit a runtime hint");
+
+    assert!(hint.contains("2 consecutive"), "{hint}");
+    assert!(hint.contains("web_search"), "{hint}");
+    assert!(hint.contains("do not repeat"), "{hint}");
+    assert!(hint.contains("alternate tool"), "{hint}");
+    assert!(hint.contains("narrow the request"), "{hint}");
+}
+
+#[test]
+fn repeated_authorization_errors_do_not_emit_degradation_hint() {
+    let tools = vec!["exec_shell".to_string()];
+
+    assert!(
+        tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Authorization]).is_none()
+    );
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -10,6 +10,7 @@ use crate::core::ops::UserInputProvenance;
 use crate::prompt_zones::PinnedPrefix;
 
 const MAX_APPROVAL_INTENT_SUMMARY_CHARS: usize = 2_000;
+const TOOL_ERROR_DEGRADATION_THRESHOLD: u32 = 2;
 
 fn approval_intent_summary(text: &str) -> Option<String> {
     let trimmed = text.trim();
@@ -40,6 +41,51 @@ pub(super) fn registered_tool_approval_required(
         return true;
     }
     !auto_approve
+}
+
+pub(super) fn tool_error_degradation_runtime_hint(
+    consecutive_tool_error_steps: u32,
+    step_error_tool_names: &[String],
+    step_error_categories: &[ErrorCategory],
+) -> Option<String> {
+    if consecutive_tool_error_steps < TOOL_ERROR_DEGRADATION_THRESHOLD {
+        return None;
+    }
+    if !step_error_categories
+        .iter()
+        .any(|category| tool_error_category_allows_degradation(*category))
+    {
+        return None;
+    }
+
+    let mut tool_names = step_error_tool_names
+        .iter()
+        .map(|name| name.trim())
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+    tool_names.sort_unstable();
+    tool_names.dedup();
+    let tools = if tool_names.is_empty() {
+        "tools".to_string()
+    } else {
+        tool_names.join(", ")
+    };
+
+    Some(format!(
+        "Tool calls have failed for {consecutive_tool_error_steps} consecutive steps ({tools}). \
+do not repeat the same call unchanged; switch to an alternate tool or source, narrow the request, \
+or ask for the required input before trying again."
+    ))
+}
+
+fn tool_error_category_allows_degradation(category: ErrorCategory) -> bool {
+    matches!(
+        category,
+        ErrorCategory::Network
+            | ErrorCategory::RateLimit
+            | ErrorCategory::Timeout
+            | ErrorCategory::Tool
+    )
 }
 
 fn registered_tool_requires_non_bypassable_approval(tool_name: &str) -> bool {
@@ -2235,6 +2281,7 @@ impl Engine {
             // (e.g.) a Tool failure that should escalate from a permission
             // denial that should not.
             let mut step_error_categories: Vec<ErrorCategory> = Vec::new();
+            let mut step_error_tool_names: Vec<String> = Vec::new();
             let mut stop_after_plan_tool = false;
 
             for outcome in outcomes.into_iter().flatten() {
@@ -2311,6 +2358,7 @@ impl Engine {
                         }));
                         step_error_count += 1;
                         step_error_categories.push(envelope.category);
+                        step_error_tool_names.push(outcome.name.clone());
                         let error = format_tool_error(&e, &outcome.name);
                         self.session.working_set.observe_tool_call(
                             &tool_name_for_ws,
@@ -2351,6 +2399,17 @@ impl Engine {
 
             if step_error_count > 0 {
                 consecutive_tool_error_steps = consecutive_tool_error_steps.saturating_add(1);
+                if let Some(hint) = tool_error_degradation_runtime_hint(
+                    consecutive_tool_error_steps,
+                    &step_error_tool_names,
+                    &step_error_categories,
+                ) {
+                    self.add_session_message(self.runtime_text_message_with_turn_metadata(
+                        hint,
+                        UserInputProvenance::Runtime,
+                    ))
+                    .await;
+                }
             } else {
                 consecutive_tool_error_steps = 0;
             }


### PR DESCRIPTION
Refs #1641

## Summary
- add a runtime hint after repeated recoverable tool-error steps so the model avoids repeating the same failed call unchanged
- include the failed tool names in the hint and suggest switching source/tool, narrowing the request, or asking for required input
- skip the degradation hint for authorization and permission failures

## Tests
- `cargo test -p codewhale-tui --bin codewhale-tui repeated_tool_errors --locked -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui repeated_ --locked -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui tool_error --locked -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
