### PR TITLE
docs: add v0.8.66 release ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added WeCom Bridge deployment and security documentation, with shipped
   runtime/bridge commands and approval-timeout environment guidance. Harvested
   from #3640 by @pkeging.
+- Added a token/cache/cost `scorecard` command for offline release gating,
+  baseline regression checks, and per-turn cost visibility (#3388). Stream-JSON
+  exec metadata now also reports conservative `input_analysis` and
+  `visible_final_answer_chars`, so benchmark harnesses can measure transcript
+  growth and final-answer bloat without guessing (#2956, #2957).
+- Added a release evidence ledger for v0.8.66 and opened the external ACP
+  registry submission for CodeWhale after validating the published
+  `codewhale@0.8.65` ACP auth handshake against the upstream registry checker
+  (#3192).
 
 ### Changed
 
 - Clarified the Fleet setup surface and docs so Fleet is treated as the durable
   sub-agent configuration layer while WhaleFlow is the agent-authored
   orchestration plan that selects and monitors Fleet slots.
+- Slimmed the default Constitution prompt while keeping its required structural
+  anchors under regression coverage, reducing the static prompt footprint for
+  cache-sensitive turns (#2953).
 
 ### Fixed
 
@@ -40,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by retrying the dependency graph probe before failing CI.
 - Updated the `/links` provider fallback to the current CodeWhale docs URL and
   added a Baidu Qianfan docs link. Harvested from #3621 by @noaft.
+- Hardened `CODEWHALE_TOOL_SURFACE=shell-only` for benchmark/exec runs: the
+  shell-only surface hides native tools from the model-visible catalog, and
+  unknown `CODEWHALE_TOOL_SURFACE` values now warn instead of silently falling
+  back to the full tool surface (#2954).
 
 ## [0.8.65] - 2026-06-24
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -27,12 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added WeCom Bridge deployment and security documentation, with shipped
   runtime/bridge commands and approval-timeout environment guidance. Harvested
   from #3640 by @pkeging.
+- Added a token/cache/cost `scorecard` command for offline release gating,
+  baseline regression checks, and per-turn cost visibility (#3388). Stream-JSON
+  exec metadata now also reports conservative `input_analysis` and
+  `visible_final_answer_chars`, so benchmark harnesses can measure transcript
+  growth and final-answer bloat without guessing (#2956, #2957).
+- Added a release evidence ledger for v0.8.66 and opened the external ACP
+  registry submission for CodeWhale after validating the published
+  `codewhale@0.8.65` ACP auth handshake against the upstream registry checker
+  (#3192).
 
 ### Changed
 
 - Clarified the Fleet setup surface and docs so Fleet is treated as the durable
   sub-agent configuration layer while WhaleFlow is the agent-authored
   orchestration plan that selects and monitors Fleet slots.
+- Slimmed the default Constitution prompt while keeping its required structural
+  anchors under regression coverage, reducing the static prompt footprint for
+  cache-sensitive turns (#2953).
 
 ### Fixed
 
@@ -40,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by retrying the dependency graph probe before failing CI.
 - Updated the `/links` provider fallback to the current CodeWhale docs URL and
   added a Baidu Qianfan docs link. Harvested from #3621 by @noaft.
+- Hardened `CODEWHALE_TOOL_SURFACE=shell-only` for benchmark/exec runs: the
+  shell-only surface hides native tools from the model-visible catalog, and
+  unknown `CODEWHALE_TOOL_SURFACE` values now warn instead of silently falling
+  back to the full tool surface (#2954).
 
 ## [0.8.65] - 2026-06-24
 

--- a/docs/ACP_REGISTRY_SUBMISSION.md
+++ b/docs/ACP_REGISTRY_SUBMISSION.md
@@ -1,11 +1,11 @@
 # ACP Registry Submission Prep
 
-Prepared for #3192. This is local maintainer prep only; do not open or push the
-external `agentclientprotocol/registry` PR from this train.
+Prepared for #3192. The external registry submission is now open as
+`agentclientprotocol/registry#411`.
 
 ## Upstream Registry Requirements
 
-Checked against `agentclientprotocol/registry` on 2026-06-14:
+Checked against `agentclientprotocol/registry` on 2026-06-27:
 
 - New entries live in a directory whose name matches the `id` field.
 - Each entry needs `agent.json` plus a required `icon.svg`.
@@ -70,11 +70,12 @@ Known limitations to state clearly:
 - ACP does not expose shell tools, file-write tools, checkpoint replay, session
   loading, or the HTTP/SSE runtime API.
 - Registry submission should be gated on a local run of the upstream registry
-  auth-check before opening the external PR.
+  auth-check before opening the external PR. That check passed locally before
+  `agentclientprotocol/registry#411` was opened.
 
-Recommendation: submit an `npx` distribution first after the matching npm
-version is published. It avoids direct release-asset URL churn and lets the npm
-wrapper handle platform selection, checksums, mirrors, and glibc preflight.
+The submitted registry PR uses the `npx` distribution because
+`codewhale@0.8.65` is already published and the npm wrapper handles platform
+selection, checksums, mirrors, and glibc preflight.
 
 ## External Registry Files
 
@@ -86,8 +87,7 @@ codewhale/
   icon.svg
 ```
 
-Replace `0.8.61` with the final published CodeWhale version. Do not use
-`@latest`.
+Use a concrete published version. Do not use `@latest`.
 
 ### `codewhale/agent.json`
 
@@ -95,7 +95,7 @@ Replace `0.8.61` with the final published CodeWhale version. Do not use
 {
   "id": "codewhale",
   "name": "CodeWhale",
-  "version": "0.8.61",
+  "version": "0.8.65",
   "description": "Provider-agnostic terminal coding agent with first-class DeepSeek support.",
   "repository": "https://github.com/Hmbown/CodeWhale",
   "website": "https://github.com/Hmbown/CodeWhale/blob/main/docs/RUNTIME_API.md#acp-stdio-adapter-codewhale-serve---acp",
@@ -103,7 +103,7 @@ Replace `0.8.61` with the final published CodeWhale version. Do not use
   "license": "MIT",
   "distribution": {
     "npx": {
-      "package": "codewhale@0.8.61",
+      "package": "codewhale@0.8.65",
       "args": ["serve", "--acp"]
     }
   }
@@ -140,19 +140,21 @@ Local readiness checked in Hmbown/CodeWhale:
 - ACP stdio adapter exists at `codewhale serve --acp`.
 - `initialize` returns terminal auth via `auth set --provider <provider>`.
 - `session/new`, `session/prompt`, and `session/cancel` are implemented.
+- `session/prompt` streams provider text deltas as `session/update` chunks.
 - The adapter is intentionally baseline: no ACP shell/file tools, no session
-  load, and no provider-token streaming yet.
+  load, and no full runtime API through ACP.
 
-Version: 0.8.61
+Version: 0.8.65
 ```
 
 ## Pre-Submission Checklist
 
-- Confirm `codewhale@0.8.61` is published to npm, or switch the draft to
-  versioned GitHub Release binary URLs that exist.
-- Run the upstream registry validator:
-  `python3 .github/workflows/verify_agents.py --auth-check --agent codewhale`
-- Verify `npx codewhale@0.8.61 serve --acp` returns `authMethods` from
-  `initialize` on a clean machine.
+- Confirm `codewhale@0.8.65` is published to npm: done on 2026-06-27.
+- Run the upstream registry validator: done on 2026-06-27 with
+  `python3 .github/workflows/verify_agents.py --auth-check --agent codewhale --verbose`;
+  result was `Auth OK: codewhale-terminal-auth(terminal)`.
+- Verify `npx -y codewhale@0.8.65 serve --acp` returns `authMethods` from
+  `initialize`: done on 2026-06-27.
 - Keep the external PR body explicit that ACP support is baseline and does not
-  imply the full TUI/runtime API is available inside ACP.
+  imply the full TUI/runtime API is available inside ACP: done in
+  `agentclientprotocol/registry#411`.

--- a/docs/V0866_RELEASE_LEDGER.md
+++ b/docs/V0866_RELEASE_LEDGER.md
@@ -1,0 +1,86 @@
+# v0.8.66 Release Ledger
+
+This ledger records the live v0.8.66 release lane as of 2026-06-27. It is a
+release-prep artifact, not a tag, GitHub Release, npm publish, or version bump.
+
+## Current Release Candidate
+
+- Main candidate: `5e9f7662f` (`Merge pull request #3706 ...`).
+- Workspace/npm version currently remains `0.8.65`; do not bump to `0.8.66`
+  without explicit maintainer approval.
+- Latest main CI, Nightly, CodeQL, CNB sync, and auto-close workflows were green
+  at `5e9f7662f` when this ledger was written.
+- `codewhale@0.8.65` is published on npm and was used for ACP registry
+  validation.
+
+## Landed v0.8.66 Highlights
+
+- ACP editor adapter hardening: `session/cancel` can abort an in-flight prompt,
+  `session/prompt` streams provider text deltas through `session/update`, and
+  the external ACP registry submission is open as
+  `agentclientprotocol/registry#411` (#3192).
+- Token/cache/context discipline: the `scorecard` command provides offline
+  token/cache/cost metrics and baseline regression checks (#3388), exec
+  stream-json metadata exposes `input_analysis` and
+  `visible_final_answer_chars` (#2956, #2957), shell-only benchmark surface
+  handling is hardened (#2954), and the default Constitution prompt is slimmer
+  with a regression guard (#2953).
+- Fleet/WhaleFlow follow-through: Fleet remains the durable sub-agent
+  configuration layer while WhaleFlow describes launch plans that select and
+  monitor Fleet slots. Launch-shape validation keeps the default workflow under
+  100 agents and 5 recursive rings.
+- Release and CI hardening: required-check placeholder jobs keep light PRs
+  mergeable, stale issue cleanup is reactivated with conservative labels, and
+  registry/provider docs were corrected.
+- Community PR intake: OpenModel, WeCom Bridge docs/runtime, ask-rules config
+  view, provider context-window overrides, direct URL fallback hints, and
+  command-registry validation have landed with contributor credit preserved.
+
+## Issue State For Release Completion
+
+### Can Be Considered v0.8.66 Done After This Ledger
+
+- #3388: the release-gate measurement machinery is in-tree. Follow-up benchmark
+  runs and long-lived trend storage should continue under #2962 and the
+  individual token/cache evidence issues rather than blocking the patch release.
+- #3192: CodeWhale-side ACP readiness is validated and the external registry PR
+  is open. Keep the issue open only until the external registry accepts or
+  rejects `agentclientprotocol/registry#411`.
+
+### Move Out Of v0.8.66
+
+These are meaningful, but too broad or externally gated for this patch:
+
+- #3541 native desktop/Rust companion: v0.9.0 or later.
+- #3495 Moraine memory backend: keep moving, but full acceptance requires
+  Moraine-side adapter/upstreaming plus `moraine up` + MCP recall verification.
+- #3480 TUI information architecture: product epic, not a single release fix.
+- #3389/#3399 Hotbar MVP/source adapters: partial foundations landed; remaining
+  source-adapter and wizard work belongs in the next UI lane.
+- #3205/#2300 Fleet automatic loadout selection: model reference and Fleet
+  substrate landed, but automatic capability-based selection still needs the
+  refined Fleet/model-lab implementation.
+- #2984 OpenAI Codex/ChatGPT OAuth: requires live-account verification and
+  usage/quota proof.
+- #2024/#2023 RLM routing/log workbench: architecture follow-up.
+- #3089 stale backlog cleanup: automation is active; manual consolidation can
+  continue after release.
+
+### Keep As Evidence/Needs-Data Follow-Ups
+
+Do not close these from code inspection alone:
+
+- #2953, #2954, #2956, #2957: code/instrumentation landed; paired benchmark
+  rows remain follow-up evidence.
+- #2962: recurring benchmark trend storage is a larger automation lane.
+- #743, #1120, #1177, #1747, #1818, #1732: user reports remain valuable, but
+  need current-version session data, request snapshots, or same-task benchmark
+  pairs before final closure.
+
+## Release Actions Not Taken
+
+- No `0.8.66` version bump.
+- No tag.
+- No npm publish.
+- No GitHub Release.
+- No release artifact push.


### PR DESCRIPTION
## Summary
- add a v0.8.66 release ledger that records the current main candidate, ACP registry submission state, issue triage, and gated release actions not taken
- update the changelog with the token/cache scorecard, stream-json metrics, shell-only benchmark hardening, prompt slimming, and ACP registry submission evidence
- refresh ACP registry prep docs for the validated `codewhale@0.8.65` auth handshake and external registry PR

## Verification
- `./scripts/release/check-versions.sh`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked scorecard -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked initialize_advertises_baseline_acp_agent -- --nocapture`

Refs #3388
Refs #3192
Refs #2953
Refs #2954
Refs #2956
Refs #2957