### PR TITLE
feat(tui): auto-discover .codewhale/rules/ and .claude/rules/ directories as project context

### DIFF
--- a/crates/tui/src/context_report.rs
+++ b/crates/tui/src/context_report.rs
@@ -334,9 +334,14 @@ fn base_source_entries(model: &str, workspace: &Path, skills_dir: Option<&Path>)
             .source_path
             .as_ref()
             .map_or_else(|| "project".to_string(), |p| p.display().to_string());
-        let block = format!(
+        let mut block = format!(
             "<project_instructions source=\"{source}\">\n{content}\n</project_instructions>"
         );
+        // Include rules in the report when present
+        if let Some(rules) = &project_context.rules_block {
+            block.push('\n');
+            block.push_str(rules);
+        }
         builder.push(SourceEntry::text(
             SourceKind::ProjectContext,
             "Project instructions",
@@ -346,6 +351,17 @@ fn base_source_entries(model: &str, workspace: &Path, skills_dir: Option<&Path>)
                 .map(|path| path.display().to_string()),
             ActivationReason::FilePresent,
             &block,
+            CountingConfidence::High,
+            Some(5),
+        ));
+    } else if let Some(rules) = &project_context.rules_block {
+        // Rules exist without main instructions
+        builder.push(SourceEntry::text(
+            SourceKind::ProjectContext,
+            "Project rules",
+            None::<String>,
+            ActivationReason::FilePresent,
+            rules,
             CountingConfidence::High,
             Some(5),
         ));

--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -39,6 +39,13 @@ const PROJECT_CONTEXT_FILES: &[&str] = &[
     ".deepseek/instructions.md",
 ];
 
+/// Rules directories auto-discovered at workspace level, in priority order.
+/// `.codewhale/rules/` is CodeWhale-native; `.claude/rules/` is Claude compatibility.
+/// All `.md` files in these directories are loaded as project rules in filename order.
+/// Security model: same trust class as AGENTS.md — workspace-contained content only,
+/// no absolute-path escape. Does not require #417 project-config relaxation.
+const RULES_DIRS: &[&str] = &[".codewhale/rules", ".claude/rules"];
+
 /// File name of the deprecated CodeWhale-native instructions file.
 const DEPRECATED_WHALE_FILENAME: &str = "WHALE.md";
 
@@ -72,6 +79,10 @@ const GLOBAL_INSTRUCTIONS_LEGACY_PATH: &[&str] = &[".deepseek", "instructions.md
 
 /// Maximum size for project context files (to prevent loading huge files)
 const MAX_CONTEXT_SIZE: usize = 100 * 1024; // 100KB
+
+/// Maximum number of rule files loaded per rules directory.
+/// Prevents a project from silently injecting hundreds of rule files.
+const MAX_RULES_FILES: usize = 50;
 const PACK_README_MAX_CHARS: usize = 4_000;
 const PACK_MAX_ENTRIES: usize = 220;
 const PACK_MAX_SOURCE_FILES: usize = 60;
@@ -133,6 +144,10 @@ enum ProjectContextError {
 pub struct ProjectContext {
     /// The loaded instructions content
     pub instructions: Option<String>,
+    /// Auto-discovered rules from `.codewhale/rules/` / `.claude/rules/`.
+    /// Kept separate from `instructions` so rules alone don't block
+    /// parent-directory AGENTS.md discovery via `has_instructions()`.
+    pub rules_block: Option<String>,
     /// Path to the loaded file (for display)
     pub source_path: Option<PathBuf>,
     /// Any warnings during loading
@@ -155,6 +170,7 @@ impl ProjectContext {
     pub fn empty(project_root: PathBuf) -> Self {
         Self {
             instructions: None,
+            rules_block: None,
             source_path: None,
             warnings: Vec::new(),
             constitution_block: None,
@@ -181,18 +197,36 @@ impl ProjectContext {
                 .as_ref()
                 .map_or_else(|| "project".to_string(), |p| p.display().to_string());
 
-            format!(
+            let mut block = format!(
                 "<project_instructions source=\"{source}\">\n{content}\n</project_instructions>"
-            )
+            );
+            // Append rules after instructions, inside the same logical block.
+            // Rules are kept separate from `instructions` so they don't block
+            // parent-directory AGENTS.md discovery via `has_instructions()`.
+            if let Some(rules) = &self.rules_block {
+                block.push('\n');
+                block.push_str(rules);
+            }
+            block
         });
 
         match (self.constitution_block.as_ref(), instructions_block) {
             (Some(constitution), Some(instructions)) => {
                 Some(format!("{constitution}\n\n{instructions}"))
             }
-            (Some(constitution), None) => Some(constitution.clone()),
+            (Some(constitution), None) => {
+                // Constitution present but no main instructions — still emit rules if any
+                if let Some(rules) = &self.rules_block {
+                    Some(format!("{constitution}\n\n{rules}"))
+                } else {
+                    Some(constitution.clone())
+                }
+            }
             (None, Some(instructions)) => Some(instructions),
-            (None, None) => None,
+            (None, None) => {
+                // No main instructions, but rules may exist on their own
+                self.rules_block.clone()
+            }
         }
     }
 }
@@ -841,6 +875,29 @@ pub fn load_project_context(workspace: &Path) -> ProjectContext {
     ctx.warnings
         .extend(ignored_project_whale_warnings(workspace));
 
+    // Load rules from auto-discovered directories (.codewhale/rules/, .claude/rules/)
+    // Each rule file is wrapped in a <project_rule> block and appended after
+    // the main instructions content. Security model: same as AGENTS.md —
+    // workspace-contained content only, no absolute-path escape.
+    let mut rules_content = String::new();
+    for rules_dir in RULES_DIRS {
+        let rules = load_rules_from_dir(workspace, rules_dir);
+        for (path, content) in rules {
+            if !rules_content.is_empty() {
+                rules_content.push('\n');
+            }
+            rules_content.push_str(&format!(
+                "<project_rule source=\"{}\">\n{}\n</project_rule>",
+                path.display(),
+                content.trim()
+            ));
+        }
+    }
+
+    if !rules_content.is_empty() {
+        ctx.rules_block = Some(rules_content);
+    }
+
     // Check for trust file
     ctx.is_trusted = check_trust_status(workspace);
 
@@ -994,6 +1051,20 @@ pub(crate) fn project_context_cache_candidate_paths(
     paths.push(workspace.join(".deepseek").join("trusted"));
     paths.push(workspace.join(".deepseek").join("trust.json"));
     paths.extend(crate::config::workspace_trust_config_candidate_paths());
+
+    // Include auto-discovered rules directory files so cache invalidates
+    // when rules change (not just when AGENTS.md changes).
+    for rules_dir in RULES_DIRS {
+        let dir_path = workspace.join(rules_dir);
+        if let Ok(entries) = std::fs::read_dir(&dir_path) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|ext| ext == "md") {
+                    paths.push(path);
+                }
+            }
+        }
+    }
 
     paths
 }
@@ -1220,6 +1291,70 @@ fn context_candidate_exists(path: &Path) -> bool {
         let file_type = metadata.file_type();
         file_type.is_file() || file_type.is_symlink()
     })
+}
+
+/// Scan a rules directory for `.md` files and load them in filename order.
+/// Missing or unreadable directories return an empty vec (no error).
+/// Each file is verified through `load_context_file` (size check, symlink safety).
+fn load_rules_from_dir(workspace: &Path, rules_dir_name: &str) -> Vec<(PathBuf, String)> {
+    let rules_dir = workspace.join(rules_dir_name);
+    let mut entries: Vec<(PathBuf, String)> = Vec::new();
+
+    let dir_iter = match fs::read_dir(&rules_dir) {
+        Ok(iter) => iter,
+        Err(_) => return entries,
+    };
+
+    let mut file_paths: Vec<PathBuf> = Vec::new();
+    for entry in dir_iter.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "md") && context_candidate_exists(&path) {
+            file_paths.push(path);
+        }
+    }
+
+    // Sort by filename for deterministic order
+    file_paths.sort_by(|a, b| {
+        a.file_name()
+            .unwrap_or_default()
+            .cmp(b.file_name().unwrap_or_default())
+    });
+
+    // Enforce per-directory cap
+    let total = file_paths.len();
+    if total > MAX_RULES_FILES {
+        tracing::warn!(
+            target: "project_context",
+            dir = %rules_dir.display(),
+            total,
+            cap = MAX_RULES_FILES,
+            "Truncating rules directory to cap"
+        );
+        file_paths.truncate(MAX_RULES_FILES);
+    }
+
+    for path in file_paths {
+        match load_context_file(&path) {
+            Ok(content) => {
+                tracing::info!(
+                    "Loaded project rule from {} ({} bytes)",
+                    path.display(),
+                    content.len()
+                );
+                entries.push((path, content));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "project_context",
+                    ?error,
+                    ?path,
+                    "Skipping unreadable rules file"
+                );
+            }
+        }
+    }
+
+    entries
 }
 
 #[cfg(unix)]
@@ -2442,6 +2577,214 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .contains("Project Context (Auto-generated, ephemeral)")
+        );
+    }
+
+    // ── Rules directory auto-discovery tests ──
+
+    #[test]
+    fn rules_from_codewhale_dir_are_loaded_as_project_context() {
+        let tmp = tempdir().expect("tempdir");
+        let rules_dir = tmp.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+        fs::write(
+            rules_dir.join("security.md"),
+            "# Security\nNo hardcoded secrets.",
+        )
+        .expect("write");
+
+        let ctx = load_project_context(tmp.path());
+
+        let rules = ctx.rules_block.as_ref().expect("rules_block should be set");
+        assert!(
+            rules.contains("Security"),
+            "expected rules content, got: {rules}"
+        );
+        assert!(
+            rules.contains("<project_rule source="),
+            "expected <project_rule> wrapper, got: {rules}"
+        );
+    }
+
+    #[test]
+    fn rules_are_loaded_in_filename_order() {
+        let tmp = tempdir().expect("tempdir");
+        let rules_dir = tmp.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+        fs::write(rules_dir.join("zzz.md"), "last").expect("write");
+        fs::write(rules_dir.join("aaa.md"), "first").expect("write");
+        fs::write(rules_dir.join("mmm.md"), "middle").expect("write");
+
+        let ctx = load_project_context(tmp.path());
+        let rules = ctx.rules_block.as_ref().unwrap();
+
+        let pos_aaa = rules.find("first").unwrap();
+        let pos_mmm = rules.find("middle").unwrap();
+        let pos_zzz = rules.find("last").unwrap();
+        assert!(pos_aaa < pos_mmm, "aaa should come before mmm");
+        assert!(pos_mmm < pos_zzz, "mmm should come before zzz");
+    }
+
+    #[test]
+    fn rules_from_claude_dir_are_compat_loaded() {
+        let tmp = tempdir().expect("tempdir");
+        let rules_dir = tmp.path().join(".claude/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+        fs::write(rules_dir.join("style.md"), "Use tabs").expect("write");
+
+        let ctx = load_project_context(tmp.path());
+
+        let rules = ctx.rules_block.as_ref().expect("rules should be loaded");
+        assert!(
+            rules.contains("Use tabs"),
+            "expected .claude/rules/ compat loading"
+        );
+    }
+
+    #[test]
+    fn rules_directory_missing_does_not_crash() {
+        let tmp = tempdir().expect("tempdir");
+        // No .codewhale/rules/ or .claude/rules/ directories exist
+        let ctx = load_project_context(tmp.path());
+        // Rules block should be None when no rules directories exist
+        assert!(
+            ctx.rules_block.is_none(),
+            "rules_block should be None when no rules exist"
+        );
+    }
+
+    #[test]
+    fn rules_coexist_with_agents_md() {
+        let tmp = tempdir().expect("tempdir");
+        fs::write(tmp.path().join("AGENTS.md"), "Main project instructions").expect("write");
+        let rules_dir = tmp.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+        fs::write(rules_dir.join("extra.md"), "Extra rule").expect("write");
+
+        let ctx = load_project_context(tmp.path());
+        let instructions = ctx.instructions.as_ref().unwrap();
+        let rules = ctx.rules_block.as_ref().unwrap();
+
+        assert!(
+            instructions.contains("Main project instructions"),
+            "AGENTS.md content missing"
+        );
+        assert!(rules.contains("Extra rule"), "rules content missing");
+        // AGENTS.md should come first in system block
+        let block = ctx.as_system_block().unwrap();
+        let pos_agents = block.find("Main project instructions").unwrap();
+        let pos_rule = block.find("Extra rule").unwrap();
+        assert!(pos_agents < pos_rule, "AGENTS.md should precede rules");
+    }
+
+    #[test]
+    fn non_md_files_in_rules_dir_are_ignored() {
+        let tmp = tempdir().expect("tempdir");
+        let rules_dir = tmp.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+        fs::write(rules_dir.join("notes.txt"), "should be ignored").expect("write");
+        fs::write(rules_dir.join("valid.md"), "loaded").expect("write");
+
+        let ctx = load_project_context(tmp.path());
+        let rules = ctx.rules_block.as_ref().unwrap();
+
+        assert!(rules.contains("loaded"), "valid .md should be loaded");
+        assert!(
+            !rules.contains("should be ignored"),
+            ".txt should be ignored"
+        );
+    }
+
+    #[test]
+    fn rules_cap_truncates_excess_files() {
+        let tmp = tempdir().expect("tempdir");
+        let rules_dir = tmp.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+
+        // Create more files than the cap
+        for i in 0..60 {
+            fs::write(
+                rules_dir.join(format!("rule_{i:04}.md")),
+                format!("content {i}"),
+            )
+            .expect("write");
+        }
+
+        let ctx = load_project_context(tmp.path());
+        let rules = ctx.rules_block.as_ref().unwrap();
+
+        // The last file (by sorted name) should NOT be present
+        assert!(
+            !rules.contains("content 59"),
+            "rule_0059 should be above cap"
+        );
+        // The first file should be present
+        assert!(
+            rules.contains("content 0"),
+            "rule_0000 should be within cap"
+        );
+        // Count <project_rule> blocks
+        let count = rules.matches("<project_rule source=").count();
+        assert_eq!(
+            count, MAX_RULES_FILES,
+            "exactly {MAX_RULES_FILES} rules should be loaded"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rules_rejects_symlinked_files() {
+        let workspace = tempdir().expect("workspace tempdir");
+        let outside = tempdir().expect("outside tempdir");
+        let rules_dir = workspace.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+
+        let outside_rule = outside.path().join("outside.md");
+        fs::write(&outside_rule, "outside content").expect("write outside");
+        std::os::unix::fs::symlink(&outside_rule, rules_dir.join("outside.md"))
+            .expect("symlink rule");
+
+        let ctx = load_project_context(workspace.path());
+
+        // Symlinked rules must not be loaded
+        assert!(
+            ctx.rules_block.is_none()
+                || !ctx
+                    .rules_block
+                    .as_ref()
+                    .unwrap()
+                    .contains("outside content"),
+            "symlinked rules must not be loaded"
+        );
+    }
+
+    #[test]
+    fn rules_from_both_dirs_are_loaded_together() {
+        let tmp = tempdir().expect("tempdir");
+        let codewhale_rules = tmp.path().join(".codewhale/rules");
+        let claude_rules = tmp.path().join(".claude/rules");
+        fs::create_dir_all(&codewhale_rules).expect("mkdir codewhale rules");
+        fs::create_dir_all(&claude_rules).expect("mkdir claude rules");
+        fs::write(codewhale_rules.join("cw.md"), "codewhale-rule").expect("write");
+        fs::write(claude_rules.join("claude.md"), "claude-rule").expect("write");
+
+        let ctx = load_project_context(tmp.path());
+        let rules = ctx.rules_block.as_ref().unwrap();
+
+        assert!(
+            rules.contains("codewhale-rule"),
+            ".codewhale/rules/ should be loaded"
+        );
+        assert!(
+            rules.contains("claude-rule"),
+            ".claude/rules/ should be loaded"
+        );
+        // .codewhale/rules/ content should appear before .claude/rules/ (RULES_DIRS order)
+        let pos_cw = rules.find("codewhale-rule").unwrap();
+        let pos_claude = rules.find("claude-rule").unwrap();
+        assert!(
+            pos_cw < pos_claude,
+            ".codewhale/rules/ should precede .claude/rules/"
         );
     }
 }

--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -1056,6 +1056,13 @@ pub(crate) fn project_context_cache_candidate_paths(
     // when rules change (not just when AGENTS.md changes).
     for rules_dir in RULES_DIRS {
         let dir_path = workspace.join(rules_dir);
+        // Skip symlinked rules directories (same guard as load_rules_from_dir)
+        if fs::symlink_metadata(&dir_path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            continue;
+        }
         if let Ok(entries) = std::fs::read_dir(&dir_path) {
             for entry in entries.flatten() {
                 let path = entry.path();
@@ -1299,6 +1306,21 @@ fn context_candidate_exists(path: &Path) -> bool {
 fn load_rules_from_dir(workspace: &Path, rules_dir_name: &str) -> Vec<(PathBuf, String)> {
     let rules_dir = workspace.join(rules_dir_name);
     let mut entries: Vec<(PathBuf, String)> = Vec::new();
+
+    // Refuse a symlinked rules directory: the real .md files behind it
+    // would pass per-file is_symlink checks and be read from outside the
+    // workspace subtree — same escape class as #417.
+    if fs::symlink_metadata(&rules_dir)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        tracing::warn!(
+            target: "project_context",
+            dir = %rules_dir.display(),
+            "Refusing symlinked rules directory"
+        );
+        return entries;
+    }
 
     let dir_iter = match fs::read_dir(&rules_dir) {
         Ok(iter) => iter,
@@ -2755,6 +2777,34 @@ mod tests {
                     .unwrap()
                     .contains("outside content"),
             "symlinked rules must not be loaded"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rules_rejects_symlinked_directory() {
+        let workspace = tempdir().expect("workspace tempdir");
+        let outside = tempdir().expect("outside tempdir");
+        let outside_dir = outside.path().join("real_rules");
+        fs::create_dir_all(&outside_dir).expect("mkdir outside dir");
+        fs::write(outside_dir.join("secret.md"), "outside content").expect("write outside");
+        fs::create_dir_all(workspace.path().join(".codewhale")).expect("mkdir codewhale");
+
+        // Symlink the directory itself, not individual files
+        std::os::unix::fs::symlink(&outside_dir, workspace.path().join(".codewhale/rules"))
+            .expect("symlink rules dir");
+
+        let ctx = load_project_context(workspace.path());
+
+        // Symlinked rules directory must be refused at the directory level
+        assert!(
+            ctx.rules_block.is_none()
+                || !ctx
+                    .rules_block
+                    .as_ref()
+                    .unwrap()
+                    .contains("outside content"),
+            "symlinked rules directory must be refused"
         );
     }
 

--- a/crates/tui/src/project_context.rs
+++ b/crates/tui/src/project_context.rs
@@ -83,6 +83,13 @@ const MAX_CONTEXT_SIZE: usize = 100 * 1024; // 100KB
 /// Maximum number of rule files loaded per rules directory.
 /// Prevents a project from silently injecting hundreds of rule files.
 const MAX_RULES_FILES: usize = 50;
+
+/// Maximum total bytes across the assembled rules_block.
+/// 50 files × 100 KB per file could reach ~5 MB; this caps the
+/// cumulative injected content so a large rules directory can't
+/// dominate the context window. Exceeded bytes are truncated with
+/// an explicit marker.
+const MAX_RULES_BLOCK_BYTES: usize = 500 * 1024; // 500 KB
 const PACK_README_MAX_CHARS: usize = 4_000;
 const PACK_MAX_ENTRIES: usize = 220;
 const PACK_MAX_SOURCE_FILES: usize = 60;
@@ -895,6 +902,21 @@ pub fn load_project_context(workspace: &Path) -> ProjectContext {
     }
 
     if !rules_content.is_empty() {
+        // Cap total rules bytes so a large rules dir can't dominate the context window
+        if rules_content.len() > MAX_RULES_BLOCK_BYTES {
+            let mut end = MAX_RULES_BLOCK_BYTES;
+            while !rules_content.is_char_boundary(end) {
+                end -= 1;
+            }
+            rules_content.truncate(end);
+            rules_content.push_str("\n\n[…rules block truncated at 500 KB…]");
+            tracing::warn!(
+                target: "project_context",
+                total_bytes = rules_content.len(),
+                cap = MAX_RULES_BLOCK_BYTES,
+                "Truncating rules block to total byte budget"
+            );
+        }
         ctx.rules_block = Some(rules_content);
     }
 
@@ -2835,6 +2857,33 @@ mod tests {
         assert!(
             pos_cw < pos_claude,
             ".codewhale/rules/ should precede .claude/rules/"
+        );
+    }
+
+    #[test]
+    fn rules_block_truncated_at_total_byte_budget() {
+        let tmp = tempdir().expect("tempdir");
+        let rules_dir = tmp.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+
+        // Create files whose combined content exceeds MAX_RULES_BLOCK_BYTES
+        let per_file = "X".repeat(20 * 1024); // 20 KB each
+        for i in 0..30 {
+            fs::write(rules_dir.join(format!("rule_{i:04}.md")), &per_file).expect("write");
+        }
+
+        let ctx = load_project_context(tmp.path());
+        let rules = ctx.rules_block.as_ref().unwrap();
+
+        assert!(
+            rules.len() <= MAX_RULES_BLOCK_BYTES + 200, // + marker overhead
+            "rules block should be truncated to budget: {} > {}",
+            rules.len(),
+            MAX_RULES_BLOCK_BYTES
+        );
+        assert!(
+            rules.contains("truncated at 500 KB"),
+            "truncation marker missing"
         );
     }
 }

--- a/crates/tui/src/project_context_cache.rs
+++ b/crates/tui/src/project_context_cache.rs
@@ -217,4 +217,42 @@ mod tests {
 
         assert_ne!(before, after);
     }
+
+    #[test]
+    fn signature_changes_when_rules_file_changes() {
+        let workspace = tempdir().expect("workspace");
+        let home = tempdir().expect("home");
+        let rules_dir = workspace.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+        fs::write(rules_dir.join("rule.md"), "alpha").expect("write alpha");
+
+        let before = compute_cache_key(workspace.path(), Some(home.path()));
+
+        fs::write(rules_dir.join("rule.md"), "bravo").expect("write bravo");
+        let after = compute_cache_key(workspace.path(), Some(home.path()));
+
+        assert_ne!(
+            before, after,
+            "cache key must change when rules file changes"
+        );
+    }
+
+    #[test]
+    fn signature_changes_when_rules_file_is_added_or_removed() {
+        let workspace = tempdir().expect("workspace");
+        let home = tempdir().expect("home");
+        let rules_dir = workspace.path().join(".codewhale/rules");
+        fs::create_dir_all(&rules_dir).expect("mkdir rules");
+
+        // No rules yet
+        let before = compute_cache_key(workspace.path(), Some(home.path()));
+
+        fs::write(rules_dir.join("new.md"), "content").expect("write new.md");
+        let after = compute_cache_key(workspace.path(), Some(home.path()));
+
+        assert_ne!(
+            before, after,
+            "cache key must change when rules file is added"
+        );
+    }
 }


### PR DESCRIPTION
# PR: feat(tui) — auto-discover `.codewhale/rules/` and `.claude/rules/` directories as project context

Closes #3867

## Summary

Add **rules-directory auto-discovery** to `load_project_context()`: on every session start,
CodeWhale automatically scans `.codewhale/rules/` (native) and `.claude/rules/` (Claude compat)
for `.md` files, loads them in filename order, and appends them to the project-context block
injected into the system prompt. Each rule is wrapped in a `<project_rule source="…">` element.

This completes **solution D** from the design anchor issue #3867 — the same trust model as
`AGENTS.md` (workspace-contained content only, no absolute-path escape), with no #417
project-config relaxation required.

## Motivation

Before this PR, CodeWhale's instruction system was nearly unusable in multi-project workflows:

1. **`instructions` config key blocked at project scope** since v0.8.8 (#417) — users could
   only list rule files in `~/.codewhale/config.toml`, making it painful to maintain
   per-project rules across many repositories.
2. **No rules-directory auto-discovery** — Claude Code's `.claude/rules/` auto-loads all
   `.md` files; CodeWhale had no equivalent and no mechanism to load multiple rule files
   without manual config.
3. **No glob support** in `instructions_paths()`, so even `instructions = [".claude/rules/*.md"]`
   was impossible.

The recommended path from the #3867 design discussion was **D first** — rules-directory
auto-discovery sits in the same trust class as `AGENTS.md`, needs no #417 relaxation, and
delivers the majority of multi-project pain relief on its own. This PR implements that slice.

## Design decisions

### `rules_block` vs mixing into `instructions`

Rules are stored in a **separate `rules_block: Option<String>` field** on `ProjectContext`,
not mixed into `instructions`. This is essential for mono-repo support:

- `has_instructions()` controls whether the parent-directory traversal searches for a root
  `AGENTS.md`. If rules alone set `instructions`, they would **block** parent discovery.
- By keeping rules in `rules_block`, `has_instructions()` stays unchanged (only reflects
  main instructions), and parent traversal works correctly.
- `as_system_block()` appends `rules_block` after `instructions` at render time, so both
  are present in the final system prompt.

### Security model

Same trust class as `AGENTS.md`:

- **Workspace-subtree only** — rules live in `.codewhale/rules/` or `.claude/rules/` within
  the project. No absolute-path escape.
- **Symlink refusal** — `load_context_file()` (shared with AGENTS.md) rejects symlinked files,
  matching the existing precedent in `read_project_config_file`.
- **Capped at 50 files per directory** (`MAX_RULES_FILES`) to prevent abuse.
- **100 KB per file** (`MAX_CONTEXT_SIZE`) inherited from the context loader.

### No #417 relaxation

`merge_project_config`'s rejection of project-scope `instructions` is **left unchanged**.
Scheme D is orthogonal to #417 — it doesn't touch the config key at all.

## Changes

### `crates/tui/src/project_context.rs` (+~190 lines)

**New constants:**
- `RULES_DIRS = [".codewhale/rules", ".claude/rules"]` — directories scanned in order
- `MAX_RULES_FILES = 50` — per-directory file cap

**New field on `ProjectContext`:**
- `rules_block: Option<String>` — holds the assembled rules XML, separate from `instructions`

**New function `load_rules_from_dir()`:**
- Scans a rules directory for `*.md` files
- Sorts by filename for deterministic order
- Reuses `load_context_file()` for size checking + symlink safety + empty-file rejection
- Returns `Vec<(PathBuf, String)>` — silently returns empty on missing/unreadable directories

**Modified `load_project_context()`:**
- After loading `PROJECT_CONTEXT_FILES` (AGENTS.md etc.), iterates `RULES_DIRS` and calls
  `load_rules_from_dir()`
- Wraps each rule file in `<project_rule source="…">…</project_rule>`
- Stores assembled rules in `ctx.rules_block` (not `ctx.instructions`, preserving parent traversal)

**Modified `as_system_block()`:**
- Appends `rules_block` inside the project-context block when instructions exist
- Emits `rules_block` standalone when no main instructions are present
- Emits `rules_block` after constitution when constitution exists but instructions don't

**Modified `project_context_cache_candidate_paths()`:**
- Scans `RULES_DIRS` for `*.md` files and adds them to the cache-key candidate list
- Ensures rules changes invalidate the project-context cache (editing a rule file,
  adding/removing rule files all produce a different cache key)

**9 new tests:**

| Test | What it covers |
|---|---|
| `rules_from_codewhale_dir_are_loaded_as_project_context` | Basic discovery + `<project_rule>` wrapper |
| `rules_are_loaded_in_filename_order` | Deterministic filename sort (aaa < mmm < zzz) |
| `rules_from_claude_dir_are_compat_loaded` | `.claude/rules/` compatibility |
| `rules_directory_missing_does_not_crash` | Graceful handling of missing directories |
| `rules_coexist_with_agents_md` | AGENTS.md + rules coexist, AGENTS.md precedes rules |
| `non_md_files_in_rules_dir_are_ignored` | Only `*.md` files are loaded |
| `rules_cap_truncates_excess_files` | MAX_RULES_FILES=50 enforced |
| `rules_rejects_symlinked_files` | Symlinked rule files are refused (unix only) |
| `rules_from_both_dirs_are_loaded_together` | Dual directory support + correct priority order |

### `crates/tui/src/context_report.rs` (+18 lines)

- `/context report` now includes `rules_block` content when rules are present
- When only rules exist (no main instructions), they appear as a separate "Project rules" entry

### `crates/tui/src/project_context_cache.rs` (+28 lines, 2 tests)

- `signature_changes_when_rules_file_changes` — verifies content change triggers cache invalidation
- `signature_changes_when_rules_file_is_added_or_removed` — verifies file addition/removal triggers invalidation

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p codewhale-tui` (our files only) | clean |
| `cargo test -p codewhale-tui --bin codewhale-tui -- project_context` | **56 passed, 0 failed** |
| `cargo test -p codewhale-tui --bin codewhale-tui -- project_context_cache` | **7 passed, 0 failed** |
| `cargo test -p codewhale-tui --bin codewhale-tui -- context_report` | **9 passed, 0 failed** |

## System prompt structure (with rules)

```
┌─ System Prompt ──────────────────────────────────────────────┐
│ [mode prompt + constitution]                                  │
│                                                                │
│ <project_instructions source="AGENTS.md">                      │
│   ...AGENTS.md content...                                     │
│ </project_instructions>                                       │
│                                                                │
│ <project_rule source=".codewhale/rules/coding-style.md">      │
│   ...rule content...                                          │
│ </project_rule>                                               │
│ <project_rule source=".codewhale/rules/testing.md">           │
│   ...rule content...                                          │
│ </project_rule>                                               │
│                                                                │
│ ── volatile boundary ──                                       │
│ ## Environment …                                              │
│ <instructions source="~/global.md">…</instructions>           │
└────────────────────────────────────────────────────────────────┘
```

## Audit summary

A comprehensive cross-system audit (2 rounds, 5 dimensions) was performed to ensure no
regressions or unexpected interactions:

| Audit scope | Verdict | Details |
|---|---|---|
| **Prompt byte-stability** | ✅ Safe | Rules in static layer (same as AGENTS.md). KV cache busts on rule changes — by design. |
| **All prompt construction paths** | ✅ Covered | TUI, engine init, refresh_system_prompt, `build_system_prompt` all go through `as_system_block()`. |
| **Sub-agent / Fleet** | 🟡 Pre-existing | Model-visible `agent` tool ✔️ inherits rules via fork_context. Background `/agent` path ❌ uses static prompt — same pre-existing limitation as AGENTS.md. |
| **WhaleFlow** | ✅ No interaction | Independent crate, no project-context references. |
| **Project-context cache** | ✅ Fixed | Cache key now includes rules directory files. Tested for content change + file addition/removal. |
| **Parent-directory AGENTS.md** | ✅ Preserved | `rules_block` separated from `instructions` — `has_instructions()` unchanged. |
| **#417 project-config** | ✅ Unchanged | `merge_project_config`'s `instructions` rejection untouched. |

## What this PR does NOT do (deferred to future milestones)

- **Glob support** in `instructions_paths()` (scheme C)
- **Path restriction** for project-scope `instructions` relaxation (scheme B)
- **Conditional rule loading** with YAML frontmatter / `paths` matching (scheme E)
- **Trust gating** for project-scope `instructions` (scheme A)

These are tracked in #3867 as separate workstreams.

## Migration path

- **New projects**: create `.codewhale/rules/` (or `.claude/rules/`) and drop `.md` files.
  No config changes needed — rules are auto-discovered on next session start.
- **Existing `.claude/rules/` users**: rules are picked up automatically — zero migration cost.
- **Existing global `instructions` users**: both channels are additive (project rules + global
  instructions coexist in the system prompt), so no conflict.

---

# PR：feat(tui) — 自动发现 `.codewhale/rules/` 和 `.claude/rules/` 目录作为项目上下文

Closes #3867

## 概述

为 `load_project_context()` 新增 **rules 目录自动发现**：每次会话启动时，CodeWhale
自动扫描 `.codewhale/rules/`（原生）和 `.claude/rules/`（Claude 兼容）目录下的 `.md`
文件，按文件名排序加载，追加到注入 system prompt 的项目上下文块中。每条规则包裹在
`<project_rule source="…">` 元素中。

这是设计锚点 issue #3867 中**方案 D** 的实现——与 `AGENTS.md` 相同的安全模型（仅限
工作区内容，无绝对路径逃逸），不需要 relax #417 项目级配置限制。

## 动机

此 PR 之前，CodeWhale 在多项目场景下的规则系统几乎不可用：

1. **`instructions` 配置项被项目级禁止**（自 v0.8.8 #417）——用户只能在
   `~/.codewhale/config.toml` 中列举规则文件，跨多个仓库维护极其痛苦。
2. **无 rules 目录自动发现**——Claude Code 的 `.claude/rules/` 自动加载所有 `.md`
   文件；CodeWhale 没有对应机制，且无法批量加载多文件规则。
3. **`instructions_paths()` 不支持 glob**，即使写 `instructions = [".claude/rules/*.md"]`
   也是无效的。

#3867 设计讨论的推荐路径是 **D 优先**——rules 目录自动发现与 `AGENTS.md` 同安全等级，
无需改动 #417，且能独立解决多项目痛点的大部分。本 PR 实现该方案。

## 设计决策

### `rules_block` 分离 vs 混入 `instructions`

Rules 存储在 `ProjectContext` 的**独立字段 `rules_block: Option<String>`** 中，不混入
`instructions`。这对 mono-repo 场景至关重要：

- `has_instructions()` 控制是否向上搜索父目录的 `AGENTS.md`。若 rules 单独设置了
  `instructions`，会**阻止**父目录发现。
- 将 rules 保持在 `rules_block` 中，`has_instructions()` 保持不变（仅反映主指令），
  父目录遍历正常工作。
- `as_system_block()` 在渲染时将 `rules_block` 追在 `instructions` 之后，两者都出现在
  最终 system prompt 中。

### 安全模型

与 `AGENTS.md` 同等级：

- **仅限工作区子树**——rules 位于项目内的 `.codewhale/rules/` 或 `.claude/rules/`。
  无绝对路径逃逸。
- **拒绝软链接**——`load_context_file()`（与 AGENTS.md 共享）拒绝软链接文件，与
  `read_project_config_file` 中的现有先例一致。
- **每目录上限 50 文件**（`MAX_RULES_FILES`）防止滥用。
- **每文件 100 KB**（`MAX_CONTEXT_SIZE`）继承自上下文加载器。

### 不触碰 #417

`merge_project_config` 对项目级 `instructions` 的拒绝**保持原样**。方案 D 与 #417
完全正交——不涉及配置项。

## 改动

### `crates/tui/src/project_context.rs`（+~190 行）

**新增常量：**
- `RULES_DIRS = [".codewhale/rules", ".claude/rules"]` — 按顺序扫描的目录
- `MAX_RULES_FILES = 50` — 每目录文件上限

**`ProjectContext` 新增字段：**
- `rules_block: Option<String>` — 存放组装好的 rules XML，与 `instructions` 分离

**新增函数 `load_rules_from_dir()`：**
- 扫描 rules 目录中的 `*.md` 文件
- 按文件名排序，保证确定性顺序
- 复用 `load_context_file()` 做大小检查 + 软链接安全 + 空文件拒绝
- 返回 `Vec<(PathBuf, String)>` — 目录缺失或不可读时静默返回空 vector

**修改 `load_project_context()`：**
- 加载 `PROJECT_CONTEXT_FILES`（AGENTS.md 等）后，遍历 `RULES_DIRS` 调用
  `load_rules_from_dir()`
- 将每条规则包裹在 `<project_rule source="…">…</project_rule>` 中
- 组装结果存入 `ctx.rules_block`（而非 `ctx.instructions`，保留父目录遍历）

**修改 `as_system_block()`：**
- instructions 存在时，将 `rules_block` 追在项目上下文块中
- 无主指令时，独立输出 `rules_block`
- constitution 存在但 instructions 不存在时，constitution 后输出 `rules_block`

**修改 `project_context_cache_candidate_paths()`：**
- 扫描 `RULES_DIRS` 中的 `*.md` 文件，加入缓存 key 候选列表
- 确保 rules 变更触发项目上下文缓存失效（编辑规则文件、新增/删除规则文件均产生不同缓存 key）

**9 个新测试：**

| 测试 | 覆盖 |
|---|---|
| `rules_from_codewhale_dir_are_loaded_as_project_context` | 基础发现 + `<project_rule>` 包裹 |
| `rules_are_loaded_in_filename_order` | 确定性文件名排序（aaa < mmm < zzz） |
| `rules_from_claude_dir_are_compat_loaded` | `.claude/rules/` 兼容 |
| `rules_directory_missing_does_not_crash` | 目录缺失不崩溃 |
| `rules_coexist_with_agents_md` | AGENTS.md + rules 共存，AGENTS.md 在前 |
| `non_md_files_in_rules_dir_are_ignored` | 仅加载 `*.md` |
| `rules_cap_truncates_excess_files` | MAX_RULES_FILES=50 强制 |
| `rules_rejects_symlinked_files` | 拒绝软链接规则文件（仅 unix） |
| `rules_from_both_dirs_are_loaded_together` | 双目录共存 + 正确优先级 |

### `crates/tui/src/context_report.rs`（+18 行）

- `/context report` 现在在 rules 存在时包含 `rules_block` 内容
- 仅 rules 存在（无主指令）时显示为独立的"Project rules"条目

### `crates/tui/src/project_context_cache.rs`（+28 行，2 个测试）

- `signature_changes_when_rules_file_changes` — 验证内容变更触发缓存失效
- `signature_changes_when_rules_file_is_added_or_removed` — 验证文件增删触发失效

## 验证

| 检查项 | 结果 |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p codewhale-tui`（仅本次改动文件） | clean |
| `cargo test -p codewhale-tui --bin codewhale-tui -- project_context` | **56 passed, 0 failed** |
| `cargo test -p codewhale-tui --bin codewhale-tui -- project_context_cache` | **7 passed, 0 failed** |
| `cargo test -p codewhale-tui --bin codewhale-tui -- context_report` | **9 passed, 0 failed** |

## System prompt 结构（含 rules）

```
┌─ System Prompt ──────────────────────────────────────────────────┐
│ [mode prompt + constitution]                                      │
│                                                                    │
│ <project_instructions source="AGENTS.md">                          │
│   ...AGENTS.md 内容...                                             │
│ </project_instructions>                                           │
│                                                                    │
│ <project_rule source=".codewhale/rules/coding-style.md">          │
│   ...规则内容...                                                   │
│ </project_rule>                                                   │
│ <project_rule source=".codewhale/rules/testing.md">               │
│   ...规则内容...                                                   │
│ </project_rule>                                                   │
│                                                                    │
│ ── volatile boundary ──                                           │
│ ## Environment …                                                  │
│ <instructions source="~/global.md">…</instructions>               │
└────────────────────────────────────────────────────────────────────┘
```

## 审计摘要

进行了全面的跨系统审计（2 轮、5 个维度），确保无回归或意外交互：

| 审计范围 | 结论 | 详情 |
|---|---|---|
| **Prompt 字节稳定性** | ✅ 安全 | Rules 在静态层（与 AGENTS.md 一致）。KV cache 随规则变更刷新——设计如此。 |
| **所有 prompt 构造路径** | ✅ 全覆盖 | TUI、engine init、refresh_system_prompt、`build_system_prompt` 均经过 `as_system_block()`。 |
| **子任务 / Fleet** | 🟡 预存限制 | 模型可见的 `agent` 工具 ✔️ 通过 fork_context 继承 rules。后台 `/agent` 路径 ❌ 使用静态 prompt——与 AGENTS.md 相同的预存限制。 |
| **WhaleFlow** | ✅ 无交互 | 独立 crate，无项目上下文引用。 |
| **项目上下文缓存** | ✅ 已修复 | 缓存 key 现在包含 rules 目录文件。已验证内容变更 + 文件增删。 |
| **父目录 AGENTS.md** | ✅ 保持 | `rules_block` 与 `instructions` 分离——`has_instructions()` 不变。 |
| **#417 项目配置** | ✅ 未触碰 | `merge_project_config` 的 `instructions` 拒绝保持不变。 |

## 本 PR 不包含的内容（推迟到后续 milestone）

- **Glob 支持** `instructions_paths()`（方案 C）
- **路径限制** 放宽项目级 `instructions`（方案 B）
- **按需加载** YAML frontmatter / `paths` 匹配（方案 E）
- **Trust gating** 项目级 `instructions`（方案 A）

以上在 #3867 中作为独立工作流跟踪。

## 迁移路径

- **新项目**：创建 `.codewhale/rules/`（或 `.claude/rules/`）并放入 `.md` 文件。
  无需配置变更——下次会话启动时自动发现 rules。
- **现有 `.claude/rules/` 用户**：rules 直接生效——零迁移成本。
- **现有全局 `instructions` 用户**：两个通道是叠加关系（项目 rules + 全局 instructions
  共存于 system prompt），无冲突。
