### PR TITLE
feat: add Sakana AI Fugu provider

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -20,7 +20,7 @@
 # `api_key` / `base_url` are
 # still read as DeepSeek defaults when `[providers.deepseek]` is absent
 # (backward compatibility).
-provider = "deepseek" # deepseek | deepseek-cn | deepseek-anthropic | nvidia-nim | openai | atlascloud | wanjie-ark | volcengine | openrouter | xiaomi-mimo | novita | fireworks | siliconflow | siliconflow-CN | arcee | moonshot | zai | stepfun | minimax | sglang | vllm | ollama | huggingface | together | qianfan | openai-codex | anthropic | openmodel | deepinfra
+provider = "deepseek" # deepseek | deepseek-cn | deepseek-anthropic | nvidia-nim | openai | atlascloud | wanjie-ark | volcengine | openrouter | xiaomi-mimo | novita | fireworks | siliconflow | siliconflow-CN | arcee | moonshot | zai | stepfun | minimax | sglang | vllm | ollama | huggingface | together | qianfan | openai-codex | anthropic | openmodel | deepinfra | sakana
 api_key = "YOUR_DEEPSEEK_API_KEY" # must be non-empty
 base_url = "https://api.deepseek.com/beta"
 # provider = "deepseek-cn"                       # legacy alias (official host is still https://api.deepseek.com)
@@ -543,6 +543,15 @@ max_subagents = 10 # optional (1-20)
 # api_key = "YOUR_DEEPINFRA_TOKEN"
 # base_url = "https://api.deepinfra.com/v1/openai"
 # model = "deepseek-ai/DeepSeek-V4-Pro"     # or deepseek-ai/DeepSeek-V4-Flash
+
+# ─────────────────────────────────────────────────────────────────────────────────
+# Sakana AI Fugu Provider (https://api.sakana.ai)
+# Provider aliases: sakana, sakana-ai, sakana_ai, fugu
+# Env var aliases: FUGU_API_KEY, SAKANA_API_KEY
+[providers.sakana]
+# api_key = "YOUR_FUGU_API_KEY"
+# base_url = "https://api.sakana.ai/v1"
+# model = "fugu"                            # or fugu-ultra-20260615
 
 # ─────────────────────────────────────────────────────────────────────────────────
 # Together AI Provider (https://www.together.ai/)

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -849,6 +849,27 @@ impl Default for ModelRegistry {
                 supports_tools: true,
                 supports_reasoning: true,
             },
+            // Sakana AI Fugu (https://api.sakana.ai)
+            ModelInfo {
+                id: "fugu".to_string(),
+                provider: ProviderKind::Sakana,
+                aliases: vec![
+                    "sakana-fugu".to_string(),
+                    "sakana/fugu".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: false,
+            },
+            ModelInfo {
+                id: "fugu-ultra-20260615".to_string(),
+                provider: ProviderKind::Sakana,
+                aliases: vec![
+                    "fugu-ultra".to_string(),
+                    "sakana-fugu-ultra".to_string(),
+                ],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
         ];
         Self::new(models)
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -62,6 +62,8 @@ enum ProviderArg {
     Minimax,
     #[value(alias = "deep-infra", alias = "deep_infra")]
     Deepinfra,
+    #[value(alias = "fugu", alias = "sakana-ai", alias = "sakana_ai")]
+    Sakana,
 }
 
 impl From<ProviderArg> for ProviderKind {
@@ -93,6 +95,7 @@ impl From<ProviderArg> for ProviderKind {
             ProviderArg::Stepfun => ProviderKind::Stepfun,
             ProviderArg::Minimax => ProviderKind::Minimax,
             ProviderArg::Deepinfra => ProviderKind::Deepinfra,
+            ProviderArg::Sakana => ProviderKind::Sakana,
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -157,6 +157,8 @@ pub struct ProvidersToml {
     pub minimax: ProviderConfigToml,
     #[serde(default, alias = "deep-infra", alias = "deep_infra")]
     pub deepinfra: ProviderConfigToml,
+    #[serde(default, alias = "sakana-ai", alias = "sakana_ai", alias = "fugu")]
+    pub sakana: ProviderConfigToml,
     /// Catch-all table for the dynamic OpenAI-compatible custom provider
     /// identity (#1519). Arbitrary `[providers.<name>]` tables are handled by
     /// the tui-side flatten map; this named slot keeps the canonical
@@ -254,6 +256,7 @@ impl ProvidersToml {
             ProviderKind::Stepfun => &self.stepfun,
             ProviderKind::Minimax => &self.minimax,
             ProviderKind::Deepinfra => &self.deepinfra,
+            ProviderKind::Sakana => &self.sakana,
             ProviderKind::Custom => &self.custom,
         }
     }
@@ -288,6 +291,7 @@ impl ProvidersToml {
             ProviderKind::Stepfun => &mut self.stepfun,
             ProviderKind::Minimax => &mut self.minimax,
             ProviderKind::Deepinfra => &mut self.deepinfra,
+            ProviderKind::Sakana => &mut self.sakana,
             ProviderKind::Custom => &mut self.custom,
         }
     }
@@ -1939,6 +1943,7 @@ impl ConfigToml {
                 ProviderKind::Stepfun => DEFAULT_STEPFUN_BASE_URL.to_string(),
                 ProviderKind::Minimax => DEFAULT_MINIMAX_BASE_URL.to_string(),
                 ProviderKind::Deepinfra => DEFAULT_DEEPINFRA_BASE_URL.to_string(),
+                ProviderKind::Sakana => DEFAULT_SAKANA_BASE_URL.to_string(),
                 // The custom provider has no built-in endpoint; fall back to its
                 // descriptor placeholder so the lookup is total. Real custom
                 // routes always supply a configured base_url before this point.
@@ -2514,6 +2519,7 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Stepfun => DEFAULT_STEPFUN_MODEL,
         ProviderKind::Minimax => DEFAULT_MINIMAX_MODEL,
         ProviderKind::Deepinfra => DEFAULT_DEEPINFRA_MODEL,
+        ProviderKind::Sakana => DEFAULT_SAKANA_MODEL,
         // No built-in default model; the registry placeholder keeps this total.
         ProviderKind::Custom => provider.provider().default_model(),
     }
@@ -2549,6 +2555,7 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Stepfun => DEFAULT_STEPFUN_BASE_URL,
         ProviderKind::Minimax => DEFAULT_MINIMAX_BASE_URL,
         ProviderKind::Deepinfra => DEFAULT_DEEPINFRA_BASE_URL,
+        ProviderKind::Sakana => DEFAULT_SAKANA_BASE_URL,
         // No built-in default base URL; the registry placeholder keeps this total.
         ProviderKind::Custom => provider.provider().default_base_url(),
     }
@@ -4011,6 +4018,8 @@ struct EnvRuntimeOverrides {
     minimax_model: Option<String>,
     deepinfra_base_url: Option<String>,
     deepinfra_model: Option<String>,
+    sakana_base_url: Option<String>,
+    sakana_model: Option<String>,
 }
 
 impl EnvRuntimeOverrides {
@@ -4243,6 +4252,12 @@ impl EnvRuntimeOverrides {
             deepinfra_model: std::env::var("DEEPINFRA_MODEL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            sakana_base_url: std::env::var("SAKANA_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            sakana_model: std::env::var("SAKANA_MODEL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
         }
     }
 
@@ -4293,6 +4308,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Stepfun => self.stepfun_base_url.clone(),
             ProviderKind::Minimax => self.minimax_base_url.clone(),
             ProviderKind::Deepinfra => self.deepinfra_base_url.clone(),
+            ProviderKind::Sakana => self.sakana_base_url.clone(),
             // No dedicated CODEWHALE_CUSTOM_BASE_URL env override: a custom
             // provider's base URL comes from its `[providers.<name>]` table.
             ProviderKind::Custom => None,
@@ -4322,6 +4338,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::Stepfun => self.stepfun_model.clone(),
             ProviderKind::Minimax => self.minimax_model.clone(),
             ProviderKind::Deepinfra => self.deepinfra_model.clone(),
+            ProviderKind::Sakana => self.sakana_model.clone(),
             _ => None,
         }?;
 

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -16,7 +16,8 @@ use super::{
     DEFAULT_OLLAMA_MODEL, DEFAULT_OPENAI_BASE_URL, DEFAULT_OPENAI_CODEX_BASE_URL,
     DEFAULT_OPENAI_CODEX_MODEL, DEFAULT_OPENAI_MODEL, DEFAULT_OPENMODEL_BASE_URL,
     DEFAULT_OPENMODEL_MODEL, DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL,
-    DEFAULT_QIANFAN_BASE_URL, DEFAULT_QIANFAN_MODEL, DEFAULT_SGLANG_BASE_URL, DEFAULT_SGLANG_MODEL,
+    DEFAULT_QIANFAN_BASE_URL, DEFAULT_QIANFAN_MODEL, DEFAULT_SAKANA_BASE_URL,
+    DEFAULT_SAKANA_MODEL, DEFAULT_SGLANG_BASE_URL, DEFAULT_SGLANG_MODEL,
     DEFAULT_SILICONFLOW_BASE_URL, DEFAULT_SILICONFLOW_CN_BASE_URL, DEFAULT_SILICONFLOW_MODEL,
     DEFAULT_STEPFUN_BASE_URL, DEFAULT_STEPFUN_MODEL, DEFAULT_TOGETHER_BASE_URL,
     DEFAULT_TOGETHER_MODEL, DEFAULT_VLLM_BASE_URL, DEFAULT_VLLM_MODEL, DEFAULT_VOLCENGINE_BASE_URL,
@@ -581,6 +582,18 @@ provider!(
     aliases: ["deep-infra", "deep_infra"]
 );
 
+provider!(
+    Sakana,
+    Sakana,
+    "sakana",
+    "Sakana AI (Fugu)",
+    DEFAULT_SAKANA_BASE_URL,
+    DEFAULT_SAKANA_MODEL,
+    ["FUGU_API_KEY", "SAKANA_API_KEY"],
+    "sakana",
+    aliases: ["sakana-ai", "sakana_ai", "fugu"]
+);
+
 /// User-defined OpenAI-compatible endpoint (#1519).
 ///
 /// A single dynamic provider identity for arbitrary `[providers.<name>]
@@ -662,9 +675,10 @@ static ZAI: Zai = Zai;
 static STEPFUN: Stepfun = Stepfun;
 static MINIMAX: Minimax = Minimax;
 static DEEPINFRA: Deepinfra = Deepinfra;
+static SAKANA: Sakana = Sakana;
 static CUSTOM: Custom = Custom;
 
-static PROVIDER_REGISTRY: [&dyn Provider; 29] = [
+static PROVIDER_REGISTRY: [&dyn Provider; 30] = [
     &DEEPSEEK,
     &DEEPSEEK_ANTHROPIC,
     &NVIDIA_NIM,
@@ -693,6 +707,7 @@ static PROVIDER_REGISTRY: [&dyn Provider; 29] = [
     &STEPFUN,
     &MINIMAX,
     &DEEPINFRA,
+    &SAKANA,
     &CUSTOM,
 ];
 

--- a/crates/config/src/provider_defaults.rs
+++ b/crates/config/src/provider_defaults.rs
@@ -127,3 +127,7 @@ pub(crate) const DEFAULT_MINIMAX_BASE_URL: &str = "https://api.minimax.io/v1";
 pub(crate) const DEFAULT_DEEPINFRA_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 pub(crate) const DEFAULT_DEEPINFRA_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub(crate) const DEFAULT_DEEPINFRA_BASE_URL: &str = "https://api.deepinfra.com/v1/openai";
+// Sakana AI Fugu defaults
+pub(crate) const DEFAULT_SAKANA_MODEL: &str = "fugu";
+pub(crate) const SAKANA_FUGU_ULTRA_MODEL: &str = "fugu-ultra-20260615";
+pub(crate) const DEFAULT_SAKANA_BASE_URL: &str = "https://api.sakana.ai/v1";

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -98,6 +98,8 @@ pub enum ProviderKind {
     Minimax,
     #[serde(alias = "deep-infra", alias = "deep_infra")]
     Deepinfra,
+    #[serde(alias = "sakana-ai", alias = "sakana_ai", alias = "fugu")]
+    Sakana,
     /// User-defined OpenAI-compatible endpoint (#1519).
     ///
     /// A single dynamic identity for arbitrary `[providers.<name>]
@@ -109,7 +111,7 @@ pub enum ProviderKind {
 }
 
 impl ProviderKind {
-    pub const ALL: [Self; 29] = [
+    pub const ALL: [Self; 30] = [
         Self::Deepseek,
         Self::DeepseekAnthropic,
         Self::NvidiaNim,
@@ -138,6 +140,7 @@ impl ProviderKind {
         Self::Stepfun,
         Self::Minimax,
         Self::Deepinfra,
+        Self::Sakana,
         Self::Custom,
     ];
 

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -864,6 +864,7 @@ pub fn env_for(name: &str) -> Option<String> {
             "WANJIE_API_KEY",
             "WANJIE_MAAS_API_KEY",
         ],
+        "sakana" | "sakana-ai" | "sakana_ai" | "fugu" => &["FUGU_API_KEY", "SAKANA_API_KEY"],
         _ => return None,
     };
     for var in candidates {

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1717,6 +1717,7 @@ pub(super) fn apply_reasoning_effort(
                 body["thinking"] = json!({ "type": "disabled" });
             }
             ApiProvider::Stepfun => {}
+            ApiProvider::Sakana => {}
         },
         "low" | "minimal" | "medium" | "mid" | "high" | "" => match provider {
             // DeepSeek compatibility: low/medium both map to high
@@ -1805,6 +1806,7 @@ pub(super) fn apply_reasoning_effort(
                 });
             }
             ApiProvider::Stepfun => {}
+            ApiProvider::Sakana => {}
         },
         "xhigh" | "max" | "highest" | "ultracode" => match provider {
             ApiProvider::Deepseek
@@ -1873,6 +1875,7 @@ pub(super) fn apply_reasoning_effort(
                 });
             }
             ApiProvider::Stepfun => {}
+            ApiProvider::Sakana => {}
         },
         _ => {}
     }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -70,6 +70,7 @@ pub enum ApiProvider {
     Stepfun,
     Minimax,
     Deepinfra,
+    Sakana,
     /// User-defined OpenAI-compatible endpoint (#1519).
     ///
     /// Selected when `provider = "<name>"` names a `[providers.<name>]
@@ -202,6 +203,7 @@ impl ApiProvider {
             Self::Stepfun => "https://platform.stepfun.ai/",
             Self::Minimax => "https://platform.minimax.io/docs/guides/quickstart-preparation",
             Self::Deepinfra => "https://deepinfra.com/dash/api_keys",
+            Self::Sakana => "https://api.sakana.ai/",
             Self::OpenaiCodex | Self::Sglang | Self::Vllm | Self::Ollama => return None,
             // Custom endpoints have no canonical credential page; the user
             // supplies the key via their own `api_key_env`.
@@ -217,7 +219,7 @@ impl ApiProvider {
 
     /// `ApiProvider` discriminant → `ProviderKind` lookup.
     /// Index 1 is `None` for the legacy `DeepseekCN` variant.
-    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 30] = [
+    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 31] = [
         Some(codewhale_config::ProviderKind::Deepseek),
         None, // DeepseekCN
         Some(codewhale_config::ProviderKind::DeepseekAnthropic),
@@ -247,11 +249,12 @@ impl ApiProvider {
         Some(codewhale_config::ProviderKind::Stepfun),
         Some(codewhale_config::ProviderKind::Minimax),
         Some(codewhale_config::ProviderKind::Deepinfra),
+        Some(codewhale_config::ProviderKind::Sakana),
         Some(codewhale_config::ProviderKind::Custom),
     ];
 
     /// `ProviderKind` discriminant → `ApiProvider` lookup.
-    const FROM_KIND_LOOKUP: [Self; 29] = [
+    const FROM_KIND_LOOKUP: [Self; 30] = [
         Self::Deepseek,
         Self::DeepseekAnthropic,
         Self::NvidiaNim,
@@ -280,6 +283,7 @@ impl ApiProvider {
         Self::Stepfun,
         Self::Minimax,
         Self::Deepinfra,
+        Self::Sakana,
         Self::Custom,
     ];
 
@@ -1152,6 +1156,7 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
             MINIMAX_M2_1_HIGHSPEED_MODEL,
             MINIMAX_M2_MODEL,
         ],
+        ApiProvider::Sakana => vec![DEFAULT_SAKANA_MODEL, SAKANA_FUGU_ULTRA_MODEL],
         // Custom endpoints expose no built-in completion names; the user
         // supplies their own model id (#1519).
         ApiProvider::Custom => Vec::new(),
@@ -2565,6 +2570,8 @@ pub struct ProvidersConfig {
     pub stepfun: ProviderConfig,
     #[serde(default)]
     pub minimax: ProviderConfig,
+    #[serde(default, alias = "sakana-ai", alias = "sakana_ai", alias = "fugu")]
+    pub sakana: ProviderConfig,
     /// Arbitrary user-named custom providers (#1519).
     ///
     /// Captures every `[providers.<name>]` table whose key is not one of the
@@ -2614,6 +2621,7 @@ impl ProvidersConfig {
             ("providers.zai", &self.zai),
             ("providers.stepfun", &self.stepfun),
             ("providers.minimax", &self.minimax),
+            ("providers.sakana", &self.sakana),
         ];
         for (name, config) in builtins {
             validate_provider_context_window(name, config.context_window)?;
@@ -2947,6 +2955,7 @@ impl Config {
             ApiProvider::Zai => &providers.zai,
             ApiProvider::Stepfun => &providers.stepfun,
             ApiProvider::Minimax => &providers.minimax,
+            ApiProvider::Sakana => &providers.sakana,
             // Handled by the name-keyed early return above (#1519).
             ApiProvider::Custom => unreachable!("custom provider resolved by name above"),
         })
@@ -3006,6 +3015,7 @@ impl Config {
             ApiProvider::Zai => &mut providers.zai,
             ApiProvider::Stepfun => &mut providers.stepfun,
             ApiProvider::Minimax => &mut providers.minimax,
+            ApiProvider::Sakana => &mut providers.sakana,
             // Handled by the name-keyed early return above (#1519).
             ApiProvider::Custom => unreachable!("custom provider resolved by name above"),
         }
@@ -3197,6 +3207,7 @@ impl Config {
             ApiProvider::Stepfun => DEFAULT_STEPFUN_MODEL,
             ApiProvider::Anthropic => DEFAULT_ANTHROPIC_MODEL,
             ApiProvider::Minimax => DEFAULT_MINIMAX_MODEL,
+            ApiProvider::Sakana => DEFAULT_SAKANA_MODEL,
             // Custom endpoints have no built-in default model; pass through the
             // descriptor placeholder when nothing is configured (#1519).
             ApiProvider::Custom => codewhale_config::ProviderKind::Custom
@@ -3249,6 +3260,7 @@ impl Config {
             | ApiProvider::Zai
             | ApiProvider::Stepfun
             | ApiProvider::Minimax
+            | ApiProvider::Sakana
             // Custom reads its base_url from the named `[providers.<name>]`
             // table (via provider_base), never from the legacy root field.
             | ApiProvider::Custom => None,
@@ -3308,6 +3320,7 @@ impl Config {
                         ApiProvider::Stepfun => DEFAULT_STEPFUN_BASE_URL,
                         ApiProvider::Anthropic => DEFAULT_ANTHROPIC_BASE_URL,
                         ApiProvider::Minimax => DEFAULT_MINIMAX_BASE_URL,
+                        ApiProvider::Sakana => DEFAULT_SAKANA_BASE_URL,
                         // No built-in endpoint; descriptor placeholder keeps the
                         // fallback total. A real custom route configures
                         // `[providers.<name>] base_url` which wins above (#1519).
@@ -4439,6 +4452,13 @@ fn apply_env_overrides(config: &mut Config) {
                     .minimax
                     .base_url = Some(value);
             }
+            ApiProvider::Sakana => {
+                config
+                    .providers
+                    .get_or_insert_with(ProvidersConfig::default)
+                    .sakana
+                    .base_url = Some(value);
+            }
             // Custom resolves to the named `[providers.<name>]` table; route the
             // override through the name-keyed mutable accessor (#1519).
             ApiProvider::Custom => {
@@ -4666,6 +4686,7 @@ fn apply_env_overrides(config: &mut Config) {
             ApiProvider::Zai => &mut providers.zai,
             ApiProvider::Stepfun => &mut providers.stepfun,
             ApiProvider::Minimax => &mut providers.minimax,
+            ApiProvider::Sakana => &mut providers.sakana,
             ApiProvider::Custom => providers
                 .custom
                 .entry(custom_key.expect("custom key captured for custom provider"))
@@ -4887,6 +4908,7 @@ fn apply_env_overrides(config: &mut Config) {
                 ApiProvider::Zai => &mut providers.zai,
                 ApiProvider::Stepfun => &mut providers.stepfun,
                 ApiProvider::Minimax => &mut providers.minimax,
+                ApiProvider::Sakana => &mut providers.sakana,
             };
             entry.model = Some(value);
         }
@@ -5653,6 +5675,7 @@ fn merge_providers(
             zai: merge_provider_config(base.zai, override_cfg.zai),
             stepfun: merge_provider_config(base.stepfun, override_cfg.stepfun),
             minimax: merge_provider_config(base.minimax, override_cfg.minimax),
+            sakana: merge_provider_config(base.sakana, override_cfg.sakana),
             custom: merge_custom_providers(base.custom, override_cfg.custom),
         }),
     }

--- a/crates/tui/src/config/models.rs
+++ b/crates/tui/src/config/models.rs
@@ -160,3 +160,6 @@ pub const MINIMAX_M2_1_MODEL: &str = "MiniMax-M2.1";
 pub const MINIMAX_M2_1_HIGHSPEED_MODEL: &str = "MiniMax-M2.1-highspeed";
 pub const MINIMAX_M2_MODEL: &str = "MiniMax-M2";
 pub const DEFAULT_MINIMAX_BASE_URL: &str = "https://api.minimax.io/v1";
+pub const DEFAULT_SAKANA_MODEL: &str = "fugu";
+pub const SAKANA_FUGU_ULTRA_MODEL: &str = "fugu-ultra-20260615";
+pub const DEFAULT_SAKANA_BASE_URL: &str = "https://api.sakana.ai/v1";

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -316,6 +316,7 @@ fn provider_base_url_table_key(provider: ApiProvider) -> anyhow::Result<&'static
         ApiProvider::Zai => Ok("zai"),
         ApiProvider::Stepfun => Ok("stepfun"),
         ApiProvider::Minimax => Ok("minimax"),
+        ApiProvider::Sakana => Ok("sakana"),
         // Custom providers live under a user-chosen `[providers.<name>]` table,
         // not a fixed key. Persisting base_url through this static-key path is
         // out of scope for the #1519 constrained slice; users edit the named

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8583,6 +8583,7 @@ fn render(f: &mut Frame, app: &mut App, config: &Config) {
             crate::config::ApiProvider::Zai => Some("Z.ai"),
             crate::config::ApiProvider::Stepfun => Some("StepFun"),
             crate::config::ApiProvider::Minimax => Some("MiniMax"),
+            crate::config::ApiProvider::Sakana => Some("Sakana"),
             crate::config::ApiProvider::Custom => Some("Custom"),
         };
         let status_indicator_started_at = if app.low_motion {
@@ -9798,6 +9799,7 @@ async fn apply_provider_picker_api_key(
             ApiProvider::Zai => &mut providers.zai,
             ApiProvider::Stepfun => &mut providers.stepfun,
             ApiProvider::Minimax => &mut providers.minimax,
+            ApiProvider::Sakana => &mut providers.sakana,
         };
         entry.api_key = Some(api_key);
     }
@@ -9877,6 +9879,7 @@ fn set_provider_auth_mode_in_memory(config: &mut Config, provider: ApiProvider, 
         ApiProvider::Zai => &mut providers.zai,
         ApiProvider::Stepfun => &mut providers.stepfun,
         ApiProvider::Minimax => &mut providers.minimax,
+        ApiProvider::Sakana => &mut providers.sakana,
     };
     entry.auth_mode = Some(auth_mode);
 }

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -32,7 +32,7 @@ The canonical provider IDs are:
 `wanjie-ark`, `volcengine`, `openrouter`, `xiaomi-mimo`, `novita`, `fireworks`,
 `siliconflow`, `arcee`, `siliconflow-CN`, `moonshot`, `sglang`, `vllm`,
 `ollama`, `huggingface`, `together`, `qianfan`, `openai-codex`, `anthropic`,
-`openmodel`, `zai`, `stepfun`, `minimax`, and `deepinfra`.
+`openmodel`, `zai`, `stepfun`, `minimax`, `deepinfra`, and `sakana`.
 
 Use any of these surfaces to select a provider:
 
@@ -105,6 +105,7 @@ the listed provider env vars.
 | `stepfun` | `[providers.stepfun]` | OpenAI Chat Completions | `STEPFUN_API_KEY`, `STEP_API_KEY` |
 | `minimax` | `[providers.minimax]` | OpenAI Chat Completions | `MINIMAX_API_KEY` |
 | `deepinfra` | `[providers.deepinfra]` | OpenAI Chat Completions | `DEEPINFRA_API_KEY`, `DEEPINFRA_TOKEN` |
+| `sakana` | `[providers.sakana]` | OpenAI Chat Completions | `FUGU_API_KEY`, `SAKANA_API_KEY` |
 
 Default base URLs and models for each route are listed in the shipped provider
 table below. The wire protocol values above are derived from
@@ -233,6 +234,7 @@ the same links where possible.
 | `openmodel` | [OpenModel API key guide](https://docs.openmodel.ai/en/docs/guides/api-key) |
 | `openai-codex` | Reuses `codex login`; no CodeWhale API key is stored. |
 | `sglang`, `vllm`, `ollama` | Local OpenAI-compatible endpoints can run without an API key on localhost. |
+| `sakana` | [Sakana AI API](https://api.sakana.ai/) |
 
 ## Shipped Providers
 
@@ -266,6 +268,7 @@ the same links where possible.
 | `openai-codex` | `[providers.openai_codex]` | OAuth via `codex login` (`~/.codex/auth.json`); env override `OPENAI_CODEX_ACCESS_TOKEN`, `CODEX_ACCESS_TOKEN` | `OPENAI_CODEX_BASE_URL`/`CODEX_BASE_URL`; default `https://chatgpt.com/backend-api` | `gpt-5.5` | **Experimental.** Reuses your existing ChatGPT/Codex CLI OAuth login and talks to the OpenAI Responses API at `/codex/responses`. The access token is read and refreshed from `~/.codex/auth.json`; no API key is stored. `OPENAI_CODEX_MODEL`/`CODEX_MODEL` and `OPENAI_CODEX_ACCOUNT_ID`/`CODEX_ACCOUNT_ID` are accepted. CodeWhale budgets this route with the 400K Codex-family effective context window even when the public API model table lists a larger native `gpt-5.5` window. |
 | `anthropic` | `[providers.anthropic]` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL`; default `https://api.anthropic.com` | `claude-opus-4-8`, `claude-sonnet-4-6` (default), `claude-haiku-4-5` | Native Anthropic Messages API route (`/v1/messages`, `x-api-key` + `anthropic-version: 2023-06-01`) — not OpenAI-compatible. Prompt caching via `cache_control` breakpoints, adaptive thinking + `output_config.effort`, signed thinking blocks replayed verbatim, cache telemetry normalized per #2961. `ANTHROPIC_MODEL` is accepted. |
 | `openmodel` | `[providers.openmodel]` | `OPENMODEL_API_KEY` | `OPENMODEL_BASE_URL`; default `https://api.openmodel.ai` | `deepseek-v4-flash`; provider-scoped custom model IDs pass through | OpenModel Anthropic-compatible Messages route. Uses `/v1/messages`, Bearer auth, and `anthropic-version: 2023-06-01`; OpenModel selects DeepSeek, DashScope, Xiaomi, Claude, and other routes by model id. `OPENMODEL_MODEL` is accepted. |
+| `sakana` | `[providers.sakana]` | `FUGU_API_KEY`, `SAKANA_API_KEY` | `SAKANA_BASE_URL`; default `https://api.sakana.ai/v1` | `fugu` (default), `fugu-ultra-20260615` | Sakana AI Fugu OpenAI-compatible route. Standard Chat Completions wire protocol; streaming supported. `fugu-ultra-20260615` is the heavy/reasoning variant. Env var aliases: `FUGU_API_KEY` (primary), `SAKANA_API_KEY`; provider aliases: `sakana-ai`, `sakana_ai`, `fugu`. |
 
 ### Hugging Face Provider vs MCP vs Hub
 
@@ -390,6 +393,7 @@ endpoint when the endpoint supports model listing.
 | `openai-codex` | `gpt-5.5` | yes | yes |
 | `anthropic` | `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | yes | yes for `claude-opus-4-8` and `claude-sonnet-4-6`; no for `claude-haiku-4-5` |
 | `openmodel` | `deepseek-v4-flash`; provider-scoped custom model IDs pass through | yes | model-dependent |
+| `sakana` | `fugu`, `fugu-ultra-20260615` | yes | yes for `fugu-ultra-20260615` |
 
 AtlasCloud keeps the same default model as the config layer and adds
 provider-scoped aliases for the Pro and Flash rows. Other AtlasCloud model IDs


### PR DESCRIPTION
## Summary

Adds `sakana` as a built-in provider, matching the existing moonshot/minimax pattern.

- Base URL `https://api.sakana.ai/v1` (OpenAI Chat Completions wire protocol; streaming supported)
- Auth via `FUGU_API_KEY` (primary) or `SAKANA_API_KEY`
- Default model `fugu`; reasoning variant `fugu-ultra-20260615`
- CLI aliases: `sakana`, `sakana-ai`, `fugu`
- Reasoning-effort: no-op (Sakana's OpenAI-compatible endpoint exposes no proprietary effort fields)

Registers `sakana` at every point the other providers touch: the `ProviderKind` enum and `provider!()` registry, the `ProvidersToml`/`ProvidersConfig` structs, the `ApiProvider` TUI enum with its `KIND_LOOKUP`/`FROM_KIND_LOOKUP` mappings, the `ProviderArg` CLI enum, `codewhale_secrets::env_for`, the `ModelRegistry`, `config.example.toml`, and `docs/PROVIDERS.md`.

## Test plan (verified locally)

- [x] `cargo build` clean
- [x] `--provider sakana exec` routes to `api.sakana.ai` and returns a live Fugu response
- [x] `--provider sakana models` lists the live Sakana catalog (`fugu`, `fugu-ultra`, `fugu-ultra-20260615`)
- [x] `FUGU_API_KEY` / `SAKANA_API_KEY` resolve via the secrets path
