### PR TITLE
fix(tui): default interactive Agent shell to approval-gated on

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3640,11 +3640,26 @@ impl Config {
         self.context.project_pack.unwrap_or(true)
     }
 
-    /// Return whether shell execution is allowed. Defaults to `false`: shell
+    /// Return whether shell execution is allowed for noninteractive and
+    /// durable-task profiles. Defaults to `false`: in headless, app-server, and
+    /// background-task contexts there is no human to approve commands, so shell
     /// access must be opted into explicitly (GHSA-72w5-pf8h-xfp4).
     #[must_use]
     pub fn allow_shell(&self) -> bool {
         self.allow_shell.unwrap_or(false)
+    }
+
+    /// Return whether shell execution is allowed for an *interactive* TUI Agent
+    /// session. Defaults to `true`: the interactive composer always gates each
+    /// shell command behind an approval prompt, so the catalog can expose shell
+    /// by default while still preserving consent (GHSA-72w5-pf8h-xfp4). An
+    /// explicit `allow_shell = false` still hides shell tools. This is the
+    /// single source of truth for the interactive default; both startup
+    /// (`run_interactive`) and the durable Agent permission baseline read it so
+    /// the default cannot drift between them.
+    #[must_use]
+    pub fn interactive_allow_shell(&self) -> bool {
+        self.allow_shell.unwrap_or(true)
     }
 
     /// Whether ghost-text prompt suggestion is enabled (opt-in, default off).

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -156,6 +156,34 @@ fn allow_shell_defaults_to_false_when_unset() {
     );
 }
 
+// The interactive default is shell-on (approval-gated). Both interactive
+// startup and the durable Agent permission baseline (app.rs) read this single
+// method so the default cannot drift between launch modes; an explicit opt-out
+// is still honored.
+#[test]
+fn interactive_allow_shell_defaults_to_true_but_honors_explicit_opt_out() {
+    let default_config = Config::default();
+    assert!(
+        default_config.interactive_allow_shell(),
+        "interactive Agent sessions expose shell by default so approvals can gate commands"
+    );
+
+    let opted_out = Config {
+        allow_shell: Some(false),
+        ..Config::default()
+    };
+    assert!(
+        !opted_out.interactive_allow_shell(),
+        "explicit allow_shell = false still hides shell in interactive sessions"
+    );
+
+    let opted_in = Config {
+        allow_shell: Some(true),
+        ..Config::default()
+    };
+    assert!(opted_in.interactive_allow_shell());
+}
+
 #[test]
 fn prompt_suggestion_defaults_to_false() {
     let config = Config::default();

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1153,7 +1153,7 @@ impl Engine {
                             "decision": "approved",
                             "source": "composer_bang",
                         }));
-                        Self::execute_tool_with_lock(
+                        let mut result = Self::execute_tool_with_lock(
                             self.tool_exec_lock.clone(),
                             spec.supports_parallel(),
                             false,
@@ -1165,7 +1165,14 @@ impl Engine {
                             None,
                             None,
                         )
-                        .await
+                        .await;
+                        if let Ok(tool_result) = result.as_mut() {
+                            stamp_tool_result_approval(
+                                tool_result,
+                                ToolApprovalStamp::ApprovedByUser,
+                            );
+                        }
+                        result
                     }
                     Ok(ApprovalResult::Denied) => {
                         emit_tool_audit(json!({
@@ -1192,7 +1199,7 @@ impl Engine {
                             .context()
                             .clone()
                             .with_elevated_sandbox_policy(policy);
-                        Self::execute_tool_with_lock(
+                        let mut result = Self::execute_tool_with_lock(
                             self.tool_exec_lock.clone(),
                             spec.supports_parallel(),
                             false,
@@ -1204,7 +1211,14 @@ impl Engine {
                             None,
                             Some(elevated_context),
                         )
-                        .await
+                        .await;
+                        if let Ok(tool_result) = result.as_mut() {
+                            stamp_tool_result_approval(
+                                tool_result,
+                                ToolApprovalStamp::ApprovedWithPolicy,
+                            );
+                        }
+                        result
                     }
                     Err(err) => Err(err),
                 }
@@ -3874,12 +3888,13 @@ use self::approval::{ApprovalDecision, ApprovalResult, UserInputDecision};
 #[cfg(test)]
 use self::dispatch::should_parallelize_tool_batch;
 use self::dispatch::{
-    ParallelToolResult, ParallelToolResultEntry, ToolExecGuard, ToolExecOutcome,
+    ParallelToolResult, ParallelToolResultEntry, ToolApprovalStamp, ToolExecGuard, ToolExecOutcome,
     ToolExecutionBatch, ToolExecutionPlan, caller_allowed_for_tool, caller_type_for_tool_use,
     final_tool_input, format_tool_error, malformed_tool_arguments_error,
     malformed_tool_arguments_input, mcp_tool_approval_description, mcp_tool_is_parallel_safe,
     mcp_tool_is_read_only, parse_parallel_tool_calls, parse_tool_input,
     plan_tool_execution_batches, should_force_update_plan_first, should_stop_after_plan_tool,
+    stamp_tool_result_approval,
 };
 #[cfg(test)]
 use self::lsp_hooks::edited_paths_for_tool;

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -72,6 +72,60 @@ pub(super) struct ParallelToolResult {
     pub(super) results: Vec<ParallelToolResultEntry>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolApprovalStamp {
+    ApprovedByUser,
+    ApprovedWithPolicy,
+}
+
+impl ToolApprovalStamp {
+    fn decision(self) -> &'static str {
+        match self {
+            Self::ApprovedByUser => "approved_by_user",
+            Self::ApprovedWithPolicy => "approved_with_policy",
+        }
+    }
+
+    fn model_visible_note(self) -> &'static str {
+        match self {
+            Self::ApprovedByUser => {
+                "[approval] This tool call required approval and was approved by the user before execution."
+            }
+            Self::ApprovedWithPolicy => {
+                "[approval] This tool call required approval and was approved by the user with an adjusted execution policy before execution."
+            }
+        }
+    }
+}
+
+pub(super) fn stamp_tool_result_approval(result: &mut ToolResult, approval: ToolApprovalStamp) {
+    let approval_metadata = json!({
+        "required": true,
+        "decision": approval.decision(),
+        "model_visible": true,
+    });
+    let metadata = result.metadata.get_or_insert_with(|| json!({}));
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert("approval".to_string(), approval_metadata);
+    } else {
+        let prior = std::mem::replace(metadata, json!({}));
+        if let Some(object) = metadata.as_object_mut() {
+            object.insert("_prior".to_string(), prior);
+            object.insert("approval".to_string(), approval_metadata);
+        }
+    }
+
+    let note = approval.model_visible_note();
+    if result.content.starts_with("[approval] ") {
+        return;
+    }
+    if result.content.is_empty() {
+        result.content = note.to_string();
+    } else {
+        result.content = format!("{note}\n\n{}", result.content);
+    }
+}
+
 // Hold the lock guard for the duration of a tool execution.
 // The inner guards are held for RAII purposes (dropped when the guard is dropped).
 pub(super) enum ToolExecGuard<'a> {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1442,6 +1442,46 @@ fn tool_exec_outcome_tracks_duration() {
 }
 
 #[test]
+fn approval_stamp_makes_user_approval_model_visible() {
+    let mut result = ToolResult::success("stdout");
+
+    stamp_tool_result_approval(&mut result, ToolApprovalStamp::ApprovedByUser);
+
+    assert!(
+        result
+            .content
+            .starts_with("[approval] This tool call required approval"),
+        "{}",
+        result.content
+    );
+    assert!(
+        result
+            .content
+            .contains("approved by the user before execution")
+    );
+    assert!(result.content.ends_with("stdout"));
+
+    let metadata = result.metadata.expect("approval metadata");
+    assert_eq!(metadata["approval"]["required"], true);
+    assert_eq!(metadata["approval"]["decision"], "approved_by_user");
+    assert_eq!(metadata["approval"]["model_visible"], true);
+}
+
+#[test]
+fn approval_stamp_preserves_existing_metadata() {
+    let mut result = ToolResult::success("ok").with_metadata(json!({
+        "summary": "kept"
+    }));
+
+    stamp_tool_result_approval(&mut result, ToolApprovalStamp::ApprovedWithPolicy);
+
+    let metadata = result.metadata.expect("metadata");
+    assert_eq!(metadata["summary"], "kept");
+    assert_eq!(metadata["approval"]["decision"], "approved_with_policy");
+    assert!(result.content.contains("adjusted execution policy"));
+}
+
+#[test]
 fn core_native_tools_stay_loaded_in_yolo_mode() {
     let always_load = HashSet::new();
     assert!(!should_default_defer_tool("exec_shell", &always_load));

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2247,10 +2247,11 @@ impl Engine {
                             continue;
                         }
 
-                        // Handle approval flow: returns (result_override, context_override)
-                        let (result_override, context_override): (
+                        // Handle approval flow: returns (result_override, context_override, approval_stamp)
+                        let (result_override, context_override, approval_stamp): (
                             Option<Result<ToolResult, ToolError>>,
                             Option<crate::tools::ToolContext>,
+                            Option<ToolApprovalStamp>,
                         ) = if plan.approval_required {
                             emit_tool_audit(json!({
                                 "event": "tool.approval_required",
@@ -2295,7 +2296,7 @@ impl Engine {
                                         "decision": "approved",
                                         "caller": caller_type_for_tool_use(tool_caller.as_ref()),
                                     }));
-                                    (None, None)
+                                    (None, None, Some(ToolApprovalStamp::ApprovedByUser))
                                 }
                                 Ok(ApprovalResult::Denied) => {
                                     emit_tool_audit(json!({
@@ -2309,6 +2310,7 @@ impl Engine {
                                         Some(Err(ToolError::permission_denied(format!(
                                             "Tool '{tool_name}' denied by user"
                                         )))),
+                                        None,
                                         None,
                                     )
                                 }
@@ -2324,12 +2326,16 @@ impl Engine {
                                     let elevated_context = tool_registry.map(|r| {
                                         r.context().clone().with_elevated_sandbox_policy(policy)
                                     });
-                                    (None, elevated_context)
+                                    (
+                                        None,
+                                        elevated_context,
+                                        Some(ToolApprovalStamp::ApprovedWithPolicy),
+                                    )
                                 }
-                                Err(err) => (Some(Err(err)), None),
+                                Err(err) => (Some(Err(err)), None, None),
                             }
                         } else {
-                            (None, None)
+                            (None, None, None)
                         };
 
                         // Per-tool snapshot for surgical undo (#384): capture workspace
@@ -2368,6 +2374,12 @@ impl Engine {
                             )
                             .await
                         };
+
+                        if let Some(approval_stamp) = approval_stamp
+                            && let Ok(tool_result) = result.as_mut()
+                        {
+                            stamp_tool_result_approval(tool_result, approval_stamp);
+                        }
 
                         // #500: spill outsized tool outputs to disk before the
                         // result fans out to the model context and the UI cell.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6410,7 +6410,7 @@ fn normalize_windows_config_path_str(path: &str) -> String {
 }
 
 fn interactive_tui_allow_shell(yolo: bool, config: &Config) -> bool {
-    yolo || config.allow_shell.unwrap_or(true)
+    yolo || config.interactive_allow_shell()
 }
 
 async fn run_interactive(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1420,7 +1420,7 @@ async fn main() -> Result<()> {
     };
 
     // Default: Interactive TUI
-    // --yolo starts in YOLO mode (auto-approve; shell if allow_shell=true)
+    // --yolo starts in YOLO mode (auto-approve; shell enabled)
     run_interactive(&cli, &config, resume_session_id, None).await
 }
 
@@ -6409,6 +6409,10 @@ fn normalize_windows_config_path_str(path: &str) -> String {
     normalized.to_ascii_lowercase()
 }
 
+fn interactive_tui_allow_shell(yolo: bool, config: &Config) -> bool {
+    yolo || config.allow_shell.unwrap_or(true)
+}
+
 async fn run_interactive(
     cli: &Cli,
     config: &Config,
@@ -6513,7 +6517,7 @@ async fn run_interactive(
             workspace,
             config_path: cli.config.clone(),
             config_profile: cli.profile.clone(),
-            allow_shell: yolo || config.allow_shell(),
+            allow_shell: interactive_tui_allow_shell(yolo, config),
             use_alt_screen,
             use_mouse_capture,
             use_bracketed_paste,
@@ -8817,6 +8821,34 @@ mod terminal_mode_tests {
             None,
             None,
         ));
+    }
+}
+
+#[cfg(test)]
+mod interactive_startup_tests {
+    use super::*;
+
+    #[test]
+    fn interactive_tui_defaults_agent_shell_to_approval_gated_on() {
+        let default_config = Config::default();
+        assert!(
+            interactive_tui_allow_shell(false, &default_config),
+            "interactive Agent mode should expose shell tools by default so approvals can gate commands"
+        );
+
+        let disabled = Config {
+            allow_shell: Some(false),
+            ..Config::default()
+        };
+        assert!(
+            !interactive_tui_allow_shell(false, &disabled),
+            "explicit allow_shell=false still hides shell tools"
+        );
+
+        assert!(
+            interactive_tui_allow_shell(true, &disabled),
+            "YOLO forces shell access for its no-guardrails contract"
+        );
     }
 }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2490,10 +2490,15 @@ impl App {
         // Durable Agent-era permission baseline (#3386). Plan/Auto/YOLO derive
         // from and restore to this. When the user starts in Auto or YOLO the
         // live shell flag is force-enabled below, so the baseline shell value is
-        // taken from config (the pre-mode surface) rather than the live mirror;
-        // otherwise it mirrors the resolved `allow_shell` option. Trust is
-        // never part of the Agent baseline (it is YOLO-only authority). Approval
-        // mirrors the configured policy.
+        // taken from the interactive default (the pre-mode Agent surface) rather
+        // than the YOLO-forced live mirror; otherwise it mirrors the resolved
+        // `allow_shell` option, which already carries that same interactive
+        // default. Using `interactive_allow_shell()` here keeps the Agent
+        // baseline identical regardless of launch mode, so a YOLO/Auto -> Agent
+        // downshift exposes shell (approval-gated) exactly as documented, while
+        // an explicit `allow_shell = false` still hides it. Trust is never part
+        // of the Agent baseline (it is YOLO-only authority). Approval mirrors the
+        // configured policy.
         let configured_approval_mode = config
             .approval_policy
             .as_deref()
@@ -2501,7 +2506,7 @@ impl App {
             .unwrap_or_default();
         let mode_prefs = ModeSessionPrefs {
             agent_allow_shell: if matches!(initial_mode, AppMode::Auto | AppMode::Yolo) {
-                config.allow_shell()
+                config.interactive_allow_shell()
             } else {
                 allow_shell
             },

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1790,6 +1790,23 @@ fn set_mode_captures_agent_edits_as_the_durable_baseline() {
 }
 
 #[test]
+fn yolo_start_with_default_config_restores_interactive_agent_shell_baseline() {
+    let mut app = App::new(test_options(true), &Config::default());
+    assert_eq!(app.mode, AppMode::Yolo);
+    assert!(app.allow_shell);
+    assert!(app.trust_mode);
+    assert_eq!(app.approval_mode, ApprovalMode::Bypass);
+
+    app.set_mode(AppMode::Agent);
+    assert!(
+        app.allow_shell,
+        "default interactive Agent baseline should expose approval-gated shell after YOLO downshift"
+    );
+    assert!(!app.trust_mode);
+    assert_eq!(app.approval_mode, ApprovalMode::Suggest);
+}
+
+#[test]
 fn leaving_yolo_after_startup_restores_baseline_policies() {
     let config = Config {
         allow_shell: Some(false),

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -28,7 +28,7 @@ Run `/mode` to open the mode picker, or switch directly with `/mode agent`,
 `/mode plan`, `/mode yolo`, `/mode 1`, `/mode 2`, or `/mode 3`.
 
 - **Plan**: design-first prompting. Read-only investigation tools stay available; shell and patch execution stay off. Use this when you want to think out loud and produce a plan to hand to a human (yourself later, or a reviewer).
-- **Agent**: multi-step tool use. Shell execution (`exec_shell`, `task_shell_start`, `task_shell_wait`) requires `allow_shell = true` in config; approval prompts gate each call. File writes are allowed without a prompt.
+- **Agent**: multi-step tool use. In interactive TUI sessions, shell tools (`exec_shell`, `task_shell_start`, `task_shell_wait`) are available by default and approval prompts gate each call. Set top-level `allow_shell = false` to hide shell tools for a workspace/profile. File writes are allowed without a prompt.
 - **YOLO**: enables shell + trust mode and auto-approves all tools. Use only in trusted repos.
 
 ### Tool availability by mode
@@ -37,15 +37,15 @@ Run `/mode` to open the mode picker, or switch directly with `/mode agent`,
 |:---|:---:|:---:|:---:|
 | Read-only file, search, and diagnostic tools | yes | yes | yes |
 | File write and patch tools | no | yes | yes |
-| Shell tools (`exec_shell`, `task_shell_start`, waits, interact, cancel) | no | approval-gated, when `allow_shell = true` | yes |
+| Shell tools (`exec_shell`, `task_shell_start`, waits, interact, cancel) | no | approval-gated by default, hidden when `allow_shell = false` | yes |
 | Paid or external-service tools | approval-gated | approval-gated | auto-approved |
 | Access outside the workspace root | no | only with trust mode | yes |
 
 If a shell tool is missing from the model-visible catalog in Agent mode, check
-`allow_shell` first. The setting can come from the active config/profile or from
-the runtime session. YOLO turns shell access on together with trust mode and
-auto-approval, which is why shell commands may work there even when the Agent
-mode catalog does not list them.
+for an explicit `allow_shell = false` in the active config/profile or runtime
+session. Durable tasks and automation keep conservative omitted-field defaults;
+they only receive shell access when their task settings explicitly grant it.
+YOLO turns shell access on together with trust mode and auto-approval.
 
 All action-capable modes have access to persistent RLM sessions through `rlm_open`, `rlm_eval`, `rlm_configure`, and `rlm_close`. Inside an RLM Python REPL, `sub_query_batch` fans out 1-16 cheap parallel child calls pinned to `deepseek-v4-flash`. The model reaches for it when work is too large or repetitive for the parent transcript.
 


### PR DESCRIPTION
## Summary
- expose shell tools by default for interactive Agent-mode TUI sessions so approvals can gate shell commands
- keep explicit allow_shell=false respected for Agent sessions
- keep GHSA-safe durable task defaults: omitted task fields still do not grant shell or auto-approve
- stamp approved tool results with model-visible approval text plus structured metadata, so agents do not infer that shell ran ungated
- update docs/MODES.md to describe the interactive default versus durable-task behavior

## Verification
- cargo fmt --all --check
- git diff --check
- ./scripts/release/check-versions.sh
- cargo test -p codewhale-tui --bin codewhale-tui --locked approval_stamp
- cargo test -p codewhale-tui --bin codewhale-tui --locked interactive_tui_defaults_agent_shell_to_approval_gated_on
- cargo test -p codewhale-tui --bin codewhale-tui --locked allow_shell_defaults_to_false_when_unset
- cargo test -p codewhale-tui --bin codewhale-tui --locked add_task_without_optional_fields_does_not_grant_shell_or_auto_approve
- cargo test -p codewhale-tui --bin codewhale-tui --locked build_tool_context_uses_typed_shell_policy_per_mode
- cargo test -p codewhale-tui --bin codewhale-tui --locked agent_tools_with_allow_shell