### PR TITLE
fix(tui): close deferred auto mode leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, and
-  `/mode` command until it has a distinct prompt and auto-review behavior;
-  existing `auto` mode text now folds back to Agent instead of selecting a
-  hollow mode (#3730, #3733).
+- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, `/mode`
+  command, and runtime-thread mode overrides until it has a distinct prompt and
+  auto-review behavior; existing `auto` mode text now folds back to Agent
+  instead of selecting a hollow mode, and approval modal copy no longer implies
+  the current mode is YOLO (#3730, #3733).
 - Clarified the Fleet setup surface and docs so Fleet is treated as the durable
   sub-agent configuration layer while WhaleFlow is the agent-authored
   orchestration plan that selects and monitors Fleet slots.

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -42,10 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, and
-  `/mode` command until it has a distinct prompt and auto-review behavior;
-  existing `auto` mode text now folds back to Agent instead of selecting a
-  hollow mode (#3730, #3733).
+- Deferred Auto mode from the user-facing mode picker, cycle, hotbar, `/mode`
+  command, and runtime-thread mode overrides until it has a distinct prompt and
+  auto-review behavior; existing `auto` mode text now folds back to Agent
+  instead of selecting a hollow mode, and approval modal copy no longer implies
+  the current mode is YOLO (#3730, #3733).
 - Clarified the Fleet setup surface and docs so Fleet is treated as the durable
   sub-agent configuration layer while WhaleFlow is the agent-authored
   orchestration plan that selects and monitors Fleet slots.

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -3889,14 +3889,15 @@ fn enforce_lru_capacity(
 
 /// Resolves only explicit mode tokens to an app mode. Free-form prompt text is
 /// never a valid mode token: `parse_mode_opt` returns `None` unless the input is
-/// exactly `agent`/`plan`/`auto`/`yolo` or numeric aliases `1`/`2`/`3`/`4`. Mode
+/// exactly `agent`/`plan`/`yolo` or numeric aliases `1`/`2`/`4`. Mode
 /// changes originate from the Tab cycle, `/mode`, the mode picker, or
 /// config/startup defaults, not from submitted natural-language prompt text.
+///
+/// Textual `auto` is a legacy alias for Agent while Auto is deferred (#3733).
 fn parse_mode_opt(mode: &str) -> Option<AppMode> {
     match mode.trim().to_ascii_lowercase().as_str() {
-        "agent" | "1" => Some(AppMode::Agent),
+        "agent" | "auto" | "1" => Some(AppMode::Agent),
         "plan" | "2" => Some(AppMode::Plan),
-        "auto" | "3" => Some(AppMode::Auto),
         "yolo" | "4" | "bypass" | "bypass-permissions" | "bypasspermissions" => Some(AppMode::Yolo),
         _ => None,
     }

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2480,8 +2480,8 @@ fn parse_mode_opt_resolves_explicit_tokens_and_aliases() {
     assert_eq!(parse_mode_opt("1"), Some(AppMode::Agent));
     assert_eq!(parse_mode_opt("plan"), Some(AppMode::Plan));
     assert_eq!(parse_mode_opt("2"), Some(AppMode::Plan));
-    assert_eq!(parse_mode_opt("auto"), Some(AppMode::Auto));
-    assert_eq!(parse_mode_opt("3"), Some(AppMode::Auto));
+    assert_eq!(parse_mode_opt("auto"), Some(AppMode::Agent));
+    assert_eq!(parse_mode_opt("3"), None);
     assert_eq!(parse_mode_opt("yolo"), Some(AppMode::Yolo));
     assert_eq!(parse_mode_opt("4"), Some(AppMode::Yolo));
     assert_eq!(parse_mode_opt(" PLAN "), Some(AppMode::Plan));
@@ -2503,9 +2503,10 @@ fn parse_mode_opt_rejects_prompt_fragments() {
 #[test]
 fn parse_mode_wrapper_defaults_and_resolves_numeric_aliases() {
     assert_eq!(parse_mode("plan a trip to Tokyo"), AppMode::Agent);
+    assert_eq!(parse_mode("auto"), AppMode::Agent);
     assert_eq!(parse_mode("1"), AppMode::Agent);
     assert_eq!(parse_mode("2"), AppMode::Plan);
-    assert_eq!(parse_mode("3"), AppMode::Auto);
+    assert_eq!(parse_mode("3"), AppMode::Agent);
     assert_eq!(parse_mode("4"), AppMode::Yolo);
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -162,6 +162,7 @@ fn onboarding_is_workspace_trust_gate(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
     Agent,
+    #[allow(dead_code)]
     Auto,
     Yolo,
     Plan,

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -2949,8 +2949,8 @@ diff --git a/src/b.rs b/src/b.rs
             "destructive hint missing:\n{joined}"
         );
         assert!(
-            joined.contains("YOLO skips ordinary approvals"),
-            "missing YOLO/review-rule semantics:\n{joined}"
+            joined.contains("active approval policy"),
+            "missing policy/review-rule semantics:\n{joined}"
         );
         assert!(
             joined.contains("Deny rejects only this tool call"),

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1810,13 +1810,10 @@ fn push_destructive_approval_semantics(
 
 fn destructive_approval_compact_semantics(locale: Locale) -> (&'static str, &'static str) {
     match locale {
-        Locale::ZhHans => (
-            "规则: ",
-            "YOLO 提示=审查/询问规则；拒绝跳过本次，Esc 中止整轮。",
-        ),
+        Locale::ZhHans => ("规则: ", "批准策略要求确认；拒绝跳过本次，Esc 中止整轮。"),
         _ => (
             "Policy: ",
-            "YOLO prompt = review rule or ask-rule; d denies this call, Esc aborts turn.",
+            "Approval policy requires review; d denies, Esc aborts.",
         ),
     }
 }
@@ -1826,14 +1823,14 @@ fn destructive_approval_semantics(locale: Locale) -> [(&'static str, &'static st
         Locale::ZhHans => [
             (
                 "规则: ",
-                "YOLO 会跳过普通批准；仍出现此提示表示命中审查规则或显式询问规则。",
+                "当前批准策略、审查规则或显式询问规则要求用户确认。",
             ),
             ("取消: ", "拒绝只跳过本次工具调用；Esc 会中止整轮。"),
         ],
         _ => [
             (
                 "Policy: ",
-                "YOLO skips ordinary approvals; this prompt means a review rule or explicit ask-rule is active.",
+                "The active approval policy, a review rule, or an explicit ask-rule requires confirmation.",
             ),
             (
                 "Cancel: ",
@@ -5246,9 +5243,12 @@ diff --git a/src/b.rs b/src/b.rs\n\
         assert!(rendered.contains("Review the Bash command"), "{rendered}");
         assert!(rendered.contains("Command:"), "{rendered}");
         assert!(rendered.contains("cargo clippy"), "{rendered}");
-        assert!(rendered.contains("YOLO prompt = review rule"), "{rendered}");
-        assert!(rendered.contains("d denies this call"), "{rendered}");
-        assert!(rendered.contains("aborts turn"), "{rendered}");
+        assert!(
+            rendered.contains("Approval policy requires review"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("d denies"), "{rendered}");
+        assert!(rendered.contains("Esc aborts"), "{rendered}");
         assert!(rendered.contains("[y]"), "{rendered}");
         assert!(rendered.contains("[a]"), "{rendered}");
         assert!(rendered.contains("[d]"), "{rendered}");


### PR DESCRIPTION
## Summary

- keep Auto deferred consistently by mapping legacy textual `auto` runtime-thread mode overrides to Agent while leaving numeric `3` unclaimed
- make destructive approval modal policy copy mode-neutral so prompts no longer imply the user is in YOLO
- update the Auto deferral changelog note and add focused regression coverage

Refs #3730, #3733.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_mode_parser_keeps_auto_deferred -- --nocapture`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked app_mode_helpers_centralize_parse_labels_and_cycle_order -- --nocapture`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked approval_shell_modal_stays_useful_on_short_terminals -- --nocapture`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked render_destructive_shows_warning_badge_and_one_step_hint -- --nocapture`
- [x] `CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked`

## Notes

This does not implement Auto as a true fourth mode yet; it closes the remaining user-facing leak while #3733 tracks the proper 0.8.67 implementation/removal decision.