### PR TITLE
docs(install): call out WSL2 cargo dependencies

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@ cargo install codewhale-cli --locked
 cargo install codewhale-tui --locked
 ```
 
-> **Linux 用户注意：** 请先安装系统构建依赖：
+> **Linux / WSL2 用户注意：** 从源码构建前请先安装系统构建依赖：
 > `sudo apt-get install -y build-essential pkg-config libdbus-1-dev`。
 > 详见 [INSTALL.md](docs/INSTALL.md#4-install-via-cargo-any-tier-1-rust-target)。
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -694,6 +694,23 @@ Install the C toolchain:
 sudo apt-get install -y build-essential pkg-config libdbus-1-dev
 ```
 
+### WSL2 / Ubuntu: `dbus-1` or `pkg-config` not found while building
+
+WSL2 uses the same Linux source-build path as Ubuntu. If `cargo install
+codewhale-tui --locked` fails while compiling the keyring or D-Bus secret
+storage crates, install the Linux build dependencies inside the WSL distro,
+then rerun both Cargo install commands:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential pkg-config libdbus-1-dev
+cargo install codewhale-cli --locked
+cargo install codewhale-tui --locked
+```
+
+The prebuilt npm/GitHub binaries do not need these build-time packages; they
+only apply when WSL2 is compiling CodeWhale from source.
+
 ### Wrapper installs but `codewhale` isn't found
 
 `npm i -g` installs into `$(npm prefix -g)/bin`; make sure that directory is on


### PR DESCRIPTION
## Summary

- Add a WSL2/Ubuntu troubleshooting entry for missing `pkg-config` / `libdbus-1-dev` during `cargo install codewhale-tui`.
- Clarify the Chinese README Linux build-dependency note also applies to WSL2.
- Credit @zlh124 for identifying the missing Ubuntu/Fedora packages in #1816.

## Testing

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [ ] `cargo clippy --workspace --all-targets --all-features` (not run; docs-only change)
- [ ] `cargo test --workspace --all-features` (not run; docs-only change)

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant (not applicable; docs-only change)
- [ ] Verified TUI behavior manually if UI changes (not applicable)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable; no harvested commit)

Closes #1816
