### PR TITLE
fix(tui): standardize Workflow/To-do/Strategy/Activity vocabulary (#4135)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -310,7 +310,7 @@
     "HomeYoloModeTip": "Act + Full Access — tools run without approval prompts",
     "HomeYoloModeCaution": "  Destructive operations can run immediately; prefer Ask when unsure",
     "HomePlanModeTip": "Plan — research and design before implementing",
-    "HomePlanModeChecklistTip": "  Present a plan/checklist, then switch to Act or Operate",
+    "HomePlanModeChecklistTip": "  Present a plan and To-do progress, then switch to Act or Operate",
     "HomeGoalModeTip": "Goal tracking - Set /goal <objective> to pursue objectives",
     "OnboardLanguageTitle": "Choose your language",
     "OnboardLanguageBlurb": "Pick the UI language. You can change it any time with `/settings set locale <tag>`.",

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -439,18 +439,19 @@ pub fn sidebar(app: &mut App, arg: Option<&str>) -> CommandResult {
             "off" | "hide" | "hidden" | "closed" | "none" => SidebarFocus::Hidden,
             "auto" => SidebarFocus::Auto,
             "work" | "plan" | "todos" => SidebarFocus::Pinned,
-            "tasks" => SidebarFocus::Tasks,
+            // Panel label is Activity; "tasks" remains the config/compat key (#4147/#4135).
+            "tasks" | "activity" | "live" | "running" => SidebarFocus::Tasks,
             "agents" | "subagents" | "sub-agents" => SidebarFocus::Agents,
             "context" | "session" => SidebarFocus::Context,
             _ => {
                 return CommandResult::error(
-                    "Usage: /sidebar [on|off|pinned|auto|tasks|agents|context] [--save]",
+                    "Usage: /sidebar [on|off|pinned|auto|activity|tasks|agents|context] [--save]",
                 );
             }
         },
         _ => {
             return CommandResult::error(
-                "Usage: /sidebar [on|off|pinned|auto|tasks|agents|context] [--save]",
+                "Usage: /sidebar [on|off|pinned|auto|activity|tasks|agents|context] [--save]",
             );
         }
     };

--- a/crates/tui/src/commands/groups/config/mod.rs
+++ b/crates/tui/src/commands/groups/config/mod.rs
@@ -43,7 +43,7 @@ static CONFIG_INFO: CommandInfo = CommandInfo {
 static SIDEBAR_INFO: CommandInfo = CommandInfo {
     name: "sidebar",
     aliases: &[],
-    usage: "/sidebar [on|off|auto|work|tasks|agents|context] [--save]",
+    usage: "/sidebar [on|off|auto|work|activity|tasks|agents|context] [--save]",
     description_id: MessageId::CmdSidebarDescription,
 };
 static SETTINGS_INFO: CommandInfo = CommandInfo {

--- a/crates/tui/src/commands/groups/session/relay.rs
+++ b/crates/tui/src/commands/groups/session/relay.rs
@@ -72,7 +72,7 @@ fn build_relay_instruction(app: &App, focus: Option<&str>) -> String {
         if !snapshot.items.is_empty() {
             let _ = writeln!(
                 out,
-                "\nWork checklist (primary progress surface, {}% complete):",
+                "\nTo-do (primary progress surface, {}% complete):",
                 snapshot.completion_pct
             );
             for item in snapshot.items {
@@ -86,10 +86,7 @@ fn build_relay_instruction(app: &App, focus: Option<&str>) -> String {
             }
         }
     } else {
-        let _ = writeln!(
-            out,
-            "\nWork checklist: unavailable because the checklist is busy."
-        );
+        let _ = writeln!(out, "\nTo-do: unavailable because the list is busy.");
     }
 
     if let Ok(plan) = app.plan_state.try_lock() {
@@ -147,7 +144,7 @@ fn build_relay_instruction(app: &App, focus: Option<&str>) -> String {
          [the user's objective and any explicit constraints]\n\
          \n\
          ## Current work\n\
-         [the active Work checklist item, progress, and what is mid-flight]\n\
+         [the active To-do item, progress, and what is mid-flight]\n\
          \n\
          ## Files and state\n\
          [changed files, important paths, sub-agents/RLM sessions, commands run]\n\

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -488,9 +488,9 @@ mod tests {
                 critical_files: vec!["crates/tui/src/commands/mod.rs".to_string()],
                 constraints: vec!["Do not invent verification".to_string()],
                 verification_plan: Some("Check relay prompt assertions".to_string()),
-                handoff_packet: Some("Next thread should read the Work checklist".to_string()),
+                handoff_packet: Some("Next thread should read the To-do list".to_string()),
                 plan: vec![PlanItemArg {
-                    step: "keep checklist primary".to_string(),
+                    step: "keep To-do primary".to_string(),
                     status: StepStatus::InProgress,
                 }],
                 ..UpdatePlanArgs::default()
@@ -516,7 +516,7 @@ mod tests {
         assert!(message.contains("Requested relay focus: verify install"));
         assert!(message.contains("Goal objective: Unify the work surface"));
         assert!(message.contains("Goal token budget: 12000"));
-        assert!(message.contains("Work checklist (primary progress surface, 50% complete)"));
+        assert!(message.contains("To-do (primary progress surface, 50% complete)"));
         assert!(message.contains("#1 [completed] inspect workspace"));
         assert!(message.contains("#2 [in_progress] patch relay command"));
         assert!(message.contains("Optional strategy metadata from update_plan"));
@@ -526,8 +526,12 @@ mod tests {
         assert!(message.contains("Critical file: crates/tui/src/commands/mod.rs"));
         assert!(message.contains("Constraint: Do not invent verification"));
         assert!(message.contains("Verification plan: Check relay prompt assertions"));
-        assert!(message.contains("Handoff packet: Next thread should read the Work checklist"));
-        assert!(message.contains("[in_progress] keep checklist primary"));
+        assert!(message.contains("Handoff packet: Next thread should read the To-do list"));
+        assert!(message.contains("[in_progress] keep To-do primary"));
+        assert!(
+            !message.contains("Work checklist"),
+            "relay copy should use To-do vocabulary: {message}"
+        );
     }
 
     #[test]
@@ -975,6 +979,14 @@ mod tests {
         assert!(!result.is_error);
         assert_eq!(app.sidebar_focus, SidebarFocus::Tasks);
         assert!(app.status_message.is_none());
+
+        let result = execute("/sidebar activity", &mut app);
+        assert!(!result.is_error);
+        assert_eq!(
+            app.sidebar_focus,
+            SidebarFocus::Tasks,
+            "activity is the user-facing alias for the Activity panel"
+        );
 
         let result = execute("/sidebar off", &mut app);
         assert!(!result.is_error);

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -817,13 +817,14 @@ impl Settings {
                 let normalized = match value.trim().to_ascii_lowercase().as_str() {
                     "auto" => "auto",
                     "pinned" | "visible" | "show" | "on" | "work" | "plan" | "todos" => "pinned",
-                    "tasks" => "tasks",
+                    // Persist as "tasks"; user-facing panel label is Activity (#4147/#4135).
+                    "tasks" | "activity" | "live" | "running" => "tasks",
                     "agents" | "subagents" | "sub-agents" => "agents",
                     "context" | "session" => "context",
                     "hidden" | "hide" | "closed" | "off" | "none" => "hidden",
                     _ => {
                         anyhow::bail!(
-                            "Failed to update setting: invalid sidebar focus '{value}'. Expected: pinned, auto, tasks, agents, context, hidden."
+                            "Failed to update setting: invalid sidebar focus '{value}'. Expected: pinned, auto, activity (tasks), agents, context, hidden."
                         )
                     }
                 };
@@ -1081,7 +1082,7 @@ impl Settings {
             ("sidebar_width", "Sidebar width percentage: 10-50"),
             (
                 "sidebar_focus",
-                "Sidebar focus: auto, work, tasks, agents, context, hidden",
+                "Sidebar focus: auto, work, activity (tasks), agents, context, hidden",
             ),
             (
                 "context_panel",
@@ -1493,7 +1494,7 @@ fn normalize_background_color_setting(value: &str) -> Result<Option<String>> {
 fn normalize_sidebar_focus(value: &str) -> &str {
     match value.trim().to_ascii_lowercase().as_str() {
         "pinned" | "visible" | "show" | "on" | "work" | "plan" | "todos" => "pinned",
-        "tasks" => "tasks",
+        "tasks" | "activity" | "live" | "running" => "tasks",
         "agents" | "subagents" | "sub-agents" => "agents",
         "context" | "session" => "context",
         "hidden" | "hide" | "closed" | "off" | "none" => "hidden",
@@ -1837,10 +1838,22 @@ mod tests {
         assert_eq!(settings.sidebar_focus, "pinned");
         assert!(!settings.sidebar_auto_collapse_opt_in);
 
+        // Activity is the user-facing panel name; config key remains "tasks" (#4135).
+        settings
+            .set("focus", "activity")
+            .expect("activity alias for Activity panel");
+        assert_eq!(settings.sidebar_focus, "tasks");
+        settings.set("focus", "live").expect("live alias");
+        assert_eq!(settings.sidebar_focus, "tasks");
+
         let err = settings
             .set("sidebar_focus", "classic")
             .expect_err("classic is not a supported public focus");
         assert!(err.to_string().contains("invalid sidebar focus"));
+        assert!(
+            err.to_string().contains("activity (tasks)"),
+            "error should teach the Activity alias: {err}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -470,7 +470,7 @@ impl ToolSpec for UpdatePlanTool {
     }
 
     fn description(&self) -> &'static str {
-        "Update optional high-level Strategy metadata for complex initiatives. Use work_update for primary To-do / Work progress; update_plan should capture phase-level approach, context, and route — not a second checklist. Include sources, critical files, constraints, verification, risks, and handoff context when they help the user review or continue the plan. Each strategy step has a description and status (pending, in_progress, completed)."
+        "Update optional high-level Strategy metadata for complex initiatives. Use work_update for primary To-do / Work progress; update_plan should capture approach, context, and route — not a second checklist. Include sources, critical files, constraints, verification, risks, and handoff context when they help the user review or continue the plan. Each strategy step has a description and status (pending, in_progress, completed). Reserve Phase for Workflow stages."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -653,6 +653,12 @@ mod tests {
         assert!(description.contains("Use work_update for primary To-do / Work progress"));
         assert!(description.contains("not a second checklist"));
         assert!(description.contains("Strategy metadata"));
+        assert!(description.contains("approach, context, and route"));
+        assert!(description.contains("Reserve Phase for Workflow stages"));
+        assert!(
+            !description.contains("phase-level"),
+            "Strategy must not reuse Workflow Phase vocabulary: {description}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -8092,7 +8092,7 @@ const EXPLORE_AGENT_INTRO: &str = concat!(
 const PLAN_AGENT_INTRO: &str = concat!(
     "You are a trusted planning sub-agent (role: `plan`). Your job is to produce a grounded, prioritized plan, not patches.\n",
     "Read enough code to avoid guessing; each step names its artifact and verification.\n",
-    "Use update_plan/work_update for plan artifacts and explain key trade-offs.\n",
+    "Use work_update for concrete To-do progress and update_plan only for Strategy metadata/context/route; explain key trade-offs.\n",
     "CHANGES should list plan artifacts only, not future speculative edits.\n\n"
 );
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -463,7 +463,8 @@ impl SidebarFocus {
     pub fn from_setting(value: &str) -> Self {
         match value.trim().to_ascii_lowercase().as_str() {
             "pinned" | "visible" | "show" | "on" | "work" | "plan" | "todos" => Self::Pinned,
-            "tasks" => Self::Tasks,
+            // Persist/compat key remains "tasks"; user-facing panel is Activity (#4147/#4135).
+            "tasks" | "activity" | "live" | "running" => Self::Tasks,
             "agents" | "subagents" | "sub-agents" => Self::Agents,
             "context" | "session" => Self::Context,
             "hidden" | "hide" | "closed" | "off" | "none" => Self::Hidden,

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -582,6 +582,9 @@ fn sidebar_focus_accepts_pinned_and_maps_legacy_trackers_to_pinned() {
     assert_eq!(SidebarFocus::from_setting("plan"), SidebarFocus::Pinned);
     assert_eq!(SidebarFocus::from_setting("todos"), SidebarFocus::Pinned);
     assert_eq!(SidebarFocus::from_setting("tasks"), SidebarFocus::Tasks);
+    assert_eq!(SidebarFocus::from_setting("activity"), SidebarFocus::Tasks);
+    assert_eq!(SidebarFocus::from_setting("live"), SidebarFocus::Tasks);
+    assert_eq!(SidebarFocus::from_setting("running"), SidebarFocus::Tasks);
     assert_eq!(SidebarFocus::from_setting("agents"), SidebarFocus::Agents);
     assert_eq!(SidebarFocus::from_setting("context"), SidebarFocus::Context);
     assert_eq!(SidebarFocus::from_setting("hidden"), SidebarFocus::Hidden);

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -629,7 +629,7 @@ fn collect_active_tool_status(
             }
         }
         ToolCell::PlanUpdate(plan) => {
-            snapshot.record("update plan".to_string(), plan.status, None);
+            snapshot.record("update Strategy".to_string(), plan.status, None);
         }
         ToolCell::PatchSummary(patch) => {
             snapshot.record(format!("patch {}", patch.path), patch.status, None);

--- a/crates/tui/src/tui/history/plan.rs
+++ b/crates/tui/src/tui/history/plan.rs
@@ -20,7 +20,7 @@ impl PlanUpdateCell {
     pub fn lines_with_motion(&self, width: u16, low_motion: bool) -> Vec<Line<'static>> {
         let mut lines = Vec::new();
         lines.push(render_tool_header(
-            "Plan",
+            "Strategy",
             tool_status_label(self.status),
             self.status,
             None,

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -1771,7 +1771,7 @@ fn plan_update_cell_renders_rich_artifact_metadata() {
             context_summary: Some("Grounded in issue #2691".to_string()),
             sources_used: vec!["gh issue view 2691".to_string()],
             critical_files: vec!["crates/tui/src/tools/plan.rs".to_string()],
-            constraints: vec!["Keep checklist primary".to_string()],
+            constraints: vec!["Keep To-do primary".to_string()],
             recommended_approach: Some(
                 "Enrich update_plan without breaking legacy calls".to_string(),
             ),

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -887,7 +887,7 @@ mod tests {
             critical_files: vec!["crates/tui/src/tools/plan.rs".to_string()],
             constraints: vec!["Preserve legacy update_plan payloads".to_string()],
             recommended_approach: Some(
-                "Keep checklist primary and enrich update_plan.".to_string(),
+                "Keep To-do primary and enrich update_plan Strategy metadata.".to_string(),
             ),
             verification_plan: Some("Run focused plan prompt tests.".to_string()),
             risks_and_unknowns: Some("Avoid dropping metadata-only plans.".to_string()),

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -809,8 +809,8 @@ fn work_panel_hover_texts(
         let remaining = earlier.saturating_add(later);
         if remaining > 0 && texts.len() < max_rows {
             let mut label = match (earlier, later) {
-                (0, later) => format!("+{later} more checklist items"),
-                (earlier, 0) => format!("+{earlier} earlier checklist items"),
+                (0, later) => format!("+{later} more To-do items"),
+                (earlier, 0) => format!("+{earlier} earlier To-do items"),
                 (earlier, later) => format!("+{earlier} earlier, +{later} later"),
             };
             // Hovering the overflow row reveals the omitted items, since
@@ -1054,8 +1054,8 @@ fn push_work_checklist_lines(
     let remaining = earlier.saturating_add(later);
     if remaining > 0 && lines.len() < max_rows {
         let label = match (earlier, later) {
-            (0, later) => format!("+{later} more checklist items"),
-            (earlier, 0) => format!("+{earlier} earlier checklist items"),
+            (0, later) => format!("+{later} more To-do items"),
+            (earlier, 0) => format!("+{earlier} earlier To-do items"),
             (earlier, later) => format!("+{earlier} earlier, +{later} later"),
         };
         lines.push(Line::from(Span::styled(
@@ -1171,10 +1171,12 @@ fn work_strategy_context_label(summary: &SidebarWorkSummary) -> &'static str {
 }
 
 fn strategy_context_step_prefix(status: &StepStatus) -> &'static str {
+    // Strategy = metadata/context/route (not a second checklist).
+    // Reserve "Phase" for Workflow stages only (#4135).
     match status {
-        StepStatus::Pending => "phase next:",
-        StepStatus::InProgress => "phase now:",
-        StepStatus::Completed => "phase done:",
+        StepStatus::Pending => "route next:",
+        StepStatus::InProgress => "route now:",
+        StepStatus::Completed => "route done:",
     }
 }
 
@@ -4031,20 +4033,20 @@ mod tests {
         );
         assert!(
             text.iter()
-                .any(|line| line.contains("phase done: Simplify sidebar")),
-            "completed strategy steps should render as phase context: {text:?}"
+                .any(|line| line.contains("route done: Simplify sidebar")),
+            "completed strategy steps should render as route context: {text:?}"
         );
         assert!(
             text.iter()
-                .any(|line| line.contains("phase next: Update prompts")),
-            "pending strategy steps should render as phase context: {text:?}"
+                .any(|line| line.contains("route next: Update prompts")),
+            "pending strategy steps should render as route context: {text:?}"
         );
         assert!(
             !text
                 .iter()
                 .any(|line| line.contains("[✓] Simplify sidebar"))
                 && !text.iter().any(|line| line.contains("[ ] Update prompts")),
-            "strategy rows must not look like a second checklist when Work checklist exists: {text:?}"
+            "strategy rows must not look like a second To-do when To-do items exist: {text:?}"
         );
     }
 
@@ -4082,14 +4084,14 @@ mod tests {
         assert!(
             hover
                 .iter()
-                .any(|line| line.contains("phase done: Map phase boundaries")),
-            "hover strategy rows should be phase context: {hover:?}"
+                .any(|line| line.contains("route done: Map phase boundaries")),
+            "hover strategy rows should be route context: {hover:?}"
         );
         assert!(
             hover
                 .iter()
-                .any(|line| line.contains("phase now: Implement counted work")),
-            "hover should expose the active strategy phase without checklist markers: {hover:?}"
+                .any(|line| line.contains("route now: Implement counted work")),
+            "hover should expose the active strategy route without To-do markers: {hover:?}"
         );
         assert!(
             !hover
@@ -4149,15 +4151,15 @@ mod tests {
             assert!(
                 rendered
                     .iter()
-                    .any(|line| line.contains("phase done: Completed context")),
+                    .any(|line| line.contains("route done: Completed context")),
                 "completed strategy context may still render: {rendered:?}"
             );
             assert!(
-                !rendered.iter().any(|line| line.contains("phase now:")),
+                !rendered.iter().any(|line| line.contains("route now:")),
                 "stale in-progress strategy must not render as active work: {rendered:?}"
             );
             assert!(
-                !rendered.iter().any(|line| line.contains("phase next:")),
+                !rendered.iter().any(|line| line.contains("route next:")),
                 "stale pending strategy must not render as upcoming work: {rendered:?}"
             );
         }
@@ -4428,6 +4430,86 @@ mod tests {
         assert!(
             text.first().is_some_and(|line| line.contains("(Paused)")),
             "paused state should be visible: {text:?}"
+        );
+    }
+
+    #[test]
+    fn workflow_vocab_avoids_dual_meanings_in_work_and_activity_copy() {
+        // #4135 copy audit: To-do / Strategy / Phase / Activity stay distinct.
+        assert_eq!(
+            super::strategy_context_step_prefix(&StepStatus::Pending),
+            "route next:"
+        );
+        assert_eq!(
+            super::strategy_context_step_prefix(&StepStatus::InProgress),
+            "route now:"
+        );
+        assert_eq!(
+            super::strategy_context_step_prefix(&StepStatus::Completed),
+            "route done:"
+        );
+        for prefix in ["route next:", "route now:", "route done:"] {
+            assert!(
+                !prefix.contains("phase"),
+                "Strategy route prefixes must not reuse Workflow Phase vocabulary: {prefix}"
+            );
+        }
+
+        let summary = SidebarWorkSummary {
+            checklist_completion_pct: 10,
+            checklist_items: (1..=6)
+                .map(|id| SidebarWorkChecklistItem {
+                    id,
+                    content: format!("Item {id}"),
+                    status: if id == 1 {
+                        TodoStatus::InProgress
+                    } else {
+                        TodoStatus::Pending
+                    },
+                })
+                .collect(),
+            strategy_steps: vec![SidebarWorkStrategyStep {
+                text: "Approach".to_string(),
+                status: StepStatus::Pending,
+                elapsed: String::new(),
+            }],
+            ..SidebarWorkSummary::default()
+        };
+        let text = lines_to_text(&work_panel_lines(
+            &summary,
+            40,
+            4,
+            PaletteMode::Dark,
+            &palette::UI_THEME,
+        ));
+        let joined = text.join("\n");
+        assert!(
+            joined.contains("To-do items") || !joined.contains("checklist items"),
+            "To-do overflow must not say checklist: {text:?}"
+        );
+        assert!(
+            !joined.contains("phase next:")
+                && !joined.contains("phase now:")
+                && !joined.contains("phase done:"),
+            "Strategy context must not use Phase labels: {text:?}"
+        );
+        assert!(
+            joined.contains("route next:") || joined.contains("Strategy context"),
+            "Strategy context should use route prefixes under To-do: {text:?}"
+        );
+
+        let mut app = create_test_app();
+        app.sidebar_focus = SidebarFocus::Tasks;
+        let activity = lines_to_text(&task_panel_lines(&app, 48, 4));
+        assert!(
+            activity
+                .iter()
+                .any(|line| line.contains("No live tools or background jobs")),
+            "Activity empty state should describe live activity: {activity:?}"
+        );
+        assert!(
+            !activity.iter().any(|line| line.contains("No active tasks")),
+            "Activity must not reuse durable Tasks wording: {activity:?}"
         );
     }
 

--- a/crates/tui/src/tui/ui/activity_detail.rs
+++ b/crates/tui/src/tui/ui/activity_detail.rs
@@ -757,7 +757,7 @@ pub(crate) fn detail_target_label(app: &App, cell_index: usize) -> Option<String
             explore.entries.len(),
             if explore.entries.len() == 1 { "" } else { "s" }
         )),
-        HistoryCell::Tool(ToolCell::PlanUpdate(_)) => Some("update plan".to_string()),
+        HistoryCell::Tool(ToolCell::PlanUpdate(_)) => Some("update Strategy".to_string()),
         HistoryCell::Tool(ToolCell::PatchSummary(patch)) => Some(format!("patch {}", patch.path)),
         HistoryCell::Tool(ToolCell::Review(review)) => {
             let target = one_line_summary(&review.target, 80);
@@ -903,7 +903,7 @@ pub(super) fn turn_inspector_text(app: &App) -> String {
         push_section(&mut out, "Selected item", vec![line]);
     }
 
-    push_section(&mut out, "Plan / checklist", turn_plan_lines(app));
+    push_section(&mut out, "Strategy / To-do", turn_plan_lines(app));
     push_section(
         &mut out,
         "Turn timeline",
@@ -969,11 +969,11 @@ pub(crate) fn turn_handoff_markdown(app: &App) -> String {
 
     push_md_section(&mut out, "Intent", vec![turn_intent_line(app, start)]);
 
-    // Plan/checklist is optional context: include it only when a plan or todo
-    // list actually ran, to keep the handoff compact.
+    // Strategy / To-do is optional context: include it only when a plan or
+    // To-do tool actually ran, to keep the handoff compact.
     let plan = turn_plan_lines(app);
     if !plan.is_empty() {
-        push_md_section(&mut out, "Plan / checklist", md_bullets(plan));
+        push_md_section(&mut out, "Strategy / To-do", md_bullets(plan));
     }
 
     push_md_section(
@@ -1078,7 +1078,7 @@ fn selected_item_context_line(app: &App) -> Option<String> {
     Some(format!("{label}{hint}"))
 }
 
-/// Section 2 — plan and/or checklist state, when a plan/todo tool has run.
+/// Section 2 — Strategy metadata and/or To-do state when those tools ran.
 fn turn_plan_lines(app: &App) -> Vec<String> {
     let mut lines = Vec::new();
 
@@ -1093,13 +1093,16 @@ fn turn_plan_lines(app: &App) -> Vec<String> {
             .map(str::trim)
             .filter(|s: &&str| !s.is_empty());
         if let Some(headline) = headline {
-            lines.push(format!("Plan: {}", truncate_line_to_width(headline, 64)));
+            lines.push(format!(
+                "Strategy: {}",
+                truncate_line_to_width(headline, 64)
+            ));
         }
         let (pending, in_progress, completed) = plan.counts();
         let total = pending + in_progress + completed;
         if total > 0 {
             lines.push(format!(
-                "Steps: {completed}/{total} done ({}%)",
+                "Route steps: {completed}/{total} done ({}%)",
                 plan.progress_percent()
             ));
         }
@@ -1115,7 +1118,7 @@ fn turn_plan_lines(app: &App) -> Vec<String> {
     if let Ok(todos) = app.todos.try_lock() {
         let snapshot = todos.snapshot();
         if !snapshot.items.is_empty() {
-            lines.push(format!("Checklist: {}% complete", snapshot.completion_pct));
+            lines.push(format!("To-do: {}% complete", snapshot.completion_pct));
             for item in &snapshot.items {
                 lines.push(format!(
                     "{} {}",
@@ -1238,7 +1241,7 @@ fn timeline_tool_summary(app: &App, idx: usize, tool: &ToolCell) -> (&'static st
                 if explore.entries.len() == 1 { "" } else { "s" }
             ),
         ),
-        ToolCell::PlanUpdate(_) => ("plan update", "plan/checklist changed".to_string()),
+        ToolCell::PlanUpdate(_) => ("Strategy", "Strategy metadata updated".to_string()),
         ToolCell::PatchSummary(patch) => {
             let summary = one_line_summary(&patch.summary, 72);
             if summary.is_empty() {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10133,7 +10133,7 @@ fn turn_inspector_renders_overview_sections_for_active_turn() {
     // Section headers for all nine sections must be present.
     for header in [
         "── Intent ──",
-        "── Plan / checklist ──",
+        "── Strategy / To-do ──",
         "── Turn timeline ──",
         "── Files changed ──",
         "── Diagnostics loop ──",
@@ -10264,7 +10264,7 @@ fn turn_inspector_degrades_empty_sections_without_panic() {
     let body = turn_inspector_text(&app);
 
     // Unavailable sections degrade to `none`, never a blank void.
-    assert!(body.contains("── Plan / checklist ──\nnone"), "{body}");
+    assert!(body.contains("── Strategy / To-do ──\nnone"), "{body}");
     assert!(body.contains("── Files changed ──\nnone"), "{body}");
     assert!(body.contains("── Tests / verifier ──\nnone"), "{body}");
     assert!(body.contains("── Approvals / denials ──\nnone"), "{body}");
@@ -10425,7 +10425,7 @@ fn turn_handoff_markdown_degrades_empty_sections_without_panic() {
     assert!(md.contains("## Files changed\n—"), "{md}");
     assert!(md.contains("## Tests / verifier\n—"), "{md}");
     // The optional plan section is dropped entirely when no plan ran.
-    assert!(!md.contains("## Plan / checklist"), "{md}");
+    assert!(!md.contains("## Strategy / To-do"), "{md}");
     // Intent still resolves; status reflects the live turn.
     assert!(md.contains("## Intent\nhello"), "{md}");
     assert!(md.contains("Status: in progress"), "{md}");

--- a/crates/tui/src/tui/widgets/tool_card.rs
+++ b/crates/tui/src/tui/widgets/tool_card.rs
@@ -67,7 +67,7 @@ pub fn tool_family_for_title(title: &str) -> ToolFamily {
         "Patch" | "Diff" => ToolFamily::Patch,
         "Workspace" | "Image" => ToolFamily::Read,
         "Search" => ToolFamily::Find,
-        "Plan" | "Review" => ToolFamily::Generic,
+        "Plan" | "Strategy" | "Review" => ToolFamily::Generic,
         _ => ToolFamily::Generic,
     }
 }
@@ -346,6 +346,7 @@ mod tests {
         assert_eq!(tool_family_for_title("Search"), ToolFamily::Find);
         assert_eq!(tool_family_for_title("Diff"), ToolFamily::Patch);
         assert_eq!(tool_family_for_title("Plan"), ToolFamily::Generic);
+        assert_eq!(tool_family_for_title("Strategy"), ToolFamily::Generic);
         assert_eq!(tool_family_for_title("unknown title"), ToolFamily::Generic);
     }
 


### PR DESCRIPTION
## Summary
Residual vocabulary polish for **#4135** after Activity (#4147), `work_update` (#4132), and Act/Plan/Operate landings. Scouting found most surfaces already correct; this PR only fixes dual-meaning leftovers.

### Canonical meanings applied
| Term | Meaning |
|------|---------|
| **To-do / Tasks** | concrete current work items |
| **Strategy** | metadata/context/route (not a second checklist) |
| **Workflow** | orchestrated maneuver/run |
| **Phase** | stage inside a workflow |
| **Agent / Fleet worker** | actor |
| **Activity / Running / Live** | live tools, shell, reasoning, background |

### Changes
- Strategy context prefixes: `phase next/now/done` → `route next/now/done` (frees **Phase** for Workflow)
- To-do overflow: `checklist items` → `To-do items`
- Session relay: `Work checklist` → `To-do`
- Turn inspector / handoff: `Plan / checklist` → `Strategy / To-do`
- Plan tool card + footer/timeline: **Strategy** labels
- `update_plan` description: drop `phase-level`; reserve Phase for Workflow
- Plan-role sub-agent intro: separate `work_update` (To-do) vs `update_plan` (Strategy)
- `/sidebar activity|live|running` aliases Activity panel (persisted key remains `tasks`)
- `en.json` Plan mode tip uses To-do wording

### Not changed (already correct / intentional)
- Sidebar section titles **To-do**, **Activity**, **Agents**
- Internal `SidebarFocus::Tasks` / config key `tasks` (compat #4172)
- Mode Act/Plan/Operate surfaces (already landed)
- Durable task ledger / `task_*` APIs

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui workflow_vocab`
- [x] `work_panel_*`, `update_plan_description_*`, `execute_sidebar_*`, `turn_inspector_*`, `turn_handoff_*`, `plan_update_cell_*`, `relay_*`, `sidebar_focus_*`, `plan_prompt_renders_rich*`

Closes #4135