### PR TITLE
tui: avoid lowercase allocations for ASCII comparisons (#4156)

### DIFF
--- a/crates/tui/src/hooks.rs
+++ b/crates/tui/src/hooks.rs
@@ -1021,7 +1021,7 @@ impl HookExecutor {
             Some(HookCondition::Mode { mode }) => context
                 .mode
                 .as_ref()
-                .is_some_and(|m| m.to_lowercase() == mode.to_lowercase()),
+                .is_some_and(|m| m.eq_ignore_ascii_case(mode)),
             Some(HookCondition::ExitCode { code }) => context.tool_exit_code == Some(*code),
             Some(HookCondition::All { conditions }) => conditions.iter().all(|c| {
                 self.matches_condition(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -4743,14 +4743,14 @@ fn doctor_auth_scheme(config: &Config) -> &'static str {
 }
 
 fn doctor_xiaomi_mimo_base_url_uses_token_plan(base_url: &str) -> bool {
-    let normalized = base_url.trim_end_matches('/').to_ascii_lowercase();
+    let normalized = base_url.trim_end_matches('/');
     [
         crate::config::XIAOMI_MIMO_TOKEN_PLAN_CN_BASE_URL,
         crate::config::XIAOMI_MIMO_TOKEN_PLAN_SGP_BASE_URL,
         crate::config::XIAOMI_MIMO_TOKEN_PLAN_AMS_BASE_URL,
     ]
     .iter()
-    .any(|candidate| normalized == candidate.trim_end_matches('/').to_ascii_lowercase())
+    .any(|candidate| normalized.eq_ignore_ascii_case(candidate.trim_end_matches('/')))
 }
 
 fn doctor_api_key_source_label(source: ApiKeySource) -> &'static str {
@@ -4895,15 +4895,19 @@ enum DeepSeekBaseUrlKind {
 }
 
 fn known_deepseek_base_url_kind(base_url: &str) -> Option<DeepSeekBaseUrlKind> {
-    match base_url.trim_end_matches('/').to_ascii_lowercase().as_str() {
-        "https://api.deepseek.com/beta" | "https://api.deepseeki.com/beta" => {
-            Some(DeepSeekBaseUrlKind::Beta)
-        }
-        "https://api.deepseek.com"
-        | "https://api.deepseek.com/v1"
-        | "https://api.deepseeki.com"
-        | "https://api.deepseeki.com/v1" => Some(DeepSeekBaseUrlKind::NonBeta),
-        _ => None,
+    let normalized = base_url.trim_end_matches('/');
+    if normalized.eq_ignore_ascii_case("https://api.deepseek.com/beta")
+        || normalized.eq_ignore_ascii_case("https://api.deepseeki.com/beta")
+    {
+        Some(DeepSeekBaseUrlKind::Beta)
+    } else if normalized.eq_ignore_ascii_case("https://api.deepseek.com")
+        || normalized.eq_ignore_ascii_case("https://api.deepseek.com/v1")
+        || normalized.eq_ignore_ascii_case("https://api.deepseeki.com")
+        || normalized.eq_ignore_ascii_case("https://api.deepseeki.com/v1")
+    {
+        Some(DeepSeekBaseUrlKind::NonBeta)
+    } else {
+        None
     }
 }
 
@@ -8870,6 +8874,21 @@ mod doctor_endpoint_tests {
         assert_eq!(status.status, "disabled");
         assert!(!status.function_strict_sent);
         assert!(status.recommended_base_url.is_none());
+    }
+
+    #[test]
+    fn doctor_known_base_urls_are_ascii_case_insensitive() {
+        assert!(doctor_xiaomi_mimo_base_url_uses_token_plan(
+            "HTTPS://TOKEN-PLAN-CN.XIAOMIMIMO.COM/V1/"
+        ));
+        assert_eq!(
+            known_deepseek_base_url_kind("HTTPS://API.DEEPSEEK.COM/BETA/"),
+            Some(DeepSeekBaseUrlKind::Beta)
+        );
+        assert_eq!(
+            known_deepseek_base_url_kind("HTTPS://API.DEEPSEEK.COM/V1/"),
+            Some(DeepSeekBaseUrlKind::NonBeta)
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -350,8 +350,8 @@ impl ToolRegistry {
         let names: Vec<&str> = self.tools.keys().map(String::as_str).collect();
         let lower = requested.to_lowercase();
 
-        // 1. lowercase exact
-        if let Some(n) = names.iter().find(|n| n.to_lowercase() == lower) {
+        // 1. ASCII case-insensitive exact
+        if let Some(n) = names.iter().find(|n| n.eq_ignore_ascii_case(requested)) {
             return Some(n);
         }
         // 2. hyphen/space → underscore
@@ -1347,6 +1347,17 @@ mod tests {
         assert!(registry.contains("test_tool"));
         assert!(!registry.contains("nonexistent"));
         assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn resolve_exact_match_is_ascii_case_insensitive() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let mut registry = ToolRegistry::new(ctx);
+
+        registry.register(make_test_tool("read_file"));
+
+        assert_eq!(registry.resolve("READ_FILE"), Some("read_file"));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8970,7 +8970,7 @@ fn parse_queue_send_command(input: &str) -> Option<Result<usize, String>> {
     let rest = strip_queue_command_prefix(input.trim())?;
     let mut parts = rest.split_whitespace();
     let action = parts.next()?;
-    if !matches!(action.to_ascii_lowercase().as_str(), "send" | "now") {
+    if !action.eq_ignore_ascii_case("send") && !action.eq_ignore_ascii_case("now") {
         return None;
     }
     let Some(raw_index) = parts.next() else {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -7512,6 +7512,7 @@ async fn ctrl_s_sends_edited_queued_draft_into_running_turn() {
 fn parse_queue_send_command_accepts_queue_alias_and_positive_index() {
     assert_eq!(parse_queue_send_command("/queue send 2"), Some(Ok(1)));
     assert_eq!(parse_queue_send_command("/queued now 1"), Some(Ok(0)));
+    assert_eq!(parse_queue_send_command("/queue SEND 1"), Some(Ok(0)));
     assert!(parse_queue_send_command("/queue drop 1").is_none());
     assert!(
         parse_queue_send_command("/queue send 0")


### PR DESCRIPTION
Summary
- Replaces five ASCII-only lowercase equality checks with eq_ignore_ascii_case.
- Covers hook mode matching, tool registry exact resolution, queue send/now parsing, and doctor endpoint classification.
- Adds regression coverage for uppercase queue commands, registry names, and known doctor URLs.

Verification
- cargo fmt --all -- --check
- RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-features --locked -- -Dwarnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants
- cargo test -p codewhale-tui --locked parse_queue_send_command_accepts_queue_alias_and_positive_index
- cargo test -p codewhale-tui --locked ascii_case_insensitive
- cargo test -p codewhale-tui --locked test_hook_condition_mode
- cargo test --workspace --all-features --locked (one accepted pre-existing flake: tui::hotbar::actions::tests::skill_hotbar_action_activates_skill_through_dollar_alias)
- cargo build --release
- python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors

Fixes #4156

Generated with Claude Code
