### PR TITLE
docs(rebrand): document Homebrew rollout strategy and add distribution-channel check to release checklist (#3489)

### DIFF
--- a/docs/REBRAND.md
+++ b/docs/REBRAND.md
@@ -129,10 +129,36 @@ to `npm install -g codewhale`.
 
 ### Homebrew
 
-The tap formula still installs through the legacy `deepseek-tui` name for
-existing Homebrew users. Keep using `brew upgrade deepseek-tui` only for that
-compatibility path. New installs should prefer npm, Cargo, Docker, or direct
-downloads until the formula and tap repo are renamed.
+**Current state (v0.8.x):** The tap formula still uses the legacy
+`deepseek-tui` name for compatibility. Existing users keep running
+`brew upgrade deepseek-tui`. The formula installs the same current-release
+`codewhale` / `codewhale-tui` binaries.
+
+**Target state:** A `codewhale` formula in a renamed tap
+(`Hmbown/codewhale` or the existing `Hmbown/deepseek-tui` tap with an
+added `codewhale` formula alias). The legacy `deepseek-tui` formula
+remains installable as a compatibility-only alias.
+
+**Rollout steps:**
+
+1. **Audit the formula Ruby file** — confirm it already installs
+   `codewhale` / `codewhale-tui` binaries and only the formula *name* is
+   legacy.
+2. **Add a `codewhale` formula** to the tap that is identical to or
+   aliases the existing `deepseek-tui` formula.
+3. **Update website and docs** — show `brew install codewhale` as the
+   primary Homebrew path, mark `brew install deepseek-tui` as legacy
+   compatibility.
+4. **One release of overlap** — ship at least one release with both
+   `codewhale` and `deepseek-tui` formulas available so existing
+   crontabs/scripts can migrate.
+5. **Deprecation notice** — add a `caveat` in the legacy formula
+   directing users to `brew uninstall deepseek-tui && brew install codewhale`.
+6. **Eventually remove** the `deepseek-tui` formula after a deprecation
+   window (e.g., two minor releases).
+
+Until the formula rename ships, new installs should prefer npm, Cargo,
+Docker, or direct downloads.
 
 ### Manual / GitHub Releases
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -191,6 +191,11 @@ release anxiety: contributors cannot tell whether their work merged.
       reports the new version on the npm registry.
 - [ ] `npm view deepseek-tui deprecated` is non-empty. The legacy npm package
       is deprecated and must not receive an `X.Y.Z` publish.
+- [ ] Distribution channels are canonical-first: the website install page
+      (codewhale.net/install) shows CodeWhale-native commands first (`npm install -g
+      codewhale`, `curl .../install.sh | sh`); Homebrew is labeled as legacy
+      compatibility; the shell installer uses codewhale-native names as documented
+      in `docs/REBRAND.md#homebrew`.
 - [ ] `crates.io` has the new version (or the `publish-crates.sh` job has
       pushed it).
 - [ ] `ghcr.io/hmbown/codewhale:vX.Y.Z` and `:latest` are updated.


### PR DESCRIPTION
- docs/REBRAND.md: expand Homebrew section with current state, target state, and six concrete rollout steps (audit formula, add codewhale alias, update website, overlap release, deprecation caveat, removal)
- docs/RELEASE_CHECKLIST.md: add distribution-channel naming check ensuring canonical CodeWhale-native paths are first on the install page and legacy deepseek-tui paths are marked as compatibility-only

Close https://github.com/Hmbown/CodeWhale/issues/3489.

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
