### PR TITLE
Add per-sub-agent provider routing

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1758,6 +1758,12 @@ pub struct SubagentsConfig {
     /// provider names such as `deepseek`, `zai`, `openrouter`, or `anthropic`.
     #[serde(default)]
     pub providers: Option<HashMap<String, SubagentProviderConfig>>,
+    /// Explicit per-role/type provider routes (#3965). Keys accept the same
+    /// role/type names as `models`. A matching sub-agent spawns on the named
+    /// provider instead of inheriting the parent session's active provider;
+    /// roles without a route keep the legacy inherit behavior.
+    #[serde(default)]
+    pub routes: Option<HashMap<String, SubagentRouteConfig>>,
 }
 
 /// Provider-specific sub-agent limit overrides.
@@ -1782,6 +1788,19 @@ pub struct SubagentProviderConfig {
     pub api_timeout_secs: Option<u64>,
     #[serde(default)]
     pub heartbeat_timeout_secs: Option<u64>,
+}
+
+/// One `[subagents.routes.<role>]` entry (#3965): pins a sub-agent role or
+/// type to a specific provider, and optionally a model on that provider.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct SubagentRouteConfig {
+    /// Built-in provider id (`deepseek`, `ollama`, …) or the name of a
+    /// `[providers.<name>]` custom entry (e.g. an LM Studio endpoint).
+    pub provider: String,
+    /// Optional model on that provider. Unset uses the provider's saved or
+    /// default model.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// `[auto]` table — knobs for the `--model auto` / `/model auto` router.
@@ -3964,6 +3983,37 @@ impl Config {
         }
 
         overrides
+    }
+
+    /// Raw per-role/type sub-agent provider routes from `[subagents.routes]`
+    /// (#3965). Keys are normalized to lowercase; provider names are validated
+    /// at spawn time so a bad route fails that spawn, not the session.
+    #[must_use]
+    pub fn subagent_provider_routes(&self) -> HashMap<String, SubagentRouteConfig> {
+        let mut routes = HashMap::new();
+        let Some(configured) = self.subagents.as_ref().and_then(|cfg| cfg.routes.as_ref()) else {
+            return routes;
+        };
+        for (key, route) in configured {
+            let key = key.trim().to_ascii_lowercase();
+            let provider = route.provider.trim();
+            if key.is_empty() || provider.is_empty() {
+                continue;
+            }
+            routes.insert(
+                key,
+                SubagentRouteConfig {
+                    provider: provider.to_string(),
+                    model: route
+                        .model
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|model| !model.is_empty())
+                        .map(str::to_string),
+                },
+            );
+        }
+        routes
     }
 
     /// Return the configured DeepSeek reasoning-effort tier, if any.

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -1886,6 +1886,36 @@ fn max_subagents_clamps_subagents_max_concurrent() {
 }
 
 #[test]
+fn subagent_provider_routes_parse_and_normalize() {
+    // #3965: [subagents.routes.<role>] assigns a role/type to an explicit
+    // provider (and optional model), independent of the active provider.
+    let config: Config = toml::from_str(
+        r#"
+        provider = "deepseek"
+
+        [subagents.routes.Explore]
+        provider = "lm-studio"
+        model = " qwen-2.5-7b "
+
+        [subagents.routes.general]
+        provider = "deepseek"
+        "#,
+    )
+    .expect("routes table parses");
+
+    let routes = config.subagent_provider_routes();
+    let explore = routes.get("explore").expect("key is lowercased");
+    assert_eq!(explore.provider, "lm-studio");
+    assert_eq!(explore.model.as_deref(), Some("qwen-2.5-7b"));
+    let general = routes.get("general").expect("general route present");
+    assert_eq!(general.provider, "deepseek");
+    assert_eq!(general.model, None);
+
+    // No [subagents.routes] → empty map (sub-agents inherit the parent).
+    assert!(Config::default().subagent_provider_routes().is_empty());
+}
+
+#[test]
 fn subagents_enabled_reports_disable_precedence() {
     assert!(Config::default().subagents_enabled());
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -763,6 +763,22 @@ impl Engine {
         format!("{message}\n\n{hint}")
     }
 
+    /// Bundle `[subagents.routes]` with the current API config for sub-agent
+    /// runtimes (#3965). Rebuilt at each runtime construction so provider or
+    /// route changes made mid-session are picked up by the next spawn.
+    fn subagent_provider_routing(
+        &self,
+    ) -> Option<Arc<crate::tools::subagent::SubagentProviderRouting>> {
+        let routes = self.api_config.subagent_provider_routes();
+        if routes.is_empty() {
+            return None;
+        }
+        Some(Arc::new(crate::tools::subagent::SubagentProviderRouting {
+            routes,
+            config: self.api_config.clone(),
+        }))
+    }
+
     fn activate_runtime_route(&mut self, provider: ApiProvider, model: &str) -> Result<(), String> {
         if self.api_provider == provider
             && self
@@ -1458,6 +1474,7 @@ impl Engine {
                             Arc::clone(&self.subagent_manager),
                         )
                         .with_role_models(self.config.subagent_model_overrides.clone())
+                        .with_provider_routing(self.subagent_provider_routing())
                         .with_auto_model(self.session.auto_model)
                         .with_reasoning_effort(
                             self.session.reasoning_effort.clone(),
@@ -2510,6 +2527,7 @@ impl Engine {
                             Arc::clone(&self.subagent_manager),
                         )
                         .with_role_models(self.config.subagent_model_overrides.clone())
+                        .with_provider_routing(self.subagent_provider_routing())
                         .with_auto_model(self.session.auto_model)
                         .with_reasoning_effort(
                             self.session.reasoning_effort.clone(),

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -5863,7 +5863,10 @@ pub(crate) fn configured_provider_route_for_role_or_type<'a>(
     runtime: &'a SubAgentRuntime,
     role: Option<&str>,
     agent_type: &SubAgentType,
-) -> Option<(&'a crate::config::SubagentRouteConfig, &'a crate::config::Config)> {
+) -> Option<(
+    &'a crate::config::SubagentRouteConfig,
+    &'a crate::config::Config,
+)> {
     let routing = runtime.provider_routing.as_deref()?;
     let mut keys = Vec::new();
     if let Some(role) = role.map(str::trim).filter(|role| !role.is_empty()) {
@@ -5900,17 +5903,19 @@ pub(crate) fn subagent_client_for_provider_route(
              configured [providers.{provider_name}] custom entry"
         )));
     }
-    let route = crate::route_runtime::resolve_runtime_route(&route_config, provider, model_selector)
-        .map_err(|reason| {
-            ToolError::invalid_input(format!(
-                "subagents route provider '{provider_name}' failed to resolve: {reason}"
+    let route =
+        crate::route_runtime::resolve_runtime_route(&route_config, provider, model_selector)
+            .map_err(|reason| {
+                ToolError::invalid_input(format!(
+                    "subagents route provider '{provider_name}' failed to resolve: {reason}"
+                ))
+            })?;
+    let client =
+        DeepSeekClient::from_candidate(&route.config, &route.candidate).map_err(|err| {
+            ToolError::execution_failed(format!(
+                "subagents route provider '{provider_name}' client failed to initialize: {err}"
             ))
         })?;
-    let client = DeepSeekClient::from_candidate(&route.config, &route.candidate).map_err(|err| {
-        ToolError::execution_failed(format!(
-            "subagents route provider '{provider_name}' client failed to initialize: {err}"
-        ))
-    })?;
     Ok((client, route.model))
 }
 

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1429,6 +1429,19 @@ pub struct SubAgentForkContext {
     pub structured_state_block: Option<String>,
 }
 
+/// Explicit per-role/type provider routing for sub-agents (#3965). Bundles
+/// the raw `[subagents.routes]` map with the `Config` snapshot needed to
+/// construct a client for a routed provider at spawn time. Shared via `Arc`
+/// so per-child runtime clones stay cheap.
+pub struct SubagentProviderRouting {
+    /// Lowercased role/type keys → route, from
+    /// `Config::subagent_provider_routes`.
+    pub routes: HashMap<String, crate::config::SubagentRouteConfig>,
+    /// Config snapshot used to resolve provider endpoints/auth for routed
+    /// clients.
+    pub config: crate::config::Config,
+}
+
 /// Runtime configuration for spawning sub-agents.
 ///
 /// Carries everything a child needs to (a) build its own tool registry —
@@ -1444,6 +1457,10 @@ pub struct SubAgentRuntime {
     pub reasoning_effort: Option<String>,
     pub reasoning_effort_auto: bool,
     pub role_models: HashMap<String, String>,
+    /// Explicit per-role/type provider routes (#3965). `None` when no
+    /// `[subagents.routes]` are configured; matching roles then inherit the
+    /// parent's client as before.
+    pub provider_routing: Option<Arc<SubagentProviderRouting>>,
     pub context: ToolContext,
     pub allow_shell: bool,
     /// Native Agent-mode tool surface inherited from the parent turn. Carries
@@ -1532,6 +1549,7 @@ impl SubAgentRuntime {
             reasoning_effort: None,
             reasoning_effort_auto: false,
             role_models: HashMap::new(),
+            provider_routing: None,
             context,
             allow_shell,
             agent_tool_surface_options: AgentToolSurfaceOptions::new(
@@ -1657,6 +1675,15 @@ impl SubAgentRuntime {
         self
     }
 
+    /// Attach explicit per-role/type provider routes (#3965). Route provider
+    /// names are validated at spawn time so bad config fails that spawn with
+    /// a clear error instead of poisoning engine construction.
+    #[must_use]
+    pub fn with_provider_routing(mut self, routing: Option<Arc<SubagentProviderRouting>>) -> Self {
+        self.provider_routing = routing;
+        self
+    }
+
     /// Preserve whether the parent session is using per-turn model routing.
     #[must_use]
     pub fn with_auto_model(mut self, auto_model: bool) -> Self {
@@ -1709,6 +1736,7 @@ impl SubAgentRuntime {
             reasoning_effort: self.reasoning_effort.clone(),
             reasoning_effort_auto: self.reasoning_effort_auto,
             role_models: self.role_models.clone(),
+            provider_routing: self.provider_routing.clone(),
             context: child_context,
             allow_shell: self.allow_shell,
             agent_tool_surface_options: self.agent_tool_surface_options.clone(),
@@ -3888,17 +3916,33 @@ async fn spawn_subagent_from_input(
     if let Some(workspace) = child_workspace {
         child_runtime.context.workspace = workspace;
     }
-    let configured_model = match spawn_request.model.clone() {
-        Some(model) => Some(normalize_requested_subagent_model(
-            &model,
-            "model",
-            runtime.client.api_provider(),
-        )?),
-        None => configured_model_for_role_or_type(
-            &runtime,
-            spawn_request.assignment.role.as_deref(),
-            &spawn_request.agent_type,
-        )?,
+    let provider_route = configured_provider_route_for_role_or_type(
+        &runtime,
+        spawn_request.assignment.role.as_deref(),
+        &spawn_request.agent_type,
+    );
+    let configured_model = if let Some((route, base_config)) = provider_route {
+        // #3965: explicit per-role provider routing. The per-call `model`
+        // still wins over the route's configured model; either selector is
+        // validated against the routed provider by the route resolver.
+        let selector = spawn_request.model.as_deref().or(route.model.as_deref());
+        let (client, model) =
+            subagent_client_for_provider_route(base_config, &route.provider, selector)?;
+        child_runtime.client = client;
+        Some(model)
+    } else {
+        match spawn_request.model.clone() {
+            Some(model) => Some(normalize_requested_subagent_model(
+                &model,
+                "model",
+                runtime.client.api_provider(),
+            )?),
+            None => configured_model_for_role_or_type(
+                &runtime,
+                spawn_request.assignment.role.as_deref(),
+                &spawn_request.agent_type,
+            )?,
+        }
     };
     let (effective_prompt, _resident_conflict) =
         if let Some(ref file_path) = spawn_request.resident_file {
@@ -3930,8 +3974,11 @@ async fn spawn_subagent_from_input(
             (spawn_request.prompt, None)
         };
 
+    // Resolve against `child_runtime`: identical to `runtime` on the inherit
+    // path, but carries the routed client when a provider route applied so
+    // reasoning-effort rules see the provider the child will actually use.
     let route = resolve_subagent_assignment_route(
-        &runtime,
+        &child_runtime,
         configured_model,
         &effective_prompt,
         &spawn_request.agent_type,
@@ -5807,6 +5854,64 @@ pub(crate) fn configured_model_for_role_or_type(
         }
     }
     Ok(None)
+}
+
+/// Look up an explicit `[subagents.routes]` provider route for a spawn,
+/// using the same role → type → `default` key precedence as
+/// `configured_model_for_role_or_type` (#3965).
+pub(crate) fn configured_provider_route_for_role_or_type<'a>(
+    runtime: &'a SubAgentRuntime,
+    role: Option<&str>,
+    agent_type: &SubAgentType,
+) -> Option<(&'a crate::config::SubagentRouteConfig, &'a crate::config::Config)> {
+    let routing = runtime.provider_routing.as_deref()?;
+    let mut keys = Vec::new();
+    if let Some(role) = role.map(str::trim).filter(|role| !role.is_empty()) {
+        keys.push(role.to_ascii_lowercase());
+    }
+    keys.push(agent_type.as_str().to_string());
+    keys.push("default".to_string());
+
+    keys.into_iter()
+        .find_map(|key| routing.routes.get(&key))
+        .map(|route| (route, &routing.config))
+}
+
+/// Build a client bound to an explicitly routed provider (#3965). The route
+/// resolver validates the model against the target provider and binds the
+/// endpoint/auth from that provider's config, so a routed sub-agent talks to
+/// its own provider regardless of the parent session's active one.
+pub(crate) fn subagent_client_for_provider_route(
+    base_config: &crate::config::Config,
+    provider_name: &str,
+    model_selector: Option<&str>,
+) -> Result<(DeepSeekClient, String), ToolError> {
+    let mut route_config = base_config.clone();
+    route_config.provider = Some(provider_name.to_string());
+    let provider = route_config.api_provider();
+    // An unknown provider name silently falls back to DeepSeek inside
+    // api_provider(); reject it here so a typo'd route fails loudly instead
+    // of misrouting to the wrong provider.
+    if crate::config::ApiProvider::parse(provider_name).is_none()
+        && provider != crate::config::ApiProvider::Custom
+    {
+        return Err(ToolError::invalid_input(format!(
+            "subagents route provider '{provider_name}' is not a built-in provider or a \
+             configured [providers.{provider_name}] custom entry"
+        )));
+    }
+    let route = crate::route_runtime::resolve_runtime_route(&route_config, provider, model_selector)
+        .map_err(|reason| {
+            ToolError::invalid_input(format!(
+                "subagents route provider '{provider_name}' failed to resolve: {reason}"
+            ))
+        })?;
+    let client = DeepSeekClient::from_candidate(&route.config, &route.candidate).map_err(|err| {
+        ToolError::execution_failed(format!(
+            "subagents route provider '{provider_name}' client failed to initialize: {err}"
+        ))
+    })?;
+    Ok((client, route.model))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4008,6 +4008,7 @@ fn stub_runtime() -> SubAgentRuntime {
         reasoning_effort: None,
         reasoning_effort_auto: false,
         role_models: std::collections::HashMap::new(),
+        provider_routing: None,
         context,
         allow_shell: true,
         agent_tool_surface_options: AgentToolSurfaceOptions::new(ShellPolicy::Full),
@@ -4863,6 +4864,122 @@ fn role_model_validation_accepts_provider_native_ids() {
     let model = configured_model_for_role_or_type(&runtime, Some("worker"), &SubAgentType::General)
         .expect("provider-native id is accepted");
     assert_eq!(model.as_deref(), Some("kimi-k2.5"));
+}
+
+// ---- #3965 per-role explicit provider routing ----
+
+fn lm_studio_route_config() -> crate::config::Config {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let mut custom = std::collections::HashMap::new();
+    custom.insert(
+        "lm-studio".to_string(),
+        crate::config::ProviderConfig {
+            kind: Some("openai-compatible".to_string()),
+            base_url: Some("http://localhost:1234/v1".to_string()),
+            api_key: Some("lm-studio".to_string()),
+            ..Default::default()
+        },
+    );
+    crate::config::Config {
+        provider: Some("deepseek".to_string()),
+        api_key: Some("test-key".to_string()),
+        providers: Some(crate::config::ProvidersConfig {
+            custom,
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn runtime_with_explore_route() -> SubAgentRuntime {
+    let mut runtime = stub_runtime();
+    let mut routes = std::collections::HashMap::new();
+    routes.insert(
+        "explore".to_string(),
+        crate::config::SubagentRouteConfig {
+            provider: "lm-studio".to_string(),
+            model: Some("qwen-2.5-7b".to_string()),
+        },
+    );
+    runtime.provider_routing = Some(Arc::new(SubagentProviderRouting {
+        routes,
+        config: lm_studio_route_config(),
+    }));
+    runtime
+}
+
+#[test]
+fn role_provider_route_builds_client_on_routed_provider() {
+    // AC (#3965): [subagents.routes.explore] provider = "lm-studio" builds the
+    // child's client against the LM Studio custom endpoint — with the route's
+    // model — while the parent session stays on DeepSeek.
+    let runtime = runtime_with_explore_route();
+
+    let (route, base_config) = configured_provider_route_for_role_or_type(
+        &runtime,
+        Some("Explore"),
+        &SubAgentType::General,
+    )
+    .expect("role has an explicit provider route (case-insensitive key)");
+    assert_eq!(route.provider, "lm-studio");
+
+    let (client, model) =
+        subagent_client_for_provider_route(base_config, &route.provider, route.model.as_deref())
+            .expect("routed client builds against the custom endpoint");
+    assert_eq!(client.api_provider(), crate::config::ApiProvider::Custom);
+    assert_eq!(client.base_url(), "http://localhost:1234/v1");
+    assert_eq!(model, "qwen-2.5-7b");
+    assert_eq!(
+        runtime.client.api_provider(),
+        crate::config::ApiProvider::Deepseek,
+        "parent client is untouched by the child's route"
+    );
+}
+
+#[test]
+fn role_without_provider_route_inherits_parent() {
+    // Fallback AC (#3965): roles without a route keep the legacy behavior —
+    // no route resolves, so the spawn path inherits the parent's client.
+    let runtime = runtime_with_explore_route();
+    assert!(
+        configured_provider_route_for_role_or_type(
+            &runtime,
+            Some("general"),
+            &SubAgentType::General,
+        )
+        .is_none()
+    );
+
+    let unrouted = stub_runtime();
+    assert!(
+        configured_provider_route_for_role_or_type(
+            &unrouted,
+            Some("explore"),
+            &SubAgentType::Explore,
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn provider_route_with_unknown_provider_fails_clearly() {
+    // Graceful-error AC (#3965): a route naming a provider that is neither
+    // built-in nor a configured [providers.<name>] entry must fail the spawn
+    // with a clear error instead of silently falling back to DeepSeek.
+    let err = match subagent_client_for_provider_route(
+        &lm_studio_route_config(),
+        "no-such-provider",
+        None,
+    ) {
+        Ok(_) => panic!("unknown provider must be rejected"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("no-such-provider"), "names the bad provider: {msg}");
+    assert!(
+        msg.contains("[providers.no-such-provider]"),
+        "points at the custom-provider config path: {msg}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4975,7 +4975,10 @@ fn provider_route_with_unknown_provider_fails_clearly() {
         Err(err) => err,
     };
     let msg = err.to_string();
-    assert!(msg.contains("no-such-provider"), "names the bad provider: {msg}");
+    assert!(
+        msg.contains("no-such-provider"),
+        "names the bad provider: {msg}"
+    );
     assert!(
         msg.contains("[providers.no-such-provider]"),
         "points at the custom-provider config path: {msg}"

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -331,6 +331,39 @@ OpenRouter, Novita, SiliconFlow, SGLang, vLLM) route between that pair;
 providers without a known cheap tier (e.g. Ollama, Moonshot) skip the
 network router and keep children on the session model.
 
+## Per-role provider routes (#3965)
+
+`[subagents.routes.<role>]` pins a role (or type — same keys as
+`[subagents.models]`, case-insensitive) to an explicit provider, and
+optionally a model on that provider. A matching spawn builds its own client
+against that provider's endpoint/auth, regardless of the parent session's
+active provider. Roles without a route inherit the parent as before.
+
+`provider` accepts any built-in provider id (`deepseek`, `ollama`, …) or the
+name of a `[providers.<name>]` custom entry — which is how LM Studio's
+OpenAI-compatible endpoint plugs in:
+
+```toml
+[providers.lm-studio]
+kind     = "openai-compatible"
+base_url = "http://localhost:1234/v1"
+api_key  = "lm-studio"            # LM Studio ignores it, but a value must exist
+
+[subagents.routes.explore]
+provider = "lm-studio"            # local for cheap, fast operations
+model    = "qwen-2.5-7b"
+
+[subagents.routes.general]
+provider = "deepseek"             # cloud for complex reasoning
+model    = "deepseek-v4-flash"
+```
+
+A per-call explicit `model` on `agent` still wins over the route's `model`;
+both are validated against the routed provider. A route naming a provider
+that is neither built-in nor configured fails that spawn with a clear error
+(no silent DeepSeek fallback). When a route applies, it takes precedence over
+the `[subagents.models]` map for that role.
+
 ## Per-step API timeout (#1806, #1808)
 
 Each sub-agent step wraps its DeepSeek `create_message` call in a


### PR DESCRIPTION
## Summary

> **Status:** held for the **v0.8.68 fleet lane** per maintainer triage — the
> branch is currently dirty against `main` and targets the pre-#4093 spawn path.
> Recommended path: **rebase and re-route through fleet profile fields** (not
> close): #4137 covers per-profile provider/model/thinking *authoring*, but the
> #3965 acceptance also needs the *resolution* side this PR builds — a validated
> provider-name → client route for custom (LM Studio-style) endpoints with a
> loud failure on unknown providers. Re-landing plan below.

### Re-landing plan (post-#4093 fleet surface)

What maps where when this is rebased onto the fleet taxonomy (#4136/#4137):

- **Survives as-is (redesign-agnostic):** `subagent_client_for_provider_route()`
  — provider name (built-in id or `[providers.<name>]` custom entry) → validated
  client + wire model via the #3830 route resolver + `from_candidate`, with the
  explicit unknown-provider rejection. This is the dispatch-time primitive an
  `AgentProfile` `provider` field needs regardless of where the field lives;
  `FleetProfile.model` is documented as "not an auth or endpoint selector", and
  this supplies exactly that missing executable decision. The four regression
  tests and the LM Studio docs example carry over with it.
- **Re-expressed on the fleet surface:** the `[subagents.routes.<role>]` keying
  (role→type→default) becomes a `provider` field on AgentProfile authoring
  alongside the existing `model` / `model_class_hint` / `route_tier`, resolved in
  the fleet worker-assignment route resolution instead of the legacy
  `spawn_subagent_from_input` hook.
- **Dropped in the rebase:** the pre-fleet spawn-path client swap and the
  `SubagentProviderRouting` runtime bundle, if the fleet dispatch path already
  carries the config snapshot needed to build routed clients.

If #4137 grows to fully cover explicit provider assignment including custom
endpoints and the graceful-failure acceptance, closing this in its favor (with
the primitive + tests harvested) is equally fine.

Adds explicit per-sub-agent provider routing (#3965): a new
`[subagents.routes.<role>]` config table pins a sub-agent role or type to a
specific provider — and optionally a model — so one session can, for example,
run `explore`/`format` children on a local LM Studio endpoint while `general`
runs on DeepSeek, with no manual provider switching.

```toml
[providers.lm-studio]
kind     = "openai-compatible"
base_url = "http://localhost:1234/v1"
api_key  = "lm-studio"

[subagents.routes.explore]
provider = "lm-studio"
model    = "qwen-2.5-7b"

[subagents.routes.general]
provider = "deepseek"
model    = "deepseek-v4-flash"
```

How it works:

- `config.rs`: new `SubagentRouteConfig` + `routes` table on `SubagentsConfig`,
  exposed via `Config::subagent_provider_routes()` (lowercased keys, trimmed
  values). Same role/type/`default` key precedence as `[subagents.models]`.
- `tools/subagent/mod.rs`: `SubAgentRuntime` carries an
  `Option<Arc<SubagentProviderRouting>>` bundle (routes + config snapshot).
  At spawn, a matching route builds the child's client through the existing
  #3830 route resolver (`route_runtime::resolve_runtime_route` +
  `DeepSeekClient::from_candidate`) — the same path `/provider` switching
  uses — and swaps it into the child runtime. The routed client drops with
  the child; no new auth/client-lifecycle machinery.
- `core/engine.rs`: routing bundle is rebuilt from `api_config` at each
  runtime construction, so mid-session `/provider` changes are picked up.
- Backward compatible: roles without a route inherit the parent's client on
  the unchanged legacy path. A per-call explicit `model` still wins over the
  route's model; both validate against the routed provider. A route naming a
  provider that is neither built-in nor a `[providers.<name>]` custom entry
  fails that spawn with a clear error instead of silently falling back to
  DeepSeek.
- `docs/SUBAGENTS.md`: new "Per-role provider routes (#3965)" section with the
  LM Studio example above.

### Scope boundary

This PR stays single-purpose: explicit provider/model assignment only.
Intentionally out of scope, as follow-ups once the fleet redesign settles the
taxonomy:

- First-class LM Studio detection — the #3861 custom-provider form already
  covers LM Studio; the missing piece was routing, which this PR adds.
- Semantic routing hints (`cheapest` / `fastest` / capability tiers) and
  keyword or complexity-based auto-routing — these belong to the new fleet
  `SubagentDefinition` design (#3935) so per-role routing isn't designed
  twice. The explicit `provider`+`model` route here is the primitive those
  can resolve onto.
- Per-role `tool_restrictions` — consensus in review is that capability
  boundaries live in the fleet configuration layer, not the routing config;
  now tracked separately in #4042 (relates to #4032).

Closes #3965

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-features`

New regression tests (all green; suite: 5727 passed / 0 failed):

- `config::tests::subagent_provider_routes_parse_and_normalize` — TOML parsing
  and key/value normalization for `[subagents.routes]`.
- `tools::subagent::tests::role_provider_route_builds_client_on_routed_provider`
  — the issue's headline scenario: parent on DeepSeek, `explore` routed to an
  LM Studio-style custom provider; asserts the routed client binds to
  `http://localhost:1234/v1` with the route's model while the parent client is
  untouched.
- `tools::subagent::tests::role_without_provider_route_inherits_parent` —
  unrouted roles keep the legacy inherit behavior.
- `tools::subagent::tests::provider_route_with_unknown_provider_fails_clearly`
  — unknown provider is rejected with an error naming it and pointing at the
  `[providers.<name>]` config path.

## Checklist

- [x] Updated docs or comments as needed (`docs/SUBAGENTS.md` section + doc
      comments on all new config/runtime surfaces)
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (no UI changes — config,
      spawn path, and engine wiring only)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address (not
      a harvest — original work for #3965)
