### PR TITLE
fix(web): fail check-docs on stale install snippets (#3770)

### DIFF
--- a/web/scripts/check-docs.mjs
+++ b/web/scripts/check-docs.mjs
@@ -143,9 +143,11 @@ function main() {
     for (const s of install.stale) {
       console.error(`  found "${s.found}", expected "${s.expected}" in: ${s.context}`);
     }
-  } else {
-    console.log(`[check-docs] OK — install snippets${install.note ? ` (${install.note})` : ""}`);
+    // #3770: a stale install snippet must fail the gate, not fall through to
+    // the final PASS. Mirror the exit(1) used by checks 1 and 2 above.
+    process.exit(1);
   }
+  console.log(`[check-docs] OK — install snippets${install.note ? ` (${install.note})` : ""}`);
 
   console.log("[check-docs] PASS");
 }


### PR DESCRIPTION
## Summary
Closes #3770. `web/scripts/check-docs.mjs` printed `FAIL` for stale install snippets but then fell through to `[check-docs] PASS` without exiting non-zero, so CI could miss public install-copy drift.

## Change
The stale-snippet branch now calls `process.exit(1)` (mirroring checks 1 & 2), and the final `PASS` is only printed when every check passes.

## Validation
- `cd web && node scripts/check-docs.mjs` on a fresh tree → `[check-docs] PASS`, exit 0.
- Stale snippets now take the `exit(1)` path before any PASS line.

## Acceptance criteria
- [x] Exits status 1 when `checkInstallSnippets()` returns stale entries
- [x] Final `PASS` printed only if every check passed
- [x] Clean `npm run check:docs` still passes