### PR TITLE
tui: enrich Turn Inspector timeline (#4106)

### DIFF
--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -184,6 +184,23 @@ __pycache__/
 ";
 
 impl SnapshotRepo {
+    /// Open an existing snapshot repo for `workspace` without creating or
+    /// initializing anything on disk.
+    ///
+    /// This is useful for read-only UI surfaces that want to report checkpoint
+    /// availability without paying the first-init size walk or surprising the
+    /// user by creating a side repo from a view action.
+    pub fn open_existing(workspace: &Path) -> io::Result<Option<Self>> {
+        let work_tree = workspace
+            .canonicalize()
+            .unwrap_or_else(|_| workspace.to_path_buf());
+        let git_dir = snapshot_git_dir(&work_tree);
+        if !git_dir.exists() || !git_dir.join("HEAD").exists() {
+            return Ok(None);
+        }
+        Ok(Some(Self { git_dir, work_tree }))
+    }
+
     /// Open or initialize the snapshot repo for `workspace`.
     ///
     /// On first use this:
@@ -1011,6 +1028,28 @@ mod tests {
         // The user's workspace must NOT have a real `.git` because we
         // never created one in their workspace — only in the side dir.
         assert!(!repo.work_tree().join(".git").exists());
+    }
+
+    #[test]
+    fn open_existing_is_read_only_and_does_not_initialize() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let _home = scoped_home(tmp.path());
+
+        let before = SnapshotRepo::open_existing(&workspace).expect("open existing");
+        assert!(before.is_none());
+        assert!(
+            !snapshot_git_dir(&workspace).exists(),
+            "read-only open must not create the side repo"
+        );
+
+        let repo = SnapshotRepo::open_or_init(&workspace).expect("open_or_init");
+        std::fs::write(repo.work_tree().join("a.txt"), b"alpha").unwrap();
+        repo.snapshot("pre-turn:1").expect("snapshot");
+
+        let after = SnapshotRepo::open_existing(&workspace).expect("open existing");
+        assert!(after.is_some());
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -6,6 +6,7 @@
 //! spillover folding), the copy-cell actions, and the footer detail labels.
 //! No logic changes were made during the extraction.
 
+use crate::snapshot::SnapshotRepo;
 use crate::tui::app::App;
 use crate::tui::footer_ui::one_line_summary;
 use crate::tui::history::{HistoryCell, ToolCell, ToolStatus};
@@ -893,8 +894,8 @@ pub(super) fn turn_inspector_text(app: &App) -> String {
     push_section(&mut out, "Plan / checklist", turn_plan_lines(app));
     push_section(
         &mut out,
-        "Tool timeline",
-        turn_tool_timeline(app, start, end),
+        "Turn timeline",
+        turn_timeline_lines(app, start, end),
     );
     push_section(
         &mut out,
@@ -970,8 +971,8 @@ pub(crate) fn turn_handoff_markdown(app: &App) -> String {
     );
     push_md_section(
         &mut out,
-        "Commands & tools",
-        md_bullets(turn_tool_timeline(app, start, end)),
+        "Turn timeline",
+        md_bullets(turn_timeline_lines(app, start, end)),
     );
     push_md_section(
         &mut out,
@@ -1132,26 +1133,261 @@ fn todo_status_glyph(status: &crate::tools::todo::TodoStatus) -> &'static str {
     }
 }
 
-/// Section 3 — the turn's tool calls with status and (where known) duration.
-fn turn_tool_timeline(app: &App, start: usize, end: usize) -> Vec<String> {
-    let mut lines = Vec::new();
+/// Section 3 — chronological turn timeline with compact action affordances.
+fn turn_timeline_lines(app: &App, start: usize, end: usize) -> Vec<String> {
+    let mut rows = Vec::new();
     for idx in start..end {
-        let Some(HistoryCell::Tool(tool)) = app.cell_at_virtual_index(idx) else {
+        let Some(cell) = app.cell_at_virtual_index(idx) else {
             continue;
         };
-        let label = detail_target_label(app, idx).unwrap_or_else(|| "tool".to_string());
-        let mut line = format!("• {}", truncate_line_to_width(&label, 64));
-        if let Some(status) = tool_status_for_activity(tool) {
-            line.push_str(" — ");
-            line.push_str(activity_status_label(status));
+        match cell {
+            HistoryCell::User { content } => {
+                let summary = one_line_summary(content, 96);
+                rows.push(timeline_row("user prompt", &summary, None, None, &[]));
+            }
+            HistoryCell::Thinking {
+                content,
+                streaming,
+                duration_secs,
+            } => {
+                let summary = one_line_summary(content, 88);
+                let status = streaming.then_some("running").unwrap_or("done");
+                let duration = duration_secs.map(|secs| format!("{secs:.1}s"));
+                let actions = timeline_cell_actions(app, idx, cell);
+                rows.push(timeline_row(
+                    "reasoning",
+                    &summary,
+                    Some(status),
+                    duration.as_deref(),
+                    &actions,
+                ));
+            }
+            HistoryCell::Tool(tool) => {
+                let (kind, summary) = timeline_tool_summary(app, idx, tool);
+                let duration = tool_duration_for_activity(tool).map(format_activity_duration_ms);
+                let status = tool_status_for_activity(tool).map(activity_status_label);
+                let actions = timeline_cell_actions(app, idx, cell);
+                rows.push(timeline_row(
+                    kind,
+                    &summary,
+                    status,
+                    duration.as_deref(),
+                    &actions,
+                ));
+            }
+            HistoryCell::SubAgent(_) => {
+                let summary = detail_target_label(app, idx).unwrap_or_else(|| "sub-agent".into());
+                let actions = timeline_cell_actions(app, idx, cell);
+                rows.push(timeline_row("sub-agent", &summary, None, None, &actions));
+            }
+            HistoryCell::Assistant { content, streaming } => {
+                let summary = one_line_summary(content, 96);
+                let status = streaming.then_some("streaming").unwrap_or("done");
+                rows.push(timeline_row(
+                    "assistant result",
+                    &summary,
+                    Some(status),
+                    None,
+                    &[],
+                ));
+            }
+            HistoryCell::Error { message, severity } => {
+                let summary = one_line_summary(message, 96);
+                let status = severity.to_string();
+                rows.push(timeline_row("error", &summary, Some(&status), None, &[]));
+            }
+            HistoryCell::System { content }
+            | HistoryCell::ArchivedContext {
+                summary: content, ..
+            } => {
+                let summary = one_line_summary(content, 96);
+                rows.push(timeline_row("system note", &summary, None, None, &[]));
+            }
         }
-        if let Some(ms) = tool_duration_for_activity(tool) {
-            line.push_str(" · ");
-            line.push_str(&format_activity_duration_ms(ms));
-        }
-        lines.push(line);
     }
-    lines
+    rows.push(turn_checkpoint_timeline_row(app));
+    rows.into_iter()
+        .enumerate()
+        .map(|(idx, row)| format!("{}. {row}", idx + 1))
+        .collect()
+}
+
+fn timeline_tool_summary(app: &App, idx: usize, tool: &ToolCell) -> (&'static str, String) {
+    match tool {
+        ToolCell::Exec(exec) if command_looks_like_verifier(&exec.command) => {
+            ("test/verifier", truncate_line_to_width(&exec.command, 88))
+        }
+        ToolCell::Exec(exec) => ("shell command", truncate_line_to_width(&exec.command, 88)),
+        ToolCell::Exploring(explore) => (
+            "read/search",
+            format!(
+                "{} item{}",
+                explore.entries.len(),
+                if explore.entries.len() == 1 { "" } else { "s" }
+            ),
+        ),
+        ToolCell::PlanUpdate(_) => ("plan update", "plan/checklist changed".to_string()),
+        ToolCell::PatchSummary(patch) => {
+            let summary = one_line_summary(&patch.summary, 72);
+            if summary.is_empty() {
+                ("edit", truncate_line_to_width(&patch.path, 88))
+            } else {
+                (
+                    "edit",
+                    truncate_line_to_width(&format!("{} — {summary}", patch.path), 88),
+                )
+            }
+        }
+        ToolCell::Review(review) => {
+            let target = one_line_summary(&review.target, 88);
+            (
+                "review",
+                if target.is_empty() {
+                    "code review".to_string()
+                } else {
+                    target
+                },
+            )
+        }
+        ToolCell::DiffPreview(diff) => ("diff", truncate_line_to_width(&diff.title, 88)),
+        ToolCell::Mcp(mcp) => ("MCP tool", truncate_line_to_width(&mcp.tool, 88)),
+        ToolCell::ViewImage(image) => (
+            "image",
+            truncate_line_to_width(&image.path.display().to_string(), 88),
+        ),
+        ToolCell::WebSearch(search) => ("web search", truncate_line_to_width(&search.query, 88)),
+        ToolCell::Generic(generic) => {
+            let mut label =
+                detail_target_label(app, idx).unwrap_or_else(|| generic.name.replace('_', " "));
+            if let Some(input) = generic.input_summary.as_deref().map(str::trim)
+                && !input.is_empty()
+            {
+                label.push_str(" · ");
+                label.push_str(input);
+            }
+            (
+                generic_tool_timeline_kind(generic),
+                truncate_line_to_width(&label, 88),
+            )
+        }
+    }
+}
+
+fn generic_tool_timeline_kind(generic: &crate::tui::history::GenericToolCell) -> &'static str {
+    let name = generic.name.as_str();
+    if generic.is_diff || name.contains("diff") {
+        "diff"
+    } else if matches!(name, "read_file" | "list_files" | "glob" | "grep_files")
+        || name.contains("read")
+        || name.contains("search")
+        || name.contains("grep")
+    {
+        "read/search"
+    } else if matches!(name, "apply_patch" | "edit_file" | "write_file")
+        || name.contains("patch")
+        || name.contains("edit")
+        || name.contains("write")
+    {
+        "edit"
+    } else if name.contains("approval") {
+        "approval"
+    } else if name.contains("diagnostic") || name.contains("lsp") {
+        "diagnostics"
+    } else {
+        "tool"
+    }
+}
+
+fn timeline_cell_actions(app: &App, idx: usize, cell: &HistoryCell) -> Vec<&'static str> {
+    let mut actions = Vec::new();
+    if app.cell_has_detail_target(idx) {
+        actions.push("v raw detail");
+    }
+    match cell {
+        HistoryCell::Tool(ToolCell::DiffPreview(_)) => actions.push("d diff"),
+        HistoryCell::Tool(ToolCell::PatchSummary(_)) => actions.push("d diff"),
+        HistoryCell::Tool(ToolCell::Generic(generic)) if generic.is_diff => actions.push("d diff"),
+        _ => {}
+    }
+    actions
+}
+
+fn timeline_row(
+    kind: &str,
+    summary: &str,
+    status: Option<&str>,
+    duration: Option<&str>,
+    actions: &[&str],
+) -> String {
+    let mut line = if summary.trim().is_empty() {
+        kind.to_string()
+    } else {
+        format!("{kind}: {}", summary.trim())
+    };
+    if let Some(status) = status.filter(|s| !s.trim().is_empty()) {
+        line.push_str(" — ");
+        line.push_str(status);
+    }
+    if let Some(duration) = duration.filter(|s| !s.trim().is_empty()) {
+        line.push_str(" · ");
+        line.push_str(duration);
+    }
+    if !actions.is_empty() {
+        line.push_str(" · actions: ");
+        line.push_str(&actions.join(", "));
+    }
+    line
+}
+
+fn turn_checkpoint_timeline_row(app: &App) -> String {
+    if app.turn_counter == 0 {
+        return "checkpoint: unavailable — no numbered turn snapshot yet · action: e export handoff"
+            .to_string();
+    }
+
+    let repo = match SnapshotRepo::open_existing(&app.workspace) {
+        Ok(Some(repo)) => repo,
+        Ok(None) => {
+            return "checkpoint: unavailable — no snapshot repo found · action: e export handoff"
+                .to_string();
+        }
+        Err(err) => {
+            return format!(
+                "checkpoint: unknown — snapshot repo could not be opened ({}) · action: e export handoff",
+                truncate_line_to_width(&err.to_string(), 72)
+            );
+        }
+    };
+    let snapshots = match repo.list(20) {
+        Ok(snapshots) => snapshots,
+        Err(err) => {
+            return format!(
+                "checkpoint: unknown — snapshot list failed ({}) · action: e export handoff",
+                truncate_line_to_width(&err.to_string(), 72)
+            );
+        }
+    };
+    let prefix = format!("pre-turn:{}", app.turn_counter);
+    let matching = snapshots
+        .iter()
+        .find(|snapshot| {
+            snapshot.label == prefix || snapshot.label.starts_with(&format!("{prefix}:"))
+        })
+        .or_else(|| {
+            snapshots
+                .iter()
+                .find(|snapshot| snapshot.label.starts_with("pre-turn:"))
+        });
+    if let Some(snapshot) = matching {
+        let short = &snapshot.id.as_str()[..snapshot.id.as_str().len().min(8)];
+        format!(
+            "checkpoint: {} ({short}) available · actions: r restore via /restore (guarded), e export handoff",
+            truncate_line_to_width(&snapshot.label, 72)
+        )
+    } else {
+        "checkpoint: unavailable — no pre-turn snapshot found · action: e export handoff"
+            .to_string()
+    }
 }
 
 /// Section 4 — files touched by patch/diff tool cells in the turn.

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10127,7 +10127,7 @@ fn turn_inspector_renders_overview_sections_for_active_turn() {
     for header in [
         "── Intent ──",
         "── Plan / checklist ──",
-        "── Tool timeline ──",
+        "── Turn timeline ──",
         "── Files changed ──",
         "── Diagnostics loop ──",
         "── Tests / verifier ──",
@@ -10139,7 +10139,7 @@ fn turn_inspector_renders_overview_sections_for_active_turn() {
     }
     // Intent + tool timeline + files + result are the must-have populated ones.
     assert!(body.contains("Fix the flaky login test"), "{body}");
-    assert!(body.contains("cargo test login"), "{body}");
+    assert!(body.contains("test/verifier: cargo test login"), "{body}");
     assert!(body.contains("2.4s"), "duration missing: {body}");
     assert!(body.contains("src/login.rs"), "{body}");
     assert!(
@@ -10152,6 +10152,97 @@ fn turn_inspector_renders_overview_sections_for_active_turn() {
         "{body}"
     );
     assert!(body.contains("Status: completed"), "{body}");
+}
+
+#[test]
+fn turn_inspector_timeline_numbers_semantic_entries_and_checkpoint_actions() {
+    let _lock = crate::test_support::lock_test_env();
+    let tmp = TempDir::new().expect("tempdir");
+    let _home = crate::test_support::EnvVarGuard::set("HOME", tmp.path());
+    let _userprofile = crate::test_support::EnvVarGuard::set("USERPROFILE", tmp.path());
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    std::fs::write(workspace.join("src.rs"), "fn main() {}\n").expect("source");
+    let repo = crate::snapshot::SnapshotRepo::open_or_init(&workspace).expect("snapshot repo");
+    repo.snapshot("pre-turn:12: Fix timeline")
+        .expect("pre-turn snapshot");
+
+    let mut app = create_test_app();
+    app.workspace = workspace;
+    app.turn_counter = 12;
+    app.runtime_turn_status = Some("completed".to_string());
+    app.history = vec![
+        HistoryCell::User {
+            content: "Fix timeline evidence".to_string(),
+        },
+        HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: "read_file".to_string(),
+            status: ToolStatus::Success,
+            input_summary: Some("src.rs".to_string()),
+            output: Some("fn main() {}".to_string()),
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        })),
+        HistoryCell::Tool(ToolCell::PatchSummary(
+            crate::tui::history::PatchSummaryCell {
+                path: "src.rs".to_string(),
+                summary: "add timeline evidence".to_string(),
+                status: ToolStatus::Success,
+                error: None,
+            },
+        )),
+        HistoryCell::Tool(ToolCell::Exec(ExecCell {
+            command: "cargo test timeline".to_string(),
+            status: ToolStatus::Success,
+            output: Some("ok".to_string()),
+            live_output: None,
+            shell_task_id: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+            started_at: None,
+            duration_ms: Some(1250),
+            source: ExecSource::Assistant,
+            interaction: None,
+            output_summary: None,
+        })),
+        HistoryCell::Assistant {
+            content: "Timeline evidence is visible.".to_string(),
+            streaming: false,
+        },
+    ];
+
+    let body = turn_inspector_text(&app);
+
+    assert!(
+        body.contains("1. user prompt: Fix timeline evidence"),
+        "{body}"
+    );
+    assert!(
+        body.contains("2. read/search: read · src.rs — done · actions: v raw detail"),
+        "{body}"
+    );
+    assert!(
+        body.contains(
+            "3. edit: src.rs — add timeline evidence — done · actions: v raw detail, d diff"
+        ),
+        "{body}"
+    );
+    assert!(
+        body.contains(
+            "4. test/verifier: cargo test timeline — done · 1.2s · actions: v raw detail"
+        ),
+        "{body}"
+    );
+    assert!(
+        body.contains("checkpoint: pre-turn:12: Fix timeline"),
+        "{body}"
+    );
+    assert!(
+        body.contains("actions: r restore via /restore (guarded), e export handoff"),
+        "{body}"
+    );
 }
 
 #[test]
@@ -10237,7 +10328,7 @@ fn ctrl_o_open_turn_inspector_pager_opens_turn_overview_not_single_cell() {
     assert_eq!(app.view_stack.top_kind(), Some(ModalKind::Pager));
     let body = pop_pager_body(&mut app);
     // Turn overview markers present; NOT the single-cell "Activity:" body.
-    assert!(body.contains("── Tool timeline ──"), "{body}");
+    assert!(body.contains("── Turn timeline ──"), "{body}");
     assert!(body.contains("do the thing"), "{body}");
     assert!(
         !body.contains("Activity chunk:"),
@@ -10293,7 +10384,7 @@ fn turn_handoff_markdown_renders_compact_sections_for_active_turn() {
     for heading in [
         "## Intent",
         "## Files changed",
-        "## Commands & tools",
+        "## Turn timeline",
         "## Tests / verifier",
         "## Model route + tokens/cost",
         "## Result / status",


### PR DESCRIPTION
Summary
- Adds a numbered Turn Inspector timeline that classifies prompts, reads/searches, edits, verifier runs, assistant results, and checkpoint state.
- Shows checkpoint availability from an existing side-git snapshot repo without initializing one from the UI.
- Reuses the same timeline in the turn handoff export.

Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-features --locked -- -Dwarnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants
- cargo test -p codewhale-tui --locked turn_inspector
- cargo test -p codewhale-tui --locked snapshot::repo::tests::open_existing_is_read_only_and_does_not_initialize
- cargo test --workspace --all-features --locked (one accepted pre-existing flake: tui::hotbar::actions::tests::skill_hotbar_action_activates_skill_through_dollar_alias)
- cargo build --release

Fixes #4106

Generated with Claude Code
