### PR TITLE
fix(engine): suggest direct urls after repeated search errors

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1355,13 +1355,13 @@ fn tool_errors_with_specific_recovery_do_not_get_generic_fallback() {
 fn repeated_tool_errors_wait_until_degradation_threshold() {
     let tools = vec!["web_search".to_string()];
 
-    assert!(tool_error_degradation_runtime_hint(1, &tools, &[ErrorCategory::Tool]).is_none());
+    assert!(tool_error_degradation_runtime_hint(1, &tools, &[ErrorCategory::Tool], &[]).is_none());
 }
 
 #[test]
 fn repeated_tool_errors_emit_model_visible_degradation_hint() {
     let tools = vec!["web_search".to_string(), "web_search".to_string()];
-    let hint = tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Tool])
+    let hint = tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Tool], &[])
         .expect("second consecutive tool-error step should emit a runtime hint");
 
     assert!(hint.contains("2 consecutive"), "{hint}");
@@ -1376,8 +1376,51 @@ fn repeated_authorization_errors_do_not_emit_degradation_hint() {
     let tools = vec!["exec_shell".to_string()];
 
     assert!(
-        tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Authorization]).is_none()
+        tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Authorization], &[])
+            .is_none()
     );
+}
+
+#[test]
+fn repeated_search_errors_suggest_direct_url_patterns_for_domains() {
+    let tools = vec!["web_search".to_string()];
+    let inputs = vec![json!({"query": "site:example.edu announcements"})];
+    let hint = tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Tool], &inputs)
+        .expect("repeated web_search failure should emit a domain-aware fallback hint");
+
+    assert!(hint.contains("fetch_url"), "{hint}");
+    assert!(hint.contains("https://example.edu/announcements"), "{hint}");
+    assert!(hint.contains("https://example.edu/news"), "{hint}");
+}
+
+#[test]
+fn repeated_web_run_errors_suggest_direct_url_patterns_for_domains_list() {
+    let tools = vec!["web.run".to_string()];
+    let inputs = vec![json!({
+        "search_query": [
+            {
+                "q": "announcements",
+                "domains": ["www.example.edu"]
+            }
+        ]
+    })];
+    let hint = tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Tool], &inputs)
+        .expect("repeated web.run failure should emit a domain-aware fallback hint");
+
+    assert!(hint.contains("https://example.edu/announcements"), "{hint}");
+    assert!(hint.contains("https://example.edu/news"), "{hint}");
+}
+
+#[test]
+fn repeated_search_errors_do_not_treat_versions_as_domains() {
+    let tools = vec!["web_search".to_string()];
+    let inputs = vec![json!({"query": "release v1.2 notes"})];
+    let hint = tool_error_degradation_runtime_hint(2, &tools, &[ErrorCategory::Tool], &inputs)
+        .expect("repeated web_search failure should still emit the generic hint");
+
+    assert!(hint.contains("alternate tool"), "{hint}");
+    assert!(!hint.contains("fetch_url"), "{hint}");
+    assert!(!hint.contains("https://v1.2"), "{hint}");
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -47,6 +47,7 @@ pub(super) fn tool_error_degradation_runtime_hint(
     consecutive_tool_error_steps: u32,
     step_error_tool_names: &[String],
     step_error_categories: &[ErrorCategory],
+    step_error_tool_inputs: &[serde_json::Value],
 ) -> Option<String> {
     if consecutive_tool_error_steps < TOOL_ERROR_DEGRADATION_THRESHOLD {
         return None;
@@ -71,11 +72,18 @@ pub(super) fn tool_error_degradation_runtime_hint(
         tool_names.join(", ")
     };
 
-    Some(format!(
+    let mut hint = format!(
         "Tool calls have failed for {consecutive_tool_error_steps} consecutive steps ({tools}). \
 do not repeat the same call unchanged; switch to an alternate tool or source, narrow the request, \
 or ask for the required input before trying again."
-    ))
+    );
+    if let Some(direct_url_hint) =
+        direct_url_pattern_fallback_hint(step_error_tool_names, step_error_tool_inputs)
+    {
+        hint.push(' ');
+        hint.push_str(&direct_url_hint);
+    }
+    Some(hint)
 }
 
 fn tool_error_category_allows_degradation(category: ErrorCategory) -> bool {
@@ -86,6 +94,99 @@ fn tool_error_category_allows_degradation(category: ErrorCategory) -> bool {
             | ErrorCategory::Timeout
             | ErrorCategory::Tool
     )
+}
+
+fn direct_url_pattern_fallback_hint(
+    step_error_tool_names: &[String],
+    step_error_tool_inputs: &[serde_json::Value],
+) -> Option<String> {
+    let mut domains = std::collections::BTreeSet::new();
+    for (tool_name, input) in step_error_tool_names
+        .iter()
+        .zip(step_error_tool_inputs.iter())
+    {
+        if matches!(tool_name.as_str(), "web_search" | "web.run") {
+            collect_search_domains(input, &mut domains);
+        }
+    }
+
+    let domain = domains.into_iter().next()?;
+    Some(format!(
+        "For blocked search, try fetch_url directly on likely URL patterns such as \
+https://{domain}/announcements and https://{domain}/news."
+    ))
+}
+
+fn collect_search_domains(
+    input: &serde_json::Value,
+    domains: &mut std::collections::BTreeSet<String>,
+) {
+    if let Some(values) = input.get("domains").and_then(serde_json::Value::as_array) {
+        for value in values {
+            if let Some(domain) = value.as_str().and_then(normalize_domain_candidate) {
+                domains.insert(domain);
+            }
+        }
+    }
+    for key in ["query", "q"] {
+        if let Some(query) = input.get(key).and_then(serde_json::Value::as_str) {
+            collect_query_domains(query, domains);
+        }
+    }
+    if let Some(searches) = input
+        .get("search_query")
+        .and_then(serde_json::Value::as_array)
+    {
+        for search in searches {
+            collect_search_domains(search, domains);
+        }
+    }
+}
+
+fn collect_query_domains(query: &str, domains: &mut std::collections::BTreeSet<String>) {
+    for token in query.split_whitespace() {
+        let token = token.trim_matches(|c: char| {
+            matches!(
+                c,
+                '"' | '\'' | '`' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';'
+            )
+        });
+        if let Some(site) = token.strip_prefix("site:") {
+            if let Some(domain) = normalize_domain_candidate(site) {
+                domains.insert(domain);
+            }
+        } else if let Some(domain) = normalize_domain_candidate(token) {
+            domains.insert(domain);
+        }
+    }
+}
+
+fn normalize_domain_candidate(value: &str) -> Option<String> {
+    let value = value
+        .trim()
+        .trim_matches(|c: char| matches!(c, '"' | '\'' | '`' | '<' | '>' | '.' | ',' | ';' | ':'));
+    if value.is_empty() {
+        return None;
+    }
+    let without_scheme = value
+        .strip_prefix("https://")
+        .or_else(|| value.strip_prefix("http://"))
+        .unwrap_or(value);
+    let host = without_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_start_matches("www.")
+        .to_ascii_lowercase();
+    let looks_like_domain = host.contains('.')
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.'))
+        && host.rsplit('.').next().is_some_and(|suffix| {
+            suffix.len() >= 2 && suffix.chars().any(|c| c.is_ascii_alphabetic())
+        });
+    if looks_like_domain { Some(host) } else { None }
 }
 
 fn registered_tool_requires_non_bypassable_approval(tool_name: &str) -> bool {
@@ -2282,6 +2383,7 @@ impl Engine {
             // denial that should not.
             let mut step_error_categories: Vec<ErrorCategory> = Vec::new();
             let mut step_error_tool_names: Vec<String> = Vec::new();
+            let mut step_error_tool_inputs: Vec<serde_json::Value> = Vec::new();
             let mut stop_after_plan_tool = false;
 
             for outcome in outcomes.into_iter().flatten() {
@@ -2359,6 +2461,7 @@ impl Engine {
                         step_error_count += 1;
                         step_error_categories.push(envelope.category);
                         step_error_tool_names.push(outcome.name.clone());
+                        step_error_tool_inputs.push(tool_input.clone());
                         let error = format_tool_error(&e, &outcome.name);
                         self.session.working_set.observe_tool_call(
                             &tool_name_for_ws,
@@ -2403,6 +2506,7 @@ impl Engine {
                     consecutive_tool_error_steps,
                     &step_error_tool_names,
                     &step_error_categories,
+                    &step_error_tool_inputs,
                 ) {
                     self.add_session_message(self.runtime_text_message_with_turn_metadata(
                         hint,


### PR DESCRIPTION
Refs #1641

Problem
Repeated search failures get a generic degradation hint, but the runtime does not use domains already present in failed search inputs to suggest a direct URL fallback.

Change
- collect domains from failed web_search queries and web.run domain filters
- add direct fetch_url URL-pattern suggestions for likely announcement/news pages
- ignore version-like tokens such as v1.2 when extracting domains

Verification
- cargo test -p codewhale-tui --bin codewhale-tui repeated_ --locked -- --nocapture
- cargo test -p codewhale-tui --bin codewhale-tui tool_error --locked -- --nocapture
- cargo fmt --all --check
- git diff --check
