### PR TITLE
docs(readme): link CodeWhale for VS Code GUI frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,21 @@ product, not an afterthought.
 - **Embedded everywhere.** HTTP/SSE and ACP runtime APIs, a VS Code extension,
   and Telegram/Feishu bridges (Weixin experimental).
 
+## CodeWhale for VS Code — GUI frontend
+
+Prefer a graphical IDE experience over the terminal? [**CodeWhale for VS Code**](https://github.com/HengQuWorld/CodeWhale-VSCode) is a community-maintained GUI frontend that wraps the same CodeWhale engine into a native VS Code sidebar — chat, slash commands, threaded conversations, live diffs, task management, and a settings UI, all without leaving the editor.
+
+The GUI talks to the same local `codewhale` runtime over the [Runtime API](docs/RUNTIME_API.md), so sessions, providers, modes, and skills stay in sync between terminal and IDE. If you live in VS Code, give it a try:
+
+```bash
+npm install -g codewhale        # install the engine first
+# then search "CodeWhale" in the VS Code extensions panel
+```
+
+> The minimal scaffold under [`extensions/vscode/`](extensions/vscode/) in this
+> repo is a separate, read-only Phase 0 viewer. For the full chat experience,
+> use the linked GUI project above.
+
 ## How instructions are ranked
 
 As a project evolves, the instructions pile up and they inevitably conflict: the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,6 +146,20 @@ codewhale exec --allowed-tools read_file,exec_shell --max-turns 10 "fix the fail
 
 完整细节见 [CHANGELOG.md](CHANGELOG.md)。
 
+## CodeWhale for VS Code —— 图形界面前端
+
+更喜欢图形化的 IDE 体验而不是终端？[**CodeWhale for VS Code**](https://github.com/HengQuWorld/CodeWhale-VSCode) 是社区维护的 GUI 前端，把同一个 CodeWhale 引擎封装成原生 VS Code 侧边栏——聊天、斜杠命令、线程管理、实时 diff、任务管理与设置 UI，全部在编辑器内完成。
+
+GUI 通过相同的 [Runtime API](docs/RUNTIME_API.md) 与本地 `codewhale` 运行时通信，会话、provider、模式与 skills 在终端与 IDE 之间保持同步。如果你日常就在 VS Code 里工作，欢迎试用：
+
+```bash
+npm install -g codewhale        # 先安装引擎
+# 然后在 VS Code 扩展面板搜索 "CodeWhale"
+```
+
+> 本仓库 [`extensions/vscode/`](extensions/vscode/) 下的最小脚手架是独立的
+> Phase 0 只读查看器。完整的聊天体验请使用上面链接的 GUI 项目。
+
 ## 核心想法 —— 这个版本放进来的 mission idea
 
 多数编程 Agent 从加码开始：更多工具、更长上下文、更多自主性。CodeWhale


### PR DESCRIPTION
## Summary

Adds a short **"CodeWhale for VS Code — GUI frontend"** section to both `README.md` and `README.zh-CN.md`, placed after the Features / 已交付的能力 sections. The new section:

- Links the community-maintained GUI frontend at [HengQuWorld/CodeWhale-VSCode](https://github.com/HengQuWorld/CodeWhale-VSCode).
- Lists what the GUI offers as a native VS Code sidebar: chat, slash commands, threaded conversations, live diffs, task management, settings UI.
- Notes that the GUI talks to the same local `codewhale` runtime over the [Runtime API](docs/RUNTIME_API.md) — sessions, providers, modes, and skills stay in sync between terminal and IDE.
- Includes a one-line install snippet (`npm install -g codewhale` + search "CodeWhale" in the extensions panel).
- Clarifies that the minimal scaffold under [`extensions/vscode/`](extensions/vscode/) in this repo is a separate, read-only Phase 0 viewer — for the full chat experience, users should use the linked GUI project.

No code or behavior changes. README-only.

## Testing

N/A — docs-only change. The three checklist items below are not applicable.

- [ ] `cargo fmt --all -- --check` — N/A (docs only)
- [ ] `cargo clippy --workspace --all-targets --all-features` — N/A (docs only)
- [ ] `cargo test --workspace --all-features` — N/A (docs only)

Manually verified:

- Markdown renders correctly in both English and Chinese.
- Heading nesting is correct: in `README.zh-CN.md` the new section is a sibling H2 of `## 已交付的能力` (placed after the section ends at "完整细节见 [CHANGELOG.md]"), not nested inside it.
- All links resolve: GUI repo URL, `docs/RUNTIME_API.md`, `extensions/vscode/`.

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant — N/A (docs only)
- [ ] Verified TUI behavior manually if UI changes — N/A (no UI changes)
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address — N/A (solo work)
