### PR TITLE
docs: align permissions.toml action docs

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1197,18 +1197,21 @@ If you are upgrading from older releases:
   with process-tree containment only and must not be described as read-only
   filesystem isolation, workspace-write enforcement, network blocking,
   registry isolation, or AppContainer isolation until those are implemented.
-- `permissions.toml` (sibling file, optional): ask-only typed permission rule
-  records loaded next to `config.toml`, for example
-  `~/.codewhale/permissions.toml`. This schema foundation accepts
-  `[[rules]]` entries with `tool` plus optional `command` or `path` fields.
-  Loaded rules feed the execution policy engine and force approval in
-  non-YOLO approval modes that can ask; under `approval_policy = "never"`,
-  matching ask rules are rejected because no prompt can be shown. YOLO / auto
-  approval retains complete freedom: ask rules do not downgrade YOLO into
-  prompting or blocking.
+- `permissions.toml` (sibling file, optional): typed permission rule records
+  loaded next to `config.toml`, for example `~/.codewhale/permissions.toml`.
+  Manually authored `[[rules]]` entries accept `tool`, optional `command` or
+  `path`, and optional `action = "deny" | "ask" | "allow"`; omitted `action`
+  defaults to `"ask"`. `deny` blocks matching invocations before mode-based
+  approval handling, `allow` skips approval for matching invocations, and
+  `ask` forces approval only in modes that can prompt. Outside the TUI
+  auto-approve path, a matching `ask` rule under `approval_policy = "never"`
+  is rejected because no prompt can be shown. In YOLO / auto-approval sessions,
+  `ask` rules do not downgrade the session into prompting or blocking; explicit
+  `deny` rules still block according to the current execution-policy logic.
 
   In a supported approval card, press `S` to approve the request once and
-  append exact ask rules to this file. Supported saves are intentionally narrow:
+  append exact `action = "ask"` rules to this file. Supported saves are
+  intentionally narrow:
   `exec_shell` stores the exact approved command string; `write_file` and
   `edit_file` store the exact workspace-relative file path; `apply_patch`
   stores one exact workspace-relative `path` rule per validated touched file
@@ -1217,10 +1220,10 @@ If you are upgrading from older releases:
   form used by runtime matching.
 
   `read_file` rules can still be authored manually when you want future reads
-  of a specific path to ask, but the approval UI does not save `read_file`
-  rules. This schema still does not accept typed allow/deny records, glob
-  expansion, broad directory/recursive rules, or UI editing/deleting of saved
-  rules.
+  of a specific path to ask, allow, or deny, but the approval UI does not save
+  `read_file` rules. The UI is not a policy editor: it does not save
+  `allow`/`deny`, edit or delete rules, expand globs, or create broad
+  directory/recursive rules.
 - `[[hotbar]]` (array of tables, optional): user-owned 1-8 slot bindings for
   the TUI hotbar. Each entry has `slot`, `action`, and optional `label`.
   Omitting `hotbar` uses the built-in default eight slots. Setting

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -78,16 +78,21 @@ stale rather than presented as live processes.
 
 Shell permission policy is evaluated by `crates/execpolicy`. Deny prefixes are
 checked before trusted prefixes and block matching commands regardless of layer.
-Trusted prefixes only skip approval in modes that permit trust shortcuts. Typed
-ask records are an ask-only layer: when one matches under
-`AskForApproval::Never`, the invocation is rejected because the runtime cannot
-ask the user; YOLO / auto approval keeps complete freedom and is not limited by
-ask rules. Existing allow/deny behavior is otherwise unchanged.
+Trusted prefixes only skip approval in modes that permit trust shortcuts.
+Manually authored `permissions.toml` records support
+`action = "deny" | "ask" | "allow"`: `deny` blocks matching invocations before
+mode-based approval handling, `allow` skips approval for matching invocations,
+and `ask` forces approval only in modes that can prompt. Outside the TUI
+auto-approve path, a matching `ask` rule under `AskForApproval::Never` is
+rejected because the runtime cannot ask the user. In YOLO / auto-approval
+sessions, `ask` rules do not downgrade the session into prompting or blocking;
+explicit `deny` rules still block according to the current execution-policy
+logic.
 
-The TUI runtime loads ask-only records from the sibling `permissions.toml` file
-and applies matching `exec_shell` command ask-rules and explicit file-path
-ask-rules in modes that can ask. In supported approval cards, `S` approves once
-and appends persistent ask rules:
+The TUI runtime loads typed records from the sibling `permissions.toml` file and
+applies matching `exec_shell` command rules and explicit file-path rules. In
+supported approval cards, `S` approves once and appends persistent
+`action = "ask"` rules:
 
 - `exec_shell`: the exact approved command string (matched by the existing
   arity-aware command matcher).
@@ -96,10 +101,10 @@ and appends persistent ask rules:
 - `apply_patch`: one exact workspace-relative path rule per validated touched
   file reported by apply-patch preflight.
 
-`read_file` path ask rules can be authored in `permissions.toml` and matched at
+`read_file` path rules can be authored in `permissions.toml` and matched at
 runtime, but the approval UI does not save `read_file` rules. This is still not
-a policy editor: no typed allow/deny records, glob expansion, broad directory
-rules, or UI edit/delete flow exist for saved ask rules.
+a policy editor: the UI does not save `allow`/`deny`, edit or delete rules,
+expand globs, or create broad directory rules.
 
 ### MCP manager and palette discovery
 


### PR DESCRIPTION
## Summary

Align permissions documentation with the current `permissions.toml` action schema.

## Scope

- Documents manually authored `action = "deny" | "ask" | "allow"` rules.
- Clarifies omitted `action` defaults to `ask`.
- Clarifies approval-card `S` still only saves exact `action = "ask"` rules.
- Clarifies the UI does not save `allow`/`deny`, edit/delete rules, expand globs, or create broad directory rules.
- Documents the YOLO/auto-approval boundary: `ask` does not downgrade YOLO/auto-approval into prompting or blocking, while explicit `deny` still blocks under current execution-policy behavior.

## Builds on

Current `upstream/main`.

## Issues

Refs #1186 (partial)  
Refs #2242 (partial)

## Validation

- `cargo fmt --all`
- `git diff --check`