### PR TITLE
fix(providers): correct Fireworks/Together metadata + Models.dev id normalization

### DIFF
--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -277,7 +277,10 @@ provider!(
     DEFAULT_NOVITA_MODEL,
     ["NOVITA_API_KEY"],
     "novita",
-    aliases: []
+    // `novita-ai` is the id Models.dev publishes for this provider; without it a
+    // live/full Models.dev catalog row keyed `novita-ai` would fail to normalize
+    // onto ProviderKind::Novita (Refs #4186).
+    aliases: ["novita-ai", "novita_ai"]
 );
 provider!(
     Fireworks,
@@ -393,7 +396,11 @@ provider!(
     DEFAULT_TOGETHER_MODEL,
     ["TOGETHER_API_KEY"],
     "together",
-    aliases: ["together-ai", "together_ai"]
+    // `togetherai` (no separator) is the id Models.dev publishes for Together;
+    // the hyphen/underscore spellings are legacy config aliases. All three must
+    // normalize onto ProviderKind::Together so live-catalog rows keyed
+    // `togetherai` resolve to the right kind (Refs #4186).
+    aliases: ["together-ai", "together_ai", "togetherai"]
 );
 provider!(
     Qianfan,

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -44,7 +44,9 @@ pub enum ProviderKind {
     Openrouter,
     #[serde(alias = "mimo", alias = "xiaomi", alias = "xiaomi_mimo")]
     XiaomiMimo,
+    #[serde(alias = "novita-ai", alias = "novita_ai")]
     Novita,
+    #[serde(alias = "fireworks-ai", alias = "fireworks_ai")]
     Fireworks,
     #[serde(alias = "silicon-flow", alias = "silicon_flow")]
     Siliconflow,
@@ -58,7 +60,7 @@ pub enum ProviderKind {
     Ollama,
     #[serde(alias = "hugging-face", alias = "hugging_face", alias = "hf")]
     Huggingface,
-    #[serde(alias = "together-ai", alias = "together_ai")]
+    #[serde(alias = "together-ai", alias = "together_ai", alias = "togetherai")]
     Together,
     #[serde(alias = "baidu-qianfan", alias = "baidu_qianfan", alias = "baidu")]
     Qianfan,

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -3367,6 +3367,105 @@ fn provider_kind_parses_openrouter_and_novita_aliases() {
     assert_eq!(parsed.provider, ProviderKind::Siliconflow);
 }
 
+/// Models.dev publishes provider ids that do not always match CodeWhale's
+/// canonical id (`fireworks-ai`, `togetherai`, `novita-ai`). These MUST
+/// normalize onto the right [`ProviderKind`] via [`ProviderKind::parse`], which
+/// is the seam `ModelReferenceCard::from_offering` uses to label a live-catalog
+/// row's provider kind. A miss here means Fireworks/Together/Novita models from
+/// the live Models.dev catalog land under an `unknown` kind (Refs #4186).
+#[test]
+fn provider_kind_normalizes_models_dev_provider_ids() {
+    let cases = [
+        ("fireworks-ai", ProviderKind::Fireworks),
+        ("togetherai", ProviderKind::Together),
+        ("together-ai", ProviderKind::Together),
+        ("together_ai", ProviderKind::Together),
+        ("novita-ai", ProviderKind::Novita),
+        ("novita_ai", ProviderKind::Novita),
+        ("deepinfra", ProviderKind::Deepinfra),
+        ("siliconflow", ProviderKind::Siliconflow),
+        // Models.dev spells the China endpoint `siliconflow-cn`; CodeWhale's
+        // canonical id is `siliconflow-CN` and `parse` is case-insensitive.
+        ("siliconflow-cn", ProviderKind::SiliconflowCN),
+        ("openrouter", ProviderKind::Openrouter),
+    ];
+    for (models_dev_id, expected) in cases {
+        assert_eq!(
+            ProviderKind::parse(models_dev_id),
+            Some(expected),
+            "Models.dev id {models_dev_id:?} must normalize onto {expected:?}"
+        );
+    }
+
+    // The separator-free Models.dev ids must also deserialize from config TOML,
+    // so a `provider = "togetherai"` / `"novita-ai"` line resolves identically.
+    for (alias, expected) in [
+        ("togetherai", ProviderKind::Together),
+        ("novita-ai", ProviderKind::Novita),
+        ("fireworks-ai", ProviderKind::Fireworks),
+    ] {
+        let parsed: ConfigToml =
+            toml::from_str(&format!("provider = \"{alias}\"")).expect("models.dev id alias");
+        assert_eq!(parsed.provider, expected, "toml provider = {alias:?}");
+    }
+}
+
+/// Pin the Fireworks and Together transport metadata against the real provider
+/// APIs: the OpenAI-compatible base URL and the canonical API-key env var. These
+/// are the two primary providers this audit targets, so a regression to a wrong
+/// base URL or env var name fails here.
+#[test]
+fn fireworks_and_together_base_url_and_auth_metadata() {
+    let fireworks = provider::provider_for_kind(ProviderKind::Fireworks);
+    assert_eq!(fireworks.id(), "fireworks");
+    assert_eq!(
+        fireworks.default_base_url(),
+        "https://api.fireworks.ai/inference/v1"
+    );
+    assert_eq!(fireworks.default_base_url(), DEFAULT_FIREWORKS_BASE_URL);
+    assert_eq!(fireworks.env_vars(), &["FIREWORKS_API_KEY"]);
+    // Fireworks wire model ids are namespaced `accounts/fireworks/models/<name>`.
+    assert!(
+        fireworks
+            .default_model()
+            .starts_with("accounts/fireworks/models/"),
+        "Fireworks default model must use the accounts/fireworks/models/ prefix, got {:?}",
+        fireworks.default_model()
+    );
+
+    let together = provider::provider_for_kind(ProviderKind::Together);
+    assert_eq!(together.id(), "together");
+    assert_eq!(together.default_base_url(), "https://api.together.xyz/v1");
+    assert_eq!(together.default_base_url(), DEFAULT_TOGETHER_BASE_URL);
+    assert_eq!(together.env_vars(), &["TOGETHER_API_KEY"]);
+    // Together wire model ids are `<org>/<Model>` (a slash-namespaced id).
+    assert!(
+        together.default_model().contains('/'),
+        "Together default model must be an <org>/<Model> id, got {:?}",
+        together.default_model()
+    );
+
+    // The env-based key resolver (secrets crate) must recognize both providers
+    // by canonical id; a shell-exported key would otherwise be ignored.
+    let _lock = env_lock();
+    unsafe {
+        std::env::set_var("FIREWORKS_API_KEY", "fw-test-key");
+        std::env::set_var("TOGETHER_API_KEY", "tg-test-key");
+    }
+    assert_eq!(
+        codewhale_secrets::env_for("fireworks").as_deref(),
+        Some("fw-test-key")
+    );
+    assert_eq!(
+        codewhale_secrets::env_for("together").as_deref(),
+        Some("tg-test-key")
+    );
+    unsafe {
+        std::env::remove_var("FIREWORKS_API_KEY");
+        std::env::remove_var("TOGETHER_API_KEY");
+    }
+}
+
 #[test]
 fn unknown_provider_error_lists_huggingface() {
     let mut config = ConfigToml::default();

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -817,9 +817,11 @@ impl Secrets {
 /// | `deepseek` | `DEEPSEEK_API_KEY` |
 /// | `openrouter` | `OPENROUTER_API_KEY` |
 /// | `xiaomi-mimo` / `mimo` | `XIAOMI_MIMO_API_KEY`, `XIAOMI_API_KEY`, `MIMO_API_KEY` |
-/// | `novita` | `NOVITA_API_KEY` |
+/// | `novita` / `novita-ai` | `NOVITA_API_KEY` |
 /// | `nvidia` / `nvidia-nim` / `nim` | `NVIDIA_API_KEY`, `NVIDIA_NIM_API_KEY`, `DEEPSEEK_API_KEY` |
-/// | `fireworks` | `FIREWORKS_API_KEY` |
+/// | `fireworks` / `fireworks-ai` | `FIREWORKS_API_KEY` |
+/// | `together` / `togetherai` | `TOGETHER_API_KEY` |
+/// | `deepinfra` | `DEEPINFRA_API_KEY`, `DEEPINFRA_TOKEN` |
 /// | `siliconflow` / `siliconflow-cn` | `SILICONFLOW_API_KEY` |
 /// | `arcee` / `arcee-ai` | `ARCEE_API_KEY` |
 /// | `moonshot` / `kimi` | `MOONSHOT_API_KEY`, `KIMI_API_KEY` |
@@ -841,7 +843,9 @@ pub fn env_for(name: &str) -> Option<String> {
         "xiaomi-mimo" | "xiaomi_mimo" | "xiaomimimo" | "mimo" | "xiaomi" => {
             &["XIAOMI_MIMO_API_KEY", "XIAOMI_API_KEY", "MIMO_API_KEY"]
         }
-        "novita" => &["NOVITA_API_KEY"],
+        "novita" | "novita-ai" | "novita_ai" => &["NOVITA_API_KEY"],
+        "together" | "together-ai" | "together_ai" | "togetherai" => &["TOGETHER_API_KEY"],
+        "deepinfra" | "deep-infra" | "deep_infra" => &["DEEPINFRA_API_KEY", "DEEPINFRA_TOKEN"],
         // NVIDIA NIM falls back to `DEEPSEEK_API_KEY` last because the
         // catalog endpoint accepts the same DeepSeek-issued key when no
         // dedicated NVIDIA token is set. This mirrors pre-v0.7 behaviour.
@@ -908,6 +912,9 @@ mod tests {
             "NVIDIA_API_KEY",
             "NVIDIA_NIM_API_KEY",
             "FIREWORKS_API_KEY",
+            "TOGETHER_API_KEY",
+            "DEEPINFRA_API_KEY",
+            "DEEPINFRA_TOKEN",
             "SILICONFLOW_API_KEY",
             "ARCEE_API_KEY",
             "SGLANG_API_KEY",
@@ -1296,6 +1303,59 @@ mod tests {
         assert_eq!(env_for("fireworks-ai").as_deref(), Some("fw-key"));
         // Safety: env mutation guarded by env_lock().
         unsafe { std::env::remove_var("FIREWORKS_API_KEY") };
+    }
+
+    #[test]
+    fn together_env_aliases_resolve() {
+        let _lock = env_lock();
+        clear_known_envs();
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::set_var("TOGETHER_API_KEY", "together-key") };
+
+        // Canonical id plus the legacy hyphen/underscore spellings AND the
+        // separator-free `togetherai` id Models.dev publishes must all resolve.
+        assert_eq!(env_for("together").as_deref(), Some("together-key"));
+        assert_eq!(env_for("together-ai").as_deref(), Some("together-key"));
+        assert_eq!(env_for("together_ai").as_deref(), Some("together-key"));
+        assert_eq!(env_for("togetherai").as_deref(), Some("together-key"));
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::remove_var("TOGETHER_API_KEY") };
+    }
+
+    #[test]
+    fn deepinfra_env_aliases_resolve() {
+        let _lock = env_lock();
+        clear_known_envs();
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::set_var("DEEPINFRA_API_KEY", "di-key") };
+
+        assert_eq!(env_for("deepinfra").as_deref(), Some("di-key"));
+        assert_eq!(env_for("deep-infra").as_deref(), Some("di-key"));
+        assert_eq!(env_for("deep_infra").as_deref(), Some("di-key"));
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::remove_var("DEEPINFRA_API_KEY") };
+
+        // The DEEPINFRA_TOKEN fallback is honored when the primary key is unset.
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::set_var("DEEPINFRA_TOKEN", "di-token") };
+        assert_eq!(env_for("deepinfra").as_deref(), Some("di-token"));
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::remove_var("DEEPINFRA_TOKEN") };
+    }
+
+    #[test]
+    fn novita_env_aliases_resolve() {
+        let _lock = env_lock();
+        clear_known_envs();
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::set_var("NOVITA_API_KEY", "novita-key") };
+
+        assert_eq!(env_for("novita").as_deref(), Some("novita-key"));
+        // `novita-ai` is the Models.dev provider id (Refs #4186).
+        assert_eq!(env_for("novita-ai").as_deref(), Some("novita-key"));
+        assert_eq!(env_for("novita_ai").as_deref(), Some("novita-key"));
+        // Safety: env mutation guarded by env_lock().
+        unsafe { std::env::remove_var("NOVITA_API_KEY") };
     }
 
     #[test]

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -115,12 +115,17 @@ scripts/release/app-server-smoke.sh --matrix --real # + exec a cheap sentinel pe
 ```
 
 The stdio probe runs against a throwaway config, so it never reads real keys.
-The matrix discovers configured providers from `codewhale auth list`, maps each
-to a cheap model (override per provider with `SMOKE_MODEL_<SLUG>`), skips
-unconfigured providers, and fails loudly on unmapped ones. `auth list` reports
-presence flags only and exec output is passed through a redactor, so secrets are
-never printed. The parser is covered by
-`scripts/release/app-server-smoke.test.sh` against a fake `codewhale` binary.
+The matrix discovers configured providers from `codewhale auth list`, skips
+unconfigured providers, and maps a provider to a cheap sentinel model only when
+it has a built-in cheap default. That built-in set is deliberately conservative
+(currently `deepseek`, `zai`, `moonshot`, and `openai`); every other provider —
+including `arcee`, `openrouter`, `xiaomi-mimo`, and `openai-codex` — is left
+unmapped on purpose and must be given a model per run via `SMOKE_MODEL_<SLUG>`
+rather than a guessed default (#3205). Any configured-but-unmapped provider
+fails loudly in `--real` mode. `auth list` reports presence flags only and exec
+output is passed through a redactor, so secrets are never printed. The parser is
+covered by `scripts/release/app-server-smoke.test.sh` against a fake `codewhale`
+binary.
 
 ## ACP stdio adapter: `codewhale serve --acp`
 

--- a/scripts/release/app-server-smoke.sh
+++ b/scripts/release/app-server-smoke.sh
@@ -36,14 +36,16 @@ SENTINEL="${SMOKE_SENTINEL:-Reply with exactly the single word: pong}"
 EXEC_TIMEOUT="${SMOKE_EXEC_TIMEOUT:-60}"
 declare -a ONLY_PROVIDERS=()
 
-# Best-effort cheap models per provider slot. These are intentionally overridable
+# Best-effort CHEAP models per provider slot. These are intentionally overridable
 # (SMOKE_MODEL_<SLUG>) because there is no committed route-effective model
 # inventory yet (#3205); unmapped configured providers fail loudly in --real mode
-# instead of guessing. Keep this list conservative.
+# instead of guessing. Keep this list conservative: only add a provider here when
+# its mapped id is a genuinely cheap/small model. Providers without a verified
+# cheap default (e.g. arcee, openrouter, xiaomi-mimo, openai-codex) are left
+# unmapped on purpose and must be given a model per run via SMOKE_MODEL_<SLUG>.
 default_model_for() {
     case "$1" in
         deepseek) echo "deepseek-chat" ;;
-        arcee) echo "trinity-large-thinking" ;;
         zai) echo "glm-4-flash" ;;
         moonshot) echo "moonshot-v1-8k" ;;
         openai) echo "gpt-4o-mini" ;;


### PR DESCRIPTION
Refs #4186

## What
Bounded provider-correctness pass for Fireworks, Together, and peer OpenAI-compatible hosts, plus two release-smoke provider-mapping fixes.

### Models.dev provider-id normalization (#4186)
`ProviderKind::parse` (the seam `ModelReferenceCard::from_offering` uses to label a live-catalog row's provider kind) resolved `fireworks-ai` but **not** `togetherai` (Together's real Models.dev id) or `novita-ai` (Novita's real Models.dev id). Together/Novita models from a live/full Models.dev catalog would land under an `unknown` provider kind.
- `provider.rs`: add `togetherai` alias to Together, `novita-ai`/`novita_ai` to Novita.
- `provider_kind.rs`: mirror as serde aliases (also `fireworks-ai`) so config `provider = "…"` deserializes identically.

### Auth env resolution (secrets)
`secrets::env_for` (the env layer for both `resolve_with_source` and `env_api_key_for_provider`) was **missing Together and DeepInfra**, so a shell-exported `TOGETHER_API_KEY`/`DEEPINFRA_API_KEY` was never resolved through the config runtime path — while Fireworks (a peer) was present. Added `together`/`togetherai` → `TOGETHER_API_KEY`, `deepinfra` → `DEEPINFRA_API_KEY`/`DEEPINFRA_TOKEN`, and folded `novita-ai` into the novita arm.

### Base URLs / model-id formats — verified, no change
Checked against the live Models.dev catalog + provider docs: Fireworks `https://api.fireworks.ai/inference/v1`, Together `https://api.together.xyz/v1`, Novita `.../openai/v1` are all correct. Curated Fireworks (`accounts/fireworks/models/…`) and Together (`deepseek-ai/DeepSeek-V4-*`) wire-id **formats** are correct and internally consistent with the repo's forward-dated model set; not rewritten to real-world v3 ids.

### Release-smoke provider mapping (coordinator findings)
- Removed `arcee -> trinity-large-thinking` from `app-server-smoke.sh` — that is Arcee's LARGE reasoning model (= `DEFAULT_ARCEE_MODEL`), the opposite of a cheap sentinel, and the committed test expected arcee UNMAPPED (was failing 3/18). Arcee is now unmapped/overridable, honoring the conservative "never guess a model id" design (#3205).
- `RUNTIME_API.md`: tightened the "maps each to a cheap model" wording to name the conservative built-in subset (deepseek/zai/moonshot/openai) and state that other providers (arcee, openrouter, xiaomi-mimo, openai-codex) require `SMOKE_MODEL_<SLUG>` overrides.

## Tests
- `provider_kind_normalizes_models_dev_provider_ids` — fireworks-ai/togetherai/novita-ai/… → correct kind + TOML round-trip.
- `fireworks_and_together_base_url_and_auth_metadata` — pins base URLs, env vars, wire-id format, and `env_for` resolution.
- `together_env_aliases_resolve`, `deepinfra_env_aliases_resolve`, `novita_env_aliases_resolve` (secrets).
- `bash scripts/release/app-server-smoke.test.sh` → all 18 checks pass.

## Flagged for humans (not changed)
- Fictional-universe model **names** (deepseek-v4-pro etc.) not touched — formats correct, consistency preserved.
- `env_for` still omits minimax/zai/stepfun/qianfan/openmodel/deepseek-anthropic/openai-codex (pre-existing, out of this audit's scope).
- Bundled asset `models_dev.bundled.json` has a stale Novita `api` (`https://api.novita.ai/v3/openai`) — left for #4188 which owns that file.
- `crates/tui/src/config.rs` Fireworks credential URL (`fireworks.ai/account/api-keys`) differs from `core.rs` (`fireworks.ai/api-keys`); canonical dashboard is `app.fireworks.ai/settings/users/api-keys`. Cosmetic UI link; left untouched to avoid churn.

## Verification
`cargo fmt --all --check` ✅ · `cargo clippy --workspace --all-features -D warnings …` ✅ · `cargo test --workspace` ✅ (only the two known pre-existing unrelated failures) · release build of `codewhale-tui` ✅ · co-author trailer check ✅ (authored as Hunter B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172k8wqL9he1teotxTS5gbu