### PR TITLE
feat(tui): make Hotbar introduced, configurable, and easy to disable

### DIFF
--- a/crates/tui/src/commands/groups/core/hotbar.rs
+++ b/crates/tui/src/commands/groups/core/hotbar.rs
@@ -25,11 +25,20 @@ impl RegisterCommand for HotbarCmd {
             None | Some("setup" | "edit" | "configure" | "config") => {
                 CommandResult::action(AppAction::OpenHotbarSetup)
             }
+            // Hide the Hotbar: persist `hotbar = []` and clear the live slots.
+            Some("off" | "disable" | "hide") => CommandResult::action(AppAction::DisableHotbar),
+            // Restore the default recommended slots (explicit reset).
+            Some("on" | "reset" | "defaults" | "default") => {
+                CommandResult::action(AppAction::RestoreHotbarDefaults)
+            }
             Some("help" | "?") => CommandResult::message(
-                "Usage: /hotbar [setup]\n\n/hotbar opens the Hotbar setup wizard.",
+                "Hotbar gives you Alt-1..Alt-8 shortcuts (Option key on macOS, Alt \
+                 elsewhere). Use `/hotbar` to customize, `/hotbar off` to hide it, \
+                 `/hotbar on` to restore the default slots.",
             ),
             Some(other) => CommandResult::error(format!(
-                "Unknown /hotbar target '{other}'. Use `/hotbar` or `/hotbar setup`."
+                "Unknown /hotbar target '{other}'. Try `/hotbar`, `/hotbar off`, \
+                 `/hotbar on`, or `/hotbar help`."
             )),
         }
     }
@@ -88,19 +97,56 @@ mod tests {
     }
 
     #[test]
-    fn hotbar_help_arg_returns_usage() {
+    fn hotbar_help_arg_explains_customize_and_disable() {
         let mut app = test_app();
 
         let result = HotbarCmd::execute(&mut app, Some("help"));
 
         assert!(!result.is_error);
         assert!(result.action.is_none());
+        let message = result
+            .message
+            .as_deref()
+            .expect("help should return a message");
         assert!(
-            result
-                .message
-                .as_deref()
-                .is_some_and(|message| message.contains("/hotbar opens"))
+            message.contains("/hotbar") && message.contains("customize"),
+            "help should point at /hotbar to customize: {message:?}"
         );
+        assert!(
+            message.contains("/hotbar off") && message.contains("/hotbar on"),
+            "help should mention both disable and restore paths: {message:?}"
+        );
+    }
+
+    #[test]
+    fn hotbar_off_and_disable_aliases_return_disable_action() {
+        for arg in ["off", "disable", "hide"] {
+            let mut app = test_app();
+            let result = HotbarCmd::execute(&mut app, Some(arg));
+            assert_eq!(
+                result.action,
+                Some(AppAction::DisableHotbar),
+                "`/hotbar {arg}` should disable the hotbar"
+            );
+            assert!(
+                result.message.is_none(),
+                "`/hotbar {arg}` should not also emit a message"
+            );
+        }
+    }
+
+    #[test]
+    fn hotbar_on_and_reset_aliases_return_restore_action() {
+        for arg in ["on", "reset", "defaults", "default"] {
+            let mut app = test_app();
+            let result = HotbarCmd::execute(&mut app, Some(arg));
+            assert_eq!(
+                result.action,
+                Some(AppAction::RestoreHotbarDefaults),
+                "`/hotbar {arg}` should restore default hotbar slots"
+            );
+            assert!(result.message.is_none());
+        }
     }
 
     #[test]

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -381,6 +381,41 @@ pub(crate) fn persist_hotbar_bindings(
     Ok(path)
 }
 
+/// Remove the `hotbar` key from the resolved config so the resolver falls back
+/// to the built-in default slots (`/hotbar on` / `/hotbar reset`). Unlike
+/// `persist_hotbar_bindings(&[])` — which writes an explicit `hotbar = []` and
+/// therefore *disables* the hotbar — this deletes the key entirely, restoring
+/// defaults. If the file or key is absent there is nothing to restore; we still
+/// return the resolved path. Surrounding keys are preserved via `toml_edit`;
+/// a comment used as the removed key's own leading decor is removed with it
+/// (standard `toml_edit` key-prefix behavior).
+pub(crate) fn remove_hotbar_from_config(config_path: Option<&Path>) -> anyhow::Result<PathBuf> {
+    use anyhow::Context;
+    use std::fs;
+
+    let path = config_toml_path(config_path)?;
+    if !path.exists() {
+        // No config file ⇒ no `hotbar` key ⇒ defaults already apply.
+        return Ok(path);
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read config at {}", path.display()))?;
+    if raw.trim().is_empty() {
+        return Ok(path);
+    }
+    let mut document = raw
+        .parse::<toml_edit::DocumentMut>()
+        .with_context(|| format!("failed to edit config at {}", path.display()))?;
+    let table = document.as_table_mut();
+    if table.remove("hotbar").is_none() {
+        // Key wasn't present ⇒ defaults already apply; avoid a needless rewrite.
+        return Ok(path);
+    }
+    fs::write(&path, document.to_string())
+        .with_context(|| format!("failed to write config at {}", path.display()))?;
+    Ok(path)
+}
+
 pub(crate) fn config_toml_path(config_path: Option<&Path>) -> anyhow::Result<PathBuf> {
     use anyhow::Context;
 
@@ -760,5 +795,66 @@ enabled = true
         let parsed: codewhale_config::ConfigToml =
             toml::from_str(&body).expect("written hotbar config should parse");
         assert_eq!(parsed.hotbar, Some(Vec::new()));
+    }
+
+    #[test]
+    fn remove_hotbar_from_config_deletes_key_to_restore_defaults() {
+        let temp_root = temp_root("codewhale-hotbar-remove");
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        let path = temp_root.join(".codewhale").join("config.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Seed a config with a hotbar binding and an unrelated key whose own
+        // trailing comment is NOT the hotbar key's decor (so it must survive).
+        fs::write(
+            &path,
+            "hotbar = [{ slot = 1, action = \"mode.plan\" }]\nother = true  # keep me\n",
+        )
+        .unwrap();
+
+        let returned = remove_hotbar_from_config(Some(&path)).expect("remove should succeed");
+        assert_eq!(returned, path);
+
+        let body = fs::read_to_string(&path).expect("written file should be readable");
+        assert!(
+            !body.contains("hotbar"),
+            "hotbar key should be gone: {body}"
+        );
+        // An unrelated key and its own trailing comment must survive the rewrite.
+        assert!(
+            body.contains("other = true"),
+            "unrelated key should survive: {body}"
+        );
+        assert!(
+            body.contains("keep me"),
+            "comment that is not the hotbar key's decor should survive: {body}"
+        );
+
+        let parsed: codewhale_config::ConfigToml =
+            toml::from_str(&body).expect("restored config should parse");
+        assert_eq!(
+            parsed.hotbar, None,
+            "removing the key reads back as None so the resolver falls back to defaults"
+        );
+    }
+
+    #[test]
+    fn remove_hotbar_from_config_is_a_noop_when_key_absent() {
+        let temp_root = temp_root("codewhale-hotbar-remove-absent");
+        fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        let path = temp_root.join(".codewhale").join("config.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "other = true\n").unwrap();
+
+        let before = fs::read_to_string(&path).unwrap();
+        remove_hotbar_from_config(Some(&path)).expect("noop should succeed");
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "an absent hotbar key should not trigger a rewrite"
+        );
     }
 }

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -350,6 +350,10 @@ pub struct Settings {
     /// point to large directory trees (e.g. `/usr`, home directories) can
     /// significantly increase first-turn latency and memory usage.
     pub workspace_follow_symlinks: bool,
+    /// One-time Fleet + Hotbar introduction has been shown. Drives a single
+    /// launch nudge (see `App::maybe_show_feature_intro`) so returning users
+    /// see it exactly once and never on subsequent launches.
+    pub feature_intro_shown: bool,
 }
 
 impl Default for Settings {
@@ -394,6 +398,7 @@ impl Default for Settings {
             synchronized_output: "auto".to_string(),
             prefer_external_pdftotext: false,
             workspace_follow_symlinks: false,
+            feature_intro_shown: false,
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2874,6 +2874,41 @@ impl App {
             self.status_message = Some(format!("Failed to mark onboarding: {err}"));
         }
         self.needs_redraw = true;
+        self.maybe_show_feature_intro();
+    }
+
+    /// Show the one-time Fleet + Hotbar introduction nudge. Idempotent and
+    /// gated by a persisted `Settings::feature_intro_shown` flag, so it appears
+    /// exactly once per install: at the end of first-run onboarding (called from
+    /// [`Self::finish_onboarding`]) and on the next launch for returning users
+    /// who haven't seen it (called from `run_tui` after `App::new`). Plain copy,
+    /// no marketing language. Stays silent while onboarding is still in progress.
+    pub fn maybe_show_feature_intro(&mut self) {
+        if self.onboarding != OnboardingState::None {
+            return;
+        }
+        let mut settings = Settings::load().unwrap_or_default();
+        if settings.feature_intro_shown {
+            return;
+        }
+        settings.feature_intro_shown = true;
+        if let Err(err) = settings.save() {
+            self.status_message = Some(format!("Failed to save feature-intro flag: {err}"));
+            // Still show the nudge; the flag write may simply retry next launch.
+        }
+        self.add_message(HistoryCell::System {
+            content: Self::feature_intro_content(),
+        });
+        self.needs_redraw = true;
+    }
+
+    /// The one-time Fleet + Hotbar introduction copy. Plain language, no
+    /// marketing. Pure so it can be unit-tested without touching disk or env.
+    pub(crate) fn feature_intro_content() -> String {
+        let alt = crate::tui::widgets::key_hint::alt_prefix();
+        format!(
+            "A couple of things you can set up any time:\n\n• Hotbar — {alt}1-8 shortcuts for common actions. Run `/hotbar` to customize, or `/hotbar off` to hide it.\n• Fleet — a durable team of sub-agents for parallel work. Run `/fleet setup` to configure a loadout.\n\nThis tip won't show again."
+        )
     }
 
     /// Apply a locale tag selected from the onboarding language picker (#566).
@@ -5877,6 +5912,11 @@ pub enum AppAction {
     OpenFleetSetup,
     /// Open the `/hotbar` setup wizard.
     OpenHotbarSetup,
+    /// Disable the Hotbar: persist `hotbar = []` and clear the live slots.
+    DisableHotbar,
+    /// Restore the default recommended Hotbar slots: remove the `hotbar` key so
+    /// the resolver falls back to the built-in defaults.
+    RestoreHotbarDefaults,
     /// Open an external URL in the system browser.
     OpenExternalUrl {
         url: String,

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::config::{ApiProvider, Config, ProviderConfig, ProvidersConfig};
+use crate::settings::Settings;
 use crate::test_support::{EnvVarGuard, lock_test_env};
 use crate::tools::plan::{PlanItemArg, StepStatus, UpdatePlanArgs};
 use crate::tools::todo::TodoStatus;
 use crate::tui::clipboard::PastedImage;
-use crate::tui::history::{GenericToolCell, ToolCell, ToolStatus};
+use crate::tui::history::{GenericToolCell, HistoryCell, ToolCell, ToolStatus};
 
 fn test_options(yolo: bool) -> TuiOptions {
     TuiOptions {
@@ -40,6 +41,80 @@ fn create_dir_symlink(target: &std::path::Path, link: &std::path::Path) -> std::
 #[cfg(windows)]
 fn create_dir_symlink(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
     std::os::windows::fs::symlink_dir(target, link)
+}
+
+#[test]
+fn feature_intro_content_mentions_features_and_disable_paths() {
+    let content = App::feature_intro_content();
+    assert!(content.contains("Hotbar"));
+    assert!(content.contains("/hotbar") && content.contains("/hotbar off"));
+    assert!(content.contains("Fleet") && content.contains("/fleet setup"));
+}
+
+#[test]
+fn feature_intro_is_silent_while_onboarding_is_in_progress() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.onboarding = OnboardingState::Welcome;
+    let before = app.history.len();
+    app.maybe_show_feature_intro();
+    assert_eq!(
+        app.history.len(),
+        before,
+        "must not nudge while onboarding is in progress"
+    );
+}
+
+#[test]
+fn feature_intro_shows_once_persists_then_is_idempotent() {
+    let _env_lock = lock_test_env();
+    let tmp = std::env::temp_dir().join(format!("cw-feature-intro-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+    let config_path = tmp.join("config.toml");
+    let _env = EnvVarGuard::set(
+        "DEEPSEEK_CONFIG_PATH",
+        config_path.to_string_lossy().as_ref(),
+    );
+    let _ = std::fs::remove_file(tmp.join("settings.toml"));
+
+    let mut app = App::new(test_options(false), &Config::default());
+    app.onboarding = OnboardingState::None;
+    let before = app.history.len();
+
+    app.maybe_show_feature_intro();
+    assert_eq!(
+        app.history.len(),
+        before + 1,
+        "intro should be added on the first call"
+    );
+    let content = match app.history.last() {
+        Some(HistoryCell::System { content }) => content.clone(),
+        other => panic!("expected a System intro cell, got {other:?}"),
+    };
+    assert!(
+        content.contains("Hotbar") && content.contains("/hotbar off"),
+        "intro should explain Hotbar + the disable path: {content:?}"
+    );
+    assert!(
+        content.contains("Fleet") && content.contains("/fleet setup"),
+        "intro should explain Fleet setup: {content:?}"
+    );
+
+    // Persisted flag now set → a second call is a no-op.
+    assert!(
+        Settings::load()
+            .expect("settings should load")
+            .feature_intro_shown,
+        "feature_intro_shown should be persisted"
+    );
+    app.maybe_show_feature_intro();
+    assert_eq!(
+        app.history.len(),
+        before + 1,
+        "intro must not repeat once the flag is persisted"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
 }
 
 #[test]

--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -354,6 +354,19 @@ impl HotbarSetupView {
 
     fn render_lines(&self) -> Vec<Line<'static>> {
         let mut lines = Vec::new();
+        // Plain intro: what Hotbar is + how to hide it, with the platform-correct
+        // modifier glyph (⌥ on macOS, alt+ elsewhere).
+        let alt_prefix = crate::tui::widgets::key_hint::alt_prefix();
+        lines.push(Line::from(Span::styled(
+            format!(
+                "Hotbar gives you {alt_prefix}1-8 shortcuts. Assign actions below; \
+                 press 'd' or run `/hotbar off` to hide it."
+            ),
+            Style::default()
+                .fg(palette::TEXT_PRIMARY)
+                .add_modifier(Modifier::DIM),
+        )));
+        lines.push(Line::from(""));
         let tabs = self
             .sources
             .iter()
@@ -434,7 +447,7 @@ impl HotbarSetupView {
         lines.push(Line::from(self.status_text()));
         if self.help_visible {
             lines.push(Line::from(
-                "Tab/Shift+Tab source  Up/Down action  1-8 slot  Enter assign  Space toggle  Delete clear  s save  Esc cancel",
+                "Tab/Shift+Tab source  Up/Down action  1-8 slot  Enter assign  Space toggle  Delete clear  s save  d disable  Esc cancel",
             ));
         }
         lines
@@ -503,6 +516,11 @@ impl ModalView for HotbarSetupView {
             }
             KeyCode::Char('s') | KeyCode::Char('S') if key.modifiers.is_empty() => {
                 self.save_action()
+            }
+            KeyCode::Char('d') | KeyCode::Char('D') if key.modifiers.is_empty() => {
+                // "Disable Hotbar" from inside the setup flow: hide it and
+                // persist `hotbar = []`. Mirrors `/hotbar off`.
+                ViewAction::EmitAndClose(ViewEvent::HotbarDisableRequested)
             }
             KeyCode::Char('?') => {
                 self.help_visible = !self.help_visible;
@@ -666,6 +684,39 @@ mod tests {
             view.handle_key(key(KeyCode::Esc)),
             ViewAction::Close
         ));
+    }
+
+    #[test]
+    fn wizard_disable_key_emits_disable_request_and_intro_mentions_it() {
+        let app = test_app();
+
+        // 'd' and 'D' hide the Hotbar from inside the setup flow (mirrors /hotbar off).
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+        assert!(matches!(
+            view.handle_key(key(KeyCode::Char('d'))),
+            ViewAction::EmitAndClose(ViewEvent::HotbarDisableRequested)
+        ));
+        let mut view = HotbarSetupView::new(&app, &Config::default());
+        assert!(matches!(
+            view.handle_key(key(KeyCode::Char('D'))),
+            ViewAction::EmitAndClose(ViewEvent::HotbarDisableRequested)
+        ));
+
+        // The always-visible intro explains what Hotbar is and the disable path.
+        let joined: String = view
+            .render_lines()
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            joined.contains("shortcuts"),
+            "intro should explain what Hotbar is: {joined:?}"
+        );
+        assert!(
+            joined.contains("/hotbar off"),
+            "intro should mention the disable path: {joined:?}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -66,7 +66,7 @@ pub fn render_sidebar(f: &mut Frame, area: Rect, app: &mut App, config: &Config)
         return;
     }
 
-    let (main_area, hotbar_area) = split_sidebar_hotbar_area(area);
+    let (main_area, hotbar_area) = split_sidebar_hotbar_area(area, !is_hotbar_disabled(config));
     match app.sidebar_focus {
         SidebarFocus::Auto => render_sidebar_auto(f, main_area, app),
         SidebarFocus::Pinned => render_sidebar_pinned(f, main_area, app),
@@ -80,8 +80,10 @@ pub fn render_sidebar(f: &mut Frame, area: Rect, app: &mut App, config: &Config)
     }
 }
 
-fn split_sidebar_hotbar_area(area: Rect) -> (Rect, Option<Rect>) {
-    if area.height < HOTBAR_PANEL_HEIGHT.saturating_add(3) {
+fn split_sidebar_hotbar_area(area: Rect, show_hotbar: bool) -> (Rect, Option<Rect>) {
+    // Hide the Hotbar entirely when the user disabled it (`hotbar = []`) or when
+    // the sidebar is too short to fit it; give the main panel the full area.
+    if !show_hotbar || area.height < HOTBAR_PANEL_HEIGHT.saturating_add(3) {
         return (area, None);
     }
 
@@ -90,6 +92,14 @@ fn split_sidebar_hotbar_area(area: Rect) -> (Rect, Option<Rect>) {
         .constraints([Constraint::Min(3), Constraint::Length(HOTBAR_PANEL_HEIGHT)])
         .split(area);
     (sections[0], Some(sections[1]))
+}
+
+/// The Hotbar is "disabled" only when the user persisted an explicit empty
+/// `hotbar = []`. A missing `hotbar` key (`None`) means "use built-in defaults",
+/// so it is *not* disabled. This keeps `/hotbar on` (remove key → defaults) and
+/// `/hotbar off` (empty array → hidden) distinct.
+fn is_hotbar_disabled(config: &Config) -> bool {
+    config.hotbar.as_deref().is_some_and(<[_]>::is_empty)
 }
 
 /// Build the Auto-mode panel stack. Empty panels collapse to zero height so
@@ -241,10 +251,14 @@ struct HotbarPanelSlot {
 fn render_hotbar_panel(f: &mut Frame, area: Rect, app: &mut App, config: &Config) {
     let slots = hotbar_panel_slots(app, config);
     let content_width = area.width.saturating_sub(4) as usize;
+    // Title carries the modifier hint (⌥ on macOS, alt+ elsewhere) so users can
+    // see *which* key to hold without it eating the tight 4-char slot cells —
+    // it renders at every sidebar width and costs no slot-row height.
+    let title = format!("Hotbar  {}1-8", super::widgets::key_hint::alt_prefix());
     render_sidebar_section(
         f,
         area,
-        "Hotbar",
+        &title,
         hotbar_panel_lines(&slots, content_width, &app.ui_theme),
         hotbar_panel_hover_texts(&slots),
         Vec::new(),
@@ -265,13 +279,16 @@ fn hotbar_panel_slots(app: &App, config: &Config) -> Vec<HotbarPanelSlot> {
         .map(|binding| (binding.slot, binding))
         .collect::<BTreeMap<_, _>>();
 
+    // Lead each hover tip with the platform-correct chord (⌥+1 / alt+1); keep
+    // the "Slot N" suffix so existing assertions and the "Slot" wording remain.
+    let alt_prefix = super::widgets::key_hint::alt_prefix();
     (1..=codewhale_config::HOTBAR_SLOT_COUNT)
         .map(|slot| {
             let Some(binding) = bindings.remove(&slot) else {
                 return HotbarPanelSlot {
                     slot,
                     label: "-".to_string(),
-                    full_text: format!("Slot {slot}: empty"),
+                    full_text: format!("{alt_prefix}{slot} · Slot {slot}: empty"),
                     state: HotbarSlotState::Empty,
                 };
             };
@@ -282,7 +299,10 @@ fn hotbar_panel_slots(app: &App, config: &Config) -> Vec<HotbarPanelSlot> {
                 return HotbarPanelSlot {
                     slot,
                     label,
-                    full_text: format!("Slot {slot}: unknown action {}", binding.action),
+                    full_text: format!(
+                        "{alt_prefix}{slot} · Slot {slot}: unknown action {}",
+                        binding.action
+                    ),
                     state: HotbarSlotState::Unknown,
                 };
             };
@@ -300,7 +320,7 @@ fn hotbar_panel_slots(app: &App, config: &Config) -> Vec<HotbarPanelSlot> {
                 slot,
                 label: label.clone(),
                 full_text: format!(
-                    "Slot {slot}: {label}{status} ({}: {})",
+                    "{alt_prefix}{slot} · Slot {slot}: {label}{status} ({}: {})",
                     action.category(),
                     action.id()
                 ),
@@ -3243,11 +3263,11 @@ mod tests {
         SidebarWorkChecklistItem, SidebarWorkStrategyStep, SidebarWorkSummary, ToolRowOrder,
         agent_row_hover_text, auto_sidebar_panels, background_task_spinner_prefix,
         context_panel_cost_line, editorial_tool_rows, hotbar_panel_hover_texts, hotbar_panel_lines,
-        hotbar_panel_slots, normalize_activity_text, render_sidebar, sidebar_agent_rows,
-        sidebar_hover_rows, sidebar_work_summary, sort_sidebar_agent_rows_as_tree,
-        subagent_panel_hover_texts, subagent_panel_lines, subagent_panel_rows,
-        task_panel_hover_texts, task_panel_lines, task_panel_rows, work_panel_empty_hint,
-        work_panel_hover_texts, work_panel_lines,
+        hotbar_panel_slots, is_hotbar_disabled, normalize_activity_text, render_sidebar,
+        sidebar_agent_rows, sidebar_hover_rows, sidebar_work_summary,
+        sort_sidebar_agent_rows_as_tree, subagent_panel_hover_texts, subagent_panel_lines,
+        subagent_panel_rows, task_panel_hover_texts, task_panel_lines, task_panel_rows,
+        work_panel_empty_hint, work_panel_hover_texts, work_panel_lines,
     };
     use crate::config::Config;
     use crate::palette;
@@ -3425,6 +3445,30 @@ mod tests {
         });
 
         assert_eq!(panels, vec![AutoSidebarPanel::Work]);
+    }
+
+    #[test]
+    fn is_hotbar_disabled_only_for_an_explicit_empty_array() {
+        // A missing `hotbar` key means "use defaults" — NOT disabled.
+        assert!(!is_hotbar_disabled(&Config::default()));
+
+        // An explicit `hotbar = []` is the disabled state.
+        let disabled = Config {
+            hotbar: Some(Vec::new()),
+            ..Config::default()
+        };
+        assert!(is_hotbar_disabled(&disabled));
+
+        // Real bindings are never disabled.
+        let active = Config {
+            hotbar: Some(vec![codewhale_config::HotbarBindingToml {
+                slot: 1,
+                action: "mode.plan".to_string(),
+                label: None,
+            }]),
+            ..Config::default()
+        };
+        assert!(!is_hotbar_disabled(&active));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -735,6 +735,13 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let mut app = App::new(options.clone(), config);
     sync_config_provider_from_app(config, &app);
 
+    // One-time Fleet + Hotbar intro for returning (non-resuming) users. First-
+    // time users see it when they finish onboarding. Gated by a persisted flag,
+    // so it shows exactly once and never inside a resumed session transcript.
+    if options.resume_session_id.is_none() {
+        app.maybe_show_feature_intro();
+    }
+
     // Load existing session if resuming.
     if let Some(ref session_id) = options.resume_session_id
         && let Ok(manager) = SessionManager::default_location()
@@ -7554,6 +7561,8 @@ async fn apply_command_result(
                         .push(crate::tui::hotbar::setup::HotbarSetupView::new(app, config));
                 }
             }
+            AppAction::DisableHotbar => disable_hotbar(app, config),
+            AppAction::RestoreHotbarDefaults => restore_hotbar_defaults(app, config),
             AppAction::OpenExternalUrl { url, label } => match open_external_url(&url) {
                 Ok(()) => {
                     app.status_message = Some(format!("Opened {label} in your browser"));
@@ -9035,6 +9044,51 @@ fn apply_hotbar_setup_saved(
     app.needs_redraw = true;
 }
 
+/// Hide the Hotbar: persist `hotbar = []` (the canonical "disabled" state) and
+/// clear the live in-memory slots so the panel disappears immediately. The
+/// explicit empty array — not a missing key — is what disables defaults, so we
+/// store `Some(vec![])` rather than `None`.
+fn disable_hotbar(app: &mut App, config: &mut Config) {
+    match crate::config_persistence::persist_hotbar_bindings(app.config_path.as_deref(), &[]) {
+        Ok(path) => {
+            config.hotbar = Some(Vec::new());
+            app.status_message = Some(format!(
+                "Hotbar hidden (hotbar = [] in {}). Bring it back with `/hotbar on`.",
+                path.display()
+            ));
+        }
+        Err(err) => {
+            app.status_message = Some(format!("Failed to hide Hotbar: {err}"));
+            app.add_message(HistoryCell::System {
+                content: format!("Failed to hide Hotbar: {err}"),
+            });
+        }
+    }
+    app.needs_redraw = true;
+}
+
+/// Restore the default recommended Hotbar slots: remove the `hotbar` key so the
+/// resolver falls back to the built-in defaults. This is an explicit reset, so
+/// any custom bindings are replaced with the recommended set.
+fn restore_hotbar_defaults(app: &mut App, config: &mut Config) {
+    match crate::config_persistence::remove_hotbar_from_config(app.config_path.as_deref()) {
+        Ok(path) => {
+            config.hotbar = None;
+            app.status_message = Some(format!(
+                "Hotbar restored to default slots ({}). Customize with `/hotbar`.",
+                path.display()
+            ));
+        }
+        Err(err) => {
+            app.status_message = Some(format!("Failed to restore Hotbar defaults: {err}"));
+            app.add_message(HistoryCell::System {
+                content: format!("Failed to restore Hotbar defaults: {err}"),
+            });
+        }
+    }
+    app.needs_redraw = true;
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_view_events(
     terminal: &mut AppTerminal,
@@ -9324,6 +9378,9 @@ async fn handle_view_events(
             }
             ViewEvent::HotbarSetupSaved { bindings } => {
                 apply_hotbar_setup_saved(app, config, bindings);
+            }
+            ViewEvent::HotbarDisableRequested => {
+                disable_hotbar(app, config);
             }
             ViewEvent::SubAgentsRefresh => {
                 app.status_message = Some("Refreshing sub-agents...".to_string());

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -252,6 +252,9 @@ pub enum ViewEvent {
     HotbarSetupSaved {
         bindings: Vec<codewhale_config::HotbarBindingToml>,
     },
+    /// Emitted by the `/hotbar` setup wizard when the user chooses "Disable
+    /// Hotbar". The host persists `hotbar = []` and hides the panel.
+    HotbarDisableRequested,
     /// Emitted by the live-transcript overlay while in backtrack preview
     /// mode (#133) when the user steps the highlighted user message with
     /// Left or Right. The handler advances `app.backtrack`, refreshes the

--- a/crates/tui/src/tui/widgets/key_hint.rs
+++ b/crates/tui/src/tui/widgets/key_hint.rs
@@ -156,6 +156,15 @@ fn key_hint_style() -> Style {
     Style::default().dim()
 }
 
+/// Platform-specific prefix for `Alt`-modified chords, matching how the rest
+/// of the TUI labels them: `⌥+` on macOS (the Option-key glyph every Mac app
+/// uses) and `alt+` on Linux/Windows. Callers that build their own key-hint
+/// strings (e.g. the hotbar slot labels) should use this so the modifier label
+/// stays consistent with the help overlay and footer hints.
+pub fn alt_prefix() -> &'static str {
+    ALT_PREFIX
+}
+
 /// `true` if `mods` carries Ctrl or Alt — but not the AltGr Ctrl+Alt
 /// combination on Windows. Shortcut handlers should prefer this predicate
 /// over `mods.contains(CONTROL) || mods.contains(ALT)` so they don't fire on


### PR DESCRIPTION
## Summary

Completes the Hotbar "introduced / configurable / easy to turn off" story for 0.8.66, plus a once-only Fleet+Hotbar launch nudge.

- **Modifier visibility** — the Hotbar panel title now reads `Hotbar  ⌥+1-8` (macOS) / `Hotbar  alt+1-8` (Linux/Windows), and slot hover-tips lead with the chord. Put in the **title**, not each cell: at minimum sidebar width the 4-column cells are only 4 chars wide, so a per-cell prefix would clip labels on macOS and the slot number on Linux. New `key_hint::alt_prefix()` is the single platform-aware source of truth.
- **`/hotbar off|disable|hide`** — persists `hotbar = []` and **hides the panel immediately** (live config update + render gate on `is_hotbar_disabled`).
- **`/hotbar on|reset|defaults`** — removes the `hotbar` key (new `remove_hotbar_from_config`, preserves surrounding keys/comments) so the resolver falls back to built-in defaults. Custom bindings are only replaced on an explicit reset; an explicit empty array never rehydrates defaults.
- **Setup wizard** — press `d` to disable from inside `/hotbar`, plus a plain intro line and updated help line. New `HotbarDisableRequested` `ViewEvent`.
- **One-time launch nudge** — returning users and users finishing onboarding get a single System message introducing both Hotbar and Fleet, gated by a persisted `Settings.feature_intro_shown` flag — shown exactly once and never inside a resumed session.

## Why `hotbar = []` means "off"
The resolver only falls back to defaults when the `hotbar` key is **absent** (`None`). An explicit `hotbar = []` (`Some([])`) yields zero bindings — so it is the canonical disabled state. `/hotbar off` writes the empty array; `/hotbar on` deletes the key.

## Verification
- `cargo test -p codewhale-tui --bin codewhale-tui --locked hotbar` → 66 passed
- `feature_intro` (3), `remove_hotbar` (2), `key_hint` (10) → all pass
- `cargo test -p codewhale-config hotbar` → 5 passed (incl. empty-config-doesn't-rehydrate)
- `cargo fmt -p codewhale-tui --check` clean; `cargo check` clean

## Out of scope
- The **CHANGELOG entry** is intentionally deferred to the 0.8.66 release-docs pass (CHANGELOG.md already carries uncommitted release-prep changes that belong to a separate commit).
- The **Fleet setup UX redesign** (`/fleet setup` progressive agent-team view) is a separate, larger effort and will be its own PR — it builds on this branch's shared view helpers.

## Manual check
`/hotbar` shows the title modifier; `/hotbar off` hides the panel + writes `hotbar = []`; `/hotbar on` restores defaults; pressing `d` in the wizard disables; the launch nudge appears once then never again.