### PR TITLE
fix(ci): only auto-label agent-ready on issue open, not on label events

### DIFF
--- a/.github/workflows/v0868-milestone-sync.yml
+++ b/.github/workflows/v0868-milestone-sync.yml
@@ -58,6 +58,11 @@ jobs:
           script: |
             const issue = context.payload.issue;
             if (!issue) return;
+            // Only auto-label freshly opened issues. Running on `labeled`
+            // events re-adds labels (e.g. agent-ready) that a maintainer or
+            // triage agent deliberately removed, breaking the
+            // "agent-ready = startable now" contract on the v0.8.68 board.
+            if (context.payload.action !== 'opened') return;
 
             const title = (issue.title || '').toLowerCase();
             const body = (issue.body || '').toLowerCase();


### PR DESCRIPTION
## Summary

The `v0.8.68 milestone hygiene` action's auto-label step runs on every `labeled`/`milestoned` event, so any label edit on a milestone issue re-triggers it and it re-adds `agent-ready` to issues whose title matches `v0.8.68:` — even when a triage pass deliberately removed the label. This just resurfaced during the lane-labeling sweep for the #4092 execution board: `agent-ready` got re-added to #4178 (blocked on #4176/#4177) and freshly added to #3488/#3875, which are gated behind stopship.

This gates the auto-label step to `context.payload.action === 'opened'` only, so:
- freshly opened, well-formed issues still get auto-labeled as before
- deliberate label removals stick, and `agent-ready` keeps meaning "startable now" per the execution board in #4092

The first step (milestone ↔ `v0.8.68` label sync) is unchanged and still runs on all trigger events.

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

(No Rust changes — this touches only a GitHub Actions workflow; gates above are N/A but left for the record.)

## Checklist

- [x] Updated docs or comments as needed (inline comment explains the gate)
- [ ] Added or updated tests where relevant (N/A — CI workflow)
- [ ] Verified TUI behavior manually if UI changes (N/A)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A — no harvested work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DfnXQrmeB4iW1nDXF42wG

---
_Generated by [Claude Code](https://claude.ai/code/session_017DfnXQrmeB4iW1nDXF42wG)_