### PR TITLE
fix(tui): remove legacy token-only pricing helpers (#4040, harvested from @DarrellThomas)

### DIFF
--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -227,44 +227,6 @@ fn deepseek_v4_flash_pricing() -> ModelPricing {
     }
 }
 
-/// Calculate cost for a turn given token usage and model.
-#[must_use]
-#[allow(dead_code)]
-pub fn calculate_turn_cost(model: &str, input_tokens: u32, output_tokens: u32) -> Option<f64> {
-    calculate_turn_cost_estimate(model, input_tokens, output_tokens).map(|estimate| estimate.usd)
-}
-
-/// Calculate cost for a turn in both official currencies.
-///
-/// This legacy helper has no cache telemetry, so it prices all input tokens as
-/// cache misses. Prefer [`calculate_turn_cost_estimate_from_usage`] when the
-/// provider returned usage details.
-#[must_use]
-pub fn calculate_turn_cost_estimate(
-    model: &str,
-    input_tokens: u32,
-    output_tokens: u32,
-) -> Option<CostEstimate> {
-    let pricing = pricing_for_model(model)?;
-    Some(CostEstimate {
-        usd: calculate_turn_cost_with_pricing(pricing.usd, input_tokens, output_tokens),
-        cny: pricing
-            .cny
-            .map(|pricing| calculate_turn_cost_with_pricing(pricing, input_tokens, output_tokens))
-            .unwrap_or(0.0),
-    })
-}
-
-fn calculate_turn_cost_with_pricing(
-    pricing: CurrencyPricing,
-    input_tokens: u32,
-    output_tokens: u32,
-) -> f64 {
-    let input_cost = (input_tokens as f64 / 1_000_000.0) * pricing.input_cache_miss_per_million;
-    let output_cost = (output_tokens as f64 / 1_000_000.0) * pricing.output_per_million;
-    input_cost + output_cost
-}
-
 /// Calculate cost from provider usage, honoring DeepSeek context-cache fields.
 #[must_use]
 pub fn calculate_turn_cost_from_usage(model: &str, usage: &Usage) -> Option<f64> {
@@ -371,13 +333,6 @@ pub fn calculate_cache_savings_for_provider(
     calculate_cache_savings(model, cache_hit_tokens)
 }
 
-/// Format a USD cost for compact display.
-#[must_use]
-#[allow(dead_code)]
-pub fn format_cost(cost: f64) -> String {
-    format_cost_amount(cost, CostCurrency::Usd)
-}
-
 /// Format a cost amount for compact display in the chosen currency.
 #[must_use]
 pub fn format_cost_amount(cost: f64, currency: CostCurrency) -> String {
@@ -415,7 +370,7 @@ mod tests {
 
     #[test]
     fn nvidia_nim_deepseek_model_does_not_use_deepseek_platform_pricing() {
-        assert!(calculate_turn_cost("deepseek-ai/deepseek-v4-pro", 1_000, 1_000).is_none());
+        assert!(!has_pricing_for_model("deepseek-ai/deepseek-v4-pro"));
     }
 
     #[test]
@@ -644,8 +599,13 @@ mod tests {
 
     #[test]
     fn cost_estimate_calculates_usd_and_cny() {
-        let estimate = calculate_turn_cost_estimate("deepseek-v4-flash", 1_000_000, 500_000)
-            .expect("estimate");
+        let usage = Usage {
+            input_tokens: 1_000_000,
+            output_tokens: 500_000,
+            ..Default::default()
+        };
+        let estimate =
+            calculate_turn_cost_estimate_from_usage("deepseek-v4-flash", &usage).expect("estimate");
 
         assert_eq!(estimate.usd, 0.28);
         assert_eq!(estimate.cny, 2.0);


### PR DESCRIPTION
Fixes #4040

Harvested from #4040 by @DarrellThomas (credit via canonical author + Co-authored-by + AUTHOR_MAP).

## Summary

Removes dead legacy token-only pricing helpers from `crates/tui/src/pricing.rs`:

- `calculate_turn_cost(model, in, out)`
- `calculate_turn_cost_estimate(model, in, out)`
- `calculate_turn_cost_with_pricing(...)` (private helper the two above shared)
- `format_cost(cost)`

Cost accounting now flows exclusively through the usage-aware
`calculate_turn_cost_from_usage` / `calculate_turn_cost_estimate_from_usage`
path (which honors cache-hit/cache-miss telemetry the legacy helpers ignored).
The two tests that only existed to exercise the legacy API were repointed at the
surviving usage-aware / lookup functions (`calculate_turn_cost_estimate_from_usage`,
`has_pricing_for_model`) so coverage is preserved.

No live callers remain: a workspace-wide search confirms nothing references the
removed symbols, and the compiler agrees (build passes). The surviving variants
(`calculate_turn_cost_from_usage`, `calculate_turn_cost_estimate_from_usage`,
`calculate_turn_cost_estimate_for_provider`, `format_cost_amount`,
`format_cost_amount_precise`, `format_cost_estimate`) are untouched. During the
cherry-pick the original diff conflicted only because current `main` had already
dropped the adjacent `input_cost_note` helper; the conflict was resolved to keep
`main`'s state and apply only the intended deletions.

## Verification

- `check-coauthor-trailers.py --check-authors` (exact CI invocation): passed, exit 0.
- `cargo build -p codewhale-tui --locked`: passed.
- `cargo test -p codewhale-tui --all-features --locked`: passed (only the known
  `skill_hotbar_action_*` skill-cache flake failed).
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-features --locked -- -D warnings ...`: clean.
- `cargo test --workspace --all-features --locked`: passed (same known
  skill-cache flake only).
- `cargo build --release`: passed.

Generated with Claude Code
