### PR TITLE
fix(fleet): honor profile-pinned provider on in-process TUI spawn (#4193)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1491,6 +1491,7 @@ impl Engine {
                             Arc::clone(&self.subagent_manager),
                         )
                         .with_role_models(self.subagent_role_models())
+                        .with_api_config(self.api_config.clone())
                         .with_fleet_roster(self.config.fleet_roster.clone())
                         .with_auto_model(self.session.auto_model)
                         .with_reasoning_effort(
@@ -2599,6 +2600,7 @@ impl Engine {
                     Arc::clone(&self.subagent_manager),
                 )
                 .with_role_models(self.subagent_role_models())
+                .with_api_config(self.api_config.clone())
                 .with_fleet_roster(self.config.fleet_roster.clone())
                 .with_auto_model(self.session.auto_model)
                 .with_reasoning_effort(

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -443,7 +443,12 @@ fn effective_fleet_provider(agent_profile: Option<&AgentProfile>) -> ApiProvider
 /// `--provider` off the worker argv and preserve today's behavior for
 /// profile-less / provider-less workers (they resolve their provider from
 /// their own session default). EPIC #2608: never inferred from `model`.
-fn explicit_fleet_provider(agent_profile: Option<&AgentProfile>) -> Option<ApiProvider> {
+///
+/// `pub(crate)` so the interactive-TUI in-process spawn path
+/// (`tools::subagent`) resolves the pinned provider from the SAME
+/// explicit-only source as the headless `codewhale exec` launch route (#4193),
+/// instead of re-deriving it and risking a second, divergent policy.
+pub(crate) fn explicit_fleet_provider(agent_profile: Option<&AgentProfile>) -> Option<ApiProvider> {
     agent_profile
         .and_then(|profile| profile.profile.provider.as_deref())
         .and_then(ApiProvider::parse)

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1339,6 +1339,19 @@ pub struct SubAgentForkContext {
 #[derive(Clone)]
 pub struct SubAgentRuntime {
     pub client: DeepSeekClient,
+    /// Session `Config` snapshot, used to build a *fresh* LLM client bound to a
+    /// different provider when a fleet roster member's profile pins one (#4193,
+    /// the interactive-TUI twin of the headless `codewhale exec --provider`
+    /// route from #4181). The engine threads it in via
+    /// [`SubAgentRuntime::with_api_config`]; `child_runtime`/`background_runtime`
+    /// clone the `Arc` so every descendant can re-derive a provider-B client.
+    ///
+    /// `None` for legacy/test runtimes that never threaded a config. When a
+    /// profile pins a provider different from the session's and this is `None`
+    /// (or the pinned provider's credentials cannot be resolved), the spawn
+    /// FAILS rather than silently reusing the session client — a silent reuse
+    /// would send model B's id to provider A's endpoint, the exact #4093 defect.
+    pub api_config: Option<std::sync::Arc<crate::config::Config>>,
     pub model: String,
     pub auto_model: bool,
     pub reasoning_effort: Option<String>,
@@ -1434,6 +1447,7 @@ impl SubAgentRuntime {
     ) -> Self {
         Self {
             client,
+            api_config: None,
             model,
             auto_model: false,
             reasoning_effort: None,
@@ -1573,6 +1587,49 @@ impl SubAgentRuntime {
         self
     }
 
+    /// Attach the session `Config` so a spawn can build a fresh LLM client for a
+    /// fleet profile's pinned provider (#4193). Without it, cross-provider
+    /// in-process spawns fail closed rather than misrouting (see the
+    /// [`api_config`](Self::api_config) field docs). Engine-only wiring; test
+    /// and legacy runtimes may leave it unset.
+    #[must_use]
+    pub fn with_api_config(mut self, config: crate::config::Config) -> Self {
+        self.api_config = Some(std::sync::Arc::new(config));
+        self
+    }
+
+    /// Build an LLM client bound to `provider` from the threaded session
+    /// `Config` (#4193). Mirrors the proven per-provider client factory used by
+    /// per-turn auto-routing (`model_routing`) and the engine's provider switch:
+    /// clone the session config, override only its `provider`, and let
+    /// [`DeepSeekClient::new`] re-resolve that provider's base URL + credentials
+    /// from config/env.
+    ///
+    /// Returns `Err` when no config was threaded in, or when the provider's
+    /// credentials/base URL cannot be resolved. Callers MUST surface that error
+    /// rather than fall back to the session client: a silent fallback would send
+    /// the pinned model id to the session provider's endpoint (#4093).
+    fn client_for_provider(
+        &self,
+        provider: crate::config::ApiProvider,
+    ) -> Result<DeepSeekClient, String> {
+        let Some(api_config) = self.api_config.as_ref() else {
+            return Err(
+                "session Config was not threaded into this runtime; cannot build a \
+                 provider-pinned client"
+                    .to_string(),
+            );
+        };
+        let mut provider_config = (**api_config).clone();
+        // EPIC #2608: the provider is taken verbatim from the profile pin
+        // (already parsed to a canonical `ApiProvider`), never inferred from the
+        // model id. Overriding only `provider` makes `Config::api_provider`,
+        // `deepseek_base_url`, and `deepseek_api_key` all re-resolve for the
+        // pinned provider.
+        provider_config.provider = Some(provider.as_str().to_string());
+        DeepSeekClient::new(&provider_config).map_err(|err| err.to_string())
+    }
+
     /// Install the merged fleet roster (#fleet-roster cutover (v0.8.67)).
     /// The engine builds it once per session config; children inherit it.
     #[must_use]
@@ -1631,6 +1688,7 @@ impl SubAgentRuntime {
         child_context.auto_approve = self.context.auto_approve;
         Self {
             client: self.client.clone(),
+            api_config: self.api_config.clone(),
             model: self.model.clone(),
             auto_model: self.auto_model,
             reasoning_effort: self.reasoning_effort.clone(),
@@ -3815,6 +3873,43 @@ async fn cancel_agent_from_input(
     Ok(tool_result)
 }
 
+/// Resolve the LLM client a freshly spawned in-process child should run on,
+/// honoring a fleet roster member's explicit provider pin (#4193).
+///
+/// - No member, a member pinning no provider (profile-less / `inherit`), or a
+///   member pinning the session's own provider: reuse the parent/session client
+///   unchanged. Preserves pre-#4193 behavior — no regression.
+/// - A member pinning a provider DIFFERENT from the session: build a fresh
+///   client for that provider (its base URL + credentials). This is the
+///   substantive fix; the `provider` metadata tag alone is inert while the
+///   client is shared, so without this the request still hits the session
+///   provider's endpoint with model B's id (#4093).
+///
+/// A pinned-but-unbuildable provider is a hard error — never a silent fallback
+/// to the session client (that silent fallback IS the #4093 misroute). The
+/// provider comes only from the explicit pin ([`explicit_fleet_provider`]),
+/// never inferred from the model id (EPIC #2608).
+fn child_client_for_member(
+    runtime: &SubAgentRuntime,
+    member: Option<&crate::fleet::profile::AgentProfile>,
+) -> Result<DeepSeekClient, ToolError> {
+    let session_provider = runtime.client.api_provider();
+    match crate::fleet::worker_runtime::explicit_fleet_provider(member) {
+        Some(pinned) if pinned != session_provider => {
+            runtime.client_for_provider(pinned).map_err(|err| {
+                ToolError::execution_failed(format!(
+                    "fleet profile pins provider '{}' but its client could not be built \
+                     ({err}). Configure that provider's credentials/base URL, or drop the \
+                     provider pin to inherit the session provider '{}'.",
+                    pinned.as_str(),
+                    session_provider.as_str()
+                ))
+            })
+        }
+        _ => Ok(runtime.client.clone()),
+    }
+}
+
 async fn spawn_subagent_from_input(
     input: Value,
     manager: SharedSubAgentManager,
@@ -3849,6 +3944,14 @@ async fn spawn_subagent_from_input(
     let child_workspace = prepare_child_workspace(&runtime.context.workspace, &spawn_request)?;
 
     let mut child_runtime = runtime.background_runtime();
+    // #4193 seam 3 (the substantive fix): if the resolved roster member's
+    // profile pins a provider different from the session's, rebind the child to
+    // a fresh client for that provider BEFORE any model normalization/routing.
+    // Every downstream model decision below derives its provider from
+    // `child_runtime.client.api_provider()`, so swapping the client here is what
+    // actually routes the request to provider B's endpoint with B's creds —
+    // rather than tagging `provider = B` on a client still pointed at A (#4093).
+    child_runtime.client = child_client_for_member(&runtime, profile_member.as_ref())?;
     child_runtime.max_spawn_depth = child_max_spawn_depth_for_spawn(
         child_runtime.max_spawn_depth,
         child_runtime.spawn_depth,
@@ -3860,14 +3963,18 @@ async fn spawn_subagent_from_input(
     if let Some(workspace) = child_workspace {
         child_runtime.context.workspace = workspace;
     }
+    // #4193 seam 2: normalize/validate the requested model against the CHILD's
+    // (pinned) provider, not the session provider. `child_runtime` carries the
+    // provider-B client set above, so a profile-less/`inherit` member still
+    // sees the session provider here (no regression).
     let configured_model = match spawn_request.model.clone() {
         Some(model) => Some(normalize_requested_subagent_model(
             &model,
             "model",
-            runtime.client.api_provider(),
+            child_runtime.client.api_provider(),
         )?),
         None => configured_model_for_role_or_type(
-            &runtime,
+            &child_runtime,
             spawn_request.assignment.role.as_deref(),
             &spawn_request.agent_type,
         )?,
@@ -3905,8 +4012,13 @@ async fn spawn_subagent_from_input(
         (spawn_request.prompt, None)
     };
 
+    // #4193 seam 2 (cont.): strength/inherit/faster routing and the final
+    // provider-namespace guard both read the provider from the runtime's client,
+    // so route them through `child_runtime` (pinned provider) instead of the
+    // session `runtime`. Router candidates, reasoning-effort defaults, and the
+    // fixed-model validation then all resolve against provider B.
     let route = resolve_subagent_assignment_route(
-        &runtime,
+        &child_runtime,
         configured_model,
         &effective_prompt,
         &spawn_request.agent_type,
@@ -3915,7 +4027,7 @@ async fn spawn_subagent_from_input(
     )
     .await;
     let effective_model =
-        ensure_subagent_model_for_provider(&runtime, &route.model_route, route.model)?;
+        ensure_subagent_model_for_provider(&child_runtime, &route.model_route, route.model)?;
     child_runtime.model = effective_model.clone();
     child_runtime.reasoning_effort = route.reasoning_effort.clone();
     child_runtime.reasoning_effort_auto = false;

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4683,6 +4683,7 @@ fn stub_runtime() -> SubAgentRuntime {
     let context = ToolContext::new(workspace.clone());
     SubAgentRuntime {
         client: stub_client(),
+        api_config: None,
         model: "deepseek-v4-flash".to_string(),
         auto_model: false,
         reasoning_effort: None,
@@ -4778,6 +4779,154 @@ fn stub_client() -> DeepSeekClient {
         ..crate::config::Config::default()
     };
     DeepSeekClient::new(&config).expect("stub client should construct")
+}
+
+// ---- #4193: interactive-TUI in-process spawn honors a profile's pinned provider ----
+
+/// A `Config` with two fully-configured providers, each on a DISTINCT host so a
+/// test can prove a child client actually re-pointed: `deepseek` is the session
+/// route, `zai` is a pinned route. Provider-scoped keys/base URLs are used (root
+/// `api_key` intentionally unset) so `deepseek_api_key`/`deepseek_base_url`
+/// resolve each provider independently.
+fn cross_provider_config() -> crate::config::Config {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let providers = crate::config::ProvidersConfig {
+        deepseek: crate::config::ProviderConfig {
+            api_key: Some("session-key".to_string()),
+            base_url: Some("https://session-provider.example.com/v1".to_string()),
+            ..Default::default()
+        },
+        zai: crate::config::ProviderConfig {
+            api_key: Some("pinned-key".to_string()),
+            base_url: Some("https://pinned-provider.example.com/v1".to_string()),
+            ..Default::default()
+        },
+        ..crate::config::ProvidersConfig::default()
+    };
+    crate::config::Config {
+        provider: Some("deepseek".to_string()),
+        providers: Some(providers),
+        ..crate::config::Config::default()
+    }
+}
+
+/// A session runtime on `deepseek` with the cross-provider `Config` threaded in,
+/// exactly as the engine wires it via `with_api_config`.
+fn cross_provider_runtime() -> SubAgentRuntime {
+    let config = cross_provider_config();
+    let client = DeepSeekClient::new(&config).expect("session client builds");
+    let mut runtime = stub_runtime().with_api_config(config);
+    runtime.client = client;
+    runtime
+}
+
+/// A roster member whose profile explicitly pins `provider` (+ an arbitrary
+/// `model`), mirroring the on-disk `[fleet]` profile shape.
+fn member_pinning_provider(provider: &str, model: &str) -> crate::fleet::profile::AgentProfile {
+    let mut profile = custom_fleet_profile("worker");
+    profile.provider = Some(provider.to_string());
+    profile.model = Some(model.to_string());
+    crate::fleet::profile::AgentProfile {
+        id: format!("{provider}-worker"),
+        display_name: Some(format!("{provider} worker")),
+        description: None,
+        profile,
+        source: std::path::PathBuf::from(format!("{provider}-worker.toml")),
+        origin: crate::fleet::roster::ProfileOrigin::Workspace,
+    }
+}
+
+#[test]
+fn spawn_child_client_targets_profile_pinned_provider() {
+    // Session runs on DeepSeek; the roster member pins Z.ai. The in-process
+    // child must issue its request to a Z.ai client (Z.ai base URL + creds),
+    // not the shared session DeepSeek client (#4193 acceptance criterion).
+    let runtime = cross_provider_runtime();
+    assert_eq!(
+        runtime.client.api_provider(),
+        crate::config::ApiProvider::Deepseek,
+        "precondition: session is on DeepSeek"
+    );
+
+    let member = member_pinning_provider("zai", "glm-4.6");
+    let child_client = child_client_for_member(&runtime, Some(&member))
+        .expect("pinned-provider client builds when its creds are configured");
+
+    assert_eq!(
+        child_client.api_provider(),
+        crate::config::ApiProvider::Zai,
+        "child client must target the profile-pinned provider (#4193)"
+    );
+    assert!(
+        child_client
+            .base_url()
+            .contains("pinned-provider.example.com"),
+        "child must talk to the pinned provider's endpoint, got {}",
+        child_client.base_url()
+    );
+    assert!(
+        !child_client
+            .base_url()
+            .contains("session-provider.example.com"),
+        "child must NOT reuse the session provider's endpoint (the #4093 misroute)"
+    );
+}
+
+#[test]
+fn spawn_child_client_inherits_session_provider_without_pin() {
+    // Regression: profile-less members and members that pin no provider (or the
+    // session's own provider) keep the session client. No cross-provider build,
+    // no misroute, no behavior change from before #4193.
+    let runtime = cross_provider_runtime();
+
+    let inherited = child_client_for_member(&runtime, None)
+        .expect("profile-less spawn reuses the session client");
+    assert_eq!(
+        inherited.api_provider(),
+        crate::config::ApiProvider::Deepseek
+    );
+    assert!(
+        inherited
+            .base_url()
+            .contains("session-provider.example.com"),
+        "profile-less child stays on the session endpoint, got {}",
+        inherited.base_url()
+    );
+
+    // A member that pins the SAME provider as the session also stays put.
+    let same = member_pinning_provider("deepseek", "deepseek-v4-flash");
+    let same_client = child_client_for_member(&runtime, Some(&same))
+        .expect("same-provider pin reuses the session client");
+    assert_eq!(
+        same_client.api_provider(),
+        crate::config::ApiProvider::Deepseek
+    );
+    assert!(
+        same_client
+            .base_url()
+            .contains("session-provider.example.com")
+    );
+}
+
+#[test]
+fn spawn_child_client_fails_closed_when_pinned_provider_unavailable() {
+    // Defense in depth (#4093): if the pinned provider's client cannot be built
+    // (here: no session Config threaded in), fail the spawn instead of silently
+    // sending the pinned model id to the session provider's endpoint.
+    let mut runtime = cross_provider_runtime();
+    runtime.api_config = None; // simulate a legacy/untethered runtime
+
+    let member = member_pinning_provider("zai", "glm-4.6");
+    // `DeepSeekClient` is not `Debug`, so match instead of `expect_err`.
+    let err = match child_client_for_member(&runtime, Some(&member)) {
+        Ok(_) => panic!("must fail closed when the pinned client cannot be built"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("zai"),
+        "error must name the pinned provider so the failure is actionable: {msg}"
+    );
 }
 
 // ---- #405 session-boundary classification ----


### PR DESCRIPTION
## Summary

Completes the interactive-TUI half of #4093's cross-provider Fleet path.

PR #4181 (merged) made the **headless** `codewhale fleet run` CLI launch workers on their profile-pinned provider+model route. But the **interactive TUI** spawns Fleet roster members **in-process** via the engine `agent` tool (`crates/tui/src/tools/subagent/mod.rs`), which still ignored the profile's pinned provider. A profile pinning provider **B** + model **B** therefore sent model B's id to provider **A**'s (the session's) endpoint — the exact #4093 defect, intact for TUI users.

Root cause: the in-process child reused the parent session's LLM client (provider A's `base_url` + creds). The `provider` metadata tag alone is **inert** while the client is shared — building a client for provider B is the actual fix.

## The three seams

**Seam 1 — `worker_profile_for_spawn` (`mod.rs`).** Left reading `runtime.client.api_provider()`, but it now reflects the pinned provider *transitively*: it is only ever called with the child runtime, whose client is rebound to provider B (seam 3), so the worker-record provider tag is correct — no hardcoded session provider.

**Seam 2 — model normalization/routing in `spawn_subagent_from_input` (`mod.rs`).** `normalize_requested_subagent_model`, `configured_model_for_role_or_type`, `resolve_subagent_assignment_route`, and `ensure_subagent_model_for_provider` all derive their provider from the runtime's client. They now run against the **child** runtime (pinned provider) instead of the session runtime, so model validation/routing happens in provider B's namespace. Profile-less / `inherit` members still see the session provider (no regression).

**Seam 3 — the substantive work (`mod.rs`, `engine.rs`).** `SubAgentRuntime` gains an `api_config: Option<Arc<Config>>` snapshot, threaded by the engine via a new `with_api_config` builder at both spawn-runtime construction sites. A new `child_client_for_member` helper resolves the member's explicit pin via `worker_runtime::explicit_fleet_provider` (now `pub(crate)`; explicit-only, **never** inferred from a model id per EPIC #2608) and, when it differs from the session provider, builds a fresh `DeepSeekClient` for it by cloning the session `Config` and overriding only `provider` — the same per-provider client factory pattern used by per-turn auto-routing (`model_routing`) and the engine's provider switch. A pinned-but-unbuildable provider **fails the spawn** rather than silently falling back to the session endpoint (that silent fallback is the #4093 misroute).

## Tests (`crates/tui/src/tools/subagent/tests.rs`)

- `spawn_child_client_targets_profile_pinned_provider` — session on DeepSeek, member pins Z.ai → child client `api_provider() == Zai` and `base_url()` is Z.ai's (not the session's).
- `spawn_child_client_inherits_session_provider_without_pin` — profile-less member **and** a member pinning the session's own provider both keep the session client (regression guard).
- `spawn_child_client_fails_closed_when_pinned_provider_unavailable` — a pin with no threaded `Config` errors instead of misrouting.

## Verification

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-features --locked -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants` — pass (0 warnings)
- `cargo test --workspace --locked` — 5994 passed; the only 2 failures are the pre-existing env-specific ones (`git_repo_root_reports_attempted_paths_when_no_repo_found`, `skill_hotbar_action_activates_skill_through_dollar_alias`), unrelated to this change
- `cargo build --release -p codewhale-tui` — pass

## Guards

- EPIC #2608: provider is explicit (from the profile) or falls back to the session — never inferred from a model id.
- #4172: no `DEEPSEEK*` env-var or active-module renames.

Fixes #4193
Refs #4093

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172k8wqL9he1teotxTS5gbu
