### PR TITLE
feat(workflow): Phase 2 fleet role on steps (#4177)

### DIFF
--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1104,6 +1104,10 @@ pub(crate) struct WorkflowTaskSpawnMetadata {
     pub resolved_provider: String,
     pub resolved_model: String,
     pub route_source: String,
+    /// Fleet role resolved for this spawn, if any (#4177).
+    pub resolved_role: Option<String>,
+    /// AgentProfile id resolved for this spawn, if any (#4177).
+    pub resolved_profile: Option<String>,
     pub parent_task_id: Option<String>,
     pub depth: u32,
     /// Workflow run that launched this child (`None` for direct `agent` spawns).
@@ -4426,10 +4430,21 @@ async fn spawn_subagent_from_input(
     child_runtime.reasoning_effort = route.reasoning_effort.clone();
     child_runtime.reasoning_effort_auto = false;
     let model_route = route.model_route;
+    let resolved_role = profile_member
+        .as_ref()
+        .map(|member| member.profile.role.name.clone())
+        .filter(|name| !name.trim().is_empty())
+        .or_else(|| spawn_request.assignment.role.clone());
+    let resolved_profile = profile_member
+        .as_ref()
+        .map(|member| member.id.clone())
+        .or_else(|| spawn_request.profile.clone());
     let spawn_metadata = WorkflowTaskSpawnMetadata {
         resolved_provider: child_runtime.client.api_provider().as_str().to_string(),
         resolved_model: effective_model.clone(),
         route_source: route_source_label(&model_route),
+        resolved_role,
+        resolved_profile,
         parent_task_id: child_runtime.parent_agent_id.clone(),
         depth: child_runtime.spawn_depth,
         workflow_run_id: None,
@@ -4527,6 +4542,9 @@ pub(crate) async fn spawn_workflow_task(
     });
     if let Some(value) = request.subagent_type {
         input["type"] = json!(value);
+    }
+    if let Some(value) = request.role {
+        input["role"] = json!(value);
     }
     if let Some(value) = request.profile {
         input["profile"] = json!(value);
@@ -6329,15 +6347,10 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
         })
         .transpose()?;
 
-    let parsed_role_type = role_input
-        .map(|role| {
-            SubAgentType::from_str(role).ok_or_else(|| {
-                ToolError::invalid_input(format!(
-                    "Invalid role alias '{role}'. Use: {VALID_ROLE_ALIASES}"
-                ))
-            })
-        })
-        .transpose()?;
+    // Role may be either a SubAgentType alias (reviewer → Review) or a fleet
+    // roster role / member id (scout, release_lead). Type aliases still set
+    // agent_type; non-alias roles defer to fleet profile resolution (#4177).
+    let parsed_role_type = role_input.and_then(SubAgentType::from_str);
 
     if let (Some(type_kind), Some(role_kind)) = (&parsed_type, &parsed_role_type)
         && type_kind != role_kind
@@ -6352,22 +6365,35 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
         .or(parsed_role_type)
         .unwrap_or(SubAgentType::General);
 
-    if let Some(role) = role_input
-        && normalize_role_alias(role).is_none()
-    {
-        return Err(ToolError::invalid_input(format!(
-            "Invalid role alias '{role}'. Use: {VALID_ROLE_ALIASES}"
-        )));
-    }
-
-    let role = role_input
+    let role_alias = role_input
         .and_then(normalize_role_alias)
         .or_else(|| type_input.and_then(normalize_role_alias))
         .map(str::to_string);
 
-    let profile = optional_input_str(input, &["profile", "fleet_profile", "roster_profile"])
+    // Fleet role token: either the raw role when it is not a type alias, or
+    // the alias form (e.g. implementer) used as a roster lookup key.
+    let fleet_role_token = match role_input {
+        Some(raw) => {
+            let token = validate_profile_name(raw)?;
+            Some(token)
+        }
+        None => None,
+    };
+
+    let role = role_alias.or_else(|| fleet_role_token.clone()).or_else(|| {
+        type_input
+            .and_then(normalize_role_alias)
+            .map(str::to_string)
+    });
+
+    let mut profile = optional_input_str(input, &["profile", "fleet_profile", "roster_profile"])
         .map(validate_profile_name)
         .transpose()?;
+    // When the caller only declared a fleet role, use it as the profile key
+    // so `apply_spawn_profile` is the single roster resolution path (#4177).
+    if profile.is_none() {
+        profile = fleet_role_token.clone();
+    }
 
     let allowed_tools = input
         .get("allowed_tools")
@@ -6534,7 +6560,7 @@ fn apply_spawn_profile(
     let Some(profile_id) = request.profile.as_deref() else {
         return Ok(None);
     };
-    let Some(member) = roster.get(profile_id) else {
+    let Some(member) = resolve_roster_member(roster, profile_id) else {
         let available = roster
             .members()
             .iter()
@@ -6542,7 +6568,8 @@ fn apply_spawn_profile(
             .collect::<Vec<_>>()
             .join(", ");
         return Err(ToolError::invalid_input(format!(
-            "Unknown profile '{profile_id}'. Available fleet roster members: {available}. See /fleet."
+            "Unknown fleet role/profile '{profile_id}'. Available fleet roster members: {available}. \
+             Type aliases: {VALID_ROLE_ALIASES}. See /fleet."
         )));
     };
 
@@ -6556,6 +6583,8 @@ fn apply_spawn_profile(
         )));
     }
     request.agent_type = member_type;
+    // Record the canonical profile id after role→profile resolution.
+    request.profile = Some(member.id.clone());
 
     // Surface the member's role in prompts and ledger records.
     let role_name = member.profile.role.name.trim();
@@ -6570,6 +6599,39 @@ fn apply_spawn_profile(
     }
 
     Ok(Some(member.clone()))
+}
+
+/// Resolve a fleet role or profile token against the roster (#4177).
+///
+/// Lookup order:
+/// 1. Member id (case-insensitive)
+/// 2. Member role name
+/// 3. Common stopship aliases (`implementer` → `builder`, `release_lead` → `manager`)
+fn resolve_roster_member<'a>(
+    roster: &'a crate::fleet::roster::FleetRoster,
+    id_or_role: &str,
+) -> Option<&'a crate::fleet::profile::AgentProfile> {
+    let key = id_or_role.trim();
+    if key.is_empty() {
+        return None;
+    }
+    if let Some(member) = roster.get(key) {
+        return Some(member);
+    }
+    if let Some(member) = roster
+        .members()
+        .iter()
+        .find(|member| member.profile.role.name.trim().eq_ignore_ascii_case(key))
+    {
+        return Some(member);
+    }
+    let alias = match key.to_ascii_lowercase().as_str() {
+        "implementer" | "implement" | "implementation" => Some("builder"),
+        "release_lead" | "release-lead" | "releaselead" => Some("manager"),
+        "scout" | "explore" | "explorer" | "exploration" => Some("scout"),
+        _ => None,
+    };
+    alias.and_then(|id| roster.get(id))
 }
 
 /// Compact profile block appended to the child prompt, mirroring the fleet

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -6374,7 +6374,7 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
     // the alias form (e.g. implementer) used as a roster lookup key.
     let fleet_role_token = match role_input {
         Some(raw) => {
-            let token = validate_profile_name(raw)?;
+            let token = validate_role_name(raw)?;
             Some(token)
         }
         None => None,
@@ -6527,17 +6527,25 @@ fn validate_session_name(name: &str) -> Result<String, ToolError> {
 /// whitespace, quotes, backticks, or '='), lowercased for the roster's
 /// case-insensitive lookup.
 fn validate_profile_name(value: &str) -> Result<String, ToolError> {
+    validate_roster_token(value, "profile")
+}
+
+fn validate_role_name(value: &str) -> Result<String, ToolError> {
+    validate_roster_token(value, "role")
+}
+
+fn validate_roster_token(value: &str, field: &str) -> Result<String, ToolError> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        return Err(ToolError::invalid_input("profile cannot be blank"));
+        return Err(ToolError::invalid_input(format!("{field} cannot be blank")));
     }
     if !trimmed
         .chars()
         .all(|ch| ch.is_ascii_graphic() && !matches!(ch, '"' | '\'' | '`' | '='))
     {
-        return Err(ToolError::invalid_input(
-            "profile must be a bare roster member id without whitespace, quotes, backticks, or '='",
-        ));
+        return Err(ToolError::invalid_input(format!(
+            "{field} must be a bare roster member id without whitespace, quotes, backticks, or '='"
+        )));
     }
     Ok(trimmed.to_ascii_lowercase())
 }

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1178,7 +1178,10 @@ fn test_apply_spawn_profile_unknown_lists_available_members() {
         parse_spawn_request(&json!({"prompt": "x", "profile": "warlock"})).expect("parse");
     let err = apply_spawn_profile(&mut request, &roster).expect_err("unknown profile should fail");
     let message = err.to_string();
-    assert!(message.contains("Unknown profile 'warlock'"), "{message}");
+    assert!(
+        message.contains("Unknown fleet role/profile 'warlock'"),
+        "{message}"
+    );
     for member in [
         "manager",
         "scout",
@@ -1619,10 +1622,27 @@ fn test_parse_spawn_request_rejects_text_and_items_together() {
 fn test_parse_spawn_request_rejects_invalid_role() {
     let input = json!({
         "prompt": "do work",
-        "role": "unknown_role"
+        "role": "unknown role"
     });
     let err = parse_spawn_request(&input).expect_err("invalid role should fail");
-    assert!(err.to_string().contains("Invalid role alias"));
+    assert!(
+        err.to_string()
+            .contains("role must be a bare roster member id"),
+        "{err}"
+    );
+}
+
+#[test]
+fn test_parse_spawn_request_accepts_fleet_role_token_for_runtime_resolution() {
+    let input = json!({
+        "prompt": "do work",
+        "role": "release_lead"
+    });
+    let parsed = parse_spawn_request(&input).expect("fleet role token should parse");
+    assert_eq!(parsed.agent_type, SubAgentType::General);
+    assert!(!parsed.agent_type_explicit);
+    assert_eq!(parsed.assignment.role.as_deref(), Some("release_lead"));
+    assert_eq!(parsed.profile.as_deref(), Some("release_lead"));
 }
 
 #[test]
@@ -1683,11 +1703,19 @@ fn test_parse_spawn_request_accepts_full_role_vocabulary() {
 
 #[test]
 fn test_invalid_role_error_lists_real_aliases() {
-    // The hint must enumerate the actually-accepted vocabulary (#2649).
+    // Well-formed fleet role tokens parse and then fail clearly at roster
+    // resolution time with both real roster members and type aliases (#4177).
+    let roster = FleetRoster::built_ins_only();
     let input = json!({ "prompt": "do work", "role": "nonsense" });
-    let err = parse_spawn_request(&input)
-        .expect_err("invalid role should fail")
+    let mut request = parse_spawn_request(&input).expect("fleet role token should parse");
+    let err = apply_spawn_profile(&mut request, &roster)
+        .expect_err("unknown fleet role should fail at runtime resolution")
         .to_string();
+    assert!(
+        err.contains("Unknown fleet role/profile 'nonsense'"),
+        "{err}"
+    );
+    assert!(err.contains("scout"), "hint should list scout: {err}");
     assert!(err.contains("reviewer"), "hint should list reviewer: {err}");
     assert!(err.contains("verifier"), "hint should list verifier: {err}");
     assert!(err.contains("custom"), "hint should list custom: {err}");

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -185,10 +185,16 @@ enum WorkflowUiEventKind {
 struct WorkflowTaskStartedEvent {
     task_id: String,
     label: Option<String>,
+    /// Fleet role declared on the step, if any (#4177).
+    role: Option<String>,
     profile: Option<String>,
     model: Option<String>,
     strength: Option<String>,
     thinking: Option<String>,
+    /// Resolved fleet role after roster lookup (#4177).
+    resolved_role: Option<String>,
+    /// Resolved AgentProfile id after fleet resolution (#4177).
+    resolved_profile: Option<String>,
     resolved_provider: String,
     resolved_model: String,
     route_source: String,
@@ -862,6 +868,9 @@ struct StructuredPlanChild {
     prompt: String,
     #[serde(default, alias = "type", alias = "agent_type")]
     agent_type: Option<String>,
+    /// Fleet role name (#4177). Preferred step identity; resolved via roster.
+    #[serde(default)]
+    role: Option<String>,
     #[serde(default)]
     profile: Option<String>,
     #[serde(default)]
@@ -1069,6 +1078,12 @@ fn plan_children_to_leaves(
                 )));
             }
         };
+        let role = child
+            .role
+            .as_deref()
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+            .map(|r| r.to_ascii_lowercase());
         let profile = child
             .profile
             .as_deref()
@@ -1079,6 +1094,7 @@ fn plan_children_to_leaves(
             id,
             prompt: prompt.to_string(),
             agent_type,
+            role,
             profile,
             mode,
             isolation: Default::default(),
@@ -1350,6 +1366,7 @@ impl DeclarativeWorkflowLowerer {
                 ),
                 "general",
                 None,
+                None,
                 false,
                 None,
                 &spec.id,
@@ -1419,6 +1436,7 @@ fn leaf_task_options_expression(
     Ok(task_options_expression(
         leaf_description_expression(spec),
         leaf_subagent_type(spec)?,
+        spec.role.as_deref(),
         spec.profile.as_deref(),
         // Parallel write-capable children default to worktree isolation (#4120).
         // Explicit isolation: shared is the approved same-worktree override.
@@ -1539,6 +1557,7 @@ fn is_write_or_shell_tool(tool: &str) -> bool {
 fn task_options_expression(
     description_expr: String,
     subagent_type: &str,
+    role: Option<&str>,
     profile: Option<&str>,
     worktree: bool,
     token_budget: Option<u64>,
@@ -1553,6 +1572,9 @@ fn task_options_expression(
     ];
     if let Some(phase) = phase {
         fields.push(format!("phase: {}", js_string(phase)));
+    }
+    if let Some(role) = role {
+        fields.push(format!("role: {}", js_string(role)));
     }
     if let Some(profile) = profile {
         fields.push(format!("profile: {}", js_string(profile)));
@@ -1765,10 +1787,20 @@ impl SubAgentWorkflowDriver {
             Box::new(WorkflowTaskStartedEvent {
                 task_id: agent_id.to_string(),
                 label,
+                role: request.role.clone(),
                 profile: request.profile.clone(),
                 model: request.model.clone(),
                 strength: request.model_strength.clone(),
                 thinking: request.thinking.clone(),
+                // Prefer spawn metadata (fleet-resolved); fall back to request.
+                resolved_role: metadata
+                    .resolved_role
+                    .clone()
+                    .or_else(|| request.role.clone()),
+                resolved_profile: metadata
+                    .resolved_profile
+                    .clone()
+                    .or_else(|| request.profile.clone()),
                 resolved_provider: metadata.resolved_provider.clone(),
                 resolved_model: metadata.resolved_model.clone(),
                 route_source: metadata.route_source.clone(),
@@ -2121,6 +2153,7 @@ fn push_leaf_execution(
         task_id: record
             .map(|record| record.agent_id.clone())
             .unwrap_or_else(|| spec.id.clone()),
+        role: spec.role.clone(),
         profile: spec.profile.clone(),
         status,
         usage: WorkflowUsage::default(),

--- a/crates/workflow-js/src/driver.rs
+++ b/crates/workflow-js/src/driver.rs
@@ -25,19 +25,24 @@ use crate::error::DriverError;
 
 /// One `task()` invocation, fully resolved and validated on the VM side.
 ///
-/// Field semantics mirror the `agent` tool's spawn options; `profile` is the
-/// Fleet roster profile token, already trimmed + lowercased and checked
-/// against the same token rule as `crates/workflow`'s leaf profiles. Roster
-/// membership is resolved by the driver (tui) at spawn time — this crate
-/// never sees the saved Fleet roster.
+/// Field semantics mirror the `agent` tool's spawn options.
+///
+/// Step identity is fleet `role` (preferred) and/or `profile` (#4177). Both
+/// tokens are normalized (trimmed + lowercased) with the same rule as
+/// `crates/workflow` leaf profiles. Roster membership is resolved by the
+/// driver (tui) at spawn time — this crate never sees the saved Fleet roster.
+/// Provider/model remain optional overrides, not required identity fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskRequest {
     /// The child prompt (JS `description` or `prompt`; required).
     pub description: String,
-    /// Subagent role (JS `subagentType` or `type`); `None` lets the driver
+    /// Subagent type (JS `subagentType` or `type`); `None` lets the driver
     /// apply its default (`general`).
     pub subagent_type: Option<String>,
+    /// Fleet role name (JS `role`), e.g. `scout` / `implementer` (#4177).
+    pub role: Option<String>,
     /// Fleet profile token, normalized (trimmed, lowercased) and validated.
+    /// Explicit profile wins over role mapping at spawn time.
     pub profile: Option<String>,
     /// Explicit model override; always wins over `model_strength`.
     pub model: Option<String>,

--- a/crates/workflow-js/src/vm.rs
+++ b/crates/workflow-js/src/vm.rs
@@ -593,6 +593,8 @@ struct TaskOptions {
     description: Option<String>,
     #[serde(alias = "type")]
     subagent_type: Option<String>,
+    /// Fleet role name (#4177). Preferred step identity field.
+    role: Option<String>,
     profile: Option<String>,
     model: Option<String>,
     model_strength: Option<String>,
@@ -614,6 +616,12 @@ fn parse_task_options(opts_json: &str) -> Result<TaskRequest, String> {
         .description
         .filter(|description| !description.trim().is_empty())
         .ok_or_else(|| "task(): 'description' (or 'prompt') is required".to_string())?;
+    let role = options
+        .role
+        .as_deref()
+        .map(normalize_profile)
+        .transpose()
+        .map_err(|err| format!("task(): role: {err}"))?;
     let profile = options
         .profile
         .as_deref()
@@ -623,6 +631,7 @@ fn parse_task_options(opts_json: &str) -> Result<TaskRequest, String> {
     Ok(TaskRequest {
         description,
         subagent_type: options.subagent_type,
+        role,
         profile,
         model: options.model,
         model_strength: options.model_strength,

--- a/crates/workflow/src/elevation.rs
+++ b/crates/workflow/src/elevation.rs
@@ -510,6 +510,7 @@ mod tests {
                 AgentType::Explore
             },
             profile: None,
+            role: None,
             mode,
             isolation: IsolationMode::Auto,
             file_scope: Vec::new(),

--- a/crates/workflow/src/js_authoring.rs
+++ b/crates/workflow/src/js_authoring.rs
@@ -57,12 +57,16 @@ fn compile_js_like_workflow(
     Ok(workflow)
 }
 
-// Profile names are case-insensitive roster keys; the IR stores the canonical
-// lowercase form. Invalid tokens are left as-is so validation reports them.
+// Role/profile names are case-insensitive roster keys; the IR stores the
+// canonical lowercase form. Invalid tokens are left as-is so validation
+// reports them.
 fn normalize_leaf_profiles(nodes: &mut [WorkflowNode]) {
     for node in nodes {
         match node {
             WorkflowNode::Leaf(spec) => {
+                if let Some(role) = spec.role.as_mut() {
+                    *role = role.trim().to_lowercase();
+                }
                 if let Some(profile) = spec.profile.as_mut() {
                     *profile = profile.trim().to_lowercase();
                 }
@@ -536,6 +540,36 @@ workflow({
             panic!("second node should be a leaf");
         };
         assert_eq!(scan.profile, None);
+    }
+
+    #[test]
+    fn javascript_workflow_accepts_and_normalizes_agent_role() {
+        let source = r#"
+workflow({
+  "goal": "role routing",
+  "nodes": [
+    { "agent": { "id": "scout-issue", "prompt": "Investigate #4090. Read-only.", "role": " Scout " } },
+    { "agent": { "id": "fix-it", "prompt": "Apply minimal fix.", "role": "implementer" } }
+  ]
+});
+"#;
+
+        let workflow = compile_javascript_workflow("role.workflow.js", source)
+            .expect("role-carrying workflow should compile");
+
+        let WorkflowNode::Leaf(scout) = &workflow.nodes[0] else {
+            panic!("first node should be a leaf");
+        };
+        assert_eq!(scout.role.as_deref(), Some("scout"));
+        assert_eq!(scout.profile, None);
+        // Provider/model are not required identity fields on role steps.
+        assert_eq!(scout.model_policy.provider, None);
+        assert_eq!(scout.model_policy.model, None);
+
+        let WorkflowNode::Leaf(fix) = &workflow.nodes[1] else {
+            panic!("second node should be a leaf");
+        };
+        assert_eq!(fix.role.as_deref(), Some("implementer"));
     }
 
     #[test]

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -9,6 +9,7 @@ mod js_authoring;
 mod model_policy;
 mod named_fleet;
 mod replay;
+mod role_resolve;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -30,6 +31,10 @@ pub use named_fleet::{
     parse_named_fleet,
 };
 pub use replay::*;
+pub use role_resolve::{
+    FleetRoleMap, FleetRoleResolveError, ResolvedWorkflowAgent, normalize_token,
+    resolve_workflow_agent, validate_role_token,
+};
 
 /// Default hard ceiling on total agents a Fleet-shaped Workflow plan may launch.
 /// Matches the imperative VM lifetime cap (1_000 agents per run).
@@ -140,10 +145,18 @@ pub struct LeafSpec {
     pub prompt: String,
     #[serde(default)]
     pub agent_type: AgentType,
+    /// Fleet role this step should run as (e.g. `scout`, `implementer`).
+    /// Resolved via the fleet roster at dispatch time (#4177). Preferred
+    /// identity field for workflow steps; `profile` remains an explicit
+    /// AgentProfile override. Provider/model live on [`ModelPolicy`] as
+    /// optional overrides — they are **not** required identity fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
     /// Named Fleet roster profile this agent should run as. Resolved against
     /// the saved Fleet roster at dispatch time; unknown names fail validation
     /// before any spawn. When set, role/model/loadout defaults come from the
     /// roster member; explicit fields on this spec override the profile.
+    /// Precedence over `role` when both are set (#4177 / #4111).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile: Option<String>,
     #[serde(default)]
@@ -555,6 +568,9 @@ pub struct BranchResult {
 pub struct LeafResult {
     pub leaf_id: String,
     pub task_id: String,
+    /// Fleet role the leaf was declared to run as, if any (#4177).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
     /// Fleet roster profile the leaf was declared to run as, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile: Option<String>,
@@ -935,6 +951,7 @@ impl MockWorkflowExecutor {
         execution.leaf_results.push(LeafResult {
             leaf_id: spec.id.clone(),
             task_id: spec.id.clone(),
+            role: spec.role.clone(),
             profile: spec.profile.clone(),
             status: outcome.status,
             usage: outcome.usage,
@@ -1574,6 +1591,10 @@ pub enum WorkflowExecutionError {
         "leaf `{leaf}` profile `{profile}` must be a non-empty token without whitespace, quotes, or `=`"
     )]
     InvalidLeafProfile { leaf: String, profile: String },
+    #[error(
+        "leaf `{leaf}` role `{role}` must be a non-empty token without whitespace, quotes, or `=`"
+    )]
+    InvalidLeafRole { leaf: String, role: String },
     #[error("duplicate workflow node `{node}`")]
     DuplicateNodeId { node: String },
     #[error("workflow node `{node}` has unknown {field} reference `{reference}`")]
@@ -1758,6 +1779,9 @@ fn validate_workflow_nodes_inner(
                         leaf: spec.id.clone(),
                     });
                 }
+                if let Some(role) = spec.role.as_deref() {
+                    validate_leaf_role(&spec.id, role)?;
+                }
                 if let Some(profile) = spec.profile.as_deref() {
                     validate_leaf_profile(&spec.id, profile)?;
                 }
@@ -1829,6 +1853,16 @@ fn validate_leaf_profile(leaf: &str, profile: &str) -> Result<(), WorkflowExecut
         return Err(WorkflowExecutionError::InvalidLeafProfile {
             leaf: leaf.to_string(),
             profile: profile.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_leaf_role(leaf: &str, role: &str) -> Result<(), WorkflowExecutionError> {
+    if validate_role_token(role).is_err() {
+        return Err(WorkflowExecutionError::InvalidLeafRole {
+            leaf: leaf.to_string(),
+            role: role.to_string(),
         });
     }
     Ok(())
@@ -2087,6 +2121,7 @@ mod tests {
             id: id.to_string(),
             prompt: format!("run {id}"),
             agent_type: AgentType::General,
+            role: None,
             profile: None,
             mode: TaskMode::ReadOnly,
             isolation: IsolationMode::Shared,
@@ -2103,6 +2138,7 @@ mod tests {
             id: id.to_string(),
             prompt: format!("run {id}"),
             agent_type: AgentType::General,
+            role: None,
             profile: None,
             mode: TaskMode::ReadOnly,
             isolation: IsolationMode::Shared,
@@ -2119,6 +2155,7 @@ mod tests {
             id: id.to_string(),
             prompt: " ".to_string(),
             agent_type: AgentType::General,
+            role: None,
             profile: None,
             mode: TaskMode::ReadOnly,
             isolation: IsolationMode::Shared,
@@ -2445,6 +2482,7 @@ mod tests {
             id: "ro".to_string(),
             prompt: "inspect".to_string(),
             agent_type: AgentType::Explore,
+            role: None,
             profile: None,
             mode: TaskMode::ReadOnly,
             isolation: IsolationMode::Auto,
@@ -2484,6 +2522,7 @@ mod tests {
             id: "scan-readme".to_string(),
             prompt: "Inspect README setup gaps".to_string(),
             agent_type: AgentType::Explore,
+            role: None,
             profile: Some("scout".to_string()),
             mode: TaskMode::ReadOnly,
             isolation: IsolationMode::Shared,
@@ -2576,6 +2615,7 @@ mod tests {
                             id: "followup-template".to_string(),
                             prompt: "Patch one independent gap".to_string(),
                             agent_type: AgentType::Implementer,
+                            role: None,
                             profile: None,
                             mode: TaskMode::ReadWrite,
                             isolation: IsolationMode::Worktree,
@@ -2803,6 +2843,7 @@ mod tests {
         let result = LeafResult {
             leaf_id: "scan-readme".to_string(),
             task_id: "scan".to_string(),
+            role: None,
             profile: Some("reviewer".to_string()),
             status: WorkflowRunStatus::Failed,
             usage: WorkflowUsage {
@@ -2926,6 +2967,69 @@ mod tests {
             Some("reviewer")
         );
         assert_eq!(execution.leaf_results[1].profile, None);
+    }
+
+    #[test]
+    fn mock_executor_surfaces_leaf_role() {
+        let mut role_leaf = match leaf_node("scout-issue") {
+            WorkflowNode::Leaf(leaf) => leaf,
+            _ => unreachable!("leaf helper returns a leaf"),
+        };
+        role_leaf.role = Some("scout".to_string());
+        let workflow = workflow_spec(vec![WorkflowNode::Leaf(role_leaf)]);
+
+        let execution = MockWorkflowExecutor::new()
+            .run(&workflow)
+            .expect("mock workflow should run");
+
+        assert_eq!(execution.leaf_results[0].role.as_deref(), Some("scout"));
+    }
+
+    #[test]
+    fn leaf_role_token_rule_rejects_invalid_names() {
+        for bad in ["", "has space", "role=scout"] {
+            let mut leaf = match leaf_node("scan") {
+                WorkflowNode::Leaf(leaf) => leaf,
+                _ => unreachable!("leaf helper returns a leaf"),
+            };
+            leaf.role = Some(bad.to_string());
+            let workflow = workflow_spec(vec![WorkflowNode::Leaf(leaf)]);
+
+            let err = MockWorkflowExecutor::new()
+                .run(&workflow)
+                .expect_err("invalid role token should fail validation");
+
+            assert!(
+                matches!(&err, WorkflowExecutionError::InvalidLeafRole { role, .. } if role == bad),
+                "role `{bad}` should be rejected, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn leaf_role_roundtrips_without_required_provider_model() {
+        let leaf = LeafSpec {
+            id: "scout-1".to_string(),
+            prompt: "Investigate #4090. Read-only.".to_string(),
+            agent_type: AgentType::Explore,
+            role: Some("scout".to_string()),
+            profile: None,
+            mode: TaskMode::ReadOnly,
+            isolation: IsolationMode::Shared,
+            file_scope: Vec::new(),
+            depends_on_results: Vec::new(),
+            budget: BudgetSpec::default(),
+            permissions: PermissionSpec::default(),
+            model_policy: ModelPolicy::default(),
+        };
+        let json = serde_json::to_string(&leaf).expect("serialize");
+        assert!(json.contains("\"role\":\"scout\""));
+        let parsed: LeafSpec = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed.role.as_deref(), Some("scout"));
+        // Provider/model are optional overrides, not required identity fields.
+        assert_eq!(parsed.model_policy.provider, None);
+        assert_eq!(parsed.model_policy.model, None);
+        assert_eq!(parsed.model_policy, ModelPolicy::default());
     }
 
     #[test]
@@ -3646,6 +3750,7 @@ mod tests {
             leaf_results: vec![LeafResult {
                 leaf_id: "verify-failure".to_string(),
                 task_id: "verify-failure".to_string(),
+                role: None,
                 profile: None,
                 status: WorkflowRunStatus::Failed,
                 usage: WorkflowUsage::default(),

--- a/crates/workflow/src/replay.rs
+++ b/crates/workflow/src/replay.rs
@@ -211,6 +211,7 @@ impl WorkflowReplayExecutor {
             let result = LeafResult {
                 leaf_id: leaf.id.clone(),
                 task_id: leaf.id.clone(),
+                role: leaf.role.clone(),
                 profile: leaf.profile.clone(),
                 status: WorkflowRunStatus::ReplayDiverged,
                 usage: WorkflowUsage::default(),
@@ -526,6 +527,7 @@ mod tests {
             id: id.to_string(),
             prompt: format!("run {id}"),
             agent_type: AgentType::General,
+            role: None,
             profile: None,
             mode: TaskMode::ReadOnly,
             isolation: crate::IsolationMode::Shared,
@@ -558,6 +560,7 @@ mod tests {
         LeafResult {
             leaf_id: id.to_string(),
             task_id: id.to_string(),
+            role: None,
             profile: None,
             status: WorkflowRunStatus::Succeeded,
             usage: WorkflowUsage {

--- a/crates/workflow/src/role_resolve.rs
+++ b/crates/workflow/src/role_resolve.rs
@@ -1,0 +1,274 @@
+//! Fleet role resolution for Workflow steps (#4177).
+//!
+//! Workflow owns **what order**; Fleet owns **who**. Steps declare a fleet
+//! `role` (and optional task prompt). At run time the fleet roster maps
+//! `role → AgentProfile id`. This module is the pure resolution path used by
+//! unit tests and by the dispatcher before spawn — it never imports tmux or
+//! session management.
+//!
+//! Precedence (aligned with #4111 / #4136):
+//! 1. Explicit `profile` on the step
+//! 2. Fleet role map entry for `role`
+//! 3. Role name used as profile id when the map has no alias
+//!
+//! Inline provider/model are **not** identity fields. They remain optional
+//! overrides on [`crate::ModelPolicy`]; step identity is role/profile only.
+
+use std::collections::BTreeMap;
+
+use thiserror::Error;
+
+/// Named fleet roster: role name → AgentProfile id.
+///
+/// Role and profile tokens are compared case-insensitively after trim +
+/// lowercase normalization.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FleetRoleMap {
+    /// Lowercased role → profile id (as configured; not re-cased).
+    roles: BTreeMap<String, String>,
+}
+
+impl FleetRoleMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a role → profile binding. Empty tokens are rejected.
+    pub fn insert(
+        &mut self,
+        role: impl Into<String>,
+        profile: impl Into<String>,
+    ) -> Result<(), FleetRoleResolveError> {
+        let role = normalize_token(&role.into()).ok_or(FleetRoleResolveError::EmptyRole)?;
+        let profile =
+            normalize_token(&profile.into()).ok_or(FleetRoleResolveError::EmptyProfile)?;
+        self.roles.insert(role, profile);
+        Ok(())
+    }
+
+    pub fn from_pairs<I, R, P>(pairs: I) -> Result<Self, FleetRoleResolveError>
+    where
+        I: IntoIterator<Item = (R, P)>,
+        R: Into<String>,
+        P: Into<String>,
+    {
+        let mut map = Self::new();
+        for (role, profile) in pairs {
+            map.insert(role, profile)?;
+        }
+        Ok(map)
+    }
+
+    /// Look up the profile id bound to `role`, if any.
+    pub fn get(&self, role: &str) -> Option<&str> {
+        let key = normalize_token(role)?;
+        self.roles.get(&key).map(String::as_str)
+    }
+
+    pub fn contains_role(&self, role: &str) -> bool {
+        self.get(role).is_some()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.roles.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.roles.len()
+    }
+}
+
+/// Result of resolving a workflow step against a fleet roster.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedWorkflowAgent {
+    /// Fleet role declared on the step, if any.
+    pub resolved_role: Option<String>,
+    /// AgentProfile id to spawn.
+    pub resolved_profile: String,
+    /// How the profile was chosen: `explicit_profile`, `fleet_role`, or
+    /// `role_as_profile`.
+    pub route_source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum FleetRoleResolveError {
+    #[error("fleet role name must be a non-empty token")]
+    EmptyRole,
+    #[error("fleet profile id must be a non-empty token")]
+    EmptyProfile,
+    #[error("unknown fleet role `{role}`: not present in fleet roster (known roles: {known})")]
+    UnknownRole { role: String, known: String },
+    #[error(
+        "workflow step requires a fleet role or explicit profile; provider/model alone are not identity"
+    )]
+    MissingRoleOrProfile,
+    #[error("role `{role}` must be a non-empty token without whitespace, quotes, or `=`")]
+    InvalidRoleToken { role: String },
+}
+
+/// Normalize a role/profile token: trim, lowercase. Returns `None` if empty
+/// or if the token contains whitespace / quotes / backticks / `=`.
+pub fn normalize_token(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed
+        .chars()
+        .any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '`' | '='))
+    {
+        return None;
+    }
+    Some(trimmed.to_ascii_lowercase())
+}
+
+/// Validate a role token the same way leaf profiles are validated.
+pub fn validate_role_token(role: &str) -> Result<String, FleetRoleResolveError> {
+    normalize_token(role).ok_or_else(|| FleetRoleResolveError::InvalidRoleToken {
+        role: role.to_string(),
+    })
+}
+
+/// Resolve step identity from optional `role` + optional explicit `profile`
+/// against a fleet role map.
+///
+/// When `require_known_role` is true and `role` is set without an explicit
+/// profile, the role must exist in `fleet` (unknown roles fail clearly).
+/// When false, an unknown role falls through to `role_as_profile` (useful
+/// when the dispatcher will validate membership later against a full roster).
+pub fn resolve_workflow_agent(
+    role: Option<&str>,
+    profile: Option<&str>,
+    fleet: &FleetRoleMap,
+    require_known_role: bool,
+) -> Result<ResolvedWorkflowAgent, FleetRoleResolveError> {
+    let role_norm = match role {
+        Some(raw) => Some(validate_role_token(raw)?),
+        None => None,
+    };
+    let profile_norm =
+        match profile {
+            Some(raw) => Some(validate_role_token(raw).map_err(|_| {
+                FleetRoleResolveError::InvalidRoleToken {
+                    role: raw.to_string(),
+                }
+            })?),
+            None => None,
+        };
+
+    // Explicit profile always wins (task-field precedence).
+    if let Some(resolved_profile) = profile_norm {
+        return Ok(ResolvedWorkflowAgent {
+            resolved_role: role_norm,
+            resolved_profile,
+            route_source: "explicit_profile",
+        });
+    }
+
+    let Some(role_name) = role_norm else {
+        return Err(FleetRoleResolveError::MissingRoleOrProfile);
+    };
+
+    if let Some(mapped) = fleet.get(&role_name) {
+        return Ok(ResolvedWorkflowAgent {
+            resolved_role: Some(role_name),
+            resolved_profile: mapped.to_string(),
+            route_source: "fleet_role",
+        });
+    }
+
+    if require_known_role {
+        let known = if fleet.is_empty() {
+            "(none)".to_string()
+        } else {
+            fleet.roles.keys().cloned().collect::<Vec<_>>().join(", ")
+        };
+        return Err(FleetRoleResolveError::UnknownRole {
+            role: role_name,
+            known,
+        });
+    }
+
+    Ok(ResolvedWorkflowAgent {
+        resolved_role: Some(role_name.clone()),
+        resolved_profile: role_name,
+        route_source: "role_as_profile",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stopship_fleet() -> FleetRoleMap {
+        FleetRoleMap::from_pairs([
+            ("scout", "scout"),
+            ("implementer", "builder"),
+            ("reviewer", "reviewer"),
+            ("verifier", "verifier"),
+            ("release_lead", "manager"),
+        ])
+        .expect("valid fleet pairs")
+    }
+
+    #[test]
+    fn known_role_resolves_to_configured_profile() {
+        let fleet = stopship_fleet();
+        let resolved =
+            resolve_workflow_agent(Some("implementer"), None, &fleet, true).expect("resolve");
+        assert_eq!(resolved.resolved_role.as_deref(), Some("implementer"));
+        assert_eq!(resolved.resolved_profile, "builder");
+        assert_eq!(resolved.route_source, "fleet_role");
+    }
+
+    #[test]
+    fn unknown_role_fails_clearly() {
+        let fleet = stopship_fleet();
+        let err = resolve_workflow_agent(Some("wizard"), None, &fleet, true)
+            .expect_err("unknown role must fail");
+        match err {
+            FleetRoleResolveError::UnknownRole { role, known } => {
+                assert_eq!(role, "wizard");
+                assert!(known.contains("scout"), "known={known}");
+                assert!(known.contains("implementer"), "known={known}");
+            }
+            other => panic!("expected UnknownRole, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_profile_wins_over_role_map() {
+        let fleet = stopship_fleet();
+        let resolved = resolve_workflow_agent(Some("scout"), Some("custom-scout"), &fleet, true)
+            .expect("resolve");
+        assert_eq!(resolved.resolved_role.as_deref(), Some("scout"));
+        assert_eq!(resolved.resolved_profile, "custom-scout");
+        assert_eq!(resolved.route_source, "explicit_profile");
+    }
+
+    #[test]
+    fn missing_role_and_profile_fails() {
+        let fleet = stopship_fleet();
+        let err = resolve_workflow_agent(None, None, &fleet, true).expect_err("identity required");
+        assert!(matches!(err, FleetRoleResolveError::MissingRoleOrProfile));
+    }
+
+    #[test]
+    fn role_token_rejects_whitespace_and_equals() {
+        for bad in ["", "has space", "role=x", "quote\"y"] {
+            assert!(
+                validate_role_token(bad).is_err(),
+                "token {bad:?} should be rejected"
+            );
+        }
+        assert_eq!(validate_role_token("  Scout  ").unwrap(), "scout");
+    }
+
+    #[test]
+    fn require_known_role_false_falls_back_to_role_as_profile() {
+        let fleet = FleetRoleMap::new();
+        let resolved = resolve_workflow_agent(Some("scout"), None, &fleet, false).expect("resolve");
+        assert_eq!(resolved.resolved_profile, "scout");
+        assert_eq!(resolved.route_source, "role_as_profile");
+    }
+}


### PR DESCRIPTION
## Summary
Implements the Phase 2 (#4177) slice: workflow steps declare fleet **roles** as identity, resolved through the Fleet roster at spawn time.

## Changes
- **IR / JS**: `LeafSpec.role` and workflow-js `task({ role })` (provider/model stay optional overrides, not identity).
- **Resolver**: `codewhale_workflow::FleetRoleMap` + `resolve_workflow_agent` with unit tests for known/unknown roles.
- **Spawn path**: role → roster member (id / role name / stopship aliases); `TaskStarted` includes `resolved_role` + `resolved_profile`.
- **Tests**: role token validation, IR roundtrip without required model/provider, JS authoring normalization.

## Acceptance vs #4177
| AC | Status |
|----|--------|
| Workflow JS/IR supports `role:` | Done |
| Rejects inline provider/model as *required* identity | Done (optional ModelPolicy only) |
| `workflow run --fleet` CLI | Deferred to #4176 (needs Lane) |
| Fleet resolver single path for spawns | Done via `apply_spawn_profile` / `resolve_roster_member` |
| `TaskStarted` resolved role+profile+route | Done |
| Unit tests unknown/known role | Done |
| stopship workflow role-based update | Deferred to #4178 |

## Test plan
- [x] `cargo test -p codewhale-workflow --lib role`
- [x] `cargo test -p codewhale-workflow-js --lib`
- [x] `cargo fmt -- --check`
- [x] `codewhale-tui` compiles with changes

Closes nothing yet — residual CLI entrypoint tracks with #4176/#4178.