### PR TITLE
tui: make work_update the canonical progress tool (#4132)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,11 @@
 # Ensure LF line endings for files consumed by include_str!() on all platforms.
 # include_str!() preserves raw bytes; CRLF breaks substring assertions and
 # produces different compiled binaries on Windows vs Linux/macOS.
+# Cover nested mode/approval/personality prompts — a top-level *.md glob alone
+# left modes/*.md on CRLF under Windows autocrlf and blew the agent token budget.
+crates/tui/src/prompts/**/*.md text eol=lf
 crates/tui/src/prompts/*.md text eol=lf
+crates/tui/src/prompts/*.txt text eol=lf
 
 # Rustfmt writes LF; keep Rust sources stable across Windows/Linux/macOS.
 *.rs text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make `work_update` the sole model-facing To-do / Work progress tool (#4132).
+  `checklist_*` and `todo_*` remain registered as hidden compat aliases for
+  transcript replay; `update_plan` stays Strategy metadata/context/route, not
+  a second checklist. Mode/approval prompts nudge the single surface.
 - Demote the bundled Models.dev snapshot to an offline/stale fallback after
   live catalog refresh (#4188). ProviderLake precedence is live Models.dev >
   bundled seed > legacy hardcoded completion names; pickers, inventory, and

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make `work_update` the sole model-facing To-do / Work progress tool (#4132).
+  `checklist_*` and `todo_*` remain registered as hidden compat aliases for
+  transcript replay; `update_plan` stays Strategy metadata/context/route, not
+  a second checklist. Mode/approval prompts nudge the single surface.
 - Demote the bundled Models.dev snapshot to an offline/stale fallback after
   live catalog refresh (#4188). ProviderLake precedence is live Models.dev >
   bundled seed > legacy hardcoded completion names; pickers, inventory, and

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -224,7 +224,7 @@ fn tool_catalog_shell_only_benchmark_surface_hides_native_tools() {
         catalog_tool("write_file"),
         catalog_tool("list_dir"),
         catalog_tool("git_status"),
-        catalog_tool("checklist_write"),
+        catalog_tool("work_update"),
     ];
     let shell_only = [
         "exec_shell".to_string(),
@@ -2398,7 +2398,7 @@ fn deferred_tool_preflight_guides_checklist_update_list_replacement() {
     assert!(result.content.contains("id, status"));
     assert!(result.content.contains("Unexpected fields:"));
     assert!(result.content.contains("todos"));
-    assert!(result.content.contains("Use checklist_write"));
+    assert!(result.content.contains("Use work_update"));
 }
 
 #[tokio::test]
@@ -3412,6 +3412,7 @@ fn turn_tool_registry_builder_keeps_plan_mode_read_only_for_files() {
         "todo_add",
         "todo_update",
         "todo_write",
+        "work_update",
         "update_plan",
     ];
     let mut write_or_exec_tools: Vec<String> = registry
@@ -6197,10 +6198,7 @@ fn missing_tool_error_message_redirects_checklist_item_miscalls() {
 
     for tool_name in ["item", "items", "todo", "checklist_item"] {
         let message = missing_tool_error_message(tool_name, &catalog);
-        assert!(
-            message.contains("checklist_write"),
-            "{tool_name}: {message}"
-        );
+        assert!(message.contains("work_update"), "{tool_name}: {message}");
         assert!(
             !message.contains("Did you mean"),
             "fuzzy suggestions are misleading for checklist mis-calls: {message}"

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2354,7 +2354,10 @@ fn deferred_tool_preflight_guides_rlm_open_misnamed_source_fields() {
 }
 
 #[test]
-fn deferred_tool_preflight_guides_checklist_update_list_replacement() {
+fn model_catalog_exposes_work_update_as_sole_progress_surface() {
+    // #4132: ordinary progress is one model-visible tool. Legacy checklist_* /
+    // todo_* spellings stay registry-callable for replay but must not appear in
+    // the deferred model catalog (so there is no deferred-preflight path for them).
     let (engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
     let registry = engine
         .build_turn_tool_registry_builder(
@@ -2370,35 +2373,54 @@ fn deferred_tool_preflight_guides_checklist_update_list_replacement() {
         AppMode::Agent,
         &always_load,
     );
-    let mut active = initial_active_tools(&catalog);
-    assert!(!active.contains("checklist_update"));
+    let active = initial_active_tools(&catalog);
+    let catalog_names: HashSet<&str> = catalog.iter().map(|tool| tool.name.as_str()).collect();
 
-    let result = preflight_requested_deferred_tool(
-        "checklist_update",
-        &json!({
-            "todos": [
-                { "content": "wire preflight", "status": "completed" }
-            ]
-        }),
-        &catalog,
-        &mut active,
-    )
-    .expect("deferred checklist_update should preflight");
-
-    assert!(active.contains("checklist_update"));
-    assert!(result.success);
     assert!(
-        result
-            .content
-            .contains("Tool `checklist_update` was deferred")
+        catalog_names.contains("work_update"),
+        "work_update must be model-visible"
     );
-    assert!(result.content.contains("id: integer required"));
-    assert!(result.content.contains("status: string"));
-    assert!(result.content.contains("Missing required fields:"));
-    assert!(result.content.contains("id, status"));
-    assert!(result.content.contains("Unexpected fields:"));
-    assert!(result.content.contains("todos"));
-    assert!(result.content.contains("Use work_update"));
+    assert!(
+        active.contains("work_update"),
+        "work_update should load with the default active native set"
+    );
+    assert!(
+        catalog_names.contains("update_plan"),
+        "update_plan remains Strategy metadata, not a second checklist"
+    );
+    for hidden in [
+        "checklist_write",
+        "checklist_add",
+        "checklist_update",
+        "checklist_list",
+        "todo_write",
+        "todo_add",
+        "todo_update",
+        "todo_list",
+    ] {
+        assert!(
+            registry.contains(hidden),
+            "{hidden} must remain callable for transcript replay"
+        );
+        assert!(
+            !catalog_names.contains(hidden),
+            "{hidden} must stay hidden from the model catalog"
+        );
+        assert!(
+            preflight_requested_deferred_tool(
+                hidden,
+                &json!({
+                    "todos": [
+                        { "content": "should not hydrate hidden alias", "status": "completed" }
+                    ]
+                }),
+                &catalog,
+                &mut active.clone(),
+            )
+            .is_none(),
+            "{hidden} must not have a deferred catalog preflight path"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -41,7 +41,6 @@ pub(super) fn is_tool_search_tool(name: &str) -> bool {
 pub(super) const DEFAULT_ACTIVE_NATIVE_TOOLS: &[&str] = &[
     "agent",
     "apply_patch",
-    "checklist_write",
     "edit_file",
     "exec_interact",
     "exec_shell",
@@ -65,6 +64,7 @@ pub(super) const DEFAULT_ACTIVE_NATIVE_TOOLS: &[&str] = &[
     "update_plan",
     "wait_for_dev_server",
     "web_search",
+    "work_update",
     "write_file",
 ];
 
@@ -669,7 +669,7 @@ pub(super) fn missing_tool_error_message(tool_name: &str, catalog: &[Tool]) -> S
         return format!(
             "Tool '{tool_name}' is not available in the current tool catalog. \
              Checklist entries are not separate tool calls — write the whole list \
-             in one `checklist_write` call with an `items` array of \
+             in one `work_update` call with a `todos` array of \
              {{content, status}} objects."
         );
     }
@@ -935,9 +935,9 @@ fn likely_field_corrections(
     } else if has_received("replacement") && has_expected("replace") {
         corrections.push("replacement -> replace".to_string());
     }
-    if tool_name == "checklist_update" && has_received("todos") {
+    if matches!(tool_name, "checklist_update" | "todo_update") && has_received("todos") {
         corrections.push(
-            "Use checklist_write to replace the full list, or retry checklist_update with id and status."
+            "Use work_update to replace the full list, or retry checklist_update/todo_update with id and status."
                 .to_string(),
         );
     }

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -2859,8 +2859,12 @@ mod tests {
             ("plan", PLAN_MODE),
             ("yolo", YOLO_MODE),
         ] {
-            let word_count = prompt.split_whitespace().count();
-            let estimated_tokens = crate::compaction::estimate_text_tokens_conservative(prompt);
+            // Measure semantic size on LF so Windows autocrlf checkouts do not
+            // inflate char/3 token estimates via extra `\r` bytes.
+            let normalized = prompt.replace("\r\n", "\n").replace('\r', "\n");
+            let word_count = normalized.split_whitespace().count();
+            let estimated_tokens =
+                crate::compaction::estimate_text_tokens_conservative(&normalized);
             let max_words = if name == "agent" { 800 } else { 350 };
             let max_tokens = if name == "agent" { 1600 } else { 700 };
 
@@ -2881,7 +2885,7 @@ mod tests {
                 "## Runtime Policy Reference",
             ] {
                 assert!(
-                    !prompt.contains(forbidden),
+                    !normalized.contains(forbidden),
                     "{name} mode prompt duplicated shared base section {forbidden:?}"
                 );
             }

--- a/crates/tui/src/prompts/agent.txt
+++ b/crates/tui/src/prompts/agent.txt
@@ -3,9 +3,9 @@
 Read-only tools (reads, searches, persistent RLM session tools, git inspection) run silently.
 Any write, patch, shell execution, sub-agent start, or CSV batch operation will ask for approval first.
 
-Before requesting approval for multi-step writes, lay out your work with `checklist_write` so the user
-can see what you intend to do and approve with context. Complex changes should also get an
-`update_plan` first. For simple writes, state the direct edit and proceed through the normal approval
+Before requesting approval for multi-step writes, lay out your work with `work_update` so the user
+can see what you intend to do and approve with context. Complex changes should also get
+`update_plan` Strategy metadata first. For simple writes, state the direct edit and proceed through the normal approval
 flow.
 
 ## Sub-agent completion sentinel

--- a/crates/tui/src/prompts/approvals/auto.md
+++ b/crates/tui/src/prompts/approvals/auto.md
@@ -4,7 +4,7 @@ All tool calls are pre-approved. You will not see approval prompts — your acti
 
 This means you carry more responsibility:
 - Pause before destructive operations (deletes, force-pushes, `rm -rf`).
-- Use `checklist_write` for multi-step work so progress stays visible even though no one is watching.
+- Use `work_update` for multi-step work so progress stays visible even though no one is watching.
 - If you're uncertain about a course of action, state your reasoning before proceeding.
 - The user can interrupt you at any time.
 

--- a/crates/tui/src/prompts/approvals/never.md
+++ b/crates/tui/src/prompts/approvals/never.md
@@ -3,7 +3,7 @@
 All write operations are blocked. You can read, search, and investigate, but you cannot modify the workspace.
 
 This is a read-only mode. Use it to:
-- Build thorough plans with `checklist_write` and, for complex initiatives, `update_plan`.
+- Build thorough plans with `work_update` and, for complex initiatives, `update_plan` Strategy metadata.
 - Investigate codebases, trace logic, and gather context.
 - Spawn read-only sub-agents for parallel exploration.
 

--- a/crates/tui/src/prompts/approvals/suggest.md
+++ b/crates/tui/src/prompts/approvals/suggest.md
@@ -3,8 +3,8 @@
 Read-only operations run silently. Write operations (file edits, patches, shell execution, sub-agent spawns, CSV batches) require user approval before executing.
 
 When you need approval:
-1. For multi-step changes, lay out your approach with `checklist_write`.
-2. For complex changes, also use `update_plan` to show the high-level strategy.
+1. For multi-step changes, lay out your approach with `work_update`.
+2. For complex changes, also use `update_plan` for Strategy metadata/context/route.
 3. The user will see your proposed action and can approve or deny it.
 
 Decomposition is your best tool for earning approvals. A clear plan with verifiable steps gets approved faster than an opaque request.

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -2,11 +2,11 @@
 
 You are running in Agent mode — autonomous task execution with tool access.
 
-Read-only tools (reads, searches, persistent RLM session tools, agent status queries, git inspection) run silently.
-Any write, patch, shell execution, sub-agent session open, or CSV batch operation will ask for approval first.
+Reads, searches, RLM session tools, agent status, and git inspection run silently.
+Writes, patches, shell, sub-agent session open, or CSV batch operation ask for approval first.
 
 Before requesting approval for multi-step writes, lay out your work with `work_update` so the user
-can approve with context. Use `update_plan` only for Strategy metadata/context/route, not as a second checklist.
+can approve with context. Use `update_plan` only for Strategy metadata, not as a second checklist.
 For simple writes, state the direct edit and proceed through the normal approval flow.
 
 ###### Efficient Approvals
@@ -16,22 +16,22 @@ When your plan includes multiple writes, present them together:
 2. Request approval for the batch ("I need to make 3 edits across 2 files...")
 3. Once approved, execute all writes in one turn (parallel `edit_file` / `apply_patch` calls)
 
-Don't sequence approvals one at a time. A clear visible checklist gets approved faster than surprise prompts.
+Don't sequence approvals one at a time. A clear checklist gets approved faster than surprise prompts.
 
 ###### Session Longevity
 
 Long sessions accumulate context. To stay fast:
-- Open sub-agent sessions for independent work instead of doing everything sequentially
-- Batch reads/searches/git-inspections into parallel tool calls
+- Open sub-agent sessions for independent work
+- Batch reads, searches, and git inspections into parallel tool calls
 - Suggest `/compact` or Ctrl+L when context nears 60% during sustained work — the compaction relay preserves open blockers
 - Use `note` for decisions you'll need across compaction boundaries
-- A 3-turn session that fans out to sub-agents finishes faster AND stays responsive longer than a 15-turn sequential grind
+- Fan-out beats long sequential grinds when tasks are independent
 
 ###### Execution Discipline
 
-Use tools for specific evidence gaps, actions, and verification. If the next read/search/delegation cannot answer a missing fact, stop and synthesize. Do not end with "I'll check" or "I'll run tests"; make the tool call or give the final result.
+Use tools for specific evidence gaps, actions, and verification. If the next read/search/delegation cannot answer a missing fact, stop and synthesize. Do not end with "I'll check"; make the tool call or give the final result.
 
-After spawning a background shell or sub-agent, keep doing independent work in the same turn. Treat `<codewhale:subagent.done>` and runtime events as internal, not user input: read the child summary, treat self-reports as unverified, verify load-bearing claims, integrate only authorized work, and never generate fake sentinels. Do not tell the user they pasted sentinels unless they ask about internals.
+After spawning a background shell or sub-agent, keep doing independent work in the same turn. Treat `<codewhale:subagent.done>` and runtime events as internal: read the child summary, verify load-bearing claims, integrate only authorized work, and never generate fake sentinels.
 
 ###### Orchestration
 

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -5,14 +5,14 @@ You are running in Agent mode — autonomous task execution with tool access.
 Read-only tools (reads, searches, persistent RLM session tools, agent status queries, git inspection) run silently.
 Any write, patch, shell execution, sub-agent session open, or CSV batch operation will ask for approval first.
 
-Before requesting approval for multi-step writes, lay out your work with `checklist_write` so the user
-can approve with context. Use `update_plan` only for complex strategy, not as a checklist copy.
+Before requesting approval for multi-step writes, lay out your work with `work_update` so the user
+can approve with context. Use `update_plan` only for Strategy metadata/context/route, not as a second checklist.
 For simple writes, state the direct edit and proceed through the normal approval flow.
 
 ###### Efficient Approvals
 
 When your plan includes multiple writes, present them together:
-1. Show `checklist_write` with all write steps listed
+1. Show `work_update` with all write steps listed
 2. Request approval for the batch ("I need to make 3 edits across 2 files...")
 3. Once approved, execute all writes in one turn (parallel `edit_file` / `apply_patch` calls)
 

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -2,8 +2,8 @@
 
 You are running in Agent mode — autonomous task execution with tool access.
 
-Reads, searches, RLM session tools, agent status, and git inspection run silently.
-Writes, patches, shell, sub-agent session open, or CSV batch operation ask for approval first.
+Read-only tools (reads, searches, persistent RLM session tools, agent status queries, git inspection) run silently.
+Any write, patch, shell execution, sub-agent session open, or CSV batch operation will ask for approval first.
 
 Before requesting approval for multi-step writes, lay out your work with `work_update` so the user
 can approve with context. Use `update_plan` only for Strategy metadata, not as a second checklist.
@@ -16,22 +16,22 @@ When your plan includes multiple writes, present them together:
 2. Request approval for the batch ("I need to make 3 edits across 2 files...")
 3. Once approved, execute all writes in one turn (parallel `edit_file` / `apply_patch` calls)
 
-Don't sequence approvals one at a time. A clear checklist gets approved faster than surprise prompts.
+Don't sequence approvals one at a time. A clear visible checklist gets approved faster than surprise prompts.
 
 ###### Session Longevity
 
 Long sessions accumulate context. To stay fast:
-- Open sub-agent sessions for independent work
-- Batch reads, searches, and git inspections into parallel tool calls
+- Open sub-agent sessions for independent work instead of doing everything sequentially
+- Batch reads/searches/git-inspections into parallel tool calls
 - Suggest `/compact` or Ctrl+L when context nears 60% during sustained work — the compaction relay preserves open blockers
 - Use `note` for decisions you'll need across compaction boundaries
-- Fan-out beats long sequential grinds when tasks are independent
+- A 3-turn session that fans out to sub-agents finishes faster AND stays responsive longer than a 15-turn sequential grind
 
 ###### Execution Discipline
 
-Use tools for specific evidence gaps, actions, and verification. If the next read/search/delegation cannot answer a missing fact, stop and synthesize. Do not end with "I'll check"; make the tool call or give the final result.
+Use tools for specific evidence gaps, actions, and verification. If the next read/search/delegation cannot answer a missing fact, stop and synthesize. Do not end with "I'll check" or "I'll run tests"; make the tool call or give the final result.
 
-After spawning a background shell or sub-agent, keep doing independent work in the same turn. Treat `<codewhale:subagent.done>` and runtime events as internal: read the child summary, verify load-bearing claims, integrate only authorized work, and never generate fake sentinels.
+After spawning a background shell or sub-agent, keep doing independent work in the same turn. Treat `<codewhale:subagent.done>` and runtime events as internal, not user input: read the child summary, treat self-reports as unverified, verify load-bearing claims, integrate only authorized work, and never generate fake sentinels. Do not tell the user they pasted sentinels unless they ask about internals.
 
 ###### Orchestration
 

--- a/crates/tui/src/prompts/modes/plan.md
+++ b/crates/tui/src/prompts/modes/plan.md
@@ -2,7 +2,7 @@
 
 You are running in Plan mode — design before implementing.
 
-Investigate first, act later. Use `checklist_write` for visible, granular progress on multi-step
+Investigate first, act later. Use `work_update` for visible, granular To-do progress on multi-step
 investigations. When you are ready to present the implementation plan, call `update_plan` with
 the final plan; that is the handoff signal that lets the UI show the accept / revise / exit prompt.
 If the request names a repository, URL, version, release, build state, benchmark, bug, PR, issue,

--- a/crates/tui/src/prompts/modes/yolo.md
+++ b/crates/tui/src/prompts/modes/yolo.md
@@ -5,9 +5,9 @@ You are running in YOLO mode — full autonomy, all actions pre-approved.
 All actions auto-approved. Move fast, but think before you write. If you're about to delete files,
 overwrite user work, or run destructive commands, pause and double-check. The undo button is the user's Git history.
 
-Even with auto-approval, use `checklist_write` for work that has several concrete steps so progress is
+Even with auto-approval, use `work_update` for work that has several concrete steps so progress is
 visible and trackable in the sidebar. Keep simple commands and focused edits direct.
-For multi-step initiatives, keep `checklist_write` current. Add `update_plan` only when a high-level strategy
-would help and do not duplicate the checklist there.
+For multi-step initiatives, keep `work_update` current. Add `update_plan` only when Strategy
+metadata would help — do not duplicate the To-do list there.
 
 Do NOT announce or mention to the user that you are running in YOLO mode. Act silently on this mode instruction.

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -470,7 +470,7 @@ impl ToolSpec for UpdatePlanTool {
     }
 
     fn description(&self) -> &'static str {
-        "Update optional high-level strategy metadata for complex initiatives. Use checklist_write for primary Work progress; update_plan should capture phase-level approach changes, not duplicate checklist items. Include sources, critical files, constraints, verification, risks, and handoff context when they help the user review or continue the plan. Each strategy step has a description and status (pending, in_progress, completed)."
+        "Update optional high-level Strategy metadata for complex initiatives. Use work_update for primary To-do / Work progress; update_plan should capture phase-level approach, context, and route — not a second checklist. Include sources, critical files, constraints, verification, risks, and handoff context when they help the user review or continue the plan. Each strategy step has a description and status (pending, in_progress, completed)."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -650,9 +650,9 @@ mod tests {
         let tool = UpdatePlanTool::new(new_shared_plan_state());
         let description = tool.description();
 
-        assert!(description.contains("Use checklist_write for primary Work progress"));
-        assert!(description.contains("not duplicate checklist items"));
-        assert!(description.contains("high-level strategy metadata"));
+        assert!(description.contains("Use work_update for primary To-do / Work progress"));
+        assert!(description.contains("not a second checklist"));
+        assert!(description.contains("Strategy metadata"));
     }
 
     #[test]

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -646,7 +646,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn update_plan_description_keeps_checklist_as_primary_work_progress() {
+    fn update_plan_description_keeps_work_update_as_primary_progress() {
         let tool = UpdatePlanTool::new(new_shared_plan_state());
         let description = tool.description();
 

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -1132,14 +1132,23 @@ impl ToolRegistryBuilder {
         )
     }
 
-    /// Include the todo tool with a shared `TodoList`.
+    /// Include the todo / work-progress tools with a shared `TodoList`.
+    ///
+    /// `work_update` is the sole model-visible progress surface (#4132).
+    /// `checklist_*` and `todo_*` remain registered as hidden compat aliases
+    /// so saved transcripts and older prompts still replay.
     #[must_use]
     pub fn with_todo_tool(self, todo_list: super::todo::SharedTodoList) -> Self {
         use super::todo::{TodoAddTool, TodoListTool, TodoUpdateTool, TodoWriteTool};
-        self.with_tool(Arc::new(TodoWriteTool::checklist(todo_list.clone())))
+        self.with_tool(Arc::new(TodoWriteTool::work_update(todo_list.clone())))
+            .with_tool(Arc::new(TodoWriteTool::checklist(todo_list.clone())))
+            .with_tool(Arc::new(TodoWriteTool::todo(todo_list.clone())))
             .with_tool(Arc::new(TodoAddTool::checklist(todo_list.clone())))
+            .with_tool(Arc::new(TodoAddTool::todo(todo_list.clone())))
             .with_tool(Arc::new(TodoUpdateTool::checklist(todo_list.clone())))
+            .with_tool(Arc::new(TodoUpdateTool::todo(todo_list.clone())))
             .with_tool(Arc::new(TodoListTool::checklist(todo_list.clone())))
+            .with_tool(Arc::new(TodoListTool::todo(todo_list.clone())))
     }
 
     /// Include the plan tool with a shared `PlanState`.
@@ -1368,21 +1377,44 @@ mod tests {
             .with_todo_tool(crate::tools::todo::new_shared_todo_list())
             .build(ctx);
 
+        // Canonical + legacy spellings stay callable for replay.
+        for name in [
+            "work_update",
+            "checklist_write",
+            "checklist_add",
+            "checklist_update",
+            "checklist_list",
+            "todo_write",
+            "todo_add",
+            "todo_update",
+            "todo_list",
+        ] {
+            assert!(registry.contains(name), "{name} should remain callable");
+        }
+
         let api_names = registry
             .to_api_tools()
             .into_iter()
             .map(|tool| tool.name)
             .collect::<Vec<_>>();
 
-        for canonical in [
+        assert!(
+            api_names.iter().any(|name| name == "work_update"),
+            "work_update should be the sole model-visible progress surface"
+        );
+        for hidden in [
             "checklist_write",
             "checklist_add",
             "checklist_update",
             "checklist_list",
+            "todo_write",
+            "todo_add",
+            "todo_update",
+            "todo_list",
         ] {
             assert!(
-                api_names.iter().any(|name| name == canonical),
-                "{canonical} should stay model-visible"
+                api_names.iter().all(|name| name != hidden),
+                "{hidden} should be hidden from the model catalog"
             );
         }
     }

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -7868,7 +7868,7 @@ const SUBAGENT_OUTPUT_FORMAT: &str = include_str!("../../prompts/subagent_output
 const GENERAL_AGENT_INTRO: &str = concat!(
     "You are a trusted general-purpose sub-agent. Your job is to complete the one task you were given, end-to-end, and report back concisely.\n",
     "Stay inside the assigned scope; put adjacent work under RISKS/BLOCKERS.\n",
-    "For genuinely multi-step work, track progress with `checklist_write` (and `update_plan` for complex strategy); skip it for short, focused tasks.\n",
+    "For genuinely multi-step work, track progress with `work_update` (and `update_plan` for Strategy metadata); skip it for short, focused tasks.\n",
     "**Stop quickly on failure**: if the same tool call fails 2 times in a row, stop retrying and return what you have so far with a one-line note explaining what's missing. Do not loop on impossible queries (e.g. external API unreachable, rate-limited, or returning empty).\n",
     "For implementer or repair-style work, keep going within the assigned scope; checkpoint before broadening the task or after repeated failures instead of forcing a tiny tool-call cap.\n\n"
 );
@@ -7886,7 +7886,7 @@ const EXPLORE_AGENT_INTRO: &str = concat!(
 const PLAN_AGENT_INTRO: &str = concat!(
     "You are a trusted planning sub-agent (role: `plan`). Your job is to produce a grounded, prioritized plan, not patches.\n",
     "Read enough code to avoid guessing; each step names its artifact and verification.\n",
-    "Use update_plan/checklist_write for plan artifacts and explain key trade-offs.\n",
+    "Use update_plan/work_update for plan artifacts and explain key trade-offs.\n",
     "CHANGES should list plan artifacts only, not future speculative edits.\n\n"
 );
 

--- a/crates/tui/src/tools/todo.rs
+++ b/crates/tui/src/tools/todo.rs
@@ -174,7 +174,8 @@ pub fn new_shared_todo_list() -> SharedTodoList {
     Arc::new(Mutex::new(TodoList::new()))
 }
 
-const CANONICAL_WORK_SURFACE: &str = "checklist";
+const CANONICAL_WORK_SURFACE: &str = "work";
+const CANONICAL_PROGRESS_TOOL: &str = "work_update";
 const DURABLE_WORK_OWNER: &str = "fleet_workflow_ledger";
 
 /// Tool for writing and updating the todo list
@@ -184,10 +185,27 @@ pub struct TodoWriteTool {
 }
 
 impl TodoWriteTool {
+    /// Canonical model-facing progress surface (#4132).
+    pub fn work_update(todo_list: SharedTodoList) -> Self {
+        Self {
+            todo_list,
+            tool_name: CANONICAL_PROGRESS_TOOL,
+        }
+    }
+
+    /// Legacy spelling kept for transcript replay and older prompts.
     pub fn checklist(todo_list: SharedTodoList) -> Self {
         Self {
             todo_list,
             tool_name: "checklist_write",
+        }
+    }
+
+    /// Pre-checklist `todo_*` spelling kept for transcript replay.
+    pub fn todo(todo_list: SharedTodoList) -> Self {
+        Self {
+            todo_list,
+            tool_name: "todo_write",
         }
     }
 }
@@ -205,6 +223,13 @@ impl TodoAddTool {
             tool_name: "checklist_add",
         }
     }
+
+    pub fn todo(todo_list: SharedTodoList) -> Self {
+        Self {
+            todo_list,
+            tool_name: "todo_add",
+        }
+    }
 }
 
 #[async_trait]
@@ -215,9 +240,9 @@ impl ToolSpec for TodoAddTool {
 
     fn description(&self) -> &'static str {
         if self.tool_name == "todo_add" {
-            "Compatibility alias for checklist_add. Adds one checklist item on the active thread/task."
+            "Compatibility alias for work_update/checklist_add. Adds one To-do item on the active thread/task."
         } else {
-            "Add one checklist item on the active thread/task. Durable tasks persist this checklist as subordinate work progress."
+            "Compatibility alias for work_update. Adds one To-do item on the active thread/task. Prefer work_update to replace the full list."
         }
     }
 
@@ -248,7 +273,8 @@ impl ToolSpec for TodoAddTool {
     }
 
     fn model_visible(&self) -> bool {
-        true
+        // Granular add stays callable for replay; models should use work_update.
+        false
     }
 
     async fn execute(
@@ -277,7 +303,7 @@ impl ToolSpec for TodoAddTool {
             item.status.as_str(),
             result
         ))
-        .with_metadata(checklist_metadata(&snapshot, self.tool_name)))
+        .with_metadata(work_progress_metadata(&snapshot, self.tool_name)))
     }
 }
 
@@ -294,6 +320,13 @@ impl TodoUpdateTool {
             tool_name: "checklist_update",
         }
     }
+
+    pub fn todo(todo_list: SharedTodoList) -> Self {
+        Self {
+            todo_list,
+            tool_name: "todo_update",
+        }
+    }
 }
 
 #[async_trait]
@@ -304,9 +337,9 @@ impl ToolSpec for TodoUpdateTool {
 
     fn description(&self) -> &'static str {
         if self.tool_name == "todo_update" {
-            "Compatibility alias for checklist_update. Updates one checklist item by id on the active thread/task."
+            "Compatibility alias for work_update/checklist_update. Updates one To-do item by id on the active thread/task."
         } else {
-            "Update one checklist item's status by id on the active thread/task."
+            "Compatibility alias for work_update. Updates one To-do item's status by id on the active thread/task."
         }
     }
 
@@ -337,7 +370,7 @@ impl ToolSpec for TodoUpdateTool {
     }
 
     fn model_visible(&self) -> bool {
-        true
+        false
     }
 
     async fn execute(
@@ -368,7 +401,7 @@ impl ToolSpec for TodoUpdateTool {
                 item.status.as_str(),
                 result
             ))
-            .with_metadata(checklist_metadata(&snapshot, self.tool_name))),
+            .with_metadata(work_progress_metadata(&snapshot, self.tool_name))),
             None => Ok(ToolResult::error(format!("Todo id {id} not found"))),
         }
     }
@@ -387,6 +420,13 @@ impl TodoListTool {
             tool_name: "checklist_list",
         }
     }
+
+    pub fn todo(todo_list: SharedTodoList) -> Self {
+        Self {
+            todo_list,
+            tool_name: "todo_list",
+        }
+    }
 }
 
 #[async_trait]
@@ -397,9 +437,9 @@ impl ToolSpec for TodoListTool {
 
     fn description(&self) -> &'static str {
         if self.tool_name == "todo_list" {
-            "Compatibility alias for checklist_list. Lists current checklist progress."
+            "Compatibility alias for work_update/checklist_list. Lists current To-do progress."
         } else {
-            "List current checklist progress for the active thread/task."
+            "Compatibility alias for work_update. Lists current To-do progress for the active thread/task."
         }
     }
 
@@ -419,7 +459,7 @@ impl ToolSpec for TodoListTool {
     }
 
     fn model_visible(&self) -> bool {
-        true
+        false
     }
 
     async fn execute(
@@ -436,7 +476,7 @@ impl ToolSpec for TodoListTool {
             snapshot.completion_pct,
             result
         ))
-        .with_metadata(checklist_metadata(&snapshot, self.tool_name)))
+        .with_metadata(work_progress_metadata(&snapshot, self.tool_name)))
     }
 }
 
@@ -447,10 +487,16 @@ impl ToolSpec for TodoWriteTool {
     }
 
     fn description(&self) -> &'static str {
-        if self.tool_name == "todo_write" {
-            "Compatibility alias for checklist_write. Replace the active thread/task checklist; durable tasks are the real executable work object."
-        } else {
-            "Replace the active thread/task checklist. Use this for granular progress under the current durable task or runtime thread; durable tasks remain the real executable work object."
+        match self.tool_name {
+            "todo_write" => {
+                "Compatibility alias for work_update. Replace the active thread/task To-do list; durable tasks are the real executable work object."
+            }
+            "checklist_write" => {
+                "Compatibility alias for work_update. Replace the active thread/task To-do list; durable tasks are the real executable work object."
+            }
+            _ => {
+                "Replace the active thread/task To-do list (concrete current work items). This is the canonical progress surface — use it for ordinary in-flight work. Use update_plan only for Strategy metadata/context/route, not as a second checklist. Durable tasks remain the real executable work object."
+            }
         }
     }
 
@@ -460,7 +506,7 @@ impl ToolSpec for TodoWriteTool {
             "properties": {
                 "todos": {
                     "type": "array",
-                    "description": "The complete list of todo items. This replaces the existing list.",
+                    "description": "The complete list of To-do items. This replaces the existing list.",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -491,7 +537,8 @@ impl ToolSpec for TodoWriteTool {
     }
 
     fn model_visible(&self) -> bool {
-        true
+        // Only the canonical work_update spelling is advertised to models.
+        self.tool_name == CANONICAL_PROGRESS_TOOL
     }
 
     async fn execute(
@@ -534,11 +581,15 @@ impl ToolSpec for TodoWriteTool {
             snapshot.completion_pct,
             result
         ))
-        .with_metadata(checklist_metadata(&snapshot, self.tool_name)))
+        .with_metadata(work_progress_metadata(&snapshot, self.tool_name)))
     }
 }
 
-fn checklist_metadata(snapshot: &TodoListSnapshot, tool_name: &str) -> serde_json::Value {
+fn is_compat_alias(tool_name: &str) -> bool {
+    tool_name != CANONICAL_PROGRESS_TOOL
+}
+
+fn work_progress_metadata(snapshot: &TodoListSnapshot, tool_name: &str) -> serde_json::Value {
     let items = snapshot
         .items
         .iter()
@@ -551,11 +602,12 @@ fn checklist_metadata(snapshot: &TodoListSnapshot, tool_name: &str) -> serde_jso
         })
         .collect::<Vec<_>>();
     json!({
-        "canonical_tool": tool_name,
-        "compat_alias": false,
+        "canonical_tool": CANONICAL_PROGRESS_TOOL,
+        "invoked_as": tool_name,
+        "compat_alias": is_compat_alias(tool_name),
         "work_surface": {
             "canonical": CANONICAL_WORK_SURFACE,
-            "model_visible": true,
+            "model_visible": tool_name == CANONICAL_PROGRESS_TOOL,
             "durable_owner": DURABLE_WORK_OWNER,
             "progress_key": "task_updates.checklist"
         },
@@ -575,8 +627,8 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn checklist_write_returns_task_update_metadata() {
-        let tool = TodoWriteTool::checklist(new_shared_todo_list());
+    async fn work_update_returns_canonical_task_update_metadata() {
+        let tool = TodoWriteTool::work_update(new_shared_todo_list());
         let context = ToolContext::new(std::env::temp_dir());
         let result = tool
             .execute(
@@ -589,12 +641,14 @@ mod tests {
                 &context,
             )
             .await
-            .expect("checklist write succeeds");
+            .expect("work_update succeeds");
 
+        assert!(tool.model_visible());
         let metadata = result.metadata.expect("metadata");
-        assert_eq!(metadata["canonical_tool"], "checklist_write");
+        assert_eq!(metadata["canonical_tool"], "work_update");
+        assert_eq!(metadata["invoked_as"], "work_update");
         assert_eq!(metadata["compat_alias"], false);
-        assert_eq!(metadata["work_surface"]["canonical"], "checklist");
+        assert_eq!(metadata["work_surface"]["canonical"], "work");
         assert_eq!(metadata["work_surface"]["model_visible"], true);
         assert_eq!(
             metadata["work_surface"]["durable_owner"],
@@ -612,5 +666,57 @@ mod tests {
             metadata["task_updates"]["checklist"]["items"][0]["content"],
             "wire durable task tools"
         );
+    }
+
+    #[tokio::test]
+    async fn checklist_write_compat_alias_still_replays() {
+        let tool = TodoWriteTool::checklist(new_shared_todo_list());
+        let context = ToolContext::new(std::env::temp_dir());
+        let result = tool
+            .execute(
+                json!({
+                    "todos": [
+                        { "content": "legacy checklist payload", "status": "completed" }
+                    ]
+                }),
+                &context,
+            )
+            .await
+            .expect("checklist_write compat succeeds");
+
+        assert!(!tool.model_visible());
+        let metadata = result.metadata.expect("metadata");
+        assert_eq!(metadata["canonical_tool"], "work_update");
+        assert_eq!(metadata["invoked_as"], "checklist_write");
+        assert_eq!(metadata["compat_alias"], true);
+        assert_eq!(metadata["work_surface"]["canonical"], "work");
+        assert_eq!(metadata["work_surface"]["model_visible"], false);
+        assert_eq!(
+            metadata["task_updates"]["checklist"]["items"][0]["content"],
+            "legacy checklist payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn todo_write_compat_alias_still_replays() {
+        let tool = TodoWriteTool::todo(new_shared_todo_list());
+        let context = ToolContext::new(std::env::temp_dir());
+        let result = tool
+            .execute(
+                json!({
+                    "todos": [
+                        { "content": "legacy todo payload", "status": "pending" }
+                    ]
+                }),
+                &context,
+            )
+            .await
+            .expect("todo_write compat succeeds");
+
+        assert!(!tool.model_visible());
+        let metadata = result.metadata.expect("metadata");
+        assert_eq!(metadata["canonical_tool"], "work_update");
+        assert_eq!(metadata["invoked_as"], "todo_write");
+        assert_eq!(metadata["compat_alias"], true);
     }
 }

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -1675,6 +1675,8 @@ mod tests {
         assert_eq!(get_tool_category("read_file"), ToolCategory::Safe);
         assert_eq!(get_tool_category("list_dir"), ToolCategory::Safe);
         assert_eq!(get_tool_category("todo_write"), ToolCategory::Safe);
+        assert_eq!(get_tool_category("work_update"), ToolCategory::Safe);
+        assert_eq!(get_tool_category("checklist_write"), ToolCategory::Safe);
         assert_eq!(get_tool_category("todo_read"), ToolCategory::Safe);
         assert_eq!(get_tool_category("note"), ToolCategory::Safe);
         assert_eq!(get_tool_category("update_plan"), ToolCategory::Safe);

--- a/crates/tui/src/tui/approval/policy.rs
+++ b/crates/tui/src/tui/approval/policy.rs
@@ -96,8 +96,10 @@ pub fn get_tool_category(name: &str) -> ToolCategory {
         name,
         "read_file"
             | "list_dir"
+            | "work_update"
             | "todo_write"
             | "todo_read"
+            | "checklist_write"
             | "note"
             | "update_plan"
             | "search"

--- a/crates/tui/src/tui/history/checklist.rs
+++ b/crates/tui/src/tui/history/checklist.rs
@@ -16,7 +16,8 @@ use super::{
 pub(super) fn is_checklist_tool_name(name: &str) -> bool {
     matches!(
         name,
-        "checklist_write"
+        "work_update"
+            | "checklist_write"
             | "checklist_add"
             | "checklist_update"
             | "todo_write"

--- a/crates/tui/src/tui/history/tool_run.rs
+++ b/crates/tui/src/tui/history/tool_run.rs
@@ -153,6 +153,7 @@ fn is_metadata_tool_name(name: &str) -> bool {
     matches!(
         name,
         "update_plan"
+            | "work_update"
             | "todo_write"
             | "todo_add"
             | "todo_update"

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -11801,7 +11801,7 @@ fn duplicate_mailbox_token_usage_does_not_regress_displayed_cost() {
 #[test]
 fn checklist_write_renders_dedicated_card() {
     let cell = GenericToolCell {
-        name: "checklist_write".to_string(),
+        name: "work_update".to_string(),
         status: ToolStatus::Success,
         input_summary: None,
         output: Some(

--- a/crates/tui/src/tui/widgets/tool_card.rs
+++ b/crates/tui/src/tui/widgets/tool_card.rs
@@ -216,6 +216,7 @@ fn is_known_metadata_tool_name(name: &str) -> bool {
     matches!(
         name,
         "update_plan"
+            | "work_update"
             | "todo_write"
             | "todo_add"
             | "todo_update"

--- a/docs/TOOL_LIFECYCLE.md
+++ b/docs/TOOL_LIFECYCLE.md
@@ -47,25 +47,23 @@ The lifecycle policy exists to **shrink and discipline the model-visible
 surface** without ever breaking the ability to replay an old transcript that
 referenced a now-retired name.
 
-### Canonical work-tracking surface for v0.8.65
+### Canonical work-tracking surface for v0.8.68
 
-The model-visible progress surface is `checklist_*`:
-`checklist_write`, `checklist_add`, `checklist_update`, and `checklist_list`.
-Agents and Fleet workers use that surface for concrete Work progress under the
+The model-visible progress surface is a single tool: `work_update` (#4132).
+Agents and Fleet workers use it for concrete To-do / Work progress under the
 active runtime thread or durable task.
 
 `task_*` and the Fleet/Workflow ledger remain the durable lifecycle owners.
 Checklist metadata is the model-visible projection of progress:
 `task_updates.checklist` carries the current items, completion percentage, and
-in-progress item. `update_plan` is optional high-level strategy metadata for
-complex initiatives; it must not duplicate checklist items or become a parallel
+in-progress item. `update_plan` is optional Strategy metadata/context/route for
+complex initiatives; it must not duplicate To-do items or become a parallel
 progress store.
 
-The legacy `todo_*` names are deprecated hidden compatibility aliases. They
-remain registered and dispatchable against the same checklist state so old
-transcripts replay without data loss, but they are not advertised to the model
-catalog and their result metadata points callers to the corresponding
-`checklist_*` tool.
+The legacy `checklist_*` and older `todo_*` names are hidden compatibility
+aliases. They remain registered and dispatchable against the same To-do state
+so old transcripts replay without data loss, but they are not advertised to the
+model catalog.
 
 ---
 

--- a/docs/TOOL_LIFECYCLE.md
+++ b/docs/TOOL_LIFECYCLE.md
@@ -28,8 +28,8 @@ tools** that map to the *same* implementation under different names:
   (`registry.rs:527,530`).
 - `tts` and `speech` are both `SpeechTool`
   (`registry.rs:787-792`, both deferred).
-- `todo_write` and `checklist_write` are the *same* `TodoWriteTool`
-  constructed two ways (`crates/tui/src/tools/todo.rs:184-196`).
+- `work_update`, `checklist_*`, and `todo_*` are the *same*
+  `TodoWriteTool` surface, with only `work_update` visible to models.
 
 For a strong model, redundant names are harmless noise. For **weaker / smaller
 models** (the Arcee Trinity lane, `deepseek-v4-flash` child executors, and any
@@ -91,7 +91,7 @@ caller-facing signal:
   re-learning it. (Example: `exec_wait` is literally `exec_shell_wait`.)
 - **deprecated:** behaves identically *and succeeds*, but the tool result's
   **metadata** carries an appended notice like
-  `"deprecated: use checklist_write instead"`. The notice goes **only in the
+  `"deprecated: use <replacement> instead"`. The notice goes **only in the
   result metadata returned for that call** — never in the cached tool catalog
   prefix (see Section 8). We use this when there is a canonical replacement we
   want the caller (and any human reading the transcript) nudged toward.
@@ -118,6 +118,14 @@ pub(super) const HIDDEN_COMPATIBILITY_TOOLS: &[&str] = &[
     "exec_wait",          // == exec_shell_wait  (ShellWaitTool)
     "exec_interact",      // == exec_shell_interact (ShellInteractTool)
     "tts",                // == speech (SpeechTool)
+    "checklist_write",    // == work_update (TodoWriteTool)
+    "checklist_add",      // == work_update single-item add
+    "checklist_update",   // == work_update single-item update
+    "checklist_list",     // == work_update list
+    "todo_write",         // == work_update
+    "todo_add",           // == work_update single-item add
+    "todo_update",        // == work_update single-item update
+    "todo_list",          // == work_update list
 ];
 
 /// Deprecated aliases: invisible + dispatchable, with a replacement notice
@@ -129,14 +137,8 @@ pub(super) struct DeprecatedAlias {
 }
 
 pub(super) const DEPRECATED_ALIASES: &[DeprecatedAlias] = &[
-    DeprecatedAlias { name: "todo_write",  replacement: "checklist_write",
-                      note: "use checklist_write instead" },
-    DeprecatedAlias { name: "todo_add",    replacement: "checklist_add",
-                      note: "use checklist_add instead" },
-    DeprecatedAlias { name: "todo_update", replacement: "checklist_update",
-                      note: "use checklist_update instead" },
-    DeprecatedAlias { name: "todo_list",   replacement: "checklist_list",
-                      note: "use checklist_list instead" },
+    // Empty in the #4132 work-surface cutover: checklist_* and todo_* are
+    // silent hidden-compatibility aliases of work_update for transcript replay.
 ];
 
 #[inline]
@@ -195,10 +197,14 @@ is "removed" in 0.8.53; replay is supported for everything listed.
 | `exec_wait` | `exec_shell_wait` | hidden-compatibility | 0.8.53 | TBD (≥ 0.9.x) | Yes |
 | `exec_interact` | `exec_shell_interact` | hidden-compatibility | 0.8.53 | TBD (≥ 0.9.x) | Yes |
 | `tts` | `speech` | hidden-compatibility | 0.8.53 | TBD (≥ 0.9.x) | Yes |
-| `todo_write` | `checklist_write` | deprecated | 0.8.53 | TBD (≥ 0.9.x) | Yes |
-| `todo_add` | `checklist_add` | deprecated | 0.8.53 | TBD (≥ 0.9.x) | Yes |
-| `todo_update` | `checklist_update` | deprecated | 0.8.53 | TBD (≥ 0.9.x) | Yes |
-| `todo_list` | `checklist_list` | deprecated | 0.8.53 | TBD (≥ 0.9.x) | Yes |
+| `checklist_write` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `checklist_add` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `checklist_update` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `checklist_list` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `todo_write` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `todo_add` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `todo_update` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
+| `todo_list` | `work_update` | hidden-compatibility | 0.8.68 | TBD (≥ 0.9.x) | Yes |
 
 **Legacy subagent names — removed, no manifest entry needed.**
 The model-visible subagent surface is only `agent`. The old lifecycle names and
@@ -266,7 +272,7 @@ else or an explicit budget bump in this doc.
 |---|---|---|---|
 | **Shell wait** | `exec_shell_wait` | `exec_wait` → hidden-compat | Same `ShellWaitTool` (`registry.rs:526,529`); router already unifies (`tool_routing.rs:1139`) |
 | **Shell interact** | `exec_shell_interact` | `exec_interact` → hidden-compat | Same `ShellInteractTool` (`registry.rs:527,530`) |
-| **Checklist / todo** | `checklist_write` | `todo_write/add/update/list` → deprecated | Same `TodoWriteTool`, `::new` vs `::checklist` (`todo.rs:184-196`) |
+| **Work progress / checklist / todo** | `work_update` | `checklist_write/add/update/list`, `todo_write/add/update/list` → hidden-compat | Same `TodoWriteTool`; compatibility names replay old transcripts only |
 | **Speech / tts** | `speech` | `tts` → hidden-compat | Same `SpeechTool` (`registry.rs:787-792`) |
 | **Subagent lifecycle** | `agent` | old lifecycle names and tool-agent lane removed | Single async launcher; child agents are leaf workers |
 | **Edit family** | `apply_patch`, `edit_file`, `write_file`, `fim_edit` | none — **all distinct niches** | NOT touched (per #2681 non-goals); doc-only canonical guidance |

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -134,20 +134,19 @@ to the model, such as `mcp_<server>_<tool>`.
 
 | Tool | Niche |
 |---|---|
-| `update_plan` | Optional high-level strategy metadata for complex multi-phase work; keep `checklist_write` as the primary progress surface. |
+| `update_plan` | Optional high-level Strategy metadata/context/route for complex multi-phase work — not a second checklist. |
 | `task_create` | Create/enqueue a durable background task through `TaskManager`. This is the real executable work object for long-running agent work. |
 | `task_list` | List durable tasks with status and linked runtime ids. |
 | `task_read` | Read durable task detail: thread/turn linkage, timeline, checklist, gates, artifacts, PR attempts, GitHub events. |
 | `task_cancel` | Cancel a queued or running durable task. Approval-required. |
-| `checklist_write` | Granular progress under the active thread/task. Checklist state is subordinate to the durable task. |
-| `checklist_add` / `checklist_update` / `checklist_list` | Single-item checklist operations. |
+| `work_update` | Canonical To-do / Work progress under the active thread/task. Ordinary in-flight progress flows through this tool. |
 | `note` | One-off important fact for later. |
 
-The legacy `todo_write`, `todo_add`, `todo_update`, and `todo_list` names are
-hidden compatibility aliases for saved transcript replay. They remain callable
-by exact name, but they are not part of the model-visible catalog; compatibility
-results include `_deprecation.use_instead = checklist_*` and
-`_deprecation.removed_in = 0.9.0`.
+The legacy `checklist_write` / `checklist_add` / `checklist_update` /
+`checklist_list` and older `todo_write` / `todo_add` / `todo_update` /
+`todo_list` names are hidden compatibility aliases for saved transcript
+replay. They remain callable by exact name, but they are not part of the
+model-visible catalog (#4132).
 
 `update_plan` accepts both the legacy shape (`explanation` plus `plan` steps)
 and a richer PlanArtifact shape for Plan mode review. The richer fields are
@@ -321,10 +320,9 @@ v0.9.0 adds the following hidden-compat aliases (#2682, #2683):
 
 | Hidden alias | Canonical replacement | Status |
 |---|---|---|
-| `todo_write` | `checklist_write` | Hidden, returns `_deprecation` metadata |
-| `todo_add` | `checklist_add` | Hidden, returns `_deprecation` metadata |
-| `todo_update` | `checklist_update` | Hidden, returns `_deprecation` metadata |
-| `todo_list` | `checklist_list` | Hidden, returns `_deprecation` metadata |
+| `checklist_write` | `work_update` | Hidden, callable for replay (#4132) |
+| `checklist_add` / `checklist_update` / `checklist_list` | `work_update` | Hidden, callable for replay |
+| `todo_write` / `todo_add` / `todo_update` / `todo_list` | `work_update` | Hidden, callable for replay |
 | `exec_wait` | `exec_shell_wait` | Hidden, callable for replay |
 | `exec_interact` | `exec_shell_interact` | Hidden, callable for replay |
 


### PR DESCRIPTION
## Summary
- Introduce `work_update` as the sole model-facing To-do / Work progress tool (#4132).
- Keep `checklist_*` and `todo_*` registered as hidden compat aliases so saved transcripts and legacy payloads still replay.
- Nudge mode/approval/subagent prompts and `update_plan` copy so Strategy stays metadata/context/route, not a second checklist.

## Test plan
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked` filters: `work_update`, `todo_aliases_stay`, compat aliases, catalog sole-surface, missing-tool redirects, card render
- [x] Replaced deferred `checklist_update` preflight expectation with catalog-visibility assertion (aliases are hidden)
- [x] `cargo fmt --all --check`
- [x] clippy `-Dwarnings` on `codewhale-tui`
- [x] `./scripts/release/check-versions.sh` (root CHANGELOG synced)

Fixes #4132
Refs #4092