### PR TITLE
fix: release-lane correctness batch from the 0.8.67 audit (#3918/#3919/#3920/#3924/#3926/#3927/#3928/#3929)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -270,7 +270,7 @@
     "HomeGoalModeTip": "Goal tracking - Set /goal <objective> to pursue objectives",
     "OnboardLanguageTitle": "Choose your language",
     "OnboardLanguageBlurb": "Pick the UI language. You can change it any time with `/settings set locale <tag>`.",
-    "OnboardLanguageFooter": "Press 1-7 to choose, or Enter to keep the current setting",
+    "OnboardLanguageFooter": "Press 1-8 to choose, or Enter to keep the current setting",
     "OnboardApiKeyTitle": "Connect your DeepSeek API key",
     "OnboardApiKeyStep1": "Step 1.  Open https://platform.deepseek.com/api_keys and create a key.",
     "OnboardApiKeyStep2": "Step 2.  Paste it below and press Enter.",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -258,7 +258,7 @@
     "HomeGoalModeTip": "Seguimiento de Goal - Usa /goal <objetivo> para seguir un objetivo persistente",
     "OnboardLanguageTitle": "Elige el idioma",
     "OnboardLanguageBlurb": "Elige el idioma de la interfaz. Puedes cambiarlo en cualquier momento con `/settings set locale <etiqueta>`.",
-    "OnboardLanguageFooter": "Presiona 1-7 para elegir, o Enter para mantener la configuración actual",
+    "OnboardLanguageFooter": "Presiona 1-8 para elegir, o Enter para mantener la configuración actual",
     "OnboardApiKeyTitle": "Conecta tu clave de API DeepSeek",
     "OnboardApiKeyStep1": "Paso 1.  Abre https://platform.deepseek.com/api_keys y crea una clave.",
     "OnboardApiKeyStep2": "Paso 2.  Pégala abajo y presiona Enter.",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -255,7 +255,7 @@
     "HomeGoalModeTip": "Goal 追跡 - /goal <目標> で持続的な目標を追跡",
     "OnboardLanguageTitle": "言語を選択",
     "OnboardLanguageBlurb": "UI 言語を選んでください。`/settings set locale <tag>` でいつでも変更できます。",
-    "OnboardLanguageFooter": "1〜7 で選択、または Enter で現在の設定を維持",
+    "OnboardLanguageFooter": "1〜8 で選択、または Enter で現在の設定を維持",
     "OnboardApiKeyTitle": "DeepSeek API キーを設定",
     "OnboardApiKeyStep1": "ステップ 1. https://platform.deepseek.com/api_keys を開いてキーを作成。",
     "OnboardApiKeyStep2": "ステップ 2. 下に貼り付けて Enter を押してください。",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -247,7 +247,7 @@
     "HomeGoalModeTip": "Rastreamento de Goal - Use /goal <objetivo> para rastrear um objetivo persistente",
     "OnboardLanguageTitle": "Escolha o idioma",
     "OnboardLanguageBlurb": "Escolha o idioma da interface. Você pode mudá-lo a qualquer momento com `/settings set locale <tag>`.",
-    "OnboardLanguageFooter": "Pressione 1-7 para escolher, ou Enter para manter a configuração atual",
+    "OnboardLanguageFooter": "Pressione 1-8 para escolher, ou Enter para manter a configuração atual",
     "OnboardApiKeyTitle": "Conecte sua chave de API DeepSeek",
     "OnboardApiKeyStep1": "Passo 1.  Abra https://platform.deepseek.com/api_keys e crie uma chave.",
     "OnboardApiKeyStep2": "Passo 2.  Cole abaixo e pressione Enter.",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -254,7 +254,7 @@
     "HomeGoalModeTip": "Theo dõi mục tiêu - Dùng /goal <mục_tiêu> để đặt mục tiêu làm việc",
     "OnboardLanguageTitle": "Chọn ngôn ngữ của bạn",
     "OnboardLanguageBlurb": "Chọn ngôn ngữ hiển thị. Bạn có thể thay đổi bất kỳ lúc nào bằng lệnh `/settings set locale <tag>`.",
-    "OnboardLanguageFooter": "Nhấn phím từ 1-7 để chọn, hoặc Enter để giữ cài đặt hiện tại",
+    "OnboardLanguageFooter": "Nhấn phím từ 1-8 để chọn, hoặc Enter để giữ cài đặt hiện tại",
     "OnboardApiKeyTitle": "Kết nối khóa API DeepSeek của bạn",
     "OnboardApiKeyStep1": "Bước 1. Truy cập https://platform.deepseek.com/api_keys và tạo một khóa.",
     "OnboardApiKeyStep2": "Bước 2. Dán khóa vào bên dưới và nhấn Enter.",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -260,7 +260,7 @@
   "HomeGoalModeTip": "Goal 跟踪 - 设置 /goal <目标> 以跟踪持久目标",
   "OnboardLanguageTitle": "选择语言",
   "OnboardLanguageBlurb": "选择界面语言。可随时使用 `/settings set locale <tag>` 修改。",
-  "OnboardLanguageFooter": "按 1-7 选择，或按 Enter 保留当前设置",
+  "OnboardLanguageFooter": "按 1-8 选择，或按 Enter 保留当前设置",
   "OnboardApiKeyTitle": "连接你的 DeepSeek API 密钥",
   "OnboardApiKeyStep1": "步骤 1.  打开 https://platform.deepseek.com/api_keys 创建一个密钥。",
   "OnboardApiKeyStep2": "步骤 2.  把密钥粘贴到下方并按 Enter。",

--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -175,7 +175,6 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
              ---\n  \
              name: my-skill\n  \
              description: What this skill does\n  \
-             allowed-tools: read_file, list_dir\n  \
              ---\n\n  \
              <instructions here>{warnings}",
             skills_dir.display(),
@@ -467,7 +466,7 @@ fn trust_skill(app: &mut App, name: &str) -> CommandResult {
     }
     match install::trust(name, &app.skills_dir) {
         Ok(()) => CommandResult::message(format!(
-            "Marked skill '{name}' as trusted. Tools that consult the .trusted marker may now invoke its scripts/."
+            "Marked skill '{name}' as trusted. The .trusted marker is advisory; it records your intent but does not sandbox or auto-authorize scripts."
         )),
         Err(err) => CommandResult::error(format!("Trust failed: {err:#}")),
     }
@@ -909,6 +908,10 @@ mod tests {
         let msg = result.message.unwrap();
         assert!(msg.contains("No skills found"));
         assert!(msg.contains("Skills location:"));
+        assert!(
+            !msg.contains("allowed-tools"),
+            "empty-state template must not advertise unenforced tool restrictions: {msg}"
+        );
     }
 
     #[test]
@@ -1230,6 +1233,29 @@ mod tests {
         let result = run_skill(&mut app, Some("uninstall absent-skill"));
         let msg = result.message.unwrap();
         assert!(msg.contains("not installed"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_skill_trust_message_marks_marker_advisory() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        create_skill_dir(
+            &tmpdir,
+            "trusted-skill",
+            "---\nname: trusted-skill\ndescription: Trust copy\n---\nbody",
+        );
+        let marker = tmpdir
+            .path()
+            .join("skills")
+            .join("trusted-skill")
+            .join(install::INSTALLED_FROM_MARKER);
+        std::fs::write(marker, "github:owner/repo\n").expect("installed marker");
+
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let result = run_skill(&mut app, Some("trust trusted-skill"));
+        let msg = result.message.expect("trust result");
+        assert!(msg.contains("advisory"), "got: {msg}");
+        assert!(!msg.contains("may now invoke"), "got: {msg}");
     }
 
     #[test]

--- a/crates/tui/src/plugins/discovery.rs
+++ b/crates/tui/src/plugins/discovery.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::manifest::{LoadedPlugin, PluginManifest};
 use super::registry::PluginRegistry;
 
 const PLUGIN_MANIFEST: &str = "plugin.toml";
+const OVERRIDES_FILE: &str = "overrides.json";
 
 pub fn default_user_plugins_dir() -> PathBuf {
     dirs::home_dir()
@@ -11,8 +13,38 @@ pub fn default_user_plugins_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("/tmp/codewhale/plugins"))
 }
 
+/// Path of the JSON file that records `/plugin enable|disable` choices so they
+/// survive restarts.
+pub fn default_overrides_path() -> PathBuf {
+    default_user_plugins_dir().join(OVERRIDES_FILE)
+}
+
+/// Read the persisted enable/disable overrides. Missing or malformed files
+/// yield an empty map — the user simply gets the default enablement.
+pub fn load_overrides(path: &Path) -> HashMap<String, bool> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str(&contents).ok())
+        .unwrap_or_default()
+}
+
+/// Persist the enable/disable overrides, creating the parent directory if
+/// needed.
+pub fn save_overrides(path: &Path, overrides: &HashMap<String, bool>) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(overrides)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, json)
+}
+
 pub fn discover_all(builtin_dirs: &[&str]) -> PluginRegistry {
     let mut registry = PluginRegistry::new();
+
+    let overrides_path = default_overrides_path();
+    let overrides = load_overrides(&overrides_path);
+    registry.set_overrides_store(overrides_path, overrides);
 
     for dir in builtin_dirs {
         let path = PathBuf::from(dir);
@@ -25,6 +57,10 @@ pub fn discover_all(builtin_dirs: &[&str]) -> PluginRegistry {
     if user_dir.exists() {
         discover_from_dir(&user_dir, &mut registry, false);
     }
+
+    // Discovery recomputes `enabled` from `!builtin`; re-apply the user's
+    // persisted choices so a prior enable/disable actually sticks (#3918).
+    registry.apply_overrides();
 
     registry
 }

--- a/crates/tui/src/plugins/registry.rs
+++ b/crates/tui/src/plugins/registry.rs
@@ -1,18 +1,38 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use super::manifest::LoadedPlugin;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PluginRegistry {
     plugins: HashMap<String, LoadedPlugin>,
     user_overrides: HashMap<String, bool>,
+    /// Where `user_overrides` is persisted. `None` in tests / when no home
+    /// directory is available, in which case enable/disable stays in-memory.
+    overrides_path: Option<PathBuf>,
 }
 
 impl PluginRegistry {
     pub fn new() -> Self {
-        Self {
-            plugins: HashMap::new(),
-            user_overrides: HashMap::new(),
+        Self::default()
+    }
+
+    /// Seed the persisted enable/disable overrides and remember where to write
+    /// them back. Called by discovery before plugins are registered; the
+    /// overrides are then applied with [`apply_overrides`](Self::apply_overrides).
+    pub fn set_overrides_store(&mut self, path: PathBuf, overrides: HashMap<String, bool>) {
+        self.overrides_path = Some(path);
+        self.user_overrides = overrides;
+    }
+
+    /// Apply every persisted override onto the currently-registered plugins.
+    /// Discovery recomputes `enabled` from scratch (`!builtin`) on each launch,
+    /// so this is what makes a prior `/plugin enable|disable` actually stick.
+    pub fn apply_overrides(&mut self) {
+        for (name, &enabled) in &self.user_overrides {
+            if let Some(plugin) = self.plugins.get_mut(name) {
+                plugin.enabled = enabled;
+            }
         }
     }
 
@@ -24,6 +44,7 @@ impl PluginRegistry {
         if let Some(plugin) = self.plugins.get_mut(name) {
             plugin.enabled = true;
             self.user_overrides.insert(name.to_string(), true);
+            self.persist_overrides();
             true
         } else {
             false
@@ -34,9 +55,24 @@ impl PluginRegistry {
         if let Some(plugin) = self.plugins.get_mut(name) {
             plugin.enabled = false;
             self.user_overrides.insert(name.to_string(), false);
+            self.persist_overrides();
             true
         } else {
             false
+        }
+    }
+
+    /// Write the current override map to disk (best-effort). A failure here is
+    /// logged but never fails the command — the in-memory toggle still applies
+    /// for the current session.
+    fn persist_overrides(&self) {
+        if let Some(path) = &self.overrides_path
+            && let Err(e) = super::discovery::save_overrides(path, &self.user_overrides)
+        {
+            tracing::warn!(
+                "failed to persist plugin overrides to {}: {e}",
+                path.display()
+            );
         }
     }
 
@@ -57,7 +93,7 @@ impl PluginRegistry {
     }
 
     pub fn is_enabled(&self, name: &str) -> bool {
-        self.plugins.get(name).map_or(false, |p| p.enabled)
+        self.plugins.get(name).is_some_and(|p| p.enabled)
     }
 
     pub fn len(&self) -> usize {

--- a/crates/tui/src/plugins/tests.rs
+++ b/crates/tui/src/plugins/tests.rs
@@ -1,7 +1,27 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
-use super::manifest::{PluginManifest, PluginMeta};
+use super::discovery::{load_overrides, save_overrides};
+use super::manifest::{LoadedPlugin, PluginManifest, PluginMeta};
 use super::registry::PluginRegistry;
+
+fn plugin_named(name: &str, enabled: bool) -> LoadedPlugin {
+    LoadedPlugin {
+        manifest: PluginManifest {
+            plugin: PluginMeta {
+                name: name.to_string(),
+                description: None,
+                version: None,
+                author: None,
+            },
+            skills: None,
+            mcp_servers: None,
+            when: None,
+        },
+        base_path: PathBuf::new(),
+        enabled,
+    }
+}
 
 #[test]
 fn test_manifest_parsing() {
@@ -143,4 +163,83 @@ fn test_registry_list() {
     assert_eq!(registry.list_enabled().len(), 1);
     assert!(registry.is_enabled("plugin-1"));
     assert!(!registry.is_enabled("plugin-2"));
+}
+
+#[test]
+fn overrides_save_load_roundtrip() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("plugins").join("overrides.json");
+
+    let mut overrides = HashMap::new();
+    overrides.insert("alpha".to_string(), false);
+    overrides.insert("beta".to_string(), true);
+
+    save_overrides(&path, &overrides).expect("save");
+    assert!(path.exists(), "save_overrides should create parent dirs");
+
+    let loaded = load_overrides(&path);
+    assert_eq!(loaded.get("alpha"), Some(&false));
+    assert_eq!(loaded.get("beta"), Some(&true));
+}
+
+#[test]
+fn load_overrides_missing_or_malformed_is_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("nope.json");
+    assert!(load_overrides(&missing).is_empty());
+
+    let malformed = tmp.path().join("bad.json");
+    std::fs::write(&malformed, "{ not json").expect("write");
+    assert!(load_overrides(&malformed).is_empty());
+}
+
+/// The core #3918 regression: a `/plugin disable` must survive the next
+/// launch even though discovery recomputes `enabled` from `!builtin`.
+#[test]
+fn disable_persists_across_rediscovery() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("overrides.json");
+
+    // First session: a user plugin defaults to enabled, user disables it.
+    let mut first = PluginRegistry::new();
+    first.set_overrides_store(path.clone(), load_overrides(&path));
+    first.register("demo".to_string(), plugin_named("demo", true));
+    first.apply_overrides();
+    assert!(first.is_enabled("demo"));
+    assert!(first.disable("demo"));
+    assert!(path.exists(), "disable should persist the override file");
+
+    // Second session: fresh discovery re-registers it enabled, but the
+    // persisted override must win and keep it disabled.
+    let mut second = PluginRegistry::new();
+    second.set_overrides_store(path.clone(), load_overrides(&path));
+    second.register("demo".to_string(), plugin_named("demo", true));
+    second.apply_overrides();
+    assert!(
+        !second.is_enabled("demo"),
+        "a persisted disable must survive re-discovery"
+    );
+}
+
+/// Symmetric case: enabling a built-in (default-disabled) plugin sticks.
+#[test]
+fn enable_persists_across_rediscovery() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("overrides.json");
+
+    let mut first = PluginRegistry::new();
+    first.set_overrides_store(path.clone(), load_overrides(&path));
+    first.register("builtin".to_string(), plugin_named("builtin", false));
+    first.apply_overrides();
+    assert!(!first.is_enabled("builtin"));
+    assert!(first.enable("builtin"));
+
+    let mut second = PluginRegistry::new();
+    second.set_overrides_store(path.clone(), load_overrides(&path));
+    second.register("builtin".to_string(), plugin_named("builtin", false));
+    second.apply_overrides();
+    assert!(
+        second.is_enabled("builtin"),
+        "a persisted enable must survive re-discovery"
+    );
 }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -12,6 +12,7 @@ use crate::models::SystemPrompt;
 use crate::project_context::{ProjectContext, load_project_context_with_parents};
 use crate::tui::app::AppMode;
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
 #[derive(Debug, Clone)]
 pub struct PromptSessionContext<'a> {
@@ -411,6 +412,8 @@ static LOCALE_CLOSER_VI_OVERRIDE: std::sync::OnceLock<String> = std::sync::OnceL
 static AUTHORITY_RECAP_OVERRIDE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 static STATIC_PROMPT_COMPOSER: std::sync::OnceLock<Box<StaticPromptComposer>> =
     std::sync::OnceLock::new();
+static PROMPT_OVERRIDE_NOTICES: LazyLock<Mutex<Vec<String>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
 
 /// Context passed to an embedder-provided static prompt composer.
 ///
@@ -559,6 +562,19 @@ fn read_prompt_override_file(config_dir: &Path, relative: &str) -> Option<String
     Some(raw)
 }
 
+fn push_prompt_override_notice(message: String) {
+    if let Ok(mut notices) = PROMPT_OVERRIDE_NOTICES.lock() {
+        notices.push(message);
+    }
+}
+
+pub fn take_prompt_override_notices() -> Vec<String> {
+    PROMPT_OVERRIDE_NOTICES
+        .lock()
+        .map(|mut notices| std::mem::take(&mut *notices))
+        .unwrap_or_default()
+}
+
 /// Load user prompt overrides from `config_dir` and install them through the
 /// existing override hooks. Returns the names of the overrides that were
 /// applied (for logging/diagnostics).
@@ -572,15 +588,18 @@ pub fn load_config_dir_prompt_overrides(config_dir: &Path) -> Vec<&'static str> 
         if !base_prompt_override_opt_in() {
             // A file exists but the user hasn't opted in. Don't silently
             // replace the base prompt — surface the gate instead.
-            tracing::warn!(
-                target: "prompts",
-                "found a base-prompt override at {}/{} but {} is not set; \
-                 leaving the bundled Constitution in place. Set {}=1 to opt in.",
+            let warning = format!(
+                "Custom Constitution override found at {}/{} but {} is not set; using the bundled Constitution. Set {}=1 to opt in.",
                 config_dir.display(),
                 CONSTITUTION_OVERRIDE_FILE,
                 BASE_PROMPT_OVERRIDE_OPT_IN_ENV,
                 BASE_PROMPT_OVERRIDE_OPT_IN_ENV,
             );
+            tracing::warn!(
+                target: "prompts",
+                "{warning}",
+            );
+            push_prompt_override_notice(warning);
         } else if set_base_prompt_override(text).is_ok() {
             applied.push("constitution");
         }
@@ -1515,9 +1534,18 @@ mod tests {
         assert!(read_prompt_override_file(tmp.path(), CONSTITUTION_OVERRIDE_FILE).is_some());
         // ...but without the opt-in flag, nothing is applied.
         if std::env::var(BASE_PROMPT_OVERRIDE_OPT_IN_ENV).is_err() {
+            let _ = take_prompt_override_notices();
             assert!(
                 load_config_dir_prompt_overrides(tmp.path()).is_empty(),
                 "override must require the explicit opt-in flag, not just a file"
+            );
+            let notices = take_prompt_override_notices();
+            assert!(
+                notices
+                    .iter()
+                    .any(|notice| notice.contains(BASE_PROMPT_OVERRIDE_OPT_IN_ENV)
+                        && notice.contains("using the bundled Constitution")),
+                "gated override should record a visible notice, got {notices:?}"
             );
         }
     }

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -555,8 +555,6 @@ fn normalize_skill_name_for_lookup(name: &str) -> String {
             if out.len() < MAX_SKILL_NAME_CHARS {
                 out.push(ch.to_ascii_lowercase());
             }
-        } else if ch == '-' || ch == '_' || ch.is_whitespace() {
-            pending_dash = true;
         } else {
             pending_dash = true;
         }

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -23,6 +23,7 @@ use crate::logging;
 
 const MAX_SKILL_DESCRIPTION_CHARS: usize = 280;
 const MAX_AVAILABLE_SKILLS_CHARS: usize = 12_000;
+const MAX_SKILL_NAME_CHARS: usize = 64;
 
 // === Defaults ===
 
@@ -237,6 +238,7 @@ impl SkillRegistry {
                             continue;
                         }
                         skill.path = skill_path.clone();
+                        registry.normalize_skill_name(&mut skill, &skill_path);
                         registry.skills.push(skill);
                         // This directory IS a skill. Don't descend further:
                         // any nested `SKILL.md` would be a fixture or
@@ -284,6 +286,19 @@ impl SkillRegistry {
     fn push_warning(&mut self, warning: String) {
         logging::warn(&warning);
         self.warnings.push(warning);
+    }
+
+    fn normalize_skill_name(&mut self, skill: &mut Skill, skill_path: &Path) {
+        let normalized = normalize_skill_name_for_lookup(&skill.name);
+        if normalized != skill.name || !is_valid_skill_name(&skill.name) {
+            let original = skill.name.clone();
+            skill.name = normalized;
+            self.push_warning(format!(
+                "Skill name `{original}` in {} is not a safe command name; using `{}` instead.",
+                skill_path.display(),
+                skill.name
+            ));
+        }
     }
 
     pub(crate) fn parse_skill(_path: &Path, content: &str) -> std::result::Result<Skill, String> {
@@ -487,7 +502,8 @@ impl SkillRegistry {
 
     /// Lookup a skill by name.
     pub fn get(&self, name: &str) -> Option<&Skill> {
-        self.skills.iter().find(|s| s.name == name)
+        let normalized = normalize_skill_name_for_lookup(name);
+        self.skills.iter().find(|s| s.name == normalized)
     }
 
     /// Return all loaded skills.
@@ -510,6 +526,54 @@ impl SkillRegistry {
     #[must_use]
     pub fn len(&self) -> usize {
         self.skills.len()
+    }
+}
+
+fn is_valid_skill_name(name: &str) -> bool {
+    let char_count = name.chars().count();
+    char_count > 0
+        && char_count <= MAX_SKILL_NAME_CHARS
+        && name
+            .chars()
+            .next()
+            .is_some_and(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+}
+
+fn normalize_skill_name_for_lookup(name: &str) -> String {
+    let mut out = String::new();
+    let mut pending_dash = false;
+
+    for ch in name.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() && out.len() < MAX_SKILL_NAME_CHARS {
+                out.push('-');
+            }
+            pending_dash = false;
+            if out.len() < MAX_SKILL_NAME_CHARS {
+                out.push(ch.to_ascii_lowercase());
+            }
+        } else if ch == '-' || ch == '_' || ch.is_whitespace() {
+            pending_dash = true;
+        } else {
+            pending_dash = true;
+        }
+
+        if out.len() >= MAX_SKILL_NAME_CHARS {
+            break;
+        }
+    }
+
+    while out.ends_with('-') {
+        out.pop();
+    }
+
+    if out.is_empty() {
+        "skill".to_string()
+    } else {
+        out
     }
 }
 
@@ -623,19 +687,7 @@ pub fn discover_in_workspace_with_mode(
     workspace: &Path,
     mode: SkillDiscoveryMode,
 ) -> SkillRegistry {
-    let mut merged = SkillRegistry::default();
-    for dir in skills_directories_for_mode(workspace, mode) {
-        let registry = SkillRegistry::discover(&dir);
-        for skill in registry.skills {
-            if !merged.skills.iter().any(|s| s.name == skill.name) {
-                merged.skills.push(skill);
-            }
-        }
-        for warning in registry.warnings {
-            merged.warnings.push(warning);
-        }
-    }
-    merged
+    discover_from_directories(skills_directories_for_mode(workspace, mode))
 }
 
 /// Discover skills from the workspace search set plus the configured install
@@ -701,7 +753,14 @@ pub(crate) fn discover_from_directories(dirs: impl IntoIterator<Item = PathBuf>)
     for dir in dirs {
         let registry = SkillRegistry::discover(&dir);
         for skill in registry.skills {
-            if !merged.skills.iter().any(|s| s.name == skill.name) {
+            if let Some(existing) = merged.skills.iter().find(|s| s.name == skill.name) {
+                merged.push_warning(format!(
+                    "Skill `{}` at {} is shadowed by {}.",
+                    skill.name,
+                    skill.path.display(),
+                    existing.path.display()
+                ));
+            } else {
                 merged.skills.push(skill);
             }
         }
@@ -1345,6 +1404,14 @@ body";
             "shared.path should be from .agents/skills, got {:?}",
             shared.path
         );
+        assert!(
+            registry
+                .warnings()
+                .iter()
+                .any(|warning| warning.contains("shared") && warning.contains("shadowed by")),
+            "duplicate shadowing should warn, got {:?}",
+            registry.warnings()
+        );
     }
 
     #[test]
@@ -1395,9 +1462,44 @@ body";
         .unwrap();
 
         let registry = super::SkillRegistry::discover(tmpdir.path());
-        let skill = registry.get("Plain Skill").expect("plain skill parsed");
+        let skill = registry.get("plain-skill").expect("plain skill parsed");
+        assert_eq!(skill.name, "plain-skill");
         assert_eq!(skill.description, "");
         assert!(skill.body.contains("Use this skill"));
+        assert!(
+            registry
+                .warnings()
+                .iter()
+                .any(|warning| warning.contains("using `plain-skill` instead")),
+            "expected slug warning, got {:?}",
+            registry.warnings()
+        );
+    }
+
+    #[test]
+    fn discover_slugifies_invalid_frontmatter_names_and_lookup_normalizes() {
+        let tmpdir = TempDir::new().unwrap();
+        let root = tmpdir.path().join("skills");
+        let skill_dir = root.join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: My Skill\ndescription: spaced name\n---\nbody",
+        )
+        .unwrap();
+
+        let registry = super::SkillRegistry::discover(&root);
+        let skill = registry.get("  MY   skill  ").expect("normalized lookup");
+        assert_eq!(skill.name, "my-skill");
+        assert!(
+            registry
+                .warnings()
+                .iter()
+                .any(|warning| warning.contains("My Skill")
+                    && warning.contains("using `my-skill` instead")),
+            "expected invalid-name warning, got {:?}",
+            registry.warnings()
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/onboarding/language.rs
+++ b/crates/tui/src/tui/onboarding/language.rs
@@ -23,6 +23,13 @@ pub const LANGUAGE_OPTIONS: &[(char, &str, &str, &str)] = &[
     ('4', "zh-Hans", "简体中文", "(Simplified Chinese)"),
     ('5', "zh-Hant", "繁體中文", "(Traditional Chinese)"),
     ('6', "pt-BR", "Português (Brasil)", "(Brazilian Portuguese)"),
+    (
+        '7',
+        "es-419",
+        "Español (Latinoamérica)",
+        "(Latin American Spanish)",
+    ),
+    ('8', "vi", "Tiếng Việt", "(Vietnamese)"),
 ];
 
 pub fn lines(app: &App) -> Vec<Line<'static>> {
@@ -81,4 +88,42 @@ pub fn lines(app: &App) -> Vec<Line<'static>> {
     )));
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::localization::Locale;
+
+    /// Every locale we ship translations for must be offered in the picker,
+    /// otherwise the footer advertises hotkeys that select nothing and users
+    /// can never reach a supported UI language (#3929).
+    #[test]
+    fn picker_offers_every_shipped_locale() {
+        let offered: Vec<&str> = LANGUAGE_OPTIONS.iter().map(|(_, tag, _, _)| *tag).collect();
+        assert!(
+            offered.contains(&"auto"),
+            "picker must keep the auto-detect entry"
+        );
+        for locale in Locale::shipped() {
+            let tag = locale.tag();
+            assert!(
+                offered.contains(&tag),
+                "shipped locale {tag} is not offered in the language picker"
+            );
+        }
+    }
+
+    /// Hotkeys must be the contiguous digits `1..=N` so the footer's "1-N"
+    /// range stays truthful and `KeyCode::Char` lookups resolve.
+    #[test]
+    fn picker_hotkeys_are_contiguous_digits() {
+        for (idx, (hotkey, tag, _, _)) in LANGUAGE_OPTIONS.iter().enumerate() {
+            let expected = char::from_digit((idx + 1) as u32, 10).expect("digit");
+            assert_eq!(
+                *hotkey, expected,
+                "option {tag} should use hotkey {expected}, not {hotkey}"
+            );
+        }
+    }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -620,6 +620,15 @@ fn back_from_api_key_onboarding(app: &mut App) {
     app.status_message = None;
 }
 
+fn surface_prompt_override_notices(app: &mut App) {
+    for notice in prompts::take_prompt_override_notices() {
+        app.add_message(HistoryCell::System {
+            content: format!("Warning: {notice}"),
+        });
+        app.push_status_toast(notice, StatusToastLevel::Warning, Some(12_000));
+    }
+}
+
 /// Run the interactive TUI event loop.
 ///
 /// # Examples
@@ -774,6 +783,7 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     let mut app = App::new(options.clone(), config);
     crate::startup_trace::mark("app_constructed");
     sync_config_provider_from_app(config, &app);
+    surface_prompt_override_notices(&mut app);
 
     if options.resume_session_id.is_none() {
         let opened_setup = open_setup_checkpoint_if_due(&mut app, config, options.skip_onboarding);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -595,6 +595,31 @@ fn open_setup_checkpoint_if_due(app: &mut App, config: &Config, skip_onboarding:
     true
 }
 
+fn complete_trust_directory_onboarding(app: &mut App, config: &Config) -> Result<(), String> {
+    onboarding::mark_trusted(&app.workspace).map_err(|err| err.to_string())?;
+    app.trust_mode = true;
+    app.hooks = HookExecutor::new(
+        crate::hooks::HooksConfig::load_with_project(config.hooks_config(), &app.workspace),
+        app.workspace.clone(),
+    );
+    app.runtime_services.hook_executor = Some(std::sync::Arc::new(app.hooks.clone()));
+    app.status_message = None;
+    if app.onboarding_workspace_trust_gate {
+        app.onboarding_workspace_trust_gate = false;
+        app.onboarding = OnboardingState::None;
+    } else {
+        app.onboarding = OnboardingState::Tips;
+    }
+    Ok(())
+}
+
+fn back_from_api_key_onboarding(app: &mut App) {
+    app.onboarding = OnboardingState::Language;
+    app.api_key_input.clear();
+    app.api_key_cursor = 0;
+    app.status_message = None;
+}
+
 /// Run the interactive TUI event loop.
 ///
 /// # Examples
@@ -3793,10 +3818,7 @@ async fn run_event_loop(
                         return Ok(());
                     }
                     KeyCode::Esc if app.onboarding == OnboardingState::ApiKey => {
-                        app.onboarding = OnboardingState::Welcome;
-                        app.api_key_input.clear();
-                        app.api_key_cursor = 0;
-                        app.status_message = None;
+                        back_from_api_key_onboarding(app);
                     }
                     KeyCode::Esc if app.onboarding == OnboardingState::Language => {
                         app.onboarding = OnboardingState::Welcome;
@@ -3901,7 +3923,12 @@ async fn run_event_loop(
                                 }
                             }
                         }
-                        OnboardingState::TrustDirectory => {}
+                        OnboardingState::TrustDirectory => {
+                            if let Err(err) = complete_trust_directory_onboarding(app, config) {
+                                app.status_message =
+                                    Some(format!("Failed to trust workspace: {err}"));
+                            }
+                        }
                         OnboardingState::Tips => {
                             app.finish_onboarding_without_feature_intro();
                             if !open_setup_checkpoint_if_due(app, config, false) {
@@ -3913,30 +3940,8 @@ async fn run_event_loop(
                     KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Char('1')
                         if app.onboarding == OnboardingState::TrustDirectory =>
                     {
-                        match onboarding::mark_trusted(&app.workspace) {
-                            Ok(_) => {
-                                app.trust_mode = true;
-                                app.hooks = HookExecutor::new(
-                                    crate::hooks::HooksConfig::load_with_project(
-                                        config.hooks_config(),
-                                        &app.workspace,
-                                    ),
-                                    app.workspace.clone(),
-                                );
-                                app.runtime_services.hook_executor =
-                                    Some(std::sync::Arc::new(app.hooks.clone()));
-                                app.status_message = None;
-                                if app.onboarding_workspace_trust_gate {
-                                    app.onboarding_workspace_trust_gate = false;
-                                    app.onboarding = OnboardingState::None;
-                                } else {
-                                    app.onboarding = OnboardingState::Tips;
-                                }
-                            }
-                            Err(err) => {
-                                app.status_message =
-                                    Some(format!("Failed to trust workspace: {err}"));
-                            }
+                        if let Err(err) = complete_trust_directory_onboarding(app, config) {
+                            app.status_message = Some(format!("Failed to trust workspace: {err}"));
                         }
                     }
                     KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Char('2')

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7375,6 +7375,39 @@ fn trust_directory_completion_advances_to_tips() {
 }
 
 #[test]
+fn prompt_override_notice_surfaces_in_transcript_and_toast() {
+    let _lock = crate::test_support::lock_test_env();
+    let _env = crate::test_support::EnvVarGuard::remove(prompts::BASE_PROMPT_OVERRIDE_OPT_IN_ENV);
+    let tmpdir = TempDir::new().expect("config tempdir");
+    let prompts_dir = tmpdir.path().join("prompts");
+    std::fs::create_dir_all(&prompts_dir).expect("prompts dir");
+    std::fs::write(prompts_dir.join("constitution.md"), "custom law\n").expect("override file");
+    let _ = prompts::take_prompt_override_notices();
+    assert!(prompts::load_config_dir_prompt_overrides(tmpdir.path()).is_empty());
+
+    let mut app = create_test_app();
+    surface_prompt_override_notices(&mut app);
+
+    assert!(
+        app.history.iter().any(|cell| matches!(
+            cell,
+            HistoryCell::System { content }
+                if content.contains(prompts::BASE_PROMPT_OVERRIDE_OPT_IN_ENV)
+                    && content.contains("bundled Constitution")
+        )),
+        "expected system warning in transcript, got {:?}",
+        app.history
+    );
+    let toast = app.status_toasts.back().expect("warning toast");
+    assert_eq!(toast.level, StatusToastLevel::Warning);
+    assert!(
+        toast
+            .text
+            .contains(prompts::BASE_PROMPT_OVERRIDE_OPT_IN_ENV)
+    );
+}
+
+#[test]
 fn api_key_paste_shortcut_is_not_plain_text_input() {
     let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
     assert!(crate::tui::key_shortcuts::is_paste_shortcut(&ctrl_v));

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7341,6 +7341,40 @@ fn onboarding_after_api_key_save_routes_to_trust_when_needed() {
 }
 
 #[test]
+fn api_key_escape_returns_to_language_step() {
+    let mut app = create_test_app();
+    app.onboarding = OnboardingState::ApiKey;
+    app.api_key_input = "sk-test-value".to_string();
+    app.api_key_cursor = 4;
+    app.status_message = Some("editing".to_string());
+
+    back_from_api_key_onboarding(&mut app);
+
+    assert_eq!(app.onboarding, OnboardingState::Language);
+    assert!(app.api_key_input.is_empty());
+    assert_eq!(app.api_key_cursor, 0);
+    assert_eq!(app.status_message, None);
+}
+
+#[test]
+fn trust_directory_completion_advances_to_tips() {
+    let _guard = ConfigPathEnvGuard::new();
+    let tmpdir = TempDir::new().expect("workspace tempdir");
+    let mut app = create_test_app();
+    app.workspace = tmpdir.path().to_path_buf();
+    app.onboarding = OnboardingState::TrustDirectory;
+    app.onboarding_workspace_trust_gate = false;
+    app.trust_mode = false;
+
+    complete_trust_directory_onboarding(&mut app, &Config::default())
+        .expect("trust completion should succeed");
+
+    assert!(app.trust_mode);
+    assert_eq!(app.onboarding, OnboardingState::Tips);
+    assert!(app.runtime_services.hook_executor.is_some());
+}
+
+#[test]
 fn api_key_paste_shortcut_is_not_plain_text_input() {
     let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
     assert!(crate::tui::key_shortcuts::is_paste_shortcut(&ctrl_v));

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -205,7 +205,7 @@ pub(super) fn slice_text(text: &str, start: usize, end: usize) -> String {
     out
 }
 
-fn char_display_width(ch: char) -> usize {
+pub(super) fn char_display_width(ch: char) -> usize {
     if ch == '\t' {
         4
     } else {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -39,6 +39,7 @@ use crate::tui::approval::{
 };
 use crate::tui::history::{GenericToolCell, HistoryCell, ToolCell, ToolRun, ToolStatus};
 use crate::tui::scrolling::TranscriptLineMeta;
+use crate::tui::ui_text::{char_display_width, text_display_width};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -2335,21 +2336,6 @@ fn apply_selection_to_line(
     }
 
     result
-}
-
-fn text_display_width(text: &str) -> usize {
-    text.chars().map(char_display_width).sum()
-}
-
-fn char_display_width(ch: char) -> usize {
-    if ch == '\t' {
-        4
-    } else {
-        // `None` (control/unassigned) defaults to one column; `Some(0)` (combining
-        // marks, ZWJ, zero-width spaces) must stay 0 so width math matches what the
-        // terminal renders. Mirrors `ui_text::char_display_width`.
-        UnicodeWidthChar::width(ch).unwrap_or(1)
-    }
 }
 
 fn truncate_display_width(text: &str, max_width: usize) -> String {

--- a/crates/tui/src/tui/widgets/pending_input_preview.rs
+++ b/crates/tui/src/tui/widgets/pending_input_preview.rs
@@ -17,7 +17,6 @@ use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
-use unicode_width::UnicodeWidthChar;
 
 use crate::palette;
 use crate::tui::widgets::Renderable;
@@ -352,10 +351,12 @@ fn wrap_to_width(text: &str, width: usize) -> Vec<String> {
     out
 }
 
+// Delegates to the canonical width contract (`ui_text::text_display_width`):
+// tabs are 4 columns and control chars occupy one, matching what the renderer
+// draws. The old local copy used `unwrap_or(0)` and ignored tabs, so preview
+// word-wrap disagreed with the real layout on those inputs (#3924).
 fn display_width(s: &str) -> usize {
-    s.chars()
-        .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
-        .sum()
+    crate::tui::ui_text::text_display_width(s)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

A batch of self-contained correctness/UX fixes triaged from the same-day adversarial audit of the merged v0.8.67 work. Each is its own commit; no version bump. The larger refactors and the design-essay items (#3930, #3937, #3934 A/B) are intentionally **not** here — they're held for maintainer direction.

Landed here:

- **#3929 — language picker omitted shipped locales.** Added `es-419`/`vi` as options 7–8 (digit handler resolves by hotkey char, no wiring change); corrected `OnboardLanguageFooter` to "1-8" across locales; guard tests enforce shipped-locale coverage + contiguous hotkeys.
- **#3924 — divergent display-width helper.** Collapsed three width impls onto `ui_text::{char_display_width, text_display_width}`; removed the `pending_input_preview` copy that mis-measured tabs/control chars.
- **#3918 — plugin enable/disable not persisted.** Overrides now persist to `~/.codewhale/plugins/overrides.json` and re-apply after discovery; soft-fail on write error; round-trip + rediscovery tests.
- **#3919 — skill names unreachable / silent shadowing.** Normalize/slugify discovered skill names so `/skill` dispatch resolves them; warn on cross-root duplicate shadowing.
- **#3920 — unenforced skills trust copy.** Removed the misleading `allowed-tools`/`/skill trust` messaging that implied sandboxing that isn't enforced.
- **#3926 / #3927 — onboarding key fixes.** Repaired the dead Enter key on the Trust step and the Esc step-counter on the API-key step (mechanical halves; the broader untrusted-continuation / offline-routing *design* questions are deferred).
- **#3928 — silent constitution-override failure.** A gated custom-constitution override now surfaces a visible notice instead of only a `tracing::warn`.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --locked -- -D warnings …` (matches CI Lint gate; green)
- [x] `cargo test --workspace` (per handoff verification) + targeted suites for each fix locally

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — covered by unit tests; not yet driven in a live terminal
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — n/a (all issues authored by the maintainer)

## Open review items

Two reviewer findings are still under maintainer consideration: the Enter-to-trust behavior on the onboarding Trust step (security/design), and a same-root skill-name collision-warning gap in #3919. See PR review threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)