### PR TITLE
fix(mcp): only advertise list-resource meta-tools when resources exist

### DIFF
--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -1915,7 +1915,13 @@ impl McpPool {
             });
         }
 
-        if !self.config.servers.is_empty() {
+        // Only advertise each resource-listing meta-tool when the servers actually
+        // expose the corresponding kind. Previously both were injected whenever any
+        // MCP server was configured, so tools-only servers left the model with
+        // meta-tools that can only ever return empty results — a wasted tool slot
+        // and prompt tokens. Gate each on its own non-empty collection, mirroring
+        // the `mcp_read_resource` guard below (`!resources.is_empty()`).
+        if !self.all_resources().is_empty() {
             api_tools.push(crate::models::Tool {
                 tool_type: None,
                 name: "list_mcp_resources".to_string(),
@@ -1932,6 +1938,8 @@ impl McpPool {
                 strict: None,
                 cache_control: None,
             });
+        }
+        if !self.all_resource_templates().is_empty() {
             api_tools.push(crate::models::Tool {
                 tool_type: None,
                 name: "list_mcp_resource_templates".to_string(),


### PR DESCRIPTION
## Problem

`list_mcp_resources` and `list_mcp_resource_templates` are injected into the model-visible tool catalog whenever **any** MCP server is configured (`!self.config.servers.is_empty()`), regardless of whether the configured servers actually expose any resources or resource templates.

For tools-only MCP servers — common in practice, e.g. a server that only implements `tools/list` + `tools/call` and returns `-32601 method not found` for `resources/list` — this means the model is permanently offered two meta-tools that can only ever return empty results. That wastes a tool slot and prompt tokens on every request, and can nudge smaller models into calling a no-op tool.

## Fix

Gate each meta-tool on its own non-empty collection (`all_resources()` / `all_resource_templates()`), mirroring the existing `mcp_read_resource` guard immediately below (`!resources.is_empty()`). Servers that do expose resources / templates are unaffected; tools-only servers simply no longer get the empty meta-tools.

## Notes

- No behavior change for servers that expose resources or templates.
- Existing tests unaffected: the `defer_loading` catalog tests construct `list_mcp_resources` directly via `api_tool(...)`, and `McpPool::is_mcp_tool(...)` classification is independent of injection.
- `cargo check -p codewhale-tui` passes.
