### PR TITLE
fix(fleet): persist AgentProfile thinking tier

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1160,6 +1160,13 @@ pub struct FleetProfile {
     /// this profile must read this field, not guess from the model id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// Optional explicit reasoning/thinking tier for this profile (#4137).
+    ///
+    /// This is a safe, non-secret route tuning value. `None` means inherit the
+    /// operator/session reasoning tier. Concrete values are normalized by the
+    /// TUI loader before they are used at runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
     /// Permission defaults requested by the profile.
     #[serde(default)]
     pub permissions: FleetProfilePermissions,

--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -27,7 +27,8 @@ use codewhale_protocol::fleet::{FleetHostSpec, FleetTaskSpec, FleetWorkerEventPa
 use super::host::{FleetHostAdapter, FleetWorkerCommand};
 use super::profile::AgentProfile;
 use super::worker_runtime::{
-    fleet_task_prompt, fleet_task_prompt_with_profiles, fleet_worker_launch_route,
+    fleet_task_prompt, fleet_task_prompt_with_profiles, fleet_worker_launch_reasoning_effort,
+    fleet_worker_launch_route,
 };
 
 /// Build the `codewhale exec` argv that runs a fleet task headlessly.
@@ -57,6 +58,7 @@ pub fn build_worker_exec_command(
         exec_config,
         model,
         None,
+        None,
     )
 }
 
@@ -79,12 +81,14 @@ pub fn build_worker_exec_command_with_profiles(
 ) -> Result<FleetWorkerCommand> {
     let (worker_model, worker_provider) =
         fleet_worker_launch_route(task_spec, agent_profiles, model.unwrap_or_default());
+    let worker_reasoning_effort = fleet_worker_launch_reasoning_effort(task_spec, agent_profiles);
     Ok(build_worker_exec_command_from_prompt(
         codewhale_binary,
         fleet_task_prompt_with_profiles(task_spec, agent_profiles)?,
         exec_config,
         Some(worker_model.as_str()),
         worker_provider.as_deref(),
+        worker_reasoning_effort.as_deref(),
     ))
 }
 
@@ -94,6 +98,7 @@ fn build_worker_exec_command_from_prompt(
     exec_config: &FleetExecConfig,
     model: Option<&str>,
     provider: Option<&str>,
+    reasoning_effort: Option<&str>,
 ) -> FleetWorkerCommand {
     let mut args: Vec<String> = vec![
         "exec".to_string(),
@@ -114,6 +119,14 @@ fn build_worker_exec_command_from_prompt(
     if let Some(provider) = provider.map(str::trim).filter(|p| !p.is_empty()) {
         args.push("--provider".to_string());
         args.push(provider.to_string());
+    }
+
+    // Non-secret thinking tier only (#4137). This is profile metadata and
+    // follows the same explicit-only policy as provider: omit it when the
+    // worker profile inherits the session/default reasoning setting.
+    if let Some(reasoning_effort) = reasoning_effort.map(str::trim).filter(|e| !e.is_empty()) {
+        args.push("--reasoning-effort".to_string());
+        args.push(reasoning_effort.to_string());
     }
 
     if !exec_config.allowed_tools.is_empty() {
@@ -467,6 +480,7 @@ mod tests {
                 loadout: FleetLoadout::Inherit,
                 model: None,
                 provider: None,
+                reasoning_effort: None,
                 permissions: FleetProfilePermissions::default(),
                 delegation: FleetDelegationHints::default(),
             },
@@ -531,9 +545,10 @@ mod tests {
 
     /// #4093 AC #4 at the LAUNCH boundary (not just the receipt): a worker whose
     /// profile pins a DIFFERENT provider+model than the parent session must
-    /// actually launch on the profile's route. The parent session is DeepSeek
-    /// here (`--model deepseek-v4-pro`); the profile pins OpenRouter + glm-5.2.
-    /// The emitted argv must carry OpenRouter's id and the profile's model as
+    /// actually launch on the profile's route and saved reasoning tier. The
+    /// parent session is DeepSeek here (`--model deepseek-v4-pro`); the profile
+    /// pins OpenRouter + glm-5.2 + max thinking. The emitted argv must carry
+    /// OpenRouter's id, the profile's model, and the profile's thinking tier as
     /// paired flag/values — never the parent's model. This is the gap the
     /// save→load→resolve receipt tests never covered.
     #[test]
@@ -544,6 +559,7 @@ mod tests {
         let mut profile = agent_profile("cross", "scout", "Read first.");
         profile.profile.provider = Some("openrouter".to_string());
         profile.profile.model = Some("glm-5.2".to_string());
+        profile.profile.reasoning_effort = Some("max".to_string());
 
         let cmd = build_worker_exec_command_with_profiles(
             "codewhale",
@@ -578,6 +594,17 @@ mod tests {
             "{:?}",
             cmd.args
         );
+        let reasoning_idx = cmd
+            .args
+            .iter()
+            .position(|a| a == "--reasoning-effort")
+            .expect("--reasoning-effort must be present for a thinking-pinned worker");
+        assert_eq!(
+            cmd.args.get(reasoning_idx + 1).map(String::as_str),
+            Some("max"),
+            "{:?}",
+            cmd.args
+        );
 
         // The parent/session model must NOT leak onto the argv.
         assert!(
@@ -604,6 +631,11 @@ mod tests {
         assert!(
             !cmd.args.iter().any(|a| a == "--provider"),
             "profile-less worker must not carry --provider: {:?}",
+            cmd.args
+        );
+        assert!(
+            !cmd.args.iter().any(|a| a == "--reasoning-effort"),
+            "profile-less worker must not carry --reasoning-effort: {:?}",
             cmd.args
         );
         let model_idx = cmd

--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -63,6 +63,11 @@ struct AgentProfileToml {
     /// smuggled one.
     #[serde(default)]
     provider: Option<String>,
+    /// Optional saved thinking tier for this profile (#4137). TOML may use
+    /// the canonical `reasoning_effort` spelling or the UI-facing `thinking`
+    /// / `reasoning` aliases; loading normalizes to a canonical setting label.
+    #[serde(default, alias = "thinking", alias = "reasoning")]
+    reasoning_effort: Option<String>,
     #[serde(default)]
     instructions: Option<AgentProfileInstructions>,
     #[serde(default)]
@@ -174,6 +179,8 @@ fn agent_profile_from_toml(path: &Path, parsed: AgentProfileToml) -> Result<Agen
         .map(str::to_string)
         .map(|provider| validate_agent_profile_provider(path, &provider).map(|()| provider))
         .transpose()?;
+    let reasoning_effort =
+        normalize_agent_profile_reasoning_effort(path, parsed.reasoning_effort.as_deref())?;
 
     let instructions = parsed
         .instructions
@@ -193,6 +200,7 @@ fn agent_profile_from_toml(path: &Path, parsed: AgentProfileToml) -> Result<Agen
         loadout,
         model,
         provider,
+        reasoning_effort,
         permissions: FleetProfilePermissions::default(),
         delegation: FleetDelegationHints::default(),
     };
@@ -290,6 +298,29 @@ fn validate_agent_profile_provider(path: &Path, value: &str) -> Result<()> {
     Ok(())
 }
 
+fn normalize_agent_profile_reasoning_effort(
+    path: &Path,
+    value: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(value) = non_empty_trimmed(value) else {
+        return Ok(None);
+    };
+    let normalized = match value.to_ascii_lowercase().as_str() {
+        "inherit" | "parent" | "same" | "current" | "default" | "unset" => return Ok(None),
+        "off" | "disabled" | "none" | "false" => "off",
+        "low" | "minimal" => "low",
+        "medium" | "mid" => "medium",
+        "high" => "high",
+        "auto" | "automatic" => "auto",
+        "max" | "maximum" | "xhigh" | "ultracode" => "max",
+        _ => bail!(
+            "agent profile {} reasoning_effort {value:?} must be one of: inherit, auto, off, low, medium, high, max",
+            path.display()
+        ),
+    };
+    Ok(Some(normalized.to_string()))
+}
+
 fn is_agent_profile_token_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
 }
@@ -353,6 +384,9 @@ pub struct FleetProfileDraft {
     /// structured picker. `None` means "no route pin" (inherit) — matching
     /// `model: None` — or a legacy/untrusted draft that predates this field.
     pub provider: Option<String>,
+    /// Explicit saved thinking tier, set only by structured setup controls.
+    /// `None` means inherit the operator/session reasoning tier.
+    pub reasoning_effort: Option<String>,
     pub instructions: Option<String>,
 }
 
@@ -461,6 +495,7 @@ impl FleetProfileDraft {
             // Never set from untrusted model output — `FleetProfileDraftJson`
             // has no `provider` field, so there is nothing to read here.
             provider: None,
+            reasoning_effort: None,
             instructions,
         };
         if draft.description.is_none() && draft.instructions.is_none() {
@@ -509,6 +544,12 @@ impl FleetProfileDraft {
                     toml::Value::String(provider.clone()),
                 );
             }
+        }
+        if let Some(ref reasoning_effort) = self.reasoning_effort {
+            root.insert(
+                "reasoning_effort".to_string(),
+                toml::Value::String(reasoning_effort.clone()),
+            );
         }
         if let Some(ref instructions) = self.instructions {
             let mut table = toml::value::Table::new();
@@ -692,6 +733,7 @@ mod tests {
             model_class_hint: None,
             model: Some("deepseek-v4-flash".to_string()),
             provider: Some("deepseek".to_string()),
+            reasoning_effort: None,
             instructions: None,
         };
 
@@ -712,6 +754,77 @@ mod tests {
     }
 
     #[test]
+    fn draft_with_reasoning_effort_round_trips_through_the_loader() {
+        let draft = FleetProfileDraft {
+            id: "scout-deep".to_string(),
+            display_name: Some("Scout".to_string()),
+            description: Some("Deep scout profile.".to_string()),
+            role_hint: "scout".to_string(),
+            model_class_hint: None,
+            model: Some("deepseek-v4-pro".to_string()),
+            provider: Some("deepseek".to_string()),
+            reasoning_effort: Some("max".to_string()),
+            instructions: None,
+        };
+
+        let rendered = draft.render_toml();
+        assert!(
+            rendered.contains("reasoning_effort = \"max\""),
+            "rendered TOML must persist explicit reasoning: {rendered}"
+        );
+
+        let dir = TempDir::new().unwrap();
+        write_profile(dir.path(), &draft.file_name(), &rendered);
+        let profiles = load_agent_profiles_from_dir(dir.path()).expect("rendered TOML loads");
+        assert_eq!(profiles.len(), 1);
+        let loaded = &profiles[0];
+        assert_eq!(loaded.profile.provider.as_deref(), Some("deepseek"));
+        assert_eq!(loaded.profile.model.as_deref(), Some("deepseek-v4-pro"));
+        assert_eq!(loaded.profile.reasoning_effort.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn profile_loader_normalizes_reasoning_aliases() {
+        let dir = TempDir::new().unwrap();
+        write_profile(
+            dir.path(),
+            "scout.toml",
+            r#"
+id = "scout"
+role_hint = "scout"
+thinking = "xhigh"
+
+[instructions]
+text = "Scout deeply."
+"#,
+        );
+
+        let profiles = load_agent_profiles_from_dir(dir.path()).expect("profile TOML loads");
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].profile.reasoning_effort.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn profile_loader_rejects_unknown_reasoning_effort() {
+        let dir = TempDir::new().unwrap();
+        write_profile(
+            dir.path(),
+            "scout.toml",
+            r#"
+id = "scout"
+role_hint = "scout"
+reasoning = "expensive"
+"#,
+        );
+
+        let err = load_agent_profiles_from_dir(dir.path()).expect_err("invalid effort must fail");
+        assert!(
+            err.to_string().contains("reasoning_effort"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn inherit_draft_never_renders_a_provider_without_a_model() {
         // `provider` is only meaningful alongside a concrete model pin; an
         // `inherit` draft (no `model`) must never render one even if a stale
@@ -724,6 +837,7 @@ mod tests {
             model_class_hint: None,
             model: None,
             provider: Some("deepseek".to_string()),
+            reasoning_effort: None,
             instructions: None,
         };
         let rendered = draft.render_toml();

--- a/crates/tui/src/fleet/roster.rs
+++ b/crates/tui/src/fleet/roster.rs
@@ -195,6 +195,7 @@ impl FleetRoster {
                 loadout,
                 model: None,
                 provider: None,
+                reasoning_effort: None,
                 permissions: FleetProfilePermissions::default(),
                 delegation: FleetDelegationHints::default(),
             },
@@ -278,6 +279,7 @@ mod tests {
             loadout: FleetLoadout::Inherit,
             model: model.map(str::to_string),
             provider: None,
+            reasoning_effort: None,
             permissions: FleetProfilePermissions::default(),
             delegation: FleetDelegationHints::default(),
         }

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -77,6 +77,7 @@ pub fn fleet_task_to_worker_spec_with_profiles(
     );
     requested_runtime.provider =
         explicit_fleet_provider(agent_profile).map(|provider| provider.as_str().to_string());
+    requested_runtime.reasoning_effort = effective_fleet_reasoning_effort(agent_profile);
     if let Some(agent_profile) = agent_profile
         && let Some(profile_depth) = agent_profile.profile.delegation.max_spawn_depth
     {
@@ -181,9 +182,7 @@ pub(crate) fn resolve_fleet_route(
             ))
             .to_string(),
         ),
-        // The offline resolver path does not know the concrete sub-agent
-        // thinking tier. Leave it absent rather than fabricating one.
-        reasoning_effort: None,
+        reasoning_effort: effective_fleet_reasoning_effort(agent_profile),
         role_source: role_source.map(str::to_string),
         loadout_source: loadout_source.map(str::to_string),
         model_class_source: model_class_source.map(str::to_string),
@@ -456,6 +455,31 @@ pub(crate) fn explicit_fleet_provider(agent_profile: Option<&AgentProfile>) -> O
     agent_profile
         .and_then(|profile| profile.profile.provider.as_deref())
         .and_then(ApiProvider::parse)
+}
+
+pub(crate) fn effective_fleet_reasoning_effort(
+    agent_profile: Option<&AgentProfile>,
+) -> Option<String> {
+    agent_profile
+        .and_then(|profile| profile.profile.reasoning_effort.as_deref())
+        .map(str::trim)
+        .filter(|effort| !effort.is_empty())
+        .map(str::to_string)
+}
+
+/// The explicit reasoning/thinking tier a fleet worker should launch with.
+///
+/// This is the launch-side twin of the receipt/runtime-profile field: it reads
+/// only the resolved AgentProfile tier, so task model overrides can change the
+/// model without accidentally inventing a thinking tier.
+pub(crate) fn fleet_worker_launch_reasoning_effort(
+    task_spec: &FleetTaskSpec,
+    agent_profiles: &[AgentProfile],
+) -> Option<String> {
+    let agent_profile = resolve_task_agent_profile(task_spec, agent_profiles)
+        .ok()
+        .flatten();
+    effective_fleet_reasoning_effort(agent_profile)
 }
 
 /// The route (model selector + optional explicit provider id) that a fleet
@@ -832,6 +856,7 @@ mod tests {
                 loadout,
                 model: None,
                 provider: None,
+                reasoning_effort: None,
                 permissions: codewhale_config::FleetProfilePermissions::default(),
                 delegation: codewhale_config::FleetDelegationHints::default(),
             },
@@ -1290,6 +1315,7 @@ mod tests {
         );
         profile.profile.model = Some("deepseek-v4-flash".to_string());
         profile.profile.provider = Some("openrouter".to_string());
+        profile.profile.reasoning_effort = Some("max".to_string());
         let task = fleet_task(
             "route-cross-provider",
             Some(worker_profile(
@@ -1331,6 +1357,7 @@ mod tests {
             route.provider_kind,
             openrouter_candidate.provider_kind.as_str()
         );
+        assert_eq!(route.reasoning_effort.as_deref(), Some("max"));
         // Differs from DeepSeek — the pre-#4093 hardcoded default AND the
         // parent/session's provider.
         assert_ne!(route.provider_id, "deepseek");
@@ -1351,6 +1378,7 @@ mod tests {
             model_class_hint: None,
             model: Some("deepseek-v4-flash".to_string()),
             provider: Some("openrouter".to_string()),
+            reasoning_effort: Some("max".to_string()),
             instructions: None,
         };
 
@@ -1360,6 +1388,7 @@ mod tests {
             .expect("rendered profile TOML loads");
         assert_eq!(profiles.len(), 1);
         assert_eq!(profiles[0].profile.provider.as_deref(), Some("openrouter"));
+        assert_eq!(profiles[0].profile.reasoning_effort.as_deref(), Some("max"));
         assert_eq!(
             profiles[0].profile.model.as_deref(),
             Some("deepseek-v4-flash")
@@ -1395,6 +1424,7 @@ mod tests {
             openrouter_candidate.wire_model_id.as_str()
         );
         assert_eq!(route.provider_id, openrouter_candidate.provider_id.as_str());
+        assert_eq!(route.reasoning_effort.as_deref(), Some("max"));
         assert_ne!(route.provider_id, "deepseek");
     }
 
@@ -1414,6 +1444,7 @@ mod tests {
         );
         pinned.profile.model = Some("glm-5.2".to_string());
         pinned.profile.provider = Some("openrouter".to_string());
+        pinned.profile.reasoning_effort = Some("high".to_string());
         let pinned_task = fleet_task(
             "launch-pinned",
             Some(worker_profile(
@@ -1425,10 +1456,15 @@ mod tests {
                 vec![],
             )),
         );
+        let pinned_profiles = vec![pinned];
         let (model, provider) =
-            fleet_worker_launch_route(&pinned_task, &[pinned], "deepseek-v4-pro");
+            fleet_worker_launch_route(&pinned_task, &pinned_profiles, "deepseek-v4-pro");
         assert_eq!(model, "glm-5.2");
         assert_eq!(provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            fleet_worker_launch_reasoning_effort(&pinned_task, &pinned_profiles).as_deref(),
+            Some("high")
+        );
 
         // 2) A DeepSeek-shaped model with NO explicit provider must NOT infer a
         //    provider — provider stays None so the worker keeps its own session
@@ -1451,10 +1487,15 @@ mod tests {
                 vec![],
             )),
         );
+        let model_only_profiles = vec![model_only];
         let (model, provider) =
-            fleet_worker_launch_route(&model_only_task, &[model_only], "deepseek-v4-pro");
+            fleet_worker_launch_route(&model_only_task, &model_only_profiles, "deepseek-v4-pro");
         assert_eq!(model, "deepseek-v4-flash");
         assert_eq!(provider, None);
+        assert_eq!(
+            fleet_worker_launch_reasoning_effort(&model_only_task, &model_only_profiles),
+            None
+        );
 
         // 3) No profile at all: run-level model, no provider (unchanged).
         let bare = fleet_task("launch-bare", None);
@@ -1572,6 +1613,7 @@ mod tests {
         );
         profile.profile.model = Some("deepseek-v4-flash".to_string());
         profile.profile.provider = Some("openrouter".to_string());
+        profile.profile.reasoning_effort = Some("max".to_string());
         let task = fleet_task(
             "scout",
             Some(worker_profile(
@@ -1594,6 +1636,7 @@ mod tests {
         };
         let mut parent = WorkerRuntimeProfile::for_role(SubAgentType::General);
         parent.provider = Some("deepseek".to_string());
+        parent.reasoning_effort = Some("low".to_string());
         parent.max_spawn_depth = 3;
 
         let spec = fleet_task_to_worker_spec_with_profiles(
@@ -1614,6 +1657,10 @@ mod tests {
             ModelRoute::Fixed("deepseek-v4-flash".to_string())
         );
         assert_eq!(spec.runtime_profile.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            spec.runtime_profile.reasoning_effort.as_deref(),
+            Some("max")
+        );
         assert_eq!(spec.runtime_profile.max_spawn_depth, 2);
     }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -348,6 +348,10 @@ struct ExecArgs {
     /// one (#4093).
     #[arg(long)]
     provider: Option<String>,
+    /// Override reasoning/thinking effort for this run.
+    /// Accepted values: auto, off, low, medium, high, max.
+    #[arg(long = "reasoning-effort", value_name = "EFFORT")]
+    reasoning_effort: Option<String>,
     /// Enable tool-backed agent mode with auto-approvals
     #[arg(long, default_value_t = false)]
     auto: bool,
@@ -1286,6 +1290,14 @@ async fn main() -> Result<()> {
                         );
                     };
                     config.provider = Some(provider.as_str().to_string());
+                }
+                if let Some(reasoning_arg) = args
+                    .reasoning_effort
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                {
+                    config.reasoning_effort = normalize_cli_reasoning_effort(reasoning_arg)?;
                 }
                 let model = resolve_exec_model(&config, args.model.as_deref());
                 let prompt = join_prompt_parts(&args.prompt);
@@ -7221,6 +7233,26 @@ fn cli_reasoning_effort_value(
         .map(str::to_string)
 }
 
+fn normalize_cli_reasoning_effort(value: &str) -> Result<Option<String>> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let normalized = match trimmed.to_ascii_lowercase().as_str() {
+        "inherit" | "parent" | "same" | "current" | "default" | "unset" => return Ok(None),
+        "off" | "disabled" | "none" | "false" => "off",
+        "low" | "minimal" => "low",
+        "medium" | "mid" => "medium",
+        "high" => "high",
+        "auto" | "automatic" => "auto",
+        "max" | "maximum" | "xhigh" | "ultracode" => "max",
+        _ => bail!(
+            "Unrecognized --reasoning-effort {trimmed:?}. Expected: auto, off, low, medium, high, max, or default."
+        ),
+    };
+    Ok(Some(normalized.to_string()))
+}
+
 fn config_for_cli_route(config: &Config, route: &CliAutoRoute) -> Config {
     let mut execution_config = config.clone();
     execution_config.provider = Some(route.provider.as_str().to_string());
@@ -9436,6 +9468,39 @@ mod terminal_mode_tests {
             crate::config::ApiProvider::parse(args.provider.as_deref().unwrap()),
             Some(crate::config::ApiProvider::Openrouter)
         );
+    }
+
+    #[test]
+    fn exec_parses_reasoning_effort_flag_alongside_provider() {
+        let cli = parse_cli(&[
+            "codewhale",
+            "exec",
+            "--provider",
+            "openrouter",
+            "--model",
+            "glm-5.2",
+            "--reasoning-effort",
+            "max",
+            "audit",
+        ]);
+        let Some(Commands::Exec(args)) = cli.command else {
+            panic!("expected exec command");
+        };
+
+        assert_eq!(args.provider.as_deref(), Some("openrouter"));
+        assert_eq!(args.model.as_deref(), Some("glm-5.2"));
+        assert_eq!(args.reasoning_effort.as_deref(), Some("max"));
+        assert_eq!(args.prompt, vec!["audit"]);
+    }
+
+    #[test]
+    fn cli_reasoning_effort_normalizes_aliases_and_rejects_typos() {
+        assert_eq!(
+            normalize_cli_reasoning_effort("xhigh").unwrap().as_deref(),
+            Some("max")
+        );
+        assert_eq!(normalize_cli_reasoning_effort("default").unwrap(), None);
+        assert!(normalize_cli_reasoning_effort("expensive").is_err());
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2118,6 +2118,9 @@ pub struct App {
                 // the model draft (which is always `provider: None`) omitted or
                 // changed it. `None` for an `inherit` pick.
                 Option<(String, String)>,
+                // The reasoning tier selected when the operator pressed `m`
+                // (#4137). `None` means inherit.
+                Option<String>,
                 Result<Box<crate::fleet::profile::FleetProfileDraft>, String>,
             )>,
         >,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2119,10 +2119,18 @@ async fn run_event_loop(
             .try_lock()
             .ok()
             .and_then(|mut guard| guard.take());
-        if let Some((draft_gen, model_label, picked_route, outcome)) = fleet_draft_delivery
+        if let Some((draft_gen, model_label, picked_route, reasoning_effort, outcome)) =
+            fleet_draft_delivery
             && draft_gen == app.current_draft_gen()
         {
-            deliver_fleet_draft_result(app, model_label, picked_route, outcome, app.ui_locale);
+            deliver_fleet_draft_result(
+                app,
+                model_label,
+                picked_route,
+                reasoning_effort,
+                outcome,
+                app.ui_locale,
+            );
         }
 
         // Poll the constitution model-draft cell (same background pattern).
@@ -5757,6 +5765,7 @@ async fn handle_fleet_profile_model_draft(
     role: String,
     model: String,
     provider: Option<String>,
+    reasoning_effort: Option<String>,
     locale: crate::localization::Locale,
 ) {
     // The route the operator actually picked at `m`-press time (#4093). A
@@ -5779,6 +5788,7 @@ async fn handle_fleet_profile_model_draft(
                 app,
                 model_label.clone(),
                 picked_route.clone(),
+                reasoning_effort.clone(),
                 Err(format!("provider not ready: {err:#}")),
                 locale,
             );
@@ -5830,7 +5840,13 @@ async fn handle_fleet_profile_model_draft(
             Ok(result) => result,
         };
         if let Ok(mut guard) = cell.lock() {
-            *guard = Some((request_gen, spawn_label, picked_route, outcome));
+            *guard = Some((
+                request_gen,
+                spawn_label,
+                picked_route,
+                reasoning_effort,
+                outcome,
+            ));
         }
     });
 }
@@ -5848,6 +5864,7 @@ fn deliver_fleet_draft_result(
     app: &mut App,
     model_label: String,
     picked_route: Option<(String, String)>,
+    reasoning_effort: Option<String>,
     outcome: Result<Box<crate::fleet::profile::FleetProfileDraft>, String>,
     locale: crate::localization::Locale,
 ) {
@@ -5860,7 +5877,12 @@ fn deliver_fleet_draft_result(
                     .as_any_mut()
                     .downcast_mut::<crate::tui::views::fleet_setup::FleetSetupView>()
                     .map(|wizard| {
-                        wizard.install_model_draft(draft, model_label.clone(), picked_route.clone())
+                        wizard.install_model_draft(
+                            draft,
+                            model_label.clone(),
+                            picked_route.clone(),
+                            reasoning_effort.clone(),
+                        )
                     })
                     .is_some();
                 app.view_stack.push_boxed(boxed);
@@ -10445,9 +10467,19 @@ async fn handle_view_events(
                 role,
                 model,
                 provider,
+                reasoning_effort,
                 locale,
             } => {
-                handle_fleet_profile_model_draft(app, config, role, model, provider, locale).await;
+                handle_fleet_profile_model_draft(
+                    app,
+                    config,
+                    role,
+                    model,
+                    provider,
+                    reasoning_effort,
+                    locale,
+                )
+                .await;
             }
             ViewEvent::FleetRosterOpenSetupRequested => {
                 // The roster view hands off to the authoring wizard (same

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -716,6 +716,7 @@ mod tests {
                 loadout: codewhale_config::FleetLoadout::Fast,
                 model: None,
                 provider: None,
+                reasoning_effort: None,
                 permissions: codewhale_config::FleetProfilePermissions::default(),
                 delegation: codewhale_config::FleetDelegationHints::default(),
             },

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -120,6 +120,50 @@ const MODEL_INHERIT: Choice = Choice {
     ),
 };
 
+const THINKING_CHOICES: &[Choice] = &[
+    Choice {
+        label: Cow::Borrowed("inherit"),
+        summary: Cow::Borrowed("Same thinking as now"),
+        description: Cow::Borrowed(
+            "Reuse the operator's current reasoning setting for this worker. Recommended default.",
+        ),
+    },
+    Choice {
+        label: Cow::Borrowed("off"),
+        summary: Cow::Borrowed("No extra thinking"),
+        description: Cow::Borrowed(
+            "Use for narrow lookups or mechanical work where speed matters.",
+        ),
+    },
+    Choice {
+        label: Cow::Borrowed("low"),
+        summary: Cow::Borrowed("Small thinking budget"),
+        description: Cow::Borrowed(
+            "Use for bounded checks that still benefit from light reasoning.",
+        ),
+    },
+    Choice {
+        label: Cow::Borrowed("medium"),
+        summary: Cow::Borrowed("Balanced thinking budget"),
+        description: Cow::Borrowed("Use for normal implementation and review work."),
+    },
+    Choice {
+        label: Cow::Borrowed("high"),
+        summary: Cow::Borrowed("Deep thinking budget"),
+        description: Cow::Borrowed("Use for harder design, debugging, and integration tasks."),
+    },
+    Choice {
+        label: Cow::Borrowed("max"),
+        summary: Cow::Borrowed("Maximum thinking budget"),
+        description: Cow::Borrowed("Use for hard release, security, and root-cause work."),
+    },
+    Choice {
+        label: Cow::Borrowed("auto"),
+        summary: Cow::Borrowed("Let CodeWhale choose"),
+        description: Cow::Borrowed("Choose a thinking tier from the worker prompt at runtime."),
+    },
+];
+
 #[derive(Debug, Clone)]
 pub struct FleetSetupSnapshot {
     workspace: PathBuf,
@@ -242,6 +286,8 @@ enum Step {
     Role,
     /// Pick the model-routing class.
     Model,
+    /// Pick the saved thinking tier.
+    Thinking,
     /// Review the full posture and start.
     Review,
 }
@@ -251,6 +297,7 @@ pub struct FleetSetupView {
     step: Step,
     role_idx: usize,
     model_idx: usize,
+    thinking_idx: usize,
     review_scroll: usize,
     /// A model-drafted profile awaiting ratification (already sanitized and
     /// bounded by the untrusted gate). Cleared when the selection changes so
@@ -304,6 +351,7 @@ impl FleetSetupView {
             step: Step::Role,
             role_idx: 0,
             model_idx: 0,
+            thinking_idx: 0,
             review_scroll: 0,
             model_draft: None,
             model_draft_label: None,
@@ -322,6 +370,7 @@ impl FleetSetupView {
         mut draft: Box<crate::fleet::profile::FleetProfileDraft>,
         model_label: String,
         picked_route: Option<(String, String)>,
+        reasoning_effort: Option<String>,
     ) -> (String, String) {
         // Re-inject the route the operator picked at `m`-press time (#4093). A
         // model draft comes from `from_untrusted_json`, which hard-sets
@@ -337,6 +386,7 @@ impl FleetSetupView {
             draft.model = Some(model);
             draft.provider = Some(provider);
         }
+        draft.reasoning_effort = reasoning_effort;
         let (title, header) = (
             tr(self.snapshot.locale, MessageId::FleetDraftTitle)
                 .replace("{model_label}", &model_label),
@@ -385,11 +435,26 @@ impl FleetSetupView {
         self.model_routes.get(self.model_idx).cloned()
     }
 
+    fn selected_reasoning_effort(&self) -> Option<String> {
+        if self.thinking_idx == 0 {
+            return None;
+        }
+        THINKING_CHOICES
+            .get(self.thinking_idx)
+            .map(|choice| choice.label.to_string())
+    }
+
+    fn selected_thinking_label(&self) -> String {
+        self.selected_reasoning_effort()
+            .unwrap_or_else(|| format!("inherit ({})", self.snapshot.reasoning))
+    }
+
     /// Number of selectable rows on the current step (0 on the review step).
     fn step_len(&self) -> usize {
         match self.step {
             Step::Role => ROLES.len(),
             Step::Model => self.model_choices.len(),
+            Step::Thinking => THINKING_CHOICES.len(),
             Step::Review => 0,
         }
     }
@@ -402,6 +467,10 @@ impl FleetSetupView {
             }
             Step::Model => {
                 self.model_idx = self.model_idx.saturating_sub(1);
+                self.discard_model_draft();
+            }
+            Step::Thinking => {
+                self.thinking_idx = self.thinking_idx.saturating_sub(1);
                 self.discard_model_draft();
             }
             Step::Review => self.review_scroll = self.review_scroll.saturating_sub(1),
@@ -425,6 +494,10 @@ impl FleetSetupView {
                 self.model_idx = (self.model_idx + 1).min(self.step_len().saturating_sub(1));
                 self.discard_model_draft();
             }
+            Step::Thinking => {
+                self.thinking_idx = (self.thinking_idx + 1).min(self.step_len().saturating_sub(1));
+                self.discard_model_draft();
+            }
             Step::Review => self.review_scroll = self.review_scroll.saturating_add(1),
         }
     }
@@ -438,6 +511,10 @@ impl FleetSetupView {
                 ViewAction::None
             }
             Step::Model => {
+                self.step = Step::Thinking;
+                ViewAction::None
+            }
+            Step::Thinking => {
                 self.step = Step::Review;
                 self.review_scroll = 0;
                 ViewAction::None
@@ -455,8 +532,12 @@ impl FleetSetupView {
                 self.step = Step::Role;
                 ViewAction::None
             }
-            Step::Review => {
+            Step::Thinking => {
                 self.step = Step::Model;
+                ViewAction::None
+            }
+            Step::Review => {
+                self.step = Step::Thinking;
                 ViewAction::None
             }
         }
@@ -498,6 +579,7 @@ impl FleetSetupView {
             model_class_hint: None,
             model: route.as_ref().map(|(_, model)| model.clone()),
             provider: route.map(|(provider, _)| provider),
+            reasoning_effort: self.selected_reasoning_effort(),
             instructions: Some(format!(
                 "Role: {}. Work only within the assigned Fleet slice. Report concise evidence and stop when the assignment is complete. Do not widen permissions, trust, route configuration, or topology.",
                 role.label
@@ -515,6 +597,11 @@ impl FleetSetupView {
                 hints.push(ActionHint::new("Enter", "next"));
             }
             Step::Model => {
+                hints.push(ActionHint::new("↑/↓", "choose"));
+                hints.push(ActionHint::new("Enter", "next"));
+                hints.push(ActionHint::new("←", "back"));
+            }
+            Step::Thinking => {
                 hints.push(ActionHint::new("↑/↓", "choose"));
                 hints.push(ActionHint::new("Enter", "next"));
                 hints.push(ActionHint::new("←", "back"));
@@ -572,6 +659,7 @@ impl ModalView for FleetSetupView {
                     // re-injects it authoritatively from the wizard's current
                     // selection, but the event stays self-describing.
                     provider: route.map(|(provider, _)| provider),
+                    reasoning_effort: self.selected_reasoning_effort(),
                     locale: self.snapshot.locale,
                 })
             }
@@ -621,7 +709,8 @@ impl ModalView for FleetSetupView {
         let step_no = match self.step {
             Step::Role => 1,
             Step::Model => 2,
-            Step::Review => 3,
+            Step::Thinking => 3,
+            Step::Review => 4,
         };
         let block = Block::default()
             .title(Line::from(Span::styled(
@@ -632,7 +721,7 @@ impl ModalView for FleetSetupView {
             )))
             .title_bottom(
                 Line::from(Span::styled(
-                    format!(" Step {step_no}/3 "),
+                    format!(" Step {step_no}/4 "),
                     Style::default().fg(palette::TEXT_MUTED),
                 ))
                 .alignment(ratatui::layout::Alignment::Right),
@@ -682,6 +771,16 @@ impl ModalView for FleetSetupView {
                     },
                 ],
             ),
+            Step::Thinking => render_choice_step(
+                chunks[1],
+                buf,
+                THINKING_CHOICES,
+                self.thinking_idx,
+                &[
+                    format!("Current reasoning: {}", self.snapshot.reasoning),
+                    format!("This worker will use {}.", self.selected_thinking_label()),
+                ],
+            ),
             Step::Review => self.render_review(chunks[1], buf),
         }
     }
@@ -697,6 +796,10 @@ impl FleetSetupView {
             Step::Model => (
                 "Choose a model",
                 "Pick this worker's model, or inherit your current route.",
+            ),
+            Step::Thinking => (
+                "Choose thinking",
+                "Pick this worker's reasoning tier, or inherit your current setting.",
             ),
             Step::Review if self.model_draft.is_some() => (
                 "Ratify the draft",
@@ -778,6 +881,7 @@ impl FleetSetupView {
                 ),
             },
         );
+        section(&mut lines, "Thinking", self.selected_thinking_label());
         section(
             &mut lines,
             "Permissions",
@@ -1042,6 +1146,7 @@ mod tests {
     fn to_review(view: &mut FleetSetupView) {
         view.handle_key(key(KeyCode::Enter));
         view.handle_key(key(KeyCode::Enter));
+        view.handle_key(key(KeyCode::Enter));
         assert_eq!(view.step, Step::Review);
     }
 
@@ -1055,6 +1160,7 @@ mod tests {
             role,
             model,
             provider,
+            reasoning_effort,
             locale,
         }) = action
         else {
@@ -1065,6 +1171,7 @@ mod tests {
         // Default selection is `inherit` (model_idx 0), which carries no
         // concrete provider route.
         assert_eq!(provider, None);
+        assert_eq!(reasoning_effort, None);
         assert_eq!(locale, crate::localization::Locale::En);
     }
 
@@ -1093,18 +1200,26 @@ mod tests {
             view.selected_route(),
             Some(("zai".to_string(), "glm-5.2".to_string()))
         );
-        view.handle_key(key(KeyCode::Enter)); // Model -> Review
+        view.handle_key(key(KeyCode::Enter)); // Model -> Thinking
+        while view.selected_reasoning_effort().as_deref() != Some("max") {
+            view.handle_key(key(KeyCode::Down));
+        }
+        view.handle_key(key(KeyCode::Enter)); // Thinking -> Review
 
         // `m` requests a draft and carries the picked cross-provider route.
         let action = view.handle_key(key(KeyCode::Char('m')));
         let ViewAction::Emit(ViewEvent::FleetProfileModelDraftRequested {
-            model, provider, ..
+            model,
+            provider,
+            reasoning_effort,
+            ..
         }) = action
         else {
             panic!("expected model draft request");
         };
         assert_eq!(model, "glm-5.2");
         assert_eq!(provider.as_deref(), Some("zai"));
+        assert_eq!(reasoning_effort.as_deref(), Some("max"));
 
         // The host reconstructs the picked route from the event exactly as
         // `handle_fleet_profile_model_draft` does, and carries it to
@@ -1117,17 +1232,24 @@ mod tests {
         assert_eq!(drafted.provider, None);
 
         // Installing it re-injects the picked route, so the ratified draft keeps
-        // BOTH the provider and the model the user actually chose.
-        let (_title, content) =
-            view.install_model_draft(drafted, "GLM-5.2".to_string(), picked_route);
+        // BOTH the provider and the model the user actually chose, plus the
+        // captured thinking tier.
+        let (_title, content) = view.install_model_draft(
+            drafted,
+            "GLM-5.2".to_string(),
+            picked_route,
+            reasoning_effort,
+        );
         let ratified = view.model_draft.as_deref().expect("draft installed");
         assert_eq!(ratified.provider.as_deref(), Some("zai"));
         assert_eq!(ratified.model.as_deref(), Some("glm-5.2"));
+        assert_eq!(ratified.reasoning_effort.as_deref(), Some("max"));
 
         // The rendered TOML the ratify keypress would persist names the provider
         // explicitly — never a provider-scoped ambiguity.
         assert!(content.contains("provider = \"zai\""), "{content}");
         assert!(content.contains("model = \"glm-5.2\""), "{content}");
+        assert!(content.contains("reasoning_effort = \"max\""), "{content}");
 
         // And ratifying commits exactly that route.
         let action = view.handle_key(key(KeyCode::Char('g')));
@@ -1138,6 +1260,7 @@ mod tests {
         };
         assert_eq!(draft.provider.as_deref(), Some("zai"));
         assert_eq!(draft.model.as_deref(), Some("glm-5.2"));
+        assert_eq!(draft.reasoning_effort.as_deref(), Some("max"));
     }
 
     #[test]
@@ -1152,7 +1275,7 @@ mod tests {
         ));
 
         let (title, content) =
-            view.install_model_draft(sample_draft(), "GLM-5.2".to_string(), None);
+            view.install_model_draft(sample_draft(), "GLM-5.2".to_string(), None, None);
         assert!(title.contains("GLM-5.2"));
         assert!(content.contains("id = \"reviewer\""), "{content}");
         assert!(content.contains("Nothing is saved until"), "{content}");
@@ -1170,11 +1293,12 @@ mod tests {
     fn changing_answers_discards_a_stale_draft() {
         let mut view = FleetSetupView::from_snapshot(snapshot());
         to_review(&mut view);
-        let _ = view.install_model_draft(sample_draft(), "GLM-5.2".to_string(), None);
+        let _ = view.install_model_draft(sample_draft(), "GLM-5.2".to_string(), None, None);
         assert!(view.model_draft.is_some());
 
         // Back to the role step and change the selection: the draft no
         // longer matches the answers and must not survive to ratification.
+        view.handle_key(key(KeyCode::Left));
         view.handle_key(key(KeyCode::Left));
         view.handle_key(key(KeyCode::Left));
         assert_eq!(view.step, Step::Role);
@@ -1203,9 +1327,17 @@ mod tests {
         assert_eq!(view.model_idx, 1);
 
         view.handle_key(key(KeyCode::Enter));
+        assert_eq!(view.step, Step::Thinking);
+
+        view.handle_key(key(KeyCode::Down));
+        assert_eq!(view.thinking_idx, 1);
+
+        view.handle_key(key(KeyCode::Enter));
         assert_eq!(view.step, Step::Review);
 
         // Left steps back through the wizard.
+        view.handle_key(key(KeyCode::Left));
+        assert_eq!(view.step, Step::Thinking);
         view.handle_key(key(KeyCode::Left));
         assert_eq!(view.step, Step::Model);
         view.handle_key(key(KeyCode::Left));
@@ -1229,6 +1361,10 @@ mod tests {
         view.handle_key(key(KeyCode::Enter)); // -> Model
         // Model: inherit(0) deepseek-v4-pro(1) -> deepseek-v4-pro.
         view.handle_key(key(KeyCode::Down));
+        view.handle_key(key(KeyCode::Enter)); // -> Thinking
+        while view.selected_reasoning_effort().as_deref() != Some("max") {
+            view.handle_key(key(KeyCode::Down));
+        }
         view.handle_key(key(KeyCode::Enter)); // -> Review
 
         // Start previews inline (#4093: no separate pager to steal the next
@@ -1245,6 +1381,7 @@ mod tests {
         assert!(content.contains("id = \"builder\""));
         assert!(content.contains("role_hint = \"builder\""));
         assert!(content.contains("model = \"deepseek-v4-pro\""));
+        assert!(content.contains("reasoning_effort = \"max\""));
         // A concrete cross-provider route pin names its own provider
         // explicitly (#4093) — the saved profile must not be ambiguously
         // scoped to whatever provider happens to be active at launch time.
@@ -1269,6 +1406,7 @@ mod tests {
         assert_eq!(draft.role_hint, "builder");
         assert_eq!(draft.model.as_deref(), Some("deepseek-v4-pro"));
         assert_eq!(draft.provider.as_deref(), Some("deepseek"));
+        assert_eq!(draft.reasoning_effort.as_deref(), Some("max"));
     }
 
     #[test]
@@ -1281,8 +1419,10 @@ mod tests {
         let draft = view.model_draft.as_deref().expect("draft installed");
         assert_eq!(draft.model, None);
         assert_eq!(draft.provider, None);
+        assert_eq!(draft.reasoning_effort, None);
         let content = view.model_draft_preview.as_deref().unwrap();
         assert!(!content.contains("provider"), "{content}");
+        assert!(!content.contains("reasoning_effort"), "{content}");
     }
 
     #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -685,6 +685,11 @@ pub enum ViewEvent {
         /// keeps the picked provider instead of collapsing to an ambiguous,
         /// provider-scoped profile — the exact bug #4093 fixes.
         provider: Option<String>,
+        /// Canonical reasoning tier selected by the wizard, or `None` for
+        /// inherit (#4137). Carried with the async draft for the same reason
+        /// as `provider`: the ratified profile must preserve the operator's
+        /// explicit choice, not whatever the model echoed.
+        reasoning_effort: Option<String>,
         locale: crate::localization::Locale,
     },
     /// Emitted by the `/fleet` roster view (`s` / Enter) to hand off to the

--- a/crates/tui/src/worker_profile.rs
+++ b/crates/tui/src/worker_profile.rs
@@ -133,6 +133,9 @@ pub struct WorkerRuntimeProfile {
     pub model: ModelRoute,
     /// Explicit provider override; `None` inherits the parent/session provider.
     pub provider: Option<String>,
+    /// Explicit reasoning/thinking tier; `None` inherits the parent/session tier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
     /// Remaining nested-delegation budget. A worker may spawn children while
     /// `max_spawn_depth > 0`; each level decrements it. Clamped to the workspace
     /// ceiling.
@@ -170,6 +173,7 @@ impl WorkerRuntimeProfile {
             tools: ToolScope::Inherit,
             model: ModelRoute::Inherit,
             provider: None,
+            reasoning_effort: None,
             max_spawn_depth: codewhale_config::DEFAULT_SPAWN_DEPTH,
             background: true,
         }
@@ -219,6 +223,10 @@ impl WorkerRuntimeProfile {
             tools,
             model: requested.model.clone(),
             provider: requested.provider.clone().or_else(|| self.provider.clone()),
+            reasoning_effort: requested
+                .reasoning_effort
+                .clone()
+                .or_else(|| self.reasoning_effort.clone()),
             max_spawn_depth,
             background: requested.background,
         }
@@ -359,5 +367,20 @@ mod tests {
         let requested = WorkerRuntimeProfile::for_role(SubAgentType::Explore); // provider None
         let child = parent.derive_child(&requested);
         assert_eq!(child.provider.as_deref(), Some("moonshot"));
+    }
+
+    #[test]
+    fn child_reasoning_effort_uses_requested_then_parent() {
+        let mut parent = WorkerRuntimeProfile::for_role(SubAgentType::General);
+        parent.reasoning_effort = Some("low".to_string());
+
+        let requested = WorkerRuntimeProfile::for_role(SubAgentType::Explore);
+        let inherited = parent.derive_child(&requested);
+        assert_eq!(inherited.reasoning_effort.as_deref(), Some("low"));
+
+        let mut requested = WorkerRuntimeProfile::for_role(SubAgentType::Explore);
+        requested.reasoning_effort = Some("max".to_string());
+        let overridden = parent.derive_child(&requested);
+        assert_eq!(overridden.reasoning_effort.as_deref(), Some("max"));
     }
 }


### PR DESCRIPTION
## Summary
- add FleetProfile / AgentProfile TOML support for explicit reasoning_effort with thinking/reasoning aliases
- add a /fleet setup Thinking step and preserve the selected tier through starter and model-drafted profiles
- thread the tier into fleet route receipts, WorkerRuntimeProfile, and codewhale exec launch via --reasoning-effort
- add focused coverage for profile round-trip, setup flow, worker argv, route receipts, CLI parsing, and child runtime inheritance

Fixes #4137

## Verification
- cargo fmt --all -- --check
- ./scripts/release/check-versions.sh
- git diff --check
- cargo test -p codewhale-tui --locked reasoning_effort -- --nocapture
- cargo test -p codewhale-tui --locked fleet_setup -- --nocapture
- cargo test -p codewhale-tui --locked worker_command -- --nocapture
- cargo test -p codewhale-tui --locked fleet_worker_launch_route -- --nocapture
- cargo test -p codewhale-tui --locked profile_loader_normalizes_reasoning_aliases -- --nocapture
- cargo test -p codewhale-tui --locked resolve_fleet_route -- --nocapture
- cargo test -p codewhale-tui --locked fleet_worker_spec -- --nocapture
- cargo test -p codewhale-config --locked fleet_profile -- --nocapture