### PR TITLE
fix(tui): strip fullwidth DSML tool wrappers

### DIFF
--- a/crates/tui/src/core/engine/streaming.rs
+++ b/crates/tui/src/core/engine/streaming.rs
@@ -127,20 +127,22 @@ pub(super) fn stream_read_error_user_message(message: &str, any_content_received
     )
 }
 
-pub(crate) const TOOL_CALL_START_MARKERS: [&str; 5] = [
+pub(crate) const TOOL_CALL_START_MARKERS: [&str; 6] = [
     "[TOOL_CALL]",
     "<codewhale:tool_call",
     "<tool_call",
     "<invoke ",
     "<function_calls>",
+    "<｜DSML｜tool_calls>",
 ];
 
-pub(crate) const TOOL_CALL_END_MARKERS: [&str; 5] = [
+pub(crate) const TOOL_CALL_END_MARKERS: [&str; 6] = [
     "[/TOOL_CALL]",
     "</codewhale:tool_call>",
     "</tool_call>",
     "</invoke>",
     "</function_calls>",
+    "</｜DSML｜tool_calls>",
 ];
 
 /// Compact one-shot notice emitted when a model attempts to forge a tool-call

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -5048,6 +5048,28 @@ fn filter_tool_call_delta_strips_siliconflow_v4_dsml_content_fixture() {
 }
 
 #[test]
+fn filter_tool_call_delta_strips_fullwidth_dsml_invoke_fixture() {
+    // #3717: Windows users reported SiliconFlow/DSML content leaking through
+    // the ordinary text channel with fullwidth DSML wrapper tags. Treat it as
+    // non-API tool markup, not visible assistant text.
+    let mut in_block = false;
+    let visible = filter_tool_call_delta(
+        "visible prefix <｜DSML｜tool_calls>\n\
+         <｜DSML｜invoke name=\"read_file\">\n\
+         <｜DSML｜parameter name=\"path\" string=\"true\">backend/open_webui/utils/auth.py</｜DSML｜parameter>\n\
+         </｜DSML｜invoke>\n\
+         </｜DSML｜tool_calls> visible suffix",
+        &mut in_block,
+    );
+
+    assert!(!in_block);
+    assert_eq!(visible, "visible prefix  visible suffix");
+    assert!(!visible.contains("DSML"));
+    assert!(!visible.contains("read_file"));
+    assert!(!visible.contains("backend/open_webui"));
+}
+
+#[test]
 fn filter_tool_call_delta_handles_chunk_split_marker() {
     let mut in_block = false;
     // First chunk opens the wrapper but does not close it.


### PR DESCRIPTION
## Problem
Windows users reported that fullwidth DSML tool-call markup can arrive through the ordinary text stream and interrupt the task.

Fixes #3717.

## Change
- Treat `<｜DSML｜tool_calls>` blocks as non-API tool-call wrappers in the streaming scrubber.
- Add a regression fixture that keeps visible text while removing the DSML block.

## Verification
- `cargo test -p codewhale-tui filter_tool_call_delta_strips_fullwidth_dsml_invoke_fixture --locked`
- `cargo test -p codewhale-tui filter_tool_call_delta --locked`
- `cargo test -p codewhale-tui contains_fake_tool_wrapper --locked`
- `cargo fmt --all --check`
- `git diff --check`
