### PR TITLE
fix(tui): pause input pump for external editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Ctrl+O external-editor freezes where CodeWhale's terminal input pump
+  could keep reading keys while Vim/editor owned the terminal, especially in
+  Windows mintty/cygwin shells. Thanks @buko for the precise repro (#3657).
 - Hardened the OHOS dependency drift check against transient Cargo registry EOFs
   by retrying the dependency graph probe before failing CI.
 - Updated the `/links` provider fallback to the current CodeWhale docs URL and

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Ctrl+O external-editor freezes where CodeWhale's terminal input pump
+  could keep reading keys while Vim/editor owned the terminal, especially in
+  Windows mintty/cygwin shells. Thanks @buko for the precise repro (#3657).
 - Hardened the OHOS dependency drift check against transient Cargo registry EOFs
   by retrying the dependency graph probe before failing CI.
 - Updated the `/links` provider fallback to the current CodeWhale docs URL and

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -335,6 +335,8 @@ const TERMINAL_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const TERMINAL_INPUT_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(500);
 const TERMINAL_INPUT_STALL_TIMEOUT: Duration = Duration::from_secs(5);
 const TERMINAL_INPUT_RECOVERY_COOLDOWN: Duration = Duration::from_secs(10);
+const TERMINAL_INPUT_CHILD_PAUSE_TIMEOUT: Duration = Duration::from_millis(500);
+const TERMINAL_INPUT_CHILD_PAUSE_POLL_INTERVAL: Duration = Duration::from_millis(5);
 const MAX_ENGINE_EVENTS_PER_DRAIN: usize = 128;
 
 enum TerminalInputMessage {
@@ -346,34 +348,52 @@ enum TerminalInputMessage {
 struct TerminalInputPump {
     rx: std::sync::mpsc::Receiver<TerminalInputMessage>,
     stop: Arc<AtomicBool>,
+    paused: Arc<AtomicBool>,
+    paused_ack: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
     last_alive_at: Cell<Instant>,
 }
 
+struct TerminalInputPumpParts {
+    rx: std::sync::mpsc::Receiver<TerminalInputMessage>,
+    stop: Arc<AtomicBool>,
+    paused: Arc<AtomicBool>,
+    paused_ack: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+}
+
 impl TerminalInputPump {
     fn spawn() -> io::Result<Self> {
-        let (rx, stop, handle) = Self::spawn_parts()?;
+        let parts = Self::spawn_parts()?;
         Ok(Self {
-            rx,
-            stop,
-            handle: Some(handle),
+            rx: parts.rx,
+            stop: parts.stop,
+            paused: parts.paused,
+            paused_ack: parts.paused_ack,
+            handle: Some(parts.handle),
             last_alive_at: Cell::new(Instant::now()),
         })
     }
 
-    fn spawn_parts() -> io::Result<(
-        std::sync::mpsc::Receiver<TerminalInputMessage>,
-        Arc<AtomicBool>,
-        JoinHandle<()>,
-    )> {
+    fn spawn_parts() -> io::Result<TerminalInputPumpParts> {
         let (tx, rx) = std::sync::mpsc::channel();
         let stop = Arc::new(AtomicBool::new(false));
+        let paused = Arc::new(AtomicBool::new(false));
+        let paused_ack = Arc::new(AtomicBool::new(false));
         let thread_stop = Arc::clone(&stop);
+        let thread_paused = Arc::clone(&paused);
+        let thread_paused_ack = Arc::clone(&paused_ack);
         let handle = thread::Builder::new()
             .name("codewhale-terminal-input".to_string())
             .spawn(move || {
                 let mut last_heartbeat = Instant::now();
                 while !thread_stop.load(Ordering::Acquire) {
+                    if thread_paused.load(Ordering::Acquire) {
+                        thread_paused_ack.store(true, Ordering::Release);
+                        thread::sleep(TERMINAL_INPUT_CHILD_PAUSE_POLL_INTERVAL);
+                        continue;
+                    }
+                    thread_paused_ack.store(false, Ordering::Release);
                     match event::poll(TERMINAL_INPUT_POLL_INTERVAL) {
                         Ok(true) => match event::read() {
                             Ok(event) => {
@@ -405,7 +425,13 @@ impl TerminalInputPump {
                     }
                 }
             })?;
-        Ok((rx, stop, handle))
+        Ok(TerminalInputPumpParts {
+            rx,
+            stop,
+            paused,
+            paused_ack,
+            handle,
+        })
     }
 
     fn recv_timeout(&self, timeout: Duration) -> io::Result<Option<Event>> {
@@ -466,14 +492,46 @@ impl TerminalInputPump {
         now.saturating_duration_since(self.last_alive_at.get())
     }
 
+    fn pause_for_child_terminal(&self) -> io::Result<()> {
+        self.paused.store(true, Ordering::Release);
+        if self.handle.is_none() {
+            self.paused_ack.store(true, Ordering::Release);
+            self.mark_alive();
+            return Ok(());
+        }
+
+        let deadline = Instant::now() + TERMINAL_INPUT_CHILD_PAUSE_TIMEOUT;
+        while !self.paused_ack.load(Ordering::Acquire) {
+            if Instant::now() >= deadline {
+                self.paused_ack.store(false, Ordering::Release);
+                self.paused.store(false, Ordering::Release);
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "terminal input pump did not pause before launching editor",
+                ));
+            }
+            thread::sleep(TERMINAL_INPUT_CHILD_PAUSE_POLL_INTERVAL);
+        }
+        self.mark_alive();
+        Ok(())
+    }
+
+    fn resume_after_child_terminal(&self) {
+        self.paused_ack.store(false, Ordering::Release);
+        self.paused.store(false, Ordering::Release);
+        self.mark_alive();
+    }
+
     #[cfg(target_os = "windows")]
     fn restart_detached(&mut self) -> io::Result<()> {
         self.stop.store(true, Ordering::Release);
         let _ = self.handle.take();
-        let (rx, stop, handle) = Self::spawn_parts()?;
-        self.rx = rx;
-        self.stop = stop;
-        self.handle = Some(handle);
+        let parts = Self::spawn_parts()?;
+        self.rx = parts.rx;
+        self.stop = parts.stop;
+        self.paused = parts.paused;
+        self.paused_ack = parts.paused_ack;
+        self.handle = Some(parts.handle);
         self.last_alive_at.set(Instant::now());
         Ok(())
     }
@@ -512,6 +570,15 @@ fn try_next_terminal_event(
         return Ok(Some(event));
     }
     input.try_recv()
+}
+
+fn drain_terminal_input_queue(
+    input: &TerminalInputPump,
+    pending: &mut VecDeque<Event>,
+) -> io::Result<()> {
+    pending.clear();
+    while input.try_recv()?.is_some() {}
+    Ok(())
 }
 
 /// Run the interactive TUI event loop.
@@ -4835,13 +4902,25 @@ async fn run_event_loop(
                     // shortcut whether or not a model turn is streaming —
                     // editing the buffer never disturbs in-flight work.
                     let seed = app.input.clone();
-                    match super::external_editor::spawn_editor_for_input(
-                        terminal,
-                        app.use_alt_screen,
-                        app.use_mouse_capture,
-                        app.use_bracketed_paste,
-                        &seed,
-                    ) {
+                    let editor_result = terminal_input.pause_for_child_terminal().and_then(|()| {
+                        let result = drain_terminal_input_queue(
+                            &terminal_input,
+                            &mut pending_terminal_events,
+                        )
+                        .and_then(|()| {
+                            super::external_editor::spawn_editor_for_input(
+                                terminal,
+                                app.use_alt_screen,
+                                app.use_mouse_capture,
+                                app.use_bracketed_paste,
+                                &seed,
+                            )
+                        });
+                        terminal_input.resume_after_child_terminal();
+                        force_terminal_repaint = true;
+                        result
+                    });
+                    match editor_result {
                         Ok(super::external_editor::EditorOutcome::Edited(new)) => {
                             app.input = new;
                             app.move_cursor_end();

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -11524,6 +11524,8 @@ fn six_worker_progress_storm_keeps_input_render_and_cancel_live() {
     let input = TerminalInputPump {
         rx,
         stop: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        paused: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        paused_ack: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         handle: None,
         last_alive_at: std::cell::Cell::new(Instant::now()),
     };
@@ -11550,4 +11552,53 @@ fn six_worker_progress_storm_keeps_input_render_and_cancel_live() {
     app.runtime_turn_status = Some("in_progress".to_string());
     assert_eq!(next_escape_action(&app, false), EscapeAction::CancelRequest);
     assert_eq!(ctrl_c_disposition(&app), CtrlCDisposition::CancelTurn);
+}
+
+#[test]
+fn terminal_input_child_pause_drains_codewhale_events_before_editor_handoff() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    tx.send(TerminalInputMessage::Event(Event::Key(KeyEvent::new(
+        KeyCode::Char('x'),
+        KeyModifiers::NONE,
+    ))))
+    .expect("send buffered key event");
+    tx.send(TerminalInputMessage::Heartbeat)
+        .expect("send buffered heartbeat");
+    tx.send(TerminalInputMessage::Event(Event::Key(KeyEvent::new(
+        KeyCode::Char('y'),
+        KeyModifiers::NONE,
+    ))))
+    .expect("send second buffered key event");
+
+    let input = TerminalInputPump {
+        rx,
+        stop: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        paused: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        paused_ack: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        handle: None,
+        last_alive_at: std::cell::Cell::new(Instant::now()),
+    };
+    let mut pending_terminal_events = VecDeque::from([Event::Key(KeyEvent::new(
+        KeyCode::Char('z'),
+        KeyModifiers::NONE,
+    ))]);
+
+    input
+        .pause_for_child_terminal()
+        .expect("synthetic pump can pause");
+    drain_terminal_input_queue(&input, &mut pending_terminal_events)
+        .expect("queued terminal events drain before launching child editor");
+
+    assert!(
+        pending_terminal_events.is_empty(),
+        "pending CodeWhale terminal events must not leak into the editor handoff"
+    );
+    assert!(
+        input.try_recv().expect("drained channel").is_none(),
+        "input pump channel should be empty after the editor handoff drain"
+    );
+
+    input.resume_after_child_terminal();
+    assert!(!input.paused.load(std::sync::atomic::Ordering::Acquire));
+    assert!(!input.paused_ack.load(std::sync::atomic::Ordering::Acquire));
 }


### PR DESCRIPTION
## Summary
- pause the terminal input pump before Ctrl+O hands the terminal to an external editor
- drain buffered CodeWhale terminal events before launching Vim/editor
- resume the input pump after the editor exits and force a repaint
- credit @buko's Windows mintty/cygwin Vim repro in the changelog

Fixes #3657.

## Why
#3659 correctly unwound terminal modes, but CodeWhale's background input reader could still call `crossterm::event::poll/read` while Vim owned stdin. That can steal editor keystrokes, especially while background agent/sub-agent activity keeps the TUI busy.

## Verification
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked terminal_input_child_pause_drains_codewhale_events_before_editor_handoff`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked external_editor`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked`