### PR TITLE
feat(config): add [workflow] keys and product defaults (#4128)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1118,6 +1118,36 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # ```
 
 # ─────────────────────────────────────────────────────────────────────────────────
+# Workflow automatic launch, approval, isolation, and activity (#4128)
+# ─────────────────────────────────────────────────────────────────────────────────
+# First-class knobs for automatic Workflow orchestration. When the table is
+# omitted entirely, the runtime uses these product defaults. Later launch,
+# approval, and activity-persistence paths all read through this one model.
+# [workflow]
+# # Allow the parent agent to auto-launch Workflow for multi-agent work.
+# # Set false to require an explicit `/workflow` opt-in.
+# automatic = true
+# # Auto-start read-only plans without an approval card when automatic is on.
+# auto_start_read_only = true
+# # Require an approval card before write/shell/network/high-budget launches.
+# require_approval_for_writes = true
+# # Soft cap on children admitted by automatic launch (larger plans ask first).
+# auto_start_child_limit = 8
+# # Hard ceiling on children in one Workflow run.
+# max_children = 64
+# # Maximum nested Workflow / child-orchestration depth.
+# max_depth = 2
+# # Default shared token budget for a Workflow run and its children.
+# default_token_budget = 120000
+# # Parallel write children that may share the parent worktree without
+# # isolation. 0 forces worktree isolation for parallel writes.
+# max_parallel_writes_without_worktree = 0
+# # Keep completed Workflow activity visible until the next run / clear.
+# persist_completed_activity = true
+# # Persist completed activity across process restarts via the run journal.
+# persist_completed_across_restarts = true
+
+# ─────────────────────────────────────────────────────────────────────────────────
 # Agent Fleet trust, security, and role registry (#3165, #3167)
 # ─────────────────────────────────────────────────────────────────────────────────
 # [fleet]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -389,6 +389,11 @@ pub struct ConfigToml {
     /// workers inherit conservative Sandbox defaults.
     #[serde(default)]
     pub fleet: Option<FleetConfigToml>,
+    /// Workflow automatic-launch, approval, isolation, and activity
+    /// persistence knobs (#4128 / Section 2.11). When absent, consumers use
+    /// [`WorkflowConfigToml::default`].
+    #[serde(default)]
+    pub workflow: Option<WorkflowConfigToml>,
     #[serde(flatten)]
     pub extras: BTreeMap<String, toml::Value>,
 }
@@ -1475,6 +1480,112 @@ impl FleetConfigToml {
             .get(name)
             .cloned()
             .or_else(|| built_in_role_presets().get(name).cloned())
+    }
+}
+
+/// On-disk schema for the `[workflow]` table (#4128 / Section 2.11).
+///
+/// Automatic Workflow launch, write/approval gates, child/isolation budgets,
+/// and completed-activity persistence all read from this one model. When the
+/// table is absent, consumers resolve [`WorkflowConfigToml::default`].
+/// See `config.example.toml` for documentation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowConfigToml {
+    /// Allow the parent agent to auto-launch Workflow for multi-agent work.
+    /// Product default is on; set `false` to require explicit `/workflow`.
+    #[serde(default = "default_workflow_automatic")]
+    pub automatic: bool,
+    /// When automatic launch is enabled, start read-only child plans without
+    /// an approval card. Write/shell/network plans still consult
+    /// [`Self::require_approval_for_writes`].
+    #[serde(default = "default_workflow_auto_start_read_only")]
+    pub auto_start_read_only: bool,
+    /// Require an operator approval card before launching plans that write,
+    /// elevate shell/network, or otherwise leave the read-only envelope.
+    #[serde(default = "default_workflow_require_approval_for_writes")]
+    pub require_approval_for_writes: bool,
+    /// Soft upper bound on children admitted by automatic launch. Larger plans
+    /// should ask the operator or use explicit `/workflow`.
+    #[serde(default = "default_workflow_auto_start_child_limit")]
+    pub auto_start_child_limit: u32,
+    /// Hard ceiling on total children in one Workflow run.
+    #[serde(default = "default_workflow_max_children")]
+    pub max_children: u32,
+    /// Maximum nested Workflow / child-orchestration depth.
+    #[serde(default = "default_workflow_max_depth")]
+    pub max_depth: u32,
+    /// Default shared token budget for a Workflow run and its children.
+    #[serde(default = "default_workflow_default_token_budget")]
+    pub default_token_budget: u64,
+    /// How many parallel write children may share the parent worktree without
+    /// isolation. `0` forces worktree isolation for parallel writes.
+    #[serde(default = "default_workflow_max_parallel_writes_without_worktree")]
+    pub max_parallel_writes_without_worktree: u32,
+    /// Keep completed Workflow activity visible in the session activity surface
+    /// until the next run (or explicit clear).
+    #[serde(default = "default_workflow_persist_completed_activity")]
+    pub persist_completed_activity: bool,
+    /// Persist completed Workflow activity across process restarts via the
+    /// durable run journal.
+    #[serde(default = "default_workflow_persist_completed_across_restarts")]
+    pub persist_completed_across_restarts: bool,
+}
+
+fn default_workflow_automatic() -> bool {
+    true
+}
+
+fn default_workflow_auto_start_read_only() -> bool {
+    true
+}
+
+fn default_workflow_require_approval_for_writes() -> bool {
+    true
+}
+
+fn default_workflow_auto_start_child_limit() -> u32 {
+    8
+}
+
+fn default_workflow_max_children() -> u32 {
+    64
+}
+
+fn default_workflow_max_depth() -> u32 {
+    2
+}
+
+fn default_workflow_default_token_budget() -> u64 {
+    120_000
+}
+
+fn default_workflow_max_parallel_writes_without_worktree() -> u32 {
+    0
+}
+
+fn default_workflow_persist_completed_activity() -> bool {
+    true
+}
+
+fn default_workflow_persist_completed_across_restarts() -> bool {
+    true
+}
+
+impl Default for WorkflowConfigToml {
+    fn default() -> Self {
+        Self {
+            automatic: default_workflow_automatic(),
+            auto_start_read_only: default_workflow_auto_start_read_only(),
+            require_approval_for_writes: default_workflow_require_approval_for_writes(),
+            auto_start_child_limit: default_workflow_auto_start_child_limit(),
+            max_children: default_workflow_max_children(),
+            max_depth: default_workflow_max_depth(),
+            default_token_budget: default_workflow_default_token_budget(),
+            max_parallel_writes_without_worktree:
+                default_workflow_max_parallel_writes_without_worktree(),
+            persist_completed_activity: default_workflow_persist_completed_activity(),
+            persist_completed_across_restarts: default_workflow_persist_completed_across_restarts(),
+        }
     }
 }
 

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -5446,6 +5446,71 @@ fn empty_fallback_providers_do_not_serialize() {
 }
 
 #[test]
+fn workflow_config_defaults_match_product_surface() {
+    // #4128 / Section 2.11: omitted `[workflow]` keys resolve to the
+    // documented product defaults so launch/approval/persist share one model.
+    let defaults = WorkflowConfigToml::default();
+    assert!(defaults.automatic);
+    assert!(defaults.auto_start_read_only);
+    assert!(defaults.require_approval_for_writes);
+    assert_eq!(defaults.auto_start_child_limit, 8);
+    assert_eq!(defaults.max_children, 64);
+    assert_eq!(defaults.max_depth, 2);
+    assert_eq!(defaults.default_token_budget, 120_000);
+    assert_eq!(defaults.max_parallel_writes_without_worktree, 0);
+    assert!(defaults.persist_completed_activity);
+    assert!(defaults.persist_completed_across_restarts);
+}
+
+#[test]
+fn workflow_config_absent_table_stays_none_empty_table_fills_defaults() {
+    let absent: ConfigToml = toml::from_str("").expect("empty config parses");
+    assert!(absent.workflow.is_none());
+
+    let empty_table: ConfigToml = toml::from_str(
+        r#"
+[workflow]
+"#,
+    )
+    .expect("empty workflow table should parse");
+    assert_eq!(
+        empty_table.workflow.expect("workflow table present"),
+        WorkflowConfigToml::default()
+    );
+}
+
+#[test]
+fn workflow_config_partial_override_and_round_trip() {
+    let config: ConfigToml = toml::from_str(
+        r#"
+[workflow]
+automatic = false
+max_children = 16
+default_token_budget = 50000
+"#,
+    )
+    .expect("workflow overrides should parse");
+
+    let workflow = config.workflow.expect("workflow table");
+    assert!(!workflow.automatic);
+    assert_eq!(workflow.max_children, 16);
+    assert_eq!(workflow.default_token_budget, 50_000);
+    // Unset keys keep product defaults.
+    assert!(workflow.auto_start_read_only);
+    assert!(workflow.require_approval_for_writes);
+    assert_eq!(workflow.auto_start_child_limit, 8);
+    assert_eq!(workflow.max_depth, 2);
+    assert_eq!(workflow.max_parallel_writes_without_worktree, 0);
+    assert!(workflow.persist_completed_activity);
+    assert!(workflow.persist_completed_across_restarts);
+
+    let serialized = toml::to_string_pretty(&workflow).expect("workflow serializes");
+    let round_tripped: WorkflowConfigToml =
+        toml::from_str(&serialized).expect("serialized workflow parses");
+    assert_eq!(round_tripped, workflow);
+}
+
+#[test]
 fn fleet_exec_config_default_matches_subagent_depth() {
     // Fleet workers and standalone sub-agents share one recursion axis:
     // the fleet default equals DEFAULT_SPAWN_DEPTH (3) and affords >=3

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2052,6 +2052,13 @@ pub struct Config {
     #[serde(default)]
     pub fleet: Option<codewhale_config::FleetConfigToml>,
 
+    /// Workflow automatic-launch, approval, isolation, and activity
+    /// persistence knobs (#4128). When absent, consumers use
+    /// [`codewhale_config::WorkflowConfigToml::default`] via
+    /// [`Self::workflow_config`].
+    #[serde(default)]
+    pub workflow: Option<codewhale_config::WorkflowConfigToml>,
+
     /// Sub-agent model overrides.
     #[serde(default)]
     pub subagents: Option<SubagentsConfig>,
@@ -4034,6 +4041,15 @@ impl Config {
         self.fleet.clone().unwrap_or_default()
     }
 
+    /// Parsed `[workflow]` table, or product defaults when the table is absent
+    /// (#4128 / Section 2.11). Automatic launch, approval, isolation, and
+    /// activity-persistence consumers should read through this accessor so
+    /// omitted keys share one model.
+    #[must_use]
+    pub fn workflow_config(&self) -> codewhale_config::WorkflowConfigToml {
+        self.workflow.clone().unwrap_or_default()
+    }
+
     /// Return the configured DeepSeek reasoning-effort tier, if any.
     #[must_use]
     pub fn reasoning_effort(&self) -> Option<&str> {
@@ -5647,6 +5663,7 @@ fn merge_config(base: Config, override_cfg: Config) -> Config {
             seam_model: override_cfg.context.seam_model.or(base.context.seam_model),
         },
         fleet: override_cfg.fleet.or(base.fleet),
+        workflow: override_cfg.workflow.or(base.workflow),
         subagents: override_cfg.subagents.or(base.subagents),
         strict_tool_mode: override_cfg.strict_tool_mode.or(base.strict_tool_mode),
         runtime_api: override_cfg.runtime_api.or(base.runtime_api),

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -685,6 +685,66 @@ fn verifier_config_parses_hunt_policy_and_merges_overrides() {
 }
 
 #[test]
+fn workflow_config_defaults_when_omitted_and_overrides_round_trip() {
+    // #4128: omitted `[workflow]` resolves through the accessor to product
+    // defaults; explicit overrides load and survive serialize → parse.
+    let omitted: Config = toml::from_str("").expect("empty config");
+    assert!(omitted.workflow.is_none());
+    assert_eq!(
+        omitted.workflow_config(),
+        codewhale_config::WorkflowConfigToml::default()
+    );
+
+    let config: Config = toml::from_str(
+        r#"
+        [workflow]
+        automatic = false
+        auto_start_read_only = false
+        require_approval_for_writes = true
+        auto_start_child_limit = 4
+        max_children = 32
+        max_depth = 1
+        default_token_budget = 90000
+        max_parallel_writes_without_worktree = 1
+        persist_completed_activity = false
+        persist_completed_across_restarts = false
+        "#,
+    )
+    .expect("parse workflow config");
+
+    let workflow = config.workflow.clone().expect("workflow table");
+    assert!(!workflow.automatic);
+    assert!(!workflow.auto_start_read_only);
+    assert!(workflow.require_approval_for_writes);
+    assert_eq!(workflow.auto_start_child_limit, 4);
+    assert_eq!(workflow.max_children, 32);
+    assert_eq!(workflow.max_depth, 1);
+    assert_eq!(workflow.default_token_budget, 90_000);
+    assert_eq!(workflow.max_parallel_writes_without_worktree, 1);
+    assert!(!workflow.persist_completed_activity);
+    assert!(!workflow.persist_completed_across_restarts);
+    assert_eq!(config.workflow_config(), workflow);
+
+    let serialized = toml::to_string_pretty(&workflow).expect("serialize workflow");
+    let round_tripped: codewhale_config::WorkflowConfigToml =
+        toml::from_str(&serialized).expect("round-trip parse");
+    assert_eq!(round_tripped, workflow);
+
+    // Profile/project overlays replace the whole table when present.
+    let merged = merge_config(
+        Config {
+            workflow: Some(codewhale_config::WorkflowConfigToml::default()),
+            ..Config::default()
+        },
+        Config {
+            workflow: Some(workflow.clone()),
+            ..Config::default()
+        },
+    );
+    assert_eq!(merged.workflow_config(), workflow);
+}
+
+#[test]
 fn search_provider_defaults_to_duckduckgo() {
     assert_eq!(SearchProvider::default(), SearchProvider::DuckDuckGo);
 }


### PR DESCRIPTION
## Summary
Adds the first-class `[workflow]` configuration surface for v0.8.68 Section 2.11 / #4128 so later automatic launch, approval, isolation, and activity-persistence work can read one shared model.

- New `WorkflowConfigToml` in `codewhale-config` with product defaults:
  - `automatic = true`
  - `auto_start_read_only = true`
  - `require_approval_for_writes = true`
  - `auto_start_child_limit = 8`
  - `max_children = 64`
  - `max_depth = 2`
  - `default_token_budget = 120000`
  - `max_parallel_writes_without_worktree = 0`
  - `persist_completed_activity = true`
  - `persist_completed_across_restarts = true`
- Wired into TUI `Config` load/merge + `Config::workflow_config()` accessor (defaults when table omitted)
- Documented in `config.example.toml`
- Round-trip + default tests in `codewhale-config` and `codewhale-tui`

**Out of scope:** automatic launch product logic (#4124–#4127), approval UI, and activity panel wiring.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p codewhale-config --locked workflow_config`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked workflow_config`

Closes #4128