### PR TITLE
feat(plugins): add manifest parsing, discovery, and registry

### DIFF
--- a/crates/tui/assets/plugins/rust-toolkit/plugin.toml
+++ b/crates/tui/assets/plugins/rust-toolkit/plugin.toml
@@ -1,0 +1,12 @@
+[plugin]
+name = "rust-toolkit"
+description = "Rust development toolkit with cargo check integration"
+version = "0.1.0"
+author = "CodeWhale Team"
+
+[skills]
+path = "skills"
+
+[when]
+os = ["windows", "linux", "macos"]
+binaries = ["cargo"]

--- a/crates/tui/assets/plugins/rust-toolkit/skills/rust-check/SKILL.md
+++ b/crates/tui/assets/plugins/rust-toolkit/skills/rust-check/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: rust-check
+description: Run cargo check on the current Rust project to find compile errors
+---
+
+Use this skill when you need to check for Rust compile errors.
+
+**How to use:**
+1. Run `cargo check` in the project root
+2. Analyze the output for errors and warnings
+3. Fix any issues found
+
+**Example:**
+```bash
+cargo check --all-targets
+```
+
+This skill is part of the rust-toolkit plugin.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -65,6 +65,7 @@ mod models;
 mod network_policy;
 mod oauth;
 mod palette;
+mod plugins;
 mod prefix_cache;
 mod pricing;
 mod project_context;
@@ -1390,6 +1391,7 @@ async fn main() -> Result<()> {
     // for follow-up messages. Use `codewhale exec` for explicit non-interactive
     // one-shot behavior (#2370).
     let config = load_config_from_cli(&cli)?;
+    crate::plugins::init_registry(&[]);
     if let Some(initial_input) = top_level_prompt_initial_input(&cli.prompt) {
         return run_interactive(&cli, &config, None, Some(initial_input)).await;
     }

--- a/crates/tui/src/plugins/discovery.rs
+++ b/crates/tui/src/plugins/discovery.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+
+use super::manifest::{LoadedPlugin, PluginManifest};
+use super::registry::PluginRegistry;
+
+const PLUGIN_MANIFEST: &str = "plugin.toml";
+
+pub fn default_user_plugins_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|p| p.join(".codewhale").join("plugins"))
+        .unwrap_or_else(|| PathBuf::from("/tmp/codewhale/plugins"))
+}
+
+pub fn discover_all(builtin_dirs: &[&str]) -> PluginRegistry {
+    let mut registry = PluginRegistry::new();
+
+    for dir in builtin_dirs {
+        let path = PathBuf::from(dir);
+        if path.exists() {
+            discover_from_dir(&path, &mut registry, true);
+        }
+    }
+
+    let user_dir = default_user_plugins_dir();
+    if user_dir.exists() {
+        discover_from_dir(&user_dir, &mut registry, false);
+    }
+
+    registry
+}
+
+fn discover_from_dir(dir: &Path, registry: &mut PluginRegistry, builtin: bool) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let manifest_path = path.join(PLUGIN_MANIFEST);
+        if !manifest_path.exists() {
+            continue;
+        }
+
+        match PluginManifest::from_path(&manifest_path) {
+            Ok(manifest) => {
+                if !manifest.check_when() {
+                    continue;
+                }
+
+                let name = manifest.plugin.name.clone();
+                let plugin = LoadedPlugin {
+                    manifest,
+                    base_path: path,
+                    enabled: !builtin,
+                };
+
+                registry.register(name, plugin);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load plugin from {}: {}", path.display(), e);
+            }
+        }
+    }
+}

--- a/crates/tui/src/plugins/manifest.rs
+++ b/crates/tui/src/plugins/manifest.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginManifest {
+    pub plugin: PluginMeta,
+    pub skills: Option<PluginSkills>,
+    pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
+    pub when: Option<PluginWhen>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginMeta {
+    pub name: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub author: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginSkills {
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpServerConfig {
+    pub command: String,
+    pub args: Option<Vec<String>>,
+    pub env: Option<HashMap<String, String>>,
+    pub cwd: Option<String>,
+    pub sandbox: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PluginWhen {
+    pub os: Option<Vec<String>>,
+    pub binaries: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedPlugin {
+    pub manifest: PluginManifest,
+    pub base_path: PathBuf,
+    pub enabled: bool,
+}
+
+impl PluginManifest {
+    pub fn from_path(path: &Path) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read plugin.toml: {}", e))?;
+        toml::from_str(&content).map_err(|e| format!("failed to parse plugin.toml: {}", e))
+    }
+
+    pub fn check_when(&self) -> bool {
+        if let Some(when) = &self.when {
+            if let Some(os_list) = &when.os {
+                let os = std::env::consts::OS;
+                if !os_list.iter().any(|o| o.eq_ignore_ascii_case(os)) {
+                    return false;
+                }
+            }
+            if let Some(binaries) = &when.binaries {
+                for binary in binaries {
+                    if !Self::has_binary(binary) {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    fn has_binary(name: &str) -> bool {
+        let paths = std::env::var_os("PATH").unwrap_or_default();
+        for path in std::env::split_paths(&paths) {
+            let candidate = path.join(name);
+            if candidate.exists() {
+                return true;
+            }
+            #[cfg(windows)]
+            {
+                let candidate_exe = candidate.with_extension("exe");
+                if candidate_exe.exists() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}

--- a/crates/tui/src/plugins/mod.rs
+++ b/crates/tui/src/plugins/mod.rs
@@ -1,0 +1,23 @@
+use std::sync::{Mutex, OnceLock};
+
+pub mod discovery;
+pub mod manifest;
+pub mod registry;
+
+use discovery::discover_all;
+use registry::PluginRegistry;
+
+static REGISTRY: OnceLock<Mutex<PluginRegistry>> = OnceLock::new();
+
+pub fn init_registry(builtin_dirs: &[&str]) {
+    let registry = discover_all(builtin_dirs);
+    REGISTRY.set(Mutex::new(registry)).ok();
+}
+
+pub fn try_with_registry<R>(f: impl FnOnce(&PluginRegistry) -> R) -> Option<R> {
+    REGISTRY.get().and_then(|lock| lock.lock().ok().map(f))
+}
+
+pub fn with_registry<R>(f: impl FnOnce(&mut PluginRegistry) -> R) -> Option<R> {
+    REGISTRY.get().and_then(|lock| lock.lock().ok().map(f))
+}

--- a/crates/tui/src/plugins/registry.rs
+++ b/crates/tui/src/plugins/registry.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+
+use super::manifest::LoadedPlugin;
+
+#[derive(Debug, Clone)]
+pub struct PluginRegistry {
+    plugins: HashMap<String, LoadedPlugin>,
+    user_overrides: HashMap<String, bool>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self {
+            plugins: HashMap::new(),
+            user_overrides: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, name: String, plugin: LoadedPlugin) {
+        self.plugins.insert(name, plugin);
+    }
+
+    pub fn enable(&mut self, name: &str) -> bool {
+        if let Some(plugin) = self.plugins.get_mut(name) {
+            plugin.enabled = true;
+            self.user_overrides.insert(name.to_string(), true);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn disable(&mut self, name: &str) -> bool {
+        if let Some(plugin) = self.plugins.get_mut(name) {
+            plugin.enabled = false;
+            self.user_overrides.insert(name.to_string(), false);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn list(&self) -> Vec<(&String, &LoadedPlugin)> {
+        self.plugins.iter().collect()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&LoadedPlugin> {
+        self.plugins.get(name)
+    }
+
+    pub fn enabled_plugins(&self) -> Vec<(&String, &LoadedPlugin)> {
+        self.plugins.iter().filter(|(_, p)| p.enabled).collect()
+    }
+
+    pub fn is_enabled(&self, name: &str) -> bool {
+        self.plugins.get(name).map_or(false, |p| p.enabled)
+    }
+
+    pub fn len(&self) -> usize {
+        self.plugins.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+}

--- a/crates/tui/src/plugins/tests.rs
+++ b/crates/tui/src/plugins/tests.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::manifest::{PluginManifest, PluginMeta};
+use super::registry::PluginRegistry;
+
+#[test]
+fn test_manifest_parsing() {
+    let toml_content = r#"
+[plugin]
+name = "test-plugin"
+description = "A test plugin"
+version = "1.0.0"
+author = "Test Author"
+
+[when]
+os = ["windows", "linux"]
+binaries = ["cargo"]
+"#;
+
+    let manifest: PluginManifest = toml::from_str(toml_content).unwrap();
+    assert_eq!(manifest.plugin.name, "test-plugin");
+    assert_eq!(manifest.plugin.description.unwrap(), "A test plugin");
+    assert_eq!(manifest.plugin.version.unwrap(), "1.0.0");
+    assert_eq!(manifest.plugin.author.unwrap(), "Test Author");
+}
+
+#[test]
+fn test_manifest_when_os_filter() {
+    let manifest = PluginManifest {
+        plugin: PluginMeta {
+            name: "test".to_string(),
+            description: None,
+            version: None,
+            author: None,
+        },
+        skills: None,
+        mcp_servers: None,
+        when: Some(super::manifest::PluginWhen {
+            os: Some(vec![std::env::consts::OS.to_string()]),
+            binaries: None,
+        }),
+    };
+
+    assert!(manifest.check_when());
+}
+
+#[test]
+fn test_manifest_when_os_mismatch() {
+    let manifest = PluginManifest {
+        plugin: PluginMeta {
+            name: "test".to_string(),
+            description: None,
+            version: None,
+            author: None,
+        },
+        skills: None,
+        mcp_servers: None,
+        when: Some(super::manifest::PluginWhen {
+            os: Some(vec!["nonexistent-os".to_string()]),
+            binaries: None,
+        }),
+    };
+
+    assert!(!manifest.check_when());
+}
+
+#[test]
+fn test_registry_enable_disable() {
+    let mut registry = PluginRegistry::new();
+
+    let manifest = PluginManifest {
+        plugin: PluginMeta {
+            name: "test-plugin".to_string(),
+            description: None,
+            version: None,
+            author: None,
+        },
+        skills: None,
+        mcp_servers: None,
+        when: None,
+    };
+
+    let plugin = super::manifest::LoadedPlugin {
+        manifest,
+        base_path: PathBuf::new(),
+        enabled: false,
+    };
+
+    registry.register("test-plugin".to_string(), plugin);
+
+    assert!(!registry.is_enabled("test-plugin"));
+    assert!(registry.enable("test-plugin"));
+    assert!(registry.is_enabled("test-plugin"));
+    assert!(registry.disable("test-plugin"));
+    assert!(!registry.is_enabled("test-plugin"));
+}
+
+#[test]
+fn test_registry_list() {
+    let mut registry = PluginRegistry::new();
+
+    let manifest1 = PluginManifest {
+        plugin: PluginMeta {
+            name: "plugin-1".to_string(),
+            description: None,
+            version: None,
+            author: None,
+        },
+        skills: None,
+        mcp_servers: None,
+        when: None,
+    };
+
+    let manifest2 = PluginManifest {
+        plugin: PluginMeta {
+            name: "plugin-2".to_string(),
+            description: None,
+            version: None,
+            author: None,
+        },
+        skills: None,
+        mcp_servers: None,
+        when: None,
+    };
+
+    let plugin1 = super::manifest::LoadedPlugin {
+        manifest: manifest1,
+        base_path: PathBuf::new(),
+        enabled: true,
+    };
+
+    let plugin2 = super::manifest::LoadedPlugin {
+        manifest: manifest2,
+        base_path: PathBuf::new(),
+        enabled: false,
+    };
+
+    registry.register("plugin-1".to_string(), plugin1);
+    registry.register("plugin-2".to_string(), plugin2);
+
+    assert_eq!(registry.len(), 2);
+    assert_eq!(registry.enabled_plugins().len(), 1);
+}

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -286,7 +286,7 @@ impl SkillRegistry {
         self.warnings.push(warning);
     }
 
-    fn parse_skill(_path: &Path, content: &str) -> std::result::Result<Skill, String> {
+    pub(crate) fn parse_skill(_path: &Path, content: &str) -> std::result::Result<Skill, String> {
         let trimmed = content.trim_start();
 
         // Try to parse frontmatter block first. If absent, fall back to


### PR DESCRIPTION
Add the core plugin system infrastructure:
· PluginManifest parsing from plugin.toml
· PluginRegistry with enable/disable/list
· Built-in + user plugin directory discovery
· [when] condition support (OS filter, required binaries) · Built-in example: rust-toolkit plugin
· Tests for manifest, discovery, and registry

This is Stage 1 of the plugin system per review feedback on PR #3699. No CLI, no MCP merging, no prompt injection — those follow in separate PRs.

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
