### PR TITLE
fix(workflow): coordinator access model + 16 concurrent / 1k per run

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1132,9 +1132,11 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # # Require an approval card before write/shell/network/high-budget launches.
 # require_approval_for_writes = true
 # # Soft cap on children admitted by automatic launch (larger plans ask first).
-# auto_start_child_limit = 8
-# # Hard ceiling on children in one Workflow run.
-# max_children = 64
+# auto_start_child_limit = 16
+# # Hard ceiling on agents in one Workflow run (matches VM lifetime cap).
+# max_children = 1000
+# # Maximum concurrently live agents inside one run (others wait for a slot).
+# max_concurrent = 16
 # # Maximum nested Workflow / child-orchestration depth.
 # max_depth = 2
 # # Default shared token budget for a Workflow run and its children.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1508,9 +1508,12 @@ pub struct WorkflowConfigToml {
     /// should ask the operator or use explicit `/workflow`.
     #[serde(default = "default_workflow_auto_start_child_limit")]
     pub auto_start_child_limit: u32,
-    /// Hard ceiling on total children in one Workflow run.
+    /// Hard ceiling on total children in one Workflow run (product: 1000).
     #[serde(default = "default_workflow_max_children")]
     pub max_children: u32,
+    /// Maximum concurrently live agents inside one Workflow run (product: 16).
+    #[serde(default = "default_workflow_max_concurrent")]
+    pub max_concurrent: u32,
     /// Maximum nested Workflow / child-orchestration depth.
     #[serde(default = "default_workflow_max_depth")]
     pub max_depth: u32,
@@ -1544,11 +1547,16 @@ fn default_workflow_require_approval_for_writes() -> bool {
 }
 
 fn default_workflow_auto_start_child_limit() -> u32 {
-    8
+    // Soft auto stays small; explicit launches may use the full concurrent cap.
+    16
 }
 
 fn default_workflow_max_children() -> u32 {
-    64
+    1000
+}
+
+fn default_workflow_max_concurrent() -> u32 {
+    16
 }
 
 fn default_workflow_max_depth() -> u32 {
@@ -1579,6 +1587,7 @@ impl Default for WorkflowConfigToml {
             require_approval_for_writes: default_workflow_require_approval_for_writes(),
             auto_start_child_limit: default_workflow_auto_start_child_limit(),
             max_children: default_workflow_max_children(),
+            max_concurrent: default_workflow_max_concurrent(),
             max_depth: default_workflow_max_depth(),
             default_token_budget: default_workflow_default_token_budget(),
             max_parallel_writes_without_worktree:

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -5453,8 +5453,9 @@ fn workflow_config_defaults_match_product_surface() {
     assert!(defaults.automatic);
     assert!(defaults.auto_start_read_only);
     assert!(defaults.require_approval_for_writes);
-    assert_eq!(defaults.auto_start_child_limit, 8);
-    assert_eq!(defaults.max_children, 64);
+    assert_eq!(defaults.auto_start_child_limit, 16);
+    assert_eq!(defaults.max_children, 1000);
+    assert_eq!(defaults.max_concurrent, 16);
     assert_eq!(defaults.max_depth, 2);
     assert_eq!(defaults.default_token_budget, 120_000);
     assert_eq!(defaults.max_parallel_writes_without_worktree, 0);
@@ -5498,7 +5499,8 @@ default_token_budget = 50000
     // Unset keys keep product defaults.
     assert!(workflow.auto_start_read_only);
     assert!(workflow.require_approval_for_writes);
-    assert_eq!(workflow.auto_start_child_limit, 8);
+    assert_eq!(workflow.auto_start_child_limit, 16);
+    assert_eq!(workflow.max_concurrent, 16);
     assert_eq!(workflow.max_depth, 2);
     assert_eq!(workflow.max_parallel_writes_without_worktree, 0);
     assert!(workflow.persist_completed_activity);

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1404,6 +1404,10 @@ pub struct SubAgentRuntime {
     pub fleet_roster: std::sync::Arc<crate::fleet::roster::FleetRoster>,
     pub context: ToolContext,
     pub allow_shell: bool,
+    /// When true, Suggest-level file writes auto-accept for write-capable roles
+    /// without full parent auto-approve. Shell/network/MCP still gated.
+    /// Set for Workflow-spawned children.
+    pub accept_edits: bool,
     /// Native Agent-mode tool surface inherited from the parent turn. Carries
     /// feature/config-dependent families such as web search, patch, memory,
     /// vision, notify, and FIM so child catalogs stay in parity with the parent.
@@ -1496,6 +1500,7 @@ impl SubAgentRuntime {
             fleet_roster: std::sync::Arc::new(crate::fleet::roster::FleetRoster::built_ins_only()),
             context,
             allow_shell,
+            accept_edits: false,
             agent_tool_surface_options: AgentToolSurfaceOptions::new(
                 ShellPolicy::from_legacy_allow_shell(allow_shell),
             ),
@@ -1757,6 +1762,7 @@ impl SubAgentRuntime {
             fleet_roster: self.fleet_roster.clone(),
             context: child_context,
             allow_shell: self.allow_shell,
+            accept_edits: self.accept_edits,
             agent_tool_surface_options: self.agent_tool_surface_options.clone(),
             worker_profile: self.worker_profile.clone(),
             event_tx: self.event_tx.clone(),
@@ -4470,7 +4476,7 @@ fn apply_session_spawn_policy(
 pub(crate) async fn spawn_workflow_task(
     request: codewhale_workflow_js::TaskRequest,
     manager: SharedSubAgentManager,
-    runtime: SubAgentRuntime,
+    mut runtime: SubAgentRuntime,
     identity: WorkflowTaskSpawnIdentity,
 ) -> Result<WorkflowTaskSpawnResult, ToolError> {
     // Capture identity fallbacks before consuming `request` fields into the
@@ -4515,6 +4521,10 @@ pub(crate) async fn spawn_workflow_task(
     if let Some(value) = request.token_budget {
         input["token_budget"] = json!(value);
     }
+    // Workflow children inherit the parent tool surface and auto-accept
+    // Suggest-level file edits for write-capable roles. Shell / network / MCP
+    // still require parent auto-approve (or fail closed).
+    runtime.accept_edits = true;
     let (result, _, mut metadata) = spawn_subagent_from_input(input, manager, runtime).await?;
     // Prefer the identity values the driver stamped; fall back to task options.
     let workflow_task_label = identity
@@ -7592,6 +7602,8 @@ struct SubAgentToolRegistry {
     /// `command_denies_tool` (exact + `prefix*`, case-insensitive).
     disallowed_tools: Vec<String>,
     auto_approve: bool,
+    /// Workflow-spawned children auto-accept Suggest-level file edits.
+    accept_edits: bool,
     /// The role/type of the sub-agent that this registry belongs to. Used to
     /// decide whether `Suggest`-level tools (write/edit/patch) may run inside
     /// the child without the parent runtime being auto-approved (#1828, #1833).
@@ -7663,6 +7675,7 @@ impl SubAgentToolRegistry {
             allowed_tools: explicit_allowed_tools,
             disallowed_tools: runtime.worker_profile.denied_tools.clone(),
             auto_approve: runtime.context.auto_approve,
+            accept_edits: runtime.accept_edits,
             agent_type,
             runtime_profile: runtime.worker_profile,
             can_spawn_child,
@@ -7803,16 +7816,12 @@ impl SubAgentToolRegistry {
                 ApprovalRequirement::Suggest => {
                     // Write/edit/patch tools land here. Explicit
                     // write-capable roles (`implementer`, `custom`) may run them
-                    // without parent auto-approve so that delegated work
-                    // can actually land file changes; the previous
-                    // behavior blocked every write under `suggest` mode
-                    // even for the role explicitly chartered to write
-                    // (#1828, #1833). Read-only roles still bounce so
-                    // exploration/review/planning/verifier children
-                    // can't mutate the workspace behind the parent's back.
-                    if !self.runtime_profile.permissions.write
-                        || !Self::role_can_delegate_writes(&self.agent_type)
-                    {
+                    // without parent auto-approve (#1828, #1833). Workflow-spawned
+                    // children also accept Suggest edits for any write-capable
+                    // posture (including general). Read-only roles still bounce.
+                    let may_write = self.runtime_profile.permissions.write
+                        && (self.accept_edits || Self::role_can_delegate_writes(&self.agent_type));
+                    if !may_write {
                         return Err(anyhow!(
                             "Tool {name} requires approval and is not delegated to {role} sub-agents; rerun the parent with auto approval or pick a write-capable role",
                             role = self.agent_type.as_str()

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -4233,6 +4233,47 @@ async fn implementer_delegation_allows_suggest_write_without_parent_auto_approve
 }
 
 #[tokio::test]
+async fn workflow_accept_edits_allows_general_file_write_without_parent_auto_approve() {
+    // Workflow-spawned children accept Suggest-level file edits for write-capable
+    // postures (including general) while shell tools still require parent auto-approve.
+    let tmp = tempdir().expect("tempdir");
+    let workspace = tmp.path().to_path_buf();
+    let mut runtime = stub_runtime();
+    runtime.context = ToolContext::new(workspace.clone());
+    runtime.context.auto_approve = false;
+    runtime.accept_edits = true;
+    let registry = SubAgentToolRegistry::new(
+        runtime,
+        SubAgentType::General,
+        None,
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+
+    let result = registry
+        .execute(
+            "agent_test",
+            "write_file",
+            json!({"path": "workflow_edit.txt", "content": "from workflow"}),
+        )
+        .await
+        .expect("workflow accept_edits should allow general write");
+    let written =
+        std::fs::read_to_string(workspace.join("workflow_edit.txt")).expect("file should exist");
+    assert_eq!(written, "from workflow");
+    assert!(!result.contains("requires approval"), "{result}");
+
+    let err = registry
+        .execute("agent_test", "exec_shell", json!({"command": "echo hi"}))
+        .await
+        .expect_err("shell must still require parent auto-approve");
+    assert!(
+        err.to_string().contains("requires approval"),
+        "unexpected: {err}"
+    );
+}
+
+#[tokio::test]
 async fn general_delegation_still_blocks_suggest_write_without_parent_auto_approve() {
     let tmp = tempdir().expect("tempdir");
     let workspace = tmp.path().to_path_buf();
@@ -4693,6 +4734,7 @@ fn stub_runtime() -> SubAgentRuntime {
         fleet_roster: std::sync::Arc::new(crate::fleet::roster::FleetRoster::built_ins_only()),
         context,
         allow_shell: true,
+        accept_edits: false,
         agent_tool_surface_options: AgentToolSurfaceOptions::new(ShellPolicy::Full),
         worker_profile: WorkerRuntimeProfile::for_role(SubAgentType::General),
         event_tx: None,

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -19,11 +19,11 @@ use codewhale_workflow::{
 };
 use codewhale_workflow_js::{
     BudgetSnapshot, DriverError, ProgressEvent, SpawnedTask, TaskCompletion, TaskRequest,
-    WorkflowDriver, WorkflowRunCancel, WorkflowVm,
+    WORKFLOW_MAX_CONCURRENT, WorkflowDriver, WorkflowRunCancel, WorkflowVm,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
 use uuid::Uuid;
 
 use crate::core::events::Event;
@@ -1591,6 +1591,10 @@ struct SubAgentWorkflowDriver {
     task_records: Arc<Mutex<HashMap<String, RuntimeTaskRecord>>>,
     total_budget: Option<u64>,
     last_budget_event: Arc<Mutex<Option<BudgetSnapshot>>>,
+    /// Caps concurrently live `task()` children for this run (product: 16).
+    concurrent_gate: Arc<Semaphore>,
+    /// Held permits for in-flight children; released on completion/cancel.
+    spawn_permits: Mutex<HashMap<String, OwnedSemaphorePermit>>,
 }
 
 impl SubAgentWorkflowDriver {
@@ -1615,6 +1619,8 @@ impl SubAgentWorkflowDriver {
             task_records: Arc::new(Mutex::new(HashMap::new())),
             total_budget,
             last_budget_event: Arc::new(Mutex::new(None)),
+            concurrent_gate: Arc::new(Semaphore::new(WORKFLOW_MAX_CONCURRENT.max(1))),
+            spawn_permits: Mutex::new(HashMap::new()),
         });
         spawn_completion_pump(driver.clone(), completion_rx);
         driver
@@ -1626,6 +1632,9 @@ impl SubAgentWorkflowDriver {
             .lock()
             .map(|ids| ids.clone())
             .unwrap_or_default();
+        if let Ok(mut permits) = self.spawn_permits.lock() {
+            permits.clear();
+        }
         cancel_child_agents(self.manager.clone(), ids);
         if let Ok(mut state) = self.completion_state.lock() {
             for (_, waiter) in state.waiters.drain() {
@@ -1823,6 +1832,9 @@ impl SubAgentWorkflowDriver {
 
     fn deliver_completion(&self, agent_id: String, completion: TaskCompletion) {
         self.record_task_completion(&agent_id, &completion);
+        if let Ok(mut permits) = self.spawn_permits.lock() {
+            permits.remove(&agent_id);
+        }
         let mut state = self
             .completion_state
             .lock()
@@ -1844,6 +1856,13 @@ struct CompletionState {
 #[async_trait]
 impl WorkflowDriver for SubAgentWorkflowDriver {
     async fn spawn_task(&self, request: TaskRequest) -> Result<SpawnedTask, DriverError> {
+        // Wait for a concurrent slot (max 16 live children per run).
+        let permit = self
+            .concurrent_gate
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| DriverError::Rejected("workflow concurrent admission closed".into()))?;
         let runtime = self
             .runtime
             .clone()
@@ -1874,10 +1893,18 @@ impl WorkflowDriver for SubAgentWorkflowDriver {
             workflow_task_label,
             workflow_child_index,
         };
-        let result = spawn_workflow_task(request, self.manager.clone(), runtime, identity)
-            .await
-            .map_err(|err| DriverError::Rejected(err.to_string()))?;
+        let result =
+            match spawn_workflow_task(request, self.manager.clone(), runtime, identity).await {
+                Ok(result) => result,
+                Err(err) => {
+                    drop(permit);
+                    return Err(DriverError::Rejected(err.to_string()));
+                }
+            };
         let task_id = result.result.agent_id.clone();
+        if let Ok(mut permits) = self.spawn_permits.lock() {
+            permits.insert(task_id.clone(), permit);
+        }
         self.record_child(&task_id);
         self.record_task_started(&task_id, &request_record, &result.metadata, &result.result);
         self.record_task_request(&task_id, &request_record);

--- a/crates/workflow-js/src/lib.rs
+++ b/crates/workflow-js/src/lib.rs
@@ -55,7 +55,18 @@ pub use vm::{VmLimits, WorkflowRunCancel, WorkflowVm};
 /// Maximum `task()` spawn attempts per run (design §4.3). Counted in the VM
 /// before the driver is consulted, so a runaway `loop-until-dry` terminates
 /// even if the driver would keep admitting work.
+///
+/// Product scale: up to 1_000 agents per Workflow run.
 pub const WORKFLOW_LIFETIME_CAP: u64 = 1000;
 
+/// Maximum concurrently executing agents within one Workflow run.
+///
+/// Fan-out may *declare* more work via `parallel()` / `pipeline()`, but the
+/// host admits at most this many live `task()` children at once; additional
+/// spawns wait for a slot.
+pub const WORKFLOW_MAX_CONCURRENT: usize = 16;
+
 /// Maximum items per `parallel()` or `pipeline()` call (design §4.2).
-pub const PARALLEL_MAX_ITEMS: usize = 4096;
+/// Kept at the per-run agent ceiling so a single fan-out cannot declare more
+/// work than the lifetime cap can ever complete.
+pub const PARALLEL_MAX_ITEMS: usize = 1000;

--- a/crates/workflow-js/tests/vm_tests.rs
+++ b/crates/workflow-js/tests/vm_tests.rs
@@ -300,12 +300,12 @@ async fn pipeline_surfaces_response_schema_errors_instead_of_null() {
 }
 
 #[tokio::test]
-async fn parallel_enforces_the_4096_item_cap_without_spawning() {
+async fn parallel_enforces_the_1000_item_cap_without_spawning() {
     let driver = Arc::new(FakeDriver::new());
     let value = run(
         &driver,
         r#"
-        const thunks = new Array(4097).fill(() => task({ description: "x" }));
+        const thunks = new Array(1001).fill(() => task({ description: "x" }));
         try {
             await parallel(thunks);
             return "no-throw";
@@ -318,17 +318,17 @@ async fn parallel_enforces_the_4096_item_cap_without_spawning() {
     .await
     .unwrap();
     let text = value.as_str().unwrap();
-    assert!(text.contains("max 4096"), "{text}");
+    assert!(text.contains("max 1000"), "{text}");
     assert_eq!(driver.spawn_count(), 0, "cap must reject before any spawn");
 }
 
 #[tokio::test]
-async fn parallel_accepts_exactly_4096_items() {
+async fn parallel_accepts_exactly_1000_items() {
     let driver = Arc::new(FakeDriver::new());
     let value = run(
         &driver,
         r#"
-        const thunks = new Array(4096).fill(() => Promise.resolve(1));
+        const thunks = new Array(1000).fill(() => Promise.resolve(1));
         const results = await parallel(thunks);
         return results.length;
         "#,
@@ -336,7 +336,7 @@ async fn parallel_accepts_exactly_4096_items() {
     )
     .await
     .unwrap();
-    assert_eq!(value, json!(4096));
+    assert_eq!(value, json!(1000));
 }
 
 #[tokio::test]

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -21,7 +21,9 @@ pub use js_authoring::{
 pub use model_policy::*;
 pub use replay::*;
 
-pub const DEFAULT_FLEET_WORKFLOW_MAX_AGENTS: usize = 100;
+/// Default hard ceiling on total agents a Fleet-shaped Workflow plan may launch.
+/// Matches the imperative VM lifetime cap (1_000 agents per run).
+pub const DEFAULT_FLEET_WORKFLOW_MAX_AGENTS: usize = 1000;
 pub const DEFAULT_FLEET_WORKFLOW_MAX_DEPTH: usize = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/WORKFLOW_AUTHORING.md
+++ b/docs/WORKFLOW_AUTHORING.md
@@ -8,6 +8,26 @@ files, shell, network, providers, cancellation, or TUI state.
 For a guided walkthrough from Fleet task specs to Workflow authoring and
 monitoring, see [Fleet + Workflow Tutorial](FLEET_WORKFLOW_TUTORIAL.md).
 
+
+## Access model
+
+The Workflow script is a **coordinator only**. It has no filesystem or shell of
+its own. Real work happens in sub-agents the script launches.
+
+| Layer | What it can access |
+|-------|--------------------|
+| Workflow script (JS VM) | Script variables, branching/loops, `task()` / `parallel()` / `pipeline()`, `phase` / `log`, `budget` / `args`. **No** direct FS, shell, network, env, imports, clock, or randomness. |
+| Workflow-spawned sub-agents | Normal tool surface (read/search/edit/write, shell, web, MCP) subject to role posture, allowlists, and parent policy. File edits for write-capable roles auto-accept under Workflow; shell / web / MCP still require parent auto-approve or fail closed. |
+| Parent session | Working directory, configured tools/MCP, permission mode, sandbox/network rules. |
+
+### Scale
+
+- Up to **16 concurrent** live agents in one run (additional spawns wait for a slot).
+- Up to **1_000 agents per run** (VM lifetime spawn cap).
+- Soft auto-launch still uses a lower child soft-cap (`auto_start_child_limit`).
+
+See the Workflow JS sandbox tests for the fail-closed host surface inventory.
+
 ## Language Choice
 
 | Surface | Strength | Tradeoff | v0.8.60 stance |


### PR DESCRIPTION
## Summary

Aligns CodeWhale dynamic Workflows with the intended access + scale model:

### Access model
| Layer | Capability |
|-------|------------|
| Workflow script (JS VM) | Coordinates only: `task` / `parallel` / `pipeline` / `phase` / `log` / `budget` / `args`. **No** FS, shell, network, env, imports (already enforced; sandbox tests green). |
| Workflow-spawned sub-agents | Inherit parent tool surface. **Accept file edits** for write-capable roles without full parent auto-approve. Shell / web / MCP still require parent auto-approve or fail closed. |
| Parent session | Workspace, tools, MCP, permission mode, sandbox/network policy. |

### Scale
- **16 concurrent** live agents per run (semaphore in the Workflow driver; extra `task()` waits for a slot)
- **1_000 agents per run** (existing `WORKFLOW_LIFETIME_CAP`)
- Config: `max_children = 1000`, `max_concurrent = 16`, `auto_start_child_limit = 16`
- `parallel()` item cap aligned to 1000

### Tests
- sandbox fail-closed (existing)
- lifetime cap at 1001
- parallel item cap at 1000
- Workflow accept-edits allows general `write_file` without parent auto-approve; shell still gated

## Test plan
- [x] `cargo test -p codewhale-workflow-js --test vm_tests item_cap / lifetime_cap / sandbox_blocks`
- [x] `cargo test -p codewhale-config --lib workflow`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui workflow_accept_edits`
- [ ] CI green