### PR TITLE
refactor(mcp): extract stdio transport

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -23,7 +23,7 @@ mod stdio;
 
 use self::headers::{apply_safe_custom_headers, with_default_mcp_http_headers};
 use self::stdio::StdioTransport;
-#[cfg(test)]
+#[cfg(all(test, unix))]
 use self::stdio::{STDIO_SHUTDOWN_GRACE, StderrTail};
 use crate::network_policy::{Decision, NetworkPolicyDecider, host_from_url};
 use crate::utils::write_atomic;

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -17,15 +16,15 @@ use anyhow::{Context, Result};
 use reqwest::StatusCode;
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
-use tokio::process::{Child, ChildStdin, ChildStdout};
-use tokio::sync::Mutex as TokioMutex;
 
 mod headers;
 pub mod oauth;
+mod stdio;
 
 use self::headers::{apply_safe_custom_headers, with_default_mcp_http_headers};
-use crate::child_env;
+use self::stdio::StdioTransport;
+#[cfg(test)]
+use self::stdio::{STDIO_SHUTDOWN_GRACE, StderrTail};
 use crate::network_policy::{Decision, NetworkPolicyDecider, host_from_url};
 use crate::utils::write_atomic;
 
@@ -406,153 +405,6 @@ pub trait McpTransport: Send + Sync {
     /// SIGKILL as the backstop. Default is a no-op for non-stdio transports
     /// that have no child process. Whalescale#420.
     async fn shutdown(&mut self) {}
-}
-
-pub struct StdioTransport {
-    child: Child,
-    stdin: ChildStdin,
-    reader: tokio::io::BufReader<ChildStdout>,
-    /// Tail of stderr lines from the spawned MCP server. A background task
-    /// drains the child's stderr into this buffer so a mid-run crash leaves
-    /// some context behind instead of `Stdio::null` swallowing it.
-    stderr_tail: Arc<StderrTail>,
-}
-
-/// How long `StdioTransport::shutdown` waits for the child to exit on SIGTERM
-/// before `kill_on_drop` fires SIGKILL. Tuned short so a hung MCP server
-/// can't stall TUI exit; well-behaved servers almost always exit within
-/// a few hundred ms.
-const STDIO_SHUTDOWN_GRACE: Duration = Duration::from_millis(2_000);
-
-/// How many lines of MCP-server stderr to keep around for crash diagnostics.
-/// Bounded so a chatty server can't grow this without limit; large enough to
-/// catch typical Node/Python startup or panic output.
-const STDERR_TAIL_CAPACITY: usize = 64;
-
-/// Bounded ring buffer for the most recent stderr lines from a spawned MCP
-/// server. Used by `StdioTransport` to surface server-side context when the
-/// transport read side fails (server crashed, exited early, etc).
-#[derive(Default)]
-pub struct StderrTail {
-    lines: TokioMutex<VecDeque<String>>,
-}
-
-impl StderrTail {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            lines: TokioMutex::new(VecDeque::with_capacity(STDERR_TAIL_CAPACITY)),
-        })
-    }
-
-    async fn push(&self, line: String) {
-        let mut buf = self.lines.lock().await;
-        if buf.len() >= STDERR_TAIL_CAPACITY {
-            buf.pop_front();
-        }
-        buf.push_back(line);
-    }
-
-    async fn snapshot(&self) -> Vec<String> {
-        self.lines.lock().await.iter().cloned().collect()
-    }
-}
-
-/// Format the captured stderr tail for inclusion in an error message. Empty
-/// tails return `None` so the caller can fall back to its original message.
-async fn format_stderr_context(tail: &StderrTail) -> Option<String> {
-    let lines = tail.snapshot().await;
-    if lines.is_empty() {
-        return None;
-    }
-    Some(format!(
-        "MCP server stderr (last {} line{}):\n{}",
-        lines.len(),
-        if lines.len() == 1 { "" } else { "s" },
-        lines.join("\n"),
-    ))
-}
-
-/// Best-effort SIGTERM. On Unix uses `libc::kill`; on Windows there's no
-/// equivalent so we let `kill_on_drop` (TerminateProcess) handle it via the
-/// subsequent Drop. Returns whether a signal was actually sent.
-fn send_sigterm(child: &Child) -> bool {
-    #[cfg(unix)]
-    {
-        if let Some(pid) = child.id() {
-            // SAFETY: pid was just obtained from `child.id()`. `libc::kill`
-            // with `SIGTERM` is async-signal-safe and never observes invalid
-            // memory. Worst case (pid wrap / process already gone) returns
-            // ESRCH, which we deliberately ignore.
-            unsafe {
-                let _ = libc::kill(pid as i32, libc::SIGTERM);
-            }
-            return true;
-        }
-        false
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = child;
-        false
-    }
-}
-
-#[async_trait::async_trait]
-impl McpTransport for StdioTransport {
-    async fn send(&mut self, mut msg: Vec<u8>) -> Result<()> {
-        msg.push(b'\n');
-        self.stdin.write_all(&msg).await?;
-        self.stdin.flush().await?;
-        Ok(())
-    }
-
-    async fn recv(&mut self) -> Result<Vec<u8>> {
-        let mut line = String::new();
-        loop {
-            line.clear();
-            let bytes = match self.reader.read_line(&mut line).await {
-                Ok(b) => b,
-                Err(err) => {
-                    if let Some(stderr) = format_stderr_context(&self.stderr_tail).await {
-                        anyhow::bail!("Stdio transport read error: {err}\n{stderr}");
-                    }
-                    return Err(err.into());
-                }
-            };
-            if bytes == 0 {
-                if let Some(stderr) = format_stderr_context(&self.stderr_tail).await {
-                    anyhow::bail!("Stdio transport closed\n{stderr}");
-                }
-                anyhow::bail!("Stdio transport closed");
-            }
-
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-
-            return Ok(trimmed.as_bytes().to_vec());
-        }
-    }
-
-    /// Send SIGTERM and wait up to `STDIO_SHUTDOWN_GRACE` for graceful exit
-    /// before letting Drop / `kill_on_drop` fire SIGKILL as the backstop.
-    async fn shutdown(&mut self) {
-        send_sigterm(&self.child);
-        // Give the child a window to exit cleanly. Discard the result —
-        // either it exits (success) or the timeout fires (Drop will SIGKILL).
-        let _ = tokio::time::timeout(STDIO_SHUTDOWN_GRACE, self.child.wait()).await;
-    }
-}
-
-/// Drop fallback (#420): if `shutdown` was never called explicitly, still
-/// fire SIGTERM before tokio's `kill_on_drop` sends SIGKILL. The two
-/// signals arrive back-to-back so well-behaved servers at least see the
-/// SIGTERM first; misbehaving ones get SIGKILL'd anyway.
-impl Drop for StdioTransport {
-    fn drop(&mut self) {
-        send_sigterm(&self.child);
-    }
 }
 
 pub struct SseTransport {
@@ -1461,56 +1313,7 @@ impl McpConnection {
                 Box::new(http)
             }
         } else if let Some(command) = &config.command {
-            let mut cmd = tokio::process::Command::new(command);
-            cmd.args(&config.args)
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .kill_on_drop(true);
-            if let Some(cwd) = &config.cwd {
-                cmd.current_dir(cwd);
-            }
-
-            // MCP stdio servers are user-configured integrations. Use the
-            // wider MCP allowlist so common Node/Python/proxy/CA-bundle
-            // bootstrap variables (NVM_DIR, NODE_OPTIONS, NPM_CONFIG_*,
-            // HTTP(S)_PROXY, …) reach the child. See `sanitized_mcp_env`
-            // and #1244 for context.
-            child_env::apply_to_tokio_command_mcp(&mut cmd, child_env::string_map_env(&config.env));
-
-            let mut child = cmd.spawn().with_context(|| {
-                let env_keys: Vec<&str> = config.env.keys().map(String::as_str).collect();
-                format!(
-                    "MCP stdio spawn failed (transport=stdio server={name} cmd={command:?} args={:?} env_keys={env_keys:?})",
-                    config.args,
-                )
-            })?;
-
-            let stdin = child.stdin.take().context("Failed to get MCP stdin")?;
-            let stdout = child.stdout.take().context("Failed to get MCP stdout")?;
-            let stderr = child.stderr.take().context("Failed to get MCP stderr")?;
-
-            // Drain stderr into a bounded ring buffer so a crash mid-run
-            // leaves diagnostic breadcrumbs instead of disappearing into
-            // `Stdio::null`. The task exits naturally when the child closes
-            // its stderr (kill_on_drop / exit / explicit shutdown).
-            let stderr_tail = StderrTail::new();
-            {
-                let tail = Arc::clone(&stderr_tail);
-                tokio::spawn(async move {
-                    let mut lines = tokio::io::BufReader::new(stderr).lines();
-                    while let Ok(Some(line)) = lines.next_line().await {
-                        tail.push(line).await;
-                    }
-                });
-            }
-
-            Box::new(StdioTransport {
-                child,
-                stdin,
-                reader: tokio::io::BufReader::new(stdout),
-                stderr_tail,
-            })
+            Box::new(StdioTransport::spawn(&name, command, &config)?)
         } else {
             anyhow::bail!("MCP server '{name}' config must have either 'command' or 'url'");
         };

--- a/crates/tui/src/mcp/stdio.rs
+++ b/crates/tui/src/mcp/stdio.rs
@@ -1,0 +1,217 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::sync::Mutex as TokioMutex;
+
+use super::{McpServerConfig, McpTransport};
+use crate::child_env;
+
+pub(super) struct StdioTransport {
+    pub(super) child: Child,
+    pub(super) stdin: ChildStdin,
+    pub(super) reader: tokio::io::BufReader<ChildStdout>,
+    /// Tail of stderr lines from the spawned MCP server. A background task
+    /// drains the child's stderr into this buffer so a mid-run crash leaves
+    /// some context behind instead of `Stdio::null` swallowing it.
+    pub(super) stderr_tail: Arc<StderrTail>,
+}
+
+/// How long `StdioTransport::shutdown` waits for the child to exit on SIGTERM
+/// before `kill_on_drop` fires SIGKILL. Tuned short so a hung MCP server
+/// can't stall TUI exit; well-behaved servers almost always exit within
+/// a few hundred ms.
+pub(super) const STDIO_SHUTDOWN_GRACE: Duration = Duration::from_millis(2_000);
+
+/// How many lines of MCP-server stderr to keep around for crash diagnostics.
+/// Bounded so a chatty server can't grow this without limit; large enough to
+/// catch typical Node/Python startup or panic output.
+const STDERR_TAIL_CAPACITY: usize = 64;
+
+/// Bounded ring buffer for the most recent stderr lines from a spawned MCP
+/// server. Used by `StdioTransport` to surface server-side context when the
+/// transport read side fails (server crashed, exited early, etc).
+#[derive(Default)]
+pub(super) struct StderrTail {
+    lines: TokioMutex<VecDeque<String>>,
+}
+
+impl StderrTail {
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            lines: TokioMutex::new(VecDeque::with_capacity(STDERR_TAIL_CAPACITY)),
+        })
+    }
+
+    pub(super) async fn push(&self, line: String) {
+        let mut buf = self.lines.lock().await;
+        if buf.len() >= STDERR_TAIL_CAPACITY {
+            buf.pop_front();
+        }
+        buf.push_back(line);
+    }
+
+    async fn snapshot(&self) -> Vec<String> {
+        self.lines.lock().await.iter().cloned().collect()
+    }
+}
+
+impl StdioTransport {
+    pub(super) fn spawn(
+        server_name: &str,
+        command: &str,
+        config: &McpServerConfig,
+    ) -> Result<Self> {
+        let mut cmd = tokio::process::Command::new(command);
+        cmd.args(&config.args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        if let Some(cwd) = &config.cwd {
+            cmd.current_dir(cwd);
+        }
+
+        // MCP stdio servers are user-configured integrations. Use the
+        // wider MCP allowlist so common Node/Python/proxy/CA-bundle
+        // bootstrap variables (NVM_DIR, NODE_OPTIONS, NPM_CONFIG_*,
+        // HTTP(S)_PROXY, …) reach the child. See `sanitized_mcp_env`
+        // and #1244 for context.
+        child_env::apply_to_tokio_command_mcp(&mut cmd, child_env::string_map_env(&config.env));
+
+        let mut child = cmd.spawn().with_context(|| {
+            let env_keys: Vec<&str> = config.env.keys().map(String::as_str).collect();
+            format!(
+                "MCP stdio spawn failed (transport=stdio server={server_name} cmd={command:?} args={:?} env_keys={env_keys:?})",
+                config.args,
+            )
+        })?;
+
+        let stdin = child.stdin.take().context("Failed to get MCP stdin")?;
+        let stdout = child.stdout.take().context("Failed to get MCP stdout")?;
+        let stderr = child.stderr.take().context("Failed to get MCP stderr")?;
+
+        // Drain stderr into a bounded ring buffer so a crash mid-run leaves
+        // diagnostic breadcrumbs instead of disappearing into `Stdio::null`.
+        // The task exits naturally when the child closes its stderr
+        // (kill_on_drop / exit / explicit shutdown).
+        let stderr_tail = StderrTail::new();
+        {
+            let tail = Arc::clone(&stderr_tail);
+            tokio::spawn(async move {
+                let mut lines = tokio::io::BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tail.push(line).await;
+                }
+            });
+        }
+
+        Ok(Self {
+            child,
+            stdin,
+            reader: tokio::io::BufReader::new(stdout),
+            stderr_tail,
+        })
+    }
+}
+
+/// Format the captured stderr tail for inclusion in an error message. Empty
+/// tails return `None` so the caller can fall back to its original message.
+async fn format_stderr_context(tail: &StderrTail) -> Option<String> {
+    let lines = tail.snapshot().await;
+    if lines.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "MCP server stderr (last {} line{}):\n{}",
+        lines.len(),
+        if lines.len() == 1 { "" } else { "s" },
+        lines.join("\n"),
+    ))
+}
+
+/// Best-effort SIGTERM. On Unix uses `libc::kill`; on Windows there's no
+/// equivalent so we let `kill_on_drop` (TerminateProcess) handle it via the
+/// subsequent Drop. Returns whether a signal was actually sent.
+fn send_sigterm(child: &Child) -> bool {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child.id() {
+            // SAFETY: pid was just obtained from `child.id()`. `libc::kill`
+            // with `SIGTERM` is async-signal-safe and never observes invalid
+            // memory. Worst case (pid wrap / process already gone) returns
+            // ESRCH, which we deliberately ignore.
+            unsafe {
+                let _ = libc::kill(pid as i32, libc::SIGTERM);
+            }
+            return true;
+        }
+        false
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child;
+        false
+    }
+}
+
+#[async_trait::async_trait]
+impl McpTransport for StdioTransport {
+    async fn send(&mut self, mut msg: Vec<u8>) -> Result<()> {
+        msg.push(b'\n');
+        self.stdin.write_all(&msg).await?;
+        self.stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> Result<Vec<u8>> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes = match self.reader.read_line(&mut line).await {
+                Ok(b) => b,
+                Err(err) => {
+                    if let Some(stderr) = format_stderr_context(&self.stderr_tail).await {
+                        anyhow::bail!("Stdio transport read error: {err}\n{stderr}");
+                    }
+                    return Err(err.into());
+                }
+            };
+            if bytes == 0 {
+                if let Some(stderr) = format_stderr_context(&self.stderr_tail).await {
+                    anyhow::bail!("Stdio transport closed\n{stderr}");
+                }
+                anyhow::bail!("Stdio transport closed");
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            return Ok(trimmed.as_bytes().to_vec());
+        }
+    }
+
+    /// Send SIGTERM and wait up to `STDIO_SHUTDOWN_GRACE` for graceful exit
+    /// before letting Drop / `kill_on_drop` fire SIGKILL as the backstop.
+    async fn shutdown(&mut self) {
+        send_sigterm(&self.child);
+        // Give the child a window to exit cleanly. Discard the result —
+        // either it exits (success) or the timeout fires (Drop will SIGKILL).
+        let _ = tokio::time::timeout(STDIO_SHUTDOWN_GRACE, self.child.wait()).await;
+    }
+}
+
+/// Drop fallback (#420): if `shutdown` was never called explicitly, still
+/// fire SIGTERM before tokio's `kill_on_drop` sends SIGKILL. The two
+/// signals arrive back-to-back so well-behaved servers at least see the
+/// SIGTERM first; misbehaving ones get SIGKILL'd anyway.
+impl Drop for StdioTransport {
+    fn drop(&mut self) {
+        send_sigterm(&self.child);
+    }
+}

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -4,6 +4,7 @@ use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(unix)]
 use tokio::io::AsyncBufReadExt;
 
 fn test_http_client() -> reqwest::Client {

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -4,6 +4,7 @@ use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex, OnceLock};
+use tokio::io::AsyncBufReadExt;
 
 fn test_http_client() -> reqwest::Client {
     let _ = rustls::crypto::ring::default_provider().install_default();


### PR DESCRIPTION
## Problem
`crates/tui/src/mcp.rs` still owns multiple transport implementations. #3310 calls out splitting those transports into focused modules.

Part of #3310.

## Change
- Move `StdioTransport`, stderr tail diagnostics, and SIGTERM shutdown handling into `mcp/stdio.rs`.
- Keep `mcp.rs` responsible for selecting the configured transport and constructing stdio via `StdioTransport::spawn`.
- Keep existing stdio behavior and tests intact.

## Verification
- `cargo test -p codewhale-tui mcp::tests --locked`
- `cargo test -p codewhale-tui stdio_transport --locked`
- `cargo fmt --all --check`
- `git diff --check upstream/main...HEAD`
