### PR TITLE
fix(release): stop sync-changelog dropping a release for Unreleased (#3768)

### DIFF
--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -1600,6 +1600,102 @@ Thanks to **@xyuai** (#2587), **@IcedOranges** (#2584), **@BH8GCJ** (#2588),
 **@gordonlu**, **@encyc**, and **@simuusang** (#2603, #2620) for reports,
 patches, retesting, and release-stabilization signals that shaped this pass.
 
+## [0.8.51] - 2026-06-02
+
+### Added
+
+- **Arcee AI as a direct provider.** New `[providers.arcee]` config block and
+  `ARCEE_API_KEY` / `ARCEE_BASE_URL` / `ARCEE_MODEL` environment variables,
+  wired through CLI auth (`codewhale auth set --provider arcee`), the TUI
+  provider picker, and the model registry. The default direct-API model is
+  `trinity-large-thinking` (reasoning-capable, 262K context and 262K max
+  output); `trinity-large-preview` (262K context, non-reasoning) and
+  `trinity-mini` (128K context) are also selectable. OpenRouter's
+  `arcee-ai/trinity-large-thinking` route remains separate.
+- **Arcee Cloudflare-WAF compatibility.** The opening turn to the Arcee gateway
+  uses a benign read-only tool surface (`read_file`, `list_dir`, `file_search`,
+  `grep_files`, `git_status`, `git_diff`, `checklist_write`, `update_plan`) and
+  splits example payloads such as `python -c …` out of the system prompt, so the
+  WAF does not reject the first request; the full tool catalog stays reachable
+  through tool-search. `trinity-large-thinking`'s `reasoning_content` is
+  recognized and replayed on tool-call turns.
+- **Expanded model catalog.** Added context-window, max-output, and
+  reasoning-capability metadata for additional model IDs, including
+  `qwen/qwen3.6-flash`, `qwen/qwen3.6-plus`, `qwen/qwen3.6-max-preview`, and
+  Xiaomi MiMo v2.5 chat/ASR/TTS variants; `trinity-large-preview`'s context
+  window was corrected to 262K.
+- **Provider-aware model picker.** The picker groups models by provider, shows
+  per-model hints, and remembers a saved model per provider.
+
+### Changed
+
+- **Auto-compaction is now percentage- and model-aware.** The per-model
+  threshold helper is `compaction_threshold_for_model_at_percent(model,
+  percent)` (replacing the effort-based variant), and the default
+  `auto_compact_threshold_percent` is 80%. Auto-compaction defaults on for
+  models with a context window of 256K or smaller and stays opt-in for 1M-token
+  models (e.g. DeepSeek V4) to protect prefix-cache economics, unless the user
+  has explicitly set `auto_compact`.
+- **Clearer provider/gateway errors.** HTTP error bodies are sanitized before
+  display — HTML interstitials and Cloudflare "Access Denied" pages collapse to
+  a one-line reason (with the ray/error ID) instead of dumping raw markup into
+  the transcript — and 403s are split into authentication vs. authorization
+  (gateway/WAF block) categories.
+- The invalid-model error now names the active provider and lists Arcee among
+  the options.
+
+### Removed
+
+- **The session "cycle" / checkpoint-restart system.** Removed the `/cycles`,
+  `/cycle <n>`, and `/recall` commands, the `recall_archive` tool, the
+  cycle-handoff briefing prompt, the sidebar "cycles" lines, and the
+  `cycle_manager` engine plumbing (`EngineConfig.cycle`, `Event::CycleAdvanced`,
+  seam-manager cycle thresholds and flash briefings). Long sessions no longer
+  auto-reset their context at a fixed token boundary — reclaim budget with
+  `/compact` or model-aware auto-compaction instead. Existing on-disk cycle
+  archives are left untouched but are no longer read or written.
+
+### Fixed
+
+- Assistant turns no longer leave an orphaned role glyph (the stray "blue dot")
+  when a turn streams only whitespace between reasoning and a tool call.
+- Scrolling the mouse wheel over the right-hand sidebar no longer leaks into the
+  transcript scroll.
+- The sidebar hover tooltip now appears only for truncated lines, sits below the
+  cursor, and uses a neutral surface color instead of the warning-orange
+  highlight that overlapped neighbouring rows.
+- Corrected the README's description of the Constitution (Article VII is the
+  hierarchy itself; Article II's truth duty overrides even a user request) to
+  match `prompts/base.md`.
+- Repaired release-blocking unit and integration tests left failing by the
+  cycle-removal and compaction-threshold refactors (relay instruction,
+  model-reject message, compaction budget, mock-LLM threshold helper).
+- Fixed DEC private-mode CSI fragment leakage into composer text after
+  terminal resets, restoring clean prompt editing (#2592).
+- The engine now recovers from turn-level panics instead of killing the
+  main event loop, keeping the session alive through transient failures
+  (#2583, #1269).
+- Deeply nested files are now discoverable via @-mention and Ctrl+P file
+  picker; the default walk depth was relaxed to handle monorepo layouts (#2488).
+- Command-palette selection stays visible when scrolling through long lists
+  instead of scrolling off-screen (#2590).
+- exec_shell child processes now inherit .NET/NuGet and Windows app-data
+  environment variables, fixing toolchain resolution on Windows (#1857).
+- A warning is emitted when shell/sandbox config keys are nested under
+  unknown top-level sections instead of being silently ignored (#2589).
+- Diff-render now preserves leading whitespace in patch content lines,
+  fixing an extra-space regression in PR previews (#2591). Thanks @zlh124.
+- Model selection from the /model command now persists per-provider across
+  restarts, with a warning when persistence fails.
+
+### Community
+
+Thanks to **@zlh124** (#2591) and **@reidliu41** (#2601) for the fixes
+harvested into this release. Thanks also to **@idling11** (#2602),
+**@gordonlu** (#2585), **@cyq1017** (#2593), **@xyuai** (#2587, #2584),
+and **@IcedOranges** (#2584) for reports, drafts, and investigations
+that shaped this release cycle.
+
 ---
 
 Older releases: [CHANGELOG.md](https://github.com/Hmbown/CodeWhale/blob/main/CHANGELOG.md) and [docs/CHANGELOG_ARCHIVE.md](https://github.com/Hmbown/CodeWhale/blob/main/docs/CHANGELOG_ARCHIVE.md).

--- a/scripts/sync-changelog.sh
+++ b/scripts/sync-changelog.sh
@@ -3,10 +3,16 @@
 # The /change command embeds this file into the binary via include_str!, so
 # it deliberately keeps only the most recent release sections.
 #
+# The `## [Unreleased]` section is always kept but does NOT count toward the
+# keep window: it is not a release, and counting it silently dropped the
+# oldest retained release whenever Unreleased had content (#3768). The window
+# therefore tracks a stable number of *released* versions regardless of
+# in-progress notes.
+#
 # Usage: scripts/sync-changelog.sh [--check] [sections-to-keep]
 #   --check  verify crates/tui/CHANGELOG.md is up to date without writing
 #            (exit 1 if regeneration would change it)
-#   sections-to-keep defaults to 15
+#   sections-to-keep defaults to 15 (released versions, excluding Unreleased)
 set -eu
 CHECK=0
 if [ "${1:-}" = "--check" ]; then
@@ -19,7 +25,9 @@ tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 awk -v keep="$KEEP" '
   /^\[/ && /\]: http/ { exit }
-  /^## \[/ { count++ }
+  # Count only released versions toward the keep window; the Unreleased
+  # section is always printed but never consumes a slot (#3768).
+  /^## \[/ && $0 !~ /\[Unreleased\]/ { count++ }
   count > keep { exit }
   { print }
 ' "$root/CHANGELOG.md" > "$tmp"


### PR DESCRIPTION
## Summary
Closes #3768. `scripts/sync-changelog.sh` keeps a rolling window of the most recent `KEEP=15` `## [` sections in the binary-embedded `crates/tui/CHANGELOG.md`, but it counted `## [Unreleased]` as a section. So whenever Unreleased had content, the window dropped the oldest *released* version — adding `## [0.8.66]` on the candidate is what silently deleted `## [0.8.52]`.

## Fix
The awk now counts only released versions toward the keep window; `## [Unreleased]` is always printed but never consumes a slot. The window tracks a stable number of releases regardless of in-progress notes.

## Effect
- On `main`: the embedded changelog regains the previously-dropped **0.8.51** (the deterministic output of the corrected generator — see the +96 lines in `crates/tui/CHANGELOG.md`).
- On the release branch (with `0.8.66` added): **0.8.52 is retained** instead of being silently deleted — which is the concrete bug #3768 reported.

## Validation
- `sh scripts/sync-changelog.sh --check` → up to date.
- `check-versions.sh` (which calls `sync-changelog.sh --check`) stays consistent because it uses the same script.

## Acceptance criteria
- [x] Historical sections aren't silently dropped when an entry is added
- [x] The 0.8.66 entry won't delete unrelated release notes
- [x] The deletion source (`sync-changelog.sh`) is fixed/guarded
- [x] `git diff` shows only intentional changelog changes
- [x] `check-versions.sh` still passes