### PR TITLE
fix(tui): force Python stdio UTF-8 on Windows shell (#4202)

### DIFF
--- a/crates/tui/src/child_env.rs
+++ b/crates/tui/src/child_env.rs
@@ -214,6 +214,10 @@ fn is_allowed_parent_env_key(key: &OsStr) -> bool {
             | "NO_PROXY"
             | "ALL_PROXY"
             | "FTP_PROXY"
+            // Python uses these to pick stdio/default encodings when stdout is
+            // piped instead of attached to a Windows console (#4202).
+            | "PYTHONIOENCODING"
+            | "PYTHONUTF8"
     ) || normalized.starts_with("LC_")
         // .NET CLI / SDK configuration (DOTNET_ROOT, DOTNET_CLI_*,
         // DOTNET_NOLOGO, DOTNET_CLI_TELEMETRY_OPTOUT, …). Paths and flags
@@ -648,6 +652,16 @@ mod tests {
             !is_allowed_parent_env_key(OsStr::new("NuGetPackageSourceCredentials_feed")),
             "NuGet credential vars must not be exported to child processes"
         );
+    }
+
+    #[test]
+    fn child_env_allowlist_includes_python_stdio_encoding_vars() {
+        for key in ["PYTHONIOENCODING", "PYTHONUTF8", "pythonioencoding"] {
+            assert!(
+                is_allowed_parent_env_key(OsStr::new(key)),
+                "child env allowlist should include Python stdio encoding key {key}"
+            );
+        }
     }
 
     #[cfg(windows)]

--- a/crates/tui/src/sandbox/mod.rs
+++ b/crates/tui/src/sandbox/mod.rs
@@ -109,11 +109,22 @@ impl CommandSpec {
         #[cfg(not(windows))]
         let (program, args) = dispatcher.build_command_parts(command);
 
+        let env = {
+            #[cfg(windows)]
+            {
+                windows_shell_default_env()
+            }
+            #[cfg(not(windows))]
+            {
+                HashMap::new()
+            }
+        };
+
         Self {
             program,
             args,
             cwd,
-            env: HashMap::new(),
+            env,
             timeout,
             sandbox_policy: SandboxPolicy::default(),
             justification: None,
@@ -209,6 +220,10 @@ impl CommandSpec {
             parts.join(" ")
         }
     }
+}
+
+fn windows_shell_default_env() -> HashMap<String, String> {
+    HashMap::from([("PYTHONIOENCODING".to_string(), "utf-8".to_string())])
 }
 
 /// The type of sandbox being used for execution.
@@ -716,6 +731,16 @@ mod tests {
         assert!(matches!(spec.sandbox_policy, SandboxPolicy::ReadOnly));
         assert_eq!(spec.env.get("FOO"), Some(&"bar".to_string()));
         assert_eq!(spec.justification, Some("Testing".to_string()));
+    }
+
+    #[test]
+    fn windows_shell_default_env_forces_python_pipe_stdio_utf8() {
+        let env = windows_shell_default_env();
+
+        assert_eq!(
+            env.get("PYTHONIOENCODING").map(String::as_str),
+            Some("utf-8")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Harvest of @cyq1017's draft PR #4281 for #4202.

On Windows, Python often picks GBK for **piped** stdout even when the console is UTF-8. CodeWhale captures `exec_shell` through pipes, so Python needs an explicit stdio encoding hint.

## Changes
- Preserve `PYTHONIOENCODING` / `PYTHONUTF8` in sanitized child env allowlist
- Default Windows shell `CommandSpec` env to `PYTHONIOENCODING=utf-8`
- Unit coverage for allowlist + default env

## Credit
Authored by **@cyq1017** (PR #4281). Landed via operator harvest onto current `main`.

## Test plan
- [x] `cargo test -p codewhale-tui -- child_env::tests sandbox::tests`
- [ ] CI green (ubuntu/macos/windows)
- [ ] Close #4202 + thank #4281 after merge

Fixes #4202