### PR TITLE
fix(subagent): keep Codex OAuth fanout actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   active Codex OAuth file, Responses API child requests encode inherited tool
   names safely, and rate-limited Codex child requests checkpoint as resumable
   provider interruptions instead of terminal opaque failures (#3884).
+- Fixed fresh launch/setup testing with an explicit `CODEWHALE_HOME` so config,
+  settings, theme prefs, and doctor legacy-state diagnostics do not inherit
+  unrelated ambient `~/.deepseek` files.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the Homebrew rollout strategy and added a distribution-channel
   check to the release checklist. Harvested from #3760 by @idling11.
 
+### Fixed
+
+- Fixed Codex OAuth/sub-agent release diagnostics so `auth list` reports an
+  active Codex OAuth file, Responses API child requests encode inherited tool
+  names safely, and rate-limited Codex child requests checkpoint as resumable
+  provider interruptions instead of terminal opaque failures (#3884).
+
 ### Removed
 
 - Removed unused model-registry helpers. Harvested from #3872 by @cyq1017.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1140,6 +1140,42 @@ fn auth_status_all_providers(store: &ConfigStore, secrets: &Secrets) -> Vec<Stri
     lines
 }
 
+fn auth_list_lines(store: &ConfigStore, secrets: &Secrets) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push("provider     config store env  active".to_string());
+    for provider in ProviderKind::ALL {
+        let slot = provider_slot(provider);
+        let file = provider_config_set(store, provider);
+        let keyring = (!file).then(|| provider_keyring_set(secrets, provider));
+        let env = provider_env_set(provider);
+        let oauth_file = provider_oauth_file_path(provider).is_some_and(|p| p.exists());
+        let active = if provider == ProviderKind::OpenaiCodex {
+            if env {
+                "env"
+            } else if oauth_file {
+                "oauth"
+            } else {
+                "missing"
+            }
+        } else if file {
+            "config"
+        } else if keyring == Some(true) {
+            "store"
+        } else if env {
+            "env"
+        } else {
+            "missing"
+        };
+        lines.push(format!(
+            "{slot:<12}  {}     {}      {}   {active}",
+            yes_no(file),
+            keyring_status_short(keyring),
+            yes_no(env)
+        ));
+    }
+    lines
+}
+
 fn auth_status_lines_for_provider(
     store: &ConfigStore,
     secrets: &Secrets,
@@ -1346,27 +1382,8 @@ fn run_auth_command_with_secrets(
             Ok(())
         }
         AuthCommand::List => {
-            println!("provider     config store env  active");
-            for provider in ProviderKind::ALL {
-                let slot = provider_slot(provider);
-                let file = provider_config_set(store, provider);
-                let keyring = (!file).then(|| provider_keyring_set(secrets, provider));
-                let env = provider_env_set(provider);
-                let active = if file {
-                    "config"
-                } else if keyring == Some(true) {
-                    "store"
-                } else if env {
-                    "env"
-                } else {
-                    "missing"
-                };
-                println!(
-                    "{slot:<12}  {}     {}      {}   {active}",
-                    yes_no(file),
-                    keyring_status_short(keyring),
-                    yes_no(env)
-                );
+            for line in auth_list_lines(store, secrets) {
+                println!("{line}");
             }
             Ok(())
         }
@@ -3615,6 +3632,36 @@ mod tests {
             "Codex OAuth file: {} (present)",
             auth_path.display()
         )));
+        assert!(!output.contains("secret-token"));
+    }
+
+    #[test]
+    fn auth_list_treats_openai_codex_oauth_file_as_active() {
+        use codewhale_secrets::InMemoryKeyringStore;
+        use std::sync::Arc;
+
+        let _lock = env_lock();
+        let _access_token = ScopedEnvVar::set("OPENAI_CODEX_ACCESS_TOKEN", "");
+        let _codex_token = ScopedEnvVar::set("CODEX_ACCESS_TOKEN", "");
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let config_path = dir.path().join("config.toml");
+        let auth_path = dir.path().join("auth.json");
+        std::fs::write(&auth_path, r#"{"tokens":{"access_token":"secret-token"}}"#)
+            .expect("write auth file");
+        let auth_path_str = auth_path.to_string_lossy().into_owned();
+        let _auth_file = ScopedEnvVar::set("OPENAI_CODEX_AUTH_FILE", &auth_path_str);
+
+        let mut store = ConfigStore::load(Some(config_path)).expect("store should load");
+        store.config.provider = ProviderKind::OpenaiCodex;
+        let secrets = Secrets::new(Arc::new(InMemoryKeyringStore::new()));
+
+        let output = auth_list_lines(&store, &secrets).join("\n");
+        let row = output
+            .lines()
+            .find(|line| line.starts_with("openai-codex"))
+            .unwrap_or_else(|| panic!("missing openai-codex row:\n{output}"));
+        assert!(row.ends_with("oauth"), "{row}");
         assert!(!output.contains("secret-token"));
     }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3296,6 +3296,14 @@ fn codewhale_home_env_override() -> Option<PathBuf> {
     }
 }
 
+/// Whether `$CODEWHALE_HOME` is set to a non-empty value.
+///
+/// An explicit CodeWhale home is an isolation boundary: state/config resolvers
+/// must not fall back to ambient legacy `~/.deepseek` data outside that root.
+pub fn codewhale_home_is_explicit() -> bool {
+    codewhale_home_env_override().is_some()
+}
+
 /// Resolve the legacy DeepSeek home directory (`$HOME/.deepseek`).
 ///
 /// Always returns the legacy path regardless of whether it exists.
@@ -3715,7 +3723,7 @@ pub fn default_config_path() -> Result<PathBuf> {
     // Prefer ~/.codewhale/config.toml when it exists (fresh install or
     // migrated), otherwise fall back to ~/.deepseek/config.toml.
     let primary = codewhale_home()?.join(CONFIG_FILE_NAME);
-    if primary.exists() {
+    if codewhale_home_is_explicit() || primary.exists() {
         return Ok(primary);
     }
     let legacy = legacy_deepseek_home()?.join(CONFIG_FILE_NAME);
@@ -3747,6 +3755,9 @@ impl ConfigMigration {
 /// is loaded; copies the legacy file if the primary doesn't exist yet.
 /// Never overwrites an existing primary config.
 pub fn migrate_config_if_needed() -> Result<Option<ConfigMigration>> {
+    if codewhale_home_is_explicit() {
+        return Ok(None);
+    }
     let primary = codewhale_home()?.join(CONFIG_FILE_NAME);
     if primary.exists() {
         return Ok(None);

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -2219,39 +2219,13 @@ fn list_values_redacts_unicode_api_key_without_byte_slicing() {
 #[test]
 fn app_homes_prefer_home_env_before_platform_home_fallback() {
     let _lock = env_lock();
-    struct HomeEnvGuard {
-        home: Option<OsString>,
-        userprofile: Option<OsString>,
-        codewhale_home: Option<OsString>,
-    }
-
-    impl Drop for HomeEnvGuard {
-        fn drop(&mut self) {
-            // Safety: test-only environment mutation is serialized by env_lock().
-            unsafe {
-                match self.home.take() {
-                    Some(value) => env::set_var("HOME", value),
-                    None => env::remove_var("HOME"),
-                }
-                match self.userprofile.take() {
-                    Some(value) => env::set_var("USERPROFILE", value),
-                    None => env::remove_var("USERPROFILE"),
-                }
-                match self.codewhale_home.take() {
-                    Some(value) => env::set_var("CODEWHALE_HOME", value),
-                    None => env::remove_var("CODEWHALE_HOME"),
-                }
-            }
-        }
-    }
-
     let home =
         std::env::temp_dir().join(format!("codewhale-config-home-env-{}", std::process::id()));
     let userprofile = std::env::temp_dir().join(format!(
         "codewhale-config-userprofile-{}",
         std::process::id()
     ));
-    let _env = HomeEnvGuard {
+    let _env = StateEnvRestore {
         home: env::var_os("HOME"),
         userprofile: env::var_os("USERPROFILE"),
         codewhale_home: env::var_os("CODEWHALE_HOME"),
@@ -2286,32 +2260,6 @@ fn app_homes_prefer_home_env_before_platform_home_fallback() {
 #[test]
 fn migrate_config_reports_copied_legacy_path() {
     let _lock = env_lock();
-    struct HomeEnvGuard {
-        home: Option<OsString>,
-        userprofile: Option<OsString>,
-        codewhale_home: Option<OsString>,
-    }
-
-    impl Drop for HomeEnvGuard {
-        fn drop(&mut self) {
-            // Safety: test-only environment mutation is serialized by env_lock().
-            unsafe {
-                match self.home.take() {
-                    Some(value) => env::set_var("HOME", value),
-                    None => env::remove_var("HOME"),
-                }
-                match self.userprofile.take() {
-                    Some(value) => env::set_var("USERPROFILE", value),
-                    None => env::remove_var("USERPROFILE"),
-                }
-                match self.codewhale_home.take() {
-                    Some(value) => env::set_var("CODEWHALE_HOME", value),
-                    None => env::remove_var("CODEWHALE_HOME"),
-                }
-            }
-        }
-    }
-
     struct LegacyConfigGuard {
         path: PathBuf,
         original: Option<Vec<u8>>,
@@ -2352,7 +2300,7 @@ fn migrate_config_reports_copied_legacy_path() {
     let legacy_config = legacy_dir.join(CONFIG_FILE_NAME);
     let _legacy = LegacyConfigGuard::install(legacy_config.clone(), b"provider = \"deepseek\"\n");
 
-    let _env = HomeEnvGuard {
+    let _env = StateEnvRestore {
         home: env::var_os("HOME"),
         userprofile: env::var_os("USERPROFILE"),
         codewhale_home: env::var_os("CODEWHALE_HOME"),
@@ -2361,7 +2309,7 @@ fn migrate_config_reports_copied_legacy_path() {
     unsafe {
         env::set_var("HOME", &home);
         env::set_var("USERPROFILE", &home);
-        env::set_var("CODEWHALE_HOME", &primary_dir);
+        env::remove_var("CODEWHALE_HOME");
     }
 
     let migration = migrate_config_if_needed()
@@ -2378,6 +2326,53 @@ fn migrate_config_reports_copied_legacy_path() {
     assert_eq!(
         fs::read_to_string(primary_dir.join(CONFIG_FILE_NAME)).expect("primary config"),
         "provider = \"deepseek\"\n"
+    );
+
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn explicit_codewhale_home_bypasses_legacy_config_fallback_and_migration() {
+    let _lock = env_lock();
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let home = std::env::temp_dir().join(format!(
+        "codewhale-config-explicit-isolation-{}-{unique}",
+        std::process::id()
+    ));
+    let legacy_config = home.join(LEGACY_APP_DIR).join(CONFIG_FILE_NAME);
+    fs::create_dir_all(legacy_config.parent().expect("legacy config parent")).expect("legacy dir");
+    fs::write(&legacy_config, b"provider = \"deepseek\"\n").expect("legacy config");
+
+    let explicit_home = home.join("isolated-codewhale");
+    let _env = StateEnvRestore {
+        home: env::var_os("HOME"),
+        userprofile: env::var_os("USERPROFILE"),
+        codewhale_home: env::var_os("CODEWHALE_HOME"),
+    };
+    // Safety: test-only environment mutation is serialized by env_lock().
+    unsafe {
+        env::set_var("HOME", &home);
+        env::set_var("USERPROFILE", &home);
+        env::set_var("CODEWHALE_HOME", &explicit_home);
+    }
+
+    assert_eq!(
+        default_config_path().expect("default config path"),
+        explicit_home.join(CONFIG_FILE_NAME),
+        "explicit CODEWHALE_HOME must not read ambient legacy config"
+    );
+    assert!(
+        migrate_config_if_needed()
+            .expect("migration check")
+            .is_none(),
+        "explicit CODEWHALE_HOME must not migrate ambient legacy config"
+    );
+    assert!(
+        !explicit_home.join(CONFIG_FILE_NAME).exists(),
+        "legacy config must not be copied into explicit CODEWHALE_HOME"
     );
 
     let _ = fs::remove_dir_all(home);

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   active Codex OAuth file, Responses API child requests encode inherited tool
   names safely, and rate-limited Codex child requests checkpoint as resumable
   provider interruptions instead of terminal opaque failures (#3884).
+- Fixed fresh launch/setup testing with an explicit `CODEWHALE_HOME` so config,
+  settings, theme prefs, and doctor legacy-state diagnostics do not inherit
+  unrelated ambient `~/.deepseek` files.
 
 ### Removed
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the Homebrew rollout strategy and added a distribution-channel
   check to the release checklist. Harvested from #3760 by @idling11.
 
+### Fixed
+
+- Fixed Codex OAuth/sub-agent release diagnostics so `auth list` reports an
+  active Codex OAuth file, Responses API child requests encode inherited tool
+  names safely, and rate-limited Codex child requests checkpoint as resumable
+  provider interruptions instead of terminal opaque failures (#3884).
+
 ### Removed
 
 - Removed unused model-registry helpers. Harvested from #3872 by @cyq1017.

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -18,7 +18,10 @@ use crate::models::{
 };
 use crate::tools::schema_sanitize;
 
-use super::{DeepSeekClient, ERROR_BODY_MAX_BYTES, bounded_error_text, system_to_instructions};
+use super::{
+    DeepSeekClient, ERROR_BODY_MAX_BYTES, bounded_error_text, from_api_tool_name,
+    system_to_instructions, to_api_tool_name,
+};
 
 /// Base URL path for the Codex Responses endpoint.
 const CODEX_RESPONSES_PATH: &str = "/codex/responses";
@@ -235,7 +238,7 @@ impl DeepSeekClient {
                                                 content_block:
                                                     ContentBlockStart::ToolUse {
                                                         id: composite_id,
-                                                        name,
+                                                        name: from_api_tool_name(&name),
                                                         input: json!({}),
                                                         caller: None,
                                                     },
@@ -546,7 +549,7 @@ fn convert_messages_to_responses_input(request: &MessageRequest) -> Vec<Value> {
                             items.push(json!({
                                 "type": "function_call",
                                 "call_id": call_id,
-                                "name": name,
+                                "name": to_api_tool_name(name),
                                 "arguments": serde_json::to_string(input).unwrap_or_default(),
                             }));
                         }
@@ -598,7 +601,7 @@ fn tool_to_responses_function(tool: &Tool) -> Value {
     };
     json!({
         "type": "function",
-        "name": tool.name,
+        "name": to_api_tool_name(&tool.name),
         "description": description,
         "parameters": parameters,
         "strict": false,
@@ -1087,16 +1090,48 @@ mod tests {
 
         assert_eq!(input[0]["type"], "function_call");
         assert_eq!(input[0]["call_id"], "call_abc");
+        assert_eq!(input[0]["name"], "checklist_write");
         assert_eq!(input[1]["type"], "function_call_output");
         assert_eq!(input[1]["call_id"], "call_abc");
         assert_eq!(input[1]["output"], "<6 items>");
     }
 
     #[test]
+    fn responses_input_encodes_tool_call_names() {
+        let request = MessageRequest {
+            model: "gpt-5.5".to_string(),
+            messages: vec![Message {
+                role: "assistant".to_string(),
+                content: vec![ContentBlock::ToolUse {
+                    id: "call_abc|fc_123".to_string(),
+                    name: "web.run".to_string(),
+                    input: json!({}),
+                    caller: None,
+                }],
+            }],
+            max_tokens: 128,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            stream: None,
+            temperature: None,
+            top_p: None,
+        };
+
+        let input = convert_messages_to_responses_input(&request);
+
+        assert_eq!(input[0]["type"], "function_call");
+        assert_eq!(input[0]["name"], to_api_tool_name("web.run"));
+    }
+
+    #[test]
     fn responses_function_tool_sanitizes_root_composition_schema() {
         let tool = Tool {
             tool_type: None,
-            name: "apply_patch".to_string(),
+            name: "web.run".to_string(),
             description: "Apply patch".to_string(),
             input_schema: json!({
                 "type": "object",
@@ -1119,6 +1154,7 @@ mod tests {
         let payload = tool_to_responses_function(&tool);
         let parameters = &payload["parameters"];
 
+        assert_eq!(payload["name"], to_api_tool_name("web.run"));
         assert_eq!(parameters["type"], "object");
         assert!(parameters.get("oneOf").is_none());
         assert!(parameters.get("anyOf").is_none());

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -583,9 +583,14 @@ pub(crate) fn config_toml_path(config_path: Option<&Path>) -> anyhow::Result<Pat
             return Ok(PathBuf::from(trimmed));
         }
     }
+    let codewhale_home = codewhale_config::codewhale_home()
+        .context("failed to resolve CodeWhale home for config.toml path")?;
+    let primary = codewhale_home.join("config.toml");
+    if codewhale_config::codewhale_home_is_explicit() {
+        return Ok(primary);
+    }
     let home =
         effective_home_dir().context("failed to resolve home directory for config.toml path")?;
-    let primary = home.join(".codewhale").join("config.toml");
     if primary.exists() {
         return Ok(primary);
     }
@@ -773,6 +778,26 @@ mod tests {
         }
 
         assert_eq!(config_toml_path(None).unwrap(), legacy_config);
+    }
+
+    #[test]
+    fn config_toml_path_ignores_legacy_config_when_codewhale_home_is_explicit() {
+        let temp_root = temp_root("codewhale-config-path-explicit-home");
+        let explicit_home = temp_root.join("isolated-codewhale");
+        let legacy_config = temp_root.join(".deepseek").join("config.toml");
+        fs::create_dir_all(legacy_config.parent().unwrap()).unwrap();
+        fs::write(&legacy_config, "").unwrap();
+        let _guard = EnvGuard::new(&temp_root);
+
+        unsafe {
+            env::remove_var("DEEPSEEK_CONFIG_PATH");
+            env::set_var("CODEWHALE_HOME", &explicit_home);
+        }
+
+        assert_eq!(
+            config_toml_path(None).unwrap(),
+            explicit_home.join("config.toml")
+        );
     }
 
     #[test]

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -632,6 +632,7 @@ mod tests {
     struct EnvGuard {
         home: Option<OsString>,
         userprofile: Option<OsString>,
+        codewhale_home: Option<OsString>,
         codewhale_config_path: Option<OsString>,
         deepseek_config_path: Option<OsString>,
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -645,6 +646,7 @@ mod tests {
             let config_str = OsString::from(config_path.as_os_str());
             let home_prev = env::var_os("HOME");
             let userprofile_prev = env::var_os("USERPROFILE");
+            let codewhale_home_prev = env::var_os("CODEWHALE_HOME");
             let codewhale_config_prev = env::var_os("CODEWHALE_CONFIG_PATH");
             let deepseek_config_prev = env::var_os("DEEPSEEK_CONFIG_PATH");
 
@@ -652,6 +654,7 @@ mod tests {
             unsafe {
                 env::set_var("HOME", &home_str);
                 env::set_var("USERPROFILE", &home_str);
+                env::remove_var("CODEWHALE_HOME");
                 env::remove_var("CODEWHALE_CONFIG_PATH");
                 env::set_var("DEEPSEEK_CONFIG_PATH", &config_str);
             }
@@ -659,6 +662,7 @@ mod tests {
             Self {
                 home: home_prev,
                 userprofile: userprofile_prev,
+                codewhale_home: codewhale_home_prev,
                 codewhale_config_path: codewhale_config_prev,
                 deepseek_config_path: deepseek_config_prev,
                 _lock: lock,
@@ -689,6 +693,18 @@ mod tests {
                 // Safety: test-only environment mutation guarded by a global mutex.
                 unsafe {
                     env::remove_var("USERPROFILE");
+                }
+            }
+
+            if let Some(value) = self.codewhale_home.take() {
+                // Safety: test-only environment mutation guarded by a global mutex.
+                unsafe {
+                    env::set_var("CODEWHALE_HOME", value);
+                }
+            } else {
+                // Safety: test-only environment mutation guarded by a global mutex.
+                unsafe {
+                    env::remove_var("CODEWHALE_HOME");
                 }
             }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2788,10 +2788,7 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
     // State root (v0.8.44)
     println!();
     println!("{}", "State Root:".bold());
-    let code_home =
-        codewhale_config::codewhale_home().unwrap_or_else(|_| PathBuf::from("~/.codewhale"));
-    let legacy_home =
-        codewhale_config::legacy_deepseek_home().unwrap_or_else(|_| PathBuf::from("~/.deepseek"));
+    let (code_home, legacy_home) = doctor_state_roots();
     let active_root = if code_home.exists() {
         &code_home
     } else if legacy_home.exists() {
@@ -3633,6 +3630,17 @@ fn doctor_legacy_state_status(
     }
 }
 
+fn doctor_state_roots() -> (PathBuf, PathBuf) {
+    let code_home =
+        codewhale_config::codewhale_home().unwrap_or_else(|_| PathBuf::from("~/.codewhale"));
+    let legacy_home = if codewhale_config::codewhale_home_is_explicit() {
+        code_home.join(codewhale_config::LEGACY_APP_DIR)
+    } else {
+        codewhale_config::legacy_deepseek_home().unwrap_or_else(|_| PathBuf::from("~/.deepseek"))
+    };
+    (code_home, legacy_home)
+}
+
 fn doctor_legacy_state_report(
     primary_root: &Path,
     legacy_root: &Path,
@@ -4331,10 +4339,7 @@ fn run_doctor_json(
     let api_target = doctor_api_target(config);
     let strict_tool_mode = doctor_strict_tool_mode_status(config);
     let tls_status = doctor_tls_status(config);
-    let code_home =
-        codewhale_config::codewhale_home().unwrap_or_else(|_| PathBuf::from("~/.codewhale"));
-    let legacy_home =
-        codewhale_config::legacy_deepseek_home().unwrap_or_else(|_| PathBuf::from("~/.deepseek"));
+    let (code_home, legacy_home) = doctor_state_roots();
     let legacy_state_report = doctor_legacy_state_report(&code_home, &legacy_home);
 
     let report = json!({
@@ -8060,8 +8065,36 @@ mod serve_bind_host_tests {
 #[cfg(test)]
 mod doctor_legacy_state_tests {
     use super::*;
+    use std::env;
+    use std::ffi::OsString;
     use std::fs;
     use tempfile::TempDir;
+
+    struct EnvVarRestore {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarRestore {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = env::var_os(key);
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     fn roots(tmp: &TempDir) -> (PathBuf, PathBuf) {
         (tmp.path().join(".codewhale"), tmp.path().join(".deepseek"))
@@ -8170,6 +8203,37 @@ mod doctor_legacy_state_tests {
         assert_eq!(json["needs_attention"], false);
         assert_eq!(json["legacy_only_count"], 0);
         assert_eq!(json["dual_present_count"], 0);
+    }
+
+    #[test]
+    fn doctor_state_roots_ignore_ambient_legacy_home_when_codewhale_home_is_explicit() {
+        let tmp = TempDir::new().expect("tempdir");
+        let explicit_home = tmp.path().join("isolated-codewhale");
+        let ambient_legacy = tmp.path().join(".deepseek");
+        fs::create_dir_all(&ambient_legacy).expect("ambient legacy root");
+        fs::write(
+            ambient_legacy.join("config.toml"),
+            "provider = 'deepseek'\n",
+        )
+        .expect("ambient legacy config");
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", &explicit_home);
+
+        let (primary_root, legacy_root) = doctor_state_roots();
+        let report = doctor_legacy_state_report(&primary_root, &legacy_root);
+
+        assert_eq!(primary_root, explicit_home);
+        assert_eq!(
+            legacy_root,
+            primary_root.join(codewhale_config::LEGACY_APP_DIR)
+        );
+        assert!(
+            report
+                .iter()
+                .all(|entry| entry.status == DoctorLegacyStateStatus::Absent),
+            "doctor must not report ambient legacy state when CODEWHALE_HOME is explicit"
+        );
+        assert!(!report.iter().any(legacy_state_needs_attention));
     }
 }
 

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -115,6 +115,11 @@ impl TuiPrefs {
         let primary = codewhale_config::codewhale_home()
             .ok()
             .map(|home| home.join(TUI_PREFS_FILE_NAME));
+        if codewhale_config::codewhale_home_is_explicit() {
+            return primary.ok_or_else(|| {
+                anyhow::anyhow!("Failed to resolve tui.toml path: no CodeWhale home found.")
+            });
+        }
         let legacy_home = codewhale_config::legacy_deepseek_home()
             .ok()
             .map(|home| home.join(TUI_PREFS_FILE_NAME));
@@ -1219,6 +1224,9 @@ fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathB
     let primary = codewhale_config::codewhale_home()
         .ok()
         .map(|home| home.join(SETTINGS_FILE_NAME));
+    if codewhale_config::codewhale_home_is_explicit() {
+        return (primary, None, None);
+    }
     let legacy_home = codewhale_config::legacy_deepseek_home()
         .ok()
         .map(|home| home.join(SETTINGS_FILE_NAME));
@@ -2763,7 +2771,7 @@ mod tests {
     }
 
     #[test]
-    fn settings_load_migrates_legacy_deepseek_home_into_codewhale_home() {
+    fn settings_load_migrates_legacy_deepseek_home_into_codewhale_home_without_explicit_home() {
         let _g = config_path_test_guard();
         let tmp = tempfile::tempdir().expect("tempdir");
         let primary = tmp.path().join(".codewhale").join("settings.toml");
@@ -2772,7 +2780,7 @@ mod tests {
         std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
         std::fs::write(&legacy_home, "low_motion = true\n").expect("legacy settings");
         let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
-        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _codewhale_home = EnvVarRestore::remove("CODEWHALE_HOME");
         let _home = EnvVarRestore::set("HOME", tmp.path());
 
         let loaded = Settings::load().expect("load settings");
@@ -2790,12 +2798,12 @@ mod tests {
     }
 
     #[test]
-    fn settings_load_migrates_platform_legacy_fallback_into_codewhale_home() {
+    fn settings_load_migrates_platform_legacy_fallback_into_codewhale_home_without_explicit_home() {
         let _g = config_path_test_guard();
         let tmp = tempfile::tempdir().expect("tempdir");
         let primary = tmp.path().join(".codewhale").join("settings.toml");
         let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
-        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", tmp.path().join(".codewhale"));
+        let _codewhale_home = EnvVarRestore::remove("CODEWHALE_HOME");
         let _home = EnvVarRestore::set("HOME", tmp.path());
         let _xdg = EnvVarRestore::set("XDG_CONFIG_HOME", tmp.path().join("platform-config"));
         #[cfg(windows)]
@@ -2819,6 +2827,31 @@ mod tests {
         assert!(
             display.contains(&format!("Config file: {}", primary.display())),
             "settings display should surface the canonical codewhale path:\n{display}"
+        );
+    }
+
+    #[test]
+    fn settings_load_ignores_legacy_files_when_codewhale_home_is_explicit() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let explicit_home = tmp.path().join("isolated-codewhale");
+        let legacy_dir = tmp.path().join(".deepseek");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
+        std::fs::write(legacy_dir.join("settings.toml"), "low_motion = true\n")
+            .expect("legacy settings");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", &explicit_home);
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+
+        let loaded = Settings::load().expect("load settings");
+
+        assert!(
+            !loaded.low_motion,
+            "explicit CODEWHALE_HOME must not inherit ambient legacy settings"
+        );
+        assert!(
+            !explicit_home.join("settings.toml").exists(),
+            "ambient legacy settings must not be migrated into explicit CODEWHALE_HOME"
         );
     }
 
@@ -2867,6 +2900,23 @@ mod tests {
         let got = TuiPrefs::path().expect("tui prefs path");
 
         assert_eq!(got, tmp.path().join(".codewhale").join("tui.toml"));
+    }
+
+    #[test]
+    fn tui_prefs_path_ignores_legacy_home_when_codewhale_home_is_explicit() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let explicit_home = tmp.path().join("isolated-codewhale");
+        let legacy_dir = tmp.path().join(".deepseek");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
+        std::fs::write(legacy_dir.join("tui.toml"), "theme = \"light\"\n").expect("legacy prefs");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", &explicit_home);
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+
+        let got = TuiPrefs::path().expect("tui prefs path");
+
+        assert_eq!(got, explicit_home.join("tui.toml"));
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -2837,16 +2837,27 @@ mod tests {
         let explicit_home = tmp.path().join("isolated-codewhale");
         let legacy_dir = tmp.path().join(".deepseek");
         std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
-        std::fs::write(legacy_dir.join("settings.toml"), "low_motion = true\n")
-            .expect("legacy settings");
+        std::fs::write(
+            legacy_dir.join("settings.toml"),
+            "theme = \"dracula\"\ncomposer_density = \"spacious\"\nsidebar_width_percent = 42\n",
+        )
+        .expect("legacy settings");
         let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
         let _codewhale_home = EnvVarRestore::set("CODEWHALE_HOME", &explicit_home);
         let _home = EnvVarRestore::set("HOME", tmp.path());
 
         let loaded = Settings::load().expect("load settings");
 
-        assert!(
-            !loaded.low_motion,
+        assert_eq!(
+            loaded.theme, "system",
+            "explicit CODEWHALE_HOME must not inherit ambient legacy settings"
+        );
+        assert_eq!(
+            loaded.composer_density, "comfortable",
+            "explicit CODEWHALE_HOME must not inherit ambient legacy settings"
+        );
+        assert_eq!(
+            loaded.sidebar_width_percent, 28,
             "explicit CODEWHALE_HOME must not inherit ambient legacy settings"
         );
         assert!(

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4578,6 +4578,10 @@ fn subagent_transient_provider_retry_delay(retry_number: u32) -> Duration {
 }
 
 fn is_transient_subagent_provider_error(error: &anyhow::Error) -> bool {
+    if let Some(LlmError::RateLimited { .. }) = error.downcast_ref::<LlmError>() {
+        return true;
+    }
+
     let message = format!("{error:#}").to_ascii_lowercase();
     [
         "did not receive response headers",
@@ -4593,6 +4597,11 @@ fn is_transient_subagent_provider_error(error: &anyhow::Error) -> bool {
         "bad gateway",
         "gateway timeout",
         "service unavailable",
+        "rate limited",
+        "rate_limit",
+        "rate_limited",
+        "too many requests",
+        "429",
         "502",
         "503",
         "504",

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -2317,6 +2317,17 @@ fn transient_provider_classifier_matches_sse_header_timeout() {
     assert!(is_transient_subagent_provider_error(&err));
 }
 
+#[test]
+fn transient_provider_classifier_matches_structured_rate_limit() {
+    let err = anyhow::Error::new(crate::llm_client::LlmError::RateLimited {
+        message: "please slow down".to_string(),
+        retry_after: Some(Duration::from_secs(2)),
+    })
+    .context("Responses API request failed");
+
+    assert!(is_transient_subagent_provider_error(&err));
+}
+
 #[tokio::test]
 async fn subagent_retries_transient_provider_header_timeout_before_succeeding() {
     let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- make `codewhale auth list` report an active OpenAI Codex OAuth file instead of marking `openai-codex` missing when `auth status` can see the login
- encode/decode Responses API function tool names with the existing reversible API-name mapping, fixing Codex child requests that inherited dotted/dashed tool names rejected as `tools[n].name` pattern violations
- treat structured `LlmError::RateLimited` / 429-style Codex child failures as transient sub-agent provider interruptions so exhausted retries preserve a continuation checkpoint instead of becoming opaque terminal failures
- treat an explicit `CODEWHALE_HOME` as a first-run isolation boundary for config, settings, TUI theme prefs, and doctor legacy-state diagnostics, while preserving normal `HOME`-based `.deepseek` migration for existing users
- add 0.8.67 release-note coverage for the Codex OAuth/sub-agent diagnostics and fresh-home setup isolation slices

Refs #3884.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p codewhale-config --locked`
- `cargo test -p codewhale-cli auth_ --locked`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked responses_ -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked transient_provider_classifier -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked subagent_failure_message_preserves_error_chain -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked setup_ -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked settings_load_migrates_legacy_deepseek_home_into_codewhale_home_without_explicit_home -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked settings_load_migrates_platform_legacy_fallback_into_codewhale_home_without_explicit_home -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked settings_load_ignores_legacy_files_when_codewhale_home_is_explicit -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked doctor_state_roots_ignore_ambient_legacy_home_when_codewhale_home_is_explicit -- --nocapture`

## Manual smoke

The locally installed 0.8.67 candidate initially reproduced the real child failure after the opaque-message fix:

`[invalid_request] Responses API request failed: Invalid request (400): Invalid 'tools[83].name': string does not match pattern...`

That points to Responses tool-name encoding, not missing Codex OAuth. This PR patches that bridge.

After patching the bridge, an installed 0.8.67 smoke launched a Codex OAuth child agent and the child completed with `PONG` instead of failing with `Responses API failed`.
