### PR TITLE
fix(tui): preserve native selection without mouse capture

### DIFF
--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -6,20 +6,17 @@ Read-only tools (reads, searches, persistent RLM session tools, agent status que
 Any write, patch, shell execution, sub-agent session open, or CSV batch operation will ask for approval first.
 
 Before requesting approval for multi-step writes, lay out your work with `checklist_write` so the user
-can see what you intend to do and approve with context. Use `update_plan` only when a complex
-initiative needs high-level strategy metadata that is not just a copy of the checklist.
+can approve with context. Use `update_plan` only for complex strategy, not as a checklist copy.
 For simple writes, state the direct edit and proceed through the normal approval flow.
-
-For multi-step initiatives, keep `checklist_write` current. Add `update_plan` only for genuinely useful strategy.
 
 ###### Efficient Approvals
 
 When your plan includes multiple writes, present them together:
-1. Show `checklist_write` with all write steps listed so the user sees the full scope
+1. Show `checklist_write` with all write steps listed
 2. Request approval for the batch ("I need to make 3 edits across 2 files...")
 3. Once approved, execute all writes in one turn (parallel `edit_file` / `apply_patch` calls)
 
-Don't sequence approvals one at a time — the user wants context, not interruption. A clear plan with visible checklist items gets approved faster than a series of surprise approval prompts.
+Don't sequence approvals one at a time. A clear visible checklist gets approved faster than surprise prompts.
 
 ###### Session Longevity
 

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -3562,11 +3562,20 @@ fn git_repo_root_discovers_one_level_nested_repo_from_harness() {
 
 #[test]
 fn git_repo_root_reports_attempted_paths_when_no_repo_found() {
-    let empty = tempdir().expect("empty dir");
-    let err = git_repo_root(empty.path()).expect_err("missing repo should fail cleanly");
+    let harness = tempdir().expect("empty harness dir");
+    let empty = harness
+        .path()
+        .join("isolated")
+        .join("a")
+        .join("b")
+        .join("c")
+        .join("d")
+        .join("empty");
+    std::fs::create_dir_all(&empty).expect("empty nested dir");
+    let err = git_repo_root(&empty).expect_err("missing repo should fail cleanly");
     let message = err.to_string();
     assert!(
-        message.contains("Tried:") && message.contains(empty.path().to_string_lossy().as_ref()),
+        message.contains("Tried:") && message.contains(empty.to_string_lossy().as_ref()),
         "expected friendly attempted-path error, got: {message}"
     );
 }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -6,7 +6,7 @@ use axum::{Json, Router, http::StatusCode, response::IntoResponse, routing::post
 use std::collections::HashSet;
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tempfile::tempdir;
+use tempfile::{Builder as TempDirBuilder, tempdir};
 
 fn make_assignment() -> SubAgentAssignment {
     SubAgentAssignment::new("prompt".to_string(), Some("worker".to_string()))
@@ -3562,7 +3562,12 @@ fn git_repo_root_discovers_one_level_nested_repo_from_harness() {
 
 #[test]
 fn git_repo_root_reports_attempted_paths_when_no_repo_found() {
-    let harness = tempdir().expect("empty harness dir");
+    let repo_root = git_repo_root(&std::env::current_dir().expect("current dir"))
+        .expect("test should run inside the checkout");
+    let harness = TempDirBuilder::new()
+        .prefix(".codewhale-no-repo-")
+        .tempdir_in(repo_root.parent().expect("repo parent"))
+        .expect("empty harness outside checkout");
     let empty = harness
         .path()
         .join("isolated")
@@ -3572,10 +3577,11 @@ fn git_repo_root_reports_attempted_paths_when_no_repo_found() {
         .join("d")
         .join("empty");
     std::fs::create_dir_all(&empty).expect("empty nested dir");
+    let expected = empty.canonicalize().expect("canonical empty dir");
     let err = git_repo_root(&empty).expect_err("missing repo should fail cleanly");
     let message = err.to_string();
     assert!(
-        message.contains("Tried:") && message.contains(empty.to_string_lossy().as_ref()),
+        message.contains("Tried:") && message.contains(expected.to_string_lossy().as_ref()),
         "expected friendly attempted-path error, got: {message}"
     );
 }

--- a/crates/tui/src/tui/external_editor.rs
+++ b/crates/tui/src/tui/external_editor.rs
@@ -416,6 +416,10 @@ mod tests {
             "external editor resume must not enable alternate-scroll without mouse capture: {seq:?}"
         );
         assert!(
+            seq.contains("\x1b[?1007l"),
+            "external editor resume must reset alternate-scroll without mouse capture: {seq:?}"
+        );
+        assert!(
             seq.contains("\x1b[?1004h"),
             "external editor resume must still restore focus events: {seq:?}"
         );

--- a/crates/tui/src/tui/external_editor.rs
+++ b/crates/tui/src/tui/external_editor.rs
@@ -387,7 +387,7 @@ mod tests {
     fn resume_tui_child_modes_reenables_shared_terminal_modes() {
         let mut out = Vec::new();
 
-        crate::tui::ui::recover_terminal_modes(&mut out, false, true);
+        crate::tui::ui::recover_terminal_modes(&mut out, true, true);
 
         let seq = String::from_utf8_lossy(&out);
         assert!(
@@ -401,6 +401,27 @@ mod tests {
         assert!(
             seq.contains("\x1b[?2004h"),
             "external editor resume must restore bracketed paste: {seq:?}"
+        );
+    }
+
+    #[test]
+    fn resume_tui_child_modes_leaves_alternate_scroll_off_when_mouse_capture_inactive() {
+        let mut out = Vec::new();
+
+        crate::tui::ui::recover_terminal_modes(&mut out, false, true);
+
+        let seq = String::from_utf8_lossy(&out);
+        assert!(
+            !seq.contains("\x1b[?1007h"),
+            "external editor resume must not enable alternate-scroll without mouse capture: {seq:?}"
+        );
+        assert!(
+            seq.contains("\x1b[?1004h"),
+            "external editor resume must still restore focus events: {seq:?}"
+        );
+        assert!(
+            seq.contains("\x1b[?2004h"),
+            "external editor resume must still restore bracketed paste: {seq:?}"
         );
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -11567,6 +11567,8 @@ pub(crate) fn recover_terminal_modes<W: Write>(
         if let Err(err) = execute!(writer, EnableMouseCapture) {
             tracing::debug!(?err, "EnableMouseCapture ignored");
         }
+    } else {
+        disable_alternate_scroll_mode(writer);
     }
     if use_bracketed_paste {
         try_enable_bracketed_paste_mode(writer);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -317,9 +317,9 @@ enum TranslationEvent {
 // plus ratatui's `terminal.clear()` are sufficient to repaint cleanly.
 const TERMINAL_ORIGIN_RESET: &[u8] = b"\x1b[r\x1b[?6l\x1b[H";
 // Xterm alternate-scroll mode keeps wheel events inside the alternate-screen
-// viewport. Crossterm's mouse-capture command does not enable this DEC private
-// mode, so terminals can still scroll the host scrollback if mouse capture is
-// disabled, dropped during focus changes, or unavailable in the host.
+// viewport when mouse capture is requested but unavailable or temporarily
+// dropped. Leave it off with `--no-mouse-capture` so the host terminal owns
+// raw mouse selection behavior end-to-end.
 const ENABLE_ALT_SCROLL_MODE: &[u8] = b"\x1b[?1007h";
 const DISABLE_ALT_SCROLL_MODE: &[u8] = b"\x1b[?1007l";
 /// Begin synchronized update (DEC 2026): tell the terminal to defer
@@ -11562,9 +11562,11 @@ pub(crate) fn recover_terminal_modes<W: Write>(
 
     pop_keyboard_enhancement_flags(writer);
     push_keyboard_enhancement_flags(writer);
-    enable_alternate_scroll_mode(writer);
-    if use_mouse_capture && let Err(err) = execute!(writer, EnableMouseCapture) {
-        tracing::debug!(?err, "EnableMouseCapture ignored");
+    if use_mouse_capture {
+        enable_alternate_scroll_mode(writer);
+        if let Err(err) = execute!(writer, EnableMouseCapture) {
+            tracing::debug!(?err, "EnableMouseCapture ignored");
+        }
     }
     if use_bracketed_paste {
         try_enable_bracketed_paste_mode(writer);

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -225,6 +225,10 @@ fn recover_terminal_modes_emits_expected_csi_sequences_with_gating() {
         !off.contains("\x1b[?1007h"),
         "alternate-scroll mode must stay off when mouse capture is disabled"
     );
+    assert!(
+        off.contains("\x1b[?1007l"),
+        "alternate-scroll mode must be reset when mouse capture is disabled"
+    );
 
     assert!(
         on.contains("\x1b[?1000h"),

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -218,8 +218,12 @@ fn recover_terminal_modes_emits_expected_csi_sequences_with_gating() {
         "Kitty keyboard disambiguation flag must be re-pushed regardless of gating"
     );
     assert!(
-        on.contains("\x1b[?1007h") && off.contains("\x1b[?1007h"),
-        "alternate-scroll mode must be re-armed regardless of mouse-capture gating"
+        on.contains("\x1b[?1007h"),
+        "alternate-scroll mode must be re-armed when mouse capture is active"
+    );
+    assert!(
+        !off.contains("\x1b[?1007h"),
+        "alternate-scroll mode must stay off when mouse capture is disabled"
     );
 
     assert!(


### PR DESCRIPTION
## Summary

- Fix #4026 by leaving xterm alternate-scroll mode off whenever `--no-mouse-capture` / `tui.mouse_capture = false` is active, so the host terminal fully owns native drag selection.
- Keep alternate-scroll recovery for the mouse-capture path, where it still helps if mouse capture is requested but unavailable or temporarily dropped.
- Stabilize the current Windows CI baseline with a compact Agent-mode prompt trim and an isolated subagent no-repo test path.

## Verification

- `cargo fmt`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked recover_terminal_modes`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked resume_tui_child_modes`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked alternate_scroll`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mode_prompts_remain_small_deltas_not_base_policy_copies`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked git_repo_root_reports_attempted_paths_when_no_repo_found`

Local full `cargo test -p codewhale-tui --bin codewhale-tui --locked` now clears the upstream Windows CI failures from main (`mode_prompts...`, `git_repo_root...`) but still fails three provider/setup tests on this workstation that passed on the latest upstream GitHub Actions Windows run.

Fixes #4026