### PR TITLE
fix(subagent): unique temp path per atomic state write (concurrent-persist corruption)

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -3443,6 +3443,14 @@ fn instant_from_duration(duration: Duration) -> Instant {
         .unwrap_or_else(Instant::now)
 }
 
+/// Per-write sequence so each `write_json_atomic` uses a distinct temp file.
+/// `persist_state_best_effort` fires a fresh thread per call, so multiple
+/// persists of the same `state.json` can be in flight at once; keying the temp
+/// name only on the pid (as before) made every thread write the *same*
+/// `state.<pid>.tmp` and a rename could publish a half-written file — corrupt
+/// state that fails to parse on reload.
+static WRITE_JSON_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 fn write_json_atomic<T: Serialize>(workspace: &Path, path: &Path, value: &T) -> Result<()> {
     let workspace = normalize_subagent_workspace(workspace);
     reject_workspace_relative_symlinks(&workspace, path)?;
@@ -3450,10 +3458,15 @@ fn write_json_atomic<T: Serialize>(workspace: &Path, path: &Path, value: &T) -> 
         fs::create_dir_all(parent)?;
     }
     let payload = serde_json::to_string_pretty(value)?;
-    let tmp_path = path.with_extension(format!("{}.tmp", std::process::id()));
+    let seq = WRITE_JSON_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp_path = path.with_extension(format!("{}.{seq}.tmp", std::process::id()));
     reject_workspace_relative_symlinks(&workspace, &tmp_path)?;
     fs::write(&tmp_path, payload)?;
-    fs::rename(tmp_path, path)?;
+    if let Err(err) = fs::rename(&tmp_path, path) {
+        // Don't leave a stray temp behind if the publish failed.
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err.into());
+    }
     Ok(())
 }
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -5509,3 +5509,41 @@ fn fanout_of_workers_with_huge_outputs_keeps_resident_state_bounded() {
         );
     });
 }
+
+#[test]
+fn write_json_atomic_survives_concurrent_writers() {
+    use std::sync::Arc;
+    // Many threads persisting the same state.json concurrently (the real
+    // persist_state_best_effort pattern) must never publish a torn file.
+    let dir = tempdir().expect("tempdir");
+    // Canonicalize so the base matches how write_json_atomic normalizes the
+    // workspace (on macOS the tempdir lives under the /var -> /private/var
+    // symlink); otherwise the workspace-relative path check would reject it.
+    let base = dir.path().canonicalize().expect("canonicalize tempdir");
+    let workspace = Arc::new(base.clone());
+    let path = Arc::new(base.join(".codewhale").join("subagents").join("state.json"));
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let ws = Arc::clone(&workspace);
+        let p = Arc::clone(&path);
+        handles.push(std::thread::spawn(move || {
+            let payload = serde_json::json!({ "writer": i, "blob": "x".repeat(8192) });
+            let _ = write_json_atomic(&ws, &p, &payload);
+        }));
+    }
+    for h in handles {
+        h.join().expect("writer thread");
+    }
+    // The published file must be complete, valid JSON — not a half-written mix.
+    let contents = std::fs::read_to_string(&*path).expect("read state.json");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&contents).expect("state.json must be complete/valid JSON");
+    assert!(parsed.get("writer").is_some());
+    // No stray temp files left behind.
+    let leftover: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+        .expect("read subagents dir")
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().contains(".tmp"))
+        .collect();
+    assert!(leftover.is_empty(), "temp files leaked: {leftover:?}");
+}


### PR DESCRIPTION
From the fleet/sub-agent orchestration hunt: a concurrency bug that can corrupt persisted sub-agent state.

## Problem
`persist_state_best_effort` fires a fresh OS thread per call (spawn, terminal update, debounced steps, cleanup), so multiple persists of the same `.codewhale/subagents/state.json` can be in flight simultaneously. `write_json_atomic` named its temp file only by pid — `state.<pid>.tmp` — **identical for every thread in the process**. Two concurrent writers therefore wrote the *same* temp file and a `rename` could publish a half-written file: a corrupt `state.json` that fails to parse on reload, losing all persisted sub-agents.

## Fix
Append a process-global atomic sequence to the temp name so every in-flight write has its own complete temp before rename (last writer wins on the final path — correct for best-effort state). A failed rename now also removes its temp instead of leaking it.

## Verification
- New `write_json_atomic_survives_concurrent_writers` (16 threads → the published file is always complete/valid JSON with no leaked temps), passes repeatedly
- `tools::subagent` 188 passing; `cargo clippy --workspace` (CI flags) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
