### PR TITLE
feat(tui): export compact turn handoff from Turn Inspector (#4108)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -117,7 +117,7 @@
     "CmdDiffDescription": "Show file changes since session start",
     "CmdEditDescription": "Revise and resubmit the last message",
     "CmdExitDescription": "Exit the application",
-    "CmdExportDescription": "Export conversation to markdown",
+    "CmdExportDescription": "Export conversation to markdown (/export turn copies a compact turn handoff)",
     "CmdFeedbackDescription": "Generate a GitHub feedback URL",
     "CmdHfDescription": "Inspect Hugging Face MCP setup and concepts",
     "CmdHelpDescription": "Show help information",

--- a/crates/tui/src/commands/groups/session/export.rs
+++ b/crates/tui/src/commands/groups/session/export.rs
@@ -9,7 +9,7 @@ use super::CommandResult;
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "export",
     aliases: &["daochu"],
-    usage: "/export [path]",
+    usage: "/export [turn|path]",
     description_id: MessageId::CmdExportDescription,
 };
 

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -311,8 +311,23 @@ pub fn purge(_app: &mut App) -> CommandResult {
     )
 }
 
-/// Export conversation to markdown
+/// Export conversation to markdown.
+///
+/// `/export turn [path]` is a distinct sub-mode (issue #4108): it produces a
+/// compact, pasteable Markdown *handoff* of the current/latest turn — reusing
+/// the Turn Inspector's (#4104) turn scope + section data — and copies it to the
+/// clipboard by default (writing to `path` instead when one is given). Every
+/// other invocation is the existing full-transcript Markdown export.
 pub fn export(app: &mut App, path: Option<&str>) -> CommandResult {
+    if let Some(arg) = path {
+        let mut parts = arg.splitn(2, char::is_whitespace);
+        let first = parts.next().unwrap_or("");
+        if first.eq_ignore_ascii_case("turn") {
+            let dest = parts.next().map(str::trim).filter(|s| !s.is_empty());
+            return export_turn_handoff(app, dest);
+        }
+    }
+
     let export_path = path.map_or_else(
         || {
             let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
@@ -361,6 +376,49 @@ pub fn export(app: &mut App, path: Option<&str>) -> CommandResult {
     match std::fs::write(&export_path, content) {
         Ok(()) => CommandResult::message(format!("Exported to {}", export_path.display())),
         Err(e) => CommandResult::error(format!("Failed to export: {e}")),
+    }
+}
+
+/// Produce the compact turn handoff (issue #4108) and surface it the way the
+/// app already surfaces exports.
+///
+/// Without a `dest`, the Markdown is copied to the system clipboard so it is
+/// immediately pasteable into a PR/issue/Slack/next session (the primary intent
+/// of the issue); if the clipboard is unavailable it falls back to a timestamped
+/// file so the artifact is never lost. With a `dest`, the Markdown is written
+/// there — matching `/export`'s file-write convention. The Markdown itself is
+/// assembled by [`crate::tui::ui::turn_handoff_markdown`], which reuses the Turn
+/// Inspector's turn scope and per-section data.
+fn export_turn_handoff(app: &mut App, dest: Option<&str>) -> CommandResult {
+    let markdown = crate::tui::ui::turn_handoff_markdown(app);
+
+    if let Some(dest) = dest {
+        let path = PathBuf::from(dest);
+        return match std::fs::write(&path, &markdown) {
+            Ok(()) => CommandResult::message(format!("Turn handoff written to {}", path.display())),
+            Err(e) => CommandResult::error(format!("Failed to write turn handoff: {e}")),
+        };
+    }
+
+    if app.clipboard.write_text(&markdown).is_ok() {
+        let lines = markdown.lines().count();
+        return CommandResult::message(format!(
+            "Turn handoff copied to clipboard ({lines} lines) — paste into a PR, issue, or Slack"
+        ));
+    }
+
+    // Clipboard unavailable (e.g. headless host): persist the artifact so the
+    // handoff is still recoverable rather than silently lost.
+    let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+    let path = PathBuf::from(format!("turn_handoff_{timestamp}.md"));
+    match std::fs::write(&path, &markdown) {
+        Ok(()) => CommandResult::message(format!(
+            "Clipboard unavailable — turn handoff written to {}",
+            path.display()
+        )),
+        Err(e) => {
+            CommandResult::error(format!("Turn handoff clipboard and file write failed: {e}"))
+        }
     }
 }
 
@@ -949,6 +1007,56 @@ mod tests {
         assert!(content.contains("**Model:**"));
         assert!(content.contains("**You:**"));
         assert!(content.contains("**Assistant:**"));
+    }
+
+    #[test]
+    fn export_turn_writes_compact_handoff_to_path() {
+        // `/export turn <path>` (issue #4108) writes the compact turn handoff
+        // to a file rather than copying to the clipboard, so this stays
+        // deterministic without touching the system clipboard.
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.history.push(HistoryCell::User {
+            content: "Fix the flaky login test".to_string(),
+        });
+        app.history.push(HistoryCell::Tool(
+            crate::tui::history::ToolCell::PatchSummary(crate::tui::history::PatchSummaryCell {
+                path: "src/login.rs".to_string(),
+                summary: "guard against empty token".to_string(),
+                status: crate::tui::history::ToolStatus::Success,
+                error: None,
+            }),
+        ));
+        app.history.push(HistoryCell::Assistant {
+            content: "Fixed the race in the login test.".to_string(),
+            streaming: false,
+        });
+        app.runtime_turn_status = Some("completed".to_string());
+
+        let out_path = tmpdir.path().join("handoff.md");
+        let result = export(&mut app, Some(&format!("turn {}", out_path.display())));
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Turn handoff written to"),
+            "{:?}",
+            result.message
+        );
+        let md = std::fs::read_to_string(&out_path).unwrap();
+        assert!(md.contains("# Turn handoff"), "{md}");
+        assert!(md.contains("## Intent"), "{md}");
+        assert!(md.contains("Fix the flaky login test"), "{md}");
+        assert!(md.contains("## Files changed"), "{md}");
+        assert!(md.contains("src/login.rs"), "{md}");
+        assert!(md.contains("## Result / status"), "{md}");
+        assert!(
+            md.contains("Result: Fixed the race in the login test."),
+            "{md}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/pager.rs
+++ b/crates/tui/src/tui/pager.rs
@@ -44,6 +44,10 @@ pub struct PagerView {
     /// keys (Ctrl+D/U, Ctrl+F/B, Space, etc.) to compute scroll deltas
     /// without access to the render area.
     last_visible_height: Cell<usize>,
+    /// Optional compact Markdown artifact surfaced by the `e` key. Set for the
+    /// Turn Inspector pager (#4108) so `e` copies a pasteable turn handoff;
+    /// `None` for every other pager, where `e` stays inert.
+    export_markdown: Option<String>,
 }
 
 impl PagerView {
@@ -60,7 +64,16 @@ impl PagerView {
             search_mode: false,
             pending_g: false,
             last_visible_height: Cell::new(0),
+            export_markdown: None,
         }
+    }
+
+    /// Attach a compact Markdown export (e.g. the #4108 turn handoff) that the
+    /// `e` key copies to the clipboard. Only the Turn Inspector pager sets this;
+    /// other pagers leave `e` inert.
+    pub fn with_export_markdown(mut self, markdown: impl Into<String>) -> Self {
+        self.export_markdown = Some(markdown.into());
+        self
     }
 
     pub fn from_text(title: impl Into<String>, text: &str, width: u16) -> Self {
@@ -352,6 +365,17 @@ impl ModalView for PagerView {
                     label: "Pager content".to_string(),
                 })
             }
+            // `e` exports the compact turn handoff (#4108) when this pager
+            // carries one — the Turn Inspector. Elsewhere the guard fails and
+            // `e` falls through to the inert arm below.
+            KeyCode::Char('e') | KeyCode::Char('E') if self.export_markdown.is_some() => {
+                self.pending_g = false;
+                let text = self.export_markdown.clone().unwrap_or_default();
+                ViewAction::Emit(ViewEvent::CopyToClipboard {
+                    text,
+                    label: "Turn handoff".to_string(),
+                })
+            }
             _ => ViewAction::None,
         }
     }
@@ -395,19 +419,19 @@ impl ModalView for PagerView {
 
         // The wrapping action footer is anchored to the bottom of the inner
         // area; the body fills the rows above it.
-        let content = render_modal_footer(
-            inner,
-            buf,
-            &[
-                ActionHint::new("q/Esc", "close"),
-                ActionHint::new("j/k", "scroll"),
-                ActionHint::new("Space", "page"),
-                ActionHint::new("Ctrl+D/U", "half"),
-                ActionHint::new("g/G", "top/bottom"),
-                ActionHint::new("/", "search"),
-                ActionHint::new("c", "copy"),
-            ],
-        );
+        let mut hints = vec![
+            ActionHint::new("q/Esc", "close"),
+            ActionHint::new("j/k", "scroll"),
+            ActionHint::new("Space", "page"),
+            ActionHint::new("Ctrl+D/U", "half"),
+            ActionHint::new("g/G", "top/bottom"),
+            ActionHint::new("/", "search"),
+            ActionHint::new("c", "copy"),
+        ];
+        if self.export_markdown.is_some() {
+            hints.push(ActionHint::new("e", "copy handoff"));
+        }
+        let content = render_modal_footer(inner, buf, &hints);
 
         // `content` already excludes the border, padding, and footer rows.
         let mut visible_height = content.height as usize;
@@ -823,6 +847,32 @@ mod tests {
             matches!(action, ViewAction::Emit(ViewEvent::CopyToClipboard { .. })),
             "y must emit a copy event for vim-yank parity"
         );
+    }
+
+    #[test]
+    fn e_exports_turn_handoff_when_attached() {
+        // #4108: the Turn Inspector pager carries a compact Markdown handoff;
+        // `e` copies that artifact (not the visible inspector body) to the
+        // clipboard via the host dispatcher.
+        let mut p = make_pager(3).with_export_markdown("# Turn handoff\n\n## Intent\ndo the thing");
+        let action = p.handle_key(key(KeyCode::Char('e')));
+        match action {
+            ViewAction::Emit(ViewEvent::CopyToClipboard { text, label }) => {
+                assert!(text.contains("# Turn handoff"), "handoff text: {text}");
+                assert_eq!(label, "Turn handoff");
+            }
+            other => panic!("expected CopyToClipboard emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn e_is_inert_without_an_attached_handoff() {
+        // Every other pager leaves `e` unbound so it never surprises the user.
+        let mut p = make_pager(3);
+        assert!(matches!(
+            p.handle_key(key(KeyCode::Char('e'))),
+            ViewAction::None
+        ));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -151,7 +151,7 @@ use super::widgets::{ChatWidget, ComposerWidget, HeaderData, HeaderWidget, Rende
 // import the ui-internal entry points used from this file's own body.
 pub(crate) use self::activity_detail::{
     copy_cell_to_clipboard, detail_target_label, open_details_pager_for_cell,
-    selected_detail_footer_label,
+    selected_detail_footer_label, turn_handoff_markdown,
 };
 use self::activity_detail::{
     copy_focused_cell, detail_target_cell_index, extract_reasoning_header, open_tool_details_pager,

--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -809,11 +809,14 @@ pub(super) fn open_turn_inspector_pager(app: &mut App) -> bool {
         .map(|area| area.width)
         .unwrap_or(80);
     let text = turn_inspector_text(app);
-    app.view_stack.push(PagerView::from_text(
-        "Turn Inspector",
-        &text,
-        width.saturating_sub(2),
-    ));
+    // Precompute the compact Markdown handoff (#4108) and attach it so the
+    // pager's `e` key can copy a pasteable artifact without reaching back into
+    // `app`. Reuses the same turn scope + section data as the overview above.
+    let handoff = turn_handoff_markdown(app);
+    app.view_stack.push(
+        PagerView::from_text("Turn Inspector", &text, width.saturating_sub(2))
+            .with_export_markdown(handoff),
+    );
     true
 }
 
@@ -894,6 +897,109 @@ pub(super) fn turn_inspector_text(app: &App) -> String {
     );
 
     out.join("\n")
+}
+
+/// Build a compact, pasteable Markdown handoff of the current/latest turn
+/// (issue #4108).
+///
+/// Reuses the exact same turn scope (`current_turn_range`) and the same
+/// per-section data helpers as the Turn Inspector (#4104), so the handoff can
+/// never drift from what Ctrl+O shows — it only re-renders that data as
+/// Markdown headings + bullets instead of the inspector's box-drawn rules.
+/// Unavailable sections degrade to a short `—` (and the optional Plan section
+/// is dropped entirely when empty) so the artifact stays paste-ready without
+/// leaving a heading over a blank void — the same graceful-degrade contract the
+/// inspector already follows.
+pub(crate) fn turn_handoff_markdown(app: &App) -> String {
+    let (start, end) = current_turn_range(app);
+    let mut out: Vec<String> = Vec::new();
+
+    // Title + identity — turn id when known, else the turn counter, else a
+    // bare heading so an empty transcript still yields a coherent artifact.
+    let heading = if let Some(turn_id) = app.runtime_turn_id.as_ref() {
+        format!("# Turn handoff — {}", truncate_line_to_width(turn_id, 48))
+    } else if app.turn_counter > 0 {
+        format!("# Turn handoff — Turn #{}", app.turn_counter)
+    } else {
+        "# Turn handoff".to_string()
+    };
+    out.push(heading);
+
+    let status = match app.runtime_turn_status.as_deref() {
+        Some("in_progress") => "in progress",
+        Some(other) => other,
+        None => "idle",
+    };
+    out.push(format!(
+        "_Status: {status} · generated {}_",
+        chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+    ));
+
+    push_md_section(&mut out, "Intent", vec![turn_intent_line(app, start)]);
+
+    // Plan/checklist is optional context: include it only when a plan or todo
+    // list actually ran, to keep the handoff compact.
+    let plan = turn_plan_lines(app);
+    if !plan.is_empty() {
+        push_md_section(&mut out, "Plan / checklist", md_bullets(plan));
+    }
+
+    push_md_section(
+        &mut out,
+        "Files changed",
+        md_bullets(turn_files_changed(app, start, end)),
+    );
+    push_md_section(
+        &mut out,
+        "Commands & tools",
+        md_bullets(turn_tool_timeline(app, start, end)),
+    );
+    push_md_section(
+        &mut out,
+        "Tests / verifier",
+        md_bullets(turn_verifier_lines(app, start, end)),
+    );
+    push_md_section(
+        &mut out,
+        "Model route + tokens/cost",
+        md_bullets(turn_route_lines(app)),
+    );
+    push_md_section(
+        &mut out,
+        "Result / status",
+        md_bullets(turn_result_lines(app, start, end)),
+    );
+
+    // Trailing newline keeps the artifact clean when pasted into a PR body.
+    out.push(String::new());
+    out.join("\n")
+}
+
+/// Append a `## Title` Markdown section. An empty body degrades to a single
+/// `—` line so a heading is never followed by a void — the Markdown analogue
+/// of [`push_section`]'s `none` degrade.
+fn push_md_section(out: &mut Vec<String>, title: &str, body: Vec<String>) {
+    out.push(String::new());
+    out.push(format!("## {title}"));
+    if body.is_empty() {
+        out.push("—".to_string());
+    } else {
+        out.extend(body);
+    }
+}
+
+/// Convert Turn Inspector section lines into Markdown bullet rows. Inspector
+/// list helpers prefix rows with `• `; swap that for `- `, and bullet the
+/// key/value rows (route, tokens, status) too so the whole section is valid
+/// Markdown.
+fn md_bullets(lines: Vec<String>) -> Vec<String> {
+    lines
+        .into_iter()
+        .map(|line| {
+            let body = line.strip_prefix("• ").unwrap_or(line.as_str());
+            format!("- {body}")
+        })
+        .collect()
 }
 
 /// Append a `── Title ──` section. An empty body degrades to a single

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10178,6 +10178,95 @@ fn ctrl_o_open_turn_inspector_pager_opens_turn_overview_not_single_cell() {
 }
 
 #[test]
+fn turn_handoff_markdown_renders_compact_sections_for_active_turn() {
+    // Same committed turn as the inspector test: prompt, a verifier command, a
+    // patch, and a final reply. The handoff must reuse that turn's scope +
+    // section data and render it as compact Markdown headings/bullets.
+    let mut app = create_test_app();
+    app.history = vec![
+        HistoryCell::User {
+            content: "Fix the flaky login test".to_string(),
+        },
+        HistoryCell::Tool(ToolCell::Exec(ExecCell {
+            command: "cargo test login".to_string(),
+            status: ToolStatus::Success,
+            output: Some("ok".to_string()),
+            live_output: None,
+            shell_task_id: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+            started_at: None,
+            duration_ms: Some(2400),
+            source: ExecSource::Assistant,
+            interaction: None,
+            output_summary: None,
+        })),
+        HistoryCell::Tool(ToolCell::PatchSummary(
+            crate::tui::history::PatchSummaryCell {
+                path: "src/login.rs".to_string(),
+                summary: "guard against empty token".to_string(),
+                status: ToolStatus::Success,
+                error: None,
+            },
+        )),
+        HistoryCell::Assistant {
+            content: "Fixed the race in the login test.".to_string(),
+            streaming: false,
+        },
+    ];
+    app.runtime_turn_id = Some("turn_abc123456789".to_string());
+    app.runtime_turn_status = Some("completed".to_string());
+
+    let md = turn_handoff_markdown(&app);
+
+    // Title carries the turn id.
+    assert!(md.contains("# Turn handoff — turn_abc123456789"), "{md}");
+    // Markdown section headings for the issue's required sections.
+    for heading in [
+        "## Intent",
+        "## Files changed",
+        "## Commands & tools",
+        "## Tests / verifier",
+        "## Model route + tokens/cost",
+        "## Result / status",
+    ] {
+        assert!(md.contains(heading), "missing heading {heading}: {md}");
+    }
+    // Populated content: intent, changed file, verifier command, route, result.
+    assert!(md.contains("Fix the flaky login test"), "{md}");
+    assert!(md.contains("- src/login.rs"), "changed file bullet: {md}");
+    assert!(md.contains("cargo test login"), "{md}");
+    assert!(md.contains("Route: DeepSeek"), "route missing: {md}");
+    assert!(
+        md.contains("Result: Fixed the race in the login test."),
+        "{md}"
+    );
+    assert!(md.contains("Status: completed"), "{md}");
+}
+
+#[test]
+fn turn_handoff_markdown_degrades_empty_sections_without_panic() {
+    // A minimal turn: only a user prompt. Empty sections must degrade to `—`
+    // (never a heading over a void), and the optional Plan section is omitted.
+    let mut app = create_test_app();
+    app.history = vec![HistoryCell::User {
+        content: "hello".to_string(),
+    }];
+    app.runtime_turn_status = Some("in_progress".to_string());
+
+    let md = turn_handoff_markdown(&app);
+
+    assert!(md.contains("## Files changed\n—"), "{md}");
+    assert!(md.contains("## Tests / verifier\n—"), "{md}");
+    // The optional plan section is dropped entirely when no plan ran.
+    assert!(!md.contains("## Plan / checklist"), "{md}");
+    // Intent still resolves; status reflects the live turn.
+    assert!(md.contains("## Intent\nhello"), "{md}");
+    assert!(md.contains("Status: in progress"), "{md}");
+    assert!(md.contains("Result: turn still running"), "{md}");
+}
+
+#[test]
 fn engine_error_finalizes_active_thinking_block() {
     use crate::error_taxonomy::StreamError;
 


### PR DESCRIPTION
Fixes #4108

## Summary
Adds a compact, pasteable Markdown **turn handoff** of the current/latest turn, built on the Turn Inspector (#4104).

**Command:** `/export turn` (a sub-mode of the existing `/export`; usage is now `/export [turn|path]`).
- **Output mechanism:** copies the handoff to the **system clipboard** by default (the issue emphasizes "pasteable" — paste into a PR/issue/Slack/next session), surfacing a confirmation message. `/export turn <path>` writes it to a file instead, matching `/export`'s existing file-write convention. If the clipboard is unavailable (e.g. headless host) it falls back to a timestamped `turn_handoff_*.md` file so the artifact is never lost. Existing `/export` (full-transcript markdown) is unchanged.

**Sections** (Markdown headings + bullets, degrade to `—` / omit when empty):
- turn id/title + generated timestamp + status
- Intent (user prompt)
- Plan / checklist (only when a plan/todo ran)
- Files changed (patch/diff summary)
- Commands & tools (tool timeline + status/duration)
- Tests / verifier (verifier-shaped commands + reviews)
- Model route + tokens/cost
- Result / status (final assistant reply, errors)

## Reuse of the Turn Inspector logic
A new shared `turn_handoff_markdown(app) -> String` in `activity_detail.rs` reuses the **exact same** turn scope (`current_turn_range`) and per-section data helpers (`turn_intent_line`, `turn_files_changed`, `turn_tool_timeline`, `turn_verifier_lines`, `turn_route_lines`, `turn_result_lines`, `turn_plan_lines`) that `turn_inspector_text` uses — it only re-renders that data as Markdown headings/bullets instead of the inspector's box-drawn rules. The two surfaces cannot drift.

## In-pager `e` action — **added**
The open Turn Inspector pager now binds **`e`** to copy the same handoff. Implemented cleanly: `PagerView` gains an optional `export_markdown` payload (set only for the Turn Inspector via a `with_export_markdown` builder), and `e` emits the existing `ViewEvent::CopyToClipboard` — no new event type or event-loop change. The footer shows an `e copy handoff` hint only when a handoff is attached; `e` stays inert in every other pager.

## Tests
- `turn_handoff_markdown_renders_compact_sections_for_active_turn` — headings + intent/files/verifier/route/result content.
- `turn_handoff_markdown_degrades_empty_sections_without_panic` — empty sections render `—`, optional plan omitted, no panic.
- `export_turn_writes_compact_handoff_to_path` — `/export turn <path>` writes the expected Markdown.
- `e_exports_turn_handoff_when_attached` / `e_is_inert_without_an_attached_handoff` — pager key behavior.

## Verification
`cargo build -p codewhale-tui --locked`, `cargo fmt --all -- --check`, clippy under `RUSTFLAGS=-Dwarnings` (workspace, all-features, with the CI's allow-list), `cargo test -p codewhale-tui --all-features`, `cargo test --workspace --all-features`, and `cargo build --release` all pass. Only the known pre-existing `skill_hotbar_action_*` env skill-cache flake fails (6107 passed / 1 failed), which is in the accepted-failures list.

Generated with Claude Code