### PR TITLE
feat(tui): dynamic MCP server infrastructure in McpPool (#3869, harvested from @bistack)

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -159,3 +159,5 @@ hxy91819 = hxy91819 <8814856+hxy91819@users.noreply.github.com>
 hxy91819@gmail.com = hxy91819 <8814856+hxy91819@users.noreply.github.com>
 heloanc = heloanc <61081755+heloanc@users.noreply.github.com>
 heloanc@users.noreply.github.com = heloanc <61081755+heloanc@users.noreply.github.com>
+bistack = Sun Zhenyuan <9128763+bistack@users.noreply.github.com>
+zhenyuan.sun@163.com = Sun Zhenyuan <9128763+bistack@users.noreply.github.com>

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -9,10 +9,12 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
 mod headers;
@@ -1467,6 +1469,9 @@ pub struct McpPool {
     config_hash: u64,
     /// Most recently observed mtime for `config_sources`.
     last_mtimes: Vec<Option<std::time::SystemTime>>,
+    /// Dynamically added MCP servers (from tool calls at runtime).
+    /// These are not persisted to disk and live for the process lifetime.
+    pub(crate) dynamic_servers: Arc<RwLock<HashMap<String, McpServerConfig>>>,
 }
 
 impl McpPool {
@@ -1481,6 +1486,7 @@ impl McpPool {
             workspace: None,
             config_hash,
             last_mtimes: Vec::new(),
+            dynamic_servers: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -1624,12 +1630,14 @@ impl McpPool {
 
         self.drop_connection(server_name, "reconnect");
 
+        // Check static config first, then dynamic servers
         let server_config = self
             .config
             .servers
             .get(server_name)
-            .ok_or_else(|| anyhow::anyhow!("Failed to find MCP server: {server_name}"))?
-            .clone();
+            .cloned()
+            .or_else(|| self.dynamic_servers.read().get(server_name).cloned())
+            .ok_or_else(|| anyhow::anyhow!("Failed to find MCP server: {server_name}"))?;
 
         if !server_config.is_enabled() {
             anyhow::bail!("Failed to connect MCP server '{server_name}': server is disabled");
@@ -2127,14 +2135,49 @@ impl McpPool {
         }
     }
 
-    /// Get list of configured server names
+    /// Get list of configured server names (static + dynamic)
     #[allow(dead_code)] // Public API for MCP consumers
-    pub fn server_names(&self) -> Vec<&str> {
-        self.config
-            .servers
-            .keys()
-            .map(std::string::String::as_str)
-            .collect()
+    pub fn server_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.config.servers.keys().cloned().collect();
+        let dynamic = self.dynamic_servers.read();
+        for name in dynamic.keys() {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+        names
+    }
+
+    /// Add a runtime server configuration (in-memory only, not persisted).
+    ///
+    /// This is used for dynamically started MCP servers from chat context.
+    /// Stored in `dynamic_servers` so it doesn't interfere with file-based config reload.
+    ///
+    /// Returns `Err` if a server with the same name already exists as a static config
+    /// or a dynamic config. The caller should surface the error to the LLM/user.
+    #[allow(dead_code)] // Public API for MCP consumers
+    pub fn add_runtime_server_config(
+        &self,
+        name: String,
+        config: McpServerConfig,
+    ) -> Result<(), String> {
+        if self.config.servers.contains_key(&name) {
+            return Err(format!(
+                "MCP server '{}' already exists in the config file. \
+                 Remove it from the config first, or choose a different name.",
+                name
+            ));
+        }
+        let mut dynamic = self.dynamic_servers.write();
+        if dynamic.contains_key(&name) {
+            return Err(format!(
+                "MCP server '{}' was already started earlier in this session. \
+                 Choose a different name.",
+                name
+            ));
+        }
+        dynamic.insert(name, config);
+        Ok(())
     }
 
     /// Get list of connected server names

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -765,7 +765,7 @@ async fn workspace_mcp_pool_reload_picks_up_project_config_creation() {
     .unwrap();
 
     let mut pool = McpPool::from_config_path_with_workspace(&global_path, &workspace).unwrap();
-    assert_eq!(pool.server_names(), vec!["global"]);
+    assert_eq!(pool.server_names(), vec!["global".to_string()]);
 
     fs::create_dir_all(&project_dir).unwrap();
     fs::write(
@@ -775,8 +775,11 @@ async fn workspace_mcp_pool_reload_picks_up_project_config_creation() {
     .unwrap();
 
     assert!(pool.reload_if_config_changed().await.unwrap());
-    let names: std::collections::BTreeSet<_> = pool.server_names().into_iter().collect();
-    let expected: std::collections::BTreeSet<_> = ["global", "project"].into_iter().collect();
+    let names: std::collections::BTreeSet<String> = pool.server_names().into_iter().collect();
+    let expected: std::collections::BTreeSet<String> =
+        ["global".to_string(), "project".to_string()]
+            .into_iter()
+            .collect();
     assert_eq!(names, expected);
 }
 
@@ -800,13 +803,16 @@ async fn workspace_mcp_pool_reload_picks_up_project_config_after_workspace_trust
     .unwrap();
 
     let mut pool = McpPool::from_config_path_with_workspace(&global_path, &workspace).unwrap();
-    assert_eq!(pool.server_names(), vec!["global"]);
+    assert_eq!(pool.server_names(), vec!["global".to_string()]);
 
     write_workspace_trust_config(&trust_env.config_path, &workspace);
 
     assert!(pool.reload_if_config_changed().await.unwrap());
-    let names: std::collections::BTreeSet<_> = pool.server_names().into_iter().collect();
-    let expected: std::collections::BTreeSet<_> = ["global", "project"].into_iter().collect();
+    let names: std::collections::BTreeSet<String> = pool.server_names().into_iter().collect();
+    let expected: std::collections::BTreeSet<String> =
+        ["global".to_string(), "project".to_string()]
+            .into_iter()
+            .collect();
     assert_eq!(names, expected);
 }
 
@@ -830,14 +836,17 @@ async fn workspace_mcp_pool_reload_drops_project_config_after_workspace_trust_re
     .unwrap();
 
     let mut pool = McpPool::from_config_path_with_workspace(&global_path, &workspace).unwrap();
-    let names: std::collections::BTreeSet<_> = pool.server_names().into_iter().collect();
-    let expected: std::collections::BTreeSet<_> = ["global", "project"].into_iter().collect();
+    let names: std::collections::BTreeSet<String> = pool.server_names().into_iter().collect();
+    let expected: std::collections::BTreeSet<String> =
+        ["global".to_string(), "project".to_string()]
+            .into_iter()
+            .collect();
     assert_eq!(names, expected);
 
     fs::remove_file(&trust.config_path).unwrap();
 
     assert!(pool.reload_if_config_changed().await.unwrap());
-    assert_eq!(pool.server_names(), vec!["global"]);
+    assert_eq!(pool.server_names(), vec!["global".to_string()]);
 }
 
 #[tokio::test]
@@ -861,14 +870,17 @@ async fn workspace_mcp_pool_reload_drops_project_config_after_deletion() {
     .unwrap();
 
     let mut pool = McpPool::from_config_path_with_workspace(&global_path, &workspace).unwrap();
-    let names: std::collections::BTreeSet<_> = pool.server_names().into_iter().collect();
-    let expected: std::collections::BTreeSet<_> = ["global", "project"].into_iter().collect();
+    let names: std::collections::BTreeSet<String> = pool.server_names().into_iter().collect();
+    let expected: std::collections::BTreeSet<String> =
+        ["global".to_string(), "project".to_string()]
+            .into_iter()
+            .collect();
     assert_eq!(names, expected);
 
     fs::remove_file(project_path).unwrap();
 
     assert!(pool.reload_if_config_changed().await.unwrap());
-    assert_eq!(pool.server_names(), vec!["global"]);
+    assert_eq!(pool.server_names(), vec!["global".to_string()]);
 }
 
 #[test]
@@ -1309,7 +1321,7 @@ async fn reload_if_config_changed_swaps_config_on_content_change() {
     assert!(reloaded, "content-changed config must trigger reload");
     let names = pool.server_names();
     assert!(
-        names.contains(&"new"),
+        names.contains(&"new".to_string()),
         "expected new server in pool after reload, got {names:?}"
     );
 }
@@ -3235,4 +3247,57 @@ async fn custom_headers_applied_to_get_preflight() {
         header_seen.load(AtomicOrdering::SeqCst),
         "GET preflight must include user-configured custom headers"
     );
+}
+
+// === add_runtime_server_config conflict tests ===
+
+#[test]
+fn add_runtime_server_config_rejects_static_conflict() {
+    let config: McpConfig = serde_json::from_str(
+        r#"{
+        "servers": {
+            "existing": {"command": "node server.js"}
+        }
+    }"#,
+    )
+    .unwrap();
+    let pool = McpPool::new(config);
+
+    let err = pool
+        .add_runtime_server_config(
+            "existing".to_string(),
+            serde_json::from_str(r#"{"command": "npx other"}"#).unwrap(),
+        )
+        .unwrap_err();
+    assert!(err.contains("already exists in the config file"));
+}
+
+#[test]
+fn add_runtime_server_config_rejects_dynamic_duplicate() {
+    let pool = McpPool::new(McpConfig::default());
+
+    pool.add_runtime_server_config(
+        "my_server".to_string(),
+        serde_json::from_str(r#"{"command": "node a.js"}"#).unwrap(),
+    )
+    .unwrap();
+
+    let err = pool
+        .add_runtime_server_config(
+            "my_server".to_string(),
+            serde_json::from_str(r#"{"command": "node b.js"}"#).unwrap(),
+        )
+        .unwrap_err();
+    assert!(err.contains("already started earlier"));
+}
+
+#[test]
+fn add_runtime_server_config_accepts_new_name() {
+    let pool = McpPool::new(McpConfig::default());
+
+    pool.add_runtime_server_config(
+        "brand_new".to_string(),
+        serde_json::from_str(r#"{"command": "node x.js"}"#).unwrap(),
+    )
+    .unwrap();
 }


### PR DESCRIPTION
Fixes #3869

Harvested from #3869 by @bistack (credit via canonical author + Co-authored-by + AUTHOR_MAP alias).

## Summary
Adds dynamic MCP server infrastructure to `McpPool`:

- New `McpPool.dynamic_servers` field (`Arc<RwLock<HashMap<String, McpServerConfig>>>`) holding in-memory, non-persisted server configs for MCP servers started dynamically from chat context, kept separate from file-based config so config reload is unaffected.
- New `add_runtime_server_config(name, config)` method that registers a runtime server, returning `Err` when the name collides with an existing static config or an already-started dynamic config.
- `server_names()` now returns `Vec<String>` and merges static + dynamic server names.

This is the keystone infrastructure that unblocks #3866. Includes bistack's conflict/duplicate-rejection tests in `crates/tui/src/mcp/tests.rs`.

## Credit
- Author preserved as `Sun Zhenyuan <9128763+bistack@users.noreply.github.com>` (canonical GitHub noreply).
- `Co-authored-by: Sun Zhenyuan <9128763+bistack@users.noreply.github.com>` trailer.
- `Harvested from PR #3869 by @bistack` marker in the commit body.
- Added `bistack` and `zhenyuan.sun@163.com` aliases to `.github/AUTHOR_MAP`.

## Verification
- `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors` -> exit 0 ("Co-author credit check passed for 1 commit(s).").
- `cargo build -p codewhale-tui --locked` -> OK.
- `cargo test -p codewhale-tui --all-features --locked` -> 6020 passed; only the known env-dependent `skill_hotbar_action_*` test failed.
- `cargo fmt --all -- --check` -> clean.
- `cargo clippy --workspace --all-features --locked -- -D warnings ...` -> clean (exit 0).
- `cargo test --workspace --all-features --locked` -> all suites pass except the same known `skill_hotbar_action_*` test.
- `cargo build --release` -> OK.

Generated with Claude Code
