### PR TITLE
refactor: McpTool storage to Arc<McpTool> in McpConnection

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -774,7 +775,7 @@ fn response_id_matches(id: Option<&serde_json::Value>, expected_id: &str) -> boo
 pub struct McpConnection {
     name: String,
     transport: Box<dyn McpTransport>,
-    tools: Vec<McpTool>,
+    tools: Vec<Arc<McpTool>>,
     resources: Vec<McpResource>,
     resource_templates: Vec<McpResourceTemplate>,
     prompts: Vec<McpPrompt>,
@@ -1036,7 +1037,7 @@ impl McpConnection {
             if let Some(arr) = result.get("tools").and_then(|t| t.as_array()) {
                 for item in arr {
                     match serde_json::from_value::<McpTool>(item.clone()) {
-                        Ok(tool) => self.tools.push(tool),
+                        Ok(tool) => self.tools.push(Arc::new(tool)),
                         Err(err) => {
                             // Skip individual malformed entries instead of
                             // dropping the whole page (#1410). The old
@@ -1299,7 +1300,7 @@ impl McpConnection {
     }
 
     /// Get discovered tools
-    pub fn tools(&self) -> &[McpTool] {
+    pub fn tools(&self) -> &[Arc<McpTool>] {
         &self.tools
     }
 
@@ -1650,7 +1651,7 @@ impl McpPool {
     }
 
     /// Get all discovered tools with server-prefixed names
-    pub fn all_tools(&self) -> Vec<(String, &McpTool)> {
+    pub fn all_tools(&self) -> Vec<(String, Arc<McpTool>)> {
         let mut tools = Vec::new();
         for (server, conn) in &self.connections {
             for tool in conn.tools() {
@@ -1658,7 +1659,7 @@ impl McpPool {
                     continue;
                 }
                 // Format: mcp_{server}_{tool}
-                tools.push((format!("mcp_{}_{}", server, tool.name), tool));
+                tools.push((format!("mcp_{}_{}", server, tool.name), Arc::clone(tool)));
             }
         }
         // Sort by prefixed name so iteration order across servers is

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -1488,11 +1488,11 @@ async fn mcp_pool_call_tool_preserves_tool_names_with_dashes() {
     };
     let mut conn = test_connection(Box::new(transport));
     conn.name = "dephy".to_string();
-    conn.tools = vec![McpTool {
+    conn.tools = vec![Arc::new(McpTool {
         name: "company--search".to_string(),
         description: None,
         input_schema: serde_json::json!({}),
-    }];
+    })];
 
     let mut pool = McpPool::new(McpConfig {
         timeouts: McpTimeouts::default(),
@@ -1531,11 +1531,11 @@ async fn mcp_pool_call_tool_preserves_server_names_with_underscores() {
     };
     let mut conn = test_connection(Box::new(transport));
     conn.name = "my_db".to_string();
-    conn.tools = vec![McpTool {
+    conn.tools = vec![Arc::new(McpTool {
         name: "execute_sql".to_string(),
         description: None,
         input_schema: serde_json::json!({}),
-    }];
+    })];
 
     let mut pool = McpPool::new(McpConfig {
         timeouts: McpTimeouts::default(),
@@ -1574,11 +1574,11 @@ async fn mcp_pool_call_tool_prefers_longest_matching_server_name() {
     };
     let mut short_conn = test_connection(Box::new(short_transport));
     short_conn.name = "my".to_string();
-    short_conn.tools = vec![McpTool {
+    short_conn.tools = vec![Arc::new(McpTool {
         name: "db_execute_sql".to_string(),
         description: None,
         input_schema: serde_json::json!({}),
-    }];
+    })];
 
     let sent_long = Arc::new(Mutex::new(Vec::new()));
     let long_transport = ScriptedValueTransport {
@@ -1591,11 +1591,11 @@ async fn mcp_pool_call_tool_prefers_longest_matching_server_name() {
     };
     let mut long_conn = test_connection(Box::new(long_transport));
     long_conn.name = "my_db".to_string();
-    long_conn.tools = vec![McpTool {
+    long_conn.tools = vec![Arc::new(McpTool {
         name: "execute_sql".to_string(),
         description: None,
         input_schema: serde_json::json!({}),
-    }];
+    })];
 
     let mut pool = McpPool::new(McpConfig {
         timeouts: McpTimeouts::default(),

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -1103,7 +1103,7 @@ fn to_snake_case(s: &str) -> String {
 #[allow(dead_code)]
 struct McpToolAdapter {
     name: String,
-    tool: crate::mcp::McpTool,
+    tool: std::sync::Arc<crate::mcp::McpTool>,
     pool: std::sync::Arc<tokio::sync::Mutex<crate::mcp::McpPool>>,
 }
 


### PR DESCRIPTION
## Summary
Refactor McpTool storage from `Vec<McpTool>` to `Vec<Arc<McpTool>>` in McpConnection, and update `all_tools()` return type accordingly.

## Motivation
This is a prerequisite for dynamic MCP server support. `dynamic_connections` is stored behind `Arc<RwLock<>>`, so `all_tools()` needs to return owned `Arc<McpTool>` instead of `&McpTool` references (which can't escape the read guard lifetime).

## Changes
- `McpConnection.tools`: `Vec<McpTool>` → `Vec<Arc<McpTool>>`
- `McpConnection::tools()`: returns `&[Arc<McpTool>]`
- `McpPool::all_tools()`: returns `Vec<(String, Arc<McpTool>)>`
- `McpToolAdapter.tool`: `McpTool` → `Arc<McpTool>`
- Test fixtures updated to use `Arc::new(McpTool { ... })`

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-tui --all-targets --all-features`
- [x] `cargo test -p codewhale-tui --locked -- workspace_mcp_pool` — 4 passed
- [x] `cargo test -p codewhale-tui --locked -- reload_if_config_changed` — 4 passed
- [x] `cargo test -p codewhale-tui --locked -- tool_catalog` — 16 passed
- [x] `cargo test -p codewhale-tui --locked -- mcp_pool` — 10 passed
