### PR TITLE
fix(tui): quiet completed reasoning + remove leaky transcript words (#4146, #4148)

### DIFF
--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1958,7 +1958,14 @@ fn render_tool_header_with_family_and_summary(
         Span::styled(state_owned, tool_status_style(status)),
     ];
 
-    if let Some(summary) = summary.and_then(normalize_header_summary) {
+    // #4148: don't let the summary echo the verb it sits next to — an
+    // identity/summary that resolves to the family word itself would render a
+    // duplicate like "delegate · delegate". When the summary collapses to the
+    // verb, the verb already carries the signal, so drop the redundant tail.
+    if let Some(summary) = summary
+        .and_then(normalize_header_summary)
+        .filter(|summary| !summary.eq_ignore_ascii_case(verb))
+    {
         spans.push(Span::styled(" · ", Style::default().fg(palette::TEXT_DIM)));
         spans.push(Span::styled(
             truncate_text(&summary, TOOL_HEADER_SUMMARY_LIMIT),

--- a/crates/tui/src/tui/history/agent_activity.rs
+++ b/crates/tui/src/tui/history/agent_activity.rs
@@ -66,7 +66,11 @@ fn delegate_identity_fallback(cell: &GenericToolCell) -> String {
             }
         }
     }
-    "unknown child".to_string()
+    // #4148: never surface the raw internal fallback token ("unknown child")
+    // in the default transcript. When we can't resolve a concrete role, slug,
+    // or agent id, a friendly, non-leaky label reads best next to the
+    // "delegate" verb ("delegate running · subagent").
+    "subagent".to_string()
 }
 
 pub(super) fn extract_agent_id(output: &str) -> Option<&str> {

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -440,6 +440,67 @@ fn other_tools_are_unaffected_by_agent_compact_path() {
     assert_eq!(lines.len(), 1, "live tools should use compact rows");
 }
 
+#[test]
+fn agent_compact_header_omits_unknown_child_fallback() {
+    // #4148: an agent whose identity can't be resolved must not leak the raw
+    // internal "unknown child" token into the default transcript.
+    let cell = GenericToolCell {
+        name: "agent".to_string(),
+        status: ToolStatus::Running,
+        input_summary: Some("agent_type: delegate".to_string()),
+        output: None,
+        prompts: None,
+        spillover_path: None,
+        output_summary: None,
+        is_diff: false,
+    };
+    let rendered: String = cell.lines_with_mode(80, true, super::RenderMode::Live)[0]
+        .spans
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(
+        !rendered.contains("unknown child"),
+        "raw fallback token must not leak: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("subagent"),
+        "friendly fallback label should be shown: {rendered:?}"
+    );
+}
+
+#[test]
+fn agent_compact_header_does_not_duplicate_delegate_verb() {
+    // #4148: when the resolved identity collapses to the "delegate" verb, the
+    // compact header must not render a redundant "delegate · delegate".
+    let cell = GenericToolCell {
+        name: "agent".to_string(),
+        status: ToolStatus::Running,
+        input_summary: Some("role: delegate".to_string()),
+        output: None,
+        prompts: None,
+        spillover_path: None,
+        output_summary: None,
+        is_diff: false,
+    };
+    let rendered: String = cell.lines_with_mode(80, true, super::RenderMode::Live)[0]
+        .spans
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(
+        !rendered.contains("delegate delegate"),
+        "no adjacent duplicate: {rendered:?}"
+    );
+    // The verb sits before the status; the redundant summary tail is dropped,
+    // so "delegate" appears exactly once.
+    assert_eq!(
+        rendered.matches("delegate").count(),
+        1,
+        "verb must not be echoed by the summary: {rendered:?}"
+    );
+}
+
 // ---- #403 concise todo / checklist update rendering ----
 //
 // The tool emits an "Updated todo #N to STATUS" leading line plus a
@@ -1841,6 +1902,62 @@ fn completed_short_thinking_without_summary_stays_visible_in_live_view() {
     assert!(
         !live_text.contains("Full reasoning in Ctrl+O"),
         "complete short reasoning should not need the detail affordance: {live_text}"
+    );
+}
+
+#[test]
+fn completed_reasoning_receipt_hides_internal_function_names_until_expanded() {
+    // #4146/#4148: a completed-reasoning receipt in the default (collapsed)
+    // transcript must not expose internal function names; the full body —
+    // identifiers intact — stays reachable on expand and in the transcript.
+    let cell = HistoryCell::Thinking {
+        content: "I will call refresh_catalog_cache to refresh the model list.".to_string(),
+        streaming: false,
+        duration_secs: Some(1.0),
+    };
+
+    // Default collapsed view: identifier scrubbed, prose preserved, and the
+    // expand affordance offered.
+    let collapsed = cell.lines_with_options(
+        80,
+        TranscriptRenderOptions {
+            low_motion: true,
+            ..TranscriptRenderOptions::default()
+        },
+    );
+    let collapsed_text = lines_text(&collapsed);
+    assert!(
+        !collapsed_text.contains("refresh_catalog_cache"),
+        "internal function name must not leak by default: {collapsed_text}"
+    );
+    assert!(
+        collapsed_text.contains("refresh the model list"),
+        "surrounding prose must still read: {collapsed_text}"
+    );
+    assert!(
+        collapsed_text.contains("Full reasoning in Ctrl+O"),
+        "collapsed receipt must offer the expand affordance: {collapsed_text}"
+    );
+
+    // Expanded view (Space toggles the fold relative to the default): the full
+    // identifier is restored.
+    let expanded = cell.lines_with_options_folded(
+        80,
+        TranscriptRenderOptions {
+            low_motion: true,
+            ..TranscriptRenderOptions::default()
+        },
+        true,
+    );
+    assert!(
+        lines_text(&expanded).contains("refresh_catalog_cache"),
+        "expanded reasoning must restore the full identifier"
+    );
+
+    // Transcript / pager / clipboard keeps the full, un-redacted body.
+    assert!(
+        lines_text(&cell.transcript_lines(80)).contains("refresh_catalog_cache"),
+        "transcript must keep the full identifier"
     );
 }
 

--- a/crates/tui/src/tui/history/thinking.rs
+++ b/crates/tui/src/tui/history/thinking.rs
@@ -76,6 +76,52 @@ fn extract_explicit_reasoning_summary(text: &str) -> Option<String> {
     None
 }
 
+/// Redact internal code identifiers from a collapsed reasoning preview so
+/// implementation details don't leak into the default transcript
+/// (#4146/#4148). Each `snake_case` token (e.g. `refresh_catalog_cache`,
+/// `agent_id`, `DEEPSEEK_API_KEY`) collapses to a single `…` so the
+/// surrounding prose still reads; the full, un-redacted body remains
+/// available on expand (Space / Ctrl+O) and in the pager/clipboard transcript.
+fn redact_internal_identifiers(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut token = String::new();
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            token.push(ch);
+            continue;
+        }
+        push_identifier_token(&mut out, &mut token);
+        out.push(ch);
+    }
+    push_identifier_token(&mut out, &mut token);
+    out
+}
+
+/// Flush a scanned word token into `out`, replacing it with `…` when it reads
+/// as an internal code identifier. No-op on an empty token.
+fn push_identifier_token(out: &mut String, token: &mut String) {
+    if token.is_empty() {
+        return;
+    }
+    if looks_like_internal_identifier(token) {
+        out.push('\u{2026}');
+    } else {
+        out.push_str(token);
+    }
+    token.clear();
+}
+
+/// A token reads as an internal code identifier when it is a `snake_case`
+/// run: it contains an underscore, has at least one letter, and is otherwise
+/// only ASCII alphanumerics/underscores. Ordinary prose words never match.
+fn looks_like_internal_identifier(token: &str) -> bool {
+    token.contains('_')
+        && token.chars().any(|ch| ch.is_ascii_alphabetic())
+        && token
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
 pub(super) fn render_thinking(
     content: &str,
     width: u16,
@@ -139,6 +185,19 @@ pub(super) fn render_thinking(
         }
     } else {
         content.to_string()
+    };
+    // #4146/#4148: completed reasoning collapses to a quiet receipt in the
+    // default transcript — scrub internal code identifiers (function names
+    // like `refresh_catalog_cache`, raw agent ids) so implementation details
+    // don't leak. Streaming reasoning stays verbatim (the user is watching it
+    // think) and the expanded / pager / clipboard transcript keeps the full,
+    // un-redacted body. The redaction changes `body_text`, which trips the
+    // affordance below so the user still sees the "expand for full reasoning"
+    // hint.
+    let body_text = if collapsed && !streaming {
+        redact_internal_identifiers(&body_text)
+    } else {
+        body_text
     };
     let mut rendered = if body_text.trim().is_empty() {
         Vec::new()

--- a/crates/tui/src/tui/widgets/agent_card.rs
+++ b/crates/tui/src/tui/widgets/agent_card.rs
@@ -378,20 +378,24 @@ fn card_header(
     let header_color = status.color();
     let glyph_text = format!("{glyph} ");
     let status_text = format!("[{}]", status.label());
-    let fixed_width = [
-        glyph_text.as_str(),
-        verb,
-        " ",
-        role,
-        " ",
-        status_text.as_str(),
-        " ",
-    ]
-    .iter()
-    .map(|text| UnicodeWidthStr::width(*text))
-    .sum::<usize>();
+    // #4148: an `agent_type` that already reads as the verb (e.g. "delegate")
+    // would otherwise render a duplicate "delegate delegate". When the role
+    // collapses to the verb, the verb already carries the signal — drop the
+    // echoed role rather than repeat it.
+    let show_role = !role.eq_ignore_ascii_case(verb);
+    let mut fixed_parts: Vec<&str> = vec![glyph_text.as_str(), verb, " "];
+    if show_role {
+        fixed_parts.push(role);
+        fixed_parts.push(" ");
+    }
+    fixed_parts.push(status_text.as_str());
+    fixed_parts.push(" ");
+    let fixed_width = fixed_parts
+        .iter()
+        .map(|text| UnicodeWidthStr::width(*text))
+        .sum::<usize>();
     let detail = truncate_action(detail, width.saturating_sub(fixed_width));
-    Line::from(vec![
+    let mut spans = vec![
         Span::styled(
             glyph_text,
             Style::default()
@@ -405,12 +409,21 @@ fn card_header(
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" "),
-        Span::styled(role.to_string(), Style::default().fg(palette::TEXT_PRIMARY)),
-        Span::raw(" "),
-        Span::styled(status_text, Style::default().fg(header_color)),
-        Span::raw(" "),
-        Span::styled(detail, Style::default().fg(palette::TEXT_MUTED)),
-    ])
+    ];
+    if show_role {
+        spans.push(Span::styled(
+            role.to_string(),
+            Style::default().fg(palette::TEXT_PRIMARY),
+        ));
+        spans.push(Span::raw(" "));
+    }
+    spans.push(Span::styled(status_text, Style::default().fg(header_color)));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        detail,
+        Style::default().fg(palette::TEXT_MUTED),
+    ));
+    Line::from(spans)
 }
 
 /// Map agent types to human-readable role labels (#1981).
@@ -544,6 +557,30 @@ mod tests {
                     .collect::<String>()
             })
             .collect()
+    }
+
+    #[test]
+    fn delegate_card_header_does_not_duplicate_verb_as_role() {
+        // #4148: a role that already reads as the "delegate" verb must not
+        // render "delegate delegate" in the default transcript. The verb
+        // stays; the echoed role is dropped.
+        let card = DelegateCard::new("agent_1", "delegate");
+        let rendered = render_to_strings(&card.render_lines(80)).join("\n");
+        assert!(
+            !rendered.contains("delegate delegate"),
+            "verb must not be echoed as the role: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("delegate"),
+            "the delegate verb itself must remain: {rendered:?}"
+        );
+        // A real role still renders next to the verb (regression guard).
+        let worker = DelegateCard::new("agent_2", "general");
+        let worker_rendered = render_to_strings(&worker.render_lines(80)).join("\n");
+        assert!(
+            worker_rendered.contains("delegate worker"),
+            "distinct roles are still shown: {worker_rendered:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #4146
Fixes #4148

## Summary

Completed reasoning and sub-agent activity leaked internal chatter and implementation identifiers into the default (collapsed) transcript. This PR polishes the copy at its source while keeping full detail available behind the existing expand affordance. Changes are surgical presentation-only edits — no renames of Rust symbols or `DEEPSEEK*` env vars (guard #4172), no provider/model inference changes (EPIC #2608).

### #4146 — quiet completed reasoning
- `render_thinking` (crates/tui/src/tui/history/thinking.rs) now scrubs internal `snake_case` code identifiers (function names like `refresh_catalog_cache`, raw agent ids) from the collapsed completed-reasoning preview. Each identifier collapses to `…` so surrounding prose still reads. Streaming reasoning stays verbatim (the user is watching it think); the expanded view (Space / Ctrl+O) and the pager/clipboard transcript keep the full, un-redacted body. Reuses the existing expand affordance — no new mechanism, no detail deleted.

### #4148 — remove duplicate and leaky words
- **`unknown child`**: `delegate_identity_fallback` (agent_activity.rs) returned the raw internal token, which surfaced in the compact agent header. Replaced with the friendly, non-leaky `subagent` label.
- **`delegate delegate` (root cause)**: `card_header` (widgets/agent_card.rs) concatenated the family verb (`delegate`) with a role that could itself read as `delegate`, producing the adjacent duplicate. It now omits the echoed role and shows the verb alone; distinct roles still render.
- **redundant verb echo**: `render_tool_header_with_family_and_summary` (history.rs) now drops a header summary that merely repeats its own verb (e.g. `delegate · delegate`), fixing the compact agent header at the shared renderer.

## Acceptance checklist

#4146:
- [x] Default transcript shows a quiet receipt for completed reasoning — collapsed preview stays bounded and identifiers are scrubbed.
- [x] Raw internal identifiers do NOT leak by default — `snake_case` code tokens are redacted in the collapsed view.
- [x] Full reasoning remains available through explicit expansion — expand (Space / Ctrl+O) and transcript restore the un-redacted body; nothing is deleted.

#4148:
- [x] Default transcript contains NO `delegate delegate` — fixed at the `card_header` source; test proves it.
- [x] Default transcript contains NO `unknown child` under normal operation — fallback now returns `subagent`; test proves it.
- [x] Default transcript does NOT expose internal function names from completed reasoning receipts — redaction; test proves `refresh_catalog_cache` is hidden by default and restored on expand.
- [x] Full detail remains available behind explicit expansion.

## Tests added
- `delegate_card_header_does_not_duplicate_verb_as_role` (agent_card.rs)
- `agent_compact_header_omits_unknown_child_fallback` (history/tests.rs)
- `agent_compact_header_does_not_duplicate_delegate_verb` (history/tests.rs)
- `completed_reasoning_receipt_hides_internal_function_names_until_expanded` (history/tests.rs)

## Verification
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --locked -- -D warnings …`, `cargo test --workspace --all-features --locked --no-fail-fast`, and `cargo build --release` all pass. The only failing test is the pre-existing env-dependent `skill_hotbar_action_*` startup-skill-cache flake (same family as the known `skill_hotbar_action_a_alias` / `git_repo_root_reports_attempted_paths_when_no_repo_found`), confirmed failing identically on the clean base and untouched by this change.

Generated with Claude Code