### PR TITLE
fix(tui): shared modal UI + progressive /fleet setup (v0.8.66 blockers #3732, #3791)

### DIFF
--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -8,7 +8,7 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget, Wrap},
+    widgets::{Block, Borders, Padding, Paragraph, Widget, Wrap},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -19,7 +19,10 @@ use crate::skills;
 use crate::tools::spec::ApprovalRequirement;
 use crate::tools::spec::ToolCapability;
 use crate::tools::{ToolContext, ToolRegistryBuilder};
-use crate::tui::views::{CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent,
+    centered_modal_area, render_modal_footer, render_modal_surface,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PaletteSection {
@@ -435,6 +438,7 @@ fn modal_block() -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))
+        .style(Style::default().bg(palette::DEEPSEEK_INK))
         .padding(Padding::uniform(1))
 }
 
@@ -863,16 +867,24 @@ impl ModalView for CommandPaletteView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 90.min(area.width.saturating_sub(4));
-        let popup_height = 22.min(area.height.saturating_sub(4));
-        let popup_area = Rect {
-            x: (area.width.saturating_sub(popup_width)) / 2,
-            y: (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        let popup_area = centered_modal_area(area, 90, 22, 44, 8);
+        let popup_width = popup_area.width;
 
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
+
+        let block = modal_block().title(" Command Palette ");
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑/↓/j/k", "move"),
+                ActionHint::new("Enter", "run/open"),
+                ActionHint::new("Esc", "close"),
+            ],
+        );
 
         let mut lines = Vec::new();
         let query_label = if self.query.is_empty() {
@@ -906,9 +918,7 @@ impl ModalView for CommandPaletteView {
         // labels and separators, so the scroll window is sized against the real
         // rendered cost rather than a flat entry count (#2590).
         let header_lines = lines.len();
-        let available = (popup_height as usize)
-            .saturating_sub(2) // top + bottom border
-            .saturating_sub(header_lines);
+        let available = (content.height as usize).saturating_sub(header_lines);
         let mut action_count = 0usize;
         let mut command_count = 0usize;
         let mut skill_count = 0usize;
@@ -988,18 +998,9 @@ impl ModalView for CommandPaletteView {
             }
         }
 
-        let block = modal_block()
-            .title(" Command Palette ")
-            .title_bottom(Line::from(vec![
-                Span::styled(" ↑/↓/j/k move  ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::styled("Enter run/open  ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::styled("Esc close", Style::default().fg(palette::TEXT_MUTED)),
-            ]));
-
         Paragraph::new(lines)
-            .block(block)
             .wrap(Wrap { trim: false })
-            .render(popup_area, buf);
+            .render(content, buf);
     }
 }
 
@@ -1686,5 +1687,66 @@ mod tests {
                 action: CommandPaletteAction::ExecuteCommand { .. }
             })
         ));
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires every
+    /// overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    fn sample_palette_view() -> CommandPaletteView {
+        let entries = vec![
+            palette_entry(PaletteSection::Command, "/config", "open config", "/config"),
+            palette_entry(PaletteSection::Command, "/model", "choose model", "/model"),
+            palette_entry(PaletteSection::Skill, "$search", "search skill", "$search"),
+            palette_entry(PaletteSection::Tool, "tool:git", "git tool", "git"),
+            palette_entry(PaletteSection::Mcp, "mcp:fs", "filesystem", "mcp_fs_read"),
+        ];
+        CommandPaletteView::new(entries)
+    }
+
+    #[test]
+    fn command_palette_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(sample_palette_view());
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| (0..w).map(|x| buf[(x, y)].symbol().to_string()).collect())
+                .collect();
+            let text = rows.join("\n");
+
+            // Footer keeps every action.
+            assert!(text.contains("move"), "{w}x{h}: missing 'move' hint");
+            assert!(
+                text.contains("run/open"),
+                "{w}x{h}: missing 'run/open' hint"
+            );
+            assert!(text.contains("close"), "{w}x{h}: missing 'close' hint");
+
+            // Composited frame is fully opaque.
+            assert!(!text.contains('X'), "{w}x{h}: background bleed-through");
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+
+            // No horizontal overflow.
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/feedback_picker.rs
+++ b/crates/tui/src/tui/feedback_picker.rs
@@ -6,11 +6,14 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 
 use crate::palette;
-use crate::tui::views::{CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent,
+    centered_modal_area, render_modal_footer, render_modal_surface,
+};
 
 #[derive(Debug, Clone, Copy)]
 struct FeedbackOption {
@@ -120,18 +123,9 @@ impl ModalView for FeedbackPickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 78.min(area.width.saturating_sub(4)).max(44);
-        let needed_height = (OPTIONS.len() as u16).saturating_add(7);
-        let popup_height = needed_height.min(area.height.saturating_sub(4)).max(8);
+        let popup_area = centered_modal_area(area, 78, (OPTIONS.len() as u16) + 7, 44, 8);
 
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
-
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
         let block = Block::default()
             .title(Line::from(Span::styled(
@@ -140,14 +134,6 @@ impl ModalView for FeedbackPickerView {
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" Up/Down ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("move "),
-                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("open "),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("cancel "),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
             .style(Style::default().bg(palette::DEEPSEEK_INK))
@@ -155,6 +141,16 @@ impl ModalView for FeedbackPickerView {
 
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("Up/Down", "move"),
+                ActionHint::new("Enter", "open"),
+                ActionHint::new("Esc", "cancel"),
+            ],
+        );
 
         let mut lines = Vec::with_capacity(OPTIONS.len() + 2);
         lines.push(Line::from(Span::styled(
@@ -190,7 +186,7 @@ impl ModalView for FeedbackPickerView {
             ]));
         }
 
-        Paragraph::new(lines).render(inner, buf);
+        Paragraph::new(lines).render(content, buf);
     }
 }
 
@@ -239,5 +235,57 @@ mod tests {
             view.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
             ViewAction::Close
         ));
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires
+    /// every overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn feedback_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        use ratatui::{buffer::Buffer, layout::Rect};
+        use unicode_width::UnicodeWidthStr;
+
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(FeedbackPickerView::new());
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            for label in ["move", "open", "cancel"] {
+                assert!(text.contains(label), "{w}x{h}: missing footer '{label}'");
+            }
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/file_picker.rs
+++ b/crates/tui/src/tui/file_picker.rs
@@ -20,11 +20,14 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 
 use crate::palette;
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer, render_modal_surface,
+};
 use crate::workspace_discovery::{DISCOVERY_ALWAYS_DIRS, path_is_excluded_from_discovery};
 
 /// Maximum number of candidates collected from the initial walk. Keeps memory
@@ -323,35 +326,25 @@ impl ModalView for FilePickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 80.min(area.width.saturating_sub(4));
-        let popup_height = ((VISIBLE_ROWS as u16) + 6).min(area.height.saturating_sub(4));
+        let popup_area = centered_modal_area(area, 80, (VISIBLE_ROWS as u16) + 7, 44, 8);
 
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        render_modal_surface(area, popup_area, buf);
 
-        Clear.render(popup_area, buf);
-
+        let match_count = self.filtered.len();
+        // The match count moves into the title so the footer only carries the
+        // navigation hints, which now wrap inside the body via the shared
+        // helper instead of clipping off the border edge (#3732).
         let title = Line::from(vec![Span::styled(
-            " File Picker ",
+            format!(
+                " File Picker ({match_count} match{}) ",
+                if match_count == 1 { "" } else { "es" },
+            ),
             Style::default()
                 .fg(palette::WHALE_ACCENT_PRIMARY)
                 .add_modifier(Modifier::BOLD),
         )]);
-        let footer_text = format!(
-            " {} match{}  ↑/↓ select  Enter insert @path  Esc close ",
-            self.filtered.len(),
-            if self.filtered.len() == 1 { "" } else { "es" },
-        );
         let block = Block::default()
             .title(title)
-            .title_bottom(Line::from(Span::styled(
-                footer_text,
-                Style::default().fg(palette::TEXT_MUTED),
-            )))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
             .style(Style::default().bg(palette::DEEPSEEK_INK))
@@ -359,6 +352,16 @@ impl ModalView for FilePickerView {
 
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑/↓", "select"),
+                ActionHint::new("Enter", "insert @path"),
+                ActionHint::new("Esc", "close"),
+            ],
+        );
 
         let mut lines: Vec<Line<'static>> = Vec::new();
         // Query line.
@@ -374,7 +377,7 @@ impl ModalView for FilePickerView {
         ]));
         lines.push(Line::from(""));
 
-        let visible = VISIBLE_ROWS.min(inner.height.saturating_sub(2) as usize);
+        let visible = VISIBLE_ROWS.min(content.height.saturating_sub(2) as usize);
         let end = (self.scroll + visible).min(self.filtered.len());
         if self.filtered.is_empty() {
             lines.push(Line::from(Span::styled(
@@ -393,13 +396,14 @@ impl ModalView for FilePickerView {
                     Style::default().fg(palette::TEXT_PRIMARY)
                 };
                 let prefix = if selected { "▶ " } else { "  " };
-                let marker_field = if inner.width >= 18 {
+                let marker_field = if content.width >= 18 {
                     format!("{} ", self.relevance.markers_for(path))
                 } else {
                     String::new()
                 };
                 let reserved = prefix.chars().count() + marker_field.chars().count();
-                let display = truncate_path(path, (inner.width as usize).saturating_sub(reserved));
+                let display =
+                    truncate_path(path, (content.width as usize).saturating_sub(reserved));
                 let mut line = Line::from(format!("{prefix}{marker_field}{display}"));
                 line.style = style;
                 lines.push(line);
@@ -408,7 +412,7 @@ impl ModalView for FilePickerView {
 
         Paragraph::new(lines)
             .style(Style::default().fg(palette::TEXT_PRIMARY))
-            .render(inner, buf);
+            .render(content, buf);
     }
 }
 
@@ -852,5 +856,67 @@ mod tests {
                 .all(|path| !path.starts_with(".claude/worktrees/")),
             ".claude worktree files must not enter picker candidates: {candidates:?}",
         );
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires
+    /// every overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn file_picker_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        use ratatui::{buffer::Buffer, layout::Rect};
+        use unicode_width::UnicodeWidthStr;
+
+        let dir = TempDir::new().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "").unwrap();
+        fs::write(root.join("src/lib.rs"), "").unwrap();
+        fs::write(root.join("README.md"), "").unwrap();
+
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(FilePickerView::new_with_relevance(
+                root,
+                FilePickerRelevance::default(),
+            ));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            for label in ["select", "insert @path", "close"] {
+                assert!(text.contains(label), "{w}x{h}: missing footer '{label}'");
+            }
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -13,7 +13,8 @@ use crate::config::Config;
 use crate::palette;
 use crate::tui::app::App;
 use crate::tui::views::{
-    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer,
 };
 
 use super::actions::{
@@ -528,14 +529,7 @@ impl ModalView for HotbarSetupView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 118.min(area.width.saturating_sub(4)).max(72);
-        let popup_height = 28.min(area.height.saturating_sub(4)).max(12);
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        let popup_area = centered_modal_area(area, 118, 28, 72, 12);
         Clear.render(popup_area, buf);
         let block = Block::default()
             .title(" Hotbar setup ")

--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Widget},
@@ -12,7 +12,9 @@ use ratatui::{
 use crate::config::Config;
 use crate::palette;
 use crate::tui::app::App;
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
+};
 
 use super::actions::{
     HotbarActionCategory, HotbarActionMetadata, HotbarArgsBehavior, HotbarRecommendationOptions,
@@ -445,11 +447,6 @@ impl HotbarSetupView {
             .join("  ");
         lines.push(Line::from(slots));
         lines.push(Line::from(self.status_text()));
-        if self.help_visible {
-            lines.push(Line::from(
-                "Tab/Shift+Tab source  Up/Down action  1-8 slot  Enter assign  Space toggle  Delete clear  s save  d disable  Esc cancel",
-            ));
-        }
         lines
     }
 }
@@ -543,17 +540,29 @@ impl ModalView for HotbarSetupView {
         let block = Block::default()
             .title(" Hotbar setup ")
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(palette::BORDER_COLOR));
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::DEEPSEEK_INK));
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
 
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(1)])
-            .split(inner);
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("Tab/Shift+Tab", "source"),
+                ActionHint::new("Up/Down", "action"),
+                ActionHint::new("1-8", "slot"),
+                ActionHint::new("Enter", "assign"),
+                ActionHint::new("Space", "toggle"),
+                ActionHint::new("Delete", "clear"),
+                ActionHint::new("s", "save"),
+                ActionHint::new("d", "disable"),
+                ActionHint::new("Esc", "cancel"),
+            ],
+        );
         Paragraph::new(self.render_lines())
             .style(Style::default().fg(palette::TEXT_PRIMARY))
-            .render(chunks[0], buf);
+            .render(content, buf);
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
@@ -790,5 +799,55 @@ mod tests {
         assert_eq!(view.selected_slot(), 8);
         view.handle_key(key(KeyCode::Left));
         assert_eq!(view.selected_slot(), 7);
+    }
+
+    #[test]
+    fn hotbar_setup_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        use unicode_width::UnicodeWidthStr;
+
+        const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+        let app = test_app();
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(HotbarSetupView::new(&app, &Config::default()));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| (0..w).map(|x| buf[(x, y)].symbol().to_string()).collect())
+                .collect();
+            let text = rows.join("\n");
+
+            // Footer keeps every action.
+            for label in [
+                "source", "action", "slot", "assign", "toggle", "clear", "save", "disable",
+                "cancel",
+            ] {
+                assert!(text.contains(label), "{w}x{h}: footer missing '{label}'");
+            }
+
+            // Composited frame is fully opaque.
+            assert!(!text.contains('X'), "{w}x{h}: background bleed-through");
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+
+            // No horizontal overflow.
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/live_transcript.rs
+++ b/crates/tui/src/tui/live_transcript.rs
@@ -36,7 +36,9 @@ use crate::tui::app::App;
 use crate::tui::backtrack::Direction;
 use crate::tui::history::{HistoryCell, TranscriptRenderOptions};
 use crate::tui::transcript_cache::{CellId, TranscriptCache};
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
+};
 
 /// Render mode for the overlay. `Tail` is the original Ctrl+T sticky-tail
 /// behaviour (#94). `BacktrackPreview` (#133) highlights the Nth-from-tail
@@ -52,10 +54,6 @@ pub enum Mode {
         selected_idx: usize,
     },
 }
-
-/// Single-line footer hint. Kept short so it fits on narrow terminals.
-const FOOTER_HINT: &str =
-    " j/k scroll  Space/C-b page  g/G top/bottom  End=resume tail  q/Esc close ";
 
 /// Snapshot of one cell, refreshed every frame from `App`. Owns the cell so
 /// the overlay's `render(&self)` can wrap without re-borrowing `App`.
@@ -503,14 +501,49 @@ impl ModalView for LiveTranscriptOverlay {
 
         Clear.render(popup_area, buf);
 
-        // Compute inner content height once: borders eat 1 row top + 1 bottom,
-        // padding eats 1 more on each side.
-        let visible_height = popup_area.height.saturating_sub(4) as usize;
+        let title: String = match self.mode {
+            Mode::BacktrackPreview { selected_idx } => format!(
+                " Backtrack preview — turn {} (\u{2190}/\u{2192} step, Enter rewind, Esc cancel) ",
+                selected_idx + 1
+            ),
+            Mode::Tail => {
+                if self.sticky_to_bottom.get() {
+                    " Live transcript (tailing) ".to_string()
+                } else {
+                    " Live transcript (paused) ".to_string()
+                }
+            }
+        };
+
+        let block = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::DEEPSEEK_INK))
+            .padding(Padding::uniform(1));
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        // Wrapping action footer along the bottom of the inner area; the body
+        // fills the rows above it.
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("j/k", "scroll"),
+                ActionHint::new("Space/C-b", "page"),
+                ActionHint::new("g/G", "top/bottom"),
+                ActionHint::new("End", "resume tail"),
+                ActionHint::new("q/Esc", "close"),
+            ],
+        );
+
+        // `content` already excludes the border, padding, and footer rows.
+        let visible_height = content.height as usize;
         self.last_visible_height.set(visible_height);
 
-        // Wrap content using the per-cell cache; subtract padding from width
-        // so wrapped lines fit between the inner edges.
-        let content_width = popup_width.saturating_sub(4);
+        // Wrap content using the per-cell cache at the body width.
+        let content_width = content.width;
         let flattened = self.flatten(content_width);
         let lines = flattened.lines;
         self.last_total_lines.set(lines.len());
@@ -547,36 +580,8 @@ impl ModalView for LiveTranscriptOverlay {
             lines[scroll..end].to_vec()
         };
 
-        let title: String = match self.mode {
-            Mode::BacktrackPreview { selected_idx } => format!(
-                " Backtrack preview — turn {} (\u{2190}/\u{2192} step, Enter rewind, Esc cancel) ",
-                selected_idx + 1
-            ),
-            Mode::Tail => {
-                if self.sticky_to_bottom.get() {
-                    " Live transcript (tailing) ".to_string()
-                } else {
-                    " Live transcript (paused) ".to_string()
-                }
-            }
-        };
-
-        let footer = Line::from(Span::styled(
-            FOOTER_HINT,
-            Style::default().fg(palette::TEXT_HINT),
-        ));
-        let block = Block::default()
-            .title(title)
-            .title_bottom(footer)
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(palette::BORDER_COLOR))
-            .style(Style::default().bg(palette::DEEPSEEK_INK))
-            .padding(Padding::uniform(1));
-
-        let paragraph = Paragraph::new(visible_lines)
-            .block(block)
-            .wrap(Wrap { trim: false });
-        paragraph.render(popup_area, buf);
+        let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
+        paragraph.render(content, buf);
 
         // #3029: same in-band OSC 8 recovery as the main transcript — extract
         // link regions from the rendered buffer and blank the payload cells.
@@ -888,6 +893,57 @@ mod tests {
             !rendered.contains("user 0"),
             "preview must not open at the oldest transcript line: {rendered}"
         );
+    }
+
+    #[test]
+    fn live_transcript_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        use unicode_width::UnicodeWidthStr;
+
+        const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+        for (w, h) in BLOCKER_SIZES {
+            // Construct an empty overlay: transcript cells paint their own
+            // backgrounds, so an empty body keeps the interior as the modal ink
+            // and lets us assert opacity at the center cell directly.
+            let overlay = LiveTranscriptOverlay::new();
+
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(overlay);
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| (0..w).map(|x| buf[(x, y)].symbol().to_string()).collect())
+                .collect();
+            let text = rows.join("\n");
+
+            // Footer keeps every action.
+            for label in ["scroll", "page", "top/bottom", "resume tail", "close"] {
+                assert!(text.contains(label), "{w}x{h}: footer missing '{label}'");
+            }
+
+            // Composited frame is fully opaque.
+            assert!(!text.contains('X'), "{w}x{h}: background bleed-through");
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+
+            // No horizontal overflow.
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -14,14 +14,17 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
+    widgets::{Block, Borders, Paragraph, Widget},
 };
 
 use crate::config::{ApiProvider, model_completion_names_for_provider};
 use crate::model_registry;
 use crate::palette;
 use crate::tui::app::{App, ReasoningEffort};
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
+    render_modal_surface,
+};
 
 /// Thinking-effort rows shown for DeepSeek-style providers, in the order
 /// DeepSeek behaviorally distinguishes them.
@@ -767,9 +770,10 @@ impl ModelPickerView {
             height: popup_height,
         };
 
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
-        // Outer chrome with title + footer hint.
+        // Outer chrome with title; the action footer moves into the body so it
+        // wraps instead of clipping at narrow widths (#3732).
         let outer = Block::default()
             .title(Line::from(Span::styled(
                 " Model & thinking ",
@@ -777,28 +781,28 @@ impl ModelPickerView {
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" ↑↓ ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("move "),
-                Span::styled(" Tab ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("switch "),
-                Span::styled(" Type ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("filter "),
-                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("apply "),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("cancel "),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
-            .style(Style::default());
+            .style(Style::default().bg(palette::DEEPSEEK_INK));
         let inner = outer.inner(popup_area);
         outer.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑↓", "move"),
+                ActionHint::new("Tab", "switch"),
+                ActionHint::new("Type", "filter"),
+                ActionHint::new("Enter", "apply"),
+                ActionHint::new("Esc", "cancel"),
+            ],
+        );
 
         let columns = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(68), Constraint::Percentage(32)])
-            .split(inner);
+            .split(content);
 
         let mut model_rows: Vec<(String, String)> = self
             .visible_model_rows()
@@ -1848,6 +1852,65 @@ mod tests {
         ));
 
         assert!(matches!(action, ViewAction::Close));
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires every
+    /// overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn model_picker_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        let (app, _lock) = create_test_app();
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            // Pre-fill with a sentinel so any cell the composited modal fails to
+            // paint (bleed-through) is detectable as a surviving 'X'. The default
+            // test app uses DeepSeek model ids, so 'X' never appears legitimately.
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            // Render through the ViewStack so the shared opaque backdrop is
+            // painted exactly as it is in production.
+            let mut stack = ViewStack::new();
+            stack.push(ModelPickerView::new(&app));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            // Footer keeps every action (it wraps instead of clipping).
+            for label in ["move", "switch", "filter", "apply", "cancel"] {
+                assert!(text.contains(label), "{w}x{h}: missing '{label}' hint");
+            }
+            // Composited frame is fully opaque: no sentinel survives and the
+            // center cell carries the modal ink background.
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            // No row exceeds the frame width (no horizontal overflow).
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    unicode_width::UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -22,8 +22,8 @@ use crate::model_registry;
 use crate::palette;
 use crate::tui::app::{App, ReasoningEffort};
 use crate::tui::views::{
-    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
-    render_modal_surface,
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer, render_modal_surface,
 };
 
 /// Thinking-effort rows shown for DeepSeek-style providers, in the order
@@ -748,27 +748,10 @@ impl ModalView for ModelPickerView {
 
 impl ModelPickerView {
     fn render_classic(&self, area: Rect, buf: &mut Buffer) {
-        let available_width = area.width.saturating_sub(4);
-        let popup_width = if available_width >= 60 {
-            available_width.min(96)
-        } else {
-            area.width.saturating_sub(2).max(1)
-        };
         let desired_height = (self.model_row_count().max(self.current_efforts().len()) as u16)
             .saturating_add(4)
             .clamp(10, 22);
-        let available_height = area.height.saturating_sub(4);
-        let popup_height = if available_height >= 10 {
-            desired_height.min(available_height)
-        } else {
-            area.height.saturating_sub(2).max(1)
-        };
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        let popup_area = centered_modal_area(area, 96, desired_height, 60, 10);
 
         render_modal_surface(area, popup_area, buf);
 

--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -26,13 +26,9 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::palette;
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
-
-/// Footer hint shown along the bottom border of the pager. Kept short so it
-/// fits on narrow terminals; full reference lives in the module docs.
-const FOOTER_HINT_NAV: &str =
-    " j/k scroll  Space page  Ctrl+D/U half  g/G top/bottom  / search  c copy";
-const FOOTER_HINT_EXIT: &str = " q/Esc close ";
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
+};
 
 pub struct PagerView {
     title: String,
@@ -388,10 +384,33 @@ impl ModalView for PagerView {
 
         Clear.render(popup_area, buf);
 
-        // Borders eat 1 row top + 1 row bottom; the block's `Padding::uniform(1)`
-        // eats 1 more on each side. Net: 4 rows of overhead to subtract from
-        // `popup_area.height` before we know how many lines fit.
-        let mut visible_height = popup_area.height.saturating_sub(4) as usize;
+        let block = Block::default()
+            .title(self.title.clone())
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::DEEPSEEK_INK))
+            .padding(Padding::uniform(1));
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        // The wrapping action footer is anchored to the bottom of the inner
+        // area; the body fills the rows above it.
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("q/Esc", "close"),
+                ActionHint::new("j/k", "scroll"),
+                ActionHint::new("Space", "page"),
+                ActionHint::new("Ctrl+D/U", "half"),
+                ActionHint::new("g/G", "top/bottom"),
+                ActionHint::new("/", "search"),
+                ActionHint::new("c", "copy"),
+            ],
+        );
+
+        // `content` already excludes the border, padding, and footer rows.
+        let mut visible_height = content.height as usize;
         if self.search_mode {
             // Reserve a row for the search prompt that gets pushed below.
             visible_height = visible_height.saturating_sub(1);
@@ -467,26 +486,8 @@ impl ModalView for PagerView {
             )));
         }
 
-        let footer = Line::from(vec![
-            Span::styled(
-                FOOTER_HINT_EXIT,
-                Style::default()
-                    .fg(palette::DEEPSEEK_SKY)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(FOOTER_HINT_NAV, Style::default().fg(palette::TEXT_HINT)),
-        ]);
-        let block = Block::default()
-            .title(self.title.clone())
-            .title_bottom(footer)
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(palette::BORDER_COLOR))
-            .padding(Padding::uniform(1));
-
-        let paragraph = Paragraph::new(visible_lines)
-            .block(block)
-            .wrap(Wrap { trim: false });
-        paragraph.render(popup_area, buf);
+        let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: false });
+        paragraph.render(content, buf);
     }
 }
 
@@ -764,22 +765,35 @@ mod tests {
 
     #[test]
     fn footer_hint_includes_new_bindings() {
-        // The rendered pager must surface the new vim-style bindings to
-        // the user; check the footer hint covers the headline keys.
+        // The rendered pager must surface the new vim-style bindings to the
+        // user. The footer is now a wrapping ActionHint row inside the modal
+        // body (not the bottom border), so assert against the rendered buffer.
+        let p = make_pager(5);
+        let area = Rect::new(0, 0, 100, 16);
+        let mut buf = Buffer::empty(area);
+        p.render(area, &mut buf);
+        let mut text = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
         for needle in &[
             "j/k",
+            "scroll",
             "g/G",
+            "top/bottom",
             "Space",
-            "Ctrl+D",
-            "/ search",
-            "c copy",
-            "q/Esc close",
+            "page",
+            "Ctrl+D/U",
+            "half",
+            "search",
+            "copy",
+            "q/Esc",
+            "close",
         ] {
-            let full_hint = format!("{FOOTER_HINT_EXIT}{FOOTER_HINT_NAV}");
-            assert!(
-                full_hint.contains(needle),
-                "footer hint missing {needle:?}: {full_hint}"
-            );
+            assert!(text.contains(needle), "footer hint missing {needle:?}");
         }
     }
 
@@ -830,17 +844,19 @@ mod tests {
         let area = Rect::new(0, 0, 100, 10);
         let mut buf = Buffer::empty(area);
         p.render(area, &mut buf);
-        // The pager renders into an inset popup_area = (1, 1, w-2, h-2),
-        // so the bottom border lives at y = popup_area.bottom() - 1, not
-        // at the outer area's last row.
-        let popup_bottom_y = (area.height as usize).saturating_sub(2);
-        let mut bottom = String::new();
-        for x in 1..area.right().saturating_sub(1) {
-            bottom.push_str(buf[(x, popup_bottom_y as u16)].symbol());
+        // The footer is now anchored to the bottom of the modal body (above the
+        // padding/border) rather than painted on the border, so scan the whole
+        // frame for the action labels.
+        let mut text = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                text.push_str(buf[(x, y)].symbol());
+            }
+            text.push('\n');
         }
         assert!(
-            bottom.contains("close") || bottom.contains("scroll"),
-            "expected footer hint on bottom border row {popup_bottom_y}, got: {bottom:?}"
+            text.contains("close") || text.contains("scroll"),
+            "expected footer hint in rendered pager, got:\n{text}"
         );
     }
 
@@ -1011,6 +1027,59 @@ mod tests {
         }
 
         assert_eq!(p.scroll, bottom);
+    }
+
+    #[test]
+    fn pager_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+
+        const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(make_pager(60));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| (0..w).map(|x| buf[(x, y)].symbol().to_string()).collect())
+                .collect();
+            let text = rows.join("\n");
+
+            // Footer keeps every action.
+            for label in [
+                "close",
+                "scroll",
+                "page",
+                "half",
+                "top/bottom",
+                "search",
+                "copy",
+            ] {
+                assert!(text.contains(label), "{w}x{h}: footer missing '{label}'");
+            }
+
+            // Composited frame is fully opaque.
+            assert!(!text.contains('X'), "{w}x{h}: background bleed-through");
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+
+            // No horizontal overflow.
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -23,7 +23,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
+    widgets::{Block, Borders, Paragraph, Widget},
 };
 
 use crate::config::{ApiProvider, Config, has_api_key_for, kimi_cli_credentials_present};
@@ -31,7 +31,10 @@ use crate::core::ops::ProviderRuntimeStatus;
 use crate::model_profile::{SupportState, resolved_capability_profile};
 use crate::palette;
 use crate::tui::app::ReasoningEffort;
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
+    render_modal_surface,
+};
 use codewhale_config::catalog::{CatalogOffering, CatalogSnapshot};
 use codewhale_config::provider::WireFormat;
 use codewhale_config::route::{
@@ -1209,27 +1212,28 @@ impl ProviderPickerView {
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" ↑↓ ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("move "),
-                Span::styled(" a-z ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("jump "),
-                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw(format!("{enter_action} ")),
-                Span::styled(" R ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("edit key "),
-                Span::styled(" M ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("models "),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("cancel "),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
-            .style(Style::default());
+            .style(Style::default().bg(palette::DEEPSEEK_INK));
         let inner = outer.inner(area);
         outer.render(area, buf);
 
-        let visible_rows = usize::from(inner.height);
+        // The action footer moves into the body so it wraps instead of clipping
+        // at narrow widths (#3732); the provider list renders above it.
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑↓", "move"),
+                ActionHint::new("a-z", "jump"),
+                ActionHint::new("Enter", enter_action),
+                ActionHint::new("R", "edit key"),
+                ActionHint::new("M", "models"),
+                ActionHint::new("Esc", "cancel"),
+            ],
+        );
+
+        let visible_rows = usize::from(content.height);
         let visible_start = self.visible_start(visible_rows);
         let mut lines: Vec<Line> = Vec::with_capacity(visible_rows);
         for (idx, row) in self
@@ -1277,7 +1281,7 @@ impl ProviderPickerView {
             ]);
             if is_selected {
                 line.style = Self::selected_row_bg_style();
-                let target_width = usize::from(inner.width);
+                let target_width = usize::from(content.width);
                 let line_width = line.width();
                 if line_width < target_width {
                     line.spans.push(Span::styled(
@@ -1288,7 +1292,7 @@ impl ProviderPickerView {
             }
             lines.push(line);
         }
-        Paragraph::new(lines).render(inner, buf);
+        Paragraph::new(lines).render(content, buf);
     }
 
     fn render_key_entry(&self, area: Rect, buf: &mut Buffer) {
@@ -1300,17 +1304,22 @@ impl ProviderPickerView {
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("save & switch "),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("back "),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
-            .style(Style::default());
+            .style(Style::default().bg(palette::DEEPSEEK_INK));
         let inner = outer.inner(area);
         outer.render(area, buf);
+
+        // The action footer moves into the body so it wraps instead of clipping
+        // at narrow widths (#3732); the key-entry fields render above it.
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("Enter", "save & switch"),
+                ActionHint::new("Esc", "back"),
+            ],
+        );
 
         let layout = Layout::default()
             .direction(Direction::Vertical)
@@ -1319,7 +1328,7 @@ impl ProviderPickerView {
                 Constraint::Length(2),
                 Constraint::Min(1),
             ])
-            .split(inner);
+            .split(content);
 
         let masked = mask_key(&self.api_key_input);
         let display = if masked.is_empty() {
@@ -1502,7 +1511,7 @@ impl ModalView for ProviderPickerView {
             height: popup_height,
         };
 
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
         match self.stage {
             Stage::List => self.render_list(popup_area, buf),
@@ -2478,6 +2487,76 @@ mod tests {
 
         assert!(rendered.contains("DeepSeek *"));
         assert!(rendered.contains("Ollama"));
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires every
+    /// overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn provider_picker_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        // Provider display names contain capital X/Q (Xiaomi MiMo, Qianfan), so
+        // use a glyph that can never appear in the modal content as the
+        // bleed-through sentinel.
+        const SENTINEL: &str = "\u{2592}"; // ▒
+        let config = Config::default();
+        // Make the first provider in the sorted list active so its highlighted
+        // row sits at the top of the list, never on the vertical center cell
+        // that must read as the opaque modal ink.
+        let active = ProviderPickerView::new(ApiProvider::Deepseek, &config).rows[0].provider;
+
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol(SENTINEL);
+                }
+            }
+            // Render through the ViewStack so the shared opaque backdrop is
+            // painted exactly as it is in production.
+            let mut stack = ViewStack::new();
+            stack.push(ProviderPickerView::new(active, &config));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            // Footer keeps every action (it wraps instead of clipping).
+            for label in ["move", "jump", "edit key", "models", "cancel"] {
+                assert!(text.contains(label), "{w}x{h}: missing '{label}' hint");
+            }
+            // The Enter action label is dynamic (apply vs set key); one shows.
+            assert!(
+                text.contains("apply") || text.contains("set key"),
+                "{w}x{h}: missing Enter action label"
+            );
+            // Composited frame is fully opaque: no sentinel survives and the
+            // center cell carries the modal ink background.
+            assert!(
+                !text.contains(SENTINEL),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            // No row exceeds the frame width (no horizontal overflow).
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    unicode_width::UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -32,8 +32,8 @@ use crate::model_profile::{SupportState, resolved_capability_profile};
 use crate::palette;
 use crate::tui::app::ReasoningEffort;
 use crate::tui::views::{
-    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
-    render_modal_surface,
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer, render_modal_surface,
 };
 use codewhale_config::catalog::{CatalogOffering, CatalogSnapshot};
 use codewhale_config::provider::WireFormat;
@@ -1497,19 +1497,11 @@ impl ModalView for ProviderPickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 120.min(area.width.saturating_sub(4)).max(64);
-        let popup_height = match self.stage {
+        let preferred_height = match self.stage {
             Stage::List => (self.rows.len() as u16).saturating_add(2),
             Stage::KeyEntry => 10,
-        }
-        .min(area.height.saturating_sub(4))
-        .max(8);
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
         };
+        let popup_area = centered_modal_area(area, 120, preferred_height, 64, 8);
 
         render_modal_surface(area, popup_area, buf);
 

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -32,6 +32,7 @@ fn modal_block(title: &str) -> Block<'static> {
         )]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))
+        .style(Style::default().bg(palette::DEEPSEEK_INK))
         .padding(Padding::uniform(1))
 }
 
@@ -1490,5 +1491,66 @@ mod tests {
         view.selected = 9;
         view.ensure_selected_visible();
         assert_eq!(view.list_scroll.get(), 7);
+    }
+
+    #[test]
+    fn session_picker_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+
+        const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+        for (w, h) in BLOCKER_SIZES {
+            let sessions = vec![
+                test_session(1, "first session"),
+                test_session(2, "second session"),
+            ];
+            let mut view = picker_with(sessions, None);
+            view.current_preview = vec![
+                "Title: preview".to_string(),
+                "Updated: 2026-06-25 10:30".to_string(),
+                String::new(),
+                "USER: hello".to_string(),
+            ];
+
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(view);
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| (0..w).map(|x| buf[(x, y)].symbol().to_string()).collect())
+                .collect();
+            let text = rows.join("\n");
+
+            // Both panes and their key hints survive at every size. The long
+            // in-pane action header truncates to the (sometimes narrow) list
+            // pane width, so assert the pane titles, which carry the digit-jump
+            // and paging shortcuts and always fit.
+            assert!(text.contains("Sessions"), "{w}x{h}: missing Sessions pane");
+            assert!(text.contains("History"), "{w}x{h}: missing History pane");
+            assert!(text.contains("1-9"), "{w}x{h}: missing 1-9 shortcut hint");
+            assert!(text.contains("PgUp/PgDn"), "{w}x{h}: missing paging hint");
+
+            // Composited frame is fully opaque.
+            assert!(!text.contains('X'), "{w}x{h}: background bleed-through");
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+
+            // No horizontal overflow.
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -19,7 +19,10 @@ use ratatui::{
 };
 
 use crate::palette::{SELECTABLE_THEMES, ThemeId, UiTheme};
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer,
+};
 
 pub struct ThemePickerView {
     selected: usize,
@@ -157,34 +160,18 @@ impl ModalView for ThemePickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        // Modal must always fit inside `area`. The old `.max(52) / .max(10)`
-        // floors could produce dimensions larger than the available area on
-        // very small terminals (or split-pane setups), which then made the
-        // centering arithmetic underflow and ratatui assert. Take a
-        // soft-preferred size and clamp it strictly to `area`.
-        let popup_width = 78u16.min(area.width.saturating_sub(4));
-        // 1 title + 1 spacer + N rows + spacer + bottom hint
+        // 1 title + 1 spacer + N rows + spacer + the in-body action footer.
+        // centered_modal_area clamps strictly to `area`, so the modal always
+        // fits even on tiny or split-pane terminals.
         let needed_height = (SELECTABLE_THEMES.len() as u16).saturating_add(9);
-        let popup_height = needed_height.min(area.height.saturating_sub(4));
-
-        if popup_width == 0 || popup_height == 0 {
-            // Nothing sensible to draw — the host's caller has already
-            // cleared the area, so we just return.
-            return;
-        }
-
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        let popup_area = centered_modal_area(area, 78, needed_height, 44, 8);
 
         // The live theme has already been swapped under us via ConfigUpdated,
         // so we pull the *current* preview's UiTheme from the cursor row to
         // skin the modal chrome. That way the popup itself shifts color as
         // the cursor moves, matching what the background will look like
-        // after Enter.
+        // after Enter. We keep the live `surface_bg` (not the shared ink) and
+        // the bare `Clear` so the preview backdrop reads as intended.
         let live = self.ui_theme_for(self.current());
 
         Clear.render(popup_area, buf);
@@ -196,14 +183,6 @@ impl ModalView for ThemePickerView {
                     .fg(live.status_working)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" ↑/↓ ", Style::default().fg(live.text_muted)),
-                Span::raw("preview "),
-                Span::styled(" Enter ", Style::default().fg(live.text_muted)),
-                Span::raw("save "),
-                Span::styled(" Esc ", Style::default().fg(live.text_muted)),
-                Span::raw("revert "),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(live.border))
             .style(Style::default().bg(live.surface_bg))
@@ -211,6 +190,16 @@ impl ModalView for ThemePickerView {
 
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑/↓", "preview"),
+                ActionHint::new("Enter", "save"),
+                ActionHint::new("Esc", "revert"),
+            ],
+        );
 
         let mut lines: Vec<Line> = Vec::with_capacity(SELECTABLE_THEMES.len() + 5);
         lines.push(Line::from(Span::styled(
@@ -272,7 +261,7 @@ impl ModalView for ThemePickerView {
             lines.push(Line::from(spans));
         }
 
-        Paragraph::new(lines).render(inner, buf);
+        Paragraph::new(lines).render(content, buf);
     }
 }
 
@@ -411,5 +400,60 @@ mod tests {
         let area = ratatui::layout::Rect::new(0, 0, 20, 6);
         let mut buf = ratatui::buffer::Buffer::empty(area);
         v.render(area, &mut buf);
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires
+    /// every overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn theme_picker_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        use ratatui::{buffer::Buffer, layout::Rect};
+        use unicode_width::UnicodeWidthStr;
+
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(ThemePickerView::new("system".to_string()));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            for label in ["preview", "save", "revert"] {
+                assert!(text.contains(label), "{w}x{h}: missing footer '{label}'");
+            }
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            // The theme picker paints the *live* theme surface (not the shared
+            // ink), so assert the center cell is painted (no surviving
+            // sentinel) rather than checking a fixed background color.
+            assert_ne!(
+                buf[(w / 2, h / 2)].symbol(),
+                "X",
+                "{w}x{h}: modal interior must be painted"
+            );
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -1,12 +1,16 @@
-//! Fleet setup and loadout planner.
+//! `/fleet setup` — a progressive "set up your agent team" flow.
 //!
-//! NOTE (audit #7 / #3167): the modal title, footer hints, and the lane/row
-//! taxonomy below are intentionally English for now. #3167 reworks this view
-//! from a read-only summary into an interactive provider/model picker, which
-//! will churn most of this text; localizing the ~90 volatile technical strings
-//! into all shipped locales before that lands would be throwaway work. The
-//! command entry (`CmdFleetDescription`) is already localized, and the
-//! functional selection wiring (audit #8) is handled here regardless of locale.
+//! Replaces the old six-column config matrix (#3791). Fleet is presented as an
+//! agent team: the user makes one focused choice at a time (a role, then a model
+//! class) and then reviews the full posture — model/route, permissions, tools,
+//! workspace/org scope, and review policy — before starting. "Start" inserts a
+//! safe profile-authoring prompt into the composer; nothing is written to disk,
+//! preserving the existing InsertText-to-compose commit path.
+//!
+//! NOTE (audit #7 / #3167): the role/model taxonomy and copy below are
+//! intentionally English for now; #3167 reworks this into an interactive
+//! provider/model picker that will churn most of this text. The command entry
+//! (`CmdFleetDescription`) is already localized.
 
 use std::path::{Path, PathBuf};
 
@@ -16,74 +20,106 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, Borders, Padding, Paragraph, Widget, Wrap},
 };
 
 use crate::config::Config;
 use crate::palette;
 use crate::tui::app::App;
 use crate::tui::views::{
-    CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent, truncate_view_text,
+    ActionHint, CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent,
+    centered_modal_area, render_modal_footer, render_modal_surface, truncate_view_text,
 };
 
 const PROFILE_DIR: &str = ".codewhale/agents";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RowTone {
-    Current,
-    Ready,
-    Info,
-    Warning,
+/// A selectable choice in a wizard step: a short identifier `label`, a one-line
+/// `summary`, and a longer `description` shown (wrapped) in the detail pane.
+struct Choice {
+    label: &'static str,
+    summary: &'static str,
+    description: &'static str,
 }
 
-impl RowTone {
-    fn style(self, selected: bool) -> Style {
-        if selected {
-            return Style::default()
-                .fg(palette::SELECTION_TEXT)
-                .bg(palette::SELECTION_BG)
-                .add_modifier(Modifier::BOLD);
-        }
+/// Agent-team roles. `label` doubles as the profile `role_hint` and file stem,
+/// so these strings are part of the generated-profile contract.
+const ROLES: [Choice; 8] = [
+    Choice {
+        label: "manager",
+        summary: "Plan & split queued work",
+        description: "Coordinates the Fleet run: plans the work, splits it into bounded tasks, and dispatches workers.",
+    },
+    Choice {
+        label: "main",
+        summary: "Default orchestrator",
+        description: "The parent for the whole Fleet. Owns topology and verifies the claims workers return.",
+    },
+    Choice {
+        label: "scout",
+        summary: "Read-first research",
+        description: "Research and repo reconnaissance. Reads and summarizes before anything is written.",
+    },
+    Choice {
+        label: "builder",
+        summary: "Implements bounded changes",
+        description: "Implements changes strictly inside its assigned task scope; writes only what the slice needs.",
+    },
+    Choice {
+        label: "reviewer",
+        summary: "Read-only review",
+        description: "Checks regressions, tests, and diffs. Read-only — it never writes.",
+    },
+    Choice {
+        label: "verifier",
+        summary: "Runs focused validation",
+        description: "Runs targeted validation and reports receipts back to the orchestrator.",
+    },
+    Choice {
+        label: "synthesizer",
+        summary: "Reduce receipts to handoff",
+        description: "Turns worker receipts into bounded handoff state instead of raw transcript replay.",
+    },
+    Choice {
+        label: "custom",
+        summary: "Author a profile by hand",
+        description: "Define the posture yourself in a workspace agent TOML profile under .codewhale/agents/.",
+    },
+];
 
-        Style::default().fg(match self {
-            Self::Current => palette::WHALE_ACCENT_PRIMARY,
-            Self::Ready => palette::STATUS_SUCCESS,
-            Self::Info => palette::TEXT_PRIMARY,
-            Self::Warning => palette::STATUS_WARNING,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-struct FleetSetupRow {
-    label: String,
-    value: String,
-    detail: String,
-    tone: RowTone,
-}
-
-impl FleetSetupRow {
-    fn new(label: impl Into<String>, value: impl Into<String>, detail: impl Into<String>) -> Self {
-        Self {
-            label: label.into(),
-            value: value.into(),
-            detail: detail.into(),
-            tone: RowTone::Info,
-        }
-    }
-
-    fn tone(mut self, tone: RowTone) -> Self {
-        self.tone = tone;
-        self
-    }
-}
-
-#[derive(Debug, Clone)]
-struct FleetSetupLane {
-    title: &'static str,
-    subtitle: &'static str,
-    rows: Vec<FleetSetupRow>,
-}
+/// Model-routing classes. `label` is mapped to a profile `model_class_hint` by
+/// [`model_class_hint`]; default is `inherit` (reuse the active route).
+const MODEL_CLASSES: [Choice; 6] = [
+    Choice {
+        label: "inherit",
+        summary: "Same model as now",
+        description: "Reuse the active provider, model, and reasoning for this worker. Recommended default.",
+    },
+    Choice {
+        label: "fast",
+        summary: "Low-latency scout",
+        description: "An opt-in low-latency class for wide fan-out and quick reconnaissance.",
+    },
+    Choice {
+        label: "balanced",
+        summary: "Everyday build/review",
+        description: "A balanced class for normal build and review work.",
+    },
+    Choice {
+        label: "strong",
+        summary: "Hard problems",
+        description: "The strongest class for security, release, and architecture work.",
+    },
+    Choice {
+        label: "deep-reasoning",
+        summary: "More reasoning",
+        description: "Higher reasoning effort when the active route supports it.",
+    },
+    Choice {
+        label: "tool-heavy",
+        summary: "Operator workflows",
+        description: "Shell- and artifact-heavy operator workflows.",
+    },
+];
 
 #[derive(Debug, Clone)]
 pub struct FleetSetupSnapshot {
@@ -140,21 +176,23 @@ impl FleetSetupSnapshot {
     }
 }
 
-/// Lane index of the role picker (lane "1 Role").
-const ROLE_LANE: usize = 0;
-/// Lane index of the model-class picker (lane "2 Model").
-const MODEL_LANE: usize = 1;
+/// Which focused screen of the wizard is showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Step {
+    /// Pick the team role.
+    Role,
+    /// Pick the model-routing class.
+    Model,
+    /// Review the full posture and start.
+    Review,
+}
 
 pub struct FleetSetupView {
-    lanes: Vec<FleetSetupLane>,
-    selected_lane: usize,
-    selected_rows: Vec<usize>,
-    scrolls: Vec<usize>,
-    // The route context the profile prompt is generated against. The prompt
-    // itself is built on demand from the *current* role/model selection (see
-    // `insert_profile_prompt_action`) so the planner selection has a functional
-    // outcome.
     snapshot: FleetSetupSnapshot,
+    step: Step,
+    role_idx: usize,
+    model_idx: usize,
+    review_scroll: usize,
 }
 
 impl FleetSetupView {
@@ -164,77 +202,85 @@ impl FleetSetupView {
     }
 
     fn from_snapshot(snapshot: FleetSetupSnapshot) -> Self {
-        let lanes = build_lanes(&snapshot);
-        let len = lanes.len();
         Self {
-            lanes,
-            selected_lane: 0,
-            selected_rows: vec![0; len],
-            scrolls: vec![0; len],
             snapshot,
+            step: Step::Role,
+            role_idx: 0,
+            model_idx: 0,
+            review_scroll: 0,
         }
     }
 
-    /// Label of the row currently selected in `lane`, if any.
-    fn selected_label(&self, lane: usize) -> Option<&str> {
-        let row = self.selected_rows.get(lane).copied().unwrap_or_default();
-        self.lanes
-            .get(lane)
-            .and_then(|lane| lane.rows.get(row))
-            .map(|row| row.label.as_str())
+    /// The planner role chosen (drives the profile file name and `role_hint`).
+    fn selected_role(&self) -> &'static str {
+        ROLES[self.role_idx.min(ROLES.len() - 1)].label
     }
 
-    /// The planner role chosen in the Role lane (drives the profile file name
-    /// and `role_hint`). Falls back to `custom` when unresolved.
-    fn selected_role(&self) -> &str {
-        self.selected_label(ROLE_LANE).unwrap_or("custom")
-    }
-
-    /// The model class chosen in the Model lane, mapped to a profile schema
-    /// `model_class_hint` value.
+    /// The model class chosen, mapped to a profile schema `model_class_hint`.
     fn selected_model_class(&self) -> &'static str {
-        model_class_hint(self.selected_label(MODEL_LANE).unwrap_or("inherit"))
+        model_class_hint(MODEL_CLASSES[self.model_idx.min(MODEL_CLASSES.len() - 1)].label)
     }
 
-    fn selected_row(&self) -> usize {
-        self.selected_rows
-            .get(self.selected_lane)
-            .copied()
-            .unwrap_or_default()
-    }
-
-    fn selected_row_mut(&mut self) -> &mut usize {
-        &mut self.selected_rows[self.selected_lane]
-    }
-
-    fn selected_scroll_mut(&mut self) -> &mut usize {
-        &mut self.scrolls[self.selected_lane]
-    }
-
-    fn move_lane_left(&mut self) {
-        self.selected_lane = self.selected_lane.saturating_sub(1);
-    }
-
-    fn move_lane_right(&mut self) {
-        if self.selected_lane + 1 < self.lanes.len() {
-            self.selected_lane += 1;
+    /// Number of selectable rows on the current step (0 on the review step).
+    fn step_len(&self) -> usize {
+        match self.step {
+            Step::Role => ROLES.len(),
+            Step::Model => MODEL_CLASSES.len(),
+            Step::Review => 0,
         }
     }
 
-    fn move_row_up(&mut self) {
-        *self.selected_row_mut() = self.selected_row().saturating_sub(1);
-        *self.selected_scroll_mut() = self.selected_row();
+    fn move_up(&mut self) {
+        match self.step {
+            Step::Role => self.role_idx = self.role_idx.saturating_sub(1),
+            Step::Model => self.model_idx = self.model_idx.saturating_sub(1),
+            Step::Review => self.review_scroll = self.review_scroll.saturating_sub(1),
+        }
     }
 
-    fn move_row_down(&mut self) {
-        let max = self
-            .lanes
-            .get(self.selected_lane)
-            .map(|lane| lane.rows.len().saturating_sub(1))
-            .unwrap_or_default();
-        let next = (self.selected_row() + 1).min(max);
-        *self.selected_row_mut() = next;
-        *self.selected_scroll_mut() = next.saturating_sub(4);
+    fn move_down(&mut self) {
+        match self.step {
+            Step::Role => {
+                self.role_idx = (self.role_idx + 1).min(self.step_len().saturating_sub(1));
+            }
+            Step::Model => {
+                self.model_idx = (self.model_idx + 1).min(self.step_len().saturating_sub(1));
+            }
+            Step::Review => self.review_scroll = self.review_scroll.saturating_add(1),
+        }
+    }
+
+    /// Advance to the next step, or — on the review step — commit by inserting
+    /// the profile-authoring prompt into the composer.
+    fn advance(&mut self) -> ViewAction {
+        match self.step {
+            Step::Role => {
+                self.step = Step::Model;
+                ViewAction::None
+            }
+            Step::Model => {
+                self.step = Step::Review;
+                self.review_scroll = 0;
+                ViewAction::None
+            }
+            Step::Review => self.insert_profile_prompt_action(),
+        }
+    }
+
+    /// Step back toward the first screen. Returns `None` at the first step (the
+    /// host closes the modal via Esc instead).
+    fn back(&mut self) -> ViewAction {
+        match self.step {
+            Step::Role => ViewAction::None,
+            Step::Model => {
+                self.step = Step::Role;
+                ViewAction::None
+            }
+            Step::Review => {
+                self.step = Step::Model;
+                ViewAction::None
+            }
+        }
     }
 
     fn insert_profile_prompt_action(&self) -> ViewAction {
@@ -245,15 +291,37 @@ impl FleetSetupView {
         })
     }
 
-    /// Build the profile authoring prompt for the *current* role/model
-    /// selection. Re-evaluated each time so navigating the planner changes what
-    /// `g`/Enter inserts.
+    /// Build the profile authoring prompt for the current role/model selection.
     fn profile_prompt(&self) -> String {
         profile_authoring_prompt(
             &self.snapshot,
             self.selected_role(),
             self.selected_model_class(),
         )
+    }
+
+    /// The action hints for the current step's footer (wrapped by the shared
+    /// footer renderer so they can never run off the modal edge).
+    fn footer_hints(&self) -> Vec<ActionHint> {
+        let mut hints = Vec::new();
+        match self.step {
+            Step::Role => {
+                hints.push(ActionHint::new("↑/↓", "choose"));
+                hints.push(ActionHint::new("Enter", "next"));
+            }
+            Step::Model => {
+                hints.push(ActionHint::new("↑/↓", "choose"));
+                hints.push(ActionHint::new("Enter", "next"));
+                hints.push(ActionHint::new("←", "back"));
+            }
+            Step::Review => {
+                hints.push(ActionHint::new("↑/↓", "scroll"));
+                hints.push(ActionHint::new("Enter", "start"));
+                hints.push(ActionHint::new("←", "back"));
+            }
+        }
+        hints.push(ActionHint::new("Esc", "cancel"));
+        hints
     }
 }
 
@@ -269,58 +337,55 @@ impl ModalView for FleetSetupView {
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => ViewAction::Close,
-            KeyCode::Left | KeyCode::Char('h') => {
-                self.move_lane_left();
-                ViewAction::None
-            }
-            KeyCode::Right | KeyCode::Char('l') => {
-                self.move_lane_right();
-                ViewAction::None
-            }
             KeyCode::Up | KeyCode::Char('k') => {
-                self.move_row_up();
+                self.move_up();
                 ViewAction::None
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                self.move_row_down();
+                self.move_down();
                 ViewAction::None
             }
-            KeyCode::Enter | KeyCode::Char('g') | KeyCode::Char('G') => {
-                self.insert_profile_prompt_action()
+            KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => self.advance(),
+            KeyCode::Left | KeyCode::Char('h') => self.back(),
+            KeyCode::Home => {
+                self.review_scroll = 0;
+                ViewAction::None
+            }
+            KeyCode::PageUp => {
+                self.review_scroll = self.review_scroll.saturating_sub(8);
+                ViewAction::None
+            }
+            KeyCode::PageDown => {
+                self.review_scroll = self.review_scroll.saturating_add(8);
+                ViewAction::None
             }
             _ => ViewAction::None,
         }
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = area.width.saturating_sub(4).clamp(72, 116).min(area.width);
-        let popup_height = area.height.saturating_sub(4).clamp(18, 38).min(area.height);
-        let popup_area = Rect {
-            x: area.x + area.width.saturating_sub(popup_width) / 2,
-            y: area.y + area.height.saturating_sub(popup_height) / 2,
-            width: popup_width,
-            height: popup_height,
+        let popup_area = centered_modal_area(area, 96, 30, 60, 16);
+        render_modal_surface(area, popup_area, buf);
+
+        let step_no = match self.step {
+            Step::Role => 1,
+            Step::Model => 2,
+            Step::Review => 3,
         };
-
-        Clear.render(popup_area, buf);
-
         let block = Block::default()
             .title(Line::from(Span::styled(
-                " Fleet Setup ",
+                " Fleet setup — your agent team ",
                 Style::default()
                     .fg(palette::WHALE_ACCENT_PRIMARY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" Left/Right ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("lane "),
-                Span::styled(" Up/Down ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("option "),
-                Span::styled(" Enter/G ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("profile prompt "),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("close "),
-            ]))
+            .title_bottom(
+                Line::from(Span::styled(
+                    format!(" Step {step_no}/3 "),
+                    Style::default().fg(palette::TEXT_MUTED),
+                ))
+                .alignment(ratatui::layout::Alignment::Right),
+            )
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
             .style(Style::default().bg(palette::DEEPSEEK_INK))
@@ -329,304 +394,258 @@ impl ModalView for FleetSetupView {
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
 
-        let direction = if inner.width >= 94 {
-            Direction::Horizontal
-        } else {
-            Direction::Vertical
-        };
-        let constraints = vec![Constraint::Ratio(1, self.lanes.len() as u32); self.lanes.len()];
-        let areas = Layout::default()
-            .direction(direction)
-            .constraints(constraints)
-            .split(inner);
+        let hints = self.footer_hints();
+        let content = render_modal_footer(inner, buf, &hints);
 
-        for (idx, lane) in self.lanes.iter().enumerate() {
-            let focused = idx == self.selected_lane;
-            let scroll = self.scrolls.get(idx).copied().unwrap_or_default();
-            let selected = self.selected_rows.get(idx).copied().unwrap_or_default();
-            render_lane(lane, areas[idx], buf, focused, selected, scroll);
+        // Header (intro + breadcrumb) above the step body.
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(1)])
+            .split(content);
+        self.render_header(chunks[0], buf);
+
+        match self.step {
+            Step::Role => render_choice_step(
+                chunks[1],
+                buf,
+                &ROLES,
+                self.role_idx,
+                &[
+                    "Fleet runs sub-agents that delegate work. Pick the role this".to_string(),
+                    "team member should play. It becomes the profile role_hint.".to_string(),
+                ],
+            ),
+            Step::Model => render_choice_step(
+                chunks[1],
+                buf,
+                &MODEL_CLASSES,
+                self.model_idx,
+                &[
+                    format!(
+                        "Current route: {} / {}  ·  reasoning {}",
+                        self.snapshot.provider, self.snapshot.model, self.snapshot.reasoning
+                    ),
+                    format!(
+                        "Maps to model_class_hint = {}.",
+                        self.selected_model_class()
+                    ),
+                ],
+            ),
+            Step::Review => self.render_review(chunks[1], buf),
         }
     }
 }
 
-fn build_lanes(snapshot: &FleetSetupSnapshot) -> Vec<FleetSetupLane> {
-    let (profile_value, profile_detail) = profile_file_status(&snapshot.workspace);
-    let token_budget = snapshot
-        .token_budget
-        .map(|budget| format!("{budget} tokens"))
-        .unwrap_or_else(|| "unbounded".to_string());
+impl FleetSetupView {
+    fn render_header(&self, area: Rect, buf: &mut Buffer) {
+        let (title, subtitle) = match self.step {
+            Step::Role => (
+                "Choose a team role",
+                "Each Fleet member plays one role in the delegation.",
+            ),
+            Step::Model => (
+                "Choose a model class",
+                "How this worker should be routed. Inherit keeps your current model.",
+            ),
+            Step::Review => (
+                "Review & start",
+                "Confirm the posture below, then start to author the profile.",
+            ),
+        };
+        let lines = vec![
+            Line::from(Span::styled(
+                title,
+                Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+            )),
+            Line::from(Span::styled(
+                subtitle,
+                Style::default().fg(palette::TEXT_MUTED),
+            )),
+        ];
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: true })
+            .render(area, buf);
+    }
 
-    vec![
-        FleetSetupLane {
-            title: "1 Role",
-            subtitle: "role and persona",
-            rows: vec![
-                FleetSetupRow::new("manager", "plan/split", "coordinates queued Fleet work"),
-                FleetSetupRow::new("main", "orchestrator", "default parent for the whole Fleet")
-                    .tone(RowTone::Ready),
-                FleetSetupRow::new("scout", "read-first", "research and repo reconnaissance"),
-                FleetSetupRow::new("builder", "write", "implements bounded changes"),
-                FleetSetupRow::new("reviewer", "read-only", "checks regressions and tests"),
-                FleetSetupRow::new("verifier", "test-runner", "runs focused validation"),
-                FleetSetupRow::new("synthesizer", "reduce", "turns receipts into handoff state"),
-                FleetSetupRow::new(
-                    "custom",
-                    "agent profile",
-                    "workspace TOML can define posture",
-                )
-                .tone(RowTone::Current),
-            ],
-        },
-        FleetSetupLane {
-            title: "2 Model",
-            subtitle: "class and route intent",
-            rows: vec![
-                FleetSetupRow::new(
-                    "current route",
-                    format!("{} / {}", snapshot.provider, snapshot.model),
-                    format!("default same model, reasoning {}", snapshot.reasoning),
-                )
-                .tone(RowTone::Current),
-                FleetSetupRow::new("inherit", "same model", "reuse active provider/model"),
-                FleetSetupRow::new("fast", "scout", "opt-in low-latency fanout"),
-                FleetSetupRow::new("balanced", "auto class", "normal build/review when chosen")
-                    .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "preset",
-                    "editable",
-                    "recommended tiers never force the orchestrator",
-                )
-                .tone(RowTone::Current),
-                FleetSetupRow::new("strong", "hard", "security, release, architecture"),
-                FleetSetupRow::new(
-                    "fixed model",
-                    "profile model",
-                    "visible model id on active route",
-                )
-                .tone(RowTone::Current),
-                FleetSetupRow::new("deep-reasoning", "debug", "higher reasoning when supported"),
-                FleetSetupRow::new("tool-heavy", "operator", "shell and artifact workflows"),
-            ],
-        },
-        FleetSetupLane {
-            title: "3 Permission",
-            subtitle: "authority posture",
-            rows: vec![
-                FleetSetupRow::new(
-                    "parent envelope",
-                    "inherit+narrow",
-                    "children cannot widen approval, trust, or secrets",
-                )
-                .tone(RowTone::Ready),
-                FleetSetupRow::new("reviewer", "read-only", "default for review/plan/scout")
-                    .tone(RowTone::Ready),
-                FleetSetupRow::new("builder", "scoped write", "write only inside task bounds"),
-                FleetSetupRow::new(
-                    "approval",
-                    "required",
-                    "profiles cannot disable required approvals",
-                )
-                .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "custom profile",
-                    "no grants",
-                    "TOML may narrow posture but not expand it",
-                ),
-            ],
-        },
-        FleetSetupLane {
-            title: "4 Tools",
-            subtitle: "capability loadout",
-            rows: vec![
-                FleetSetupRow::new("workspace files", profile_value, profile_detail)
-                    .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "custom profile",
-                    "generate TOML",
-                    "Enter inserts a safe authoring prompt",
-                )
-                .tone(RowTone::Current),
-                FleetSetupRow::new("read tools", "default", "search, inspect, summarize")
-                    .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "write tools",
-                    "builder only",
-                    "edit/apply patch after scope",
-                ),
-                FleetSetupRow::new("shell", "policy gated", "allowed by parent/runtime posture"),
-                FleetSetupRow::new(
-                    "artifacts",
-                    "receipts",
-                    "logs and handoff data stay inspectable",
-                ),
-            ],
-        },
-        FleetSetupLane {
-            title: "5 Org",
-            subtitle: "team and recursion",
-            rows: vec![
-                FleetSetupRow::new(
-                    "Fleet config",
-                    "sub-agents",
-                    "durable slots, profiles, models, tools, ledger",
-                )
-                .tone(RowTone::Current),
-                FleetSetupRow::new(
-                    "WhaleFlow",
-                    "agent plan",
-                    "agent-authored workflow selects and monitors slots",
-                )
-                .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "role workers",
-                    if snapshot.subagents_enabled {
-                        "enabled"
-                    } else {
-                        "disabled"
-                    },
-                    format!(
-                        "{} concurrent, {} launch slots, {} admitted",
-                        snapshot.max_subagents, snapshot.launch_concurrency, snapshot.max_admitted
-                    ),
-                )
-                .tone(if snapshot.subagents_enabled {
-                    RowTone::Ready
+    fn render_review(&self, area: Rect, buf: &mut Buffer) {
+        let role = &ROLES[self.role_idx.min(ROLES.len() - 1)];
+        let model = &MODEL_CLASSES[self.model_idx.min(MODEL_CLASSES.len() - 1)];
+        let (profile_value, _) = profile_file_status(&self.snapshot.workspace);
+        let file_stem = profile_file_stem(role.label);
+        let token_budget = self
+            .snapshot
+            .token_budget
+            .map(|budget| format!("{budget} tokens"))
+            .unwrap_or_else(|| "unbounded".to_string());
+
+        let mut lines: Vec<Line> = Vec::new();
+        let section = |lines: &mut Vec<Line>, label: &str, body: String| {
+            lines.push(Line::from(Span::styled(
+                label.to_string(),
+                Style::default().fg(palette::DEEPSEEK_SKY).bold(),
+            )));
+            lines.push(Line::from(Span::styled(
+                body,
+                Style::default().fg(palette::TEXT_PRIMARY),
+            )));
+            lines.push(Line::from(""));
+        };
+
+        section(
+            &mut lines,
+            "Role",
+            format!("{} — {}", role.label, role.summary),
+        );
+        section(
+            &mut lines,
+            "Model",
+            format!(
+                "{} (model_class_hint = {})  ·  route {} / {}, reasoning {}",
+                model.label,
+                self.selected_model_class(),
+                self.snapshot.provider,
+                self.snapshot.model,
+                self.snapshot.reasoning
+            ),
+        );
+        section(
+            &mut lines,
+            "Permissions",
+            "Inherit the parent envelope and narrow only. Children cannot widen approval, trust, or secrets, and required approvals stay on.".to_string(),
+        );
+        section(
+            &mut lines,
+            "Tools",
+            "Read tools by default; write tools for builders within scope; shell stays policy-gated; artifacts and receipts stay inspectable.".to_string(),
+        );
+        section(
+            &mut lines,
+            "Workspace & org",
+            format!(
+                "{} · sub-agents {} ({} concurrent, {} launch slots, {} admitted) · recursion agent {} / fleet {} (ceiling {})",
+                self.snapshot.workspace.display(),
+                if self.snapshot.subagents_enabled {
+                    "enabled"
                 } else {
-                    RowTone::Warning
-                }),
-                FleetSetupRow::new(
-                    "recursion",
-                    format!(
-                        "agent {} / fleet {}",
-                        snapshot.subagent_spawn_depth, snapshot.fleet_spawn_depth
-                    ),
-                    format!("ceiling {}", codewhale_config::MAX_SPAWN_DEPTH_CEILING),
-                )
-                .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "slot grid",
-                    "1-5 slots",
-                    "add or drill right into a recursive ring",
-                )
-                .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "limits",
-                    "100 total / depth 5",
-                    "workflow population cap, separate from launch concurrency",
-                ),
-                FleetSetupRow::new(
-                    "DeepSeek preset",
-                    "Pro -> Flash",
-                    "editable per slot; cheaper as rings expand",
-                ),
-                FleetSetupRow::new(
-                    "budget",
-                    token_budget,
-                    format!(
-                        "{}s api, {}s heartbeat",
-                        snapshot.api_timeout_secs, snapshot.heartbeat_timeout_secs
-                    ),
-                ),
-                FleetSetupRow::new("retry/ledger", "Fleet", "durable receipts and inspection"),
-            ],
-        },
-        FleetSetupLane {
-            title: "6 Review",
-            subtitle: "check and run",
-            rows: vec![
-                FleetSetupRow::new(
-                    "runtime",
-                    "Fleet -> exec",
-                    "durable workers launch the headless runtime",
-                )
-                .tone(RowTone::Current),
-                FleetSetupRow::new(
-                    "status",
-                    "/fleet status",
-                    "compat /subagents opens the same worker view",
-                )
-                .tone(RowTone::Ready),
-                FleetSetupRow::new(
-                    "inspect",
-                    "ledger",
-                    "route, receipt, artifact, terminal state",
-                ),
-                FleetSetupRow::new(
-                    "run spec",
-                    "review first",
-                    "confirm role/profile/loadout before launch",
-                ),
-                FleetSetupRow::new("handoff", "bounded", "summaries over raw transcript replay"),
-            ],
-        },
-    ]
+                    "disabled"
+                },
+                self.snapshot.max_subagents,
+                self.snapshot.launch_concurrency,
+                self.snapshot.max_admitted,
+                self.snapshot.subagent_spawn_depth,
+                self.snapshot.fleet_spawn_depth,
+                codewhale_config::MAX_SPAWN_DEPTH_CEILING,
+            ),
+        );
+        section(
+            &mut lines,
+            "Review policy",
+            format!(
+                "Budget {token_budget} · {}s api, {}s heartbeat. Fleet -> exec runs the workers; /fleet status (or /subagents) inspects the ledger.",
+                self.snapshot.api_timeout_secs, self.snapshot.heartbeat_timeout_secs
+            ),
+        );
+        section(
+            &mut lines,
+            "Profile",
+            format!(
+                "{PROFILE_DIR}/{file_stem}.toml  ·  {profile_value} present. Start inserts a safe authoring prompt into the composer — nothing is written to disk.",
+            ),
+        );
+
+        // `scroll` offsets by *visual* (post-wrap) rows, so the bound must count
+        // wrapped rows — not logical lines — or the bottom sections become
+        // unreachable. Estimate each line's wrapped height from its display
+        // width; an over-estimate is harmless (scroll clamps at the real end).
+        let wrap_width = usize::from(area.width).max(1);
+        let visual_rows: usize = lines
+            .iter()
+            .map(|line| line.width().div_ceil(wrap_width).max(1))
+            .sum();
+        let max_scroll = visual_rows.saturating_sub(usize::from(area.height).max(1));
+        let scroll = self.review_scroll.min(max_scroll);
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: true })
+            .scroll((scroll as u16, 0))
+            .render(area, buf);
+    }
 }
 
-fn render_lane(
-    lane: &FleetSetupLane,
+/// Render a wizard choice step: a list of selectable identifiers on the left and
+/// a wrapped detail pane (summary + description + context) on the right. Stacks
+/// vertically when the body is too narrow for two columns so nothing truncates.
+fn render_choice_step(
     area: Rect,
     buf: &mut Buffer,
-    focused: bool,
+    choices: &[Choice],
     selected: usize,
-    scroll: usize,
+    context: &[String],
 ) {
-    let border = if focused {
-        palette::WHALE_ACCENT_PRIMARY
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let (list_area, detail_area) = if area.width >= 56 {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(22), Constraint::Min(20)])
+            .split(area);
+        (cols[0], cols[1])
     } else {
-        palette::BORDER_COLOR
+        let list_height = (choices.len() as u16 + 1).min(area.height.saturating_sub(1).max(1));
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(list_height), Constraint::Min(1)])
+            .split(area);
+        (rows[0], rows[1])
     };
-    let block = Block::default()
-        .title(Line::from(Span::styled(
-            format!(" {} ", lane.title),
+
+    // List: labels are identifiers, so a `>`-marked single line each is safe.
+    let list_width = usize::from(list_area.width);
+    let mut list_lines: Vec<Line> = Vec::with_capacity(choices.len());
+    for (idx, choice) in choices.iter().enumerate() {
+        let is_selected = idx == selected;
+        let pointer = if is_selected { "> " } else { "  " };
+        let style = if is_selected {
             Style::default()
-                .fg(if focused {
-                    palette::WHALE_ACCENT_PRIMARY
-                } else {
-                    palette::TEXT_MUTED
-                })
-                .add_modifier(Modifier::BOLD),
-        )))
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(border))
-        .style(Style::default().bg(palette::DEEPSEEK_INK))
-        .padding(Padding::horizontal(1));
-    let inner = block.inner(area);
-    block.render(area, buf);
-
-    let width = inner.width.saturating_sub(1) as usize;
-    let visible_rows = inner.height.saturating_sub(2) as usize;
-    let max_scroll = lane.rows.len().saturating_sub(visible_rows);
-    let scroll = scroll.min(max_scroll);
-
-    let mut lines = Vec::with_capacity(visible_rows + 2);
-    lines.push(Line::from(Span::styled(
-        truncate_view_text(lane.subtitle, width),
-        Style::default().fg(palette::TEXT_MUTED),
-    )));
-
-    for (row_idx, row) in lane.rows.iter().enumerate().skip(scroll).take(visible_rows) {
-        let is_selected = focused && row_idx == selected;
-        let row_style = row.tone.style(is_selected);
-        let muted_style = if is_selected {
-            row_style
+                .fg(palette::SELECTION_TEXT)
+                .bg(palette::SELECTION_BG)
+                .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(palette::TEXT_MUTED)
+            Style::default().fg(palette::TEXT_PRIMARY)
         };
-        let pointer = if is_selected { ">" } else { " " };
-        let summary = format!("{pointer} {}: {}", row.label, row.value);
-        lines.push(Line::from(Span::styled(
-            truncate_view_text(&summary, width),
-            row_style,
+        list_lines.push(Line::from(Span::styled(
+            truncate_view_text(&format!("{pointer}{}", choice.label), list_width),
+            style,
         )));
-        if inner.height >= 9 {
-            lines.push(Line::from(Span::styled(
-                truncate_view_text(&format!("  {}", row.detail), width),
-                muted_style,
+    }
+    Paragraph::new(list_lines).render(list_area, buf);
+
+    // Detail: summary + wrapped description + wrapped context, all word-wrapped.
+    let choice = &choices[selected.min(choices.len().saturating_sub(1))];
+    let mut detail_lines: Vec<Line> = vec![
+        Line::from(Span::styled(
+            choice.summary,
+            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            choice.description,
+            Style::default().fg(palette::TEXT_PRIMARY),
+        )),
+    ];
+    if !context.is_empty() {
+        detail_lines.push(Line::from(""));
+        for entry in context {
+            detail_lines.push(Line::from(Span::styled(
+                entry.clone(),
+                Style::default().fg(palette::TEXT_MUTED),
             )));
         }
     }
-
-    Paragraph::new(lines).render(inner, buf);
+    Paragraph::new(detail_lines)
+        .wrap(Wrap { trim: true })
+        .render(detail_area, buf);
 }
 
 fn profile_file_status(workspace: &Path) -> (String, String) {
@@ -658,14 +677,13 @@ fn profile_file_status(workspace: &Path) -> (String, String) {
     }
 }
 
-/// Map a Model-lane row label to a profile-schema `model_class_hint` value.
-/// Route-context rows (`current route`, `fixed model`) and anything unknown
-/// resolve to `inherit` so the generated profile reuses the active route.
+/// Map a Model-step row label to a profile-schema `model_class_hint` value.
+/// Unknown/route-context labels resolve to `inherit`.
 fn model_class_hint(label: &str) -> &'static str {
     match label {
         "fast" => "fast",
         "balanced" => "balanced",
-        // "strong" = security/release/architecture work → the strongest schema class.
+        // "strong" = security/release/architecture → the strongest schema class.
         "strong" => "deep-reasoning",
         "deep-reasoning" => "deep-reasoning",
         "tool-heavy" => "tool-heavy",
@@ -727,7 +745,11 @@ fn profile_authoring_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui::views::ViewStack;
     use crossterm::event::KeyModifiers;
+    use unicode_width::UnicodeWidthStr;
+
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
 
     fn snapshot() -> FleetSetupSnapshot {
         FleetSetupSnapshot {
@@ -752,42 +774,60 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_move_across_lanes_and_rows() {
+    fn arrows_move_within_step_and_enter_advances() {
         let mut view = FleetSetupView::from_snapshot(snapshot());
+        assert_eq!(view.step, Step::Role);
 
-        view.handle_key(key(KeyCode::Right));
         view.handle_key(key(KeyCode::Down));
+        assert_eq!(view.role_idx, 1);
 
-        assert_eq!(view.selected_lane, 1);
-        assert_eq!(view.selected_row(), 1);
+        view.handle_key(key(KeyCode::Enter));
+        assert_eq!(view.step, Step::Model);
 
+        view.handle_key(key(KeyCode::Down));
+        assert_eq!(view.model_idx, 1);
+
+        view.handle_key(key(KeyCode::Enter));
+        assert_eq!(view.step, Step::Review);
+
+        // Left steps back through the wizard.
         view.handle_key(key(KeyCode::Left));
-
-        assert_eq!(view.selected_lane, 0);
-        assert_eq!(view.selected_row(), 0);
+        assert_eq!(view.step, Step::Model);
+        view.handle_key(key(KeyCode::Left));
+        assert_eq!(view.step, Step::Role);
     }
 
     #[test]
-    fn enter_inserts_profile_authoring_prompt() {
+    fn esc_cancels_from_any_step() {
         let mut view = FleetSetupView::from_snapshot(snapshot());
+        view.handle_key(key(KeyCode::Enter)); // -> Model
+        let action = view.handle_key(key(KeyCode::Esc));
+        assert!(matches!(action, ViewAction::Close));
+    }
 
-        let action = view.handle_key(key(KeyCode::Enter));
+    #[test]
+    fn start_on_review_inserts_profile_prompt_for_selection() {
+        let mut view = FleetSetupView::from_snapshot(snapshot());
+        // Role: manager(0) main(1) scout(2) builder(3) -> builder.
+        view.handle_key(key(KeyCode::Down));
+        view.handle_key(key(KeyCode::Down));
+        view.handle_key(key(KeyCode::Down));
+        view.handle_key(key(KeyCode::Enter)); // -> Model
+        // Model: inherit(0) fast(1) -> fast.
+        view.handle_key(key(KeyCode::Down));
+        view.handle_key(key(KeyCode::Enter)); // -> Review
 
+        let action = view.handle_key(key(KeyCode::Enter)); // Start
         match action {
             ViewAction::EmitAndClose(ViewEvent::CommandPaletteSelected {
                 action: CommandPaletteAction::InsertText { text },
             }) => {
-                // Default selection is the first Role row ("manager").
-                assert!(text.contains("Target path: .codewhale/agents/manager.toml"));
-                assert!(text.contains("role_hint (set to \"manager\")"));
+                assert!(text.contains("Target path: .codewhale/agents/builder.toml"));
+                assert!(text.contains("role_hint (set to \"builder\")"));
+                assert!(text.contains("model_class_hint (set to \"fast\""));
                 assert!(text.contains("provider = DeepSeek"));
-                assert!(text.contains("model (optional explicit model id"));
                 assert!(text.contains("Do not include provider, base_url"));
                 assert!(text.contains("Fleet is the durable sub-agent config surface"));
-                assert!(text.contains("workers are summoned as focused Fleet members"));
-                assert!(text.contains("default model behavior is same-route inheritance"));
-                assert!(text.contains("model tiers are recommendations"));
-                assert!(text.contains("Fleet owns the worker config"));
                 assert!(text.contains("topology belongs to the orchestrator"));
             }
             other => panic!("expected profile prompt insertion, got {other:?}"),
@@ -795,84 +835,113 @@ mod tests {
     }
 
     #[test]
-    fn selected_role_and_model_class_drive_generated_profile() {
-        let mut view = FleetSetupView::from_snapshot(snapshot());
-
-        // Role lane: manager(0) main(1) scout(2) builder(3) ... → move to builder.
-        view.handle_key(key(KeyCode::Down));
-        view.handle_key(key(KeyCode::Down));
-        view.handle_key(key(KeyCode::Down));
-        // Model lane: current route(0) inherit(1) fast(2) ... → move right then to fast.
-        view.handle_key(key(KeyCode::Right));
-        view.handle_key(key(KeyCode::Down));
-        view.handle_key(key(KeyCode::Down));
-
+    fn default_selection_targets_manager_inherit() {
+        let view = FleetSetupView::from_snapshot(snapshot());
         let prompt = view.profile_prompt();
-        assert!(
-            prompt.contains("Target path: .codewhale/agents/builder.toml"),
-            "selection should drive the profile file name; got: {prompt}"
-        );
-        assert!(
-            prompt.contains("role_hint (set to \"builder\")"),
-            "selection should drive role_hint; got: {prompt}"
-        );
-        assert!(
-            prompt.contains("model_class_hint (set to \"fast\""),
-            "selection should drive model_class_hint; got: {prompt}"
-        );
-        assert!(prompt.contains("Selected planner role: builder. Selected model class: fast."));
+        assert!(prompt.contains("Target path: .codewhale/agents/manager.toml"));
+        assert!(prompt.contains("model_class_hint (set to \"inherit\""));
+        assert!(prompt.contains("Current route context only"));
+        assert!(prompt.contains("permission-narrowing"));
+    }
+
+    fn render_through_stack(view_at: impl Fn() -> FleetSetupView, w: u16, h: u16) -> Vec<String> {
+        let area = Rect::new(0, 0, w, h);
+        let mut buf = Buffer::empty(area);
+        for y in 0..h {
+            for x in 0..w {
+                buf[(x, y)].set_symbol("X");
+            }
+        }
+        let mut stack = ViewStack::new();
+        stack.push(view_at());
+        stack.render(area, &mut buf);
+        (0..h)
+            .map(|y| {
+                (0..w)
+                    .map(|x| buf[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect()
     }
 
     #[test]
-    fn profile_prompt_uses_current_route_only_as_context() {
-        let view = FleetSetupView::from_snapshot(snapshot());
+    fn fleet_setup_is_usable_and_opaque_at_blocker_sizes() {
+        // Exercise each step so all three screens are validated at every size.
+        let builders: [(&str, fn() -> FleetSetupView); 3] = [
+            ("role", || FleetSetupView::from_snapshot(snapshot())),
+            ("model", || {
+                let mut v = FleetSetupView::from_snapshot(snapshot());
+                v.step = Step::Model;
+                v
+            }),
+            ("review", || {
+                let mut v = FleetSetupView::from_snapshot(snapshot());
+                v.step = Step::Review;
+                v
+            }),
+        ];
 
-        assert!(view.profile_prompt().contains("Current route context only"));
-        assert!(view.profile_prompt().contains("permission-narrowing"));
-        assert!(view.profile_prompt().contains("same-route inheritance"));
-        assert!(
-            view.profile_prompt()
-                .contains("durable sub-agent config surface")
-        );
-        assert!(
-            view.profile_prompt()
-                .contains("topology belongs to the orchestrator")
-        );
-        assert!(!view.profile_prompt().contains("builder + reviewer"));
+        for (label, make) in builders {
+            for (w, h) in BLOCKER_SIZES {
+                let rows = render_through_stack(make, w, h);
+                let text = rows.join("\n");
+
+                // No bleed-through anywhere in the composited frame.
+                assert!(
+                    !text.contains('X'),
+                    "{label} {w}x{h}: background bleed-through"
+                );
+                // Some action label is always visible.
+                assert!(text.contains("cancel"), "{label} {w}x{h}: missing footer");
+                // The first impression communicates Fleet = agent team.
+                assert!(
+                    text.contains("agent team"),
+                    "{label} {w}x{h}: missing framing"
+                );
+                // No row overflows the frame width.
+                for (y, row) in rows.iter().enumerate() {
+                    assert!(
+                        UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                        "{label} {w}x{h}: row {y} overflows: {row:?}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]
-    fn render_mentions_fleet_to_agent_bridge_and_recursion() {
-        let view = FleetSetupView::from_snapshot(snapshot());
-        let mut buf = Buffer::empty(Rect::new(0, 0, 120, 32));
+    fn review_lists_model_permissions_tools_and_scope() {
+        // Top of the review: the leading sections are visible without scrolling.
+        let top = render_through_stack(
+            || {
+                let mut v = FleetSetupView::from_snapshot(snapshot());
+                v.step = Step::Review;
+                v
+            },
+            120,
+            40,
+        )
+        .join("\n");
+        for section in ["Role", "Model", "Permissions", "Tools"] {
+            assert!(top.contains(section), "review missing section: {section}");
+        }
 
-        assert!(
-            view.lanes
-                .iter()
-                .flat_map(|lane| lane.rows.iter())
-                .any(|row| row.value == "Fleet -> exec")
-        );
-        assert!(
-            view.lanes
-                .iter()
-                .flat_map(|lane| lane.rows.iter())
-                .any(|row| row.label == "slot grid" && row.value == "1-5 slots")
-        );
-        assert!(
-            view.lanes
-                .iter()
-                .flat_map(|lane| lane.rows.iter())
-                .any(|row| row.label == "limits" && row.value == "100 total / depth 5")
-        );
-        view.render(Rect::new(0, 0, 120, 32), &mut buf);
-        let rendered = buf
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect::<String>();
-
-        assert!(rendered.contains("Fleet"));
-        assert!(rendered.contains("recursion"));
-        assert!(rendered.contains("WhaleFlow"));
+        // The review is intentionally scrollable; scrolling to the bottom reveals
+        // the workspace/org scope, review policy, and the honest "no disk write"
+        // note on the Start action.
+        let bottom = render_through_stack(
+            || {
+                let mut v = FleetSetupView::from_snapshot(snapshot());
+                v.step = Step::Review;
+                v.review_scroll = 999; // clamps to max in render
+                v
+            },
+            120,
+            40,
+        )
+        .join("\n");
+        for needle in ["Workspace", "Review policy", "nothing is written to disk"] {
+            assert!(bottom.contains(needle), "scrolled review missing: {needle}");
+        }
     }
 }

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -20,7 +20,7 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -28,7 +28,10 @@ use crate::commands;
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::keybindings::KEYBINDINGS;
-use crate::tui::views::{ModalKind, ModalView, ViewAction};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, centered_modal_area, render_modal_footer,
+    render_modal_surface,
+};
 
 /// Two top-level sections rendered in the overlay.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -377,16 +380,34 @@ impl ModalView for HelpView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 90.min(area.width.saturating_sub(4));
-        let popup_height = 28.min(area.height.saturating_sub(4));
-        let popup_area = Rect {
-            x: area.width.saturating_sub(popup_width) / 2,
-            y: area.height.saturating_sub(popup_height) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        let popup_area = centered_modal_area(area, 90, 28, 44, 8);
 
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
+
+        let block = modal_block().title(Line::from(vec![Span::styled(
+            format!(" {} ", self.tr(MessageId::HelpTitle)),
+            Style::default()
+                .fg(palette::WHALE_ACCENT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]));
+
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        // The action footer wraps inside the modal body (#3732) rather than the
+        // single-line border title that silently clipped hints at narrow
+        // widths; the list renders into the content area above it. Empty hint
+        // keys keep the existing localized footer phrases as plain labels.
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("", self.tr(MessageId::HelpFooterTypeFilter)),
+                ActionHint::new("", self.tr(MessageId::HelpFooterMove)),
+                ActionHint::new("", self.tr(MessageId::HelpFooterJump)),
+                ActionHint::new("", self.tr(MessageId::HelpFooterClose)),
+            ],
+        );
 
         let mut lines: Vec<Line<'static>> = Vec::new();
 
@@ -426,17 +447,15 @@ impl ModalView for HelpView {
             // The chord/label column takes up to 28 cols on wide screens;
             // descriptions fill the remainder. Borders and padding eat 4
             // cells from each side (border 1 + padding 1) × 2.
-            let inner_width = popup_width.saturating_sub(4) as usize;
+            let inner_width = content.width as usize;
             let label_width = 28.min(inner_width.saturating_sub(8));
             let desc_capacity = inner_width.saturating_sub(label_width + 4);
 
-            // The block uses a one-cell border plus one-cell padding, so the
-            // real paragraph body is four rows shorter than the outer popup.
-            // Budget against that body height so selected rows are not clipped
-            // by the bottom border/padding.
+            // `content` is the body area above the wrapping footer (the block's
+            // border, padding, and footer rows already removed), so budgeting
+            // against its height keeps selected rows clear of the footer.
             let header_lines = lines.len();
-            let visible_budget = (popup_height as usize)
-                .saturating_sub(4)
+            let visible_budget = (content.height as usize)
                 .saturating_sub(header_lines)
                 .max(1);
 
@@ -479,33 +498,7 @@ impl ModalView for HelpView {
             }
         }
 
-        let block = modal_block()
-            .title(Line::from(vec![Span::styled(
-                format!(" {} ", self.tr(MessageId::HelpTitle)),
-                Style::default()
-                    .fg(palette::WHALE_ACCENT_PRIMARY)
-                    .add_modifier(Modifier::BOLD),
-            )]))
-            .title_bottom(Line::from(vec![
-                Span::styled(
-                    self.tr(MessageId::HelpFooterTypeFilter),
-                    Style::default().fg(palette::TEXT_MUTED),
-                ),
-                Span::styled(
-                    self.tr(MessageId::HelpFooterMove),
-                    Style::default().fg(palette::TEXT_MUTED),
-                ),
-                Span::styled(
-                    self.tr(MessageId::HelpFooterJump),
-                    Style::default().fg(palette::TEXT_MUTED),
-                ),
-                Span::styled(
-                    self.tr(MessageId::HelpFooterClose),
-                    Style::default().fg(palette::TEXT_MUTED),
-                ),
-            ]));
-
-        Paragraph::new(lines).block(block).render(popup_area, buf);
+        Paragraph::new(lines).render(content, buf);
     }
 }
 
@@ -838,6 +831,60 @@ mod tests {
                 "keybinding description not localized: {}",
                 entry.description
             );
+        }
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires
+    /// every overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn help_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(HelpView::new_for_locale(Locale::En));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            for label in [
+                "type to filter",
+                "Up/Down move",
+                "PgUp/PgDn jump",
+                "Esc close",
+            ] {
+                assert!(text.contains(label), "{w}x{h}: missing footer '{label}'");
+            }
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
         }
     }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -2,12 +2,14 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::Style,
-    widgets::{Block, Clear, Widget},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Clear, Paragraph, Widget},
 };
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::fmt;
+use unicode_width::UnicodeWidthStr;
 
 use crate::config::{ApiProvider, Config};
 use crate::features::{FEATURES, Stage};
@@ -94,6 +96,211 @@ fn render_modal_backdrop(area: Rect, buf: &mut Buffer) {
                 .set_style(Style::default().bg(palette::DEEPSEEK_INK));
         }
     }
+}
+
+/// Compute a centered, responsive popup rect for a modal.
+///
+/// The size starts from `preferred_*`, but is clamped so it never exceeds the
+/// frame (leaving a small breathing-room margin when there is space) and never
+/// drops below `min_*` unless the frame itself is smaller. Centering the result
+/// inside `area` replaces the repeated, error-prone
+/// `N.min(area.width.saturating_sub(..))` arithmetic scattered across modals so
+/// every overlay sizes itself the same way at 80x24, 100x30, 120x32, 160x40,
+/// and beyond. See #3732.
+pub(crate) fn centered_modal_area(
+    area: Rect,
+    preferred_width: u16,
+    preferred_height: u16,
+    min_width: u16,
+    min_height: u16,
+) -> Rect {
+    // Keep a 2-cell margin on each axis when the frame can spare it so the
+    // backdrop stays visible around the card; otherwise fill the frame.
+    let avail_width = area.width.saturating_sub(2).max(1);
+    let avail_height = area.height.saturating_sub(2).max(1);
+    let width = preferred_width.clamp(min_width.min(avail_width), avail_width);
+    let height = preferred_height.clamp(min_height.min(avail_height), avail_height);
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+/// A single key/label hint shown in a modal's action footer.
+///
+/// Footers built from `ActionHint`s are laid out by [`action_footer_lines`],
+/// which wraps to additional rows instead of letting an action run off the
+/// right edge of the modal — the core overflow bug behind #3732. Use this for
+/// action/navigation hints; truncate only identifiers/paths/hashes elsewhere.
+pub(crate) struct ActionHint {
+    key: Cow<'static, str>,
+    label: Cow<'static, str>,
+}
+
+impl ActionHint {
+    pub(crate) fn new(
+        key: impl Into<Cow<'static, str>>,
+        label: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            label: label.into(),
+        }
+    }
+
+    /// Display columns this hint occupies: ` key ` (key padded by a space on
+    /// each side) followed by the label.
+    fn width(&self) -> usize {
+        UnicodeWidthStr::width(self.key.as_ref()) + 2 + UnicodeWidthStr::width(self.label.as_ref())
+    }
+
+    fn spans(&self) -> [Span<'static>; 2] {
+        [
+            Span::styled(
+                format!(" {} ", self.key),
+                Style::default()
+                    .fg(palette::DEEPSEEK_SKY)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                self.label.clone().into_owned(),
+                Style::default().fg(palette::TEXT_MUTED),
+            ),
+        ]
+    }
+}
+
+/// Lay out action hints into one or more lines that each fit within `width`.
+///
+/// Hints are packed greedily; when the next hint would overflow the current row
+/// the layout starts a new row rather than truncating. No action is ever
+/// dropped or clipped (a single hint wider than `width` is emitted alone, which
+/// only happens at degenerate widths below the modal minimums). This is the
+/// shared replacement for the single-line `title_bottom` footers that silently
+/// pushed actions off-screen.
+pub(crate) fn action_footer_lines(hints: &[ActionHint], width: u16) -> Vec<Line<'static>> {
+    let width = usize::from(width);
+    if hints.is_empty() || width == 0 {
+        return Vec::new();
+    }
+    const GAP: usize = 1;
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut current: Vec<Span<'static>> = Vec::new();
+    let mut current_width = 0usize;
+    for hint in hints {
+        let hint_width = hint.width();
+        let needed = if current.is_empty() {
+            hint_width
+        } else {
+            current_width + GAP + hint_width
+        };
+        if !current.is_empty() && needed > width {
+            lines.push(Line::from(std::mem::take(&mut current)));
+            current_width = 0;
+        }
+        if !current.is_empty() {
+            current.push(Span::raw(" ".repeat(GAP)));
+            current_width += GAP;
+        }
+        current.extend(hint.spans());
+        current_width += hint_width;
+    }
+    if !current.is_empty() {
+        lines.push(Line::from(current));
+    }
+    lines
+}
+
+/// Reserve `lines` worth of rows at the bottom of `inner`, paint them, and
+/// return the content area that remains above. Shared by the action-hint and
+/// free-text modal footers.
+fn place_footer_lines(inner: Rect, buf: &mut Buffer, lines: Vec<Line<'static>>) -> Rect {
+    if lines.is_empty() || inner.height == 0 {
+        return inner;
+    }
+    let footer_height = u16::try_from(lines.len())
+        .unwrap_or(u16::MAX)
+        .min(inner.height);
+    let footer_area = Rect {
+        x: inner.x,
+        y: inner.y + inner.height - footer_height,
+        width: inner.width,
+        height: footer_height,
+    };
+    Paragraph::new(lines).render(footer_area, buf);
+    Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: inner.height - footer_height,
+    }
+}
+
+/// Render a wrapping action footer anchored to the bottom of `inner` and
+/// return the content area that remains above it.
+///
+/// Modals call this after painting their block so the footer reserves exactly
+/// as many rows as it needs (bounded by the available height) and the body
+/// fills the rest. Centralizing it keeps every modal's action row visible and
+/// reachable at narrow widths.
+pub(crate) fn render_modal_footer(inner: Rect, buf: &mut Buffer, hints: &[ActionHint]) -> Rect {
+    let lines = action_footer_lines(hints, inner.width);
+    place_footer_lines(inner, buf, lines)
+}
+
+/// Word-wrap a free-form footer string into styled lines that each fit `width`.
+///
+/// For footers that are pre-composed prose/sentences (e.g. localized config
+/// hints) rather than discrete key/label hints. Wrapping on whitespace keeps
+/// every word visible instead of clipping the tail at the modal edge.
+pub(crate) fn wrapped_footer_lines(text: &str, width: u16, style: Style) -> Vec<Line<'static>> {
+    let width = usize::from(width);
+    if text.trim().is_empty() || width == 0 {
+        return Vec::new();
+    }
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0usize;
+    for word in text.split_whitespace() {
+        let word_width = UnicodeWidthStr::width(word);
+        let needed = if current.is_empty() {
+            word_width
+        } else {
+            current_width + 1 + word_width
+        };
+        if !current.is_empty() && needed > width {
+            lines.push(Line::from(Span::styled(
+                std::mem::take(&mut current),
+                style,
+            )));
+            current_width = 0;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+            current_width += 1;
+        }
+        current.push_str(word);
+        current_width += word_width;
+    }
+    if !current.is_empty() {
+        lines.push(Line::from(Span::styled(current, style)));
+    }
+    lines
+}
+
+/// Render a wrapping free-text footer anchored to the bottom of `inner` and
+/// return the content area above it. The prose counterpart to
+/// [`render_modal_footer`].
+pub(crate) fn render_modal_text_footer(
+    inner: Rect,
+    buf: &mut Buffer,
+    text: &str,
+    style: Style,
+) -> Rect {
+    let lines = wrapped_footer_lines(text, inner.width, style);
+    place_footer_lines(inner, buf, lines)
 }
 
 #[derive(Debug, Clone)]
@@ -1634,20 +1841,12 @@ impl ModalView for ConfigView {
         use ratatui::{
             style::Style,
             text::{Line, Span},
-            widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+            widgets::{Block, Borders, Padding, Paragraph, Widget},
         };
 
-        let popup_width = 84.min(area.width.saturating_sub(4));
-        let popup_height = 22.min(area.height.saturating_sub(4));
+        let popup_area = centered_modal_area(area, 84, 22, 60, 12);
 
-        let popup_area = Rect {
-            x: (area.width - popup_width) / 2,
-            y: (area.height - popup_height) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
-
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
         let base_block = Block::default()
             .borders(Borders::ALL)
@@ -1706,8 +1905,12 @@ impl ModalView for ConfigView {
             let content_height = usize::from(inner.height);
             let header_lines = 5usize;
             let bottom_lines = 1usize;
+            // The action footer now lives inside the modal body (reserved by
+            // `render_modal_text_footer` below) rather than on the border, so it
+            // claims one inner row that the table must not draw over.
+            let footer_lines = 1usize;
             let visible_rows = content_height
-                .saturating_sub(header_lines + bottom_lines)
+                .saturating_sub(header_lines + bottom_lines + footer_lines)
                 .max(1);
             self.last_visible_rows.set(visible_rows);
 
@@ -1858,10 +2061,6 @@ impl ModalView for ConfigView {
                 self.tr(MessageId::ConfigModalTitle),
                 Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
             )]))
-            .title_bottom(Line::from(Span::styled(
-                footer,
-                Style::default().fg(palette::TEXT_MUTED),
-            )))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
             .style(Style::default().bg(palette::DEEPSEEK_INK))
@@ -1869,10 +2068,18 @@ impl ModalView for ConfigView {
 
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
+        // Footer wraps inside the body so its hints can never run off the modal
+        // edge (#3732); the table renders into the area above it.
+        let content = render_modal_text_footer(
+            inner,
+            buf,
+            &footer,
+            Style::default().fg(palette::TEXT_MUTED),
+        );
         Paragraph::new(lines)
             .style(Style::default().fg(palette::TEXT_PRIMARY))
             .scroll((0, 0))
-            .render(inner, buf);
+            .render(content, buf);
     }
 }
 
@@ -2051,25 +2258,18 @@ impl ModalView for SubAgentsView {
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
         use ratatui::{
+            layout::Alignment,
             style::Style,
             text::{Line, Span},
-            widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+            widgets::{Block, Borders, Padding, Paragraph, Widget},
         };
 
-        let popup_width = 78.min(area.width.saturating_sub(4));
-        let popup_height = 20.min(area.height.saturating_sub(4));
+        let popup_area = centered_modal_area(area, 78, 20, 56, 12);
 
-        let popup_area = Rect {
-            x: (area.width - popup_width) / 2,
-            y: (area.height - popup_height) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
-
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
         let mut lines: Vec<Line> = Vec::new();
-        let content_width = popup_width.saturating_sub(4) as usize;
+        let content_width = popup_area.width.saturating_sub(4) as usize;
 
         if self.agents.is_empty() {
             lines.push(Line::from(Span::styled(
@@ -2194,8 +2394,9 @@ impl ModalView for SubAgentsView {
             );
         }
 
+        // Reserve one body row for the wrapping footer below.
         let total_lines = lines.len();
-        let visible_lines = (popup_height as usize).saturating_sub(3);
+        let visible_lines = usize::from(popup_area.height).saturating_sub(5).max(1);
         let max_scroll = total_lines.saturating_sub(visible_lines);
         let scroll = self.scroll.min(max_scroll);
 
@@ -2205,27 +2406,39 @@ impl ModalView for SubAgentsView {
             String::new()
         };
 
-        let view = Paragraph::new(lines)
-            .block(
-                Block::default()
-                    .title(Line::from(vec![Span::styled(
-                        " Fleet workers ",
-                        Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
-                    )]))
-                    .title_bottom(Line::from(vec![
-                        Span::styled(" Esc to close ", Style::default().fg(palette::TEXT_MUTED)),
-                        Span::styled(" R to refresh ", Style::default().fg(palette::TEXT_MUTED)),
-                        Span::styled(" F setup ", Style::default().fg(palette::TEXT_MUTED)),
-                        Span::styled(scroll_indicator, Style::default().fg(palette::DEEPSEEK_SKY)),
-                    ]))
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(palette::BORDER_COLOR))
-                    .style(Style::default().bg(palette::DEEPSEEK_INK))
-                    .padding(Padding::uniform(1)),
+        let block = Block::default()
+            .title(Line::from(vec![Span::styled(
+                " Fleet workers ",
+                Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+            )]))
+            .title_bottom(
+                Line::from(Span::styled(
+                    scroll_indicator,
+                    Style::default().fg(palette::DEEPSEEK_SKY),
+                ))
+                .alignment(Alignment::Right),
             )
-            .scroll((scroll as u16, 0));
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::DEEPSEEK_INK))
+            .padding(Padding::uniform(1));
 
-        view.render(popup_area, buf);
+        let inner = block.inner(popup_area);
+        block.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("Esc", "close"),
+                ActionHint::new("R", "refresh"),
+                ActionHint::new("F", "setup"),
+            ],
+        );
+
+        Paragraph::new(lines)
+            .scroll((scroll as u16, 0))
+            .render(content, buf);
     }
 }
 
@@ -2401,8 +2614,9 @@ fn truncate_view_text(text: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfigListItem, ConfigView, HelpView, ModalKind, ModalView, ViewAction, ViewEvent,
-        ViewStack, subagent_view_agents, truncate_view_text,
+        ActionHint, ConfigListItem, ConfigView, HelpView, ModalKind, ModalView, ViewAction,
+        ViewEvent, ViewStack, action_footer_lines, centered_modal_area, render_modal_footer,
+        subagent_view_agents, truncate_view_text,
     };
     use crate::config::Config;
     use crate::localization::{Locale, MessageId, tr};
@@ -2429,6 +2643,150 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::MutexGuard;
     use tempfile::TempDir;
+    use unicode_width::UnicodeWidthStr;
+
+    /// Terminal sizes the v0.8.66 modal blocker (#3732) requires every overlay
+    /// to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    /// Render a modal through the `ViewStack` (so the shared opaque backdrop is
+    /// painted exactly as in production) over a sentinel-filled buffer, then
+    /// assert: every `required_label` is visible, no sentinel `X` survives
+    /// anywhere (fully opaque), the center cell carries the modal ink, and no
+    /// row overflows the frame width.
+    fn assert_modal_usable_and_opaque<V: ModalView + 'static>(
+        make: impl Fn() -> V,
+        required_labels: &[&str],
+    ) {
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(make());
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            for label in required_labels {
+                assert!(text.contains(label), "{w}x{h}: missing '{label}'");
+            }
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn config_modal_is_usable_and_opaque_at_blocker_sizes() {
+        let _lock = crate::test_support::lock_test_env();
+        // "Search" is the hardcoded English search-row label; asserting it (plus
+        // the opacity/overflow checks) proves the modal renders fully and its
+        // footer wraps inside bounds rather than clipping.
+        assert_modal_usable_and_opaque(|| create_config_view(Locale::En), &["Search"]);
+    }
+
+    #[test]
+    fn subagents_modal_is_usable_and_opaque_at_blocker_sizes() {
+        assert_modal_usable_and_opaque(
+            || SubAgentsView::new(Vec::new()),
+            &["close", "refresh", "setup"],
+        );
+    }
+
+    #[test]
+    fn centered_modal_area_clamps_and_centers() {
+        // Roomy frame: preferred size honoured, centered.
+        let area = Rect::new(0, 0, 160, 40);
+        let rect = centered_modal_area(area, 80, 20, 40, 10);
+        assert_eq!((rect.width, rect.height), (80, 20));
+        assert_eq!(rect.x, (160 - 80) / 2);
+        assert_eq!(rect.y, (40 - 20) / 2);
+
+        // Tiny frame: never exceeds the frame even below the requested minimum.
+        let tiny = Rect::new(0, 0, 30, 8);
+        let rect = centered_modal_area(tiny, 80, 20, 40, 10);
+        assert!(rect.width <= tiny.width, "width must fit frame");
+        assert!(rect.height <= tiny.height, "height must fit frame");
+        assert!(rect.x + rect.width <= tiny.width);
+        assert!(rect.y + rect.height <= tiny.height);
+    }
+
+    #[test]
+    fn action_footer_wraps_instead_of_overflowing() {
+        let hints = [
+            ActionHint::new("↑↓", "move"),
+            ActionHint::new("a-z", "jump"),
+            ActionHint::new("Enter", "apply"),
+            ActionHint::new("R", "edit key"),
+            ActionHint::new("M", "models"),
+            ActionHint::new("Esc", "cancel"),
+        ];
+
+        // Wide enough for a single row.
+        let wide = action_footer_lines(&hints, 120);
+        assert_eq!(wide.len(), 1);
+        assert!(wide[0].width() <= 120);
+
+        // Narrow forces wrapping but never truncates: every action survives and
+        // no produced line exceeds the available width.
+        let narrow = action_footer_lines(&hints, 28);
+        assert!(narrow.len() >= 2, "narrow footer should wrap to >1 row");
+        for line in &narrow {
+            assert!(
+                line.width() <= 28,
+                "wrapped footer row overflows: {} cols",
+                line.width()
+            );
+        }
+        let joined: String = narrow
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        for label in ["move", "jump", "apply", "edit key", "models", "cancel"] {
+            assert!(joined.contains(label), "footer dropped action: {label}");
+        }
+    }
+
+    #[test]
+    fn render_modal_footer_reserves_rows_and_returns_body() {
+        let inner = Rect::new(2, 2, 40, 10);
+        let mut buf = Buffer::empty(Rect::new(0, 0, 44, 14));
+        let hints = [
+            ActionHint::new("Enter", "save"),
+            ActionHint::new("Esc", "cancel"),
+        ];
+        let body = render_modal_footer(inner, &mut buf, &hints);
+        // The footer (a single row at this width) is reserved off the bottom and
+        // the body fills the rows above it.
+        assert_eq!(body.y, inner.y);
+        assert_eq!(body.height, inner.height - 1);
+        assert_eq!(body.y + body.height, inner.y + inner.height - 1);
+    }
 
     struct ConfigSettingsEnvGuard {
         _tmp: TempDir,

--- a/crates/tui/src/tui/views/mode_picker.rs
+++ b/crates/tui/src/tui/views/mode_picker.rs
@@ -6,14 +6,17 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 use unicode_width::UnicodeWidthStr;
 
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::app::AppMode;
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer, render_modal_surface,
+};
 
 pub struct ModePickerView {
     cursor: usize,
@@ -90,16 +93,10 @@ impl ModalView for ModePickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 68.min(area.width.saturating_sub(4)).max(44);
-        let popup_height = 9.min(area.height.saturating_sub(4)).max(7);
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
+        let popup_height = u16::try_from(AppMode::CHOICES.len()).unwrap_or(3) + 7;
+        let popup_area = centered_modal_area(area, 68, popup_height, 44, 8);
 
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
         let block = Block::default()
             .title(Line::from(Span::styled(
@@ -108,14 +105,6 @@ impl ModalView for ModePickerView {
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" Up/Down ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("move "),
-                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("select "),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw("cancel "),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
             .style(Style::default().bg(palette::DEEPSEEK_INK))
@@ -123,6 +112,16 @@ impl ModalView for ModePickerView {
 
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑/↓", "move"),
+                ActionHint::new("Enter", "select"),
+                ActionHint::new("Esc", "cancel"),
+            ],
+        );
 
         let mut lines = Vec::with_capacity(AppMode::CHOICES.len() + 1);
         lines.push(Line::from(Span::styled(
@@ -162,7 +161,7 @@ impl ModalView for ModePickerView {
             ]));
         }
 
-        Paragraph::new(lines).render(inner, buf);
+        Paragraph::new(lines).render(content, buf);
     }
 }
 
@@ -187,6 +186,73 @@ mod tests {
                 assert_eq!(mode, AppMode::Plan);
             }
             other => panic!("expected ModeSelected, got {other:?}"),
+        }
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires
+    /// every overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    fn render_at(width: u16, height: u16) -> (Buffer, Rect) {
+        use crate::tui::views::ViewStack;
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        // Pre-fill with a sentinel so any cell the composited modal fails to
+        // paint (bleed-through) is detectable as a surviving 'X'.
+        for y in 0..height {
+            for x in 0..width {
+                buf[(x, y)].set_symbol("X");
+            }
+        }
+        // Render through the ViewStack so the shared opaque backdrop is painted
+        // exactly as it is in production.
+        let mut stack = ViewStack::new();
+        stack.push(ModePickerView::new(AppMode::Agent, Locale::En));
+        stack.render(area, &mut buf);
+        (buf, area)
+    }
+
+    fn rows(buf: &Buffer, area: Rect) -> Vec<String> {
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mode_picker_is_usable_and_opaque_at_blocker_sizes() {
+        for (w, h) in BLOCKER_SIZES {
+            let (buf, area) = render_at(w, h);
+            let text = rows(&buf, area).join("\n");
+
+            // Action labels are present (footer never drops an action).
+            assert!(text.contains("move"), "{w}x{h}: missing 'move' hint");
+            assert!(text.contains("select"), "{w}x{h}: missing 'select' hint");
+            assert!(text.contains("cancel"), "{w}x{h}: missing 'cancel' hint");
+
+            // Composited frame is fully opaque: no sentinel survives and every
+            // cell carries the modal/backdrop ink background.
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            let center = &buf[(w / 2, h / 2)];
+            assert_eq!(
+                center.bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+
+            // No row exceeds the frame width (no horizontal overflow).
+            for (y, row) in rows(&buf, area).iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
         }
     }
 

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -15,13 +15,16 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
+    widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 
 use crate::config::{ApiProvider, StatusItem};
 use crate::localization::{Locale, MessageId, tr, truncate_to_width};
 use crate::palette;
-use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
+use crate::tui::views::{
+    ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
+    render_modal_footer, render_modal_surface,
+};
 use unicode_width::UnicodeWidthStr;
 
 const STATUS_PICKER_SELECTION_BG: ratatui::style::Color = ratatui::style::Color::Rgb(54, 72, 104);
@@ -168,22 +171,14 @@ impl ModalView for StatusPickerView {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let popup_width = 64.min(area.width.saturating_sub(4)).max(40);
-        // Two header lines + one row per StatusItem + one footer hint line.
-        // When the full list is taller than the screen, cap the popup so it
-        // stays on-screen and let the scroll offset handle overflow.
-        let needed_height = (self.rows.len() as u16).saturating_add(4);
-        let max_fit = area.height.saturating_sub(4).max(8);
-        let popup_height = needed_height.min(max_fit);
+        // Two header lines + one row per StatusItem + the wrapping action
+        // footer that now lives inside the body (one row more than the old
+        // border footer). centered_modal_area clamps this to the frame and
+        // lets the scroll offset absorb any remaining overflow.
+        let needed_height = (self.rows.len() as u16).saturating_add(5);
+        let popup_area = centered_modal_area(area, 64, needed_height, 40, 8);
 
-        let popup_area = Rect {
-            x: area.x + (area.width.saturating_sub(popup_width)) / 2,
-            y: area.y + (area.height.saturating_sub(popup_height)) / 2,
-            width: popup_width,
-            height: popup_height,
-        };
-
-        Clear.render(popup_area, buf);
+        render_modal_surface(area, popup_area, buf);
 
         let block = Block::default()
             .title(Line::from(Span::styled(
@@ -192,18 +187,6 @@ impl ModalView for StatusPickerView {
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
             )))
-            .title_bottom(Line::from(vec![
-                Span::styled(" Space ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw(tr(self.locale, MessageId::StatusPickerActionToggle)),
-                Span::styled(" a ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw(tr(self.locale, MessageId::StatusPickerActionAll)),
-                Span::styled(" n ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw(tr(self.locale, MessageId::StatusPickerActionNone)),
-                Span::styled(" Enter ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw(tr(self.locale, MessageId::StatusPickerActionSave)),
-                Span::styled(" Esc ", Style::default().fg(palette::TEXT_MUTED)),
-                Span::raw(tr(self.locale, MessageId::StatusPickerActionCancel)),
-            ]))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette::BORDER_COLOR))
             .style(Style::default().bg(palette::DEEPSEEK_INK))
@@ -212,7 +195,22 @@ impl ModalView for StatusPickerView {
         let inner = block.inner(popup_area);
         block.render(popup_area, buf);
 
-        let visible_rows = inner.height.saturating_sub(2) as usize;
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new(
+                    "Space",
+                    tr(self.locale, MessageId::StatusPickerActionToggle),
+                ),
+                ActionHint::new("a", tr(self.locale, MessageId::StatusPickerActionAll)),
+                ActionHint::new("n", tr(self.locale, MessageId::StatusPickerActionNone)),
+                ActionHint::new("Enter", tr(self.locale, MessageId::StatusPickerActionSave)),
+                ActionHint::new("Esc", tr(self.locale, MessageId::StatusPickerActionCancel)),
+            ],
+        );
+
+        let visible_rows = content.height.saturating_sub(2) as usize;
         let row_start = visible_row_start(self.rows.len(), self.cursor, visible_rows);
 
         let mut lines: Vec<Line> = Vec::with_capacity(visible_rows + 2);
@@ -257,7 +255,7 @@ impl ModalView for StatusPickerView {
                     .fg(palette::SELECTION_TEXT)
                     .bg(STATUS_PICKER_SELECTION_BG)
                     .add_modifier(Modifier::BOLD);
-                let line = status_row_text(pointer, mark, item, inner.width as usize);
+                let line = status_row_text(pointer, mark, item, content.width as usize);
                 lines.push(Line::from(Span::styled(line, selected_style)));
             } else {
                 lines.push(Line::from(vec![
@@ -271,7 +269,7 @@ impl ModalView for StatusPickerView {
             }
         }
 
-        Paragraph::new(lines).render(inner, buf);
+        Paragraph::new(lines).render(content, buf);
     }
 }
 
@@ -413,6 +411,60 @@ mod tests {
     #[test]
     fn status_picker_displays_localized_title_for_zh_hans() {
         assert_eq!(tr(Locale::ZhHans, MessageId::StatusPickerTitle), " 状态行 ");
+    }
+
+    /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires
+    /// every overlay to remain readable and fully operable at.
+    const BLOCKER_SIZES: [(u16, u16); 4] = [(80, 24), (100, 30), (120, 32), (160, 40)];
+
+    #[test]
+    fn status_picker_is_usable_and_opaque_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        let active = StatusItem::default_footer();
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            for y in 0..h {
+                for x in 0..w {
+                    buf[(x, y)].set_symbol("X");
+                }
+            }
+            let mut stack = ViewStack::new();
+            stack.push(StatusPickerView::new(
+                &active,
+                ApiProvider::Deepseek,
+                Locale::En,
+            ));
+            stack.render(area, &mut buf);
+
+            let rows: Vec<String> = (0..h)
+                .map(|y| {
+                    (0..w)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect();
+            let text = rows.join("\n");
+
+            for label in ["toggle", "all", "none", "save", "cancel"] {
+                assert!(text.contains(label), "{w}x{h}: missing footer '{label}'");
+            }
+            assert!(
+                !text.contains('X'),
+                "{w}x{h}: background bleed-through into modal surface"
+            );
+            assert_eq!(
+                buf[(w / 2, h / 2)].bg,
+                palette::DEEPSEEK_INK,
+                "{w}x{h}: modal interior must be opaque"
+            );
+            for (y, row) in rows.iter().enumerate() {
+                assert!(
+                    UnicodeWidthStr::width(row.trim_end()) <= w as usize,
+                    "{w}x{h}: row {y} overflows width: {row:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## v0.8.66 release blockers: shared modal UI + progressive /fleet setup

Fixes #3732
Fixes #3791

### #3732 — shared modal renderer

Two systemic bugs lived in per-modal render paths: opaque-surface bleed-through
and footer/action-row overflow. Fixed centrally and adopted across every
`ModalKind`.

New shared helpers in `crates/tui/src/tui/views/mod.rs`:

- **`centered_modal_area(area, pref_w, pref_h, min_w, min_h)`** — responsive,
  clamped, centered popup sizing. Replaces the scattered, panic-prone
  `N.min(area.width.saturating_sub(..))` + manual centering.
- **`ActionHint` + `action_footer_lines()` + `render_modal_footer()`** — action
  footers that **wrap to additional rows** instead of letting hints run off the
  right edge. No action is ever dropped or truncated.
- **`wrapped_footer_lines()` / `render_modal_text_footer()`** — prose-footer
  variant for pre-composed localized hint sentences (Config).
- Reuses the existing opaque `render_modal_surface()`.

Modals migrated onto the helpers (opaque surface + responsive size + wrapping
footer): Config, Fleet workers (SubAgents), mode picker, model picker, provider
picker, command palette, hotbar setup, session picker, pager, live transcript,
help, status picker, file picker, feedback picker, theme picker. Bleed-through-
prone blocks (model/provider/command-palette/hotbar/session/pager) gained an
opaque `DEEPSEEK_INK` background.

### #3791 — /fleet setup

Replaced the unreadable six-column config matrix with a progressive
"set up your agent team" wizard:

1. **Role** — list + wrapped detail of team roles (manager, main, scout,
   builder, reviewer, verifier, synthesizer, custom).
2. **Model class** — inherit/fast/balanced/strong/deep-reasoning/tool-heavy,
   with the current route shown as context.
3. **Review & start** — readable, wrapped summary of role, model/route,
   permissions, tools, workspace/org scope + recursion, and review policy.

**Start** still inserts the safe profile-authoring prompt into the composer —
no fake/persistent disk write — preserving the existing InsertText flow. Backed
by list+detail at wide widths, stacking when narrow; everything wraps,
identifiers truncate.

### Verification

- Render tests per modal kind assert, at **80×24, 100×30, 120×32, 160×40**: no
  background bleed-through, action labels present, and no row overflows the
  frame width — rendered through `ViewStack` so the real opaque backdrop is in
  play. Fleet validates all three wizard steps at each size.
- Helper unit tests cover sizing clamp/center, footer wrapping (no action
  dropped, every wrapped row within width), and footer row reservation.
- Manually rendered the redesigned Fleet flow at 80×24 / 120×32 and eyeballed
  layout, wrapping, and footer fit.
- `cargo fmt` clean; targeted `cargo test -p codewhale-tui --bin codewhale-tui`
  modal suites green.
- Pre-existing, environment-dependent failures unrelated to this change
  (`config_command_allow_shell_*`, `run_verifiers_background_*`, and the
  auto-model-routing/hook-timeout tests in `tui::hotbar::actions` /
  `tui::ui`) were confirmed to fail identically on clean `HEAD`.

No version bump, tag, or release artifact.

