### PR TITLE
fix(catalog): wire live cache into pickers + OFFERING_SEEDS dedupe (#4139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Wire live catalog cache into provider/model pickers without dropping stale or
+  prior rows after TTL expiry / refresh failure (#4139). Remove the dead
+  `OFFERING_SEEDS` hand table so the bundled Models.dev catalog is the sole
+  seed source; pickers show a compact `stale` / `cache failed` chrome chip when
+  the Models.dev layer is past TTL or last refresh failed.
+
 - Demote the bundled Models.dev snapshot to an offline/stale fallback after
   live catalog refresh (#4188). ProviderLake precedence is live Models.dev >
   bundled seed > legacy hardcoded completion names; pickers, inventory, and

--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -526,6 +526,23 @@ impl ProviderCatalogCache {
             .flat_map(|entry| entry.offerings.clone())
             .collect()
     }
+
+    /// Live offerings that pickers may still show: fresh rows plus stale / prior
+    /// rows that survived a failed refresh (#4139).
+    ///
+    /// Unlike [`Self::all_fresh_offerings`], this keeps past-TTL and
+    /// `Failed`-status entries as long as they still hold offering rows. Empty
+    /// entries contribute nothing; callers fall back to the bundled snapshot.
+    /// `now_unix` is accepted for API symmetry with the fresh helper (age chips
+    /// live above this layer).
+    #[must_use]
+    pub fn all_visible_offerings(&self, _now_unix: u64) -> Vec<CatalogOffering> {
+        self.entries
+            .values()
+            .filter(|entry| !entry.offerings.is_empty())
+            .flat_map(|entry| entry.offerings.clone())
+            .collect()
+    }
 }
 
 /// A compiled, layer-merged catalog snapshot.

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -497,6 +497,12 @@ fn all_fresh_offerings_spans_providers_and_skips_stale() {
     let fresh = cache.all_fresh_offerings(1_100);
     assert_eq!(fresh.len(), 1);
     assert_eq!(fresh[0].wire_model_id, "fresh-row");
+
+    // #4139: pickers still see stale rows; only the fresh helper drops them.
+    let visible = cache.all_visible_offerings(1_100);
+    assert_eq!(visible.len(), 2);
+    assert!(visible.iter().any(|row| row.wire_model_id == "fresh-row"));
+    assert!(visible.iter().any(|row| row.wire_model_id == "stale-row"));
 }
 
 #[test]

--- a/crates/config/src/route/conformance_tests.rs
+++ b/crates/config/src/route/conformance_tests.rs
@@ -83,9 +83,9 @@ fn every_provider_kind_resolves_its_default_route() {
 
         // The resolver prefers this provider's bundled *default offering* wire id
         // when one exists, and otherwise falls back to the descriptor default
-        // wire model. Assert that exact contract so a future drift between
-        // OFFERING_SEEDS and `Provider::default_model()` fails with an honest
-        // message instead of coincidentally passing.
+        // wire model. Assert that exact contract so a future drift between the
+        // catalog-backed default and `Provider::default_model()` fails with an
+        // honest message instead of coincidentally passing.
         let expected_wire = bundled
             .iter()
             .find(|offering| {

--- a/crates/config/src/route/offering.rs
+++ b/crates/config/src/route/offering.rs
@@ -6,10 +6,11 @@
 //! by multiple providers under DIFFERENT wire ids (some aggregator-prefixed),
 //! and a prefix never implies provider ownership.
 //!
-//! [`BUNDLED_OFFERINGS`] is intentionally tiny: a couple DeepSeek-native rows
-//! plus a couple aggregator rows (Together / OpenRouter) whose wire ids carry
-//! prefixes such as `deepseek-ai/DeepSeek-V4-Pro`. It exists to exercise the
-//! seam, not to be the eventual catalog.
+//! The hand-curated seed table is gone (#4139 / #3830 P1): catalog-derived
+//! offerings from [`crate::catalog::bundled_catalog_offerings`] are the single
+//! bundled source of truth. [`bundled_offerings`] remains as an empty seam so
+//! the resolver can still prepend curated overrides later without reintroducing
+//! a parallel seed list.
 
 use serde::{Deserialize, Serialize};
 
@@ -70,62 +71,13 @@ pub struct ProviderModelOffering {
     pub pricing: PricingSku,
 }
 
-/// A static, lazily-materialized seam catalog.
-///
-/// Each row binds a provider id, an optional canonical model id, the wire id
-/// it is served under, the endpoint key, and whether it is the provider
-/// default. Aggregator rows demonstrate prefixed wire ids.
-struct OfferingSeed {
-    provider: &'static str,
-    canonical_model: Option<&'static str>,
-    wire_model_id: &'static str,
-    endpoint_key: &'static str,
-    default_for_provider: bool,
-}
-
-const OFFERING_SEEDS: &[OfferingSeed] = &[
-    // DeepSeek-native: wire id equals the bare model name, no prefix.
-    OfferingSeed {
-        provider: "deepseek",
-        canonical_model: Some("deepseek-v4-pro"),
-        wire_model_id: "deepseek-v4-pro",
-        endpoint_key: "chat",
-        default_for_provider: true,
-    },
-    OfferingSeed {
-        provider: "deepseek",
-        canonical_model: Some("deepseek-v4-flash"),
-        wire_model_id: "deepseek-v4-flash",
-        endpoint_key: "chat",
-        default_for_provider: false,
-    },
-    // Together aggregator: same canonical model, prefixed wire id.
-    OfferingSeed {
-        provider: "together",
-        canonical_model: Some("deepseek-v4-pro"),
-        wire_model_id: "deepseek-ai/DeepSeek-V4-Pro",
-        endpoint_key: "chat",
-        default_for_provider: true,
-    },
-    // OpenRouter aggregator: same canonical model, different prefixed wire id.
-    OfferingSeed {
-        provider: "openrouter",
-        canonical_model: Some("deepseek-v4-pro"),
-        wire_model_id: "deepseek/deepseek-v4-pro",
-        endpoint_key: "chat",
-        default_for_provider: true,
-    },
-];
-
 /// Return the bundled offering seam as owned [`ProviderModelOffering`] rows.
 ///
-/// Formerly derived from a hand-curated `OFFERING_SEEDS` table; now empty because
-/// every seed row is covered by the bundled Models.dev catalog
-/// ([`crate::catalog::bundled_catalog_offerings`]), which carries the same
-/// canonical-model joins via `base_model` plus honest limits and pricing that the
-/// seeds lacked (#3830 P1 OFFERING_SEEDS dedupe).
+/// Empty by design: every former hand-seed row is covered by the bundled
+/// Models.dev catalog ([`crate::catalog::bundled_catalog_offerings`]), which
+/// carries the same canonical-model joins via `base_model` plus honest limits
+/// and pricing the old seeds lacked (#4139 / #3830 P1 OFFERING_SEEDS dedupe).
 #[must_use]
 pub fn bundled_offerings() -> Vec<ProviderModelOffering> {
-    // The hand-seam is now empty: the catalog is the single source of truth.
     Vec::new()
 }

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -330,15 +330,11 @@ impl RouteResolver {
     }
 }
 
-/// Build the default resolver offerings: the bundled Models.dev asset rows
-/// merged under the hand seam, with the seam winning a `(provider, wire id)`
-/// collision.
+/// Build the default resolver offerings from the bundled Models.dev asset.
 ///
-/// The seam is appended *after* the asset rows and de-duplicated keeping the
-/// first-seen row per identity, so seam rows (which carry the curated canonical
-/// joins and the deliberately unpriced DeepSeek-native entries the route
-/// invariants assert) shadow any asset row with the same `(provider, wire id)`.
-/// Order is otherwise preserved for deterministic resolution.
+/// [`bundled_offerings`] is an empty override seam (#4139): when it later gains
+/// curated rows again, those win a `(provider, wire id)` collision over the
+/// asset. Today the asset is the sole bundled source of truth.
 fn default_offerings() -> Vec<ProviderModelOffering> {
     let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
     let mut out = Vec::new();

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Wire live catalog cache into provider/model pickers without dropping stale or
+  prior rows after TTL expiry / refresh failure (#4139). Remove the dead
+  `OFFERING_SEEDS` hand table so the bundled Models.dev catalog is the sole
+  seed source; pickers show a compact `stale` / `cache failed` chrome chip when
+  the Models.dev layer is past TTL or last refresh failed.
+
 - Demote the bundled Models.dev snapshot to an offline/stale fallback after
   live catalog refresh (#4188). ProviderLake precedence is live Models.dev >
   bundled seed > legacy hardcoded completion names; pickers, inventory, and

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1735,7 +1735,10 @@ fn parse_openrouter_models_response(
 }
 
 fn publish_provider_lake_snapshot(cache: &ProviderCatalogCache) {
-    let offerings = cache.all_fresh_offerings(now_unix());
+    // Publish fresh *and* stale/prior rows so pickers keep live catalog coverage
+    // after TTL expiry or a failed refresh (#4139). Empty caches clear the live
+    // layer and fall back to the bundled snapshot.
+    let offerings = cache.all_visible_offerings(now_unix());
     if offerings.is_empty() {
         crate::provider_lake::clear_live_snapshot();
     } else {
@@ -4640,6 +4643,16 @@ mod tests {
             "rows from the prior success must survive a failed refresh"
         );
         assert!(matches!(cached.status, CatalogStatus::Failed { .. }));
+
+        // #4139: failed/stale rows must still publish into ProviderLake so
+        // pickers keep live coverage instead of dropping back to bundled-only.
+        let visible = cache.all_visible_offerings(now_unix());
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].wire_model_id, "synthetic-model-gamma");
+        assert!(
+            cache.all_fresh_offerings(now_unix()).is_empty(),
+            "Failed entries are not fresh, but they remain visible"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -227,7 +227,13 @@ pub async fn refresh(force_network: bool) -> Result<usize, ModelsDevRefreshError
     }
 
     let url = resolve_catalog_url();
-    let body = fetch_catalog_body(&url).await?;
+    let body = match fetch_catalog_body(&url).await {
+        Ok(body) => body,
+        Err(err) => {
+            mark_failed(err.clone());
+            return Err(err);
+        }
+    };
     let fetched_at = now_unix();
     let fingerprint = base_url_fingerprint(&url);
     let count = publish_from_body(
@@ -278,9 +284,14 @@ pub fn spawn_background_refresh() {
 }
 
 async fn refresh_from_path(path: &Path) -> Result<usize, ModelsDevRefreshError> {
-    let body = tokio::fs::read_to_string(path)
-        .await
-        .map_err(|err| ModelsDevRefreshError::Io(err.to_string()))?;
+    let body = match tokio::fs::read_to_string(path).await {
+        Ok(body) => body,
+        Err(err) => {
+            let mapped = ModelsDevRefreshError::Io(err.to_string());
+            mark_failed(mapped.clone());
+            return Err(mapped);
+        }
+    };
     let fetched_at = now_unix();
     let label = format!("file:{}", path.display());
     let fingerprint = base_url_fingerprint(&label);
@@ -322,9 +333,7 @@ async fn fetch_catalog_body(url: &str) -> Result<String, ModelsDevRefreshError> 
 
     let status = response.status();
     if !status.is_success() {
-        let err = ModelsDevRefreshError::HttpStatus(status.as_u16());
-        mark_failed(err.clone());
-        return Err(err);
+        return Err(ModelsDevRefreshError::HttpStatus(status.as_u16()));
     }
 
     response
@@ -365,12 +374,9 @@ fn publish_from_body(
 
 fn mark_failed(err: ModelsDevRefreshError) {
     let mut next = status();
-    // Keep prior offering_count / fetched_at so UI can still show stale rows.
-    next.freshness = if next.offering_count > 0 {
-        ModelsDevFreshness::Stale
-    } else {
-        ModelsDevFreshness::Failed
-    };
+    // Keep prior offering_count / fetched_at so UI can still show the last
+    // rows, but mark the last refresh outcome distinctly from TTL staleness.
+    next.freshness = ModelsDevFreshness::Failed;
     next.last_error = Some(err.to_string());
     set_status(next);
 }
@@ -556,6 +562,9 @@ mod tests {
 
         let after = all_catalog_models_for_provider(ApiProvider::Together);
         assert_eq!(after, before, "bundled rows must survive parse failure");
+        let st = status();
+        assert_eq!(st.freshness, ModelsDevFreshness::Failed);
+        assert!(st.last_error.is_some());
         clear_live_snapshot();
     }
 
@@ -589,7 +598,7 @@ mod tests {
     }
 
     #[test]
-    fn network_failure_keeps_prior_rows() {
+    fn network_failure_keeps_prior_rows_and_marks_failed() {
         let _lock = lock_test_env();
         clear_live_snapshot();
         let dir = tempfile::tempdir().expect("tempdir");
@@ -618,6 +627,13 @@ mod tests {
         assert!(
             together.iter().any(|m| m == "deepseek-ai/DeepSeek-V4-Pro"),
             "prior live rows must survive network failure"
+        );
+        let st = status();
+        assert_eq!(st.freshness, ModelsDevFreshness::Failed);
+        assert!(st.last_error.is_some());
+        assert!(
+            st.offering_count >= 2,
+            "status should retain prior live row count after failure"
         );
         clear_live_snapshot();
     }

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -19,6 +19,7 @@ use ratatui::{
 
 use crate::config::{ApiProvider, Config};
 use crate::model_registry;
+use crate::models_dev_live::{self, ModelsDevFreshness};
 use crate::palette;
 use crate::provider_lake::{all_catalog_models_for_provider, configured_providers};
 use crate::tui::app::{App, ReasoningEffort};
@@ -702,6 +703,18 @@ fn push_model_row(
     rows.push(ModelPickerRow { id, provider, hint });
 }
 
+/// Compact Models.dev freshness chip for the picker chrome (#4139).
+///
+/// Fresh/live rows stay unmarked; stale and failed caches get an explicit
+/// suffix so users know the live layer is still visible but not current.
+fn catalog_freshness_title_suffix() -> &'static str {
+    match models_dev_live::status().freshness {
+        ModelsDevFreshness::Stale => " · stale",
+        ModelsDevFreshness::Failed => " · cache failed",
+        ModelsDevFreshness::Bundled | ModelsDevFreshness::Live => "",
+    }
+}
+
 /// Cross-field search (#4141): match a query against the provider name
 /// (provider key + display name), the display model name, and the wire model
 /// id, mirroring `ProviderDashboardRow::matches_query` so the two pickers behave
@@ -949,8 +962,15 @@ impl ModelPickerView {
         let outer = Block::default()
             .title(Line::from(Span::styled(
                 match self.view {
-                    ModelListView::Configured => " Model & thinking ",
-                    ModelListView::Catalog => " Model & thinking · all ",
+                    ModelListView::Configured => {
+                        format!(" Model & thinking{} ", catalog_freshness_title_suffix())
+                    }
+                    ModelListView::Catalog => {
+                        format!(
+                            " Model & thinking · all{} ",
+                            catalog_freshness_title_suffix()
+                        )
+                    }
                 },
                 Style::default()
                     .fg(palette::WHALE_INFO)

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -35,6 +35,7 @@ use crate::config::{
 };
 use crate::core::ops::ProviderRuntimeStatus;
 use crate::model_profile::{SupportState, resolved_capability_profile};
+use crate::models_dev_live::{self, ModelsDevFreshness};
 use crate::palette;
 use crate::provider_lake::catalog_model_count_for_provider;
 use crate::tui::app::ReasoningEffort;
@@ -755,6 +756,15 @@ impl ProviderReadiness {
             Self::Legacy => "legacy",
             Self::Invalid => "invalid",
         }
+    }
+}
+
+/// Compact Models.dev freshness chip for the provider picker chrome (#4139).
+fn catalog_freshness_title_suffix() -> &'static str {
+    match models_dev_live::status().freshness {
+        ModelsDevFreshness::Stale => " · stale",
+        ModelsDevFreshness::Failed => " · cache failed",
+        ModelsDevFreshness::Bundled | ModelsDevFreshness::Live => "",
     }
 }
 
@@ -1481,10 +1491,18 @@ impl ProviderPickerView {
             "set key"
         };
         let title = match (self.setup_mode, self.view) {
-            (true, ProviderListView::Configured) => " Provider setup ".to_string(),
-            (true, ProviderListView::Catalog) => " Provider setup · all ".to_string(),
-            (false, ProviderListView::Configured) => " Provider ".to_string(),
-            (false, ProviderListView::Catalog) => " Provider · all ".to_string(),
+            (true, ProviderListView::Configured) => {
+                format!(" Provider setup{} ", catalog_freshness_title_suffix())
+            }
+            (true, ProviderListView::Catalog) => {
+                format!(" Provider setup · all{} ", catalog_freshness_title_suffix())
+            }
+            (false, ProviderListView::Configured) => {
+                format!(" Provider{} ", catalog_freshness_title_suffix())
+            }
+            (false, ProviderListView::Catalog) => {
+                format!(" Provider · all{} ", catalog_freshness_title_suffix())
+            }
         };
         let outer = Block::default()
             .title(Line::from(Span::styled(


### PR DESCRIPTION
## Summary
- Keep stale / prior live catalog rows visible in ProviderLake after TTL expiry or refresh failure (`all_visible_offerings`), so pickers do not drop back to bundled-only when refresh fails (#4139).
- Remove the dead `OFFERING_SEEDS` hand table; bundled Models.dev catalog remains the sole seed source (empty override seam retained).
- Show a compact `stale` / `cache failed` chrome chip on `/model` and `/provider` picker titles when the Models.dev layer is past TTL or last refresh failed.

## Test plan
- [x] `cargo test -p codewhale-config --locked all_fresh_offerings_spans_providers_and_skips_stale`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked refresh_catalog_cache_records_success_then_preserves_rows_on_failure`
- [x] `cargo fmt --all -- --check`
- [ ] CI green on this PR
- [ ] Manual: after a Models.dev refresh failure / stale cache, `/model` and `/provider` still list live rows and show the chrome chip

Closes #4139

Made with [Cursor](https://cursor.com)