### PR TITLE
feat(tui): cross-field search in model + provider pickers (#4141)

### DIFF
--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -675,6 +675,13 @@ fn push_model_row(
     rows.push(ModelPickerRow { id, provider, hint });
 }
 
+/// Cross-field search (#4141): match a query against the provider name
+/// (provider key + display name), the display model name, and the wire model
+/// id, mirroring `ProviderDashboardRow::matches_query` so the two pickers behave
+/// consistently. `row.id` is both the model's display name and the id it is
+/// sent to the provider as, so matching it covers the display model name and
+/// the wire model id. The compact hint is only searched for the active
+/// provider / `auto` rows, preserving the existing cross-provider behavior.
 fn model_row_matches_query(
     row: &ModelPickerRow,
     query: &str,
@@ -685,7 +692,7 @@ fn model_row_matches_query(
         return true;
     }
     let provider_matches = row.provider.is_some_and(|provider| {
-        provider.as_str().contains(&query)
+        provider.as_str().to_ascii_lowercase().contains(&query)
             || provider
                 .display_name()
                 .to_ascii_lowercase()
@@ -1666,6 +1673,103 @@ mod tests {
             view.resolved_effort(),
             ReasoningEffort::Medium,
             "OpenAI Codex rows should normalize auto to medium"
+        );
+    }
+
+    /// A cross-provider row used by the #4141 cross-field search tests: an
+    /// active DeepSeek session browsing Z.ai's `z-ai/glm-5.2` route.
+    fn cross_provider_row() -> ModelPickerRow {
+        ModelPickerRow {
+            id: "z-ai/glm-5.2".to_string(),
+            provider: Some(ApiProvider::Zai),
+            hint: "switch route · reasoning".to_string(),
+        }
+    }
+
+    #[test]
+    fn model_row_query_matches_provider_name() {
+        let row = cross_provider_row();
+        // Provider key (`zai`) and human display name (`Zhipu AI / Z.ai`) both
+        // match, even though neither is a substring of the wire model id.
+        assert!(model_row_matches_query(&row, "zai", ApiProvider::Deepseek));
+        assert!(model_row_matches_query(
+            &row,
+            "zhipu",
+            ApiProvider::Deepseek
+        ));
+        // Case-insensitive, matching the provider picker.
+        assert!(model_row_matches_query(
+            &row,
+            "ZHIPU",
+            ApiProvider::Deepseek
+        ));
+    }
+
+    #[test]
+    fn model_row_query_matches_display_model_name() {
+        let row = cross_provider_row();
+        // `row.id` is what the picker renders as the model's display name.
+        assert!(model_row_matches_query(
+            &row,
+            "glm-5.2",
+            ApiProvider::Deepseek
+        ));
+        assert!(model_row_matches_query(&row, "GLM", ApiProvider::Deepseek));
+    }
+
+    #[test]
+    fn model_row_query_matches_wire_model_id() {
+        let row = cross_provider_row();
+        // The full wire id (as sent to the provider) is searchable too, mirroring
+        // the provider picker's route wire-model match (#4141).
+        assert!(model_row_matches_query(
+            &row,
+            "z-ai/glm-5.2",
+            ApiProvider::Deepseek
+        ));
+        assert!(model_row_matches_query(
+            &row,
+            "z-ai/",
+            ApiProvider::Deepseek
+        ));
+    }
+
+    #[test]
+    fn model_row_query_no_field_match_returns_false() {
+        let row = cross_provider_row();
+        // `openai` is in neither the provider name/key, the display model name,
+        // nor the wire id, and the hint is not searched for cross-provider rows,
+        // so the row must not match.
+        assert!(!model_row_matches_query(
+            &row,
+            "openai",
+            ApiProvider::Deepseek
+        ));
+    }
+
+    #[test]
+    fn picker_query_by_wire_id_surfaces_cross_provider_row_and_hides_others() {
+        let (mut app, config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+
+        let mut view = ModelPickerView::new(&app, &config);
+        // A GLM model id belongs to Z.ai; searching it surfaces that route while
+        // a query that matches no provider/model/wire field yields no rows.
+        type_model_query(&mut view, "glm");
+        assert!(
+            view.visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Zai)),
+            "searching a model name must surface the provider that serves it"
+        );
+
+        view.update_query(String::new());
+        type_model_query(&mut view, "zzz-no-such-provider-or-model");
+        assert!(
+            view.visible_model_rows().is_empty(),
+            "a query matching no provider/model/wire field must return no rows"
         );
     }
 

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -595,8 +595,12 @@ impl ProviderDashboardRow {
         }
     }
 
-    /// Cross-field search (#3830 P1): match a query against display name,
-    /// provider id, kind, base URL, and the compact hint fields.
+    /// Cross-field search (#3830 P1, #4141): match a query against the provider
+    /// name (display name, provider id, kind, provider key), the base URL, and
+    /// the default route's display model name and wire model id. Matching the
+    /// route means a model name or wire id surfaces the provider that serves it,
+    /// keeping this picker consistent with the model picker's cross-field search
+    /// (`model_row_matches_query`).
     fn matches_query(&self, query: &str) -> bool {
         let query = query.trim().to_ascii_lowercase();
         if query.is_empty() {
@@ -607,6 +611,16 @@ impl ProviderDashboardRow {
             || self.kind.to_ascii_lowercase().contains(&query)
             || self.base_url.to_ascii_lowercase().contains(&query)
             || self.provider.as_str().to_ascii_lowercase().contains(&query)
+            || self
+                .default_route
+                .logical_model
+                .to_ascii_lowercase()
+                .contains(&query)
+            || self
+                .default_route
+                .wire_model
+                .to_ascii_lowercase()
+                .contains(&query)
     }
 }
 
@@ -2677,6 +2691,35 @@ mod tests {
         assert_eq!(row.reasoning.selected_control.as_deref(), Some("max"));
         assert!(row.compact_hint().contains("reasoning:high/max"));
         assert!(row.compact_hint().contains("stream:structured"));
+    }
+
+    #[test]
+    fn provider_row_query_matches_default_route_model_and_wire_id() {
+        // #4141: cross-field search must also match the default route's display
+        // model name and wire model id, keeping this picker consistent with the
+        // model picker (`model_row_matches_query`). Z.ai's provider key,
+        // display name, kind, and base URL contain no "glm", so a "glm" match
+        // can only come from the route's model/wire fields.
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                zai: crate::config::ProviderConfig {
+                    api_key: Some("zai-key".to_string()),
+                    model: Some("GLM-5.2".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let row = ProviderDashboardRow::from_config(ApiProvider::Zai, ApiProvider::Zai, &config);
+        assert_eq!(row.default_route.wire_model, "GLM-5.2");
+
+        // Wire model id + display model name, case-insensitively.
+        assert!(row.matches_query("glm-5.2"));
+        assert!(row.matches_query("GLM"));
+        // Provider name still matches, and an unrelated token still does not.
+        assert!(row.matches_query("zhipu"));
+        assert!(!row.matches_query("anthropic"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #4141

## Summary
Completes cross-field search across **provider name**, **display model name**, and **wire model id** in *both* the model picker and the provider picker, so the two pickers behave consistently.

### What now matches
- **Model picker** (`model_row_matches_query`): already matched the provider key, the provider display name, and `row.id` — which in the model picker is *both* the displayed model name and the id sent to the provider (its wire id). Made case handling consistent with the provider picker by lowercasing the provider key before comparing (everything else was already `to_ascii_lowercase()` + substring).
- **Provider picker** (`ProviderDashboardRow::matches_query`): now *also* searches the default route's **display model name** (`logical_model`) and **wire model id** (`wire_model`), in addition to the existing provider name / id / kind / base URL / provider key. This means a model name or wire id now surfaces the provider that serves it — aligning the code with its own doc comment ("the compact hint fields") and with the model picker.

### Consistency
Both matchers use identical semantics: trim, `to_ascii_lowercase()`, case-insensitive substring across the relevant fields. A query that matches a provider name / model name / wire id in one picker matches the analogous field in the other.

## Acceptance criteria
- [x] Search matches provider name, display model name, and wire model id.
- [x] Search behavior is consistent between the provider and model pickers.
- [x] Disclosure stays trimmed/readable in dense/narrow layouts — only the *matching* logic changed; rendering/truncation is untouched (existing `narrow_picker_rows_hide_hint_before_clipping_model_id` stays green).

## Tests
- `model_row_query_matches_provider_name` — matches by provider key and display name.
- `model_row_query_matches_display_model_name` — matches by the displayed model name.
- `model_row_query_matches_wire_model_id` — matches by the full wire id.
- `model_row_query_no_field_match_returns_false` + `picker_query_by_wire_id_surfaces_cross_provider_row_and_hides_others` — a non-matching query returns no rows; a model-name query surfaces the serving provider's route.
- `provider_row_query_matches_default_route_model_and_wire_id` — the provider picker now matches its route model/wire id (consistency lock).

## Verification
`cargo build -p codewhale-tui --locked`, `cargo test -p codewhale-tui --all-features --locked`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --locked -- -D warnings ...`, `cargo test --workspace --all-features --locked`, and `cargo build --release` all pass. The only failing test is the known pre-existing `skill_hotbar_action_*` env/skill-cache flake.

Guards respected: no module/struct/fn renames, no `DEEPSEEK*` env changes, no provider/model inference, no provider privileging, no `crates/config` edits — TUI-only.

Generated with Claude Code
