### PR TITLE
perf(tui): Wave-A micro-optimizations (#4153, #4157, #4151)

### DIFF
--- a/crates/tui/src/tools/git.rs
+++ b/crates/tui/src/tools/git.rs
@@ -278,14 +278,9 @@ fn run_git_command(working_dir: &Path, args: &[String]) -> Result<std::process::
 }
 
 fn format_command(working_dir: &Path, args: &[String]) -> String {
-    format!(
-        "git -C {} {}",
-        working_dir.display(),
-        args.iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(" ")
-    )
+    // `[String]::join` produces the same string as collecting `&str` first, so
+    // join the slice directly and skip the intermediate `Vec<&str>` allocation.
+    format!("git -C {} {}", working_dir.display(), args.join(" "))
 }
 
 fn truncate_with_note(text: &str, max_chars: usize) -> (String, bool, usize) {
@@ -479,6 +474,31 @@ mod tests {
         assert!(result.content.contains(unicode_name));
         assert!(!result.content.contains("\\344"));
         assert!(!result.content.contains("\\320"));
+    }
+
+    #[test]
+    fn format_command_joins_args_without_intermediate_vec() {
+        // Locks the output shape after dropping the collect-before-join
+        // allocation: joining the `&[String]` slice directly must be byte-for-byte
+        // identical to the previous `.map(String::as_str).collect().join(" ")`.
+        let args = vec![
+            "-c".to_string(),
+            "core.quotepath=false".to_string(),
+            "status".to_string(),
+            "--porcelain=v1".to_string(),
+            "-b".to_string(),
+        ];
+        let rendered = format_command(Path::new("/tmp/repo"), &args);
+        assert_eq!(
+            rendered,
+            "git -C /tmp/repo -c core.quotepath=false status --porcelain=v1 -b"
+        );
+
+        // Empty args still render cleanly (trailing space, matching prior behavior).
+        assert_eq!(
+            format_command(Path::new("/tmp/repo"), &[]),
+            "git -C /tmp/repo "
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/tasks.rs
+++ b/crates/tui/src/tools/tasks.rs
@@ -781,6 +781,9 @@ impl ToolSpec for PrAttemptPreflightTool {
         })
         .await
         .map_err(|join_err| {
+            // Surface the otherwise-discarded join error for debugging; the
+            // returned ToolError (and thus user-facing behavior) is unchanged.
+            tracing::debug!(error = %join_err, "git apply --check spawn_blocking task failed to join");
             ToolError::execution_failed(format!("git apply --check panicked: {join_err}"))
         })?
         .map_err(|e| ToolError::execution_failed(format!("git apply --check failed: {e}")))?;
@@ -856,7 +859,12 @@ async fn write_runtime_artifact(
         Ok::<(), std::io::Error>(())
     })
     .await
-    .map_err(|e| ToolError::execution_failed(format!("artifact write task panicked: {e}")))?
+    .map_err(|e| {
+        // Surface the otherwise-discarded join error for debugging; the
+        // returned ToolError (and thus user-facing behavior) is unchanged.
+        tracing::debug!(error = %e, "artifact write spawn_blocking task failed to join");
+        ToolError::execution_failed(format!("artifact write task panicked: {e}"))
+    })?
     .map_err(|e| ToolError::execution_failed(format!("write artifact: {e}")))?;
     Ok(Some(
         absolute
@@ -942,7 +950,12 @@ async fn git_output(workspace: &Path, args: &[&str]) -> Result<String, ToolError
         crate::dependencies::Git::output(&arg_refs, &cwd)
     })
     .await
-    .map_err(|e| ToolError::execution_failed(format!("git task panicked: {e}")))?
+    .map_err(|e| {
+        // Surface the otherwise-discarded join error for debugging; the
+        // returned ToolError (and thus user-facing behavior) is unchanged.
+        tracing::debug!(error = %e, "git spawn_blocking task failed to join");
+        ToolError::execution_failed(format!("git task panicked: {e}"))
+    })?
     .map_err(|e| ToolError::execution_failed(format!("failed to run git: {e}")))?;
     if !out.status.success() {
         return Err(ToolError::execution_failed(format!(


### PR DESCRIPTION
Wave-A mechanical, behavior-identical performance micro-optimizations for the perf umbrella (#4113). Each change was audited to preserve output/behavior exactly; sites that could not be changed safely were left in place and are noted below.

## Fixes #4153 — remove collect-before-join allocations
- `crates/tui/src/tools/git.rs` (`format_command`): replaced
  `args.iter().map(String::as_str).collect::<Vec<_>>().join(" ")` with a direct
  `args.join(" ")` on the `&[String]` slice. `[String]::join(&str)` yields a
  byte-for-byte identical `String`, so this drops the throwaway `Vec<&str>`
  allocation with no output change. Added a `format_command` unit test asserting
  the rendered command string (including the empty-args trailing-space case) is
  unchanged.
- `crates/tui/src/tools/finance.rs` (`finalize_failure`): audited and left as-is.
  Its `failures.iter().map(AttemptFailure::summary).collect::<Vec<_>>().join("; ")`
  maps to owned `String`s, and `std::iter::Iterator` has no `join` (only slices
  implement it), so the `Vec` is genuinely required here — the "legitimately
  needs the Vec" case. No safe allocation to remove.

## Fixes #4157 — log discarded spawn_blocking results
- `crates/tui/src/tools/tasks.rs` (all 3 `spawn_blocking` sites: PR-attempt
  preflight `git apply --check`, runtime-artifact write, and `git_output`):
  added a `tracing::debug!` on each join-error (task-panic) path. The `JoinError`
  was previously formatted into a message and otherwise discarded; it is now also
  surfaced at debug level for observability. Control flow and the returned
  `ToolError` (user-facing behavior) are unchanged — only a debug log line is
  added on the error path, matching the crate's existing `tracing::` convention.

## Refs #4151 — cache lowercased search haystacks (SKIPPED after audit)
Audited both target files and found no per-needle haystack re-lowercasing to
hoist — the described anti-pattern does not exist here, so there is nothing to
cache (and thus no staleness/invalidation risk to weigh):
- `crates/tui/src/tools/file_search.rs`: the query needle is lowercased once
  (`query_norm`) outside the walk loop; inside `score_match` each haystack
  (`rel_path`, `name`) is lowercased exactly once and reused across all
  comparisons; `extension_matches` lowercases the file's extension once against a
  pre-lowercased extension list. Lowercase computations are already hoisted.
- `crates/tui/src/skills/mod.rs`: its only `to_ascii_lowercase` calls are the
  once-per-call locale normalization, frontmatter-key parsing, and name
  slugification — none is a per-needle re-lowercasing of an immutable haystack in
  a search hot loop. Lookups compare against already-normalized names.

## Verification
- `cargo build -p codewhale-tui --locked` — ok
- `cargo test -p codewhale-tui --all-features --locked` — pass except the known
  `skill_hotbar_action_*` env skill-cache flake
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --locked -- -D warnings -A ...` — clean
- `cargo test --workspace --all-features --locked` — pass except the known
  `skill_hotbar_action_*` flake (the known `git_repo_root_reports_attempted_paths_when_no_repo_found`
  failure passed here since git is available)
- `cargo build --release` — ok

Implemented with agent assistance.

Generated with Claude Code
