### PR TITLE
feat(workflows): v0.8.68 agent execution lanes and milestone sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,7 +1,7 @@
 name: Agent task
 description: Create a self-contained task that a headless agent (DeepSeek V4, remote droplet) can execute end-to-end without human context.
-title: "v0.8.67: "
-labels: ["agent-ready", "v0.8.67"]
+title: "v0.8.68: "
+labels: ["agent-ready", "v0.8.68"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/v0868-milestone-sync.yml
+++ b/.github/workflows/v0868-milestone-sync.yml
@@ -1,0 +1,92 @@
+name: v0.8.68 milestone hygiene
+
+on:
+  issues:
+    types: [opened, labeled, milestoned]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync v0.8.68 label with milestone
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) return;
+
+            const milestoneTitle = issue.milestone?.title || '';
+            const labels = (issue.labels || []).map(l => l.name);
+            const hasMilestone = milestoneTitle === 'v0.8.68';
+            const hasLabel = labels.includes('v0.8.68');
+
+            if (hasMilestone && !hasLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['v0.8.68'],
+              });
+              core.info(`Added v0.8.68 label to #${issue.number}`);
+            }
+
+            if (hasLabel && !hasMilestone && issue.state === 'open') {
+              const milestones = await github.paginate(
+                github.rest.issues.listMilestones,
+                { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 }
+              );
+              const target = milestones.find(m => m.title === 'v0.8.68');
+              if (target) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  milestone: target.number,
+                });
+                core.info(`Added #${issue.number} to v0.8.68 milestone`);
+              }
+            }
+
+      - name: Auto-label agent-task issues
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) return;
+
+            const title = (issue.title || '').toLowerCase();
+            const body = (issue.body || '').toLowerCase();
+            const labels = new Set((issue.labels || []).map(l => l.name));
+
+            // Agent-ready tasks: title starts with v0.8.68 and has structured sections
+            if (title.startsWith('v0.8.68:') && body.includes('acceptance criteria')) {
+              labels.add('agent-ready');
+            }
+
+            // Area hints for v0.8.68 work
+            const text = `${title}\n${body}`;
+            if (/\bworkflow\b|whaleflow|workflow-runtime/.test(text)) labels.add('workflow-runtime');
+            if (/crates\/tui|\btui\b|ratatui/.test(text)) labels.add('tui');
+            if (/fleet|subagent|sub-agent/.test(text)) labels.add('subagents');
+            if (/catalog|openrouter|model.?picker|provider.?lake/.test(text)) labels.add('reliability');
+
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const existingNames = new Set(existing.map(l => l.name));
+            const toAdd = [...labels].filter(name => existingNames.has(name) && !(issue.labels || []).some(l => l.name === name));
+            if (toAdd.length === 0) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: toAdd,
+            });

--- a/docs/AGENT_WORKFLOWS_0868.md
+++ b/docs/AGENT_WORKFLOWS_0868.md
@@ -1,0 +1,160 @@
+# CodeWhale v0.8.68 — Agent Workflow Playbook
+
+This document tells autonomous agents how to systematically complete the v0.8.68
+release. It pairs with:
+
+- **Milestone:** `v0.8.68` (GitHub milestone #53)
+- **Triage packet:** issue [#4092](https://github.com/Hmbown/CodeWhale/issues/4092)
+- **Master checklist:** `CODEWHALE_0_8_68.md` (harness workspace) or tracker in repo root after merge
+- **Workflow files:** `workflows/v0868_*.workflow.js`
+
+## Source of truth
+
+- **Implementation base:** `main` — all v0.8.68 fix branches start here. PR #4099
+  merged the quick-win cutover; do not use `work/v0.9.0-cutover` or
+  `.cw-worktrees/v0867-pr4047`.
+- **`codex/0868-next`:** stale reference only. Cherry-pick from it only when a
+  specific issue needs a specific commit — never treat it as the active dev branch.
+- **Playbook/workflow PR:** `codex/v0868-agent-workflows` (PR #4163) — docs and
+  workflow definitions only; implementation PRs branch from `main`.
+
+## Defer policy (v0.8.69 / architecture refactors)
+
+Defer v0.8.69 refactors and broad feature lanes unless they **directly unblock**
+a stopship issue (#4090, #4093, #4094).
+
+| Category | When | Notes |
+|----------|------|-------|
+| Stopship (#4090, #4093, #4094) | **Now** | Wave 1 — release-blocking |
+| Dogfood regressions (#3986, #3990) | After stopship | Same lane, lower priority |
+| Catalog lane (Wave 2) | After stopship green | #4109, #4114–#4119, #4139–#4141 |
+| Workflow UI lane (Wave 3) | After stopship green | #4038, #4110, #4120–#4135 |
+| TUI copy lane (Wave 4) | After stopship green | #4112, #4142–#4148 |
+| v0.8.69 refactors / 0.9.0 architecture | **Deferred** | Unless required to fix #4090/#4093/#4094 |
+
+Issues labeled `v0.8.69` still in milestone `v0.8.68` should be reclassified to
+DEFER (0.9.0) during sweep unless tied to a stopship fix.
+
+## Quick start
+
+```bash
+# 1. Sync and verify branch (implementation always from main)
+cd CodeWhale
+git fetch origin
+git checkout main && git pull origin main
+git checkout -b codex/v0868-fix-<issue>   # e.g. codex/v0868-fix-4090
+git status -sb
+
+# 2. Board truth
+gh issue list -R Hmbown/CodeWhale --milestone "v0.8.68" --state open --limit 200
+gh pr list -R Hmbown/CodeWhale --state open --limit 50 \
+  --json number,title,isDraft,mergeable,milestone
+
+# 3. Read the triage packet (do not skip)
+gh issue view 4092 -R Hmbown/CodeWhale
+
+# 4. Run verification gate before and after changes
+cargo fmt --all --check
+cargo clippy --workspace --all-features --locked -D warnings \
+  -A clippy::uninlined_format_args -A clippy::too_many_arguments \
+  -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants
+cargo test --workspace --locked
+cargo build --release -p codewhale-tui
+```
+
+## Execution order (waves)
+
+Work top-to-bottom. **Do not start Waves 2–4 or v0.8.69 refactors until stopship
+is green** (#4090, #4093, #4094 closed or verified fixed on `main`).
+
+| Wave | Workflow file | Theme | GitHub issues | Status |
+|------|---------------|-------|---------------|--------|
+| 0 | `v0868_issue_sweep.workflow.js` | Triage + release plan | all milestone | On demand |
+| 1 | `v0868_stopship_lane.workflow.js` | Release blockers + dogfood regressions | #4090, #4093, #4094, #3986, #3990 | **Active** |
+| 2 | `v0868_catalog_lane.workflow.js` | Model catalog consolidation | #4109, #4114–#4119, #4139–#4141 | Deferred |
+| 3 | `v0868_workflow_ui_lane.workflow.js` | Workflow orchestration UI | #4038, #4110, #4120–#4135 | Deferred |
+| 4 | `v0868_tui_copy_lane.workflow.js` | Transcript/copy polish | #4112, #4142–#4148 | Deferred |
+| 5 | `v0868_release_gate.workflow.js` | Final verification + handoff | milestone closeout | After Waves 1–4 |
+
+## How to launch a workflow
+
+Branch from `main` before starting implementation agents:
+
+```bash
+git checkout main && git pull origin main
+git checkout -b codex/v0868-stopship-<issue>
+```
+
+From CodeWhale TUI or headless exec:
+
+```bash
+# Headless stopship lane (preferred for CI/VM agents)
+codewhale exec --auto --output-format stream-json \
+  "Run workflows/v0868_stopship_lane.workflow.js on branch codex/v0868-stopship. Fix #4090, #4093, #4094. Branch from main."
+
+# Per-issue headless (single stopship issue)
+codewhale exec --auto --output-format stream-json \
+  "Run workflows/v0868_issue_implement.workflow.js for issue #4090. Branch from main."
+
+# TUI explicit path
+/workflow start workflows/v0868_stopship_lane.workflow.js
+```
+
+Workflows use read-only scouts first, then implementation agents in sequence.
+Write agents require approval in default modes; use `--auto` for headless VM runs.
+
+## Per-issue implementation (single issue)
+
+For one `agent-ready` issue:
+
+1. `gh issue view <N> -R Hmbown/CodeWhale`
+2. Confirm issue is in milestone `v0.8.68` and has label `v0.8.68`
+3. Run `workflows/v0868_issue_implement.workflow.js` with the issue number in the goal
+4. Or use headless: `codewhale exec --auto` with the issue body as prompt
+5. Open PR referencing `Fixes #<N>`; do not close issues until merged
+
+Label hygiene for agent execution:
+
+```bash
+gh issue edit <N> --add-label agent-in-progress --remove-label agent-ready
+# after PR merged:
+gh issue close <N> --comment "Fixed in PR #<PR>"
+```
+
+## PR harvest lane (parallel to waves)
+
+Review community PRs without squashing authorship. Order from #4092:
+
+| PR | Issue | Notes |
+|----|-------|-------|
+| #4088 | #4026 | Mergeable; terminal selection highlight |
+| #4087 | #4082 | Draft refactor; finish review |
+| #4084 | #4065 | Fleet alias cleanup |
+| #3761 | #3757 | Conflicting; cherry-pick if needed |
+| #3969 | #3965 | Conflicting; align with #4065 first |
+
+## Skills to load
+
+Copy or reference these maintainer skills from `docs/skills/`:
+
+- `gh-compile-issues` — classify done/quick-fix/design/defer with evidence
+- `codew-release-qa-sweep` — release gate commands
+- `gh-find-prs` — locate related PRs before implementing
+
+## Agent constraints
+
+- **Do not** push to `main`, tag, release, or close issues without explicit approval
+- **Do not** force-push or amend pushed commits
+- **Do** cite `path:line` evidence for every "done" claim
+- **Do** run the verification gate after each wave
+- **Do** update issue #4092 with handoff notes when switching agents
+
+## Milestone status (2026-07-07)
+
+- **Source of truth:** `main` (PR #4099 merged — quick-win cutover landed)
+- Milestone `v0.8.68` (#53): ~70 open / ~105 total
+- Labels: `v0.8.68` synced with milestone membership
+- Release blockers: #4093, #4094
+- Top dogfood regression: #4090 (Ctrl+C re-prompt)
+- **Deferred:** v0.8.69 refactors and Waves 2–4 until stopship green
+- **Stale reference only:** `codex/0868-next` — cherry-pick per-commit when needed

--- a/workflows/v0868_catalog_lane.workflow.js
+++ b/workflows/v0868_catalog_lane.workflow.js
@@ -1,0 +1,89 @@
+export default workflow({
+  "id": "v0868-catalog-lane",
+  "goal": "Complete v0.8.68 model catalog consolidation (Section 1)",
+  "description": "Parallel scouts for catalog gaps, then sequential implementation of live refresh, picker views, and legacy source migration. DEFERRED until stopship (#4090, #4093, #4094) is green — do not start unless explicitly unblocked.",
+  "nodes": [
+    {
+      "branch": {
+        "id": "scout-catalog",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "scout-openrouter",
+              "prompt": "Audit OpenRouter live catalog integration for v0.8.68 (#4109, #4114). Read `crates/tui/src/client.rs` (`fetch_catalog_delta`, `refresh_catalog_cache`, `parse_openrouter_models_response`) and `crates/config/src/catalog.rs`. Compare against issue bodies: `gh issue view 4114 -R Hmbown/CodeWhale`. Report: fields preserved vs dropped, sort order handling, TTL/backoff gaps. Output SUMMARY + EVIDENCE (path:line) + effort S/M/L.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/client.rs", "crates/config/src/catalog.rs", "crates/tui/src/provider_lake.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-picker-views",
+              "prompt": "Audit model picker UX for v0.8.68 (#4115, #4139, #4140, #4141). Read `crates/tui/src/tui/model_picker.rs` and `provider_picker.rs`. Check ModelListView modes, configured vs catalog toggle, cross-field search, metadata rows. Issues: `gh issue view 4115 4139 4140 4141 -R Hmbown/CodeWhale`. Report done/partial/missing per acceptance criterion.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/model_picker.rs", "crates/tui/src/tui/provider_picker.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-legacy-sources",
+              "prompt": "Find remaining `model_completion_names_for_provider` consumers (#4116). Run `git grep -n model_completion_names_for_provider -- crates/`. For each call site (picker, hotbar, inventory, subagent, widgets), report whether it uses ConfiguredProviderLake or legacy table. Map to issue #4116 acceptance. Read-only.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/"],
+              "budget": { "max_steps": 10, "timeout_secs": 600 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequence": {
+        "id": "implement-catalog",
+        "children": [
+          {
+            "agent": {
+              "id": "impl-refresh-policy",
+              "prompt": "Implement catalog refresh policy (#4114) per scout-openrouter findings: manual `/model refresh` or `/provider refresh`, background TTL refresh, stale chip, fail-closed on auth errors, secret-free cache persistence. Touch `client.rs` and `catalog.rs`. Add tests. Run `cargo test -p codewhale-config catalog` and `cargo test -p codewhale-tui provider_lake`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/client.rs", "crates/config/src/catalog.rs"],
+              "budget": { "max_steps": 24, "timeout_secs": 1800 }
+            }
+          },
+          {
+            "agent": {
+              "id": "impl-picker-views",
+              "prompt": "Implement model picker catalog views (#4115, #4139-4141) per scout-picker-views: Configured/Catalog/Recent/Coding/Cheap/Long-context views, metadata rows, cross-field search on provider+model. Minimal diff matching existing picker patterns. Tests in `cargo test -p codewhale-tui model_picker`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tui/model_picker.rs", "crates/tui/src/tui/provider_picker.rs"],
+              "budget": { "max_steps": 24, "timeout_secs": 1800 }
+            }
+          },
+          {
+            "agent": {
+              "id": "impl-migrate-consumers",
+              "prompt": "Migrate remaining legacy model source consumers to ProviderLake (#4116). Replace `model_completion_names_for_provider` at each scout-legacy-sources call site. Keep bundled fallback for unconfigured providers. Run `cargo test -p codewhale-tui model_inventory hotbar subagent`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tui/hotbar/", "crates/tui/src/tools/subagent/mod.rs"],
+              "budget": { "max_steps": 20, "timeout_secs": 1200 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "reduce": {
+        "id": "catalog-handoff",
+        "inputs": ["scout-openrouter", "scout-picker-views", "scout-legacy-sources", "impl-refresh-policy", "impl-picker-views", "impl-migrate-consumers"],
+        "prompt": "Synthesize catalog lane.\n\n## SECTION 1 STATUS (1.1-1.5)\n| Item | Issue | Status | Evidence |\n\n## TESTS\n\n## DEFERRED TO 0.9.0\n\n## READY FOR WORKFLOW UI LANE?\nyes/no + why"
+      }
+    }
+  ]
+});

--- a/workflows/v0868_issue_implement.workflow.js
+++ b/workflows/v0868_issue_implement.workflow.js
@@ -1,0 +1,52 @@
+export default workflow({
+  "id": "v0868-issue-implement",
+  "goal": "Implement a single v0.8.68 GitHub issue end-to-end (set ISSUE_NUMBER in prompt)",
+  "description": "Generic per-issue workflow: fetch issue, scout code, implement fix, verify, prepare PR handoff. Branch from main; do not use codex/0868-next unless cherry-picking a specific commit.",
+  "nodes": [
+    {
+      "agent": {
+        "id": "fetch-issue",
+        "prompt": "The target issue number is provided in the workflow goal or user message. Run:\n```\ngh issue view <ISSUE_NUMBER> -R Hmbown/CodeWhale --json number,title,body,labels,milestone,comments\n```\nExtract: goal, acceptance criteria, key files mentioned, verification commands, out-of-scope items. Confirm issue is in milestone v0.8.68 or has label v0.8.68. Output structured ISSUE_BRIEF with SCOPE, KEY_FILES, ACCEPTANCE, VERIFICATION, OUT_OF_SCOPE.",
+        "agent_type": "explore",
+        "mode": "read_only",
+        "budget": { "max_steps": 8, "timeout_secs": 300 }
+      }
+    },
+    {
+      "agent": {
+        "id": "scout-code",
+        "prompt": "Using ISSUE_BRIEF from fetch-issue, inspect current code at cited paths. Use `git grep` and read files. Report: already-done / partial / not-started with path:line evidence. Propose minimal implementation plan (numbered steps). Read-only.",
+        "agent_type": "explore",
+        "mode": "read_only",
+        "file_scope": ["crates/"],
+        "budget": { "max_steps": 12, "timeout_secs": 600 }
+      }
+    },
+    {
+      "agent": {
+        "id": "implement-fix",
+        "prompt": "Implement the issue per scout-code plan. Branch from main (`git checkout main && git pull && git checkout -b codex/v0868-fix-<N>`). Stay within OUT_OF_SCOPE. Smallest correct diff. Run VERIFICATION commands from ISSUE_BRIEF. If blocked, report blocker clearly instead of guessing.",
+        "agent_type": "implementer",
+        "mode": "write",
+        "file_scope": ["crates/"],
+        "budget": { "max_steps": 24, "timeout_secs": 1800 }
+      }
+    },
+    {
+      "agent": {
+        "id": "verify-fix",
+        "prompt": "Re-run all verification commands from ISSUE_BRIEF. Map each acceptance criterion to pass/fail with evidence. Prepare PR title and body with `Fixes #<N>` footer. Do not push or open PR without approval.",
+        "agent_type": "verifier",
+        "mode": "read_only",
+        "budget": { "max_steps": 8, "timeout_secs": 900 }
+      }
+    },
+    {
+      "reduce": {
+        "id": "issue-handoff",
+        "inputs": ["fetch-issue", "scout-code", "implement-fix", "verify-fix"],
+        "prompt": "Synthesize per-issue implementation handoff.\n\n## ISSUE\n\n## STATUS\nimplemented / partial / blocked\n\n## CHANGES\n\n## TESTS\n\n## PR DRAFT\nTitle + body\n\n## BLOCKERS"
+      }
+    }
+  ]
+});

--- a/workflows/v0868_issue_sweep.workflow.js
+++ b/workflows/v0868_issue_sweep.workflow.js
@@ -1,0 +1,97 @@
+export default workflow({
+  "id": "v0868-issue-sweep",
+  "goal": "Triage, investigate, and produce an actionable release plan for all CodeWhale v0.8.68 issues",
+  "description": "Parallel issue sweep for v0.8.68. Phase 1 scouts each lane via gh CLI; Phase 2 deep-triages blockers; Phase 3 synthesizes tracker-ready release plan.",
+  "nodes": [
+    {
+      "branch": {
+        "id": "phase1-scout",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "scout-milestone-board",
+              "prompt": "Fetch live v0.8.68 board truth. Run:\n```\ngh issue view 4092 -R Hmbown/CodeWhale\ngh issue list -R Hmbown/CodeWhale --milestone v0.8.68 --state open --limit 200\ngh issue list -R Hmbown/CodeWhale --label release-blocker --state open\ngh pr list -R Hmbown/CodeWhale --state open --limit 50 --json number,title,isDraft,mergeable,milestone\n```\nRead `docs/AGENT_WORKFLOWS_0868.md` for wave structure. Summarize: open count, release blockers, PR candidates, recommended execution order from #4092.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["docs/AGENT_WORKFLOWS_0868.md"],
+              "budget": { "max_steps": 10, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-workflow-runtime",
+              "prompt": "Audit workflow runtime for v0.8.68 (#4038, #4011, #4013, #4110). Read `crates/tui/src/tools/workflow.rs` for completion_from_manager, cancel/VM interrupt, budget.spent(), SharedWorkflowRuns usage. Read issues: `gh issue view 4038 4011 4013 4110 -R Hmbown/CodeWhale`. Report per item: done/partial/stub/missing with path:line, effort S/M/L, release-blocking yes/no.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tools/workflow.rs", "crates/tui/src/tui/history.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-catalog-lane",
+              "prompt": "Audit model catalog lane (#4109, #4114-#4119, #4139-#4141). Read `crates/tui/src/client.rs`, `crates/config/src/catalog.rs`, `crates/tui/src/provider_lake.rs`, `crates/tui/src/tui/model_picker.rs`. Run `git grep -n model_completion_names_for_provider -- crates/`. Report Section 1 status with evidence.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/client.rs", "crates/config/src/catalog.rs", "crates/tui/src/provider_lake.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-tui-stopship",
+              "prompt": "Audit TUI stopship issues: #4090, #4093, #4094, #3986, #3990, #3985, #3987, #3993, #3995. Fetch via `gh issue view`. Search `crates/tui/src/tui/` for Ctrl+C handling, fleet setup modal, sub-agent sidebar, onboarding copy, slash autocomplete. Per issue: severity P0-P3, root cause hypothesis, fix complexity S/M/L.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/"],
+              "budget": { "max_steps": 14, "timeout_secs": 600 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequence": {
+        "id": "phase2-deep-triage",
+        "children": [
+          {
+            "agent": {
+              "id": "triage-stopship",
+              "prompt": "Using scout-tui-stopship findings, produce ordered stopship fix train for #4090, #4093, #4094. Minimal fix approach per issue, test strategy, whether fixes ship independently. Read-only plan only.",
+              "agent_type": "review",
+              "mode": "read_only",
+              "profile": "reviewer",
+              "file_scope": ["crates/tui/src/tui/app.rs", "crates/tui/src/tui/sidebar.rs"],
+              "budget": { "max_steps": 10, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "triage-defer-matrix",
+              "prompt": "Using scout-milestone-board, classify ALL open v0.8.68 issues into: SHIP (0.8.68), DEFER (0.9.0), CLOSE (duplicate/wontfix), INVESTIGATE. Use gh-compile-issues disposition style with evidence. Flag v0.8.69-labeled issues still in milestone — default DEFER unless they unblock stopship (#4090, #4093, #4094). Defer v0.8.69 refactors and Waves 2–4 feature lanes until stopship is green. Implementation source of truth is main (not codex/0868-next). Output counts per bucket.",
+              "agent_type": "review",
+              "mode": "read_only",
+              "profile": "reviewer",
+              "budget": { "max_steps": 12, "timeout_secs": 900 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "reduce": {
+        "id": "release-plan",
+        "inputs": [
+          "scout-milestone-board",
+          "scout-workflow-runtime",
+          "scout-catalog-lane",
+          "scout-tui-stopship",
+          "triage-stopship",
+          "triage-defer-matrix"
+        ],
+        "prompt": "Synthesize ALL upstream findings into a CodeWhale v0.8.68 release plan.\n\n## VERDICT\nready / partial / blocked — one sentence why\n\n## SCOPE (ship in 0.8.68)\n- Stopship / release-blockers\n- P1 features\n- Good-first issues\n\n## DEFER (0.9.0+)\n- Issue numbers + reason\n\n## CLOSE\n- Issue numbers + reason\n\n## WAVES (map to workflow files)\n| Wave | Workflow file | Issues | Owner lane |\n\n## PR HARVEST\n| PR | Issue | Action |\n\n## VERIFICATION GATE\n- Commands + manual checklist\n\n## OPEN RISKS\n\nBe decisive. Cite issue numbers. Use only upstream evidence."
+      }
+    }
+  ]
+});

--- a/workflows/v0868_release_gate.workflow.js
+++ b/workflows/v0868_release_gate.workflow.js
@@ -1,0 +1,49 @@
+export default workflow({
+  "id": "v0868-release-gate",
+  "goal": "Run final v0.8.68 verification gate and produce release handoff",
+  "description": "Parallel verification agents (build, test, milestone audit) then synthesize release readiness verdict.",
+  "nodes": [
+    {
+      "branch": {
+        "id": "verify-parallel",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "verify-build",
+              "prompt": "Run the v0.8.68 verification gate build steps:\n```\ncargo fmt --all --check\ncargo clippy --workspace --all-features --locked -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants\ncargo build --release -p codewhale-tui -p codewhale-cli --locked\n```\nReport pass/fail per command with error excerpts if any fail.",
+              "agent_type": "verifier",
+              "mode": "read_only",
+              "budget": { "max_steps": 8, "timeout_secs": 1800 }
+            }
+          },
+          {
+            "agent": {
+              "id": "verify-tests",
+              "prompt": "Run workspace tests and focused TUI suites:\n```\ncargo test --workspace --locked\ncargo test -p codewhale-tui -- workflow fleet model_picker subagent\n```\nReport pass/fail counts and any failing test names with likely cause.",
+              "agent_type": "verifier",
+              "mode": "read_only",
+              "budget": { "max_steps": 8, "timeout_secs": 2400 }
+            }
+          },
+          {
+            "agent": {
+              "id": "audit-milestone",
+              "prompt": "Audit v0.8.68 milestone readiness using gh CLI:\n```\ngh issue list -R Hmbown/CodeWhale --milestone v0.8.68 --state open --limit 200\ngh issue list -R Hmbown/CodeWhale --label release-blocker --state open\ngh pr list -R Hmbown/CodeWhale --state open --json number,title,isDraft,mergeable,milestone\n```\nClassify open issues: stopship / should-ship / defer-0.9.0. Count by theme (catalog, workflow, tui, refactor). Read #4092 for prior handoff context.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "budget": { "max_steps": 10, "timeout_secs": 600 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "reduce": {
+        "id": "release-verdict",
+        "inputs": ["verify-build", "verify-tests", "audit-milestone"],
+        "prompt": "Produce v0.8.68 release gate report.\n\n## VERDICT\nready-to-tag / partial / blocked\n\n## GATE RESULTS\n| Check | Status |\n\n## OPEN STOPSHIP\n\n## SHIP LIST (issues that can close on tag)\n\n## DEFER LIST (move to 0.9.0)\n\n## HANDOFF FOR NEXT AGENT\nBranch, HEAD, PRs to review, recommended next wave.\n\nUpdate guidance for issue #4092 comment draft (do not post without approval)."
+      }
+    }
+  ]
+});

--- a/workflows/v0868_stopship_lane.workflow.js
+++ b/workflows/v0868_stopship_lane.workflow.js
@@ -1,0 +1,89 @@
+export default workflow({
+  "id": "v0868-stopship-lane",
+  "goal": "Fix v0.8.68 release-stopship blockers before any feature work",
+  "description": "Sequential stopship lane: #4090 Ctrl+C regression, release-blockers #4093/#4094, then re-verify dogfood fixes #3986/#3990. Branch all implementation from main (not codex/0868-next).",
+  "nodes": [
+    {
+      "branch": {
+        "id": "scout-stopship",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "scout-ctrl-c",
+              "prompt": "Investigate GitHub issue #4090 (repeated Ctrl+C re-prompts in PTY/raw-mode). Run: `gh issue view 4090 -R Hmbown/CodeWhale`. Then search `crates/tui/src/` for Ctrl+C handling, raw mode teardown, and exit confirmation paths. Report: repro hypothesis, exact files/functions, whether a regression test or PTY trace exists, minimal fix approach. Read-only.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/app.rs", "crates/tui/src/tui/ui.rs", "crates/tui/src/main.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-fleet-modal",
+              "prompt": "Investigate release-blocker #4093 (Fleet setup modal provider-scoped instead of role/profile roster). Run: `gh issue view 4093 -R Hmbown/CodeWhale`. Inspect `crates/tui/src/tui/views/fleet_setup.rs`, `crates/tui/src/fleet/roster.rs`, and related Fleet UI. Report current vs expected behavior, root cause, files to change, test strategy. Read-only.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/views/fleet_setup.rs", "crates/tui/src/fleet/"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-subagent-panel",
+              "prompt": "Investigate release-blocker #4094 (sub-agent detail panel empty / TUI freeze). Run: `gh issue view 4094 -R Hmbown/CodeWhale`. Inspect sidebar agents panel, sub-agent detail rendering, and redraw paths under load. Report root cause hypothesis, files, whether throttle or empty-state bug, severity. Read-only.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/sidebar.rs", "crates/tui/src/tui/widgets/agent_card.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequence": {
+        "id": "implement-stopship",
+        "children": [
+          {
+            "agent": {
+              "id": "fix-4090",
+              "prompt": "Fix #4090 using scout-ctrl-c findings. Branch from main (git checkout main && git pull && git checkout -b codex/v0868-fix-4090). Implement minimal fix so double Ctrl+C exits cleanly in PTY/raw-mode while preserving cancel/copy behavior. Add regression test or PTY/key-path trace. Run: `cargo test -p codewhale-tui` for touched modules and `cargo clippy -p codewhale-tui -- -D warnings`. Do not close the issue; report files changed and test output.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tui/app.rs", "crates/tui/src/tui/ui.rs"],
+              "budget": { "max_steps": 20, "timeout_secs": 1200 }
+            }
+          },
+          {
+            "agent": {
+              "id": "fix-4093-4094",
+              "prompt": "Using scout findings, fix #4093 and/or #4094 if root causes are clear and independent. Branch from main (separate branches per issue if needed: codex/v0868-fix-4093, codex/v0868-fix-4094). Prefer smallest correct diffs. For #4093: Fleet setup should edit role/profile roster not provider scope. For #4094: sub-agent detail panel must render and not freeze TUI. Add tests where feasible. Run targeted `cargo test -p codewhale-tui fleet sidebar`. Report per-issue status: fixed/partial/blocked.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tui/views/fleet_setup.rs", "crates/tui/src/tui/sidebar.rs"],
+              "budget": { "max_steps": 24, "timeout_secs": 1800 }
+            }
+          },
+          {
+            "agent": {
+              "id": "verify-dogfood",
+              "prompt": "Re-verify dogfood fixes for #3986 (API-key onboarding copy shows CODEWHALE_HOME path) and #3990 (slash autocomplete alias duplication). Read issue bodies via `gh issue view`. Check if fixes exist on current branch; if missing, implement minimal fixes. Run verification gate subset: `cargo fmt --all --check`, `cargo test -p codewhale-tui -- onboarding slash`. Report done/partial/missing per issue.",
+              "agent_type": "verifier",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tui/", "crates/tui/locales/en.json"],
+              "budget": { "max_steps": 16, "timeout_secs": 900 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "reduce": {
+        "id": "stopship-handoff",
+        "inputs": ["scout-ctrl-c", "scout-fleet-modal", "scout-subagent-panel", "fix-4090", "fix-4093-4094", "verify-dogfood"],
+        "prompt": "Synthesize stopship lane results.\n\n## VERDICT\nstopship-green / partial / blocked\n\n## PER-ISSUE STATUS\n| Issue | Status | Evidence |\n\n## TESTS RUN\n\n## REMAINING BLOCKERS\n\n## NEXT WAVE\nRecommend whether catalog lane (v0868_catalog_lane) is safe to start.\n\nCite only upstream agent evidence. Be decisive."
+      }
+    }
+  ]
+});

--- a/workflows/v0868_tui_copy_lane.workflow.js
+++ b/workflows/v0868_tui_copy_lane.workflow.js
@@ -1,0 +1,79 @@
+export default workflow({
+  "id": "v0868-tui-copy-lane",
+  "goal": "Polish v0.8.68 default transcript copy and progressive disclosure (Section 5)",
+  "description": "Parallel audit of copy-slop findings, then batch implementation of P1/P2 dedupe items. DEFERRED until stopship (#4090, #4093, #4094) is green.",
+  "nodes": [
+    {
+      "branch": {
+        "id": "scout-copy",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "scout-context-disclosure",
+              "prompt": "Audit context percent disclosure (#4142, copy finding #11). Read `header.rs`, `footer_ui.rs`, `sidebar.rs` for context % rendering. Issue: `gh issue view 4142 -R Hmbown/CodeWhale`. Report how many surfaces show context % simultaneously and recommended single disclosure point.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/widgets/header.rs", "crates/tui/src/tui/footer_ui.rs", "crates/tui/src/tui/sidebar.rs"],
+              "budget": { "max_steps": 10, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-transcript-words",
+              "prompt": "Audit default transcript copy issues (#4112, #4143-#4148). Read issues via `gh issue view 4112 4143 4144 4145 4146 4147 4148 -R Hmbown/CodeWhale`. Search `en.json` and history renderers for: mode picker body copy, setup hints, Searching verb mismatch, reasoning quiet default, sidebar Tasks label, duplicate/leaky words. Report per-issue file targets.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/locales/en.json", "crates/tui/src/tui/history.rs", "crates/tui/src/tui/views/mode_picker.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-compact-mode",
+              "prompt": "Audit compact mode default (#4095). `gh issue view 4095 -R Hmbown/CodeWhale`. Find compact mode config, default TUI presentation settings, busy chrome sources. Report whether compact should become default and what changes are needed in config/TuiPrefs.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/config.rs", "crates/tui/src/tui/ui.rs"],
+              "budget": { "max_steps": 10, "timeout_secs": 600 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequence": {
+        "id": "implement-copy",
+        "children": [
+          {
+            "agent": {
+              "id": "impl-copy-dedupe",
+              "prompt": "Implement copy dedupe batch (#4142-#4148, #4112) per scout findings. Rules: disclose once not thrice; header OR footer OR sidebar owns each fact. Touch `en.json`, `mode_picker.rs`, `history.rs`, `sidebar.rs` as needed. Add/adjust tests. `cargo test -p codewhale-tui history mode_picker`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/locales/en.json", "crates/tui/src/tui/history.rs"],
+              "budget": { "max_steps": 20, "timeout_secs": 1200 }
+            }
+          },
+          {
+            "agent": {
+              "id": "impl-compact-default",
+              "prompt": "If scout-compact-mode recommends it, make compact presentation the default (#4095) with safe migration for existing users. Minimal config/default change. Document in CHANGELOG snippet. `cargo test -p codewhale-tui config`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/config.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 900 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "reduce": {
+        "id": "copy-handoff",
+        "inputs": ["scout-context-disclosure", "scout-transcript-words", "scout-compact-mode", "impl-copy-dedupe", "impl-compact-default"],
+        "prompt": "Synthesize TUI copy lane.\n\n## SECTION 5 STATUS\n| Issue | Status | Files |\n\n## COPY SLOP REMAINING\n\n## UX VERDICT\nready for release polish / needs more work"
+      }
+    }
+  ]
+});

--- a/workflows/v0868_workflow_ui_lane.workflow.js
+++ b/workflows/v0868_workflow_ui_lane.workflow.js
@@ -1,0 +1,89 @@
+export default workflow({
+  "id": "v0868-workflow-ui-lane",
+  "goal": "Build v0.8.68 Workflow automatic orchestration UI (Section 2)",
+  "description": "Scout workflow.rs and TUI activity surfaces, then implement typed events, WorkflowPanel, and automatic launch path. DEFERRED until stopship (#4090, #4093, #4094) is green — v0.8.69 refactors out of scope unless they unblock stopship.",
+  "nodes": [
+    {
+      "branch": {
+        "id": "scout-workflow",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "scout-typed-events",
+              "prompt": "Audit workflow progress typing for v0.8.68 (#4118, #4120-4125). Read `crates/tui/src/tools/workflow.rs` and `crates/tui/src/tui/history.rs`. Check if progress uses Vec<String> or typed WorkflowUiEvent. Read issues: `gh issue view 4118 4120 4121 4122 4123 4124 4125 -R Hmbown/CodeWhale`. Report done/partial/missing with path:line evidence.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tools/workflow.rs", "crates/tui/src/tui/history.rs"],
+              "budget": { "max_steps": 14, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-workflow-panel",
+              "prompt": "Audit WorkflowPanel / unified activity surface (#4121, #4038, #4110). Search for `workflow_panel`, `SharedWorkflowRuns`, activity panel above input. Read `gh issue view 4038 4110 4121 -R Hmbown/CodeWhale`. Report whether TUI reads workflow run state, panel file exists, history card renderer status.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/tui/", "crates/tui/src/tools/workflow.rs"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          },
+          {
+            "agent": {
+              "id": "scout-auto-launch",
+              "prompt": "Audit automatic Workflow launch path (#4127, #4128, #4129). Read engine prompts and workflow tool schema for auto-trigger, suppression rules, config keys. Issues: `gh issue view 4127 4128 4129 4130 -R Hmbown/CodeWhale`. Check `config.example.toml` for `[workflow]` section. Report gaps.",
+              "agent_type": "explore",
+              "mode": "read_only",
+              "file_scope": ["crates/tui/src/core/engine/", "crates/tui/src/config.rs", "config.example.toml"],
+              "budget": { "max_steps": 12, "timeout_secs": 600 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequence": {
+        "id": "implement-workflow-ui",
+        "children": [
+          {
+            "agent": {
+              "id": "impl-typed-events",
+              "prompt": "Implement typed WorkflowUiEvent stream (#4118) per scout findings. Replace string progress where needed; add resolution fields (provider, model, route_source). Wire sub-agent spawn metadata (#4119). Default parallel write children to worktree (#4120). Tests: `cargo test -p codewhale-tui workflow`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tools/workflow.rs", "crates/tui/src/tools/subagent/mod.rs"],
+              "budget": { "max_steps": 28, "timeout_secs": 2400 }
+            }
+          },
+          {
+            "agent": {
+              "id": "impl-workflow-panel",
+              "prompt": "Implement WorkflowPanel unified activity surface (#4121, #4122, #4125) and history card routing (#4122). Create or extend `workflow_panel.rs`. Panel: collapsed/expanded, phase list, child rows, cancel. History card: phase summary, failure details. Tests for state transitions (#4123). `cargo test -p codewhale-tui workflow_panel history`.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tui/history.rs"],
+              "budget": { "max_steps": 28, "timeout_secs": 2400 }
+            }
+          },
+          {
+            "agent": {
+              "id": "impl-auto-launch",
+              "prompt": "Implement automatic launch pieces (#4127-4129): planner-to-workflow structured launch (#4124), parent prompt update (#4125), approval card for elevated plans (#4126), trigger suppression (#4127), config defaults (#4128), sandbox regression tests (#4129). Prioritize config keys + suppression + prompt; defer full dogfood (#4131) if timeboxed.",
+              "agent_type": "implementer",
+              "mode": "write",
+              "file_scope": ["crates/tui/src/tools/workflow.rs", "crates/workflow-js/src/vm.rs", "config.example.toml"],
+              "budget": { "max_steps": 28, "timeout_secs": 2400 }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "reduce": {
+        "id": "workflow-ui-handoff",
+        "inputs": ["scout-typed-events", "scout-workflow-panel", "scout-auto-launch", "impl-typed-events", "impl-workflow-panel", "impl-auto-launch"],
+        "prompt": "Synthesize Workflow UI lane.\n\n## SECTION 2 STATUS (2.1-2.14)\n| Phase | Items | Status |\n\n## RELEASE-BLOCKING GAPS\n\n## DOGFOOD SCENARIOS READY?\n\n## NEXT: Fleet/AgentProfile lane or TUI copy lane?"
+      }
+    }
+  ]
+});


### PR DESCRIPTION
## Summary
- Add wave-based agent workflow files for v0.8.68 (stopship → catalog → workflow UI → TUI copy → release gate)
- Add `docs/AGENT_WORKFLOWS_0868.md` playbook with wave order, gh commands, and constraints
- Add `.github/workflows/v0868-milestone-sync.yml` to keep `v0.8.68` label/milestone in sync and tag `agent-ready` issues
- Update `.github/ISSUE_TEMPLATE/agent-task.yml` target from v0.8.67 → v0.8.68

## Agent usage
Start with stopship lane (#4090, #4093, #4094), then feature waves, then release gate:

```
/workflow start workflows/v0868_stopship_lane.workflow.js
/workflow start workflows/v0868_catalog_lane.workflow.js
/workflow start workflows/v0868_workflow_ui_lane.workflow.js
/workflow start workflows/v0868_tui_copy_lane.workflow.js
/workflow start workflows/v0868_release_gate.workflow.js
```

See `docs/AGENT_WORKFLOWS_0868.md` for full playbook.

## Test plan
- [ ] Verify workflow JS files load in CodeWhale TUI
- [ ] Confirm milestone sync Action runs on issue open/edit
- [ ] Run stopship lane against #4090, #4093, #4094
- [ ] Tag first batch of issues `agent-ready` using updated template


Made with [Cursor](https://cursor.com)