### PR TITLE
fix(tui): no 'setup is ready' intro without auth (#3985)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3069,6 +3069,12 @@ impl App {
         if self.onboarding != OnboardingState::None {
             return;
         }
+        // Never claim "setup is ready" when auth is still missing — e.g.
+        // `--skip-onboarding` with no API key (#3985). Leave the flag unset so
+        // the tip can appear after the user finishes provider setup.
+        if self.onboarding_needs_api_key {
+            return;
+        }
         let mut settings = Settings::load().unwrap_or_default();
         if settings.feature_intro_shown {
             return;

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -70,6 +70,21 @@ fn feature_intro_is_silent_while_onboarding_is_in_progress() {
 }
 
 #[test]
+fn feature_intro_is_silent_when_auth_setup_is_incomplete() {
+    // --skip-onboarding with no provider key must not claim setup is ready (#3985).
+    let mut app = App::new(test_options(false), &Config::default());
+    app.onboarding = OnboardingState::None;
+    app.onboarding_needs_api_key = true;
+    let before = app.history.len();
+    app.maybe_show_feature_intro();
+    assert_eq!(
+        app.history.len(),
+        before,
+        "must not show 'setup is ready' when API key / auth is missing"
+    );
+}
+
+#[test]
 fn feature_intro_shows_once_persists_then_is_idempotent() {
     let _env_lock = lock_test_env();
     let tmp = std::env::temp_dir().join(format!("cw-feature-intro-{}", std::process::id()));
@@ -84,6 +99,8 @@ fn feature_intro_shows_once_persists_then_is_idempotent() {
 
     let mut app = App::new(test_options(false), &Config::default());
     app.onboarding = OnboardingState::None;
+    // Isolated config has no key; pin readiness so the ready-tip path is exercised.
+    app.onboarding_needs_api_key = false;
     let before = app.history.len();
 
     app.maybe_show_feature_intro();


### PR DESCRIPTION
## Summary

Fixes #3985: the one-time feature intro no longer claims \"Your CodeWhale setup is ready\" when `onboarding_needs_api_key` is true (typical `--skip-onboarding` isolated launch with no provider key).

The `feature_intro_shown` flag is **not** set in that case, so the tip can still appear once auth is configured.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui --locked feature_intro` (4 passed)