### PR TITLE
feat(tui): fetch and cache live Models.dev catalog into ProviderLake (#4187)

### DIFF
--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -186,14 +186,62 @@ pub fn bundled_catalog_offerings() -> Vec<CatalogOffering> {
 /// [`ModelsDevCatalog::provider_offerings`]). Each row is tagged
 /// [`CatalogSource::Bundled`]. No canonical model is inferred from a prefix; the
 /// canonical link is set only from an explicit `base_model`.
+///
+/// Provider ids are kept verbatim from the Models.dev payload (the committed
+/// bundled asset already uses CodeWhale ids). Live refresh normalizes aliases
+/// via [`live_offerings_from_models_dev`].
 #[must_use]
 pub fn bundled_offerings_from_models_dev(catalog: &ModelsDevCatalog) -> Vec<CatalogOffering> {
+    offerings_from_models_dev(catalog, CatalogSource::Bundled, false)
+}
+
+/// Hydrate live [`CatalogOffering`] rows from a fetched Models.dev catalog (#4187).
+///
+/// Same text-chat filter as [`bundled_offerings_from_models_dev`], but each row is
+/// tagged [`CatalogSource::Live`] with the Models.dev URL fingerprint and fetch
+/// timestamp. Provider keys are normalized onto CodeWhale [`crate::ProviderKind`]
+/// ids when an alias match exists (`moonshotai` → `moonshot`, `togetherai` →
+/// `together`, `zhipuai` → `zai`, …); unknown Models.dev providers keep their
+/// upstream id so they stay discoverable without becoming executable routes.
+#[must_use]
+pub fn live_offerings_from_models_dev(
+    catalog: &ModelsDevCatalog,
+    base_url_fingerprint: &str,
+    fetched_at: u64,
+) -> Vec<CatalogOffering> {
+    offerings_from_models_dev(
+        catalog,
+        CatalogSource::Live {
+            base_url_fingerprint: base_url_fingerprint.to_string(),
+            fetched_at,
+        },
+        true,
+    )
+}
+
+fn offerings_from_models_dev(
+    catalog: &ModelsDevCatalog,
+    source: CatalogSource,
+    normalize_provider_ids: bool,
+) -> Vec<CatalogOffering> {
     let mut out = Vec::new();
     for (provider_key, provider) in &catalog.providers {
-        let provider_id = if provider.id.trim().is_empty() {
-            provider_key.trim().to_string()
+        let raw_id = if provider.id.trim().is_empty() {
+            provider_key.trim()
         } else {
-            provider.id.trim().to_string()
+            provider.id.trim()
+        };
+        if raw_id.is_empty() {
+            continue;
+        }
+        let provider_id = if normalize_provider_ids {
+            // Normalize Models.dev provider ids onto CodeWhale kinds when known
+            // (#4186). Unknown upstream ids are kept verbatim for catalog browsing.
+            crate::ProviderKind::parse(raw_id)
+                .map(|kind| kind.as_str().to_string())
+                .unwrap_or_else(|| raw_id.to_string())
+        } else {
+            raw_id.to_string()
         };
         for model in provider.models.values() {
             if !model.supports_text_chat() {
@@ -211,7 +259,7 @@ pub fn bundled_offerings_from_models_dev(catalog: &ModelsDevCatalog) -> Vec<Cata
                 modalities: model.modalities.clone(),
                 reasoning: model.reasoning,
                 reasoning_options: model.reasoning_options.clone(),
-                source: CatalogSource::Bundled,
+                source: source.clone(),
             });
         }
     }

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -598,3 +598,66 @@ fn bundled_asset_pricing_is_honest() {
     assert_eq!(cost.input, Some(0.98));
     assert_eq!(cost.output, Some(3.08));
 }
+
+#[test]
+fn live_offerings_normalize_models_dev_provider_aliases() {
+    // Live Models.dev ids that must map onto CodeWhale kinds (#4186/#4187).
+    let raw = r#"{
+      "models": {},
+      "providers": {
+        "moonshotai": {
+          "id": "moonshotai",
+          "models": {
+            "kimi-k2.5": {
+              "id": "kimi-k2.5",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        },
+        "togetherai": {
+          "id": "togetherai",
+          "models": {
+            "deepseek-ai/DeepSeek-V4-Pro": {
+              "id": "deepseek-ai/DeepSeek-V4-Pro",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        },
+        "zhipuai": {
+          "id": "zhipuai",
+          "models": {
+            "glm-5.2": {
+              "id": "glm-5.2",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        },
+        "brand-new-gateway": {
+          "id": "brand-new-gateway",
+          "models": {
+            "x-1": {
+              "id": "x-1",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        }
+      }
+    }"#;
+    let catalog = ModelsDevCatalog::parse_json(raw).expect("fixture parses");
+    let rows = live_offerings_from_models_dev(&catalog, "fp-models-dev", 1_700);
+
+    assert_eq!(
+        find(&rows, "moonshot", "kimi-k2.5").source,
+        CatalogSource::Live {
+            base_url_fingerprint: "fp-models-dev".into(),
+            fetched_at: 1_700,
+        }
+    );
+    find(&rows, "together", "deepseek-ai/DeepSeek-V4-Pro");
+    find(&rows, "zai", "glm-5.2");
+    // Unknown upstream providers keep their Models.dev id.
+    find(&rows, "brand-new-gateway", "x-1");
+    assert!(rows.iter().all(|r| r.provider != "moonshotai"));
+    assert!(rows.iter().all(|r| r.provider != "togetherai"));
+    assert!(rows.iter().all(|r| r.provider != "zhipuai"));
+}

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -341,7 +341,10 @@ provider!(
     DEFAULT_MOONSHOT_MODEL,
     ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
     "moonshot",
-    aliases: ["moonshot-ai", "kimi", "kimi-k2"]
+    // `moonshotai` is the id Models.dev publishes for Moonshot/Kimi; without
+    // it a live/full Models.dev catalog row keyed `moonshotai` would fail to
+    // normalize onto ProviderKind::Moonshot (Refs #4186).
+    aliases: ["moonshot-ai", "moonshotai", "moonshot_ai", "kimi", "kimi-k2"]
 );
 provider!(
     Sglang,

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -54,6 +54,7 @@ pub enum ProviderKind {
     Arcee,
     #[serde(alias = "siliconflow-cn", alias = "siliconflow-CN")]
     SiliconflowCN,
+    #[serde(alias = "moonshot-ai", alias = "moonshotai", alias = "moonshot_ai")]
     Moonshot,
     Sglang,
     Vllm,

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -3368,11 +3368,12 @@ fn provider_kind_parses_openrouter_and_novita_aliases() {
 }
 
 /// Models.dev publishes provider ids that do not always match CodeWhale's
-/// canonical id (`fireworks-ai`, `togetherai`, `novita-ai`). These MUST
-/// normalize onto the right [`ProviderKind`] via [`ProviderKind::parse`], which
-/// is the seam `ModelReferenceCard::from_offering` uses to label a live-catalog
-/// row's provider kind. A miss here means Fireworks/Together/Novita models from
-/// the live Models.dev catalog land under an `unknown` kind (Refs #4186).
+/// canonical id (`fireworks-ai`, `togetherai`, `novita-ai`, `moonshotai`).
+/// These MUST normalize onto the right [`ProviderKind`] via
+/// [`ProviderKind::parse`], which is the seam `ModelReferenceCard::from_offering`
+/// uses to label a live-catalog row's provider kind. A miss here means
+/// Fireworks/Together/Novita/Moonshot models from the live Models.dev catalog
+/// land under an `unknown` kind (Refs #4186).
 #[test]
 fn provider_kind_normalizes_models_dev_provider_ids() {
     let cases = [
@@ -3382,12 +3383,19 @@ fn provider_kind_normalizes_models_dev_provider_ids() {
         ("together_ai", ProviderKind::Together),
         ("novita-ai", ProviderKind::Novita),
         ("novita_ai", ProviderKind::Novita),
+        // Live Models.dev key for Moonshot/Kimi (verified 2026-07-08).
+        ("moonshotai", ProviderKind::Moonshot),
+        ("moonshot-ai", ProviderKind::Moonshot),
+        ("moonshot_ai", ProviderKind::Moonshot),
+        ("nvidia", ProviderKind::NvidiaNim),
+        ("xiaomi", ProviderKind::XiaomiMimo),
         ("deepinfra", ProviderKind::Deepinfra),
         ("siliconflow", ProviderKind::Siliconflow),
         // Models.dev spells the China endpoint `siliconflow-cn`; CodeWhale's
         // canonical id is `siliconflow-CN` and `parse` is case-insensitive.
         ("siliconflow-cn", ProviderKind::SiliconflowCN),
         ("openrouter", ProviderKind::Openrouter),
+        ("longcat", ProviderKind::LongCat),
     ];
     for (models_dev_id, expected) in cases {
         assert_eq!(
@@ -3398,11 +3406,13 @@ fn provider_kind_normalizes_models_dev_provider_ids() {
     }
 
     // The separator-free Models.dev ids must also deserialize from config TOML,
-    // so a `provider = "togetherai"` / `"novita-ai"` line resolves identically.
+    // so a `provider = "togetherai"` / `"novita-ai"` / `"moonshotai"` line
+    // resolves identically.
     for (alias, expected) in [
         ("togetherai", ProviderKind::Together),
         ("novita-ai", ProviderKind::Novita),
         ("fireworks-ai", ProviderKind::Fireworks),
+        ("moonshotai", ProviderKind::Moonshot),
     ] {
         let parsed: ConfigToml =
             toml::from_str(&format!("provider = \"{alias}\"")).expect("models.dev id alias");

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -122,6 +122,11 @@ pub fn exit() -> CommandResult {
 /// way to flip both knobs without memorising the docs.
 pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
     if let Some(name) = model_name {
+        // Manual Models.dev catalog refresh (#4187). Dispatched async so the
+        // TUI event loop is not blocked; failure keeps prior/bundled rows.
+        if name.trim().eq_ignore_ascii_case("refresh") {
+            return CommandResult::action(AppAction::RefreshModelsDevCatalog);
+        }
         if name.trim().eq_ignore_ascii_case("auto") {
             let old_model = app.model_display_label();
             let model_changed = !app.auto_model || app.model != "auto";
@@ -1279,6 +1284,17 @@ mod tests {
         let result = models(&mut app);
         assert!(result.message.is_none());
         assert!(matches!(result.action, Some(AppAction::FetchModels)));
+    }
+
+    #[test]
+    fn model_refresh_dispatches_models_dev_catalog_action() {
+        let mut app = create_test_app();
+        let result = model(&mut app, Some("refresh"));
+        assert!(result.message.is_none());
+        assert!(matches!(
+            result.action,
+            Some(AppAction::RefreshModelsDevCatalog)
+        ));
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/core/model.rs
+++ b/crates/tui/src/commands/groups/core/model.rs
@@ -9,7 +9,7 @@ use super::CommandResult;
 pub(in crate::commands) const COMMAND_INFO: CommandInfo = CommandInfo {
     name: "model",
     aliases: &["moxing"],
-    usage: "/model [name]",
+    usage: "/model [name|refresh]",
     description_id: MessageId::CmdModelDescription,
 };
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -65,6 +65,7 @@ mod model_profile;
 mod model_registry;
 mod model_routing;
 mod models;
+mod models_dev_live;
 mod network_policy;
 mod oauth;
 mod palette;
@@ -7124,6 +7125,12 @@ async fn run_interactive(
     }
 
     startup_trace::mark("interactive_config");
+
+    // Seed ProviderLake from the secret-free Models.dev disk cache before any
+    // picker/inventory read, then kick a best-effort background refresh (#4187).
+    // Failures are quiet: bundled catalog rows always remain available.
+    crate::models_dev_live::maybe_load_persisted_cache();
+    crate::models_dev_live::spawn_background_refresh();
 
     // Boot janitors — snapshot prune (7-day default), spillover prune
     // (#422), and managed-session cleanup (v0.8.44) — are best-effort disk

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -1,0 +1,619 @@
+//! Live Models.dev catalog fetch + secret-free disk cache (#4187).
+//!
+//! OpenCode-style producer that:
+//! - reads a stale/fresh disk cache on startup (never blocks model selection),
+//! - fetches `https://models.dev/catalog.json` in the background with a bounded
+//!   timeout and explicit user-agent (no credentials),
+//! - writes the cache atomically via temp file + rename,
+//! - compiles parsed rows into [`CatalogOffering`]s and publishes them into
+//!   [`crate::provider_lake`],
+//! - falls back to the prior cache or the bundled snapshot on any failure.
+//!
+//! Override knobs (tests / dogfood):
+//! - `CODEWHALE_MODELS_DEV_URL` — base URL (appends `/catalog.json`) or a full
+//!   `*.json` URL.
+//! - `CODEWHALE_MODELS_DEV_PATH` — local file path; skips the network.
+//! - `CODEWHALE_DISABLE_MODELS_DEV_FETCH` — when truthy, never hits the network.
+
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::Duration;
+
+use codewhale_config::catalog::{
+    CatalogSnapshot, base_url_fingerprint, live_offerings_from_models_dev, now_unix,
+};
+use codewhale_config::models_dev::{MODELS_DEV_CATALOG_URL, ModelsDevCatalog};
+use codewhale_config::persistence::atomic_write;
+use serde::{Deserialize, Serialize};
+
+/// Default TTL for a live Models.dev snapshot (24h, #4187 / #4114).
+pub const DEFAULT_MODELS_DEV_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Bounded HTTP timeout for the Models.dev fetch.
+pub const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Explicit user-agent; no credentials, no session cookies.
+pub const USER_AGENT: &str = concat!("CodeWhale/", env!("CARGO_PKG_VERSION"), " (+models-dev)");
+
+/// Filename under the CodeWhale `catalog` state dir.
+pub const CACHE_FILE: &str = "models-dev-catalog.json";
+
+/// Env: override Models.dev base URL or full catalog URL.
+pub const ENV_MODELS_DEV_URL: &str = "CODEWHALE_MODELS_DEV_URL";
+/// Env: load catalog JSON from a local path (skips network).
+pub const ENV_MODELS_DEV_PATH: &str = "CODEWHALE_MODELS_DEV_PATH";
+/// Env: disable network fetch entirely (`1`/`true`/`yes`/`on`).
+pub const ENV_DISABLE_FETCH: &str = "CODEWHALE_DISABLE_MODELS_DEV_FETCH";
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+/// Provenance / freshness of the Models.dev live layer for UI chips (#4187).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelsDevFreshness {
+    /// No live/cache layer; pickers see bundled rows only.
+    #[default]
+    Bundled,
+    /// Live (or disk-cache) rows within TTL.
+    Live,
+    /// Disk-cache / prior live rows past TTL; still visible.
+    Stale,
+    /// Last refresh failed; prior/bundled rows remain available.
+    Failed,
+}
+
+/// Quiet status snapshot for UI / `/model refresh` feedback.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ModelsDevStatus {
+    pub freshness: ModelsDevFreshness,
+    pub offering_count: usize,
+    pub fetched_at: Option<u64>,
+    pub source_label: String,
+    pub last_error: Option<String>,
+}
+
+static STATUS: RwLock<ModelsDevStatus> = RwLock::new(ModelsDevStatus {
+    freshness: ModelsDevFreshness::Bundled,
+    offering_count: 0,
+    fetched_at: None,
+    source_label: String::new(),
+    last_error: None,
+});
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedModelsDevCache {
+    schema_version: u32,
+    /// Unix seconds the payload was fetched (or loaded from an override path).
+    fetched_at: u64,
+    /// Fingerprint of the source URL/path used for [`CatalogSource::Live`].
+    source_fingerprint: String,
+    /// Human-readable source label (URL or `file:…`); never a secret.
+    source_label: String,
+    /// Raw Models.dev catalog JSON body (secret-free by construction).
+    body: String,
+}
+
+/// Why a Models.dev refresh did not publish new rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelsDevRefreshError {
+    Disabled,
+    Network(String),
+    HttpStatus(u16),
+    InvalidResponse(String),
+    EmptyCatalog,
+    Io(String),
+}
+
+impl std::fmt::Display for ModelsDevRefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "Models.dev fetch disabled"),
+            Self::Network(msg) => write!(f, "network: {msg}"),
+            Self::HttpStatus(code) => write!(f, "HTTP {code}"),
+            Self::InvalidResponse(msg) => write!(f, "invalid response: {msg}"),
+            Self::EmptyCatalog => write!(f, "empty catalog"),
+            Self::Io(msg) => write!(f, "io: {msg}"),
+        }
+    }
+}
+
+/// Resolve the on-disk cache path under the CodeWhale `catalog` state dir.
+#[must_use]
+pub fn cache_path() -> Option<PathBuf> {
+    codewhale_config::resolve_state_dir("catalog")
+        .ok()
+        .map(|dir| dir.join(CACHE_FILE))
+}
+
+/// Current quiet status (for UI / slash-command feedback).
+#[must_use]
+pub fn status() -> ModelsDevStatus {
+    STATUS.read().map(|guard| guard.clone()).unwrap_or_default()
+}
+
+fn set_status(next: ModelsDevStatus) {
+    if let Ok(mut guard) = STATUS.write() {
+        *guard = next;
+    }
+}
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Resolve the catalog URL from env override or the Models.dev default.
+#[must_use]
+pub fn resolve_catalog_url() -> String {
+    match std::env::var(ENV_MODELS_DEV_URL) {
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                MODELS_DEV_CATALOG_URL.to_string()
+            } else if trimmed.ends_with(".json") {
+                trimmed.to_string()
+            } else {
+                format!("{}/catalog.json", trimmed.trim_end_matches('/'))
+            }
+        }
+        Err(_) => MODELS_DEV_CATALOG_URL.to_string(),
+    }
+}
+
+/// Seed ProviderLake from the on-disk Models.dev cache before any picker read.
+///
+/// Missing / corrupt / empty caches are a no-op — bundled rows remain available.
+/// Stale caches still publish (freshness = Stale) so offline startups keep the
+/// last-known live rows.
+pub fn maybe_load_persisted_cache() {
+    let Some(path) = cache_path() else {
+        return;
+    };
+    if let Some(cache) = load_cache_file(&path) {
+        let age = now_unix().saturating_sub(cache.fetched_at);
+        let freshness = if age > DEFAULT_MODELS_DEV_TTL_SECS {
+            ModelsDevFreshness::Stale
+        } else {
+            ModelsDevFreshness::Live
+        };
+        if let Err(err) = publish_from_body(
+            &cache.body,
+            &cache.source_fingerprint,
+            cache.fetched_at,
+            &cache.source_label,
+            freshness,
+        ) {
+            tracing::debug!(
+                target: "models_dev_live",
+                error = %err,
+                "persisted Models.dev cache failed to publish; keeping bundled"
+            );
+        }
+    }
+}
+
+/// Force a refresh: prefer `CODEWHALE_MODELS_DEV_PATH`, else network fetch.
+///
+/// On success, updates the disk cache and ProviderLake. On failure, keeps any
+/// prior live/bundled rows and records a quiet Failed status.
+pub async fn refresh(force_network: bool) -> Result<usize, ModelsDevRefreshError> {
+    if let Ok(path) = std::env::var(ENV_MODELS_DEV_PATH) {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return refresh_from_path(Path::new(trimmed)).await;
+        }
+    }
+
+    if env_truthy(ENV_DISABLE_FETCH) {
+        mark_failed(ModelsDevRefreshError::Disabled);
+        return Err(ModelsDevRefreshError::Disabled);
+    }
+
+    if !force_network {
+        let current = status();
+        if current.freshness == ModelsDevFreshness::Live
+            && current
+                .fetched_at
+                .is_some_and(|ts| now_unix().saturating_sub(ts) < DEFAULT_MODELS_DEV_TTL_SECS)
+        {
+            return Ok(current.offering_count);
+        }
+    }
+
+    let url = resolve_catalog_url();
+    let body = fetch_catalog_body(&url).await?;
+    let fetched_at = now_unix();
+    let fingerprint = base_url_fingerprint(&url);
+    let count = publish_from_body(
+        &body,
+        &fingerprint,
+        fetched_at,
+        &url,
+        ModelsDevFreshness::Live,
+    )?;
+    if let Some(path) = cache_path() {
+        let _ = save_cache_file(
+            &path,
+            &PersistedModelsDevCache {
+                schema_version: CACHE_SCHEMA_VERSION,
+                fetched_at,
+                source_fingerprint: fingerprint,
+                source_label: url,
+                body,
+            },
+        );
+    }
+    Ok(count)
+}
+
+/// Best-effort background refresh: never panics, never blocks callers.
+pub fn spawn_background_refresh() {
+    if env_truthy(ENV_DISABLE_FETCH) && std::env::var(ENV_MODELS_DEV_PATH).is_err() {
+        return;
+    }
+    tokio::spawn(async {
+        match refresh(false).await {
+            Ok(count) => {
+                tracing::debug!(
+                    target: "models_dev_live",
+                    offering_count = count,
+                    "Models.dev live catalog refreshed"
+                );
+            }
+            Err(err) => {
+                tracing::debug!(
+                    target: "models_dev_live",
+                    error = %err,
+                    "Models.dev live catalog refresh skipped"
+                );
+            }
+        }
+    });
+}
+
+async fn refresh_from_path(path: &Path) -> Result<usize, ModelsDevRefreshError> {
+    let body = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|err| ModelsDevRefreshError::Io(err.to_string()))?;
+    let fetched_at = now_unix();
+    let label = format!("file:{}", path.display());
+    let fingerprint = base_url_fingerprint(&label);
+    let count = publish_from_body(
+        &body,
+        &fingerprint,
+        fetched_at,
+        &label,
+        ModelsDevFreshness::Live,
+    )?;
+    if let Some(cache) = cache_path() {
+        let _ = save_cache_file(
+            &cache,
+            &PersistedModelsDevCache {
+                schema_version: CACHE_SCHEMA_VERSION,
+                fetched_at,
+                source_fingerprint: fingerprint,
+                source_label: label,
+                body,
+            },
+        );
+    }
+    Ok(count)
+}
+
+async fn fetch_catalog_body(url: &str) -> Result<String, ModelsDevRefreshError> {
+    let client = crate::tls::reqwest_client_builder()
+        .timeout(FETCH_TIMEOUT)
+        .connect_timeout(Duration::from_secs(10))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|err| ModelsDevRefreshError::Network(err.to_string()))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| ModelsDevRefreshError::Network(err.to_string()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let err = ModelsDevRefreshError::HttpStatus(status.as_u16());
+        mark_failed(err.clone());
+        return Err(err);
+    }
+
+    response
+        .text()
+        .await
+        .map_err(|err| ModelsDevRefreshError::Network(err.to_string()))
+}
+
+fn publish_from_body(
+    body: &str,
+    fingerprint: &str,
+    fetched_at: u64,
+    source_label: &str,
+    freshness: ModelsDevFreshness,
+) -> Result<usize, ModelsDevRefreshError> {
+    let catalog = ModelsDevCatalog::parse_json(body).map_err(|err| {
+        let mapped = ModelsDevRefreshError::InvalidResponse(err.to_string());
+        mark_failed(mapped.clone());
+        mapped
+    })?;
+    let offerings = live_offerings_from_models_dev(&catalog, fingerprint, fetched_at);
+    if offerings.is_empty() {
+        let err = ModelsDevRefreshError::EmptyCatalog;
+        mark_failed(err.clone());
+        return Err(err);
+    }
+    let count = offerings.len();
+    crate::provider_lake::set_live_snapshot(CatalogSnapshot { offerings });
+    set_status(ModelsDevStatus {
+        freshness,
+        offering_count: count,
+        fetched_at: Some(fetched_at),
+        source_label: source_label.to_string(),
+        last_error: None,
+    });
+    Ok(count)
+}
+
+fn mark_failed(err: ModelsDevRefreshError) {
+    let mut next = status();
+    // Keep prior offering_count / fetched_at so UI can still show stale rows.
+    next.freshness = if next.offering_count > 0 {
+        ModelsDevFreshness::Stale
+    } else {
+        ModelsDevFreshness::Failed
+    };
+    next.last_error = Some(err.to_string());
+    set_status(next);
+}
+
+fn load_cache_file(path: &Path) -> Option<PersistedModelsDevCache> {
+    let bytes = std::fs::read(path).ok()?;
+    let cache: PersistedModelsDevCache = serde_json::from_slice(&bytes).ok()?;
+    if cache.schema_version != CACHE_SCHEMA_VERSION {
+        return None;
+    }
+    if cache.body.trim().is_empty() {
+        return None;
+    }
+    Some(cache)
+}
+
+fn save_cache_file(
+    path: &Path,
+    cache: &PersistedModelsDevCache,
+) -> Result<(), ModelsDevRefreshError> {
+    let bytes =
+        serde_json::to_vec(cache).map_err(|err| ModelsDevRefreshError::Io(err.to_string()))?;
+    atomic_write(path, &bytes).map_err(|err| ModelsDevRefreshError::Io(err.to_string()))
+}
+
+/// Compile helper exposed for unit tests: body → live offerings with normalized
+/// provider ids.
+#[cfg(test)]
+pub(crate) fn offerings_from_json_for_test(
+    body: &str,
+) -> Result<Vec<codewhale_config::catalog::CatalogOffering>, String> {
+    let catalog = ModelsDevCatalog::parse_json(body).map_err(|e| e.to_string())?;
+    Ok(live_offerings_from_models_dev(
+        &catalog,
+        "test-fp",
+        1_700_000_000,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ApiProvider;
+    use crate::provider_lake::{all_catalog_models_for_provider, clear_live_snapshot};
+    use crate::test_support::{EnvVarGuard, lock_test_env};
+    use codewhale_config::catalog::CatalogSource;
+
+    const FIXTURE: &str = r#"{
+      "models": {},
+      "providers": {
+        "togetherai": {
+          "id": "togetherai",
+          "models": {
+            "deepseek-ai/DeepSeek-V4-Pro": {
+              "id": "deepseek-ai/DeepSeek-V4-Pro",
+              "name": "DeepSeek V4 Pro",
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 128000, "output": 8192 }
+            }
+          }
+        },
+        "moonshotai": {
+          "id": "moonshotai",
+          "models": {
+            "kimi-k2.5": {
+              "id": "kimi-k2.5",
+              "name": "Kimi K2.5",
+              "modalities": { "input": ["text"], "output": ["text"] },
+              "limit": { "context": 256000, "output": 8192 }
+            }
+          }
+        },
+        "unknown-gateway": {
+          "id": "unknown-gateway",
+          "models": {
+            "mystery-1": {
+              "id": "mystery-1",
+              "modalities": { "input": ["text"], "output": ["text"] }
+            }
+          }
+        }
+      }
+    }"#;
+
+    #[test]
+    fn resolve_catalog_url_defaults_and_overrides() {
+        let _lock = lock_test_env();
+        let _url = EnvVarGuard::remove(ENV_MODELS_DEV_URL);
+        assert_eq!(resolve_catalog_url(), MODELS_DEV_CATALOG_URL);
+
+        let _url = EnvVarGuard::set(ENV_MODELS_DEV_URL, "https://example.test");
+        assert_eq!(resolve_catalog_url(), "https://example.test/catalog.json");
+
+        let _url = EnvVarGuard::set(ENV_MODELS_DEV_URL, "https://example.test/api.json");
+        assert_eq!(resolve_catalog_url(), "https://example.test/api.json");
+    }
+
+    #[test]
+    fn live_offerings_normalize_models_dev_provider_ids() {
+        let rows = offerings_from_json_for_test(FIXTURE).expect("fixture");
+        let providers: Vec<_> = rows.iter().map(|r| r.provider.as_str()).collect();
+        assert!(providers.contains(&"together"));
+        assert!(providers.contains(&"moonshot"));
+        assert!(providers.contains(&"unknown-gateway"));
+        assert!(!providers.contains(&"togetherai"));
+        assert!(!providers.contains(&"moonshotai"));
+        assert!(
+            rows.iter()
+                .all(|r| matches!(r.source, CatalogSource::Live { .. }))
+        );
+    }
+
+    #[test]
+    fn publish_from_path_updates_provider_lake() {
+        let _lock = lock_test_env();
+        clear_live_snapshot();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("catalog.json");
+        std::fs::write(&path, FIXTURE).expect("write fixture");
+
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", dir.path().join("home"));
+        let _disable = EnvVarGuard::set(ENV_DISABLE_FETCH, "1");
+        let _path = EnvVarGuard::set(ENV_MODELS_DEV_PATH, &path);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let count = rt.block_on(refresh(true)).expect("refresh from path");
+        assert!(count >= 2);
+
+        let together = all_catalog_models_for_provider(ApiProvider::Together);
+        assert!(
+            together.iter().any(|m| m == "deepseek-ai/DeepSeek-V4-Pro"),
+            "Together lake missing live Models.dev row: {together:?}"
+        );
+        let moonshot = all_catalog_models_for_provider(ApiProvider::Moonshot);
+        assert!(
+            moonshot.iter().any(|m| m == "kimi-k2.5"),
+            "Moonshot lake missing live Models.dev row: {moonshot:?}"
+        );
+
+        let st = status();
+        assert_eq!(st.freshness, ModelsDevFreshness::Live);
+        assert!(st.last_error.is_none());
+        assert!(st.offering_count >= 2);
+
+        // Cache file should exist and be secret-free.
+        let cache = cache_path().expect("cache path");
+        assert!(cache.exists());
+        let on_disk = std::fs::read_to_string(&cache).expect("read cache");
+        let lowered = on_disk.to_lowercase();
+        for needle in ["api_key", "authorization", "bearer", "password"] {
+            assert!(
+                !lowered.contains(&format!("\"{needle}\"")),
+                "cache must not persist `{needle}`"
+            );
+        }
+
+        clear_live_snapshot();
+    }
+
+    #[test]
+    fn invalid_json_keeps_bundled_and_marks_failed() {
+        let _lock = lock_test_env();
+        clear_live_snapshot();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, "{not-json").expect("write");
+
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", dir.path().join("home"));
+        let _path = EnvVarGuard::set(ENV_MODELS_DEV_PATH, &path);
+
+        let before = all_catalog_models_for_provider(ApiProvider::Together);
+        assert!(!before.is_empty(), "bundled Together rows required");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let err = rt.block_on(refresh(true)).expect_err("bad json");
+        assert!(matches!(err, ModelsDevRefreshError::InvalidResponse(_)));
+
+        let after = all_catalog_models_for_provider(ApiProvider::Together);
+        assert_eq!(after, before, "bundled rows must survive parse failure");
+        clear_live_snapshot();
+    }
+
+    #[test]
+    fn stale_disk_cache_still_publishes() {
+        let _lock = lock_test_env();
+        clear_live_snapshot();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = dir.path().join("home");
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", &home);
+
+        let cache_dir = home.join("catalog");
+        std::fs::create_dir_all(&cache_dir).expect("mkdir");
+        let cache = cache_dir.join(CACHE_FILE);
+        let stale = PersistedModelsDevCache {
+            schema_version: CACHE_SCHEMA_VERSION,
+            fetched_at: 1, // far in the past → stale
+            source_fingerprint: "stale-fp".into(),
+            source_label: "https://models.dev/catalog.json".into(),
+            body: FIXTURE.into(),
+        };
+        save_cache_file(&cache, &stale).expect("save");
+
+        maybe_load_persisted_cache();
+        let st = status();
+        assert_eq!(st.freshness, ModelsDevFreshness::Stale);
+        assert!(st.offering_count >= 2);
+        let together = all_catalog_models_for_provider(ApiProvider::Together);
+        assert!(together.iter().any(|m| m == "deepseek-ai/DeepSeek-V4-Pro"));
+        clear_live_snapshot();
+    }
+
+    #[tokio::test]
+    async fn network_failure_keeps_prior_rows() {
+        let _lock = lock_test_env();
+        clear_live_snapshot();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("catalog.json");
+        std::fs::write(&path, FIXTURE).expect("write");
+
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", dir.path().join("home"));
+        let _path = EnvVarGuard::set(ENV_MODELS_DEV_PATH, &path);
+        let count = refresh(true).await.expect("seed from path");
+        assert!(count >= 2);
+
+        // Point at a dead URL and force network (clear path override).
+        let _path = EnvVarGuard::remove(ENV_MODELS_DEV_PATH);
+        let _disable = EnvVarGuard::remove(ENV_DISABLE_FETCH);
+        let _url = EnvVarGuard::set(ENV_MODELS_DEV_URL, "http://127.0.0.1:1");
+
+        let err = refresh(true).await.expect_err("dead URL");
+        assert!(matches!(err, ModelsDevRefreshError::Network(_)));
+
+        let together = all_catalog_models_for_provider(ApiProvider::Together);
+        assert!(
+            together.iter().any(|m| m == "deepseek-ai/DeepSeek-V4-Pro"),
+            "prior live rows must survive network failure"
+        );
+        clear_live_snapshot();
+    }
+}

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -6217,6 +6217,8 @@ pub enum AppAction {
     },
     ListSubAgents,
     FetchModels,
+    /// Force a Models.dev live-catalog refresh into ProviderLake (#4187).
+    RefreshModelsDevCatalog,
     CacheWarmup,
     /// Switch the active LLM backend (DeepSeek vs NVIDIA NIM) without
     /// restarting the process. The runtime rebuilds its API client from

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8089,6 +8089,34 @@ async fn apply_command_result(
                     }
                 }
             }
+            AppAction::RefreshModelsDevCatalog => {
+                app.status_message = Some("Refreshing Models.dev catalog...".to_string());
+                let message = match crate::models_dev_live::refresh(true).await {
+                    Ok(count) => {
+                        let status = crate::models_dev_live::status();
+                        let source = if status.source_label.is_empty() {
+                            "unknown"
+                        } else {
+                            status.source_label.as_str()
+                        };
+                        format!(
+                            "Models.dev catalog refreshed: {count} offerings ({:?}, source {source})",
+                            status.freshness
+                        )
+                    }
+                    Err(err) => {
+                        let status = crate::models_dev_live::status();
+                        format!(
+                            "Models.dev refresh failed ({err}); keeping prior/bundled rows ({} offerings, {:?})",
+                            status.offering_count, status.freshness
+                        )
+                    }
+                };
+                app.add_message(HistoryCell::System {
+                    content: message.clone(),
+                });
+                app.status_message = Some(message);
+            }
             AppAction::CacheWarmup => {
                 app.status_message = Some("Warming DeepSeek cache...".to_string());
                 match run_cache_warmup(app, config).await {


### PR DESCRIPTION
## Summary
- Adds a secret-free Models.dev live producer (`crates/tui/src/models_dev_live.rs`) that loads disk cache on startup, background-refreshes `catalog.json`, compiles offerings, and publishes into `provider_lake`.
- Live rows normalize Models.dev provider aliases onto CodeWhale kinds (`moonshotai`→`moonshot`, `togetherai`→`together`, `zhipuai`→`zai`, …); unknown upstream providers keep their id.
- Manual refresh via `/model refresh`; failures keep prior/bundled rows and never break model selection.
- Stacked on #4245 (`moonshotai` alias) so live Moonshot rows resolve correctly.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy -p codewhale-config -p codewhale-tui --bin codewhale-tui --locked` (with CI allows)
- [x] `cargo test -p codewhale-config --locked live_offerings_normalize`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked models_dev_live`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked model_refresh_dispatches`
- [ ] CI green

Refs #4187 · Depends on #4245 · Parent #4184 / tracking #4092

Made with [Cursor](https://cursor.com)