### PR TITLE
[codex] defer startup maintenance cleanup

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6470,7 +6470,11 @@ async fn run_interactive(
         logging::warn(format!("Failed to install system skills: {e}"));
     }
 
-    spawn_interactive_startup_maintenance(workspace.clone(), config.snapshots_config());
+    spawn_interactive_startup_maintenance(
+        workspace.clone(),
+        config.snapshots_config(),
+        resume_session_id.clone(),
+    );
 
     // The `deepseek` launcher forwards `--yolo` to this binary via the
     // DEEPSEEK_YOLO env var (config.yolo), not as a CLI flag. Honour either.
@@ -6506,13 +6510,18 @@ async fn run_interactive(
 fn spawn_interactive_startup_maintenance(
     workspace: PathBuf,
     snapshots: crate::config::SnapshotsConfig,
+    protected_session_id: Option<String>,
 ) {
     let spawn_result = std::thread::Builder::new()
         .name("codewhale-startup-maintenance".to_string())
         .spawn(move || {
             // Keep the first interactive frame ahead of optional disk cleanup.
             std::thread::sleep(Duration::from_millis(500));
-            run_interactive_startup_maintenance(&workspace, &snapshots);
+            run_interactive_startup_maintenance(
+                &workspace,
+                &snapshots,
+                protected_session_id.as_deref(),
+            );
         });
 
     if let Err(err) = spawn_result {
@@ -6523,6 +6532,7 @@ fn spawn_interactive_startup_maintenance(
 fn run_interactive_startup_maintenance(
     workspace: &Path,
     snapshots: &crate::config::SnapshotsConfig,
+    protected_session_id: Option<&str>,
 ) {
     let started = Instant::now();
 
@@ -6552,7 +6562,7 @@ fn run_interactive_startup_maintenance(
     // Keeps at most MAX_SESSIONS (50) recent sessions; non-fatal on error.
     match session_manager::SessionManager::default_location() {
         Ok(manager) => {
-            if let Err(err) = manager.cleanup_old_sessions() {
+            if let Err(err) = manager.cleanup_old_sessions_except(protected_session_id) {
                 tracing::warn!(target: "session", ?err, "session cleanup skipped on boot");
             }
         }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5,7 +5,7 @@
 use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -6470,14 +6470,13 @@ async fn run_interactive(
         logging::warn(format!("Failed to install system skills: {e}"));
     }
 
-    let startup_maintenance_started_at = SystemTime::now();
+    // Snapshot pruning rewrites side-repo refs and can run GC, so keep it
+    // before the TUI exposes snapshot list/restore commands.
+    if config.snapshots_config().enabled {
+        session_manager::prune_workspace_snapshots(&workspace, config.snapshots_config().max_age());
+    }
     let protected_session_token = resume_session_id.clone();
-    spawn_interactive_startup_maintenance(
-        workspace.clone(),
-        config.snapshots_config(),
-        protected_session_token,
-        startup_maintenance_started_at,
-    );
+    spawn_interactive_startup_maintenance(workspace.clone(), protected_session_token);
 
     // The `deepseek` launcher forwards `--yolo` to this binary via the
     // DEEPSEEK_YOLO env var (config.yolo), not as a CLI flag. Honour either.
@@ -6512,21 +6511,14 @@ async fn run_interactive(
 
 fn spawn_interactive_startup_maintenance(
     workspace: PathBuf,
-    snapshots: crate::config::SnapshotsConfig,
     protected_session_token: Option<String>,
-    started_at: SystemTime,
 ) {
     let spawn_result = std::thread::Builder::new()
         .name("codewhale-startup-maintenance".to_string())
         .spawn(move || {
             // Keep the first interactive frame ahead of optional disk cleanup.
             std::thread::sleep(Duration::from_millis(500));
-            run_interactive_startup_maintenance(
-                &workspace,
-                &snapshots,
-                protected_session_token.as_deref(),
-                started_at,
-            );
+            run_interactive_startup_maintenance(&workspace, protected_session_token.as_deref());
         });
 
     if let Err(err) = spawn_result {
@@ -6554,20 +6546,8 @@ fn startup_maintenance_protected_session_id(
         .map(|session| session.id)
 }
 
-fn run_interactive_startup_maintenance(
-    workspace: &Path,
-    snapshots: &crate::config::SnapshotsConfig,
-    protected_session_token: Option<&str>,
-    started_at: SystemTime,
-) {
+fn run_interactive_startup_maintenance(workspace: &Path, protected_session_token: Option<&str>) {
     let started = Instant::now();
-
-    // Prune stale workspace snapshots from prior sessions (7-day default).
-    // Non-fatal: a flaky disk, missing `git`, or read-only home should
-    // never block the TUI from starting.
-    if snapshots.enabled {
-        session_manager::prune_workspace_snapshots_at(workspace, snapshots.max_age(), started_at);
-    }
 
     // Prune stale tool-output spillover files (#422). Non-fatal: home
     // missing or directory unreadable just means nothing got pruned.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5,7 +5,7 @@
 use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -6470,37 +6470,7 @@ async fn run_interactive(
         logging::warn(format!("Failed to install system skills: {e}"));
     }
 
-    // Prune stale workspace snapshots from prior sessions (7-day default).
-    // Non-fatal: a flaky disk, missing `git`, or read-only home should
-    // never block the TUI from starting.
-    let snapshots = config.snapshots_config();
-    if snapshots.enabled {
-        session_manager::prune_workspace_snapshots(&workspace, snapshots.max_age());
-    }
-
-    // Prune stale tool-output spillover files (#422). Non-fatal: home
-    // missing or directory unreadable just means nothing got pruned;
-    // we never block startup. Runs unconditionally because the
-    // spillover store is created lazily on first write — there's no
-    // user-facing setting to gate.
-    match crate::tools::truncate::prune_older_than(crate::tools::truncate::SPILLOVER_MAX_AGE) {
-        Ok(0) => {}
-        Ok(n) => tracing::debug!(
-            target: "spillover",
-            "boot prune removed {n} spillover file(s)"
-        ),
-        Err(err) => tracing::warn!(
-            target: "spillover",
-            ?err,
-            "spillover prune skipped on boot"
-        ),
-    }
-
-    // v0.8.44: prune managed sessions on boot to prevent unbounded growth.
-    // Keeps at most MAX_SESSIONS (50) recent sessions; non-fatal on error.
-    if let Ok(manager) = session_manager::SessionManager::default_location() {
-        let _ = manager.cleanup_old_sessions();
-    }
+    spawn_interactive_startup_maintenance(workspace.clone(), config.snapshots_config());
 
     // The `deepseek` launcher forwards `--yolo` to this binary via the
     // DEEPSEEK_YOLO env var (config.yolo), not as a CLI flag. Honour either.
@@ -6531,6 +6501,69 @@ async fn run_interactive(
         },
     )
     .await
+}
+
+fn spawn_interactive_startup_maintenance(
+    workspace: PathBuf,
+    snapshots: crate::config::SnapshotsConfig,
+) {
+    let spawn_result = std::thread::Builder::new()
+        .name("codewhale-startup-maintenance".to_string())
+        .spawn(move || {
+            // Keep the first interactive frame ahead of optional disk cleanup.
+            std::thread::sleep(Duration::from_millis(500));
+            run_interactive_startup_maintenance(&workspace, &snapshots);
+        });
+
+    if let Err(err) = spawn_result {
+        logging::warn(format!("Startup maintenance skipped: {err}"));
+    }
+}
+
+fn run_interactive_startup_maintenance(
+    workspace: &Path,
+    snapshots: &crate::config::SnapshotsConfig,
+) {
+    let started = Instant::now();
+
+    // Prune stale workspace snapshots from prior sessions (7-day default).
+    // Non-fatal: a flaky disk, missing `git`, or read-only home should
+    // never block the TUI from starting.
+    if snapshots.enabled {
+        session_manager::prune_workspace_snapshots(workspace, snapshots.max_age());
+    }
+
+    // Prune stale tool-output spillover files (#422). Non-fatal: home
+    // missing or directory unreadable just means nothing got pruned.
+    match crate::tools::truncate::prune_older_than(crate::tools::truncate::SPILLOVER_MAX_AGE) {
+        Ok(0) => {}
+        Ok(n) => tracing::debug!(
+            target: "spillover",
+            "boot prune removed {n} spillover file(s)"
+        ),
+        Err(err) => tracing::warn!(
+            target: "spillover",
+            ?err,
+            "spillover prune skipped on boot"
+        ),
+    }
+
+    // v0.8.44: prune managed sessions to prevent unbounded growth.
+    // Keeps at most MAX_SESSIONS (50) recent sessions; non-fatal on error.
+    match session_manager::SessionManager::default_location() {
+        Ok(manager) => {
+            if let Err(err) = manager.cleanup_old_sessions() {
+                tracing::warn!(target: "session", ?err, "session cleanup skipped on boot");
+            }
+        }
+        Err(err) => tracing::warn!(target: "session", ?err, "session cleanup skipped on boot"),
+    }
+
+    tracing::debug!(
+        target: "startup",
+        elapsed_ms = started.elapsed().as_millis(),
+        "startup maintenance finished"
+    );
 }
 
 #[derive(Debug)]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6470,10 +6470,12 @@ async fn run_interactive(
         logging::warn(format!("Failed to install system skills: {e}"));
     }
 
+    let protected_session_id =
+        startup_maintenance_protected_session_id(resume_session_id.as_deref(), &workspace);
     spawn_interactive_startup_maintenance(
         workspace.clone(),
         config.snapshots_config(),
-        resume_session_id.clone(),
+        protected_session_id,
     );
 
     // The `deepseek` launcher forwards `--yolo` to this binary via the
@@ -6527,6 +6529,26 @@ fn spawn_interactive_startup_maintenance(
     if let Err(err) = spawn_result {
         logging::warn(format!("Startup maintenance skipped: {err}"));
     }
+}
+
+fn startup_maintenance_protected_session_id(
+    resume_session_id: Option<&str>,
+    workspace: &Path,
+) -> Option<String> {
+    let session_id = resume_session_id?;
+    if session_id != "latest" {
+        return Some(session_id.to_string());
+    }
+
+    session_manager::SessionManager::default_location()
+        .ok()
+        .and_then(|manager| {
+            manager
+                .get_latest_session_for_workspace(workspace)
+                .ok()
+                .flatten()
+        })
+        .map(|session| session.id)
 }
 
 fn run_interactive_startup_maintenance(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5,7 +5,7 @@
 use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -6470,12 +6470,13 @@ async fn run_interactive(
         logging::warn(format!("Failed to install system skills: {e}"));
     }
 
-    let protected_session_id =
-        startup_maintenance_protected_session_id(resume_session_id.as_deref(), &workspace);
+    let startup_maintenance_started_at = SystemTime::now();
+    let protected_session_token = resume_session_id.clone();
     spawn_interactive_startup_maintenance(
         workspace.clone(),
         config.snapshots_config(),
-        protected_session_id,
+        protected_session_token,
+        startup_maintenance_started_at,
     );
 
     // The `deepseek` launcher forwards `--yolo` to this binary via the
@@ -6512,7 +6513,8 @@ async fn run_interactive(
 fn spawn_interactive_startup_maintenance(
     workspace: PathBuf,
     snapshots: crate::config::SnapshotsConfig,
-    protected_session_id: Option<String>,
+    protected_session_token: Option<String>,
+    started_at: SystemTime,
 ) {
     let spawn_result = std::thread::Builder::new()
         .name("codewhale-startup-maintenance".to_string())
@@ -6522,7 +6524,8 @@ fn spawn_interactive_startup_maintenance(
             run_interactive_startup_maintenance(
                 &workspace,
                 &snapshots,
-                protected_session_id.as_deref(),
+                protected_session_token.as_deref(),
+                started_at,
             );
         });
 
@@ -6554,7 +6557,8 @@ fn startup_maintenance_protected_session_id(
 fn run_interactive_startup_maintenance(
     workspace: &Path,
     snapshots: &crate::config::SnapshotsConfig,
-    protected_session_id: Option<&str>,
+    protected_session_token: Option<&str>,
+    started_at: SystemTime,
 ) {
     let started = Instant::now();
 
@@ -6562,7 +6566,7 @@ fn run_interactive_startup_maintenance(
     // Non-fatal: a flaky disk, missing `git`, or read-only home should
     // never block the TUI from starting.
     if snapshots.enabled {
-        session_manager::prune_workspace_snapshots(workspace, snapshots.max_age());
+        session_manager::prune_workspace_snapshots_at(workspace, snapshots.max_age(), started_at);
     }
 
     // Prune stale tool-output spillover files (#422). Non-fatal: home
@@ -6582,9 +6586,11 @@ fn run_interactive_startup_maintenance(
 
     // v0.8.44: prune managed sessions to prevent unbounded growth.
     // Keeps at most MAX_SESSIONS (50) recent sessions; non-fatal on error.
+    let protected_session_id =
+        startup_maintenance_protected_session_id(protected_session_token, workspace);
     match session_manager::SessionManager::default_location() {
         Ok(manager) => {
-            if let Err(err) = manager.cleanup_old_sessions_except(protected_session_id) {
+            if let Err(err) = manager.cleanup_old_sessions_except(protected_session_id.as_deref()) {
                 tracing::warn!(target: "session", ?err, "session cleanup skipped on boot");
             }
         }

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -489,11 +489,19 @@ impl SessionManager {
 
     /// Clean up old sessions to stay within `MAX_SESSIONS` limit.
     pub fn cleanup_old_sessions(&self) -> std::io::Result<()> {
+        self.cleanup_old_sessions_except(None)
+    }
+
+    /// Clean up old sessions while preserving an active/resumed session.
+    pub fn cleanup_old_sessions_except(&self, protected_id: Option<&str>) -> std::io::Result<()> {
         let sessions = self.list_sessions()?;
 
         if sessions.len() > MAX_SESSIONS {
             // Delete oldest sessions
             for session in sessions.iter().skip(MAX_SESSIONS) {
+                if protected_id.is_some_and(|id| id == session.id) {
+                    continue;
+                }
                 let _ = self.delete_session(&session.id);
             }
         }
@@ -1108,6 +1116,23 @@ mod tests {
         workspace: &Path,
         updated_at: DateTime<Utc>,
     ) {
+        let session = make_session_record(id, workspace, updated_at);
+        manager.save_session(&session).expect("save");
+    }
+
+    fn write_session_record_without_cleanup(
+        manager: &SessionManager,
+        id: &str,
+        workspace: &Path,
+        updated_at: DateTime<Utc>,
+    ) {
+        let session = make_session_record(id, workspace, updated_at);
+        let path = manager.validated_session_path(id).expect("path");
+        let content = serde_json::to_string_pretty(&session).expect("json");
+        fs::write(path, content).expect("write session");
+    }
+
+    fn make_session_record(id: &str, workspace: &Path, updated_at: DateTime<Utc>) -> SavedSession {
         let session = SavedSession {
             schema_version: CURRENT_SESSION_SCHEMA_VERSION,
             messages: vec![make_test_message("user", "hi")],
@@ -1130,7 +1155,7 @@ mod tests {
             context_references: Vec::new(),
             artifacts: Vec::new(),
         };
-        manager.save_session(&session).expect("save");
+        session
     }
 
     fn write_empty_session_record(
@@ -2182,6 +2207,31 @@ mod tests {
         let loaded = manager.load_session(&session.metadata.id).expect("load");
 
         assert_eq!(loaded.artifacts, session.artifacts);
+    }
+
+    #[test]
+    fn cleanup_old_sessions_except_preserves_protected_old_session() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let now = Utc::now();
+        for idx in 0..(MAX_SESSIONS + 2) {
+            write_session_record_without_cleanup(
+                &manager,
+                &format!("session-{idx:02}"),
+                Path::new("/tmp"),
+                now - chrono::Duration::minutes(idx as i64),
+            );
+        }
+
+        manager
+            .cleanup_old_sessions_except(Some("session-51"))
+            .expect("cleanup");
+        let sessions = manager.list_sessions().expect("list");
+        let ids: Vec<_> = sessions.iter().map(|session| session.id.as_str()).collect();
+
+        assert!(ids.contains(&"session-51"));
+        assert!(!ids.contains(&"session-50"));
+        assert_eq!(sessions.len(), MAX_SESSIONS + 1);
     }
 
     // ---- #406 prune_sessions_older_than ----

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -15,7 +15,6 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
-use std::time::SystemTime;
 use uuid::Uuid;
 
 /// Maximum number of sessions to retain
@@ -726,26 +725,6 @@ fn copy_file_create_new(src: &Path, dst: &Path) -> io::Result<bool> {
 /// (the underlying repo logs at WARN if anything blew up).
 pub fn prune_workspace_snapshots(workspace: &Path, max_age: std::time::Duration) {
     match crate::snapshot::prune_older_than(workspace, max_age) {
-        Ok(0) => {}
-        Ok(n) => {
-            tracing::debug!(target: "snapshot", "boot prune removed {n} snapshot(s)");
-        }
-        Err(e) => {
-            tracing::warn!(target: "snapshot", "boot prune failed: {e}");
-        }
-    }
-}
-
-/// Prune snapshots older than `max_age` as of `now`.
-///
-/// Startup maintenance passes the launch timestamp so delayed cleanup does not
-/// prune snapshots created by the first interactive turn.
-pub fn prune_workspace_snapshots_at(
-    workspace: &Path,
-    max_age: std::time::Duration,
-    now: SystemTime,
-) {
-    match crate::snapshot::prune_older_than_at(workspace, max_age, now) {
         Ok(0) => {}
         Ok(n) => {
             tracing::debug!(target: "snapshot", "boot prune removed {n} snapshot(s)");

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
+use std::time::SystemTime;
 use uuid::Uuid;
 
 /// Maximum number of sessions to retain
@@ -725,6 +726,26 @@ fn copy_file_create_new(src: &Path, dst: &Path) -> io::Result<bool> {
 /// (the underlying repo logs at WARN if anything blew up).
 pub fn prune_workspace_snapshots(workspace: &Path, max_age: std::time::Duration) {
     match crate::snapshot::prune_older_than(workspace, max_age) {
+        Ok(0) => {}
+        Ok(n) => {
+            tracing::debug!(target: "snapshot", "boot prune removed {n} snapshot(s)");
+        }
+        Err(e) => {
+            tracing::warn!(target: "snapshot", "boot prune failed: {e}");
+        }
+    }
+}
+
+/// Prune snapshots older than `max_age` as of `now`.
+///
+/// Startup maintenance passes the launch timestamp so delayed cleanup does not
+/// prune snapshots created by the first interactive turn.
+pub fn prune_workspace_snapshots_at(
+    workspace: &Path,
+    max_age: std::time::Duration,
+    now: SystemTime,
+) {
+    match crate::snapshot::prune_older_than_at(workspace, max_age, now) {
         Ok(0) => {}
         Ok(n) => {
             tracing::debug!(target: "snapshot", "boot prune removed {n} snapshot(s)");

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -493,13 +493,16 @@ impl SessionManager {
     }
 
     /// Clean up old sessions while preserving an active/resumed session.
+    ///
+    /// Accepts a full id or resume prefix; startup passes the same user-facing
+    /// resume token that `load_session_by_prefix` accepts.
     pub fn cleanup_old_sessions_except(&self, protected_id: Option<&str>) -> std::io::Result<()> {
         let sessions = self.list_sessions()?;
 
         if sessions.len() > MAX_SESSIONS {
             // Delete oldest sessions
             for session in sessions.iter().skip(MAX_SESSIONS) {
-                if protected_id.is_some_and(|id| id == session.id) {
+                if protected_id.is_some_and(|id| session.id == id || session.id.starts_with(id)) {
                     continue;
                 }
                 let _ = self.delete_session(&session.id);
@@ -2217,7 +2220,7 @@ mod tests {
         for idx in 0..(MAX_SESSIONS + 2) {
             write_session_record_without_cleanup(
                 &manager,
-                &format!("session-{idx:02}"),
+                &format!("session-{idx:02}-abcdef"),
                 Path::new("/tmp"),
                 now - chrono::Duration::minutes(idx as i64),
             );
@@ -2229,8 +2232,8 @@ mod tests {
         let sessions = manager.list_sessions().expect("list");
         let ids: Vec<_> = sessions.iter().map(|session| session.id.as_str()).collect();
 
-        assert!(ids.contains(&"session-51"));
-        assert!(!ids.contains(&"session-50"));
+        assert!(ids.contains(&"session-51-abcdef"));
+        assert!(!ids.contains(&"session-50-abcdef"));
         assert_eq!(sessions.len(), MAX_SESSIONS + 1);
     }
 

--- a/crates/tui/src/snapshot/mod.rs
+++ b/crates/tui/src/snapshot/mod.rs
@@ -40,7 +40,7 @@ pub mod repo;
 #[allow(unused_imports)]
 pub use paths::{snapshot_dir_for, snapshot_git_dir};
 #[allow(unused_imports)]
-pub use prune::{DEFAULT_MAX_AGE, prune_older_than, prune_older_than_at};
+pub use prune::{DEFAULT_MAX_AGE, prune_older_than};
 
 /// Maximum snapshots kept per workspace side-repo. Oldest are pruned
 /// after each new snapshot to cap disk usage (#1112).

--- a/crates/tui/src/snapshot/mod.rs
+++ b/crates/tui/src/snapshot/mod.rs
@@ -39,7 +39,8 @@ pub mod repo;
 
 #[allow(unused_imports)]
 pub use paths::{snapshot_dir_for, snapshot_git_dir};
-pub use prune::{DEFAULT_MAX_AGE, prune_older_than};
+#[allow(unused_imports)]
+pub use prune::{DEFAULT_MAX_AGE, prune_older_than, prune_older_than_at};
 
 /// Maximum snapshots kept per workspace side-repo. Oldest are pruned
 /// after each new snapshot to cap disk usage (#1112).

--- a/crates/tui/src/snapshot/prune.rs
+++ b/crates/tui/src/snapshot/prune.rs
@@ -6,7 +6,7 @@
 
 use std::io;
 use std::path::Path;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use super::paths::snapshot_git_dir;
 use super::repo::SnapshotRepo;
@@ -29,31 +29,11 @@ pub fn prune_older_than(workspace: &Path, max_age: Duration) -> io::Result<usize
     Ok(removed)
 }
 
-/// Prune snapshots older than `max_age` relative to `now`.
-///
-/// This fixed-cutoff variant is conservative at the cutoff second because git
-/// commit timestamps do not preserve subsecond ordering.
-pub fn prune_older_than_at(
-    workspace: &Path,
-    max_age: Duration,
-    now: SystemTime,
-) -> io::Result<usize> {
-    let git_dir = snapshot_git_dir(workspace);
-    if !git_dir.exists() {
-        return Ok(0);
-    }
-    let repo = SnapshotRepo::open_or_init(workspace)?;
-    let removed = repo.prune_older_than_at(max_age, now)?;
-    repo.prune_unreachable_objects()?;
-    Ok(removed)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::lock_test_env;
     use std::sync::MutexGuard;
-    use std::time::UNIX_EPOCH;
     use tempfile::tempdir;
 
     /// Same guard shape as in `repo::tests` — pins HOME for the lifetime
@@ -109,23 +89,5 @@ mod tests {
 
         let removed = prune_older_than(&workspace, Duration::from_secs(0)).unwrap();
         assert!(removed >= 1);
-    }
-
-    #[test]
-    fn prune_with_launch_cutoff_keeps_cutoff_second_snapshots() {
-        let tmp = tempdir().unwrap();
-        let _home = scoped_home(tmp.path());
-        let workspace = tmp.path().join("ws");
-        std::fs::create_dir_all(&workspace).unwrap();
-        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
-
-        std::fs::write(workspace.join("f.txt"), "x").unwrap();
-        repo.snapshot("turn:0").unwrap();
-        let snapshot = repo.list(1).unwrap().pop().unwrap();
-        let launch_time = UNIX_EPOCH + Duration::from_secs(snapshot.timestamp as u64);
-
-        let removed = prune_older_than_at(&workspace, Duration::from_secs(0), launch_time).unwrap();
-        assert_eq!(removed, 0);
-        assert_eq!(repo.list(10).unwrap().len(), 1);
     }
 }

--- a/crates/tui/src/snapshot/prune.rs
+++ b/crates/tui/src/snapshot/prune.rs
@@ -6,7 +6,7 @@
 
 use std::io;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use super::paths::snapshot_git_dir;
 use super::repo::SnapshotRepo;
@@ -29,11 +29,31 @@ pub fn prune_older_than(workspace: &Path, max_age: Duration) -> io::Result<usize
     Ok(removed)
 }
 
+/// Prune snapshots older than `max_age` relative to `now`.
+///
+/// This fixed-cutoff variant is conservative at the cutoff second because git
+/// commit timestamps do not preserve subsecond ordering.
+pub fn prune_older_than_at(
+    workspace: &Path,
+    max_age: Duration,
+    now: SystemTime,
+) -> io::Result<usize> {
+    let git_dir = snapshot_git_dir(workspace);
+    if !git_dir.exists() {
+        return Ok(0);
+    }
+    let repo = SnapshotRepo::open_or_init(workspace)?;
+    let removed = repo.prune_older_than_at(max_age, now)?;
+    repo.prune_unreachable_objects()?;
+    Ok(removed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::lock_test_env;
     use std::sync::MutexGuard;
+    use std::time::UNIX_EPOCH;
     use tempfile::tempdir;
 
     /// Same guard shape as in `repo::tests` — pins HOME for the lifetime
@@ -89,5 +109,23 @@ mod tests {
 
         let removed = prune_older_than(&workspace, Duration::from_secs(0)).unwrap();
         assert!(removed >= 1);
+    }
+
+    #[test]
+    fn prune_with_launch_cutoff_keeps_cutoff_second_snapshots() {
+        let tmp = tempdir().unwrap();
+        let _home = scoped_home(tmp.path());
+        let workspace = tmp.path().join("ws");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let repo = SnapshotRepo::open_or_init(&workspace).unwrap();
+
+        std::fs::write(workspace.join("f.txt"), "x").unwrap();
+        repo.snapshot("turn:0").unwrap();
+        let snapshot = repo.list(1).unwrap().pop().unwrap();
+        let launch_time = UNIX_EPOCH + Duration::from_secs(snapshot.timestamp as u64);
+
+        let removed = prune_older_than_at(&workspace, Duration::from_secs(0), launch_time).unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(repo.list(10).unwrap().len(), 1);
     }
 }

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -13,6 +13,7 @@
 //! directory".
 
 use std::collections::HashSet;
+use std::fs::OpenOptions;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::process::Output;
@@ -51,6 +52,7 @@ pub struct SnapshotRepo {
 }
 
 const STALE_TMP_PACK_AGE: Duration = Duration::from_secs(60 * 60);
+const SNAPSHOT_LOCK_FILE: &str = "codewhale-snapshot.lock";
 
 /// Maximum total snapshot storage in megabytes before pruning kicks in at
 /// snapshot time. Keeps the side repo from blowing up the user's disk during
@@ -305,6 +307,10 @@ impl SnapshotRepo {
     ///
     /// Returns the snapshot's commit SHA.
     pub fn snapshot(&self, label: &str) -> io::Result<SnapshotId> {
+        self.with_repo_write_lock(|| self.snapshot_locked(label))
+    }
+
+    fn snapshot_locked(&self, label: &str) -> io::Result<SnapshotId> {
         // Guard against disk blowup (#1112): if the snapshot directory has
         // grown beyond the limit, prune aggressively before adding more.
         if let Ok(current_mb) = dir_size_mb(&self.git_dir)
@@ -320,7 +326,7 @@ impl SnapshotRepo {
             // we're under the target, or until there's nothing left.
             let mut age = Duration::from_secs(1);
             for _ in 0..10 {
-                let _ = self.prune_older_than(age);
+                let _ = self.prune_older_than_locked(age);
                 if let Ok(new_size) = dir_size_mb(&self.git_dir)
                     && new_size <= PRUNE_TARGET_MB
                 {
@@ -343,7 +349,7 @@ impl SnapshotRepo {
                     target: "snapshot",
                     "snapshot storage still over limit after pruning; wiping history"
                 );
-                let _ = self.prune_older_than(Duration::ZERO);
+                let _ = self.prune_older_than_locked(Duration::ZERO);
                 let _ = self.prune_unreachable_objects();
             }
         }
@@ -550,6 +556,10 @@ impl SnapshotRepo {
     /// `git gc --prune=now` to actually reclaim space. Cheap and avoids
     /// rewriting history when nothing has aged out.
     pub fn prune_older_than(&self, max_age: Duration) -> io::Result<usize> {
+        self.with_repo_write_lock(|| self.prune_older_than_locked(max_age))
+    }
+
+    fn prune_older_than_locked(&self, max_age: Duration) -> io::Result<usize> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|e| io_other(format!("clock error: {e}")))?
@@ -710,6 +720,19 @@ impl SnapshotRepo {
             &["gc", "--prune=now", "--quiet"],
         );
         Ok(removed)
+    }
+
+    fn with_repo_write_lock<T>(&self, f: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+        let lock_path = self.git_dir.join(SNAPSHOT_LOCK_FILE);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)?;
+        let mut lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock.write()?;
+        f()
     }
 
     /// Drop unreachable loose objects left behind by interrupted or

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -425,6 +425,10 @@ impl SnapshotRepo {
     /// snapshot tree relative to the workspace root. We do NOT touch the
     /// user's own `.git` — snapshots only contain working-tree files.
     pub fn restore(&self, id: &SnapshotId) -> io::Result<()> {
+        self.with_repo_write_lock(|| self.restore_locked(id))
+    }
+
+    fn restore_locked(&self, id: &SnapshotId) -> io::Result<()> {
         let current_paths = self.tree_paths("HEAD")?;
         let target_paths = self.tree_paths(id.as_str())?;
         let checkout = run_git(
@@ -452,12 +456,14 @@ impl SnapshotRepo {
     /// again would be a no-op, so the caller should continue scanning
     /// older snapshots.
     pub fn work_tree_matches_snapshot(&self, id: &SnapshotId) -> io::Result<bool> {
-        let diff = run_git(
-            &self.git_dir,
-            &self.work_tree,
-            &["diff", "--quiet", id.as_str(), "--", ":/"],
-        )?;
-        Ok(diff.status.success())
+        self.with_repo_read_lock(|| {
+            let diff = run_git(
+                &self.git_dir,
+                &self.work_tree,
+                &["diff", "--quiet", id.as_str(), "--", ":/"],
+            )?;
+            Ok(diff.status.success())
+        })
     }
 
     fn tree_paths(&self, treeish: &str) -> io::Result<HashSet<PathBuf>> {
@@ -512,6 +518,10 @@ impl SnapshotRepo {
 
     /// List up to `limit` most-recent snapshots, newest first.
     pub fn list(&self, limit: usize) -> io::Result<Vec<Snapshot>> {
+        self.with_repo_read_lock(|| self.list_locked(limit))
+    }
+
+    fn list_locked(&self, limit: usize) -> io::Result<Vec<Snapshot>> {
         // `git log -<n>` is the short form of `--max-count=<n>`; if `limit`
         // is `usize::MAX` (caller asked for "everything") we pass an empty
         // count so git defaults to no upper bound.
@@ -559,43 +569,25 @@ impl SnapshotRepo {
         self.with_repo_write_lock(|| self.prune_older_than_locked(max_age))
     }
 
-    pub fn prune_older_than_at(&self, max_age: Duration, now: SystemTime) -> io::Result<usize> {
-        self.with_repo_write_lock(|| self.prune_older_than_locked_at(max_age, now, false))
-    }
-
     fn prune_older_than_locked(&self, max_age: Duration) -> io::Result<usize> {
-        self.prune_older_than_locked_at(max_age, SystemTime::now(), true)
-    }
-
-    fn prune_older_than_locked_at(
-        &self,
-        max_age: Duration,
-        now: SystemTime,
-        include_cutoff_second: bool,
-    ) -> io::Result<usize> {
-        let now = now
+        let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|e| io_other(format!("clock error: {e}")))?
             .as_secs() as i64;
         let cutoff = now - max_age.as_secs() as i64;
 
-        let snapshots = self.list(usize::MAX)?;
+        let snapshots = self.list_locked(usize::MAX)?;
         if snapshots.is_empty() {
             return Ok(0);
         }
 
-        // Snapshots are newest-first. Find the index of the first prune
-        // candidate; every entry from that index onward is removed. The
-        // immediate path includes the cutoff second so zero-age manual prune
-        // remains aggressive. The fixed-cutoff startup path excludes it
-        // because git timestamps cannot distinguish subsecond launch order.
-        let cut_index = snapshots.iter().position(|s| {
-            if include_cutoff_second {
-                s.timestamp <= cutoff
-            } else {
-                s.timestamp < cutoff
-            }
-        });
+        // Snapshots are newest-first. Find the index of the first one
+        // at-or-older than the cutoff — every entry from that index
+        // onward is a candidate for removal. We use `<=` so a 0-second
+        // retention drops same-second commits (otherwise tests calling
+        // `prune_older_than(Duration::ZERO)` immediately after creating
+        // a snapshot would never prune anything).
+        let cut_index = snapshots.iter().position(|s| s.timestamp <= cutoff);
         let Some(cut) = cut_index else {
             return Ok(0);
         };
@@ -669,7 +661,7 @@ impl SnapshotRepo {
     }
 
     fn prune_keep_last_n_locked(&self, max_count: usize) -> io::Result<usize> {
-        let snapshots = self.list(usize::MAX)?;
+        let snapshots = self.list_locked(usize::MAX)?;
         if snapshots.len() <= max_count {
             return Ok(0);
         }
@@ -754,6 +746,19 @@ impl SnapshotRepo {
             .open(lock_path)?;
         let mut lock = fd_lock::RwLock::new(lock_file);
         let _guard = lock.write()?;
+        f()
+    }
+
+    fn with_repo_read_lock<T>(&self, f: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+        let lock_path = self.git_dir.join(SNAPSHOT_LOCK_FILE);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)?;
+        let lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock.read()?;
         f()
     }
 

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -350,7 +350,7 @@ impl SnapshotRepo {
                     "snapshot storage still over limit after pruning; wiping history"
                 );
                 let _ = self.prune_older_than_locked(Duration::ZERO);
-                let _ = self.prune_unreachable_objects();
+                let _ = self.prune_unreachable_objects_locked();
             }
         }
         // Stage every tracked + untracked path the workspace exposes.
@@ -647,6 +647,10 @@ impl SnapshotRepo {
     /// are preserved — only the parent chain to older snapshots is cut.
     /// Old objects become unreachable and gc reclaims them.
     pub fn prune_keep_last_n(&self, max_count: usize) -> io::Result<usize> {
+        self.with_repo_write_lock(|| self.prune_keep_last_n_locked(max_count))
+    }
+
+    fn prune_keep_last_n_locked(&self, max_count: usize) -> io::Result<usize> {
         let snapshots = self.list(usize::MAX)?;
         if snapshots.len() <= max_count {
             return Ok(0);
@@ -738,6 +742,10 @@ impl SnapshotRepo {
     /// Drop unreachable loose objects left behind by interrupted or
     /// orphaned side-repo operations.
     pub fn prune_unreachable_objects(&self) -> io::Result<()> {
+        self.with_repo_write_lock(|| self.prune_unreachable_objects_locked())
+    }
+
+    fn prune_unreachable_objects_locked(&self) -> io::Result<()> {
         let prune = run_git(&self.git_dir, &self.work_tree, &["prune", "--expire=now"])?;
         if !prune.status.success() {
             return Err(io_other(format!(

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -559,8 +559,21 @@ impl SnapshotRepo {
         self.with_repo_write_lock(|| self.prune_older_than_locked(max_age))
     }
 
+    pub fn prune_older_than_at(&self, max_age: Duration, now: SystemTime) -> io::Result<usize> {
+        self.with_repo_write_lock(|| self.prune_older_than_locked_at(max_age, now, false))
+    }
+
     fn prune_older_than_locked(&self, max_age: Duration) -> io::Result<usize> {
-        let now = SystemTime::now()
+        self.prune_older_than_locked_at(max_age, SystemTime::now(), true)
+    }
+
+    fn prune_older_than_locked_at(
+        &self,
+        max_age: Duration,
+        now: SystemTime,
+        include_cutoff_second: bool,
+    ) -> io::Result<usize> {
+        let now = now
             .duration_since(UNIX_EPOCH)
             .map_err(|e| io_other(format!("clock error: {e}")))?
             .as_secs() as i64;
@@ -571,13 +584,18 @@ impl SnapshotRepo {
             return Ok(0);
         }
 
-        // Snapshots are newest-first. Find the index of the first one
-        // at-or-older than the cutoff — every entry from that index
-        // onward is a candidate for removal. We use `<=` so a 0-second
-        // retention drops same-second commits (otherwise tests calling
-        // `prune_older_than(Duration::ZERO)` immediately after creating
-        // a snapshot would never prune anything).
-        let cut_index = snapshots.iter().position(|s| s.timestamp <= cutoff);
+        // Snapshots are newest-first. Find the index of the first prune
+        // candidate; every entry from that index onward is removed. The
+        // immediate path includes the cutoff second so zero-age manual prune
+        // remains aggressive. The fixed-cutoff startup path excludes it
+        // because git timestamps cannot distinguish subsecond launch order.
+        let cut_index = snapshots.iter().position(|s| {
+            if include_cutoff_second {
+                s.timestamp <= cutoff
+            } else {
+                s.timestamp < cutoff
+            }
+        });
         let Some(cut) = cut_index else {
             return Ok(0);
         };

--- a/crates/tui/src/tools/truncate.rs
+++ b/crates/tui/src/tools/truncate.rs
@@ -152,13 +152,18 @@ pub fn write_sha_spillover(sha: &str, content: &str) -> io::Result<PathBuf> {
         })?
         .to_path_buf();
     if path.exists() {
-        let _ = with_spillover_write_lock(&parent, || {
+        return match with_spillover_write_lock(&parent, || {
             if path.exists() {
                 let _ = refresh_modified(&path);
+            } else {
+                crate::utils::write_atomic(&path, content.as_bytes())?;
             }
-            Ok(())
-        });
-        return Ok(path);
+            Ok(path.clone())
+        }) {
+            Ok(path) => Ok(path),
+            Err(_) if path.exists() => Ok(path),
+            Err(err) => Err(err),
+        };
     }
 
     with_spillover_write_lock(&parent, || {

--- a/crates/tui/src/tools/truncate.rs
+++ b/crates/tui/src/tools/truncate.rs
@@ -33,19 +33,16 @@
 //! tool-details pager opens the spillover file when the user
 //! presses the tool-details shortcut on a spilled tool cell.
 
-use std::fs;
+use std::fs::{self, FileTimes, OpenOptions};
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::tools::spec::ToolResult;
 
-// `Path` is only referenced from helpers gated to test builds.
-#[cfg(test)]
-use std::path::Path;
-
 /// Name of the spillover directory under the CodeWhale home.
 pub const SPILLOVER_DIR_NAME: &str = "tool_outputs";
+const SPILLOVER_LOCK_FILE: &str = ".codewhale-tool-outputs.lock";
 
 /// Default threshold above which a tool result is a candidate for
 /// spillover. Mirrors the `MAX_MEMORY_SIZE` ceiling we use elsewhere
@@ -145,14 +142,23 @@ pub fn write_sha_spillover(sha: &str, content: &str) -> io::Result<PathBuf> {
             "sha must be a 64-char lowercase hex digest",
         )
     })?;
-    if path.exists() {
-        return Ok(path);
-    }
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    crate::utils::write_atomic(&path, content.as_bytes())?;
-    Ok(path)
+    let parent = path
+        .parent()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "could not resolve sha spillover directory",
+            )
+        })?
+        .to_path_buf();
+    with_spillover_write_lock(&parent, || {
+        if path.exists() {
+            refresh_modified(&path)?;
+            return Ok(path.clone());
+        }
+        crate::utils::write_atomic(&path, content.as_bytes())?;
+        Ok(path.clone())
+    })
 }
 
 /// Write `content` to the spillover file for `id`. Creates the
@@ -169,11 +175,19 @@ pub fn write_spillover(id: &str, content: &str) -> io::Result<PathBuf> {
             "could not resolve spillover path (empty/invalid id or missing home directory)",
         )
     })?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    crate::utils::write_atomic(&path, content.as_bytes())?;
-    Ok(path)
+    let parent = path
+        .parent()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "could not resolve spillover directory",
+            )
+        })?
+        .to_path_buf();
+    with_spillover_write_lock(&parent, || {
+        crate::utils::write_atomic(&path, content.as_bytes())?;
+        Ok(path.clone())
+    })
 }
 
 /// Drop spillover files older than `max_age`. Returns the number of
@@ -187,11 +201,15 @@ pub fn prune_older_than(max_age: Duration) -> io::Result<usize> {
     if !root.exists() {
         return Ok(0);
     }
+    with_spillover_write_lock(&root, || prune_older_than_locked(&root, max_age))
+}
+
+fn prune_older_than_locked(root: &Path, max_age: Duration) -> io::Result<usize> {
     let cutoff = SystemTime::now()
         .checked_sub(max_age)
         .unwrap_or(SystemTime::UNIX_EPOCH);
     let mut pruned = 0usize;
-    for entry in fs::read_dir(&root)? {
+    for entry in fs::read_dir(root)? {
         let entry = match entry {
             Ok(e) => e,
             Err(err) => {
@@ -200,6 +218,12 @@ pub fn prune_older_than(max_age: Duration) -> io::Result<usize> {
             }
         };
         let path = entry.path();
+        if path
+            .file_name()
+            .is_some_and(|name| name == SPILLOVER_LOCK_FILE)
+        {
+            continue;
+        }
         if !path.is_file() {
             continue;
         }
@@ -219,6 +243,24 @@ pub fn prune_older_than(max_age: Duration) -> io::Result<usize> {
         }
     }
     Ok(pruned)
+}
+
+fn refresh_modified(path: &Path) -> io::Result<()> {
+    let file = OpenOptions::new().write(true).open(path)?;
+    file.set_times(FileTimes::new().set_modified(SystemTime::now()))
+}
+
+fn with_spillover_write_lock<T>(root: &Path, f: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+    fs::create_dir_all(root)?;
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(SPILLOVER_LOCK_FILE))?;
+    let mut lock = fd_lock::RwLock::new(lock_file);
+    let _guard = lock.write()?;
+    f()
 }
 
 /// Convenience for the common "too long? spill it." pattern. If
@@ -625,6 +667,32 @@ mod tests {
         with_test_home(tmp.path(), || {
             let err = write_spillover("...", "x").unwrap_err();
             assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        });
+    }
+
+    #[test]
+    fn write_sha_spillover_refreshes_reused_file_mtime() {
+        let _g = setup();
+        let tmp = tempdir().unwrap();
+        with_test_home(tmp.path(), || {
+            let sha = "a".repeat(64);
+            let path = write_sha_spillover(&sha, "large result").expect("write sha");
+            let stale_time = SystemTime::now() - Duration::from_secs(30 * 24 * 60 * 60);
+            let file = OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("open sha");
+            file.set_times(FileTimes::new().set_modified(stale_time))
+                .expect("backdate sha");
+
+            let reused = write_sha_spillover(&sha, "large result").expect("reuse sha");
+            let refreshed = fs::metadata(&reused)
+                .expect("metadata")
+                .modified()
+                .expect("modified");
+
+            assert_eq!(reused, path);
+            assert!(refreshed > stale_time);
         });
     }
 

--- a/crates/tui/src/tools/truncate.rs
+++ b/crates/tui/src/tools/truncate.rs
@@ -151,9 +151,19 @@ pub fn write_sha_spillover(sha: &str, content: &str) -> io::Result<PathBuf> {
             )
         })?
         .to_path_buf();
+    if path.exists() {
+        let _ = with_spillover_write_lock(&parent, || {
+            if path.exists() {
+                let _ = refresh_modified(&path);
+            }
+            Ok(())
+        });
+        return Ok(path);
+    }
+
     with_spillover_write_lock(&parent, || {
         if path.exists() {
-            refresh_modified(&path)?;
+            let _ = refresh_modified(&path);
             return Ok(path.clone());
         }
         crate::utils::write_atomic(&path, content.as_bytes())?;
@@ -693,6 +703,27 @@ mod tests {
 
             assert_eq!(reused, path);
             assert!(refreshed > stale_time);
+        });
+    }
+
+    #[test]
+    fn write_sha_spillover_reuses_existing_file_when_refresh_fails() {
+        let _g = setup();
+        let tmp = tempdir().unwrap();
+        with_test_home(tmp.path(), || {
+            let sha = "b".repeat(64);
+            let path = write_sha_spillover(&sha, "first").expect("write sha");
+            let original_permissions = fs::metadata(&path).expect("metadata").permissions();
+            let mut readonly_permissions = original_permissions.clone();
+            readonly_permissions.set_readonly(true);
+            fs::set_permissions(&path, readonly_permissions).expect("make readonly");
+
+            let reused = write_sha_spillover(&sha, "second");
+            fs::set_permissions(&path, original_permissions).expect("restore permissions");
+
+            let reused = reused.expect("reuse readonly sha");
+            assert_eq!(reused, path);
+            assert_eq!(fs::read_to_string(&path).unwrap(), "first");
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes #3757.

This moves the startup cleanup work that does not mutate snapshot refs off the synchronous interactive path:

- stale tool-output spillover pruning now runs in a delayed best-effort maintenance thread
- old saved-session cleanup now runs in that thread and protects the active `--resume` target
- `--resume latest` protection is resolved inside the maintenance thread, avoiding a second pre-frame session scan

Snapshot pruning stays before the TUI exposes snapshot list/restore commands because it rewrites side-repo refs and can run GC. The side-repo snapshot operations now share the repo lock across snapshot, prune, list, restore, and workspace comparison paths.

SHA-addressed spillover reuse now refreshes mtimes best-effort, treats read-only existing files as cache hits, and recreates the file if it disappears after the optimistic existence check but before the spillover lock is held.

## Validation

Local:

- `cargo fmt`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked startup`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked prune_with_existing_repo_zero_age_clears_all`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked restore_reverts_workspace_files`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked list_respects_limit`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked snapshot_and_restore_do_not_move_user_git_head`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked write_sha_spillover_reuses_existing_file_when_refresh_fails`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked write_sha_spillover_refreshes_reused_file_mtime`
- `cargo clippy --workspace --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`
- `cargo test --workspace --all-features --locked`
- `cargo build --release -p codewhale-cli -p codewhale-tui --locked`

Cloud:

- CI green on `eba988c99d`
- Claude review passed
- Codex review on `eba988c99d`: no major issues
- All Codex review threads resolved
