### PR TITLE
fix(release): guard public install/version snippets (#3767)

### DIFF
--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -177,6 +177,30 @@ for readme in README.md README.zh-CN.md README.ja-JP.md README.vi.md README.ko-K
   fi
 done
 
+# 9b) Public install/version snippets stay on the current release (#3767).
+# `codewhale --version   # X.Y.Z` verify-your-install lines across README
+# locales and docs/INSTALL.md, plus the docs/INSTALL.md npm-wrapper publish
+# pointer ("published at vX.Y.Z"). These drifted while this gate still passed
+# on a prior lane, so guard them explicitly. Narrowly scoped to those two
+# snippet shapes to avoid flagging unrelated prose.
+for doc in README.md README.zh-CN.md README.ja-JP.md README.vi.md README.ko-KR.md docs/INSTALL.md; do
+  [[ -f "${doc}" ]] || continue
+  stale_version_comments="$(grep -nE -- "codewhale --version[[:space:]]+#[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+" "${doc}" | grep -vE -- "#[[:space:]]*${workspace_version}([^0-9]|$)" || true)"
+  if [[ -n "${stale_version_comments}" ]]; then
+    echo "::error::${doc} has 'codewhale --version # X' snippet(s) not on ${workspace_version}:" >&2
+    echo "${stale_version_comments}" >&2
+    fail=1
+  fi
+done
+
+stale_wrapper_pointer="$(grep -nE -- "wrapper is published at" docs/INSTALL.md | grep -E -- "v[0-9]+\.[0-9]+\.[0-9]+" | grep -v -- "v${workspace_version}" || true)"
+# The publish pointer can wrap onto the next line; also scan the line after the lead-in.
+wrapper_pointer_version="$(grep -A1 -E -- "wrapper is published at" docs/INSTALL.md | grep -oE -- "v[0-9]+\.[0-9]+\.[0-9]+" | head -n1 || true)"
+if [[ -n "${wrapper_pointer_version}" && "${wrapper_pointer_version}" != "v${workspace_version}" ]]; then
+  echo "::error::docs/INSTALL.md npm-wrapper publish pointer is ${wrapper_pointer_version}, want v${workspace_version}." >&2
+  fail=1
+fi
+
 # 10) App-server is not a standalone binary.
 app_server_bins="$(
   cargo metadata --locked --format-version 1 --no-deps \

--- a/scripts/release/prepare-release.sh
+++ b/scripts/release/prepare-release.sh
@@ -79,6 +79,40 @@ bump(
 # 4) README install-tag examples (all translations).
 for readme in ["README.md", "README.zh-CN.md", "README.ja-JP.md", "README.vi.md", "README.ko-KR.md"]:
     bump(readme, rf"--tag v{old_re}\b", f"--tag v{new}", 1)
+
+# 5) Public install/version snippets in README*.md and docs/INSTALL.md.
+#    These are the user-facing "verify your install" lines and the npm wrapper
+#    publish pointer. They drifted on a prior lane while check-versions still
+#    passed (#3767, #3552), so bump and (in check-versions.sh) guard them.
+version_doc_files = [
+    "README.md",
+    "README.zh-CN.md",
+    "README.ja-JP.md",
+    "README.vi.md",
+    "README.ko-KR.md",
+    "docs/INSTALL.md",
+]
+version_comment_hits = 0
+for doc in version_doc_files:
+    p = pathlib.Path(doc)
+    text = p.read_text()
+    out, n = re.subn(
+        rf"(codewhale --version\s+#\s*){old_re}\b", rf"\g<1>{new}", text
+    )
+    if n:
+        p.write_text(out)
+        print(f"  {doc}: {n} version-comment replacement(s)")
+        version_comment_hits += n
+if version_comment_hits == 0:
+    sys.exit("error: no 'codewhale --version # X' snippets were bumped — wrong old version?")
+
+# docs/INSTALL.md npm-wrapper publish pointer ("published at vX.Y.Z").
+bump(
+    "docs/INSTALL.md",
+    rf"(wrapper is published at\s+)v{old_re}\b",
+    rf"\g<1>v{new}",
+    1,
+)
 PY
 
 echo "Refreshing Cargo.lock..."


### PR DESCRIPTION
## Summary
Closes #3767. `prepare-release.sh` / `check-versions.sh` only updated/guarded README `--tag vX.Y.Z` examples, so the user-facing `codewhale --version   # X.Y.Z` lines and the `docs/INSTALL.md` npm-wrapper publish pointer could drift while the gate stayed green (on the 0.8.66 candidate, INSTALL.md still said 0.8.65 while `check-versions.sh` passed).

## Changes
- **`prepare-release.sh`** now bumps `codewhale --version   # <version>` across `README*.md` + `docs/INSTALL.md`, and the `docs/INSTALL.md` "wrapper is published at vX.Y.Z" sentence. The `v0.8.56` minimum-wrapper floor is preserved.
- **`check-versions.sh`** now fails when any of those snippets drift from the workspace version. Narrowly scoped to those two snippet shapes to avoid flagging unrelated historical prose (e.g. "as of vX").

## Validation (on this branch @ main 0.8.65)
- `./scripts/release/check-versions.sh` → `Version state OK`, exit 0.
- Negative: drifting a README `--version` comment → `::error:: ... not on 0.8.65`, exit 1; reverted.
- `prepare-release.sh` bump regexes unit-checked for the next version (and preserve the v0.8.56 floor).

## Acceptance criteria
- [x] `prepare-release.sh` updates README + INSTALL.md `--version` comments
- [x] `prepare-release.sh` updates the INSTALL.md wrapper-published-at sentence
- [x] `check-versions.sh` fails when those snippets drift
- [x] Passes only after install docs align
- [x] Guard is scoped (no brittleness on unrelated prose)