### PR TITLE
fix(config): surface legacy state migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Surfaced legacy state relocation with a user-visible migration notice whenever
+  `~/.deepseek/<state>` is moved or copied into `~/.codewhale/<state>`, so
+  upgraded users know their data was preserved and where the canonical state
+  now lives (#3726).
 - Restored legacy `.deepseek/sessions` visibility for upgraded installs where
   an empty `~/.codewhale/sessions` directory already existed, by copying
   missing legacy session entries into the primary CodeWhale session store

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3333,31 +3333,81 @@ pub fn resolve_state_dir(subdir: &str) -> Result<PathBuf> {
 /// stops growing (#3240). After migration, [`resolve_state_dir`] finds the
 /// data in the primary location; the read resolver itself is unchanged.
 pub fn ensure_state_dir(subdir: &str) -> Result<PathBuf> {
+    let (dir, migration) = ensure_state_dir_with_migration(subdir)?;
+    if let Some(migration) = migration {
+        eprintln!("{}", migration.user_notice());
+    }
+    Ok(dir)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateMigrationKind {
+    Relocated,
+    Copied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateMigration {
+    pub subdir: String,
+    pub legacy_path: PathBuf,
+    pub primary_path: PathBuf,
+    pub kind: StateMigrationKind,
+}
+
+impl StateMigration {
+    pub fn user_notice(&self) -> String {
+        let action = match self.kind {
+            StateMigrationKind::Relocated => "relocated",
+            StateMigrationKind::Copied => "copied",
+        };
+        let legacy_detail = match self.kind {
+            StateMigrationKind::Relocated => {
+                "The legacy .deepseek copy for this state path was removed by the move."
+            }
+            StateMigrationKind::Copied => {
+                "The legacy .deepseek copy was left in place because a direct move failed."
+            }
+        };
+
+        format!(
+            "CodeWhale migrated legacy state ({action}):\n  {} -> {}\nYour data was preserved. Use .codewhale as the canonical state location from now on.\n{legacy_detail}\nIf no other apps use it, you can remove the legacy .deepseek tree after confirming everything looks right.",
+            self.legacy_path.display(),
+            self.primary_path.display(),
+        )
+    }
+}
+
+/// Variant of [`ensure_state_dir`] that exposes whether a legacy state path was
+/// migrated. Most callers should use [`ensure_state_dir`]; this is kept for
+/// tests and future UI surfaces that want to render the notice themselves.
+pub fn ensure_state_dir_with_migration(subdir: &str) -> Result<(PathBuf, Option<StateMigration>)> {
     ensure_safe_state_subdir(subdir)?;
     let explicit_codewhale_home = codewhale_home_env_override().is_some();
     let dir = codewhale_home()?.join(subdir);
-    if !explicit_codewhale_home {
-        migrate_legacy_state_dir(&dir, subdir)?;
-    }
+    let migration = if !explicit_codewhale_home {
+        migrate_legacy_state_dir(&dir, subdir)?
+    } else {
+        None
+    };
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("failed to create {}/", dir.display()))?;
-    Ok(dir)
+    Ok((dir, migration))
 }
 
 /// One-time relocation of a legacy `~/.deepseek/<subdir>` state directory into
 /// the primary `~/.codewhale/<subdir>` location (#3240). No-op once the primary
 /// exists, for the root sentinel `"."` (a whole-tree move is owned by the
 /// config-file migration), or when no legacy directory is present.
-fn migrate_legacy_state_dir(primary: &Path, subdir: &str) -> Result<()> {
+fn migrate_legacy_state_dir(primary: &Path, subdir: &str) -> Result<Option<StateMigration>> {
     if primary.exists() || subdir == "." || subdir.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     let legacy = match legacy_deepseek_home() {
         Ok(home) => home.join(subdir),
-        Err(_) => return Ok(()),
+        Err(_) => return Ok(None),
     };
     if !legacy.exists() {
-        return Ok(());
+        return Ok(None);
     }
     // The primary's parent (the ~/.codewhale root) must exist for the rename.
     if let Some(parent) = primary.parent()
@@ -3378,6 +3428,12 @@ fn migrate_legacy_state_dir(primary: &Path, subdir: &str) -> Result<()> {
                 legacy.display(),
                 primary.display()
             );
+            return Ok(Some(StateMigration {
+                subdir: subdir.to_string(),
+                legacy_path: legacy,
+                primary_path: primary.to_path_buf(),
+                kind: StateMigrationKind::Relocated,
+            }));
         }
         Err(err) => {
             // Cross-device rename or permission issue: fall back to a
@@ -3393,6 +3449,12 @@ fn migrate_legacy_state_dir(primary: &Path, subdir: &str) -> Result<()> {
                         legacy.display(),
                         primary.display()
                     );
+                    return Ok(Some(StateMigration {
+                        subdir: subdir.to_string(),
+                        legacy_path: legacy,
+                        primary_path: primary.to_path_buf(),
+                        kind: StateMigrationKind::Copied,
+                    }));
                 }
                 Err(copy_err) => {
                     tracing::warn!(
@@ -3406,7 +3468,7 @@ fn migrate_legacy_state_dir(primary: &Path, subdir: &str) -> Result<()> {
             }
         }
     }
-    Ok(())
+    Ok(None)
 }
 
 /// Recursively copy a directory tree from `src` to `dst`, creating `dst`.

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -2464,8 +2464,14 @@ fn ensure_state_dir_relocates_legacy_subdir_on_first_write() {
     .expect("legacy file");
     assert!(!state_env.primary("slop_ledger").exists());
 
-    let dir = ensure_state_dir("slop_ledger").expect("ensure_state_dir");
+    let (dir, migration) =
+        ensure_state_dir_with_migration("slop_ledger").expect("ensure_state_dir");
     assert_eq!(dir, state_env.primary("slop_ledger"));
+    let migration = migration.expect("legacy migration should be reported");
+    assert_eq!(migration.kind, StateMigrationKind::Relocated);
+    assert_eq!(migration.subdir, "slop_ledger");
+    assert_eq!(migration.legacy_path, state_env.legacy("slop_ledger"));
+    assert_eq!(migration.primary_path, state_env.primary("slop_ledger"));
     // Legacy contents relocated into primary.
     assert_eq!(
         fs::read_to_string(state_env.primary("slop_ledger").join("slop_ledger.json"))
@@ -2478,8 +2484,44 @@ fn ensure_state_dir_relocates_legacy_subdir_on_first_write() {
         "legacy subdir should be removed after relocation"
     );
     // Idempotent: a second call is a no-op now that primary exists.
-    ensure_state_dir("slop_ledger").expect("idempotent ensure");
+    let (_, repeated_migration) =
+        ensure_state_dir_with_migration("slop_ledger").expect("idempotent ensure");
+    assert!(repeated_migration.is_none());
     let _ = fs::remove_dir_all(&state_env.home);
+}
+
+#[test]
+fn state_migration_notice_explains_preserved_data_and_canonical_root() {
+    let migration = StateMigration {
+        subdir: "sessions".to_string(),
+        legacy_path: PathBuf::from("/home/alice/.deepseek/sessions"),
+        primary_path: PathBuf::from("/home/alice/.codewhale/sessions"),
+        kind: StateMigrationKind::Relocated,
+    };
+
+    let notice = migration.user_notice();
+
+    assert!(notice.contains("CodeWhale migrated legacy state"));
+    assert!(notice.contains("/home/alice/.deepseek/sessions"));
+    assert!(notice.contains("/home/alice/.codewhale/sessions"));
+    assert!(notice.contains("Your data was preserved"));
+    assert!(notice.contains("Use .codewhale as the canonical state location"));
+    assert!(notice.contains("remove the legacy .deepseek tree"));
+}
+
+#[test]
+fn copied_state_migration_notice_says_legacy_copy_remains() {
+    let migration = StateMigration {
+        subdir: "catalog".to_string(),
+        legacy_path: PathBuf::from("/home/alice/.deepseek/catalog"),
+        primary_path: PathBuf::from("/home/alice/.codewhale/catalog"),
+        kind: StateMigrationKind::Copied,
+    };
+
+    let notice = migration.user_notice();
+
+    assert!(notice.contains("copied"));
+    assert!(notice.contains("legacy .deepseek copy was left in place"));
 }
 
 #[test]
@@ -2496,8 +2538,12 @@ fn ensure_state_dir_writes_to_primary_when_both_exist() {
     fs::create_dir_all(state_env.legacy("sessions")).expect("legacy dir");
     fs::write(state_env.legacy("sessions").join("old.json"), b"legacy").expect("legacy file");
 
-    let dir = ensure_state_dir("sessions").expect("ensure_state_dir");
+    let (dir, migration) = ensure_state_dir_with_migration("sessions").expect("ensure_state_dir");
     assert_eq!(dir, state_env.primary("sessions"));
+    assert!(
+        migration.is_none(),
+        "existing primary must not emit a migration event"
+    );
     // Primary untouched; legacy orphan left as-is (not migrated, not deleted).
     assert_eq!(
         fs::read_to_string(state_env.primary("sessions").join("a.json")).expect("primary"),

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -63,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Surfaced legacy state relocation with a user-visible migration notice whenever
+  `~/.deepseek/<state>` is moved or copied into `~/.codewhale/<state>`, so
+  upgraded users know their data was preserved and where the canonical state
+  now lives (#3726).
 - Restored legacy `.deepseek/sessions` visibility for upgraded installs where
   an empty `~/.codewhale/sessions` directory already existed, by copying
   missing legacy session entries into the primary CodeWhale session store


### PR DESCRIPTION
## Summary

- Add a structured state migration event when legacy `.deepseek/<state>` is moved or copied into `.codewhale/<state>`.
- Print a visible one-time notice from the normal `ensure_state_dir` path so upgraded users know their data was preserved and where the canonical state now lives.
- Cover relocated, copied, and no-op primary-existing cases, and update changelogs.

## Testing

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-config --locked`
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; config-only fix)
- [ ] `cargo test --workspace --all-features` (not run; targeted config crate passed)

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (not applicable; config migration stderr notice covered by tests)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable; no harvested community commit)

Closes #3726
