### PR TITLE
chore(tui): remove dead fleet task helpers

### DIFF
--- a/crates/tui/src/automation_manager.rs
+++ b/crates/tui/src/automation_manager.rs
@@ -987,7 +987,6 @@ mod tests {
             default_mode: "plan".to_string(),
             allow_shell: true,
             trust_mode: true,
-            max_subagents: 2,
         }
     }
 

--- a/crates/tui/src/fleet/alerts.rs
+++ b/crates/tui/src/fleet/alerts.rs
@@ -95,10 +95,6 @@ pub struct FleetAlertDispatcher<R = FleetEnvSecretResolver> {
 }
 
 impl FleetAlertConfig {
-    pub fn disabled() -> Self {
-        Self::default()
-    }
-
     pub fn dry_run_for_adapter(adapter: FleetAlertAdapterConfig) -> Self {
         let mut adapters = BTreeMap::new();
         adapters.insert("dry-run".to_string(), adapter);

--- a/crates/tui/src/fleet/ledger.rs
+++ b/crates/tui/src/fleet/ledger.rs
@@ -210,23 +210,6 @@ impl FleetLedger {
         })
     }
 
-    /// Mark a task as completed or failed.
-    pub fn complete_or_fail_task(
-        &self,
-        run_id: &FleetRunId,
-        task_id: &str,
-        worker_id: &str,
-        timestamp: &str,
-    ) -> Result<()> {
-        self.append_record(&FleetLedgerRecord::TaskCompletedOrFailed {
-            run_id: run_id.clone(),
-            task_id: task_id.to_string(),
-            worker_id: worker_id.to_string(),
-            timestamp: timestamp.to_string(),
-            status: FleetTaskLedgerStatus::Completed,
-        })
-    }
-
     pub fn mark_task_terminal_status(
         &self,
         run_id: &FleetRunId,

--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -194,11 +194,6 @@ impl FleetManager {
         self
     }
 
-    /// True when the manager has a sub-agent runtime for headless worker execution.
-    pub fn has_worker_runtime(&self) -> bool {
-        self.sub_agent_manager.is_some()
-    }
-
     pub fn ledger_path(&self) -> &Path {
         self.ledger.path()
     }

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -540,7 +540,6 @@ async fn spawn_test_server_with_root_token_mobile_workspace_subagents_and_config
             default_mode: "agent".to_string(),
             allow_shell: false,
             trust_mode: false,
-            max_subagents: 2,
         },
         Arc::new(MockExecutor),
     )

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -22,7 +22,7 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::config::{Config, DEFAULT_TEXT_MODEL, MAX_SUBAGENTS};
+use crate::config::{Config, DEFAULT_TEXT_MODEL};
 use crate::runtime_threads::{
     CreateThreadRequest, RuntimeThreadManager, RuntimeThreadManagerConfig, RuntimeTurnStatus,
     SharedRuntimeThreadManager, StartTurnRequest,
@@ -314,8 +314,6 @@ pub struct TaskManagerConfig {
     pub default_mode: String,
     pub allow_shell: bool,
     pub trust_mode: bool,
-    #[allow(dead_code)]
-    pub max_subagents: usize,
 }
 
 impl TaskManagerConfig {
@@ -339,9 +337,6 @@ impl TaskManagerConfig {
             default_mode: "agent".to_string(),
             allow_shell: config.allow_shell(),
             trust_mode: false,
-            max_subagents: config
-                .max_subagents_for_provider(config.api_provider())
-                .clamp(1, MAX_SUBAGENTS),
         }
     }
 }
@@ -1827,7 +1822,6 @@ mod tests {
             default_mode: "agent".to_string(),
             allow_shell: false,
             trust_mode: false,
-            max_subagents: 2,
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove unused fleet/task-manager wrappers called out in #3855.
- Drop the unread `TaskManagerConfig::max_subagents` field and update test config initializers.
- Keep the active terminal-status and runtime config paths unchanged.

## Verification
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked task_manager -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p codewhale-tui --all-targets --locked`
- `RUSTFLAGS="-D warnings" cargo test -p codewhale-tui --bin codewhale-tui --locked --no-run`

Closes #3855.
