### PR TITLE
[codex] fix edit_file UTF-8 fuzzy cursor panic

### DIFF
--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -759,6 +759,18 @@ fn line_start_before(input: &str, idx: usize) -> usize {
         .map_or(0, |newline| newline.saturating_add(1))
 }
 
+fn next_char_boundary(input: &str, idx: usize) -> usize {
+    if idx >= input.len() {
+        return input.len();
+    }
+
+    let mut next = idx.saturating_add(1);
+    while next < input.len() && !input.is_char_boundary(next) {
+        next = next.saturating_add(1);
+    }
+    next
+}
+
 fn leading_whitespace_fuzzy_matches(contents: &str, search: &str) -> Vec<(usize, usize)> {
     let (normalized_contents, byte_map) = strip_line_leading_whitespace_with_map(contents);
     let (normalized_search, _) = strip_line_leading_whitespace_with_map(search);
@@ -788,7 +800,7 @@ fn leading_whitespace_fuzzy_matches(contents: &str, search: &str) -> Vec<(usize,
             };
         let original_end = byte_map.get(norm_end).copied().unwrap_or(contents.len());
         matches.push((original_start, original_end));
-        cursor = norm_start.saturating_add(1);
+        cursor = next_char_boundary(&normalized_contents, norm_start);
     }
     matches
 }
@@ -850,7 +862,7 @@ fn punctuation_normalized_matches(contents: &str, search: &str) -> Vec<(usize, u
         };
         let original_end = byte_map.get(norm_end).copied().unwrap_or(contents.len());
         matches.push((original_start, original_end));
-        cursor = norm_start.saturating_add(1);
+        cursor = next_char_boundary(&norm_contents, norm_start);
     }
     matches
 }
@@ -1792,6 +1804,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_edit_file_fuzz_tolerates_leading_whitespace_after_multibyte_start() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+
+        let test_file = tmp.path().join("fuzzy_cjk.txt");
+        fs::write(&test_file, "数据\n").expect("write");
+        read_before_edit(&ctx, "fuzzy_cjk.txt").await;
+
+        let tool = EditFileTool;
+        let result = tool
+            .execute(
+                json!({
+                    "path": "fuzzy_cjk.txt",
+                    "search": "    数据",
+                    "replace": "记录",
+                    "fuzz": true
+                }),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        assert!(result.success, "{}", result.content);
+        assert!(result.content.contains("fuzzy indentation match"));
+        let edited = fs::read_to_string(&test_file).expect("read");
+        assert_eq!(edited, "记录\n");
+    }
+
+    #[tokio::test]
     async fn test_edit_file_fuzz_tolerates_smart_quote_substitution() {
         // The file on disk has ASCII quotes. The search comes from a
         // browser paste with curly quotes. Exact match fails; the
@@ -1826,6 +1867,35 @@ mod tests {
         );
         let edited = fs::read_to_string(&test_file).expect("read");
         assert_eq!(edited, "let s = \"hello universe\";\n");
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_fuzz_tolerates_smart_quote_after_multibyte_start() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+
+        let test_file = tmp.path().join("smart_cjk.md");
+        fs::write(&test_file, "数据 \"x\"\n").expect("write");
+        read_before_edit(&ctx, "smart_cjk.md").await;
+
+        let tool = EditFileTool;
+        let result = tool
+            .execute(
+                json!({
+                    "path": "smart_cjk.md",
+                    "search": "数据 \u{201C}x\u{201D}",
+                    "replace": "数据 y",
+                    "fuzz": true
+                }),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        assert!(result.success, "{}", result.content);
+        assert!(result.content.contains("fuzzy punctuation match"));
+        let edited = fs::read_to_string(&test_file).expect("read");
+        assert_eq!(edited, "数据 y\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes `edit_file` fuzzy matching when a normalized match starts on a multibyte UTF-8 character. The previous cursor advance used `norm_start + 1`, so the next search iteration could slice from the middle of a CJK character and panic.

This patch advances the normalized cursor to the next UTF-8 character boundary for both fuzzy paths:

- leading-whitespace fuzzy matching
- punctuation-normalized fuzzy matching

It also adds CJK-starting regression tests for both paths.

Fixes #3971.

Credit: reported with repro and suggested fix direction by @taixinguo.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked test_edit_file_fuzz_tolerates` (5 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked test_edit_file` (12 passed)
- `python scripts/check-coauthor-trailers.py --range HEAD~1..HEAD`

Full-suite note: `cargo test -p codewhale-tui --bin codewhale-tui --locked` was attempted on this branch and failed only in unrelated full-suite tests. A clean `upstream/main` worktree also fails under the same local Windows environment in full-suite mode, including `core::engine::tests::edit_last_turn_preserves_current_mode` timing out with `Elapsed(())`, so the targeted `edit_file` validation above is the authoritative coverage for this change.