### PR TITLE
fix(tui): label session-scoped approval honestly, not "always" (#3766)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -344,7 +344,7 @@
     "ApprovalFieldImpact": "Impact: ",
     "ApprovalFieldParams": "Params: ",
     "ApprovalOptionApproveOnce": "Approve once",
-    "ApprovalOptionApproveAlways": "Approve always for this kind",
+    "ApprovalOptionApproveAlways": "Approve for this session (this kind)",
     "ApprovalOptionDeny": "Deny this call",
     "ApprovalOptionAbortTurn": "Abort the turn",
     "ApprovalBlockTitle": "approval",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -331,7 +331,7 @@
     "ApprovalFieldImpact": "Impacto:",
     "ApprovalFieldParams": "Parámetros:",
     "ApprovalOptionApproveOnce": "Aprobar una vez",
-    "ApprovalOptionApproveAlways": "Aprobar siempre para este tipo",
+    "ApprovalOptionApproveAlways": "Aprobar en esta sesión (este tipo)",
     "ApprovalOptionDeny": "Denegar esta llamada",
     "ApprovalOptionAbortTurn": "Abortar turno",
     "ApprovalBlockTitle": "aprobación",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -330,7 +330,7 @@
     "ApprovalFieldImpact": "影響：",
     "ApprovalFieldParams": "パラメータ：",
     "ApprovalOptionApproveOnce": "1回だけ承認",
-    "ApprovalOptionApproveAlways": "常に承認（この種類）",
+    "ApprovalOptionApproveAlways": "このセッションで承認（この種類）",
     "ApprovalOptionDeny": "拒否",
     "ApprovalOptionAbortTurn": "中断",
     "ApprovalBlockTitle": "承認",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -320,7 +320,7 @@
     "ApprovalFieldImpact": "Impacto:",
     "ApprovalFieldParams": "Parâmetros:",
     "ApprovalOptionApproveOnce": "Aprovar uma vez",
-    "ApprovalOptionApproveAlways": "Aprovar sempre para este tipo",
+    "ApprovalOptionApproveAlways": "Aprovar nesta sessão (este tipo)",
     "ApprovalOptionDeny": "Negar esta chamada",
     "ApprovalOptionAbortTurn": "Abortar turno",
     "ApprovalBlockTitle": "aprovação",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -329,7 +329,7 @@
     "ApprovalFieldImpact": "Tác động:",
     "ApprovalFieldParams": "Tham số:",
     "ApprovalOptionApproveOnce": "Phê duyệt một lần",
-    "ApprovalOptionApproveAlways": "Phê duyệt mọi lần cho loại này",
+    "ApprovalOptionApproveAlways": "Phê duyệt trong phiên này (loại này)",
     "ApprovalOptionDeny": "Từ chối lần gọi này",
     "ApprovalOptionAbortTurn": "Hủy bỏ lượt",
     "ApprovalBlockTitle": "phê duyệt",

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1757,9 +1757,13 @@ fn push_compact_approval_controls(
     locale: Locale,
     can_save_rule: bool,
 ) {
-    let (once, always, deny, abort, save) = match locale {
-        Locale::ZhHans => ("仅本次", "始终", "拒绝", "中止", "保存"),
-        _ => ("once", "always", "deny", "abort", "save"),
+    // `[a]` maps to ReviewDecision::ApprovedForSession (stored only in the
+    // in-memory session approval set), so the label must say "session", not
+    // "always". Persisting an approval across sessions is the separate `[s]`
+    // save-rule action (#3766).
+    let (once, session, deny, abort, save) = match locale {
+        Locale::ZhHans => ("仅本次", "本会话", "拒绝", "中止", "保存"),
+        _ => ("once", "session", "deny", "abort", "save"),
     };
     lines.push(Line::from(vec![
         Span::raw("  "),
@@ -1767,7 +1771,7 @@ fn push_compact_approval_controls(
         Span::styled(format!("{once}  "), Style::default().fg(palette::TEXT_BODY)),
         Span::styled("[a] ", Style::default().fg(shortcut).bold()),
         Span::styled(
-            format!("{always}  "),
+            format!("{session}  "),
             Style::default().fg(palette::TEXT_BODY),
         ),
         Span::styled("[d] ", Style::default().fg(accent).bold()),
@@ -4925,6 +4929,43 @@ mod tests {
         assert!(
             rendered.contains('\u{2500}'),
             "approve and deny groups should be split by a divider:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn approval_option_two_reads_as_session_scoped_not_always() {
+        // #3766: option 2 / `a` maps to ReviewDecision::ApprovedForSession, so
+        // neither the full option rows nor the compact controls may tell the
+        // user the approval is "always"/permanent. Persisting is the separate
+        // `s` save-rule action.
+        let request = crate::tui::approval::ApprovalRequest::new(
+            "approval-1",
+            "exec_shell",
+            "Run git commit",
+            &serde_json::json!({ "command": "git commit -m fix" }),
+            "exec_shell:git commit",
+        );
+
+        // Full card (tall): full option rows render the session-scoped label.
+        let full = render_approval_request(&request, Rect::new(0, 0, 100, 30));
+        assert!(
+            full.to_lowercase().contains("this session"),
+            "full approval option must state session scope:\n{full}"
+        );
+        assert!(
+            !full.to_lowercase().contains("always"),
+            "full approval card must not call the session option 'always':\n{full}"
+        );
+
+        // Compact card (short): `[a]` control label must say session, not always.
+        let compact = render_approval_request(&request, Rect::new(0, 0, 60, 17));
+        assert!(
+            compact.contains("[a]") && compact.to_lowercase().contains("session"),
+            "compact controls must label [a] as session-scoped:\n{compact}"
+        );
+        assert!(
+            !compact.to_lowercase().contains("always"),
+            "compact controls must not label the session option 'always':\n{compact}"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #3766. Approval option 2 / `a` maps to `ReviewDecision::ApprovedForSession` (stored only in the in-memory `app.approval_session_approved` set), but the UI said **"always" / "Approve always for this kind"** — implying permanence. The actual cross-session persistence path is the separate `[s]` save-rule action. This corrects the copy so the trust boundary is honest.

## Changes

- **Compact controls** (`crates/tui/src/tui/widgets/mod.rs`): `[a]` now renders `session` (en) / `本会话` (zh-Hans) instead of `always` / `始终`.
- **Full option label** (`ApprovalOptionApproveAlways`): now session-scoped in `en`, `es-419`, `ja`, `pt-BR`, `vi`. `zh-Hans` / `zh-Hant` already said `本会话` / `本會話` and are unchanged.
- Keyboard hints (`a`, option 2) unchanged.
- **Regression test** `approval_option_two_reads_as_session_scoped_not_always` asserts both full and compact paths say "session" and never "always".

## Validation

- `cargo test -p codewhale-tui --bin codewhale-tui approval` → 167 passed (incl. `benign_a_two_approves_for_session` and the new test).

## Acceptance criteria
- [x] Compact controls no longer render "always" for the session option
- [x] Full option text no longer renders "Approve always"
- [x] Label clearly communicates current-session scope
- [x] Approval stays session-scoped (no accidental persistence)
- [x] `benign_a_two_approves_for_session` still passes
- [x] Added a copy regression test