### PR TITLE
feat(workflow): elevated plan approval card (#4126)

### DIFF
--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -63,6 +63,7 @@ pub mod verifier;
 pub mod web_run;
 pub mod web_search;
 pub mod workflow;
+pub mod workflow_plan_approval;
 
 pub use registry::{AgentToolSurfaceOptions, ToolRegistry, ToolRegistryBuilder};
 pub use review::ReviewOutput;

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -36,6 +36,10 @@ use crate::tools::subagent::{
     WorkflowTaskSpawnIdentity, WorkflowTaskSpawnMetadata, spawn_workflow_task,
 };
 use crate::tools::verifier::run_workflow_completion_gates;
+use crate::tools::workflow_plan_approval::{
+    WorkflowPlanApprovalReceipt, analyze_workflow_plan_approval_with_config, analyze_workflow_spec,
+    workflow_approval_requirement_for,
+};
 use crate::utils::spawn_supervised;
 
 #[derive(Clone)]
@@ -241,6 +245,9 @@ struct WorkflowRunRecord {
     verify_on_complete: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     verification: Option<Value>,
+    /// Durable elevated-plan approval receipt for audit (#4126).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    plan_approval: Option<WorkflowPlanApprovalReceipt>,
 }
 
 impl WorkflowRunRecord {
@@ -268,6 +275,7 @@ impl WorkflowRunRecord {
             error: None,
             verify_on_complete: false,
             verification: None,
+            plan_approval: None,
         }
     }
 
@@ -413,14 +421,16 @@ impl ToolSpec for WorkflowTool {
     }
 
     fn approval_requirement(&self) -> ApprovalRequirement {
+        // Default posture: elevated starts require approval. Concrete inputs
+        // refine this via `approval_requirement_for` (#4126).
         ApprovalRequirement::Required
     }
 
     fn approval_requirement_for(&self, input: &Value) -> ApprovalRequirement {
-        match parse_workflow_action(input) {
-            Ok(WorkflowAction::Status) => ApprovalRequirement::Auto,
-            _ => ApprovalRequirement::Required,
-        }
+        // Product defaults for [workflow] when the tool has no live Config
+        // handle. YOLO/bypass still short-circuit upstream of this check.
+        let config = codewhale_config::WorkflowConfigToml::default();
+        workflow_approval_requirement_for(input, &config)
     }
 
     fn starts_detached_for(&self, input: &Value) -> bool {
@@ -484,6 +494,21 @@ async fn start_workflow(
     let verify_on_complete = optional_bool(&input, "verify", false);
     let run_id = format!("workflow_{}", &Uuid::new_v4().to_string()[..8]);
 
+    // Capture the approved plan envelope for audit/receipt (#4126). Reaching
+    // execute means the approval gate already passed (or YOLO/auto-start).
+    let workflow_cfg = codewhale_config::WorkflowConfigToml::default();
+    let summary = source
+        .spec
+        .as_ref()
+        .map(|spec| analyze_workflow_spec(spec, token_budget, &workflow_cfg))
+        .unwrap_or_else(|| analyze_workflow_plan_approval_with_config(&input, &workflow_cfg));
+    let approval_decision = if summary.is_read_only_envelope() {
+        "auto_read_only"
+    } else {
+        "approved"
+    };
+    let plan_approval = summary.to_receipt(approval_decision, now_ms());
+
     {
         let mut runs_guard = lock_mutex(&state.runs)?;
         let mut record = WorkflowRunRecord::new(
@@ -493,6 +518,7 @@ async fn start_workflow(
             source.spec.as_ref(),
         );
         record.verify_on_complete = verify_on_complete;
+        record.plan_approval = Some(plan_approval.clone());
         let started = WorkflowUiEvent::at(
             record.started_at_ms,
             WorkflowUiEventKind::RunStarted {
@@ -737,6 +763,8 @@ fn workflow_result_for(
         "branch_count": summary.branch_count,
         "control_count": summary.control_count,
         "execution_status": summary.execution_status,
+        // #4126: durable plan-approval receipt for audit/receipt consumers.
+        "plan_approval": record.plan_approval,
     }));
     Ok(result)
 }
@@ -2563,6 +2591,7 @@ mod journal {
                 error: None,
                 verify_on_complete: false,
                 verification: None,
+                plan_approval: None,
             }
         }
 

--- a/crates/tui/src/tools/workflow_plan_approval.rs
+++ b/crates/tui/src/tools/workflow_plan_approval.rs
@@ -1,0 +1,911 @@
+//! Elevated Workflow plan approval analysis (#4126).
+//!
+//! Builds the approval-card summary (goal, children, writes/shell/network/budget)
+//! and decides whether a launch is elevated enough to require operator approval
+//! beyond read-only auto-start.
+
+use codewhale_config::WorkflowConfigToml;
+use codewhale_workflow::{
+    ElevationOptions, WorkflowPlanElevation, WorkflowSpec, assess_workflow_elevation,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::tools::spec::ApprovalRequirement;
+
+/// Capability / budget summary shown on the Workflow approval card.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowPlanApprovalSummary {
+    pub goal: String,
+    pub risk: Option<String>,
+    pub child_count: usize,
+    pub child_labels: Vec<String>,
+    pub child_summary: String,
+    pub phase_count: usize,
+    pub writes: bool,
+    pub shell: bool,
+    pub network: bool,
+    pub secrets: bool,
+    pub worktree: bool,
+    pub high_budget: bool,
+    pub broader_authority: bool,
+    pub token_budget: Option<u64>,
+    pub budget_label: String,
+    pub elevated: bool,
+    pub reasons: Vec<String>,
+}
+
+impl WorkflowPlanApprovalSummary {
+    /// Card field pairs: Goal, Children, Writes, Shell, Network, Budget.
+    #[must_use]
+    pub fn card_fields(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("Goal", self.goal.clone()),
+            ("Children", self.child_summary.clone()),
+            ("Writes", yn(self.writes).to_string()),
+            ("Shell", yn(self.shell).to_string()),
+            ("Network", yn(self.network).to_string()),
+            ("Budget", self.budget_label.clone()),
+        ]
+    }
+
+    /// One-line impacts for the shared ApprovalView card.
+    #[must_use]
+    pub fn approval_impacts(&self) -> Vec<String> {
+        let mut impacts = Vec::new();
+        if !self.goal.is_empty() {
+            impacts.push(format!("Goal: {}", truncate(&self.goal, 96)));
+        }
+        if let Some(risk) = &self.risk {
+            impacts.push(format!("Risk: {risk}"));
+        }
+        impacts.push(format!("Children: {}", self.child_summary));
+        if self.phase_count > 0 {
+            impacts.push(format!("Phases: {}", self.phase_count));
+        }
+        impacts.push(format!("Writes: {}", yn(self.writes)));
+        impacts.push(format!("Shell: {}", yn(self.shell)));
+        impacts.push(format!("Network: {}", yn(self.network)));
+        if self.secrets {
+            impacts.push(format!("Secrets: {}", yn(self.secrets)));
+        }
+        if self.worktree {
+            impacts.push(format!("Worktree: {}", yn(self.worktree)));
+        }
+        impacts.push(format!("Budget: {}", self.budget_label));
+        if self.broader_authority {
+            impacts.push("Broader authority than parent mode".into());
+        }
+        if self.elevated {
+            impacts.push(
+                "Elevated plan — Approve to launch, Edit plan to revise, Cancel to abort.".into(),
+            );
+        } else {
+            impacts.push("Read-only plan.".into());
+        }
+        impacts
+    }
+
+    /// Durable receipt fragment for audit after approval/launch.
+    #[must_use]
+    pub fn to_receipt(&self, decision: &str, approved_at_ms: u64) -> WorkflowPlanApprovalReceipt {
+        WorkflowPlanApprovalReceipt {
+            decision: decision.to_string(),
+            approved_at_ms,
+            goal: self.goal.clone(),
+            child_summary: self.child_summary.clone(),
+            writes: self.writes,
+            shell: self.shell,
+            network: self.network,
+            secrets: self.secrets,
+            worktree: self.worktree,
+            high_budget: self.high_budget,
+            broader_authority: self.broader_authority,
+            budget_label: self.budget_label.clone(),
+            reasons: self.reasons.clone(),
+            elevated: self.elevated,
+            token_budget: self.token_budget,
+            risk: self.risk.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_read_only_envelope(&self) -> bool {
+        !self.elevated
+    }
+}
+
+/// Durable snapshot of an approved (or auto-started) plan for audit (#4126).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowPlanApprovalReceipt {
+    pub decision: String,
+    pub approved_at_ms: u64,
+    pub goal: String,
+    pub child_summary: String,
+    pub writes: bool,
+    pub shell: bool,
+    pub network: bool,
+    pub secrets: bool,
+    pub worktree: bool,
+    pub high_budget: bool,
+    pub broader_authority: bool,
+    pub budget_label: String,
+    pub reasons: Vec<String>,
+    pub elevated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk: Option<String>,
+}
+
+/// Analyze a `workflow` tool input for approval elevation (#4126).
+#[must_use]
+pub fn analyze_workflow_plan_approval(input: &Value) -> WorkflowPlanApprovalSummary {
+    analyze_workflow_plan_approval_with_config(input, &WorkflowConfigToml::default())
+}
+
+/// Same as [`analyze_workflow_plan_approval`] with an explicit workflow config.
+#[must_use]
+pub fn analyze_workflow_plan_approval_with_config(
+    input: &Value,
+    config: &WorkflowConfigToml,
+) -> WorkflowPlanApprovalSummary {
+    let action = input
+        .get("action")
+        .and_then(Value::as_str)
+        .unwrap_or("start");
+    if matches!(action, "status" | "cancel") {
+        return empty_summary(format!("workflow {action}"), None);
+    }
+
+    if let Some(plan) = input.get("plan").filter(|v| v.is_object()) {
+        return analyze_plan_object(plan, optional_u64(input, "token_budget"), config);
+    }
+
+    // script / source_path — conservative elevated unless clearly status-only.
+    let goal = input
+        .get("source_path")
+        .and_then(Value::as_str)
+        .map(|p| format!("source_path: {p}"))
+        .or_else(|| {
+            input
+                .get("script")
+                .and_then(Value::as_str)
+                .map(|s| truncate(s.lines().next().unwrap_or("inline script"), 80))
+        })
+        .unwrap_or_else(|| "workflow launch".into());
+
+    let script = input
+        .get("script")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let writes = script_suggests_writes(script);
+    let shell = script_suggests_shell(script);
+    let network = script_suggests_network(script);
+    let worktree = script.contains("worktree") || script.contains("isolation");
+    let token_budget = optional_u64(input, "token_budget");
+    let high_budget = token_budget.is_some_and(|b| b > config.default_token_budget);
+    // Unknown script authority: always elevated so the card is required.
+    let elevated = true;
+    let mut reasons = vec!["script_or_source".to_string()];
+    if writes {
+        reasons.push("writes".into());
+    }
+    if shell {
+        reasons.push("shell".into());
+    }
+    if network {
+        reasons.push("network".into());
+    }
+    if worktree {
+        reasons.push("worktree".into());
+    }
+    if high_budget {
+        reasons.push("high_budget".into());
+    }
+    let child_count = count_script_tasks(script);
+    let child_summary = if child_count == 0 {
+        "script/source (authority unknown until run)".into()
+    } else {
+        format!("{child_count} task() calls")
+    };
+    WorkflowPlanApprovalSummary {
+        goal,
+        risk: None,
+        child_count,
+        child_labels: Vec::new(),
+        child_summary,
+        phase_count: script.matches("phase(").count(),
+        writes: writes || elevated,
+        shell: shell || elevated,
+        network: network || elevated,
+        secrets: false,
+        worktree,
+        high_budget,
+        broader_authority: false,
+        token_budget,
+        budget_label: budget_label(token_budget, high_budget),
+        elevated,
+        reasons,
+    }
+}
+
+/// Assess a compiled Workflow IR for the approval card / receipt.
+#[must_use]
+pub fn analyze_workflow_spec(
+    spec: &WorkflowSpec,
+    token_budget: Option<u64>,
+    config: &WorkflowConfigToml,
+) -> WorkflowPlanApprovalSummary {
+    let elevation = assess_workflow_elevation(
+        spec,
+        ElevationOptions {
+            token_budget,
+            high_budget_threshold: config.default_token_budget,
+            ..ElevationOptions::default()
+        },
+    );
+    summary_from_elevation(elevation, spec.description.clone(), token_budget)
+}
+
+fn summary_from_elevation(
+    elevation: WorkflowPlanElevation,
+    risk: Option<String>,
+    token_budget: Option<u64>,
+) -> WorkflowPlanApprovalSummary {
+    WorkflowPlanApprovalSummary {
+        goal: elevation.goal,
+        risk,
+        child_count: elevation.child_count,
+        child_labels: Vec::new(),
+        child_summary: elevation.child_summary,
+        phase_count: 0,
+        writes: elevation.writes,
+        shell: elevation.shell,
+        network: elevation.network,
+        secrets: elevation.secrets,
+        worktree: elevation.worktree,
+        high_budget: elevation.high_budget,
+        broader_authority: elevation.broader_authority,
+        token_budget,
+        budget_label: elevation.budget_label,
+        elevated: elevation.elevated,
+        reasons: elevation.reasons,
+    }
+}
+
+/// Decide whether the workflow tool call requires an approval card (#4126).
+#[must_use]
+pub fn workflow_approval_requirement_for(
+    input: &Value,
+    config: &WorkflowConfigToml,
+) -> ApprovalRequirement {
+    let action = input
+        .get("action")
+        .and_then(Value::as_str)
+        .unwrap_or("start");
+    match action {
+        "status" => ApprovalRequirement::Auto,
+        "cancel" => ApprovalRequirement::Required,
+        _ => {
+            let summary = analyze_workflow_plan_approval_with_config(input, config);
+            if summary.is_read_only_envelope() {
+                if config.auto_start_read_only {
+                    ApprovalRequirement::Auto
+                } else {
+                    ApprovalRequirement::Required
+                }
+            } else if config.require_approval_for_writes {
+                ApprovalRequirement::Required
+            } else {
+                ApprovalRequirement::Auto
+            }
+        }
+    }
+}
+
+fn empty_summary(goal: String, token_budget: Option<u64>) -> WorkflowPlanApprovalSummary {
+    WorkflowPlanApprovalSummary {
+        goal,
+        risk: None,
+        child_count: 0,
+        child_labels: Vec::new(),
+        child_summary: "0 children".into(),
+        phase_count: 0,
+        writes: false,
+        shell: false,
+        network: false,
+        secrets: false,
+        worktree: false,
+        high_budget: false,
+        broader_authority: false,
+        token_budget,
+        budget_label: budget_label(token_budget, false),
+        elevated: false,
+        reasons: Vec::new(),
+    }
+}
+
+fn analyze_plan_object(
+    plan: &Value,
+    token_budget_override: Option<u64>,
+    config: &WorkflowConfigToml,
+) -> WorkflowPlanApprovalSummary {
+    let goal = plan
+        .get("goal")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let risk = plan
+        .get("risk")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let token_budget = token_budget_override.or_else(|| {
+        plan.get("token_budget")
+            .and_then(Value::as_u64)
+            .or_else(|| {
+                plan.get("budget")
+                    .and_then(|b| b.get("max_tokens"))
+                    .and_then(Value::as_u64)
+            })
+    });
+
+    let mut child_labels = Vec::new();
+    let mut child_count = 0usize;
+    let mut phase_count = 0usize;
+    let mut writes = false;
+    let mut shell = false;
+    let mut network = false;
+    let mut secrets = false;
+    let mut worktree = false;
+
+    if let Some(phases) = plan.get("phases").and_then(Value::as_array) {
+        phase_count = phases.len();
+        for phase in phases {
+            collect_children(
+                phase.get("children").and_then(Value::as_array),
+                &mut child_labels,
+                &mut child_count,
+                &mut writes,
+                &mut shell,
+                &mut network,
+                &mut secrets,
+                &mut worktree,
+            );
+        }
+    }
+    collect_children(
+        plan.get("children").and_then(Value::as_array),
+        &mut child_labels,
+        &mut child_count,
+        &mut writes,
+        &mut shell,
+        &mut network,
+        &mut secrets,
+        &mut worktree,
+    );
+    // IR nodes escape hatch
+    if let Some(nodes) = plan.get("nodes").and_then(Value::as_array) {
+        walk_nodes(
+            nodes,
+            &mut child_labels,
+            &mut child_count,
+            &mut phase_count,
+            &mut writes,
+            &mut shell,
+            &mut network,
+            &mut secrets,
+            &mut worktree,
+        );
+    }
+
+    if matches!(
+        risk.as_deref(),
+        Some("writes" | "write" | "read_write" | "elevated" | "high" | "shell" | "network")
+    ) {
+        writes = writes
+            || matches!(
+                risk.as_deref(),
+                Some("writes" | "write" | "read_write" | "elevated" | "high" | "shell")
+            );
+        shell = shell || matches!(risk.as_deref(), Some("elevated" | "high" | "shell"));
+        network = network || matches!(risk.as_deref(), Some("elevated" | "high" | "network"));
+    }
+
+    // Parallel write children default to worktree isolation (#4120).
+    if writes && child_count > 1 {
+        worktree = true;
+    }
+
+    let high_budget = token_budget.is_some_and(|b| b > config.default_token_budget);
+    let mut reasons = Vec::new();
+    if writes {
+        reasons.push("writes".into());
+    }
+    if shell {
+        reasons.push("shell".into());
+    }
+    if network {
+        reasons.push("network".into());
+    }
+    if secrets {
+        reasons.push("secrets".into());
+    }
+    if worktree {
+        reasons.push("worktree".into());
+    }
+    if high_budget {
+        reasons.push("high_budget".into());
+    }
+    let elevated = !reasons.is_empty();
+
+    let child_summary = if child_labels.is_empty() {
+        format!(
+            "{child_count} child{}",
+            if child_count == 1 { "" } else { "ren" }
+        )
+    } else {
+        let shown: Vec<_> = child_labels.iter().take(4).map(String::as_str).collect();
+        let mut line = format!(
+            "{child_count} child{}: {}",
+            if child_count == 1 { "" } else { "ren" },
+            shown.join(", ")
+        );
+        if child_labels.len() > 4 {
+            line.push_str(", …");
+        }
+        line
+    };
+
+    WorkflowPlanApprovalSummary {
+        goal,
+        risk,
+        child_count,
+        child_labels,
+        child_summary,
+        phase_count,
+        writes,
+        shell,
+        network,
+        secrets,
+        worktree,
+        high_budget,
+        broader_authority: false,
+        token_budget,
+        budget_label: budget_label(token_budget, high_budget),
+        elevated,
+        reasons,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_children(
+    children: Option<&Vec<Value>>,
+    labels: &mut Vec<String>,
+    count: &mut usize,
+    writes: &mut bool,
+    shell: &mut bool,
+    network: &mut bool,
+    secrets: &mut bool,
+    worktree: &mut bool,
+) {
+    let Some(children) = children else {
+        return;
+    };
+    for child in children {
+        *count += 1;
+        if let Some(label) = child
+            .get("label")
+            .or_else(|| child.get("id"))
+            .and_then(Value::as_str)
+        {
+            labels.push(label.to_string());
+        }
+        let mode = child
+            .get("mode")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let agent_type = child
+            .get("type")
+            .or_else(|| child.get("agent_type"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if mode.contains("write") || agent_type == "implementer" || agent_type == "builder" {
+            *writes = true;
+            // Write-capable implementers may run shell beyond read-only.
+            if agent_type == "implementer" || agent_type == "builder" || agent_type == "general" {
+                *shell = true;
+            }
+        }
+        if child
+            .get("permissions")
+            .and_then(|p| p.get("allow_write"))
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            *writes = true;
+        }
+        if child
+            .get("permissions")
+            .and_then(|p| p.get("allow_network"))
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            *network = true;
+        }
+        let isolation = child
+            .get("isolation")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if isolation == "worktree" {
+            *worktree = true;
+        }
+        if let Some(tools) = child
+            .get("permissions")
+            .and_then(|p| p.get("allowed_tools"))
+            .and_then(Value::as_array)
+        {
+            for tool in tools {
+                let name = tool.as_str().unwrap_or_default();
+                if name.contains("shell") || name.contains("exec") {
+                    *shell = true;
+                }
+                if name.contains("secret") || name.contains("credential") || name == "read_env" {
+                    *secrets = true;
+                }
+                if matches!(name, "web_search" | "web_run" | "fetch_url")
+                    || name.starts_with("mcp_")
+                {
+                    *network = true;
+                }
+                if matches!(name, "write_file" | "edit_file" | "apply_patch") {
+                    *writes = true;
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_nodes(
+    nodes: &[Value],
+    labels: &mut Vec<String>,
+    count: &mut usize,
+    phase_count: &mut usize,
+    writes: &mut bool,
+    shell: &mut bool,
+    network: &mut bool,
+    secrets: &mut bool,
+    worktree: &mut bool,
+) {
+    for node in nodes {
+        if let Some(agent) = node.get("agent") {
+            collect_children(
+                Some(&vec![agent.clone()]),
+                labels,
+                count,
+                writes,
+                shell,
+                network,
+                secrets,
+                worktree,
+            );
+        }
+        if let Some(branch) = node.get("branch") {
+            *phase_count += 1;
+            collect_children(
+                branch.get("children").and_then(Value::as_array),
+                labels,
+                count,
+                writes,
+                shell,
+                network,
+                secrets,
+                worktree,
+            );
+        }
+        if let Some(seq) = node.get("sequence") {
+            *phase_count += 1;
+            if let Some(children) = seq.get("children").and_then(Value::as_array) {
+                walk_nodes(
+                    children,
+                    labels,
+                    count,
+                    phase_count,
+                    writes,
+                    shell,
+                    network,
+                    secrets,
+                    worktree,
+                );
+            }
+        }
+        if let Some(kind) = node.get("kind").and_then(Value::as_str)
+            && kind == "leaf"
+            && let Some(spec) = node.get("spec")
+        {
+            collect_children(
+                Some(&vec![spec.clone()]),
+                labels,
+                count,
+                writes,
+                shell,
+                network,
+                secrets,
+                worktree,
+            );
+        }
+    }
+}
+
+fn script_suggests_writes(script: &str) -> bool {
+    let lower = script.to_ascii_lowercase();
+    lower.contains("implementer")
+        || lower.contains("read_write")
+        || lower.contains("allow_write")
+        || lower.contains("write_file")
+        || lower.contains("apply_patch")
+}
+
+fn script_suggests_shell(script: &str) -> bool {
+    let lower = script.to_ascii_lowercase();
+    lower.contains("exec_shell") || (lower.contains("allowedtools") && lower.contains("shell"))
+}
+
+fn script_suggests_network(script: &str) -> bool {
+    let lower = script.to_ascii_lowercase();
+    lower.contains("allow_network") || lower.contains("web_search") || lower.contains("fetch_url")
+}
+
+fn count_script_tasks(script: &str) -> usize {
+    script.matches("task(").count()
+}
+
+fn optional_u64(value: &Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(Value::as_u64)
+}
+
+fn budget_label(token_budget: Option<u64>, high_budget: bool) -> String {
+    match token_budget {
+        Some(n) if high_budget => format!("{n} tokens (high)"),
+        Some(n) => format!("{n} tokens"),
+        None => "default".to_string(),
+    }
+}
+
+fn yn(v: bool) -> &'static str {
+    if v { "yes" } else { "no" }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let s = s.trim();
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn config() -> WorkflowConfigToml {
+        WorkflowConfigToml::default()
+    }
+
+    #[test]
+    fn read_only_plan_is_not_elevated_and_auto_starts() {
+        let input = json!({
+            "action": "start",
+            "plan": {
+                "goal": "scout crates",
+                "risk": "read_only",
+                "token_budget": 50000,
+                "phases": [{
+                    "id": "scout",
+                    "children": [
+                        { "id": "a", "prompt": "look left", "type": "explore" },
+                        { "id": "b", "prompt": "look right", "type": "explore" }
+                    ]
+                }]
+            }
+        });
+        let summary = analyze_workflow_plan_approval(&input);
+        assert!(!summary.elevated, "{summary:?}");
+        assert_eq!(summary.child_count, 2);
+        assert_eq!(summary.phase_count, 1);
+        assert!(!summary.writes);
+        assert_eq!(
+            workflow_approval_requirement_for(&input, &config()),
+            ApprovalRequirement::Auto
+        );
+        let fields = summary.card_fields();
+        assert_eq!(fields.len(), 6);
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Goal" && v.contains("scout"))
+        );
+        assert!(fields.iter().any(|(k, v)| *k == "Writes" && v == "no"));
+        assert!(fields.iter().any(|(k, v)| *k == "Shell" && v == "no"));
+        assert!(fields.iter().any(|(k, v)| *k == "Network" && v == "no"));
+        assert!(fields.iter().any(|(k, _)| *k == "Children"));
+        assert!(fields.iter().any(|(k, _)| *k == "Budget"));
+        let impacts = summary.approval_impacts();
+        assert!(impacts.iter().any(|i| i.contains("Goal: scout")));
+        assert!(impacts.iter().any(|i| i.contains("Writes: no")));
+    }
+
+    #[test]
+    fn write_plan_is_elevated_with_card_fields_and_requires_approval() {
+        let input = json!({
+            "action": "start",
+            "plan": {
+                "goal": "land the fix",
+                "risk": "writes",
+                "token_budget": 120000,
+                "children": [
+                    {
+                        "id": "builder",
+                        "label": "impl",
+                        "prompt": "patch it",
+                        "type": "implementer",
+                        "mode": "read_write"
+                    }
+                ]
+            }
+        });
+        let summary = analyze_workflow_plan_approval(&input);
+        assert!(summary.elevated);
+        assert!(summary.writes);
+        assert!(summary.shell);
+        assert_eq!(
+            workflow_approval_requirement_for(&input, &config()),
+            ApprovalRequirement::Required
+        );
+        let fields = summary.card_fields();
+        assert!(fields.iter().any(|(k, v)| *k == "Writes" && v == "yes"));
+        assert!(fields.iter().any(|(k, v)| *k == "Shell" && v == "yes"));
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Budget" && v.contains("120000"))
+        );
+        let impacts = summary.approval_impacts();
+        assert!(impacts.iter().any(|i| i.contains("Writes: yes")));
+        assert!(impacts.iter().any(|i| i.contains("Approve to launch")));
+        let receipt = summary.to_receipt("approved", 99);
+        assert_eq!(receipt.decision, "approved");
+        assert_eq!(receipt.approved_at_ms, 99);
+        assert_eq!(receipt.goal, "land the fix");
+        assert!(receipt.elevated);
+        assert!(receipt.writes);
+    }
+
+    #[test]
+    fn elevated_risk_flags_shell_and_network() {
+        let summary = analyze_workflow_plan_approval(&json!({
+            "plan": {
+                "goal": "full authority",
+                "risk": "elevated",
+                "children": [{ "prompt": "go", "type": "implementer" }]
+            }
+        }));
+        assert!(summary.elevated);
+        assert!(summary.writes);
+        assert!(summary.shell);
+        assert!(summary.network);
+        let fields = summary.card_fields();
+        assert!(fields.iter().any(|(k, v)| *k == "Network" && v == "yes"));
+    }
+
+    #[test]
+    fn high_budget_elevates_read_only_plan() {
+        let input = json!({
+            "action": "start",
+            "plan": {
+                "goal": "huge scout",
+                "risk": "read_only",
+                "token_budget": 250_000,
+                "children": [{ "prompt": "scan", "type": "explore" }]
+            }
+        });
+        let summary = analyze_workflow_plan_approval(&input);
+        assert!(summary.high_budget, "{summary:?}");
+        assert!(summary.elevated);
+        assert!(summary.budget_label.contains("high"));
+        assert_eq!(
+            workflow_approval_requirement_for(&input, &config()),
+            ApprovalRequirement::Required
+        );
+    }
+
+    #[test]
+    fn secrets_and_network_tools_elevate() {
+        let summary = analyze_workflow_plan_approval(&json!({
+            "plan": {
+                "goal": "creds",
+                "risk": "read_only",
+                "children": [{
+                    "id": "s",
+                    "prompt": "read secrets",
+                    "type": "explore",
+                    "permissions": {
+                        "allow_network": true,
+                        "allowed_tools": ["read_secret", "fetch_url"]
+                    }
+                }]
+            }
+        }));
+        assert!(summary.elevated);
+        assert!(summary.secrets);
+        assert!(summary.network);
+    }
+
+    #[test]
+    fn status_is_auto_cancel_is_required() {
+        assert_eq!(
+            workflow_approval_requirement_for(&json!({"action": "status"}), &config()),
+            ApprovalRequirement::Auto
+        );
+        assert_eq!(
+            workflow_approval_requirement_for(
+                &json!({"action": "cancel", "run_id": "x"}),
+                &config()
+            ),
+            ApprovalRequirement::Required
+        );
+    }
+
+    #[test]
+    fn require_approval_for_writes_false_allows_elevated_auto() {
+        let mut cfg = config();
+        cfg.require_approval_for_writes = false;
+        let input = json!({
+            "action": "start",
+            "plan": {
+                "goal": "write freely",
+                "risk": "writes",
+                "children": [{ "prompt": "edit", "type": "implementer" }]
+            }
+        });
+        assert_eq!(
+            workflow_approval_requirement_for(&input, &cfg),
+            ApprovalRequirement::Auto
+        );
+    }
+
+    #[test]
+    fn script_launch_requires_approval() {
+        assert_eq!(
+            workflow_approval_requirement_for(
+                &json!({"action": "start", "script": "return 1;"}),
+                &config()
+            ),
+            ApprovalRequirement::Required
+        );
+    }
+
+    #[test]
+    fn card_fields_always_six_required_labels() {
+        let summary = analyze_workflow_plan_approval(&json!({
+            "plan": {
+                "goal": "x",
+                "risk": "read_only",
+                "children": [{ "prompt": "y", "type": "explore" }]
+            }
+        }));
+        let labels: Vec<_> = summary.card_fields().iter().map(|(k, _)| *k).collect();
+        assert_eq!(
+            labels,
+            vec!["Goal", "Children", "Writes", "Shell", "Network", "Budget"]
+        );
+    }
+}

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -528,6 +528,11 @@ fn build_impact_summary(tool_name: &str, category: ToolCategory, params: &Value)
             }
             impacts
         }
+        ToolCategory::Agent if tool_name == "workflow" => {
+            // #4126: elevated Workflow plan card — goal, children, capability flags, budget.
+            crate::tools::workflow_plan_approval::analyze_workflow_plan_approval(params)
+                .approval_impacts()
+        }
         ToolCategory::Agent => {
             let mut impacts = vec![
                 "Starts or inspects a child agent task; the child's own tool gates still apply."
@@ -691,6 +696,18 @@ fn build_prominent_details(
                 details.push(ApprovalDetail {
                     label: "Target".to_string(),
                     value: target,
+                    shell_lines: None,
+                });
+            }
+        }
+        ToolCategory::Agent if tool_name == "workflow" => {
+            // #4126: elevated Workflow plan card fields.
+            let summary =
+                crate::tools::workflow_plan_approval::analyze_workflow_plan_approval(params);
+            for (label, value) in summary.card_fields() {
+                details.push(ApprovalDetail {
+                    label: label.to_string(),
+                    value,
                     shell_lines: None,
                 });
             }
@@ -929,6 +946,12 @@ fn localize_detail_label(label: &str, locale: Locale) -> Cow<'static, str> {
             "Action" => tr(locale, MessageId::ApprovalLabelAction),
             "Type" => tr(locale, MessageId::ApprovalLabelType),
             "Prompt" => tr(locale, MessageId::ApprovalLabelPrompt),
+            "Goal" => "目标".into(),
+            "Children" => "子任务".into(),
+            "Writes" => "写入".into(),
+            "Shell" => "Shell".into(),
+            "Network" => "网络".into(),
+            "Budget" => "预算".into(),
             _ => label.to_string().into(),
         },
         _ => label.to_string().into(),
@@ -1143,21 +1166,40 @@ impl ApprovalOption {
         ApprovalOption::Abort,
     ];
 
-    fn from_index(idx: usize) -> ApprovalOption {
-        Self::ORDER.get(idx).copied().unwrap_or(Self::Abort)
+    /// Workflow elevated-plan card (#4126): Approve / Edit plan / Cancel.
+    const WORKFLOW_ORDER: [ApprovalOption; 3] = [
+        ApprovalOption::ApproveOnce,
+        ApprovalOption::Deny,
+        ApprovalOption::Abort,
+    ];
+
+    fn order_for(tool_name: &str) -> &'static [ApprovalOption] {
+        if tool_name == "workflow" {
+            &Self::WORKFLOW_ORDER
+        } else {
+            &Self::ORDER
+        }
     }
 
-    fn index(self) -> usize {
-        Self::ORDER
+    fn from_index_for(tool_name: &str, idx: usize) -> ApprovalOption {
+        Self::order_for(tool_name)
+            .get(idx)
+            .copied()
+            .unwrap_or(Self::Abort)
+    }
+
+    fn index_for(self, tool_name: &str) -> usize {
+        Self::order_for(tool_name)
             .iter()
             .position(|o| *o == self)
-            .unwrap_or(Self::ORDER.len() - 1)
+            .unwrap_or(Self::order_for(tool_name).len().saturating_sub(1))
     }
 
     fn decision(self) -> ReviewDecision {
         match self {
             ApprovalOption::ApproveOnce => ReviewDecision::Approved,
             ApprovalOption::ApproveAlways => ReviewDecision::ApprovedForSession,
+            // Workflow maps Deny → "Edit plan" (model revises plan).
             ApprovalOption::Deny => ReviewDecision::Denied,
             ApprovalOption::Abort => ReviewDecision::Abort,
         }
@@ -1198,11 +1240,20 @@ impl ApprovalView {
     }
 
     fn select_next(&mut self) {
-        self.selected = (self.selected + 1).min(ApprovalOption::ORDER.len() - 1);
+        let max = ApprovalOption::order_for(&self.request.tool_name)
+            .len()
+            .saturating_sub(1);
+        self.selected = (self.selected + 1).min(max);
     }
 
     fn current_option(&self) -> ApprovalOption {
-        ApprovalOption::from_index(self.selected)
+        ApprovalOption::from_index_for(&self.request.tool_name, self.selected)
+    }
+
+    /// Whether this approval is the elevated Workflow plan card (#4126).
+    #[must_use]
+    pub fn is_workflow_plan_approval(&self) -> bool {
+        self.request.tool_name == "workflow"
     }
 
     /// Test-only accessor for the selected option's decision.
@@ -1228,7 +1279,7 @@ impl ApprovalView {
 
     /// Commit the given option and close the approval modal.
     fn commit_option(&mut self, option: ApprovalOption) -> ViewAction {
-        self.selected = option.index();
+        self.selected = option.index_for(&self.request.tool_name);
         self.emit_decision(option.decision(), false)
     }
 
@@ -1316,8 +1367,16 @@ impl ModalView for ApprovalView {
             KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Char('1') => {
                 self.commit_option(ApprovalOption::ApproveOnce)
             }
-            KeyCode::Char('a') | KeyCode::Char('A') | KeyCode::Char('2') => {
+            KeyCode::Char('a') | KeyCode::Char('A') | KeyCode::Char('2')
+                if !self.is_workflow_plan_approval() =>
+            {
                 self.commit_option(ApprovalOption::ApproveAlways)
+            }
+            // Workflow plan card (#4126): [2/e] Edit plan, [3/n/d] Cancel.
+            KeyCode::Char('e') | KeyCode::Char('E') | KeyCode::Char('2')
+                if self.is_workflow_plan_approval() =>
+            {
+                self.commit_option(ApprovalOption::Deny)
             }
             KeyCode::Char('s') | KeyCode::Char('S') if self.request.can_save_ask_rule() => self
                 .emit_decision_with_rules(
@@ -1329,7 +1388,14 @@ impl ModalView for ApprovalView {
             | KeyCode::Char('N')
             | KeyCode::Char('d')
             | KeyCode::Char('D')
-            | KeyCode::Char('3') => self.commit_option(ApprovalOption::Deny),
+            | KeyCode::Char('3') => {
+                if self.is_workflow_plan_approval() {
+                    // Cancel (abort turn) rather than session-deny.
+                    self.commit_option(ApprovalOption::Abort)
+                } else {
+                    self.commit_option(ApprovalOption::Deny)
+                }
+            }
             KeyCode::Char('v') | KeyCode::Char('V') => self.emit_params_pager(),
             KeyCode::Esc => self.emit_decision(ReviewDecision::Abort, false),
             _ => ViewAction::None,
@@ -3557,6 +3623,121 @@ diff --git a/src/b.rs b/src/b.rs
                 .iter()
                 .any(|o| matches!(o, ElevationOption::Abort))
         );
+    }
+
+    // ========================================================================
+    // Workflow elevated plan approval card (#4126)
+    // ========================================================================
+
+    #[test]
+    fn workflow_tool_is_agent_category_and_shows_plan_card_fields() {
+        assert_eq!(get_tool_category("workflow"), ToolCategory::Agent);
+        let request = ApprovalRequest::new(
+            "wf-1",
+            "workflow",
+            "Launch workflow",
+            &json!({
+                "action": "start",
+                "plan": {
+                    "goal": "ship the fix",
+                    "risk": "writes",
+                    "token_budget": 80_000,
+                    "children": [
+                        {
+                            "id": "impl",
+                            "label": "builder",
+                            "prompt": "edit files",
+                            "type": "implementer",
+                            "mode": "read_write"
+                        }
+                    ]
+                }
+            }),
+            "tool:workflow",
+        );
+        assert_eq!(request.category, ToolCategory::Agent);
+        let details = request.prominent_detail_items(Locale::En);
+        let labels: Vec<_> = details.iter().map(|d| d.label.as_str()).collect();
+        assert!(labels.contains(&"Goal"), "{labels:?}");
+        assert!(labels.contains(&"Children"), "{labels:?}");
+        assert!(labels.contains(&"Writes"), "{labels:?}");
+        assert!(labels.contains(&"Shell"), "{labels:?}");
+        assert!(labels.contains(&"Network"), "{labels:?}");
+        assert!(labels.contains(&"Budget"), "{labels:?}");
+        assert!(
+            details
+                .iter()
+                .any(|d| d.label == "Goal" && d.value.contains("ship the fix")),
+            "{details:?}"
+        );
+        assert!(
+            details
+                .iter()
+                .any(|d| d.label == "Writes" && d.value == "yes"),
+            "{details:?}"
+        );
+        assert!(
+            request
+                .impacts
+                .iter()
+                .any(|i| i.contains("Approve to launch")),
+            "{:?}",
+            request.impacts
+        );
+
+        let view = ApprovalView::new(request);
+        assert!(view.is_workflow_plan_approval());
+        assert_eq!(view.current_decision(), ReviewDecision::Approved);
+    }
+
+    #[test]
+    fn workflow_plan_card_edit_plan_and_cancel_keys() {
+        let request = ApprovalRequest::new(
+            "wf-2",
+            "workflow",
+            "Launch workflow",
+            &json!({
+                "action": "start",
+                "plan": {
+                    "goal": "risky",
+                    "risk": "elevated",
+                    "children": [{ "prompt": "go", "type": "implementer" }]
+                }
+            }),
+            "tool:workflow",
+        );
+        let mut view = ApprovalView::new(request);
+        // [2 / e] → Edit plan → Denied
+        let action = view.handle_key(create_key_event(KeyCode::Char('e')));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ApprovalDecision { decision, .. }) => {
+                assert_eq!(decision, ReviewDecision::Denied);
+            }
+            other => panic!("expected edit-plan denial, got {other:?}"),
+        }
+
+        let request = ApprovalRequest::new(
+            "wf-3",
+            "workflow",
+            "Launch workflow",
+            &json!({
+                "action": "start",
+                "plan": {
+                    "goal": "risky",
+                    "risk": "elevated",
+                    "children": [{ "prompt": "go", "type": "implementer" }]
+                }
+            }),
+            "tool:workflow",
+        );
+        let mut view = ApprovalView::new(request);
+        let action = view.handle_key(create_key_event(KeyCode::Char('3')));
+        match action {
+            ViewAction::EmitAndClose(ViewEvent::ApprovalDecision { decision, .. }) => {
+                assert_eq!(decision, ReviewDecision::Abort);
+            }
+            other => panic!("expected cancel abort, got {other:?}"),
+        }
     }
 
     // ========================================================================

--- a/crates/tui/src/tui/approval/policy.rs
+++ b/crates/tui/src/tui/approval/policy.rs
@@ -65,7 +65,9 @@ pub enum ApprovalStakes {
 
 /// Get the category for a tool by name.
 pub fn get_tool_category(name: &str) -> ToolCategory {
-    if name == "agent" {
+    if name == "agent" || name == "workflow" {
+        // Workflow is multi-agent orchestration; reuse Agent stakes/routing
+        // and specialize the impact card via build_impact_summary (#4126).
         ToolCategory::Agent
     } else if matches!(name, "write_file" | "edit_file" | "apply_patch") {
         ToolCategory::FileWrite

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -1579,7 +1579,8 @@ fn build_approval_controls(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
-    for (i, opt) in approval_options_for(risk, locale).iter().enumerate() {
+    let options = approval_options_for_request(request, risk, locale);
+    for (i, opt) in options.iter().enumerate() {
         let is_selected = i == view.selected();
         let label_color = if opt.dangerous {
             accent
@@ -1933,6 +1934,7 @@ fn save_ask_rule_hint(locale: Locale) -> &'static str {
     }
 }
 
+#[derive(Clone)]
 struct ApprovalOptionRow {
     label: Cow<'static, str>,
     key_hint: &'static str,
@@ -1963,6 +1965,61 @@ fn approval_options_for(risk: RiskLevel, locale: Locale) -> [ApprovalOptionRow; 
             dangerous: false,
         },
     ]
+}
+
+/// Workflow elevated-plan card options (#4126): Approve / Edit plan / Cancel.
+fn workflow_approval_options(risk: RiskLevel, locale: Locale) -> [ApprovalOptionRow; 3] {
+    let dangerous = matches!(risk, RiskLevel::Destructive);
+    [
+        ApprovalOptionRow {
+            label: workflow_option_approve(locale),
+            key_hint: "1 / y",
+            dangerous,
+        },
+        ApprovalOptionRow {
+            label: workflow_option_edit_plan(locale),
+            key_hint: "2 / e",
+            dangerous: false,
+        },
+        ApprovalOptionRow {
+            label: workflow_option_cancel(locale),
+            key_hint: "3 / Esc",
+            dangerous: false,
+        },
+    ]
+}
+
+fn approval_options_for_request(
+    request: &ApprovalRequest,
+    risk: RiskLevel,
+    locale: Locale,
+) -> Vec<ApprovalOptionRow> {
+    if request.tool_name == "workflow" {
+        workflow_approval_options(risk, locale).to_vec()
+    } else {
+        approval_options_for(risk, locale).to_vec()
+    }
+}
+
+fn workflow_option_approve(locale: Locale) -> Cow<'static, str> {
+    match locale {
+        Locale::ZhHans => Cow::Borrowed("批准"),
+        _ => Cow::Borrowed("Approve"),
+    }
+}
+
+fn workflow_option_edit_plan(locale: Locale) -> Cow<'static, str> {
+    match locale {
+        Locale::ZhHans => Cow::Borrowed("编辑计划"),
+        _ => Cow::Borrowed("Edit plan"),
+    }
+}
+
+fn workflow_option_cancel(locale: Locale) -> Cow<'static, str> {
+    match locale {
+        Locale::ZhHans => Cow::Borrowed("取消"),
+        _ => Cow::Borrowed("Cancel"),
+    }
 }
 
 fn option_approve_once(locale: Locale) -> Cow<'static, str> {

--- a/crates/workflow/src/elevation.rs
+++ b/crates/workflow/src/elevation.rs
@@ -1,0 +1,688 @@
+//! Elevated Workflow plan assessment for approval cards (#4126).
+//!
+//! Pure, UI-free analysis of a [`WorkflowSpec`] (and optional planner risk
+//! string) so callers can decide whether an operator approval card is required
+//! and what fields that card should show.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    IsolationMode, LeafSpec, PermissionSpec, TaskMode, WorkflowNode, WorkflowSpec,
+    leaf_is_write_capable, leaf_wants_worktree,
+};
+
+/// Default soft token budget from product config (`[workflow].default_token_budget`).
+/// Plans requesting more than this are treated as high-budget.
+pub const DEFAULT_HIGH_BUDGET_THRESHOLD: u64 = 120_000;
+
+/// Options that refine elevation assessment beyond the IR itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElevationOptions {
+    /// Token budget declared on the tool call (may outrank `spec.budget`).
+    pub token_budget: Option<u64>,
+    /// Threshold above which a token budget is considered high.
+    pub high_budget_threshold: u64,
+    /// Whether the parent session currently allows writes.
+    pub parent_allows_write: bool,
+    /// Whether the parent session currently allows network.
+    pub parent_allows_network: bool,
+}
+
+impl Default for ElevationOptions {
+    fn default() -> Self {
+        Self {
+            token_budget: None,
+            high_budget_threshold: DEFAULT_HIGH_BUDGET_THRESHOLD,
+            // Assume Act/read-write parent unless callers narrow posture.
+            parent_allows_write: true,
+            parent_allows_network: true,
+        }
+    }
+}
+
+/// Summary of why a Workflow plan needs (or does not need) elevated approval.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowPlanElevation {
+    pub elevated: bool,
+    pub goal: String,
+    pub child_count: usize,
+    pub child_summary: String,
+    pub writes: bool,
+    pub shell: bool,
+    pub network: bool,
+    pub secrets: bool,
+    pub worktree: bool,
+    pub high_budget: bool,
+    pub broader_authority: bool,
+    /// Human-readable budget line for the approval card.
+    pub budget_label: String,
+    /// Distinct elevation reasons (for audit / impact lines).
+    pub reasons: Vec<String>,
+}
+
+impl WorkflowPlanElevation {
+    /// Card field labels/values used by the TUI approval modal (#4126).
+    #[must_use]
+    pub fn card_fields(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("Goal", self.goal.clone()),
+            ("Children", self.child_summary.clone()),
+            ("Writes", yes_no(self.writes)),
+            ("Shell", yes_no(self.shell)),
+            ("Network", yes_no(self.network)),
+            ("Budget", self.budget_label.clone()),
+        ]
+    }
+
+    /// True when the plan is fully inside the read-only envelope.
+    #[must_use]
+    pub fn is_read_only_envelope(&self) -> bool {
+        !self.elevated
+            && !self.writes
+            && !self.shell
+            && !self.network
+            && !self.secrets
+            && !self.worktree
+            && !self.high_budget
+            && !self.broader_authority
+    }
+}
+
+fn yes_no(flag: bool) -> String {
+    if flag {
+        "yes".to_string()
+    } else {
+        "no".to_string()
+    }
+}
+
+/// Assess elevation for a compiled [`WorkflowSpec`].
+#[must_use]
+pub fn assess_workflow_elevation(
+    spec: &WorkflowSpec,
+    options: ElevationOptions,
+) -> WorkflowPlanElevation {
+    let mut child_ids = Vec::new();
+    let mut writes = false;
+    let mut shell = false;
+    let mut network = false;
+    let mut secrets = false;
+    let mut worktree = false;
+
+    walk_nodes(
+        &spec.nodes,
+        /* parallel */ false,
+        &mut child_ids,
+        &mut writes,
+        &mut shell,
+        &mut network,
+        &mut secrets,
+        &mut worktree,
+    );
+
+    // Spec-level permissions also elevate.
+    merge_permissions(
+        &spec.permissions,
+        &mut writes,
+        &mut shell,
+        &mut network,
+        &mut secrets,
+    );
+
+    // Planner risk string is stored on `description` by the structured-plan
+    // lowerer when present (`risk: elevated|writes|shell|network|…`).
+    apply_plan_risk_hint(
+        spec.description.as_deref(),
+        &mut writes,
+        &mut shell,
+        &mut network,
+    );
+
+    let effective_tokens = options
+        .token_budget
+        .or(spec.budget.max_tokens)
+        .filter(|n| *n > 0);
+    let high_budget = effective_tokens.is_some_and(|n| n > options.high_budget_threshold);
+
+    let broader_authority =
+        (!options.parent_allows_write && writes) || (!options.parent_allows_network && network);
+
+    let mut reasons = Vec::new();
+    if writes {
+        reasons.push("writes".to_string());
+    }
+    if shell {
+        reasons.push("shell".to_string());
+    }
+    if network {
+        reasons.push("network".to_string());
+    }
+    if secrets {
+        reasons.push("secrets".to_string());
+    }
+    if worktree {
+        reasons.push("worktree".to_string());
+    }
+    if high_budget {
+        reasons.push("high_budget".to_string());
+    }
+    if broader_authority {
+        reasons.push("broader_authority".to_string());
+    }
+
+    let elevated = !reasons.is_empty();
+    let child_count = child_ids.len();
+    let child_summary = if child_ids.is_empty() {
+        "0 children".to_string()
+    } else if child_ids.len() <= 4 {
+        format!(
+            "{} child{}: {}",
+            child_ids.len(),
+            if child_ids.len() == 1 { "" } else { "ren" },
+            child_ids.join(", ")
+        )
+    } else {
+        format!(
+            "{} children: {}, {}… (+{})",
+            child_ids.len(),
+            child_ids[0],
+            child_ids[1],
+            child_ids.len() - 2
+        )
+    };
+
+    let budget_label = format_budget_label(effective_tokens, &spec.budget, high_budget);
+
+    WorkflowPlanElevation {
+        elevated,
+        goal: spec.goal.clone(),
+        child_count,
+        child_summary,
+        writes,
+        shell,
+        network,
+        secrets,
+        worktree,
+        high_budget,
+        broader_authority,
+        budget_label,
+        reasons,
+    }
+}
+
+/// Lightweight assessment from a planner `risk` string alone (before IR lower).
+#[must_use]
+pub fn assess_plan_risk_string(risk: Option<&str>) -> PlanRiskHint {
+    match risk.map(str::trim).filter(|s| !s.is_empty()) {
+        None | Some("read_only") | Some("readonly") | Some("low") | Some("safe") => {
+            PlanRiskHint::ReadOnly
+        }
+        Some("writes") | Some("write") | Some("read_write") | Some("readwrite")
+        | Some("medium") => PlanRiskHint::Writes,
+        Some("shell") => PlanRiskHint::Shell,
+        Some("network") => PlanRiskHint::Network,
+        Some("elevated") | Some("high") => PlanRiskHint::Elevated,
+        Some(_) => PlanRiskHint::Elevated,
+    }
+}
+
+/// Coarse risk classification from the structured plan `risk` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanRiskHint {
+    ReadOnly,
+    Writes,
+    Shell,
+    Network,
+    Elevated,
+}
+
+impl PlanRiskHint {
+    #[must_use]
+    pub fn elevates(self) -> bool {
+        !matches!(self, Self::ReadOnly)
+    }
+}
+
+fn apply_plan_risk_hint(
+    risk: Option<&str>,
+    writes: &mut bool,
+    shell: &mut bool,
+    network: &mut bool,
+) {
+    match assess_plan_risk_string(risk) {
+        PlanRiskHint::ReadOnly => {}
+        PlanRiskHint::Writes => *writes = true,
+        PlanRiskHint::Shell => {
+            *shell = true;
+            *writes = true;
+        }
+        PlanRiskHint::Network => {
+            *network = true;
+        }
+        PlanRiskHint::Elevated => {
+            *writes = true;
+            *shell = true;
+            *network = true;
+        }
+    }
+}
+
+fn format_budget_label(
+    effective_tokens: Option<u64>,
+    budget: &crate::BudgetSpec,
+    high_budget: bool,
+) -> String {
+    let mut parts = Vec::new();
+    if let Some(tokens) = effective_tokens {
+        parts.push(format!("{tokens} tokens"));
+    }
+    if let Some(steps) = budget.max_steps {
+        parts.push(format!("max_steps={steps}"));
+    }
+    if let Some(timeout) = budget.timeout_secs {
+        parts.push(format!("timeout={timeout}s"));
+    }
+    if let Some(parallel) = budget.max_parallel {
+        parts.push(format!("max_parallel={parallel}"));
+    }
+    if parts.is_empty() {
+        "default".to_string()
+    } else if high_budget {
+        format!("{} (high)", parts.join(", "))
+    } else {
+        parts.join(", ")
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_nodes(
+    nodes: &[WorkflowNode],
+    parallel: bool,
+    child_ids: &mut Vec<String>,
+    writes: &mut bool,
+    shell: &mut bool,
+    network: &mut bool,
+    secrets: &mut bool,
+    worktree: &mut bool,
+) {
+    for node in nodes {
+        match node {
+            WorkflowNode::Leaf(leaf) => {
+                inspect_leaf(
+                    leaf, parallel, child_ids, writes, shell, network, secrets, worktree,
+                );
+            }
+            WorkflowNode::BranchSet(branch) => {
+                merge_permissions(&branch.permissions, writes, shell, network, secrets);
+                walk_nodes(
+                    &branch.children,
+                    branch.parallel || parallel,
+                    child_ids,
+                    writes,
+                    shell,
+                    network,
+                    secrets,
+                    worktree,
+                );
+            }
+            WorkflowNode::Sequence(seq) => {
+                walk_nodes(
+                    &seq.children,
+                    parallel,
+                    child_ids,
+                    writes,
+                    shell,
+                    network,
+                    secrets,
+                    worktree,
+                );
+            }
+            WorkflowNode::LoopUntil(loop_spec) => {
+                walk_nodes(
+                    &loop_spec.children,
+                    parallel,
+                    child_ids,
+                    writes,
+                    shell,
+                    network,
+                    secrets,
+                    worktree,
+                );
+            }
+            WorkflowNode::Cond(cond) => {
+                walk_nodes(
+                    &cond.then_nodes,
+                    parallel,
+                    child_ids,
+                    writes,
+                    shell,
+                    network,
+                    secrets,
+                    worktree,
+                );
+                walk_nodes(
+                    &cond.else_nodes,
+                    parallel,
+                    child_ids,
+                    writes,
+                    shell,
+                    network,
+                    secrets,
+                    worktree,
+                );
+            }
+            WorkflowNode::Expand(expand) => {
+                if let Some(template) = expand.template.as_deref() {
+                    walk_nodes(
+                        std::slice::from_ref(template),
+                        parallel,
+                        child_ids,
+                        writes,
+                        shell,
+                        network,
+                        secrets,
+                        worktree,
+                    );
+                }
+            }
+            WorkflowNode::Reduce(_) | WorkflowNode::TeacherReview(_) => {
+                // Control/reduce nodes do not spawn write-capable leaves themselves.
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inspect_leaf(
+    leaf: &LeafSpec,
+    parallel: bool,
+    child_ids: &mut Vec<String>,
+    writes: &mut bool,
+    shell: &mut bool,
+    network: &mut bool,
+    secrets: &mut bool,
+    worktree: &mut bool,
+) {
+    child_ids.push(leaf.id.clone());
+    if leaf_is_write_capable(leaf) {
+        *writes = true;
+    }
+    merge_permissions(&leaf.permissions, writes, shell, network, secrets);
+    if leaf_wants_worktree(leaf, parallel) || matches!(leaf.isolation, IsolationMode::Worktree) {
+        *worktree = true;
+    }
+    // Explicit read_write mode with shell tools already handled; implementer
+    // without a tool denylist can run shell.
+    if leaf.mode == TaskMode::ReadWrite
+        && leaf.permissions.allowed_tools.is_empty()
+        && matches!(
+            leaf.agent_type,
+            crate::AgentType::Implementer | crate::AgentType::General
+        )
+    {
+        // Write-capable implementers/general agents may run shell beyond
+        // read-only — flag shell as elevated for the approval card.
+        *shell = true;
+    }
+}
+
+fn merge_permissions(
+    permissions: &PermissionSpec,
+    writes: &mut bool,
+    shell: &mut bool,
+    network: &mut bool,
+    secrets: &mut bool,
+) {
+    if permissions.allow_write {
+        *writes = true;
+    }
+    if permissions.allow_network {
+        *network = true;
+    }
+    for tool in &permissions.allowed_tools {
+        let name = tool.trim();
+        if is_write_tool(name) {
+            *writes = true;
+        }
+        if is_shell_tool(name) {
+            *shell = true;
+        }
+        if is_network_tool(name) {
+            *network = true;
+        }
+        if is_secret_tool(name) {
+            *secrets = true;
+        }
+    }
+}
+
+fn is_write_tool(tool: &str) -> bool {
+    matches!(
+        tool,
+        "write_file" | "edit_file" | "apply_patch" | "checklist_write" | "todo_write"
+    )
+}
+
+fn is_shell_tool(tool: &str) -> bool {
+    matches!(
+        tool,
+        "exec_shell"
+            | "exec_shell_wait"
+            | "exec_shell_interact"
+            | "exec_wait"
+            | "exec_interact"
+            | "task_shell_start"
+            | "task_shell_wait"
+    )
+}
+
+fn is_network_tool(tool: &str) -> bool {
+    matches!(
+        tool,
+        "web_search" | "web_run" | "fetch_url" | "wait_for_dev_server"
+    ) || tool.starts_with("mcp_")
+}
+
+fn is_secret_tool(tool: &str) -> bool {
+    let lower = tool.to_ascii_lowercase();
+    lower.contains("secret")
+        || lower.contains("credential")
+        || lower.contains("password")
+        || lower == "read_env"
+        || lower == "env"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AgentType, BranchSpec, BudgetSpec, LeafSpec, ModelPolicy, PermissionSpec, PromotionPolicy,
+        SequenceSpec, TaskMode,
+    };
+
+    fn leaf(id: &str, mode: TaskMode) -> LeafSpec {
+        LeafSpec {
+            id: id.to_string(),
+            prompt: format!("do {id}"),
+            agent_type: if mode == TaskMode::ReadWrite {
+                AgentType::Implementer
+            } else {
+                AgentType::Explore
+            },
+            profile: None,
+            mode,
+            isolation: IsolationMode::Auto,
+            file_scope: Vec::new(),
+            depends_on_results: Vec::new(),
+            budget: BudgetSpec::default(),
+            permissions: PermissionSpec::default(),
+            model_policy: ModelPolicy::default(),
+        }
+    }
+
+    fn spec_with(nodes: Vec<WorkflowNode>, risk: Option<&str>) -> WorkflowSpec {
+        WorkflowSpec {
+            id: Some("test".to_string()),
+            goal: "ship feature".to_string(),
+            description: risk.map(str::to_string),
+            budget: BudgetSpec::default(),
+            permissions: PermissionSpec::default(),
+            model_policy: ModelPolicy::default(),
+            promotion_policy: PromotionPolicy::default(),
+            nodes,
+        }
+    }
+
+    #[test]
+    fn read_only_plan_is_not_elevated() {
+        let spec = spec_with(
+            vec![WorkflowNode::Leaf(leaf("scan", TaskMode::ReadOnly))],
+            Some("read_only"),
+        );
+        let elevation = assess_workflow_elevation(&spec, ElevationOptions::default());
+        assert!(!elevation.elevated, "{elevation:?}");
+        assert!(elevation.is_read_only_envelope());
+        assert_eq!(elevation.goal, "ship feature");
+        assert!(elevation.child_summary.contains("scan"));
+        assert!(!elevation.writes);
+        assert!(!elevation.shell);
+        assert!(!elevation.network);
+        let fields = elevation.card_fields();
+        assert_eq!(fields.len(), 6);
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Goal" && v == "ship feature")
+        );
+        assert!(fields.iter().any(|(k, v)| *k == "Writes" && v == "no"));
+    }
+
+    #[test]
+    fn write_plan_elevates_and_flags_shell_for_implementer() {
+        let spec = spec_with(
+            vec![WorkflowNode::Leaf(leaf("impl", TaskMode::ReadWrite))],
+            Some("writes"),
+        );
+        let elevation = assess_workflow_elevation(&spec, ElevationOptions::default());
+        assert!(elevation.elevated);
+        assert!(elevation.writes);
+        assert!(elevation.shell);
+        assert!(elevation.reasons.iter().any(|r| r == "writes"));
+    }
+
+    #[test]
+    fn network_and_secrets_tools_elevate() {
+        let mut network_leaf = leaf("fetch", TaskMode::ReadOnly);
+        network_leaf.permissions.allow_network = true;
+        network_leaf.permissions.allowed_tools = vec!["fetch_url".to_string()];
+
+        let mut secret_leaf = leaf("creds", TaskMode::ReadOnly);
+        secret_leaf.permissions.allowed_tools = vec!["read_secret".to_string()];
+
+        let spec = spec_with(
+            vec![WorkflowNode::Sequence(SequenceSpec {
+                id: "seq".to_string(),
+                children: vec![
+                    WorkflowNode::Leaf(network_leaf),
+                    WorkflowNode::Leaf(secret_leaf),
+                ],
+            })],
+            None,
+        );
+        let elevation = assess_workflow_elevation(&spec, ElevationOptions::default());
+        assert!(elevation.elevated);
+        assert!(elevation.network);
+        assert!(elevation.secrets);
+        assert!(elevation.reasons.iter().any(|r| r == "network"));
+        assert!(elevation.reasons.iter().any(|r| r == "secrets"));
+    }
+
+    #[test]
+    fn parallel_write_children_flag_worktree() {
+        let left = leaf("left", TaskMode::ReadWrite);
+        let right = leaf("right", TaskMode::ReadWrite);
+        let spec = spec_with(
+            vec![WorkflowNode::BranchSet(BranchSpec {
+                id: "parallel".to_string(),
+                description: None,
+                parallel: true,
+                budget: BudgetSpec::default(),
+                permissions: PermissionSpec::default(),
+                model_policy: ModelPolicy::default(),
+                children: vec![WorkflowNode::Leaf(left), WorkflowNode::Leaf(right)],
+            })],
+            Some("writes"),
+        );
+        let elevation = assess_workflow_elevation(&spec, ElevationOptions::default());
+        assert!(elevation.worktree, "{elevation:?}");
+        assert!(elevation.writes);
+    }
+
+    #[test]
+    fn high_budget_elevates() {
+        let mut spec = spec_with(
+            vec![WorkflowNode::Leaf(leaf("scan", TaskMode::ReadOnly))],
+            Some("read_only"),
+        );
+        spec.budget.max_tokens = Some(250_000);
+        let elevation = assess_workflow_elevation(&spec, ElevationOptions::default());
+        assert!(elevation.high_budget);
+        assert!(elevation.elevated);
+        assert!(elevation.budget_label.contains("high"));
+    }
+
+    #[test]
+    fn broader_authority_when_parent_is_read_only() {
+        let spec = spec_with(
+            vec![WorkflowNode::Leaf(leaf("impl", TaskMode::ReadWrite))],
+            Some("writes"),
+        );
+        let elevation = assess_workflow_elevation(
+            &spec,
+            ElevationOptions {
+                parent_allows_write: false,
+                parent_allows_network: false,
+                ..ElevationOptions::default()
+            },
+        );
+        assert!(elevation.broader_authority);
+        assert!(elevation.reasons.iter().any(|r| r == "broader_authority"));
+    }
+
+    #[test]
+    fn plan_risk_string_classifies_elevated_variants() {
+        assert_eq!(
+            assess_plan_risk_string(Some("read_only")),
+            PlanRiskHint::ReadOnly
+        );
+        assert_eq!(
+            assess_plan_risk_string(Some("writes")),
+            PlanRiskHint::Writes
+        );
+        assert_eq!(assess_plan_risk_string(Some("shell")), PlanRiskHint::Shell);
+        assert_eq!(
+            assess_plan_risk_string(Some("network")),
+            PlanRiskHint::Network
+        );
+        assert_eq!(
+            assess_plan_risk_string(Some("elevated")),
+            PlanRiskHint::Elevated
+        );
+        assert!(assess_plan_risk_string(Some("elevated")).elevates());
+        assert!(!assess_plan_risk_string(Some("read_only")).elevates());
+    }
+
+    #[test]
+    fn card_fields_always_include_required_labels() {
+        let spec = spec_with(
+            vec![WorkflowNode::Leaf(leaf("a", TaskMode::ReadOnly))],
+            None,
+        );
+        let fields = assess_workflow_elevation(&spec, ElevationOptions::default()).card_fields();
+        let labels: Vec<_> = fields.iter().map(|(k, _)| *k).collect();
+        assert_eq!(
+            labels,
+            vec!["Goal", "Children", "Writes", "Shell", "Network", "Budget"]
+        );
+    }
+}

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -4,6 +4,7 @@
 //! exposure, worktree application, replay, and model execution are layered on
 //! top only after their cancellation and evidence semantics are proven.
 
+mod elevation;
 mod js_authoring;
 mod model_policy;
 mod replay;
@@ -14,6 +15,10 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub use elevation::{
+    DEFAULT_HIGH_BUDGET_THRESHOLD, ElevationOptions, PlanRiskHint, WorkflowPlanElevation,
+    assess_plan_risk_string, assess_workflow_elevation,
+};
 pub use js_authoring::{
     JavascriptWorkflowError, JavascriptWorkflowResult, compile_javascript_workflow,
     compile_typescript_workflow,


### PR DESCRIPTION
## Summary
Implements **#4126** — approval card for elevated Workflow plans (write / shell / network / secrets / worktree / high budget).

### What landed
- **Elevation detection** (`codewhale_workflow::elevation` + TUI `workflow_plan_approval`)
  - Walks structured plans / IR for writes, shell, network, secrets, worktree, high budget, broader authority
  - Plan `risk` string (`read_only` / `writes` / `elevated` / `shell` / `network`) feeds the envelope
- **Gate** via `WorkflowTool::approval_requirement_for`
  - Status → Auto
  - Read-only + `auto_start_read_only` (product default) → Auto
  - Elevated + `require_approval_for_writes` (product default) → Required
  - Script/source launches without a plan → Required (unknown authority)
- **Approval card** reuses the shared approval modal
  - Fields: **Goal, Children, Writes, Shell, Network, Budget**
  - Buttons: **Approve**, **Edit plan** (deny → model revises), **Cancel** (abort)
- **Durable receipt**: `plan_approval` on `WorkflowRunRecord` (journal snapshot + tool result metadata)

### Already on main (not reimplemented)
- `[workflow].require_approval_for_writes` / `auto_start_read_only` via **#4128** (`WorkflowConfigToml`)
- Structured plan lower via **#4124**

### Tests
- `codewhale-workflow` elevation unit tests (8)
- `workflow_plan_approval` unit tests (9) — elevation + card field presence + config gate
- Approval modal tests for workflow card fields + Edit plan / Cancel keys
- Existing `tools::workflow` suite still green (25)

### Remaining gaps
- Live `Config` is not threaded into `WorkflowTool` yet — gate uses `WorkflowConfigToml::default()` (product defaults). Session overrides of `[workflow]` require a follow-up registry wire-up.
- "Edit plan" returns a generic tool denial; copy could be specialized in the engine denial message.
- Broader-authority vs parent mode is computed when parent posture is supplied; tool-input path currently leaves it false unless IR assessment sets it.

Closes #4126