### PR TITLE
fix(tui): persist sub-agent state to .codewhale/ instead of .deepseek/

### DIFF
--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -1616,10 +1616,10 @@ mod tests {
         fs::write(tmp.path().join("src").join("main.rs"), "fn main() {}").expect("write src");
         fs::write(tmp.path().join(".DS_Store"), "noise").expect("write ds store");
         fs::write(tmp.path().join("paper.pdf"), "not a real pdf").expect("write pdf");
-        fs::create_dir_all(tmp.path().join(".deepseek").join("state")).expect("mkdir state");
+        fs::create_dir_all(tmp.path().join(".codewhale").join("state")).expect("mkdir state");
         fs::write(
             tmp.path()
-                .join(".deepseek")
+                .join(".codewhale")
                 .join("state")
                 .join("subagents.v1.json"),
             "{}",

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -2077,9 +2077,29 @@ impl SubAgentManager {
             return Ok(());
         };
         let path = checked_subagent_state_path(&self.workspace, path)?;
-        if !path.exists() {
-            return Ok(());
-        }
+
+        // If canonical path doesn't exist, try legacy .deepseek/ path for one-time
+        // migration. The next persist will write to the canonical .codewhale/ path.
+        let path = if path.exists() {
+            path
+        } else {
+            let legacy = checked_subagent_state_path(
+                &self.workspace,
+                &Path::new(".deepseek")
+                    .join("state")
+                    .join(SUBAGENT_STATE_FILE),
+            )?;
+            if legacy.exists() {
+                tracing::info!(
+                    target: "subagent",
+                    "loading sub-agent state from legacy path for migration: {}",
+                    legacy.display()
+                );
+                legacy
+            } else {
+                return Ok(());
+            }
+        };
 
         let raw = read_subagent_state_file(&self.workspace, &path)?;
         let state = serde_json::from_str::<PersistedSubAgentState>(&raw)?;
@@ -3232,19 +3252,12 @@ async fn subagent_session_projection(
 
 fn default_state_path(workspace: &Path) -> Result<PathBuf> {
     let workspace = normalize_subagent_workspace(workspace);
-    // Prefer .codewhale, fall back to .deepseek for project-local state
-    let primary = checked_subagent_state_path(
-        &workspace,
-        &Path::new(".codewhale")
-            .join("state")
-            .join(SUBAGENT_STATE_FILE),
-    )?;
-    if primary.exists() {
-        return Ok(primary);
-    }
+    // Canonical post-rebrand state path. On first run the file won't exist yet;
+    // write_json_atomic creates parent directories. Legacy .deepseek/state/ data
+    // is migrated on load (see load_state).
     checked_subagent_state_path(
         &workspace,
-        &Path::new(".deepseek")
+        &Path::new(".codewhale")
             .join("state")
             .join(SUBAGENT_STATE_FILE),
     )


### PR DESCRIPTION
# PR: fix(tui) — persist sub-agent state to `.codewhale/` instead of `.deepseek/`

Closes #3864

## Summary

`default_state_path` contained a rebrand-era fallback: when `.codewhale/state/subagents.v1.json`
did not yet exist (always true on first run), it returned the legacy `.deepseek/state/` path
as the **write** target.  This meant the canonical post-rebrand path was never created — every
sub-agent state write landed in `.deepseek/state/subagents.v1.json`, making the project root
accumulate two dot-directories after every `agent` tool invocation.

## Root cause

**`crates/tui/src/tools/subagent/mod.rs:3233–3251`** — `default_state_path`:

```rust
fn default_state_path(workspace: &Path) -> Result<PathBuf> {
    // Prefer .codewhale, fall back to .deepseek for project-local state
    let primary = checked_subagent_state_path(&workspace, ".codewhale/state/subagents.v1.json")?;
    if primary.exists() {
        return Ok(primary);
    }
    // ⚠️ BUG: .deepseek/ returned as *write* path, not read-only fallback
    checked_subagent_state_path(&workspace, ".deepseek/state/subagents.v1.json")
}
```

Because `.codewhale/state/` is never pre-created (only `.codewhale/` root is), the
`primary.exists()` gate always evaluated to `false` on fresh projects, and all subsequent
`persist_state()` → `write_json_atomic()` → `fs::create_dir_all()` calls created and wrote to
the legacy path.

## Changes

### `crates/tui/src/tools/subagent/mod.rs`

- **`default_state_path`** — always return `.codewhale/state/subagents.v1.json`.  No fallback.
  `write_json_atomic` already handles `fs::create_dir_all`, so the directory is created on
  first persist.

- **`load_state`** — when the canonical path does not exist, try the legacy
  `.deepseek/state/subagents.v1.json` as a **read-only** fallback.  If legacy data is found,
  it is loaded into memory; the next `persist_state` will write to `.codewhale/`, achieving
  a natural one-time migration.  A `tracing::info!` log is emitted so operators can observe
  the migration.

### `crates/tui/src/project_context.rs`

- Test fixture `project_context_pack_ignores_agent_state_and_binary_noise` now creates the
  state file under `.codewhale/state/` instead of `.deepseek/state/`, matching the canonical
  path.

## Verification

| Check | Result |
|-------|--------|
| `cargo fmt` | clean (no changes) |
| `cargo check -p codewhale-tui` | passed |
| `cargo test -p codewhale-tui -- "tools::subagent::tests"` | **167 passed, 0 failed** |
| `cargo test -p codewhale-tui -- "project_context::tests::project_context_pack..."` | passed |
| `cargo clippy -p codewhale-tui` | 14 pre-existing warnings (unrelated files) |

## Migration path for existing users

Users who already have `.deepseek/state/subagents.v1.json`:

1. On next `codewhale` session start, `load_state` will read from `.deepseek/` (with an info log)
2. First sub-agent persist will write to `.codewhale/state/subagents.v1.json`
3. The old `.deepseek/state/subagents.v1.json` is **not** deleted — users may remove it manually
   or it will naturally age out

New installs (or projects that never ran sub-agents) will never create `.deepseek/state/`.

---

# PR：fix(tui) — 子任务状态持久化从 `.deepseek/` 迁移至 `.codewhale/`

Closes #3864

## 概述

`default_state_path` 存在品牌化遗留的 fallback 逻辑：当 `.codewhale/state/subagents.v1.json`
不存在时（首次运行必然如此），返回旧品牌路径 `.deepseek/state/` 作为**写入**目标。这导致
权威品牌化路径永远不会被创建——所有子任务状态写入都落在 `.deepseek/state/subagents.v1.json`，
项目根目录在使用 `agent` 工具后出现两个隐藏目录。

## 根因

**`crates/tui/src/tools/subagent/mod.rs:3233–3251`** — `default_state_path`：

```rust
fn default_state_path(workspace: &Path) -> Result<PathBuf> {
    // Prefer .codewhale, fall back to .deepseek for project-local state
    let primary = checked_subagent_state_path(&workspace, ".codewhale/state/subagents.v1.json")?;
    if primary.exists() {
        return Ok(primary);
    }
    // ⚠️ BUG：.deepseek/ 被当作写入路径返回，而非只读兼容路径
    checked_subagent_state_path(&workspace, ".deepseek/state/subagents.v1.json")
}
```

`.codewhale/state/` 子目录从未被预先创建（仅 `.codewhale/` 根目录存在），因此
`primary.exists()` 在全新项目上永远返回 `false`，后续所有 `persist_state()` →
`write_json_atomic()` → `fs::create_dir_all()` 调用均在遗留路径下创建并写入。

## 改动

### `crates/tui/src/tools/subagent/mod.rs`

- **`default_state_path`** — 始终返回 `.codewhale/state/subagents.v1.json`，不再 fallback。
  `write_json_atomic` 已包含 `fs::create_dir_all`，首次持久化时自动创建目录。

- **`load_state`** — 当权威路径不存在时，尝试以**只读**方式从遗留路径
  `.deepseek/state/subagents.v1.json` 读取。若旧数据存在则载入内存；下次 `persist_state`
  将写入 `.codewhale/`，实现自然的一次性迁移。迁移时输出 `tracing::info!` 日志便于运维观察。

### `crates/tui/src/project_context.rs`

- 测试 fixture `project_context_pack_ignores_agent_state_and_binary_noise` 的状态文件路径
  从 `.deepseek/state/` 改为 `.codewhale/state/`，与权威路径一致。

## 验证

| 检查项 | 结果 |
|--------|------|
| `cargo fmt` | 无改动 |
| `cargo check -p codewhale-tui` | 通过 |
| `cargo test -p codewhale-tui -- "tools::subagent::tests"` | **167 通过，0 失败** |
| `cargo test -p codewhale-tui -- "project_context::tests::project_context_pack..."` | 通过 |
| `cargo clippy -p codewhale-tui` | 14 个预存 warning（非本次改动文件） |

## 存量用户迁移路径

已有 `.deepseek/state/subagents.v1.json` 的用户：

1. 下次启动 `codewhale` 时，`load_state` 从 `.deepseek/` 读取（并输出 info 日志）
2. 首次子任务持久化将写入 `.codewhale/state/subagents.v1.json`
3. 旧 `.deepseek/state/subagents.v1.json` **不自动删除**——用户可手动清理，或自然老化

全新安装（或从未使用子任务的项目）将不再创建 `.deepseek/state/`。
