### PR TITLE
config: add verifier preview policy table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry submission for CodeWhale after validating the published
   `codewhale@0.8.65` ACP auth handshake against the upstream registry checker
   (#3192).
+- Added a typed `[verifier]` config table for the verifier-preview lane, with
+  `enabled` and the shipped `verdict_policy = "hunt"` mapping documented and
+  validated (#2093).
 
 ### Changed
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -659,6 +659,17 @@ max_subagents = 10 # optional (1-20)
 # audit = true            # one line per call to ~/.codewhale/audit.log
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Verifier preview (#2093)
+# ─────────────────────────────────────────────────────────────────────────────────
+# Enables automatic claim-of-done verifier preview once the runtime trigger is
+# active. Manual `run_verifiers` remains available even when this is false.
+# The shipped policy maps pass/partial/fail to hunted/wounded/escaped.
+#
+# [verifier]
+# enabled = false
+# verdict_policy = "hunt"
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Skills (#140)
 # ─────────────────────────────────────────────────────────────────────────────────
 # Settings for the `/skill install <spec>` community-skill installer.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -329,6 +329,10 @@ pub struct ConfigToml {
     /// to a permissive default that mirrors pre-v0.7.0 behavior.
     #[serde(default)]
     pub network: Option<NetworkPolicyToml>,
+    /// Verifier-preview behavior (#2093). When absent, verifier tools keep the
+    /// shipped defaults: disabled automatic preview and hunt verdict mapping.
+    #[serde(default)]
+    pub verifier: Option<VerifierConfigToml>,
     /// Community skill installer settings (#140). Mirrors
     /// [`SkillsToml`] from the TUI side; the dispatcher consults
     /// `registry_url` when running `deepseek skill install`.
@@ -1452,6 +1456,40 @@ pub fn built_in_role_presets() -> BTreeMap<String, FleetRolePreset> {
         ),
     ]
     .into()
+}
+
+/// Verdict policy for the verifier-preview surface (#2093).
+///
+/// Only the hunt vocabulary is shipped today. Keeping this typed lets future
+/// policy additions reject misspellings instead of silently accepting unknown
+/// strings.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum VerifierVerdictPolicy {
+    #[default]
+    Hunt,
+}
+
+/// On-disk schema for `[verifier]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VerifierConfigToml {
+    /// Enable automatic verifier preview when the runtime wires a
+    /// claim-of-done trigger. Manual `run_verifiers` remains available
+    /// regardless.
+    #[serde(default)]
+    pub enabled: bool,
+    /// How verifier verdicts map into the goal/hunt system.
+    #[serde(default)]
+    pub verdict_policy: VerifierVerdictPolicy,
+}
+
+impl Default for VerifierConfigToml {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            verdict_policy: VerifierVerdictPolicy::Hunt,
+        }
+    }
 }
 
 /// On-disk schema for the `[network]` table (#135). See `config.example.toml`

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -27,6 +27,37 @@ fn network_policy_toml_deserializes_proxy_hosts() {
 }
 
 #[test]
+fn verifier_config_defaults_to_hunt_verdict_policy() {
+    let config: ConfigToml = toml::from_str(
+        r#"
+        [verifier]
+        enabled = true
+        "#,
+    )
+    .expect("verifier config toml");
+
+    let verifier = config.verifier.expect("verifier table");
+    assert!(verifier.enabled);
+    assert_eq!(verifier.verdict_policy, VerifierVerdictPolicy::Hunt);
+}
+
+#[test]
+fn verifier_config_rejects_unknown_verdict_policy() {
+    let err = toml::from_str::<ConfigToml>(
+        r#"
+        [verifier]
+        verdict_policy = "strict"
+        "#,
+    )
+    .expect_err("only the shipped hunt policy should parse");
+
+    assert!(
+        err.message().contains("unknown variant"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn permissions_toml_deserializes_typed_ask_rules() {
     let permissions: PermissionsToml = toml::from_str(
         r#"

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry submission for CodeWhale after validating the published
   `codewhale@0.8.65` ACP auth handshake against the upstream registry checker
   (#3192).
+- Added a typed `[verifier]` config table for the verifier-preview lane, with
+  `enabled` and the shipped `verdict_policy = "hunt"` mapping documented and
+  validated (#2093).
 
 ### Changed
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1930,6 +1930,11 @@ pub struct Config {
     #[serde(default)]
     pub network: Option<NetworkPolicyToml>,
 
+    /// Verifier-preview behavior (#2093). When absent, automatic verifier
+    /// preview stays off and verifier verdicts use the hunt policy.
+    #[serde(default)]
+    pub verifier: Option<codewhale_config::VerifierConfigToml>,
+
     /// Community skill installer settings (#140). When absent, installer
     /// commands fall back to the bundled defaults
     /// ([`crate::skills::install::DEFAULT_REGISTRY_URL`] +
@@ -5475,6 +5480,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
         features: merge_features(base.features, override_cfg.features),
         notifications: override_cfg.notifications.or(base.notifications),
         network: override_cfg.network.or(base.network),
+        verifier: override_cfg.verifier.or(base.verifier),
         skills: merge_skills_config(base.skills, override_cfg.skills),
         snapshots: override_cfg.snapshots.or(base.snapshots),
         search: override_cfg.search.or(base.search),

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -618,6 +618,44 @@ fn network_policy_toml_maps_proxy_hosts_to_runtime_policy() {
 }
 
 #[test]
+fn verifier_config_parses_hunt_policy_and_merges_overrides() {
+    let config: Config = toml::from_str(
+        r#"
+        [verifier]
+        enabled = true
+        verdict_policy = "hunt"
+        "#,
+    )
+    .expect("parse verifier config");
+
+    let verifier = config.verifier.expect("verifier table");
+    assert!(verifier.enabled);
+    assert_eq!(
+        verifier.verdict_policy,
+        codewhale_config::VerifierVerdictPolicy::Hunt
+    );
+
+    let merged = merge_config(
+        Config {
+            verifier: Some(codewhale_config::VerifierConfigToml {
+                enabled: false,
+                verdict_policy: codewhale_config::VerifierVerdictPolicy::Hunt,
+            }),
+            ..Config::default()
+        },
+        Config {
+            verifier: Some(codewhale_config::VerifierConfigToml {
+                enabled: true,
+                verdict_policy: codewhale_config::VerifierVerdictPolicy::Hunt,
+            }),
+            ..Config::default()
+        },
+    );
+
+    assert!(merged.verifier.expect("merged verifier").enabled);
+}
+
+#[test]
 fn search_provider_defaults_to_duckduckgo() {
     assert_eq!(SearchProvider::default(), SearchProvider::DuckDuckGo);
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1233,6 +1233,13 @@ If you are upgrading from older releases:
   `.opencode/skills`, `.cursor/skills`, and `~/.agents/skills`. CodeWhale still
   scans `<workspace>/.codewhale/skills`, `~/.codewhale/skills`, and any explicit
   `skills_dir` override.
+- `[verifier].enabled` (bool, default `false`): enables automatic
+  claim-of-done verifier preview once that runtime trigger is active. The
+  manual `run_verifiers` tool is still available when this is false.
+- `[verifier].verdict_policy` (string, default `"hunt"`): maps verifier
+  `pass` / `partial` / `fail` into the goal verdict vocabulary
+  `hunted` / `wounded` / `escaped`. `"hunt"` is the only shipped policy today;
+  unknown values are rejected so future policies can be added deliberately.
 - `mcp_config_path` (string, optional): defaults to `~/.codewhale/mcp.json`, with
   legacy `~/.deepseek/mcp.json` fallback when the CodeWhale path is absent.
   It is visible in `/config` and can be changed from the TUI. The new path is


### PR DESCRIPTION
## Summary
- Add a typed `[verifier]` config table for the verifier-preview lane.
- Keep the shipped policy deliberately narrow: `verdict_policy = "hunt"` maps verifier pass/partial/fail to hunted/wounded/escaped, and unknown policies are rejected.
- Document the new table in `config.example.toml`, `docs/CONFIGURATION.md`, the root changelog, and the synced TUI changelog.

Part of #2093.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `./scripts/release/check-versions.sh`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-config verifier_config --locked`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui config::tests::verifier_config_parses_hunt_policy_and_merges_overrides --locked`