### PR TITLE
test: Add lock to fix env conflict in test

### DIFF
--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -3953,6 +3953,8 @@ fn openai_codex_default_model_falls_back_to_codex_model() {
 
 #[test]
 fn direct_provider_ignores_foreign_deepseek_root_default_model() {
+    let _lock = lock_test_env();
+
     let config = Config {
         provider: Some("zai".to_string()),
         default_text_model: Some(DEFAULT_TEXT_MODEL.to_string()),


### PR DESCRIPTION
## Summary

 The test `direct_provider_ignores_foreign_deepseek_root_default_model` will read env `DEEPSEEK_BASE_URL`.
 But `deepseek_base_url_env_scopes_to_self_hosted_providers` will write it and cause test failed.
 Use `lock_test_env` get lock before test in `direct_provider_ignores_foreign_deepseek_root_default_model`.

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes
- [ x ] Harvested/co-authored credit uses a GitHub numeric noreply address
