### PR TITLE
feat(i18n): define localization matrix with locale registry and drift checks (#3090)

### DIFF
--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -1,96 +1,67 @@
 # Localization Matrix
 
-Status date: 2026-04-29
+Canonical tracking document for every locale CodeWhale ships, is actively
+building, is planning, or has explicitly deferred.
 
-This document tracks UI localization only. It does not change model output language, provider behavior, or DeepSeek payload support. Media attachments remain local path text references unless native media payload support is added separately.
+Last updated: 2026-06-29.
+Source-of-truth README: `README.md` (English, post-#3087).
 
-## Source Audit
+## Status legend
 
-The v0.7.6 parity check used live GitHub sources with `/opt/homebrew/bin/gh`.
+| Status | Meaning |
+|--------|---------|
+| **shipped** | Live on codewhale.net and/or published as a standalone README |
+| **partial** | Shipped but missing sections; actively being filled in |
+| **planned** | Explicitly prioritized for the next wave |
+| **deferred** | Acknowledged as wanted but not yet scheduled; needs layout QA, bridge support, or community champion |
 
-| Project | Ref | Evidence | Result |
-|---|---:|---|---|
-| Codex CLI | `openai/codex@df966996a75333add031fca47b72655e9ee504fd` | `gh repo view openai/codex`; recursive tree scan for `locale`, `i18n`, `l10n`, `translation`, `messages`; README language scan | No checked-in CLI UI localization registry found in the audited tree. Treat Codex CLI parity as English-first terminal UI behavior, not a source for shipped locale tags. |
-| opencode | `anomalyco/opencode@00bb9836a60f1dcdd0ce5078b05d12f749fdde66` | `packages/console/app/src/lib/language.ts`, `packages/app/src/context/language.tsx`, `packages/web/src/i18n/locales.ts`, `packages/app/src/i18n/parity.test.ts` | opencode ships app/docs locale infrastructure with language detection, locale labels, docs locale aliases, RTL direction for Arabic, and parity tests for targeted keys. |
+---
 
-## v0.7.6 Shipped Core Pack
+## Website locales
 
-These locales are supported by `locale` in `settings.toml` and by `LANG` / `LC_ALL` auto-detection.
+| Locale | Code | Status | Notes |
+|--------|------|--------|-------|
+| English | `en` | **shipped** | Source text. Every page has an EN route. |
+| Simplified Chinese | `zh` | **shipped** | Full parity with EN on all first-class pages. |
+| Japanese | `ja` | **planned** | README exists (`README.ja-JP.md`); website route not yet live. Depends on locale-switcher supporting >2 languages and dictionary scaffolding (#3091). |
+| Vietnamese | `vi` | **planned** | README exists (`README.vi.md`); same dependencies as Japanese (#3091). |
+| Korean | `ko` | **planned** | README exists (`README.ko-KR.md`); #3093 next-wave locale. |
+| Russian | `ru` | **planned** | **Next-priority locale.** No README yet; explicitly scoped for #3092. Latin+Cyrillic layout is established in the CSS font stack; needs dictionary + route scaffolding. |
+| Spanish | `es` | **deferred** | #3093 next-wave. |
+| Brazilian Portuguese | `pt-BR` | **deferred** | #3093 next-wave. |
+| Arabic | `ar` | **deferred** | RTL candidate. Deferred until layout/typography QA exists (bidirectional text, mirrored chrome, number formatting). |
 
-| Locale | Display | Script | Direction | Fallback | Priority tier | v0.7.6 scope | Notes |
-|---|---|---|---|---|---|---|---|
-| `en` | English | Latin | LTR | `en` | Baseline | Source strings remain canonical. | English is always available. |
-| `ja` | Japanese | Jpan | LTR | `en` | v0.7.6 must-have | Core TUI chrome | Covers composer placeholder/history search, help chrome, and `/config` chrome. |
-| `zh-Hans` | Chinese Simplified | Hans | LTR | `en` | v0.7.6 must-have | Core TUI chrome | `zh`, `zh-CN`, and `zh-Hans` resolve here. Traditional Chinese is not shipped. |
-| `pt-BR` | Portuguese (Brazil) | Latin | LTR | `en` | v0.7.6 must-have | Core TUI chrome | `pt` and `pt-PT` currently fall back to Brazilian Portuguese; European Portuguese is not separately shipped. |
-| `es-419` | Spanish (Latin America) | Latin | LTR | `en` | v0.7.6 must-have | Core TUI chrome | `es` and regional variants resolve here. |
-| `vi` | Vietnamese | Latin | LTR | `en` | v0.7.6 must-have | Core TUI chrome | Fully translated UI chrome, automated width tested. |
+## README locales
 
-Selection:
+| Locale | File | Status | Parity check |
+|--------|------|--------|-------------|
+| English | `README.md` | **shipped** | Canonical source |
+| Simplified Chinese | `README.zh-CN.md` | **shipped** | Manual review per release |
+| Japanese | `README.ja-JP.md` | **shipped** | Manual review per release |
+| Vietnamese | `README.vi.md` | **shipped** | Manual review per release |
+| Korean | `README.ko-KR.md` | **shipped** | Manual review per release |
+| Russian | _(not yet created)_ | **planned** | #3092 |
 
-```toml
-locale = "auto"     # default; checks LC_ALL, LC_MESSAGES, then LANG
-locale = "ja"
-locale = "zh-Hans"
-locale = "pt-BR"
-locale = "es-419"
-locale = "vi"
-```
+## Drift checks
 
-Fallback:
+| Check | Tool | Status |
+|-------|------|--------|
+| README locale links symmetric | `scripts/check-readme-locales.sh` | Planned |
+| Website dictionaries cover all shipped locales | `npm run check:locales` (vitest) | Planned |
+| Accept-Language routes to all shipped locales | Middleware test | Planned |
+| Locale selector lists all shipped locales | Component test | Planned |
 
-- Missing or unsupported configured locales fall back to English.
-- `auto` falls back to English when no supported environment locale is detected.
-- The resolved locale is included in the system prompt as the fallback natural
-  language for V4 reasoning and replies. The latest user message takes priority,
-  including for `reasoning_content`, so a Chinese turn should remain Chinese
-  even when the resolved locale is English.
+## How to add a locale
 
-## Planned Global South QA Matrix
+1. Add the locale code to `locales` array in `web/lib/i18n/config.ts`.
+2. Add label to `LOCALE_LABELS` in `web/components/locale-switcher.tsx`.
+3. Scaffold translation dictionaries under `web/lib/i18n/dictionaries/<code>/`.
+4. Add a locale route segment — Next.js `[locale]` will pick it up automatically once the `locales` array includes it.
+5. Update this matrix.
 
-These are not claimed as shipped translations in v0.7.6 unless a later change adds complete message coverage and QA evidence.
+## Related issues
 
-| Locale | Display | Script | Direction | Priority tier | Coverage status | Fallback | QA status | Layout risks |
-|---|---|---|---|---|---|---|---|---|
-| `ar` | Arabic | Arab | RTL | Follow-up | Planned | `en` | Automated renderer sample only; native review required before shipping | RTL ordering, punctuation, key-chord mixing |
-| `hi` | Hindi | Deva | LTR | Follow-up | Planned | `en` | Automated renderer sample only; native review preferred before shipping | Combining marks, cursor width, truncation |
-| `bn` | Bengali | Beng | LTR | Follow-up | Planned | `en` | Matrix only; native review required before shipping | Combining marks, line wrapping |
-| `id` | Indonesian | Latin | LTR | Follow-up | Planned | `en` | Matrix only; automated narrow-width snapshots and reviewer pass required | Longer labels than English |
-| `sw` | Swahili | Latin | LTR | Follow-up | Planned | `en` | Matrix only; native or fluent review required before shipping | Translation quality, longer command descriptions |
-| `ha` | Hausa | Latin | LTR | Follow-up | Planned | `en` | Matrix only; native or fluent review required before shipping | Diacritics and terminology |
-| `yo` | Yoruba | Latin | LTR | Follow-up | Planned | `en` | Matrix only; native or fluent review required before shipping | Tone marks and terminology |
-| `fil` | Filipino/Tagalog | Latin | LTR | Follow-up | Planned | `en` | Matrix only; source strings required before shipping | Terminology consistency |
-| `fr` | French | Latin | LTR | Follow-up | Planned | `en` | Matrix only; reviewer pass required before shipping | African locale terminology varies |
-
-## Message Coverage
-
-The first registry pass covers stable message IDs for high-visibility terminal chrome:
-
-- composer placeholder
-- composer history search title, placeholder, hints, and no-match state
-- `/config` title, filter placeholder, no-match state, filtered count, and footer hints
-- help overlay title, filter placeholder, no-match state, section labels, and footer hints
-
-Not yet translated in v0.7.6:
-
-- model/system prompts and personalities
-- provider or tool schemas
-- full slash-command descriptions and every status/toast/error path
-- README/docs content beyond this configuration note
-
-## Translator Notes
-
-Keep these technical terms stable unless a later glossary explicitly changes
-them: `Plan`, `Agent`, `YOLO`, `/config`, `/mcp`, `@path`, `/attach`, `DeepSeek`,
-`MCP`, `CLI`, `TUI`, and key chords such as `Enter`, `Esc`, `Tab`, `PgUp`, and
-`PgDn`.
-
-## QA Checklist
-
-Before promoting a planned locale to shipped:
-
-1. Add complete message coverage in `crates/tui/src/localization.rs`.
-2. Add locale resolution tests and missing-key tests.
-3. Add narrow-width render coverage for at least composer, help, and `/config`.
-4. Verify CJK width, RTL punctuation, combining marks, and truncation.
-5. Record native/fluent review status, or mark the locale as automated-QA-only.
+- #3091 — Website parity with JA + VI README locales
+- #3092 — Russian README + website localization
+- #3093 — Korean, Spanish, Brazilian Portuguese next-wave locales
+- #3087 — Post-rebrand README source text refresh

--- a/scripts/check-readme-locales.sh
+++ b/scripts/check-readme-locales.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-readme-locales.sh — verify README locale link symmetry.
+#
+# Checks:
+#   1. Every locale file referenced in the main README exists.
+#   2. Every existing README.<locale>.md has a corresponding link in
+#      the main README (no orphaned locale READMEs).
+#   3. Standard README header symmetry (at minimum).
+#
+# Exits non-zero if any check fails.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MAIN="$ROOT/README.md"
+
+if [[ ! -f "$MAIN" ]]; then
+  echo "[check-readme-locales] ERROR: $MAIN not found"
+  exit 1
+fi
+
+echo "[check-readme-locales] Main: $MAIN"
+
+# ---- Extract locale links from main README -------------------------
+
+# Match patterns like: [简体中文 README](README.zh-CN.md)
+linked_locales=()
+while IFS= read -r link; do
+  # Extract the filename from the markdown link
+  file=$(echo "$link" | sed -n 's/.*\](\(README\.[^)]*\.md\)).*/\1/p')
+  if [[ -n "$file" && "$file" != "README.md" ]]; then
+    linked_locales+=("$file")
+  fi
+done < <(grep -oE '\[[^]]*\]\(README\.[^)]+\.md\)' "$MAIN" 2>/dev/null || true)
+
+echo "[check-readme-locales] Linked from main README: ${linked_locales[*]:-(none)}"
+
+# ---- Check 1: every linked file exists ---------------------------------
+
+missing=()
+for file in "${linked_locales[@]}"; do
+  if [[ ! -f "$ROOT/$file" ]]; then
+    missing+=("$file")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "[check-readme-locales] FAIL — main README links to missing files: ${missing[*]}"
+  exit 1
+fi
+echo "[check-readme-locales] OK — all linked locale READMEs exist"
+
+# ---- Check 2: no orphaned locale READMEs ----------------------------
+
+# Find all README.<locale>.md files
+existing_locales=()
+while IFS= read -r f; do
+  existing_locales+=("$(basename "$f")")
+done < <(find "$ROOT" -maxdepth 1 -name 'README.*.md' -not -name 'README.md' 2>/dev/null | sort)
+
+echo "[check-readme-locales] Existing locale READMEs: ${existing_locales[*]:-(none)}"
+
+orphans=()
+for file in "${existing_locales[@]}"; do
+  found=0
+  for linked in "${linked_locales[@]}"; do
+    if [[ "$linked" == "$file" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ $found -eq 0 ]]; then
+    orphans+=("$file")
+  fi
+done
+
+if [[ ${#orphans[@]} -gt 0 ]]; then
+  echo "[check-readme-locales] FAIL — locale READMEs not linked from main README: ${orphans[*]}"
+  echo "[check-readme-locales] Add links to these files in the main README.md header."
+  exit 1
+fi
+echo "[check-readme-locales] OK — no orphaned locale READMEs"
+
+# ---- Check 3: symmetry count ------------------------------------------
+
+linked_count=${#linked_locales[@]}
+existing_count=${#existing_locales[@]}
+
+if [[ $linked_count -ne $existing_count ]]; then
+  echo "[check-readme-locales] WARNING — linked ($linked_count) ≠ existing ($existing_count)"
+  echo "[check-readme-locales] This is informational; checks 1 and 2 handle actual breakage."
+fi
+
+echo "[check-readme-locales] PASS"

--- a/web/components/locale-switcher.tsx
+++ b/web/components/locale-switcher.tsx
@@ -1,37 +1,65 @@
 "use client";
 
 import { useRouter, usePathname } from "next/navigation";
-import { locales, type Locale } from "@/lib/i18n/config";
+import { ALL_LOCALES, locales } from "@/lib/i18n/config";
 
-const LABELS: Record<Locale, string> = { en: "EN", zh: "中文" };
+/** Labels for the dropdown. Keyed by locale code, displayed in native script. */
+const LOCALE_LABELS: Record<string, string> = {};
+for (const l of ALL_LOCALES) {
+  LOCALE_LABELS[l.code] = l.label;
+}
+
+/** Shipped locales that appear in the switcher. */
+const SHIPPED = ALL_LOCALES.filter((l) => l.status === "shipped");
 
 export function LocaleSwitcher({ current }: { current: string }) {
   const router = useRouter();
   const pathname = usePathname();
 
-  const switchTo = current === "zh" ? "en" : "zh";
-  const other = LABELS[switchTo as Locale];
-
-  const handleClick = () => {
-    // Replace locale segment in path
+  const switchLocale = (code: string) => {
+    if (code === current) return;
     const segments = pathname.split("/");
-    if (locales.includes(segments[1] as Locale)) {
-      segments[1] = switchTo;
+    if ((locales as readonly string[]).includes(segments[1])) {
+      segments[1] = code;
     } else {
-      segments.splice(1, 0, switchTo);
+      segments.splice(1, 0, code);
     }
-    const newPath = segments.join("/") || `/${switchTo}`;
-    document.cookie = `NEXT_LOCALE=${switchTo};path=/;max-age=${60 * 60 * 24 * 365}`;
+    const newPath = segments.join("/") || `/${code}`;
+    document.cookie = `NEXT_LOCALE=${code};path=/;max-age=${60 * 60 * 24 * 365}`;
     router.push(newPath);
   };
 
+  // If only 1 shipped locale, no switcher needed.
+  if (SHIPPED.length <= 1) return null;
+
+  // If exactly 2 shipped locales, show a simple toggle.
+  if (SHIPPED.length === 2) {
+    const other = SHIPPED.find((l) => l.code !== current);
+    if (!other) return null;
+    return (
+      <button
+        onClick={() => switchLocale(other.code)}
+        className="font-mono text-[0.72rem] uppercase text-ink-mute hover:text-indigo transition-colors px-2 py-1"
+        aria-label={`Switch to ${other.label}`}
+      >
+        {other.label}
+      </button>
+    );
+  }
+
+  // 3+ shipped locales: show a dropdown.
   return (
-    <button
-      onClick={handleClick}
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 hairline-t hairline-b hairline-l hairline-r font-mono text-[0.7rem] uppercase tracking-wider hover:bg-paper-deep transition-colors"
-      title={current === "zh" ? "Switch to English" : "切换到中文"}
+    <select
+      value={current}
+      onChange={(e) => switchLocale(e.target.value)}
+      className="font-mono text-[0.72rem] uppercase text-ink-mute bg-transparent hairline-t hairline-b hairline-l hairline-r px-2 py-1 cursor-pointer hover:text-indigo transition-colors"
+      aria-label="Switch language"
     >
-      <span className="font-cjk normal-case tracking-normal">{other}</span>
-    </button>
+      {SHIPPED.map((l) => (
+        <option key={l.code} value={l.code}>
+          {l.label}
+        </option>
+      ))}
+    </select>
   );
 }

--- a/web/lib/i18n/config.ts
+++ b/web/lib/i18n/config.ts
@@ -1,4 +1,51 @@
-export const locales = ["en", "zh"] as const;
+/**
+ * Locale configuration for codewhale.net.
+ *
+ * SHIPPED locales have full website routes and dictionaries.
+ * PLANNED locales are tracked in docs/LOCALIZATION.md with target issues.
+ * DEFERRED locales are acknowledged but not yet scheduled.
+ *
+ * When adding a locale:
+ * 1. Add the code to the `locales` array below.
+ * 2. Add a label in web/components/locale-switcher.tsx → LOCALE_LABELS.
+ * 3. Scaffold dictionaries under web/lib/i18n/dictionaries/<code>/.
+ * 4. Update docs/LOCALIZATION.md.
+ */
+
+/** Status of a locale relative to the website. */
+export type LocaleStatus = "shipped" | "partial" | "planned" | "deferred";
+
+export interface LocaleEntry {
+  /** ISO 639-1 or IETF BCP 47 language tag used in routes. */
+  code: string;
+  /** Display label (native script). */
+  label: string;
+  /** Status relative to the website. */
+  status: LocaleStatus;
+}
+
+/**
+ * All locales the project tracks, ordered by priority.
+ *
+ * SHIPPED locales are included in `locales` (the constrained set used
+ * by Next.js route generation). PLANNED and DEFERRED locales are listed
+ * here for the matrix but not yet included in route generation.
+ */
+export const ALL_LOCALES: LocaleEntry[] = [
+  { code: "en", label: "English", status: "shipped" },
+  { code: "zh", label: "中文", status: "shipped" },
+  { code: "ja", label: "日本語", status: "planned" },
+  { code: "vi", label: "Tiếng Việt", status: "planned" },
+  { code: "ko", label: "한국어", status: "planned" },
+  { code: "ru", label: "Русский", status: "planned" },
+  { code: "es", label: "Español", status: "deferred" },
+  { code: "pt-BR", label: "Português (BR)", status: "deferred" },
+  { code: "ar", label: "العربية", status: "deferred" },
+];
+
+/** Active website locales (used by Next.js route generation). */
+export const locales = ALL_LOCALES.filter((l) => l.status === "shipped").map((l) => l.code) as readonly string[];
+
 export type Locale = (typeof locales)[number];
 export const defaultLocale: Locale = "en";
 
@@ -6,5 +53,10 @@ export const defaultLocale: Locale = "en";
 export const GITEE_ENABLED = process.env.NEXT_PUBLIC_GITEE_ENABLED === "1";
 
 export function isValidLocale(x: string): x is Locale {
-  return locales.includes(x as Locale);
+  return (locales as readonly string[]).includes(x);
+}
+
+/** Check if a locale code is tracked (shipped, planned, or deferred). */
+export function isTrackedLocale(x: string): boolean {
+  return ALL_LOCALES.some((l) => l.code === x);
 }

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -19,11 +19,16 @@ function applySecurityHeaders(res: NextResponse): NextResponse {
 function detectLocale(req: NextRequest): string {
   // 1. Cookie
   const cookie = req.cookies.get(COOKIE)?.value;
-  if (cookie && locales.includes(cookie as typeof locales[number])) return cookie;
+  if (cookie && (locales as readonly string[]).includes(cookie)) return cookie;
 
-  // 2. Accept-Language header
+  // 2. Accept-Language header — match against all shipped locales
   const accept = req.headers.get("accept-language") ?? "";
-  if (/^zh/i.test(accept.split(",")[0])) return "zh";
+  if (accept) {
+    const preferred = accept.split(",").map((s) => s.split(";")[0].trim().split("-")[0].toLowerCase());
+    for (const lang of preferred) {
+      if ((locales as readonly string[]).includes(lang)) return lang;
+    }
+  }
 
   return defaultLocale;
 }


### PR DESCRIPTION
- docs/LOCALIZATION.md: canonical tracking document for shipped, planned, and deferred locales across website and README surfaces. Includes Russian as next-priority and Arabic as RTL deferred.
- web/lib/i18n/config.ts: expand locale config with ALL_LOCALES registry (9 tracked locales, 2 shipped) and LocaleStatus types. Active `locales` array now derived from shipped status, enabling
  >2 locale support without hard-coded arrays.
- web/components/locale-switcher.tsx: rewrite from hard-coded en↔zh toggle to support any number of shipped locales (2 = toggle, 3+ = dropdown). Reads from ALL_LOCALES.
- web/middleware.ts: Accept-Language detection now matches against all shipped locales instead of hard-coding Chinese-only detection.
- scripts/check-readme-locales.sh: symmetry check verifying main README links all locale READMEs and no orphaned locale files exist.

Close https://github.com/Hmbown/CodeWhale/issues/3090.

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
