### PR TITLE
test: enforce English locale for hardcoded string assertions

### DIFF
--- a/crates/tui/src/commands/groups/plugins/mod.rs
+++ b/crates/tui/src/commands/groups/plugins/mod.rs
@@ -178,6 +178,7 @@ fn default_codewhale_tools_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::localization::Locale;
     use crate::tui::app::{App, TuiOptions};
     use tempfile::TempDir;
 
@@ -236,6 +237,7 @@ mod tests {
         .unwrap();
 
         let (mut app, _tmp) = create_test_app_with_plugin_dir(dir.path());
+        app.ui_locale = Locale::En;
         let result = plugins(&mut app, None);
         let msg = result.message.expect("should return list");
         assert!(msg.contains("Plugin tools (2):"));
@@ -251,6 +253,7 @@ mod tests {
     fn test_plugins_empty_directory() {
         let dir = TempDir::new().unwrap();
         let (mut app, _tmp) = create_test_app_with_plugin_dir(dir.path());
+        app.ui_locale = Locale::En;
         let result = plugins(&mut app, None);
         let msg = result.message.expect("should return message");
         assert!(msg.contains("No plugin tools discovered"));
@@ -289,6 +292,7 @@ mod tests {
         .unwrap();
 
         let (mut app, _tmp) = create_test_app_with_plugin_dir(dir.path());
+        app.ui_locale = Locale::En;
         let result = plugins(&mut app, Some("missing"));
         assert!(result.is_error);
         let msg = result.message.expect("should return error");


### PR DESCRIPTION
## Summary

Follow-up of #4033

Hardcoded string literals in test assertions
currently fail on non-English devices due to UI localization.

I fixed it in #4033, but new tests have same problem.

Force the default locale to Locale::En in the test setup to ensure
consistent assertion behavior across all build environments.

This addresses the flaky test runs on international CI nodes and
local developer machines with non-English system settings.

## Testing

- [ x ] `cargo fmt --all -- --check`
- [ x ] `cargo clippy --workspace --all-targets --all-features`
- [ x ] `cargo test --workspace --all-features`

## Checklist

- [ x ] Updated docs or comments as needed
- [ x ] Added or updated tests where relevant
- [ x ] Verified TUI behavior manually if UI changes
- [ x ] Harvested/co-authored credit uses a GitHub numeric noreply address
