### PR TITLE
fix(tui): Fleet setup role/profile roster editor (#4093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fleet setup is a role/profile roster editor, not a provider-scoped model
+  picker: the Model step lists routes from every configured provider (not
+  only the active one), a picked route's provider is persisted explicitly in
+  the saved profile TOML (`provider = "..."`, never inferred from the model
+  id), and the loader/route resolver read that field back out verbatim. The
+  draft-preview ratify keypress no longer competes with a separate pager's
+  `g`/`G` scroll bindings — the exact TOML preview now renders inline on the
+  same Review step that ratifies it (#4093).
 - Workflow correctness: completion polling fails closed instead of
   fabricating success when a sub-agent reports no terminal status; cancel
   interrupts the JS VM (cancel handle + abort) and blocks further spawns;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,14 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft-preview ratify keypress no longer competes with a separate pager's
   `g`/`G` scroll bindings — the exact TOML preview now renders inline on the
   same Review step that ratifies it (#4093).
-- Fleet workers now actually launch on their profile-pinned route, not just
-  record it on the receipt: `codewhale exec` gains a non-secret `--provider`
-  flag, and a worker whose profile pins provider B is dispatched with
-  `--provider B --model <B's model>` even when the parent session is on
-  provider A (credentials still resolve from the worker's own environment;
-  provider is never inferred from the model id). Workers with no
-  profile-bound provider are unchanged — no `--provider`, run-level model
-  (#4093).
+- The headless `codewhale fleet run` CLI now launches workers on their profile-pinned route, not just records it on the receipt: `codewhale exec` gains a non-secret `--provider` flag, and a worker whose profile pins provider B is dispatched with `--provider B --model <B's model>` even when the parent session is on provider A (credentials still resolve from the worker's own environment; provider is never inferred from the model id). Workers with no profile-bound provider are unchanged — no `--provider`, run-level model. The interactive TUI spawns roster members in-process and does not yet honor the pinned provider (it uses the session provider); that remainder is tracked in #4193 (#4093).
 - The Fleet setup `m` model-assisted redraft no longer drops a picked
   cross-provider route: the provider/model the operator chose are re-pinned
   onto the drafted profile (a model draft is always `provider: None`), so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft-preview ratify keypress no longer competes with a separate pager's
   `g`/`G` scroll bindings — the exact TOML preview now renders inline on the
   same Review step that ratifies it (#4093).
+- Fleet workers now actually launch on their profile-pinned route, not just
+  record it on the receipt: `codewhale exec` gains a non-secret `--provider`
+  flag, and a worker whose profile pins provider B is dispatched with
+  `--provider B --model <B's model>` even when the parent session is on
+  provider A (credentials still resolve from the worker's own environment;
+  provider is never inferred from the model id). Workers with no
+  profile-bound provider are unchanged — no `--provider`, run-level model
+  (#4093).
+- The Fleet setup `m` model-assisted redraft no longer drops a picked
+  cross-provider route: the provider/model the operator chose are re-pinned
+  onto the drafted profile (a model draft is always `provider: None`), so
+  ratifying it keeps the explicit route instead of persisting an ambiguous,
+  provider-scoped profile (#4093).
+- Ratifying a Fleet profile now fails with a clear message when it pins a
+  provider that has no configured credentials, using the same
+  configured-provider check the model picker uses (#4093).
 - Workflow correctness: completion polling fails closed instead of
   fabricating success when a sub-agent reports no terminal status; cancel
   interrupts the JS VM (cancel handle + abort) and blocks further spawns;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1146,6 +1146,20 @@ pub struct FleetProfile {
     /// validates the executable provider/model/wire-model decision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Optional explicit provider id for this profile's model (#4093).
+    ///
+    /// Present only when the profile was created against a specific,
+    /// credential-checked provider (e.g. via the Fleet setup model picker),
+    /// so a worker can be pinned to a route independent of the parent/current
+    /// session provider. `None` means "no route pin" (inherit), matching
+    /// `model: None`; a profile must never carry `provider` without `model`.
+    ///
+    /// EPIC #2608 explicit-config-only mandate: this field is the ONLY
+    /// authority for the profile's provider. It is never inferred by sniffing
+    /// a substring/prefix out of `model` — callers that need the provider for
+    /// this profile must read this field, not guess from the model id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
     /// Permission defaults requested by the profile.
     #[serde(default)]
     pub permissions: FleetProfilePermissions,

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fleet setup is a role/profile roster editor, not a provider-scoped model
+  picker: the Model step lists routes from every configured provider (not
+  only the active one), a picked route's provider is persisted explicitly in
+  the saved profile TOML (`provider = "..."`, never inferred from the model
+  id), and the loader/route resolver read that field back out verbatim. The
+  draft-preview ratify keypress no longer competes with a separate pager's
+  `g`/`G` scroll bindings — the exact TOML preview now renders inline on the
+  same Review step that ratifies it (#4093).
 - Workflow correctness: completion polling fails closed instead of
   fabricating success when a sub-agent reports no terminal status; cancel
   interrupts the JS VM (cancel handle + abort) and blocks further spawns;

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -47,14 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft-preview ratify keypress no longer competes with a separate pager's
   `g`/`G` scroll bindings — the exact TOML preview now renders inline on the
   same Review step that ratifies it (#4093).
-- Fleet workers now actually launch on their profile-pinned route, not just
-  record it on the receipt: `codewhale exec` gains a non-secret `--provider`
-  flag, and a worker whose profile pins provider B is dispatched with
-  `--provider B --model <B's model>` even when the parent session is on
-  provider A (credentials still resolve from the worker's own environment;
-  provider is never inferred from the model id). Workers with no
-  profile-bound provider are unchanged — no `--provider`, run-level model
-  (#4093).
+- The headless `codewhale fleet run` CLI now launches workers on their profile-pinned route, not just records it on the receipt: `codewhale exec` gains a non-secret `--provider` flag, and a worker whose profile pins provider B is dispatched with `--provider B --model <B's model>` even when the parent session is on provider A (credentials still resolve from the worker's own environment; provider is never inferred from the model id). Workers with no profile-bound provider are unchanged — no `--provider`, run-level model. The interactive TUI spawns roster members in-process and does not yet honor the pinned provider (it uses the session provider); that remainder is tracked in #4193 (#4093).
 - The Fleet setup `m` model-assisted redraft no longer drops a picked
   cross-provider route: the provider/model the operator chose are re-pinned
   onto the drafted profile (a model draft is always `provider: None`), so

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -47,6 +47,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft-preview ratify keypress no longer competes with a separate pager's
   `g`/`G` scroll bindings — the exact TOML preview now renders inline on the
   same Review step that ratifies it (#4093).
+- Fleet workers now actually launch on their profile-pinned route, not just
+  record it on the receipt: `codewhale exec` gains a non-secret `--provider`
+  flag, and a worker whose profile pins provider B is dispatched with
+  `--provider B --model <B's model>` even when the parent session is on
+  provider A (credentials still resolve from the worker's own environment;
+  provider is never inferred from the model id). Workers with no
+  profile-bound provider are unchanged — no `--provider`, run-level model
+  (#4093).
+- The Fleet setup `m` model-assisted redraft no longer drops a picked
+  cross-provider route: the provider/model the operator chose are re-pinned
+  onto the drafted profile (a model draft is always `provider: None`), so
+  ratifying it keeps the explicit route instead of persisting an ambiguous,
+  provider-scoped profile (#4093).
+- Ratifying a Fleet profile now fails with a clear message when it pins a
+  provider that has no configured credentials, using the same
+  configured-provider check the model picker uses (#4093).
 - Workflow correctness: completion polling fails closed instead of
   fabricating success when a sub-agent reports no terminal status; cancel
   interrupts the JS VM (cancel handle + abort) and blocks further spawns;

--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -26,7 +26,9 @@ use codewhale_protocol::fleet::{FleetHostSpec, FleetTaskSpec, FleetWorkerEventPa
 
 use super::host::{FleetHostAdapter, FleetWorkerCommand};
 use super::profile::AgentProfile;
-use super::worker_runtime::{fleet_task_prompt, fleet_task_prompt_with_profiles};
+use super::worker_runtime::{
+    fleet_task_prompt, fleet_task_prompt_with_profiles, fleet_worker_launch_route,
+};
 
 /// Build the `codewhale exec` argv that runs a fleet task headlessly.
 ///
@@ -38,7 +40,11 @@ use super::worker_runtime::{fleet_task_prompt, fleet_task_prompt_with_profiles};
 ///
 /// Secrets are NEVER placed on the argv: provider credentials are resolved by
 /// the worker process from its own config/keyring exactly like an interactive
-/// run. The host adapter additionally refuses secret-bearing env keys.
+/// run. The host adapter additionally refuses secret-bearing env keys. The
+/// `--provider` flag threaded by [`build_worker_exec_command_with_profiles`] is
+/// a non-secret provider *identifier* only (#4093) — the worker still resolves
+/// that provider's credentials from its own env/config, so this invariant
+/// holds.
 pub fn build_worker_exec_command(
     codewhale_binary: &str,
     task_spec: &FleetTaskSpec,
@@ -50,10 +56,20 @@ pub fn build_worker_exec_command(
         fleet_task_prompt(task_spec),
         exec_config,
         model,
+        None,
     )
 }
 
 /// Build a worker command after resolving workspace Fleet profile input.
+///
+/// The launched subprocess runs on the worker's RESOLVED route, not blindly on
+/// the run-level session model (#4093 AC #4): the per-worker model+provider are
+/// resolved from the task's agent profile via the same explicit-only path the
+/// receipt uses ([`fleet_worker_launch_route`]). A worker whose profile pins
+/// provider B thus launches on provider B's model even when the parent session
+/// is on provider A. Workers with no profile-bound provider fall back to the
+/// run-level model and emit no `--provider`, so the worker keeps its own
+/// session default (today's behavior, unchanged).
 pub fn build_worker_exec_command_with_profiles(
     codewhale_binary: &str,
     task_spec: &FleetTaskSpec,
@@ -61,11 +77,14 @@ pub fn build_worker_exec_command_with_profiles(
     model: Option<&str>,
     agent_profiles: &[AgentProfile],
 ) -> Result<FleetWorkerCommand> {
+    let (worker_model, worker_provider) =
+        fleet_worker_launch_route(task_spec, agent_profiles, model.unwrap_or_default());
     Ok(build_worker_exec_command_from_prompt(
         codewhale_binary,
         fleet_task_prompt_with_profiles(task_spec, agent_profiles)?,
         exec_config,
-        model,
+        Some(worker_model.as_str()),
+        worker_provider.as_deref(),
     ))
 }
 
@@ -74,6 +93,7 @@ fn build_worker_exec_command_from_prompt(
     task_prompt: String,
     exec_config: &FleetExecConfig,
     model: Option<&str>,
+    provider: Option<&str>,
 ) -> FleetWorkerCommand {
     let mut args: Vec<String> = vec![
         "exec".to_string(),
@@ -85,6 +105,15 @@ fn build_worker_exec_command_from_prompt(
     if let Some(model) = model.map(str::trim).filter(|m| !m.is_empty()) {
         args.push("--model".to_string());
         args.push(model.to_string());
+    }
+
+    // Non-secret provider identifier only (#4093): the worker resolves the
+    // provider's credentials from its own env/config. Emitted ONLY when the
+    // worker's profile explicitly pins a provider, so profile-less workers keep
+    // their own session default exactly as before.
+    if let Some(provider) = provider.map(str::trim).filter(|p| !p.is_empty()) {
+        args.push("--provider".to_string());
+        args.push(provider.to_string());
     }
 
     if !exec_config.allowed_tools.is_empty() {
@@ -498,6 +527,96 @@ mod tests {
 
         assert!(prompt.contains("Fleet profile: reviewer"));
         assert!(prompt.contains("Focus on defects, regressions, and missing tests."));
+    }
+
+    /// #4093 AC #4 at the LAUNCH boundary (not just the receipt): a worker whose
+    /// profile pins a DIFFERENT provider+model than the parent session must
+    /// actually launch on the profile's route. The parent session is DeepSeek
+    /// here (`--model deepseek-v4-pro`); the profile pins OpenRouter + glm-5.2.
+    /// The emitted argv must carry OpenRouter's id and the profile's model as
+    /// paired flag/values — never the parent's model. This is the gap the
+    /// save→load→resolve receipt tests never covered.
+    #[test]
+    fn worker_command_launches_profile_bound_provider_and_model_not_the_parent() {
+        let mut task = task("audit");
+        task.worker.as_mut().unwrap().agent_profile = Some("cross".to_string());
+
+        let mut profile = agent_profile("cross", "scout", "Read first.");
+        profile.profile.provider = Some("openrouter".to_string());
+        profile.profile.model = Some("glm-5.2".to_string());
+
+        let cmd = build_worker_exec_command_with_profiles(
+            "codewhale",
+            &task,
+            &FleetExecConfig::default(),
+            Some("deepseek-v4-pro"), // parent/session model on provider A.
+            &[profile],
+        )
+        .unwrap();
+
+        // Assert the flag/value PAIRS, so the provider and model are proven to
+        // ride together rather than merely appearing somewhere on the argv.
+        let provider_idx = cmd
+            .args
+            .iter()
+            .position(|a| a == "--provider")
+            .expect("--provider must be threaded for a provider-pinned worker");
+        assert_eq!(
+            cmd.args.get(provider_idx + 1).map(String::as_str),
+            Some("openrouter"),
+            "{:?}",
+            cmd.args
+        );
+        let model_idx = cmd
+            .args
+            .iter()
+            .position(|a| a == "--model")
+            .expect("--model must be present");
+        assert_eq!(
+            cmd.args.get(model_idx + 1).map(String::as_str),
+            Some("glm-5.2"),
+            "{:?}",
+            cmd.args
+        );
+
+        // The parent/session model must NOT leak onto the argv.
+        assert!(
+            !cmd.args.iter().any(|a| a == "deepseek-v4-pro"),
+            "parent model leaked into a profile-pinned worker's argv: {:?}",
+            cmd.args
+        );
+    }
+
+    /// A worker with no profile-bound provider preserves today's behavior: the
+    /// run-level model on `--model`, and NO `--provider` (the worker keeps its
+    /// own session default). Guards against regressing profile-less workers.
+    #[test]
+    fn worker_command_without_profile_provider_omits_provider_and_keeps_run_model() {
+        let cmd = build_worker_exec_command_with_profiles(
+            "codewhale",
+            &task("read"),
+            &FleetExecConfig::default(),
+            Some("deepseek-v4-pro"),
+            &[],
+        )
+        .unwrap();
+
+        assert!(
+            !cmd.args.iter().any(|a| a == "--provider"),
+            "profile-less worker must not carry --provider: {:?}",
+            cmd.args
+        );
+        let model_idx = cmd
+            .args
+            .iter()
+            .position(|a| a == "--model")
+            .expect("--model must be present");
+        assert_eq!(
+            cmd.args.get(model_idx + 1).map(String::as_str),
+            Some("deepseek-v4-pro"),
+            "{:?}",
+            cmd.args
+        );
     }
 
     #[test]

--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -437,6 +437,7 @@ mod tests {
                 },
                 loadout: FleetLoadout::Inherit,
                 model: None,
+                provider: None,
                 permissions: FleetProfilePermissions::default(),
                 delegation: FleetDelegationHints::default(),
             },

--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -55,6 +55,14 @@ struct AgentProfileToml {
     loadout: Option<String>,
     #[serde(default, alias = "model_hint", alias = "model_id")]
     model: Option<String>,
+    /// Explicit provider id for `model` (#4093), e.g. `"deepseek"` or
+    /// `"openrouter"`. Validated against the known `ApiProvider` vocabulary at
+    /// load time — never inferred by sniffing `model` for a provider-shaped
+    /// substring (EPIC #2608). `deny_unknown_fields` no longer needs to guard
+    /// this name: it is now a first-class, validated field instead of a
+    /// smuggled one.
+    #[serde(default)]
+    provider: Option<String>,
     #[serde(default)]
     instructions: Option<AgentProfileInstructions>,
     #[serde(default)]
@@ -162,6 +170,11 @@ fn agent_profile_from_toml(path: &Path, parsed: AgentProfileToml) -> Result<Agen
     let model = non_empty_trimmed(parsed.model.as_deref()).map(str::to_string);
     validate_agent_profile_model_hint(path, model.as_deref())?;
 
+    let provider = non_empty_trimmed(parsed.provider.as_deref())
+        .map(str::to_string)
+        .map(|provider| validate_agent_profile_provider(path, &provider).map(|()| provider))
+        .transpose()?;
+
     let instructions = parsed
         .instructions
         .as_ref()
@@ -179,6 +192,7 @@ fn agent_profile_from_toml(path: &Path, parsed: AgentProfileToml) -> Result<Agen
         },
         loadout,
         model,
+        provider,
         permissions: FleetProfilePermissions::default(),
         delegation: FleetDelegationHints::default(),
     };
@@ -261,6 +275,21 @@ fn validate_agent_profile_model_hint(path: &Path, value: Option<&str>) -> Result
     Ok(())
 }
 
+/// Validate an explicit `provider` field against the known `ApiProvider`
+/// vocabulary (#4093). This is the ONLY place a profile's provider is
+/// established — a name that doesn't parse is rejected outright rather than
+/// silently ignored or guessed from `model` (EPIC #2608: explicit config
+/// only, never a model-id prefix/substring sniff).
+fn validate_agent_profile_provider(path: &Path, value: &str) -> Result<()> {
+    if crate::config::ApiProvider::parse(value).is_none() {
+        bail!(
+            "agent profile {} provider {value:?} is not a recognized provider id",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 fn is_agent_profile_token_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
 }
@@ -305,6 +334,13 @@ pub enum UntrustedProfileParse {
 /// validation, prose bounds, and control-character stripping. The persisted
 /// TOML is rendered deterministically from this struct — model bytes are
 /// never written to disk verbatim.
+///
+/// `provider` (#4093) is set ONLY by the structured Fleet setup picker (a
+/// user's explicit, credential-checked selection) — never by
+/// [`Self::from_untrusted_json`], whose wire schema
+/// ([`FleetProfileDraftJson`]) has no `provider` field and rejects one via
+/// `deny_unknown_fields`. A model's untrusted reply can never smuggle a
+/// provider; only an interactive pick can set this field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FleetProfileDraft {
     pub id: String,
@@ -313,6 +349,10 @@ pub struct FleetProfileDraft {
     pub role_hint: String,
     pub model_class_hint: Option<String>,
     pub model: Option<String>,
+    /// Explicit provider id for `model` (e.g. `"deepseek"`), set only by the
+    /// structured picker. `None` means "no route pin" (inherit) — matching
+    /// `model: None` — or a legacy/untrusted draft that predates this field.
+    pub provider: Option<String>,
     pub instructions: Option<String>,
 }
 
@@ -418,6 +458,9 @@ impl FleetProfileDraft {
             role_hint,
             model_class_hint,
             model,
+            // Never set from untrusted model output — `FleetProfileDraftJson`
+            // has no `provider` field, so there is nothing to read here.
+            provider: None,
             instructions,
         };
         if draft.description.is_none() && draft.instructions.is_none() {
@@ -457,6 +500,15 @@ impl FleetProfileDraft {
         }
         if let Some(ref model) = self.model {
             root.insert("model".to_string(), toml::Value::String(model.clone()));
+            // A provider pin is only meaningful alongside a concrete model
+            // (#4093): an `inherit` draft (`model: None`) never carries one,
+            // so the rendered TOML can't imply a route it doesn't have.
+            if let Some(ref provider) = self.provider {
+                root.insert(
+                    "provider".to_string(),
+                    toml::Value::String(provider.clone()),
+                );
+            }
         }
         if let Some(ref instructions) = self.instructions {
             let mut table = toml::value::Table::new();
@@ -625,6 +677,59 @@ mod tests {
         assert_eq!(path, loaded.source);
     }
 
+    #[test]
+    fn draft_with_explicit_provider_round_trips_through_the_loader() {
+        // A structured (picker-driven) draft that pins a model on a provider
+        // other than whatever the parent session happens to use (#4093): the
+        // rendered TOML must carry both fields explicitly, and the loader
+        // must read the provider back out verbatim — never re-derive it by
+        // sniffing `model` for a provider-shaped substring.
+        let draft = FleetProfileDraft {
+            id: "scout-deepseek".to_string(),
+            display_name: Some("Scout".to_string()),
+            description: Some("Cross-provider scout profile.".to_string()),
+            role_hint: "scout".to_string(),
+            model_class_hint: None,
+            model: Some("deepseek-v4-flash".to_string()),
+            provider: Some("deepseek".to_string()),
+            instructions: None,
+        };
+
+        let rendered = draft.render_toml();
+        assert!(
+            rendered.contains("provider = \"deepseek\""),
+            "rendered TOML must persist the explicit provider: {rendered}"
+        );
+        assert!(rendered.contains("model = \"deepseek-v4-flash\""));
+
+        let dir = TempDir::new().unwrap();
+        write_profile(dir.path(), &draft.file_name(), &rendered);
+        let profiles = load_agent_profiles_from_dir(dir.path()).expect("rendered TOML loads");
+        assert_eq!(profiles.len(), 1);
+        let loaded = &profiles[0];
+        assert_eq!(loaded.profile.model.as_deref(), Some("deepseek-v4-flash"));
+        assert_eq!(loaded.profile.provider.as_deref(), Some("deepseek"));
+    }
+
+    #[test]
+    fn inherit_draft_never_renders_a_provider_without_a_model() {
+        // `provider` is only meaningful alongside a concrete model pin; an
+        // `inherit` draft (no `model`) must never render one even if a stale
+        // caller sets the field.
+        let draft = FleetProfileDraft {
+            id: "inherit".to_string(),
+            display_name: None,
+            description: None,
+            role_hint: "general".to_string(),
+            model_class_hint: None,
+            model: None,
+            provider: Some("deepseek".to_string()),
+            instructions: None,
+        };
+        let rendered = draft.render_toml();
+        assert!(!rendered.contains("provider"), "{rendered}");
+    }
+
     fn write_profile(dir: &Path, filename: &str, contents: &str) -> PathBuf {
         let path = dir.join(filename);
         std::fs::write(&path, contents).unwrap();
@@ -771,7 +876,10 @@ posture = "read-only"
     }
 
     #[test]
-    fn agent_profile_loader_rejects_hidden_provider_policy_fields() {
+    fn agent_profile_loader_accepts_and_round_trips_explicit_provider_field() {
+        // #4093: `provider` is now a first-class, validated field — a Fleet
+        // profile can name its own route explicitly, independent of whatever
+        // provider is active when the profile is later loaded/launched.
         let tmp = TempDir::new().unwrap();
         write_profile(
             tmp.path(),
@@ -783,12 +891,37 @@ model = "deepseek/deepseek-v4-pro"
 "#,
         );
 
+        let profiles = load_agent_profiles_from_dir(tmp.path()).expect("profile loads");
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].profile.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            profiles[0].profile.model.as_deref(),
+            Some("deepseek/deepseek-v4-pro")
+        );
+    }
+
+    #[test]
+    fn agent_profile_loader_rejects_unrecognized_provider_name() {
+        // EPIC #2608 explicit-config-only mandate: an unrecognized provider
+        // name is rejected outright at load time — never silently ignored,
+        // and never guessed from `model`.
+        let tmp = TempDir::new().unwrap();
+        write_profile(
+            tmp.path(),
+            "reviewer.toml",
+            r#"
+name = "reviewer"
+provider = "not-a-real-provider"
+model = "some-model"
+"#,
+        );
+
         let err = load_agent_profiles_from_dir(tmp.path())
             .unwrap_err()
             .to_string();
 
         assert!(
-            err.contains("provider") || err.contains("unknown field"),
+            err.contains("not a recognized provider"),
             "unexpected error: {err}"
         );
     }

--- a/crates/tui/src/fleet/roster.rs
+++ b/crates/tui/src/fleet/roster.rs
@@ -194,6 +194,7 @@ impl FleetRoster {
                 },
                 loadout,
                 model: None,
+                provider: None,
                 permissions: FleetProfilePermissions::default(),
                 delegation: FleetDelegationHints::default(),
             },
@@ -276,6 +277,7 @@ mod tests {
             },
             loadout: FleetLoadout::Inherit,
             model: model.map(str::to_string),
+            provider: None,
             permissions: FleetProfilePermissions::default(),
             delegation: FleetDelegationHints::default(),
         }
@@ -408,7 +410,10 @@ mod tests {
     #[test]
     fn broken_workspace_dir_degrades_to_built_ins_and_config() {
         let tmp = TempDir::new().unwrap();
-        write_workspace_profile(tmp.path(), "broken.toml", "provider = \"openrouter\"\n");
+        // An unrecognized provider id is still a load failure (#4093):
+        // `provider` is now a first-class field, but it's validated against
+        // the known `ApiProvider` vocabulary, not accepted as any string.
+        write_workspace_profile(tmp.path(), "broken.toml", "provider = \"not-a-real-provider\"\n");
         let config = config_with_profiles(BTreeMap::from([(
             "extra".to_string(),
             config_profile("scout", None),

--- a/crates/tui/src/fleet/roster.rs
+++ b/crates/tui/src/fleet/roster.rs
@@ -413,7 +413,11 @@ mod tests {
         // An unrecognized provider id is still a load failure (#4093):
         // `provider` is now a first-class field, but it's validated against
         // the known `ApiProvider` vocabulary, not accepted as any string.
-        write_workspace_profile(tmp.path(), "broken.toml", "provider = \"not-a-real-provider\"\n");
+        write_workspace_profile(
+            tmp.path(),
+            "broken.toml",
+            "provider = \"not-a-real-provider\"\n",
+        );
         let config = config_with_profiles(BTreeMap::from([(
             "extra".to_string(),
             config_profile("scout", None),

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -118,9 +118,15 @@ pub fn fleet_task_to_worker_spec_with_profiles(
 ///
 /// Honesty rules:
 /// - `canonical_model` stays `None` when the resolver could not pin one.
-/// - The provider comes from the resolver default (the worker profile carries
-///   no provider authority); a task-level `model` selector is forwarded as the
-///   model selector. No reasoning/pricing fields are fabricated.
+/// - The provider comes from the resolved agent profile's own explicit
+///   `provider` field when it has one (#4093) — a Fleet worker profile can be
+///   pinned to a route independent of the parent/current session provider.
+///   Absent an explicit pin, the worker profile carries no provider authority
+///   and resolution falls back to the existing default scope. Either way, the
+///   provider is NEVER inferred by sniffing a substring/prefix out of `model`
+///   (EPIC #2608: explicit config only). A task-level `model` selector is
+///   forwarded as the model selector. No reasoning/pricing fields are
+///   fabricated.
 ///
 /// Returns `None` (never a fabricated route) when resolution fails, so callers
 /// degrade gracefully without inventing detail.
@@ -140,17 +146,17 @@ pub(crate) fn resolve_fleet_route(
 
     // Task/profile model pins are visible route intent; next the session
     // route (the operator's model) applies as the run-level fallback; only
-    // then does the resolver pick the provider default. Provider authority
-    // belongs to route resolution, so we do not infer a provider here.
+    // then does the resolver pick the provider default.
     let (model_selector, model_source) =
         fleet_route_model_selector_with_source(worker_profile, agent_profile, session_model);
     let model_selector = model_selector.as_deref();
 
-    // The worker profile carries no provider authority, so resolve within the
-    // default provider scope (mirrors `ProviderKind::default()`). The resolver
-    // is fully offline/hermetic and never reads secrets, env, or config.
-    let candidate =
-        resolve_route_candidate(ApiProvider::Deepseek, model_selector, None, None, None).ok()?;
+    // Resolve within the profile's own explicit provider scope when it has
+    // one (#4093); otherwise fall back to the existing default scope (mirrors
+    // `ProviderKind::default()`). The resolver is fully offline/hermetic and
+    // never reads secrets, env, or config.
+    let provider = effective_fleet_provider(agent_profile);
+    let candidate = resolve_route_candidate(provider, model_selector, None, None, None).ok()?;
 
     Some(FleetResolvedRoute {
         provider_id: candidate.provider_id.as_str().to_string(),
@@ -416,6 +422,21 @@ fn effective_fleet_model_with_source(
         return (model.to_string(), "agent_profile.model");
     }
     (run_model.to_string(), "run.model")
+}
+
+/// The provider this task's resolved route should use (#4093).
+///
+/// Only an explicit `provider` field on the resolved agent profile ever
+/// selects a provider here — EPIC #2608 forbids inferring one by sniffing a
+/// substring/prefix out of `model`. Absent an explicit pin (no profile, or a
+/// profile that never named a provider), the worker profile carries no
+/// provider authority and resolution falls back to the existing default
+/// scope, unchanged from prior behavior.
+fn effective_fleet_provider(agent_profile: Option<&AgentProfile>) -> ApiProvider {
+    agent_profile
+        .and_then(|profile| profile.profile.provider.as_deref())
+        .and_then(ApiProvider::parse)
+        .unwrap_or(ApiProvider::Deepseek)
 }
 
 fn task_model_class_with_source(
@@ -753,6 +774,7 @@ mod tests {
                 },
                 loadout,
                 model: None,
+                provider: None,
                 permissions: codewhale_config::FleetProfilePermissions::default(),
                 delegation: codewhale_config::FleetDelegationHints::default(),
             },
@@ -1194,6 +1216,129 @@ mod tests {
             .expect("pinned route should resolve");
         assert_eq!(pinned.model_source.as_deref(), Some("agent_profile.model"));
         assert_eq!(pinned.wire_model_id, "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn resolve_fleet_route_honors_explicit_profile_provider_not_the_default() {
+        // EPIC #2608 / #4093: the resolved provider must come ONLY from the
+        // profile's explicit `provider` field — never inferred from a
+        // provider-shaped substring in `model`, and never the parent/session
+        // route's provider. `deepseek-v4-flash` is deliberately DeepSeek-shaped
+        // while the profile pins `openrouter`.
+        let mut profile = agent_profile(
+            "cross-provider",
+            "scout",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        profile.profile.model = Some("deepseek-v4-flash".to_string());
+        profile.profile.provider = Some("openrouter".to_string());
+        let task = fleet_task(
+            "route-cross-provider",
+            Some(worker_profile(
+                Some("cross-provider"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+
+        // The "parent"/session route is a completely different provider's
+        // model, proving the resolved route does not fall back to it.
+        let route = resolve_fleet_route(&task, &[profile], Some("deepseek-v4-pro"))
+            .expect("cross-provider profile route should resolve");
+
+        assert_eq!(route.model_source.as_deref(), Some("agent_profile.model"));
+
+        // Resolving `openrouter` directly with the same selector is the
+        // ground truth for what this route SHOULD produce — comparing
+        // against it (rather than hardcoding a wire id) proves the profile's
+        // provider actually drove resolution, whatever wire id/aggregator
+        // mapping the resolver's catalog assigns.
+        let openrouter_candidate = resolve_route_candidate(
+            ApiProvider::Openrouter,
+            Some("deepseek-v4-flash"),
+            None,
+            None,
+            None,
+        )
+        .expect("openrouter should resolve the pinned model directly");
+        assert_eq!(
+            route.wire_model_id,
+            openrouter_candidate.wire_model_id.as_str()
+        );
+        assert_eq!(route.provider_id, openrouter_candidate.provider_id.as_str());
+        assert_eq!(
+            route.provider_kind,
+            openrouter_candidate.provider_kind.as_str()
+        );
+        // Differs from DeepSeek — the pre-#4093 hardcoded default AND the
+        // parent/session's provider.
+        assert_ne!(route.provider_id, "deepseek");
+    }
+
+    #[test]
+    fn cross_provider_profile_saves_reloads_and_resolves_to_its_own_provider() {
+        // Required cross-provider save/load/launch coverage for #4093: create
+        // a Fleet profile whose provider differs from the parent/session
+        // provider, save it to a real TOML file, reload it from disk through
+        // the same loader Fleet uses, then resolve its route and confirm the
+        // resolved provider+model are the SAVED ones — never the parent's.
+        let draft = crate::fleet::profile::FleetProfileDraft {
+            id: "scout-openrouter".to_string(),
+            display_name: Some("Scout".to_string()),
+            description: Some("Cross-provider scout profile.".to_string()),
+            role_hint: "scout".to_string(),
+            model_class_hint: None,
+            model: Some("deepseek-v4-flash".to_string()),
+            provider: Some("openrouter".to_string()),
+            instructions: None,
+        };
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join(draft.file_name()), draft.render_toml()).unwrap();
+        let profiles = crate::fleet::profile::load_agent_profiles_from_dir(dir.path())
+            .expect("rendered profile TOML loads");
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].profile.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            profiles[0].profile.model.as_deref(),
+            Some("deepseek-v4-flash")
+        );
+
+        let task = fleet_task(
+            "route-saved-profile",
+            Some(worker_profile(
+                Some("scout-openrouter"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+
+        // "Parent"/session route: a different provider's model entirely, so a
+        // fallback to it would be an obvious, loud test failure.
+        let route = resolve_fleet_route(&task, &profiles, Some("deepseek-v4-pro"))
+            .expect("saved cross-provider profile route should resolve");
+
+        let openrouter_candidate = resolve_route_candidate(
+            ApiProvider::Openrouter,
+            Some("deepseek-v4-flash"),
+            None,
+            None,
+            None,
+        )
+        .expect("openrouter should resolve the saved model directly");
+        assert_eq!(
+            route.wire_model_id,
+            openrouter_candidate.wire_model_id.as_str()
+        );
+        assert_eq!(route.provider_id, openrouter_candidate.provider_id.as_str());
+        assert_ne!(route.provider_id, "deepseek");
     }
 
     #[test]

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -433,10 +433,53 @@ fn effective_fleet_model_with_source(
 /// provider authority and resolution falls back to the existing default
 /// scope, unchanged from prior behavior.
 fn effective_fleet_provider(agent_profile: Option<&AgentProfile>) -> ApiProvider {
+    explicit_fleet_provider(agent_profile).unwrap_or(ApiProvider::Deepseek)
+}
+
+/// The provider a resolved agent profile EXPLICITLY pins, if any (#4093).
+///
+/// Unlike [`effective_fleet_provider`], this returns `None` (never the DeepSeek
+/// default) when no profile names a provider, so the launch path can leave
+/// `--provider` off the worker argv and preserve today's behavior for
+/// profile-less / provider-less workers (they resolve their provider from
+/// their own session default). EPIC #2608: never inferred from `model`.
+fn explicit_fleet_provider(agent_profile: Option<&AgentProfile>) -> Option<ApiProvider> {
     agent_profile
         .and_then(|profile| profile.profile.provider.as_deref())
         .and_then(ApiProvider::parse)
-        .unwrap_or(ApiProvider::Deepseek)
+}
+
+/// The route (model selector + optional explicit provider id) that a fleet
+/// worker's actual `codewhale exec` subprocess should launch on (#4093 AC #4).
+///
+/// This is the launch-side twin of [`resolve_fleet_route`] (the receipt): both
+/// read the worker's model from the same task/profile/run precedence
+/// ([`effective_fleet_model`]) and the provider from the same explicit-only
+/// source ([`explicit_fleet_provider`]), so a worker whose profile is pinned to
+/// provider B launches on provider B even when the parent session is on
+/// provider A.
+///
+/// - `model`: never empty in practice — falls back to `run_model` when neither
+///   the task nor the profile pins a model, matching pre-#4093 dispatch.
+/// - `provider`: `Some(canonical_id)` ONLY when the resolved agent profile
+///   explicitly pins a provider. `None` means "no provider authority" — the
+///   caller omits `--provider` and the worker keeps its own session default,
+///   preserving today's behavior for profile-less workers. The id is
+///   [`ApiProvider::as_str`], which round-trips through `ApiProvider::parse` on
+///   the worker's `--provider` flag.
+pub(crate) fn fleet_worker_launch_route(
+    task_spec: &FleetTaskSpec,
+    agent_profiles: &[AgentProfile],
+    run_model: &str,
+) -> (String, Option<String>) {
+    let agent_profile = resolve_task_agent_profile(task_spec, agent_profiles)
+        .ok()
+        .flatten();
+    let worker_profile = task_spec.worker.as_ref();
+    let model = effective_fleet_model(run_model, worker_profile, agent_profile);
+    let provider =
+        explicit_fleet_provider(agent_profile).map(|provider| provider.as_str().to_string());
+    (model, provider)
 }
 
 fn task_model_class_with_source(
@@ -1339,6 +1382,71 @@ mod tests {
         );
         assert_eq!(route.provider_id, openrouter_candidate.provider_id.as_str());
         assert_ne!(route.provider_id, "deepseek");
+    }
+
+    #[test]
+    fn fleet_worker_launch_route_is_explicit_provider_only() {
+        // The LAUNCH resolver (twin of the receipt) must emit a provider ONLY
+        // when the profile explicitly pins one, and NEVER infer it from a
+        // provider-shaped model id (EPIC #2608).
+
+        // 1) Explicit cross-provider pin: model + provider both come from the
+        //    profile, not the parent/session model.
+        let mut pinned = agent_profile(
+            "cross",
+            "scout",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        pinned.profile.model = Some("glm-5.2".to_string());
+        pinned.profile.provider = Some("openrouter".to_string());
+        let pinned_task = fleet_task(
+            "launch-pinned",
+            Some(worker_profile(
+                Some("cross"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+        let (model, provider) =
+            fleet_worker_launch_route(&pinned_task, &[pinned], "deepseek-v4-pro");
+        assert_eq!(model, "glm-5.2");
+        assert_eq!(provider.as_deref(), Some("openrouter"));
+
+        // 2) A DeepSeek-shaped model with NO explicit provider must NOT infer a
+        //    provider — provider stays None so the worker keeps its own session
+        //    default, and no `--provider` is emitted.
+        let mut model_only = agent_profile(
+            "modelonly",
+            "scout",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        model_only.profile.model = Some("deepseek-v4-flash".to_string());
+        let model_only_task = fleet_task(
+            "launch-model-only",
+            Some(worker_profile(
+                Some("modelonly"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+        let (model, provider) =
+            fleet_worker_launch_route(&model_only_task, &[model_only], "deepseek-v4-pro");
+        assert_eq!(model, "deepseek-v4-flash");
+        assert_eq!(provider, None);
+
+        // 3) No profile at all: run-level model, no provider (unchanged).
+        let bare = fleet_task("launch-bare", None);
+        let (model, provider) = fleet_worker_launch_route(&bare, &[], "deepseek-v4-pro");
+        assert_eq!(model, "deepseek-v4-pro");
+        assert_eq!(provider, None);
     }
 
     #[test]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -340,6 +340,13 @@ struct ExecArgs {
     /// Override model for this run
     #[arg(long)]
     model: Option<String>,
+    /// Override the provider for this run (e.g. `deepseek`, `openrouter`).
+    /// Non-secret identifier only — credentials still resolve from the
+    /// environment/config. Fleet uses this to launch a worker on its
+    /// profile-pinned provider even when the parent session is on another
+    /// one (#4093).
+    #[arg(long)]
+    provider: Option<String>,
     /// Enable tool-backed agent mode with auto-approvals
     #[arg(long, default_value_t = false)]
     auto: bool,
@@ -1255,6 +1262,29 @@ async fn main() -> Result<()> {
                     if !trimmed.is_empty() {
                         config.base_url = Some(trimmed.to_string());
                     }
+                }
+                // Honour `--provider` (#4093): a Fleet worker whose profile pins
+                // a provider launches on that provider even when the parent
+                // session is on another one. This sets ONLY the non-secret
+                // provider identity (`config.provider`); credentials/base URL
+                // still resolve from the worker's own env/config, and for a
+                // non-DeepSeek provider the legacy root `base_url` above is
+                // ignored by `deepseek_base_url()`. Must precede model
+                // resolution so an `auto`/default model resolves to the
+                // overridden provider's default.
+                if let Some(provider_arg) = args
+                    .provider
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                {
+                    let Some(provider) = crate::config::ApiProvider::parse(provider_arg) else {
+                        bail!(
+                            "Unrecognized --provider {provider_arg:?}. Known providers: {}",
+                            crate::config::ApiProvider::names_hint()
+                        );
+                    };
+                    config.provider = Some(provider.as_str().to_string());
                 }
                 let model = resolve_exec_model(&config, args.model.as_deref());
                 let prompt = join_prompt_parts(&args.prompt);
@@ -9352,6 +9382,34 @@ mod terminal_mode_tests {
 
         assert!(args.json);
         assert_eq!(args.prompt, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn exec_parses_provider_flag_alongside_model() {
+        // #4093: Fleet threads `--provider <id>` so a worker launches on its
+        // profile-pinned provider even when the parent session is elsewhere.
+        let cli = parse_cli(&[
+            "codewhale",
+            "exec",
+            "--provider",
+            "openrouter",
+            "--model",
+            "glm-5.2",
+            "audit",
+        ]);
+        let Some(Commands::Exec(args)) = cli.command else {
+            panic!("expected exec command");
+        };
+
+        assert_eq!(args.provider.as_deref(), Some("openrouter"));
+        assert_eq!(args.model.as_deref(), Some("glm-5.2"));
+        assert_eq!(args.prompt, vec!["audit"]);
+        // The threaded id round-trips through the provider vocabulary the exec
+        // handler validates against — never a model-id sniff (EPIC #2608).
+        assert_eq!(
+            crate::config::ApiProvider::parse(args.provider.as_deref().unwrap()),
+            Some(crate::config::ApiProvider::Openrouter)
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2051,6 +2051,12 @@ pub struct App {
             Option<(
                 u64,
                 String,
+                // The `(provider, model)` route the operator picked when they
+                // pressed `m` (#4093). Carried alongside the async draft so the
+                // ratified profile keeps the picked cross-provider route even if
+                // the model draft (which is always `provider: None`) omitted or
+                // changed it. `None` for an `inherit` pick.
+                Option<(String, String)>,
                 Result<Box<crate::fleet::profile::FleetProfileDraft>, String>,
             )>,
         >,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -5782,9 +5782,14 @@ async fn handle_fleet_profile_model_draft(
 }
 
 /// Install a completed fleet-profile draft into the wizard (if it is still on
-/// top) and open its preview, or surface a failure. Called from the event
-/// loop when the background draft lands, and directly on the pre-spawn
+/// top), or surface a failure. Called from the event loop when the
+/// background draft lands, and directly on the pre-spawn
 /// provider-construction failure.
+///
+/// The preview renders inline on the wizard's own Review step — deliberately
+/// NOT in a separate pager (#4093): a standalone pager view owns its own
+/// `g`/`G` scroll bindings and would swallow the ratify keypress, forcing an
+/// Esc-then-g round trip before the user could actually save.
 fn deliver_fleet_draft_result(
     app: &mut App,
     model_label: String,
@@ -5796,19 +5801,19 @@ fn deliver_fleet_draft_result(
             if app.view_stack.top_kind() == Some(ModalKind::FleetSetup)
                 && let Some(mut boxed) = app.view_stack.pop()
             {
-                let preview = boxed
+                let installed = boxed
                     .as_any_mut()
                     .downcast_mut::<crate::tui::views::fleet_setup::FleetSetupView>()
-                    .map(|wizard| wizard.install_model_draft(draft, model_label.clone()));
+                    .map(|wizard| wizard.install_model_draft(draft, model_label.clone()))
+                    .is_some();
                 app.view_stack.push_boxed(boxed);
-                if let Some((title, content)) = preview {
-                    open_text_pager(app, title, content);
+                if installed {
                     app.status_message = Some(match locale {
                         crate::localization::Locale::ZhHans => {
-                            format!("{model_label} 已起草配置。请查看 TOML，然后按 g 批准。")
+                            format!("{model_label} 已起草配置。请查看下方 TOML，然后按 g 批准。")
                         }
                         _ => format!(
-                            "{model_label} drafted the profile. Review the TOML, then press g to ratify."
+                            "{model_label} drafted the profile. Review the TOML below, then press g to ratify."
                         ),
                     });
                 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2104,10 +2104,10 @@ async fn run_event_loop(
             .try_lock()
             .ok()
             .and_then(|mut guard| guard.take());
-        if let Some((draft_gen, model_label, outcome)) = fleet_draft_delivery
+        if let Some((draft_gen, model_label, picked_route, outcome)) = fleet_draft_delivery
             && draft_gen == app.current_draft_gen()
         {
-            deliver_fleet_draft_result(app, model_label, outcome, app.ui_locale);
+            deliver_fleet_draft_result(app, model_label, picked_route, outcome, app.ui_locale);
         }
 
         // Poll the constitution model-draft cell (same background pattern).
@@ -5711,8 +5711,16 @@ async fn handle_fleet_profile_model_draft(
     config: &Config,
     role: String,
     model: String,
+    provider: Option<String>,
     locale: crate::localization::Locale,
 ) {
+    // The route the operator actually picked at `m`-press time (#4093). A
+    // model draft always comes back `provider: None` (the untrusted gate
+    // strips any provider), so this captured `(provider, model)` is what the
+    // ratified profile is pinned to — immune to the model omitting/altering
+    // the route AND to the selection changing while the draft is in flight.
+    // `None` for an `inherit` pick (no concrete route to keep).
+    let picked_route = provider.map(|provider| (provider, model.clone()));
     // Do NOT await the network call on the event loop — that parks the whole
     // TUI for up to the timeout (#3757 review). Spawn it into the shared
     // fleet_draft_cell and let the loop poll + deliver the result, keeping
@@ -5725,6 +5733,7 @@ async fn handle_fleet_profile_model_draft(
             deliver_fleet_draft_result(
                 app,
                 model_label.clone(),
+                picked_route.clone(),
                 Err(format!("provider not ready: {err:#}")),
                 locale,
             );
@@ -5776,7 +5785,7 @@ async fn handle_fleet_profile_model_draft(
             Ok(result) => result,
         };
         if let Ok(mut guard) = cell.lock() {
-            *guard = Some((request_gen, spawn_label, outcome));
+            *guard = Some((request_gen, spawn_label, picked_route, outcome));
         }
     });
 }
@@ -5793,6 +5802,7 @@ async fn handle_fleet_profile_model_draft(
 fn deliver_fleet_draft_result(
     app: &mut App,
     model_label: String,
+    picked_route: Option<(String, String)>,
     outcome: Result<Box<crate::fleet::profile::FleetProfileDraft>, String>,
     locale: crate::localization::Locale,
 ) {
@@ -5804,7 +5814,9 @@ fn deliver_fleet_draft_result(
                 let installed = boxed
                     .as_any_mut()
                     .downcast_mut::<crate::tui::views::fleet_setup::FleetSetupView>()
-                    .map(|wizard| wizard.install_model_draft(draft, model_label.clone()))
+                    .map(|wizard| {
+                        wizard.install_model_draft(draft, model_label.clone(), picked_route.clone())
+                    })
                     .is_some();
                 app.view_stack.push_boxed(boxed);
                 if installed {
@@ -10358,9 +10370,10 @@ async fn handle_view_events(
             ViewEvent::FleetProfileModelDraftRequested {
                 role,
                 model,
+                provider,
                 locale,
             } => {
-                handle_fleet_profile_model_draft(app, config, role, model, locale).await;
+                handle_fleet_profile_model_draft(app, config, role, model, provider, locale).await;
             }
             ViewEvent::FleetRosterOpenSetupRequested => {
                 // The roster view hands off to the authoring wizard (same
@@ -10422,6 +10435,36 @@ async fn handle_view_events(
                             "Profile id `{}` is already used by {}; redraft with a different role or remove the old file first.",
                             draft.id,
                             existing.source.display()
+                        )
+                    });
+                    app.needs_redraw = true;
+                    continue;
+                }
+                // #4093 AC #5: a profile may only pin a provider the operator
+                // has actually configured/credentialed. The picker already
+                // offers models only from configured providers, but a
+                // model-drafted or hand-edited route (or credentials removed
+                // after the pick) could still name an unconfigured one — which
+                // would fail loudly at launch. Catch it at save time with a
+                // clear message, reusing the SAME predicate the picker uses.
+                if let Some(provider_id) = draft.provider.as_deref()
+                    && let Some(provider) = crate::config::ApiProvider::parse(provider_id)
+                    && !crate::config::provider_is_configured_for_active(
+                        config,
+                        provider,
+                        app.api_provider,
+                    )
+                {
+                    let zh = app.ui_locale == crate::localization::Locale::ZhHans;
+                    app.status_message = Some(if zh {
+                        format!(
+                            "配置指定的 provider `{provider_id}` 尚未配置凭据（{}）；请先在 /provider 中设置，再保存。",
+                            provider.env_vars_label()
+                        )
+                    } else {
+                        format!(
+                            "Profile pins provider `{provider_id}`, which has no configured credentials ({}); set it up in /provider before saving.",
+                            provider.env_vars_label()
                         )
                     });
                     app.needs_redraw = true;

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -715,6 +715,7 @@ mod tests {
                 },
                 loadout: codewhale_config::FleetLoadout::Fast,
                 model: None,
+                provider: None,
                 permissions: codewhale_config::FleetProfilePermissions::default(),
                 delegation: codewhale_config::FleetDelegationHints::default(),
             },

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -142,10 +142,13 @@ pub struct FleetSetupSnapshot {
     /// config / project), so the wizard can say when a chosen role would
     /// override an existing roster member.
     roster_members: Vec<(String, String)>,
-    /// `(provider display name, model id)` pairs selectable for a worker,
+    /// `(canonical provider id, model id)` pairs selectable for a worker,
     /// drawn from ALL configured providers — not only the active one (#4093).
     /// Shown after `inherit` in the Model step so a Fleet worker can be pinned
-    /// to a route independent of the parent/current provider.
+    /// to a route independent of the parent/current provider. The provider id
+    /// is the canonical [`crate::config::ApiProvider::as_str`] identifier
+    /// (e.g. `"deepseek"`), not a display label — see
+    /// [`cross_provider_model_routes`].
     available_models: Vec<(String, String)>,
 }
 
@@ -197,11 +200,17 @@ impl FleetSetupSnapshot {
     }
 }
 
-/// Build the `(provider display name, model id)` pairs selectable for a worker
+/// Build the `(canonical provider id, model id)` pairs selectable for a worker
 /// from EVERY configured provider — not only the active one (#4093). Fleet
 /// workers can be pinned to a route independent of the parent/current provider,
 /// so the Model step must offer the same cross-provider catalog the model
 /// picker does, instead of the active provider's models alone.
+///
+/// The provider id here is the canonical [`crate::config::ApiProvider::as_str`]
+/// identifier (e.g. `"deepseek"`), not a display label — this is the exact
+/// value persisted into the saved profile's `provider` field and read back by
+/// the loader (#4093), so it must round-trip through `ApiProvider::parse`.
+/// Callers derive a human-readable label from it for UI text.
 fn cross_provider_model_routes(
     config: &Config,
     active: crate::config::ApiProvider,
@@ -209,10 +218,20 @@ fn cross_provider_model_routes(
     let mut routes = Vec::new();
     for provider in crate::provider_lake::configured_providers(config, active) {
         for model in crate::provider_lake::models_for_provider(config, active, provider) {
-            routes.push((provider.display_name().to_string(), model));
+            routes.push((provider.as_str().to_string(), model));
         }
     }
     routes
+}
+
+/// Human-readable label for a canonical provider id, falling back to the raw
+/// id verbatim when it doesn't parse (defensive — every id this module hands
+/// out itself comes from [`crate::config::ApiProvider::as_str`], so this only
+/// matters for a foreign/stale id read back from an old snapshot).
+fn provider_display_label(provider_id: &str) -> String {
+    crate::config::ApiProvider::parse(provider_id)
+        .map(|provider| provider.display_name().to_string())
+        .unwrap_or_else(|| provider_id.to_string())
 }
 
 /// Which focused screen of the wizard is showing.
@@ -238,6 +257,14 @@ pub struct FleetSetupView {
     model_draft: Option<Box<crate::fleet::profile::FleetProfileDraft>>,
     /// Display label of the model that authored `model_draft`.
     model_draft_label: Option<String>,
+    /// Exact rendered TOML preview for `model_draft` (header comment + the
+    /// deterministic bytes ratifying would persist). Rendered inline on the
+    /// Review step — never in a separate pager (#4093): a standalone pager
+    /// view owns its own `g`/`G` scroll bindings, which silently swallowed
+    /// the ratify keypress and left users unable to save without first
+    /// pressing Esc. Keeping the preview and the ratify control in the same
+    /// view means the footer's `g`/Enter hints are never a lie.
+    model_draft_preview: Option<String>,
     /// Model-step rows: `inherit` followed by one row per concrete model from
     /// every configured provider (#4093).
     model_choices: Vec<Choice>,
@@ -259,13 +286,16 @@ impl FleetSetupView {
         // concrete (provider, model) drawn from all configured providers.
         let mut model_routes = vec![(snapshot.provider.clone(), snapshot.model.clone())];
         for (provider, model) in &snapshot.available_models {
+            let provider_label = provider_display_label(provider);
             model_choices.push(Choice {
                 label: Cow::Owned(model.clone()),
-                summary: Cow::Owned(format!("Pin this model ({provider})")),
+                summary: Cow::Owned(format!("Pin this model ({provider_label})")),
                 description: Cow::Owned(format!(
-                    "Route this worker to {model} on {provider} instead of inheriting the session route."
+                    "Route this worker to {model} on {provider_label} instead of inheriting the session route."
                 )),
             });
+            // Canonical provider id (not the display label above) — this is
+            // what gets persisted into the saved profile (#4093).
             model_routes.push((provider.clone(), model.clone()));
         }
         Self {
@@ -276,14 +306,16 @@ impl FleetSetupView {
             review_scroll: 0,
             model_draft: None,
             model_draft_label: None,
+            model_draft_preview: None,
             model_choices,
             model_routes,
         }
     }
 
-    /// Install a sanitized, bounded model draft and return the preview the
-    /// host must open in the same breath — that preview is the exact TOML the
-    /// ratify keypress would persist.
+    /// Install a sanitized, bounded model draft. The exact TOML preview
+    /// (returned here for the caller's status message) renders inline on the
+    /// Review step — not in a separate pager — so the footer's `g`/Enter
+    /// ratify hints stay true the instant the draft lands (#4093).
     pub fn install_model_draft(
         &mut self,
         draft: Box<crate::fleet::profile::FleetProfileDraft>,
@@ -308,6 +340,8 @@ impl FleetSetupView {
         let content = format!("{header}{}", draft.render_toml());
         self.model_draft = Some(draft);
         self.model_draft_label = Some(model_label);
+        self.model_draft_preview = Some(content.clone());
+        self.review_scroll = 0;
         (title, content)
     }
 
@@ -371,6 +405,7 @@ impl FleetSetupView {
     fn discard_model_draft(&mut self) {
         self.model_draft = None;
         self.model_draft_label = None;
+        self.model_draft_preview = None;
     }
 
     fn move_down(&mut self) {
@@ -420,42 +455,50 @@ impl FleetSetupView {
         }
     }
 
+    /// Preview the exact starter profile TOML the next ratify keypress would
+    /// persist. Renders inline within the Review step's own scrollable pane —
+    /// deliberately NOT via `ViewEvent::OpenTextPager` (#4093): a standalone
+    /// pager view has its own `g`/`G` scroll bindings and would swallow the
+    /// ratify keypress, forcing an Esc-then-g round trip to actually save.
     fn preview_starter_profile_action(&mut self) -> ViewAction {
         let draft = self.starter_profile_draft();
-        let (title, header) = match self.snapshot.locale {
-            crate::localization::Locale::ZhHans => (
-                "Fleet 配置 — 起始草案（Enter/g 批准）".to_string(),
-                format!(
-                    "# .codewhale/agents/{}\n# CodeWhale 根据当前角色和模型选择确定性渲染。\n# 权限保持在 Fleet 底线：无 shell、无 trust、需审批。\n# 在向导中按 Enter 或 g 之前不会保存任何内容。\n\n",
-                    draft.file_name()
-                ),
+        let header = match self.snapshot.locale {
+            crate::localization::Locale::ZhHans => format!(
+                "# .codewhale/agents/{}\n# CodeWhale 根据当前角色和模型选择确定性渲染。\n# 权限保持在 Fleet 底线：无 shell、无 trust、需审批。\n# 在向导中按 Enter 或 g 之前不会保存任何内容。\n\n",
+                draft.file_name()
             ),
-            _ => (
-                "Fleet profile — starter draft (Enter/g ratifies)".to_string(),
-                format!(
-                    "# .codewhale/agents/{}\n# Deterministic starter profile rendered by CodeWhale from your role/model choices.\n# Permissions stay at the fleet floor: no shell, no trust, approval required.\n# Nothing is saved until you press Enter or g in the wizard.\n\n",
-                    draft.file_name()
-                ),
+            _ => format!(
+                "# .codewhale/agents/{}\n# Deterministic starter profile rendered by CodeWhale from your role/model choices.\n# Permissions stay at the fleet floor: no shell, no trust, approval required.\n# Nothing is saved until you press Enter or g in the wizard.\n\n",
+                draft.file_name()
             ),
         };
-        let content = format!("{header}{}", draft.render_toml());
+        self.model_draft_preview = Some(format!("{header}{}", draft.render_toml()));
         self.model_draft = Some(draft);
         self.model_draft_label = Some("CodeWhale starter".to_string());
-        ViewAction::Emit(ViewEvent::OpenTextPager { title, content })
+        self.review_scroll = 0;
+        ViewAction::None
     }
 
     /// Build a deterministic starter profile for the current role/model
     /// selection. The same ratify event persists this as model-drafted profiles,
     /// so duplicate-id checks and atomic writes stay in one host path.
+    ///
+    /// `provider` is seeded from whatever the user actually picked in the
+    /// Model step (#4093) — a concrete route names its own provider
+    /// explicitly, so the saved profile is never ambiguously scoped to
+    /// whatever provider happens to be active at launch time. `inherit`
+    /// carries no provider, matching its `model: None`.
     fn starter_profile_draft(&self) -> Box<crate::fleet::profile::FleetProfileDraft> {
         let role = &ROLES[self.role_idx.min(ROLES.len() - 1)];
+        let route = self.selected_route();
         Box::new(crate::fleet::profile::FleetProfileDraft {
             id: profile_file_stem(&role.label),
             display_name: Some(role.label.to_string()),
             description: Some(format!("{} - {}", role.summary, role.description)),
             role_hint: role.label.to_string(),
             model_class_hint: None,
-            model: self.selected_model(),
+            model: route.as_ref().map(|(_, model)| model.clone()),
+            provider: route.map(|(provider, _)| provider),
             instructions: Some(format!(
                 "Role: {}. Work only within the assigned Fleet slice. Report concise evidence and stop when the assignment is complete. Do not widen permissions, trust, route configuration, or topology.",
                 role.label
@@ -519,7 +562,7 @@ impl ModalView for FleetSetupView {
             }
             KeyCode::Char('m') if self.step == Step::Review && self.snapshot.provider_ready => {
                 ViewAction::Emit(ViewEvent::FleetProfileModelDraftRequested {
-                    role: self.selected_role().to_string(),
+                    role: self.selected_role(),
                     model: self
                         .selected_model()
                         .unwrap_or_else(|| "inherit".to_string()),
@@ -649,6 +692,10 @@ impl FleetSetupView {
                 "Choose a model",
                 "Pick this worker's model, or inherit your current route.",
             ),
+            Step::Review if self.model_draft.is_some() => (
+                "Ratify the draft",
+                "Exact TOML shown below. Press Enter or g to ratify, m to redraft.",
+            ),
             Step::Review => (
                 "Review & start",
                 "Confirm the posture below, preview exact TOML, then ratify to save.",
@@ -670,6 +717,15 @@ impl FleetSetupView {
     }
 
     fn render_review(&self, area: Rect, buf: &mut Buffer) {
+        // A ratify-ready draft is on screen: show the exact TOML preview
+        // inline, scrolled by the same `review_scroll` state, so `g`/Enter in
+        // THIS view's own `handle_key` ratify it directly — no separate pager
+        // in the way to swallow the keypress (#4093).
+        if let Some(preview) = self.model_draft_preview.as_deref() {
+            render_scrollable_text(area, buf, preview, self.review_scroll);
+            return;
+        }
+
         let role = &ROLES[self.role_idx.min(ROLES.len() - 1)];
         let (profile_value, _) = profile_file_status(&self.snapshot.workspace);
         let file_stem = profile_file_stem(&role.label);
@@ -703,8 +759,13 @@ impl FleetSetupView {
         section(
             &mut lines,
             "Model",
-            match self.selected_model() {
-                Some(model) => format!("{model}  ·  provider {}", self.snapshot.provider),
+            // The picked route's OWN provider, not the parent/current
+            // session's — a cross-provider pin must never be misreported as
+            // running on the active provider (#4093).
+            match self.selected_route() {
+                Some((provider, model)) => {
+                    format!("{model}  ·  provider {}", provider_display_label(&provider))
+                }
                 None => format!(
                     "inherit  ·  route {} / {}, reasoning {}",
                     self.snapshot.provider, self.snapshot.model, self.snapshot.reasoning
@@ -772,6 +833,28 @@ impl FleetSetupView {
             .scroll((scroll as u16, 0))
             .render(area, buf);
     }
+}
+
+/// Render wrapped, line-scrolled plain text (the ratify-ready draft TOML
+/// preview) into `area`, clamping `scroll` to the real wrapped-row bound the
+/// same way [`FleetSetupView::render_review`]'s summary does — an
+/// over-estimate of wrapped height is harmless (scroll clamps at the end).
+fn render_scrollable_text(area: Rect, buf: &mut Buffer, text: &str, scroll: usize) {
+    let lines: Vec<Line> = text
+        .lines()
+        .map(|line| Line::from(line.to_string()))
+        .collect();
+    let wrap_width = usize::from(area.width).max(1);
+    let visual_rows: usize = lines
+        .iter()
+        .map(|line| line.width().div_ceil(wrap_width).max(1))
+        .sum();
+    let max_scroll = visual_rows.saturating_sub(usize::from(area.height).max(1));
+    let scroll = scroll.min(max_scroll);
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: true })
+        .scroll((scroll as u16, 0))
+        .render(area, buf);
 }
 
 /// Render a wizard choice step: a list of selectable identifiers on the left and
@@ -1055,7 +1138,7 @@ mod tests {
     }
 
     #[test]
-    fn start_on_review_previews_and_ratifies_starter_profile_for_selection() {
+    fn start_on_review_previews_inline_and_ratifies_starter_profile_for_selection() {
         let mut view = FleetSetupView::from_snapshot(snapshot());
         // Role: manager(0) scout(1) builder(2) -> builder.
         view.handle_key(key(KeyCode::Down));
@@ -1065,27 +1148,35 @@ mod tests {
         view.handle_key(key(KeyCode::Down));
         view.handle_key(key(KeyCode::Enter)); // -> Review
 
+        // Start previews inline (#4093: no separate pager to steal the next
+        // ratify keypress) — the action stays `None` and the draft/preview
+        // land directly on this same view.
         let action = view.handle_key(key(KeyCode::Enter)); // Start
-        match action {
-            ViewAction::Emit(ViewEvent::OpenTextPager { title, content }) => {
-                assert!(title.contains("starter draft"));
-                assert!(content.contains("# .codewhale/agents/builder.toml"));
-                assert!(content.contains("id = \"builder\""));
-                assert!(content.contains("role_hint = \"builder\""));
-                assert!(content.contains("model = \"deepseek-v4-pro\""));
-                assert!(content.contains("Nothing is saved until"));
-                for forbidden in ["provider", "base_url", "api_key"] {
-                    assert!(
-                        !content.contains(forbidden),
-                        "starter profile must not carry {forbidden}: {content}"
-                    );
-                }
-            }
-            other => panic!("expected starter profile preview, got {other:?}"),
-        }
+        assert!(matches!(action, ViewAction::None));
         assert!(view.model_draft.is_some());
+        let content = view
+            .model_draft_preview
+            .as_deref()
+            .expect("preview installed inline");
+        assert!(content.contains("# .codewhale/agents/builder.toml"));
+        assert!(content.contains("id = \"builder\""));
+        assert!(content.contains("role_hint = \"builder\""));
+        assert!(content.contains("model = \"deepseek-v4-pro\""));
+        // A concrete cross-provider route pin names its own provider
+        // explicitly (#4093) — the saved profile must not be ambiguously
+        // scoped to whatever provider happens to be active at launch time.
+        assert!(content.contains("provider = \"deepseek\""), "{content}");
+        assert!(content.contains("Nothing is saved until"));
+        for forbidden in ["base_url", "api_key"] {
+            assert!(
+                !content.contains(forbidden),
+                "starter profile must not carry {forbidden}: {content}"
+            );
+        }
 
-        let action = view.handle_key(key(KeyCode::Enter)); // ratify previewed draft
+        // `g` ratifies directly from this same view — no Esc-then-g round
+        // trip through a separate pager required.
+        let action = view.handle_key(key(KeyCode::Char('g')));
         let ViewAction::EmitAndClose(ViewEvent::FleetProfileDraftCommitRequested { draft }) =
             action
         else {
@@ -1094,6 +1185,21 @@ mod tests {
         assert_eq!(draft.id, "builder");
         assert_eq!(draft.role_hint, "builder");
         assert_eq!(draft.model.as_deref(), Some("deepseek-v4-pro"));
+        assert_eq!(draft.provider.as_deref(), Some("deepseek"));
+    }
+
+    #[test]
+    fn inherit_selection_starter_draft_carries_no_provider() {
+        // `inherit` (no concrete route pin) must never carry a provider —
+        // there's no explicit route to name (#4093).
+        let mut view = FleetSetupView::from_snapshot(snapshot());
+        to_review(&mut view);
+        view.handle_key(key(KeyCode::Enter)); // Start -> preview inherit draft
+        let draft = view.model_draft.as_deref().expect("draft installed");
+        assert_eq!(draft.model, None);
+        assert_eq!(draft.provider, None);
+        let content = view.model_draft_preview.as_deref().unwrap();
+        assert!(!content.contains("provider"), "{content}");
     }
 
     #[test]

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -12,6 +12,7 @@
 //! provider/model picker that will churn most of this text. The command entry
 //! (`CmdFleetDescription`) is already localized.
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent};
@@ -36,9 +37,9 @@ const PROFILE_DIR: &str = ".codewhale/agents";
 /// A selectable choice in a wizard step: a short identifier `label`, a one-line
 /// `summary`, and a longer `description` shown (wrapped) in the detail pane.
 struct Choice {
-    label: &'static str,
-    summary: &'static str,
-    description: &'static str,
+    label: Cow<'static, str>,
+    summary: Cow<'static, str>,
+    description: Cow<'static, str>,
 }
 
 const CHOICE_LIST_WIDTH: u16 = 22;
@@ -49,54 +50,73 @@ const CHOICE_TWO_COLUMN_MIN_WIDTH: u16 = CHOICE_LIST_WIDTH + CHOICE_DETAIL_MIN_W
 /// so these strings are part of the generated-profile contract.
 const ROLES: [Choice; 8] = [
     Choice {
-        label: "manager",
-        summary: "Plan & split queued work",
-        description: "Coordinates the Fleet run: plans the work, splits it into bounded tasks, and dispatches workers.",
+        label: Cow::Borrowed("manager"),
+        summary: Cow::Borrowed("Plan & split queued work"),
+        description: Cow::Borrowed(
+            "Coordinates the Fleet run: plans the work, splits it into bounded tasks, and dispatches workers.",
+        ),
     },
     Choice {
-        label: "scout",
-        summary: "Read-first research",
-        description: "Research and repo reconnaissance. Reads and summarizes before anything is written.",
+        label: Cow::Borrowed("scout"),
+        summary: Cow::Borrowed("Read-first research"),
+        description: Cow::Borrowed(
+            "Research and repo reconnaissance. Reads and summarizes before anything is written.",
+        ),
     },
     Choice {
-        label: "builder",
-        summary: "Implements bounded changes",
-        description: "Implements changes strictly inside its assigned task scope; writes only what the slice needs.",
+        label: Cow::Borrowed("builder"),
+        summary: Cow::Borrowed("Implements bounded changes"),
+        description: Cow::Borrowed(
+            "Implements changes strictly inside its assigned task scope; writes only what the slice needs.",
+        ),
     },
     Choice {
-        label: "reviewer",
-        summary: "Read-only review",
-        description: "Checks regressions, tests, and diffs. Read-only — it never writes.",
+        label: Cow::Borrowed("reviewer"),
+        summary: Cow::Borrowed("Read-only review"),
+        description: Cow::Borrowed(
+            "Checks regressions, tests, and diffs. Read-only — it never writes.",
+        ),
     },
     Choice {
-        label: "verifier",
-        summary: "Runs focused validation",
-        description: "Runs targeted validation and reports receipts back to the orchestrator.",
+        label: Cow::Borrowed("verifier"),
+        summary: Cow::Borrowed("Runs focused validation"),
+        description: Cow::Borrowed(
+            "Runs targeted validation and reports receipts back to the orchestrator.",
+        ),
     },
     Choice {
-        label: "synthesizer",
-        summary: "Reduce receipts to handoff",
-        description: "Turns worker receipts into bounded handoff state instead of raw transcript replay.",
+        label: Cow::Borrowed("synthesizer"),
+        summary: Cow::Borrowed("Reduce receipts to handoff"),
+        description: Cow::Borrowed(
+            "Turns worker receipts into bounded handoff state instead of raw transcript replay.",
+        ),
     },
     Choice {
-        label: "general",
-        summary: "General-purpose worker",
-        description: "A flexible worker with no specialized posture — use it when the task doesn't fit a named role.",
+        label: Cow::Borrowed("general"),
+        summary: Cow::Borrowed("General-purpose worker"),
+        description: Cow::Borrowed(
+            "A flexible worker with no specialized posture — use it when the task doesn't fit a named role.",
+        ),
     },
     Choice {
-        label: "custom",
-        summary: "Author a profile by hand",
-        description: "Define the posture yourself in a workspace agent TOML profile under .codewhale/agents/.",
+        label: Cow::Borrowed("custom"),
+        summary: Cow::Borrowed("Author a profile by hand"),
+        description: Cow::Borrowed(
+            "Define the posture yourself in a workspace agent TOML profile under .codewhale/agents/.",
+        ),
     },
 ];
 
 /// The `inherit` row shown first in the Model step (#3167). Concrete provider
-/// models follow it, built per-run from the active provider's catalog, so the
-/// user picks a real model instead of an abstract class.
+/// models follow it, built per-run from EVERY configured provider's catalog
+/// (#4093), so the user picks a real route — including cross-provider ones —
+/// instead of an abstract class or only the active provider's models.
 const MODEL_INHERIT: Choice = Choice {
-    label: "inherit",
-    summary: "Same model as now",
-    description: "Reuse the active provider, model, and reasoning for this worker — the operator's route. Recommended default.",
+    label: Cow::Borrowed("inherit"),
+    summary: Cow::Borrowed("Same model as now"),
+    description: Cow::Borrowed(
+        "Reuse the active provider, model, and reasoning for this worker — the operator's route. Recommended default.",
+    ),
 };
 
 #[derive(Debug, Clone)]
@@ -122,9 +142,11 @@ pub struct FleetSetupSnapshot {
     /// config / project), so the wizard can say when a chosen role would
     /// override an existing roster member.
     roster_members: Vec<(String, String)>,
-    /// Concrete model ids selectable for a worker on the active provider,
-    /// shown after `inherit` in the Model step.
-    available_models: Vec<&'static str>,
+    /// `(provider display name, model id)` pairs selectable for a worker,
+    /// drawn from ALL configured providers — not only the active one (#4093).
+    /// Shown after `inherit` in the Model step so a Fleet worker can be pinned
+    /// to a route independent of the parent/current provider.
+    available_models: Vec<(String, String)>,
 }
 
 impl FleetSetupSnapshot {
@@ -170,9 +192,27 @@ impl FleetSetupSnapshot {
             heartbeat_timeout_secs: config
                 .subagent_heartbeat_timeout_secs_for_provider(app.api_provider),
             roster_members,
-            available_models: crate::config::model_completion_names_for_provider(app.api_provider),
+            available_models: cross_provider_model_routes(config, app.api_provider),
         }
     }
+}
+
+/// Build the `(provider display name, model id)` pairs selectable for a worker
+/// from EVERY configured provider — not only the active one (#4093). Fleet
+/// workers can be pinned to a route independent of the parent/current provider,
+/// so the Model step must offer the same cross-provider catalog the model
+/// picker does, instead of the active provider's models alone.
+fn cross_provider_model_routes(
+    config: &Config,
+    active: crate::config::ApiProvider,
+) -> Vec<(String, String)> {
+    let mut routes = Vec::new();
+    for provider in crate::provider_lake::configured_providers(config, active) {
+        for model in crate::provider_lake::models_for_provider(config, active, provider) {
+            routes.push((provider.display_name().to_string(), model));
+        }
+    }
+    routes
 }
 
 /// Which focused screen of the wizard is showing.
@@ -198,8 +238,13 @@ pub struct FleetSetupView {
     model_draft: Option<Box<crate::fleet::profile::FleetProfileDraft>>,
     /// Display label of the model that authored `model_draft`.
     model_draft_label: Option<String>,
-    /// Model-step rows: `inherit` followed by the active provider's models.
+    /// Model-step rows: `inherit` followed by one row per concrete model from
+    /// every configured provider (#4093).
     model_choices: Vec<Choice>,
+    /// `(provider, model)` aligned with `model_choices`. Index 0 is `inherit`
+    /// (the active route); later rows pin a concrete, possibly cross-provider
+    /// route. Drives the review/copy so a pinned route names its own provider.
+    model_routes: Vec<(String, String)>,
 }
 
 impl FleetSetupView {
@@ -210,12 +255,18 @@ impl FleetSetupView {
 
     fn from_snapshot(snapshot: FleetSetupSnapshot) -> Self {
         let mut model_choices = vec![MODEL_INHERIT];
-        for &name in &snapshot.available_models {
+        // `inherit` (index 0) maps to the active route; every later row pins a
+        // concrete (provider, model) drawn from all configured providers.
+        let mut model_routes = vec![(snapshot.provider.clone(), snapshot.model.clone())];
+        for (provider, model) in &snapshot.available_models {
             model_choices.push(Choice {
-                label: name,
-                summary: "Pin this model",
-                description: "Route this worker to this specific model on the active provider instead of inheriting the session route.",
+                label: Cow::Owned(model.clone()),
+                summary: Cow::Owned(format!("Pin this model ({provider})")),
+                description: Cow::Owned(format!(
+                    "Route this worker to {model} on {provider} instead of inheriting the session route."
+                )),
             });
+            model_routes.push((provider.clone(), model.clone()));
         }
         Self {
             snapshot,
@@ -226,6 +277,7 @@ impl FleetSetupView {
             model_draft: None,
             model_draft_label: None,
             model_choices,
+            model_routes,
         }
     }
 
@@ -260,8 +312,8 @@ impl FleetSetupView {
     }
 
     /// The planner role chosen (drives the profile file name and `role_hint`).
-    fn selected_role(&self) -> &'static str {
-        ROLES[self.role_idx.min(ROLES.len() - 1)].label
+    fn selected_role(&self) -> String {
+        ROLES[self.role_idx.min(ROLES.len() - 1)].label.to_string()
     }
 
     /// Copy note when the chosen role would override an existing roster
@@ -276,13 +328,20 @@ impl FleetSetupView {
             .map(|(id, origin)| format!("Overrides the {origin} '{id}' roster member."))
     }
 
-    /// The concrete model chosen for this worker, or `None` for `inherit`
-    /// (reuse the session route). Written to the profile `model` field.
+    /// The concrete model chosen for this worker, written to the profile
+    /// `model` field. `None` means `inherit` (reuse the session route).
     fn selected_model(&self) -> Option<String> {
-        match self.model_choices.get(self.model_idx) {
-            Some(choice) if choice.label != "inherit" => Some(choice.label.to_string()),
-            _ => None,
+        self.selected_route().map(|(_, model)| model)
+    }
+
+    /// The concrete `(provider, model)` chosen for this worker — a pinned route
+    /// independent of the parent/current provider (#4093) — or `None` when
+    /// `inherit` is selected (reuse the session route).
+    fn selected_route(&self) -> Option<(String, String)> {
+        if self.model_idx == 0 {
+            return None;
         }
+        self.model_routes.get(self.model_idx).cloned()
     }
 
     /// Number of selectable rows on the current step (0 on the review step).
@@ -391,7 +450,7 @@ impl FleetSetupView {
     fn starter_profile_draft(&self) -> Box<crate::fleet::profile::FleetProfileDraft> {
         let role = &ROLES[self.role_idx.min(ROLES.len() - 1)];
         Box::new(crate::fleet::profile::FleetProfileDraft {
-            id: profile_file_stem(role.label),
+            id: profile_file_stem(&role.label),
             display_name: Some(role.label.to_string()),
             description: Some(format!("{} - {}", role.summary, role.description)),
             role_hint: role.label.to_string(),
@@ -613,7 +672,7 @@ impl FleetSetupView {
     fn render_review(&self, area: Rect, buf: &mut Buffer) {
         let role = &ROLES[self.role_idx.min(ROLES.len() - 1)];
         let (profile_value, _) = profile_file_status(&self.snapshot.workspace);
-        let file_stem = profile_file_stem(role.label);
+        let file_stem = profile_file_stem(&role.label);
         let token_budget = self
             .snapshot
             .token_budget
@@ -772,12 +831,12 @@ fn render_choice_step(
     let choice = &choices[selected.min(choices.len().saturating_sub(1))];
     let mut detail_lines: Vec<Line> = vec![
         Line::from(Span::styled(
-            choice.summary,
+            choice.summary.clone(),
             Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
         )),
         Line::from(""),
         Line::from(Span::styled(
-            choice.description,
+            choice.description.clone(),
             Style::default().fg(palette::TEXT_PRIMARY),
         )),
     ];
@@ -869,7 +928,10 @@ mod tests {
                 .iter()
                 .map(|member| (member.id.to_lowercase(), member.origin.to_string()))
                 .collect(),
-            available_models: vec!["deepseek-v4-pro", "deepseek-v4-flash"],
+            available_models: vec![
+                ("deepseek".to_string(), "deepseek-v4-pro".to_string()),
+                ("deepseek".to_string(), "deepseek-v4-flash".to_string()),
+            ],
         }
     }
 

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -318,9 +318,24 @@ impl FleetSetupView {
     /// ratify hints stay true the instant the draft lands (#4093).
     pub fn install_model_draft(
         &mut self,
-        draft: Box<crate::fleet::profile::FleetProfileDraft>,
+        mut draft: Box<crate::fleet::profile::FleetProfileDraft>,
         model_label: String,
+        picked_route: Option<(String, String)>,
     ) -> (String, String) {
+        // Re-inject the route the operator picked at `m`-press time (#4093). A
+        // model draft comes from `from_untrusted_json`, which hard-sets
+        // `provider: None` and echoes whatever `model` the model happened to
+        // emit — so ratifying it verbatim would drop a concrete cross-provider
+        // pick and persist the ambiguous, provider-scoped profile #4093 exists
+        // to prevent. Pinning BOTH fields from the CARRIED route keeps the route
+        // the user actually chose (the model only authored the prose), and is
+        // immune to the selection changing while the async draft is in flight.
+        // `inherit` (a `None` route) leaves `model`/`provider` untouched,
+        // matching the deterministic Enter path.
+        if let Some((provider, model)) = picked_route {
+            draft.model = Some(model);
+            draft.provider = Some(provider);
+        }
         let (title, header) = match self.snapshot.locale {
             crate::localization::Locale::ZhHans => (
                 format!("Fleet 配置 — 由 {model_label} 起草（按 g 批准）"),
@@ -561,11 +576,18 @@ impl ModalView for FleetSetupView {
                 ViewAction::None
             }
             KeyCode::Char('m') if self.step == Step::Review && self.snapshot.provider_ready => {
+                let route = self.selected_route();
                 ViewAction::Emit(ViewEvent::FleetProfileModelDraftRequested {
                     role: self.selected_role(),
-                    model: self
-                        .selected_model()
+                    model: route
+                        .as_ref()
+                        .map(|(_, model)| model.clone())
                         .unwrap_or_else(|| "inherit".to_string()),
+                    // Carry the picked provider so the redrafted profile keeps
+                    // the cross-provider route (#4093). `install_model_draft`
+                    // re-injects it authoritatively from the wizard's current
+                    // selection, but the event stays self-describing.
+                    provider: route.map(|(provider, _)| provider),
                     locale: self.snapshot.locale,
                 })
             }
@@ -1048,6 +1070,7 @@ mod tests {
         let ViewAction::Emit(ViewEvent::FleetProfileModelDraftRequested {
             role,
             model,
+            provider,
             locale,
         }) = action
         else {
@@ -1055,7 +1078,82 @@ mod tests {
         };
         assert!(!role.is_empty());
         assert!(!model.is_empty());
+        // Default selection is `inherit` (model_idx 0), which carries no
+        // concrete provider route.
+        assert_eq!(provider, None);
         assert_eq!(locale, crate::localization::Locale::En);
+    }
+
+    #[test]
+    fn m_redraft_preserves_a_cross_provider_pick_regression_4093() {
+        // #4093 BLOCKER 2 regression: a cross-provider route pick followed by an
+        // `m` model-assisted redraft must STILL persist the picked provider. A
+        // model draft comes from `from_untrusted_json`, which hard-sets
+        // `provider: None` (and can echo any model). Without re-injection the
+        // ratified profile would carry `model` with no `provider` — the exact
+        // ambiguous, provider-scoped profile #4093 removes.
+        //
+        // The active/session provider is DeepSeek; the picked route is a
+        // GLM model on Zai — a genuinely different provider than the parent.
+        let mut snap = snapshot();
+        snap.provider = "DeepSeek".to_string();
+        snap.model = "deepseek-v4-pro".to_string();
+        snap.available_models = vec![("zai".to_string(), "glm-5.2".to_string())];
+        let mut view = FleetSetupView::from_snapshot(snap);
+
+        // Role step: keep the first role. Model step: inherit(0), then the one
+        // cross-provider row (1) -> pick it. Then advance to Review.
+        view.handle_key(key(KeyCode::Enter)); // Role -> Model
+        view.handle_key(key(KeyCode::Down)); // -> the zai/glm-5.2 row
+        assert_eq!(
+            view.selected_route(),
+            Some(("zai".to_string(), "glm-5.2".to_string()))
+        );
+        view.handle_key(key(KeyCode::Enter)); // Model -> Review
+
+        // `m` requests a draft and carries the picked cross-provider route.
+        let action = view.handle_key(key(KeyCode::Char('m')));
+        let ViewAction::Emit(ViewEvent::FleetProfileModelDraftRequested {
+            model, provider, ..
+        }) = action
+        else {
+            panic!("expected model draft request");
+        };
+        assert_eq!(model, "glm-5.2");
+        assert_eq!(provider.as_deref(), Some("zai"));
+
+        // The host reconstructs the picked route from the event exactly as
+        // `handle_fleet_profile_model_draft` does, and carries it to
+        // `install_model_draft` (immune to the selection changing mid-draft).
+        let picked_route = provider.map(|provider| (provider, model.clone()));
+
+        // The model returns a draft that (as always) has provider: None — the
+        // untrusted gate strips any provider a model tries to smuggle.
+        let drafted = sample_draft();
+        assert_eq!(drafted.provider, None);
+
+        // Installing it re-injects the picked route, so the ratified draft keeps
+        // BOTH the provider and the model the user actually chose.
+        let (_title, content) =
+            view.install_model_draft(drafted, "GLM-5.2".to_string(), picked_route);
+        let ratified = view.model_draft.as_deref().expect("draft installed");
+        assert_eq!(ratified.provider.as_deref(), Some("zai"));
+        assert_eq!(ratified.model.as_deref(), Some("glm-5.2"));
+
+        // The rendered TOML the ratify keypress would persist names the provider
+        // explicitly — never a provider-scoped ambiguity.
+        assert!(content.contains("provider = \"zai\""), "{content}");
+        assert!(content.contains("model = \"glm-5.2\""), "{content}");
+
+        // And ratifying commits exactly that route.
+        let action = view.handle_key(key(KeyCode::Char('g')));
+        let ViewAction::EmitAndClose(ViewEvent::FleetProfileDraftCommitRequested { draft }) =
+            action
+        else {
+            panic!("expected ratify commit event");
+        };
+        assert_eq!(draft.provider.as_deref(), Some("zai"));
+        assert_eq!(draft.model.as_deref(), Some("glm-5.2"));
     }
 
     #[test]
@@ -1069,7 +1167,8 @@ mod tests {
             ViewAction::None
         ));
 
-        let (title, content) = view.install_model_draft(sample_draft(), "GLM-5.2".to_string());
+        let (title, content) =
+            view.install_model_draft(sample_draft(), "GLM-5.2".to_string(), None);
         assert!(title.contains("GLM-5.2"));
         assert!(content.contains("id = \"reviewer\""), "{content}");
         assert!(content.contains("Nothing is saved until"), "{content}");
@@ -1087,7 +1186,7 @@ mod tests {
     fn changing_answers_discards_a_stale_draft() {
         let mut view = FleetSetupView::from_snapshot(snapshot());
         to_review(&mut view);
-        let _ = view.install_model_draft(sample_draft(), "GLM-5.2".to_string());
+        let _ = view.install_model_draft(sample_draft(), "GLM-5.2".to_string(), None);
         assert!(view.model_draft.is_some());
 
         // Back to the role step and change the selection: the draft no

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -663,6 +663,11 @@ pub enum ViewEvent {
         role: String,
         /// Target model for the worker: a concrete model id, or "inherit".
         model: String,
+        /// Canonical provider id for a concrete cross-provider route pick, or
+        /// `None` for `inherit` (#4093). Carried so the model-drafted profile
+        /// keeps the picked provider instead of collapsing to an ambiguous,
+        /// provider-scoped profile — the exact bug #4093 fixes.
+        provider: Option<String>,
         locale: crate::localization::Locale,
     },
     /// Emitted by the `/fleet` roster view (`s` / Enter) to hand off to the

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -48,11 +48,15 @@ profiles). `/fleet status` opens the worker-status view; `/subagents` is a
 compatibility shortcut for that status view.
 
 The wizard is progressive: you make one focused choice at a time — a **role**,
-then a **model** (`inherit`, or a concrete model from the active provider) — and
-then review the full posture (model/route,
-permissions, tools, workspace/org scope, and review policy) before doing
-anything. Pressing **Enter** ("start") on the review step inserts a safe
-profile-authoring prompt into the composer; it does not write a file itself.
+then a **model** (`inherit`, or a concrete model from *any configured
+provider*, not only the one the parent session is currently using) — and then
+review the full posture (model/route, permissions, tools, workspace/org
+scope, and review policy) before doing anything. Picking a concrete model
+pins its provider explicitly: the saved profile records both `model` and
+`provider` fields, so the route it names doesn't depend on whichever provider
+happens to be active when the profile is later loaded. Pressing **Enter**
+("start") on the review step previews the exact starter profile TOML inline
+on that same screen; nothing is written until you ratify it.
 
 When a provider is configured, the review step also offers model-assisted
 drafting behind a ratify gate:
@@ -61,9 +65,10 @@ drafting behind a ratify gate:
   draft arrives sanitized and bounded — permissions stay at the **fleet floor**
   (no shell, no trust, approval required) regardless of what the model
   proposes.
-- **Drafting is not ratifying.** The exact rendered TOML preview is shown and
-  nothing is saved until you press **`g`** to ratify (or press `m` again to
-  redraft). Ratifying writes the profile to `.codewhale/agents/<role>`.
+- **Drafting is not ratifying.** The exact rendered TOML preview renders
+  inline on the review step (not in a separate scrollable viewer), so nothing
+  is saved until you press **`g`** or **Enter** to ratify (or press `m` again
+  to redraft). Ratifying writes the profile to `.codewhale/agents/<role>`.
 
 ## Naming: Modes, Workflow, and Fleet
 


### PR DESCRIPTION
Refs #4093 (headline cross-provider fix landed for the `codewhale fleet run` CLI path; the interactive TUI in-process remainder is tracked in #4193, so this does not auto-close #4093)

## Summary
- Align Fleet setup modal with role/profile roster editing instead of provider-scoped model picker
- Expose model routes from all configured providers when editing Fleet profiles
- Persist unambiguous provider+model route identity in saved profiles
- Fix draft preview ratify key binding conflict (`g` scroll vs ratify)

## Acceptance criteria
- [ ] User can create/edit a Fleet profile for a model from any configured provider while parent session uses a different provider
- [ ] Modal shows role/profile roster state with coherent edit flow for role behavior and model routes
- [ ] Saved profile clearly identifies intended provider/model route on inspection
- [ ] Profile usable by Fleet without depending on current provider at launch time
- [ ] Route validation catches missing credentials before save/launch
- [ ] Ratifying preview has discoverable, non-conflicting key path

Issue: https://github.com/Hmbown/CodeWhale/issues/4093

## Test plan
- [ ] `cargo test -p codewhale-tui fleet_setup` (or focused fleet setup tests)
- [ ] Manual: create Scout profile with DeepSeek route while parent on different provider
- [ ] Manual: verify saved TOML includes provider/route identity, not bare model id
- [ ] Manual: ratify draft preview without `g` scroll conflict
- [ ] CI green

Signed-off-by: Hunter <hunter@codewhale.dev>

Made with [Cursor](https://cursor.com)
