### PR TITLE
fix(tui): pace workflow budget redraws under fan-out (#4095)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1910,6 +1910,10 @@ pub struct App {
     /// Last time a sub-agent progress event triggered a redraw.
     /// Used to throttle redraws under high sub-agent concurrency (#3033).
     pub last_agent_progress_redraw: Option<Instant>,
+    /// Last time a workflow `budget_updated` event was allowed to request a
+    /// repaint. High-signal workflow events (task/run lifecycle) always paint;
+    /// budget-only chatter is paced under fan-out (#4095 residual).
+    pub last_workflow_budget_redraw: Option<Instant>,
     pub ui_theme: UiTheme,
     /// Active named theme. Drives the cell-level color remap in
     /// `tui::color_compat::ColorCompatBackend` so community presets
@@ -2869,6 +2873,7 @@ impl App {
             agent_counter: 0,
             agent_label_map: HashMap::new(),
             last_agent_progress_redraw: None,
+            last_workflow_budget_redraw: None,
             ui_theme,
             theme_id,
             onboarding,
@@ -4107,11 +4112,16 @@ impl App {
     }
 
     /// Apply a workflow panel event, creating the panel on first `RunStarted`.
+    ///
+    /// Returns whether this event should request an immediate repaint.
+    /// Budget-only updates always mutate panel state but leave repaint to the
+    /// caller so high-frequency fan-out budget ticks can be paced (#4095).
     pub fn apply_workflow_panel_event(
         &mut self,
         event: crate::tui::widgets::workflow_panel::WorkflowPanelEvent,
-    ) {
+    ) -> bool {
         use crate::tui::widgets::workflow_panel::{WorkflowPanel, WorkflowPanelEvent};
+        let budget_only = matches!(event, WorkflowPanelEvent::BudgetUpdated { .. });
         match (&mut self.workflow_panel, &event) {
             (
                 None,
@@ -4144,7 +4154,10 @@ impl App {
                 panel.apply_event(event);
             }
         }
-        self.needs_redraw = true;
+        if !budget_only {
+            self.needs_redraw = true;
+        }
+        !budget_only
     }
 
     /// Toggle the workflow panel expand/collapse state. Returns true when a

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3283,6 +3283,23 @@ async fn run_event_loop(
                     EngineEvent::WorkflowUi { run_id, event } => {
                         // #4122: live typed workflow events → panel + history card.
                         apply_workflow_ui_event(app, &run_id, &event);
+                        // #4095 residual: budget_updated is high-frequency under
+                        // multi-agent fan-out. Data is already applied; pace the
+                        // repaint like AgentProgress so the panel does not churn.
+                        let is_budget = event
+                            .get("type")
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|t| t == "budget_updated");
+                        if is_budget {
+                            if workflow_budget_redraw_permitted(
+                                &mut app.last_workflow_budget_redraw,
+                                Instant::now(),
+                            ) {
+                                app.needs_redraw = true;
+                            } else {
+                                received_engine_event = redraw_requested_before_event;
+                            }
+                        }
                         transcript_batch_updated = true;
                     }
                     EngineEvent::ApprovalRequired {
@@ -6210,6 +6227,14 @@ fn agent_progress_redraw_permitted(last_redraw: &mut Option<Instant>, now: Insta
             true
         }
     }
+}
+
+/// #4095 residual: pace workflow budget-only repaints under fan-out.
+///
+/// Same 100ms floor as AgentProgress. High-signal workflow lifecycle events
+/// bypass this gate and always paint.
+fn workflow_budget_redraw_permitted(last_redraw: &mut Option<Instant>, now: Instant) -> bool {
+    agent_progress_redraw_permitted(last_redraw, now)
 }
 
 fn agent_progress_redraw_permitted_for_drain(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -12792,6 +12792,27 @@ fn agent_progress_redraw_throttle_permits_first_and_spaced_events() {
     );
 }
 
+// ── #4095 residual: workflow budget_updated redraw throttle ────────────────
+
+#[test]
+fn workflow_budget_redraw_throttle_matches_progress_pace() {
+    let mut last_redraw = None;
+    let t0 = Instant::now();
+
+    assert!(
+        workflow_budget_redraw_permitted(&mut last_redraw, t0),
+        "first budget tick may repaint"
+    );
+    assert!(
+        !workflow_budget_redraw_permitted(&mut last_redraw, t0 + Duration::from_millis(40)),
+        "budget churn inside 100ms is coalesced"
+    );
+    assert!(
+        workflow_budget_redraw_permitted(&mut last_redraw, t0 + Duration::from_millis(120)),
+        "budget ticks past the window repaint again"
+    );
+}
+
 #[test]
 fn throttled_progress_event_does_not_cancel_other_events_redraw() {
     // Repro for the #3033 audit finding: `received_engine_event` is a shared


### PR DESCRIPTION
## Summary
- Compact/calm defaults already on main (`calm_mode`, compact tool collapse, low_motion, etc.) — **not re-flipped**.
- Residual: high-frequency workflow `budget_updated` events forced full repaints under multi-agent fan-out.
- Apply budget data immediately; throttle budget-only redraws to the same 100ms floor as AgentProgress. Lifecycle events still paint immediately.

Related: #4095 residual busy surfaces. Does not claim full #4014 measurement.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p codewhale-tui --locked workflow_budget_redraw`