### PR TITLE
fix(catalog): demote bundled Models.dev snapshot (#4188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Demote the bundled Models.dev snapshot to an offline/stale fallback after
+  live catalog refresh (#4188). ProviderLake precedence is live Models.dev >
+  bundled seed > legacy hardcoded completion names; pickers, inventory, and
+  subagent validation stay catalog-backed, and CodeWhale-only providers keep
+  defaults when Models.dev has no rows.
+
 ### Added
 
 - Workflow runs are now durable: every run appends to a

--- a/crates/config/assets/models_dev.bundled.json
+++ b/crates/config/assets/models_dev.bundled.json
@@ -1,11 +1,12 @@
 {
   "_meta": {
-    "about": "Bundled, network-free Models.dev-shaped catalog snapshot for CodeWhale (#3385).",
+    "about": "Offline/stale fallback Models.dev-shaped catalog snapshot for CodeWhale (#3385, demoted by #4188).",
     "schema": "Matches crates/config/src/models_dev.rs ModelsDevCatalog ({ models, providers }).",
-    "source": "Curated from in-repo verified facts, NOT a live models.dev dump. Context windows and max-output are sourced from crates/tui/src/models.rs (context_window_for_model / max_output_tokens_for_model); USD-per-million pricing is sourced from crates/tui/src/pricing.rs. The public models.dev catalog tracks a different (real) model generation than CodeWhale's curated forward-dated model set, so a live transform would disagree with the repo's own model registry and tests. Curated-but-accurate is preferred per the issue.",
+    "role": "NOT a competing source of truth. Preferred metadata is the live Models.dev catalog published into ProviderLake (#4187). This asset is used only when live/cache rows are unavailable (offline startup, failed refresh, or empty cache).",
+    "source": "Compact offline seed of verified in-repo defaults (context/output from crates/tui/src/models.rs; USD pricing from crates/tui/src/pricing.rs) for providers CodeWhale ships with. It is intentionally smaller than a full Models.dev dump; live refresh supersedes these rows on (provider, wire_model_id) identity.",
     "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), Anthropic rows (no in-repo per-token table), and Xiaomi MiMo Token-Plan rows (credit/quota based). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
-    "default_rows": "Each provider's `default: true` wire id equals that provider's built-in DEFAULT_*_MODEL so RouteResolver::new() and the descriptor stay in agreement.",
-    "coverage": "13 providers, 31 chat offerings."
+    "default_rows": "Each provider's `default: true` wire id equals that provider's built-in DEFAULT_*_MODEL so RouteResolver::new() and the descriptor stay in agreement when offline.",
+    "coverage": "13 providers, 31 chat offerings (offline seed only)."
   },
   "models": {
     "deepseek-v4-pro": {

--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -6,13 +6,16 @@
 //! refresh) and live [`ProviderCatalogDelta`]s; the HTTP `/models` fetch layer
 //! lives above this module. Nothing here performs I/O or reads credentials.
 //!
-//! Layering (lowest precedence first):
+//! Layering (lowest precedence first; #4188):
 //!
 //! ```text
-//! bundled Models.dev snapshot / built-in seeds
-//!   < provider live `/models` cache  (scoped per provider + base-URL fingerprint)
+//! bundled Models.dev snapshot       (offline/stale fallback only — not competing truth)
+//!   < live Models.dev / provider `/models` cache
 //!   < user / custom overrides        (custom endpoints, pinned models, explicit facts)
 //! ```
+//!
+//! After #4187, live Models.dev rows are preferred whenever present. The bundled
+//! asset remains so offline startup and failed refreshes still resolve defaults.
 //!
 //! Invariants preserved from #2608 / #3497:
 //! - A catalog row is **not** an executable route. Rows still compile through
@@ -41,7 +44,8 @@ use crate::route::{ModelId, ProviderId, ProviderModelOffering, RouteLimits, Wire
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CatalogSource {
-    /// Bundled, network-free seed (a Models.dev snapshot or built-in defaults).
+    /// Offline/stale bundled seed (Models.dev-shaped snapshot). Not competing
+    /// truth — live Models.dev rows override this layer (#4188).
     #[default]
     Bundled,
     /// A provider live `/models` row, scoped to a base-URL fingerprint and the
@@ -146,15 +150,15 @@ impl CatalogOffering {
     }
 }
 
-/// The committed, network-free Models.dev-shaped catalog snapshot (#3385).
+/// Committed offline/stale Models.dev-shaped catalog snapshot (#3385 / #4188).
 ///
-/// Curated from in-repo verified model facts (context windows / output caps from
-/// `crates/tui/src/models.rs`, USD pricing from `crates/tui/src/pricing.rs`)
-/// rather than a live models.dev dump, because the public catalog tracks a
-/// different real model generation than CodeWhale's curated forward-dated set.
-/// This is the default bundled layer feeding [`crate::route::RouteResolver::new`].
-/// See the asset's `_meta` block for sourcing and the honesty rule on omitted
-/// pricing (`UnknownOrStale`, never a fabricated zero).
+/// This is **not** a competing curated source of truth. Preferred metadata comes
+/// from the live Models.dev catalog (#4187). The bundled asset is a compact
+/// network-free seed of verified in-repo defaults (context/output from
+/// `crates/tui/src/models.rs`, USD pricing from `crates/tui/src/pricing.rs`) so
+/// [`crate::route::RouteResolver::new`] and pickers still work offline or after
+/// a failed refresh. See the asset's `_meta.role` / `_meta.source` and the
+/// honesty rule on omitted pricing (`UnknownOrStale`, never a fabricated zero).
 pub const BUNDLED_MODELS_DEV_JSON: &str = include_str!("../assets/models_dev.bundled.json");
 
 /// Parse the committed bundled Models.dev snapshot.
@@ -169,11 +173,11 @@ pub fn bundled_models_dev_catalog() -> ModelsDevCatalog {
         .expect("committed bundled Models.dev asset must be valid JSON")
 }
 
-/// The bundled-layer [`CatalogOffering`] rows from the committed snapshot.
+/// Bundled-layer [`CatalogOffering`] rows from the offline snapshot (#4188).
 ///
-/// This is the real-data source for the default resolver: every text-chat row
-/// from [`BUNDLED_MODELS_DEV_JSON`], tagged [`CatalogSource::Bundled`], with
-/// honest limits and pricing.
+/// Lowest-precedence catalog layer: every text-chat row from
+/// [`BUNDLED_MODELS_DEV_JSON`], tagged [`CatalogSource::Bundled`]. Live Models.dev
+/// rows override these on `(provider, wire_model_id)` when available.
 #[must_use]
 pub fn bundled_catalog_offerings() -> Vec<CatalogOffering> {
     bundled_offerings_from_models_dev(&bundled_models_dev_catalog())

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -521,7 +521,7 @@ fn snapshot_feeds_route_resolver_offerings() {
 }
 
 // ---------------------------------------------------------------------------
-// #3385: the committed bundled Models.dev asset.
+// #3385 / #4188: the committed offline/stale bundled Models.dev asset.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -537,6 +537,30 @@ fn bundled_asset_parses() {
     );
     // The helper returns the same parsed catalog.
     assert_eq!(bundled_models_dev_catalog(), catalog);
+}
+
+#[test]
+fn bundled_asset_meta_describes_offline_fallback_not_competing_truth() {
+    // #4188: the asset must document itself as offline/stale fallback, not a
+    // competing curated source of truth alongside live Models.dev.
+    let raw: serde_json::Value =
+        serde_json::from_str(BUNDLED_MODELS_DEV_JSON).expect("bundled JSON");
+    let meta = raw
+        .get("_meta")
+        .and_then(|m| m.as_object())
+        .expect("_meta object");
+    let role = meta
+        .get("role")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        role.to_ascii_lowercase().contains("not a competing"),
+        "_meta.role must demote the bundled asset: {role}"
+    );
+    assert!(
+        role.to_ascii_lowercase().contains("live"),
+        "_meta.role must point at live Models.dev preference: {role}"
+    );
 }
 
 #[test]

--- a/crates/config/src/model_reference.rs
+++ b/crates/config/src/model_reference.rs
@@ -212,10 +212,11 @@ impl ModelReferenceDatabase {
         Self::from_offerings(&snapshot.offerings)
     }
 
-    /// Build from CodeWhale's bundled, network-free catalog snapshot.
+    /// Build from CodeWhale's offline/stale bundled catalog snapshot (#4188).
     ///
-    /// This is the curated reference set every install carries; it needs no
-    /// credentials or network and is always available.
+    /// Prefer a live/compiled [`CatalogSnapshot`] when available. The bundled
+    /// set needs no credentials or network and remains the offline fallback
+    /// every install carries.
     #[must_use]
     pub fn bundled() -> Self {
         Self::from_offerings(&bundled_catalog_offerings())
@@ -492,7 +493,7 @@ mod tests {
         assert!(!db.is_empty());
         assert!(
             db.len() >= 20,
-            "bundled snapshot should carry the curated offerings, got {}",
+            "bundled offline snapshot should carry seed offerings, got {}",
             db.len()
         );
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Demote the bundled Models.dev snapshot to an offline/stale fallback after
+  live catalog refresh (#4188). ProviderLake precedence is live Models.dev >
+  bundled seed > legacy hardcoded completion names; pickers, inventory, and
+  subagent validation stay catalog-backed, and CodeWhale-only providers keep
+  defaults when Models.dev has no rows.
+
 ### Added
 
 - Workflow runs are now durable: every run appends to a

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1101,6 +1101,14 @@ pub fn wire_model_for_provider(provider: ApiProvider, model: &str) -> String {
     normalize_model_name_for_provider(provider, trimmed).unwrap_or_else(|| trimmed.to_string())
 }
 
+/// Hardcoded per-provider model id list used **only as a compatibility
+/// fallback** (#4188).
+///
+/// Preferred sources are the live Models.dev catalog and the offline bundled
+/// snapshot via [`crate::provider_lake`]. Call this directly only for
+/// CodeWhale-only / local providers Models.dev does not represent, or when
+/// probing the fallback table in tests. Picker, inventory, and subagent
+/// surfaces must go through the provider lake.
 #[must_use]
 pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'static str> {
     match provider {

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -588,8 +588,8 @@ mod tests {
         clear_live_snapshot();
     }
 
-    #[tokio::test]
-    async fn network_failure_keeps_prior_rows() {
+    #[test]
+    fn network_failure_keeps_prior_rows() {
         let _lock = lock_test_env();
         clear_live_snapshot();
         let dir = tempfile::tempdir().expect("tempdir");
@@ -598,7 +598,12 @@ mod tests {
 
         let _home = EnvVarGuard::set("CODEWHALE_HOME", dir.path().join("home"));
         let _path = EnvVarGuard::set(ENV_MODELS_DEV_PATH, &path);
-        let count = refresh(true).await.expect("seed from path");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let count = rt.block_on(refresh(true)).expect("seed from path");
         assert!(count >= 2);
 
         // Point at a dead URL and force network (clear path override).
@@ -606,7 +611,7 @@ mod tests {
         let _disable = EnvVarGuard::remove(ENV_DISABLE_FETCH);
         let _url = EnvVarGuard::set(ENV_MODELS_DEV_URL, "http://127.0.0.1:1");
 
-        let err = refresh(true).await.expect_err("dead URL");
+        let err = rt.block_on(refresh(true)).expect_err("dead URL");
         assert!(matches!(err, ModelsDevRefreshError::Network(_)));
 
         let together = all_catalog_models_for_provider(ApiProvider::Together);

--- a/crates/tui/src/provider_lake.rs
+++ b/crates/tui/src/provider_lake.rs
@@ -1,11 +1,15 @@
-//! Configured provider/model lake facade (#3830, Wave 5b).
+//! Configured provider/model lake facade (#3830, Wave 5b / #4188).
 //!
-//! Single seam over the bundled Models.dev catalog, the configured-provider
-//! predicate shared with `/provider`, and an optional live-catalog snapshot
-//! (#3385 P1) that merges with bundled data. Pickers, hotbar route slots,
-//! [`crate::model_inventory::ModelInventory`], slash completions, and subagent
-//! validation should read model lists from here instead of the legacy hardcoded
-//! table in [`crate::config::model_completion_names_for_provider`].
+//! Single seam over the Models.dev catalog layers and the configured-provider
+//! predicate shared with `/provider`. Precedence is **live Models.dev >
+//! bundled offline snapshot > legacy hardcoded fallback**. Pickers, hotbar
+//! route slots, [`crate::model_inventory::ModelInventory`], slash completions,
+//! and subagent validation should read model lists from here.
+//!
+//! [`crate::config::model_completion_names_for_provider`] is retained only as a
+//! compatibility fallback for CodeWhale-only / local providers that Models.dev
+//! does not represent (and for unbundled gateways until the live catalog covers
+//! them).
 
 use std::sync::RwLock;
 
@@ -17,8 +21,8 @@ use crate::config::{
 
 static BUNDLED_SNAPSHOT: std::sync::OnceLock<CatalogSnapshot> = std::sync::OnceLock::new();
 
-/// Optional live-catalog snapshot, set by the app after a background refresh
-/// (#3385 P1). When `None`, only bundled rows are visible.
+/// Optional live Models.dev snapshot (#4187). When `None`, only the bundled
+/// offline/stale fallback rows are visible.
 static LIVE_SNAPSHOT: RwLock<Option<CatalogSnapshot>> = RwLock::new(None);
 
 fn bundled_snapshot() -> &'static CatalogSnapshot {
@@ -44,8 +48,8 @@ pub fn clear_live_snapshot() {
 }
 
 /// The merged catalog snapshot: live rows override bundled rows on
-/// `(provider, wire_model_id)` identity. When no live snapshot is present,
-/// this is just the bundled snapshot.
+/// `(provider, wire_model_id)` identity (#4188). When no live snapshot is
+/// present, this is just the offline bundled snapshot.
 fn merged_snapshot() -> CatalogSnapshot {
     let live = LIVE_SNAPSHOT.read().ok().and_then(|guard| guard.clone());
     match live {
@@ -111,11 +115,13 @@ fn catalog_models_from_offerings<'a>(
     models
 }
 
-/// Bundled-catalog model ids for one provider, merged with any live snapshot.
+/// Catalog-backed model ids for one provider (#4188).
 ///
-/// Returns provider wire ids from the merged catalog (bundled + live).
-/// Providers not yet represented in the bundled asset fall back to the legacy
-/// hardcoded table so routing surfaces stay usable until the asset catches up.
+/// Precedence: live Models.dev rows (when published) override bundled offline
+/// rows on `(provider, wire_model_id)`; if the merged catalog still has no rows
+/// for the provider, fall back to
+/// [`crate::config::model_completion_names_for_provider`] so CodeWhale-only /
+/// local providers (and gateways not yet in the offline seed) keep defaults.
 #[must_use]
 pub fn all_catalog_models_for_provider(provider: ApiProvider) -> Vec<String> {
     let catalog_id = catalog_provider_id(provider);
@@ -178,9 +184,20 @@ pub fn all_catalog_providers() -> Vec<ApiProvider> {
 mod tests {
     use super::*;
     use crate::config::{DEFAULT_TOGETHER_FLASH_MODEL, DEFAULT_TOGETHER_MODEL};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    /// Serialize tests that mutate the process-wide live snapshot.
+    fn lock_live_snapshot() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     #[test]
     fn together_catalog_includes_flash_from_bundled_asset() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
         let models = all_catalog_models_for_provider(ApiProvider::Together);
         assert!(
             models.contains(&DEFAULT_TOGETHER_MODEL.to_string()),
@@ -230,14 +247,16 @@ mod tests {
     /// catalog-sourced model to pick and never narrows to fewer choices than the
     /// legacy path offered.
     ///
-    /// Note: the facade is intentionally *catalog-authoritative*, so for some
-    /// providers whose bundled catalog supersedes stale entries in the legacy
-    /// placeholder table (e.g. curated OpenRouter/MiniMax revisions), the facade
-    /// is not a strict superset of every legacy id. That divergence predates this
-    /// migration and does not affect subagent model *acceptance*, which is gated
-    /// by `validate_route`/`requested_model_for_provider`, not by this list.
+    /// Note: the facade is intentionally *catalog-authoritative* (live >
+    /// bundled > legacy fallback, #4188), so for some providers whose catalog
+    /// supersedes stale entries in the legacy placeholder table (e.g.
+    /// OpenRouter/MiniMax revisions), the facade is not a strict superset of
+    /// every legacy id. That divergence does not affect subagent model
+    /// *acceptance*, which is gated by `validate_route` /
+    /// `requested_model_for_provider`, not by this list.
     #[test]
     fn catalog_facade_covers_every_provider_with_a_legacy_table() {
+        let _live = lock_live_snapshot();
         clear_live_snapshot();
         for &provider in ApiProvider::all() {
             let legacy_len = model_completion_names_for_provider(provider).len();
@@ -253,13 +272,40 @@ mod tests {
         }
     }
 
-    /// #4116 (AC b): a provider with no bundled/live catalog coverage must fall
-    /// back to the legacy table verbatim, so routing surfaces stay usable until
-    /// the asset catches up. We assert this for every currently-unbundled
-    /// provider that still carries a non-empty legacy list, and require at least
-    /// one such provider to exist so the fallback path is actually exercised.
+    /// #4188: CodeWhale-only / local providers keep defaults via the legacy
+    /// fallback when Models.dev (live or bundled) has no rows for them.
+    #[test]
+    fn codewhale_only_providers_keep_legacy_defaults() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+        let openai_codex = all_catalog_models_for_provider(ApiProvider::OpenaiCodex);
+        assert!(
+            !openai_codex.is_empty(),
+            "openai-codex must keep a default model offline: {openai_codex:?}"
+        );
+        assert_eq!(
+            openai_codex,
+            model_completion_names_for_provider(ApiProvider::OpenaiCodex)
+                .iter()
+                .map(|m| (*m).to_string())
+                .collect::<Vec<_>>(),
+            "openai-codex should come from the compatibility fallback table"
+        );
+
+        // Ollama intentionally has an empty legacy table (user-supplied ids);
+        // the lake must still return empty rather than inventing rows.
+        assert!(all_catalog_models_for_provider(ApiProvider::Ollama).is_empty());
+        assert!(model_completion_names_for_provider(ApiProvider::Ollama).is_empty());
+    }
+
+    /// #4116 / #4188 (AC): a provider with no bundled/live catalog coverage must
+    /// fall back to the legacy table verbatim, so CodeWhale-only routes stay
+    /// usable. We assert this for every currently-unbundled provider that still
+    /// carries a non-empty legacy list, and require at least one such provider
+    /// to exist so the fallback path is actually exercised.
     #[test]
     fn unbundled_provider_falls_back_to_legacy_table() {
+        let _live = lock_live_snapshot();
         clear_live_snapshot();
         let merged = merged_snapshot();
         let mut exercised = 0usize;
@@ -285,8 +331,11 @@ mod tests {
         );
     }
 
+    /// #4188: live Models.dev rows win over bundled on identity, and clearing
+    /// live restores the offline bundled snapshot (offline startup still works).
     #[test]
     fn live_snapshot_merges_over_bundled() {
+        let _live = lock_live_snapshot();
         clear_live_snapshot();
         // With no live snapshot, we get bundled models.
         let bundled = all_catalog_models_for_provider(ApiProvider::Deepseek);
@@ -310,5 +359,157 @@ mod tests {
         clear_live_snapshot();
         let after_clear = all_catalog_models_for_provider(ApiProvider::Deepseek);
         assert_eq!(after_clear, bundled);
+    }
+
+    /// #4188: live > bundled > legacy fallback precedence, including live
+    /// override of a bundled wire id and no duplicate rows after alias
+    /// normalization (`moonshotai` → `moonshot`).
+    #[test]
+    fn live_over_bundled_over_legacy_precedence_and_alias_dedupe() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+
+        let bundled_moonshot = all_catalog_models_for_provider(ApiProvider::Moonshot);
+        assert!(
+            !bundled_moonshot.is_empty(),
+            "offline bundled Moonshot seed required: {bundled_moonshot:?}"
+        );
+
+        // Live rows use the Models.dev alias id; lake merge must normalize onto
+        // CodeWhale `moonshot` and not leave a parallel `moonshotai` bucket.
+        let live = CatalogSnapshot {
+            offerings: vec![
+                CatalogOffering {
+                    provider: "moonshot".to_string(),
+                    wire_model_id: "kimi-k2.5-live".to_string(),
+                    endpoint_key: "chat".to_string(),
+                    default_for_provider: true,
+                    ..Default::default()
+                },
+                // Same identity as a typical bundled Moonshot default — live wins.
+                CatalogOffering {
+                    provider: "moonshot".to_string(),
+                    wire_model_id: bundled_moonshot[0].clone(),
+                    endpoint_key: "chat".to_string(),
+                    family: Some("live-override".to_string()),
+                    ..Default::default()
+                },
+            ],
+        };
+        set_live_snapshot(live);
+
+        let merged = merged_snapshot();
+        let moonshot_rows = merged.offerings_for_provider("moonshot");
+        assert!(
+            moonshot_rows
+                .iter()
+                .any(|r| r.wire_model_id == "kimi-k2.5-live"),
+            "live-only Moonshot row missing: {moonshot_rows:?}"
+        );
+        let overridden = moonshot_rows
+            .iter()
+            .find(|r| r.wire_model_id == bundled_moonshot[0])
+            .expect("bundled Moonshot id should still exist after live merge");
+        assert_eq!(
+            overridden.family.as_deref(),
+            Some("live-override"),
+            "live row must replace bundled facts on the same wire id"
+        );
+        assert!(
+            merged.offerings_for_provider("moonshotai").is_empty(),
+            "alias-normalized providers must not leave a duplicate moonshotai bucket"
+        );
+
+        let models = all_catalog_models_for_provider(ApiProvider::Moonshot);
+        let mut seen = std::collections::BTreeSet::new();
+        for model in &models {
+            assert!(
+                seen.insert(model.to_ascii_lowercase()),
+                "duplicate Moonshot model row after alias merge: {model}"
+            );
+        }
+        assert!(models.contains(&"kimi-k2.5-live".to_string()));
+
+        // Legacy fallback is skipped when catalog rows exist (even if legacy
+        // lists additional ids) — catalog is authoritative once non-empty.
+        assert!(
+            !model_completion_names_for_provider(ApiProvider::Moonshot).is_empty(),
+            "legacy Moonshot table should still exist as fallback documentation"
+        );
+
+        clear_live_snapshot();
+        assert_eq!(
+            all_catalog_models_for_provider(ApiProvider::Moonshot),
+            bundled_moonshot,
+            "clearing live must restore offline bundled Moonshot rows"
+        );
+    }
+
+    /// #4188: when live Models.dev emits both an alias id and the CodeWhale id
+    /// for the same provider, compiling through `live_offerings_from_models_dev`
+    /// then merging into the lake must not produce duplicate model rows.
+    #[test]
+    fn alias_normalized_live_rows_do_not_duplicate_in_lake() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+        let body = r#"{
+          "models": {},
+          "providers": {
+            "moonshotai": {
+              "id": "moonshotai",
+              "models": {
+                "kimi-k2.5": {
+                  "id": "kimi-k2.5",
+                  "modalities": { "input": ["text"], "output": ["text"] }
+                }
+              }
+            },
+            "moonshot": {
+              "id": "moonshot",
+              "models": {
+                "kimi-k2.5": {
+                  "id": "kimi-k2.5",
+                  "modalities": { "input": ["text"], "output": ["text"] },
+                  "limit": { "context": 262144, "output": 8192 }
+                },
+                "kimi-k2.7-code": {
+                  "id": "kimi-k2.7-code",
+                  "modalities": { "input": ["text"], "output": ["text"] }
+                }
+              }
+            }
+          }
+        }"#;
+        let catalog =
+            codewhale_config::models_dev::ModelsDevCatalog::parse_json(body).expect("parse");
+        let live_rows = codewhale_config::catalog::live_offerings_from_models_dev(
+            &catalog,
+            "alias-fp",
+            1_700_000_000,
+        );
+        assert!(
+            live_rows.iter().all(|r| r.provider == "moonshot"),
+            "both moonshotai and moonshot must normalize onto moonshot: {:?}",
+            live_rows
+                .iter()
+                .map(|r| r.provider.as_str())
+                .collect::<Vec<_>>()
+        );
+        set_live_snapshot(CatalogSnapshot {
+            offerings: live_rows,
+        });
+
+        let models = all_catalog_models_for_provider(ApiProvider::Moonshot);
+        let kimi_count = models.iter().filter(|m| m.as_str() == "kimi-k2.5").count();
+        assert_eq!(
+            kimi_count, 1,
+            "alias-normalized providers must not duplicate kimi-k2.5: {models:?}"
+        );
+        assert!(
+            merged_snapshot()
+                .offerings_for_provider("moonshotai")
+                .is_empty()
+        );
+        clear_live_snapshot();
     }
 }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -6677,14 +6677,10 @@ fn fallback_subagent_assignment_route(
 /// must not cross namespaces (#3227, subagent route validation 2026-07-07).
 ///
 /// Enumerates through the catalog-backed [`crate::provider_lake`] facade rather
-/// than the raw legacy `model_completion_names_for_provider` table (#4116). The
-/// facade returns bundled+live catalog rows for the provider and, for providers
-/// with no catalog coverage, falls back to that same legacy table internally.
-/// This consumer only reads the first entry, and it already preferred the
-/// catalog facade before the migration — the removed raw-legacy tail only ran
-/// when the facade was empty, which never happens while the legacy table is
-/// non-empty. Dropping it is therefore behavior-preserving and never narrows
-/// the operator model chosen here.
+/// than the raw legacy `model_completion_names_for_provider` table (#4116 /
+/// #4188). The facade prefers live Models.dev, then the offline bundled
+/// snapshot, and only then the legacy hardcoded table for CodeWhale-only /
+/// unbundled providers. This consumer only reads the first entry.
 fn operator_model_for_subagent(runtime: &SubAgentRuntime) -> String {
     let provider = runtime.client.api_provider();
     if crate::config::validate_route(provider, &runtime.model).is_ok() {


### PR DESCRIPTION
## Summary
- Demote `models_dev.bundled.json` / ProviderLake docs so the bundled asset is an **offline/stale fallback**, not competing curated truth after live Models.dev (#4187).
- Document `model_completion_names_for_provider()` as a **compatibility fallback only** for CodeWhale-only / unbundled providers; pickers/inventory/subagents stay lake-backed.
- Add tests for **live > bundled > legacy** precedence, CodeWhale-only defaults (`openai-codex`), and **alias-normalized dedupe** (`moonshotai`/`moonshot`).
- Fix `models_dev_live` network-failure test to avoid `clippy::await_holding_lock` under `-Dwarnings`.

Closes #4188.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked 'provider_lake::'`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked 'models_dev_live::'`
- [x] `cargo test -p codewhale-config --locked bundled_asset_`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy -p codewhale-tui -p codewhale-config --locked --tests` (with playbook allows)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)