### PR TITLE
fix(provider): verify setup keys before saving (#3875)

### DIFF
--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -943,6 +943,58 @@ fn api_provider_skips_models_probe(api_provider: ApiProvider) -> bool {
     matches!(api_provider, ApiProvider::DeepseekAnthropic)
 }
 
+/// Verify a provider API key by hitting the `/models` endpoint
+/// (#3875). Builds a minimal HTTP client with the canonical auth
+/// headers for `provider`, issues a single GET, and returns
+/// `Ok(())` on a 2xx response or `Err(reason)` on any failure.
+///
+/// This is intentionally a one-shot call — no retry, no rate-limit
+/// wait — so a bad key is surfaced immediately.
+pub async fn verify_provider_api_key(
+    provider: ApiProvider,
+    api_key: &str,
+    base_url: &str,
+) -> Result<(), String> {
+    if api_provider_skips_models_probe(provider) {
+        // Providers without a /models endpoint can't be verified this
+        // way; accept the key optimistically (same as health_check).
+        return Ok(());
+    }
+    let headers = build_default_headers(api_key, &Default::default(), provider, base_url)
+        .map_err(|err| format!("failed to build auth headers: {err:#}"))?;
+    let client = crate::tls::reqwest_client_builder()
+        .default_headers(headers)
+        .user_agent(concat!(
+            "Mozilla/5.0 (compatible; codewhale/",
+            env!("CARGO_PKG_VERSION"),
+            "; +https://github.com/Hmbown/CodeWhale)"
+        ))
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|err| format!("failed to build HTTP client: {err:#}"))?;
+    let url = api_url(base_url, "models");
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|err| format!("request failed: {err:#}"))?;
+    let status = response.status();
+    if status.is_success() {
+        // Consume the body so the connection returns to the pool.
+        let _ = response.text().await;
+        Ok(())
+    } else {
+        let body = response.text().await.unwrap_or_default();
+        let summary = if body.chars().count() > 200 {
+            format!("{}...", body.chars().take(200).collect::<String>())
+        } else {
+            body
+        };
+        Err(format!("HTTP {status}: {summary}"))
+    }
+}
+
 fn translation_system_prompt(target_language: &str) -> String {
     format!(
         "You are a professional translator. Your ONLY task is to translate text to {target_language}. \
@@ -2285,7 +2337,7 @@ mod tests {
         ContentBlock, ContentBlockStart, Delta, Message, MessageRequest, StreamEvent, Tool,
     };
     use serde_json::json;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_tool(name: &str) -> Tool {
@@ -4531,6 +4583,38 @@ mod tests {
             .respond_with(ResponseTemplate::new(status).set_body_json(body))
             .mount(server)
             .await;
+    }
+
+    #[tokio::test]
+    async fn verify_provider_api_key_accepts_mocked_models_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": []})))
+            .mount(&server)
+            .await;
+
+        verify_provider_api_key(ApiProvider::Openrouter, "test-key", &server.uri())
+            .await
+            .expect("mocked /models success should verify");
+    }
+
+    #[tokio::test]
+    async fn verify_provider_api_key_returns_status_and_unicode_body_without_panic() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("密钥无效"))
+            .mount(&server)
+            .await;
+
+        let err = verify_provider_api_key(ApiProvider::Openrouter, "bad-key", &server.uri())
+            .await
+            .expect_err("mocked /models failure should be reported");
+
+        assert!(err.contains("HTTP 401"), "status is preserved: {err}");
+        assert!(err.contains("密钥无效"), "unicode body is preserved: {err}");
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -83,6 +83,9 @@ pub struct ProviderPickerView {
     setup_mode: bool,
     query: String,
     api_key_input: String,
+    /// An error surfaced after a failed key verification, shown inline
+    /// in the key-entry stage. Cleared when the user edits the input.
+    key_entry_error: Option<String>,
     custom_provider_field: CustomProviderField,
     custom_provider_id: String,
     custom_provider_base_url: String,
@@ -1193,8 +1196,9 @@ impl ProviderPickerView {
             stage: Stage::List,
             view,
             setup_mode: false,
-            api_key_input: String::new(),
             query: String::new(),
+            api_key_input: String::new(),
+            key_entry_error: None,
             custom_provider_field: CustomProviderField::Name,
             custom_provider_id: String::new(),
             custom_provider_base_url: String::new(),
@@ -1368,6 +1372,29 @@ impl ProviderPickerView {
     fn enter_key_entry(&mut self) {
         self.stage = Stage::KeyEntry;
         self.api_key_input.clear();
+        self.key_entry_error = None;
+    }
+
+    /// Open the picker already focused on `target` in its key-entry stage
+    /// with a validation error message - the verify-then-persist handoff
+    /// (#3875): when a submitted key fails live validation, drop the user
+    /// back on that provider's key prompt with the provider's actual error
+    /// instead of dead-ending with a status toast.
+    #[must_use]
+    pub fn new_for_key_entry_with_error(
+        active: ApiProvider,
+        target: ApiProvider,
+        config: &Config,
+        runtime_status: Option<ProviderRuntimeStatus>,
+        error: String,
+    ) -> Option<Self> {
+        let mut picker = Self::new_with_runtime_status(active, config, runtime_status);
+        let idx = picker.rows.iter().position(|row| row.provider == target)?;
+        picker.selected_idx = idx;
+        picker.view = ProviderListView::Catalog;
+        picker.stage = Stage::KeyEntry;
+        picker.key_entry_error = Some(error);
+        Some(picker)
     }
 
     fn enter_custom_form(&mut self) {
@@ -1768,15 +1795,6 @@ impl ProviderPickerView {
             )
         };
 
-        let layout = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(3),
-                Constraint::Length(2),
-                Constraint::Min(1),
-            ])
-            .split(content);
-
         let masked = mask_key(&self.api_key_input);
         let display = if codex_oauth {
             "(run codex login; no token is stored here)".to_string()
@@ -1797,8 +1815,6 @@ impl ProviderPickerView {
                     .add_modifier(Modifier::BOLD),
             ),
         ])];
-        Paragraph::new(key_lines).render(layout[0], buf);
-
         let reopen_command = if self.setup_mode {
             "/setup provider"
         } else {
@@ -1827,6 +1843,25 @@ impl ProviderPickerView {
                 Style::default().fg(palette::TEXT_MUTED),
             )));
         };
+
+        if let Some(ref error) = self.key_entry_error {
+            hint_lines.push(Line::from(Span::styled(
+                format!("Verification failed: {error}"),
+                Style::default().fg(palette::STATUS_ERROR),
+            )));
+        }
+
+        let hint_height = hint_lines.len().clamp(1, 3) as u16;
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Length(hint_height),
+                Constraint::Min(1),
+            ])
+            .split(content);
+
+        Paragraph::new(key_lines).render(layout[0], buf);
         Paragraph::new(hint_lines).render(layout[1], buf);
     }
 
@@ -3595,6 +3630,24 @@ mod tests {
         assert_eq!(picker.view, ProviderListView::Catalog);
         assert_eq!(picker.stage, Stage::List);
         assert_eq!(picker.selected_provider(), ApiProvider::Openai);
+    }
+
+    #[test]
+    fn new_for_key_entry_with_error_opens_prompt_and_renders_reason() {
+        let config = Config::default();
+        let picker = ProviderPickerView::new_for_key_entry_with_error(
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            &config,
+            None,
+            "HTTP 401: unauthorized".to_string(),
+        )
+        .expect("OpenRouter has a picker row");
+
+        assert_eq!(picker.stage, Stage::KeyEntry);
+        assert_eq!(picker.selected_provider(), ApiProvider::Openrouter);
+        let rendered = render_text(&picker, 90, 14);
+        assert!(rendered.contains("Verification failed: HTTP 401: unauthorized"));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3,8 +3,10 @@
 use std::cell::Cell;
 use std::collections::{HashSet, VecDeque};
 use std::fmt::Write as _;
+use std::future::Future;
 use std::io::{self, Stdout, Write};
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::{
     Arc, LazyLock,
     atomic::{AtomicBool, Ordering},
@@ -11292,7 +11294,92 @@ async fn apply_provider_picker_api_key(
     provider: ApiProvider,
     api_key: String,
 ) {
+    apply_provider_picker_api_key_with_verifier(
+        app,
+        engine_handle,
+        config,
+        provider,
+        api_key,
+        &LiveProviderKeyVerifier,
+    )
+    .await;
+}
+
+type ProviderKeyVerification<'a> = Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
+
+trait ProviderKeyVerifier {
+    fn verify<'a>(
+        &'a self,
+        provider: ApiProvider,
+        api_key: &'a str,
+        base_url: &'a str,
+    ) -> ProviderKeyVerification<'a>;
+}
+
+struct LiveProviderKeyVerifier;
+
+impl ProviderKeyVerifier for LiveProviderKeyVerifier {
+    fn verify<'a>(
+        &'a self,
+        provider: ApiProvider,
+        api_key: &'a str,
+        base_url: &'a str,
+    ) -> ProviderKeyVerification<'a> {
+        Box::pin(crate::client::verify_provider_api_key(
+            provider, api_key, base_url,
+        ))
+    }
+}
+
+async fn apply_provider_picker_api_key_with_verifier(
+    app: &mut App,
+    engine_handle: &mut EngineHandle,
+    config: &mut Config,
+    provider: ApiProvider,
+    api_key: String,
+    verifier: &dyn ProviderKeyVerifier,
+) {
     use crate::config::save_api_key_for;
+
+    // #3875: verify the key against the provider before persisting.
+    // Use the provider's configured base URL (or the default) for the
+    // models-endpoint probe so custom endpoints are also verified.
+    let base_url = config
+        .provider_config_for(provider)
+        .and_then(|entry| entry.base_url.as_deref())
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or_else(|| provider.default_base_url());
+    match verifier.verify(provider, &api_key, base_url).await {
+        Ok(()) => { /* key is valid, proceed to persist */ }
+        Err(reason) => {
+            // Verification failed - keep the picker open at the key-entry
+            // stage with the provider's actual error so the user can fix
+            // the key instead of dead-ending with a status toast.
+            let runtime_status = query_provider_runtime_status(engine_handle).await;
+            if let Some(picker) =
+                crate::tui::provider_picker::ProviderPickerView::new_for_key_entry_with_error(
+                    app.api_provider,
+                    provider,
+                    config,
+                    runtime_status,
+                    reason,
+                )
+            {
+                app.view_stack.push(picker);
+                app.status_message = Some(format!(
+                    "{} API key verification failed - check the key and try again.",
+                    provider.as_str()
+                ));
+            } else {
+                app.status_message = Some(format!(
+                    "{} API key verification failed, but the provider could not be re-opened.",
+                    provider.as_str()
+                ));
+            }
+            app.needs_redraw = true;
+            return;
+        }
+    }
 
     match save_api_key_for(provider, &api_key) {
         Ok(path) => {
@@ -12618,6 +12705,230 @@ fn parse_semver(v: &str) -> Option<(u32, u32, u32)> {
 }
 
 mod activity_detail;
+
+#[cfg(test)]
+mod provider_key_validation_tests {
+    use super::*;
+    use crate::core::engine::mock_engine_handle;
+    use ratatui::{buffer::Buffer, layout::Rect};
+    use std::ffi::OsString;
+    use std::sync::MutexGuard;
+    use tempfile::TempDir;
+
+    struct ConfigPathEnvGuard {
+        _tmp: TempDir,
+        previous: Option<OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl ConfigPathEnvGuard {
+        fn new() -> Self {
+            let lock = crate::test_support::lock_test_env();
+            let tmp = TempDir::new().expect("config tempdir");
+            let config_path = tmp.path().join(".codewhale").join("config.toml");
+            std::fs::create_dir_all(config_path.parent().expect("config parent"))
+                .expect("config dir");
+            let previous = std::env::var_os("DEEPSEEK_CONFIG_PATH");
+            // Safety: test-only environment mutation guarded by a global mutex.
+            unsafe {
+                std::env::set_var("DEEPSEEK_CONFIG_PATH", &config_path);
+            }
+            Self {
+                _tmp: tmp,
+                previous,
+                _lock: lock,
+            }
+        }
+
+        fn config_path(&self) -> PathBuf {
+            std::env::var_os("DEEPSEEK_CONFIG_PATH")
+                .map(PathBuf::from)
+                .expect("config path set")
+        }
+    }
+
+    impl Drop for ConfigPathEnvGuard {
+        fn drop(&mut self) {
+            // Safety: test-only environment mutation guarded by a global mutex.
+            unsafe {
+                if let Some(previous) = self.previous.take() {
+                    std::env::set_var("DEEPSEEK_CONFIG_PATH", previous);
+                } else {
+                    std::env::remove_var("DEEPSEEK_CONFIG_PATH");
+                }
+            }
+        }
+    }
+
+    fn create_test_app() -> App {
+        let options = TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace: PathBuf::from("."),
+            config_path: None,
+            config_profile: None,
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: PathBuf::from("."),
+            memory_path: PathBuf::from("memory.md"),
+            notes_path: PathBuf::from("notes.txt"),
+            mcp_config_path: PathBuf::from("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: true,
+            skip_onboarding: false,
+            yolo: false,
+            resume_session_id: None,
+            initial_input: None,
+        };
+        let mut app = App::new(options, &Config::default());
+        app.api_provider = ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+        app
+    }
+
+    struct MockProviderKeyVerifier {
+        result: Result<(), String>,
+        calls: std::sync::Mutex<Vec<(ApiProvider, String, String)>>,
+    }
+
+    impl MockProviderKeyVerifier {
+        fn new(result: Result<(), String>) -> Self {
+            Self {
+                result,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<(ApiProvider, String, String)> {
+            self.calls.lock().expect("calls lock").clone()
+        }
+    }
+
+    impl ProviderKeyVerifier for MockProviderKeyVerifier {
+        fn verify<'a>(
+            &'a self,
+            provider: ApiProvider,
+            api_key: &'a str,
+            base_url: &'a str,
+        ) -> ProviderKeyVerification<'a> {
+            self.calls.lock().expect("calls lock").push((
+                provider,
+                api_key.to_string(),
+                base_url.to_string(),
+            ));
+            Box::pin(std::future::ready(self.result.clone()))
+        }
+    }
+
+    fn openrouter_config(base_url: &str) -> Config {
+        Config {
+            providers: Some(ProvidersConfig {
+                openrouter: ProviderConfig {
+                    base_url: Some(base_url.to_string()),
+                    ..ProviderConfig::default()
+                },
+                ..ProvidersConfig::default()
+            }),
+            ..Config::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_key_submit_persists_after_mocked_validation_success() {
+        let config_env = ConfigPathEnvGuard::new();
+        let mut app = create_test_app();
+        let mut engine = mock_engine_handle();
+        let mut config = openrouter_config("https://mock.openrouter.test/v1");
+        let verifier = MockProviderKeyVerifier::new(Ok(()));
+
+        apply_provider_picker_api_key_with_verifier(
+            &mut app,
+            &mut engine.handle,
+            &mut config,
+            ApiProvider::Openrouter,
+            "sk-verified".to_string(),
+            &verifier,
+        )
+        .await;
+
+        assert_eq!(
+            verifier.calls(),
+            vec![(
+                ApiProvider::Openrouter,
+                "sk-verified".to_string(),
+                "https://mock.openrouter.test/v1".to_string()
+            )]
+        );
+        assert_eq!(app.api_provider, ApiProvider::Openrouter);
+        assert_eq!(config.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.openrouter.api_key.as_deref()),
+            Some("sk-verified")
+        );
+        let saved = std::fs::read_to_string(config_env.config_path()).expect("saved config");
+        assert!(saved.contains("[providers.openrouter]"));
+        assert!(saved.contains("api_key = \"sk-verified\""));
+    }
+
+    #[tokio::test]
+    async fn provider_key_submit_reopens_picker_without_persisting_on_validation_failure() {
+        let config_env = ConfigPathEnvGuard::new();
+        let mut app = create_test_app();
+        let mut engine = mock_engine_handle();
+        let mut config = openrouter_config("https://mock.openrouter.test/v1");
+        let verifier = MockProviderKeyVerifier::new(Err("HTTP 401: unauthorized".to_string()));
+
+        apply_provider_picker_api_key_with_verifier(
+            &mut app,
+            &mut engine.handle,
+            &mut config,
+            ApiProvider::Openrouter,
+            "sk-rejected".to_string(),
+            &verifier,
+        )
+        .await;
+
+        assert_eq!(app.api_provider, ApiProvider::Deepseek);
+        assert_eq!(config.provider.as_deref(), None);
+        assert_eq!(
+            config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.openrouter.api_key.as_deref()),
+            None
+        );
+        let saved = std::fs::read_to_string(config_env.config_path()).unwrap_or_default();
+        assert!(!saved.contains("sk-rejected"));
+        assert_eq!(app.view_stack.top_kind(), Some(ModalKind::ProviderPicker));
+        assert!(
+            app.status_message
+                .as_deref()
+                .is_some_and(|status| status.contains("API key verification failed")),
+            "status names validation failure: {:?}",
+            app.status_message
+        );
+
+        let picker = app.view_stack.pop().expect("provider picker reopened");
+        let area = Rect::new(0, 0, 90, 14);
+        let mut buf = Buffer::empty(area);
+        picker.render(area, &mut buf);
+        let rendered = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("Verification failed: HTTP 401: unauthorized"));
+    }
+}
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

- Verifies provider API keys against the provider `/models` endpoint before saving from `/provider` key entry.
- Reopens the provider picker at the same provider with the actual validation error when verification fails, without persisting the rejected key.
- Adds mocked success/failure tests for the probe, picker error rendering, and persistence/no-persistence behavior.

Refs #3875

Scope note: this is the key-validation slice of the guided setup wizard. Model-pick and confirmation-summary steps remain follow-up work.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo check -p codewhale-tui --locked`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked verify_provider_api_key -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_picker::tests -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_key_validation_tests -- --nocapture`
- [x] `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (not run; covered here by picker render and persistence tests)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (N/A: Hunter-authored local slice; guard passed)
