### PR TITLE
[codex] hide plugin command from root slash menu

### DIFF
--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -753,6 +753,25 @@ mod tests {
     }
 
     #[test]
+    fn command_discovery_tier_lists_use_canonical_registered_names() {
+        for (tier_name, names) in [
+            ("advanced", traits::ADVANCED_DISCOVERY_COMMANDS),
+            ("compatibility", traits::COMPATIBILITY_DISCOVERY_COMMANDS),
+        ] {
+            for &name in names {
+                let info = registry()
+                    .get_info(name)
+                    .unwrap_or_else(|| panic!("{tier_name} discovery entry {name:?} must resolve"));
+                assert_eq!(
+                    info.name, name,
+                    "{tier_name} discovery entry {name:?} must be canonical, not an alias for /{}",
+                    info.name
+                );
+            }
+        }
+    }
+
+    #[test]
     fn command_info_resolves_canonical_names_and_aliases() {
         for command in command_infos() {
             for lookup in [command.name.to_string(), format!("/{}", command.name)] {

--- a/crates/tui/src/commands/traits.rs
+++ b/crates/tui/src/commands/traits.rs
@@ -23,6 +23,43 @@ pub enum CommandDiscovery {
     Compatibility,
 }
 
+pub(crate) const ADVANCED_DISCOVERY_COMMANDS: &[&str] = &[
+    "anchor",
+    "balance",
+    "cache",
+    "change",
+    "context",
+    "debt",
+    "diff",
+    "edit",
+    "goal",
+    "hf",
+    "hooks",
+    "lsp",
+    "modeldb",
+    "models",
+    "network",
+    "plugin",
+    "profile",
+    "purge",
+    "relay",
+    "rename",
+    "rlm",
+    "settings",
+    "share",
+    "sidebar",
+    "status",
+    "system",
+    "theme",
+    "tokens",
+    "translate",
+    "trust",
+    "verbose",
+    "workspace",
+];
+
+pub(crate) const COMPATIBILITY_DISCOVERY_COMMANDS: &[&str] = &["subagents"];
+
 impl CommandDiscovery {
     pub fn show_at_root(self) -> bool {
         matches!(self, CommandDiscovery::Primary)
@@ -69,14 +106,12 @@ impl CommandInfo {
     }
 
     pub fn discovery(&self) -> CommandDiscovery {
-        match self.name {
-            "subagents" => CommandDiscovery::Compatibility,
-            "anchor" | "balance" | "cache" | "change" | "context" | "debt" | "diff" | "edit"
-            | "goal" | "hf" | "hooks" | "lsp" | "modeldb" | "models" | "network" | "plugins"
-            | "profile" | "purge" | "relay" | "rename" | "rlm" | "settings" | "share"
-            | "sidebar" | "status" | "system" | "theme" | "tokens" | "translate" | "trust"
-            | "verbose" | "workspace" => CommandDiscovery::Advanced,
-            _ => CommandDiscovery::Primary,
+        if COMPATIBILITY_DISCOVERY_COMMANDS.contains(&self.name) {
+            CommandDiscovery::Compatibility
+        } else if ADVANCED_DISCOVERY_COMMANDS.contains(&self.name) {
+            CommandDiscovery::Advanced
+        } else {
+            CommandDiscovery::Primary
         }
     }
 

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -3784,6 +3784,7 @@ mod tests {
         assert!(!root.iter().any(|hint| hint.name == "/rlm"));
         assert!(!root.iter().any(|hint| hint.name == "/modeldb"));
         assert!(!root.iter().any(|hint| hint.name == "/models"));
+        assert!(!root.iter().any(|hint| hint.name == "/plugin"));
         assert!(!root.iter().any(|hint| hint.name == "/subagents"));
 
         let rlm = slash_completion_hints("/rl", 128, &[], Locale::En, None, ApiProvider::Deepseek);
@@ -3792,6 +3793,10 @@ mod tests {
         let modeldb =
             slash_completion_hints("/modeld", 128, &[], Locale::En, None, ApiProvider::Deepseek);
         assert!(modeldb.iter().any(|hint| hint.name == "/modeldb"));
+
+        let plugin =
+            slash_completion_hints("/pl", 128, &[], Locale::En, None, ApiProvider::Deepseek);
+        assert!(plugin.iter().any(|hint| hint.name == "/plugin"));
 
         let subagents =
             slash_completion_hints("/sub", 128, &[], Locale::En, None, ApiProvider::Deepseek);


### PR DESCRIPTION
## Summary

- Fix `/plugin` discovery tiering by using the canonical command name in the Advanced list.
- Expose discovery tier name lists to registry tests so aliases cannot drift into the hardcoded tier list again.
- Cover the slash menu acceptance: `/plugin` is hidden from bare `/` discovery but appears when typing `/pl`.

Fixes #3910

## Validation

- `cargo fmt`
- `git diff --check`
- `python scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range upstream/main..HEAD --check-authors`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked command_discovery_tier_lists_use_canonical_registered_names -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked slash_completion_hints_hide_toolbox_commands_until_typed -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked slash_completion_hints -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked command_registry -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked command_info -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked`
- `cargo test --workspace --locked`

## Self-review

- Scope is limited to command discovery metadata and existing slash completion tests.
- No command dispatch, plugin registry, or alias behavior changes beyond hiding the canonical `/plugin` entry from root discovery.
- The new registry test fails if a future Advanced/Compatibility tier entry names an alias or a nonexistent command.
