### PR TITLE
fix(tui): split trust from approval bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed runtime API approval handling so workspace trust no longer auto-resolves
+  ordinary tool approvals; trust now only participates in full-access retry
+  decisions while YOLO/auto-approve remains the approval bypass (#3736).
 - Fixed Plan/request-input modal surfaces so popup interiors are painted
   opaquely, and compacted the Plan confirmation footer so action choices stay
   visible on narrow terminals instead of truncating (#3732).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed runtime API approval handling so workspace trust no longer auto-resolves
+  ordinary tool approvals; trust now only participates in full-access retry
+  decisions while YOLO/auto-approve remains the approval bypass (#3736).
 - Fixed Plan/request-input modal surfaces so popup interiors are painted
   opaquely, and compacted the Plan confirmation footer so action choices stay
   visible on narrow terminals instead of truncating (#3732).

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3293,7 +3293,7 @@ impl RuntimeThreadManager {
                         continue;
                     };
 
-                    if auto_approve || trust_mode {
+                    if auto_approve {
                         let auto_decision =
                             Self::approval_decision(auto_approve, trust_mode, false);
                         let (dec_str, approved) = match auto_decision {

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -510,9 +510,13 @@ fn enforce_lru_capacity_does_not_loop_when_all_threads_are_active() {
 }
 
 #[test]
-fn approval_decision_matches_auto_approve_and_trust_mode() {
+fn approval_decision_keeps_trust_mode_out_of_tool_approval() {
     assert!(matches!(
         RuntimeThreadManager::approval_decision(false, false, false),
+        RuntimeApprovalDecision::DenyTool
+    ));
+    assert!(matches!(
+        RuntimeThreadManager::approval_decision(false, true, false),
         RuntimeApprovalDecision::DenyTool
     ));
     assert!(matches!(
@@ -2290,6 +2294,10 @@ fn summarize_text_truncates() {
 fn approval_decision_requires_auto_approve_and_trust_for_full_access() {
     assert_eq!(
         RuntimeThreadManager::approval_decision(false, false, false),
+        RuntimeApprovalDecision::DenyTool
+    );
+    assert_eq!(
+        RuntimeThreadManager::approval_decision(false, true, false),
         RuntimeApprovalDecision::DenyTool
     );
     assert_eq!(

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1105,8 +1105,9 @@ struct ModeSessionPrefs {
 ///
 /// This is a pure projection of `(mode, prefs)` — see [`base_policy_for_mode`].
 /// The App keeps `allow_shell`/`trust_mode`/`approval_mode`/`yolo` as derived
-/// mirrors of these values so the rest of the crate can keep reading the plain
-/// booleans without a type migration.
+/// mirrors of these values so the rest of the crate can keep reading the
+/// existing fields without a type migration. YOLO authority is derived from
+/// `ApprovalMode::Bypass`, not carried as a separate mode-table knob (#3736).
 #[derive(Debug, Clone, Copy)]
 struct EffectiveModePolicy {
     #[allow(dead_code)]
@@ -1114,8 +1115,6 @@ struct EffectiveModePolicy {
     allow_shell: bool,
     trust_mode: bool,
     approval_mode: ApprovalMode,
-    /// Whether tool calls auto-approve (YOLO authority). Mirrors `self.yolo`.
-    auto_approve: bool,
 }
 
 /// Resolve a mode's effective permission policy from the durable Agent baseline.
@@ -1135,28 +1134,24 @@ fn base_policy_for_mode(mode: AppMode, prefs: &ModeSessionPrefs) -> EffectiveMod
             allow_shell: false,
             trust_mode: false,
             approval_mode: ApprovalMode::Suggest,
-            auto_approve: false,
         },
         AppMode::Agent => EffectiveModePolicy {
             mode,
             allow_shell: prefs.agent_allow_shell,
             trust_mode: prefs.agent_trust_mode,
             approval_mode: prefs.agent_approval_mode,
-            auto_approve: false,
         },
         AppMode::Auto => EffectiveModePolicy {
             mode,
             allow_shell: true,
             trust_mode: false,
             approval_mode: ApprovalMode::Auto,
-            auto_approve: false,
         },
         AppMode::Yolo => EffectiveModePolicy {
             mode,
             allow_shell: true,
             trust_mode: true,
             approval_mode: ApprovalMode::Bypass,
-            auto_approve: true,
         },
     }
 }
@@ -2921,7 +2916,7 @@ impl App {
         self.allow_shell = policy.allow_shell;
         self.trust_mode = policy.trust_mode;
         self.approval_mode = policy.approval_mode;
-        self.yolo = policy.auto_approve;
+        self.yolo = matches!(policy.approval_mode, ApprovalMode::Bypass);
 
         if mode != AppMode::Plan {
             self.plan_prompt_pending = false;

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1655,14 +1655,13 @@ fn base_policy_for_mode_projects_the_mode_permission_table() {
         agent_approval_mode: ApprovalMode::Never,
     };
 
-    // Plan: read-only, no shell, no trust, Suggest, no auto-approve — and it
-    // never inherits the (here elevated) Agent baseline.
+    // Plan: read-only, no shell, no trust, Suggest — and it never inherits the
+    // (here elevated) Agent baseline.
     let plan = base_policy_for_mode(AppMode::Plan, &prefs);
     assert_eq!(plan.mode, AppMode::Plan);
     assert!(!plan.allow_shell);
     assert!(!plan.trust_mode);
     assert_eq!(plan.approval_mode, ApprovalMode::Suggest);
-    assert!(!plan.auto_approve);
 
     // Agent: exactly the durable baseline.
     let agent = base_policy_for_mode(AppMode::Agent, &prefs);
@@ -1670,7 +1669,6 @@ fn base_policy_for_mode_projects_the_mode_permission_table() {
     assert!(agent.allow_shell);
     assert!(agent.trust_mode);
     assert_eq!(agent.approval_mode, ApprovalMode::Never);
-    assert!(!agent.auto_approve);
 
     // Auto: shell-enabled smart review, no trust authority.
     let auto = base_policy_for_mode(AppMode::Auto, &prefs);
@@ -1678,15 +1676,14 @@ fn base_policy_for_mode_projects_the_mode_permission_table() {
     assert!(auto.allow_shell);
     assert!(!auto.trust_mode);
     assert_eq!(auto.approval_mode, ApprovalMode::Auto);
-    assert!(!auto.auto_approve);
 
-    // YOLO: full authority regardless of the baseline.
+    // YOLO: full authority is represented by Bypass, not a separate
+    // auto-approve field (#3736).
     let yolo = base_policy_for_mode(AppMode::Yolo, &prefs);
     assert_eq!(yolo.mode, AppMode::Yolo);
     assert!(yolo.allow_shell);
     assert!(yolo.trust_mode);
     assert_eq!(yolo.approval_mode, ApprovalMode::Bypass);
-    assert!(yolo.auto_approve);
 
     // A minimal Agent baseline projects through Agent unchanged.
     let minimal = ModeSessionPrefs {


### PR DESCRIPTION
## Summary

- stop treating runtime workspace trust as authority to auto-resolve ordinary tool approvals
- keep trust mode in its distinct lane: permitting full-access retry only when auto-approve/YOLO already allowed the retry path
- remove the redundant `auto_approve` field from the TUI mode policy projection so YOLO authority derives from `ApprovalMode::Bypass`
- update the changelog for the v0.8.67 mode-permission cleanup

Refs #3736.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [x] `git diff --check`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked approval_decision -- --nocapture`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked base_policy_for_mode -- --nocapture`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
