### PR TITLE
feat(engine): expose context_input_budget_for_route for external budget reuse

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3905,10 +3905,13 @@ mod approval;
 mod context;
 mod handle;
 pub(crate) use context::compact_tool_result_for_context;
+/// Public so external hosts/wrappers can reuse the engine's input-budget math
+/// (see `context_input_budget_for_route`'s doc) instead of re-deriving it.
+pub use context::context_input_budget_for_route;
 #[cfg(test)]
 use context::route_context_budget_for_provider;
 use context::{
-    MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP, context_input_budget_for_route,
+    MAX_CONTEXT_RECOVERY_ATTEMPTS, MIN_RECENT_MESSAGES_TO_KEEP,
     effective_max_output_tokens_for_route, estimate_input_tokens_conservative,
     extract_compaction_summary_prompt, is_context_length_error_message,
     route_context_budget_for_route, summarize_text,

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -597,7 +597,13 @@ pub(super) fn context_input_budget_for_provider(
     context_input_budget_for_route(provider, model, None, 0)
 }
 
-pub(super) fn context_input_budget_for_route(
+/// Public so external callers (e.g. a host/bridge deriving its own compaction
+/// trigger line) can reuse the *exact* same internal input-budget math — window
+/// minus the window-dependent output reservation (`route_output_reservation_for_window`,
+/// which encodes the ≥500K→262K vs smaller-window split) minus headroom —
+/// instead of re-deriving those constants and silently drifting from the engine.
+/// Pass `input_tokens = 0` to get the full emergency input budget for the route.
+pub fn context_input_budget_for_route(
     provider: ApiProvider,
     model: &str,
     route_limits: Option<RouteLimits>,


### PR DESCRIPTION
## Problem

`context_input_budget_for_route` — the internal input-budget computation (`window − window-dependent output reservation − headroom`) that is the single source of truth for the preflight / emergency-recovery / capacity-trim decisions — is `pub(super)` to `core::engine`.

External hosts / wrappers that embed the engine and derive their own compaction or pressure trigger line have no way to reuse it, so they end up **mirroring the constants**: the `≥500K` large-window threshold, `TURN_MAX_OUTPUT_TOKENS`, the output-reservation split in `route_output_reservation_for_window`, and the headroom. When the engine later changes any of these, the mirrored copy still compiles but **silently diverges** — the host computes a different budget than the engine actually enforces. (In our case the host's "compact now" line drifted above the engine's emergency line, so the graceful summarize path stopped firing and every long session fell through to emergency recovery.)

## Change

Make `context_input_budget_for_route` `pub` and re-export it from `core::engine`, so a host can compute the **exact** same budget the engine uses. Pass `input_tokens = 0` to get the full route budget.

Purely a visibility change:
- No behavior change; the function body is untouched.
- All parameters and the return type are already public (`ApiProvider`, `RouteLimits`, `usize`).
- `cargo check -p codewhale-tui` passes.

This lets downstream embedders reuse the engine's budget math instead of re-deriving (and drifting from) its internal constants.
