### PR TITLE
fix: suppress background console windows on Windows

### DIFF
--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -69,6 +69,7 @@ pub fn probe_executable_with_flag(spec: &str, version_flag: &str) -> bool {
         return false;
     };
     let mut cmd = Command::new(program);
+    crate::utils::suppress_console_window(&mut cmd);
     for arg in parts {
         cmd.arg(arg);
     }
@@ -314,6 +315,7 @@ pub trait ExternalTool {
         let spec = Self::resolve()?;
         let (program, fixed_args) = split_interpreter_spec(&spec);
         let mut cmd = Command::new(&program);
+        crate::utils::suppress_console_window(&mut cmd);
         for arg in &fixed_args {
             cmd.arg(arg);
         }
@@ -355,6 +357,7 @@ pub trait ExternalTool {
         let spec = Self::resolve()?;
         let (program, fixed_args) = split_interpreter_spec(&spec);
         let mut cmd = tokio::process::Command::new(&program);
+        crate::utils::suppress_tokio_console_window(&mut cmd);
         for arg in &fixed_args {
             cmd.arg(arg);
         }

--- a/crates/tui/src/hooks.rs
+++ b/crates/tui/src/hooks.rs
@@ -637,6 +637,7 @@ impl HookExecutor {
         {
             use std::os::windows::process::CommandExt as _;
             let mut cmd = Command::new("cmd");
+            crate::utils::suppress_console_window(&mut cmd);
             // raw_arg: cmd.exe does not parse the CRT-style \" escapes that
             // Command::arg would insert, so pass the command line verbatim.
             cmd.arg("/C").raw_arg(command);

--- a/crates/tui/src/mcp/stdio.rs
+++ b/crates/tui/src/mcp/stdio.rs
@@ -66,6 +66,7 @@ impl StdioTransport {
         config: &McpServerConfig,
     ) -> Result<Self> {
         let mut cmd = tokio::process::Command::new(command);
+        crate::utils::suppress_tokio_console_window(&mut cmd);
         cmd.args(&config.args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())

--- a/crates/tui/src/tools/plugin.rs
+++ b/crates/tui/src/tools/plugin.rs
@@ -155,10 +155,13 @@ impl ToolSpec for CommandPluginTool {
         // we let tokio::process::Command resolve via PATH.
         let mut cmd = if cfg!(windows) && !self.command.contains('.') {
             let mut c = tokio::process::Command::new("cmd");
+            crate::utils::suppress_tokio_console_window(&mut c);
             c.arg("/c").arg(&self.command);
             c
         } else {
-            tokio::process::Command::new(&self.command)
+            let mut c = tokio::process::Command::new(&self.command);
+            crate::utils::suppress_tokio_console_window(&mut c);
+            c
         };
         cmd.args(&self.args);
         let label = format!("command '{}'", self.command);
@@ -260,6 +263,7 @@ async fn run_plugin_child(
     input: Value,
 ) -> Result<ToolResult, ToolError> {
     let mut cmd = tokio::process::Command::new(command);
+    crate::utils::suppress_tokio_console_window(&mut cmd);
     cmd.args(args);
     run_plugin_child_raw(&mut cmd, label, input).await
 }

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1153,6 +1153,7 @@ impl ShellManager {
         let args = exec_env.args();
 
         let mut cmd = Command::new(program);
+        crate::utils::suppress_console_window(&mut cmd);
         push_shell_args(&mut cmd, program, args);
         cmd.current_dir(working_dir)
             .stdout(Stdio::piped())
@@ -1311,6 +1312,7 @@ impl ShellManager {
         let args = exec_env.args();
 
         let mut cmd = Command::new(program);
+        crate::utils::suppress_console_window(&mut cmd);
         push_shell_args(&mut cmd, program, args);
         cmd.current_dir(working_dir)
             .stdin(Stdio::inherit())
@@ -1495,6 +1497,7 @@ impl ShellManager {
             }
         } else {
             let mut cmd = Command::new(program);
+            crate::utils::suppress_console_window(&mut cmd);
             push_shell_args(&mut cmd, program, args);
             cmd.current_dir(working_dir)
                 .stdin(Stdio::piped())

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -34,6 +34,26 @@ pub fn redacted_identifier_for_log(identifier: &str) -> String {
     format!("<redacted:{hash:016x}>")
 }
 
+#[cfg(windows)]
+pub(crate) fn suppress_console_window(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+pub(crate) fn suppress_console_window(_cmd: &mut Command) {}
+
+#[cfg(windows)]
+pub(crate) fn suppress_tokio_console_window(cmd: &mut tokio::process::Command) {
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+pub(crate) fn suppress_tokio_console_window(_cmd: &mut tokio::process::Command) {}
+
 // === Project Mapping Helpers ===
 
 /// Identify if a file is a "key" file for project identification.


### PR DESCRIPTION
## Problem

On Windows, every child process spawned with the default creation flags briefly pops a console window. Because the TUI spawns children constantly — shell commands, MCP stdio servers, hooks, command plugins, and dependency probes — these windows flicker over the UI and steal keyboard focus.

## Fix

Add two small helpers in `utils`:

- `suppress_console_window(&mut std::process::Command)`
- `suppress_tokio_console_window(&mut tokio::process::Command)`

On Windows they set `CREATE_NO_WINDOW` (`0x0800_0000`) via `CommandExt::creation_flags`; on every other platform they are no-ops, so there is no behavior change off Windows.

The helpers are applied at every child-spawn site:

- `tools/shell.rs` — shell command execution (3 sites)
- `mcp/stdio.rs` — MCP stdio server spawn
- `hooks.rs` — hook command execution
- `tools/plugin.rs` — command plugin execution
- `dependencies.rs` — external-tool / dependency probes

## Testing

`cargo check -p codewhale-tui --bin codewhale-tui` passes. The Windows codepath is gated behind `#[cfg(windows)]`; non-Windows builds compile the no-op stubs.