### PR TITLE
fix(subagent): preserve event headroom for progress

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -83,6 +83,7 @@ const DEFAULT_MAX_STEPS: u32 = u32::MAX;
 /// floors remain the independent stall detectors.
 const DEFAULT_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
 const MIN_SUBAGENT_SPAWN_TOKEN_RESERVE: u64 = 1;
+const MIN_EVENT_CHANNEL_HEADROOM_FOR_ROUTINE_PROGRESS: usize = 32;
 
 /// Format a step counter for sub-agent progress messages.
 ///
@@ -6155,6 +6156,12 @@ fn emit_agent_progress(
     spawn_depth: u32,
 ) {
     if let Some(event_tx) = event_tx {
+        if event_tx.max_capacity() > MIN_EVENT_CHANNEL_HEADROOM_FOR_ROUTINE_PROGRESS
+            && event_tx.capacity() <= MIN_EVENT_CHANNEL_HEADROOM_FOR_ROUTINE_PROGRESS
+            && routine_agent_progress_can_preserve_event_headroom(&status)
+        {
+            return;
+        }
         let _ = event_tx.try_send(Event::AgentProgress {
             id: agent_id.to_string(),
             status,
@@ -6162,6 +6169,13 @@ fn emit_agent_progress(
             spawn_depth,
         });
     }
+}
+
+fn routine_agent_progress_can_preserve_event_headroom(status: &str) -> bool {
+    matches!(
+        worker_progress_event_parts(status).0,
+        AgentWorkerStatus::Running | AgentWorkerStatus::ModelWait | AgentWorkerStatus::RunningTool
+    )
 }
 
 // === Tool Registry Helpers ===

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -310,6 +310,71 @@ fn subagent_progress_displays_shell_tools_as_bash() {
 }
 
 #[test]
+fn agent_progress_preserves_event_channel_headroom_under_load() {
+    let (tx, mut rx) = mpsc::channel(40);
+    for _ in 0..8 {
+        tx.try_send(Event::status("filler")).expect("fill channel");
+    }
+    assert_eq!(tx.capacity(), 32);
+
+    emit_agent_progress(
+        Some(&tx),
+        "agent_busy",
+        "step 1: requesting model response".to_string(),
+        None,
+        1,
+    );
+    assert_eq!(
+        tx.capacity(),
+        32,
+        "routine progress should preserve reserved event-channel headroom"
+    );
+
+    emit_agent_progress(
+        Some(&tx),
+        "agent_waiting",
+        "waiting for user input".to_string(),
+        None,
+        1,
+    );
+    assert_eq!(
+        tx.capacity(),
+        31,
+        "high-value progress should still reach the UI when headroom is reserved"
+    );
+
+    for _ in 0..8 {
+        assert!(matches!(rx.try_recv(), Ok(Event::Status { .. })));
+    }
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(Event::AgentProgress { id, status, .. })
+            if id == "agent_waiting" && status == "waiting for user input"
+    ));
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn agent_progress_uses_small_event_channels_without_headroom_reservation() {
+    let (tx, mut rx) = mpsc::channel(8);
+
+    emit_agent_progress(
+        Some(&tx),
+        "agent_small_channel",
+        "step 1: requesting model response".to_string(),
+        None,
+        1,
+    );
+
+    assert_eq!(tx.capacity(), 7);
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(Event::AgentProgress { id, status, .. })
+            if id == "agent_small_channel" && status == "step 1: requesting model response"
+    ));
+}
+
+#[test]
 fn headless_worker_records_persist_with_subagent_state() {
     let tmp = tempdir().expect("tempdir");
     let state_path = tmp.path().join("subagents.v1.json");


### PR DESCRIPTION
## Summary
- keep routine sub-agent progress from consuming reserved UI event-channel headroom under load
- still deliver high-value progress such as waiting-for-user updates
- cover both reserved-headroom behavior and small-channel compatibility

## Verification
- cargo test -p codewhale-tui agent_progress_ --locked
- cargo check -p codewhale-tui --locked
- cargo fmt --all --check
- git diff --check