### PR TITLE
fix(engine): support wildcard disallowed tool prefixes

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -3001,7 +3001,15 @@ pub(super) fn command_denies_tool(disallowed_tools: Option<&[String]>, tool_name
     let Some(disallowed_tools) = disallowed_tools else {
         return false;
     };
-    disallowed_tools.contains(&tool_name.to_ascii_lowercase())
+    let tool_name = tool_name.to_ascii_lowercase();
+    disallowed_tools.iter().any(|rule| {
+        let rule = rule.to_ascii_lowercase();
+        if let Some(prefix) = rule.strip_suffix('*') {
+            tool_name.starts_with(prefix)
+        } else {
+            tool_name == rule
+        }
+    })
 }
 
 fn resolve_tool_definition<'a>(
@@ -3376,6 +3384,19 @@ mod tests {
     fn disallowed_tools_gate_blocks_case_insensitively() {
         let disallowed = vec!["exec_shell".to_string()];
         assert!(command_denies_tool(Some(&disallowed), "Exec_Shell"));
+    }
+
+    #[test]
+    fn disallowed_tools_gate_blocks_prefix_wildcard() {
+        let disallowed = vec!["mcp_acme_*".to_string()];
+        assert!(command_denies_tool(
+            Some(&disallowed),
+            "mcp_acme_get_profile"
+        ));
+        assert!(!command_denies_tool(
+            Some(&disallowed),
+            "mcp_other_make_thing"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`disallowed_tools` currently matches tool names by exact (case-insensitive) string equality. That works when the full tool name is known up front, but it can't express "hide everything from this MCP server" when the server's tools are discovered dynamically at connect time — the individual tool names aren't known when the rule is written, so there is nothing to enumerate.

## Fix

`command_denies_tool` now treats a rule ending in `*` as a prefix match. A single rule like `mcp_acme_*` hides every tool exposed by that server, regardless of how many tools it advertises or what they are called.

Rules without a trailing `*` keep exact-match semantics, so existing `disallowed_tools` configurations behave exactly as before — this is purely additive and backward compatible.

```rust
// before: had to know every tool name
disallowed_tools = ["mcp_acme_get_profile", "mcp_acme_search", ...]

// after: one rule covers the whole server
disallowed_tools = ["mcp_acme_*"]
```

## Testing

Added `disallowed_tools_gate_blocks_prefix_wildcard` covering both the match and non-match cases. `cargo test -p codewhale-tui --bin codewhale-tui disallowed_tools_gate_blocks_prefix_wildcard` passes.