### PR TITLE
docs(fleet): retire loadout-first copy

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -6227,7 +6227,7 @@ pub enum AppAction {
     OpenThemePicker,
     /// Open the `/fleet` roster — the saved-party view of the agent team.
     OpenFleetRoster,
-    /// Open the `/fleet` setup and loadout planner.
+    /// Open the `/fleet` profile authoring wizard.
     OpenFleetSetup,
     /// Open the `/hotbar` setup wizard.
     OpenHotbarSetup,

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -385,8 +385,8 @@ fn member_posture(member: &AgentProfile) -> String {
     format!("{} worker · {write} · {shell}", agent_type.as_str())
 }
 
-/// The routing truth for a member: explicit model pin, else loadout class,
-/// else same-route inheritance. `[subagents]` overrides still win at dispatch.
+/// The routing truth for a member: explicit model pin, else route preset, else
+/// same-route inheritance. `[subagents]` overrides still win at dispatch.
 fn member_routing(member: &AgentProfile) -> String {
     if let Some(model) = member
         .profile
@@ -399,7 +399,7 @@ fn member_routing(member: &AgentProfile) -> String {
     }
     match member.profile.loadout.as_str() {
         "inherit" => "inherit session route".to_string(),
-        loadout => format!("loadout {loadout}"),
+        loadout => format!("route preset {loadout}"),
     }
 }
 
@@ -653,13 +653,13 @@ mod tests {
         );
         assert_eq!(member_routing(&reviewer), "inherit session route");
 
-        // Built-in scout: fast loadout label is the routing truth.
+        // Built-in scout: fast route preset is the routing truth.
         let scout = FleetRoster::built_ins_only().get("scout").unwrap().clone();
         assert_eq!(
             member_posture(&scout),
             "explore worker · read-only · shell read-only"
         );
-        assert_eq!(member_routing(&scout), "loadout fast");
+        assert_eq!(member_routing(&scout), "route preset fast");
 
         // Builder writes with full shell.
         let builder = FleetRoster::built_ins_only()
@@ -671,7 +671,7 @@ mod tests {
             "implementer worker · write · shell full"
         );
 
-        // A pinned model beats the loadout label.
+        // A pinned model beats the route preset label.
         let mut pinned = reviewer.clone();
         pinned.profile.model = Some("glm-5.2".to_string());
         assert_eq!(member_routing(&pinned), "model glm-5.2 (pinned)");
@@ -728,7 +728,7 @@ mod tests {
         let view = FleetRosterView::from_parts(operator(), FleetRoster::load(&config, tmp.path()));
         let extra = view.members.iter().find(|m| m.id == "docs-writer").unwrap();
         assert_eq!(extra.origin, ProfileOrigin::Config);
-        assert_eq!(member_routing(extra), "loadout fast");
+        assert_eq!(member_routing(extra), "route preset fast");
     }
 
     #[test]

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -43,20 +43,21 @@ logs and adapter logs are stored under `.codewhale/fleet/` and
 
 `/fleet setup` (also `/fleet setup edit` / `new`) opens an in-TUI wizard for
 authoring a reusable agent-team profile. Bare `/fleet` and the
-`roster`/`roles`/`profiles`/`loadout`/`party` aliases open the roster (the saved
-profiles). `/fleet status` opens the worker-status view; `/subagents` is a
+`roster`/`roles`/`profiles`/`party` aliases open the roster (the saved profiles).
+`/fleet status` opens the worker-status view; `/subagents` is a
 compatibility shortcut for that status view.
 
 The wizard is progressive: you make one focused choice at a time — a **role**,
 then a **model** (`inherit`, or a concrete model from *any configured
-provider*, not only the one the parent session is currently using) — and then
-review the full posture (model/route, permissions, tools, workspace/org
-scope, and review policy) before doing anything. Picking a concrete model
-pins its provider explicitly: the saved profile records both `model` and
-`provider` fields, so the route it names doesn't depend on whichever provider
-happens to be active when the profile is later loaded. Pressing **Enter**
-("start") on the review step previews the exact starter profile TOML inline
-on that same screen; nothing is written until you ratify it.
+provider*, not only the one the parent session is currently using), then a
+**thinking tier** (`inherit`, `off`, `low`, `medium`, `high`, `max`, or `auto`)
+— and then review the full posture (route, thinking, permissions, tools,
+workspace/org scope, and review policy) before doing anything. Picking a
+concrete model pins its provider explicitly: the saved profile records both
+`model` and `provider` fields, so the route it names doesn't depend on
+whichever provider happens to be active when the profile is later loaded.
+Pressing **Enter** ("start") on the review step previews the exact starter
+profile TOML inline on that same screen; nothing is written until you ratify it.
 
 When a provider is configured, the review step also offers model-assisted
 drafting behind a ratify gate:
@@ -123,7 +124,7 @@ calls, it drafts a Workflow script/IR, presents the run plan according to the
 active permission mode, and the runtime compiles it into typed Fleet work.
 
 Fleet remains the sub-agent config surface. It owns slot count, role profiles,
-model/loadout selection, tool posture, launch concurrency, and the ledger.
+saved route pins or inheritance, tool posture, launch concurrency, and the ledger.
 Workflow owns only the orchestration plan: branch, sequence, loop, expand,
 review, and reduce decisions. The workflow script must not get direct shell,
 filesystem, network, provider-secret, cancellation, or TUI authority; workers

--- a/docs/FLEET_WORKFLOW_TUTORIAL.md
+++ b/docs/FLEET_WORKFLOW_TUTORIAL.md
@@ -31,8 +31,9 @@ If you want named reusable workers, open the TUI and run:
 /fleet setup
 ```
 
-Pick a role, pick a model class, review the permissions/tools/route posture,
-and ratify the rendered TOML. Ratified profiles are saved under
+Pick a role, choose whether that profile inherits the operator route or pins a
+specific provider/model/thinking tier, review the permissions/tools/route
+posture, and ratify the rendered TOML. Ratified profiles are saved under
 `.codewhale/agents/<role>.toml`. Fleet task specs can reference those profiles
 with `worker.agent_profile` or the shorter `worker.profile` alias.
 
@@ -67,7 +68,7 @@ one bounded docs-note worker. It keeps secrets disabled and caps trust at
         "role": "reviewer",
         "profile": "reviewer",
         "tools": ["rg", "sed", "git"],
-        "model_class": "fast"
+        "model": "deepseek-v4-flash"
       },
       "workspace": {
         "required_files": ["docs/FLEET.md", "docs/WORKFLOW_AUTHORING.md"],
@@ -93,8 +94,7 @@ one bounded docs-note worker. It keeps secrets disabled and caps trust at
       "instructions": "Write a concise Markdown note with the missing Fleet + Workflow tutorial steps. Do not edit public docs unless explicitly asked.",
       "worker": {
         "role": "builder",
-        "tools": ["rg", "sed"],
-        "model_class": "inherit"
+        "tools": ["rg", "sed"]
       },
       "workspace": {
         "required_files": ["docs/FLEET.md"],
@@ -123,7 +123,8 @@ Common task fields:
 | `worker.role` | Built-in or custom role intent, such as `reviewer`, `builder`, `read-only`, or `smoke-runner`. |
 | `worker.profile` / `worker.agent_profile` | Ratified Fleet roster profile from `.codewhale/agents/`. |
 | `worker.tools` | Tool names the task expects the worker to use. |
-| `worker.model_class`, `worker.loadout`, `worker.model` | Routing hints or explicit model intent. Route resolution still owns provider/model validation. |
+| `worker.model` | Preferred explicit model pin. Route resolution still owns provider/model validation. |
+| `worker.model_class`, `worker.loadout` | Compatibility routing hints for older task specs; prefer `worker.profile` plus saved profile route pins for new specs. |
 | `workspace.required_files` | Files that must exist before the task starts. |
 | `workspace.writable_paths` | Paths the task is allowed to write when the effective runtime posture allows writing. |
 | `workspace.environment` | Required or allowlisted environment variables, by name only. |


### PR DESCRIPTION
## Summary
- change Fleet roster route labels from loadout wording to route preset wording
- update Fleet docs to describe profile route pins, inheritance, and thinking-tier selection
- update the Fleet + Workflow tutorial examples to prefer explicit model/profile route pins and document model_class/loadout only as compatibility fields

Fixes #4138

## Verification
- cargo fmt --all -- --check
- cargo test -p codewhale-tui --locked fleet_roster -- --nocapture
- cargo test -p codewhale-tui --locked fleet_help_arg_returns_usage -- --nocapture
- ./scripts/release/check-versions.sh
- git diff --check
- rg -n "loadout|model_class|model class|model-class|route_tier|route tier" docs/FLEET.md docs/FLEET_WORKFLOW_TUTORIAL.md crates/tui/src/tui/views/fleet_roster.rs crates/tui/src/tui/views/fleet_setup.rs crates/tui/locales -g "*.md" -g "*.rs" -g "*.json"

Copy-audit note: remaining hits are compatibility table fields or internal/test field names; visible roster/docs copy no longer presents loadout/model class as the primary Fleet concept.