### PR TITLE
ci(release): build Termux Android arm64 assets (#4240)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,15 @@ jobs:
             cli_artifact: codewhale-linux-arm64
             shim_artifact: codew-linux-arm64
             tui_artifact: codewhale-tui-linux-arm64
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            platform: android-arm64
+            cli_binary: codewhale
+            shim_binary: codew
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-android-arm64
+            shim_artifact: codew-android-arm64
+            tui_artifact: codewhale-tui-android-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             platform: macos-x64
@@ -190,7 +199,7 @@ jobs:
         with:
           cache-bin: false
       - name: Install Linux system dependencies
-        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-musl'
+        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           for i in 1 2 3 4 5; do
             sudo apt-get update && break
@@ -221,6 +230,47 @@ jobs:
           sudo dpkg --add-architecture arm64
           sudo apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/arm64.sources -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0
           sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross libdbus-1-dev:arm64 pkg-config
+      - name: Configure Android NDK linker
+        if: matrix.target == 'aarch64-linux-android' && runner.os == 'Linux'
+        shell: bash
+        env:
+          ANDROID_NDK_VERSION: 27.2.12479018
+        run: |
+          set -euo pipefail
+          ndk="${ANDROID_NDK_ROOT:-${ANDROID_NDK_HOME:-}}"
+          linker=""
+          if [[ -n "${ndk}" ]]; then
+            linker="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+          fi
+          if [[ -z "${linker}" || ! -x "${linker}" ]]; then
+            if ! command -v sdkmanager >/dev/null 2>&1; then
+              echo "sdkmanager is required to install Android NDK ${ANDROID_NDK_VERSION}" >&2
+              exit 1
+            fi
+            android_home="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+            if [[ -z "${android_home}" ]]; then
+              echo "ANDROID_HOME or ANDROID_SDK_ROOT is required to install Android NDK ${ANDROID_NDK_VERSION}" >&2
+              exit 1
+            fi
+            yes | sdkmanager --licenses >/dev/null || true
+            sdkmanager --install "ndk;${ANDROID_NDK_VERSION}"
+            ndk="${android_home}/ndk/${ANDROID_NDK_VERSION}"
+            linker="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+          fi
+          ar="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+          if [[ ! -x "${linker}" ]]; then
+            echo "Android linker not found: ${linker}" >&2
+            exit 1
+          fi
+          if [[ ! -x "${ar}" ]]; then
+            echo "Android archiver not found: ${ar}" >&2
+            exit 1
+          fi
+          echo "ANDROID_NDK_ROOT=${ndk}" >> "${GITHUB_ENV}"
+          echo "ANDROID_NDK_HOME=${ndk}" >> "${GITHUB_ENV}"
+          echo "CC_aarch64_linux_android=${linker}" >> "${GITHUB_ENV}"
+          echo "AR_aarch64_linux_android=${ar}" >> "${GITHUB_ENV}"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${linker}" >> "${GITHUB_ENV}"
       - name: Build
         if: matrix.target != 'x86_64-unknown-linux-musl'
         shell: bash
@@ -283,7 +333,7 @@ jobs:
           : > "$MANIFEST"
 
           bundle() {
-            local platform="$1"   # linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64
+            local platform="$1"   # linux-x64, linux-arm64, android-arm64, macos-x64, macos-arm64, windows-x64
             local cli_src="$2"    # artifact name for codewhale binary
             local shim_src="$3"   # artifact name for codew shim
             local tui_src="$4"    # artifact name for codewhale-tui binary
@@ -337,6 +387,10 @@ jobs:
           # Platform: linux-arm64
           bundle linux-arm64 \
             codewhale-linux-arm64 codew-linux-arm64 codewhale-tui-linux-arm64 tar.gz ""
+
+          # Platform: android-arm64 (Termux)
+          bundle android-arm64 \
+            codewhale-android-arm64 codew-android-arm64 codewhale-tui-android-arm64 tar.gz ""
 
           # Platform: macos-x64
           bundle macos-x64 \

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -210,6 +210,10 @@ const VERSION_HINT_TOAST_TTL_MS: u64 = 12_000;
 
 const REQUIRED_RELEASE_ASSETS: &[&str] = &[
     "codewhale-artifacts-sha256.txt",
+    "codew-android-arm64",
+    "codewhale-android-arm64",
+    "codewhale-android-arm64.tar.gz",
+    "codewhale-tui-android-arm64",
     "codewhale-linux-arm64",
     "codewhale-linux-arm64.tar.gz",
     "codewhale-linux-x64",

--- a/npm/codewhale/scripts/artifacts.js
+++ b/npm/codewhale/scripts/artifacts.js
@@ -8,6 +8,9 @@ const ASSET_MATRIX = {
     x64: ["codewhale-linux-x64", "codewhale-tui-linux-x64", "codew-linux-x64"],
     arm64: ["codewhale-linux-arm64", "codewhale-tui-linux-arm64", "codew-linux-arm64"],
   },
+  android: {
+    arm64: ["codewhale-android-arm64", "codewhale-tui-android-arm64", "codew-android-arm64"],
+  },
   darwin: {
     x64: ["codewhale-macos-x64", "codewhale-tui-macos-x64", "codew-macos-x64"],
     arm64: ["codewhale-macos-arm64", "codewhale-tui-macos-arm64", "codew-macos-arm64"],

--- a/npm/codewhale/test/artifacts.test.js
+++ b/npm/codewhale/test/artifacts.test.js
@@ -40,6 +40,16 @@ test("openharmony arm64 resolves to linux arm64 binaries", () => {
   });
 });
 
+test("android arm64 resolves to Termux-native Android assets", () => {
+  withMockedOs("android", "arm64", () => {
+    const { detectBinaryNames } = require(ARTIFACTS_PATH);
+    const result = detectBinaryNames();
+    assert.equal(result.codewhale, "codewhale-android-arm64");
+    assert.equal(result.tui, "codewhale-tui-android-arm64");
+    assert.equal(result.codew, "codew-android-arm64");
+  });
+});
+
 test("genuinely unsupported platform throws with raw platform name", () => {
   withMockedOs("freebsd", "x64", () => {
     const { detectBinaryNames } = require(ARTIFACTS_PATH);
@@ -89,7 +99,11 @@ test("allAssetNames includes every matrix entry", () => {
   assert.ok(assetNames.includes("codewhale-tui-windows-x64.exe"));
   assert.ok(assetNames.includes("codew-windows-x64.exe"));
   assert.ok(assetNames.includes("codewhale.bat"));
+  assert.ok(assetNames.includes("codewhale-android-arm64"));
+  assert.ok(assetNames.includes("codewhale-tui-android-arm64"));
+  assert.ok(assetNames.includes("codew-android-arm64"));
   assert.ok(!assetNames.includes("codewhale-linux-riscv64"));
   assert.ok(allReleaseAssetNames().includes("codew-windows-x64.exe"));
   assert.ok(allReleaseAssetNames().includes("codewhale.bat"));
+  assert.ok(allReleaseAssetNames().includes("codew-android-arm64"));
 });


### PR DESCRIPTION
## Summary

Refs #4240.

- Adds an `aarch64-linux-android` / `android-arm64` row to the Release workflow for `codewhale`, `codew`, and `codewhale-tui`.
- Configures the Android NDK clang/`llvm-ar` toolchain for the Android release row without applying Linux DBus/pkg-config setup to it.
- Bundles `codewhale-android-arm64.tar.gz` with all three binaries plus the existing Unix `install.sh`.
- Teaches the npm release asset matrix to resolve Termux/Node `process.platform === "android"` + `arm64` to Android assets instead of Linux arm64 assets.
- Requires Android assets in TUI release-completeness checks so update/version hints do not advertise a partial release.

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parses"'`
- `cargo fmt --all -- --check`
- `node --test npm/codewhale/test/artifacts.test.js`
- `cargo test -p codewhale-cli --locked android -- --nocapture`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked version_hint_requires_complete_release_assets -- --nocapture`
- `DEEPSEEK_TUI_PREPARE_ALL_ASSETS=1 node scripts/release/prepare-local-release-assets.js <tmp-out> <tmp-build>` with dummy binaries, verified checksum rows for `codewhale-android-arm64`, `codew-android-arm64`, and `codewhale-tui-android-arm64`
- `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors`

Attempted local Android target check:

- `rustup target add aarch64-linux-android` succeeded.
- `cargo check --target aarch64-linux-android --locked -p codewhale-cli -p codewhale-tui` could not run to completion on this Mac because no Android NDK clang is installed locally (`aarch64-linux-android-clang` missing). The Release workflow now supplies the NDK linker/archiver for CI release builds.

## Release note

This PR wires release production for Android/Termux artifacts, but #4240 should stay open until a release workflow run actually publishes and checksums the new Android assets.
