### PR TITLE
fix(tui): restore legacy session visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored legacy `.deepseek/sessions` visibility for upgraded installs where
+  an empty `~/.codewhale/sessions` directory already existed, by copying
+  missing legacy session entries into the primary CodeWhale session store
+  without overwriting newer data (#3724).
 - Calmed approval risk classification for read-only shell commands such as
   `codewhale --version`, `codewhale --help`, and `git status --porcelain` so
   the modal no longer labels proven read-only shell as destructive (#3730).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restored legacy `.deepseek/sessions` visibility for upgraded installs where
+  an empty `~/.codewhale/sessions` directory already existed, by copying
+  missing legacy session entries into the primary CodeWhale session store
+  without overwriting newer data (#3724).
 - Calmed approval risk classification for read-only shell commands such as
   `codewhale --version`, `codewhale --help`, and `git status --porcelain` so
   the modal no longer labels proven read-only shell as destructive (#3730).

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -13,6 +13,7 @@ use crate::utils::write_atomic;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io;
 use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
@@ -621,10 +622,90 @@ fn is_git_metadata_entry(path: &Path) -> bool {
 /// v0.8.44: prefers `~/.codewhale/sessions`, falls back to
 /// `~/.deepseek/sessions` for existing installs. Uses the write-path resolver
 /// so the first access relocates any legacy `~/.deepseek/sessions` into
-/// `~/.codewhale/sessions` (#3240); reads still surface migrated data.
+/// `~/.codewhale/sessions` when the primary directory is missing (#3240).
+/// If an older build already created an empty primary sessions directory, copy
+/// missing legacy entries into it without overwriting newer CodeWhale data.
 pub fn default_sessions_dir() -> std::io::Result<PathBuf> {
-    codewhale_config::ensure_state_dir("sessions")
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotFound, e.to_string()))
+    let dir = codewhale_config::ensure_state_dir("sessions")
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotFound, e.to_string()))?;
+    match merge_missing_legacy_session_entries(&dir) {
+        Ok(0) => {}
+        Ok(count) => {
+            tracing::info!(
+                target: "session::migration",
+                "Copied {count} missing legacy session entries into {}",
+                dir.display()
+            );
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "session::migration",
+                "Could not copy legacy sessions into {}: {err}",
+                dir.display()
+            );
+        }
+    }
+    Ok(dir)
+}
+
+fn merge_missing_legacy_session_entries(primary: &Path) -> io::Result<usize> {
+    if codewhale_home_is_explicit() {
+        return Ok(0);
+    }
+
+    let legacy = codewhale_config::legacy_deepseek_home()
+        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e.to_string()))?
+        .join("sessions");
+    if !legacy.is_dir() || paths_equivalent(primary, &legacy) {
+        return Ok(0);
+    }
+
+    copy_missing_dir_entries(&legacy, primary)
+}
+
+fn codewhale_home_is_explicit() -> bool {
+    std::env::var("CODEWHALE_HOME")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+}
+
+fn copy_missing_dir_entries(src: &Path, dst: &Path) -> io::Result<usize> {
+    fs::create_dir_all(dst)?;
+    let mut copied = 0;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let source = entry.path();
+        let target = dst.join(entry.file_name());
+
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            if entry.file_name() == std::ffi::OsStr::new("checkpoints") || target.exists() {
+                continue;
+            }
+            copied += copy_missing_dir_entries(&source, &target)?;
+        } else if file_type.is_file() {
+            copied += usize::from(copy_file_create_new(&source, &target)?);
+        }
+    }
+    Ok(copied)
+}
+
+fn copy_file_create_new(src: &Path, dst: &Path) -> io::Result<bool> {
+    let mut source = fs::File::open(src)?;
+    let mut target = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(dst)
+    {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    if let Err(err) = io::copy(&mut source, &mut target) {
+        let _ = fs::remove_file(dst);
+        return Err(err);
+    }
+    Ok(true)
 }
 
 /// Prune snapshots older than `max_age` for `workspace`.
@@ -1294,6 +1375,99 @@ mod tests {
 
         let sessions = manager.list_sessions().expect("list");
         assert_eq!(sessions.len(), 3);
+    }
+
+    #[test]
+    fn default_manager_copies_legacy_sessions_when_primary_already_exists() {
+        let _lock = crate::test_support::lock_test_env();
+        let tmp = tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let _home = crate::test_support::EnvVarGuard::set("HOME", &home);
+        let _codewhale_home = crate::test_support::EnvVarGuard::remove("CODEWHALE_HOME");
+
+        let primary_sessions = home.join(".codewhale").join("sessions");
+        let legacy_sessions = home.join(".deepseek").join("sessions");
+        fs::create_dir_all(&primary_sessions).expect("primary sessions");
+        fs::create_dir_all(&legacy_sessions).expect("legacy sessions");
+        fs::create_dir_all(legacy_sessions.join("checkpoints")).expect("legacy checkpoints");
+        fs::write(
+            legacy_sessions.join("checkpoints").join("latest.json"),
+            "{}",
+        )
+        .expect("legacy checkpoint");
+
+        let mut legacy_session = create_saved_session(
+            &[make_test_message("user", "find my old session")],
+            "test-model",
+            tmp.path(),
+            100,
+            None,
+        );
+        legacy_session.metadata.id = "legacy-visible".to_string();
+        legacy_session.metadata.title = "session from legacy home".to_string();
+        fs::write(
+            legacy_sessions.join("legacy-visible.json"),
+            serde_json::to_string_pretty(&legacy_session).expect("serialize legacy session"),
+        )
+        .expect("write legacy session");
+
+        let manager = SessionManager::default_location().expect("default manager");
+        assert_eq!(manager.sessions_dir(), primary_sessions.as_path());
+        assert!(primary_sessions.join("legacy-visible.json").exists());
+        assert!(!primary_sessions.join("checkpoints").exists());
+        assert!(legacy_sessions.join("legacy-visible.json").exists());
+
+        let sessions = manager.list_sessions().expect("list");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "legacy-visible");
+    }
+
+    #[test]
+    fn legacy_session_copy_never_overwrites_primary_session() {
+        let _lock = crate::test_support::lock_test_env();
+        let tmp = tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let _home = crate::test_support::EnvVarGuard::set("HOME", &home);
+        let _codewhale_home = crate::test_support::EnvVarGuard::remove("CODEWHALE_HOME");
+
+        let primary_sessions = home.join(".codewhale").join("sessions");
+        let legacy_sessions = home.join(".deepseek").join("sessions");
+        fs::create_dir_all(&primary_sessions).expect("primary sessions");
+        fs::create_dir_all(&legacy_sessions).expect("legacy sessions");
+
+        let primary_path = primary_sessions.join("same-id.json");
+        fs::write(&primary_path, "primary data wins").expect("write primary session");
+        fs::write(
+            legacy_sessions.join("same-id.json"),
+            "legacy data must not overwrite",
+        )
+        .expect("write legacy session");
+
+        let dir = default_sessions_dir().expect("default session dir");
+        assert_eq!(dir, primary_sessions);
+        assert_eq!(
+            fs::read_to_string(primary_path).expect("read primary session"),
+            "primary data wins"
+        );
+    }
+
+    #[test]
+    fn explicit_codewhale_home_disables_legacy_session_copy() {
+        let _lock = crate::test_support::lock_test_env();
+        let tmp = tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let explicit_home = tmp.path().join("explicit-codewhale");
+        let _home = crate::test_support::EnvVarGuard::set("HOME", &home);
+        let _codewhale_home =
+            crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &explicit_home);
+
+        let legacy_sessions = home.join(".deepseek").join("sessions");
+        fs::create_dir_all(&legacy_sessions).expect("legacy sessions");
+        fs::write(legacy_sessions.join("legacy-visible.json"), "{}").expect("write legacy session");
+
+        let dir = default_sessions_dir().expect("default session dir");
+        assert_eq!(dir, explicit_home.join("sessions"));
+        assert!(!dir.join("legacy-visible.json").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #3724 by copying missing entries from `~/.deepseek/sessions` into `~/.codewhale/sessions` when an older upgrade already created the primary sessions dir
- Keeps the copy additive only: existing CodeWhale session data is not overwritten, explicit `CODEWHALE_HOME` still opts out, and legacy files remain in place
- Adds a regression test for the hidden-history case plus changelog notes

## Testing

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; targeted TUI session tests passed)
- [ ] `cargo test --workspace --all-features` (not run; targeted TUI session tests passed)
- [x] `git diff --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked default_manager_copies_legacy_sessions_when_primary_already_exists`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked session_manager::tests::`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (N/A: session path migration only)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A: no harvest)
