### PR TITLE
tui: /model picker remembers browsing context across reopens (dogfood A1)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -364,6 +364,17 @@ pub enum SidebarFocus {
     Hidden,
 }
 
+/// Browsing context captured when the `/model` picker is dismissed (#4109).
+/// Plain data so `App` does not depend on the picker's internal view enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelPickerMemory {
+    /// True when the user left the picker in the full-catalog view
+    /// (`A` toggle), false for the configured-only default view.
+    pub catalog_view: bool,
+    /// Model row id highlighted at dismissal, if it was a real row.
+    pub selected_row_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AgentProgressMeta {
     pub parent_run_id: Option<String>,
@@ -1766,6 +1777,10 @@ pub struct App {
     /// Last successfully rendered Work panel summary. Transient mutex misses
     /// should not wipe completed checklist/strategy state from the sidebar.
     pub(crate) cached_work_summary: Option<SidebarWorkSummary>,
+    /// Browsing context from the last dismissed `/model` picker, so reopening
+    /// restores the view mode and highlighted row instead of resetting to the
+    /// top (#4109 picker memory). Session-scoped, never persisted.
+    pub model_picker_memory: Option<ModelPickerMemory>,
     /// Last known mouse position for tooltip placement.
     pub last_mouse_pos: Option<(u16, u16)>,
     /// Whether the user is currently dragging the sidebar resize handle.
@@ -2757,6 +2772,7 @@ impl App {
             sidebar_hover: SidebarHoverState::default(),
             sidebar_hover_tooltip: None,
             cached_work_summary: None,
+            model_picker_memory: None,
             last_mouse_pos: None,
             sidebar_resizing: false,
             sidebar_resize_anchor_x: 0,

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -132,7 +132,7 @@ impl ModelPickerView {
             .position(|e| *e == normalized)
             .unwrap_or_else(|| default_picker_effort_idx(app.api_provider, app.auto_model));
 
-        Self {
+        let mut view = Self {
             initial_model,
             initial_provider: app.api_provider,
             initial_effort,
@@ -145,7 +145,34 @@ impl ModelPickerView {
             model_rows,
             view: ModelListView::Configured,
             configured_providers,
+        };
+        view.restore_memory(app.model_picker_memory.as_ref());
+        view
+    }
+
+    /// Restore the browsing context from the last dismissed picker (#4109):
+    /// the Configured/Catalog view mode and, when the remembered row still
+    /// exists in that view, the highlighted row. The active model remains the
+    /// selection when nothing was remembered or the row is gone.
+    fn restore_memory(&mut self, memory: Option<&crate::tui::app::ModelPickerMemory>) {
+        let Some(memory) = memory else {
+            return;
+        };
+        if memory.catalog_view {
+            self.view = ModelListView::Catalog;
         }
+        if let Some(remembered_id) = memory.selected_row_id.as_deref() {
+            let position = self
+                .visible_model_rows()
+                .iter()
+                .position(|row| row.id == remembered_id);
+            if let Some(position) = position {
+                let effort = self.resolved_effort();
+                self.selected_model_idx = position;
+                self.select_effort_for_current_model(effort);
+            }
+        }
+        self.clamp_model_selection();
     }
 
     #[cfg(test)]
@@ -798,7 +825,15 @@ impl ModalView for ModelPickerView {
 
     fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
         match key.code {
-            KeyCode::Esc => ViewAction::Close,
+            // Esc carries the browsing context out so the next open can
+            // restore it (#4109 picker memory).
+            KeyCode::Esc => ViewAction::EmitAndClose(ViewEvent::ModelPickerDismissed {
+                catalog_view: self.view == ModelListView::Catalog,
+                selected_row_id: {
+                    let rows = self.visible_model_rows();
+                    rows.get(self.selected_model_idx).map(|row| row.id.clone())
+                },
+            }),
             KeyCode::Enter if self.model_row_count() == 0 => ViewAction::None,
             KeyCode::Enter => ViewAction::EmitAndClose(self.build_event()),
             // Toggle between configured-only and full-catalog views (#3830).
@@ -2260,7 +2295,10 @@ mod tests {
             KeyCode::Esc,
             crossterm::event::KeyModifiers::NONE,
         ));
-        assert!(matches!(action, ViewAction::Close));
+        assert!(matches!(
+            action,
+            ViewAction::EmitAndClose(ViewEvent::ModelPickerDismissed { .. })
+        ));
     }
 
     #[test]
@@ -2278,7 +2316,67 @@ mod tests {
             crossterm::event::KeyModifiers::NONE,
         ));
 
-        assert!(matches!(action, ViewAction::Close));
+        assert!(matches!(
+            action,
+            ViewAction::EmitAndClose(ViewEvent::ModelPickerDismissed { .. })
+        ));
+    }
+
+    #[test]
+    fn esc_reports_browsing_context_and_reopen_restores_it() {
+        let (mut app, config, _lock) = create_test_app();
+        let mut view = ModelPickerView::new(&app, &config);
+
+        // Browse: switch to the full catalog and move the highlight down two.
+        view.handle_key(KeyEvent::new(
+            KeyCode::Char('a'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        view.handle_key(KeyEvent::new(
+            KeyCode::Down,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        view.handle_key(KeyEvent::new(
+            KeyCode::Down,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        let browsed_id = view.resolved_model();
+
+        let action = view.handle_key(KeyEvent::new(
+            KeyCode::Esc,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        let ViewAction::EmitAndClose(ViewEvent::ModelPickerDismissed {
+            catalog_view,
+            selected_row_id,
+        }) = action
+        else {
+            panic!("expected ModelPickerDismissed, got something else");
+        };
+        assert!(catalog_view, "catalog view should be remembered");
+        assert_eq!(selected_row_id.as_deref(), Some(browsed_id.as_str()));
+
+        // Reopen with the memory applied — same view, same highlighted row.
+        app.model_picker_memory = Some(crate::tui::app::ModelPickerMemory {
+            catalog_view,
+            selected_row_id,
+        });
+        let reopened = ModelPickerView::new(&app, &config);
+        assert_eq!(reopened.view, ModelListView::Catalog);
+        assert_eq!(reopened.resolved_model(), browsed_id);
+    }
+
+    #[test]
+    fn reopen_with_stale_memory_falls_back_to_active_model() {
+        let (mut app, config, _lock) = create_test_app();
+        app.model_picker_memory = Some(crate::tui::app::ModelPickerMemory {
+            catalog_view: false,
+            selected_row_id: Some("model-that-no-longer-exists".to_string()),
+        });
+        let view = ModelPickerView::new(&app, &config);
+        // The remembered row is gone; the picker must still open on a valid
+        // selection (the active model path from the default constructor).
+        assert!(view.selected_model_idx <= view.model_row_count());
     }
 
     /// The four terminal sizes the v0.8.66 modal blocker (#3732) requires every

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -10645,6 +10645,15 @@ async fn handle_view_events(
                 )
                 .await;
             }
+            ViewEvent::ModelPickerDismissed {
+                catalog_view,
+                selected_row_id,
+            } => {
+                app.model_picker_memory = Some(crate::tui::app::ModelPickerMemory {
+                    catalog_view,
+                    selected_row_id,
+                });
+            }
             ViewEvent::ProviderPickerApplied {
                 provider,
                 provider_id,

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -573,6 +573,12 @@ pub enum ViewEvent {
         previous_model: String,
         previous_effort: crate::tui::app::ReasoningEffort,
     },
+    /// Emitted by the `/model` picker on Esc so the next open can restore
+    /// the browsing context — view mode and highlighted row (#4109).
+    ModelPickerDismissed {
+        catalog_view: bool,
+        selected_row_id: Option<String>,
+    },
     /// Emitted by the `/provider` picker when the user selects a provider
     /// that already has credentials — the handler should perform the same
     /// switch as `AppAction::SwitchProvider`.


### PR DESCRIPTION
## Summary

Catalog-lane slice of dogfood finding **A1** on #4092 (#4109): `/model` had no picker memory — reopening reset scroll/selection.

- Esc emits a new `ModelPickerDismissed` event carrying the view mode (configured/catalog) + highlighted row id.
- Stored on `App` session-scoped; the next open restores the view and re-highlights the row (the visible-row window follows the highlight, so scroll restores too). Stale row ids fall back to the active-model selection.
- **No `crates/config` changes** — the contended config lane is untouched.

Note: the configured-only default view + `A` toggle (#3830/#4139 intent) already exists on main; this fills the memory gap the maintainer hit.

## Testing
- 2 new tests (round-trip restore, stale-id fallback), 2 updated Esc tests; `model_picker` module 61 pass
- fmt + CI-flag clippy clean