### PR TITLE
fix(tui): show routes in cache telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added provider/model route columns to `/cache` turn telemetry so DeepSeek
+  cache-hit regressions can be correlated with Auto route changes (#3738).
 - Fixed runtime API approval handling so workspace trust no longer auto-resolves
   ordinary tool approvals; trust now only participates in full-access retry
   decisions while YOLO/auto-approve remains the approval bypass (#3736).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added provider/model route columns to `/cache` turn telemetry so DeepSeek
+  cache-hit regressions can be correlated with Auto route changes (#3738).
 - Fixed runtime API approval handling so workspace trust no longer auto-resolves
   ordinary tool approvals; trust now only participates in full-access retry
   decisions while YOLO/auto-approve remains the approval bypass (#3736).

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -852,6 +852,9 @@ mod tests {
             layers: Vec::new(),
         });
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 100,
             output_tokens: 25,
             cache_hit_tokens: Some(70),
@@ -1113,6 +1116,9 @@ mod tests {
         app.auto_model = false;
         app.model = "deepseek-v4-pro".to_string();
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 100,
             output_tokens: 25,
             cache_hit_tokens: Some(70),
@@ -1134,6 +1140,9 @@ mod tests {
         app.auto_model = false;
         app.model = "deepseek-v4-pro".to_string();
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 100,
             output_tokens: 25,
             cache_hit_tokens: Some(70),

--- a/crates/tui/src/commands/groups/debug/debug.rs
+++ b/crates/tui/src/commands/groups/debug/debug.rs
@@ -712,10 +712,12 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
         .replace("{count}", &rows.len().to_string())
         .replace("{total}", &total.to_string())
         .replace("{model}", &app.model);
-    header.push_str(&"─".repeat(76));
+    header.push_str(&"─".repeat(96));
     header.push('\n');
-    header.push_str("turn   in    out   hit   miss   replay   ratio   age\n");
-    header.push_str(&"─".repeat(76));
+    header.push_str(
+        "turn  route                       in    out    hit   miss  replay   ratio   age\n",
+    );
+    header.push_str(&"─".repeat(96));
     header.push('\n');
 
     let now = Instant::now();
@@ -728,6 +730,7 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
         let replay_cell = rec
             .reasoning_replay_tokens
             .map_or_else(|| "—".to_string(), |t| t.to_string());
+        let route_cell = format_turn_cache_route(rec);
         let age = humanize_age(now.saturating_duration_since(rec.recorded_at));
 
         // No cache telemetry → render `—` everywhere and don't pollute totals
@@ -736,8 +739,9 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
         // would make every aggregate ratio look broken.
         let Some(hit) = rec.cache_hit_tokens else {
             body.push_str(&format!(
-                "{turn:>4}  {input:>5}  {output:>5}  {hit:>5}  {miss:>5}  {replay:>6}   {ratio:>6}   {age}\n",
+                "{turn:>4}  {route:<24}  {input:>5}  {output:>5}  {hit:>5}  {miss:>5}  {replay:>6}   {ratio:>6}   {age}\n",
                 turn = turn_index,
+                route = route_cell,
                 input = rec.input_tokens,
                 output = rec.output_tokens,
                 hit = "—",
@@ -766,8 +770,9 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
         };
 
         body.push_str(&format!(
-            "{turn:>4}  {input:>5}  {output:>5}  {hit:>5}  {miss:>5}  {replay:>6}   {ratio}   {age}\n",
+            "{turn:>4}  {route:<24}  {input:>5}  {output:>5}  {hit:>5}  {miss:>5}  {replay:>6}   {ratio}   {age}\n",
             turn = turn_index,
+            route = route_cell,
             input = rec.input_tokens,
             output = rec.output_tokens,
             hit = hit,
@@ -789,7 +794,7 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
     };
 
     let mut footer = String::new();
-    footer.push_str(&"─".repeat(76));
+    footer.push_str(&"─".repeat(96));
     footer.push('\n');
     footer.push_str(
         &tr(locale, MessageId::CmdCacheTotals)
@@ -802,6 +807,34 @@ fn format_cache_history(app: &App, count: usize, locale: Locale) -> String {
     footer.push_str(&tr(locale, MessageId::CmdCacheAdvice));
 
     format!("{header}{body}{footer}")
+}
+
+fn format_turn_cache_route(rec: &TurnCacheRecord) -> String {
+    let Some(model) = rec.model.as_deref().filter(|model| !model.is_empty()) else {
+        return "—".to_string();
+    };
+    let provider = rec
+        .provider
+        .map(|provider| provider.as_str())
+        .unwrap_or("?");
+    let route = if rec.auto_model {
+        format!("auto:{provider}/{model}")
+    } else {
+        format!("{provider}/{model}")
+    };
+    truncate_route_cell(&route, 24)
+}
+
+fn truncate_route_cell(route: &str, max_chars: usize) -> String {
+    if route.chars().count() <= max_chars {
+        return route.to_string();
+    }
+    if max_chars <= 3 {
+        return route.chars().take(max_chars).collect();
+    }
+    let mut out: String = route.chars().take(max_chars - 3).collect();
+    out.push_str("...");
+    out
 }
 
 fn humanize_age(d: std::time::Duration) -> String {
@@ -1331,6 +1364,9 @@ mod tests {
         let now = Instant::now();
         // Three turns: 75% hit, 50% hit, miss-only (provider didn't report hit).
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: Some(crate::config::ApiProvider::Deepseek),
+            model: Some("deepseek-v4-pro".to_string()),
+            auto_model: true,
             input_tokens: 4_000,
             output_tokens: 200,
             cache_hit_tokens: Some(3_000),
@@ -1339,6 +1375,9 @@ mod tests {
             recorded_at: now,
         });
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 6_000,
             output_tokens: 250,
             cache_hit_tokens: Some(3_000),
@@ -1349,6 +1388,9 @@ mod tests {
         // Turn 3: hit reported but provider didn't report miss separately —
         // infer miss = input − hit and mark with `*`.
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 5_000,
             output_tokens: 100,
             cache_hit_tokens: Some(2_500),
@@ -1358,6 +1400,9 @@ mod tests {
         });
         // Turn 4: no telemetry at all — must not pollute aggregate ratios.
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 1_000,
             output_tokens: 50,
             cache_hit_tokens: None,
@@ -1374,6 +1419,7 @@ mod tests {
         // Per-turn ratios are rendered.
         assert!(msg.contains("75.0%"), "got: {msg}");
         assert!(msg.contains("50.0%"), "got: {msg}");
+        assert!(msg.contains("auto:deepseek/deepsee..."), "got: {msg}");
         // Turn 3: hit=2500, inferred miss=2500 → 50.0% with `*`-marked miss.
         assert!(msg.contains("2500*"), "got: {msg}");
         // Turn 4 (no telemetry) shows em-dashes and is excluded from totals.
@@ -1397,6 +1443,9 @@ mod tests {
             (45_982, 294, 26_112, 19_870),
         ] {
             app.push_turn_cache_record(TurnCacheRecord {
+                provider: None,
+                model: None,
+                auto_model: false,
                 input_tokens: input,
                 output_tokens: output,
                 cache_hit_tokens: Some(hit),
@@ -1422,6 +1471,9 @@ mod tests {
         let mut app = create_test_app();
         for _ in 0..3 {
             app.push_turn_cache_record(TurnCacheRecord {
+                provider: None,
+                model: None,
+                auto_model: false,
                 input_tokens: 1_000,
                 output_tokens: 100,
                 cache_hit_tokens: Some(500),
@@ -1441,6 +1493,9 @@ mod tests {
         let mut app = create_test_app();
         for i in 0..(crate::tui::app::App::TURN_CACHE_HISTORY_CAP + 12) {
             app.push_turn_cache_record(TurnCacheRecord {
+                provider: None,
+                model: None,
+                auto_model: false,
                 input_tokens: i as u32,
                 output_tokens: 1,
                 cache_hit_tokens: Some(i as u32),
@@ -2117,6 +2172,9 @@ mod tests {
             Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
 
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 10_000,
             output_tokens: 1_000,
             cache_hit_tokens: Some(8_000),
@@ -2125,6 +2183,9 @@ mod tests {
             recorded_at: Instant::now(),
         });
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 5_000,
             output_tokens: 500,
             cache_hit_tokens: Some(4_500),
@@ -2150,6 +2211,9 @@ mod tests {
             Some("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234".to_string());
 
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 10_000,
             output_tokens: 1_000,
             cache_hit_tokens: Some(1_000),
@@ -2180,6 +2244,9 @@ mod tests {
         // Fixture from #1747 / Amund's DeepSeek-TUI session aggregate:
         // hit=21,356,928, miss=8,470,281, output=165,624.
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 29_827_209,
             output_tokens: 165_624,
             cache_hit_tokens: Some(21_356_928),

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -872,6 +872,9 @@ mod tests {
         app.session.last_prompt_cache_miss_tokens = Some(40);
         app.session.last_reasoning_replay_tokens = Some(12);
         app.push_turn_cache_record(TurnCacheRecord {
+            provider: None,
+            model: None,
+            auto_model: false,
             input_tokens: 120,
             output_tokens: 35,
             cache_hit_tokens: Some(80),

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -170,6 +170,14 @@ pub enum AppMode {
 /// One row in the per-turn cache-telemetry ring (`/cache` debug surface, #263).
 #[derive(Debug, Clone)]
 pub struct TurnCacheRecord {
+    /// API provider used for the turn. This is recorded so cache misses can be
+    /// correlated with provider/model route changes.
+    pub provider: Option<ApiProvider>,
+    /// Concrete model used for the turn. For auto-model turns this is the
+    /// routed model, not the literal `auto` setting.
+    pub model: Option<String>,
+    /// Whether the route came from the auto-model selector.
+    pub auto_model: bool,
     /// Provider-reported total input tokens for the turn (cache-hit +
     ///   cache-miss + uncategorized). Useful for sanity-checking that hits +
     ///   misses sum back to roughly the prompt size.
@@ -1600,6 +1608,9 @@ pub struct App {
     pub auto_model: bool,
     /// Last concrete model chosen while `auto_model` is active.
     pub last_effective_model: Option<String>,
+    /// Route selected for the in-flight turn. Consumed by `TurnComplete` to
+    /// annotate `/cache` telemetry without widening the engine event surface.
+    pub pending_turn_route: Option<(ApiProvider, String, bool)>,
     /// Current API provider (mirrors `Config::api_provider`).
     /// Updated by `/provider` switches so the UI/commands can read the
     /// active backend without re-deriving it from the live config.
@@ -2237,6 +2248,7 @@ impl App {
         self.session.last_prompt_cache_miss_tokens = None;
         self.session.last_reasoning_replay_tokens = None;
         self.session.turn_cache_history.clear();
+        self.pending_turn_route = None;
         self.last_pinned_prefix_hash = None;
     }
 
@@ -2588,6 +2600,7 @@ impl App {
             provider_models,
             auto_model,
             last_effective_model: None,
+            pending_turn_route: None,
             api_provider: provider,
             provider_chain,
             provider_readiness,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2259,6 +2259,7 @@ async fn run_event_loop(
                         tool_catalog,
                         base_url,
                     } => {
+                        let pending_turn_route = app.pending_turn_route.take();
                         app.session.last_tool_catalog = tool_catalog;
                         app.session.last_base_url = base_url;
                         let was_locally_cancelled = app.suppress_stream_events_until_turn_complete;
@@ -2374,7 +2375,15 @@ async fn run_event_loop(
                         app.session.last_prompt_cache_hit_tokens = usage.prompt_cache_hit_tokens;
                         app.session.last_prompt_cache_miss_tokens = usage.prompt_cache_miss_tokens;
                         app.session.last_reasoning_replay_tokens = usage.reasoning_replay_tokens;
+                        let (provider, model, auto_model) = pending_turn_route
+                            .map(|(provider, model, auto_model)| {
+                                (Some(provider), Some(model), auto_model)
+                            })
+                            .unwrap_or((None, None, false));
                         app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+                            provider,
+                            model,
+                            auto_model,
                             input_tokens: usage.input_tokens,
                             output_tokens: usage.output_tokens,
                             cache_hit_tokens: usage.prompt_cache_hit_tokens,
@@ -6411,6 +6420,7 @@ async fn dispatch_user_message(
         app.last_effective_model = None;
     }
 
+    app.pending_turn_route = Some((effective_provider, effective_model.clone(), app.auto_model));
     if let Err(err) = engine_handle
         .send(Op::SendMessage {
             content,
@@ -6440,6 +6450,7 @@ async fn dispatch_user_message(
         app.is_loading = false;
         app.dispatch_started_at = None;
         app.last_send_at = None;
+        app.pending_turn_route = None;
         return Err(err);
     }
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2168,6 +2168,9 @@ fn apply_loaded_session_resets_unpersisted_telemetry() {
     app.session.last_prompt_cache_miss_tokens = Some(40);
     app.session.last_reasoning_replay_tokens = Some(12);
     app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+        provider: None,
+        model: None,
+        auto_model: false,
         input_tokens: 120,
         output_tokens: 35,
         cache_hit_tokens: Some(80),
@@ -2780,6 +2783,9 @@ async fn provider_switch_clears_turn_cache_history() {
 
     let mut app = create_test_app();
     app.push_turn_cache_record(crate::tui::app::TurnCacheRecord {
+        provider: None,
+        model: None,
+        auto_model: false,
         input_tokens: 100,
         output_tokens: 25,
         cache_hit_tokens: Some(70),
@@ -3232,6 +3238,10 @@ async fn dispatch_user_message_failed_send_clears_loading_state() {
     );
     assert!(app.last_send_at.is_none());
     assert!(app.dispatch_started_at.is_none());
+    assert!(
+        app.pending_turn_route.is_none(),
+        "failed dispatch must not leave stale route telemetry"
+    );
 }
 
 #[cfg(not(windows))]
@@ -3580,6 +3590,14 @@ async fn dispatch_user_message_keeps_auto_review_separate_from_bypass() {
     )
     .await
     .expect("dispatch user message");
+
+    let pending_route = app
+        .pending_turn_route
+        .as_ref()
+        .expect("successful dispatch records route telemetry");
+    assert_eq!(pending_route.0, app.api_provider);
+    assert_eq!(pending_route.1, app.model);
+    assert!(!pending_route.2);
 
     match engine.rx_op.recv().await.expect("send message op") {
         crate::core::ops::Op::SendMessage {


### PR DESCRIPTION
## Summary
- record the provider/model route selected for each dispatched turn
- show that route in `/cache` turn history, including auto-model routes
- keep failed dispatches from leaving stale pending route telemetry

Refs #3738.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked cache_command -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked dispatch_user_message_keeps_auto_review_separate_from_bypass -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked dispatch_user_message_failed_send_clears_loading_state -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked`