### PR TITLE
fix(runtime): persist compaction summary so it survives engine reloads / compaction 摘要跨 engine 重载存活

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -700,6 +700,7 @@ impl Engine {
         messages_before: Option<usize>,
         messages_after: Option<usize>,
     ) {
+        let summary_prompt = self.rendered_compaction_summary();
         let _ = self
             .tx_event
             .send(Event::CompactionCompleted {
@@ -708,8 +709,28 @@ impl Engine {
                 message,
                 messages_before,
                 messages_after,
+                summary_prompt,
             })
             .await;
+    }
+
+    /// Render the accumulated compaction summary prompt to plain text so it
+    /// can travel in events and be persisted by host layers. All emit sites
+    /// run after `merge_compaction_summary`, so this reflects the summary
+    /// state the engine will use for subsequent requests.
+    fn rendered_compaction_summary(&self) -> Option<String> {
+        self.session
+            .compaction_summary_prompt
+            .as_ref()
+            .map(|prompt| match prompt {
+                SystemPrompt::Text(text) => text.clone(),
+                SystemPrompt::Blocks(blocks) => blocks
+                    .iter()
+                    .map(|block| block.text.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n\n"),
+            })
+            .filter(|text| !text.trim().is_empty())
     }
 
     pub(super) async fn emit_compaction_failed(&mut self, id: String, auto: bool, message: String) {

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -116,6 +116,12 @@ pub enum Event {
         /// Number of messages after compaction.
         #[allow(dead_code)]
         messages_after: Option<usize>,
+        /// Rendered text of the accumulated compaction summary prompt, if any.
+        /// Host layers (e.g. the /v1 runtime) persist this into the thread
+        /// record so the summary survives engine reloads — without it the
+        /// summary lives only in engine memory and is lost on LRU eviction
+        /// or restart (SyncSession re-extracts it from the record prompt).
+        summary_prompt: Option<String>,
     },
 
     /// Context purge started.

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -47,6 +47,54 @@ const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const MAX_ACTIVE_THREADS_DEFAULT: usize = 8;
 const SUMMARY_LIMIT: usize = 280;
 
+/// Sentinel delimiters wrapping the compaction summary section persisted in a
+/// thread record's `system_prompt`. The section carries the engine-rendered
+/// summary (which contains the `Conversation Summary (Auto-Generated)` marker,
+/// so `SyncSession` → `extract_compaction_summary_prompt` restores it on
+/// engine reload). Delimiters make replacement idempotent: each completed
+/// compaction swaps the section in place instead of stacking duplicates.
+/// External `PATCH /v1/threads/{id}` callers that rewrite `system_prompt`
+/// should preserve this section verbatim or the summary is lost on reload.
+const COMPACTION_SUMMARY_BEGIN: &str = "<!-- compaction-summary:begin -->";
+const COMPACTION_SUMMARY_END: &str = "<!-- compaction-summary:end -->";
+
+/// Merge a rendered compaction summary into a thread record's system prompt,
+/// replacing any previously persisted summary section.
+fn merge_summary_into_prompt(base: Option<&str>, summary_text: &str) -> String {
+    let stripped = base.map(strip_summary_section).unwrap_or_default();
+    let mut out = stripped.trim_end().to_string();
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str(COMPACTION_SUMMARY_BEGIN);
+    out.push('\n');
+    out.push_str(summary_text.trim());
+    out.push('\n');
+    out.push_str(COMPACTION_SUMMARY_END);
+    out
+}
+
+/// Remove a previously persisted compaction summary section, if present.
+fn strip_summary_section(base: &str) -> String {
+    let Some(start) = base.find(COMPACTION_SUMMARY_BEGIN) else {
+        return base.to_string();
+    };
+    let end = base[start..]
+        .find(COMPACTION_SUMMARY_END)
+        .map(|rel| start + rel + COMPACTION_SUMMARY_END.len());
+    let mut out = base[..start].trim_end().to_string();
+    if let Some(end) = end {
+        let tail = base[end..].trim_start();
+        if !tail.is_empty() {
+            if !out.is_empty() {
+                out.push_str("\n\n");
+            }
+            out.push_str(tail);
+        }
+    }
+    out
+}
+
 fn validated_record_id<'a>(id: &'a str, label: &str) -> Result<&'a str> {
     let trimmed = id.trim();
     if trimmed.is_empty() {
@@ -3129,7 +3177,42 @@ impl RuntimeThreadManager {
                     message,
                     messages_before,
                     messages_after,
+                    summary_prompt,
                 } => {
+                    // Persist the summary into the thread record so engine
+                    // reloads (LRU eviction / restart) restore it: reload
+                    // passes the record prompt through SyncSession, where
+                    // `extract_compaction_summary_prompt` picks the summary
+                    // back up. Without this the summary lives only in engine
+                    // memory and silently dies with the engine.
+                    if let Some(summary) =
+                        summary_prompt.as_deref().filter(|s| !s.trim().is_empty())
+                    {
+                        match self.get_thread(&thread_id).await {
+                            Ok(mut thread) => {
+                                let merged = merge_summary_into_prompt(
+                                    thread.system_prompt.as_deref(),
+                                    summary,
+                                );
+                                if thread.system_prompt.as_deref() != Some(merged.as_str()) {
+                                    thread.system_prompt = Some(merged);
+                                    thread.updated_at = Utc::now();
+                                    if let Err(e) = self.store.save_thread(&thread) {
+                                        tracing::warn!(
+                                            thread_id = %thread_id,
+                                            "Failed to persist compaction summary to thread record: {e}"
+                                        );
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    thread_id = %thread_id,
+                                    "Failed to load thread for compaction summary persistence: {e}"
+                                );
+                            }
+                        }
+                    }
                     if let Some(item_id) = compaction_items.remove(&id) {
                         let mut item = self.store.load_item(&item_id)?;
                         item.status = TurnItemLifecycleStatus::Completed;

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2295,6 +2295,7 @@ async fn compaction_lifecycle_emits_item_events_with_compaction_counts() -> Resu
                             message: "auto compact done".to_string(),
                             messages_before: Some(7),
                             messages_after: Some(3),
+                            summary_prompt: None,
                         })
                         .await;
                     let _ = tx_event
@@ -2327,6 +2328,10 @@ async fn compaction_lifecycle_emits_item_events_with_compaction_counts() -> Resu
                             message: "manual compact done".to_string(),
                             messages_before: Some(5),
                             messages_after: Some(2),
+                            summary_prompt: Some(
+                                "## 📋 Conversation Summary (Auto-Generated)\n\nkey facts."
+                                    .to_string(),
+                            ),
                         })
                         .await;
                     let _ = tx_event
@@ -2416,6 +2421,16 @@ async fn compaction_lifecycle_emits_item_events_with_compaction_counts() -> Resu
             && ev.payload.get("messages_before").and_then(Value::as_u64) == Some(5)
             && ev.payload.get("messages_after").and_then(Value::as_u64) == Some(2)
     }));
+
+    // The manual compact carried a summary_prompt → it must be persisted into
+    // the thread record so engine reloads restore it. The auto compact carried
+    // None → exactly one summary section, from the manual pass.
+    let record = manager.get_thread(&thread.id).await?;
+    let record_prompt = record.system_prompt.expect("record keeps a system prompt");
+    assert!(record_prompt.contains(COMPACTION_SUMMARY_BEGIN));
+    assert!(record_prompt.contains("Conversation Summary (Auto-Generated)"));
+    assert!(record_prompt.contains("key facts."));
+    assert_eq!(record_prompt.matches(COMPACTION_SUMMARY_BEGIN).count(), 1);
     Ok(())
 }
 
@@ -2932,4 +2947,67 @@ async fn fork_at_user_message_does_not_mutate_source() -> Result<()> {
         );
     }
     Ok(())
+}
+
+// ── compaction summary persistence (merge_summary_into_prompt) ──
+
+#[test]
+fn summary_merge_appends_section_to_base_prompt() {
+    let merged = merge_summary_into_prompt(
+        Some("You are a helpful agent."),
+        "## 📋 Conversation Summary (Auto-Generated)\n\nUser prefers lists.",
+    );
+    assert!(merged.starts_with("You are a helpful agent."));
+    assert!(merged.contains(COMPACTION_SUMMARY_BEGIN));
+    assert!(merged.contains("User prefers lists."));
+    assert!(merged.ends_with(COMPACTION_SUMMARY_END));
+    // Reload restore keys on the marker: SyncSession maps the record to
+    // SystemPrompt::Text and extract_compaction_summary_prompt checks
+    // `contains("Conversation Summary (Auto-Generated)")`.
+    assert!(merged.contains("Conversation Summary (Auto-Generated)"));
+}
+
+#[test]
+fn summary_merge_replaces_existing_section_idempotently() {
+    let first = merge_summary_into_prompt(Some("Base prompt."), "summary v1");
+    let second = merge_summary_into_prompt(Some(&first), "summary v2");
+    assert!(second.contains("summary v2"));
+    assert!(!second.contains("summary v1"));
+    assert_eq!(
+        second.matches(COMPACTION_SUMMARY_BEGIN).count(),
+        1,
+        "repeated compactions must swap the section, not stack duplicates"
+    );
+    assert!(second.starts_with("Base prompt."));
+}
+
+#[test]
+fn summary_merge_handles_missing_base() {
+    let merged = merge_summary_into_prompt(None, "only summary");
+    assert!(merged.starts_with(COMPACTION_SUMMARY_BEGIN));
+    assert!(merged.contains("only summary"));
+    let empty_base = merge_summary_into_prompt(Some(""), "only summary");
+    assert!(empty_base.starts_with(COMPACTION_SUMMARY_BEGIN));
+}
+
+#[test]
+fn summary_strip_preserves_text_after_section() {
+    let with_tail = format!(
+        "Base.\n\n{COMPACTION_SUMMARY_BEGIN}\nold summary\n{COMPACTION_SUMMARY_END}\n\nTrailing rules."
+    );
+    let stripped = strip_summary_section(&with_tail);
+    assert!(stripped.contains("Base."));
+    assert!(stripped.contains("Trailing rules."));
+    assert!(!stripped.contains("old summary"));
+    // Re-merge keeps the tail intact.
+    let merged = merge_summary_into_prompt(Some(&with_tail), "new summary");
+    assert!(merged.contains("Trailing rules."));
+    assert!(merged.contains("new summary"));
+}
+
+#[test]
+fn summary_strip_handles_missing_end_sentinel() {
+    let broken = format!("Base.\n\n{COMPACTION_SUMMARY_BEGIN}\ntruncated…");
+    let stripped = strip_summary_section(&broken);
+    assert_eq!(stripped, "Base.");
 }


### PR DESCRIPTION
## Summary / 摘要

Compaction summaries currently live only in engine memory and silently die on engine reload — this PR persists them into the thread record so the existing restore path can pick them back up.

compaction 摘要目前只存在于 engine 内存中，engine 重载时静默丢失——本 PR 把摘要持久化进 thread record，让既有的恢复通路能够接住它。

## Problem / 问题

On the `/v1` runtime path:

1. When compaction runs, the summary is merged into `session.system_prompt` and kept in the dedicated `session.compaction_summary_prompt` field — **engine memory only**.
2. The thread record's `system_prompt` is only ever written by `PATCH /v1/threads/{id}` (`update_thread` is the sole writer). Compaction never writes back to the record.
3. On engine reload — LRU eviction (`MAX_ACTIVE_THREADS = 8`) or a server restart — `ensure_engine_loaded` rebuilds the engine from the **record's** prompt. `SyncSession → extract_compaction_summary_prompt` is clearly designed to restore summaries at exactly this point, but the record never contains one, so the extraction always yields `None`.

Net effect: the compacted-away messages are gone, and the summary that was supposed to stand in for them is gone too. Long-running `/v1` threads lose precisely the context that compaction was built to preserve, and the loss is invisible to the client.

在 `/v1` 路径上：

1. compaction 完成后，摘要合并进 `session.system_prompt` 并保存在专用字段 `session.compaction_summary_prompt`——**只在 engine 内存里**。
2. thread record 的 `system_prompt` 唯一写入者是 `PATCH /v1/threads/{id}`（`update_thread` 是全文件唯一赋值点），compaction 从不回写 record。
3. engine 重载时——LRU 驱逐（`MAX_ACTIVE_THREADS = 8`）或服务重启——`ensure_engine_loaded` 用 **record** 的 prompt 重建 engine。`SyncSession → extract_compaction_summary_prompt` 显然就是为这个时刻的恢复而设计的，但 record 里从来没有摘要，提取恒为 `None`。

净效果：被压缩掉的消息没了，本该替代它们的摘要也没了。长会话丢失的恰恰是 compaction 要保护的上下文，而且客户端完全无感。

## Fix / 修复

Three small changes, feeding the existing restore path instead of inventing a new one:

- **`core/events.rs`** — `CompactionCompleted` gains a `summary_prompt: Option<String>` field.
- **`core/engine.rs`** — the emit helper renders the accumulated `session.compaction_summary_prompt` into the event. All three emit paths (manual `/compact`, auto, emergency recovery) get this with zero call-site changes.
- **`runtime_threads.rs`** — on `CompactionCompleted`, merge the summary into the thread record's `system_prompt`, wrapped in sentinel comments (`<!-- compaction-summary:begin/end -->`) so repeated compactions swap the section in place instead of stacking duplicates. Reload restoration then happens through the **existing** `extract_compaction_summary_prompt` path (the summary text contains the `Conversation Summary (Auto-Generated)` marker) with no further changes.

三处小改动，喂给既有恢复通路而不是另起炉灶：

- **`core/events.rs`**——`CompactionCompleted` 事件新增 `summary_prompt: Option<String>` 字段。
- **`core/engine.rs`**——emit 内部把累积的 `session.compaction_summary_prompt` 渲染进事件，三个发射点（手动 `/compact`、自动、紧急恢复）零调用点改动。
- **`runtime_threads.rs`**——消费事件时把摘要用哨兵注释（`<!-- compaction-summary:begin/end -->`）包裹后合并进 record 的 `system_prompt`，重复压缩原地替换不堆叠。重载恢复完全走**既有**的 `extract_compaction_summary_prompt` 通路（摘要文本自带 `Conversation Summary (Auto-Generated)` 标记），无需任何额外改动。

External callers that rewrite `system_prompt` via `PATCH` should preserve the sentinel section verbatim (documented on the constants); clients that never `PATCH` get the fix for free.

通过 `PATCH` 整体重写 `system_prompt` 的外部调用方需要原样保留哨兵段（常量处已写明文档）；从不 `PATCH` 的客户端零成本受益。

## Verification / 验证

- **Unit tests (+6)**: merge/strip idempotency, replace-not-stack on repeated compaction, missing base, broken/missing end sentinel, tail-text preservation. The `compaction_lifecycle_emits_item_events_with_compaction_counts` integration test now also asserts the record ends up with exactly one summary section after a manual compact carrying a summary and an auto compact carrying `None`.
- **Live `/v1` E2E** (DeepSeek V4, agent mode): 5 real turns (a passphrase planted in turn 2) → manual `POST /v1/threads/{id}/compact` → genuine compaction `10 → 7 messages (3 removed)` → the record's `system_prompt` grew 3247 → 5103 bytes and contains sentinel + marker. After a **full server restart** (guaranteed engine reload), the reloaded engine quoted its summary section verbatim and correctly recalled the passphrase from five turns earlier.
- `check-coauthor-trailers.py --check-authors` passes on the branch.

- **单测（+6）**：merge/strip 幂等、重复压缩替换不堆叠、无 base、断尾哨兵、段后文本保留；`compaction_lifecycle` 集成测试新增断言——手动压缩（带摘要）+ 自动压缩（`None`）后 record 恰好一份摘要段。
- **真机 `/v1` E2E**（DeepSeek V4，agent mode）：5 轮真对话（第 2 轮埋通关密语）→ 手动 compact → 真实压缩 `10 → 7 (3 removed)` → record 从 3247 涨到 5103 字节，哨兵 + 标记齐全。**完整重启服务**（必然触发 engine 重载）后，重载的 engine 原文引用了自己 system prompt 里的摘要段，并答对了五轮前的密语。

---

Found while building on CodeWhale as a base for a downstream harness — the reload gap bites hard there because per-turn helper threads make LRU eviction routine, but the fix benefits any long-running `/v1` thread. Implemented and verified with AI agent assistance (Chinatsu / 千夏), reviewed end-to-end before submission.

这个缺口是我们基于 CodeWhale 做下游 harness 时发现的——那边每轮的辅助线程让 LRU 驱逐成为常态，问题暴露得很快，但修复对任何长跑的 `/v1` 会话都有效。由 AI agent（千夏 / Chinatsu）协助实现与验证，提交前已端到端复核。
