### PR TITLE
[codex] Remove unused approval-cache containers

### DIFF
--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -1,10 +1,9 @@
-#![allow(dead_code)]
-//! Per‑call approval cache with fingerprint keys (§5.A).
+//! Approval fingerprint keys (§5.A).
 //!
 //! Instead of caching by tool name alone (which would let an approved
 //! `exec_shell "cat foo"` silently pass `exec_shell "rm -rf /"`), the
-//! cache keys off a **call fingerprint** — a digest of the tool name and
-//! the semantically‑relevant portion of its arguments.
+//! approval flow uses a **call fingerprint** — a digest of the tool name
+//! and the semantically‑relevant portion of its arguments.
 //!
 //! ## Two fingerprint shapes
 //!
@@ -32,14 +31,7 @@
 //!   | `fetch_url`    | `net:<hostname>`                         |
 //!   | everything else| `tool:<tool_name>:<hash of input>`       |
 //!
-//! The cache is **session‑keyed**: entries carry an
-//! `ApprovedForSession` flag. When true, the approval is reused for the
-//! remainder of the session; when false, it is a one‑shot grant (future
-//! calls with the same fingerprint still prompt).
-
-use std::collections::HashMap;
 use std::fmt::Write as _;
-use std::time::Instant;
 
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -50,87 +42,6 @@ use crate::command_safety::classify_command;
 /// calls but specific enough to avoid privilege confusion.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ApprovalKey(pub String);
-
-/// Status of a previously‑rendered approval decision.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ApprovalCacheStatus {
-    /// Call fingerprint matched and the session‑level flag says reuse.
-    Approved,
-    /// Call fingerprint matched but the grant was one‑shot (already consumed).
-    Denied,
-    /// No match — requires fresh approval.
-    Unknown,
-}
-
-/// A single cache entry.
-#[derive(Debug, Clone)]
-struct ApprovalCacheEntry {
-    /// When this entry was created.
-    created: Instant,
-    /// Whether the approval should be reused across the session.
-    approved_for_session: bool,
-}
-
-/// An approval cache backed by tool‑call fingerprints.
-#[derive(Debug, Default)]
-pub struct ApprovalCache {
-    entries: HashMap<ApprovalKey, ApprovalCacheEntry>,
-}
-
-impl ApprovalCache {
-    /// Construct an empty cache.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            entries: HashMap::new(),
-        }
-    }
-
-    /// Look up a previously‑rendered approval decision.
-    pub fn check(&self, key: &ApprovalKey) -> ApprovalCacheStatus {
-        let Some(entry) = self.entries.get(key) else {
-            return ApprovalCacheStatus::Unknown;
-        };
-        if entry.approved_for_session {
-            ApprovalCacheStatus::Approved
-        } else {
-            ApprovalCacheStatus::Denied
-        }
-    }
-
-    /// Record an approval decision under the given fingerprint.
-    ///
-    /// When `approved_for_session` is true, subsequent calls with the
-    /// same key will auto‑approve for the remainder of the session.
-    pub fn insert(&mut self, key: ApprovalKey, approved_for_session: bool) {
-        self.entries.insert(
-            key,
-            ApprovalCacheEntry {
-                created: Instant::now(),
-                approved_for_session,
-            },
-        );
-    }
-
-    /// Clear all entries.
-    pub fn clear(&mut self) {
-        self.entries.clear();
-    }
-
-    /// Number of cached entries.
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    /// Whether the cache is empty.
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-}
-
-// ── Fingerprint helpers ────────────────────────────────────────────
 
 /// Build the approval‑cache key for a tool call.
 ///
@@ -313,29 +224,6 @@ fn push_canonical_json(value: &Value, out: &mut String) {
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn cache_hit_returns_approved_for_session() {
-        let mut cache = ApprovalCache::new();
-        let key = build_approval_key("exec_shell", &json!({"command": "ls -la"}));
-        cache.insert(key.clone(), true);
-        assert_eq!(cache.check(&key), ApprovalCacheStatus::Approved);
-    }
-
-    #[test]
-    fn cache_one_shot_is_not_reused() {
-        let mut cache = ApprovalCache::new();
-        let key = build_approval_key("exec_shell", &json!({"command": "cargo build"}));
-        cache.insert(key.clone(), false);
-        assert_eq!(cache.check(&key), ApprovalCacheStatus::Denied);
-    }
-
-    #[test]
-    fn cache_miss_is_unknown() {
-        let cache = ApprovalCache::new();
-        let key = build_approval_key("exec_shell", &json!({"command": "ls"}));
-        assert_eq!(cache.check(&key), ApprovalCacheStatus::Unknown);
-    }
 
     #[test]
     fn different_commands_different_keys() {


### PR DESCRIPTION
## Summary

- Remove the unused `ApprovalCacheStatus`, `ApprovalCacheEntry`, and `ApprovalCache` container types from `approval_cache.rs`.
- Keep the live approval fingerprint builders and their behavior-focused tests.
- Narrow the module docs so they describe fingerprint key generation instead of a removed cache container.

## Issue

Fixes #3845.

## Risk

Low. Production code only calls `build_approval_key` and `build_approval_grouping_key`; the removed storage types were only exercised by self-tests.

## Verification

- `cargo fmt`
- `cargo test -p codewhale-tui approval_cache -- --nocapture`
- `cargo check -p codewhale-tui --all-targets`
- `rg "ApprovalCache|ApprovalCacheStatus|ApprovalCacheEntry" crates/tui/src crates/tui/tests` returned no matches
- `cargo test --workspace`
- `cargo build --release -p codewhale-cli -p codewhale-tui`