### PR TITLE
fix(tui): default /model to configured providers, not just the active one

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -5325,7 +5325,11 @@ fn normalize_auth_mode(mode: &str) -> String {
     mode.trim().to_ascii_lowercase().replace(['-', ' '], "_")
 }
 
-fn base_url_uses_local_host(base_url: &str) -> bool {
+/// Whether a base URL points at a loopback/unspecified host, i.e. a local
+/// runtime rather than a hosted endpoint. Shared by the active-provider
+/// local-base-url check above and the `/provider` picker's custom-provider
+/// auth-optionality heuristic (#3830).
+pub(crate) fn base_url_uses_local_host(base_url: &str) -> bool {
     let Some(host) = base_url_host(base_url) else {
         return false;
     };
@@ -6215,6 +6219,82 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     }
 
     false
+}
+
+/// Whether a provider counts as "configured" for the default `/provider`
+/// and `/model` manager views (#3830). Shared by both pickers so "what shows
+/// up without browsing the full catalog" stays a single definition.
+/// Self-hosted providers (Ollama/Sglang/Vllm) report `has_key = true`
+/// unconditionally in [`has_api_key_for`] since they don't require auth to
+/// route to — that's correct for routing, but wrong for "did the user set
+/// this up," so a self-hosted provider only qualifies via an explicit
+/// `[providers.<name>]` entry or being active, never via `has_key` alone
+/// (otherwise every self-hosted provider type would always show up).
+#[must_use]
+pub(crate) fn provider_is_configured(
+    provider: ApiProvider,
+    is_active: bool,
+    has_key: bool,
+    configured: Option<&ProviderConfig>,
+    is_named_custom_entry: bool,
+) -> bool {
+    // A *named* custom provider entry (one the user actually added) always
+    // counts. The unconfigured `Custom` placeholder row that fills the slot
+    // when no custom provider exists yet is not itself "configured" — it's
+    // the catalog's invitation to add one.
+    if is_active || is_named_custom_entry {
+        return true;
+    }
+    if configured.is_some_and(provider_config_is_explicit) {
+        return true;
+    }
+    if provider.is_self_hosted() {
+        return false;
+    }
+    has_key
+}
+
+/// Convenience wrapper around [`provider_is_configured`] for callers that
+/// just want "is this provider configured given the active one," without
+/// the provider picker's multi-row named-custom-provider bookkeeping
+/// (`is_named_custom_entry`) — e.g. the `/model` picker (#3830), which only
+/// ever resolves the single, currently-selected `Custom` slot via
+/// [`Config::provider_config_for`], the same way model/route resolution
+/// does everywhere else.
+#[must_use]
+pub(crate) fn provider_is_configured_for_active(
+    config: &Config,
+    provider: ApiProvider,
+    active: ApiProvider,
+) -> bool {
+    provider_is_configured(
+        provider,
+        provider == active,
+        has_api_key_for(config, provider),
+        config.provider_config_for(provider),
+        false,
+    )
+}
+
+/// True when a `[providers.<name>]` table entry has any field the user would
+/// have had to set explicitly — base URL, model, auth, etc. Used by
+/// [`provider_is_configured`]: merely existing in the
+/// (always-`Some`-once-any-provider-is-configured) `ProvidersConfig` struct
+/// isn't enough, since untouched providers still resolve to a
+/// `ProviderConfig::default()` there.
+fn provider_config_is_explicit(entry: &ProviderConfig) -> bool {
+    entry.api_key.is_some()
+        || entry.base_url.is_some()
+        || entry.model.is_some()
+        || entry.auth_mode.is_some()
+        || entry.auth.is_some()
+        || entry.context_window.is_some()
+        || entry.mode.is_some()
+        || entry.max_concurrency.is_some()
+        || entry.http_headers.is_some()
+        || entry.path_suffix.is_some()
+        || entry.reasoning_stream_style.is_some()
+        || entry.insecure_skip_tls_verify.is_some()
 }
 
 /// Save an API key to the appropriate place for the given provider.

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -17,7 +17,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Widget},
 };
 
-use crate::config::{ApiProvider, model_completion_names_for_provider};
+use crate::config::{ApiProvider, Config, model_completion_names_for_provider};
 use crate::model_registry;
 use crate::palette;
 use crate::tui::app::{App, ReasoningEffort};
@@ -63,6 +63,16 @@ pub struct ModelPickerView {
     /// so the picker doesn't quietly forget the user's chosen IDs.
     show_custom_model_row: bool,
     model_rows: Vec<ModelPickerRow>,
+    /// Other providers considered "configured" (#3830), shown by default
+    /// alongside `initial_provider`'s own rows without requiring the user to
+    /// type a search query first. Uses the same definition as the
+    /// `/provider` manager's default view
+    /// (`crate::config::provider_is_configured_for_active`): active
+    /// provider, working credentials/OAuth, or an explicit
+    /// `[providers.<name>]` entry. Self-hosted providers (Ollama/Sglang/
+    /// Vllm) don't qualify just because routing to them doesn't require a
+    /// key.
+    configured_providers: Vec<ApiProvider>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,22 +84,29 @@ struct ModelPickerRow {
 
 impl ModelPickerView {
     #[must_use]
-    pub fn new(app: &App) -> Self {
+    pub fn new(app: &App, config: &Config) -> Self {
         let initial_model = if app.auto_model {
             "auto".to_string()
         } else {
             app.model.clone()
         };
         let model_rows = picker_model_rows_for_app(app);
+        let configured_providers = configured_providers_for(config, app.api_provider);
         let mut selected_model_idx = model_rows.iter().position(|row| {
             row.id == initial_model
                 && (row.provider.is_none() || row.provider == Some(app.api_provider))
         });
         let show_custom_model_row = selected_model_idx.is_none();
         if show_custom_model_row {
-            selected_model_idx = Some(active_provider_model_row_count(
+            // The custom row is conceptually appended right after every row
+            // the default (empty-query) view shows, so its index must match
+            // that count, not just the active-provider-scoped one (#3830) —
+            // `resolved_model`/`model_row_count` treat any selection at or
+            // past `visible_model_rows().len()` as "the custom row."
+            selected_model_idx = Some(default_visible_model_row_count(
                 &model_rows,
                 app.api_provider,
+                &configured_providers,
             ));
         }
         let selected_model_idx = selected_model_idx.unwrap_or(0);
@@ -113,6 +130,7 @@ impl ModelPickerView {
             focus: Pane::Model,
             show_custom_model_row,
             model_rows,
+            configured_providers,
         }
     }
 
@@ -130,7 +148,11 @@ impl ModelPickerView {
             .iter()
             .filter(|row| {
                 if query.is_empty() {
-                    row.provider.is_none() || row.provider == Some(self.initial_provider)
+                    model_row_visible_by_default(
+                        row.provider,
+                        self.initial_provider,
+                        &self.configured_providers,
+                    )
                 } else {
                     model_row_matches_query(row, query, self.initial_provider)
                 }
@@ -595,10 +617,48 @@ fn model_row_label(row: &ModelPickerRow, initial_provider: ApiProvider) -> Strin
     }
 }
 
-fn active_provider_model_row_count(rows: &[ModelPickerRow], provider: ApiProvider) -> usize {
+/// Whether a model row shows up without the user typing a search query
+/// (#3830): `auto`, the active provider's own rows, and any other
+/// provider's rows once that provider is "configured" — same definition the
+/// `/provider` manager's default view uses.
+fn model_row_visible_by_default(
+    row_provider: Option<ApiProvider>,
+    initial_provider: ApiProvider,
+    configured_providers: &[ApiProvider],
+) -> bool {
+    match row_provider {
+        None => true,
+        Some(provider) => provider == initial_provider || configured_providers.contains(&provider),
+    }
+}
+
+/// Count of rows the default (empty-query) view shows — i.e. how many
+/// `model_rows` entries satisfy [`model_row_visible_by_default`]. Used to
+/// position the custom-model row right after them (#3830).
+fn default_visible_model_row_count(
+    rows: &[ModelPickerRow],
+    initial_provider: ApiProvider,
+    configured_providers: &[ApiProvider],
+) -> usize {
     rows.iter()
-        .filter(|row| row.provider.is_none() || row.provider == Some(provider))
+        .filter(|row| {
+            model_row_visible_by_default(row.provider, initial_provider, configured_providers)
+        })
         .count()
+}
+
+/// Providers other than `active` that should be treated as "configured" for
+/// the `/model` picker's default view (#3830). Reuses the same predicate the
+/// `/provider` manager applies so the two pickers never disagree about what
+/// "configured" means.
+fn configured_providers_for(config: &Config, active: ApiProvider) -> Vec<ApiProvider> {
+    ApiProvider::sorted_for_display()
+        .into_iter()
+        .filter(|provider| {
+            *provider != active
+                && crate::config::provider_is_configured_for_active(config, *provider, active)
+        })
+        .collect()
 }
 
 fn picker_model_hint(id: &str) -> String {
@@ -910,12 +970,30 @@ fn default_picker_effort_idx(provider: ApiProvider, model_is_auto: bool) -> usiz
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
     use crate::tui::app::{App, TuiOptions};
     use std::path::PathBuf;
 
-    fn create_test_app() -> (App, std::sync::MutexGuard<'static, ()>) {
+    /// `_lock` bundles the process-wide test-env mutex with a guard that
+    /// neutralizes the real Codex CLI OAuth login on disk (`~/.codex/auth.json`),
+    /// if any — `has_api_key_for` checks `crate::oauth::auth_file_path().exists()`
+    /// unconditionally for `OpenaiCodex` (#3830), so without this, "default view
+    /// shows only configured providers" tests would pass or fail depending on
+    /// whether the machine running them happens to have a prior Codex login.
+    /// Declared in this order so the env var is restored (dropped first) while
+    /// the mutex is still held, before the mutex itself is released.
+    fn create_test_app() -> (
+        App,
+        Config,
+        (
+            crate::test_support::EnvVarGuard,
+            std::sync::MutexGuard<'static, ()>,
+        ),
+    ) {
         let lock = crate::test_support::lock_test_env();
+        let codex_auth_guard = crate::test_support::EnvVarGuard::set(
+            "OPENAI_CODEX_AUTH_FILE",
+            "/nonexistent/codewhale-test-codex-auth.json",
+        );
         let options = TuiOptions {
             model: "deepseek-v4-pro".to_string(),
             workspace: PathBuf::from("."),
@@ -937,7 +1015,8 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        let mut app = App::new(options, &Config::default());
+        let config = Config::default();
+        let mut app = App::new(options, &config);
         // App::new merges in the user's persisted settings.toml, which can override
         // the model, effort, and provider with whatever the developer
         // happens to have saved. Pin all three back to known values so
@@ -951,7 +1030,7 @@ mod tests {
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
         app.provider_models.clear();
-        (app, lock)
+        (app, config, (codex_auth_guard, lock))
     }
 
     fn type_model_query(view: &mut ModelPickerView, query: &str) {
@@ -993,7 +1072,7 @@ mod tests {
 
     #[test]
     fn picker_main_rows_are_scoped_to_active_provider() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Together;
         app.model = crate::config::DEFAULT_TOGETHER_MODEL.to_string();
         app.provider_models.insert(
@@ -1001,7 +1080,7 @@ mod tests {
             crate::config::DEFAULT_OPENROUTER_MODEL.to_string(),
         );
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
 
         assert!(
             view.visible_model_rows()
@@ -1018,24 +1097,130 @@ mod tests {
     }
 
     #[test]
+    fn picker_default_view_includes_explicitly_configured_provider_rows() {
+        // #3830: an explicit `[providers.together]` entry (base URL override,
+        // no key) makes Together "configured," so its model rows surface in
+        // the default (no-query) view alongside DeepSeek's own rows and
+        // `auto` — not just when the user types a search query.
+        let (mut app, _default_config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                together: crate::config::ProviderConfig {
+                    base_url: Some("https://custom.together.example/v1".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        let view = ModelPickerView::new(&app, &config);
+        let visible_ids = view.visible_model_ids();
+
+        assert!(
+            view.visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Together)),
+            "explicitly configured Together should surface rows by default: {visible_ids:?}"
+        );
+        assert!(visible_ids.contains(&crate::config::DEFAULT_TOGETHER_MODEL));
+        // Auto and the active provider's own rows are still present.
+        assert!(visible_ids.contains(&"auto"));
+        assert!(visible_ids.contains(&"deepseek-v4-pro"));
+    }
+
+    #[test]
+    fn picker_default_view_excludes_self_hosted_provider_without_explicit_setup() {
+        // #3830: `has_api_key_for` reports `true` unconditionally for
+        // self-hosted providers (no auth required to route to them) — that
+        // alone must not surface Sglang/Vllm in the default view for every
+        // user. Sglang (unlike Ollama) has real catalog model ids, so it's a
+        // meaningful row to check rather than an empty contribution.
+        let (mut app, _default_config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+        let config = Config::default();
+
+        let view = ModelPickerView::new(&app, &config);
+        assert!(
+            !view
+                .visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Sglang)),
+            "self-hosted Sglang has no explicit setup and isn't active"
+        );
+
+        // Discoverability is preserved: typing a query still reveals it.
+        let mut queried = ModelPickerView::new(&app, &config);
+        type_model_query(&mut queried, "sglang");
+        assert!(
+            queried
+                .visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Sglang)),
+            "searching should still surface unconfigured providers"
+        );
+    }
+
+    #[test]
+    fn custom_model_row_position_accounts_for_other_configured_providers() {
+        // #3830 regression: `resolved_model`/`model_row_count` treat any
+        // selection at or past `visible_model_rows().len()` as "the custom
+        // row." Once other configured providers' rows are mixed into the
+        // default view, the initial selection must still land past *all* of
+        // them, not just past the active provider's own rows.
+        let (mut app, _default_config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro-2026-04-XX".to_string();
+        app.auto_model = false;
+
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                together: crate::config::ProviderConfig {
+                    base_url: Some("https://custom.together.example/v1".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        let view = ModelPickerView::new(&app, &config);
+        assert!(view.show_custom_model_row);
+        assert!(
+            view.visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Together)),
+            "sanity check: Together rows are actually in the default view"
+        );
+        assert_eq!(view.selected_model_idx, view.visible_model_rows().len());
+        assert_eq!(view.resolved_model(), "deepseek-v4-pro-2026-04-XX");
+    }
+
+    #[test]
     fn picker_initial_selection_matches_app_state() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-flash".to_string();
         app.auto_model = false;
         app.reasoning_effort = ReasoningEffort::Max;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert_eq!(view.resolved_model(), "deepseek-v4-flash");
         assert_eq!(view.resolved_effort(), ReasoningEffort::Max);
     }
 
     #[test]
     fn picker_initial_selection_matches_auto_state() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "auto".to_string();
         app.auto_model = true;
         app.reasoning_effort = ReasoningEffort::Auto;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
 
         assert_eq!(view.resolved_model(), "auto");
         assert_eq!(view.resolved_effort(), ReasoningEffort::Auto);
@@ -1043,12 +1228,12 @@ mod tests {
 
     #[test]
     fn picker_auto_model_forces_auto_effort_on_apply() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "auto".to_string();
         app.auto_model = true;
         app.reasoning_effort = ReasoningEffort::Off;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
 
         assert_eq!(view.resolved_model(), "auto");
         assert_eq!(view.resolved_effort(), ReasoningEffort::Auto);
@@ -1056,10 +1241,10 @@ mod tests {
 
     #[test]
     fn picker_normalizes_low_medium_to_high() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.reasoning_effort = ReasoningEffort::Medium;
         app.auto_model = false;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert_eq!(
             view.resolved_effort(),
             ReasoningEffort::High,
@@ -1085,13 +1270,13 @@ mod tests {
 
     #[test]
     fn codex_picker_exposes_responses_reasoning_tiers() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::OpenaiCodex;
         app.model = "gpt-5.5-codex".to_string();
         app.auto_model = false;
         app.reasoning_effort = ReasoningEffort::Off;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
 
         assert_eq!(view.resolved_effort(), ReasoningEffort::Low);
         let labels: Vec<_> =
@@ -1106,7 +1291,7 @@ mod tests {
 
     #[test]
     fn picker_excludes_saved_codex_model_from_deepseek_main_section() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
@@ -1114,7 +1299,7 @@ mod tests {
         app.provider_models
             .insert("openai-codex".to_string(), "gpt-5.5".to_string());
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert_eq!(view.resolved_effort(), ReasoningEffort::Off);
         assert!(
             view.visible_model_rows()
@@ -1127,7 +1312,7 @@ mod tests {
 
     #[test]
     fn picker_does_not_switch_provider_when_moving_through_model_rows() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
@@ -1135,7 +1320,7 @@ mod tests {
         app.provider_models
             .insert("openai-codex".to_string(), "gpt-5.5".to_string());
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         while view.move_down() {
             assert_ne!(
                 view.resolved_provider(),
@@ -1148,12 +1333,12 @@ mod tests {
 
     #[test]
     fn picker_query_reveals_cross_provider_route_rows() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         assert!(
             view.visible_model_rows()
                 .iter()
@@ -1177,12 +1362,12 @@ mod tests {
 
     #[test]
     fn picker_query_cross_provider_enter_emits_provider_switch() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         type_model_query(&mut view, "openrouter");
 
         let action = view.handle_key(KeyEvent::new(
@@ -1205,13 +1390,13 @@ mod tests {
 
     #[test]
     fn picker_query_no_match_custom_row_stays_active_provider_scoped() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Openrouter;
         app.model_ids_passthrough = true;
         app.model = crate::config::DEFAULT_OPENROUTER_MODEL.to_string();
         app.auto_model = false;
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         type_model_query(&mut view, "custom-org/custom-model");
 
         assert_eq!(view.resolved_model(), "custom-org/custom-model");
@@ -1236,13 +1421,13 @@ mod tests {
 
     #[test]
     fn picker_query_no_match_strict_provider_enter_is_noop() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         type_model_query(&mut view, "definitely-not-a-deepseek-model");
 
         assert_eq!(view.model_row_count(), 0);
@@ -1255,12 +1440,12 @@ mod tests {
 
     #[test]
     fn picker_query_backspace_restores_active_provider_rows() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         type_model_query(&mut view, "openrouter");
         assert!(
             view.visible_model_rows()
@@ -1286,8 +1471,8 @@ mod tests {
 
     #[test]
     fn picker_effort_pane_ignores_query_typing() {
-        let (app, _lock) = create_test_app();
-        let mut view = ModelPickerView::new(&app);
+        let (app, config, _lock) = create_test_app();
+        let mut view = ModelPickerView::new(&app, &config);
         view.handle_key(KeyEvent::new(
             KeyCode::Tab,
             crossterm::event::KeyModifiers::NONE,
@@ -1307,13 +1492,13 @@ mod tests {
 
     #[test]
     fn picker_query_resyncs_effort_for_codex_rows() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
         app.reasoning_effort = ReasoningEffort::Auto;
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         assert_eq!(view.resolved_effort(), ReasoningEffort::Auto);
 
         type_model_query(&mut view, "codex");
@@ -1331,23 +1516,23 @@ mod tests {
 
     #[test]
     fn picker_preserves_unknown_model_via_custom_row() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-pro-2026-04-XX".to_string();
         app.auto_model = false;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert!(view.show_custom_model_row);
         assert_eq!(view.resolved_model(), "deepseek-v4-pro-2026-04-XX");
     }
 
     #[test]
     fn picker_lists_openrouter_large_models() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Openrouter;
         app.model_ids_passthrough = true;
         app.model = "minimax/minimax-m3".to_string();
         app.auto_model = false;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         let model_ids = view.visible_model_ids();
 
         assert!(model_ids.contains(&"arcee-ai/trinity-large-thinking"));
@@ -1367,12 +1552,12 @@ mod tests {
 
     #[test]
     fn picker_lists_xiaomi_mimo_chat_models_without_speech_models() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::XiaomiMimo;
         app.model = "mimo-v2.5-pro".to_string();
         app.auto_model = false;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         let model_ids = view.visible_model_ids();
 
         for expected in ["mimo-v2.5-pro", "mimo-v2.5-pro-ultraspeed", "mimo-v2.5"] {
@@ -1399,13 +1584,13 @@ mod tests {
 
     #[test]
     fn picker_for_ollama_preserves_current_local_tag_without_hosted_static_rows() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Ollama;
         app.model_ids_passthrough = true;
         app.model = "qwen2.5-coder:7b".to_string();
         app.auto_model = false;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         let model_ids = view.visible_model_ids();
 
         assert_eq!(model_ids, vec!["auto"]);
@@ -1444,13 +1629,13 @@ mod tests {
 
     #[test]
     fn picker_preserves_custom_passthrough_model_ids() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Openrouter;
         app.model_ids_passthrough = true;
         app.model = "opencode-go/glm-5.1".to_string();
         app.auto_model = false;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
 
         assert!(view.show_custom_model_row);
         assert_eq!(view.resolved_model(), "opencode-go/glm-5.1");
@@ -1458,13 +1643,13 @@ mod tests {
 
     #[test]
     fn picker_exposes_active_custom_provider_model_row() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Custom;
         app.model_ids_passthrough = true;
         app.model = "vendor/custom-model-v1".to_string();
         app.auto_model = false;
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
 
         assert!(view.show_custom_model_row);
         assert_eq!(view.resolved_model(), "vendor/custom-model-v1");
@@ -1476,14 +1661,14 @@ mod tests {
 
     #[test]
     fn picker_exposes_saved_model_for_active_provider() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::XiaomiMimo;
         app.model = "mimo-v2.5-custom".to_string();
         app.auto_model = false;
         app.provider_models
             .insert("xiaomi-mimo".to_string(), "mimo-v2.5-custom".to_string());
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         view.selected_model_idx = view
             .visible_model_rows()
             .iter()
@@ -1510,7 +1695,7 @@ mod tests {
 
     #[test]
     fn picker_excludes_saved_models_from_other_providers() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::XiaomiMimo;
         app.model = "mimo-v2.5-pro".to_string();
         app.auto_model = false;
@@ -1525,7 +1710,7 @@ mod tests {
             "custom-qianfan-service-id".to_string(),
         );
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         let model_ids = view.visible_model_ids();
 
         // Active provider's own model stays present (and ahead of the tail).
@@ -1548,27 +1733,27 @@ mod tests {
     fn picker_skips_unknown_provider_saved_models() {
         // A config key that maps to no known provider cannot be applied, so it
         // must not produce a picker row (#2596).
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::XiaomiMimo;
         app.model = "mimo-v2.5-pro".to_string();
         app.auto_model = false;
         app.provider_models
             .insert("totally-unknown".to_string(), "ghost-model".to_string());
 
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert!(!view.visible_model_ids().contains(&"ghost-model"));
     }
 
     #[test]
     fn picker_does_not_hijack_current_custom_model_with_saved_provider_row() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.api_provider = crate::config::ApiProvider::Openai;
         app.model_ids_passthrough = true;
         app.model = "kimi-k2.6".to_string();
         app.provider_models
             .insert("moonshot".to_string(), "kimi-k2.6".to_string());
 
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
 
         assert!(view.show_custom_model_row);
         assert_eq!(view.resolved_model(), "kimi-k2.6");
@@ -1589,10 +1774,10 @@ mod tests {
 
     #[test]
     fn arrow_keys_move_within_focused_pane() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-pro".to_string();
         app.reasoning_effort = ReasoningEffort::High;
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         assert_eq!(view.selected_model_idx, 1);
         view.handle_key(KeyEvent::new(
             KeyCode::Down,
@@ -1620,9 +1805,9 @@ mod tests {
 
     #[test]
     fn mouse_wheel_moves_focused_picker_pane() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-pro".to_string();
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         assert_eq!(view.selected_model_idx, 1);
 
         view.handle_mouse(crossterm::event::MouseEvent {
@@ -1644,8 +1829,8 @@ mod tests {
 
     #[test]
     fn tab_switches_between_model_and_thinking() {
-        let (app, _lock) = create_test_app();
-        let mut view = ModelPickerView::new(&app);
+        let (app, config, _lock) = create_test_app();
+        let mut view = ModelPickerView::new(&app, &config);
         assert_eq!(view.focus, Pane::Model);
         view.handle_key(KeyEvent::new(
             KeyCode::Tab,
@@ -1661,11 +1846,11 @@ mod tests {
 
     #[test]
     fn enter_emits_current_model_and_thinking() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.reasoning_effort = ReasoningEffort::High;
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         assert_eq!(view.selected_model_idx, 1);
         assert_eq!(view.selected_effort_idx, 2);
 
@@ -1704,11 +1889,11 @@ mod tests {
 
     #[test]
     fn deepseek_provider_uses_neutral_two_pane_selection() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-flash".to_string();
         app.auto_model = false;
         app.reasoning_effort = ReasoningEffort::Max;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert_eq!(view.selected_model_idx, 2);
         assert_eq!(view.selected_effort_idx, 3);
         assert_eq!(view.focus, Pane::Model);
@@ -1718,10 +1903,10 @@ mod tests {
 
     #[test]
     fn model_picker_selected_row_renders_readable_selection_contrast() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-flash".to_string();
         app.auto_model = false;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         let area = Rect::new(0, 0, 100, 28);
         let mut buf = Buffer::empty(area);
 
@@ -1751,11 +1936,11 @@ mod tests {
 
     #[test]
     fn known_model_with_auto_effort_preserves_explicit_model() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-pro".to_string();
         app.auto_model = false;
         app.reasoning_effort = ReasoningEffort::Auto;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert!(!view.show_custom_model_row);
         assert_eq!(view.selected_model_idx, 1);
         assert_eq!(view.selected_effort_idx, 0);
@@ -1765,11 +1950,11 @@ mod tests {
 
     #[test]
     fn auto_model_selects_auto_row() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "auto".to_string();
         app.auto_model = true;
         app.reasoning_effort = ReasoningEffort::Auto;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert_eq!(view.selected_model_idx, 0);
         assert_eq!(view.selected_effort_idx, 0);
         assert_eq!(view.resolved_model(), "auto");
@@ -1778,11 +1963,11 @@ mod tests {
 
     #[test]
     fn custom_model_row_preserves_current_model_and_effort() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.model = "deepseek-v4-pro-2026-04-XX".to_string();
         app.auto_model = false;
         app.reasoning_effort = ReasoningEffort::High;
-        let view = ModelPickerView::new(&app);
+        let view = ModelPickerView::new(&app, &config);
         assert!(view.show_custom_model_row);
         assert_eq!(view.selected_model_idx, view.visible_model_rows().len());
         assert_eq!(view.selected_effort_idx, 2);
@@ -1792,8 +1977,8 @@ mod tests {
 
     #[test]
     fn move_down_from_last_model_is_noop() {
-        let (app, _lock) = create_test_app();
-        let mut view = ModelPickerView::new(&app);
+        let (app, config, _lock) = create_test_app();
+        let mut view = ModelPickerView::new(&app, &config);
         view.selected_model_idx = view.model_row_count() - 1;
         let result = view.move_down();
         assert!(!result);
@@ -1801,8 +1986,8 @@ mod tests {
 
     #[test]
     fn move_up_from_first_model_is_noop() {
-        let (app, _lock) = create_test_app();
-        let mut view = ModelPickerView::new(&app);
+        let (app, config, _lock) = create_test_app();
+        let mut view = ModelPickerView::new(&app, &config);
         view.selected_model_idx = 0;
         let result = view.move_up();
         assert!(!result);
@@ -1810,8 +1995,8 @@ mod tests {
 
     #[test]
     fn immediate_esc_closes_without_apply() {
-        let (app, _lock) = create_test_app();
-        let mut view = ModelPickerView::new(&app);
+        let (app, config, _lock) = create_test_app();
+        let mut view = ModelPickerView::new(&app, &config);
         let action = view.handle_key(KeyEvent::new(
             KeyCode::Esc,
             crossterm::event::KeyModifiers::NONE,
@@ -1821,9 +2006,9 @@ mod tests {
 
     #[test]
     fn esc_after_selection_move_closes_without_apply() {
-        let (mut app, _lock) = create_test_app();
+        let (mut app, config, _lock) = create_test_app();
         app.reasoning_effort = ReasoningEffort::High;
-        let mut view = ModelPickerView::new(&app);
+        let mut view = ModelPickerView::new(&app, &config);
         view.handle_key(KeyEvent::new(
             KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
@@ -1844,7 +2029,7 @@ mod tests {
     #[test]
     fn model_picker_is_usable_and_opaque_at_blocker_sizes() {
         use crate::tui::views::ViewStack;
-        let (app, _lock) = create_test_app();
+        let (app, config, _lock) = create_test_app();
         for (w, h) in BLOCKER_SIZES {
             let area = Rect::new(0, 0, w, h);
             let mut buf = Buffer::empty(area);
@@ -1859,7 +2044,7 @@ mod tests {
             // Render through the ViewStack so the shared opaque backdrop is
             // painted exactly as it is in production.
             let mut stack = ViewStack::new();
-            stack.push(ModelPickerView::new(&app));
+            stack.push(ModelPickerView::new(&app, &config));
             stack.render(area, &mut buf);
 
             let rows: Vec<String> = (0..h)

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -26,7 +26,10 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Widget},
 };
 
-use crate::config::{ApiProvider, Config, has_api_key_for, kimi_cli_credentials_present};
+use crate::config::{
+    ApiProvider, Config, base_url_uses_local_host, has_api_key_for, kimi_cli_credentials_present,
+    provider_is_configured,
+};
 use crate::core::ops::ProviderRuntimeStatus;
 use crate::model_profile::{SupportState, resolved_capability_profile};
 use crate::palette;
@@ -929,58 +932,6 @@ fn custom_provider_has_auth(configured: Option<&crate::config::ProviderConfig>) 
     })
 }
 
-/// Whether a provider counts as "configured" for the default `/provider`
-/// view (#3830). Self-hosted providers (Ollama/Sglang/Vllm) report
-/// `has_key = true` unconditionally in `has_api_key_for` since they don't
-/// require auth to route to — that's correct for routing, but wrong for "did
-/// the user set this up," so a self-hosted provider only qualifies via an
-/// explicit `[providers.<name>]` entry or being active, never via `has_key`
-/// alone (otherwise every self-hosted provider type would always show up).
-fn provider_is_configured(
-    provider: ApiProvider,
-    is_active: bool,
-    has_key: bool,
-    configured: Option<&crate::config::ProviderConfig>,
-    is_named_custom_entry: bool,
-) -> bool {
-    // A *named* custom provider entry (one the user actually added) always
-    // counts. The unconfigured `Custom` placeholder row that fills the slot
-    // when no custom provider exists yet (`provider_id_override: None` in
-    // `from_config_with_provider_id`) is not itself "configured" — it's the
-    // catalog's invitation to add one.
-    if is_active || is_named_custom_entry {
-        return true;
-    }
-    if configured.is_some_and(provider_config_is_explicit) {
-        return true;
-    }
-    if provider.is_self_hosted() {
-        return false;
-    }
-    has_key
-}
-
-/// True when a `[providers.<name>]` table entry has any field the user would
-/// have had to set explicitly — base URL, model, auth, etc. Used by
-/// [`provider_is_configured`]: merely existing in the
-/// (always-`Some`-once-any-provider-is-configured) `ProvidersConfig` struct
-/// isn't enough, since untouched providers still resolve to a
-/// `ProviderConfig::default()` there.
-fn provider_config_is_explicit(entry: &crate::config::ProviderConfig) -> bool {
-    entry.api_key.is_some()
-        || entry.base_url.is_some()
-        || entry.model.is_some()
-        || entry.auth_mode.is_some()
-        || entry.auth.is_some()
-        || entry.context_window.is_some()
-        || entry.mode.is_some()
-        || entry.max_concurrency.is_some()
-        || entry.http_headers.is_some()
-        || entry.path_suffix.is_some()
-        || entry.reasoning_stream_style.is_some()
-        || entry.insecure_skip_tls_verify.is_some()
-}
-
 fn custom_provider_auth_is_optional(configured: Option<&crate::config::ProviderConfig>) -> bool {
     configured.is_some_and(|entry| {
         entry
@@ -1002,29 +953,6 @@ fn auth_mode_disables_api_key(mode: &str) -> bool {
             .as_str(),
         "none" | "off" | "disabled" | "no_auth" | "noapi" | "no_api_key" | "anonymous"
     )
-}
-
-fn base_url_uses_local_host(base_url: &str) -> bool {
-    let without_scheme = base_url
-        .split_once("://")
-        .map_or(base_url, |(_, rest)| rest);
-    let authority = without_scheme.split('/').next().unwrap_or_default();
-    let host = authority
-        .rsplit('@')
-        .next()
-        .unwrap_or(authority)
-        .trim_start_matches('[')
-        .split(']')
-        .next()
-        .unwrap_or(authority)
-        .split(':')
-        .next()
-        .unwrap_or(authority)
-        .to_ascii_lowercase();
-    matches!(host.as_str(), "localhost" | "0.0.0.0")
-        || host
-            .parse::<std::net::IpAddr>()
-            .is_ok_and(|addr| addr.is_loopback() || addr.is_unspecified())
 }
 
 fn missing_auth_message(
@@ -1848,6 +1776,9 @@ mod tests {
     fn mouse_scroll_moves_selection_in_list_stage() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        // Scroll across the full catalog (#3830), not just the configured
+        // subset, which would only contain the active provider here.
+        picker.toggle_view();
         let before = picker.selected_idx;
         picker.handle_mouse(MouseEvent {
             kind: MouseEventKind::ScrollDown,

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -49,10 +49,20 @@ enum Stage {
     KeyEntry,
 }
 
+/// Which subset of `rows` the list stage shows (#3830). `Configured` is the
+/// default; `A` toggles to `Catalog` to add a new provider or look at one
+/// that hasn't been set up yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderListView {
+    Configured,
+    Catalog,
+}
+
 pub struct ProviderPickerView {
     rows: Vec<ProviderDashboardRow>,
     selected_idx: usize,
     stage: Stage,
+    view: ProviderListView,
     api_key_input: String,
 }
 
@@ -78,6 +88,15 @@ pub struct ProviderDashboardRow {
     pub messages: Vec<String>,
     pub is_active: bool,
     has_key: bool,
+    /// Whether this provider should appear in the default `/provider`
+    /// manager view (#3830) without the user explicitly browsing the full
+    /// catalog: the active provider, one with working credentials/OAuth, a
+    /// custom provider entry, or any provider with a non-default
+    /// `[providers.<name>]` table entry. A self-hosted provider type
+    /// (Ollama/Sglang/Vllm) does *not* auto-qualify just because its auth is
+    /// optional — that would clutter the default view with every untouched
+    /// local-provider slot.
+    pub is_configured: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -383,6 +402,13 @@ impl ProviderDashboardRow {
                 ],
                 is_active,
                 has_key,
+                is_configured: provider_is_configured(
+                    provider,
+                    is_active,
+                    has_key,
+                    configured,
+                    provider == ApiProvider::Custom && provider_id_override.is_some(),
+                ),
             };
         };
 
@@ -482,6 +508,13 @@ impl ProviderDashboardRow {
             messages,
             is_active,
             has_key,
+            is_configured: provider_is_configured(
+                provider,
+                is_active,
+                has_key,
+                configured,
+                provider == ApiProvider::Custom && provider_id_override.is_some(),
+            ),
         }
     }
 
@@ -896,6 +929,58 @@ fn custom_provider_has_auth(configured: Option<&crate::config::ProviderConfig>) 
     })
 }
 
+/// Whether a provider counts as "configured" for the default `/provider`
+/// view (#3830). Self-hosted providers (Ollama/Sglang/Vllm) report
+/// `has_key = true` unconditionally in `has_api_key_for` since they don't
+/// require auth to route to — that's correct for routing, but wrong for "did
+/// the user set this up," so a self-hosted provider only qualifies via an
+/// explicit `[providers.<name>]` entry or being active, never via `has_key`
+/// alone (otherwise every self-hosted provider type would always show up).
+fn provider_is_configured(
+    provider: ApiProvider,
+    is_active: bool,
+    has_key: bool,
+    configured: Option<&crate::config::ProviderConfig>,
+    is_named_custom_entry: bool,
+) -> bool {
+    // A *named* custom provider entry (one the user actually added) always
+    // counts. The unconfigured `Custom` placeholder row that fills the slot
+    // when no custom provider exists yet (`provider_id_override: None` in
+    // `from_config_with_provider_id`) is not itself "configured" — it's the
+    // catalog's invitation to add one.
+    if is_active || is_named_custom_entry {
+        return true;
+    }
+    if configured.is_some_and(provider_config_is_explicit) {
+        return true;
+    }
+    if provider.is_self_hosted() {
+        return false;
+    }
+    has_key
+}
+
+/// True when a `[providers.<name>]` table entry has any field the user would
+/// have had to set explicitly — base URL, model, auth, etc. Used by
+/// [`provider_is_configured`]: merely existing in the
+/// (always-`Some`-once-any-provider-is-configured) `ProvidersConfig` struct
+/// isn't enough, since untouched providers still resolve to a
+/// `ProviderConfig::default()` there.
+fn provider_config_is_explicit(entry: &crate::config::ProviderConfig) -> bool {
+    entry.api_key.is_some()
+        || entry.base_url.is_some()
+        || entry.model.is_some()
+        || entry.auth_mode.is_some()
+        || entry.auth.is_some()
+        || entry.context_window.is_some()
+        || entry.mode.is_some()
+        || entry.max_concurrency.is_some()
+        || entry.http_headers.is_some()
+        || entry.path_suffix.is_some()
+        || entry.reasoning_stream_style.is_some()
+        || entry.insecure_skip_tls_verify.is_some()
+}
+
 fn custom_provider_auth_is_optional(configured: Option<&crate::config::ProviderConfig>) -> bool {
     configured.is_some_and(|entry| {
         entry
@@ -1091,39 +1176,81 @@ impl ProviderPickerView {
             .position(|row| row.is_active)
             .or_else(|| rows.iter().position(|row| row.provider == active))
             .unwrap_or(0);
+        // Default to the configured-only view (#3830); if nothing is
+        // configured yet (a fresh install), open straight on the full
+        // catalog instead of an empty list with no obvious next step.
+        let view = if rows.iter().any(|row| row.is_configured) {
+            ProviderListView::Configured
+        } else {
+            ProviderListView::Catalog
+        };
         Self {
             rows,
             selected_idx,
             stage: Stage::List,
+            view,
             api_key_input: String::new(),
         }
     }
 
-    fn move_up(&mut self) {
-        if self.rows.is_empty() {
+    fn row_visible(&self, idx: usize) -> bool {
+        match self.view {
+            ProviderListView::Catalog => true,
+            ProviderListView::Configured => self.rows[idx].is_configured,
+        }
+    }
+
+    fn visible_row_count(&self) -> usize {
+        (0..self.rows.len())
+            .filter(|idx| self.row_visible(*idx))
+            .count()
+    }
+
+    /// Toggle between the configured-only and full-catalog views (#3830),
+    /// keeping the current selection if it stays visible and otherwise
+    /// jumping to the nearest visible row.
+    fn toggle_view(&mut self) {
+        self.view = match self.view {
+            ProviderListView::Configured => ProviderListView::Catalog,
+            ProviderListView::Catalog => ProviderListView::Configured,
+        };
+        if !self.rows.is_empty() && !self.row_visible(self.selected_idx) {
+            self.selected_idx = (0..self.rows.len())
+                .find(|idx| self.row_visible(*idx))
+                .unwrap_or(0);
+        }
+    }
+
+    /// Move the selection one visible row forward (`step = 1`) or backward
+    /// (`step = -1`), skipping rows hidden by the current `view` filter
+    /// (#3830) and wrapping at the ends.
+    fn move_selection(&mut self, step: i64) {
+        let count = self.rows.len();
+        if count == 0 || self.visible_row_count() == 0 {
             return;
         }
-        if self.selected_idx == 0 {
-            self.selected_idx = self.rows.len() - 1;
-        } else {
-            self.selected_idx -= 1;
+        let mut idx = self.selected_idx;
+        loop {
+            idx = ((idx as i64 + step).rem_euclid(count as i64)) as usize;
+            if self.row_visible(idx) {
+                self.selected_idx = idx;
+                return;
+            }
         }
+    }
+
+    fn move_up(&mut self) {
+        self.move_selection(-1);
     }
 
     fn move_down(&mut self) {
-        if self.rows.is_empty() {
-            return;
-        }
-        if self.selected_idx + 1 == self.rows.len() {
-            self.selected_idx = 0;
-        } else {
-            self.selected_idx += 1;
-        }
+        self.move_selection(1);
     }
 
-    /// Type-ahead: move the selection to the next provider whose display name
-    /// starts with the given character (case-insensitive), wrapping so repeated
-    /// presses cycle through matches — e.g. pressing `z` jumps to "Z.ai".
+    /// Type-ahead: move the selection to the next visible provider whose
+    /// display name starts with the given character (case-insensitive),
+    /// wrapping so repeated presses cycle through matches — e.g. pressing
+    /// `z` jumps to "Z.ai".
     fn jump_to_letter(&mut self, c: char) {
         let count = self.rows.len();
         if count == 0 {
@@ -1132,10 +1259,11 @@ impl ProviderPickerView {
         let target = c.to_ascii_lowercase();
         for offset in 1..=count {
             let idx = (self.selected_idx + offset) % count;
-            if self.rows[idx]
-                .display_name
-                .to_ascii_lowercase()
-                .starts_with(target)
+            if self.row_visible(idx)
+                && self.rows[idx]
+                    .display_name
+                    .to_ascii_lowercase()
+                    .starts_with(target)
             {
                 self.selected_idx = idx;
                 return;
@@ -1177,12 +1305,23 @@ impl ProviderPickerView {
         Self::env_var_for(row.provider)
     }
 
-    fn visible_start(&self, visible_rows: usize) -> usize {
+    /// Rows visible under the current `view` filter (#3830), as
+    /// `(original_index, row)` pairs so callers can still compare against
+    /// `self.selected_idx`.
+    fn filtered_rows(&self) -> Vec<(usize, &ProviderDashboardRow)> {
+        self.rows
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| self.row_visible(*idx))
+            .collect()
+    }
+
+    fn visible_start(selected_pos: usize, total: usize, visible_rows: usize) -> usize {
         if visible_rows == 0 {
             return 0;
         }
-        let max_start = self.rows.len().saturating_sub(visible_rows);
-        self.selected_idx
+        let max_start = total.saturating_sub(visible_rows);
+        selected_pos
             .saturating_add(1)
             .saturating_sub(visible_rows)
             .min(max_start)
@@ -1205,9 +1344,13 @@ impl ProviderPickerView {
         } else {
             "set key"
         };
+        let title = match self.view {
+            ProviderListView::Configured => " Provider ".to_string(),
+            ProviderListView::Catalog => " Provider · all ".to_string(),
+        };
         let outer = Block::default()
             .title(Line::from(Span::styled(
-                " Provider ",
+                title,
                 Style::default()
                     .fg(palette::DEEPSEEK_SKY)
                     .add_modifier(Modifier::BOLD),
@@ -1218,6 +1361,10 @@ impl ProviderPickerView {
         let inner = outer.inner(area);
         outer.render(area, buf);
 
+        let view_action = match self.view {
+            ProviderListView::Configured => "browse all",
+            ProviderListView::Catalog => "configured",
+        };
         // The action footer moves into the body so it wraps instead of clipping
         // at narrow widths (#3732); the provider list renders above it.
         let content = render_modal_footer(
@@ -1227,23 +1374,44 @@ impl ProviderPickerView {
                 ActionHint::new("↑↓", "move"),
                 ActionHint::new("a-z", "jump"),
                 ActionHint::new("Enter", enter_action),
+                ActionHint::new("A", view_action),
                 ActionHint::new("R", "edit key"),
                 ActionHint::new("M", "models"),
                 ActionHint::new("Esc", "cancel"),
             ],
         );
 
+        let filtered = self.filtered_rows();
+        if filtered.is_empty() {
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "No providers configured yet.",
+                    Style::default().fg(palette::TEXT_MUTED),
+                )),
+                Line::from(Span::styled(
+                    "Press A to browse every supported provider and add one.",
+                    Style::default().fg(palette::TEXT_MUTED),
+                )),
+            ])
+            .render(content, buf);
+            return;
+        }
+
+        let selected_pos = filtered
+            .iter()
+            .position(|(idx, _)| *idx == self.selected_idx)
+            .unwrap_or(0);
         let visible_rows = usize::from(content.height);
-        let visible_start = self.visible_start(visible_rows);
+        let visible_start = Self::visible_start(selected_pos, filtered.len(), visible_rows);
         let mut lines: Vec<Line> = Vec::with_capacity(visible_rows);
-        for (idx, row) in self
-            .rows
+        for (pos, (idx, row)) in filtered
             .iter()
             .enumerate()
             .skip(visible_start)
             .take(visible_rows)
         {
-            let is_selected = idx == self.selected_idx;
+            let is_selected = *idx == self.selected_idx;
+            debug_assert_eq!(is_selected, pos == selected_pos);
             let is_active = row.is_active;
             let arrow = if is_selected { "▸" } else { " " };
             let active_dot = if is_active { " *" } else { "  " };
@@ -1412,7 +1580,11 @@ impl ModalView for ProviderPickerView {
                     self.move_down();
                     ViewAction::None
                 }
-                KeyCode::Enter => {
+                // Row-dependent actions are no-ops when the current filter
+                // (#3830) hides every row — e.g. a fresh Configured view
+                // with nothing configured yet shows the empty state and
+                // `selected_idx` doesn't point at anything on screen.
+                KeyCode::Enter if self.row_visible(self.selected_idx) => {
                     let provider = self.selected_provider();
                     if self.selected_has_key() {
                         ViewAction::EmitAndClose(ViewEvent::ProviderPickerApplied { provider })
@@ -1425,14 +1597,30 @@ impl ModalView for ProviderPickerView {
                         ViewAction::None
                     }
                 }
-                KeyCode::Char(c) if key.modifiers.is_empty() && c.eq_ignore_ascii_case(&'r') => {
+                KeyCode::Char(c)
+                    if key.modifiers.is_empty()
+                        && c.eq_ignore_ascii_case(&'r')
+                        && self.row_visible(self.selected_idx) =>
+                {
                     self.enter_key_entry();
+                    ViewAction::None
+                }
+                // Toggle between the configured-only default view and the
+                // full provider catalog (#3830). Handled before the
+                // type-ahead arm so `a`/`A` always toggles instead of
+                // seeking a provider whose name starts with "a".
+                KeyCode::Char(c) if key.modifiers.is_empty() && c.eq_ignore_ascii_case(&'a') => {
+                    self.toggle_view();
                     ViewAction::None
                 }
                 // Jump to the `/model` picker pre-filtered to this provider
                 // (#3083). Handled before the type-ahead arm so `m`/`M` opens
                 // models instead of seeking a provider whose name starts with m.
-                KeyCode::Char(c) if key.modifiers.is_empty() && c.eq_ignore_ascii_case(&'m') => {
+                KeyCode::Char(c)
+                    if key.modifiers.is_empty()
+                        && c.eq_ignore_ascii_case(&'m')
+                        && self.row_visible(self.selected_idx) =>
+                {
                     let provider = self.selected_provider();
                     ViewAction::EmitAndClose(ViewEvent::ProviderPickerOpenModels { provider })
                 }
@@ -1596,6 +1784,14 @@ mod tests {
     }
 
     fn move_to_provider(picker: &mut ProviderPickerView, provider: ApiProvider) {
+        // The target may be hidden by the default configured-only view
+        // (#3830); switch to the full catalog so navigation can still reach
+        // it, matching what a user pressing `A` would do.
+        if let Some(idx) = picker.rows.iter().position(|row| row.provider == provider)
+            && !picker.row_visible(idx)
+        {
+            picker.toggle_view();
+        }
         let max_steps = picker.rows.len();
         for _ in 0..max_steps {
             if picker.selected_provider() == provider {
@@ -1620,6 +1816,9 @@ mod tests {
     fn type_ahead_jumps_to_provider_by_first_letter() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        // Z.ai isn't configured, so it's hidden by the default view (#3830);
+        // browse the full catalog like a user pressing `A` would.
+        picker.toggle_view();
         // `z` is unique to Z.ai among provider display names.
         picker.handle_key(key(KeyCode::Char('z')));
         assert_eq!(picker.selected_provider(), ApiProvider::Zai);
@@ -1687,6 +1886,121 @@ mod tests {
         );
         // DeepSeek is no longer hard-coded first.
         assert_ne!(names.first(), Some(&"DeepSeek"));
+    }
+
+    #[test]
+    fn default_view_shows_only_configured_providers() {
+        // #3830: with nothing but the active provider set up, the default
+        // list view excludes the unconfigured catalog noise — even though
+        // `rows` (the underlying data) still has every provider, per
+        // `picker_lists_all_providers` above. Doesn't assert an exact count:
+        // `OpenaiCodex` reads a real OAuth file from disk in
+        // `has_api_key_for`, so it's legitimately "configured" on a machine
+        // with a prior Codex login and must not make this test host-dependent.
+        let config = Config::default();
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+
+        assert_eq!(picker.view, ProviderListView::Configured);
+        let visible: Vec<ApiProvider> = picker
+            .filtered_rows()
+            .iter()
+            .map(|(_, row)| row.provider)
+            .collect();
+        assert!(visible.contains(&ApiProvider::Deepseek), "{visible:?}");
+        assert!(
+            !visible.contains(&ApiProvider::Custom),
+            "the unused custom-provider placeholder slot isn't \"configured\": {visible:?}"
+        );
+        for unconfigured in [
+            ApiProvider::Zai,
+            ApiProvider::Openrouter,
+            ApiProvider::Novita,
+            ApiProvider::Ollama,
+        ] {
+            assert!(
+                !visible.contains(&unconfigured),
+                "{unconfigured:?} has no credentials and isn't active: {visible:?}"
+            );
+        }
+        assert!(
+            picker.rows.len() > visible.len(),
+            "underlying data keeps every provider"
+        );
+    }
+
+    #[test]
+    fn explicit_provider_config_marks_provider_configured_without_active_or_key() {
+        // #3830: a non-default `[providers.<name>]` entry (here just a base
+        // URL override, no key) counts as "configured" even though the
+        // provider is neither active nor has working credentials.
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                openrouter: crate::config::ProviderConfig {
+                    base_url: Some("https://custom.openrouter.example/v1".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let row = picker
+            .rows
+            .iter()
+            .find(|row| row.provider == ApiProvider::Openrouter)
+            .expect("openrouter row");
+        assert!(row.is_configured);
+        assert!(!row.has_key, "explicit config doesn't imply a working key");
+    }
+
+    #[test]
+    fn self_hosted_provider_not_auto_configured_without_explicit_setup() {
+        // #3830: `has_api_key_for` always reports `true` for self-hosted
+        // providers (no auth required to route to them) — that must not, on
+        // its own, make Ollama/Sglang/Vllm show up in the default
+        // configured-only view for every user regardless of setup.
+        let config = Config::default();
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let ollama = picker
+            .rows
+            .iter()
+            .find(|row| row.provider == ApiProvider::Ollama)
+            .expect("ollama row");
+        assert!(
+            ollama.has_key,
+            "self-hosted providers report has_key unconditionally"
+        );
+        assert!(
+            !ollama.is_configured,
+            "but that alone must not mark them configured"
+        );
+
+        // Active self-hosted provider still counts as configured.
+        let active_picker = ProviderPickerView::new(ApiProvider::Ollama, &config);
+        let active_ollama = active_picker
+            .rows
+            .iter()
+            .find(|row| row.provider == ApiProvider::Ollama)
+            .expect("ollama row");
+        assert!(active_ollama.is_configured);
+    }
+
+    #[test]
+    fn toggle_view_reveals_full_catalog_and_back() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let configured_count = picker.filtered_rows().len();
+        assert_eq!(picker.view, ProviderListView::Configured);
+
+        let action = picker.handle_key(key(KeyCode::Char('a')));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(picker.view, ProviderListView::Catalog);
+        assert_eq!(picker.filtered_rows().len(), picker.rows.len());
+        assert!(picker.filtered_rows().len() > configured_count);
+
+        picker.handle_key(key(KeyCode::Char('A')));
+        assert_eq!(picker.view, ProviderListView::Configured);
+        assert_eq!(picker.filtered_rows().len(), configured_count);
     }
 
     #[test]
@@ -2299,6 +2613,9 @@ mod tests {
     fn list_navigation_wraps_between_first_and_last_provider() {
         let config = Config::default();
         let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        // Wrap across the full catalog (#3830), not just the configured
+        // subset, which would only contain the active provider here.
+        picker.toggle_view();
         let first = picker.rows.first().expect("non-empty list").provider;
         let last = picker.rows.last().expect("non-empty list").provider;
 
@@ -2473,7 +2790,9 @@ mod tests {
     #[test]
     fn tall_list_render_shows_all_providers_without_scrolling() {
         let config = Config::default();
-        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        // "All providers" means the full catalog (#3830), not just configured.
+        picker.toggle_view();
 
         let rendered = render_text(&picker, 80, 23);
 

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -1136,7 +1136,9 @@ impl ProviderPickerView {
 
     /// Toggle between the configured-only and full-catalog views (#3830),
     /// keeping the current selection if it stays visible and otherwise
-    /// jumping to the nearest visible row.
+    /// jumping to the first visible row (`rows` is sorted alphabetically by
+    /// display name, so this lands on the alphabetically-first match, not
+    /// necessarily the row positionally nearest the old selection).
     fn toggle_view(&mut self) {
         self.view = match self.view {
             ProviderListView::Configured => ProviderListView::Catalog,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -7529,7 +7529,7 @@ async fn apply_command_result(
             AppAction::OpenModelPicker => {
                 if app.view_stack.top_kind() != Some(ModalKind::ModelPicker) {
                     app.view_stack
-                        .push(crate::tui::model_picker::ModelPickerView::new(app));
+                        .push(crate::tui::model_picker::ModelPickerView::new(app, config));
                 }
             }
             AppAction::OpenProviderPicker => {
@@ -9040,10 +9040,14 @@ fn toggle_live_transcript_overlay(app: &mut App) {
 /// the standard "open model picker" path and seed its query by replaying the
 /// provider's display name as character input through the public view-stack
 /// key path — no model-picker internals are touched.
-fn open_model_picker_for_provider(app: &mut App, provider: crate::config::ApiProvider) {
+fn open_model_picker_for_provider(
+    app: &mut App,
+    config: &Config,
+    provider: crate::config::ApiProvider,
+) {
     if app.view_stack.top_kind() != Some(ModalKind::ModelPicker) {
         app.view_stack
-            .push(crate::tui::model_picker::ModelPickerView::new(app));
+            .push(crate::tui::model_picker::ModelPickerView::new(app, config));
     }
     for ch in provider.display_name().chars() {
         // Char input updates the query and never emits a ViewEvent, so the
@@ -9481,7 +9485,7 @@ async fn handle_view_events(
                 .await;
             }
             ViewEvent::ProviderPickerOpenModels { provider } => {
-                open_model_picker_for_provider(app, provider);
+                open_model_picker_for_provider(app, config, provider);
             }
             ViewEvent::ModeSelected { mode } => {
                 let prior_mode = app.mode;


### PR DESCRIPTION
## Summary

Partial work on #3830. This PR covers the `/provider` and `/model` "default view shows only configured providers" halves of the issue's v1 spec.

- `/provider` (previous commit on this branch, already covered): default list view shows only configured providers — active provider, working credentials/OAuth, an explicit non-default `[providers.<name>]` entry, or a real named custom provider. Press `A` to browse the full ~30-provider catalog.
- `/model` (this commit): default (empty-query) view now spans every *configured* provider's model rows, not just the active provider's. `auto` and the active provider's own rows are always shown; other configured providers' rows are mixed in without needing to type a search query. Typing a query still searches the full catalog across all providers as before.
- Both pickers now share one `provider_is_configured` definition (moved into `config.rs`) instead of two separately-evolving copies.
- Fixed a position bug in the custom-model-row logic that the broadened default view exposed (see commit message for detail), with a regression test.
- Fixed a latent, host-dependent test bug in `provider_picker.rs` (`mouse_scroll_moves_selection_in_list_stage`) that this work's testing surfaced — it relied on there happening to be more than one "configured" provider under a bare `Config::default()`, which was only true by accident on machines with a prior Codex CLI login.

### Not in this PR (flagging explicitly, not closing #3830)

Per the issue's "Build this v1" list, these remain:
- A real multi-step provider Add/Edit/Auth **wizard** (today's flow reuses the existing single-step key-entry/OAuth screen).
- A true "create a new **named custom provider**" form (name/base URL/auth/default model) — today's Custom slot is singular; you can edit it but not create a second one.
- Adding a custom model under a **non-active** configured provider from the route picker (typing an unrecognized id is still always scoped to the active provider).

These are each meaningfully larger than the filtering fix in this PR. Leaving #3830 open with a comment describing exactly what's landed and what's left.

## Test plan

- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked -- provider_picker:: model_picker::` — 96 passed, 0 failed (re-ran 5x under default parallelism to confirm the scroll-test race fix holds).
- [x] Full suite: `cargo test -p codewhale-tui --bin codewhale-tui --locked` — 5617 passed, 3 failed; all 3 are the pre-existing, host-dependent papercuts already documented in `AGENTS.md` (`config_command_allow_shell_*`, `run_verifiers_background_*`), confirmed unrelated by running each in isolation.
- [x] `cargo test -p codewhale-config --locked` — 289 passed.
- [x] `cargo fmt --all -- --check` and `git diff --check` clean.
- [x] `cargo clippy -p codewhale-tui --bin codewhale-tui --locked` — no new warnings in any changed file.
- [x] `cargo build --release --locked -p codewhale-cli -p codewhale-tui` succeeds.
- [ ] Manual TUI inspection at 80x24/100x30/120x32/160x40 (covered by existing render tests; not manually re-verified in this session).
