### PR TITLE
fix(tui): keep mode policy in sync with engine

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1027,6 +1027,7 @@ impl Engine {
         &mut self,
         command: String,
         mode: AppMode,
+        allow_shell: bool,
         trust_mode: bool,
         auto_approve: bool,
         approval_mode: crate::tui::approval::ApprovalMode,
@@ -1047,15 +1048,7 @@ impl Engine {
             .unwrap_or_default()
             .to_string();
 
-        self.session.trust_mode = trust_mode;
-        self.config.trust_mode = trust_mode;
-        self.session.auto_approve = auto_approve;
-        let agent_approval_mode = agent_approval_mode_for_turn(auto_approve, approval_mode);
-        // Only track the Agent-mode approval — Yolo/Plan have fixed
-        // approval policies that are derived from the mode itself.
-        if mode == AppMode::Agent {
-            self.session.approval_mode = agent_approval_mode;
-        }
+        self.apply_runtime_mode_policy(mode, allow_shell, trust_mode, auto_approve, approval_mode);
 
         let _ = self
             .tx_event
@@ -1290,6 +1283,23 @@ impl Engine {
         }
     }
 
+    fn apply_runtime_mode_policy(
+        &mut self,
+        mode: AppMode,
+        allow_shell: bool,
+        trust_mode: bool,
+        auto_approve: bool,
+        approval_mode: crate::tui::approval::ApprovalMode,
+    ) {
+        self.current_mode = mode;
+        self.session.allow_shell = allow_shell;
+        self.config.allow_shell = allow_shell;
+        self.session.trust_mode = trust_mode;
+        self.config.trust_mode = trust_mode;
+        self.session.auto_approve = auto_approve;
+        self.session.approval_mode = agent_approval_mode_for_turn(auto_approve, approval_mode);
+    }
+
     /// Run the engine event loop
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) {
@@ -1365,6 +1375,7 @@ impl Engine {
                     Op::RunShellCommand {
                         command,
                         mode,
+                        allow_shell,
                         trust_mode,
                         auto_approve,
                         approval_mode,
@@ -1372,6 +1383,7 @@ impl Engine {
                         self.handle_run_shell_command(
                             command,
                             mode,
+                            allow_shell,
                             trust_mode,
                             auto_approve,
                             approval_mode,
@@ -1494,8 +1506,20 @@ impl Engine {
                         };
                         let _ = self.tx_event.send(Event::AgentList { agents }).await;
                     }
-                    Op::ChangeMode { mode } => {
-                        self.current_mode = mode;
+                    Op::ChangeMode {
+                        mode,
+                        allow_shell,
+                        trust_mode,
+                        auto_approve,
+                        approval_mode,
+                    } => {
+                        self.apply_runtime_mode_policy(
+                            mode,
+                            allow_shell,
+                            trust_mode,
+                            auto_approve,
+                            approval_mode,
+                        );
                         self.emit_session_updated().await;
                         let _ = self
                             .tx_event
@@ -2198,8 +2222,16 @@ impl Engine {
         // Reset cancel token for fresh turn (in case previous was cancelled)
         self.reset_cancel_token();
 
-        // Track current mode so mid-turn messages include the right mode in turn metadata.
-        self.current_mode = input_policy.mode;
+        // Track the complete effective mode policy so mid-turn metadata, `/edit`,
+        // idle worker resumptions, and approval gates cannot read a stale policy
+        // after the UI changed modes (#3568).
+        self.apply_runtime_mode_policy(
+            input_policy.mode,
+            input_policy.allow_shell,
+            input_policy.trust_mode,
+            input_policy.auto_approve,
+            input_policy.approval_mode,
+        );
 
         // Drain stale steer messages from previous turns.
         while self.rx_steer.try_recv().is_ok() {}
@@ -2297,15 +2329,6 @@ impl Engine {
             .observe_user_message(&content, &self.session.workspace);
         let force_update_plan_first = should_force_update_plan_first(input_policy.mode, &content);
 
-        let agent_approval_mode =
-            agent_approval_mode_for_turn(input_policy.auto_approve, input_policy.approval_mode);
-        self.session.auto_approve = input_policy.auto_approve;
-        // Only track the Agent-mode approval — Yolo/Plan have fixed
-        // approval policies that are derived from the mode itself.
-        if input_policy.mode == AppMode::Agent {
-            self.session.approval_mode = agent_approval_mode;
-        }
-
         // Add user message to session
         let user_msg = self.user_text_message_with_turn_metadata_for_route_and_provenance(
             content,
@@ -2343,10 +2366,6 @@ impl Engine {
         self.session.reasoning_effort = reasoning_effort;
         self.session.reasoning_effort_auto = reasoning_effort_auto;
         self.session.auto_model = auto_model;
-        self.session.allow_shell = input_policy.allow_shell;
-        self.config.allow_shell = input_policy.allow_shell;
-        self.session.trust_mode = input_policy.trust_mode;
-        self.config.trust_mode = input_policy.trust_mode;
         self.config.translation_enabled = translation_enabled;
         self.config.show_thinking = show_thinking;
         self.config.verbosity = verbosity;

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2201,6 +2201,8 @@ fn deferred_tool_preflight_guides_checklist_update_list_replacement() {
 #[tokio::test]
 async fn run_shell_command_op_requests_approval_and_executes_shell() {
     let (mut engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
+    engine.session.allow_shell = false;
+    engine.config.allow_shell = false;
     let handle_for_approval = handle.clone();
 
     let task = tokio::spawn(async move {
@@ -2208,6 +2210,7 @@ async fn run_shell_command_op_requests_approval_and_executes_shell() {
             .handle_run_shell_command(
                 "echo bang-ok".to_string(),
                 AppMode::Agent,
+                true,
                 false,
                 false,
                 crate::tui::approval::ApprovalMode::Suggest,
@@ -2276,6 +2279,7 @@ async fn run_shell_command_op_skips_approval_when_auto_approved() {
             AppMode::Yolo,
             true,
             true,
+            true,
             crate::tui::approval::ApprovalMode::Auto,
         )
         .await;
@@ -2323,6 +2327,7 @@ async fn yolo_mode_does_not_prompt_for_typed_ask_rule() {
         .handle_run_shell_command(
             "echo yolo-ask-rule".to_string(),
             AppMode::Yolo,
+            true,
             true,
             true,
             crate::tui::approval::ApprovalMode::Auto,
@@ -2629,6 +2634,7 @@ async fn run_shell_command_op_preserves_plan_mode_shell_block() {
         .handle_run_shell_command(
             "echo blocked".to_string(),
             AppMode::Plan,
+            false,
             false,
             false,
             crate::tui::approval::ApprovalMode::Suggest,
@@ -3139,6 +3145,10 @@ async fn change_mode_refreshes_session_prompt_and_updates_session() {
     handle
         .send(Op::ChangeMode {
             mode: AppMode::Yolo,
+            allow_shell: true,
+            trust_mode: true,
+            auto_approve: true,
+            approval_mode: crate::tui::approval::ApprovalMode::Bypass,
         })
         .await
         .expect("send change mode");
@@ -3238,6 +3248,10 @@ async fn change_mode_op_updates_current_mode_and_emits_status() {
     handle
         .send(Op::ChangeMode {
             mode: AppMode::Yolo,
+            allow_shell: true,
+            trust_mode: true,
+            auto_approve: true,
+            approval_mode: crate::tui::approval::ApprovalMode::Bypass,
         })
         .await
         .expect("send change mode");
@@ -3267,6 +3281,61 @@ async fn change_mode_op_updates_current_mode_and_emits_status() {
     );
 
     run.abort();
+}
+
+#[test]
+fn runtime_mode_policy_updates_engine_session_mirrors() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        allow_shell: false,
+        trust_mode: false,
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    engine.current_mode = AppMode::Plan;
+    engine.session.allow_shell = false;
+    engine.session.trust_mode = false;
+    engine.session.auto_approve = false;
+    engine.session.approval_mode = crate::tui::approval::ApprovalMode::Suggest;
+
+    engine.apply_runtime_mode_policy(
+        AppMode::Agent,
+        true,
+        false,
+        false,
+        crate::tui::approval::ApprovalMode::Never,
+    );
+
+    assert_eq!(engine.current_mode, AppMode::Agent);
+    assert!(engine.session.allow_shell);
+    assert!(engine.config.allow_shell);
+    assert!(!engine.session.trust_mode);
+    assert!(!engine.config.trust_mode);
+    assert!(!engine.session.auto_approve);
+    assert_eq!(
+        engine.session.approval_mode,
+        crate::tui::approval::ApprovalMode::Never
+    );
+
+    engine.apply_runtime_mode_policy(
+        AppMode::Yolo,
+        true,
+        true,
+        true,
+        crate::tui::approval::ApprovalMode::Bypass,
+    );
+
+    assert_eq!(engine.current_mode, AppMode::Yolo);
+    assert!(engine.session.allow_shell);
+    assert!(engine.session.trust_mode);
+    assert!(engine.config.trust_mode);
+    assert!(engine.session.auto_approve);
+    assert_eq!(
+        engine.session.approval_mode,
+        crate::tui::approval::ApprovalMode::Bypass
+    );
 }
 
 #[tokio::test]
@@ -3352,6 +3421,10 @@ async fn edit_last_turn_preserves_current_mode() {
     handle
         .send(Op::ChangeMode {
             mode: AppMode::Plan,
+            allow_shell: false,
+            trust_mode: false,
+            auto_approve: false,
+            approval_mode: crate::tui::approval::ApprovalMode::Suggest,
         })
         .await
         .expect("send plan mode");

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -123,6 +123,7 @@ pub enum Op {
     RunShellCommand {
         command: String,
         mode: AppMode,
+        allow_shell: bool,
         trust_mode: bool,
         auto_approve: bool,
         approval_mode: ApprovalMode,
@@ -159,7 +160,13 @@ pub enum Op {
 
     /// Change the operating mode
     #[allow(dead_code)]
-    ChangeMode { mode: AppMode },
+    ChangeMode {
+        mode: AppMode,
+        allow_shell: bool,
+        trust_mode: bool,
+        auto_approve: bool,
+        approval_mode: ApprovalMode,
+    },
 
     /// Update the model being used and refresh stable prompt context.
     #[allow(dead_code)]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4454,7 +4454,7 @@ async fn run_event_loop(
                     let prior_mode = app.mode;
                     app.cycle_mode();
                     if app.mode != prior_mode {
-                        sync_mode_update(&engine_handle, app.mode).await;
+                        sync_mode_update(app, &engine_handle).await;
                     }
                     if app.model != prior_model {
                         let _ = engine_handle
@@ -6414,13 +6414,21 @@ pub(crate) fn apply_goal_snapshot_to_app(app: &mut App, snapshot: &GoalSnapshot)
     true
 }
 
-async fn sync_mode_update(engine_handle: &EngineHandle, mode: AppMode) {
-    let _ = engine_handle.send(Op::ChangeMode { mode }).await;
+async fn sync_mode_update(app: &App, engine_handle: &EngineHandle) {
+    let _ = engine_handle
+        .send(Op::ChangeMode {
+            mode: app.mode,
+            allow_shell: app.allow_shell,
+            trust_mode: app.trust_mode,
+            auto_approve: app_auto_approve_enabled(app),
+            approval_mode: app.approval_mode,
+        })
+        .await;
 }
 
 async fn apply_mode_update(app: &mut App, engine_handle: &EngineHandle, mode: AppMode) -> bool {
     if app.set_mode(mode) {
-        sync_mode_update(engine_handle, mode).await;
+        sync_mode_update(app, engine_handle).await;
         true
     } else {
         false
@@ -6445,6 +6453,7 @@ async fn handle_bang_shell_input(
         .send(Op::RunShellCommand {
             command: command.to_string(),
             mode: app.mode,
+            allow_shell: app.allow_shell,
             trust_mode: app.trust_mode,
             auto_approve: app_auto_approve_enabled(app),
             approval_mode: app.approval_mode,
@@ -7156,8 +7165,8 @@ async fn apply_command_result(
                     persistence_actor::persist(PersistRequest::ClearCheckpoint);
                 }
             }
-            AppAction::ModeChanged(mode) => {
-                sync_mode_update(engine_handle, mode).await;
+            AppAction::ModeChanged(_mode) => {
+                sync_mode_update(app, engine_handle).await;
             }
             AppAction::SendMessage(content) => {
                 let queued = build_queued_message(app, content);
@@ -9293,7 +9302,7 @@ async fn handle_view_events(
                 let prior_mode = app.mode;
                 let msg = commands::switch_mode(app, mode);
                 if app.mode != prior_mode {
-                    sync_mode_update(engine_handle, app.mode).await;
+                    sync_mode_update(app, engine_handle).await;
                 }
                 app.add_message(HistoryCell::System { content: msg });
             }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2688,8 +2688,47 @@ async fn mode_change_update_notifies_engine() {
     assert!(apply_mode_update(&mut app, &engine.handle, crate::tui::app::AppMode::Yolo).await);
 
     match engine.rx_op.recv().await.expect("change mode op") {
-        crate::core::ops::Op::ChangeMode { mode } => {
+        crate::core::ops::Op::ChangeMode {
+            mode,
+            allow_shell,
+            trust_mode,
+            auto_approve,
+            approval_mode,
+        } => {
             assert_eq!(mode, crate::tui::app::AppMode::Yolo);
+            assert!(allow_shell);
+            assert!(trust_mode);
+            assert!(auto_approve);
+            assert_eq!(approval_mode, crate::tui::approval::ApprovalMode::Bypass);
+        }
+        other => panic!("expected ChangeMode, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mode_change_update_sends_restored_agent_policy() {
+    let mut app = create_test_app();
+    app.allow_shell = true;
+    app.trust_mode = false;
+    app.approval_mode = crate::tui::approval::ApprovalMode::Never;
+    let _ = app.set_mode(crate::tui::app::AppMode::Plan);
+    let mut engine = crate::core::engine::mock_engine_handle();
+
+    assert!(apply_mode_update(&mut app, &engine.handle, crate::tui::app::AppMode::Agent).await);
+
+    match engine.rx_op.recv().await.expect("change mode op") {
+        crate::core::ops::Op::ChangeMode {
+            mode,
+            allow_shell,
+            trust_mode,
+            auto_approve,
+            approval_mode,
+        } => {
+            assert_eq!(mode, crate::tui::app::AppMode::Agent);
+            assert!(allow_shell);
+            assert!(!trust_mode);
+            assert!(!auto_approve);
+            assert_eq!(approval_mode, crate::tui::approval::ApprovalMode::Never);
         }
         other => panic!("expected ChangeMode, got {other:?}"),
     }
@@ -5155,12 +5194,14 @@ async fn bang_shell_input_dispatches_shell_op_instead_of_model_message() {
         Op::RunShellCommand {
             command,
             mode,
+            allow_shell,
             trust_mode,
             auto_approve,
             approval_mode,
         } => {
             assert_eq!(command, "pwd");
             assert_eq!(mode, AppMode::Agent);
+            assert!(!allow_shell);
             assert!(!trust_mode);
             assert!(!auto_approve);
             assert_eq!(approval_mode, ApprovalMode::Suggest);
@@ -5188,12 +5229,14 @@ async fn bang_shell_input_keeps_auto_review_separate_from_bypass() {
         Op::RunShellCommand {
             command,
             mode,
+            allow_shell,
             trust_mode,
             auto_approve,
             approval_mode,
         } => {
             assert_eq!(command, "pwd");
             assert_eq!(mode, AppMode::Agent);
+            assert!(!allow_shell);
             assert!(trust_mode);
             assert!(!auto_approve);
             assert_eq!(approval_mode, ApprovalMode::Auto);


### PR DESCRIPTION
## Summary
- carry the full effective mode policy through `ChangeMode` instead of sending only the visible mode label
- update the engine session/config policy mirrors from one helper on mode changes, normal turns, and composer `!` shell commands
- add regressions for restored Agent policy after Plan and for engine-side policy mirror updates

Fixes #3568.
Refs #3279.

Thank you @DracheTek for the concrete export, and thank you @orz0219 and @yekern for confirming the opposite drift shapes. Those reports made it clear this was mode-policy state desync, not just a shell-specific failure.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked mode_change_update`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_mode_policy_updates_engine_session_mirrors`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked run_shell_command_op`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked bang_shell_input`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked edit_last_turn_preserves_current_mode`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked plan_mode`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked mode_policy`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked`