### PR TITLE
tui: quiet transcript noise from agent checks and unknown-tool calls (dogfood A5)

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -6190,6 +6190,23 @@ fn missing_tool_error_message_includes_discovery_guidance_when_no_match() {
 }
 
 #[test]
+fn missing_tool_error_message_redirects_checklist_item_miscalls() {
+    let catalog = vec![api_tool("note"), api_tool("tts")];
+
+    for tool_name in ["item", "items", "todo", "checklist_item"] {
+        let message = missing_tool_error_message(tool_name, &catalog);
+        assert!(
+            message.contains("checklist_write"),
+            "{tool_name}: {message}"
+        );
+        assert!(
+            !message.contains("Did you mean"),
+            "fuzzy suggestions are misleading for checklist mis-calls: {message}"
+        );
+    }
+}
+
+#[test]
 fn missing_shell_tool_error_message_names_allow_shell_gate() {
     let catalog = vec![api_tool("read_file")];
 

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -658,6 +658,21 @@ pub(super) fn tool_catalog_consistency_issues(
 }
 
 pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> String {
+    // Dogfood A5 (#4092): models mid-checklist sometimes emit each list entry
+    // as its own tool call named `item`/`todo`/... . Fuzzy suggestions are
+    // actively misleading there ("Did you mean: note, tts?"); name the actual
+    // fix instead.
+    if matches!(
+        tool_name,
+        "item" | "items" | "todo" | "todos" | "checklist" | "checklist_item" | "plan_item"
+    ) {
+        return format!(
+            "Tool '{tool_name}' is not available in the current tool catalog. \
+             Checklist entries are not separate tool calls — write the whole list \
+             in one `checklist_write` call with an `items` array of \
+             {{content, status}} objects."
+        );
+    }
     let suggestions = suggest_tool_names(catalog, tool_name, 3);
     let shell_hint = if is_shell_tool_name(tool_name) {
         Some(shell_tool_allow_shell_hint())

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1324,9 +1324,34 @@ impl GenericToolCell {
         // 3-4 lines per spawn — N parallel spawns multiply the noise. In
         // live mode, render one compact summary line and let the
         // DelegateCard be the source of truth. Transcript mode keeps the
-        // full block so session replay remains complete.
-        if matches!(mode, RenderMode::Live) && self.name == "agent" {
+        // full block for spawns so session replay remains complete, but
+        // inspection calls (peek/status/wait) stay compact there too — a
+        // full projection dump per check is exactly the dogfood-A5 noise
+        // and carries no replay value (#4112).
+        if self.name == "agent"
+            && (matches!(mode, RenderMode::Live) || agent_activity::is_agent_inspection(self))
+        {
             return agent_activity::render_agent_compact(self, low_motion);
+        }
+
+        // A call to a tool that doesn't exist carries exactly one useful
+        // fact: the catalog error. The full name:/args:/result: block turns
+        // each model slip into a four-line card (dogfood A5) — collapse it
+        // to a single header line in both render modes.
+        if self.status == ToolStatus::Failed
+            && let Some(output) = self.output.as_deref()
+            && output.contains("is not available in the current tool catalog")
+        {
+            let family = crate::tui::widgets::tool_card::tool_family_for_name(&self.name);
+            let summary = truncate_text(output.trim(), 200);
+            return wrap_card_rail(vec![render_tool_header_with_family_and_summary(
+                family,
+                Some(summary.as_str()),
+                tool_status_label(self.status),
+                self.status,
+                None,
+                low_motion,
+            )]);
         }
 
         // Live mode stays calm: successful tool calls collapse to one header

--- a/crates/tui/src/tui/history/agent_activity.rs
+++ b/crates/tui/src/tui/history/agent_activity.rs
@@ -17,14 +17,53 @@ pub(super) fn render_agent_compact(cell: &GenericToolCell, low_motion: bool) -> 
         .and_then(extract_agent_id)
         .map(str::to_string)
         .unwrap_or_else(|| delegate_identity_fallback(cell));
+    // Inspections and joins must not draw the same "delegate done" line as a
+    // spawn — during a fan-out session every peek/status/wait would otherwise
+    // read as yet another completed delegate (#4112, dogfood A5). The action
+    // is stamped at the front of the args summary by tool_routing.
+    let state_label = match agent_inspection_action(cell) {
+        Some(AgentCompactAction::Check) => match cell.status {
+            super::ToolStatus::Running => "checking",
+            _ => "checked",
+        },
+        Some(AgentCompactAction::Wait) => match cell.status {
+            super::ToolStatus::Running => "waiting",
+            _ => "waited",
+        },
+        None => tool_status_label(cell.status),
+    };
     vec![render_tool_header_with_family_and_summary(
         family,
         Some(agent_id.as_str()),
-        tool_status_label(cell.status),
+        state_label,
         cell.status,
         None,
         low_motion,
     )]
+}
+
+enum AgentCompactAction {
+    /// Read-only inspection: peek / status / progress / list / inspect.
+    Check,
+    /// Blocking join: wait / join / await / block.
+    Wait,
+}
+
+/// Whether this `agent` cell is a read-only inspection or join rather than a
+/// spawn — those stay compact even in Transcript mode.
+pub(super) fn is_agent_inspection(cell: &GenericToolCell) -> bool {
+    agent_inspection_action(cell).is_some()
+}
+
+fn agent_inspection_action(cell: &GenericToolCell) -> Option<AgentCompactAction> {
+    let summary = cell.input_summary.as_deref()?;
+    let action = summary.strip_prefix("action:")?.trim_start();
+    let action = action.split_whitespace().next().unwrap_or("");
+    match action.trim_end_matches(',') {
+        "peek" | "progress" | "status" | "list" | "inspect" => Some(AgentCompactAction::Check),
+        "wait" | "join" | "await" | "block" => Some(AgentCompactAction::Wait),
+        _ => None,
+    }
 }
 
 pub(super) fn render_activity_group(cell: &GenericToolCell, width: u16) -> Vec<Line<'static>> {

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -2747,3 +2747,125 @@ fn tool_run_summary_uses_metadata_fallback_for_unknown_groups() {
 
     assert_eq!(super::tool_run_summary(&run), "Updated metadata");
 }
+
+// ---- #4112 / dogfood A5: transcript noise ----
+
+fn agent_cell(
+    action_summary: Option<&str>,
+    status: ToolStatus,
+    output: Option<&str>,
+) -> GenericToolCell {
+    GenericToolCell {
+        name: "agent".to_string(),
+        status,
+        input_summary: action_summary.map(str::to_string),
+        output: output.map(str::to_string),
+        prompts: None,
+        spillover_path: None,
+        output_summary: None,
+        is_diff: false,
+    }
+}
+
+fn joined_lines(cell: &GenericToolCell, mode: super::RenderMode) -> String {
+    cell.lines_with_mode(120, true, mode)
+        .iter()
+        .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref().to_string()))
+        .collect()
+}
+
+#[test]
+fn unknown_tool_failure_collapses_to_one_line() {
+    let cell = GenericToolCell {
+        name: "item".to_string(),
+        status: ToolStatus::Failed,
+        input_summary: Some("status: pending".to_string()),
+        output: Some(
+            "Tool 'item' is not available in the current tool catalog. \
+             Checklist entries are not separate tool calls."
+                .to_string(),
+        ),
+        prompts: None,
+        spillover_path: None,
+        output_summary: None,
+        is_diff: false,
+    };
+    for mode in [super::RenderMode::Live, super::RenderMode::Transcript] {
+        let lines = cell.lines_with_mode(120, true, mode);
+        assert_eq!(
+            lines.len(),
+            1,
+            "unknown-tool failure should be a single header line in {mode:?}: {lines:?}"
+        );
+        let joined = joined_lines(&cell, mode);
+        assert!(
+            joined.contains("Tool 'item' is not available"),
+            "the catalog error is the useful part: {joined:?}"
+        );
+        assert!(
+            !joined.contains("name: item"),
+            "no name:/args:/result: block for unknown tools: {joined:?}"
+        );
+    }
+}
+
+#[test]
+fn agent_peek_renders_checked_not_done() {
+    let cell = agent_cell(
+        Some("action: peek agent_id: agent_scout_1"),
+        ToolStatus::Success,
+        Some(r#"{"agent_id":"agent_scout_1","status":"running"}"#),
+    );
+    let joined = joined_lines(&cell, super::RenderMode::Live);
+    assert!(
+        joined.contains("checked") && joined.contains("agent_scout_1"),
+        "peek should read as a check, not a completed delegate: {joined:?}"
+    );
+    assert!(
+        !joined.contains("delegate done"),
+        "peek must not draw the spawn-completion line: {joined:?}"
+    );
+}
+
+#[test]
+fn agent_wait_renders_waited_label() {
+    let cell = agent_cell(
+        Some("action: wait"),
+        ToolStatus::Success,
+        Some(r#"{"action":"wait","settled":[{"agent_id":"agent_scout_1"}]}"#),
+    );
+    let joined = joined_lines(&cell, super::RenderMode::Live);
+    assert!(
+        joined.contains("waited"),
+        "wait cells should read as a join: {joined:?}"
+    );
+}
+
+#[test]
+fn agent_inspection_stays_compact_in_transcript_mode() {
+    let cell = agent_cell(
+        Some("action: status agent_id: agent_scout_1"),
+        ToolStatus::Success,
+        Some(r#"{"agent_id":"agent_scout_1","status":"running","terminal":false}"#),
+    );
+    let lines = cell.lines_with_mode(120, true, super::RenderMode::Transcript);
+    assert_eq!(
+        lines.len(),
+        1,
+        "status checks should not dump full projections in the pager: {lines:?}"
+    );
+}
+
+#[test]
+fn agent_spawn_keeps_full_block_in_transcript_mode() {
+    let cell = agent_cell(
+        Some("prompt: map the repo"),
+        ToolStatus::Success,
+        Some(r#"{"agent_id":"agent_scout_1","status":"running"}"#),
+    );
+    let lines = cell.lines_with_mode(120, true, super::RenderMode::Transcript);
+    assert!(
+        lines.len() > 1,
+        "spawns keep the full block for session replay: {lines:?}"
+    );
+}

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -250,7 +250,30 @@ pub(super) fn handle_tool_call_started(
         return;
     }
 
-    let input_summary = summarize_tool_args(input);
+    let mut input_summary = summarize_tool_args(input);
+    // Lead the `agent` args summary with the non-default action so renderers
+    // can tell inspections (peek/status/wait) apart from spawns without a
+    // schema change — a peek must not draw the same "delegate done" line as
+    // a launch (#4112, dogfood A5).
+    if name == "agent"
+        && let Some(action) = input.get("action").and_then(serde_json::Value::as_str)
+    {
+        let action = action.trim().to_ascii_lowercase();
+        let already_leads = input_summary
+            .as_deref()
+            .is_some_and(|summary| summary.starts_with("action:"));
+        if !action.is_empty()
+            && !already_leads
+            && action != "start"
+            && action != "spawn"
+            && action != "run"
+        {
+            input_summary = Some(match input_summary {
+                Some(rest) => format!("action: {action} {rest}"),
+                None => format!("action: {action}"),
+            });
+        }
+    }
     push_active_tool_cell(
         app,
         &id,


### PR DESCRIPTION
## Summary

Transcript lane (#4112), dogfood finding **A5** on #4092. Three cuts at the reported noise:

1. **Agent inspection cells stop impersonating spawns.** `agent` peek/status/wait calls rendered the same compact `delegate done · agent_x` line as a completed launch — in a fan-out session every poll read as another finished delegate. `tool_routing` now stamps the non-default action at the front of the args summary and `render_agent_compact` labels checks `checking/checked` and joins `waiting/waited`.
2. **Inspection cells stay compact in Transcript mode** (the pager/Ctrl-O surface) instead of dumping a full session projection per check. Spawns keep the full block for session replay.
3. **Unknown-tool failures collapse to one line.** The observed `tool issue · item / name: item / args: status: pending / result: … Did you mean: note, tts?` card becomes a single header carrying the catalog error. For the checklist mis-call shape (`item`/`todo`/… with per-entry calls) the error now names the actual fix — one `checklist_write` call with an `items` array — instead of a misleading fuzzy match.

Pairs with #4229 (which removes the polling that generates most of these cells in the first place).

## Testing
- 5 new render tests + 1 catalog-message test
- `tui::history::tests`: 101 pass; `missing_tool`: 4 pass; `tool_routing`: 5 pass
- fmt + CI-flag clippy clean