### PR TITLE
feat(lane): Phase 1 Lane CLI + Runtime backends (#4176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "codewhale-build-support",
  "codewhale-config",
  "codewhale-execpolicy",
+ "codewhale-lane",
  "codewhale-mcp",
  "codewhale-release",
  "codewhale-secrets",
@@ -885,6 +886,20 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "codewhale-lane"
+version = "0.8.67"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "codewhale-config",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/core",
     "crates/execpolicy",
     "crates/hooks",
+    "crates/lane",
     "crates/mcp",
     "crates/protocol",
     "crates/release",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ clap_complete.workspace = true
 codewhale-agent = { path = "../agent", version = "0.8.67" }
 codewhale-app-server = { path = "../app-server", version = "0.8.67" }
 codewhale-config = { path = "../config", version = "0.8.67" }
+codewhale-lane = { path = "../lane", version = "0.8.67" }
 codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
 codewhale-mcp = { path = "../mcp", version = "0.8.67" }
 codewhale-release = { path = "../release", version = "0.8.67" }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -461,8 +461,8 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
                 println!("No lanes under {}", reg.root().display());
             } else {
                 println!(
-                    "{:<16} {:<10} {:<12} {:<16} {:<10} {}",
-                    "ID", "STATUS", "RUNTIME", "WORKFLOW", "ISSUE", "STARTED"
+                    "{:<16} {:<10} {:<12} {:<16} {:<10} STARTED",
+                    "ID", "STATUS", "RUNTIME", "WORKFLOW", "ISSUE"
                 );
                 for lane in lanes {
                     println!(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -220,6 +220,20 @@ path used by stream-json wrappers.
     Exec(TuiPassthroughArgs),
     /// Manage durable Agent Fleet runs via the TUI runtime.
     Fleet(TuiPassthroughArgs),
+    /// Manage running workflow instances (Lanes) and Runtime backends (#4176).
+    #[command(after_help = "\
+Examples:
+  codewhale lane list
+  codewhale lane status <lane-id>
+  codewhale lane attach <lane-id>
+  codewhale lane logs <lane-id>
+  codewhale lane stop <lane-id>
+  codewhale lane start --workflow stopship --fleet v0868-stopship --runtime tmux --issue 4090 -- echo hello
+
+Lane records persist under $CODEWHALE_HOME/lanes/. tmux durability belongs to
+Runtime, not Fleet.
+")]
+    Lane(LaneArgs),
     /// Run a CodeWhale-powered code review over a git diff.
     Review(TuiPassthroughArgs),
     /// Apply a patch file or stdin to the working tree.
@@ -349,6 +363,285 @@ struct RunArgs {
 struct TuiPassthroughArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     args: Vec<String>,
+}
+
+/// `codewhale lane …` — running workflow instances (#4176).
+#[derive(Debug, Args)]
+struct LaneArgs {
+    #[command(subcommand)]
+    command: LaneCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum LaneCommand {
+    /// List known lanes (newest first).
+    List {
+        /// Emit JSON.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Show one lane's status and attach metadata.
+    Status {
+        /// Lane id (e.g. `lane-a1b2c3d4`).
+        lane_id: String,
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Attach to a tmux-backed lane (prints attach command; execs when possible).
+    Attach {
+        lane_id: String,
+        /// Only print the attach command; do not exec.
+        #[arg(long, default_value_t = false)]
+        print: bool,
+    },
+    /// Tail the lane stream-json / NDJSON journal.
+    Logs {
+        lane_id: String,
+        /// Follow the log file (like `tail -f`).
+        #[arg(long, short = 'f', default_value_t = false)]
+        follow: bool,
+        /// Number of trailing lines when not following (default 50).
+        #[arg(long, default_value_t = 50)]
+        tail: usize,
+    },
+    /// Stop a running lane and run worktree TTL cleanup.
+    Stop { lane_id: String },
+    /// Start a lane under a Runtime backend (tmux|inline|vm|ci).
+    Start {
+        /// Workflow name (e.g. `stopship`).
+        #[arg(long)]
+        workflow: Option<String>,
+        /// Fleet roster name (e.g. `v0868-stopship`).
+        #[arg(long)]
+        fleet: Option<String>,
+        /// Issue id binding.
+        #[arg(long)]
+        issue: Option<String>,
+        /// Free-form goal text.
+        #[arg(long)]
+        goal: Option<String>,
+        /// Runtime backend: tmux, inline, vm, or ci.
+        #[arg(long, default_value = "tmux")]
+        runtime: String,
+        /// Create an isolated worktree under this repo root.
+        #[arg(long, value_name = "DIR")]
+        worktree_repo: Option<PathBuf>,
+        /// Branch name for the worktree (requires `--worktree-repo`).
+        #[arg(long)]
+        branch: Option<String>,
+        /// Worktree path (defaults to `<repo>/.codewhale/lanes/<lane-id>`).
+        #[arg(long, value_name = "DIR")]
+        worktree_path: Option<PathBuf>,
+        /// Worktree cleanup TTL seconds after stop (0 = immediate on stop).
+        #[arg(long)]
+        worktree_ttl_secs: Option<u64>,
+        /// Command to run in the runtime (after `--`).
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+}
+
+fn run_lane_command(args: LaneArgs) -> Result<()> {
+    use codewhale_lane::{
+        LaneRegistry, LaneStartSpec, RuntimeBackendKind, WorktreeProvision, backend_for,
+        resolve_backend,
+    };
+    use std::io::{BufRead, Seek, Write};
+    use std::process::Command;
+    use std::thread;
+    use std::time::Duration;
+
+    match args.command {
+        LaneCommand::List { json } => {
+            let reg = LaneRegistry::open_default()?;
+            let lanes = reg.list()?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&lanes)?);
+            } else if lanes.is_empty() {
+                println!("No lanes under {}", reg.root().display());
+            } else {
+                println!(
+                    "{:<16} {:<10} {:<12} {:<16} {:<10} {}",
+                    "ID", "STATUS", "RUNTIME", "WORKFLOW", "ISSUE", "STARTED"
+                );
+                for lane in lanes {
+                    println!(
+                        "{:<16} {:<10} {:<12} {:<16} {:<10} {}",
+                        lane.id,
+                        lane.status.as_str(),
+                        lane.runtime.as_str(),
+                        lane.workflow.as_deref().unwrap_or("-"),
+                        lane.issue.as_deref().unwrap_or("-"),
+                        lane.started_at,
+                    );
+                }
+            }
+            Ok(())
+        }
+        LaneCommand::Status { lane_id, json } => {
+            let reg = LaneRegistry::open_default()?;
+            let lane = reg.load(&lane_id)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&lane)?);
+            } else {
+                println!("lane:     {}", lane.id);
+                println!("status:   {}", lane.status.as_str());
+                println!("runtime:  {}", lane.runtime.as_str());
+                println!("workflow: {}", lane.workflow.as_deref().unwrap_or("-"));
+                println!("fleet:    {}", lane.fleet.as_deref().unwrap_or("-"));
+                println!("issue:    {}", lane.issue.as_deref().unwrap_or("-"));
+                println!("goal:     {}", lane.goal.as_deref().unwrap_or("-"));
+                println!("started:  {}", lane.started_at);
+                println!("stopped:  {}", lane.stopped_at.as_deref().unwrap_or("-"));
+                println!(
+                    "worktree: {}",
+                    lane.worktree_path
+                        .as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|| "-".into())
+                );
+                println!("branch:   {}", lane.branch.as_deref().unwrap_or("-"));
+                println!("tmux:     {}", lane.tmux_session.as_deref().unwrap_or("-"));
+                println!("attach:   {}", lane.attach_target.as_deref().unwrap_or("-"));
+                println!("log:      {}", lane.log_path.display());
+            }
+            Ok(())
+        }
+        LaneCommand::Attach { lane_id, print } => {
+            let reg = LaneRegistry::open_default()?;
+            let lane = reg.load(&lane_id)?;
+            let backend = backend_for(&lane);
+            let Some(attach) = backend.attach_command(&lane) else {
+                bail!(
+                    "lane `{lane_id}` runtime `{}` has no attach target",
+                    lane.runtime.as_str()
+                );
+            };
+            if print {
+                println!("{attach}");
+                return Ok(());
+            }
+            if let Some(session) = lane.tmux_session.as_deref() {
+                let status = Command::new("tmux")
+                    .args(["attach", "-t", session])
+                    .status();
+                match status {
+                    Ok(s) if s.success() => Ok(()),
+                    Ok(s) => bail!("tmux attach failed ({s}); command was: {attach}"),
+                    Err(err) => {
+                        eprintln!("could not exec tmux: {err}");
+                        println!("{attach}");
+                        bail!("tmux attach unavailable");
+                    }
+                }
+            } else {
+                println!("{attach}");
+                Ok(())
+            }
+        }
+        LaneCommand::Logs {
+            lane_id,
+            follow,
+            tail,
+        } => {
+            let reg = LaneRegistry::open_default()?;
+            let lane = reg.load(&lane_id)?;
+            let path = lane.log_path;
+            if !path.exists() {
+                bail!("log file missing: {}", path.display());
+            }
+            let content = std::fs::read_to_string(&path)?;
+            let lines: Vec<&str> = content.lines().collect();
+            let start = lines.len().saturating_sub(tail);
+            for line in &lines[start..] {
+                println!("{line}");
+            }
+            if !follow {
+                return Ok(());
+            }
+            let mut file = std::fs::File::open(&path)?;
+            file.seek(std::io::SeekFrom::End(0))?;
+            let mut reader = std::io::BufReader::new(file);
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => {
+                        thread::sleep(Duration::from_millis(200));
+                        continue;
+                    }
+                    Ok(_) => {
+                        print!("{line}");
+                        let _ = std::io::stdout().flush();
+                    }
+                    Err(err) => return Err(err.into()),
+                }
+            }
+        }
+        LaneCommand::Stop { lane_id } => {
+            let reg = LaneRegistry::open_default()?;
+            let mut lane = reg.load(&lane_id)?;
+            let backend = backend_for(&lane);
+            backend.stop(&reg, &mut lane)?;
+            println!("stopped {}", lane.id);
+            Ok(())
+        }
+        LaneCommand::Start {
+            workflow,
+            fleet,
+            issue,
+            goal,
+            runtime,
+            worktree_repo,
+            branch,
+            worktree_path,
+            worktree_ttl_secs,
+            command,
+        } => {
+            let kind = RuntimeBackendKind::parse(&runtime)?;
+            let reg = LaneRegistry::open_default()?;
+            let mut record =
+                reg.create_pending(workflow, fleet, issue, goal, kind, worktree_ttl_secs)?;
+            let worktree = match (worktree_repo, branch) {
+                (Some(repo_root), Some(branch_name)) => {
+                    let path = worktree_path.unwrap_or_else(|| {
+                        repo_root.join(".codewhale").join("lanes").join(&record.id)
+                    });
+                    Some(WorktreeProvision {
+                        repo_root,
+                        branch: branch_name,
+                        path,
+                        base_ref: None,
+                    })
+                }
+                (None, None) => None,
+                _ => bail!("--worktree-repo and --branch must be provided together"),
+            };
+            let cmd = if command.is_empty() {
+                vec![
+                    "sh".into(),
+                    "-c".into(),
+                    format!("echo lane {} started", record.id),
+                ]
+            } else {
+                command
+            };
+            let spec = LaneStartSpec {
+                command: cmd,
+                cwd: None,
+                worktree,
+            };
+            let backend = resolve_backend(kind);
+            backend.start(&reg, &mut record, &spec)?;
+            println!("started {}", record.id);
+            println!("status:  {}", record.status.as_str());
+            println!("runtime: {}", record.runtime.as_str());
+            println!("log:     {}", record.log_path.display());
+            if let Some(attach) = backend.attach_command(&record) {
+                println!("attach:  {attach}");
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Flags for `codewhale remote-setup`. Forwarded to the TUI binary, which owns
@@ -724,6 +1017,7 @@ fn run() -> Result<()> {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("fleet", args))
         }
+        Some(Commands::Lane(args)) => run_lane_command(args),
         Some(Commands::Review(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("review", args))

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "codewhale-lane"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Lane registry and Runtime backends for CodeWhale workflow instances"
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+codewhale-config = { path = "../config", version = "0.8.67" }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/lane/src/lib.rs
+++ b/crates/lane/src/lib.rs
@@ -1,0 +1,18 @@
+//! Lane registry + Runtime backends (#4176).
+//!
+//! A **Lane** is a running workflow instance (one issue/goal). **Runtime** owns
+//! where/how it executes (tmux, inline, vm, ci) — never Fleet.
+//!
+//! Persistence: `$CODEWHALE_HOME/lanes/<lane-id>.json` plus stream-json logs
+//! under `$CODEWHALE_HOME/lanes/logs/<lane-id>.ndjson`.
+
+mod registry;
+mod runtime;
+mod worktree;
+
+pub use registry::{LaneRecord, LaneRegistry, LaneStatus, lanes_dir};
+pub use runtime::{
+    InlineRuntime, LaneStartSpec, RuntimeBackend, RuntimeBackendKind, TmuxRuntime, backend_for,
+    resolve_backend,
+};
+pub use worktree::{WorktreeProvision, provision_worktree, remove_worktree_if_expired};

--- a/crates/lane/src/registry.rs
+++ b/crates/lane/src/registry.rs
@@ -1,0 +1,257 @@
+//! Durable lane registry under `$CODEWHALE_HOME/lanes/`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::runtime::RuntimeBackendKind;
+
+const LANES_SUBDIR: &str = "lanes";
+const LOGS_SUBDIR: &str = "logs";
+
+/// Lifecycle status for a running workflow instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaneStatus {
+    Pending,
+    Running,
+    Stopped,
+    Failed,
+    Completed,
+}
+
+impl LaneStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+            Self::Completed => "completed",
+        }
+    }
+
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Pending | Self::Running)
+    }
+}
+
+/// One lane record: a running (or completed) workflow instance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneRecord {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fleet: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<String>,
+    pub runtime: RuntimeBackendKind,
+    pub status: LaneStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// tmux session name when `runtime == tmux`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmux_session: Option<String>,
+    /// Absolute path to the stream-json / NDJSON journal for this lane.
+    pub log_path: PathBuf,
+    pub started_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopped_at: Option<String>,
+    /// Optional human-readable attach target (e.g. `tmux attach -t …`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attach_target: Option<String>,
+    /// Worktree cleanup TTL in seconds (None = no auto-cleanup).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_ttl_secs: Option<u64>,
+}
+
+impl LaneRecord {
+    pub fn new_id() -> String {
+        let short = uuid::Uuid::new_v4().to_string();
+        format!("lane-{}", &short[..8])
+    }
+
+    pub fn now_rfc3339() -> String {
+        Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+    }
+}
+
+/// Registry root: `$CODEWHALE_HOME/lanes`.
+pub fn lanes_dir() -> Result<PathBuf> {
+    codewhale_config::ensure_state_dir(LANES_SUBDIR)
+}
+
+/// Persist and load lane records.
+#[derive(Debug, Clone)]
+pub struct LaneRegistry {
+    root: PathBuf,
+}
+
+impl LaneRegistry {
+    /// Open the default registry under `$CODEWHALE_HOME/lanes`.
+    pub fn open_default() -> Result<Self> {
+        Self::open(lanes_dir()?)
+    }
+
+    /// Open a registry at an explicit root (tests / custom homes).
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self> {
+        let root = root.into();
+        fs::create_dir_all(&root)
+            .with_context(|| format!("create lane registry {}", root.display()))?;
+        fs::create_dir_all(root.join(LOGS_SUBDIR))
+            .with_context(|| format!("create lane logs under {}", root.display()))?;
+        Ok(Self { root })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn logs_dir(&self) -> PathBuf {
+        self.root.join(LOGS_SUBDIR)
+    }
+
+    pub fn record_path(&self, id: &str) -> PathBuf {
+        self.root.join(format!("{id}.json"))
+    }
+
+    pub fn log_path_for(&self, id: &str) -> PathBuf {
+        self.logs_dir().join(format!("{id}.ndjson"))
+    }
+
+    pub fn save(&self, record: &LaneRecord) -> Result<()> {
+        let path = self.record_path(&record.id);
+        let json = serde_json::to_string_pretty(record).context("serialize lane record")?;
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, json).with_context(|| format!("write {}", tmp.display()))?;
+        fs::rename(&tmp, &path).with_context(|| format!("rename {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn load(&self, id: &str) -> Result<LaneRecord> {
+        let path = self.record_path(id);
+        if !path.is_file() {
+            bail!("lane `{id}` not found under {}", self.root.display());
+        }
+        let text = fs::read_to_string(&path)
+            .with_context(|| format!("read lane record {}", path.display()))?;
+        serde_json::from_str(&text).with_context(|| format!("parse lane record {}", path.display()))
+    }
+
+    pub fn list(&self) -> Result<Vec<LaneRecord>> {
+        let mut records = Vec::new();
+        for entry in fs::read_dir(&self.root)
+            .with_context(|| format!("read lane registry {}", self.root.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let text =
+                fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+            match serde_json::from_str::<LaneRecord>(&text) {
+                Ok(record) => records.push(record),
+                Err(err) => {
+                    // Skip corrupt records rather than failing the whole list.
+                    eprintln!(
+                        "warning: skip corrupt lane record {}: {err}",
+                        path.display()
+                    );
+                }
+            }
+        }
+        records.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(records)
+    }
+
+    /// Create a pending lane with log file reserved.
+    pub fn create_pending(
+        &self,
+        workflow: Option<String>,
+        fleet: Option<String>,
+        issue: Option<String>,
+        goal: Option<String>,
+        runtime: RuntimeBackendKind,
+        worktree_ttl_secs: Option<u64>,
+    ) -> Result<LaneRecord> {
+        let id = LaneRecord::new_id();
+        let log_path = self.log_path_for(&id);
+        // Touch the log so `lane logs` works immediately.
+        fs::write(&log_path, "").with_context(|| format!("create log {}", log_path.display()))?;
+        let record = LaneRecord {
+            id,
+            workflow,
+            fleet,
+            issue,
+            goal,
+            runtime,
+            status: LaneStatus::Pending,
+            worktree_path: None,
+            branch: None,
+            tmux_session: None,
+            log_path,
+            started_at: LaneRecord::now_rfc3339(),
+            stopped_at: None,
+            attach_target: None,
+            worktree_ttl_secs,
+        };
+        self.save(&record)?;
+        Ok(record)
+    }
+
+    pub fn mark_running(&self, record: &mut LaneRecord) -> Result<()> {
+        record.status = LaneStatus::Running;
+        self.save(record)
+    }
+
+    pub fn mark_stopped(&self, record: &mut LaneRecord, status: LaneStatus) -> Result<()> {
+        record.status = status;
+        record.stopped_at = Some(LaneRecord::now_rfc3339());
+        self.save(record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn registry_persists_across_open() {
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let record = reg
+            .create_pending(
+                Some("stopship".into()),
+                Some("v0868-stopship".into()),
+                Some("4090".into()),
+                None,
+                RuntimeBackendKind::Tmux,
+                Some(3600),
+            )
+            .unwrap();
+        let id = record.id.clone();
+
+        let reg2 = LaneRegistry::open(dir.path()).unwrap();
+        let loaded = reg2.load(&id).unwrap();
+        assert_eq!(loaded.workflow.as_deref(), Some("stopship"));
+        assert_eq!(loaded.fleet.as_deref(), Some("v0868-stopship"));
+        assert_eq!(loaded.issue.as_deref(), Some("4090"));
+        assert_eq!(loaded.runtime, RuntimeBackendKind::Tmux);
+        assert_eq!(loaded.status, LaneStatus::Pending);
+        assert!(loaded.log_path.is_file() || loaded.log_path.exists());
+
+        let listed = reg2.list().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, id);
+    }
+}

--- a/crates/lane/src/runtime.rs
+++ b/crates/lane/src/runtime.rs
@@ -1,0 +1,459 @@
+//! Runtime backends: tmux durability, inline, vm/ci stubs (#4176).
+//!
+//! Runtime owns process/session lifecycle and stream-json log capture.
+//! Fleet modules must not import this module.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::registry::{LaneRecord, LaneRegistry, LaneStatus};
+use crate::worktree::{WorktreeProvision, provision_worktree, remove_worktree_if_expired};
+
+/// Execution backend for a lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBackendKind {
+    Tmux,
+    Inline,
+    Vm,
+    Ci,
+}
+
+impl RuntimeBackendKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tmux => "tmux",
+            Self::Inline => "inline",
+            Self::Vm => "vm",
+            Self::Ci => "ci",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "tmux" => Ok(Self::Tmux),
+            "inline" => Ok(Self::Inline),
+            "vm" => Ok(Self::Vm),
+            "ci" => Ok(Self::Ci),
+            other => bail!("unknown runtime backend `{other}` (use tmux|inline|vm|ci)"),
+        }
+    }
+}
+
+/// Inputs for starting a lane under a runtime backend.
+#[derive(Debug, Clone)]
+pub struct LaneStartSpec {
+    /// Command argv to run inside the backend (e.g. `codewhale exec …`).
+    pub command: Vec<String>,
+    /// Working directory for the command (defaults to worktree or cwd).
+    pub cwd: Option<PathBuf>,
+    /// When set, provision an isolated git worktree + branch under this repo.
+    pub worktree: Option<WorktreeProvision>,
+}
+
+/// Runtime adapter contract.
+pub trait RuntimeBackend {
+    fn kind(&self) -> RuntimeBackendKind;
+
+    /// Start the lane process/session; mutates record with attach/log metadata.
+    fn start(
+        &self,
+        registry: &LaneRegistry,
+        record: &mut LaneRecord,
+        spec: &LaneStartSpec,
+    ) -> Result<()>;
+
+    /// Human attach command, if any (tmux).
+    fn attach_command(&self, record: &LaneRecord) -> Option<String>;
+
+    /// Stop the running session/process.
+    fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()>;
+
+    /// Optional worktree TTL cleanup after stop.
+    fn cleanup_worktree(&self, record: &LaneRecord) -> Result<()> {
+        if let Some(path) = record.worktree_path.as_ref() {
+            remove_worktree_if_expired(
+                path,
+                record.worktree_ttl_secs,
+                record.stopped_at.as_deref(),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+pub fn resolve_backend(kind: RuntimeBackendKind) -> Box<dyn RuntimeBackend> {
+    match kind {
+        RuntimeBackendKind::Tmux => Box::new(TmuxRuntime),
+        RuntimeBackendKind::Inline => Box::new(InlineRuntime),
+        RuntimeBackendKind::Vm => Box::new(StubRuntime {
+            kind: RuntimeBackendKind::Vm,
+        }),
+        RuntimeBackendKind::Ci => Box::new(StubRuntime {
+            kind: RuntimeBackendKind::Ci,
+        }),
+    }
+}
+
+pub fn backend_for(record: &LaneRecord) -> Box<dyn RuntimeBackend> {
+    resolve_backend(record.runtime)
+}
+
+fn append_log_event(log_path: &Path, event: serde_json::Value) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .with_context(|| format!("open lane log {}", log_path.display()))?;
+    writeln!(file, "{event}").with_context(|| format!("write lane log {}", log_path.display()))?;
+    Ok(())
+}
+
+fn apply_worktree(record: &mut LaneRecord, spec: &LaneStartSpec) -> Result<Option<PathBuf>> {
+    let Some(wt) = spec.worktree.as_ref() else {
+        return Ok(spec.cwd.clone());
+    };
+    let provisioned = provision_worktree(wt)?;
+    record.worktree_path = Some(provisioned.path.clone());
+    record.branch = Some(provisioned.branch.clone());
+    Ok(Some(provisioned.path))
+}
+
+/// Durable local tmux sessions + attach + stream-json log file.
+#[derive(Debug, Default)]
+pub struct TmuxRuntime;
+
+impl RuntimeBackend for TmuxRuntime {
+    fn kind(&self) -> RuntimeBackendKind {
+        RuntimeBackendKind::Tmux
+    }
+
+    fn start(
+        &self,
+        registry: &LaneRegistry,
+        record: &mut LaneRecord,
+        spec: &LaneStartSpec,
+    ) -> Result<()> {
+        if spec.command.is_empty() {
+            bail!("tmux runtime requires a non-empty command");
+        }
+        // tmux may be absent in CI; fall back to a dry-run session record when
+        // CODEWHALE_LANE_TMUX_DRY_RUN=1 or tmux is missing (tests).
+        let dry_run = std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some()
+            || Command::new("tmux")
+                .arg("-V")
+                .output()
+                .map(|o| !o.status.success())
+                .unwrap_or(true);
+
+        let cwd = apply_worktree(record, spec)?;
+        let session = format!("cw-{}", record.id);
+        record.tmux_session = Some(session.clone());
+        record.attach_target = Some(format!("tmux attach -t {session}"));
+
+        append_log_event(
+            &record.log_path,
+            serde_json::json!({
+                "type": "lane_started",
+                "lane_id": record.id,
+                "runtime": "tmux",
+                "session": session,
+                "workflow": record.workflow,
+                "fleet": record.fleet,
+                "issue": record.issue,
+                "dry_run": dry_run,
+            }),
+        )?;
+
+        if dry_run {
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({
+                    "type": "lane_log",
+                    "message": "tmux dry-run: session recorded without spawning process",
+                    "command": spec.command,
+                    "cwd": cwd.as_ref().map(|p| p.display().to_string()),
+                }),
+            )?;
+            registry.mark_running(record)?;
+            return Ok(());
+        }
+
+        // Detached session: run command, tee stdout into the lane log.
+        let log_path = record.log_path.display().to_string();
+        let shell_cmd = format!(
+            "({}) 2>&1 | while IFS= read -r line; do printf '%s\\n' \"$line\" >> {}; done",
+            shell_join(&spec.command),
+            shell_escape(&log_path)
+        );
+
+        let mut cmd = Command::new("tmux");
+        cmd.args(["new-session", "-d", "-s", &session]);
+        if let Some(cwd) = cwd.as_ref() {
+            cmd.arg("-c").arg(cwd);
+        }
+        cmd.arg(shell_cmd);
+        let status = cmd
+            .status()
+            .with_context(|| format!("spawn tmux session {session}"))?;
+        if !status.success() {
+            record.status = LaneStatus::Failed;
+            registry.save(record)?;
+            bail!("tmux new-session failed with {status}");
+        }
+
+        registry.mark_running(record)?;
+        Ok(())
+    }
+
+    fn attach_command(&self, record: &LaneRecord) -> Option<String> {
+        record.attach_target.clone().or_else(|| {
+            record
+                .tmux_session
+                .as_ref()
+                .map(|s| format!("tmux attach -t {s}"))
+        })
+    }
+
+    fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
+        if let Some(session) = record.tmux_session.as_deref() {
+            let dry_run = std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some();
+            if !dry_run {
+                let _ = Command::new("tmux")
+                    .args(["kill-session", "-t", session])
+                    .status();
+            }
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({
+                    "type": "lane_stopped",
+                    "lane_id": record.id,
+                    "session": session,
+                }),
+            )?;
+        }
+        registry.mark_stopped(record, LaneStatus::Stopped)?;
+        self.cleanup_worktree(record)?;
+        Ok(())
+    }
+}
+
+/// In-process / local command runtime (no tmux). Used for tests and headless.
+#[derive(Debug, Default)]
+pub struct InlineRuntime;
+
+impl RuntimeBackend for InlineRuntime {
+    fn kind(&self) -> RuntimeBackendKind {
+        RuntimeBackendKind::Inline
+    }
+
+    fn start(
+        &self,
+        registry: &LaneRegistry,
+        record: &mut LaneRecord,
+        spec: &LaneStartSpec,
+    ) -> Result<()> {
+        if spec.command.is_empty() {
+            bail!("inline runtime requires a non-empty command");
+        }
+        let cwd = apply_worktree(record, spec)?;
+        append_log_event(
+            &record.log_path,
+            serde_json::json!({
+                "type": "lane_started",
+                "lane_id": record.id,
+                "runtime": "inline",
+                "command": spec.command,
+            }),
+        )?;
+
+        let mut cmd = Command::new(&spec.command[0]);
+        if spec.command.len() > 1 {
+            cmd.args(&spec.command[1..]);
+        }
+        if let Some(cwd) = cwd.as_ref() {
+            cmd.current_dir(cwd);
+        }
+        let output = cmd
+            .output()
+            .with_context(|| format!("run inline command {:?}", spec.command))?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        for line in stdout.lines().chain(stderr.lines()) {
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({"type": "lane_log", "message": line}),
+            )?;
+        }
+        if output.status.success() {
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({"type": "lane_completed", "lane_id": record.id}),
+            )?;
+            registry.mark_stopped(record, LaneStatus::Completed)?;
+        } else {
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({
+                    "type": "lane_failed",
+                    "lane_id": record.id,
+                    "status": format!("{}", output.status),
+                }),
+            )?;
+            registry.mark_stopped(record, LaneStatus::Failed)?;
+        }
+        Ok(())
+    }
+
+    fn attach_command(&self, _record: &LaneRecord) -> Option<String> {
+        None
+    }
+
+    fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
+        if record.status.is_active() {
+            registry.mark_stopped(record, LaneStatus::Stopped)?;
+        }
+        self.cleanup_worktree(record)?;
+        Ok(())
+    }
+}
+
+/// Placeholder for remote VM / CI backends (surface only in Phase 1).
+#[derive(Debug)]
+struct StubRuntime {
+    kind: RuntimeBackendKind,
+}
+
+impl RuntimeBackend for StubRuntime {
+    fn kind(&self) -> RuntimeBackendKind {
+        self.kind
+    }
+
+    fn start(
+        &self,
+        registry: &LaneRegistry,
+        record: &mut LaneRecord,
+        _spec: &LaneStartSpec,
+    ) -> Result<()> {
+        append_log_event(
+            &record.log_path,
+            serde_json::json!({
+                "type": "lane_started",
+                "lane_id": record.id,
+                "runtime": self.kind.as_str(),
+                "message": format!("{} runtime is a Phase 1 stub", self.kind.as_str()),
+            }),
+        )?;
+        registry.mark_running(record)?;
+        Ok(())
+    }
+
+    fn attach_command(&self, _record: &LaneRecord) -> Option<String> {
+        None
+    }
+
+    fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
+        registry.mark_stopped(record, LaneStatus::Stopped)?;
+        Ok(())
+    }
+}
+
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+fn shell_join(args: &[String]) -> String {
+    args.iter()
+        .map(|a| shell_escape(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn tmux_dry_run_start_attach_stop_roundtrip() {
+        // SAFETY: test-only env toggle for tmux dry-run; single-threaded unit test.
+        unsafe {
+            std::env::set_var("CODEWHALE_LANE_TMUX_DRY_RUN", "1");
+        }
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let mut record = reg
+            .create_pending(
+                Some("stopship".into()),
+                Some("v0868-stopship".into()),
+                Some("4090".into()),
+                None,
+                RuntimeBackendKind::Tmux,
+                None,
+            )
+            .unwrap();
+        let backend = TmuxRuntime;
+        backend
+            .start(
+                &reg,
+                &mut record,
+                &LaneStartSpec {
+                    command: vec!["echo".into(), "hello-lane".into()],
+                    cwd: None,
+                    worktree: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(record.status, LaneStatus::Running);
+        assert!(record.tmux_session.is_some());
+        let attach = backend.attach_command(&record).expect("attach");
+        assert!(attach.contains("tmux attach"));
+        let log = std::fs::read_to_string(&record.log_path).unwrap();
+        assert!(log.contains("lane_started"));
+
+        backend.stop(&reg, &mut record).unwrap();
+        assert_eq!(record.status, LaneStatus::Stopped);
+        let reloaded = reg.load(&record.id).unwrap();
+        assert_eq!(reloaded.status, LaneStatus::Stopped);
+        // SAFETY: paired cleanup of the test-only dry-run flag.
+        unsafe {
+            std::env::remove_var("CODEWHALE_LANE_TMUX_DRY_RUN");
+        }
+    }
+
+    #[test]
+    fn inline_runtime_writes_stream_json_log() {
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let mut record = reg
+            .create_pending(
+                Some("demo".into()),
+                None,
+                None,
+                Some("echo".into()),
+                RuntimeBackendKind::Inline,
+                None,
+            )
+            .unwrap();
+        InlineRuntime
+            .start(
+                &reg,
+                &mut record,
+                &LaneStartSpec {
+                    command: vec!["echo".into(), "inline-ok".into()],
+                    cwd: None,
+                    worktree: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(record.status, LaneStatus::Completed);
+        let log = std::fs::read_to_string(&record.log_path).unwrap();
+        assert!(log.contains("inline-ok"), "log={log}");
+        assert!(log.contains("lane_completed"));
+    }
+}

--- a/crates/lane/src/worktree.rs
+++ b/crates/lane/src/worktree.rs
@@ -1,0 +1,187 @@
+//! Worktree provisioning owned by Runtime (not Fleet) — #4176 / #4016.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use chrono::DateTime;
+
+/// Spec for an isolated worktree + branch for a lane.
+#[derive(Debug, Clone)]
+pub struct WorktreeProvision {
+    /// Git repository root (must contain `.git`).
+    pub repo_root: PathBuf,
+    /// Branch to create (from `base_ref`).
+    pub branch: String,
+    /// Directory for the new worktree (created by `git worktree add`).
+    pub path: PathBuf,
+    /// Base ref to branch from (default `HEAD`).
+    pub base_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProvisionedWorktree {
+    pub path: PathBuf,
+    pub branch: String,
+}
+
+/// Create a git worktree + branch for a lane.
+pub fn provision_worktree(spec: &WorktreeProvision) -> Result<ProvisionedWorktree> {
+    if spec.branch.trim().is_empty() {
+        bail!("worktree branch must not be empty");
+    }
+    if !spec.repo_root.exists() {
+        bail!("repo root does not exist: {}", spec.repo_root.display());
+    }
+    if let Some(parent) = spec.path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create worktree parent {}", parent.display()))?;
+    }
+    let base = spec.base_ref.as_deref().unwrap_or("HEAD");
+    let status = Command::new("git")
+        .current_dir(&spec.repo_root)
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            &spec.branch,
+            &spec.path.to_string_lossy(),
+            base,
+        ])
+        .status()
+        .context("git worktree add")?;
+    if !status.success() {
+        bail!(
+            "git worktree add failed for branch {} at {}",
+            spec.branch,
+            spec.path.display()
+        );
+    }
+    Ok(ProvisionedWorktree {
+        path: spec.path.clone(),
+        branch: spec.branch.clone(),
+    })
+}
+
+/// Remove a worktree when TTL has expired (or immediately when TTL is 0).
+///
+/// `stopped_at` is RFC3339. When `ttl_secs` is `None`, no cleanup is performed.
+pub fn remove_worktree_if_expired(
+    worktree_path: &Path,
+    ttl_secs: Option<u64>,
+    stopped_at: Option<&str>,
+) -> Result<()> {
+    let Some(ttl) = ttl_secs else {
+        return Ok(());
+    };
+    if !worktree_path.exists() {
+        return Ok(());
+    }
+    if ttl > 0 {
+        let Some(stopped) = stopped_at else {
+            return Ok(());
+        };
+        let stopped_ts = DateTime::parse_from_rfc3339(stopped)
+            .with_context(|| format!("parse stopped_at {stopped}"))?
+            .timestamp() as u64;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if now.saturating_sub(stopped_ts) < ttl {
+            return Ok(());
+        }
+    }
+
+    // Best-effort: git worktree remove --force, then rm -rf.
+    let _ = Command::new("git")
+        .args([
+            "worktree",
+            "remove",
+            "--force",
+            &worktree_path.to_string_lossy(),
+        ])
+        .status();
+    if worktree_path.exists() {
+        fs::remove_dir_all(worktree_path)
+            .with_context(|| format!("remove worktree {}", worktree_path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn init_repo(root: &Path) {
+        assert!(
+            Command::new("git")
+                .args(["init", "-b", "main"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .args(["config", "user.email", "lane@test"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .args(["config", "user.name", "lane"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+        fs::write(root.join("README"), "lane").unwrap();
+        assert!(
+            Command::new("git")
+                .args(["add", "README"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .args(["commit", "-m", "init"])
+                .current_dir(root)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+
+    #[test]
+    fn provision_and_ttl_zero_cleanup() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        let wt_path = dir.path().join("wt-lane");
+        let provisioned = provision_worktree(&WorktreeProvision {
+            repo_root: repo,
+            branch: "codex/lane-test".into(),
+            path: wt_path.clone(),
+            base_ref: Some("main".into()),
+        })
+        .unwrap();
+        assert!(provisioned.path.is_dir());
+        assert!(wt_path.join("README").is_file());
+
+        remove_worktree_if_expired(&wt_path, Some(0), Some("2020-01-01T00:00:00Z")).unwrap();
+        assert!(
+            !wt_path.exists(),
+            "TTL 0 should remove worktree immediately"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1 (#4176) of the Fleet/Workflow/Lane/Runtime model: first-class **Lane** registry + **Runtime** backends, with CLI surface under `codewhale lane`.

## Changes
- New crate `codewhale-lane`:
  - Durable registry at `$CODEWHALE_HOME/lanes/<id>.json` + stream-json logs
  - Runtime backends: `tmux` (session + attach metadata + dry-run for CI), `inline`, `vm`/`ci` stubs
  - Worktree provision/TTL cleanup owned by Runtime (not Fleet)
- CLI: `codewhale lane list|status|attach|logs|stop|start`

## Acceptance vs #4176
| AC | Status |
|----|--------|
| `lane list\|status\|attach\|logs\|stop` vs tmux-backed lane | Done (dry-run path for CI/tests) |
| Registry persists under CODEWHALE_HOME | Done |
| tmux adapter: session, stream-json log, attach, stop | Done |
| Worktree + branch when configured | Done (`--worktree-repo` + `--branch`) |
| Fleet does not import tmux/session mgmt | Done (new crate; fleet untouched) |
| Integration test start→attach→stop→TTL cleanup | Done (unit tests + worktree TTL) |

## Smoke
```bash
export CODEWHALE_HOME=/tmp/cw-lanes CODEWHALE_LANE_TMUX_DRY_RUN=1
codewhale lane start --workflow stopship --fleet v0868-stopship --runtime tmux --issue 4090 -- echo hi
codewhale lane list
codewhale lane attach <id> --print
codewhale lane logs <id>
codewhale lane stop <id>
```

## Test plan
- [x] `cargo test -p codewhale-lane --lib`
- [x] CLI smoke against CODEWHALE_HOME
- [x] `cargo fmt -- --check`