### PR TITLE
fix(tui): defer hollow Auto mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, and
+  `/mode` command until it has a distinct prompt and auto-review behavior;
+  existing `auto` mode text now folds back to Agent instead of selecting a
+  hollow mode (#3730, #3733).
 - Clarified the Fleet setup surface and docs so Fleet is treated as the durable
   sub-agent configuration layer while WhaleFlow is the agent-authored
   orchestration plan that selects and monitors Fleet slots.
@@ -51,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added a turn-loop Plan-mode guard for file-writing tools and write-capable MCP
+  tools so Plan's "no writes" promise is enforced before approval or execution,
+  not only by the sandbox/catalog layer (#3734).
 - Preserved the durable review safety floor for publish-like shell actions in
   YOLO mode, so `cargo publish`, `npm publish`, and tag/release pushes force
   approval instead of silently auto-approving (#3735).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, and
+  `/mode` command until it has a distinct prompt and auto-review behavior;
+  existing `auto` mode text now folds back to Agent instead of selecting a
+  hollow mode (#3730, #3733).
 - Clarified the Fleet setup surface and docs so Fleet is treated as the durable
   sub-agent configuration layer while WhaleFlow is the agent-authored
   orchestration plan that selects and monitors Fleet slots.
@@ -51,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added a turn-loop Plan-mode guard for file-writing tools and write-capable MCP
+  tools so Plan's "no writes" promise is enforced before approval or execution,
+  not only by the sandbox/catalog layer (#3734).
 - Preserved the durable review safety floor for publish-like shell actions in
   YOLO mode, so `cargo publish`, `npm publish`, and tag/release pushes force
   approval instead of silently auto-approving (#3735).

--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -101,7 +101,7 @@
     "CmdPluginDetailApproval": "Approval: {approval}",
     "CmdPluginDetailPath": "Path: {path}",
     "CmdMemoryDescription": "Inspect or manage the persistent user-memory file",
-    "CmdModeDescription": "Switch mode or open picker: /mode [agent|plan|yolo|1|2|3]",
+    "CmdModeDescription": "Switch mode or open picker: /mode [agent|plan|yolo|1|2|4]",
     "CmdModelDescription": "Switch or view current model",
     "CmdModelsDescription": "Toolbox: fetch live model IDs from the active API",
     "CmdModelDbDescription": "Reference: browse the bundled model database",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -96,7 +96,7 @@
     "CmdPluginDetailApproval": "Approval: {approval}",
     "CmdPluginDetailPath": "Path: {path}",
     "CmdMemoryDescription": "Inspeccionar o gestionar el archivo persistente de memoria del usuario",
-    "CmdModeDescription": "Alternar modo o abrir selector: /mode [agent|plan|yolo|1|2|3]",
+    "CmdModeDescription": "Alternar modo o abrir selector: /mode [agent|plan|yolo|1|2|4]",
     "CmdModelDescription": "Cambiar o mostrar el modelo actual",
     "CmdModelsDescription": "Listar los modelos disponibles por la API",
     "CmdModelDbDescription": "Explorar la base de datos de referencia de modelos integrada",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -91,7 +91,7 @@
     "CmdLogoutDescription": "API キーを消去してセットアップに戻る",
     "CmdMcpDescription": "MCP サーバを開く・管理する",
     "CmdMemoryDescription": "永続ユーザーメモリファイルを確認・管理",
-    "CmdModeDescription": "動作モードを切り替え、または選択画面を開く: /mode [agent|plan|yolo|1|2|3]",
+    "CmdModeDescription": "動作モードを切り替え、または選択画面を開く: /mode [agent|plan|yolo|1|2|4]",
     "CmdModelDescription": "現在のモデルを切り替え・確認",
     "CmdModelsDescription": "API から利用可能なモデルを一覧表示",
     "CmdModelDbDescription": "内蔵のモデルリファレンスデータベースを閲覧",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -87,7 +87,7 @@
     "CmdLogoutDescription": "Limpar a chave de API e voltar à configuração",
     "CmdMcpDescription": "Abrir ou gerenciar servidores MCP",
     "CmdMemoryDescription": "Inspecionar ou gerenciar o arquivo persistente de memória do usuário",
-    "CmdModeDescription": "Alternar modo ou abrir seletor: /mode [agent|plan|yolo|1|2|3]",
+    "CmdModeDescription": "Alternar modo ou abrir seletor: /mode [agent|plan|yolo|1|2|4]",
     "CmdModelDescription": "Trocar ou exibir o modelo atual",
     "CmdModelsDescription": "Listar os modelos disponíveis pela API",
     "CmdModelDbDescription": "Navegar pelo banco de dados de referência de modelos integrado",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -91,7 +91,7 @@
     "CmdLogoutDescription": "Xóa khóa API và quay lại bước thiết lập",
     "CmdMcpDescription": "Mở hoặc quản lý các máy chủ MCP",
     "CmdMemoryDescription": "Kiểm tra hoặc quản lý tệp bộ nhớ người dùng liên tục",
-    "CmdModeDescription": "Chuyển đổi chế độ hoặc mở bảng chọn: /mode [agent|plan|yolo|1|2|3]",
+    "CmdModeDescription": "Chuyển đổi chế độ hoặc mở bảng chọn: /mode [agent|plan|yolo|1|2|4]",
     "CmdModelDescription": "Chuyển đổi hoặc xem mô hình AI hiện tại",
     "CmdModelsDescription": "Liệt kê các mô hình khả dụng từ API",
     "CmdModelDbDescription": "Duyệt cơ sở dữ liệu tham chiếu mô hình tích hợp",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -92,7 +92,7 @@
   "CmdLogoutDescription": "清除 API 密钥并返回设置",
   "CmdMcpDescription": "打开或管理 MCP 服务器",
   "CmdMemoryDescription": "查看或管理持久用户记忆文件",
-  "CmdModeDescription": "切换运行模式或打开选择器：/mode [agent|plan|yolo|1|2|3]",
+  "CmdModeDescription": "切换运行模式或打开选择器：/mode [agent|plan|yolo|1|2|4]",
   "CmdModelDescription": "切换或查看当前模型",
   "CmdModelsDescription": "列出 API 中可用的模型",
   "CmdModelDbDescription": "浏览内置的模型参考数据库",

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -1781,7 +1781,7 @@ pub fn mode(app: &mut App, arg: Option<&str>) -> CommandResult {
                 CommandResult::message(message)
             }
         }
-        None => CommandResult::error("Usage: /mode [agent|plan|yolo|1|2|3]"),
+        None => CommandResult::error("Usage: /mode [agent|plan|yolo|1|2|4]"),
     }
 }
 
@@ -2392,8 +2392,8 @@ Rule count: 2\n\
         assert_eq!(result.action, Some(AppAction::ModeChanged(AppMode::Plan)));
         assert_eq!(app.mode, AppMode::Plan);
         let result = mode(&mut app, Some("3"));
-        assert_eq!(result.action, Some(AppAction::ModeChanged(AppMode::Auto)));
-        assert_eq!(app.mode, AppMode::Auto);
+        assert!(result.is_error);
+        assert_eq!(app.mode, AppMode::Plan);
         let result = mode(&mut app, Some("4"));
         assert_eq!(result.action, Some(AppAction::ModeChanged(AppMode::Yolo)));
         assert_eq!(app.mode, AppMode::Yolo);

--- a/crates/tui/src/commands/groups/config/mod.rs
+++ b/crates/tui/src/commands/groups/config/mod.rs
@@ -67,7 +67,7 @@ static STATUSLINE_INFO: CommandInfo = CommandInfo {
 static MODE_INFO: CommandInfo = CommandInfo {
     name: "mode",
     aliases: &["jihua", "zidong"],
-    usage: "/mode [agent|plan|yolo|1|2|3]",
+    usage: "/mode [agent|plan|yolo|1|2|4]",
     description_id: MessageId::CmdModeDescription,
 };
 static THEME_INFO: CommandInfo = CommandInfo {

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -231,7 +231,6 @@ pub enum TranscriptSpacingValue {
 pub enum DefaultModeValue {
     Agent,
     Plan,
-    Auto,
     Yolo,
 }
 
@@ -842,7 +841,6 @@ impl DefaultModeValue {
         match self {
             Self::Agent => "agent",
             Self::Plan => "plan",
-            Self::Auto => "auto",
             Self::Yolo => "yolo",
         }
     }
@@ -955,7 +953,7 @@ impl From<&str> for DefaultModeValue {
         match AppMode::from_setting(value) {
             AppMode::Agent => Self::Agent,
             AppMode::Plan => Self::Plan,
-            AppMode::Auto => Self::Auto,
+            AppMode::Auto => Self::Agent,
             AppMode::Yolo => Self::Yolo,
         }
     }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1750,6 +1750,15 @@ impl Engine {
                     read_only = true;
                 }
 
+                if blocked_error.is_none()
+                    && mode == AppMode::Plan
+                    && plan_mode_blocks_write_capable_tool(&tool_name, read_only)
+                {
+                    blocked_error = Some(ToolError::permission_denied(format!(
+                        "'{tool_name}' is not available in Plan mode - switch to Agent or YOLO mode to modify files or run write-capable tools."
+                    )));
+                }
+
                 // #3026: a hook `ask` decision forces the approval prompt even
                 // for tools the registry would auto-run. Must stay after the
                 // registry-based computation above, which assigns rather than
@@ -2783,6 +2792,11 @@ fn should_pre_tool_snapshot(
         && matches!(tool_name, "write_file" | "edit_file" | "apply_patch")
 }
 
+fn plan_mode_blocks_write_capable_tool(tool_name: &str, read_only: bool) -> bool {
+    matches!(tool_name, "write_file" | "edit_file" | "apply_patch")
+        || (McpPool::is_mcp_tool(tool_name) && !read_only)
+}
+
 /// Synthesize the tool result recorded for a tool call that never executed
 /// because the turn was cancelled mid-batch (#3216 / #2211).
 ///
@@ -2857,6 +2871,27 @@ mod pre_tool_snapshot_gate_tests {
                 "{tool} does not modify the workspace and must not be snapshotted"
             );
         }
+    }
+
+    #[test]
+    fn plan_mode_blocks_file_and_mcp_write_tools() {
+        for tool in ["write_file", "edit_file", "apply_patch"] {
+            assert!(plan_mode_blocks_write_capable_tool(tool, false));
+        }
+
+        assert!(plan_mode_blocks_write_capable_tool(
+            "mcp_filesystem_write",
+            false
+        ));
+        assert!(!plan_mode_blocks_write_capable_tool(
+            "mcp_filesystem_read",
+            true
+        ));
+        assert!(!plan_mode_blocks_write_capable_tool("read_file", true));
+        assert!(!plan_mode_blocks_write_capable_tool(
+            "request_user_input",
+            false
+        ));
     }
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -903,18 +903,20 @@ const MAX_COMPOSER_DISPLAY_CHARS: usize = 4_000;
 const MAX_DRAFT_HISTORY: usize = 50;
 
 impl AppMode {
-    /// Keyboard cycle order: Plan -> Agent -> Auto -> YOLO -> Plan.
-    pub const CYCLE: [Self; 4] = [Self::Plan, Self::Agent, Self::Auto, Self::Yolo];
+    /// Keyboard cycle order: Plan -> Agent -> YOLO -> Plan.
+    ///
+    /// `Auto` remains an internal variant while the real implementation is
+    /// redesigned; do not expose it through user-facing mode selection (#3733).
+    pub const CYCLE: [Self; 3] = [Self::Plan, Self::Agent, Self::Yolo];
 
     /// User-facing picker / numeric command order.
-    pub const CHOICES: [Self; 4] = [Self::Agent, Self::Plan, Self::Auto, Self::Yolo];
+    pub const CHOICES: [Self; 3] = [Self::Agent, Self::Plan, Self::Yolo];
 
     #[must_use]
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "agent" | "1" => Some(Self::Agent),
+            "agent" | "auto" | "1" => Some(Self::Agent),
             "plan" | "2" => Some(Self::Plan),
-            "auto" | "3" => Some(Self::Auto),
             "yolo" | "4" | "bypass" | "bypass-permissions" | "bypasspermissions" => {
                 Some(Self::Yolo)
             }
@@ -1008,19 +1010,17 @@ impl AppMode {
 
     #[must_use]
     pub fn next(self) -> Self {
-        let index = Self::CYCLE
-            .iter()
-            .position(|mode| *mode == self)
-            .unwrap_or(0);
+        let Some(index) = Self::CYCLE.iter().position(|mode| *mode == self) else {
+            return Self::Agent;
+        };
         Self::CYCLE[(index + 1) % Self::CYCLE.len()]
     }
 
     #[must_use]
     pub fn previous(self) -> Self {
-        let index = Self::CYCLE
-            .iter()
-            .position(|mode| *mode == self)
-            .unwrap_or(0);
+        let Some(index) = Self::CYCLE.iter().position(|mode| *mode == self) else {
+            return Self::Agent;
+        };
         Self::CYCLE[(index + Self::CYCLE.len() - 1) % Self::CYCLE.len()]
     }
 }

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1394,8 +1394,8 @@ fn clear_todos_resets_plan_state() {
 fn app_mode_helpers_centralize_parse_labels_and_cycle_order() {
     assert_eq!(AppMode::parse("agent"), Some(AppMode::Agent));
     assert_eq!(AppMode::parse("2"), Some(AppMode::Plan));
-    assert_eq!(AppMode::parse("auto"), Some(AppMode::Auto));
-    assert_eq!(AppMode::parse("3"), Some(AppMode::Auto));
+    assert_eq!(AppMode::parse("auto"), Some(AppMode::Agent));
+    assert_eq!(AppMode::parse("3"), None);
     assert_eq!(AppMode::parse("YOLO"), Some(AppMode::Yolo));
     assert_eq!(AppMode::parse("4"), Some(AppMode::Yolo));
     assert_eq!(AppMode::parse("fast"), None);
@@ -1410,21 +1410,21 @@ fn app_mode_helpers_centralize_parse_labels_and_cycle_order() {
     assert_eq!(AppMode::Yolo.number(), '4');
     assert_eq!(
         AppMode::CHOICES,
-        [AppMode::Agent, AppMode::Plan, AppMode::Auto, AppMode::Yolo]
+        [AppMode::Agent, AppMode::Plan, AppMode::Yolo]
     );
     assert_eq!(
         AppMode::CYCLE,
-        [AppMode::Plan, AppMode::Agent, AppMode::Auto, AppMode::Yolo]
+        [AppMode::Plan, AppMode::Agent, AppMode::Yolo]
     );
 
     assert_eq!(AppMode::Plan.next(), AppMode::Agent);
-    assert_eq!(AppMode::Agent.next(), AppMode::Auto);
-    assert_eq!(AppMode::Auto.next(), AppMode::Yolo);
+    assert_eq!(AppMode::Agent.next(), AppMode::Yolo);
+    assert_eq!(AppMode::Auto.next(), AppMode::Agent);
     assert_eq!(AppMode::Yolo.next(), AppMode::Plan);
     assert_eq!(AppMode::Plan.previous(), AppMode::Yolo);
     assert_eq!(AppMode::Agent.previous(), AppMode::Plan);
     assert_eq!(AppMode::Auto.previous(), AppMode::Agent);
-    assert_eq!(AppMode::Yolo.previous(), AppMode::Auto);
+    assert_eq!(AppMode::Yolo.previous(), AppMode::Agent);
 }
 
 #[test]
@@ -1446,7 +1446,7 @@ fn test_cycle_mode_reverse_transitions() {
 
     app.mode = AppMode::Yolo;
     app.cycle_mode_reverse();
-    assert_eq!(app.mode, AppMode::Auto);
+    assert_eq!(app.mode, AppMode::Agent);
 
     app.mode = AppMode::Agent;
     app.cycle_mode_reverse();

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -510,13 +510,6 @@ impl HotbarActionSource for BuiltinHotbarActionSource {
             AppHotbarKind::Mode(AppMode::Agent),
         ));
         registry.register(AppHotbarAction::new(
-            "mode.auto",
-            "auto",
-            "Auto mode",
-            "Switch the conversation into Auto mode.",
-            AppHotbarKind::Mode(AppMode::Auto),
-        ));
-        registry.register(AppHotbarAction::new(
             "mode.yolo",
             "yolo",
             "YOLO mode",
@@ -1406,7 +1399,6 @@ mod tests {
             vec![
                 "filetree.toggle",
                 "mode.agent",
-                "mode.auto",
                 "mode.plan",
                 "mode.yolo",
                 "palette.open",
@@ -1512,7 +1504,6 @@ mod tests {
         let registry = HotbarActionRegistry::with_builtins();
         let plan = registry.get("mode.plan").expect("plan action");
         let agent = registry.get("mode.agent").expect("agent action");
-        let auto = registry.get("mode.auto").expect("auto action");
         let yolo = registry.get("mode.yolo").expect("yolo action");
         let mut app = test_app();
 
@@ -1526,14 +1517,6 @@ mod tests {
         assert_eq!(app.mode, AppMode::Plan);
         assert!(plan.is_active(&app));
         assert!(!agent.is_active(&app));
-
-        assert_eq!(
-            auto.dispatch(&mut app).expect("dispatch auto"),
-            HotbarDispatch::AppAction(AppAction::ModeChanged(AppMode::Auto))
-        );
-        assert!(app.allow_shell);
-        assert!(!app.trust_mode);
-        assert!(auto.is_active(&app));
 
         assert_eq!(
             yolo.dispatch(&mut app).expect("dispatch yolo"),

--- a/crates/tui/src/tui/views/mode_picker.rs
+++ b/crates/tui/src/tui/views/mode_picker.rs
@@ -194,12 +194,7 @@ mod tests {
     fn number_keys_select_modes() {
         let mut view = ModePickerView::new(AppMode::Agent, Locale::En);
         let action = view.handle_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
-        match action {
-            ViewAction::EmitAndClose(ViewEvent::ModeSelected { mode }) => {
-                assert_eq!(mode, AppMode::Auto);
-            }
-            other => panic!("expected ModeSelected, got {other:?}"),
-        }
+        assert!(matches!(action, ViewAction::None));
 
         let mut view = ModePickerView::new(AppMode::Agent, Locale::En);
         let action = view.handle_key(KeyEvent::new(KeyCode::Char('4'), KeyModifiers::NONE));


### PR DESCRIPTION
## Summary
- hide Auto from the user-facing mode cycle, picker, hotbar, config UI, and /mode numeric surface until it has a real prompt + auto-review implementation
- fold textual `auto` back to Agent for old settings/commands while leaving numeric `3` unassigned so it cannot accidentally escalate to YOLO
- add an explicit Plan-mode turn-loop guard for file-writing tools and write-capable MCP tools

Refs #3730, #3733, #3734.

## Verification
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- ./scripts/release/check-versions.sh
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked app_mode_helpers_centralize_parse_labels_and_cycle_order
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked number_keys_select_modes
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked mode_actions_report_active_state_and_dispatch
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked builtins_register_expected_actions
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked test_mode_switch_command_accepts_names_and_numbers
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked plan_mode_blocks_file_and_mcp_write_tools
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked run_shell_command_op_preserves_plan_mode_shell_block
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked localization
- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked config_ui