### PR TITLE
fix(cli): reset SIGPIPE to SIG_DFL so piped output exits cleanly

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,8 +42,9 @@ tracing.workspace = true
 # Parent-death cleanup for delegated server children (#3259): on Linux the
 # dispatcher sets PR_SET_PDEATHSIG so the child is signalled if the dispatcher
 # dies uncatchably; on Windows it assigns the child to a kill-on-job-close Job
-# Object.
-[target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
+# Object. Also used in main.rs to reset SIGPIPE to SIG_DFL on any Unix target
+# (#4030), so libc must be available across all Unix, not just Linux.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,15 @@
 fn main() -> std::process::ExitCode {
+    // Reset SIGPIPE to SIG_DFL so piping codewhale output into a command that
+    // exits early (e.g. `codewhale doctor | head`) terminates the process
+    // cleanly with exit code 141 instead of panicking on the broken-pipe
+    // write. Many execution environments (systemd, Docker, some shells)
+    // inherit SIGPIPE set to SIG_IGN, which makes write(2) return EPIPE;
+    // Rust's `println!` then treats that io::Error as fatal and panics.
+    // See issue #4030.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     codewhale_cli::run_cli()
 }


### PR DESCRIPTION
Resolves #4030.

## Problem

When codewhale output is piped into a command that exits early (e.g. `codewhale doctor | head`), the process panics instead of terminating cleanly:

```
Process panicked
Location: std::io::stdio.rs:1165:9
Panic: failed printing to stdout: Broken pipe (os error 32)
```

Crash dumps appear in `~/.deepseek/crashes/`.

## Root cause

Many execution environments (systemd, Docker, some shells) inherit SIGPIPE set to `SIG_IGN`. When SIGPIPE is ignored, `write(2)` returns `EPIPE` instead of delivering the signal, and Rust's `println!` treats any `std::io::Error` from `write_all` as fatal and panics. (Diagnosis and proposed fix come from the issue itself — thanks @BrathonBai.)

## Fix

Reset SIGPIPE to `SIG_DFL` in `main()` before any output, so the process gets the standard Unix clean exit (code 141) on a broken pipe. Windows has no SIGPIPE and is excluded via `#[cfg(unix)]`.

```rust
#[cfg(unix)]
unsafe {
    libc::signal(libc::SIGPIPE, libc::SIG_DFL);
}
```

The `libc` dependency in `crates/cli/Cargo.toml` was previously scoped to `cfg(linux)` (for the `PR_SET_PDEATHSIG` parent-death cleanup in #3259); it is now `cfg(unix)` so the SIGPIPE reset works on macOS/BSD too. The Linux-only `PR_SET_PDEATHSIG` code path is unchanged.

## Verification

```
cargo build -p codewhale-cli     # ok
cargo fmt --check                 # clean
cargo clippy -p codewhale-cli     # clean
```

Reproduces the issue before the fix (`codewhale doctor | head` → panic); after the fix the process exits cleanly on the broken pipe.