### PR TITLE
test(tui): Unicode/CJK/width QA coverage (#3488)

### DIFF
--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -1991,4 +1991,117 @@ mod tests {
         // Any output is acceptable (the path is degenerate); assert no panic.
         let _ = rendered;
     }
+
+    fn rendered_text(rendered: &[Line<'static>]) -> String {
+        rendered
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect()
+    }
+
+    fn assert_rendered_widths_fit(rendered: &[Line<'static>], width: usize, label: &str) {
+        for line_width in rendered_widths(rendered) {
+            assert!(
+                line_width <= width,
+                "{label} width={width}: rendered line width {line_width} exceeds budget"
+            );
+        }
+    }
+
+    // ── Unicode / CJK / emoji / combining-char width QA (#3488) ────────────
+
+    #[test]
+    fn paragraph_wrap_keeps_unicode_runs_within_qa_widths() {
+        let cases = [
+            ("cjk", "界".repeat(300)),
+            ("emoji", "😀".repeat(200)),
+            ("mixed-cjk-emoji", "界😀世🚀".repeat(90)),
+        ];
+
+        for (label, text) in cases {
+            for &width in &[80usize, 100, 120] {
+                let rendered = render_paragraph_for_test(&text, width);
+                assert_rendered_widths_fit(&rendered, width, label);
+                assert_eq!(
+                    rendered_text(&rendered),
+                    text,
+                    "{label} width={width}: content changed while wrapping"
+                );
+
+                let min_lines = text.width().div_ceil(width);
+                assert!(
+                    rendered.len() >= min_lines,
+                    "{label} width={width}: expected at least {min_lines} lines, got {}",
+                    rendered.len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn paragraph_wrap_preserves_mixed_unicode_and_ascii_fragments() {
+        let cjk = "这是一个测试字符串".repeat(10); // 80 Han chars = 160 cols
+        let emoji = "🚀".repeat(12);
+        let text = format!("Note: {cjk} done {emoji}");
+
+        for &width in &[80usize, 100, 120] {
+            let rendered = render_paragraph_for_test(&text, width);
+            assert_rendered_widths_fit(&rendered, width, "mixed unicode/ascii");
+
+            let visible = visible_lines(&rendered).join("\n");
+            for fragment in ["Note:", "测试", "done"] {
+                assert!(
+                    visible.contains(fragment),
+                    "width={width}: fragment {fragment:?} missing from output:\n{visible}"
+                );
+            }
+            assert_eq!(
+                visible.matches('🚀').count(),
+                12,
+                "width={width}: emoji content lost"
+            );
+        }
+    }
+
+    #[test]
+    fn lower_level_wrap_text_keeps_unicode_runs_within_qa_widths() {
+        let cases = [
+            ("cjk", "中".repeat(140)),
+            ("emoji", "😀".repeat(110)),
+            ("combining", "e\u{301}".repeat(140)),
+        ];
+
+        for (label, input) in cases {
+            for &width in &[80usize, 100, 120] {
+                let lines = wrap_text(&input, width);
+                for line in &lines {
+                    assert!(
+                        line.width() <= width,
+                        "{label} width={width}: wrap_text line {line:?} exceeds budget"
+                    );
+                }
+                let combined: String = lines.join("");
+                assert_eq!(
+                    combined, input,
+                    "{label} width={width}: wrap_text changed content"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn table_render_keeps_cjk_cells_within_qa_widths() {
+        let cjk = "界".repeat(80);
+        let src = format!("| Name | Value |\n|---|---|\n| CJK | {cjk} |\n");
+
+        for &width in &[80usize, 100, 120] {
+            let rendered = render_markdown(&src, width as u16, Style::default());
+            assert_rendered_widths_fit(&rendered, width, "table cjk");
+            assert_eq!(
+                rendered_text(&rendered).matches('界').count(),
+                80,
+                "width={width}: CJK table cell content lost"
+            );
+        }
+    }
 }

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -2104,4 +2104,22 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn paragraph_wrap_keeps_cjk_transcript_within_narrow_widths() {
+        // The seed cases cover 80/100/120; narrow terminals (resize / small
+        // panes) are the other half of #3488's terminal-width lane. A CJK
+        // transcript paragraph must still wrap inside tiny windows without
+        // overflowing the border or dropping content.
+        let text = "实时输出结果显示正常".repeat(6); // 60 Han glyphs, 120 cols
+        for &width in &[20usize, 40] {
+            let rendered = render_paragraph_for_test(&text, width);
+            assert_rendered_widths_fit(&rendered, width, "narrow cjk transcript");
+            assert_eq!(
+                rendered_text(&rendered),
+                text,
+                "width={width}: CJK transcript content changed while wrapping"
+            );
+        }
+    }
 }

--- a/crates/tui/src/tui/ui_text.rs
+++ b/crates/tui/src/tui/ui_text.rs
@@ -356,4 +356,66 @@ mod tests {
         assert_eq!(label, "cargo test --workspace");
         assert!(!label.contains("38;2"));
     }
+
+    // --- New #3488 fixtures: CJK/wide-glyph truncation on selector-style rows.
+    // truncate_line_to_width is the production helper behind sidebar (file_tree),
+    // statusline (footer_ui), hotbar, and picker (mouse_ui) row rendering, so
+    // these exercise the same truncation path those surfaces use.
+
+    #[test]
+    fn truncate_line_to_width_full_width_cjk_lands_on_glyph_boundary() {
+        // Each Han glyph is two columns. With an odd budget the truncation must
+        // land on a whole-glyph boundary (reserving three columns for the
+        // ellipsis), never leaving a half-rendered wide cell or emitting U+FFFD.
+        let title = "项目报告结果"; // 6 glyphs, 12 columns
+        let out = truncate_line_to_width(title, 7);
+        // Budget 7 -> limit 4 columns -> two glyphs fit, then the ellipsis.
+        assert_eq!(out, "项目...");
+        assert_eq!(text_display_width(&out), 7);
+        // The kept prefix is composed only of whole wide glyphs (each 2 cols),
+        // proving the boundary glyph was dropped whole, not split.
+        let prefix = out.strip_suffix("...").expect("ellipsis present");
+        assert!(prefix.chars().all(|c| char_display_width(c) == 2));
+        assert!(!out.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn truncate_line_to_width_mixed_ascii_cjk_row_keeps_ellipsis_within_budget() {
+        // A sidebar/selector row mixing an ASCII label with a CJK title, wider
+        // than the column budget, must truncate with a trailing ellipsis that
+        // still fits by display width and must not split a wide glyph.
+        let row = "Task: 数据库迁移任务 done"; // ASCII label + 7 Han glyphs
+        let budget = 12;
+        let out = truncate_line_to_width(row, budget);
+        assert!(out.ends_with("..."), "expected ellipsis, got {out:?}");
+        // Ellipsis-and-content fit within the budget by *display* width.
+        assert!(text_display_width(&out) <= budget);
+        // The non-ellipsis prefix stays within budget-minus-ellipsis, so the
+        // wide glyph on the boundary was dropped whole rather than half-drawn.
+        let prefix = out.strip_suffix("...").expect("ellipsis present");
+        assert!(text_display_width(prefix) <= budget - 3);
+        assert!(!out.contains('\u{FFFD}'));
+        // The semantic ASCII prefix survives truncation.
+        assert!(out.starts_with("Task:"));
+    }
+
+    #[test]
+    fn truncate_line_to_width_dense_cjk_selector_row_survives_narrow_widths() {
+        // Picker/selector rows degrade through truncate_line_to_width when the
+        // terminal is narrow. A dense row with a leading marker glyph and CJK
+        // content must stay within budget at tiny widths, without panicking or
+        // emitting a replacement char from a mid-glyph byte split.
+        let row = "▸ 中文项目 · main"; // marker + CJK + separator + branch
+        for width in [1usize, 2, 3, 4, 6, 8] {
+            let out = truncate_line_to_width(row, width);
+            assert!(
+                text_display_width(&out) <= width,
+                "width={width}: {out:?} exceeds budget"
+            );
+            assert!(
+                !out.contains('\u{FFFD}'),
+                "width={width}: truncation split a wide glyph"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Refs #3488.

Bounded, test-only coverage slice for the Unicode/CJK/terminal-width QA umbrella. No production behavior changes — these tests exercise the existing production width/truncation helpers directly.

## What's in this PR

Seed (harvested, `test(tui): cover unicode markdown widths`) — markdown_render.rs:
- Paragraph wrap keeps CJK / emoji / mixed CJK+emoji runs within 80/100/120 columns.
- Paragraph wrap preserves mixed Unicode + ASCII fragments.
- Lower-level `wrap_text` keeps CJK / emoji / combining-char runs within budget.
- Table render keeps CJK cells within budget.

New fixtures (this commit):
- `truncate_line_to_width_full_width_cjk_lands_on_glyph_boundary` (ui_text.rs) — full-width CJK measured through the real width helper; asserts an odd column budget truncates on a whole-glyph boundary (each Han glyph = 2 cols), width is exact, and never emits U+FFFD.
- `truncate_line_to_width_mixed_ascii_cjk_row_keeps_ellipsis_within_budget` (ui_text.rs) — a mixed English+CJK selector/sidebar-style row truncated via `truncate_line_to_width`; asserts the ellipsis fits by display width, no mid-glyph split, and the semantic ASCII prefix survives.
- `truncate_line_to_width_dense_cjk_selector_row_survives_narrow_widths` (ui_text.rs) — a dense picker/selector row (marker glyph + CJK + separator + branch) degrades cleanly at widths 1–8: stays within budget, no panic, no replacement char.
- `paragraph_wrap_keeps_cjk_transcript_within_narrow_widths` (markdown_render.rs) — CJK transcript paragraph wraps inside narrow terminals (20/40 cols) without overflowing the border or dropping content.

`truncate_line_to_width` / `text_display_width` are the production helpers behind sidebar (file_tree), statusline (footer_ui), hotbar, and picker (mouse_ui) rendering, so these assertions track the same code path the renderer uses.

## Coverage vs. #3488 enumerated cases

Now covered:
- CJK task titles / transcript output — narrow + medium/wide widths.
- Mixed English/CJK rows in sidebars/modals/selectors — via the real truncation helper.
- Wide glyphs, combining marks, emoji, ambiguous-width punctuation — width + wrap.
- Terminal narrow-width / resize behavior — 20/40 cols added alongside the seed's 80/100/120.
- Selector/picker rows — dense CJK rows truncate cleanly at narrow widths.

Remaining (left for the umbrella / follow-ups):
- Copy/export behavior for wrapped output (visual line-break artifacts, #1853).
- macOS-Terminal vs. Windows/PowerShell golden-state snapshots.
- Statusline/modal title truncation as end-to-end rendered snapshots (helper-level truncation is covered here).

## Verification

`cargo build -p codewhale-tui --locked`, `cargo test -p codewhale-tui --all-features --locked`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --locked -- -D warnings …`, `cargo test --workspace --all-features --locked`, and `cargo build --release` all green, except the known pre-existing `skill_hotbar_action_*` skill-cache flake and `git_repo_root_reports_attempted_paths_when_no_repo_found`, which are unrelated to this change.

Generated with Claude Code
