### PR TITLE
test: enforce English locale for hardcoded string assertions

### DIFF
--- a/crates/tui/src/commands/groups/core/constitution.rs
+++ b/crates/tui/src/commands/groups/core/constitution.rs
@@ -975,6 +975,7 @@ mod tests {
     #[test]
     fn constitution_default_opens_manager_pager() {
         let mut app = test_app();
+        app.ui_locale = Locale::En;
 
         let result = ConstitutionCmd::execute(&mut app, None);
 
@@ -988,6 +989,7 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         std::fs::write(tmp.path().join("WHALE.md"), "legacy instructions").expect("write whale");
         let mut app = test_app_with_workspace(tmp.path().to_path_buf());
+        app.ui_locale = Locale::En;
 
         let result = ConstitutionCmd::execute(&mut app, None);
 
@@ -1024,6 +1026,7 @@ mod tests {
     #[test]
     fn constitution_help_lists_repair_and_runtime_boundary() {
         let mut app = test_app();
+        app.ui_locale = Locale::En;
 
         let result = ConstitutionCmd::execute(&mut app, Some("help"));
 
@@ -1044,6 +1047,7 @@ mod tests {
         std::fs::write(home.join("constitution.json"), "{not valid json").expect("invalid file");
         let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", home.as_os_str());
         let mut app = test_app();
+        app.ui_locale = Locale::En;
 
         let result = ConstitutionCmd::execute(&mut app, Some("repair"));
 

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -3878,6 +3878,7 @@ mod tests {
     #[test]
     fn pinned_sidebar_renders_agents_section_when_subagents_are_active() {
         let mut app = create_test_app();
+        app.ui_locale = Locale::En;
         app.sidebar_focus = SidebarFocus::Pinned;
         app.subagent_cache
             .push(cached_agent("agent-active-1", Some("critic")));


### PR DESCRIPTION
## Summary

Hardcoded string literals (e.g., "Constitution Manager", "Legacy WHALE.md: ignored") in test assertions
currently fail on non-English devices due to UI localization.

Force the default locale to `Locale::En` in the test setup to ensure
consistent assertion behavior across all build environments.

This addresses the flaky test runs on international CI nodes and
local developer machines with non-English system settings.

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes
- [ x ] Harvested/co-authored credit uses a GitHub numeric noreply address
