### PR TITLE
feat(provider): guided model pick + confirm after key validation (#3875)

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -6415,6 +6415,37 @@ pub fn save_api_key_for(provider: ApiProvider, api_key: &str) -> Result<PathBuf>
     Ok(config_path)
 }
 
+/// Persist a default model for `provider` via the comment-preserving config
+/// path used by guided provider setup (#3875). DeepSeek writes root
+/// `default_text_model`; other hosted providers write `[providers.<name>] model`.
+pub fn save_provider_model_for(provider: ApiProvider, model: &str) -> Result<PathBuf> {
+    let model = model.trim();
+    anyhow::ensure!(!model.is_empty(), "model cannot be empty");
+
+    let config_path = default_config_path()
+        .context("Failed to resolve config path: home directory not found.")?;
+    ensure_parent_dir(&config_path)?;
+
+    if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+        crate::config_persistence::mutate_config_document(&config_path, |doc| {
+            crate::config_persistence::set_document_value(doc, &["default_text_model"], model)
+        })
+        .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+        return Ok(config_path);
+    }
+
+    let key_inside = provider_config_key(provider).context("provider model table")?;
+    crate::config_persistence::mutate_config_document(&config_path, |doc| {
+        crate::config_persistence::set_document_value(
+            doc,
+            &["providers", key_inside, "model"],
+            model,
+        )
+    })
+    .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+    Ok(config_path)
+}
+
 pub fn save_provider_auth_mode_for(provider: ApiProvider, auth_mode: &str) -> Result<PathBuf> {
     let config_path = default_config_path()
         .context("Failed to resolve config path: home directory not found.")?;

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -2,7 +2,7 @@
 //! hosted providers / self-hosted providers) and, if it lacks credentials, type the API key
 //! inline before completing the switch (#52).
 //!
-//! The picker is intentionally a single modal with three visible states:
+//! The picker is intentionally a single modal with guided stages (#3875):
 //!
 //! 1. **List** — pick a provider; each row shows the active provider arrow
 //!    and an "API key configured" / "needs API key" hint. Enter on a
@@ -11,14 +11,20 @@
 //!    transitions the same modal into the key-entry state.
 //! 2. **Key entry** — masked input box pre-filled with the provider's
 //!    canonical env-var name as a hint. Enter submits
-//!    [`ViewEvent::ProviderPickerApiKeySubmitted`], which the UI handler
-//!    persists via `save_api_key_for` before switching.
-//! 3. **Custom form** — a named OpenAI-compatible endpoint form. Enter submits
+//!    [`ViewEvent::ProviderPickerApiKeySubmitted`] for live validation.
+//!    Failed verification reopens this stage with the provider error and
+//!    never persists the rejected secret.
+//! 3. **Model pick** — after a key validates, choose a default model from
+//!    the provider catalog (provider default pre-selected).
+//! 4. **Confirm** — summary of provider + masked key + model. Enter emits
+//!    [`ViewEvent::ProviderPickerSetupConfirmed`], which the UI handler
+//!    persists (comment-preserving) before switching.
+//! 5. **Custom form** — a named OpenAI-compatible endpoint form. Enter submits
 //!    [`ViewEvent::ProviderPickerCustomProviderSubmitted`], which persists a
 //!    `[providers.<name>]` table without storing raw secrets.
 //!
-//! Pressing Esc backs out: from key entry returns to the list; from the
-//! list closes the modal without changes.
+//! Pressing Esc backs out one stage at a time; from the list it closes the
+//! modal without changes.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use ratatui::{
@@ -55,6 +61,10 @@ use std::sync::OnceLock;
 enum Stage {
     List,
     KeyEntry,
+    /// Default model pick after a key has been live-validated (#3875).
+    ModelPick,
+    /// Confirmation summary before any secret or model is persisted (#3875).
+    Confirm,
     CustomForm,
 }
 
@@ -86,6 +96,13 @@ pub struct ProviderPickerView {
     /// An error surfaced after a failed key verification, shown inline
     /// in the key-entry stage. Cleared when the user edits the input.
     key_entry_error: Option<String>,
+    /// Validated key held only in memory until the confirm stage persists it.
+    pending_api_key: Option<String>,
+    /// Catalog models offered during the model-pick stage.
+    model_options: Vec<String>,
+    model_selected_idx: usize,
+    /// Model chosen on the model-pick stage (and shown on confirm).
+    selected_model: Option<String>,
     custom_provider_field: CustomProviderField,
     custom_provider_id: String,
     custom_provider_base_url: String,
@@ -1199,6 +1216,10 @@ impl ProviderPickerView {
             query: String::new(),
             api_key_input: String::new(),
             key_entry_error: None,
+            pending_api_key: None,
+            model_options: Vec::new(),
+            model_selected_idx: 0,
+            selected_model: None,
             custom_provider_field: CustomProviderField::Name,
             custom_provider_id: String::new(),
             custom_provider_base_url: String::new(),
@@ -1373,6 +1394,10 @@ impl ProviderPickerView {
         self.stage = Stage::KeyEntry;
         self.api_key_input.clear();
         self.key_entry_error = None;
+        self.pending_api_key = None;
+        self.model_options.clear();
+        self.model_selected_idx = 0;
+        self.selected_model = None;
     }
 
     /// Open the picker already focused on `target` in its key-entry stage
@@ -1395,6 +1420,87 @@ impl ProviderPickerView {
         picker.stage = Stage::KeyEntry;
         picker.key_entry_error = Some(error);
         Some(picker)
+    }
+
+    /// Open the guided flow on the model-pick stage after a key has been
+    /// live-validated (#3875). The key stays in memory only until confirm.
+    #[must_use]
+    pub fn new_for_model_pick_after_validation(
+        active: ApiProvider,
+        target: ApiProvider,
+        config: &Config,
+        runtime_status: Option<ProviderRuntimeStatus>,
+        api_key: String,
+    ) -> Option<Self> {
+        let mut picker = Self::new_with_runtime_status(active, config, runtime_status);
+        let idx = picker.rows.iter().position(|row| row.provider == target)?;
+        picker.selected_idx = idx;
+        picker.view = ProviderListView::Catalog;
+        picker.pending_api_key = Some(api_key);
+        picker.api_key_input.clear();
+        picker.key_entry_error = None;
+        picker.enter_model_pick();
+        Some(picker)
+    }
+
+    fn enter_model_pick(&mut self) {
+        self.stage = Stage::ModelPick;
+        let provider = self.selected_provider();
+        let preferred = self.rows[self.selected_idx]
+            .default_route
+            .logical_model
+            .clone();
+        let mut models = crate::provider_lake::all_catalog_models_for_provider(provider);
+        if models.is_empty() && !preferred.trim().is_empty() {
+            models.push(preferred.clone());
+        }
+        if models.is_empty() {
+            // Last-resort so the guided flow never dead-ends without a choice.
+            models.push(provider.as_str().to_string());
+        }
+        let selected = models
+            .iter()
+            .position(|model| model.eq_ignore_ascii_case(preferred.trim()))
+            .unwrap_or(0);
+        self.model_options = models;
+        self.model_selected_idx = selected.min(self.model_options.len().saturating_sub(1));
+        self.selected_model = self.model_options.get(self.model_selected_idx).cloned();
+    }
+
+    fn enter_confirm(&mut self) {
+        if self.selected_model.is_none() {
+            self.selected_model = self.model_options.get(self.model_selected_idx).cloned();
+        }
+        self.stage = Stage::Confirm;
+    }
+
+    fn move_model_selection(&mut self, delta: isize) {
+        let len = self.model_options.len();
+        if len == 0 {
+            return;
+        }
+        let current = self.model_selected_idx as isize;
+        let next = (current + delta).rem_euclid(len as isize) as usize;
+        self.model_selected_idx = next;
+        self.selected_model = self.model_options.get(next).cloned();
+    }
+
+    fn build_setup_confirmed_event(&self) -> Option<ViewEvent> {
+        let api_key = self.pending_api_key.as_ref()?.trim();
+        if api_key.is_empty() {
+            return None;
+        }
+        let model = self
+            .selected_model
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())?;
+        Some(ViewEvent::ProviderPickerSetupConfirmed {
+            provider: self.selected_provider(),
+            provider_id: self.selected_provider_id(),
+            api_key: api_key.to_string(),
+            model: model.to_string(),
+        })
     }
 
     fn enter_custom_form(&mut self) {
@@ -1789,7 +1895,7 @@ impl ProviderPickerView {
                 inner,
                 buf,
                 &[
-                    ActionHint::new("Enter", "save & switch"),
+                    ActionHint::new("Enter", "continue"),
                     ActionHint::new("Esc", "back"),
                 ],
             )
@@ -1863,6 +1969,164 @@ impl ProviderPickerView {
 
         Paragraph::new(key_lines).render(layout[0], buf);
         Paragraph::new(hint_lines).render(layout[1], buf);
+    }
+
+    fn render_model_pick(&self, area: Rect, buf: &mut Buffer) {
+        let provider_name = self.rows[self.selected_idx].display_name.clone();
+        let outer = Block::default()
+            .title(Line::from(Span::styled(
+                format!(" Default model · {provider_name} "),
+                Style::default()
+                    .fg(palette::WHALE_INFO)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::WHALE_BG));
+        let inner = outer.inner(area);
+        outer.render(area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑↓", "move"),
+                ActionHint::new("Enter", "continue"),
+                ActionHint::new("Esc", "back"),
+            ],
+        );
+
+        let header = Paragraph::new(Line::from(Span::styled(
+            "Key verified. Pick a default model for this provider.",
+            Style::default().fg(palette::TEXT_MUTED),
+        )));
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1)])
+            .split(content);
+        header.render(layout[0], buf);
+
+        let list_area = layout[1];
+        let visible_rows = usize::from(list_area.height);
+        let visible_start = Self::visible_start(
+            self.model_selected_idx,
+            self.model_options.len(),
+            visible_rows,
+        );
+        let mut lines: Vec<Line> = Vec::with_capacity(visible_rows);
+        for (idx, model) in self
+            .model_options
+            .iter()
+            .enumerate()
+            .skip(visible_start)
+            .take(visible_rows)
+        {
+            let is_selected = idx == self.model_selected_idx;
+            let arrow = if is_selected { "▸" } else { " " };
+            let label_style = if is_selected {
+                Self::selected_row_style(palette::TEXT_PRIMARY)
+            } else {
+                Style::default().fg(palette::TEXT_PRIMARY)
+            };
+            let default_tag = self.rows[self.selected_idx]
+                .default_route
+                .logical_model
+                .eq_ignore_ascii_case(model)
+                .then_some("default")
+                .unwrap_or("");
+            let mut line = Line::from(vec![
+                Span::styled(format!(" {arrow} {model}"), label_style),
+                if default_tag.is_empty() {
+                    Span::raw("")
+                } else {
+                    Span::styled(
+                        format!("  ({default_tag})"),
+                        if is_selected {
+                            Self::selected_row_style(palette::TEXT_MUTED)
+                        } else {
+                            Style::default().fg(palette::TEXT_MUTED)
+                        },
+                    )
+                },
+            ]);
+            if is_selected {
+                line.style = Self::selected_row_bg_style();
+            }
+            lines.push(line);
+        }
+        if lines.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No catalog models available.",
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        }
+        Paragraph::new(lines).render(list_area, buf);
+    }
+
+    fn render_confirm(&self, area: Rect, buf: &mut Buffer) {
+        let row = &self.rows[self.selected_idx];
+        let outer = Block::default()
+            .title(Line::from(Span::styled(
+                " Confirm provider setup ",
+                Style::default()
+                    .fg(palette::WHALE_INFO)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::WHALE_BG));
+        let inner = outer.inner(area);
+        outer.render(area, buf);
+
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("Enter", "save & switch"),
+                ActionHint::new("Esc", "back"),
+            ],
+        );
+
+        let masked = self
+            .pending_api_key
+            .as_deref()
+            .map(mask_key)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "(none)".to_string());
+        let model = self
+            .selected_model
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("(none)");
+        let lines = vec![
+            Line::from(Span::styled(
+                "Review before saving. Nothing is written until you confirm.",
+                Style::default().fg(palette::TEXT_MUTED),
+            )),
+            Line::from(vec![
+                Span::styled("Provider: ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::styled(
+                    row.display_name.clone(),
+                    Style::default()
+                        .fg(palette::TEXT_PRIMARY)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("API key:  ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::styled(masked, Style::default().fg(palette::TEXT_PRIMARY)),
+            ]),
+            Line::from(vec![
+                Span::styled("Model:    ", Style::default().fg(palette::TEXT_MUTED)),
+                Span::styled(
+                    model.to_string(),
+                    Style::default()
+                        .fg(palette::TEXT_PRIMARY)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+        ];
+        Paragraph::new(lines).render(content, buf);
     }
 
     fn render_custom_form(&self, area: Rect, buf: &mut Buffer) {
@@ -2011,6 +2275,7 @@ impl ModalView for ProviderPickerView {
                 let sanitized: String = text.chars().filter(|c| !c.is_whitespace()).collect();
                 if !sanitized.is_empty() {
                     self.api_key_input.push_str(&sanitized);
+                    self.key_entry_error = None;
                 }
                 true
             }
@@ -2019,7 +2284,7 @@ impl ModalView for ProviderPickerView {
                 self.custom_form_field_mut().push_str(sanitized.trim());
                 true
             }
-            Stage::List => false,
+            Stage::List | Stage::ModelPick | Stage::Confirm => false,
         }
     }
 
@@ -2134,17 +2399,24 @@ impl ModalView for ProviderPickerView {
                 KeyCode::Esc => {
                     self.stage = Stage::List;
                     self.api_key_input.clear();
+                    self.key_entry_error = None;
+                    self.pending_api_key = None;
+                    self.model_options.clear();
+                    self.model_selected_idx = 0;
+                    self.selected_model = None;
                     ViewAction::None
                 }
                 KeyCode::Backspace => {
                     if self.selected_provider() != ApiProvider::OpenaiCodex {
                         self.api_key_input.pop();
+                        self.key_entry_error = None;
                     }
                     ViewAction::None
                 }
                 KeyCode::Char('h') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     if self.selected_provider() != ApiProvider::OpenaiCodex {
                         self.api_key_input.pop();
+                        self.key_entry_error = None;
                     }
                     ViewAction::None
                 }
@@ -2175,9 +2447,50 @@ impl ModalView for ProviderPickerView {
                     // path that already trims on submit.
                     if !c.is_whitespace() {
                         self.api_key_input.push(c);
+                        self.key_entry_error = None;
                     }
                     ViewAction::None
                 }
+                _ => ViewAction::None,
+            },
+            Stage::ModelPick => match key.code {
+                KeyCode::Esc => {
+                    // Back to key entry with the validated key pre-filled so the
+                    // user can retype without losing progress.
+                    self.stage = Stage::KeyEntry;
+                    if let Some(pending) = self.pending_api_key.clone() {
+                        self.api_key_input = pending;
+                    }
+                    self.key_entry_error = None;
+                    ViewAction::None
+                }
+                KeyCode::Up => {
+                    self.move_model_selection(-1);
+                    ViewAction::None
+                }
+                KeyCode::Down => {
+                    self.move_model_selection(1);
+                    ViewAction::None
+                }
+                KeyCode::Enter => {
+                    if self.model_options.is_empty() {
+                        return ViewAction::None;
+                    }
+                    self.selected_model = self.model_options.get(self.model_selected_idx).cloned();
+                    self.enter_confirm();
+                    ViewAction::None
+                }
+                _ => ViewAction::None,
+            },
+            Stage::Confirm => match key.code {
+                KeyCode::Esc => {
+                    self.stage = Stage::ModelPick;
+                    ViewAction::None
+                }
+                KeyCode::Enter => self
+                    .build_setup_confirmed_event()
+                    .map(ViewAction::EmitAndClose)
+                    .unwrap_or(ViewAction::None),
                 _ => ViewAction::None,
             },
             Stage::CustomForm => match key.code {
@@ -2223,12 +2536,18 @@ impl ModalView for ProviderPickerView {
     }
 
     fn handle_mouse(&mut self, mouse: MouseEvent) -> ViewAction {
-        if self.stage == Stage::List {
-            match mouse.kind {
+        match self.stage {
+            Stage::List => match mouse.kind {
                 MouseEventKind::ScrollUp => self.move_up(),
                 MouseEventKind::ScrollDown => self.move_down(),
                 _ => {}
-            }
+            },
+            Stage::ModelPick => match mouse.kind {
+                MouseEventKind::ScrollUp => self.move_model_selection(-1),
+                MouseEventKind::ScrollDown => self.move_model_selection(1),
+                _ => {}
+            },
+            Stage::KeyEntry | Stage::Confirm | Stage::CustomForm => {}
         }
         ViewAction::None
     }
@@ -2237,6 +2556,8 @@ impl ModalView for ProviderPickerView {
         let preferred_height = match self.stage {
             Stage::List => (self.rows.len() as u16).saturating_add(2),
             Stage::KeyEntry => 10,
+            Stage::ModelPick => 12,
+            Stage::Confirm => 10,
             Stage::CustomForm => 12,
         };
         let popup_area = centered_modal_area(area, 120, preferred_height, 64, 8);
@@ -2246,6 +2567,8 @@ impl ModalView for ProviderPickerView {
         match self.stage {
             Stage::List => self.render_list(popup_area, buf),
             Stage::KeyEntry => self.render_key_entry(popup_area, buf),
+            Stage::ModelPick => self.render_model_pick(popup_area, buf),
+            Stage::Confirm => self.render_confirm(popup_area, buf),
             Stage::CustomForm => self.render_custom_form(popup_area, buf),
         }
     }
@@ -3648,6 +3971,158 @@ mod tests {
         assert_eq!(picker.selected_provider(), ApiProvider::Openrouter);
         let rendered = render_text(&picker, 90, 14);
         assert!(rendered.contains("Verification failed: HTTP 401: unauthorized"));
+    }
+
+    #[test]
+    fn new_for_model_pick_after_validation_opens_model_stage() {
+        let config = Config::default();
+        let picker = ProviderPickerView::new_for_model_pick_after_validation(
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            &config,
+            None,
+            "sk-validated".to_string(),
+        )
+        .expect("OpenRouter has a picker row");
+
+        assert_eq!(picker.stage, Stage::ModelPick);
+        assert_eq!(picker.selected_provider(), ApiProvider::Openrouter);
+        assert_eq!(picker.pending_api_key.as_deref(), Some("sk-validated"));
+        assert!(!picker.model_options.is_empty());
+        assert!(picker.selected_model.is_some());
+    }
+
+    #[test]
+    fn model_pick_enter_advances_to_confirm_and_confirm_emits_setup() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new_for_model_pick_after_validation(
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            &config,
+            None,
+            "sk-validated".to_string(),
+        )
+        .expect("OpenRouter has a picker row");
+
+        assert_eq!(picker.stage, Stage::ModelPick);
+        let action = picker.handle_key(key(KeyCode::Enter));
+        assert!(matches!(action, ViewAction::None));
+        assert_eq!(picker.stage, Stage::Confirm);
+
+        let selected_model = picker
+            .selected_model
+            .clone()
+            .expect("model selected on confirm");
+        let action = picker.handle_key(key(KeyCode::Enter));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ProviderPickerSetupConfirmed {
+                provider,
+                provider_id,
+                api_key,
+                model,
+            }) => {
+                assert_eq!(provider, ApiProvider::Openrouter);
+                assert_eq!(provider_id, None);
+                assert_eq!(api_key, "sk-validated");
+                assert_eq!(model, selected_model);
+            }
+            other => panic!("expected ProviderPickerSetupConfirmed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn model_pick_and_confirm_esc_backs_out_without_emitting() {
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new_for_model_pick_after_validation(
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            &config,
+            None,
+            "sk-validated".to_string(),
+        )
+        .expect("OpenRouter has a picker row");
+
+        picker.handle_key(key(KeyCode::Enter));
+        assert_eq!(picker.stage, Stage::Confirm);
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Esc)),
+            ViewAction::None
+        ));
+        assert_eq!(picker.stage, Stage::ModelPick);
+
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Esc)),
+            ViewAction::None
+        ));
+        assert_eq!(picker.stage, Stage::KeyEntry);
+        assert_eq!(picker.api_key_input, "sk-validated");
+        assert!(picker.pending_api_key.is_some());
+    }
+
+    #[test]
+    fn guided_flow_stages_render_at_80x24_and_120x32() {
+        let config = Config::default();
+        let model_pick = ProviderPickerView::new_for_model_pick_after_validation(
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            &config,
+            None,
+            "sk-validated-key".to_string(),
+        )
+        .expect("OpenRouter has a picker row");
+        let mut confirm = ProviderPickerView::new_for_model_pick_after_validation(
+            ApiProvider::Deepseek,
+            ApiProvider::Openrouter,
+            &config,
+            None,
+            "sk-validated-key".to_string(),
+        )
+        .expect("OpenRouter has a picker row");
+        confirm.handle_key(key(KeyCode::Enter));
+        assert_eq!(confirm.stage, Stage::Confirm);
+
+        for (w, h) in [(80u16, 24u16), (120u16, 32u16)] {
+            let model_text = render_text(&model_pick, w, h);
+            assert!(
+                model_text.contains("Default model") || model_text.contains("default model"),
+                "{w}x{h} model pick missing title:\n{model_text}"
+            );
+            assert!(
+                model_text.contains("continue") || model_text.contains("Enter"),
+                "{w}x{h} model pick missing continue affordance:\n{model_text}"
+            );
+            for (idx, line) in model_text.lines().enumerate() {
+                assert!(
+                    crate::tui::ui_text::text_display_width(line) <= w as usize,
+                    "{w}x{h} model pick line {idx} overflows: {line:?}"
+                );
+            }
+
+            let confirm_text = render_text(&confirm, w, h);
+            assert!(
+                confirm_text.contains("Confirm"),
+                "{w}x{h} confirm missing title:\n{confirm_text}"
+            );
+            assert!(
+                confirm_text.contains("Provider:") || confirm_text.contains("OpenRouter"),
+                "{w}x{h} confirm missing provider summary:\n{confirm_text}"
+            );
+            assert!(
+                confirm_text.contains("Model:") || confirm_text.contains("model"),
+                "{w}x{h} confirm missing model summary:\n{confirm_text}"
+            );
+            // Masked key only — never the raw secret.
+            assert!(
+                !confirm_text.contains("sk-validated-key"),
+                "{w}x{h} confirm leaked raw key:\n{confirm_text}"
+            );
+            for (idx, line) in confirm_text.lines().enumerate() {
+                assert!(
+                    crate::tui::ui_text::text_display_width(line) <= w as usize,
+                    "{w}x{h} confirm line {idx} overflows: {line:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -2028,12 +2028,15 @@ impl ProviderPickerView {
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
-            let default_tag = self.rows[self.selected_idx]
+            let default_tag = if self.rows[self.selected_idx]
                 .default_route
                 .logical_model
                 .eq_ignore_ascii_case(model)
-                .then_some("default")
-                .unwrap_or("");
+            {
+                "default"
+            } else {
+                ""
+            };
             let mut line = Line::from(vec![
                 Span::styled(format!(" {arrow} {model}"), label_style),
                 if default_tag.is_empty() {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -10850,6 +10850,25 @@ async fn handle_view_events(
                 }
                 apply_provider_picker_api_key(app, engine_handle, config, provider, api_key).await;
             }
+            ViewEvent::ProviderPickerSetupConfirmed {
+                provider,
+                provider_id,
+                api_key,
+                model,
+            } => {
+                if let Some(provider_id) = provider_id {
+                    set_active_custom_provider_in_memory(config, &provider_id);
+                }
+                apply_provider_picker_setup_confirmed(
+                    app,
+                    engine_handle,
+                    config,
+                    provider,
+                    api_key,
+                    model,
+                )
+                .await;
+            }
             ViewEvent::ProviderPickerCustomProviderSubmitted {
                 provider_id,
                 base_url,
@@ -11410,9 +11429,8 @@ async fn apply_provider_picker_api_key_with_verifier(
     api_key: String,
     verifier: &dyn ProviderKeyVerifier,
 ) {
-    use crate::config::save_api_key_for;
-
-    // #3875: verify the key against the provider before persisting.
+    // #3875: verify the key against the provider before opening the rest of
+    // the guided flow. Nothing is persisted until the confirm stage.
     // Use the provider's configured base URL (or the default) for the
     // models-endpoint probe so custom endpoints are also verified.
     let base_url = config
@@ -11421,7 +11439,32 @@ async fn apply_provider_picker_api_key_with_verifier(
         .filter(|url| !url.trim().is_empty())
         .unwrap_or_else(|| provider.default_base_url());
     match verifier.verify(provider, &api_key, base_url).await {
-        Ok(()) => { /* key is valid, proceed to persist */ }
+        Ok(()) => {
+            // Key is valid — continue the guided flow at model pick without
+            // writing the secret yet.
+            let runtime_status = query_provider_runtime_status(engine_handle).await;
+            if let Some(picker) =
+                crate::tui::provider_picker::ProviderPickerView::new_for_model_pick_after_validation(
+                    app.api_provider,
+                    provider,
+                    config,
+                    runtime_status,
+                    api_key,
+                )
+            {
+                app.view_stack.push(picker);
+                app.status_message = Some(format!(
+                    "{} API key verified — pick a default model.",
+                    provider.as_str()
+                ));
+            } else {
+                app.status_message = Some(format!(
+                    "{} API key verified, but the guided setup could not be re-opened.",
+                    provider.as_str()
+                ));
+            }
+            app.needs_redraw = true;
+        }
         Err(reason) => {
             // Verification failed - keep the picker open at the key-entry
             // stage with the provider's actual error so the user can fix
@@ -11448,17 +11491,51 @@ async fn apply_provider_picker_api_key_with_verifier(
                 ));
             }
             app.needs_redraw = true;
-            return;
         }
     }
+}
 
+async fn apply_provider_picker_setup_confirmed(
+    app: &mut App,
+    engine_handle: &mut EngineHandle,
+    config: &mut Config,
+    provider: ApiProvider,
+    api_key: String,
+    model: String,
+) {
+    use crate::config::{save_api_key_for, save_provider_model_for};
+
+    let model = model.trim().to_string();
+    if model.is_empty() {
+        app.add_message(HistoryCell::System {
+            content: format!(
+                "Cannot finish {} setup: default model is empty.\nProvider unchanged.",
+                provider.as_str()
+            ),
+        });
+        return;
+    }
+
+    // Persist key first via the existing comment-preserving path, then pin the
+    // chosen default model on the same document when the provider uses a
+    // `[providers.<name>]` table.
     match save_api_key_for(provider, &api_key) {
         Ok(path) => {
-            app.status_message = Some(format!(
-                "Saved {} API key to {}",
-                provider.as_str(),
-                path.display()
-            ));
+            if let Err(err) = save_provider_model_for(provider, &model) {
+                app.add_message(HistoryCell::System {
+                    content: format!(
+                        "Saved {} API key to {}, but failed to pin model `{model}`: {err}",
+                        provider.as_str(),
+                        path.display()
+                    ),
+                });
+            } else {
+                app.status_message = Some(format!(
+                    "Saved {} API key and model to {}",
+                    provider.as_str(),
+                    path.display()
+                ));
+            }
             app.api_key_env_only = false;
         }
         Err(err) => {
@@ -11473,7 +11550,16 @@ async fn apply_provider_picker_api_key_with_verifier(
     }
 
     mirror_saved_api_key_in_config(config, provider, api_key);
-    switch_provider(app, engine_handle, config, provider, None).await;
+    mirror_saved_model_in_config(config, provider, model.clone());
+    switch_provider(app, engine_handle, config, provider, Some(model)).await;
+}
+
+fn mirror_saved_model_in_config(config: &mut Config, provider: ApiProvider, model: String) {
+    if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+        config.default_text_model = Some(model);
+        return;
+    }
+    config.provider_config_for_mut(provider).model = Some(model);
 }
 
 fn mirror_saved_api_key_in_config(config: &mut Config, provider: ApiProvider, api_key: String) {
@@ -12908,7 +12994,7 @@ mod provider_key_validation_tests {
     }
 
     #[tokio::test]
-    async fn provider_key_submit_persists_after_mocked_validation_success() {
+    async fn provider_key_submit_opens_model_pick_without_persisting_on_validation_success() {
         let config_env = ConfigPathEnvGuard::new();
         let mut app = create_test_app();
         let mut engine = mock_engine_handle();
@@ -12933,6 +13019,75 @@ mod provider_key_validation_tests {
                 "https://mock.openrouter.test/v1".to_string()
             )]
         );
+        // Validation success must not persist or switch yet (#3875 residual):
+        // the guided flow continues at model pick first.
+        assert_eq!(app.api_provider, ApiProvider::Deepseek);
+        assert_eq!(config.provider.as_deref(), None);
+        assert_eq!(
+            config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.openrouter.api_key.as_deref()),
+            None
+        );
+        let saved = std::fs::read_to_string(config_env.config_path()).unwrap_or_default();
+        assert!(!saved.contains("sk-verified"));
+        assert_eq!(app.view_stack.top_kind(), Some(ModalKind::ProviderPicker));
+        assert!(
+            app.status_message
+                .as_deref()
+                .is_some_and(|status| status.contains("API key verified")),
+            "status names verification success: {:?}",
+            app.status_message
+        );
+
+        let picker = app.view_stack.pop().expect("provider picker reopened");
+        let area = Rect::new(0, 0, 90, 16);
+        let mut buf = Buffer::empty(area);
+        picker.render(area, &mut buf);
+        let rendered = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            rendered.contains("Default model") || rendered.contains("Pick a default model"),
+            "expected model-pick stage UI, got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_setup_confirm_persists_provider_model_and_preserves_comments() {
+        let config_env = ConfigPathEnvGuard::new();
+        // Seed a commented config so the confirm path must preserve it.
+        std::fs::write(
+            config_env.config_path(),
+            r#"# keep-me-comment
+[providers.openrouter]
+# openrouter-table-comment
+base_url = "https://mock.openrouter.test/v1"
+"#,
+        )
+        .expect("seed config");
+
+        let mut app = create_test_app();
+        let mut engine = mock_engine_handle();
+        let mut config = openrouter_config("https://mock.openrouter.test/v1");
+        let model = "deepseek/deepseek-v4-pro".to_string();
+
+        apply_provider_picker_setup_confirmed(
+            &mut app,
+            &mut engine.handle,
+            &mut config,
+            ApiProvider::Openrouter,
+            "sk-confirmed".to_string(),
+            model.clone(),
+        )
+        .await;
+
         assert_eq!(app.api_provider, ApiProvider::Openrouter);
         assert_eq!(config.provider.as_deref(), Some("openrouter"));
         assert_eq!(
@@ -12940,11 +13095,27 @@ mod provider_key_validation_tests {
                 .providers
                 .as_ref()
                 .and_then(|providers| providers.openrouter.api_key.as_deref()),
-            Some("sk-verified")
+            Some("sk-confirmed")
+        );
+        assert_eq!(
+            config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.openrouter.model.as_deref()),
+            Some(model.as_str())
         );
         let saved = std::fs::read_to_string(config_env.config_path()).expect("saved config");
+        assert!(
+            saved.contains("# keep-me-comment"),
+            "root comment lost:\n{saved}"
+        );
+        assert!(
+            saved.contains("# openrouter-table-comment"),
+            "table comment lost:\n{saved}"
+        );
         assert!(saved.contains("[providers.openrouter]"));
-        assert!(saved.contains("api_key = \"sk-verified\""));
+        assert!(saved.contains("api_key = \"sk-confirmed\""));
+        assert!(saved.contains(&format!("model = \"{model}\"")));
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -598,12 +598,22 @@ pub enum ViewEvent {
         provider_id: Option<String>,
     },
     /// Emitted by the `/provider` picker after the user types an API key
-    /// inline for a provider that lacked one. The handler should persist
-    /// the key via `save_api_key_for` and then perform the provider switch.
+    /// inline for a provider that lacked one. The handler validates the key
+    /// live; on success it reopens the guided flow at the model-pick stage
+    /// without persisting yet (#3875).
     ProviderPickerApiKeySubmitted {
         provider: crate::config::ApiProvider,
         provider_id: Option<String>,
         api_key: String,
+    },
+    /// Emitted by the `/provider` guided setup confirm stage after the user
+    /// accepted provider + model. The handler persists the key (and model)
+    /// via the comment-preserving config path, then performs the switch.
+    ProviderPickerSetupConfirmed {
+        provider: crate::config::ApiProvider,
+        provider_id: Option<String>,
+        api_key: String,
+        model: String,
     },
     /// Emitted by the `/provider` picker after the custom provider form is
     /// completed. The handler persists a named OpenAI-compatible provider


### PR DESCRIPTION
## Summary

Residual of #3875 after key-validation slice #4268.

Adds multi-step guided setup stages on top of live key validation:

1. **Key entry** → validates live (existing #4268 path; no persist on failure)
2. **Model pick** → choose default model from the provider catalog (provider default pre-selected)
3. **Confirm** → summary of provider + masked key + model; only then persists and switches

Persistence uses the existing comment-preserving config path for the API key and pins the chosen model (`[providers.<name>] model` or root `default_text_model` for DeepSeek) before `switch_provider` with the model override.

Does **not** rework key validation itself.

## Testing

- [x] `cargo fmt --all -- --check` (via `cargo fmt --all`)
- [x] `cargo check -p codewhale-tui --locked`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_picker`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked provider_key_`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

Focused coverage:
- ModelPick / Confirm render at 80x24 and 120x32
- Failed validation still does not persist
- Completed confirm flow persists provider + model and preserves config comments
- Stage back-out (Esc) does not emit persist events

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] No bot Co-authored-by; no version bump

Closes #3875