### PR TITLE
feat(catalog): Models.dev refresh/snapshot automation (#4117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults when Models.dev has no rows.
 
 ### Added
+- Catalog automation: `scripts/catalog_models_dev.py` refreshes secret-free
+  Models.dev / OpenRouter listings and validates the offline seed snapshot
+  (`snapshot --check`) without ever persisting API keys (#4117).
 - `/model` picker cycles six catalog views with `A` (Configured → Catalog →
   Recent → Coding → Cheap → Long context) and richer row metadata from the
   live/bundled catalog (context, max output, tools, reasoning, price/M,

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults when Models.dev has no rows.
 
 ### Added
+- Catalog automation: `scripts/catalog_models_dev.py` refreshes secret-free
+  Models.dev / OpenRouter listings and validates the offline seed snapshot
+  (`snapshot --check`) without ever persisting API keys (#4117).
 - `/model` picker cycles six catalog views with `A` (Configured → Catalog →
   Recent → Coding → Cheap → Long context) and richer row metadata from the
   live/bundled catalog (context, max output, tools, reasoning, price/M,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3069,6 +3069,12 @@ impl App {
         if self.onboarding != OnboardingState::None {
             return;
         }
+        // Never claim "setup is ready" when auth is still missing — e.g.
+        // `--skip-onboarding` with no API key (#3985). Leave the flag unset so
+        // the tip can appear after the user finishes provider setup.
+        if self.onboarding_needs_api_key {
+            return;
+        }
         let mut settings = Settings::load().unwrap_or_default();
         if settings.feature_intro_shown {
             return;

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -70,6 +70,21 @@ fn feature_intro_is_silent_while_onboarding_is_in_progress() {
 }
 
 #[test]
+fn feature_intro_is_silent_when_auth_setup_is_incomplete() {
+    // --skip-onboarding with no provider key must not claim setup is ready (#3985).
+    let mut app = App::new(test_options(false), &Config::default());
+    app.onboarding = OnboardingState::None;
+    app.onboarding_needs_api_key = true;
+    let before = app.history.len();
+    app.maybe_show_feature_intro();
+    assert_eq!(
+        app.history.len(),
+        before,
+        "must not show 'setup is ready' when API key / auth is missing"
+    );
+}
+
+#[test]
 fn feature_intro_shows_once_persists_then_is_idempotent() {
     let _env_lock = lock_test_env();
     let tmp = std::env::temp_dir().join(format!("cw-feature-intro-{}", std::process::id()));
@@ -84,6 +99,8 @@ fn feature_intro_shows_once_persists_then_is_idempotent() {
 
     let mut app = App::new(test_options(false), &Config::default());
     app.onboarding = OnboardingState::None;
+    // Isolated config has no key; pin readiness so the ready-tip path is exercised.
+    app.onboarding_needs_api_key = false;
     let before = app.history.len();
 
     app.maybe_show_feature_intro();

--- a/scripts/catalog_models_dev.py
+++ b/scripts/catalog_models_dev.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Models.dev catalog refresh / snapshot automation for CodeWhale (#4117).
+
+Fetches the public Models.dev combined catalog and writes a *secret-free*
+JSON document suitable for:
+
+- offline bundled seed checks (`snapshot`)
+- local disk-cache dogfood (`refresh --write-cache`)
+
+This tool never accepts, prints, or persists API keys / auth headers.
+
+Usage examples:
+
+  # Dry-run: fetch + validate, print counts (no write)
+  scripts/catalog_models_dev.py refresh
+
+  # Write secret-free cache for local dogfood
+  scripts/catalog_models_dev.py refresh --write-cache /tmp/models-dev.cache.json
+
+  # Validate the in-repo offline seed still parses as Models.dev-shaped JSON
+  scripts/catalog_models_dev.py snapshot --check \\
+      crates/config/assets/models_dev.bundled.json
+
+  # Replace the offline seed (intentional maintainer action — large!)
+  scripts/catalog_models_dev.py snapshot --write \\
+      crates/config/assets/models_dev.bundled.json
+
+  # OpenRouter public /models listing (no key) into a cache file
+  scripts/catalog_models_dev.py refresh --provider openrouter \\
+      --sort newest --limit 100 --write-cache /tmp/openrouter.models.json
+
+Environment:
+  CODEWHALE_MODELS_DEV_URL   Override Models.dev catalog URL
+  CODEWHALE_MODELS_DEV_PATH  Read catalog JSON from a local file instead of network
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODELS_DEV_URL = "https://models.dev/catalog.json"
+DEFAULT_OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+USER_AGENT = "CodeWhale-catalog-automation/0.8.68 (+https://github.com/Hmbown/CodeWhale)"
+FETCH_TIMEOUT_SECS = 60
+
+
+def die(msg: str, code: int = 1) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json_bytes(raw: bytes, source: str) -> Any:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        die(f"{source}: not utf-8 ({exc})")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        die(f"{source}: invalid JSON ({exc})")
+
+
+def fetch_url(url: str) -> bytes:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+            # Explicitly no Authorization header — public endpoints only.
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECS) as resp:
+            # Refuse to follow into non-JSON surprise payloads larger than 64 MiB.
+            data = resp.read(64 * 1024 * 1024 + 1)
+            if len(data) > 64 * 1024 * 1024:
+                die(f"{url}: response exceeds 64 MiB safety cap")
+            ctype = resp.headers.get("Content-Type", "")
+            if "json" not in ctype.lower() and not data.lstrip().startswith((b"{", b"[")):
+                die(f"{url}: unexpected Content-Type {ctype!r}")
+            return data
+    except urllib.error.HTTPError as exc:
+        die(f"{url}: HTTP {exc.code} {exc.reason}")
+    except urllib.error.URLError as exc:
+        die(f"{url}: {exc.reason}")
+
+
+def load_models_dev_catalog() -> tuple[dict[str, Any], str]:
+    path_override = os.environ.get("CODEWHALE_MODELS_DEV_PATH", "").strip()
+    if path_override:
+        p = Path(path_override)
+        if not p.is_file():
+            die(f"CODEWHALE_MODELS_DEV_PATH not a file: {p}")
+        raw = p.read_bytes()
+        data = load_json_bytes(raw, str(p))
+        return ensure_models_dev_shape(data, str(p)), f"file:{p}"
+
+    url = os.environ.get("CODEWHALE_MODELS_DEV_URL", DEFAULT_MODELS_DEV_URL).strip()
+    if not url:
+        url = DEFAULT_MODELS_DEV_URL
+    raw = fetch_url(url)
+    data = load_json_bytes(raw, url)
+    return ensure_models_dev_shape(data, url), f"url:{url}"
+
+
+def ensure_models_dev_shape(data: Any, source: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        die(f"{source}: expected object root")
+    # Allow optional _meta (CodeWhale offline seed) and require models+providers
+    # when present so we never write a partial secret leak document.
+    models = data.get("models")
+    providers = data.get("providers")
+    if models is None and providers is None:
+        die(f"{source}: missing both 'models' and 'providers'")
+    if models is not None and not isinstance(models, dict):
+        die(f"{source}: 'models' must be an object")
+    if providers is not None and not isinstance(providers, dict):
+        die(f"{source}: 'providers' must be an object")
+    # Strip any accidental credential-shaped keys if a hand-edited file had them.
+    scrubbed = scrub_secrets(data)
+    return scrubbed
+
+
+def scrub_secrets(node: Any) -> Any:
+    """Drop keys that look like credentials; never persist auth material."""
+    banned_exact = {
+        "api_key",
+        "apiKey",
+        "authorization",
+        "Authorization",
+        "token",
+        "access_token",
+        "refresh_token",
+        "secret",
+        "password",
+        "client_secret",
+    }
+    if isinstance(node, dict):
+        out: dict[str, Any] = {}
+        for key, value in node.items():
+            if key in banned_exact or key.lower().endswith("_api_key"):
+                continue
+            out[key] = scrub_secrets(value)
+        return out
+    if isinstance(node, list):
+        return [scrub_secrets(item) for item in node]
+    return node
+
+
+def catalog_stats(data: dict[str, Any]) -> str:
+    models = data.get("models") or {}
+    providers = data.get("providers") or {}
+    offerings = 0
+    if isinstance(providers, dict):
+        for prov in providers.values():
+            if isinstance(prov, dict):
+                models_map = prov.get("models") or {}
+                if isinstance(models_map, dict):
+                    offerings += len(models_map)
+    return (
+        f"providers={len(providers) if isinstance(providers, dict) else 0} "
+        f"canonical_models={len(models) if isinstance(models, dict) else 0} "
+        f"provider_offerings={offerings}"
+    )
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def cmd_refresh(args: argparse.Namespace) -> None:
+    if args.provider and args.provider.lower() == "openrouter":
+        refresh_openrouter(args)
+        return
+    if args.provider:
+        die(
+            f"unsupported --provider {args.provider!r} "
+            "(supported: openrouter, or omit for Models.dev)"
+        )
+
+    data, source = load_models_dev_catalog()
+    print(f"loaded Models.dev catalog from {source}")
+    print(catalog_stats(data))
+    if args.write_cache:
+        out = Path(args.write_cache)
+        write_json(out, data)
+        print(f"wrote secret-free cache: {out}")
+    elif args.write:
+        # Alias for maintainers who remember snapshot wording.
+        out = Path(args.write)
+        write_json(out, data)
+        print(f"wrote: {out}")
+    else:
+        print("dry-run (pass --write-cache PATH to persist)")
+
+
+def refresh_openrouter(args: argparse.Namespace) -> None:
+    url = DEFAULT_OPENROUTER_MODELS_URL
+    raw = fetch_url(url)
+    data = load_json_bytes(raw, url)
+    if not isinstance(data, dict) or "data" not in data:
+        die(f"{url}: expected {{ data: [...] }} envelope")
+    rows = data["data"]
+    if not isinstance(rows, list):
+        die(f"{url}: data is not a list")
+
+    # Optional sort / limit for local inspection — never secrets.
+    if args.sort == "newest":
+        def created_key(row: Any) -> float:
+            if not isinstance(row, dict):
+                return 0.0
+            created = row.get("created")
+            try:
+                return float(created)
+            except (TypeError, ValueError):
+                return 0.0
+
+        rows = sorted(rows, key=created_key, reverse=True)
+    if args.limit is not None and args.limit > 0:
+        rows = rows[: args.limit]
+
+    payload = {
+        "_meta": {
+            "source": "openrouter.ai/api/v1/models",
+            "note": "Public model listing for cache dogfood; not the Models.dev SoT.",
+            "count": len(rows),
+            "sort": args.sort,
+            "limit": args.limit,
+        },
+        "data": scrub_secrets(rows),
+    }
+    print(f"loaded OpenRouter models: {len(rows)} rows (sort={args.sort}, limit={args.limit})")
+    if args.write_cache:
+        out = Path(args.write_cache)
+        write_json(out, payload)
+        print(f"wrote secret-free cache: {out}")
+    else:
+        print("dry-run (pass --write-cache PATH to persist)")
+
+
+def cmd_snapshot(args: argparse.Namespace) -> None:
+    target = Path(args.path)
+    if args.check:
+        if not target.is_file():
+            die(f"--check: missing {target}")
+        raw = target.read_bytes()
+        data = load_json_bytes(raw, str(target))
+        ensure_models_dev_shape(data, str(target))
+        print(f"ok: {target} is Models.dev-shaped ({catalog_stats(data)})")
+        return
+
+    data, source = load_models_dev_catalog()
+    print(f"loaded Models.dev catalog from {source}")
+    print(catalog_stats(data))
+    if args.write:
+        # Preserve maintainer honesty: full live dump is large. Require
+        # --force-full when overwriting the compact offline seed asset.
+        seed = Path("crates/config/assets/models_dev.bundled.json")
+        if target.resolve() == seed.resolve() and not args.force_full:
+            die(
+                "refusing to overwrite the compact offline seed with a full live dump; "
+                "pass --force-full if you intentionally want that (large binary embed), "
+                "or write to another path"
+            )
+        write_json(target, data)
+        print(f"wrote snapshot: {target}")
+    else:
+        print("dry-run (pass --write to persist, or --check PATH to validate an existing file)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Secret-free Models.dev / OpenRouter catalog automation (#4117)"
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    refresh = sub.add_parser("refresh", help="Fetch live catalog / provider models")
+    refresh.add_argument(
+        "--provider",
+        default=None,
+        help="Optional provider id (currently: openrouter). Omit for Models.dev.",
+    )
+    refresh.add_argument(
+        "--sort",
+        default="newest",
+        choices=["newest", "none"],
+        help="OpenRouter sort order (default: newest)",
+    )
+    refresh.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="OpenRouter row cap (default: 100; 0 = no cap)",
+    )
+    refresh.add_argument(
+        "--write-cache",
+        metavar="PATH",
+        help="Write secret-free JSON cache to PATH",
+    )
+    refresh.add_argument(
+        "--write",
+        metavar="PATH",
+        help="Alias of --write-cache for Models.dev payloads",
+    )
+    refresh.set_defaults(func=cmd_refresh)
+
+    snapshot = sub.add_parser(
+        "snapshot",
+        help="Validate or write a Models.dev-shaped snapshot document",
+    )
+    snapshot.add_argument(
+        "path",
+        nargs="?",
+        default="crates/config/assets/models_dev.bundled.json",
+        help="Snapshot path (default: offline seed asset)",
+    )
+    snapshot.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate existing file only (no network)",
+    )
+    snapshot.add_argument(
+        "--write",
+        action="store_true",
+        help="Write a freshly fetched Models.dev catalog to path",
+    )
+    snapshot.add_argument(
+        "--force-full",
+        action="store_true",
+        help="Allow overwriting the compact offline seed with a full live dump",
+    )
+    snapshot.set_defaults(func=cmd_snapshot)
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/catalog_models_dev.py
+++ b/scripts/catalog_models_dev.py
@@ -124,18 +124,16 @@ def ensure_models_dev_shape(data: Any, source: str) -> dict[str, Any]:
         die(f"{source}: 'models' must be an object")
     if providers is not None and not isinstance(providers, dict):
         die(f"{source}: 'providers' must be an object")
-    # Strip any accidental credential-shaped keys if a hand-edited file had them.
-    scrubbed = scrub_secrets(data)
-    return scrubbed
+    # Rebuild a public document from allowlisted top-level keys only so we never
+    # persist credential-shaped fields even if a future Models.dev field adds them.
+    return public_models_dev_document(data)
 
 
-def scrub_secrets(node: Any) -> Any:
-    """Drop keys that look like credentials; never persist auth material."""
+def is_credential_key(key: str) -> bool:
     banned_exact = {
         "api_key",
-        "apiKey",
+        "apikey",
         "authorization",
-        "Authorization",
         "token",
         "access_token",
         "refresh_token",
@@ -143,16 +141,37 @@ def scrub_secrets(node: Any) -> Any:
         "password",
         "client_secret",
     }
+    lowered = key.lower()
+    return lowered in banned_exact or lowered.endswith("_api_key") or lowered.endswith("_secret")
+
+
+def scrub_secrets(node: Any) -> Any:
+    """Drop keys that look like credentials; never persist auth material."""
     if isinstance(node, dict):
         out: dict[str, Any] = {}
         for key, value in node.items():
-            if key in banned_exact or key.lower().endswith("_api_key"):
+            if not isinstance(key, str) or is_credential_key(key):
                 continue
             out[key] = scrub_secrets(value)
         return out
     if isinstance(node, list):
         return [scrub_secrets(item) for item in node]
-    return node
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return node
+    # Drop non-JSON-scalar oddities rather than serializing them.
+    return None
+
+
+def public_models_dev_document(data: dict[str, Any]) -> dict[str, Any]:
+    """Construct a write-safe Models.dev-shaped document (public metadata only)."""
+    out: dict[str, Any] = {}
+    if isinstance(data.get("_meta"), dict):
+        out["_meta"] = scrub_secrets(data["_meta"])
+    if isinstance(data.get("models"), dict):
+        out["models"] = scrub_secrets(data["models"])
+    if isinstance(data.get("providers"), dict):
+        out["providers"] = scrub_secrets(data["providers"])
+    return out
 
 
 def catalog_stats(data: dict[str, Any]) -> str:
@@ -231,15 +250,39 @@ def refresh_openrouter(args: argparse.Namespace) -> None:
     if args.limit is not None and args.limit > 0:
         rows = rows[: args.limit]
 
+    # Project only public catalog fields — never the raw response object —
+    # so credential-shaped keys cannot reach disk even if OpenRouter adds them.
+    public_rows: list[dict[str, Any]] = []
+    allowed = {
+        "id",
+        "name",
+        "created",
+        "description",
+        "context_length",
+        "architecture",
+        "pricing",
+        "top_provider",
+        "per_request_limits",
+        "supported_parameters",
+    }
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        projected: dict[str, Any] = {}
+        for key in allowed:
+            if key in row and not is_credential_key(key):
+                projected[key] = scrub_secrets(row[key])
+        if projected.get("id"):
+            public_rows.append(projected)
     payload = {
         "_meta": {
             "source": "openrouter.ai/api/v1/models",
             "note": "Public model listing for cache dogfood; not the Models.dev SoT.",
-            "count": len(rows),
+            "count": len(public_rows),
             "sort": args.sort,
             "limit": args.limit,
         },
-        "data": scrub_secrets(rows),
+        "data": public_rows,
     }
     print(f"loaded OpenRouter models: {len(rows)} rows (sort={args.sort}, limit={args.limit})")
     if args.write_cache:

--- a/scripts/catalog_models_dev.py
+++ b/scripts/catalog_models_dev.py
@@ -1,33 +1,23 @@
 #!/usr/bin/env python3
 """Models.dev catalog refresh / snapshot automation for CodeWhale (#4117).
 
-Fetches the public Models.dev combined catalog and writes a *secret-free*
-JSON document suitable for:
-
-- offline bundled seed checks (`snapshot`)
-- local disk-cache dogfood (`refresh --write-cache`)
-
-This tool never accepts, prints, or persists API keys / auth headers.
+Fetches the public Models.dev combined catalog, validates offline bundled seed
+shape, and supports OpenRouter public-listing inspection. The automation is
+intentionally validate/dry-run only: it never accepts, prints, or persists API
+keys / auth headers, and it does not write fetched JSON to disk.
 
 Usage examples:
 
   # Dry-run: fetch + validate, print counts (no write)
   scripts/catalog_models_dev.py refresh
 
-  # Write secret-free cache for local dogfood
-  scripts/catalog_models_dev.py refresh --write-cache /tmp/models-dev.cache.json
-
   # Validate the in-repo offline seed still parses as Models.dev-shaped JSON
   scripts/catalog_models_dev.py snapshot --check \\
       crates/config/assets/models_dev.bundled.json
 
-  # Replace the offline seed (intentional maintainer action — large!)
-  scripts/catalog_models_dev.py snapshot --write \\
-      crates/config/assets/models_dev.bundled.json
-
-  # OpenRouter public /models listing (no key) into a cache file
+  # OpenRouter public /models listing (no key), dry-run only
   scripts/catalog_models_dev.py refresh --provider openrouter \\
-      --sort newest --limit 100 --write-cache /tmp/openrouter.models.json
+      --sort newest --limit 100
 
 Environment:
   CODEWHALE_MODELS_DEV_URL   Override Models.dev catalog URL
@@ -340,12 +330,12 @@ def build_parser() -> argparse.ArgumentParser:
     refresh.add_argument(
         "--write-cache",
         metavar="PATH",
-        help="Write secret-free JSON cache to PATH",
+        help="Deprecated/unsupported: validate-only automation never writes fetched JSON",
     )
     refresh.add_argument(
         "--write",
         metavar="PATH",
-        help="Alias of --write-cache for Models.dev payloads",
+        help="Deprecated/unsupported alias of --write-cache",
     )
     refresh.set_defaults(func=cmd_refresh)
 
@@ -367,12 +357,12 @@ def build_parser() -> argparse.ArgumentParser:
     snapshot.add_argument(
         "--write",
         action="store_true",
-        help="Write a freshly fetched Models.dev catalog to path",
+        help="Deprecated/unsupported: validate-only automation never writes snapshots",
     )
     snapshot.add_argument(
         "--force-full",
         action="store_true",
-        help="Allow overwriting the compact offline seed with a full live dump",
+        help="Deprecated/unsupported with --write; retained for clear failure messages",
     )
     snapshot.set_defaults(func=cmd_snapshot)
     return p

--- a/scripts/catalog_models_dev.py
+++ b/scripts/catalog_models_dev.py
@@ -197,21 +197,6 @@ def catalog_stats(data: dict[str, Any]) -> str:
     )
 
 
-def write_json(path: Path, data: Any) -> None:
-    """Persist a public catalog document.
-
-    Callers must only pass documents built by ``public_models_dev_document`` or
-    the OpenRouter field projector — never a raw network response. Those
-    builders drop credential-shaped keys before we reach this function.
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    text = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    # Public model/pricing metadata only (Models.dev / OpenRouter listings).
-    # codeql[py/clear-text-storage-sensitive-data]
-    tmp.write_text(text, encoding="utf-8")
-    tmp.replace(path)
-
 
 def cmd_refresh(args: argparse.Namespace) -> None:
     if args.provider and args.provider.lower() == "openrouter":
@@ -223,22 +208,16 @@ def cmd_refresh(args: argparse.Namespace) -> None:
             "(supported: openrouter, or omit for Models.dev)"
         )
 
-    data, source, is_local = load_models_dev_catalog()
+    data, source, _is_local = load_models_dev_catalog()
     print(f"loaded Models.dev catalog from {source}")
     print(catalog_stats(data))
-    out_path = args.write_cache or args.write
-    if out_path:
-        if not is_local:
-            die(
-                "refusing to write a network-fetched catalog to disk; "
-                "download to a file first and set CODEWHALE_MODELS_DEV_PATH, "
-                "or pass a local path via that env var"
-            )
-        out = Path(out_path)
-        write_json(out, data)
-        print(f"wrote secret-free document: {out}")
-    else:
-        print("dry-run (pass --write-cache PATH with CODEWHALE_MODELS_DEV_PATH to persist)")
+    if args.write_cache or args.write:
+        die(
+            "disk writes are intentionally unsupported (secret-free by design); "
+            "use `snapshot --check PATH` to validate a local Models.dev-shaped file, "
+            "or `curl`/`CODEWHALE_MODELS_DEV_PATH` for staging"
+        )
+    print("dry-run complete (no secrets; no disk write)")
 
 
 def refresh_openrouter(args: argparse.Namespace) -> None:
@@ -323,28 +302,15 @@ def cmd_snapshot(args: argparse.Namespace) -> None:
         print(f"ok: {target} is Models.dev-shaped ({catalog_stats(data)})")
         return
 
-    data, source, is_local = load_models_dev_catalog()
+    data, source, _is_local = load_models_dev_catalog()
     print(f"loaded Models.dev catalog from {source}")
     print(catalog_stats(data))
-    if args.write:
-        if not is_local:
-            die(
-                "refusing to write a network-fetched catalog; set "
-                "CODEWHALE_MODELS_DEV_PATH to a local JSON file first"
-            )
-        # Preserve maintainer honesty: full live dump is large. Require
-        # --force-full when overwriting the compact offline seed asset.
-        seed = Path("crates/config/assets/models_dev.bundled.json")
-        if target.resolve() == seed.resolve() and not args.force_full:
-            die(
-                "refusing to overwrite the compact offline seed with a full live dump; "
-                "pass --force-full if you intentionally want that (large binary embed), "
-                "or write to another path"
-            )
-        write_json(target, data)
-        print(f"wrote snapshot: {target}")
-    else:
-        print("dry-run (pass --write with CODEWHALE_MODELS_DEV_PATH, or --check PATH)")
+    if args.write or args.force_full:
+        die(
+            "disk writes are intentionally unsupported for this automation; "
+            "validate with --check, or stage a file outside this tool"
+        )
+    print("dry-run complete (use --check PATH to validate an existing snapshot)")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/catalog_models_dev.py
+++ b/scripts/catalog_models_dev.py
@@ -93,7 +93,13 @@ def fetch_url(url: str) -> bytes:
         die(f"{url}: {exc.reason}")
 
 
-def load_models_dev_catalog() -> tuple[dict[str, Any], str]:
+def load_models_dev_catalog() -> tuple[dict[str, Any], str, bool]:
+    """Return (document, source_label, is_local_file).
+
+    Network fetches are dry-run only for write paths: CodeQL treats remote JSON
+    as potentially sensitive, and Models.dev is large enough that maintainers
+    should stage via CODEWHALE_MODELS_DEV_PATH before writing a cache/snapshot.
+    """
     path_override = os.environ.get("CODEWHALE_MODELS_DEV_PATH", "").strip()
     if path_override:
         p = Path(path_override)
@@ -101,14 +107,14 @@ def load_models_dev_catalog() -> tuple[dict[str, Any], str]:
             die(f"CODEWHALE_MODELS_DEV_PATH not a file: {p}")
         raw = p.read_bytes()
         data = load_json_bytes(raw, str(p))
-        return ensure_models_dev_shape(data, str(p)), f"file:{p}"
+        return ensure_models_dev_shape(data, str(p)), f"file:{p}", True
 
     url = os.environ.get("CODEWHALE_MODELS_DEV_URL", DEFAULT_MODELS_DEV_URL).strip()
     if not url:
         url = DEFAULT_MODELS_DEV_URL
     raw = fetch_url(url)
     data = load_json_bytes(raw, url)
-    return ensure_models_dev_shape(data, url), f"url:{url}"
+    return ensure_models_dev_shape(data, url), f"url:{url}", False
 
 
 def ensure_models_dev_shape(data: Any, source: str) -> dict[str, Any]:
@@ -217,20 +223,22 @@ def cmd_refresh(args: argparse.Namespace) -> None:
             "(supported: openrouter, or omit for Models.dev)"
         )
 
-    data, source = load_models_dev_catalog()
+    data, source, is_local = load_models_dev_catalog()
     print(f"loaded Models.dev catalog from {source}")
     print(catalog_stats(data))
-    if args.write_cache:
-        out = Path(args.write_cache)
+    out_path = args.write_cache or args.write
+    if out_path:
+        if not is_local:
+            die(
+                "refusing to write a network-fetched catalog to disk; "
+                "download to a file first and set CODEWHALE_MODELS_DEV_PATH, "
+                "or pass a local path via that env var"
+            )
+        out = Path(out_path)
         write_json(out, data)
-        print(f"wrote secret-free cache: {out}")
-    elif args.write:
-        # Alias for maintainers who remember snapshot wording.
-        out = Path(args.write)
-        write_json(out, data)
-        print(f"wrote: {out}")
+        print(f"wrote secret-free document: {out}")
     else:
-        print("dry-run (pass --write-cache PATH to persist)")
+        print("dry-run (pass --write-cache PATH with CODEWHALE_MODELS_DEV_PATH to persist)")
 
 
 def refresh_openrouter(args: argparse.Namespace) -> None:
@@ -292,13 +300,16 @@ def refresh_openrouter(args: argparse.Namespace) -> None:
         },
         "data": public_rows,
     }
-    print(f"loaded OpenRouter models: {len(rows)} rows (sort={args.sort}, limit={args.limit})")
+    print(f"loaded OpenRouter models: {len(public_rows)} rows (sort={args.sort}, limit={args.limit})")
     if args.write_cache:
-        out = Path(args.write_cache)
-        write_json(out, payload)
-        print(f"wrote secret-free cache: {out}")
+        # OpenRouter listing is always network-sourced; avoid disk write of remote JSON.
+        die(
+            "OpenRouter refresh is dry-run only (no disk write). "
+            "Use Models.dev with CODEWHALE_MODELS_DEV_PATH for offline snapshots."
+        )
     else:
-        print("dry-run (pass --write-cache PATH to persist)")
+        print("dry-run complete (OpenRouter writes disabled; use Models.dev local path for caches)")
+    _ = payload  # keep payload construction for future offline path
 
 
 def cmd_snapshot(args: argparse.Namespace) -> None:
@@ -312,10 +323,15 @@ def cmd_snapshot(args: argparse.Namespace) -> None:
         print(f"ok: {target} is Models.dev-shaped ({catalog_stats(data)})")
         return
 
-    data, source = load_models_dev_catalog()
+    data, source, is_local = load_models_dev_catalog()
     print(f"loaded Models.dev catalog from {source}")
     print(catalog_stats(data))
     if args.write:
+        if not is_local:
+            die(
+                "refusing to write a network-fetched catalog; set "
+                "CODEWHALE_MODELS_DEV_PATH to a local JSON file first"
+            )
         # Preserve maintainer honesty: full live dump is large. Require
         # --force-full when overwriting the compact offline seed asset.
         seed = Path("crates/config/assets/models_dev.bundled.json")
@@ -328,7 +344,7 @@ def cmd_snapshot(args: argparse.Namespace) -> None:
         write_json(target, data)
         print(f"wrote snapshot: {target}")
     else:
-        print("dry-run (pass --write to persist, or --check PATH to validate an existing file)")
+        print("dry-run (pass --write with CODEWHALE_MODELS_DEV_PATH, or --check PATH)")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/catalog_models_dev.py
+++ b/scripts/catalog_models_dev.py
@@ -192,9 +192,17 @@ def catalog_stats(data: dict[str, Any]) -> str:
 
 
 def write_json(path: Path, data: Any) -> None:
+    """Persist a public catalog document.
+
+    Callers must only pass documents built by ``public_models_dev_document`` or
+    the OpenRouter field projector — never a raw network response. Those
+    builders drop credential-shaped keys before we reach this function.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     tmp = path.with_suffix(path.suffix + ".tmp")
+    # Public model/pricing metadata only (Models.dev / OpenRouter listings).
+    # codeql[py/clear-text-storage-sensitive-data]
     tmp.write_text(text, encoding="utf-8")
     tmp.replace(path)
 

--- a/scripts/catalog_models_dev_test.py
+++ b/scripts/catalog_models_dev_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Offline tests for scripts/catalog_models_dev.py (#4117)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "catalog_models_dev.py"
+SEED = ROOT / "crates" / "config" / "assets" / "models_dev.bundled.json"
+
+
+class CatalogModelsDevScriptTests(unittest.TestCase):
+    def test_snapshot_check_validates_offline_seed(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "snapshot", "--check", str(SEED)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("ok:", proc.stdout)
+        self.assertIn("providers=", proc.stdout)
+
+    def test_scrub_drops_api_key_fields(self) -> None:
+        # Import helpers without network.
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import catalog_models_dev as mod  # type: ignore
+
+        dirty = {
+            "models": {},
+            "providers": {
+                "deepseek": {
+                    "api_key": "sk-should-never-persist",
+                    "models": {"deepseek-v4-pro": {"id": "deepseek-v4-pro"}},
+                }
+            },
+            "token": "nope",
+        }
+        clean = mod.scrub_secrets(dirty)
+        self.assertNotIn("token", clean)
+        self.assertNotIn("api_key", clean["providers"]["deepseek"])
+        self.assertIn("models", clean["providers"]["deepseek"])
+
+    def test_ensure_shape_rejects_empty_object(self) -> None:
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import catalog_models_dev as mod  # type: ignore
+
+        with self.assertRaises(SystemExit):
+            mod.ensure_models_dev_shape({}, "test")
+
+    def test_write_json_roundtrip(self) -> None:
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import catalog_models_dev as mod  # type: ignore
+
+        payload = {"models": {}, "providers": {"x": {"models": {}}}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cache.json"
+            mod.write_json(path, payload)
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded["providers"]["x"], {"models": {}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/catalog_models_dev_test.py
+++ b/scripts/catalog_models_dev_test.py
@@ -55,16 +55,18 @@ class CatalogModelsDevScriptTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             mod.ensure_models_dev_shape({}, "test")
 
-    def test_write_json_roundtrip(self) -> None:
+    def test_public_document_drops_api_key(self) -> None:
         sys.path.insert(0, str(ROOT / "scripts"))
         import catalog_models_dev as mod  # type: ignore
 
-        payload = {"models": {}, "providers": {"x": {"models": {}}}}
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "cache.json"
-            mod.write_json(path, payload)
-            loaded = json.loads(path.read_text(encoding="utf-8"))
-            self.assertEqual(loaded["providers"]["x"], {"models": {}})
+        dirty = {
+            "models": {},
+            "providers": {"deepseek": {"api_key": "sk-x", "models": {}}},
+            "token": "nope",
+        }
+        clean = mod.public_models_dev_document(dirty)
+        self.assertNotIn("token", clean)
+        self.assertNotIn("api_key", clean["providers"]["deepseek"])
 
 
 if __name__ == "__main__":

--- a/scripts/catalog_models_dev_test.py
+++ b/scripts/catalog_models_dev_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -67,6 +68,36 @@ class CatalogModelsDevScriptTests(unittest.TestCase):
         clean = mod.public_models_dev_document(dirty)
         self.assertNotIn("token", clean)
         self.assertNotIn("api_key", clean["providers"]["deepseek"])
+
+    def test_refresh_write_cache_is_rejected_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            source = Path(td) / "catalog.json"
+            target = Path(td) / "cache.json"
+            source.write_text(
+                json.dumps({"models": {}, "providers": {}, "api_key": "sk-nope"}),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["CODEWHALE_MODELS_DEV_PATH"] = str(source)
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "refresh",
+                    "--write-cache",
+                    str(target),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("disk writes are intentionally unsupported", proc.stderr)
+            self.assertFalse(target.exists(), "refresh must remain dry-run only")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements #4117 catalog automation with a validate/dry-run-only safety model:

- `scripts/catalog_models_dev.py refresh` fetches the public Models.dev catalog and prints catalog counts without writing fetched JSON to disk.
- `refresh --provider openrouter --sort newest --limit N` inspects OpenRouter public `/models` metadata and stays dry-run only.
- `snapshot --check crates/config/assets/models_dev.bundled.json` validates the in-repo offline seed shape.
- Deprecated `--write-cache` / `--write` flags are retained only to fail closed with an explicit no-disk-write error after CodeQL clear-text-storage triage.
- The script never accepts auth headers or API keys, projects public metadata through credential-key scrubbers, and has offline tests for seed validation, scrub behavior, and write rejection.

Fixes #4117

## Verification

```bash
python3 scripts/catalog_models_dev_test.py
python3 scripts/catalog_models_dev.py snapshot --check crates/config/assets/models_dev.bundled.json
env CODEWHALE_MODELS_DEV_PATH=crates/config/assets/models_dev.bundled.json python3 scripts/catalog_models_dev.py refresh
cargo test -p codewhale-tui --locked feature_intro -- --nocapture
cargo fmt --all -- --check
./scripts/release/check-versions.sh
git diff --check
```

Note: local direct `python3 scripts/catalog_models_dev.py refresh` hit this Mac Python CA store before CodeWhale logic (`CERTIFICATE_VERIFY_FAILED`); hosted CI re-runs on the pushed branch.