### PR TITLE
fix(tui): remove legacy token-only pricing helpers

### DIFF
--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -241,44 +241,6 @@ pub fn input_cost_note(model: &str) -> Option<String> {
     ))
 }
 
-/// Calculate cost for a turn given token usage and model.
-#[must_use]
-#[allow(dead_code)]
-pub fn calculate_turn_cost(model: &str, input_tokens: u32, output_tokens: u32) -> Option<f64> {
-    calculate_turn_cost_estimate(model, input_tokens, output_tokens).map(|estimate| estimate.usd)
-}
-
-/// Calculate cost for a turn in both official currencies.
-///
-/// This legacy helper has no cache telemetry, so it prices all input tokens as
-/// cache misses. Prefer [`calculate_turn_cost_estimate_from_usage`] when the
-/// provider returned usage details.
-#[must_use]
-pub fn calculate_turn_cost_estimate(
-    model: &str,
-    input_tokens: u32,
-    output_tokens: u32,
-) -> Option<CostEstimate> {
-    let pricing = pricing_for_model(model)?;
-    Some(CostEstimate {
-        usd: calculate_turn_cost_with_pricing(pricing.usd, input_tokens, output_tokens),
-        cny: pricing
-            .cny
-            .map(|pricing| calculate_turn_cost_with_pricing(pricing, input_tokens, output_tokens))
-            .unwrap_or(0.0),
-    })
-}
-
-fn calculate_turn_cost_with_pricing(
-    pricing: CurrencyPricing,
-    input_tokens: u32,
-    output_tokens: u32,
-) -> f64 {
-    let input_cost = (input_tokens as f64 / 1_000_000.0) * pricing.input_cache_miss_per_million;
-    let output_cost = (output_tokens as f64 / 1_000_000.0) * pricing.output_per_million;
-    input_cost + output_cost
-}
-
 /// Calculate cost from provider usage, honoring DeepSeek context-cache fields.
 #[must_use]
 pub fn calculate_turn_cost_from_usage(model: &str, usage: &Usage) -> Option<f64> {
@@ -385,13 +347,6 @@ pub fn calculate_cache_savings_for_provider(
     calculate_cache_savings(model, cache_hit_tokens)
 }
 
-/// Format a USD cost for compact display.
-#[must_use]
-#[allow(dead_code)]
-pub fn format_cost(cost: f64) -> String {
-    format_cost_amount(cost, CostCurrency::Usd)
-}
-
 /// Format a cost amount for compact display in the chosen currency.
 #[must_use]
 pub fn format_cost_amount(cost: f64, currency: CostCurrency) -> String {
@@ -429,7 +384,7 @@ mod tests {
 
     #[test]
     fn nvidia_nim_deepseek_model_does_not_use_deepseek_platform_pricing() {
-        assert!(calculate_turn_cost("deepseek-ai/deepseek-v4-pro", 1_000, 1_000).is_none());
+        assert!(!has_pricing_for_model("deepseek-ai/deepseek-v4-pro"));
     }
 
     #[test]
@@ -648,7 +603,12 @@ mod tests {
 
     #[test]
     fn cost_estimate_calculates_usd_and_cny() {
-        let estimate = calculate_turn_cost_estimate("deepseek-v4-flash", 1_000_000, 500_000)
+        let usage = Usage {
+            input_tokens: 1_000_000,
+            output_tokens: 500_000,
+            ..Default::default()
+        };
+        let estimate = calculate_turn_cost_estimate_from_usage("deepseek-v4-flash", &usage)
             .expect("estimate");
 
         assert_eq!(estimate.usd, 0.28);


### PR DESCRIPTION
## Summary
- Removes `calculate_turn_cost`, `calculate_turn_cost_estimate`, `calculate_turn_cost_with_pricing`, and `format_cost` from `crates/tui/src/pricing.rs` — all had no production callers, only their own unit tests.
- Production cost accounting already goes through the usage-aware path (`calculate_turn_cost_from_usage`, `calculate_turn_cost_estimate_from_usage`, `token_usage_for_pricing`), which honors cache-hit/cache-miss fields the removed helpers ignored.
- Rewrote the two tests that only existed to exercise the legacy API (`nvidia_nim_deepseek_model_does_not_use_deepseek_platform_pricing`, `cost_estimate_calculates_usd_and_cny`) to assert the same behavior through the surviving usage-aware/lookup functions, instead of dropping coverage.

Fixes #3848

## Test plan
- [x] `cargo check -p codewhale-tui --all-targets` — clean, no warnings
- [x] `cargo test -p codewhale-tui pricing -- --nocapture` — all 24 pricing/scorecard unit tests pass
- [x] `rg "calculate_turn_cost\(|calculate_turn_cost_estimate\(|format_cost\("` over `crates/tui/src` and `crates/tui/tests` — no stale references