### PR TITLE
fix(subagent): persist state off the manager write-lock hot path (#3805)

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1920,9 +1920,14 @@ impl SubAgentManager {
         }
     }
 
-    fn persist_state(&self) -> Result<()> {
+    /// Build the [`PersistedSubAgentState`] snapshot from the current fleet.
+    ///
+    /// This is a cheap clone operation that runs under the caller's lock.
+    /// The returned payload is fully owned and safe to move to a background
+    /// thread for disk I/O.
+    fn build_persist_payload(&self) -> Result<Option<(PathBuf, PersistedSubAgentState)>> {
         let Some(path) = self.state_path.as_ref() else {
-            return Ok(());
+            return Ok(None);
         };
         let path = checked_subagent_state_path(&self.workspace, path)?;
         let now_ms = epoch_millis_now();
@@ -1959,9 +1964,36 @@ impl SubAgentManager {
             agents,
             workers: self.sorted_worker_records(),
         };
-        write_json_atomic(&self.workspace, &path, &payload)
+        Ok(Some((path, payload)))
     }
 
+    /// Persist the current fleet state to disk.
+    ///
+    /// #freeze: JSON serialization runs cheaply under the caller's lock; the
+    /// expensive disk I/O (`write_json_atomic`) is spawned onto a background
+    /// thread so the caller's write lock is released before touching the
+    /// filesystem.
+    ///
+    /// Returns a [`std::thread::JoinHandle`] that resolves when the disk write
+    /// completes.  Callers may `.join()` for synchronous semantics or drop it
+    /// for fire-and-forget.
+    fn persist_state(&self) -> Result<std::thread::JoinHandle<()>> {
+        let Some((path, payload)) = self.build_persist_payload()? else {
+            // Nothing to persist — return a no-op handle.
+            return Ok(std::thread::spawn(|| {}));
+        };
+        let workspace = self.workspace.clone();
+        // Spawn disk I/O off the write-lock hot path.  `payload` is fully
+        // owned (cloned from `self.agents`) so it is `Send` and safe to move.
+        let handle = std::thread::spawn(move || {
+            if let Err(err) = write_json_atomic(&workspace, &path, &payload) {
+                tracing::warn!(target: "subagent", ?err, "failed to persist sub-agent state");
+            }
+        });
+        Ok(handle)
+    }
+
+    /// Fire-and-forget persist — logs errors, drops the join handle.
     fn persist_state_best_effort(&self) {
         if let Err(err) = self.persist_state() {
             // Must not be `eprintln!` — raw stderr inside the alt-screen
@@ -1969,6 +2001,8 @@ impl SubAgentManager {
             // regression (#1085). Routed through tracing so the
             // file-backed subscriber in `runtime_log` captures it.
             tracing::warn!(target: "subagent", ?err, "failed to persist sub-agent state");
+        } else {
+            // Join handle is dropped here — disk I/O proceeds in background.
         }
     }
 
@@ -2007,11 +2041,20 @@ impl SubAgentManager {
     /// #freeze: force a persist if a hot-path write was previously coalesced
     /// away. Call on graceful shutdown / session teardown so the most recent
     /// intermediate checkpoint is not lost.
+    ///
+    /// Unlike [`persist_state`], this performs disk I/O **synchronously** to
+    /// guarantee data is flushed before the process exits.
     pub fn flush_pending_persist(&mut self) {
         if self.persist_pending {
             self.last_persist_at = Some(Instant::now());
             self.persist_pending = false;
-            self.persist_state_best_effort();
+            // Synchronous disk I/O — safe because we are shutting down and no
+            // callers depend on releasing the write lock quickly.
+            if let Ok(Some((path, payload))) = self.build_persist_payload() {
+                if let Err(err) = write_json_atomic(&self.workspace, &path, &payload) {
+                    tracing::warn!(target: "subagent", ?err, "failed to flush pending sub-agent state");
+                }
+            }
         }
     }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -325,7 +325,11 @@ fn headless_worker_records_persist_with_subagent_state() {
     result.name = "agent_persisted".to_string();
     result.steps_taken = 3;
     manager.complete_worker_from_result("agent_persisted", &result);
-    manager.persist_state().expect("persist state");
+    manager
+        .persist_state()
+        .expect("persist state")
+        .join()
+        .expect("persist thread");
 
     let mut loaded = SubAgentManager::new(tmp.path().to_path_buf(), 4).with_state_path(state_path);
     loaded.load_state().expect("load state");
@@ -2581,7 +2585,11 @@ fn test_persist_and_reload_marks_running_agent_as_interrupted() {
     );
     let running_id = running.id.clone();
     manager.agents.insert(running_id.clone(), running);
-    manager.persist_state().expect("persist state");
+    manager
+        .persist_state()
+        .expect("persist state")
+        .join()
+        .expect("persist thread");
 
     let mut reloaded = SubAgentManager::new(workspace, 2)
         .with_state_path(default_state_path(tmp.path()).expect("default state path"));
@@ -2626,7 +2634,11 @@ fn persist_and_reload_preserves_checkpoint_for_interrupted_running_agent() {
     ));
     let running_id = running.id.clone();
     manager.agents.insert(running_id.clone(), running);
-    manager.persist_state().expect("persist state");
+    manager
+        .persist_state()
+        .expect("persist state")
+        .join()
+        .expect("persist thread");
 
     let mut reloaded = SubAgentManager::new(workspace, 2)
         .with_state_path(default_state_path(tmp.path()).expect("default state path"));
@@ -3958,7 +3970,9 @@ fn persist_round_trip_preserves_session_boot_id() {
         );
         writer
             .persist_state()
-            .expect("persist round-trip should write");
+            .expect("persist round-trip should write")
+            .join()
+            .expect("persist thread");
     }
 
     // A fresh manager comes up with a *different* boot id and reloads


### PR DESCRIPTION
Closes #3805. Child of #3800.

## Problem

Sub-agent state persistence cloned/serialized/wrote JSON while callers still held the manager write lock. Under high fanout, spawn/completion/list operations can bunch behind disk I/O even when the write itself is only bookkeeping.

## Change

- Split persistence into a cheap owned snapshot (`build_persist_payload`) and a disk-write phase.
- Keep the snapshot under the existing manager lock, then spawn the atomic JSON write onto a background thread so lock holders release before filesystem I/O.
- Return a `JoinHandle<()>` from `persist_state()` so tests and synchronous callers can wait for completion when needed.
- Preserve synchronous `flush_pending_persist()` behavior for shutdown durability.

## Guardrails

- Does not change path/symlink hardening: writes still go through `checked_subagent_state_path` and `write_json_atomic`.
- Does not invent a broad worker-pool/blocking-I/O theory; this is scoped to shrinking the manager write-lock critical section.
- Terminal state still flushes on shutdown through the synchronous flush path.

## Verification

- `cargo fmt`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked persist`
- `git diff --check`
