### PR TITLE
ci(web): check facts drift before regenerating tracked facts (#3771)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -32,16 +32,19 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install dependencies
         run: npm ci
-      - name: Generate derived facts
-        # facts.generated.ts is gitignored and produced by derive-facts.mjs;
-        # tsc --noEmit fails without it (TS2307) and downstream inferences
-        # cascade into spurious TS7006 errors, so regenerate before type check.
-        run: npm run prebuild
       - name: Check facts drift
-        # Fails CI when facts.generated.ts is stale (version, providers, etc.
-        # differ from the workspace sources). Catches mechanical drift before
-        # deploy so the website never serves wrong version/provider data.
+        # facts.generated.ts is TRACKED (committed), so verify the committed
+        # copy matches the workspace BEFORE regenerating. Running prebuild first
+        # would self-heal the working tree and let a stale committed file pass
+        # (#3771). check:facts ignores the volatile generatedAt/latestRelease
+        # fields by design, so it is safe to run against the committed copy that
+        # exists at checkout.
         run: npm run check:facts
+      - name: Generate derived facts
+        # Regenerate after the drift gate so tsc --noEmit (TS2307 without it) and
+        # the build use a current facts.generated.ts. When the gate passes this
+        # only refreshes the generatedAt timestamp.
+        run: npm run prebuild
       - name: Check docs parity
         # Fails CI when docs-map.ts references non-existent repo files or
         # when website version / command snippets are stale.


### PR DESCRIPTION
## Summary
Closes #3771. `web/lib/facts.generated.ts` is **tracked**, but `.github/workflows/web.yml` ran `npm run prebuild` (regenerate) *before* `npm run check:facts`, so CI regenerated the file and then compared it against itself — a stale committed file could pass.

## Change
Reordered: **`check:facts` now runs before `prebuild`**. The committed file exists at checkout and `check:facts` ignores the volatile `generatedAt`/`latestRelease` fields, so it compares the committed copy against the workspace and fails on stale. `prebuild` still runs afterward for tsc/build. The misleading "gitignored" comment is corrected to "tracked".

> Note: a `git diff --exit-code` approach would false-positive because `generatedAt` always changes; running `check:facts` first is the correct fix.

## Acceptance criteria
- [x] Web CI fails when committed facts are stale
- [x] `check:facts` runs before `prebuild`
- [x] Workflow no longer claims the tracked file is gitignored
- [x] `cd web && npm run check:facts` still passes when committed facts match