### PR TITLE
docs(constitution): add anti-polling rule for sub-agent waiting strategy

### DIFF
--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1203,6 +1203,10 @@ impl Engine {
                                 "Turn ending with {running} sub-agent(s) still running in the background; they'll report when done."
                             )))
                             .await;
+                        // Inject a waiting hint so the model does not poll
+                        // with peek/status/sleep on the next turn (issue #4097).
+                        self.add_session_message(waiting_for_subagents_runtime_message(running))
+                            .await;
                     }
                 }
                 if subagent_completions > 0 {
@@ -2505,6 +2509,28 @@ XML unless the user explicitly asks to debug sub-agent internals.\n\n\
 {payload}\n\
 </codewhale:runtime_event>"
     )
+}
+
+fn waiting_for_subagents_runtime_message(running: usize) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text {
+                text: format!(
+                    "<codewhale:runtime_event kind=\"waiting_for_subagents\" visibility=\"internal\">\n\
+This is an internal runtime event, not user input. Your {running} sub-agent(s) \
+are still running. Do NOT poll them with agent(action=\"peek\") or \
+agent(action=\"status\"). Do NOT use sleep or any shell blocking primitive as a \
+waiting strategy. The runtime will deliver <codewhale:subagent.done> sentinels \
+automatically when each child finishes — polling will never make that happen \
+sooner. Stop immediately: emit zero tool calls and end the turn.\n\
+</codewhale:runtime_event>"
+                ),
+                cache_control: None,
+            },
+            runtime_event_turn_metadata_block(UserInputProvenance::SubAgentHandoff),
+        ],
+    }
 }
 
 fn subagent_completion_runtime_message(payload: &str) -> Message {

--- a/crates/tui/src/prompts/constitution.md
+++ b/crates/tui/src/prompts/constitution.md
@@ -373,6 +373,15 @@ Reach for them when the work is genuinely independent:
   launch more; do not invent a smaller per-turn limit. To fan out more gently
   you can lower `[subagents].launch_concurrency` (how many start at once);
   the default is the full running cap.
+- **Waiting, not polling**: When you end a turn because every remaining task
+  depends on background results that haven't arrived yet, do **not** poll those
+  children with `agent(action="peek")` or `agent(action="status")` on your next
+  turn. Do not use `sleep` or any shell blocking primitive as a waiting strategy.
+  The runtime delivers `<codewhale:subagent.done>` sentinels automatically as
+  user messages the moment a child finishes — polling will never make that happen
+  sooner, it only burns turns and budget. If you receive a new turn with no new
+  user message and your children are still running, stop immediately: emit zero
+  tool calls and end the turn.
 
 ## Thinking Delegation
 


### PR DESCRIPTION
## Problem

When the parent launches sub-agents and runs out of independent work, it falls into a wasteful peek-sleep-peek-sleep polling loop instead of passively waiting for subagent_completion events. This burns turns and budget without changing the outcome (sub-agents don't finish faster because you poll them).

Evidence: issue #4097 documents a real session where 3 sub-agents triggered 13 peek calls and 5 artificial sleep calls (140s blocked), with $0.086 sub-agent cost where the majority was polling overhead.

## Solution

Add explicit "Waiting, not polling" guidance to the Sub-Agent Strategy section in constitution.md:

- Do not poll with peek or status actions
- Do not use sleep as a wait primitive
- If the runtime gives you a new turn with no new user message and children are running: stop immediately, emit zero tool calls, end the turn

The runtime already delivers subagent.done sentinels as user messages when children complete. Polling is pure waste.

## Change

One file: crates/tui/src/prompts/constitution.md — new bullet in the Sub-Agent Strategy section.

Closes #4097
