### PR TITLE
fix(tui): rename sidebar Tasks panel to Activity (#4147)

### DIFF
--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1,4 +1,4 @@
-//! Sidebar rendering — Pinned / Tasks / Agents / Context panels.
+//! Sidebar rendering — Pinned / Activity / Agents / Context panels.
 //!
 //! Extracted from `tui/ui.rs` (P1.2). The sidebar appears to the right of
 //! the chat transcript when the available width allows it. Each section
@@ -1249,7 +1249,11 @@ fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &mut App) {
     let (lines, row_actions) = task_panel_rows(app, content_width.max(1), usable_rows.max(1));
 
     let full_texts = task_panel_hover_texts(app, usable_rows.max(1));
-    render_sidebar_section(f, area, "Tasks", lines, full_texts, row_actions, app);
+    // #4147: This panel renders live tools / background jobs, not durable task
+    // state, so the user-facing label is "Activity" to match its contents and
+    // avoid colliding with durable tasks. The internal identifiers keep the
+    // "task_panel"/`SidebarFocus::Tasks` names (guard #4172).
+    render_sidebar_section(f, area, "Activity", lines, full_texts, row_actions, app);
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Fixes #4147

## Summary
The sidebar panel titled "Tasks" actually renders live tools and background jobs, not durable task state, causing a confusing label/content mismatch. This renames the panel's user-facing label to "Activity" so the title matches what it shows and no longer collides with durable tasks. This is a surgical copy/label change — one rendered title string plus the module doc-comment — with no renaming of Rust modules, structs, or functions (guard #4172).

"Activity" was chosen over the "Running"/"Live" fallbacks because it does not collide with any existing sidebar section title (Pinned / To-do / Agents / Session / Hotbar).

## Acceptance criteria
- [x] **AC1 — No user-facing collision with durable tasks:** the sidebar title is now "Activity"; the literal user-facing "Tasks" title is gone (internal `task_panel`/`SidebarFocus::Tasks` identifiers are unchanged per guard #4172).
- [x] **AC2 — Label matches contents (live activity):** the panel renders live tools / background jobs, and "Activity" describes exactly that.
- [x] **AC3 — Distinct from the WorkflowPanel above the input (#4121):** no concepts merged; the Activity panel and WorkflowPanel remain separate (no WorkflowPanel references in `sidebar.rs`).

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --locked -- -D warnings <CI allow-list>` — clean (exit 0)
- `cargo test --workspace --all-features --locked` — passes except the pre-existing, environment-dependent startup-skill-cache test `skill_hotbar_action_activates_skill_through_dollar_alias`, which fails identically on the clean base commit without this change (unrelated to a sidebar label edit)
- `cargo build --release` — succeeds

Generated with Claude Code