### PR TITLE
fix(tui): semantic truncation for dense picker rows (#3987)

### DIFF
--- a/crates/tui/src/tui/hotbar/setup.rs
+++ b/crates/tui/src/tui/hotbar/setup.rs
@@ -17,6 +17,8 @@ use crate::tui::views::{
     centered_modal_area, render_modal_footer, render_modal_surface,
 };
 
+#[cfg(test)]
+use super::actions::HotbarRecommendation;
 use super::actions::{
     HotbarActionCategory, HotbarActionMetadata, HotbarArgsBehavior, HotbarRecommendationOptions,
     HotbarSafetyClass, recommend_hotbar_actions,
@@ -392,7 +394,7 @@ impl HotbarSetupView {
         };
 
         for (idx, row) in self.actions_for_source(source).iter().enumerate() {
-            lines.push(self.action_row_line(source, idx, row));
+            lines.push(self.action_row_line(source, idx, row, 80));
         }
 
         lines.push(Line::from(""));
@@ -497,6 +499,7 @@ impl HotbarSetupView {
         source: HotbarActionCategory,
         idx: usize,
         row: &HotbarSetupActionRow,
+        max_width: u16,
     ) -> Line<'static> {
         let selected = idx == self.selected_action_idx(source);
         let marker = if selected { ">" } else { " " };
@@ -514,18 +517,23 @@ impl HotbarSetupView {
         } else {
             ""
         };
-        let mut text = format!(
-            "{marker}{checked} {:<3} {:<22} {:<8} {}",
+        let prefix = format!(
+            "{marker}{checked} {:<3} {:<22} {:<8} ",
             recommended,
             row.metadata.display_name,
-            row.status_label(),
-            row.metadata.description
+            row.status_label()
         );
-        if let Some(reason) = row.disabled_reason.as_deref() {
-            text.push_str(" (");
-            text.push_str(reason);
-            text.push(')');
-        }
+        let suffix = if let Some(reason) = row.disabled_reason.as_deref() {
+            format!(" ({reason})")
+        } else {
+            String::new()
+        };
+        let text = crate::tui::ui_text::semantic_truncate_with_affixes(
+            &prefix,
+            &row.metadata.description,
+            &suffix,
+            usize::from(max_width),
+        );
         Line::from(Span::styled(
             text,
             Style::default()
@@ -573,7 +581,7 @@ impl HotbarSetupView {
                 .add_modifier(Modifier::BOLD),
         ))];
         for (idx, row) in rows.iter().enumerate() {
-            lines.push(self.action_row_line(source, idx, row));
+            lines.push(self.action_row_line(source, idx, row, area.width));
         }
         Paragraph::new(lines)
             .style(Style::default().fg(palette::TEXT_PRIMARY))
@@ -1199,6 +1207,33 @@ mod tests {
 
         assert!(rendered.contains("After save: Alt+1 through Alt+8 dispatch Hotbar slots"));
         assert!(rendered.contains("Bare 1-8 stay composer text outside setup"));
+    }
+
+    #[test]
+    fn action_rows_semantically_truncate_descriptions_at_narrow_width() {
+        let app = test_app();
+        let view = HotbarSetupView::new(&app, &Config::default());
+        let row = HotbarSetupActionRow {
+            metadata: HotbarActionMetadata {
+                id: "test.long-description".to_string(),
+                source_id: "test".to_string(),
+                display_name: "Open settings row".to_string(),
+                compact_label: "test".to_string(),
+                description: "Open a detailed settings panel without clipping".to_string(),
+                category: HotbarActionCategory::App,
+                args: HotbarArgsBehavior::None,
+                safety: HotbarSafetyClass::LocalUi,
+                recommendation: HotbarRecommendation::Eligible,
+            },
+            disabled_reason: None,
+        };
+
+        let text = view
+            .action_row_line(HotbarActionCategory::App, 0, &row, 58)
+            .to_string();
+        assert!(crate::tui::ui_text::text_display_width(&text) <= 58);
+        assert!(text.contains("Open a detailed…"), "{text:?}");
+        assert!(!text.contains("Open a detailed s"), "{text:?}");
     }
 
     #[test]

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -1543,7 +1543,13 @@ impl ProviderPickerView {
             } else {
                 Style::default().fg(palette::STATUS_WARNING)
             };
-            let hint = row.list_row_hint(self.view);
+            let prefix = format!(" {arrow} {}{active_dot}  ", row.display_name);
+            let hint = crate::tui::ui_text::semantic_truncate_between_affixes(
+                &prefix,
+                &row.list_row_hint(self.view),
+                "",
+                usize::from(layout.list.width),
+            );
             let mut line = Line::from(vec![
                 Span::styled(" ", spacer_style),
                 Span::styled(arrow, label_style),
@@ -2245,6 +2251,22 @@ mod tests {
             .map(|y| (0..width).map(|x| buf[(x, y)].symbol()).collect::<String>())
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn provider_picker_semantically_truncates_dense_rows_at_narrow_width() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        picker.toggle_view();
+
+        let text = render_text(&picker, 64, 16);
+        assert!(text.contains('…'), "{text}");
+        for (idx, line) in text.lines().enumerate() {
+            assert!(
+                crate::tui::ui_text::text_display_width(line) <= 64,
+                "line {idx} overflows: {line:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -256,7 +256,13 @@ impl ModalView for ThemePickerView {
             ));
             spans.extend(swatch);
             spans.push(Span::raw("  "));
-            spans.push(Span::styled(id.tagline(), tagline_style));
+
+            let prefix_width = Line::from(spans.clone()).width();
+            let tagline = crate::tui::ui_text::semantic_truncate(
+                id.tagline(),
+                usize::from(content.width).saturating_sub(prefix_width),
+            );
+            spans.push(Span::styled(tagline, tagline_style));
 
             lines.push(Line::from(spans));
         }
@@ -400,6 +406,30 @@ mod tests {
         let area = ratatui::layout::Rect::new(0, 0, 20, 6);
         let mut buf = ratatui::buffer::Buffer::empty(area);
         v.render(area, &mut buf);
+    }
+
+    #[test]
+    fn render_semantically_truncates_taglines_at_narrow_width() {
+        let v = ThemePickerView::new("system".to_string());
+        let area = ratatui::layout::Rect::new(0, 0, 56, 12);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        v.render(area, &mut buf);
+        let rows = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        let text = rows.join("\n");
+
+        assert!(text.contains('…'), "{text}");
+        for (idx, row) in rows.iter().enumerate() {
+            assert!(
+                crate::tui::ui_text::text_display_width(row) <= usize::from(area.width),
+                "line {idx} overflows: {row:?}"
+            );
+        }
     }
 
     /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -61,6 +61,88 @@ pub(crate) fn truncate_line_to_width(text: &str, max_width: usize) -> String {
     out
 }
 
+/// Truncate `text` to `max_width` display columns, preferring whole words.
+pub(crate) fn semantic_truncate(text: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    if text_display_width(text) <= max_width {
+        return text.to_string();
+    }
+
+    const ELLIPSIS: char = '…';
+    let ellipsis_width = char_display_width(ELLIPSIS);
+    let limit = max_width.saturating_sub(ellipsis_width);
+    if limit == 0 {
+        return ELLIPSIS.to_string();
+    }
+
+    let mut width = 0usize;
+    let mut cut_byte = 0usize;
+    let mut last_word_end = None;
+    let mut in_word = false;
+    for (byte_idx, ch) in text.char_indices() {
+        let ch_width = char_display_width(ch);
+        if width + ch_width > limit {
+            break;
+        }
+        width += ch_width;
+        cut_byte = byte_idx + ch.len_utf8();
+        if ch.is_whitespace() {
+            if in_word {
+                last_word_end = Some(byte_idx);
+                in_word = false;
+            }
+        } else {
+            in_word = true;
+        }
+    }
+    if cut_byte == 0 {
+        return ELLIPSIS.to_string();
+    }
+
+    let mut body = if let Some(word_end) = last_word_end {
+        text[..word_end].trim_end()
+    } else {
+        text[..cut_byte].trim_end()
+    };
+    if body.is_empty() {
+        body = text[..cut_byte].trim_end();
+    }
+    let mut out = body.to_string();
+    out.push(ELLIPSIS);
+    out
+}
+
+pub(crate) fn semantic_truncate_with_affixes(
+    prefix: &str,
+    text: &str,
+    suffix: &str,
+    max_width: usize,
+) -> String {
+    let fixed_width = text_display_width(prefix) + text_display_width(suffix);
+    if fixed_width > max_width {
+        return semantic_truncate(&format!("{prefix}{text}{suffix}"), max_width);
+    }
+    format!(
+        "{prefix}{}{suffix}",
+        semantic_truncate_between_affixes(prefix, text, suffix, max_width)
+    )
+}
+
+pub(crate) fn semantic_truncate_between_affixes(
+    prefix: &str,
+    text: &str,
+    suffix: &str,
+    max_width: usize,
+) -> String {
+    let fixed_width = text_display_width(prefix) + text_display_width(suffix);
+    if fixed_width > max_width {
+        return String::new();
+    }
+    semantic_truncate(text, max_width - fixed_width)
+}
+
 pub(crate) fn concise_shell_command_label(command: &str, max_width: usize) -> String {
     let normalized = normalize_shell_text(command);
     if let Some(label) = gh_command_label(&normalized) {
@@ -179,7 +261,7 @@ where
     }
 }
 
-pub(super) fn text_display_width(text: &str) -> usize {
+pub(crate) fn text_display_width(text: &str) -> usize {
     text.chars().map(char_display_width).sum()
 }
 
@@ -321,6 +403,44 @@ mod tests {
         let clipped = truncate_line_to_width("界界界界界", 5);
         assert!(text_display_width(&clipped) <= 5);
         assert!(!clipped.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn semantic_truncate_prefers_word_boundaries() {
+        let out = semantic_truncate("hello world foo bar", 14);
+        assert_eq!(out, "hello world…");
+        assert!(text_display_width(&out) <= 14);
+    }
+
+    #[test]
+    fn semantic_truncate_falls_back_with_long_words_and_wide_glyphs() {
+        let long_word = semantic_truncate("supercalifragilistic", 8);
+        assert_eq!(long_word, "superca…");
+        assert!(text_display_width(&long_word) <= 8);
+
+        let cjk = semantic_truncate("中文测试文本", 7);
+        assert_eq!(cjk, "中文测…");
+        assert!(text_display_width(&cjk) <= 7);
+    }
+
+    #[test]
+    fn semantic_truncate_handles_empty_and_tiny_budgets() {
+        assert_eq!(semantic_truncate("", 10), "");
+        assert_eq!(semantic_truncate("hello", 0), "");
+        assert_eq!(semantic_truncate("hello", 1), "…");
+    }
+
+    #[test]
+    fn semantic_truncate_between_affixes_reserves_fixed_columns() {
+        let hint = semantic_truncate_between_affixes(
+            " > [ ] Prefix stability  (",
+            "whether system/tools stayed cacheable",
+            ")",
+            49,
+        );
+        let row = format!(" > [ ] Prefix stability  ({hint})");
+        assert_eq!(hint, "whether system/tools…");
+        assert!(text_display_width(&row) <= 49);
     }
 
     #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -2295,7 +2295,7 @@ impl ModalView for ConfigView {
                 selected_hint.unwrap_or_default()
             };
             lines.push(Line::from(Span::styled(
-                truncate_view_text(&bottom_text, usize::from(inner.width)),
+                crate::tui::ui_text::semantic_truncate(&bottom_text, usize::from(inner.width)),
                 Style::default().fg(palette::TEXT_MUTED),
             )));
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -3966,6 +3966,53 @@ base_url = "https://api.xiaomimimo.com/v1"
     }
 
     #[test]
+    fn config_view_bottom_hint_semantically_truncates_at_narrow_width() {
+        // The dense bottom status line must truncate on a word boundary with an
+        // ellipsis instead of leaving a mid-word fragment clipped by the
+        // terminal (#3987).
+        let app = create_test_app();
+        let mut view = ConfigView::new_for_app(&app);
+        view.status = Some(
+            "CFGSTATUS persisted the configuration override to disk successfully \
+             without clipping the trailing MARKEREND status text"
+                .to_string(),
+        );
+
+        let area = Rect::new(0, 0, 100, 40);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        let rows: Vec<String> = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect();
+
+        // No rendered row may overflow the available columns.
+        for (idx, row) in rows.iter().enumerate() {
+            assert!(
+                crate::tui::ui_text::text_display_width(row) <= usize::from(area.width),
+                "line {idx} overflows: {row:?}"
+            );
+        }
+
+        let status_line = rows
+            .iter()
+            .find(|row| row.contains("CFGSTATUS"))
+            .expect("bottom status hint should be rendered");
+        assert!(
+            status_line.contains('…'),
+            "status should be truncated with an ellipsis: {status_line:?}"
+        );
+        assert!(
+            !status_line.contains("MARKEREND"),
+            "truncated status must drop trailing text: {status_line:?}"
+        );
+    }
+
+    #[test]
     fn config_view_typing_replaces_on_first_char() {
         let app = create_test_app();
         let mut view = ConfigView::new_for_app(&app);

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -19,7 +19,7 @@ use ratatui::{
 };
 
 use crate::config::{ApiProvider, StatusItem};
-use crate::localization::{Locale, MessageId, tr, truncate_to_width};
+use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
@@ -258,13 +258,22 @@ impl ModalView for StatusPickerView {
                 let line = status_row_text(pointer, mark, item, content.width as usize);
                 lines.push(Line::from(Span::styled(line, selected_style)));
             } else {
+                let label = item.label();
+                let hint = item.hint();
+                let prefix = format!(" {pointer} {mark} {label}  (");
+                let truncated_hint = crate::tui::ui_text::semantic_truncate_between_affixes(
+                    &prefix,
+                    hint,
+                    ")",
+                    usize::from(content.width),
+                );
                 lines.push(Line::from(vec![
                     Span::styled(format!(" {pointer} "), row_style),
                     Span::styled(mark.to_string(), row_style),
                     Span::styled(" ", row_style),
-                    Span::styled(item.label().to_string(), row_style),
+                    Span::styled(label.to_string(), row_style),
                     Span::styled("  ", row_style),
-                    Span::styled(format!("({})", item.hint()), hint_style),
+                    Span::styled(format!("({})", truncated_hint), hint_style),
                 ]));
             }
         }
@@ -285,8 +294,9 @@ fn visible_row_start(total_rows: usize, cursor: usize, visible_rows: usize) -> u
 }
 
 fn status_row_text(pointer: &str, mark: &str, item: &StatusItem, width: usize) -> String {
-    let text = format!(" {pointer} {mark} {}  ({})", item.label(), item.hint());
-    let mut text = truncate_to_width(&text, width);
+    let prefix = format!(" {pointer} {mark} {}  (", item.label());
+    let mut text =
+        crate::tui::ui_text::semantic_truncate_with_affixes(&prefix, item.hint(), ")", width);
     let current_width = text.width();
     if current_width < width {
         text.push_str(&" ".repeat(width - current_width));
@@ -398,6 +408,14 @@ mod tests {
         let text = status_row_text("▸", "[ ]", &StatusItem::LastToolElapsed, 40);
         assert_eq!(text.width(), 40);
         assert!(text.starts_with(" ▸ [ ] Last tool elapsed"));
+    }
+
+    #[test]
+    fn selected_row_text_semantically_truncates_hint_at_narrow_width() {
+        let text = status_row_text("▸", "[ ]", &StatusItem::LastToolElapsed, 49);
+        assert_eq!(text.width(), 49);
+        assert!(text.contains("ms of the most…"), "{text:?}");
+        assert!(!text.contains("ms of the most r"), "{text:?}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3987

## Summary
Several dense TUI rows and pickers relied on raw terminal clipping, which produced mid-word / mid-token fragments (`COLORF`, `cost: un`, `fir`, `cachea`, `Agent mo`). This adds a shared, width-aware semantic-truncation strategy so dense rows cut on a sensible boundary and append an ellipsis (`…`) without splitting a glyph, and wires it into every dense-row surface. Visual/text only — no change to selection or logic.

A shared primitive lives in `tui/ui_text.rs`:
- `semantic_truncate(text, max_width)` — width-aware, prefers whole-word boundaries, appends `…`, never splits a multi-column glyph.
- `semantic_truncate_with_affixes` / `semantic_truncate_between_affixes` — reserve fixed prefix/suffix columns (arrow, marker, parens) and truncate only the variable middle.

## Acceptance criteria
- [x] Shared width-aware truncation helper in `ui_text.rs` (respects display width, ellipsis, no mid-glyph split)
- [x] Applied to theme picker (`theme_picker.rs`)
- [x] Applied to provider picker (`provider_picker.rs`)
- [x] Applied to ConfigView (`views/mod.rs`)
- [x] Applied to status picker (`views/status_picker.rs`)
- [x] Applied to hotbar setup (`hotbar/setup.rs`)
- [x] Render/unit tests: helper unit tests (word boundaries, wide glyphs, tiny budgets, affix reservation) plus a focused test per surface asserting long strings truncate to target width with `…` and no mid-token fragment
- [x] No behavior change to selection/logic; no config/inference/env changes

## Provenance
Harvested from Hunter B's existing local commit "Tighten dense row truncation". Cherry-picked onto current `main`; one conflict in `provider_picker.rs` (main had since introduced `list_row_hint(view)` dispatch) was resolved by keeping main's hint source and wrapping it in the semantic-truncation call. A follow-up commit adds a ConfigView render test to complete per-surface coverage.

## Verification
`cargo fmt --check`, `cargo clippy --workspace --all-features -D warnings`, `cargo test --workspace --all-features`, and `cargo build --release` all pass. The only failing test is the known env-dependent `skill_hotbar_action_*` startup-skill-cache case, unrelated to this change.

Generated with Claude Code
