### PR TITLE
fix(subagents): age-evict terminal worker_records (#4217)

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -519,6 +519,17 @@ pub enum AgentWorkerStatus {
     Interrupted,
 }
 
+impl AgentWorkerStatus {
+    /// Terminal worker statuses may be age-evicted from the run ledger (#4217).
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Cancelled | Self::Interrupted
+        )
+    }
+}
+
 /// Tool capability profile requested for a headless worker.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -3041,6 +3052,7 @@ impl SubAgentManager {
     /// during this pass.
     pub fn cleanup(&mut self, max_age: Duration) -> usize {
         let before = self.agents.len();
+        let before_workers = self.worker_records.len();
         let mut auto_cancelled = 0;
         let timeout = self.running_heartbeat_timeout;
         let mut worker_cancellations = Vec::new();
@@ -3089,7 +3101,23 @@ impl SubAgentManager {
                 agent.started_at.elapsed() < max_age
             }
         });
-        if self.agents.len() != before || auto_cancelled > 0 {
+        // #4217: age-evict terminal worker ledger entries. Agents already drop
+        // after `max_age`, but worker_records previously only had an LRU cap of
+        // 256 — long-lived sessions rewrote multi-MB subagents.v1.json forever.
+        // Running / starting / waiting records are always preserved.
+        let now_ms = epoch_millis_now();
+        let max_age_ms = max_age.as_millis() as u64;
+        self.worker_records.retain(|_, record| {
+            if !record.status.is_terminal() {
+                return true;
+            }
+            let anchor_ms = record.completed_at_ms.unwrap_or(record.updated_at_ms);
+            now_ms.saturating_sub(anchor_ms) < max_age_ms
+        });
+        if self.agents.len() != before
+            || auto_cancelled > 0
+            || self.worker_records.len() != before_workers
+        {
             self.persist_state_best_effort();
         }
         self.last_cleanup_at = Some(Instant::now());

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -6501,6 +6501,88 @@ async fn worker_is_not_stranded_by_transient_global_rate_limit_window() {
     );
 }
 
+/// #4217: terminal worker records must age out of the persisted ledger so
+/// long-lived sessions do not rewrite multi-MB `subagents.v1.json` forever.
+#[test]
+fn cleanup_evicts_stale_terminal_worker_records_and_keeps_live_ones() {
+    let tmp = tempdir().expect("tempdir");
+    let state_path = tmp.path().join("subagents.v1.json");
+    let mut manager =
+        SubAgentManager::new(tmp.path().to_path_buf(), 4).with_state_path(state_path.clone());
+
+    manager.register_worker(make_worker_spec("agent_old_done", tmp.path().to_path_buf()));
+    manager.register_worker(make_worker_spec(
+        "agent_recent_done",
+        tmp.path().to_path_buf(),
+    ));
+    manager.register_worker(make_worker_spec(
+        "agent_still_running",
+        tmp.path().to_path_buf(),
+    ));
+
+    let mut old_done = make_snapshot(SubAgentStatus::Completed);
+    old_done.agent_id = "agent_old_done".to_string();
+    old_done.name = "agent_old_done".to_string();
+    manager.complete_worker_from_result("agent_old_done", &old_done);
+
+    let mut recent_done = make_snapshot(SubAgentStatus::Failed("boom".to_string()));
+    recent_done.agent_id = "agent_recent_done".to_string();
+    recent_done.name = "agent_recent_done".to_string();
+    manager.complete_worker_from_result("agent_recent_done", &recent_done);
+
+    manager.record_worker_event(
+        "agent_still_running",
+        AgentWorkerStatus::Running,
+        Some("working".to_string()),
+        Some(1),
+        None,
+    );
+
+    let now_ms = epoch_millis_now();
+    let two_hours_ago = now_ms.saturating_sub(2 * 60 * 60 * 1000);
+    {
+        let old = manager
+            .worker_records
+            .get_mut("agent_old_done")
+            .expect("old terminal worker");
+        old.completed_at_ms = Some(two_hours_ago);
+        old.updated_at_ms = two_hours_ago;
+    }
+
+    // One-hour retention matches COMPLETED_AGENT_RETENTION used by cleanup callers.
+    let auto_cancelled = manager.cleanup(Duration::from_secs(60 * 60));
+    assert_eq!(auto_cancelled, 0);
+
+    assert!(
+        manager.get_worker_record("agent_old_done").is_none(),
+        "terminal worker older than retention must be evicted"
+    );
+    assert!(
+        manager.get_worker_record("agent_recent_done").is_some(),
+        "recent terminal worker must be retained"
+    );
+    let running = manager
+        .get_worker_record("agent_still_running")
+        .expect("running worker");
+    assert_eq!(running.status, AgentWorkerStatus::Running);
+
+    // Persist the pruned ledger and confirm eviction survives reload.
+    manager
+        .persist_state()
+        .expect("persist after cleanup")
+        .join()
+        .expect("persist thread");
+    let mut reloaded =
+        SubAgentManager::new(tmp.path().to_path_buf(), 4).with_state_path(state_path);
+    reloaded.load_state().expect("load pruned state");
+    assert!(
+        reloaded.get_worker_record("agent_old_done").is_none(),
+        "eviction must survive reload of subagents.v1.json"
+    );
+    assert!(reloaded.get_worker_record("agent_recent_done").is_some());
+    assert!(reloaded.get_worker_record("agent_still_running").is_some());
+}
+
 #[test]
 fn cleanup_due_gates_write_locked_cleanup_to_a_bounded_cadence() {
     // #3803: a fresh manager is always due (never cleaned); right after a

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -494,6 +494,11 @@ don't go through the standard write-approval flow.
 - Persisted state: `<workspace>/.codewhale/state/subagents.v1.json`. Schema
   version `1` (forward-compatible — new optional fields use
   `#[serde(default)]`).
+- Worker records are pruned by time: completed / failed / cancelled /
+  interrupted records are evicted after the same retention window used for
+  finished agents (default 1h, `COMPLETED_AGENT_RETENTION`). Running /
+  starting / waiting records are preserved. The hard cap of 256 records
+  remains as a safety bound (#4217).
 - `SubAgentRuntime::background_runtime()` starts from `child_runtime()` but
   replaces the turn-scoped child token with a fresh cancellation token, so
   parent turn cancellation does not stop detached background sessions.


### PR DESCRIPTION
## Summary

Long-lived sessions grew `.codewhale/state/subagents.v1.json` without bound because `worker_records` only had an LRU cap of 256 and no age/status eviction. Finished agents already age out after 1h; the run ledger did not.

This PR:
- Adds `AgentWorkerStatus::is_terminal()`
- Age-evicts terminal worker records in `SubAgentManager::cleanup(max_age)` using `completed_at_ms` (fallback `updated_at_ms`)
- Persists when the worker ledger shrinks (not only when `agents` change)
- Documents the retention policy in `docs/SUBAGENTS.md`
- Adds a regression test for eviction + reload survival

### Measurement notes (#4014 overlap)

| Surface | Before | After (expected) |
|---|---|---|
| Terminal worker_records lifetime | Indefinite until LRU 256 | Evicted after 1h (same as agents) |
| Worst-case ledger size | ~256 saturated records (~300k lines / multi-MB as reported) | Bound by live workers + recent terminals within retention |
| Persist rewrite cost | Full multi-MB rewrite every 1.5s debounce | Shrinks as terminals age out |

No fan-out latency benchmark yet; this is the bounded-state slice of #4014 memory pressure (disk I/O + load_state + resident map).

Closes #4217  
Related to #4014, #3885

## Credit

Thanks **@yekern** for the detailed root-cause analysis (missing cleanup for `worker_records`, persist gate gap, and the suggested fix shape).

## Testing

- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked cleanup_evicts_stale_terminal_worker_records -- --nocapture`
- [x] `cargo fmt --all`

## Checklist

- [x] Updated docs (`docs/SUBAGENTS.md` Implementation notes)
- [x] Added regression test
- [x] No version bump / no tags