### PR TITLE
chore(tui): remove unused model registry helpers

### DIFF
--- a/crates/tui/src/model_registry.rs
+++ b/crates/tui/src/model_registry.rs
@@ -336,5 +336,4 @@ mod tests {
     fn lookup_returns_none_for_completely_unknown_model() {
         assert!(lookup("totally-made-up-model-xyz").is_none());
     }
-
 }

--- a/crates/tui/src/model_registry.rs
+++ b/crates/tui/src/model_registry.rs
@@ -73,24 +73,6 @@ pub enum ModelProvider {
     Other,
 }
 
-/// Default concrete provider that can serve a registry provider family.
-#[must_use]
-pub fn serving_provider(provider: ModelProvider) -> crate::config::ApiProvider {
-    match provider {
-        ModelProvider::DeepSeek => crate::config::ApiProvider::Deepseek,
-        ModelProvider::Anthropic => crate::config::ApiProvider::Anthropic,
-        ModelProvider::OpenAi => crate::config::ApiProvider::Openai,
-        ModelProvider::OpenAiCodex => crate::config::ApiProvider::OpenaiCodex,
-        ModelProvider::Moonshot => crate::config::ApiProvider::Moonshot,
-        ModelProvider::Zai => crate::config::ApiProvider::Zai,
-        ModelProvider::Minimax => crate::config::ApiProvider::Minimax,
-        ModelProvider::Qwen => crate::config::ApiProvider::Openrouter,
-        ModelProvider::Arcee => crate::config::ApiProvider::Arcee,
-        ModelProvider::XiaomiMimo => crate::config::ApiProvider::XiaomiMimo,
-        ModelProvider::Other => crate::config::ApiProvider::Openrouter,
-    }
-}
-
 /// One row of model facts, looked up in [`lookup`].
 ///
 /// All numeric fields are seeded from `crate::models` so they stay in lockstep
@@ -239,13 +221,6 @@ pub fn lookup(model: &str) -> Option<ModelMetadata> {
     })
 }
 
-/// All pre-seeded model ids, for callers that want to enumerate the canonical
-/// catalog (e.g. a future provider-aware model picker, #3075).
-#[must_use]
-pub fn seeded_model_ids() -> Vec<&'static str> {
-    registry().keys().copied().collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,47 +295,6 @@ mod tests {
     }
 
     #[test]
-    fn serving_provider_maps_each_family() {
-        use crate::config::ApiProvider;
-
-        assert_eq!(
-            serving_provider(ModelProvider::DeepSeek),
-            ApiProvider::Deepseek
-        );
-        assert_eq!(
-            serving_provider(ModelProvider::Anthropic),
-            ApiProvider::Anthropic
-        );
-        assert_eq!(serving_provider(ModelProvider::OpenAi), ApiProvider::Openai);
-        assert_eq!(
-            serving_provider(ModelProvider::OpenAiCodex),
-            ApiProvider::OpenaiCodex
-        );
-        assert_eq!(
-            serving_provider(ModelProvider::Moonshot),
-            ApiProvider::Moonshot
-        );
-        assert_eq!(serving_provider(ModelProvider::Zai), ApiProvider::Zai);
-        assert_eq!(
-            serving_provider(ModelProvider::Minimax),
-            ApiProvider::Minimax
-        );
-        assert_eq!(
-            serving_provider(ModelProvider::Qwen),
-            ApiProvider::Openrouter
-        );
-        assert_eq!(serving_provider(ModelProvider::Arcee), ApiProvider::Arcee);
-        assert_eq!(
-            serving_provider(ModelProvider::XiaomiMimo),
-            ApiProvider::XiaomiMimo
-        );
-        assert_eq!(
-            serving_provider(ModelProvider::Other),
-            ApiProvider::Openrouter
-        );
-    }
-
-    #[test]
     fn deepseek_models_are_classified_as_deepseek() {
         // Branding / first-class DeepSeek support guard: the default DeepSeek
         // models must be present and classified as DeepSeek.
@@ -403,13 +337,4 @@ mod tests {
         assert!(lookup("totally-made-up-model-xyz").is_none());
     }
 
-    #[test]
-    fn seeded_model_ids_are_non_empty_and_unique() {
-        let ids = seeded_model_ids();
-        assert!(!ids.is_empty());
-        let mut sorted = ids.clone();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(sorted.len(), ids.len(), "seed ids must be unique");
-    }
 }


### PR DESCRIPTION
## Summary
- remove unused model registry enumeration helpers
- drop tests that only preserved the unused helper API
- keep active lookup, metadata drift, and model-picker coverage

## Verification
- `cargo test -p codewhale-tui model_registry -- --nocapture`
- `cargo check -p codewhale-tui --all-targets`
- `git diff --check`

Fixes #3849