### PR TITLE
fix(tui): label readonly shell approvals calmly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Calmed approval risk classification for read-only shell commands such as
+  `codewhale --version`, `codewhale --help`, and `git status --porcelain` so
+  the modal no longer labels proven read-only shell as destructive (#3730).
 - Added provider/model route columns to `/cache` turn telemetry so DeepSeek
   cache-hit regressions can be correlated with Auto route changes (#3738).
 - Fixed runtime API approval handling so workspace trust no longer auto-resolves

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Calmed approval risk classification for read-only shell commands such as
+  `codewhale --version`, `codewhale --help`, and `git status --porcelain` so
+  the modal no longer labels proven read-only shell as destructive (#3730).
 - Added provider/model route columns to `/cache` turn telemetry so DeepSeek
   cache-hit regressions can be correlated with Auto route changes (#3738).
 - Fixed runtime API approval handling so workspace trust no longer auto-resolves

--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -413,6 +413,9 @@ pub fn is_parallel_readonly_command(command: &str) -> bool {
         .iter()
         .map(String::as_str)
         .collect::<Vec<_>>();
+    if is_codewhale_readonly_invocation(&command_refs) {
+        return true;
+    }
     let canonical = classify_command(&command_refs);
     if canonical == "tail"
         && command_refs.iter().skip(1).any(|token| {
@@ -428,6 +431,16 @@ pub fn is_parallel_readonly_command(command: &str) -> bool {
     PARALLEL_READONLY_PREFIXES
         .iter()
         .any(|prefix| *prefix == canonical)
+}
+
+fn is_codewhale_readonly_invocation(tokens: &[&str]) -> bool {
+    let Some((command, args)) = tokens.split_first() else {
+        return false;
+    };
+    if !matches!(*command, "codewhale" | "codew") {
+        return false;
+    }
+    matches!(args, ["--version"] | ["-V"] | ["-v"] | ["--help"] | ["-h"])
 }
 
 fn readonly_shell_wrapper_inner_command(tokens: &[String]) -> Option<&str> {
@@ -1033,6 +1046,16 @@ fn target_contains_parent_escape(target: &str) -> bool {
 /// Check if a command is known to be safe
 fn is_safe_command(command: &str) -> bool {
     let command_lower = command.to_lowercase();
+    let tokens = shell_words(command);
+    if let Some(start) = primary_token_index(&tokens) {
+        let refs = tokens[start..]
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if is_codewhale_readonly_invocation(&refs) {
+            return true;
+        }
+    }
 
     for safe_cmd in SAFE_COMMANDS {
         if command_lower.starts_with(safe_cmd) {
@@ -1120,6 +1143,11 @@ mod tests {
         assert_eq!(analyze_command("ls -la").level, SafetyLevel::Safe);
         assert_eq!(analyze_command("cat file.txt").level, SafetyLevel::Safe);
         assert_eq!(analyze_command("git status").level, SafetyLevel::Safe);
+        assert_eq!(
+            analyze_command("codewhale --version").level,
+            SafetyLevel::Safe
+        );
+        assert_eq!(analyze_command("codewhale --help").level, SafetyLevel::Safe);
         assert_eq!(
             analyze_command("grep pattern file").level,
             SafetyLevel::Safe

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -14,9 +14,10 @@
 //! - **Benign** (`RiskLevel::Benign`) — read-only ops, MCP discovery,
 //!   query-only network. A single `Enter` / `1` / `y` approves once;
 //!   `2` / `a` approves for the session.
-//! - **Destructive** (`RiskLevel::Destructive`) — file writes, shell,
-//!   patches, MCP actions, unclassified tools, and any "fetch arbitrary
-//!   content" surface. The takeover keeps the destructive badge and
+//! - **Destructive** (`RiskLevel::Destructive`) — file writes, shell
+//!   commands that are not proven read-only, patches, MCP actions,
+//!   unclassified tools, and any "fetch arbitrary content" surface.
+//!   The takeover keeps the destructive badge and
 //!   impact summary visible, then lets `Enter` commit the highlighted
 //!   option or `y` / `a` / `d` commit directly.
 //!
@@ -26,6 +27,7 @@
 //! happen *before* the view is constructed (see `tui/ui.rs`); this
 //! module always assumes the user is being asked.
 
+use crate::command_safety::is_parallel_readonly_command;
 use crate::localization::Locale;
 use crate::sandbox::SandboxPolicy;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
@@ -509,12 +511,13 @@ pub fn classify_risk(tool_name: &str, category: ToolCategory, params: &Value) ->
             "web_search" | "web_run" | "wait_for_dev_server" => RiskLevel::Benign,
             _ => RiskLevel::Destructive,
         },
-        // Shell is always destructive. We probe command_safety for
-        // shape so a future routing tweak (say, pure-readonly `ls`
-        // staying benign) lands here without a second pass.
+        // Shell stays destructive unless the existing command-safety analyzer
+        // can prove the concrete command is read-only.
         ToolCategory::Shell => {
             if let Some(cmd) = params.get("command").and_then(Value::as_str) {
-                let _ = crate::command_safety::analyze_command(cmd);
+                if is_parallel_readonly_command(cmd) {
+                    return RiskLevel::Benign;
+                }
             }
             RiskLevel::Destructive
         }
@@ -1769,6 +1772,22 @@ mod tests {
                 classify_risk(name, cat, &json!({})),
                 RiskLevel::Destructive,
                 "expected {name:?} to be Destructive",
+            );
+        }
+    }
+
+    #[test]
+    fn risk_read_only_shell_commands_route_benign() {
+        let cat = ToolCategory::Shell;
+        for command in [
+            "codewhale --version",
+            "codewhale --help",
+            "git status --porcelain",
+        ] {
+            assert_eq!(
+                classify_risk("exec_shell", cat, &json!({ "command": command })),
+                RiskLevel::Benign,
+                "expected read-only shell command {command:?} to be Benign",
             );
         }
     }

--- a/crates/tui/src/tui/auto_review.rs
+++ b/crates/tui/src/tui/auto_review.rs
@@ -357,7 +357,7 @@ fn safety_floor(ctx: &AutoReviewContext<'_>) -> Option<AutoReviewDecision> {
 
 fn deterministic_fallback(ctx: &AutoReviewContext<'_>) -> AutoReviewDecision {
     match (ctx.category, ctx.risk, ctx.action_kind) {
-        (ToolCategory::Safe | ToolCategory::McpRead, RiskLevel::Benign, _) => {
+        (_, RiskLevel::Benign, _) => {
             AutoReviewDecision::new(AutoReviewAction::Allow, "read-only action is allowed")
         }
         (_, _, ToolActionKind::McpAction) => AutoReviewDecision::new(
@@ -371,10 +371,6 @@ fn deterministic_fallback(ctx: &AutoReviewContext<'_>) -> AutoReviewDecision {
         (_, RiskLevel::Destructive, _) => AutoReviewDecision::new(
             AutoReviewAction::AskUser,
             "destructive action requires explicit review",
-        ),
-        _ => AutoReviewDecision::new(
-            AutoReviewAction::AskUser,
-            "no deterministic allow rule matched",
         ),
     }
 }
@@ -581,6 +577,24 @@ mod tests {
 
         let decision = policy.evaluate(&ctx);
 
+        assert_eq!(decision.action, AutoReviewAction::Allow);
+        assert!(decision.reason.contains("read-only"));
+    }
+
+    #[test]
+    fn read_only_shell_allows_by_default() {
+        let policy = AutoReviewPolicy::default();
+        let ctx = ctx_for(
+            "exec_shell",
+            json!({ "command": "codewhale --version" }),
+            RunOrigin::Interactive,
+            ApprovalMode::Auto,
+        );
+
+        let decision = policy.evaluate(&ctx);
+
+        assert_eq!(ctx.category, ToolCategory::Shell);
+        assert_eq!(ctx.risk, RiskLevel::Benign);
         assert_eq!(decision.action, AutoReviewAction::Allow);
         assert!(decision.reason.contains("read-only"));
     }


### PR DESCRIPTION
## Summary\n- use the strict read-only shell classifier when routing approval modal risk for shell commands\n- mark CodeWhale version/help invocations as read-only for the shell classifier\n- let benign shell risk flow through auto-review as read-only while keeping destructive shell guarded\n\nThis complements #3746: that PR skips unnecessary direct Auto shell prompts; this follow-up fixes the remaining approval-modal risk label path so proven read-only shell is not called DESTRUCTIVE when a prompt is still shown.\n\n## Verification\n- cargo fmt --all -- --check\n- git diff --check\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked risk_read_only_shell_commands_route_benign -- --nocapture\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked read_only_shell_allows_by_default -- --nocapture\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked test_safe_commands -- --nocapture\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked run_shell_command_op_allows_readonly_shell_in_auto_mode -- --nocapture\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked risk_dangerous_shell_command_stays_destructive -- --nocapture\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo test -p codewhale-tui --bin codewhale-tui --locked parallel_readonly_command_classifier_is_strict -- --nocapture\n- CARGO_TARGET_DIR=/Volumes/VIXinSSD/codewhale-target cargo check -p codewhale-tui --bin codewhale-tui --locked\n\nRefs #3730