### PR TITLE
feat(web): redesign homepage with trust strip, GitHub nav link, and mirror footer (#3413)

### DIFF
--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -184,6 +184,37 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
         </div>
       </section>
 
+      {/* TRUST STRIP — key facts, no overclaiming */}
+      <section className="hairline-t hairline-b">
+        <div className="mx-auto max-w-[1400px] px-6 py-4">
+          <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-[0.7rem] font-mono text-ink-mute">
+            <span>
+              <span className="text-jade mr-1">✓</span>
+              {facts.license ?? "MIT"} {isZh ? "开源" : "license"}
+            </span>
+            <span className="hidden sm:inline">·</span>
+            <span>
+              <span className="text-jade mr-1">✓</span>
+              {isZh ? "本地运行，无需云端" : "local-first, no cloud required"}
+            </span>
+            <span className="hidden sm:inline">·</span>
+            <span>
+              <span className="text-jade mr-1">✓</span>
+              {isZh ? `${facts.providers.length} 个提供商，开放模型优先` : `${facts.providers.length} providers, open models first`}
+            </span>
+            <span className="hidden sm:inline">·</span>
+            <Link href="https://github.com/Hmbown/CodeWhale/blob/main/SECURITY.md" className="hover:text-indigo transition-colors">
+              <span className="text-jade mr-1">✓</span>
+              {isZh ? "安全模型" : "security model"}
+            </Link>
+            <span className="hidden sm:inline">·</span>
+            <Link href="/docs" className="hover:text-indigo transition-colors">
+              {isZh ? "文档 →" : "docs →"}
+            </Link>
+          </div>
+        </div>
+      </section>
+
       <StatGrid stats={stats} />
 
       {/* GET STARTED — the two or three steps, with the real links */}

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -35,6 +35,7 @@ const EN_COLS = [
       { label: "Code of Conduct", href: "https://github.com/Hmbown/CodeWhale/blob/main/CODE_OF_CONDUCT.md" },
       { label: "Security", href: "https://github.com/Hmbown/CodeWhale/blob/main/SECURITY.md" },
       { label: "License (MIT)", href: "https://github.com/Hmbown/CodeWhale/blob/main/LICENSE" },
+      { label: "Mirrors (CNB · Tsinghua)", href: "/en/install#other-ways" },
     ],
   },
 ];
@@ -69,6 +70,7 @@ const ZH_COLS = [
       { label: "行为准则", href: "https://github.com/Hmbown/CodeWhale/blob/main/CODE_OF_CONDUCT.md" },
       { label: "安全策略", href: "https://github.com/Hmbown/CodeWhale/blob/main/SECURITY.md" },
       { label: "MIT 许可证", href: "https://github.com/Hmbown/CodeWhale/blob/main/LICENSE" },
+      { label: "国内镜像（CNB · 清华 Tuna）", href: "/zh/install#other-ways" },
     ],
   },
 ];

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -15,6 +15,7 @@ const EN_LINKS = [
   { href: "/en/roadmap", label: "Roadmap", cn: "路线" },
   { href: "/en/faq", label: "FAQ", cn: "问答" },
   { href: "/en/contribute", label: "Contribute", cn: "参与" },
+  { href: "https://github.com/Hmbown/CodeWhale", label: "GitHub", cn: "源码" },
 ];
 
 const ZH_LINKS = [
@@ -26,6 +27,7 @@ const ZH_LINKS = [
   { href: "/zh/roadmap", label: "路线图", cn: "" },
   { href: "/zh/faq", label: "常见问题", cn: "" },
   { href: "/zh/contribute", label: "参与贡献", cn: "" },
+  { href: "https://github.com/Hmbown/CodeWhale", label: "GitHub", cn: "" },
 ];
 
 export function Nav({ locale = "en" }: { locale?: Locale }) {


### PR DESCRIPTION
- web/app/[locale]/page.tsx: add trust strip below hero showing MIT license, local-first, provider count, and security model
- web/components/nav.tsx: add GitHub link to main nav (EN + ZH)
- web/components/footer.tsx: add mirror/provenance links (CNB, Tsinghua)

Close https://github.com/Hmbown/CodeWhale/issues/3413.

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
