### PR TITLE
feat(mcp): expand ${VAR} env placeholders in MCP stdio config

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -48,6 +48,55 @@ fn validate_mcp_config_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Expand `${NAME}` placeholders in an MCP config value from the process
+/// environment. This lets secrets (API keys, bearer tokens, …) be supplied
+/// through environment variables instead of being written in cleartext into
+/// the MCP config file on disk.
+///
+/// On a missing or malformed placeholder the error names only the offending
+/// variable, never the surrounding value, so a secret-bearing string is never
+/// echoed into logs or error output.
+fn expand_env_placeholders(value: &str) -> Result<String> {
+    let mut out = String::new();
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let Some(end) = after.find('}') else {
+            anyhow::bail!("unterminated environment placeholder in MCP config value");
+        };
+        let name = &after[..end];
+        if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            anyhow::bail!("invalid environment placeholder in MCP config value");
+        }
+        let env_value = std::env::var(name).with_context(|| {
+            format!("environment variable {name} required by MCP config is not set")
+        })?;
+        out.push_str(&env_value);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Expand `${NAME}` placeholders across every value of an MCP config map
+/// (e.g. the stdio child `env`). `context` only labels expansion errors so a
+/// failure can be attributed to the right map.
+fn expand_env_placeholders_map(
+    values: &HashMap<String, String>,
+    context: &str,
+) -> Result<HashMap<String, String>> {
+    let mut expanded = HashMap::with_capacity(values.len());
+    for (key, value) in values {
+        expanded.insert(
+            key.clone(),
+            expand_env_placeholders(value)
+                .with_context(|| format!("failed to expand MCP {context} value for {key}"))?,
+        );
+    }
+    Ok(expanded)
+}
+
 /// Mask a URL so any embedded credentials in the userinfo portion (e.g.
 /// `https://user:secret@host`) are replaced with `***`. Failures fall back to
 /// the original string so we don't lose context — we never want masking to

--- a/crates/tui/src/mcp/stdio.rs
+++ b/crates/tui/src/mcp/stdio.rs
@@ -75,15 +75,22 @@ impl StdioTransport {
             cmd.current_dir(cwd);
         }
 
+        // Expand `${NAME}` placeholders so secret env values can be sourced
+        // from the process environment instead of being stored in cleartext
+        // in the MCP config. The child env is allowlist-sanitized below, so
+        // these vars would not otherwise be inherited by the child.
+        let expanded_env = super::expand_env_placeholders_map(&config.env, "env")
+            .with_context(|| format!("MCP server '{server_name}' env expansion failed"))?;
+
         // MCP stdio servers are user-configured integrations. Use the
         // wider MCP allowlist so common Node/Python/proxy/CA-bundle
         // bootstrap variables (NVM_DIR, NODE_OPTIONS, NPM_CONFIG_*,
         // HTTP(S)_PROXY, …) reach the child. See `sanitized_mcp_env`
         // and #1244 for context.
-        child_env::apply_to_tokio_command_mcp(&mut cmd, child_env::string_map_env(&config.env));
+        child_env::apply_to_tokio_command_mcp(&mut cmd, child_env::string_map_env(&expanded_env));
 
         let mut child = cmd.spawn().with_context(|| {
-            let env_keys: Vec<&str> = config.env.keys().map(String::as_str).collect();
+            let env_keys: Vec<&str> = expanded_env.keys().map(String::as_str).collect();
             format!(
                 "MCP stdio spawn failed (transport=stdio server={server_name} cmd={command:?} args={:?} env_keys={env_keys:?})",
                 config.args,

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -232,6 +232,40 @@ fn mcp_server_config_omits_headers_when_empty() {
     );
 }
 
+#[test]
+fn expand_env_placeholders_expands_value_from_environment() {
+    let _lock = crate::test_support::lock_test_env();
+    let _secret =
+        crate::test_support::EnvVarGuard::set("MCP_TEST_SECRET_TOKEN", "test-secret-123456");
+    let mut env = HashMap::new();
+    env.insert(
+        "API_TOKEN".to_string(),
+        "${MCP_TEST_SECRET_TOKEN}".to_string(),
+    );
+
+    let expanded = expand_env_placeholders_map(&env, "env").unwrap();
+
+    assert_eq!(
+        expanded.get("API_TOKEN").map(String::as_str),
+        Some("test-secret-123456")
+    );
+}
+
+#[test]
+fn expand_env_placeholders_reports_missing_variable_without_secret_value() {
+    let _lock = crate::test_support::lock_test_env();
+    let _missing = crate::test_support::EnvVarGuard::remove("MCP_TEST_MISSING_SECRET");
+
+    let err = expand_env_placeholders("Bearer ${MCP_TEST_MISSING_SECRET}")
+        .expect_err("missing env should fail")
+        .to_string();
+
+    // The error must name the variable but must not leak the surrounding
+    // value (which in practice carries the secret).
+    assert!(err.contains("MCP_TEST_MISSING_SECRET"));
+    assert!(!err.contains("Bearer "));
+}
+
 #[tokio::test]
 async fn mcp_http_auth_prefers_static_authorization_over_bearer_env() {
     let mut headers = HashMap::new();


### PR DESCRIPTION
## Problem

MCP stdio servers are spawned with an allowlist-sanitized child environment (`sanitized_mcp_env`), so arbitrary secret env vars set in the parent process are **not** inherited by the child. That leaves the MCP config file itself as the only place to pass a secret — an API key, a bearer token — to a stdio server, which means writing it in cleartext on disk.

## Fix

Allow `${NAME}` placeholders in a stdio server's `env` map. Each placeholder is expanded from the process environment when the server is spawned:

```toml
[mcp_servers.example]
command = "some-mcp-server"
env = { API_TOKEN = "${MY_SECRET_TOKEN}" }
```

Now the secret lives in an environment variable and the config on disk only references it.

Details:
- Expansion happens in `StdioTransport::spawn`, just before the child env is applied.
- Missing or malformed placeholders fail fast. The error names **only** the offending variable, never the surrounding value, so a secret-bearing string is never echoed into logs or error output.
- Values without `${...}` are passed through unchanged, so existing configs are unaffected.

This only touches the stdio child `env`; HTTP transports already have `bearer_token_env_var` / `env_headers` for credentials.

## Testing

Added `expand_env_placeholders_expands_value_from_environment` and `expand_env_placeholders_reports_missing_variable_without_secret_value` (the latter asserts the error does not leak the surrounding value). Both pass:

```
cargo test -p codewhale-tui --bin codewhale-tui expand_env_placeholders
# test result: ok. 2 passed
```