### PR TITLE
fix(workflow): default parallel write children to worktree isolation (#4120)

### DIFF
--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -10,11 +10,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use codewhale_workflow::{
-    AgentType, BranchResult, BranchSpec, BudgetSpec, ControlNodeKind, ControlNodeResult,
-    IsolationMode, LeafResult, LeafSpec, ReduceSpec, SequenceSpec, TaskMode,
-    WorkflowExecution as IrWorkflowExecution, WorkflowMemoUsage, WorkflowNode,
-    WorkflowRunStatus as IrWorkflowRunStatus, WorkflowSpec, WorkflowUsage,
-    compile_javascript_workflow, compile_typescript_workflow,
+    AgentType, BranchResult, BranchSpec, BudgetSpec, ControlNodeKind, ControlNodeResult, LeafResult,
+    LeafSpec, ReduceSpec, SequenceSpec, TaskMode, WorkflowExecution as IrWorkflowExecution,
+    WorkflowMemoUsage, WorkflowNode, WorkflowRunStatus as IrWorkflowRunStatus, WorkflowSpec,
+    WorkflowUsage, compile_javascript_workflow, compile_typescript_workflow, leaf_wants_worktree,
 };
 use codewhale_workflow_js::{
     BudgetSnapshot, DriverError, ProgressEvent, SpawnedTask, TaskCompletion, TaskRequest,
@@ -871,7 +870,7 @@ impl DeclarativeWorkflowLowerer {
 
     fn lower_node(&mut self, node: &WorkflowNode, phase: Option<&str>) -> Result<(), ToolError> {
         match node {
-            WorkflowNode::Leaf(spec) => self.lower_leaf(spec, phase),
+            WorkflowNode::Leaf(spec) => self.lower_leaf(spec, phase, /* parallel */ false),
             WorkflowNode::BranchSet(spec) => self.lower_branch(spec),
             WorkflowNode::Sequence(spec) => self.lower_sequence(spec),
             WorkflowNode::Reduce(spec) => self.lower_reduce(spec),
@@ -882,11 +881,16 @@ impl DeclarativeWorkflowLowerer {
         }
     }
 
-    fn lower_leaf(&mut self, spec: &LeafSpec, phase: Option<&str>) -> Result<(), ToolError> {
+    fn lower_leaf(
+        &mut self,
+        spec: &LeafSpec,
+        phase: Option<&str>,
+        parallel: bool,
+    ) -> Result<(), ToolError> {
         self.line(format!(
             "__results[{}] = await task({});",
             js_string(&spec.id),
-            leaf_task_options_expression(spec, phase)?
+            leaf_task_options_expression(spec, phase, parallel)?
         ));
         Ok(())
     }
@@ -907,9 +911,11 @@ impl DeclarativeWorkflowLowerer {
             let temp = self.next_temp("parallel");
             self.line(format!("const {temp} = await Promise.all(["));
             for leaf in &leaves {
+                // Parallel write-capable children default to worktree isolation
+                // (#4120) unless the plan explicitly sets isolation: shared.
                 self.line(format!(
                     "  task({}),",
-                    leaf_task_options_expression(leaf, Some(&spec.id))?
+                    leaf_task_options_expression(leaf, Some(&spec.id), /* parallel */ true)?
                 ));
             }
             self.line("]);");
@@ -1008,13 +1014,19 @@ fn leaf_description(spec: &LeafSpec) -> String {
     description
 }
 
-fn leaf_task_options_expression(spec: &LeafSpec, phase: Option<&str>) -> Result<String, ToolError> {
+fn leaf_task_options_expression(
+    spec: &LeafSpec,
+    phase: Option<&str>,
+    parallel: bool,
+) -> Result<String, ToolError> {
     validate_leaf_runtime_contract(spec)?;
     Ok(task_options_expression(
         leaf_description_expression(spec),
         leaf_subagent_type(spec)?,
         spec.profile.as_deref(),
-        matches!(spec.isolation, IsolationMode::Worktree),
+        // Parallel write-capable children default to worktree isolation (#4120).
+        // Explicit isolation: shared is the approved same-worktree override.
+        leaf_wants_worktree(spec, parallel),
         spec.budget.max_tokens,
         &spec.id,
         phase,
@@ -2174,6 +2186,7 @@ mod tests {
     use crate::tools::ToolRegistryBuilder;
     use crate::tools::subagent::{SubAgentRuntime, new_shared_subagent_manager};
     use axum::{Json, Router, routing::post};
+    use codewhale_workflow::{IsolationMode, leaf_is_write_capable};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
@@ -2204,6 +2217,223 @@ mod tests {
         assert_eq!(
             parse_workflow_action(&json!({"action": "run"})).unwrap(),
             WorkflowAction::Run
+        );
+    }
+
+    #[test]
+    fn parallel_write_children_default_to_worktree_isolation() {
+        // #4120: write-capable parallel leaves get worktree: true by default.
+        let source = r#"
+export default workflow({
+  "goal": "parallel write isolation default",
+  "nodes": [
+    {
+      "branch": {
+        "id": "implement",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "left",
+              "prompt": "Patch left lane",
+              "agent_type": "implementer",
+              "mode": "read_write",
+              "file_scope": ["src/left.rs"]
+            }
+          },
+          {
+            "agent": {
+              "id": "right",
+              "prompt": "Patch right lane",
+              "agent_type": "implementer",
+              "mode": "read_write",
+              "file_scope": ["src/right.rs"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+});
+"#;
+        let adapted = adapt_workflow_source(source, None).expect("lower parallel write workflow");
+        let spec = adapted.spec.expect("declarative spec");
+        let WorkflowNode::BranchSet(branch) = &spec.nodes[0] else {
+            panic!("expected branch_set");
+        };
+        assert!(branch.parallel);
+        for child in &branch.children {
+            let WorkflowNode::Leaf(leaf) = child else {
+                panic!("expected leaf");
+            };
+            assert!(leaf_is_write_capable(leaf));
+            assert!(
+                leaf_wants_worktree(leaf, true),
+                "parallel write leaf {} should default to worktree",
+                leaf.id
+            );
+            assert_eq!(leaf.isolation, IsolationMode::Auto);
+        }
+        assert!(
+            adapted.source.contains("worktree: true"),
+            "lowered JS should request worktree isolation:\n{}",
+            adapted.source
+        );
+        // Both parallel children should carry the worktree flag.
+        assert_eq!(
+            adapted.source.matches("worktree: true").count(),
+            2,
+            "each parallel write child should get worktree: true:\n{}",
+            adapted.source
+        );
+    }
+
+    #[test]
+    fn parallel_write_same_worktree_requires_explicit_shared_isolation() {
+        // #4120: isolation: shared is the approved same-worktree override.
+        let source = r#"
+export default workflow({
+  "goal": "parallel write same-worktree override",
+  "nodes": [
+    {
+      "branch": {
+        "id": "implement",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "shared-writer",
+              "prompt": "Patch in the parent checkout",
+              "agent_type": "implementer",
+              "mode": "read_write",
+              "isolation": "shared",
+              "file_scope": ["src/shared.rs"]
+            }
+          },
+          {
+            "agent": {
+              "id": "isolated-writer",
+              "prompt": "Patch in a worktree",
+              "agent_type": "implementer",
+              "mode": "read_write",
+              "isolation": "worktree",
+              "file_scope": ["src/isolated.rs"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+});
+"#;
+        let adapted =
+            adapt_workflow_source(source, None).expect("lower same-worktree override workflow");
+        let spec = adapted.spec.expect("declarative spec");
+        let WorkflowNode::BranchSet(branch) = &spec.nodes[0] else {
+            panic!("expected branch_set");
+        };
+        let leaves: Vec<&LeafSpec> = branch
+            .children
+            .iter()
+            .map(|child| match child {
+                WorkflowNode::Leaf(leaf) => leaf,
+                _ => panic!("expected leaf"),
+            })
+            .collect();
+        assert_eq!(leaves[0].isolation, IsolationMode::Shared);
+        assert!(
+            !leaf_wants_worktree(leaves[0], true),
+            "explicit shared should keep same-worktree"
+        );
+        assert_eq!(leaves[1].isolation, IsolationMode::Worktree);
+        assert!(leaf_wants_worktree(leaves[1], true));
+
+        // Only the explicit worktree child should emit worktree: true.
+        assert_eq!(
+            adapted.source.matches("worktree: true").count(),
+            1,
+            "same-worktree override must not force worktree on shared leaf:\n{}",
+            adapted.source
+        );
+        assert!(
+            adapted.source.contains("shared-writer")
+                && adapted.source.contains("isolated-writer"),
+            "both children should still be lowered:\n{}",
+            adapted.source
+        );
+    }
+
+    #[test]
+    fn parallel_read_only_children_do_not_default_to_worktree() {
+        let source = r#"
+export default workflow({
+  "goal": "parallel read-only stays shared",
+  "nodes": [
+    {
+      "branch": {
+        "id": "audit",
+        "parallel": true,
+        "children": [
+          {
+            "agent": {
+              "id": "review-a",
+              "prompt": "Review A",
+              "agent_type": "review",
+              "mode": "read_only"
+            }
+          },
+          {
+            "agent": {
+              "id": "review-b",
+              "prompt": "Review B",
+              "agent_type": "verifier",
+              "mode": "read_only"
+            }
+          }
+        ]
+      }
+    }
+  ]
+});
+"#;
+        let adapted = adapt_workflow_source(source, None).expect("lower parallel read-only");
+        assert!(
+            !adapted.source.contains("worktree: true"),
+            "read-only parallel children should not get worktree isolation:\n{}",
+            adapted.source
+        );
+    }
+
+    #[test]
+    fn sequential_write_children_do_not_default_to_worktree() {
+        let source = r#"
+export default workflow({
+  "goal": "sequential write stays shared by default",
+  "nodes": [
+    {
+      "sequence": {
+        "id": "implement",
+        "children": [
+          {
+            "agent": {
+              "id": "writer",
+              "prompt": "Patch sequentially",
+              "agent_type": "implementer",
+              "mode": "read_write",
+              "file_scope": ["src/main.rs"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+});
+"#;
+        let adapted = adapt_workflow_source(source, None).expect("lower sequential write");
+        assert!(
+            !adapted.source.contains("worktree: true"),
+            "sequential writes should not default to worktree:\n{}",
+            adapted.source
         );
     }
 

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -10,10 +10,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use codewhale_workflow::{
-    AgentType, BranchResult, BranchSpec, BudgetSpec, ControlNodeKind, ControlNodeResult, LeafResult,
-    LeafSpec, ReduceSpec, SequenceSpec, TaskMode, WorkflowExecution as IrWorkflowExecution,
-    WorkflowMemoUsage, WorkflowNode, WorkflowRunStatus as IrWorkflowRunStatus, WorkflowSpec,
-    WorkflowUsage, compile_javascript_workflow, compile_typescript_workflow, leaf_wants_worktree,
+    AgentType, BranchResult, BranchSpec, BudgetSpec, ControlNodeKind, ControlNodeResult,
+    LeafResult, LeafSpec, ReduceSpec, SequenceSpec, TaskMode,
+    WorkflowExecution as IrWorkflowExecution, WorkflowMemoUsage, WorkflowNode,
+    WorkflowRunStatus as IrWorkflowRunStatus, WorkflowSpec, WorkflowUsage,
+    compile_javascript_workflow, compile_typescript_workflow, leaf_wants_worktree,
 };
 use codewhale_workflow_js::{
     BudgetSnapshot, DriverError, ProgressEvent, SpawnedTask, TaskCompletion, TaskRequest,
@@ -2356,8 +2357,7 @@ export default workflow({
             adapted.source
         );
         assert!(
-            adapted.source.contains("shared-writer")
-                && adapted.source.contains("isolated-writer"),
+            adapted.source.contains("shared-writer") && adapted.source.contains("isolated-writer"),
             "both children should still be lowered:\n{}",
             adapted.source
         );

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -471,9 +471,57 @@ pub enum TaskMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum IsolationMode {
+    /// Runtime chooses isolation.
+    ///
+    /// Parallel write-capable children resolve to [`IsolationMode::Worktree`]
+    /// so concurrent writers do not collide in the parent checkout. Explicit
+    /// [`IsolationMode::Shared`] is the plan-level same-worktree override.
     #[default]
+    Auto,
+    /// Share the parent checkout (same-worktree).
     Shared,
+    /// Dedicated git worktree / branch.
     Worktree,
+}
+
+impl IsolationMode {
+    /// Resolve [`IsolationMode::Auto`] for a leaf.
+    ///
+    /// When `parallel_write` is true (leaf is write-capable inside a parallel
+    /// branch), Auto becomes Worktree. Otherwise Auto becomes Shared.
+    #[must_use]
+    pub fn resolve(self, parallel_write: bool) -> Self {
+        match self {
+            Self::Auto if parallel_write => Self::Worktree,
+            Self::Auto => Self::Shared,
+            other => other,
+        }
+    }
+
+    /// Whether the resolved mode provisions a dedicated worktree.
+    #[must_use]
+    pub fn wants_worktree(self, parallel_write: bool) -> bool {
+        matches!(self.resolve(parallel_write), Self::Worktree)
+    }
+}
+
+/// A leaf is write-capable when it can mutate the workspace.
+///
+/// Used by workflow lowering to decide the default isolation for parallel
+/// children (#4120).
+#[must_use]
+pub fn leaf_is_write_capable(spec: &LeafSpec) -> bool {
+    spec.mode == TaskMode::ReadWrite
+        || spec.permissions.allow_write
+        || matches!(spec.agent_type, AgentType::Implementer)
+}
+
+/// Effective worktree flag for a leaf given whether it is being lowered inside
+/// a parallel branch.
+#[must_use]
+pub fn leaf_wants_worktree(spec: &LeafSpec, parallel: bool) -> bool {
+    let parallel_write = parallel && leaf_is_write_capable(spec);
+    spec.isolation.wants_worktree(parallel_write)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2357,6 +2405,65 @@ mod tests {
 
         let parsed: WorkflowConfig = serde_json::from_str(&json).expect("parse workflow");
         assert_eq!(parsed, workflow);
+    }
+
+    #[test]
+    fn isolation_auto_defaults_parallel_write_to_worktree() {
+        assert_eq!(IsolationMode::default(), IsolationMode::Auto);
+        assert_eq!(
+            IsolationMode::Auto.resolve(/* parallel_write */ true),
+            IsolationMode::Worktree
+        );
+        assert_eq!(
+            IsolationMode::Auto.resolve(/* parallel_write */ false),
+            IsolationMode::Shared
+        );
+        // Explicit shared is the approved same-worktree override.
+        assert_eq!(
+            IsolationMode::Shared.resolve(/* parallel_write */ true),
+            IsolationMode::Shared
+        );
+        assert!(IsolationMode::Worktree.wants_worktree(false));
+        assert!(!IsolationMode::Shared.wants_worktree(true));
+    }
+
+    #[test]
+    fn leaf_write_capable_and_worktree_defaults() {
+        let read_only = LeafSpec {
+            id: "ro".to_string(),
+            prompt: "inspect".to_string(),
+            agent_type: AgentType::Explore,
+            profile: None,
+            mode: TaskMode::ReadOnly,
+            isolation: IsolationMode::Auto,
+            file_scope: Vec::new(),
+            depends_on_results: Vec::new(),
+            budget: BudgetSpec::default(),
+            permissions: PermissionSpec::default(),
+            model_policy: ModelPolicy::default(),
+        };
+        assert!(!leaf_is_write_capable(&read_only));
+        assert!(!leaf_wants_worktree(&read_only, true));
+
+        let mut write = read_only.clone();
+        write.id = "rw".to_string();
+        write.mode = TaskMode::ReadWrite;
+        write.agent_type = AgentType::Implementer;
+        assert!(leaf_is_write_capable(&write));
+        // Parallel write-capable + Auto → worktree by default.
+        assert!(leaf_wants_worktree(&write, true));
+        // Sequential write-capable stays shared unless isolation is worktree.
+        assert!(!leaf_wants_worktree(&write, false));
+
+        write.isolation = IsolationMode::Shared;
+        assert!(
+            !leaf_wants_worktree(&write, true),
+            "explicit shared is the same-worktree override"
+        );
+
+        write.isolation = IsolationMode::Worktree;
+        assert!(leaf_wants_worktree(&write, true));
+        assert!(leaf_wants_worktree(&write, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #4120: parallel write-capable workflow children default to worktree isolation unless the plan explicitly opts into same-worktree writes.

### Changes
- **`IsolationMode::Auto`** is now the default. For parallel write-capable leaves, Auto resolves to `Worktree`; otherwise it resolves to `Shared`.
- **Explicit `isolation: "shared"`** is the approved same-worktree override in the plan.
- Declarative lowerer (`Promise.all` path) passes the parallel context into leaf task options so write-capable children emit `worktree: true` by default.
- Helpers: `leaf_is_write_capable`, `leaf_wants_worktree`, `IsolationMode::resolve` / `wants_worktree`.

### Acceptance
- [x] Workflow lowering detects parallel write-capable children.
- [x] Parallel write children get isolated worktrees by default.
- [x] Same-worktree writes require explicit plan approval (`isolation: "shared"`).
- [x] Regression tests cover isolated default and approved same-worktree override.

## Test plan
- [x] `cargo test -p codewhale-workflow --locked`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui tools::workflow::tests`
- [x] `cargo test -p codewhale-workflow-js --locked`
- [x] `cargo clippy -p codewhale-workflow -p codewhale-tui --locked` (warnings denied with project allows)

Closes #4120