### PR TITLE
fix(tui): try_lock shell manager in async UI refresh paths (#3804)

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1429,26 +1429,42 @@ async fn refresh_active_task_panel(app: &mut App, task_manager: &SharedTaskManag
     entries.extend(active_reasoning_task_entries(app));
     entries.extend(active_rlm_task_entries(app));
 
-    if let Some(shell_mgr) = app.runtime_services.shell_manager.as_ref()
-        && let Ok(mut mgr) = shell_mgr.lock()
-    {
-        for job in mgr.list_jobs() {
-            if !matches!(job.status, crate::tools::shell::ShellStatus::Running) {
-                continue;
-            }
-            entries.push(TaskPanelEntry {
-                id: job.id,
-                status: "running".to_string(),
-                prompt_summary: format!("shell: {}", job.command),
-                duration_ms: Some(job.elapsed_ms),
-                kind: TaskPanelEntryKind::Background,
-                stale: job.stale,
-                elapsed_since_output_ms: job.elapsed_since_output_ms,
-                owner_agent_id: job.owner_agent_id,
-                owner_agent_name: job.owner_agent_name,
-            });
-        }
-    }
+    // #3804: this is a render-only read of shell jobs and must not block the
+    // async UI loop on the shell manager's std::sync Mutex. Use try_lock; on
+    // contention, retain the previous frame's background shell entries so
+    // running shells don't flicker out of the Work panel. Shell ownership,
+    // cancellation, approval state, and output capture never depend on this
+    // refresh succeeding.
+    let prev_shell_entries: Vec<TaskPanelEntry> = app
+        .task_panel
+        .iter()
+        .filter(|entry| matches!(entry.kind, TaskPanelEntryKind::Background))
+        .cloned()
+        .collect();
+    let shell_entries: Vec<TaskPanelEntry> = match app.runtime_services.shell_manager.as_ref() {
+        Some(shell_mgr) => match shell_mgr.try_lock() {
+            Ok(mut mgr) => mgr
+                .list_jobs()
+                .into_iter()
+                .filter(|job| matches!(job.status, crate::tools::shell::ShellStatus::Running))
+                .map(|job| TaskPanelEntry {
+                    id: job.id,
+                    status: "running".to_string(),
+                    prompt_summary: format!("shell: {}", job.command),
+                    duration_ms: Some(job.elapsed_ms),
+                    kind: TaskPanelEntryKind::Background,
+                    stale: job.stale,
+                    elapsed_since_output_ms: job.elapsed_since_output_ms,
+                    owner_agent_id: job.owner_agent_id,
+                    owner_agent_name: job.owner_agent_name,
+                })
+                .collect(),
+            // Contended: keep the last known snapshot rather than blocking.
+            Err(_) => prev_shell_entries,
+        },
+        None => Vec::new(),
+    };
+    entries.extend(shell_entries);
 
     app.task_panel = entries;
 }
@@ -1457,8 +1473,11 @@ fn refresh_shell_exec_live_output(app: &mut App) -> bool {
     let Some(shell_mgr) = app.runtime_services.shell_manager.as_ref().cloned() else {
         return false;
     };
+    // #3804: render-only read — try_lock so a contended shell Mutex can never
+    // block the async UI loop; skip this frame's live-output update on
+    // contention (the next refresh picks it up).
     let jobs = {
-        let Ok(mut mgr) = shell_mgr.lock() else {
+        let Ok(mut mgr) = shell_mgr.try_lock() else {
             return false;
         };
         mgr.list_jobs()

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2253,6 +2253,33 @@ async fn apply_loaded_session_resets_workspace_runtime_state() {
 }
 
 #[test]
+fn shell_live_output_refresh_does_not_block_on_contended_lock() {
+    // #3804: the async UI loop must never block on the shell manager's
+    // std::sync Mutex. While the lock is held, the render-only live-output
+    // refresh must return immediately via try_lock — the previous blocking
+    // lock() would deadlock on this same thread, so reaching the assert at all
+    // proves the path no longer blocks under contention.
+    let mut app = create_test_app();
+    let shell_mgr = app
+        .runtime_services
+        .shell_manager
+        .as_ref()
+        .expect("shell manager")
+        .clone();
+
+    let guard = shell_mgr.lock().expect("hold shell lock");
+    let changed = refresh_shell_exec_live_output(&mut app);
+    assert!(
+        !changed,
+        "contended live-output refresh should skip this frame, not block or update"
+    );
+    drop(guard);
+
+    // With the lock free again the path runs normally (no jobs → no change).
+    assert!(!refresh_shell_exec_live_output(&mut app));
+}
+
+#[test]
 fn apply_loaded_session_updates_current_workspace_display() {
     let mut app = create_test_app();
     let config = Config::default();


### PR DESCRIPTION
Closes #3804 (child of #3800).

## Problem
The async UI loop took a **blocking** `std::sync::Mutex::lock()` on the shell manager in two render-only refresh paths (`refresh_active_task_panel` ui.rs:1432, `refresh_shell_exec_live_output` ui.rs:1461). A contended lock could stall render/input — an amplifier of the fanout freeze.

## Change
Both paths now use `try_lock()`:
- **`refresh_active_task_panel`**: on contention, retain the previous frame's background shell entries (last-known snapshot) so running shells don't flicker out.
- **`refresh_shell_exec_live_output`**: on contention, skip this frame's live-output update (next refresh picks it up).

## Guardrails (per the issue)
Shell ownership, cancellation, approval state, and output capture do **not** depend on these UI refreshes — they're render-only reads — so `try_lock` + snapshot/skip cannot weaken enforcement or hide a running shell beyond one frame.

## Test
`shell_live_output_refresh_does_not_block_on_contended_lock`: holds the lock and asserts the refresh returns immediately (the old blocking `lock()` would deadlock on the same thread, so reaching the assert proves non-blocking). Build green; no regressions.

## Acceptance
- [x] UI refresh paths no longer synchronously block on the shell `std::sync::Mutex`
- [x] On contention the UI keeps rendering and reuses the last snapshot / skips
- [x] Test covers shell-manager lock contention
- [x] Does not loosen shell approval/sandbox behavior

Note: this is the `[safe-now]` child #2 from the #3800 audit; it's isolated from the in-flight backpressure/parallel-dispatch branches.