### PR TITLE
fix(tui): keep provider links readable in narrow layouts

### DIFF
--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -480,7 +480,7 @@ pub fn deepseek_links(app: &mut App) -> CommandResult {
         if let Some(key_url) = links.key_url {
             let _ = writeln!(
                 message,
-                "{} {}",
+                "{} `{}`",
                 tr(locale, MessageId::LinksDashboard),
                 key_url
             );
@@ -494,7 +494,7 @@ pub fn deepseek_links(app: &mut App) -> CommandResult {
         }
         let _ = writeln!(
             message,
-            "{}      {}",
+            "{}      `{}`",
             tr(locale, MessageId::LinksDocs),
             links.docs_url
         );
@@ -1298,6 +1298,30 @@ mod tests {
         assert!(msg.contains("XIAOMI_MIMO_TOKEN_PLAN_API_KEY"));
         assert!(!msg.contains("https://codewhale.dev/docs/providers"));
         assert!(result.action.is_none());
+    }
+
+    #[test]
+    fn provider_links_emit_urls_as_inline_code_for_narrow_transcripts() {
+        let mut app = create_test_app();
+        let result = deepseek_links(&mut app);
+        let msg = result.message.expect("links should return a message");
+
+        assert!(msg.contains("`https://platform.openai.com/api-keys`"));
+        assert!(
+            msg.contains(
+                "`https://platform.minimax.io/user-center/basic-information/interface-key`"
+            )
+        );
+
+        for line in msg.lines().filter(|line| line.contains("http")) {
+            let Some(url_start) = line.find("http") else {
+                continue;
+            };
+            assert!(
+                line[..url_start].ends_with('`') && line[url_start..].contains('`'),
+                "provider URL should be inline-code wrapped so narrow TUI renders do not emit oversized OSC8 link payloads: {line}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #3991.

- render `/links` provider Dashboard/Docs URLs as inline code instead of bare markdown URLs
- keep the full URL visible and copyable while avoiding oversized OSC 8 autolink payloads in narrow terminal layouts
- add a regression covering provider link output so future provider URLs do not reintroduce bare autolinks

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
  - Not clean locally due pre-existing lint backlog outside this diff, e.g. `crates/tui/src/tools/subagent/mod.rs:3024` (`unnecessary_map_or`) and `crates/tui/src/tui/approval.rs:1027` (`collapsible_if`).
- [ ] `cargo test --workspace --all-features`
  - Not run; this PR is covered by the focused command/link test surface below.
- [x] `cargo test -p codewhale-tui --bin codewhale-tui links --locked` — 16 passed
- [x] `git diff --check`
- [x] added-line secret scan — 0 findings
- [x] CRLF scan for changed file — none

## Checklist

- [ ] Updated docs or comments as needed
  - Not needed; this only changes `/links` rendering.
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
  - Not manually captured; verified with a focused `/links` command-output regression.
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
  - Not applicable; original change, no harvested/co-authored patch.
