### PR TITLE
docs(tui): clarify Hotbar help shortcuts

### DIFF
--- a/crates/tui/src/commands/groups/core/hotbar.rs
+++ b/crates/tui/src/commands/groups/core/hotbar.rs
@@ -26,7 +26,12 @@ impl RegisterCommand for HotbarCmd {
                 CommandResult::action(AppAction::OpenHotbarSetup)
             }
             Some("help" | "?") => CommandResult::message(
-                "Usage: /hotbar [setup]\n\n/hotbar opens the Hotbar setup wizard.",
+                "Usage: /hotbar [setup]\n\n\
+                 /hotbar opens the Hotbar setup wizard. Hotbar slots dispatch with \
+                 Alt+1 through Alt+8 when no modal, inline picker, or onboarding \
+                 surface owns input. Bare 1-8 insert text in the composer. \
+                 Cmd-number and F-keys are not Hotbar shortcuts unless a future \
+                 release documents and implements them.",
             ),
             Some(other) => CommandResult::error(format!(
                 "Unknown /hotbar target '{other}'. Use `/hotbar` or `/hotbar setup`."
@@ -88,19 +93,17 @@ mod tests {
     }
 
     #[test]
-    fn hotbar_help_arg_returns_usage() {
+    fn hotbar_help_arg_documents_supported_terminal_chord() {
         let mut app = test_app();
 
         let result = HotbarCmd::execute(&mut app, Some("help"));
 
         assert!(!result.is_error);
         assert!(result.action.is_none());
-        assert!(
-            result
-                .message
-                .as_deref()
-                .is_some_and(|message| message.contains("/hotbar opens"))
-        );
+        let message = result.message.as_deref().expect("help text");
+        assert!(message.contains("Alt+1 through Alt+8"));
+        assert!(message.contains("Bare 1-8 insert text"));
+        assert!(message.contains("Cmd-number and F-keys are not Hotbar shortcuts"));
     }
 
     #[test]

--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -436,6 +436,9 @@ impl HotbarSetupView {
             lines.push(Line::from(
                 "Tab/Shift+Tab source  Up/Down action  1-8 slot  Enter assign  Space toggle  Delete clear  s save  Esc cancel",
             ));
+            lines.push(Line::from(
+                "After save: Alt+1 through Alt+8 dispatch Hotbar slots. Bare 1-8 stay composer text outside setup.",
+            ));
         }
         lines
     }
@@ -709,6 +712,26 @@ mod tests {
                 .map(|binding| binding.action.as_str()),
             Some("slash.rename")
         );
+    }
+
+    #[test]
+    fn wizard_help_documents_runtime_hotbar_shortcut() {
+        let app = test_app();
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+
+        assert!(matches!(
+            view.handle_key(key(KeyCode::Char('?'))),
+            ViewAction::None
+        ));
+        let rendered = view
+            .render_lines()
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("After save: Alt+1 through Alt+8 dispatch Hotbar slots"));
+        assert!(rendered.contains("Bare 1-8 stay composer text outside setup"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Document the supported Hotbar terminal chord directly in `/hotbar help`.
- Add the same runtime shortcut caveat to the Hotbar setup wizard help copy.
- Clarify that only `Alt+1` through `Alt+8` dispatch Hotbar slots when no modal/inline picker/onboarding surface owns input, while bare `1-8` stays composer text.
- Add focused regression assertions so the command help and setup help keep these caveats.

## Scope

This is a small partial follow-up for the Hotbar activation lane. It does **not** complete the real terminal QA matrix across macOS Terminal.app, iTerm2, Ghostty, Kitty, or non-US keyboard layouts.

Refs #3758.
Refs #3731.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar_help_arg_documents_supported_terminal_chord -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked wizard_help_documents_runtime_hotbar_shortcut -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar -- --nocapture`

RED checks:

- With the strengthened `/hotbar help` test kept and the command help copy reverted to the prior one-line text, `hotbar_help_arg_documents_supported_terminal_chord` fails on the missing shortcut caveat.
- With the setup-help test added before the setup help copy change, `wizard_help_documents_runtime_hotbar_shortcut` fails on the missing runtime shortcut line.

The Docker test environment needed `pkg-config` and `libdbus-1-dev` for `libdbus-sys`.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes

Manual terminal QA is not claimed here; this only aligns command/setup help copy with the documented shortcut contract.
