### PR TITLE
perf(git): drop intermediate Vec in format_command join (#4153)

### DIFF
--- a/crates/tui/src/tools/git.rs
+++ b/crates/tui/src/tools/git.rs
@@ -278,14 +278,7 @@ fn run_git_command(working_dir: &Path, args: &[String]) -> Result<std::process::
 }
 
 fn format_command(working_dir: &Path, args: &[String]) -> String {
-    format!(
-        "git -C {} {}",
-        working_dir.display(),
-        args.iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(" ")
-    )
+    format!("git -C {} {}", working_dir.display(), args.join(" "))
 }
 
 fn truncate_with_note(text: &str, max_chars: usize) -> (String, bool, usize) {


### PR DESCRIPTION
Closes #4153 (v0.8.68 §6.7 / B3.3 — remove collect before join allocations).

## What

`format_command` in `crates/tui/src/tools/git.rs` collected `args` into a
`Vec<&str>` purely to `.join(" ")` it. Since `args` is `&[String]`,
`<[String]>::join(" ")` does the same directly with no intermediate
allocation and byte-identical output.

```diff
-        args.iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(" ")
+        args.join(" ")
```

## finance.rs left as-is

The issue also lists `finance.rs`, but its site maps
`AttemptFailure::summary()` which returns an owned `String`. There is no
`Iterator::join` in std, so joining requires materializing the `Vec`
first — the allocation is *not* unnecessary there. Per the acceptance
note ("where type constraints allow it"), that site is unchanged.

## Verification

Output is unchanged. Verified the idiom compiles and the new expression
produces identical output to the old one:

```
args = ["status", "--porcelain"]
new: args.join(" ")                                   == "status --porcelain"
old: args.iter().map(as_str).collect::<Vec<_>>().join(" ") == "status --porcelain"
```