### PR TITLE
docs(workflow): automatic Workflow soft-auto guide (#4130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The README is the short version. The rest is in docs and on
   output contract, and recovery behavior.
 - [Architecture](docs/ARCHITECTURE.md) — crate layout, runtime flow, tool system,
   extension points, and security model.
-- [Workflow authoring](docs/WORKFLOW_AUTHORING.md) · [MCP](docs/MCP.md) ·
+- [Automatic Workflows](docs/AUTOMATIC_WORKFLOWS.md) · [Workflow authoring](docs/WORKFLOW_AUTHORING.md) · [MCP](docs/MCP.md) ·
   [Runtime API](docs/RUNTIME_API.md) · [Model Lab](docs/MODEL_LAB.md)
 - [Keybindings](docs/KEYBINDINGS.md) · [Sandbox & approvals](docs/SANDBOX.md)
   · [Accessibility](docs/ACCESSIBILITY.md) · [Docker](docs/DOCKER.md)

--- a/docs/AUTOMATIC_WORKFLOWS.md
+++ b/docs/AUTOMATIC_WORKFLOWS.md
@@ -1,0 +1,83 @@
+# Automatic Workflows
+
+You do **not** need to say “workflow” or write a `.workflow.js` file for ordinary
+multi-agent work. CodeWhale decides when orchestration helps, tells you the
+shape, may ask a short setup question, then launches a Workflow.
+
+Related docs:
+
+- [Workflow Authoring](WORKFLOW_AUTHORING.md) — checked-in scripts and IR
+- [Fleet + Workflow Tutorial](FLEET_WORKFLOW_TUTORIAL.md) — manual Fleet paths
+- [Configuration](CONFIGURATION.md) — `[workflow]` knobs
+- [Sandbox](SANDBOX.md) — what the Workflow VM cannot do
+
+## Soft-auto (default product path)
+
+1. **You ask naturally** — “audit every crate for unsafe,” “scout then implement,”
+   “compare these two providers in parallel.”
+2. **CodeWhale decides** — broad, independent, or staged work triggers Workflow;
+   one-file edits, simple commands, and pure Q&A do not.
+3. **It tells you first** — e.g. “This looks set up for a Workflow — three scouts
+   then one verifier.”
+4. **Optional setup** — if one or two facts would change the plan (read-only vs
+   writes, scope, child count), it opens the **`request_user_input`** modal
+   (structured multiple choice, not a long free-form interview).
+5. **Launch** — structured `plan` JSON (goal / phases / children) or a short
+   inline script. Parallel branches use `parallel()` partial-success semantics.
+
+You can still type `/workflow` to force “orchestrate the current work.”
+
+## Read-only auto-start vs write approval
+
+`[workflow]` config (see `config.example.toml`):
+
+| Knob | Default | Meaning |
+|------|---------|---------|
+| `automatic` | `true` | Soft-auto orchestration is enabled |
+| `auto_start_read_only` | `true` | Read-only plans may start without a write-approval card |
+| `require_approval_for_writes` | `true` | Writes / elevated plans need explicit approval |
+| `auto_start_child_limit` | `8` | Soft cap on automatic child count |
+| `max_children` / `max_depth` | `64` / `2` | Hard ceilings |
+| `default_token_budget` | `120000` | Shared budget hint |
+| `persist_completed_activity` | `true` | Keep completed panel/history activity |
+
+Elevated work (writes, shell beyond read-only, network, secrets, worktrees, high
+budget) should surface an approval card with goal, child summary, capability
+flags, and budget before launch (#4126).
+
+## What you see while it runs
+
+- **Workflow panel** — phases, children, status, budget
+- **Compact history card** — one calm row that expands for detail
+- **One artifact per delegated unit** — no duplicate “delegate + tool card”
+- **Typed child identity** — labels/roles; no “unknown child” in the default UI
+
+Cancel stops the run and child agents. Completed activity can persist across the
+session (and across restarts when configured).
+
+## Sandbox guarantees
+
+The Workflow JS VM has **no** filesystem, shell, network, env, imports, clock, or
+randomness. Allowed host calls: `task`, `parallel`, `pipeline`, `phase`, `log`,
+`budget`, `args`. Real work happens in sub-agents / Fleet under normal tool and
+approval policy. See [Sandbox](SANDBOX.md).
+
+## Synthesis and compatibility
+
+- Prefer `responseSchema` on children that must return structured fields.
+- Failed parallel slots become `null` (partial success); filter them before
+  synthesizing one operator-facing summary.
+- Compatibility paths remain: `script`, `source_path` (checked-in
+  `.workflow.js` / `.workflow.ts`), and structured `plan`.
+
+## When automatic stays off
+
+Automatic Workflow is suppressed for:
+
+- One-file edits and tiny one-step asks  
+- Simple commands / factual questions  
+- Highly interactive design conversations  
+- Risky writes without a clear decomposition  
+- Estimated children above `auto_start_child_limit` (ask or shrink first)
+
+In those cases CodeWhale uses direct tools or a single `agent` instead.

--- a/docs/FLEET_WORKFLOW_TUTORIAL.md
+++ b/docs/FLEET_WORKFLOW_TUTORIAL.md
@@ -8,10 +8,16 @@ of the problem:
 - **Workflow** describes orchestration: phases, branches, reducers, loops, and
   agent leaves that can dispatch through the Fleet/sub-agent runtime.
 
-The supported path today is a reviewed structured spec. CodeWhale can help you
-draft a Fleet task spec or Workflow source, but it should show the plan before
-launching multi-worker work. A one-sentence natural language request should not
-silently generate `tasks.json` and start workers without review.
+**Default product path:** ask in natural language. Soft-auto Workflow decides
+when orchestration helps, **tells you the shape**, may open
+`request_user_input` for 1–2 setup choices, then launches — you do not need to
+write workflow files for ordinary multi-agent work. Details:
+[Automatic Workflows](AUTOMATIC_WORKFLOWS.md).
+
+This tutorial covers the **manual** Fleet task-spec / checked-in Workflow path
+for operators who want durable host workers and reviewable specs. A
+one-sentence request should still not silently generate `tasks.json` and start
+workers without indication or approval.
 
 ## 1. Prepare The Workspace
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -290,6 +290,8 @@ Use `/provider` when you want to switch away from the default DeepSeek route.
 Provider IDs, environment variables, model defaults, and capability notes are
 kept in the provider registry document.
 
+Soft-auto multi-agent work: [AUTOMATIC_WORKFLOWS.md](AUTOMATIC_WORKFLOWS.md).
+
 Next for durable multi-worker work: [FLEET_WORKFLOW_TUTORIAL.md](FLEET_WORKFLOW_TUTORIAL.md)
 walks through Fleet task specs, monitoring, and Workflow authoring.
 

--- a/docs/WORKFLOW_AUTHORING.md
+++ b/docs/WORKFLOW_AUTHORING.md
@@ -1,9 +1,22 @@
 # Workflow Authoring
 
+> **Ordinary multi-agent work does not require this file.** Prefer natural
+> language + soft-auto launch: CodeWhale decides, indicates the plan, and may
+> ask setup questions via the TUI modal. See
+> [Automatic Workflows](AUTOMATIC_WORKFLOWS.md).
+
 Workflow has one runtime boundary: authored source lowers to typed
 Rust `WorkflowSpec`, Rust validates the IR, and the scheduler/headless worker
 runtime executes leaves. Authoring languages do not get hidden authority to own
 files, shell, network, providers, cancellation, or TUI state.
+
+Compatibility launch paths on the `workflow` tool:
+
+| Input | When to use |
+|-------|-------------|
+| `plan` | Structured goal / phases / children (preferred agent path) |
+| `script` | Short inline JS the model owns |
+| `source_path` | Checked-in `.workflow.js` / `.workflow.ts` in the workspace |
 
 For a guided walkthrough from Fleet task specs to Workflow authoring and
 monitoring, see [Fleet + Workflow Tutorial](FLEET_WORKFLOW_TUTORIAL.md).


### PR DESCRIPTION
## Summary
User-facing Automatic Workflows docs for soft-auto (no required workflow files).

## Test plan
- [x] Docs-only
- [ ] CI green