### PR TITLE
fix(fleet): report local worker memory usage (salvage #3895 by @cyq1017)

### DIFF
--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -131,6 +131,7 @@ pub struct FleetHostWorkerStatus {
     pub state: FleetHostWorkerState,
     pub pid: Option<u32>,
     pub exit_code: Option<i32>,
+    pub memory_mb: Option<u64>,
     pub retryable: bool,
 }
 
@@ -157,9 +158,11 @@ pub struct LocalProcessFleetHostAdapter {
 struct LocalWorkerProcess {
     request: FleetWorkerStartRequest,
     child: Child,
+    host_kind: FleetHostKind,
     log_path: PathBuf,
     stopped: bool,
     last_exit: Option<ExitStatus>,
+    last_memory_mb: Option<u64>,
 }
 
 impl LocalProcessFleetHostAdapter {
@@ -222,9 +225,11 @@ impl LocalProcessFleetHostAdapter {
             LocalWorkerProcess {
                 request,
                 child,
+                host_kind,
                 log_path,
                 stopped: false,
                 last_exit: None,
+                last_memory_mb: None,
             },
         );
         Ok(handle)
@@ -262,16 +267,27 @@ impl FleetHostAdapter for LocalProcessFleetHostAdapter {
                 Some(process.child.id()),
                 status,
                 process.stopped,
+                process.last_memory_mb,
             ));
         }
         match process.child.try_wait() {
-            Ok(None) => Ok(FleetHostWorkerStatus {
-                worker_id: worker_id.to_string(),
-                state: FleetHostWorkerState::Running,
-                pid: Some(process.child.id()),
-                exit_code: None,
-                retryable: false,
-            }),
+            Ok(None) => {
+                let pid = process.child.id();
+                let memory_mb = if process.host_kind == FleetHostKind::LocalProcess {
+                    sample_process_memory_mb(pid)
+                } else {
+                    None
+                };
+                process.last_memory_mb = memory_mb.or(process.last_memory_mb);
+                Ok(FleetHostWorkerStatus {
+                    worker_id: worker_id.to_string(),
+                    state: FleetHostWorkerState::Running,
+                    pid: Some(pid),
+                    exit_code: None,
+                    memory_mb,
+                    retryable: false,
+                })
+            }
             Ok(Some(status)) => {
                 process.last_exit = Some(status);
                 Ok(status_from_exit(
@@ -279,6 +295,7 @@ impl FleetHostAdapter for LocalProcessFleetHostAdapter {
                     Some(process.child.id()),
                     status,
                     process.stopped,
+                    process.last_memory_mb,
                 ))
             }
             Err(err) => Err(FleetHostError::retryable(format!(
@@ -623,6 +640,7 @@ fn status_from_exit(
     pid: Option<u32>,
     status: ExitStatus,
     stopped: bool,
+    memory_mb: Option<u64>,
 ) -> FleetHostWorkerStatus {
     let success = status.success();
     FleetHostWorkerStatus {
@@ -636,8 +654,31 @@ fn status_from_exit(
         },
         pid,
         exit_code: status.code(),
+        memory_mb,
         retryable: !success && !stopped,
     }
+}
+
+#[cfg(unix)]
+fn sample_process_memory_mb(pid: u32) -> Option<u64> {
+    let output = Command::new("/bin/ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let rss_kb = String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()?;
+    (rss_kb > 0).then_some(rss_kb.div_ceil(1024))
+}
+
+#[cfg(not(unix))]
+fn sample_process_memory_mb(_pid: u32) -> Option<u64> {
+    None
 }
 
 fn classify_spawn_error(err: std::io::Error, context: String) -> FleetHostError {
@@ -788,6 +829,24 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    #[cfg(unix)]
+    #[test]
+    fn sample_process_memory_reports_nonzero_for_self() {
+        // The current test process is alive, so its RSS must sample to Some(>0).
+        let mb = sample_process_memory_mb(std::process::id());
+        assert!(
+            matches!(mb, Some(v) if v > 0),
+            "expected Some(>0) MB for the live self process, got {mb:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sample_process_memory_is_none_for_dead_pid() {
+        // PID 0 is not a real user process to `ps -p`, so sampling yields None.
+        assert_eq!(sample_process_memory_mb(0), None);
+    }
+
     fn shell_command(script: &str) -> FleetWorkerCommand {
         if cfg!(windows) {
             FleetWorkerCommand::new("cmd", ["/C", script])
@@ -865,6 +924,52 @@ mod tests {
         let logs = wait_for_log(&adapter, "local-restart", "restart-ready");
         assert!(logs.contains("restart-ready"));
         adapter.stop_worker("local-restart").unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fleet_host_local_adapter_reports_running_worker_memory_usage() {
+        let tmp = TempDir::new().unwrap();
+        let mut adapter = LocalProcessFleetHostAdapter::new(tmp.path());
+        let request =
+            FleetWorkerStartRequest::new("local-memory", shell_command("printf ready; sleep 30"));
+
+        adapter.start_worker(request).unwrap();
+        let _ = wait_for_log(&adapter, "local-memory", "ready");
+
+        let status = adapter.read_status("local-memory").unwrap();
+
+        assert_eq!(status.state, FleetHostWorkerState::Running);
+        assert!(
+            status.memory_mb.is_some_and(|memory_mb| memory_mb > 0),
+            "running local worker status should include RSS memory_mb, got {status:?}"
+        );
+
+        adapter.stop_worker("local-memory").unwrap();
+    }
+
+    #[test]
+    fn fleet_host_ssh_kind_does_not_report_local_process_memory() {
+        let tmp = TempDir::new().unwrap();
+        let mut adapter = LocalProcessFleetHostAdapter::new(tmp.path());
+        let script = if cfg!(windows) {
+            "echo ready & ping -n 30 127.0.0.1 >NUL"
+        } else {
+            "printf ready; sleep 30"
+        };
+        let request = FleetWorkerStartRequest::new("ssh-memory", shell_command(script));
+
+        adapter
+            .start_with_kind(request, FleetHostKind::Ssh)
+            .unwrap();
+        let _ = wait_for_log(&adapter, "ssh-memory", "ready");
+
+        let status = adapter.read_status("ssh-memory").unwrap();
+
+        assert_eq!(status.state, FleetHostWorkerState::Running);
+        assert_eq!(status.memory_mb, None);
+
+        adapter.stop_worker("ssh-memory").unwrap();
     }
 
     #[test]

--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -284,7 +284,10 @@ impl FleetHostAdapter for LocalProcessFleetHostAdapter {
                     state: FleetHostWorkerState::Running,
                     pid: Some(pid),
                     exit_code: None,
-                    memory_mb,
+                    // Report the retained value, not the raw sample: a
+                    // transient ps failure must not flicker a live worker's
+                    // memory to None (the Exited arm already does this).
+                    memory_mb: process.last_memory_mb,
                     retryable: false,
                 })
             }
@@ -661,7 +664,10 @@ fn status_from_exit(
 
 #[cfg(unix)]
 fn sample_process_memory_mb(pid: u32) -> Option<u64> {
-    let output = Command::new("/bin/ps")
+    // Resolve `ps` via PATH like every other external command in the
+    // codebase: /bin/ps does not exist on NixOS and some minimal containers,
+    // which would silently report permanent None for live workers.
+    let output = Command::new("ps")
         .args(["-o", "rss=", "-p", &pid.to_string()])
         .output()
         .ok()?;
@@ -843,8 +849,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn sample_process_memory_is_none_for_dead_pid() {
-        // PID 0 is not a real user process to `ps -p`, so sampling yields None.
-        assert_eq!(sample_process_memory_mb(0), None);
+        // Use a PID beyond every mainstream kernel's default pid ceiling
+        // (Linux pid_max default 4M/32k, macOS ~99998, BSDs 99999): PID 0 is
+        // kernel_task on macOS and semantically special to `ps -p`, so it is
+        // not a portable "no such process" probe.
+        assert_eq!(sample_process_memory_mb(999_999_999), None);
     }
 
     fn shell_command(script: &str) -> FleetWorkerCommand {


### PR DESCRIPTION
Salvages @cyq1017's #3895 (which had a red CI Lint) so it can land with credit.

## What
Samples per-worker RSS for LocalProcess fleet hosts (`ps -o rss=`) and surfaces
it as `memory_mb` on `FleetHostWorkerStatus`, retaining the last sample across
the transition to exited. Non-unix returns `None`. This feeds the host status
view and the fleet memory telemetry tracked in #3885.

## Changes vs the original #3895
- Fixed the CI Lint failure: `u64::div_ceil(1024)` instead of the manual
  `(rss_kb + 1023) / 1024` (`clippy::manual_div_ceil`, which `-D warnings`
  rejects).
- Added unix tests: RSS samples `Some(>0)` for the live self process and `None`
  for a non-existent PID.

## Credit
Authored by @cyq1017 (canonical identity preserved) with `Co-authored-by` and a
`Harvested from PR #3895` note. Closes #3895 on merge.

## Verification
- `cargo clippy --workspace` (CI flags) clean
- `fleet::host` 10 / `fleet` 127 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
