### PR TITLE
docs(shell): align CONFIGURATION/TOOL_SURFACE/error message with shell default (#3756 follow-up)

### DIFF
--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -72,7 +72,7 @@ const CORE_ACTION_TOOL_FALLBACKS: &[CoreActionToolFallback] = &[
     CoreActionToolFallback {
         name: "exec_shell",
         description: "Run shell commands in the workspace.",
-        unavailable_reason: "Not present in the current model-visible catalog. Shell requires Agent or Yolo mode with allow_shell = true and no command tool allow/deny gate blocking it.",
+        unavailable_reason: "Not present in the current model-visible catalog. Interactive Agent sessions expose shell by default unless allow_shell = false; noninteractive and durable profiles require allow_shell = true. Plan mode hides shell, and command tool allow/deny gates can also block it.",
     },
     CoreActionToolFallback {
         name: "write_file",
@@ -650,10 +650,11 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
 }
 
 fn shell_tool_allow_shell_hint() -> &'static str {
-    "Shell tools are disabled because top-level `allow_shell = false`; \
-     they require `allow_shell = true`. \
-     In Agent mode, run `/config allow_shell true` for this session or add `--save` \
-     for future sessions; the next turn will expose shell with approval gating"
+    "Shell tools are absent because this session or profile disabled shell access, \
+     commonly via top-level `allow_shell = false` or Plan mode. \
+     Interactive Agent mode exposes shell by default with approval gating unless disabled. \
+     Run `/config allow_shell true` for this session or add `--save` for future sessions; \
+     the next turn will expose shell again"
 }
 
 fn is_shell_tool_name(tool_name: &str) -> bool {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,7 +120,9 @@ but still require restarting the model client.
 
 ### User workspace entries
 
-For a shell opt-in that should live in the user's global config rather than in
+Interactive Agent sessions expose shell tools by default with approval gating
+unless you explicitly disable them. For a shell opt-in that should live in the
+user's global config for noninteractive or durable-task profiles rather than in
 the repository, add a workspace-scoped entry:
 
 ```toml
@@ -1061,7 +1063,12 @@ If you are upgrading from older releases:
   `eval`) default to `concise` unless config/env/CLI overrides it.
   Override per process with `CODEWHALE_VERBOSITY` or the legacy
   `DEEPSEEK_VERBOSITY` alias.
-- `allow_shell` (bool, optional): defaults to `false`; shell tools must be explicitly enabled.
+- `allow_shell` (bool, optional): in interactive TUI Agent sessions, omitting
+  this keeps shell tools available with approval prompts; setting it to `false`
+  hides shell tools. Headless, durable-task, and other noninteractive profiles
+  keep the conservative omitted-field default and require `allow_shell = true`
+  to expose shell. Plan mode always hides shell; YOLO enables shell and
+  auto-approval.
 - `approval_policy` (string, optional): `on-request`, `untrusted`, or `never`. Runtime `approval_mode` editing in `/config` also accepts `on-request` and `untrusted` aliases.
 - `sandbox_mode` (string, optional): `read-only`, `workspace-write`, `danger-full-access`, `external-sandbox`.
   Platform support is not identical. macOS uses Seatbelt for policy

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -41,9 +41,11 @@ chosen over the available shell equivalent. Companion to `crates/tui/src/prompts
 ### Shell
 
 Shell tools appear in the model-visible tool catalog only when shell access is
-enabled for the active session or profile. In Agent mode that usually means
-`allow_shell = true`; YOLO enables shell access automatically. Plan mode keeps
-shell execution off.
+enabled for the active session or profile. Interactive TUI Agent sessions expose
+shell by default with approval prompts unless top-level `allow_shell = false`
+hides it. Headless, durable-task, and other noninteractive profiles keep the
+conservative omitted-field default and require `allow_shell = true`. YOLO
+enables shell access automatically. Plan mode keeps shell execution off.
 
 | Tool | Niche |
 |---|---|


### PR DESCRIPTION
## Why
#3756 (merged) flipped interactive Agent shell to **on-by-default (approval-gated)** and updated `MODES.md`, but left three surfaces describing the **old opt-in** model. Post-merge `main` now has self-contradictory docs:
- `docs/CONFIGURATION.md` — still said shell must be explicitly enabled.
- `docs/TOOL_SURFACE.md` — still said Agent mode "usually means `allow_shell = true`".
- `crates/tui/src/core/engine/tool_catalog.rs` — the `exec_shell` unavailable-reason and `allow_shell` hint still said shell "requires `allow_shell = true`".

## Change
Docs + user-facing error message only — **no behavior change**. All three now state: interactive TUI Agent exposes shell by default with approval prompts unless `allow_shell = false`; headless/durable/noninteractive profiles keep the conservative default and require `allow_shell = true`; Plan hides shell; YOLO enables shell + auto-approval. Consistent with `MODES.md`.

## Validation
`cargo test -p codewhale-tui --bin codewhale-tui` — `missing_shell_tool_error_message_*` (2) and `tool_search_reports_known_core_action_tool...` (1) pass; the improved message keeps every asserted substring. (Deliberately did not touch the #3756-entangled approval tests.)

Completes the documentation for #3756.