### PR TITLE
feat(workflow): stamp workflow identity on sub-agent spawn records (#4119)

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1078,6 +1078,16 @@ pub(crate) struct WorkflowTaskSpawnResult {
     pub metadata: WorkflowTaskSpawnMetadata,
 }
 
+/// Workflow identity stamped onto children launched via `spawn_workflow_task`
+/// (#4119). Lets panel/history render without parsing the child prompt.
+#[derive(Debug, Clone)]
+pub(crate) struct WorkflowTaskSpawnIdentity {
+    pub workflow_run_id: String,
+    pub workflow_phase_id: Option<String>,
+    pub workflow_task_label: Option<String>,
+    pub workflow_child_index: u32,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct WorkflowTaskSpawnMetadata {
     pub resolved_provider: String,
@@ -1085,6 +1095,14 @@ pub(crate) struct WorkflowTaskSpawnMetadata {
     pub route_source: String,
     pub parent_task_id: Option<String>,
     pub depth: u32,
+    /// Workflow run that launched this child (`None` for direct `agent` spawns).
+    pub workflow_run_id: Option<String>,
+    /// Active phase title/id when the child was admitted (`None` outside workflows).
+    pub workflow_phase_id: Option<String>,
+    /// Human label from the Workflow `task({ label })` option.
+    pub workflow_task_label: Option<String>,
+    /// 0-based admission order among children of this workflow run.
+    pub workflow_child_index: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4380,6 +4398,10 @@ async fn spawn_subagent_from_input(
         route_source: route_source_label(&model_route),
         parent_task_id: child_runtime.parent_agent_id.clone(),
         depth: child_runtime.spawn_depth,
+        workflow_run_id: None,
+        workflow_phase_id: None,
+        workflow_task_label: None,
+        workflow_child_index: None,
     };
 
     let mut manager_guard = manager.write().await;
@@ -4442,11 +4464,29 @@ fn apply_session_spawn_policy(
 /// Spawn one Workflow `task(...)` through the same path as the public `agent`
 /// tool. Keeping this adapter inside the sub-agent module prevents the
 /// Workflow driver from copying Fleet roster/profile/depth/budget semantics.
+///
+/// `identity` is stamped onto the returned spawn metadata so panel/history
+/// consumers can render workflow children without parsing prompt text (#4119).
 pub(crate) async fn spawn_workflow_task(
     request: codewhale_workflow_js::TaskRequest,
     manager: SharedSubAgentManager,
     runtime: SubAgentRuntime,
+    identity: WorkflowTaskSpawnIdentity,
 ) -> Result<WorkflowTaskSpawnResult, ToolError> {
+    // Capture identity fallbacks before consuming `request` fields into the
+    // agent-tool input JSON.
+    let request_label = request
+        .label
+        .as_ref()
+        .map(|label| label.trim())
+        .filter(|label| !label.is_empty())
+        .map(str::to_string);
+    let request_phase = request
+        .phase
+        .as_ref()
+        .map(|phase| phase.trim())
+        .filter(|phase| !phase.is_empty())
+        .map(str::to_string);
     let mut input = json!({
         "prompt": request.description,
         "worktree": request.worktree,
@@ -4475,7 +4515,20 @@ pub(crate) async fn spawn_workflow_task(
     if let Some(value) = request.token_budget {
         input["token_budget"] = json!(value);
     }
-    let (result, _, metadata) = spawn_subagent_from_input(input, manager, runtime).await?;
+    let (result, _, mut metadata) = spawn_subagent_from_input(input, manager, runtime).await?;
+    // Prefer the identity values the driver stamped; fall back to task options.
+    let workflow_task_label = identity
+        .workflow_task_label
+        .filter(|label| !label.trim().is_empty())
+        .or(request_label);
+    let workflow_phase_id = identity
+        .workflow_phase_id
+        .filter(|phase| !phase.trim().is_empty())
+        .or(request_phase);
+    metadata.workflow_run_id = Some(identity.workflow_run_id);
+    metadata.workflow_phase_id = workflow_phase_id;
+    metadata.workflow_task_label = workflow_task_label;
+    metadata.workflow_child_index = Some(identity.workflow_child_index);
     Ok(WorkflowTaskSpawnResult { result, metadata })
 }
 

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -31,7 +32,7 @@ use crate::tools::spec::{
 };
 use crate::tools::subagent::{
     SharedSubAgentManager, SubAgentCompletion, SubAgentRuntime, SubAgentStatus,
-    WorkflowTaskSpawnMetadata, spawn_workflow_task,
+    WorkflowTaskSpawnIdentity, WorkflowTaskSpawnMetadata, spawn_workflow_task,
 };
 use crate::tools::verifier::run_workflow_completion_gates;
 use crate::utils::spawn_supervised;
@@ -191,6 +192,14 @@ struct WorkflowTaskStartedEvent {
     git_branch: Option<String>,
     parent_task_id: Option<String>,
     depth: u32,
+    /// Workflow run that admitted this child (#4119).
+    workflow_run_id: Option<String>,
+    /// Phase title/id active (or declared on the task) at spawn (#4119).
+    workflow_phase_id: Option<String>,
+    /// Typed task label — UI must prefer this over prompt text (#4119).
+    workflow_task_label: Option<String>,
+    /// 0-based admission order among children of this run (#4119).
+    workflow_child_index: Option<u32>,
 }
 
 impl WorkflowUiEventKind {
@@ -1203,6 +1212,11 @@ struct SubAgentWorkflowDriver {
     completion_tx: mpsc::UnboundedSender<SubAgentCompletion>,
     completion_state: Arc<Mutex<CompletionState>>,
     child_ids: Arc<Mutex<Vec<String>>>,
+    /// Monotonic 0-based child admission counter for `workflow_child_index`.
+    child_counter: AtomicU32,
+    /// Latest `phase(...)` title observed on this run (used when a task omits
+    /// an explicit `phase` option).
+    current_phase: Mutex<Option<String>>,
     task_records: Arc<Mutex<HashMap<String, RuntimeTaskRecord>>>,
     total_budget: Option<u64>,
     last_budget_event: Arc<Mutex<Option<BudgetSnapshot>>>,
@@ -1225,6 +1239,8 @@ impl SubAgentWorkflowDriver {
             completion_tx,
             completion_state: Arc::new(Mutex::new(CompletionState::default())),
             child_ids: Arc::new(Mutex::new(Vec::new())),
+            child_counter: AtomicU32::new(0),
+            current_phase: Mutex::new(None),
             task_records: Arc::new(Mutex::new(HashMap::new())),
             total_budget,
             last_budget_event: Arc::new(Mutex::new(None)),
@@ -1311,10 +1327,16 @@ impl SubAgentWorkflowDriver {
         metadata: &WorkflowTaskSpawnMetadata,
         result: &crate::tools::subagent::SubAgentResult,
     ) {
+        // Prefer typed spawn metadata over request fields so panel/history never
+        // need to re-derive labels from the child prompt (#4119).
+        let label = metadata
+            .workflow_task_label
+            .clone()
+            .or_else(|| request.label.clone());
         self.record_run_event(WorkflowUiEvent::new(WorkflowUiEventKind::TaskStarted(
             Box::new(WorkflowTaskStartedEvent {
                 task_id: agent_id.to_string(),
-                label: request.label.clone(),
+                label,
                 profile: request.profile.clone(),
                 model: request.model.clone(),
                 strength: request.model_strength.clone(),
@@ -1327,6 +1349,10 @@ impl SubAgentWorkflowDriver {
                 git_branch: result.git_branch.clone(),
                 parent_task_id: metadata.parent_task_id.clone(),
                 depth: metadata.depth,
+                workflow_run_id: metadata.workflow_run_id.clone(),
+                workflow_phase_id: metadata.workflow_phase_id.clone(),
+                workflow_task_label: metadata.workflow_task_label.clone(),
+                workflow_child_index: metadata.workflow_child_index,
             }),
         )));
     }
@@ -1432,7 +1458,32 @@ impl WorkflowDriver for SubAgentWorkflowDriver {
             .clone()
             .with_parent_completion_tx(self.completion_tx.clone());
         let request_record = request.clone();
-        let result = spawn_workflow_task(request, self.manager.clone(), runtime)
+        let workflow_child_index = self.child_counter.fetch_add(1, Ordering::SeqCst);
+        let workflow_phase_id = request
+            .phase
+            .as_ref()
+            .map(|phase| phase.trim())
+            .filter(|phase| !phase.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                self.current_phase
+                    .lock()
+                    .ok()
+                    .and_then(|phase| phase.clone())
+            });
+        let workflow_task_label = request
+            .label
+            .as_ref()
+            .map(|label| label.trim())
+            .filter(|label| !label.is_empty())
+            .map(str::to_string);
+        let identity = WorkflowTaskSpawnIdentity {
+            workflow_run_id: self.run_id.clone(),
+            workflow_phase_id,
+            workflow_task_label,
+            workflow_child_index,
+        };
+        let result = spawn_workflow_task(request, self.manager.clone(), runtime, identity)
             .await
             .map_err(|err| DriverError::Rejected(err.to_string()))?;
         let task_id = result.result.agent_id.clone();
@@ -1468,10 +1519,15 @@ impl WorkflowDriver for SubAgentWorkflowDriver {
                 format!("log: {message}"),
                 WorkflowUiEvent::new(WorkflowUiEventKind::Log { message }),
             ),
-            ProgressEvent::Phase { title } => (
-                format!("phase: {title}"),
-                WorkflowUiEvent::new(WorkflowUiEventKind::PhaseStarted { title }),
-            ),
+            ProgressEvent::Phase { title } => {
+                if let Ok(mut current) = self.current_phase.lock() {
+                    *current = Some(title.clone());
+                }
+                (
+                    format!("phase: {title}"),
+                    WorkflowUiEvent::new(WorkflowUiEventKind::PhaseStarted { title }),
+                )
+            }
             ProgressEvent::TaskSchemaValidationFailed { task_id, message } => {
                 self.record_schema_validation_failure(&task_id, message.clone());
                 schema_error = Some(WorkflowSchemaError {
@@ -2345,6 +2401,14 @@ mod tests {
         assert_eq!(task_started["worktree"], false);
         assert!(task_started["parent_task_id"].is_null());
         assert_eq!(task_started["depth"], 1);
+        // #4119: workflow identity on spawn / task_started metadata.
+        assert_eq!(
+            task_started["workflow_run_id"].as_str(),
+            payload["run_id"].as_str()
+        );
+        assert_eq!(task_started["workflow_phase_id"], "dispatch");
+        assert_eq!(task_started["workflow_task_label"], "inspect-child");
+        assert_eq!(task_started["workflow_child_index"], 0);
         assert!(
             events.iter().any(|event| event["type"] == "task_completed"
                 && event["task_id"] == child_id
@@ -2358,6 +2422,64 @@ mod tests {
             .expect("child result");
         assert_eq!(child.status, SubAgentStatus::Completed);
         assert_eq!(child.result.as_deref(), Some("child done"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn workflow_spawn_records_carry_child_index_and_phase_metadata() {
+        // #4119: sequential children get monotonic workflow_child_index and
+        // inherit the active phase when task options omit `phase`.
+        let _retry_guard = workflow_test_retry_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
+        let (client, calls) = fake_chat_client("ok").await;
+        let runtime = SubAgentRuntime::new(
+            client,
+            "deepseek-v4-flash".to_string(),
+            ctx.clone(),
+            true,
+            None,
+            manager.clone(),
+        );
+        let tool = WorkflowTool::new(manager.clone(), runtime);
+
+        let result = tool
+            .execute(
+                json!({
+                    "action": "run",
+                    "script": "phase('alpha'); await task({ description: 'first', type: 'explore', allowedTools: [], label: 'one' }); phase('beta'); await task({ description: 'second', type: 'explore', allowedTools: [], label: 'two', phase: 'beta-explicit' }); return { ok: true };"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("workflow run should complete");
+        let payload: Value = serde_json::from_str(&result.content).expect("json result");
+        assert_eq!(payload["status"], "completed", "{payload}");
+        assert_eq!(payload["child_ids"].as_array().unwrap().len(), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        let mut started: Vec<&Value> = payload["events"]
+            .as_array()
+            .expect("events")
+            .iter()
+            .filter(|event| event["type"] == "task_started")
+            .collect();
+        started.sort_by_key(|event| event["workflow_child_index"].as_u64().unwrap_or(u64::MAX));
+        assert_eq!(started.len(), 2, "{started:#?}");
+
+        assert_eq!(started[0]["workflow_run_id"], payload["run_id"]);
+        assert_eq!(started[0]["workflow_phase_id"], "alpha");
+        assert_eq!(started[0]["workflow_task_label"], "one");
+        assert_eq!(started[0]["workflow_child_index"], 0);
+        assert_eq!(started[0]["label"], "one");
+
+        assert_eq!(started[1]["workflow_run_id"], payload["run_id"]);
+        // Explicit task phase wins over the driver's current phase.
+        assert_eq!(started[1]["workflow_phase_id"], "beta-explicit");
+        assert_eq!(started[1]["workflow_task_label"], "two");
+        assert_eq!(started[1]["workflow_child_index"], 1);
+        assert_eq!(started[1]["label"], "two");
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1620,6 +1620,42 @@ impl GenericToolCell {
             tool_value_style(),
             width,
         ));
+        // Prefer typed task_started metadata (workflow_task_label / label) over
+        // free-form progress strings so the card never re-parses prompts (#4119).
+        if let Some(events) = value.get("events").and_then(serde_json::Value::as_array) {
+            let mut child_labels: Vec<String> = Vec::new();
+            for event in events {
+                if event.get("type").and_then(serde_json::Value::as_str) != Some("task_started") {
+                    continue;
+                }
+                let label = event
+                    .get("workflow_task_label")
+                    .and_then(serde_json::Value::as_str)
+                    .or_else(|| event.get("label").and_then(serde_json::Value::as_str))
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty());
+                if let Some(label) = label {
+                    child_labels.push(label.to_string());
+                }
+            }
+            if !child_labels.is_empty() {
+                let summary = if child_labels.len() <= 3 {
+                    child_labels.join(", ")
+                } else {
+                    format!(
+                        "{}, +{} more",
+                        child_labels[..3].join(", "),
+                        child_labels.len() - 3
+                    )
+                };
+                lines.extend(render_card_detail_line(
+                    Some("tasks"),
+                    &truncate_text(&summary, 200),
+                    tool_value_style(),
+                    width,
+                ));
+            }
+        }
         if let Some(progress) = value.get("progress").and_then(serde_json::Value::as_array)
             && let Some(last) = progress.last().and_then(serde_json::Value::as_str)
         {

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -144,7 +144,9 @@ fn workflow_tool_renders_run_card_instead_of_generic_oneliner() {
     assert!(joined.contains("children: 3"), "child count: {joined:?}");
     // #4119: history card uses typed task labels, not prompt text.
     assert!(
-        joined.contains("scan-docs") && joined.contains("check-fleet") && joined.contains("summarize"),
+        joined.contains("scan-docs")
+            && joined.contains("check-fleet")
+            && joined.contains("summarize"),
         "typed task labels: {joined:?}"
     );
     assert!(

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -89,6 +89,31 @@ fn workflow_tool_renders_run_card_instead_of_generic_oneliner() {
         "workflow_goal": "audit the FLEET and WORKFLOW docs",
         "child_ids": ["a1", "a2", "a3"],
         "progress": ["phase: Scan", "log: 3 findings"],
+        "events": [
+            {
+                "type": "task_started",
+                "task_id": "a1",
+                "label": "scan-docs",
+                "workflow_run_id": "workflow_2400c600",
+                "workflow_phase_id": "Scan",
+                "workflow_task_label": "scan-docs",
+                "workflow_child_index": 0,
+            },
+            {
+                "type": "task_started",
+                "task_id": "a2",
+                "workflow_task_label": "check-fleet",
+                "workflow_run_id": "workflow_2400c600",
+                "workflow_child_index": 1,
+            },
+            {
+                "type": "task_started",
+                "task_id": "a3",
+                "label": "summarize",
+                "workflow_run_id": "workflow_2400c600",
+                "workflow_child_index": 2,
+            },
+        ],
         "schema_errors": [],
     })
     .to_string();
@@ -117,6 +142,11 @@ fn workflow_tool_renders_run_card_instead_of_generic_oneliner() {
     );
     assert!(joined.contains("audit the FLEET"), "goal: {joined:?}");
     assert!(joined.contains("children: 3"), "child count: {joined:?}");
+    // #4119: history card uses typed task labels, not prompt text.
+    assert!(
+        joined.contains("scan-docs") && joined.contains("check-fleet") && joined.contains("summarize"),
+        "typed task labels: {joined:?}"
+    );
     assert!(
         joined.contains("log: 3 findings"),
         "last progress: {joined:?}"

--- a/crates/tui/src/tui/widgets/workflow_panel.rs
+++ b/crates/tui/src/tui/widgets/workflow_panel.rs
@@ -277,7 +277,9 @@ impl WorkflowPanelEvent {
             }),
             "task_started" => Some(Self::TaskStarted {
                 task_id: opt_str(value, "task_id")?,
-                label: opt_str(value, "label"),
+                // Prefer typed workflow metadata over generic label so rows
+                // never fall back to prompt parsing (#4119).
+                label: opt_str(value, "workflow_task_label").or_else(|| opt_str(value, "label")),
                 profile: opt_str(value, "profile"),
                 model: opt_str(value, "model").or_else(|| opt_str(value, "resolved_model")),
                 strength: opt_str(value, "strength"),
@@ -1219,5 +1221,43 @@ mod tests {
         assert!(header.contains("1 fail"), "{header}");
         assert!(header.contains("1 cancel"), "{header}");
         assert!(header.contains("2/2"), "{header}");
+    }
+
+    #[test]
+    fn task_started_json_prefers_workflow_task_label_over_generic_label() {
+        // #4119: panel rows use typed workflow metadata, not prompt text.
+        let event = WorkflowPanelEvent::from_json_value(&json!({
+            "type": "task_started",
+            "task_id": "child-1",
+            "label": "fallback-label",
+            "workflow_task_label": "typed-label",
+            "workflow_run_id": "run-xyz",
+            "workflow_phase_id": "dispatch",
+            "workflow_child_index": 2,
+            "at_ms": 42,
+        }))
+        .expect("task_started parses");
+        match event {
+            WorkflowPanelEvent::TaskStarted { label, .. } => {
+                assert_eq!(label.as_deref(), Some("typed-label"));
+            }
+            other => panic!("expected TaskStarted, got {other:?}"),
+        }
+
+        let mut panel = WorkflowPanel::new("run-xyz", "goal", 1);
+        panel.apply_json_event(&json!({
+            "type": "task_started",
+            "task_id": "child-1",
+            "label": "fallback-label",
+            "workflow_task_label": "typed-label",
+            "at_ms": 42,
+        }));
+        let row = panel
+            .phases
+            .iter()
+            .flat_map(|phase| phase.rows.iter())
+            .find(|row| row.task_id == "child-1")
+            .expect("row recorded");
+        assert_eq!(row.label, "typed-label");
     }
 }


### PR DESCRIPTION
## Summary
- Extend `WorkflowTaskSpawnMetadata` with `workflow_run_id`, `workflow_phase_id`, `workflow_task_label`, and `workflow_child_index`.
- `spawn_workflow_task` stamps these from driver identity + task options; sequential children get a monotonic admission index; phase falls back to the active `phase(...)` title when omitted.
- Surface the fields on typed `task_started` UI events.
- Workflow panel prefers `workflow_task_label` over generic `label`; history run cards list typed task labels from events (no prompt parsing).

Closes #4119

## Test plan
- [x] `cargo test -p codewhale-tui --bin codewhale-tui workflow_`
- [x] `workflow_spawn_records_carry_child_index_and_phase_metadata`
- [x] `task_started_json_prefers_workflow_task_label_over_generic_label`
- [x] `workflow_tool_renders_run_card_instead_of_generic_oneliner`