### PR TITLE
feat(tui): route workflow events to panel and compact history card (#4122)

### DIFF
--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -185,6 +185,16 @@ pub enum Event {
         message: crate::tools::subagent::MailboxMessage,
     },
 
+    /// Live workflow UI event (#4122). Mirrors a typed `WorkflowUiEvent` JSON
+    /// object so the TUI can advance the WorkflowPanel and the compact history
+    /// card while a run is still in flight (not only on tool complete).
+    WorkflowUi {
+        run_id: String,
+        /// Flattened event JSON: `{"type":"task_started", "at_ms":…, …}`.
+        /// Callers inject `run_id` on the object when available.
+        event: Value,
+    },
+
     // === System Events ===
     /// An error occurred
     Error {

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -26,6 +26,7 @@ use serde_json::{Value, json};
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
+use crate::core::events::Event;
 use crate::tools::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_bool, optional_str, optional_u64,
@@ -487,7 +488,7 @@ async fn start_workflow(
             source.spec.as_ref(),
         );
         record.verify_on_complete = verify_on_complete;
-        record.events.push(WorkflowUiEvent::at(
+        let started = WorkflowUiEvent::at(
             record.started_at_ms,
             WorkflowUiEventKind::RunStarted {
                 workflow_id: record.workflow_id.clone(),
@@ -495,9 +496,23 @@ async fn start_workflow(
                 source_path: record.source_path.clone(),
                 token_budget: record.token_budget,
             },
-        ));
+        );
+        record.events.push(started.clone());
         runs_guard.insert(run_id.clone(), record.clone());
         state.record_snapshot(&record);
+        // #4122: emit RunStarted immediately so the panel + history card open
+        // before the first task/phase (including wait:false fire-and-forget).
+        if let Some(tx) = runtime.event_tx.as_ref() {
+            if let Ok(mut value) = serde_json::to_value(&started) {
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert("run_id".to_string(), json!(run_id));
+                }
+                let _ = tx.try_send(Event::WorkflowUi {
+                    run_id: run_id.clone(),
+                    event: value,
+                });
+            }
+        }
     }
 
     let driver = SubAgentWorkflowDriver::new(
@@ -671,15 +686,17 @@ async fn run_workflow_vm(
         .and_then(|mut guard| {
             let record = guard.get_mut(&run_id)?;
             if record.status != WorkflowRunStatus::Cancelled {
-                record
-                    .events
-                    .push(WorkflowUiEvent::new(budget_event_kind(final_budget)));
-                record
-                    .events
-                    .push(WorkflowUiEvent::new(WorkflowUiEventKind::RunCompleted {
-                        status: record.status,
-                        error: record.error.clone(),
-                    }));
+                let budget_event = WorkflowUiEvent::new(budget_event_kind(final_budget));
+                let completed = WorkflowUiEvent::new(WorkflowUiEventKind::RunCompleted {
+                    status: record.status,
+                    error: record.error.clone(),
+                });
+                record.events.push(budget_event.clone());
+                record.events.push(completed.clone());
+                // Live stream terminal events even when recorded outside the
+                // driver helper (completion path).
+                driver.emit_ui_event(&budget_event);
+                driver.emit_ui_event(&completed);
             }
             Some(record.clone())
         })
@@ -1315,6 +1332,26 @@ impl SubAgentWorkflowDriver {
         if recorded {
             self.state.record_event(&self.run_id, &event);
         }
+        // #4122: stream typed events live into the panel + history card.
+        self.emit_ui_event(&event);
+    }
+
+    /// Publish a flattened WorkflowUiEvent on the engine event bus so the TUI
+    /// can hydrate the panel while the tool is still running.
+    fn emit_ui_event(&self, event: &WorkflowUiEvent) {
+        let Some(tx) = self.runtime.event_tx.as_ref() else {
+            return;
+        };
+        let Ok(mut value) = serde_json::to_value(event) else {
+            return;
+        };
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("run_id".to_string(), json!(self.run_id));
+        }
+        let _ = tx.try_send(Event::WorkflowUi {
+            run_id: self.run_id.clone(),
+            event: value,
+        });
     }
 
     fn record_budget_snapshot(&self, snapshot: BudgetSnapshot) {
@@ -1567,6 +1604,8 @@ impl WorkflowDriver for SubAgentWorkflowDriver {
         }
         self.state.record_progress(&self.run_id, &message);
         self.state.record_event(&self.run_id, &ui_event);
+        // #4122: phase/schema/log progress streams into the live panel path.
+        self.emit_ui_event(&ui_event);
     }
 }
 

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1648,7 +1648,6 @@ impl GenericToolCell {
                 ));
             }
         }
-        }
         Some(wrap_card_rail(lines))
     }
 }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1311,10 +1311,9 @@ impl GenericToolCell {
             return lines;
         }
 
-        // #4038: give the `workflow` tool a purpose-built run card (run_id,
-        // status, goal, children, progress, schema errors) instead of
-        // collapsing to a one-line generic header or dumping raw JSON.
-        if let Some(lines) = self.try_render_as_workflow(width, low_motion) {
+        // #4038 / #4122: purpose-built workflow run card (compact in live,
+        // expanded in transcript) shared with the WorkflowPanel state machine.
+        if let Some(lines) = self.try_render_as_workflow(width, low_motion, mode) {
             return lines;
         }
 
@@ -1518,15 +1517,17 @@ impl GenericToolCell {
         ))
     }
 
-    /// Render the `workflow` tool as a compact run card rather than the
-    /// generic one-line header (live) or a large JSON dump (transcript).
-    /// Fields are parsed defensively from the tool's JSON output, which is
-    /// either a single `WorkflowRunRecord` or a `{action:"status",
-    /// runs:[...]}` list; anything that does not parse falls back to the
-    /// generic renderer. The header owns the lifecycle label (Wave 5c #7);
-    /// the body deliberately carries no `status:` KV. Full live overlay
-    /// (#4038) is future work.
-    fn try_render_as_workflow(&self, width: u16, low_motion: bool) -> Option<Vec<Line<'static>>> {
+    /// Render the `workflow` tool via the shared WorkflowPanel history-card
+    /// renderer (#4122). Live mode stays compact (lifecycle, children, phases,
+    /// failures, elapsed); transcript mode expands phase/child summaries,
+    /// artifact/transcript links, final result, and failure details.
+    /// Status-list payloads keep a multi-run summary card.
+    fn try_render_as_workflow(
+        &self,
+        width: u16,
+        low_motion: bool,
+        mode: RenderMode,
+    ) -> Option<Vec<Line<'static>>> {
         if self.name != "workflow" {
             return None;
         }
@@ -1585,121 +1586,68 @@ impl GenericToolCell {
             return Some(wrap_card_rail(lines));
         }
 
-        let run_id = value
-            .get("run_id")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("workflow");
+        use crate::tui::widgets::workflow_panel::{WorkflowHistoryExtras, WorkflowPanel};
+        let panel = WorkflowPanel::from_run_json(&value)?;
+        // Prefer the panel's lifecycle-aware status label when the tool cell
+        // is still marked running but the snapshot already terminal (or vice
+        // versa during live streaming).
+        let header_status = match panel.lifecycle {
+            crate::tui::widgets::workflow_panel::WorkflowPanelLifecycle::Failed
+            | crate::tui::widgets::workflow_panel::WorkflowPanelLifecycle::Cancelled => {
+                ToolStatus::Failed
+            }
+            crate::tui::widgets::workflow_panel::WorkflowPanelLifecycle::Succeeded => {
+                ToolStatus::Success
+            }
+            crate::tui::widgets::workflow_panel::WorkflowPanelLifecycle::Pending
+            | crate::tui::widgets::workflow_panel::WorkflowPanelLifecycle::Running => {
+                if self.status == ToolStatus::Failed {
+                    ToolStatus::Failed
+                } else if self.status == ToolStatus::Success {
+                    ToolStatus::Success
+                } else {
+                    ToolStatus::Running
+                }
+            }
+        };
+        let summary = panel.history_header_summary(usize::from(width).saturating_sub(18));
         lines.push(render_tool_header_with_family_and_summary(
             family,
-            Some(run_id),
-            tool_status_label(self.status),
-            self.status,
+            Some(summary.as_str()),
+            tool_status_label(header_status),
+            header_status,
             None,
             low_motion,
         ));
-        if let Some(goal) = value
-            .get("workflow_goal")
-            .and_then(serde_json::Value::as_str)
-            && !goal.trim().is_empty()
-        {
-            lines.extend(render_card_detail_line(
-                Some("goal"),
-                &truncate_text(goal.trim(), 200),
-                tool_value_style(),
-                width,
-            ));
-        }
-        let child_count = value
-            .get("child_ids")
-            .and_then(serde_json::Value::as_array)
-            .map(|a| a.len())
-            .unwrap_or(0);
-        lines.extend(render_compact_kv(
-            "children",
-            &child_count.to_string(),
-            tool_value_style(),
-            width,
-        ));
-        // Prefer typed task_started metadata (workflow_task_label / label) over
-        // free-form progress strings so the card never re-parses prompts (#4119).
-        if let Some(events) = value.get("events").and_then(serde_json::Value::as_array) {
-            let mut child_labels: Vec<String> = Vec::new();
-            for event in events {
-                if event.get("type").and_then(serde_json::Value::as_str) != Some("task_started") {
-                    continue;
-                }
-                let label = event
-                    .get("workflow_task_label")
+        let expanded = matches!(mode, RenderMode::Transcript);
+        if expanded {
+            let extras = WorkflowHistoryExtras {
+                result_summary: panel.result_summary.clone(),
+                source_path: panel.source_path.clone().or_else(|| {
+                    value
+                        .get("source_path")
+                        .and_then(serde_json::Value::as_str)
+                        .map(std::path::PathBuf::from)
+                }),
+                spillover_path: self.spillover_path.clone(),
+                verification_summary: value
+                    .get("verification")
+                    .and_then(|v| v.get("summary"))
                     .and_then(serde_json::Value::as_str)
-                    .or_else(|| event.get("label").and_then(serde_json::Value::as_str))
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty());
-                if let Some(label) = label {
-                    child_labels.push(label.to_string());
-                }
-            }
-            if !child_labels.is_empty() {
-                let summary = if child_labels.len() <= 3 {
-                    child_labels.join(", ")
-                } else {
-                    format!(
-                        "{}, +{} more",
-                        child_labels[..3].join(", "),
-                        child_labels.len() - 3
-                    )
-                };
+                    .map(str::to_string),
+            };
+            for detail in panel.history_expanded_lines(width, &extras) {
+                // history_expanded_lines omit the leading indent; re-use the
+                // card detail path so rails and spacing stay consistent.
+                let text: String = detail.spans.iter().map(|s| s.content.as_ref()).collect();
                 lines.extend(render_card_detail_line(
-                    Some("tasks"),
-                    &truncate_text(&summary, 200),
+                    None,
+                    &text,
                     tool_value_style(),
                     width,
                 ));
             }
         }
-        if let Some(progress) = value.get("progress").and_then(serde_json::Value::as_array)
-            && let Some(last) = progress.last().and_then(serde_json::Value::as_str)
-        {
-            lines.extend(render_card_detail_line(
-                Some("progress"),
-                &format!("{} ({} events)", truncate_text(last, 160), progress.len()),
-                tool_value_style(),
-                width,
-            ));
-        }
-        if let Some(verification) = value.get("verification")
-            && let Some(summary) = verification
-                .get("summary")
-                .and_then(serde_json::Value::as_str)
-        {
-            lines.extend(render_card_detail_line(
-                Some("verification"),
-                &truncate_text(summary, 200),
-                tool_value_style(),
-                width,
-            ));
-        }
-        let schema_error_count = value
-            .get("schema_errors")
-            .and_then(serde_json::Value::as_array)
-            .map(|a| a.len())
-            .unwrap_or(0);
-        if schema_error_count > 0 {
-            lines.extend(render_card_detail_line(
-                Some("schema errors"),
-                &schema_error_count.to_string(),
-                tool_value_style(),
-                width,
-            ));
-        }
-        if let Some(error) = value.get("error").and_then(serde_json::Value::as_str)
-            && !error.trim().is_empty()
-        {
-            lines.extend(render_card_detail_line(
-                Some("error"),
-                &truncate_text(error.trim(), 200),
-                tool_value_style(),
-                width,
-            ));
         }
         Some(wrap_card_rail(lines))
     }

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -212,8 +212,14 @@ fn workflow_tool_expanded_card_shows_phase_child_result_and_failures() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(joined.contains("ship v0.8.68"), "goal: {joined}");
-    assert!(joined.contains("phases:") || joined.contains("Verify"), "phase: {joined}");
-    assert!(joined.contains("children:") || joined.contains("child"), "child: {joined}");
+    assert!(
+        joined.contains("phases:") || joined.contains("Verify"),
+        "phase: {joined}"
+    );
+    assert!(
+        joined.contains("children:") || joined.contains("child"),
+        "child: {joined}"
+    );
     assert!(joined.contains("run tests"), "child label: {joined}");
     assert!(
         joined.contains("result:") || joined.contains("2 of 3"),

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -132,26 +132,102 @@ fn workflow_tool_renders_run_card_instead_of_generic_oneliner() {
         .iter()
         .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
         .collect();
-    assert!(joined.contains("workflow_2400c600"), "run_id: {joined:?}");
-    // Copy dedupe (Wave 5c #7): the header owns the lifecycle label; the body
-    // no longer repeats it as a `status:` KV row.
-    assert!(joined.contains("done"), "header lifecycle: {joined:?}");
+    // Compact (#4122): lifecycle, children, phases, failures, elapsed.
+    assert!(
+        joined.contains("3 children") || joined.contains("children"),
+        "child count: {joined:?}"
+    );
+    assert!(
+        joined.contains("success") || joined.contains("done"),
+        "header lifecycle: {joined:?}"
+    );
+    assert!(joined.contains("phase"), "phase count: {joined:?}");
+    assert!(joined.contains("fail"), "failure count present: {joined:?}");
+    assert!(
+        joined.contains('s') || joined.contains('m'),
+        "elapsed: {joined:?}"
+    );
     assert!(
         !joined.contains("status:"),
         "body must not repeat the header lifecycle: {joined:?}"
     );
-    assert!(joined.contains("audit the FLEET"), "goal: {joined:?}");
-    assert!(joined.contains("children: 3"), "child count: {joined:?}");
-    // #4119: history card uses typed task labels, not prompt text.
+}
+
+#[test]
+fn workflow_tool_expanded_card_shows_phase_child_result_and_failures() {
+    let output = serde_json::json!({
+        "run_id": "workflow_exp",
+        "status": "failed",
+        "workflow_goal": "ship v0.8.68",
+        "started_at_ms": 1000,
+        "completed_at_ms": 5000,
+        "source_path": "workflows/demo.workflow.js",
+        "error": "phase Verify failed",
+        "result": {"summary": "2 of 3 children ok"},
+        "events": [
+            {
+                "type": "run_started",
+                "at_ms": 1000,
+                "run_id": "workflow_exp",
+                "workflow_goal": "ship v0.8.68"
+            },
+            {"type": "phase_started", "at_ms": 1100, "title": "Verify"},
+            {
+                "type": "task_started",
+                "at_ms": 1200,
+                "task_id": "t1",
+                "label": "run tests",
+                "workflow_task_label": "run tests",
+                "profile": "implementer"
+            },
+            {
+                "type": "task_completed",
+                "at_ms": 4000,
+                "task_id": "t1",
+                "status": "failed"
+            },
+            {
+                "type": "run_completed",
+                "at_ms": 5000,
+                "status": "failed",
+                "error": "phase Verify failed"
+            }
+        ]
+    })
+    .to_string();
+    let cell = GenericToolCell {
+        name: "workflow".to_string(),
+        status: ToolStatus::Failed,
+        input_summary: Some("action: run".to_string()),
+        output: Some(output),
+        prompts: None,
+        spillover_path: Some(std::path::PathBuf::from("/tmp/wf-artifact.json")),
+        output_summary: None,
+        is_diff: false,
+    };
+    let joined: String = cell
+        .lines_with_mode(140, true, super::RenderMode::Transcript)
+        .iter()
+        .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(joined.contains("ship v0.8.68"), "goal: {joined}");
+    assert!(joined.contains("phases:") || joined.contains("Verify"), "phase: {joined}");
+    assert!(joined.contains("children:") || joined.contains("child"), "child: {joined}");
+    assert!(joined.contains("run tests"), "child label: {joined}");
     assert!(
-        joined.contains("scan-docs")
-            && joined.contains("check-fleet")
-            && joined.contains("summarize"),
-        "typed task labels: {joined:?}"
+        joined.contains("result:") || joined.contains("2 of 3"),
+        "final result: {joined}"
     );
     assert!(
-        joined.contains("log: 3 findings"),
-        "last progress: {joined:?}"
+        joined.contains("artifact:")
+            || joined.contains("source:")
+            || joined.contains("transcript:"),
+        "links: {joined}"
+    );
+    assert!(
+        joined.contains("error:") || joined.contains("phase Verify failed"),
+        "failure details: {joined}"
     );
 }
 

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -1001,16 +1001,11 @@ fn sync_workflow_history_card_from_panel(app: &mut App) {
                     return;
                 }
                 // Prefer full event-bearing records when the tool has completed.
-                if generic.status != ToolStatus::Running
-                    && value
+                generic.status == ToolStatus::Running
+                    || !value
                         .get("events")
                         .and_then(|e| e.as_array())
                         .is_some_and(|e| !e.is_empty())
-                {
-                    false
-                } else {
-                    true
-                }
             }
         };
         if replace {

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -1001,11 +1001,14 @@ fn sync_workflow_history_card_from_panel(app: &mut App) {
                     return;
                 }
                 // Prefer full event-bearing records when the tool has completed.
-                generic.status == ToolStatus::Running
-                    || !value
+                if generic.status == ToolStatus::Running {
+                    true
+                } else {
+                    value
                         .get("events")
                         .and_then(|e| e.as_array())
-                        .is_some_and(|e| !e.is_empty())
+                        .map_or(true, |e| e.is_empty())
+                }
             }
         };
         if replace {

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -721,9 +721,9 @@ pub(super) fn handle_tool_call_complete(
         }
     }
 
-    // #4121: feed typed workflow events into the panel so progress lives
-    // above the composer instead of flooding the chat transcript. Full
-    // routing + compact history-card convergence is #4122.
+    // #4121 / #4122: feed typed workflow events into the panel *and* keep the
+    // history card snapshot in sync. Live streaming also arrives via
+    // `Event::WorkflowUi`; this path covers tool-complete hydration.
     if let Some(output) = workflow_panel_output.as_deref() {
         apply_workflow_output_to_panel(app, output);
     }
@@ -781,7 +781,8 @@ pub(super) fn handle_tool_call_complete(
 /// Hydrate or advance the WorkflowPanel from a workflow tool JSON payload.
 /// Accepts a single run record (with optional `events` array) or a status
 /// list. Log-only events are filtered by the panel itself so the transcript
-/// stays free of progress spam (#4121).
+/// stays free of progress spam (#4121). Also keeps the matching history card
+/// snapshot aligned (#4122).
 fn apply_workflow_output_to_panel(app: &mut App, output: &str) {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(output) else {
         return;
@@ -811,19 +812,53 @@ fn apply_workflow_output_to_panel(app: &mut App, output: &str) {
             ));
         }
         if let Some(panel) = app.workflow_panel.as_mut() {
-            panel.apply_json_events(events);
+            let run_id = value
+                .get("run_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&panel.run_id)
+                .to_string();
+            let mut injected = Vec::with_capacity(events.len());
+            for event in events {
+                let mut event = event.clone();
+                if let Some(obj) = event.as_object_mut() {
+                    obj.entry("run_id".to_string())
+                        .or_insert_with(|| serde_json::Value::String(run_id.clone()));
+                }
+                injected.push(event);
+            }
+            panel.apply_json_events(&injected);
+            // Carry final result / source into panel for expanded history card.
+            if let Some(summary) = value
+                .get("result")
+                .map(|v| v.to_string())
+                .filter(|s| s != "null")
+            {
+                panel.result_summary = Some(summary);
+            }
+            if let Some(path) = value.get("source_path").and_then(|v| v.as_str()) {
+                panel.source_path = Some(PathBuf::from(path));
+            }
             app.needs_redraw = true;
         }
+        sync_workflow_history_card_from_panel(app);
         return;
     }
 
     // Fallback: status list — show the most recent run as a shell panel.
     if value.get("action").and_then(|v| v.as_str()) == Some("status") {
-        if let Some(runs) = value.get("runs").and_then(|r| r.as_array()) {
-            if let Some(run) = runs.last() {
-                apply_workflow_output_to_panel(app, &run.to_string());
-            }
+        if let Some(runs) = value.get("runs").and_then(|r| r.as_array())
+            && let Some(run) = runs.last()
+        {
+            apply_workflow_output_to_panel(app, &run.to_string());
         }
+        return;
+    }
+
+    // Prefer full panel hydration from summary/phases snapshot when present.
+    if let Some(panel) = crate::tui::widgets::workflow_panel::WorkflowPanel::from_run_json(&value) {
+        app.workflow_panel = Some(panel);
+        app.needs_redraw = true;
+        sync_workflow_history_card_from_panel(app);
         return;
     }
 
@@ -851,7 +886,10 @@ fn apply_workflow_output_to_panel(app: &mut App, output: &str) {
                 .and_then(|v| v.as_str())
                 .map(str::to_string),
             workflow_goal: Some(label),
-            source_path: None,
+            source_path: value
+                .get("source_path")
+                .and_then(|v| v.as_str())
+                .map(PathBuf::from),
             token_budget: value.get("token_budget").and_then(|v| v.as_u64()),
             at_ms,
         });
@@ -875,6 +913,110 @@ fn apply_workflow_output_to_panel(app: &mut App, output: &str) {
                         .unwrap_or(at_ms),
                 });
             }
+        }
+        sync_workflow_history_card_from_panel(app);
+    }
+}
+
+/// Apply one live `WorkflowUi` engine event to the panel and history card.
+pub(super) fn apply_workflow_ui_event(app: &mut App, run_id: &str, event: &serde_json::Value) {
+    use crate::tui::widgets::workflow_panel::WorkflowPanelEvent;
+
+    let mut event = event.clone();
+    if let Some(obj) = event.as_object_mut() {
+        obj.entry("run_id".to_string())
+            .or_insert_with(|| serde_json::Value::String(run_id.to_string()));
+    }
+    if let Some(panel_event) = WorkflowPanelEvent::from_json_value(&event) {
+        app.apply_workflow_panel_event(panel_event);
+    }
+    sync_workflow_history_card_from_panel(app);
+}
+
+/// Mirror the live WorkflowPanel snapshot into the in-flight (or most recent)
+/// workflow history tool cell so compact/expanded cards stay current.
+fn sync_workflow_history_card_from_panel(app: &mut App) {
+    let Some(panel) = app.workflow_panel.as_ref() else {
+        return;
+    };
+    let run_id = panel.run_id.clone();
+    let snapshot = panel.to_run_json().to_string();
+
+    // Prefer an in-flight Generic(workflow) cell whose output already carries
+    // this run_id, else the newest running workflow cell, else any workflow
+    // cell (tool-complete path already wrote the final output).
+    let mut target: Option<usize> = None;
+    let history_len = app.history.len();
+    let total = history_len
+        + app
+            .active_cell
+            .as_ref()
+            .map(|a| a.entries().len())
+            .unwrap_or(0);
+
+    for idx in (0..total).rev() {
+        let Some(cell) = app.cell_at_virtual_index(idx) else {
+            continue;
+        };
+        let HistoryCell::Tool(ToolCell::Generic(generic)) = cell else {
+            continue;
+        };
+        if generic.name != "workflow" {
+            continue;
+        }
+        let matches_run = generic
+            .output
+            .as_deref()
+            .and_then(|out| serde_json::from_str::<serde_json::Value>(out).ok())
+            .and_then(|v| {
+                v.get("run_id")
+                    .and_then(|id| id.as_str())
+                    .map(|id| id == run_id)
+            })
+            .unwrap_or(false);
+        let is_running = generic.status == ToolStatus::Running;
+        if matches_run || (is_running && target.is_none()) {
+            target = Some(idx);
+            if matches_run {
+                break;
+            }
+        }
+    }
+
+    let Some(idx) = target else {
+        return;
+    };
+    if let Some(HistoryCell::Tool(ToolCell::Generic(generic))) = app.cell_at_virtual_index_mut(idx)
+    {
+        // Preserve a richer final output if the tool completion already wrote
+        // a full run record with an events array longer than the snapshot.
+        let replace = match generic.output.as_deref() {
+            None => true,
+            Some(existing) => {
+                let Ok(value) = serde_json::from_str::<serde_json::Value>(existing) else {
+                    return;
+                };
+                let existing_run = value.get("run_id").and_then(|v| v.as_str()).unwrap_or("");
+                if !existing_run.is_empty() && existing_run != run_id {
+                    return;
+                }
+                // Prefer full event-bearing records when the tool has completed.
+                if generic.status != ToolStatus::Running
+                    && value
+                        .get("events")
+                        .and_then(|e| e.as_array())
+                        .is_some_and(|e| !e.is_empty())
+                {
+                    false
+                } else {
+                    true
+                }
+            }
+        };
+        if replace {
+            generic.output = Some(snapshot);
+            generic.output_summary = Some(format!("workflow {}", run_id));
+            app.mark_history_updated();
         }
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -118,7 +118,8 @@ use crate::tui::subagent_routing::{
 #[cfg(test)]
 use crate::tui::tool_routing::exploring_label;
 use crate::tui::tool_routing::{
-    handle_tool_call_complete, handle_tool_call_started, maybe_add_patch_preview,
+    apply_workflow_ui_event, handle_tool_call_complete, handle_tool_call_started,
+    maybe_add_patch_preview,
 };
 use crate::tui::ui_text::{history_cell_to_text, text_display_width};
 use crate::tui::user_input::UserInputView;
@@ -3278,6 +3279,11 @@ async fn run_event_loop(
                             // AgentProgress redraw throttle.
                             received_engine_event = redraw_requested_before_event;
                         }
+                    }
+                    EngineEvent::WorkflowUi { run_id, event } => {
+                        // #4122: live typed workflow events → panel + history card.
+                        apply_workflow_ui_event(app, &run_id, &event);
+                        transcript_batch_updated = true;
                     }
                     EngineEvent::ApprovalRequired {
                         id,

--- a/crates/tui/src/tui/widgets/agent_card.rs
+++ b/crates/tui/src/tui/widgets/agent_card.rs
@@ -97,6 +97,39 @@ impl DelegateCard {
         }
     }
 
+    /// Project this direct sub-agent card onto the shared workflow history
+    /// renderer (#4122) so collapsed/expanded concepts stay aligned.
+    #[must_use]
+    #[allow(dead_code)] // public #4122 convergence API; covered by unit tests
+    pub fn as_workflow_history_panel(
+        &self,
+        started_at_ms: u64,
+        completed_at_ms: Option<u64>,
+    ) -> crate::tui::widgets::workflow_panel::WorkflowPanel {
+        use crate::tui::widgets::workflow_panel::{WorkflowPanel, WorkflowPanelLifecycle};
+        let lifecycle = match self.status {
+            AgentLifecycle::Pending => WorkflowPanelLifecycle::Pending,
+            AgentLifecycle::Running => WorkflowPanelLifecycle::Running,
+            AgentLifecycle::Completed => WorkflowPanelLifecycle::Succeeded,
+            AgentLifecycle::Failed => WorkflowPanelLifecycle::Failed,
+            AgentLifecycle::Cancelled => WorkflowPanelLifecycle::Cancelled,
+            AgentLifecycle::Interrupted => WorkflowPanelLifecycle::Failed,
+        };
+        WorkflowPanel::from_direct_subagent(
+            self.agent_id.clone(),
+            readable_agent_role(&self.agent_type),
+            lifecycle,
+            started_at_ms,
+            completed_at_ms,
+            self.summary.clone(),
+            if matches!(self.status, AgentLifecycle::Failed) {
+                self.summary.clone()
+            } else {
+                None
+            },
+        )
+    }
+
     pub fn push_action(&mut self, action: impl Into<String>) {
         self.actions.push(action.into());
         if self.actions.len() > DELEGATE_MAX_ACTIONS {
@@ -933,5 +966,36 @@ mod tests {
             !rendered.iter().any(|line| line.contains('·')),
             "counts line should be dropped: {rendered:?}"
         );
+    }
+
+    #[test]
+    fn direct_subagent_projects_onto_shared_workflow_history_card() {
+        use crate::tui::widgets::workflow_panel::WorkflowHistoryExtras;
+
+        let mut card = DelegateCard::new("agent_xyz", "explore");
+        card.status = AgentLifecycle::Completed;
+        card.summary = Some("mapped 4 call sites".to_string());
+        let panel = card.as_workflow_history_panel(1_000, Some(5_000));
+        let compact = panel.render_history_card(100, false, &WorkflowHistoryExtras::default());
+        let joined = render_to_strings(&compact).join("\n");
+        assert!(
+            joined.contains("success") || joined.contains("explore"),
+            "shared compact lifecycle: {joined}"
+        );
+        assert!(
+            joined.contains("1 child") || joined.contains("children"),
+            "shared child count: {joined}"
+        );
+        let expanded = panel.render_history_card(
+            100,
+            true,
+            &WorkflowHistoryExtras {
+                result_summary: Some("mapped 4 call sites".to_string()),
+                ..WorkflowHistoryExtras::default()
+            },
+        );
+        let joined = render_to_strings(&expanded).join("\n");
+        assert!(joined.contains("result:"), "{joined}");
+        assert!(joined.contains("mapped 4 call sites"), "{joined}");
     }
 }

--- a/crates/tui/src/tui/widgets/tool_card.rs
+++ b/crates/tui/src/tui/widgets/tool_card.rs
@@ -97,6 +97,10 @@ pub fn tool_family_for_name(name: &str) -> ToolFamily {
         | "task_gate_run"
         | "validate_data"
         | "wait_for_dev_server" => ToolFamily::Verify,
+        // Workflow runs are multi-child activity; reuse fanout glyph so the
+        // compact history card (#4122) shares visual vocabulary with direct
+        // multi-agent cards rather than the neutral generic bullet.
+        "workflow" => ToolFamily::Fanout,
         _ => ToolFamily::Generic,
     }
 }

--- a/crates/tui/src/tui/widgets/workflow_panel.rs
+++ b/crates/tui/src/tui/widgets/workflow_panel.rs
@@ -1834,7 +1834,8 @@ mod tests {
         assert_eq!(row.label, "typed-label");
     }
 
-        fn compact_history_card_summarizes_lifecycle_children_phases_failures_elapsed() {
+    #[test]
+    fn compact_history_card_summarizes_lifecycle_children_phases_failures_elapsed() {
         let mut panel = started_panel();
         panel.apply_event(WorkflowPanelEvent::TaskCompleted {
             task_id: "t1".to_string(),

--- a/crates/tui/src/tui/widgets/workflow_panel.rs
+++ b/crates/tui/src/tui/widgets/workflow_panel.rs
@@ -2,8 +2,13 @@
 //!
 //! Issue #4121 (CODEWHALE_0_8_68 §2.4). Progress lives here instead of flooding
 //! the chat transcript: a collapsible header above the composer plus an
-//! expanded phase/row body. Events are applied through [`WorkflowPanelEvent`];
-//! routing from the tool event stream lands in #4122.
+//! expanded phase/row body. Events are applied through [`WorkflowPanelEvent`].
+//!
+//! Issue #4122 routes the same event stream into a compact history card that
+//! reuses this state machine: collapsed summarizes lifecycle/children/phases/
+//! failures/elapsed; expanded adds phase/child summaries, artifact links,
+//! final result, and failure details. Direct sub-agent cards share helpers
+//! from this module where practical.
 
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -13,7 +18,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
-use serde_json::Value;
+use serde_json::{Value, json};
 use unicode_width::UnicodeWidthStr;
 
 use crate::palette;
@@ -340,9 +345,25 @@ pub struct WorkflowPanel {
     pub completed_at_ms: Option<u64>,
     pub error: Option<String>,
     pub cancel_requested: bool,
+    /// Optional final result / verification summary for the history card.
+    pub result_summary: Option<String>,
+    /// Source script path or other durable artifact pointer.
+    pub source_path: Option<PathBuf>,
+    /// Spillover / full-output path when the tool result was large.
+    pub spillover_path: Option<PathBuf>,
     /// Set when the operator requested cancel from the panel (mouse/key).
     /// Consumed by the host to drive `/workflow cancel`.
     cancel_emit: Option<String>,
+}
+
+/// Extra fields the history card can show that are not part of the live panel
+/// progress surface (artifact links, final result text).
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowHistoryExtras {
+    pub result_summary: Option<String>,
+    pub source_path: Option<PathBuf>,
+    pub spillover_path: Option<PathBuf>,
+    pub verification_summary: Option<String>,
 }
 
 impl WorkflowPanel {
@@ -363,8 +384,525 @@ impl WorkflowPanel {
             completed_at_ms: None,
             error: None,
             cancel_requested: false,
+            result_summary: None,
+            source_path: None,
+            spillover_path: None,
             cancel_emit: None,
         }
+    }
+
+    /// Hydrate panel state from a workflow tool JSON payload (run record or a
+    /// snapshot produced by [`Self::to_run_json`]). Prefers the typed `events`
+    /// array when present; falls back to summary + phase fields.
+    #[must_use]
+    pub fn from_run_json(value: &Value) -> Option<Self> {
+        if value.get("action").and_then(Value::as_str) == Some("status") {
+            return None;
+        }
+        let run_id = value
+            .get("run_id")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())?
+            .to_string();
+        let label = value
+            .get("workflow_goal")
+            .and_then(Value::as_str)
+            .or_else(|| value.get("workflow_id").and_then(Value::as_str))
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or(&run_id)
+            .to_string();
+        let at_ms = value
+            .get("started_at_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let mut panel = Self::new(run_id.clone(), label.clone(), at_ms);
+
+        if let Some(events) = value.get("events").and_then(Value::as_array) {
+            for event in events {
+                let mut event = event.clone();
+                if let Some(obj) = event.as_object_mut() {
+                    obj.entry("run_id".to_string())
+                        .or_insert_with(|| Value::String(run_id.clone()));
+                }
+                panel.apply_json_event(&event);
+            }
+        } else if let Some(phases) = value.get("phases").and_then(Value::as_array) {
+            for phase_val in phases {
+                let title = phase_val
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Work");
+                panel.phases.push(WorkflowPanelPhase::new(title));
+                let phase_idx = panel.phases.len() - 1;
+                if let Some(rows) = phase_val.get("rows").and_then(Value::as_array) {
+                    for row in rows {
+                        let task_id = row
+                            .get("task_id")
+                            .and_then(Value::as_str)
+                            .unwrap_or("task")
+                            .to_string();
+                        let status = row
+                            .get("status")
+                            .and_then(Value::as_str)
+                            .map(WorkflowRowStatus::from_ir_status)
+                            .unwrap_or(WorkflowRowStatus::Pending);
+                        panel.phases[phase_idx].rows.push(WorkflowPanelRow {
+                            task_id: task_id.clone(),
+                            label: row
+                                .get("label")
+                                .and_then(Value::as_str)
+                                .unwrap_or(&task_id)
+                                .to_string(),
+                            profile: opt_str(row, "profile"),
+                            model: opt_str(row, "model"),
+                            strength: opt_str(row, "strength"),
+                            worktree: row
+                                .get("worktree")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false),
+                            workspace: opt_str(row, "workspace").map(PathBuf::from),
+                            status,
+                            started_at_ms: row
+                                .get("started_at_ms")
+                                .and_then(Value::as_u64)
+                                .unwrap_or(at_ms),
+                            completed_at_ms: row.get("completed_at_ms").and_then(Value::as_u64),
+                            error: opt_str(row, "error"),
+                            schema_error: opt_str(row, "schema_error"),
+                        });
+                    }
+                }
+            }
+            if !panel.phases.is_empty() {
+                panel.selected_phase = panel.phases.len() - 1;
+            }
+        } else if let Some(child_count) =
+            value
+                .get("child_count")
+                .and_then(Value::as_u64)
+                .or_else(|| {
+                    value
+                        .get("child_ids")
+                        .and_then(Value::as_array)
+                        .map(|a| a.len() as u64)
+                })
+        {
+            // Bare summary without events: synthesize a Work phase so child
+            // count still surfaces on the history card.
+            if child_count > 0 {
+                let mut phase = WorkflowPanelPhase::new("Work");
+                for i in 0..child_count {
+                    let id = value
+                        .get("child_ids")
+                        .and_then(Value::as_array)
+                        .and_then(|ids| ids.get(i as usize))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .unwrap_or_else(|| format!("child-{i}"));
+                    phase.rows.push(WorkflowPanelRow {
+                        task_id: id.clone(),
+                        label: id,
+                        profile: None,
+                        model: None,
+                        strength: None,
+                        worktree: false,
+                        workspace: None,
+                        status: WorkflowRowStatus::Succeeded,
+                        started_at_ms: at_ms,
+                        completed_at_ms: value.get("completed_at_ms").and_then(Value::as_u64),
+                        error: None,
+                        schema_error: None,
+                    });
+                }
+                panel.phases.push(phase);
+            }
+        }
+
+        if let Some(status) = value.get("status").and_then(Value::as_str) {
+            let life = lifecycle_from_status(status);
+            if life.is_terminal() {
+                panel.lifecycle = life;
+                panel.completed_at_ms = value
+                    .get("completed_at_ms")
+                    .and_then(Value::as_u64)
+                    .or(panel.completed_at_ms);
+            } else if panel.lifecycle.is_running() {
+                panel.lifecycle = life;
+            }
+        }
+        if let Some(error) = opt_str(value, "error") {
+            panel.error = Some(error);
+        }
+        if let Some(spent) = value.get("budget_spent").and_then(Value::as_u64) {
+            panel.budget_spent = spent;
+        }
+        if let Some(total) = value
+            .get("token_budget")
+            .or_else(|| value.get("budget_total"))
+            .and_then(Value::as_u64)
+        {
+            panel.budget_total = Some(total);
+        }
+        if let Some(remaining) = value.get("budget_remaining").and_then(Value::as_u64) {
+            panel.budget_remaining = Some(remaining);
+        }
+        // Apply extras after events so RunStarted reset does not wipe them.
+        if panel.source_path.is_none() {
+            panel.source_path = opt_str(value, "source_path").map(PathBuf::from);
+        }
+        if panel.result_summary.is_none() {
+            panel.result_summary = value
+                .get("result")
+                .and_then(summarize_result_value)
+                .or_else(|| opt_str(value, "result_summary"));
+        }
+        if let Some(verification) = value.get("verification")
+            && let Some(summary) = verification.get("summary").and_then(Value::as_str)
+        {
+            let trimmed = summary.trim();
+            if !trimmed.is_empty() {
+                panel.result_summary = Some(match panel.result_summary.take() {
+                    Some(existing) => format!("{existing} · verify: {trimmed}"),
+                    None => format!("verify: {trimmed}"),
+                });
+            }
+        }
+        // Prefer the goal label from the payload when events used a fallback.
+        if !label.is_empty() && panel.label == run_id {
+            panel.label = label;
+        }
+        Some(panel)
+    }
+
+    /// Snapshot panel state into a JSON blob suitable for the history cell
+    /// (and re-hydration via [`Self::from_run_json`]).
+    #[must_use]
+    pub fn to_run_json(&self) -> Value {
+        let status = match self.lifecycle {
+            WorkflowPanelLifecycle::Pending => "pending",
+            WorkflowPanelLifecycle::Running => "running",
+            WorkflowPanelLifecycle::Succeeded => "completed",
+            WorkflowPanelLifecycle::Failed => "failed",
+            WorkflowPanelLifecycle::Cancelled => "cancelled",
+        };
+        let (done, total) = self.done_total();
+        let (failed, cancelled) = self.failure_cancel_counts();
+        json!({
+            "run_id": self.run_id,
+            "status": status,
+            "workflow_goal": self.label,
+            "started_at_ms": self.started_at_ms,
+            "completed_at_ms": self.completed_at_ms,
+            "child_count": total,
+            "done_count": done,
+            "phase_count": self.phase_count(),
+            "failure_count": failed,
+            "cancel_count": cancelled,
+            "error": self.error,
+            "result_summary": self.result_summary,
+            "source_path": self.source_path.as_ref().map(|p| p.display().to_string()),
+            "spillover_path": self.spillover_path.as_ref().map(|p| p.display().to_string()),
+            "token_budget": self.budget_total,
+            "budget_spent": self.budget_spent,
+            "budget_remaining": self.budget_remaining,
+            "phases": self.phases.iter().map(|phase| {
+                json!({
+                    "title": phase.title,
+                    "rows": phase.rows.iter().map(|row| {
+                        json!({
+                            "task_id": row.task_id,
+                            "label": row.label,
+                            "profile": row.profile,
+                            "model": row.model,
+                            "strength": row.strength,
+                            "worktree": row.worktree,
+                            "workspace": row.workspace.as_ref().map(|p| p.display().to_string()),
+                            "status": row.status.label(),
+                            "started_at_ms": row.started_at_ms,
+                            "completed_at_ms": row.completed_at_ms,
+                            "error": row.error,
+                            "schema_error": row.schema_error,
+                        })
+                    }).collect::<Vec<_>>(),
+                })
+            }).collect::<Vec<_>>(),
+        })
+    }
+
+    /// Compact one-line history-card summary: lifecycle, children, phases,
+    /// failures, elapsed (#4122 AC). The free-text goal lives on the expanded
+    /// body so the fixed header summary budget (≈56 cols) never drops counts.
+    #[must_use]
+    pub fn compact_summary_text(&self, width: usize) -> String {
+        let (_done, total) = self.done_total();
+        let (failed, _cancelled) = self.failure_cancel_counts();
+        let phases = self.phase_count();
+        let elapsed = self.elapsed_label();
+        let child_word = if total == 1 { "child" } else { "children" };
+        let phase_word = if phases == 1 { "phase" } else { "phases" };
+        let raw = format!(
+            "workflow {life} · {total} {child_word} · {phases} {phase_word} · {failed} fail · {elapsed}",
+            life = self.lifecycle.label(),
+        );
+        truncate_line_to_width(&raw, width.max(1))
+    }
+
+    /// Elapsed label shared with direct sub-agent cards.
+    #[must_use]
+    pub fn elapsed_label(&self) -> String {
+        // Guard against epoch-zero starts (bare status payloads without
+        // timestamps) which would otherwise render multi-year elapsed times.
+        if self.started_at_ms == 0 {
+            if let Some(completed) = self.completed_at_ms {
+                return format_elapsed(completed);
+            }
+            return "0s".to_string();
+        }
+        let end = self.completed_at_ms.unwrap_or_else(now_ms);
+        format_elapsed(end.saturating_sub(self.started_at_ms))
+    }
+
+    /// Compact summary line content (without card chrome). Callers in
+    /// `history.rs` wrap this with the shared tool-header + rail.
+    #[must_use]
+    pub fn history_header_summary(&self, width: usize) -> String {
+        self.compact_summary_text(width)
+    }
+
+    /// Expanded history-card body lines (phase/child summaries, links,
+    /// result, failures). Empty when the card should stay compact.
+    #[must_use]
+    pub fn history_expanded_lines(
+        &self,
+        width: u16,
+        extras: &WorkflowHistoryExtras,
+    ) -> Vec<Line<'static>> {
+        let content_width = usize::from(width).max(1);
+        let mut lines = Vec::new();
+
+        if !self.label.trim().is_empty() {
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(
+                    &format!("goal: {}", short_label(self.label.trim(), 160)),
+                    content_width,
+                ),
+                Style::default().fg(palette::TEXT_TOOL_OUTPUT),
+            )));
+        }
+
+        // Phase summary strip (same chips as the panel body).
+        if !self.phases.is_empty() {
+            let mut chips = Vec::new();
+            for (idx, phase) in self.phases.iter().take(MAX_PHASE_SUMMARY).enumerate() {
+                let (done, running, failed, cancelled) = phase.counts();
+                let marker = if idx == self.selected_phase { ">" } else { " " };
+                chips.push(format!(
+                    "{marker}{title}[{done}✓ {running}… {failed}! {cancelled}⊘]",
+                    title = short_label(&phase.title, 14),
+                ));
+            }
+            if self.phases.len() > MAX_PHASE_SUMMARY {
+                chips.push(format!("+{}", self.phases.len() - MAX_PHASE_SUMMARY));
+            }
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(&format!("phases: {}", chips.join("  ")), content_width),
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        }
+
+        // Child summary across all phases.
+        let children: Vec<String> = self
+            .phases
+            .iter()
+            .flat_map(|p| p.rows.iter())
+            .take(8)
+            .map(|row| {
+                format!(
+                    "{label} ({status})",
+                    label = short_label(&row.label, 16),
+                    status = row.status.label()
+                )
+            })
+            .collect();
+        if !children.is_empty() {
+            let more = self
+                .phases
+                .iter()
+                .map(|p| p.rows.len())
+                .sum::<usize>()
+                .saturating_sub(children.len());
+            let mut body = children.join(" · ");
+            if more > 0 {
+                body = format!("{body} · +{more} more");
+            }
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(&format!("children: {body}"), content_width),
+                Style::default().fg(palette::TEXT_TOOL_OUTPUT),
+            )));
+        }
+
+        let result = extras
+            .result_summary
+            .as_deref()
+            .or(self.result_summary.as_deref())
+            .or(extras.verification_summary.as_deref());
+        if let Some(result) = result.filter(|s| !s.trim().is_empty()) {
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(
+                    &format!("result: {}", short_label(result.trim(), 160)),
+                    content_width,
+                ),
+                Style::default().fg(palette::TEXT_TOOL_OUTPUT),
+            )));
+        }
+
+        let source = extras
+            .source_path
+            .as_ref()
+            .or(self.source_path.as_ref())
+            .map(|p| p.display().to_string());
+        if let Some(path) = source.filter(|s| !s.is_empty()) {
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(&format!("source: {path}"), content_width),
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        }
+        let spill = extras
+            .spillover_path
+            .as_ref()
+            .or(self.spillover_path.as_ref())
+            .map(|p| p.display().to_string());
+        if let Some(path) = spill.filter(|s| !s.is_empty()) {
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(&format!("artifact: {path}"), content_width),
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        } else if self.lifecycle.is_terminal() {
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(
+                    "transcript: full run JSON available via tool details (v)",
+                    content_width,
+                ),
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        }
+
+        if let Some(error) = self.error.as_deref().filter(|s| !s.trim().is_empty()) {
+            lines.push(Line::from(Span::styled(
+                truncate_line_to_width(
+                    &format!("error: {}", short_label(error, 160)),
+                    content_width,
+                ),
+                Style::default().fg(palette::STATUS_ERROR),
+            )));
+        }
+        for row in self.phases.iter().flat_map(|p| p.rows.iter()) {
+            if let Some(schema) = row.schema_error.as_deref() {
+                lines.push(Line::from(Span::styled(
+                    truncate_line_to_width(
+                        &format!(
+                            "schema {}: {}",
+                            short_label(&row.task_id, 12),
+                            short_label(schema, 120)
+                        ),
+                        content_width,
+                    ),
+                    Style::default().fg(palette::STATUS_ERROR),
+                )));
+            } else if row.status.is_failure()
+                && let Some(err) = row.error.as_deref()
+            {
+                lines.push(Line::from(Span::styled(
+                    truncate_line_to_width(
+                        &format!(
+                            "fail {}: {}",
+                            short_label(&row.label, 14),
+                            short_label(err, 120)
+                        ),
+                        content_width,
+                    ),
+                    Style::default().fg(palette::STATUS_ERROR),
+                )));
+            }
+        }
+
+        lines
+    }
+
+    /// Full history-card lines including a simple self-contained header so
+    /// unit tests (and direct sub-agent cards) can render without history.rs.
+    ///
+    /// Public convergence API for #4122 — also exercised by unit tests and
+    /// `DelegateCard::as_workflow_history_panel`.
+    #[must_use]
+    #[allow(dead_code)] // public API used by direct sub-agent projection + tests
+    pub fn render_history_card(
+        &self,
+        width: u16,
+        expanded: bool,
+        extras: &WorkflowHistoryExtras,
+    ) -> Vec<Line<'static>> {
+        let content_width = usize::from(width).max(1);
+        let mut lines = Vec::new();
+        let glyph = if expanded { '▼' } else { '▶' };
+        let summary = self.compact_summary_text(content_width.saturating_sub(2));
+        lines.push(Line::from(Span::styled(
+            truncate_line_to_width(&format!("{glyph} {summary}"), content_width),
+            Style::default()
+                .fg(self.lifecycle.color())
+                .add_modifier(Modifier::BOLD),
+        )));
+        if expanded {
+            lines.extend(self.history_expanded_lines(width, extras));
+        }
+        lines
+    }
+
+    /// Single-agent "mini workflow" view for direct sub-agent cards so they
+    /// share the same lifecycle/elapsed/result concepts as workflow runs.
+    #[must_use]
+    #[allow(dead_code)] // public API used by DelegateCard + tests
+    pub fn from_direct_subagent(
+        agent_id: impl Into<String>,
+        role: impl Into<String>,
+        lifecycle: WorkflowPanelLifecycle,
+        started_at_ms: u64,
+        completed_at_ms: Option<u64>,
+        summary: Option<String>,
+        error: Option<String>,
+    ) -> Self {
+        let agent_id = agent_id.into();
+        let role = role.into();
+        let mut panel = Self::new(agent_id.clone(), role.clone(), started_at_ms);
+        panel.lifecycle = lifecycle;
+        panel.completed_at_ms = completed_at_ms;
+        panel.expanded = false;
+        panel.result_summary = summary.clone();
+        panel.error = error.clone();
+        let status = match lifecycle {
+            WorkflowPanelLifecycle::Pending => WorkflowRowStatus::Pending,
+            WorkflowPanelLifecycle::Running => WorkflowRowStatus::Running,
+            WorkflowPanelLifecycle::Succeeded => WorkflowRowStatus::Succeeded,
+            WorkflowPanelLifecycle::Failed => WorkflowRowStatus::Failed,
+            WorkflowPanelLifecycle::Cancelled => WorkflowRowStatus::Cancelled,
+        };
+        let mut phase = WorkflowPanelPhase::new("Agent");
+        phase.rows.push(WorkflowPanelRow {
+            task_id: agent_id,
+            label: role,
+            profile: None,
+            model: None,
+            strength: None,
+            worktree: false,
+            workspace: None,
+            status,
+            started_at_ms,
+            completed_at_ms,
+            error,
+            schema_error: None,
+        });
+        panel.phases.push(phase);
+        panel
     }
 
     /// Apply a stream of events. `RunStarted` replaces any prior completed run.
@@ -374,7 +912,7 @@ impl WorkflowPanel {
                 run_id,
                 workflow_id,
                 workflow_goal,
-                source_path: _,
+                source_path,
                 token_budget,
                 at_ms,
             } => {
@@ -388,6 +926,7 @@ impl WorkflowPanel {
                 );
                 self.budget_total = token_budget;
                 self.budget_remaining = token_budget;
+                self.source_path = source_path;
             }
             WorkflowPanelEvent::RunCompleted {
                 status,
@@ -864,7 +1403,10 @@ fn short_label(text: &str, max: usize) -> String {
     truncate_line_to_width(trimmed, max)
 }
 
-fn format_elapsed(ms: u64) -> String {
+/// Format an elapsed duration for panel headers and history cards. Shared with
+/// direct sub-agent cards so both surfaces use the same vocabulary.
+#[must_use]
+pub fn format_elapsed(ms: u64) -> String {
     let secs = ms / 1000;
     if secs < 60 {
         format!("{secs}s")
@@ -880,6 +1422,37 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+fn summarize_result_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(s) => {
+            let t = s.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(short_label(t, 200))
+            }
+        }
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Array(items) => Some(format!("{} item(s)", items.len())),
+        Value::Object(map) => {
+            if let Some(s) = map
+                .get("summary")
+                .or_else(|| map.get("message"))
+                .or_else(|| map.get("text"))
+                .and_then(Value::as_str)
+            {
+                let t = s.trim();
+                if !t.is_empty() {
+                    return Some(short_label(t, 200));
+                }
+            }
+            Some(format!("{} field(s)", map.len()))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1259,5 +1832,188 @@ mod tests {
             .find(|row| row.task_id == "child-1")
             .expect("row recorded");
         assert_eq!(row.label, "typed-label");
+    }
+
+        fn compact_history_card_summarizes_lifecycle_children_phases_failures_elapsed() {
+        let mut panel = started_panel();
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "t1".to_string(),
+            status: WorkflowRowStatus::Failed,
+            at_ms: 2_000,
+        });
+        panel.apply_event(WorkflowPanelEvent::RunCompleted {
+            status: WorkflowPanelLifecycle::Failed,
+            error: Some("scout failed".to_string()),
+            at_ms: 2_100,
+        });
+        let lines = panel.render_history_card(120, false, &WorkflowHistoryExtras::default());
+        assert_eq!(lines.len(), 1, "compact is a single summary line");
+        let joined: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        assert!(joined.contains('▶'), "collapsed glyph: {joined}");
+        assert!(
+            joined.contains("failed") || joined.contains("fail"),
+            "{joined}"
+        );
+        assert!(joined.contains("1 child"), "{joined}");
+        assert!(joined.contains("1 phase"), "{joined}");
+        assert!(joined.contains("1 fail"), "{joined}");
+        // elapsed is present (0s or more depending on timestamps)
+        assert!(
+            joined.contains('s') || joined.contains('m'),
+            "elapsed time expected: {joined}"
+        );
+        // Goal is reserved for the expanded body so compact stays under the
+        // tool-header summary budget.
+        assert!(
+            !joined.contains("ship v0.8.68"),
+            "compact must not spend budget on free-text goal: {joined}"
+        );
+    }
+
+    #[test]
+    fn expanded_history_card_shows_phase_child_result_links_and_failures() {
+        let mut panel = started_panel();
+        panel.source_path = Some(PathBuf::from("workflows/demo.workflow.js"));
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "t1".to_string(),
+            status: WorkflowRowStatus::Failed,
+            at_ms: 2_000,
+        });
+        if let Some(row) = panel.find_row_mut("t1") {
+            row.error = Some("timeout waiting for model".to_string());
+        }
+        panel.apply_event(WorkflowPanelEvent::RunCompleted {
+            status: WorkflowPanelLifecycle::Failed,
+            error: Some("phase Analyze failed".to_string()),
+            at_ms: 2_100,
+        });
+        let extras = WorkflowHistoryExtras {
+            result_summary: Some("no ship blockers found".to_string()),
+            source_path: None,
+            spillover_path: Some(PathBuf::from("/tmp/workflow-out.json")),
+            verification_summary: None,
+        };
+        let lines = panel.render_history_card(120, true, &extras);
+        let joined: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains('▼'), "expanded glyph: {joined}");
+        assert!(joined.contains("goal:"), "{joined}");
+        assert!(joined.contains("ship v0.8.68"), "{joined}");
+        assert!(joined.contains("phases:"), "{joined}");
+        assert!(joined.contains("Analyze"), "{joined}");
+        assert!(joined.contains("children:"), "{joined}");
+        assert!(joined.contains("scout crates"), "{joined}");
+        assert!(joined.contains("result:"), "{joined}");
+        assert!(joined.contains("no ship blockers"), "{joined}");
+        assert!(
+            joined.contains("source:") || joined.contains("demo.workflow"),
+            "{joined}"
+        );
+        assert!(joined.contains("artifact:"), "{joined}");
+        assert!(joined.contains("error:"), "{joined}");
+        assert!(joined.contains("phase Analyze failed"), "{joined}");
+        assert!(
+            joined.contains("fail") || joined.contains("timeout"),
+            "{joined}"
+        );
+    }
+
+    #[test]
+    fn direct_subagent_card_reuses_history_renderer() {
+        let panel = WorkflowPanel::from_direct_subagent(
+            "agent_abc",
+            "explore",
+            WorkflowPanelLifecycle::Succeeded,
+            1_000,
+            Some(4_500),
+            Some("found 3 call sites".to_string()),
+            None,
+        );
+        let compact = panel.render_history_card(100, false, &WorkflowHistoryExtras::default());
+        let joined: String = compact
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        assert!(
+            joined.contains("success") || joined.contains("explore"),
+            "{joined}"
+        );
+        assert!(
+            joined.contains("1 child") || joined.contains("1 children"),
+            "{joined}"
+        );
+        assert!(joined.contains("3s") || joined.contains("s"), "{joined}");
+
+        let expanded = panel.render_history_card(
+            100,
+            true,
+            &WorkflowHistoryExtras {
+                result_summary: Some("found 3 call sites".to_string()),
+                ..WorkflowHistoryExtras::default()
+            },
+        );
+        let joined: String = expanded
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("children:"), "{joined}");
+        assert!(joined.contains("result:"), "{joined}");
+        assert!(joined.contains("found 3 call sites"), "{joined}");
+    }
+
+    #[test]
+    fn from_run_json_round_trips_events_into_history_card() {
+        let value = json!({
+            "run_id": "workflow_demo",
+            "status": "completed",
+            "workflow_goal": "ship it",
+            "started_at_ms": 1000,
+            "completed_at_ms": 5000,
+            "events": [
+                {
+                    "type": "run_started",
+                    "at_ms": 1000,
+                    "run_id": "workflow_demo",
+                    "workflow_goal": "ship it"
+                },
+                {"type": "phase_started", "at_ms": 1100, "title": "Build"},
+                {
+                    "type": "task_started",
+                    "at_ms": 1200,
+                    "task_id": "t1",
+                    "label": "compile",
+                    "profile": "implementer"
+                },
+                {
+                    "type": "task_completed",
+                    "at_ms": 4000,
+                    "task_id": "t1",
+                    "status": "succeeded"
+                },
+                {"type": "run_completed", "at_ms": 5000, "status": "completed"}
+            ]
+        });
+        let panel = WorkflowPanel::from_run_json(&value).expect("hydrate");
+        assert_eq!(panel.lifecycle, WorkflowPanelLifecycle::Succeeded);
+        let compact = panel.compact_summary_text(120);
+        assert!(compact.contains("1 child"), "{compact}");
+        assert!(compact.contains("success"), "{compact}");
+        let expanded = panel.history_expanded_lines(120, &WorkflowHistoryExtras::default());
+        let joined: String = expanded
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("goal:"), "{joined}");
+        assert!(joined.contains("ship it"), "{joined}");
+        assert!(joined.contains("Build"), "{joined}");
+        assert!(joined.contains("compile"), "{joined}");
     }
 }


### PR DESCRIPTION
## Summary

Routes typed workflow UI events to **both** the WorkflowPanel (live, while running) and a compact/expanded history card (issue #4122 / CODEWHALE_0_8_68 §2.5). Direct sub-agent cards can project onto the same renderer concepts.

### Acceptance

| Criterion | Status |
|-----------|--------|
| Collapsed workflow card summarizes lifecycle, child count, phases, failures, and elapsed time | ✅ |
| Expanded card shows phase summary, child summary, transcript/artifact links, final result, and failure details | ✅ |
| Direct sub-agent cards use the same renderer/concepts where possible | ✅ (`DelegateCard::as_workflow_history_panel` + shared panel helpers) |
| Tests cover compact and expanded rendering | ✅ |

### Implementation

- **`Event::WorkflowUi`** — engine bus carries flattened `WorkflowUiEvent` JSON while a run is in flight (not only on tool complete)
- **`tools/workflow.rs`** — emit live events from `record_run_event`, `progress`, run start, and terminal completion
- **`workflow_panel.rs`** — shared `from_run_json` / `to_run_json`, compact summary + expanded body helpers, direct-subagent projection
- **`tool_routing.rs`** — `apply_workflow_ui_event` updates panel + mirrors snapshot into the in-flight history cell; complete-path hydration also syncs the card
- **`history.rs`** — `try_render_as_workflow` uses the shared renderer (Live = compact, Transcript = expanded)
- **`agent_card.rs` / `tool_card.rs`** — convergence helpers; workflow tool family maps to fanout glyph

### Tests

- Compact history card (lifecycle / children / phases / failures / elapsed)
- Expanded history card (phases, children, result, source/artifact, errors)
- `from_run_json` event hydration
- Direct sub-agent projection onto shared renderer
- Existing status-list + panel lifecycle tests still green

## Test plan

- [x] `cargo fmt -p codewhale-tui`
- [x] `git diff --check`
- [x] `cargo test -p codewhale-tui --locked --bin codewhale-tui -- workflow_panel workflow_tool_renders workflow_tool_expanded direct_subagent`
- [x] `cargo check -p codewhale-tui --locked`
- [x] `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors`
- [ ] Manual: start a long workflow (`wait: true`), confirm panel updates mid-run and history card stays compact
- [ ] Manual: open transcript / tool details for expanded phase/child/result/artifact lines

Fixes #4122