### PR TITLE
perf(tui): hot linear scans → map lookups (#4152)

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1587,6 +1587,41 @@ fn non_yolo_mode_retains_default_defer_policy() {
 }
 
 #[test]
+fn default_defer_lookup_matches_linear_scan_over_active_native_tools() {
+    // Parity guard for #4152: `should_default_defer_tool` now consults an O(1)
+    // side set built from DEFAULT_ACTIVE_NATIVE_TOOLS instead of a linear
+    // `.iter().any(...)` scan. Assert the set returns the SAME hit/miss as an
+    // explicit linear scan over the ordered array — every array member is a hit
+    // (not deferred); names outside the array miss (deferred by default).
+    let always_load = HashSet::new();
+    let active = default_active_native_tool_names();
+
+    for name in active {
+        // Reference linear scan == what the converted lookup must agree with.
+        let linear_hit = active.iter().any(|core| core == name);
+        assert!(linear_hit, "reference scan should find array member {name}");
+        assert!(
+            !should_default_defer_tool(name, &always_load),
+            "array member {name} must stay active (not deferred)"
+        );
+    }
+
+    for name in [
+        "git_blame",
+        "task_shell_start",
+        REQUEST_USER_INPUT_NAME,
+        "definitely_not_a_tool",
+    ] {
+        let linear_hit = active.iter().any(|core| *core == name);
+        assert!(!linear_hit, "non-member {name} should be absent from array");
+        assert!(
+            should_default_defer_tool(name, &always_load),
+            "non-member {name} must default to deferred"
+        );
+    }
+}
+
+#[test]
 fn model_tool_catalog_applies_native_and_mcp_deferral() {
     let always_load = HashSet::new();
     let catalog = build_model_tool_catalog(

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -125,6 +125,21 @@ fn cached_fallbacks() -> &'static [CachedFallback] {
     })
 }
 
+/// Membership index over [`DEFAULT_ACTIVE_NATIVE_TOOLS`], built once for the
+/// process lifetime. The array stays the source of truth for *ordered*
+/// iteration (see [`tool_catalog_consistency_issues`] and
+/// `engine::default_active_native_tool_names`); this set only accelerates the
+/// hot membership check in [`should_default_defer_tool`], which runs once per
+/// catalog tool on every catalog rebuild (i.e. per turn) — an O(n·m) linear
+/// scan over the array collapses to O(1) hashed lookups.
+static DEFAULT_ACTIVE_NATIVE_TOOLS_SET: std::sync::OnceLock<HashSet<&'static str>> =
+    std::sync::OnceLock::new();
+
+fn default_active_native_tools_set() -> &'static HashSet<&'static str> {
+    DEFAULT_ACTIVE_NATIVE_TOOLS_SET
+        .get_or_init(|| DEFAULT_ACTIVE_NATIVE_TOOLS.iter().copied().collect())
+}
+
 pub(super) fn should_default_defer_tool(name: &str, always_load: &HashSet<String>) -> bool {
     if always_load.contains(name) {
         return false;
@@ -134,9 +149,10 @@ pub(super) fn should_default_defer_tool(name: &str, always_load: &HashSet<String
         return false;
     }
 
-    !DEFAULT_ACTIVE_NATIVE_TOOLS
-        .iter()
-        .any(|core_tool| core_tool == &name)
+    // Membership-only test (no ordering dependency): the side set built from
+    // DEFAULT_ACTIVE_NATIVE_TOOLS returns identical hit/miss results as the
+    // former `.iter().any(...)` linear scan.
+    !default_active_native_tools_set().contains(name)
 }
 
 pub(super) fn apply_native_tool_deferral(catalog: &mut [Tool], always_load: &HashSet<String>) {


### PR DESCRIPTION
Fixes #4152

## Summary
Perf-only (behavior-identical) pass over the three candidate files for issue #4152: replace hot linear `Vec`/slice scans that are repeatedly queried by a stable key with an O(1) map lookup, where — and only where — building the map genuinely amortizes.

One genuinely hot site was converted; the other candidate scans were audited and left as linear scans because converting them would be neutral or slower.

## Per-file audit

### `crates/tui/src/core/engine/tool_catalog.rs` — CONVERTED
- **`should_default_defer_tool` → membership over `DEFAULT_ACTIVE_NATIVE_TOOLS`.** Was `!DEFAULT_ACTIVE_NATIVE_TOOLS.iter().any(|core_tool| core_tool == &name)` — a linear scan of a 28-element array. `apply_native_tool_deferral` calls this **once per native catalog tool**, and the catalog is rebuilt **every turn** (`build_model_tool_catalog_with_surface`, called from `engine.rs` `handle_deepseek_turn`), so the real cost was O(catalog_len × 28) per turn. Converted to an O(1) `contains` against a process-lifetime `OnceLock<HashSet<&'static str>>` side index (`default_active_native_tools_set()`). The `OnceLock` builds the set once for the whole process, so it amortizes across every turn/tool rather than per-call.
- **Ordering preserved:** the `DEFAULT_ACTIVE_NATIVE_TOOLS` array is kept as the source of truth for *ordered* iteration (`tool_catalog_consistency_issues` iterates it; `engine::default_active_native_tool_names()` returns it). Only a side `HashSet` is added; the membership test carries no ordering dependency, so results are hit/miss-identical.
- Left as-is: `catalog_contains_tool` (used in `unavailable_core_action_tools_*`) loops over only 4 cached fallbacks, and runs solely on a `tool_search` invocation — not hot enough to justify a per-call name set. `tool_catalog_consistency_issues`, `active_tool_list_from_catalog`, and `initial_active_tools` already use `HashSet`s.

### `crates/tui/src/features.rs` — LEFT AS-IS
- `Feature::info`, `is_known_feature_key`, `feature_from_key`, `feature_spec_by_key` all scan `FEATURES`, but it is a **7-element** compile-time constant and the lookups run at config-load / deserialization time, not per-turn. `apply_map` loops config entries calling `feature_from_key`, but over 7 static entries and once at load. Building a `HashMap` for 7 entries queried a handful of times would be slower, not faster. No hot repeated-key path here.

### `crates/tui/src/core/engine/turn_loop.rs` — LEFT AS-IS
- `resolve_tool_definition` (`tool_catalog.iter().find(|d| d.name == …)`) is called once per tool in the per-batch `tool_uses` loop. Batches are frequently a **single** tool call, so a per-batch `HashMap` build would be a net loss for the common case (the issue explicitly says one-off lookups should stay linear scans). Left as a linear scan.
- `command_allows_tool` / `command_denies_tool` scan user `allowed_tools`/`disallowed_tools` rule lists, but matching supports trailing-`*` **wildcards** (`rule.strip_suffix('*')`) — there is no pure stable key to hash, so a set/map is not applicable.
- `fold_tool_call_before_results`, the `plans.iter().any/filter`, and `content_blocks.iter().any` scans are each one-off passes over a batch, not repeated keyed lookups.

## Tests
Added `default_defer_lookup_matches_linear_scan_over_active_native_tools` (in `core/engine/tests.rs`): asserts the new side-set lookup returns the **same hit/miss** as an explicit linear scan over the ordered array — every array member is a hit (not deferred), and names outside the array (plus `request_user_input`) miss (deferred). The pre-existing `core_native_tools_stay_loaded_in_yolo_mode` / `non_yolo_mode_retains_default_defer_policy` tests continue to exercise the converted function.

## Verification (CI gate, from worktree root)
- `cargo build -p codewhale-tui --locked` — ok
- `cargo test -p codewhale-tui --all-features --locked` — ok except the known `skill_hotbar_action_*` env skill-cache flake
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --locked -- -D warnings …` — clean
- `cargo test --workspace --all-features --locked` — ok except the same known `skill_hotbar_action_*` flake
- `cargo build --release` — ok

Generated with Claude Code
