### PR TITLE
fix(tui): render sub-agent sidebar from a read-only snapshot (#3803)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1523,10 +1523,24 @@ impl Engine {
                         }
                     }
                     Op::ListSubAgents => {
-                        let agents = {
+                        // #3803: the sidebar refresh is a read-only snapshot.
+                        // Render from a read lock; only take the write lock to
+                        // run cleanup on a bounded cadence, so a UI refresh storm
+                        // during a sub-agent fanout no longer contends for the
+                        // write lock (against completions/persistence) on every
+                        // request. Cleanup still auto-cancels stale agents.
+                        let due = {
+                            let manager = self.subagent_manager.read().await;
+                            manager.cleanup_due(
+                                crate::tools::subagent::SUBAGENT_LIST_CLEANUP_MIN_INTERVAL,
+                            )
+                        };
+                        let agents = if due {
                             let mut manager = self.subagent_manager.write().await;
                             manager.cleanup(Duration::from_secs(60 * 60));
                             manager.list()
+                        } else {
+                            self.subagent_manager.read().await.list()
                         };
                         let _ = self.tx_event.send(Event::AgentList { agents }).await;
                     }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -130,6 +130,13 @@ const SUBAGENT_MODEL_WAIT_REASON: &str = "waiting for model response";
 /// checkpoints) to disk.
 const SUBAGENT_PERSIST_DEBOUNCE: Duration = Duration::from_millis(1500);
 
+/// #3803: minimum interval between write-locked `cleanup` runs triggered by the
+/// sidebar refresh (`Op::ListSubAgents`). Cleanup auto-cancels stale agents
+/// (heartbeat timeout, default 300s) and drops old finished records, so a 2s
+/// floor keeps it responsive while preventing per-refresh write-lock contention
+/// during a high-fanout burst.
+pub const SUBAGENT_LIST_CLEANUP_MIN_INTERVAL: Duration = Duration::from_secs(2);
+
 /// #freeze: lightweight perf counters for the sub-agent persist hot path,
 /// gated behind `CODEWHALE_SUBAGENT_PERF_TRACE=1`. The atomic increments are
 /// always cheap; only the structured `subagent_perf` log line is gated.
@@ -1805,6 +1812,11 @@ pub struct SubAgentManager {
     /// capture the most recent checkpoint.
     last_persist_at: Option<Instant>,
     persist_pending: bool,
+    /// #3803: last time `cleanup` ran. The sidebar refresh (`Op::ListSubAgents`)
+    /// renders from a read-only `list()` snapshot and only runs the
+    /// write-locked `cleanup` on a bounded cadence, so a UI refresh storm during
+    /// a sub-agent fanout no longer contends for the write lock on every request.
+    last_cleanup_at: Option<Instant>,
 }
 
 impl SubAgentManager {
@@ -1832,6 +1844,7 @@ impl SubAgentManager {
             launch_gate: Arc::new(Semaphore::new(max_agents.max(1))),
             last_persist_at: None,
             persist_pending: false,
+            last_cleanup_at: None,
         }
     }
 
@@ -2871,7 +2884,18 @@ impl SubAgentManager {
         if self.agents.len() != before || auto_cancelled > 0 {
             self.persist_state_best_effort();
         }
+        self.last_cleanup_at = Some(Instant::now());
         auto_cancelled
+    }
+
+    /// #3803: whether enough time has elapsed since the last `cleanup` that the
+    /// next sidebar refresh should run the write-locked cleanup again. Every
+    /// other refresh renders from the read-only `list()` snapshot, so a UI
+    /// refresh storm during a fanout does not take the write lock per request.
+    #[must_use]
+    pub fn cleanup_due(&self, min_interval: Duration) -> bool {
+        self.last_cleanup_at
+            .map_or(true, |last| last.elapsed() >= min_interval)
     }
 
     fn update_from_result(&mut self, agent_id: &str, result: SubAgentResult) {

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4955,3 +4955,28 @@ async fn per_worker_token_budget_does_not_double_count_scope_accounting() {
         worker_record.usage
     );
 }
+
+#[test]
+fn cleanup_due_gates_write_locked_cleanup_to_a_bounded_cadence() {
+    // #3803: a fresh manager is always due (never cleaned); right after a
+    // cleanup it is not due again until the interval elapses, so the sidebar
+    // refresh (Op::ListSubAgents) renders from the read-only snapshot in
+    // between instead of taking the write lock on every request.
+    let tmp = tempdir().expect("tempdir");
+    let mut manager = SubAgentManager::new(tmp.path().to_path_buf(), 4);
+
+    assert!(
+        manager.cleanup_due(Duration::from_secs(2)),
+        "a never-cleaned manager should be due"
+    );
+
+    manager.cleanup(Duration::from_secs(3600));
+    assert!(
+        !manager.cleanup_due(Duration::from_secs(3600)),
+        "immediately after cleanup it should not be due again within the interval"
+    );
+    assert!(
+        manager.cleanup_due(Duration::from_secs(0)),
+        "a zero interval is always due"
+    );
+}


### PR DESCRIPTION
Closes #3803 (child of #3800).

## Problem
`Op::ListSubAgents` (engine.rs:1525) took the `SubAgentManager` **write** lock on every UI refresh — running `cleanup` then `list` — so during a fanout/completion burst the sidebar refresh contended with completion updates and synchronous JSON persistence on the manager write lock.

## Change
- The handler now renders from a **read-only** snapshot (`read().await.list()`).
- `cleanup` (which needs the write lock) runs only on a **bounded cadence** via `SubAgentManager::cleanup_due(SUBAGENT_LIST_CLEANUP_MIN_INTERVAL)` (2s floor), stamped by `cleanup` in `last_cleanup_at`.
- Refresh requests remain coalesced to one trailing-edge send per drain (existing #freeze behavior).

## Guardrails (per the issue)
Cleanup is **not removed** — it still auto-cancels stale agents (heartbeat timeout) and drops old finished records, just on a bounded cadence instead of per-refresh, so lifecycle enforcement and authoritative manager state are preserved. A coalesced/skipped refresh never affects child cancellation or completion recording.

## Test
`cleanup_due_gates_write_locked_cleanup_to_a_bounded_cadence`: fresh manager is due; immediately after `cleanup` it isn't due within the interval; a zero interval is always due. Build green; existing `cleanup` tests still pass.

## Acceptance
- [x] `ListSubAgents` no longer needs the write lock merely to render
- [x] Cleanup cadence is bounded, not tied to every refresh
- [x] Refresh requests stay coalesced (≤1 in flight)
- [x] Cleanup still times out/cancels stale children

Note: `[safe-now]` child #1 from the #3800 audit. Scoped to the manager + handler; does **not** touch the op/event-channel backpressure path (#3802) to avoid colliding with the in-flight backpressure branches.