### PR TITLE
tui: humanize Turn Inspector identity headers (dogfood A6)

### DIFF
--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -142,11 +142,8 @@ fn activity_detail_text(app: &App, cell_index: usize, width: u16) -> Option<Stri
     let mut sections = Vec::new();
 
     if let Some(turn_id) = app.runtime_turn_id.as_ref() {
-        let status = app.runtime_turn_status.as_deref().unwrap_or("in progress");
-        sections.push(format!(
-            "Turn: {} ({status})",
-            truncate_line_to_width(turn_id, 24)
-        ));
+        let status = humanized_turn_status(app);
+        sections.push(format!("Turn {} \u{00B7} {status}", short_turn_id(turn_id)));
     }
 
     sections.push(format!(
@@ -211,11 +208,8 @@ fn reasoning_timeline_text(app: &App, selected_cell_index: usize) -> Option<Stri
 
     let mut sections = Vec::new();
     if let Some(turn_id) = app.runtime_turn_id.as_ref() {
-        let status = app.runtime_turn_status.as_deref().unwrap_or("in progress");
-        sections.push(format!(
-            "Turn: {} ({status})",
-            truncate_line_to_width(turn_id, 24)
-        ));
+        let status = humanized_turn_status(app);
+        sections.push(format!("Turn {} \u{00B7} {status}", short_turn_id(turn_id)));
     }
     sections.push("Activity: reasoning timeline".to_string());
     sections.push(format!(
@@ -861,22 +855,40 @@ fn current_turn_range(app: &App) -> (usize, usize) {
     (start, end)
 }
 
+/// Human form of the runtime turn status — raw enum-ish values like
+/// "in_progress" must never reach the inspector (dogfood A6, #4102).
+fn humanized_turn_status(app: &App) -> &str {
+    match app.runtime_turn_status.as_deref() {
+        Some("in_progress") | None => "in progress",
+        Some(other) => other,
+    }
+}
+
+/// Short display form of a runtime turn id. The full UUID reads as internal
+/// state in the inspector header (dogfood A6); twelve characters is plenty
+/// to correlate with logs.
+fn short_turn_id(turn_id: &str) -> &str {
+    turn_id.get(..12).unwrap_or(turn_id)
+}
+
 /// Assemble the Turn Inspector overview text from all available turn data.
 pub(super) fn turn_inspector_text(app: &App) -> String {
     let (start, end) = current_turn_range(app);
     let mut out: Vec<String> = Vec::new();
 
-    // Turn identity header.
-    if let Some(turn_id) = app.runtime_turn_id.as_ref() {
-        let status = app.runtime_turn_status.as_deref().unwrap_or("in progress");
-        out.push(format!(
-            "Turn: {} ({status})",
-            truncate_line_to_width(turn_id, 32)
-        ));
-    } else if app.turn_counter > 0 {
-        out.push(format!("Turn #{}", app.turn_counter));
+    // Turn identity header. Lead with the human turn number and status; the
+    // id is a short correlation suffix, never a raw UUID dump (dogfood A6).
+    let status = humanized_turn_status(app);
+    if app.turn_counter > 0 {
+        let mut line = format!("Turn #{} \u{00B7} {status}", app.turn_counter);
+        if let Some(turn_id) = app.runtime_turn_id.as_ref() {
+            line.push_str(&format!(" \u{00B7} id {}", short_turn_id(turn_id)));
+        }
+        out.push(line);
+    } else if let Some(turn_id) = app.runtime_turn_id.as_ref() {
+        out.push(format!("Turn {} \u{00B7} {status}", short_turn_id(turn_id)));
     } else {
-        out.push("Turn: — (no turn recorded yet)".to_string());
+        out.push("Turn: \u{2014} (no turn recorded yet)".to_string());
     }
     // Restate the Ctrl+O (overview) vs. `v` (raw leaf detail) contract so the
     // two surfaces never get confused.
@@ -936,10 +948,10 @@ pub(crate) fn turn_handoff_markdown(app: &App) -> String {
 
     // Title + identity — turn id when known, else the turn counter, else a
     // bare heading so an empty transcript still yields a coherent artifact.
-    let heading = if let Some(turn_id) = app.runtime_turn_id.as_ref() {
-        format!("# Turn handoff — {}", truncate_line_to_width(turn_id, 48))
-    } else if app.turn_counter > 0 {
+    let heading = if app.turn_counter > 0 {
         format!("# Turn handoff — Turn #{}", app.turn_counter)
+    } else if let Some(turn_id) = app.runtime_turn_id.as_ref() {
+        format!("# Turn handoff — {}", short_turn_id(turn_id))
     } else {
         "# Turn handoff".to_string()
     };

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10034,7 +10034,12 @@ fn activity_detail_fallback_prefers_live_activity_context() {
     assert!(open_activity_detail_pager(&mut app));
     let body = pop_pager_body(&mut app);
 
-    assert!(body.contains("Turn: turn_live_123456789"));
+    // A6 (#4102): short id + humanized status, never the raw UUID/"in_progress".
+    assert!(
+        body.contains("Turn turn_live_12 \u{00B7} in progress"),
+        "{body}"
+    );
+    assert!(!body.contains("turn_live_123456789"), "{body}");
     assert!(body.contains("Activity: delegate"));
     assert!(body.contains("Status: running"));
     assert!(body.contains("agent_id: agent_af58ba3a"));
@@ -10117,9 +10122,10 @@ fn turn_inspector_renders_overview_sections_for_active_turn() {
 
     // Overview framing + Ctrl+O vs. v contract.
     assert!(
-        body.contains("Turn: turn_abc123456789 (completed)"),
+        body.contains("Turn turn_abc1234 \u{00B7} completed"),
         "{body}"
     );
+    assert!(!body.contains("turn_abc123456789"), "{body}");
     assert!(
         body.contains("press v for the selected item's raw detail"),
         "{body}"
@@ -10379,8 +10385,8 @@ fn turn_handoff_markdown_renders_compact_sections_for_active_turn() {
 
     let md = turn_handoff_markdown(&app);
 
-    // Title carries the turn id.
-    assert!(md.contains("# Turn handoff — turn_abc123456789"), "{md}");
+    // Title carries the short turn id (A6: no raw UUID dumps).
+    assert!(md.contains("# Turn handoff — turn_abc1234"), "{md}");
     // Markdown section headings for the issue's required sections.
     for heading in [
         "## Intent",


### PR DESCRIPTION
## Summary

First cut at dogfood finding **A6** on #4092 (part of #4102): the Ctrl-O Turn Inspector led with a raw turn UUID and the literal `in_progress` status.

- Header now reads `Turn #12 · in progress · id turn_7cbb7126` — human number + status first, 12-char id as a correlation suffix.
- Same helpers applied to the two activity-detail panes and the turn-handoff Markdown heading.
- `in_progress` no longer leaks through these paths.

Deeper timeline grouping/semantics stay with #4102/#4107 (the #4106 numbered timeline is already on main).

## Testing
- Assertions updated for new headers; `tui::ui::tests` 476 pass
- fmt + CI-flag clippy clean