### PR TITLE
docs(test): dogfood automatic Workflow scenarios (#4131)

### DIFF
--- a/crates/tui/src/tui/widgets/workflow_panel.rs
+++ b/crates/tui/src/tui/widgets/workflow_panel.rs
@@ -2017,4 +2017,364 @@ mod tests {
         assert!(joined.contains("Build"), "{joined}");
         assert!(joined.contains("compile"), "{joined}");
     }
+
+    // ── #4131 dogfood scenario projections ──────────────────────────────────
+
+    /// WF-A1: read-only repo audit — scout phase on main workspace, labeled
+    /// children, no worktree marker, synthesizer phase present.
+    #[test]
+    fn dogfood_read_only_repo_audit_panel() {
+        let mut panel = WorkflowPanel::new("wf_a1", "read-only repo audit", 1_000);
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Scout".to_string(),
+            at_ms: 1_100,
+        });
+        for (id, label, role) in [
+            ("t1", "map crates", "explore"),
+            ("t2", "scan unsafe", "explore"),
+            ("t3", "scan unwrap", "explore"),
+        ] {
+            panel.apply_event(WorkflowPanelEvent::TaskStarted {
+                task_id: id.to_string(),
+                label: Some(label.to_string()),
+                profile: Some(role.to_string()),
+                model: Some("flash".to_string()),
+                strength: Some("low".to_string()),
+                resolved_model: Some("deepseek-v4-flash".to_string()),
+                worktree: false,
+                workspace: None,
+                at_ms: 1_200,
+            });
+            panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+                task_id: id.to_string(),
+                status: WorkflowRowStatus::Succeeded,
+                at_ms: 1_500,
+            });
+        }
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Synthesize".to_string(),
+            at_ms: 1_600,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskStarted {
+            task_id: "t4".to_string(),
+            label: Some("audit summary".to_string()),
+            profile: Some("general".to_string()),
+            model: None,
+            strength: None,
+            resolved_model: None,
+            worktree: false,
+            workspace: None,
+            at_ms: 1_700,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "t4".to_string(),
+            status: WorkflowRowStatus::Succeeded,
+            at_ms: 2_000,
+        });
+        panel.apply_event(WorkflowPanelEvent::RunCompleted {
+            status: WorkflowPanelLifecycle::Succeeded,
+            error: None,
+            at_ms: 2_100,
+        });
+
+        let header = panel.header_text(140);
+        assert!(
+            header.contains("success") || header.contains("completed"),
+            "{header}"
+        );
+        assert!(header.contains("0 fail"), "{header}");
+        assert!(
+            header.contains("4/") || header.contains("4 child") || header.contains("0/"),
+            "{header}"
+        );
+
+        // Selected phase is Synthesize; scout labels live in earlier phases.
+        panel.selected_phase = 0;
+        let scout_body = panel.render_lines(120);
+        let scout_joined: String = scout_body
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(scout_joined.contains("map crates"), "{scout_joined}");
+        assert!(scout_joined.contains("main"), "{scout_joined}");
+        assert!(
+            !scout_joined.contains(" wt "),
+            "read-only scouts stay on main: {scout_joined}"
+        );
+
+        let card = panel.render_history_card(
+            120,
+            true,
+            &WorkflowHistoryExtras {
+                result_summary: Some("no critical issues".to_string()),
+                ..WorkflowHistoryExtras::default()
+            },
+        );
+        let card_text: String = card
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            card_text.contains("Scout") || card_text.contains("Synthesize"),
+            "{card_text}"
+        );
+        assert!(card_text.contains("no critical issues"), "{card_text}");
+        assert!(
+            !card_text.to_ascii_lowercase().contains("unknown child"),
+            "{card_text}"
+        );
+    }
+
+    /// WF-A2: staged bugfix — implementer worktree + verifier on main.
+    #[test]
+    fn dogfood_staged_worktree_implementer_verifier() {
+        let mut panel = WorkflowPanel::new("wf_a2", "staged docs fix", 1_000);
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Implement".to_string(),
+            at_ms: 1_100,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskStarted {
+            task_id: "impl".to_string(),
+            label: Some("implementer".to_string()),
+            profile: Some("implementer".to_string()),
+            model: Some("pro".to_string()),
+            strength: None,
+            resolved_model: Some("deepseek-v4-pro".to_string()),
+            worktree: true,
+            workspace: Some(PathBuf::from("/tmp/wt-impl")),
+            at_ms: 1_200,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "impl".to_string(),
+            status: WorkflowRowStatus::Succeeded,
+            at_ms: 2_000,
+        });
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Verify".to_string(),
+            at_ms: 2_100,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskStarted {
+            task_id: "ver".to_string(),
+            label: Some("verifier".to_string()),
+            profile: Some("verifier".to_string()),
+            model: Some("flash".to_string()),
+            strength: None,
+            resolved_model: None,
+            worktree: false,
+            workspace: None,
+            at_ms: 2_200,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "ver".to_string(),
+            status: WorkflowRowStatus::Succeeded,
+            at_ms: 3_000,
+        });
+        panel.apply_event(WorkflowPanelEvent::RunCompleted {
+            status: WorkflowPanelLifecycle::Succeeded,
+            error: None,
+            at_ms: 3_100,
+        });
+
+        assert_eq!(panel.phases.len(), 2);
+        assert_eq!(panel.phases[0].title, "Implement");
+        assert_eq!(panel.phases[1].title, "Verify");
+
+        panel.selected_phase = 0;
+        let implement_body = panel.render_lines(140);
+        let impl_text: String = implement_body
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(impl_text.contains("implementer"), "{impl_text}");
+        assert!(
+            impl_text.contains("wt") || impl_text.contains("worktree"),
+            "implementer should show worktree marker: {impl_text}"
+        );
+
+        panel.selected_phase = 1;
+        let verify_body = panel.render_lines(140);
+        let ver_text: String = verify_body
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(ver_text.contains("verifier"), "{ver_text}");
+        assert!(ver_text.contains("main"), "{ver_text}");
+    }
+
+    /// WF-A3: partial failure + synthesis — fail count visible, summary card.
+    #[test]
+    fn dogfood_partial_failure_and_synthesis() {
+        let mut panel = WorkflowPanel::new("wf_a3", "partial failure synthesis", 1_000);
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Parallel scouts".to_string(),
+            at_ms: 1_100,
+        });
+        for (id, label, status) in [
+            ("a", "scout-a", WorkflowRowStatus::Succeeded),
+            ("b", "scout-b-fail", WorkflowRowStatus::Failed),
+            ("c", "scout-c", WorkflowRowStatus::Succeeded),
+        ] {
+            panel.apply_event(WorkflowPanelEvent::TaskStarted {
+                task_id: id.to_string(),
+                label: Some(label.to_string()),
+                profile: Some("explore".to_string()),
+                model: None,
+                strength: None,
+                resolved_model: None,
+                worktree: false,
+                workspace: None,
+                at_ms: 1_200,
+            });
+            panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+                task_id: id.to_string(),
+                status,
+                at_ms: 1_500,
+            });
+        }
+        if let Some(row) = panel.find_row_mut("b") {
+            row.error = Some("scout refused to produce summary".to_string());
+        }
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Synthesize".to_string(),
+            at_ms: 1_600,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskStarted {
+            task_id: "syn".to_string(),
+            label: Some("synthesizer".to_string()),
+            profile: Some("general".to_string()),
+            model: None,
+            strength: None,
+            resolved_model: None,
+            worktree: false,
+            workspace: None,
+            at_ms: 1_700,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "syn".to_string(),
+            status: WorkflowRowStatus::Succeeded,
+            at_ms: 2_000,
+        });
+        // Partial success at run level: completed with surviving synthesis.
+        panel.apply_event(WorkflowPanelEvent::RunCompleted {
+            status: WorkflowPanelLifecycle::Succeeded,
+            error: None,
+            at_ms: 2_100,
+        });
+
+        let (failed, cancelled) = panel.failure_cancel_counts();
+        assert_eq!(failed, 1, "exactly one parallel slot failed");
+        assert_eq!(cancelled, 0);
+        let header = panel.header_text(140);
+        assert!(header.contains("1 fail"), "{header}");
+
+        let card = panel.render_history_card(
+            140,
+            true,
+            &WorkflowHistoryExtras {
+                result_summary: Some("2/3 scouts ok; scout-b failed".to_string()),
+                ..WorkflowHistoryExtras::default()
+            },
+        );
+        let joined: String = card
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            joined.contains("scout-b-fail") || joined.contains("fail"),
+            "{joined}"
+        );
+        assert!(joined.contains("2/3 scouts ok"), "{joined}");
+    }
+
+    /// WF-A4: cancellation mid-run — running children cancelled, done preserved.
+    #[test]
+    fn dogfood_cancellation_mid_run() {
+        let mut panel = WorkflowPanel::new("wf_a4", "cancel mid-run", 1_000);
+        panel.apply_event(WorkflowPanelEvent::PhaseStarted {
+            title: "Long work".to_string(),
+            at_ms: 1_100,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskStarted {
+            task_id: "slow-1".to_string(),
+            label: Some("slow-1".to_string()),
+            profile: Some("explore".to_string()),
+            model: None,
+            strength: None,
+            resolved_model: None,
+            worktree: false,
+            workspace: None,
+            at_ms: 1_200,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskStarted {
+            task_id: "slow-2".to_string(),
+            label: Some("slow-2".to_string()),
+            profile: Some("explore".to_string()),
+            model: None,
+            strength: None,
+            resolved_model: None,
+            worktree: false,
+            workspace: None,
+            at_ms: 1_210,
+        });
+        panel.apply_event(WorkflowPanelEvent::TaskCompleted {
+            task_id: "slow-1".to_string(),
+            status: WorkflowRowStatus::Succeeded,
+            at_ms: 1_500,
+        });
+
+        // Operator hits panel cancel.
+        let run_id = panel.request_cancel().expect("cancel while running");
+        assert_eq!(run_id, "wf_a4");
+        assert!(panel.cancel_requested);
+        assert!(panel.request_cancel().is_none(), "second cancel is no-op");
+        assert_eq!(panel.take_cancel_emit().as_deref(), Some("wf_a4"));
+
+        // Host interrupt finalizes remaining runners.
+        panel.finalize_interrupt();
+        assert_eq!(panel.lifecycle, WorkflowPanelLifecycle::Cancelled);
+
+        let slow1 = panel
+            .phases
+            .iter()
+            .flat_map(|p| p.rows.iter())
+            .find(|r| r.task_id == "slow-1")
+            .expect("slow-1");
+        let slow2 = panel
+            .phases
+            .iter()
+            .flat_map(|p| p.rows.iter())
+            .find(|r| r.task_id == "slow-2")
+            .expect("slow-2");
+        assert_eq!(slow1.status, WorkflowRowStatus::Succeeded);
+        assert_eq!(slow2.status, WorkflowRowStatus::Cancelled);
+
+        let (failed, cancelled) = panel.failure_cancel_counts();
+        assert_eq!(failed, 0);
+        assert_eq!(cancelled, 1);
+        let header = panel.header_text(120);
+        assert!(
+            header.contains("cancel") || header.contains("cancelled"),
+            "{header}"
+        );
+    }
 }

--- a/docs/AUTOMATIC_WORKFLOWS.md
+++ b/docs/AUTOMATIC_WORKFLOWS.md
@@ -81,3 +81,17 @@ Automatic Workflow is suppressed for:
 - Estimated children above `auto_start_child_limit` (ask or shrink first)
 
 In those cases CodeWhale uses direct tools or a single `agent` instead.
+
+## Dogfood scenarios (#4131)
+
+Release-lane dogfood for automatic Workflow lives in
+[DOGFOOD_AUTOMATIC_WORKFLOWS.md](DOGFOOD_AUTOMATIC_WORKFLOWS.md). It covers:
+
+1. Read-only repo audit  
+2. Staged bug fix with worktree implementer + verifier  
+3. Partial failure and synthesis  
+4. Cancellation mid-run  
+
+Checked-in fixtures: [`docs/examples/dogfood-automatic/`](examples/dogfood-automatic/).
+Panel regression tests use the `dogfood_` prefix in
+`crates/tui/src/tui/widgets/workflow_panel.rs`.

--- a/docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md
+++ b/docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md
@@ -1,0 +1,298 @@
+# Dogfood: Automatic Workflow scenarios (#4131)
+
+Reproducible checks for the soft-auto Workflow product path. Another engineer
+should be able to rerun every scenario from this doc alone.
+
+Related:
+
+- [Automatic Workflows](AUTOMATIC_WORKFLOWS.md) — product behavior
+- [Workflow Authoring](WORKFLOW_AUTHORING.md) — checked-in scripts / IR
+- [Fleet + Workflow Tutorial](FLEET_WORKFLOW_TUTORIAL.md) — manual Fleet path
+- Example scripts: [`docs/examples/dogfood-automatic/`](examples/dogfood-automatic/)
+- Panel unit coverage: `crates/tui/src/tui/widgets/workflow_panel.rs` (`dogfood_*` tests)
+- Runtime resilience: `crates/workflow-js/tests/vm_tests.rs` (`parallel_*`, cancel drop)
+
+## Preconditions
+
+```bash
+# From a clean worktree on origin/main (or the PR under test)
+cargo build -p codewhale-tui --locked
+# Optional headless/runtime checks used by the scenarios below
+cargo test -p codewhale-tui --locked dogfood_ -- --nocapture
+cargo test -p codewhale-workflow-js --locked parallel_ fan_out cancel -- --nocapture
+```
+
+Isolate config so dogfood does not touch your real home:
+
+```bash
+export DOGFOOD_ROOT="$(mktemp -d)"
+export CODEWHALE_HOME="$DOGFOOD_ROOT/codewhale-home"
+export HOME="$DOGFOOD_ROOT/home"
+mkdir -p "$HOME" "$CODEWHALE_HOME" "$DOGFOOD_ROOT/workspace"
+cd "$DOGFOOD_ROOT/workspace"
+# Point at the CodeWhale checkout under test for read/audit work
+export CODEWHALE_SRC=/path/to/CodeWhale
+```
+
+Safety:
+
+1. Do not `git push` during dogfood.
+2. Prefer read-only prompts first; approve write/worktree runs deliberately.
+3. Tear down with `rm -rf "$DOGFOOD_ROOT"` when finished.
+
+Primary interactive surface:
+
+```bash
+codewhale-tui   # or: cargo run -p codewhale-tui --locked
+```
+
+Confirm soft-auto is on (`[workflow] automatic = true` is the default).
+
+---
+
+## Scenario matrix
+
+| ID | Scenario | Primary prompt / command | Expected UI | Automated check |
+|----|----------|--------------------------|-------------|-----------------|
+| WF-A1 | Read-only repo audit | natural-language audit prompt | soft-auto or `/workflow`; panel phases; no write-approval for pure read plan | `dogfood_read_only_repo_audit_panel` |
+| WF-A2 | Staged bug fix (worktree implementer + verifier) | staged implement+verify prompt | implementer row `wt`, verifier on main or second phase; write approval if elevated | `dogfood_staged_worktree_implementer_verifier` |
+| WF-A3 | Partial failure + synthesis | parallel partial-fail script / prompt | failed slots null/`fail` count; synthesis still produces operator summary | `dogfood_partial_failure_and_synthesis` + workflow-js `parallel_fan_out_*` |
+| WF-A4 | Cancellation mid-run | start long run → panel `[c]` or `/workflow cancel` | lifecycle `cancelled`; running children cancelled; cancel_all invoked | `dogfood_cancellation_mid_run` + workflow-js drop/cancel tests |
+
+Fill the pass/fail table at the bottom after each interactive pass.
+
+---
+
+## WF-A1 — Read-only repo audit
+
+### Reproducible prompt
+
+In `codewhale-tui` with workspace = CodeWhale checkout (or a copy):
+
+```text
+Audit this repository for security and reliability risks. Stay read-only:
+list crates, scan for unsafe blocks and unwrap in hot paths, and summarize
+findings by severity. Do not edit files or run destructive commands.
+```
+
+Force orchestration if soft-auto does not trigger:
+
+```text
+/workflow
+```
+
+Then restate the same audit goal, or run the checked-in example:
+
+```text
+/workflow run docs/examples/dogfood-automatic/wf_a1_read_only_audit.workflow.js
+```
+
+### Expected UI behavior
+
+- Soft-auto may announce shape (“scout crates then synthesize”) before launch.
+- Read-only plan may start without a write-approval card when
+  `auto_start_read_only = true`.
+- Workflow panel shows ≥1 phase and child rows with roles/labels (not
+  “unknown child”).
+- Compact history card remains calm; expand for phase/child detail.
+- No worktree-required rows for pure read scouts (workspace = main).
+
+### Pass / fail notes
+
+| Check | Pass? | Notes |
+|-------|-------|-------|
+| Orchestration started (soft-auto or `/workflow`) | | |
+| Panel shows phases + labeled children | | |
+| No write approval for pure read plan | | |
+| No file edits / no push | | |
+| Synthesis summary operator-readable | | |
+
+Automated:
+
+```bash
+cargo test -p codewhale-tui --locked dogfood_read_only_repo_audit_panel
+```
+
+---
+
+## WF-A2 — Staged bug fix (worktree implementer + verifier)
+
+### Reproducible prompt
+
+```text
+Staged fix for a small bug in the docs only:
+1) implementer: add a one-line clarification to docs/AUTOMATIC_WORKFLOWS.md
+   in an isolated worktree (do not touch main workspace).
+2) verifier: re-read the file and confirm the change is correct; do not
+   implement further edits.
+Keep the change minimal and reversible.
+```
+
+Or run:
+
+```text
+/workflow run docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
+```
+
+### Expected UI behavior
+
+- Elevated plan (writes / worktree) surfaces an approval card when
+  `require_approval_for_writes = true` (#4126).
+- Panel phases resemble: Implement → Verify (or equivalent labels).
+- Implementer child row shows `wt` (worktree) isolation.
+- Verifier child completes with a short confirmation summary.
+- One artifact / card per delegated unit (no duplicate delegate spam).
+
+### Pass / fail notes
+
+| Check | Pass? | Notes |
+|-------|-------|-------|
+| Approval card for write/worktree plan | | |
+| Implementer row marks worktree | | |
+| Verifier runs after implementer | | |
+| Main workspace untouched until merge/apply | | |
+| Compact history card summarizes phases | | |
+
+Automated:
+
+```bash
+cargo test -p codewhale-tui --locked dogfood_staged_worktree_implementer_verifier
+```
+
+---
+
+## WF-A3 — Partial failure and synthesis
+
+### Reproducible command / script
+
+Headless runtime (always runnable):
+
+```bash
+cargo test -p codewhale-workflow-js --locked \
+  parallel_fan_out_maps_one_failure_to_null_slot \
+  parallel_logs_a_breadcrumb_when_a_slot_is_dropped_to_null
+```
+
+Interactive / tool path:
+
+```text
+/workflow run docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js
+```
+
+Natural-language equivalent:
+
+```text
+Run three parallel scouts; deliberately allow one to fail. Synthesize a single
+operator-facing summary from the successful slots and call out the failed branch.
+```
+
+### Expected UI behavior
+
+- Parallel slots that fail appear as failed/cancelled rows or null slots with
+  a log breadcrumb (not a silent drop).
+- Panel header shows non-zero `fail` count when a child fails.
+- Run can still complete with a synthesis summary from surviving slots
+  (`parallel()` partial-success semantics).
+- Expanded history card lists failed child + overall result summary.
+
+### Pass / fail notes
+
+| Check | Pass? | Notes |
+|-------|-------|-------|
+| Failed slot visible (row and/or breadcrumb) | | |
+| Successful slots still contribute to summary | | |
+| Header fail count ≥ 1 | | |
+| No full-run panic on single child failure | | |
+
+Automated:
+
+```bash
+cargo test -p codewhale-tui --locked dogfood_partial_failure_and_synthesis
+cargo test -p codewhale-workflow-js --locked parallel_fan_out_maps_one_failure_to_null_slot
+```
+
+---
+
+## WF-A4 — Cancellation mid-run
+
+### Reproducible steps
+
+1. Start a long-running multi-child workflow:
+
+```text
+/workflow run docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
+```
+
+Or a natural long audit with several scouts.
+
+2. While status is `running`, cancel via one of:
+
+```text
+# Panel focus + key
+[c]   # or X — Workflow panel cancel
+
+# Slash
+/workflow status
+/workflow cancel <run_id>
+```
+
+### Expected UI behavior
+
+- Panel shows `cancelling…` then lifecycle `cancelled`.
+- Still-running children finalize as cancelled; already-succeeded rows stay
+  succeeded.
+- Host cancel path is idempotent (second cancel is a no-op).
+- Completed panel remains visible until the next run starts.
+
+### Pass / fail notes
+
+| Check | Pass? | Notes |
+|-------|-------|-------|
+| Cancel accepted while running | | |
+| Lifecycle becomes cancelled | | |
+| Running children cancelled; done children preserved | | |
+| Second cancel no-op | | |
+| No hung agents after cancel | | |
+
+Automated:
+
+```bash
+cargo test -p codewhale-tui --locked dogfood_cancellation_mid_run
+cargo test -p codewhale-workflow-js --locked dropping_the_run_future_cancels_outstanding_tasks
+```
+
+---
+
+## Bugs discovered
+
+File or link bugs found during dogfood here (do not silently absorb them):
+
+| Date | Scenario | Symptom | Issue / PR |
+|------|----------|---------|------------|
+| | | | |
+
+---
+
+## Interactive results log (copy per pass)
+
+```
+Tree / binary: _______________
+Operator: _______________
+Date: _______________
+
+WF-A1: PASS / FAIL — notes:
+WF-A2: PASS / FAIL — notes:
+WF-A3: PASS / FAIL — notes:
+WF-A4: PASS / FAIL — notes:
+
+New bugs filed:
+Follow-ups:
+```
+
+### CI / PR gate (non-interactive)
+
+```bash
+cargo fmt --all -- --check
+cargo test -p codewhale-tui --locked dogfood_
+cargo test -p codewhale-workflow-js --locked parallel_ fan_out cancel drop
+```

--- a/docs/examples/dogfood-automatic/wf_a1_read_only_audit.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a1_read_only_audit.workflow.js
@@ -1,0 +1,64 @@
+/**
+ * #4131 WF-A1 — read-only repo audit (dogfood fixture).
+ *
+ * Expected: scout phase with read-only children, then a synthesizer that
+ * produces an operator-facing summary. No write tools required.
+ *
+ * Run: /workflow run docs/examples/dogfood-automatic/wf_a1_read_only_audit.workflow.js
+ */
+export default async function (args) {
+  phase("Scout");
+  const [crates, unsafeHits, unwrapHits] = await parallel([
+    () =>
+      task({
+        description:
+          "List top-level crates and one-line role for each under crates/.",
+        label: "map crates",
+        type: "explore",
+        prompt:
+          "Read Cargo.toml workspace members and crates/*/Cargo.toml. Return a short bullet list of crate names and purposes. Read-only.",
+      }),
+    () =>
+      task({
+        description: "Find unsafe blocks in Rust sources.",
+        label: "scan unsafe",
+        type: "explore",
+        prompt:
+          "Search for `unsafe` in crates/**/*.rs (exclude target). Summarize count and notable hot paths. Read-only; no edits.",
+      }),
+    () =>
+      task({
+        description: "Find unwrap/expect in hot paths.",
+        label: "scan unwrap",
+        type: "explore",
+        prompt:
+          "Search for `.unwrap(` and `.expect(` in crates/tui and crates/engine (if present). Note densest files. Read-only.",
+      }),
+  ]);
+
+  phase("Synthesize");
+  const summary = await task({
+    description: "Synthesize audit findings for the operator.",
+    label: "audit summary",
+    type: "general",
+    prompt: [
+      "Synthesize a concise security/reliability audit from these scout results.",
+      "Filter null/failed scouts. Group by severity. No file edits.",
+      "",
+      "crates:",
+      String(crates ?? "(missing)"),
+      "",
+      "unsafe:",
+      String(unsafeHits ?? "(missing)"),
+      "",
+      "unwrap:",
+      String(unwrapHits ?? "(missing)"),
+    ].join("\n"),
+  });
+
+  return {
+    scenario: "WF-A1",
+    goal: args?.goal ?? "read-only repo audit",
+    summary,
+  };
+}

--- a/docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
@@ -1,0 +1,53 @@
+/**
+ * #4131 WF-A2 — staged bug fix with worktree implementer + verifier.
+ *
+ * Expected UI: Implement phase with worktree-isolated implementer, then Verify
+ * phase. Write/worktree plans should surface approval when
+ * require_approval_for_writes is true.
+ *
+ * Run: /workflow run docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
+ */
+export default async function (args) {
+  const target = args?.target ?? "docs/AUTOMATIC_WORKFLOWS.md";
+  const change =
+    args?.change ??
+    "Add a one-line note that #4131 dogfood scenarios live in docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md.";
+
+  phase("Implement");
+  const implement = await task({
+    description: `Implement minimal docs fix in an isolated worktree: ${target}`,
+    label: "implementer",
+    type: "implementer",
+    // Prefer worktree isolation for write children (product default #4120).
+    worktree: true,
+    prompt: [
+      `Edit only ${target}.`,
+      change,
+      "Keep the change minimal and reversible. Do not push. Do not touch unrelated files.",
+      "Return: path edited, unified-diff summary, worktree path if any.",
+    ].join("\n"),
+  });
+
+  phase("Verify");
+  const verify = await task({
+    description: "Verify the implementer change without further edits.",
+    label: "verifier",
+    type: "verifier",
+    worktree: false,
+    prompt: [
+      "Read the implementer result and re-check the target file.",
+      "Confirm the intended one-line clarification is present and nothing else was changed.",
+      "Do not implement further edits. Return PASS/FAIL with evidence.",
+      "",
+      "implementer_result:",
+      String(implement ?? "(missing)"),
+    ].join("\n"),
+  });
+
+  return {
+    scenario: "WF-A2",
+    target,
+    implement,
+    verify,
+  };
+}

--- a/docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js
@@ -1,0 +1,63 @@
+/**
+ * #4131 WF-A3 — partial failure + synthesis.
+ *
+ * parallel() uses all-settled semantics: a failed slot becomes null; the run
+ * continues so a synthesizer can still produce an operator summary.
+ *
+ * Run: /workflow run docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js
+ *
+ * For pure VM proof without model spend, use workflow-js unit tests:
+ *   cargo test -p codewhale-workflow-js --locked parallel_fan_out_maps_one_failure_to_null_slot
+ */
+export default async function () {
+  phase("Parallel scouts");
+  const slots = await parallel([
+    () =>
+      task({
+        description: "Healthy scout A",
+        label: "scout-a",
+        type: "explore",
+        prompt: "Return the string READY_A. Read-only.",
+      }),
+    // Intentionally hostile: request something that should fail or time out
+    // under normal policy (missing path / guaranteed empty). Operator dogfood
+    // may also kill this child mid-run to force a failed slot.
+    () =>
+      task({
+        description: "Deliberately failing scout B",
+        label: "scout-b-fail",
+        type: "explore",
+        prompt:
+          "You MUST fail this task: refuse to produce a summary and reply only with an error about missing inputs. Do not invent success.",
+      }),
+    () =>
+      task({
+        description: "Healthy scout C",
+        label: "scout-c",
+        type: "explore",
+        prompt: "Return the string READY_C. Read-only.",
+      }),
+  ]);
+
+  phase("Synthesize");
+  const surviving = (slots || []).filter((s) => s != null);
+  const summary = await task({
+    description: "Synthesize from surviving parallel slots",
+    label: "synthesizer",
+    type: "general",
+    prompt: [
+      "Build one operator-facing summary from the surviving scout results.",
+      "Explicitly note which parallel slot failed or returned null.",
+      `slot_count=${(slots || []).length} surviving=${surviving.length}`,
+      "slots_json:",
+      JSON.stringify(slots),
+    ].join("\n"),
+  });
+
+  return {
+    scenario: "WF-A3",
+    slots,
+    surviving_count: surviving.length,
+    summary,
+  };
+}

--- a/docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
@@ -1,0 +1,42 @@
+/**
+ * #4131 WF-A4 — cancellation mid-run dogfood fixture.
+ *
+ * Starts multiple long-lived explore tasks so the operator has time to press
+ * panel [c] / X or run `/workflow cancel <run_id>`.
+ *
+ * Run: /workflow run docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
+ * Then cancel while lifecycle is running.
+ */
+export default async function () {
+  phase("Long work");
+  // Fan-out several slow scouts; cancel should finalize outstanding children.
+  const results = await parallel([
+    () =>
+      task({
+        description: "Slow scout 1 — cancel target",
+        label: "slow-1",
+        type: "explore",
+        prompt:
+          "Thoroughly inventory crates/tui/src file names (read-only). Take your time; list directories depth-first. Return a count at the end.",
+      }),
+    () =>
+      task({
+        description: "Slow scout 2 — cancel target",
+        label: "slow-2",
+        type: "explore",
+        prompt:
+          "Thoroughly inventory crates/config/src file names (read-only). Take your time; list directories depth-first. Return a count at the end.",
+      }),
+    () =>
+      task({
+        description: "Slow scout 3 — cancel target",
+        label: "slow-3",
+        type: "explore",
+        prompt:
+          "Thoroughly inventory docs/ markdown titles (read-only). Take your time. Return a count at the end.",
+      }),
+  ]);
+
+  phase("Unreachable if cancelled");
+  return { scenario: "WF-A4", results };
+}


### PR DESCRIPTION
## Summary
- Adds `docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md` with reproducible prompts/commands, expected UI, and pass/fail tables for the four automatic Workflow dogfood scenarios from #4131.
- Checks in `docs/examples/dogfood-automatic/` workflow fixtures (WF-A1…A4) and links them from `docs/AUTOMATIC_WORKFLOWS.md`.
- Adds `dogfood_*` WorkflowPanel projection tests covering read-only audit, worktree implementer+verifier, partial failure synthesis, and mid-run cancel.

Progresses #4131

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p codewhale-tui --locked dogfood_` (4 dogfood + fleet dogfood smoke)
- [ ] Interactive TUI pass of WF-A1…A4 (results table in the dogfood doc)
