### PR TITLE
fix(tui): allow agent starts to join parallel dispatch batches (#3801)

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1168,6 +1168,68 @@ fn background_verifier_starts_batch_with_readonly_tools_when_auto_approved() {
     }
 }
 
+// #3801: agent `action=start` plans with `detached_start=true` and no approval
+// (YOLO / auto-approve mode) should all join one parallel batch instead of
+// being serialized N ways under the global tool-execution write lock.
+#[test]
+fn agent_start_detached_plans_join_single_parallel_batch() {
+    // Simulate 4 independent `agent start` calls — each is a detached_start,
+    // not read-only, not parallel-safe in the read-only sense, but qualifies
+    // for the detached-start parallel-batch path.
+    let plans: Vec<ToolExecutionPlan> = (0..4)
+        .map(|i| {
+            let mut plan = make_plan_at(i, false, false, false, false);
+            plan.name = "agent".to_string();
+            plan.detached_start = true;
+            plan
+        })
+        .collect();
+
+    let batches = plan_tool_execution_batches(plans);
+    assert_eq!(
+        batches.len(),
+        1,
+        "all 4 agent starts should form 1 parallel batch"
+    );
+    match &batches[0] {
+        ToolExecutionBatch::Parallel(plans) => {
+            assert_eq!(plans.len(), 4);
+            assert!(
+                plans.iter().all(|p| p.detached_start),
+                "every plan in the parallel batch should be a detached_start"
+            );
+        }
+        ToolExecutionBatch::Serial(_) => {
+            panic!("agent starts should be parallel, not serial");
+        }
+    }
+}
+
+// #3801: mixed agent starts and read-only tools should coexist in a parallel batch.
+#[test]
+fn agent_start_detached_plans_batch_with_readonly_tools() {
+    let mut grep_a = make_plan_at(0, true, true, false, false);
+    grep_a.name = "grep_files".to_string();
+
+    let mut agent_start = make_plan_at(1, false, false, false, false);
+    agent_start.name = "agent".to_string();
+    agent_start.detached_start = true;
+
+    let mut grep_b = make_plan_at(2, true, true, false, false);
+    grep_b.name = "grep_files".to_string();
+
+    let batches = plan_tool_execution_batches(vec![grep_a, agent_start, grep_b]);
+    assert_eq!(batches.len(), 1);
+    match &batches[0] {
+        ToolExecutionBatch::Parallel(plans) => {
+            assert_eq!(plans.len(), 3);
+        }
+        ToolExecutionBatch::Serial(_) => {
+            panic!("read-only tools + detached agent start should form 1 parallel batch");
+        }
+    }
+}
+
 #[test]
 fn successful_update_plan_ends_plan_mode_turn_immediately() {
     assert!(should_stop_after_plan_tool(

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3531,6 +3531,40 @@ impl ToolSpec for AgentTool {
         ApprovalRequirement::Required
     }
 
+    /// #3801: status and peek are read-only queries — no approval needed.
+    fn approval_requirement_for(&self, input: &Value) -> ApprovalRequirement {
+        match parse_agent_tool_action(input) {
+            Ok(AgentToolAction::Status) | Ok(AgentToolAction::Peek) => ApprovalRequirement::Auto,
+            _ => ApprovalRequirement::Required,
+        }
+    }
+
+    /// #3801: `action=start` launches a background agent and returns immediately —
+    /// it is a detached start that should not hold the global tool-exec write
+    /// lock while the child spins up.  In auto-approved modes (YOLO) this lets
+    /// multiple independent `agent start` calls join a single parallel batch
+    /// instead of being serialized N ways.
+    fn starts_detached_for(&self, input: &Value) -> bool {
+        matches!(parse_agent_tool_action(input), Ok(AgentToolAction::Start))
+    }
+
+    /// #3801: Read-only `agent` actions (status, peek) can safely run in
+    /// parallel batches.
+    fn supports_parallel_for(&self, input: &Value) -> bool {
+        matches!(
+            parse_agent_tool_action(input),
+            Ok(AgentToolAction::Status) | Ok(AgentToolAction::Peek)
+        )
+    }
+
+    /// #3801: status/peek/cancel actions are read-only queries of manager state.
+    fn is_read_only_for(&self, input: &Value) -> bool {
+        matches!(
+            parse_agent_tool_action(input),
+            Ok(AgentToolAction::Status) | Ok(AgentToolAction::Peek)
+        )
+    }
+
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let action = parse_agent_tool_action(&input)?;
         match action {


### PR DESCRIPTION
Closes #3801 (child of #3800).

## Problem

Multiple `agent` tool calls in one parent turn were serialized as non-parallel tools because the `agent` tool spec did not override `supports_parallel()` (defaulting to `false`). In high fanout (e.g. 20 concurrent agent launches), launch latency scaled linearly — each agent resolved its model route under the global tool-execution write lock, making the TUI feel frozen.

## Change

Three input-aware overrides on `AgentTool`'s `ToolSpec` impl:

1. **`starts_detached_for(action=start) = true`** — `action=start` launches a background agent and returns immediately. This lets agent launches join parallel batches via the `detached_start` path in `plan_tool_execution_batches` (which requires `detached_start && !approval_required && !interactive`). In auto-approved modes (YOLO), `approval_required` is already `false`, so the path fires.

2. **`supports_parallel_for(status|peek) = true`** and **`is_read_only_for(status|peek) = true`** — read-only queries of manager state can safely run in parallel batches.

3. **`approval_requirement_for(status|peek) = Auto`** — status/peek are read-only queries that don't need user approval.

## Security / policy guardrails (per the issue)

- **No bypass of approval requirements**: `action=start` and `action=cancel` still return `ApprovalRequirement::Required`. In non-YOLO modes, each agent launch still prompts for approval and is thus serial (expected). The parallel path only fires when `auto_approve = true`.
- **No bypass of concurrency limits**: the manager's launch_gate semaphore, max_depth, and configured concurrency caps are unchanged. The global tool lock just doesn't serialize the launch portion.
- **Preserves one tool_result per tool_use**: the existing dispatch/planner/executor pipeline handles this unchanged.
- **Does NOT mark arbitrary tools parallel-safe**: only the `agent` tool opts in via its own `ToolSpec` impl.

## Tests

- `agent_start_detached_plans_join_single_parallel_batch`: 4 agent starts form 1 parallel batch, not 4 serial batches.
- `agent_start_detached_plans_batch_with_readonly_tools`: mixed grep + agent start + grep form 1 parallel batch.