### PR TITLE
perf(tui): rebased hotpaths from #3902 (#3896/#3898/#3900)

### DIFF
--- a/crates/tui/src/tui/file_tree.rs
+++ b/crates/tui/src/tui/file_tree.rs
@@ -133,6 +133,20 @@ impl FileTreeState {
         }
     }
 
+    /// Drain any completed background walks (initial build or expands).
+    /// Returns `true` when new results were applied so the event loop can
+    /// schedule a repaint — without this, a walk finishing while the loop
+    /// is idle would leave the expanded directory looking empty until the
+    /// next unrelated input event (#3900).
+    pub fn poll_background(&mut self) -> bool {
+        let was_loading = self.is_loading;
+        self.poll_loading();
+        let finished_loading = was_loading && !self.is_loading;
+        let pending_before = self.pending_expands.len();
+        self.poll_pending_expands();
+        finished_loading || self.pending_expands.len() != pending_before
+    }
+
     /// Poll for background expand-walk results and splice them in.
     /// Call from the render loop, after [`Self::poll_loading`] (#3900).
     pub fn poll_pending_expands(&mut self) {
@@ -755,5 +769,42 @@ mod tests {
             entry_names(&state)
         );
         assert!(state.pending_expands.is_empty());
+    }
+
+    #[test]
+    fn poll_background_reports_applied_expand_results() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        let src_norm = normalize_path(&ws.path().join("src"));
+        let src_idx = index_of(&state, "src");
+
+        state.expanded_dirs.insert(src_norm.clone());
+        state.entries[src_idx].expanded = true;
+        let children = build_file_tree_inner(
+            ws.path(),
+            &state.expanded_dirs,
+            Some(&ws.path().join("src")),
+        );
+        state.pending_expands.insert(
+            src_norm.clone(),
+            PendingExpand {
+                seq: 1,
+                cell: Arc::new(Mutex::new(Some(children))),
+            },
+        );
+
+        assert!(
+            state.poll_background(),
+            "a drained expand result must request a repaint"
+        );
+        assert!(state.entries.iter().any(|e| e.name == "main.rs"));
+        assert!(
+            state.pending_expands.is_empty(),
+            "applied expand must clear pending state"
+        );
+        assert!(
+            !state.poll_background(),
+            "idle poll must not request a second repaint"
+        );
     }
 }

--- a/crates/tui/src/tui/file_tree.rs
+++ b/crates/tui/src/tui/file_tree.rs
@@ -4,7 +4,7 @@
 //! navigate, Enter expands/collapses directories or inserts `@path` for files,
 //! Esc closes the pane.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -34,6 +34,15 @@ pub struct FileTreeEntry {
     pub expanded: bool,
 }
 
+/// An in-flight background expand walk (#3900). The sequence number
+/// distinguishes the latest walk for a directory from superseded ones so a
+/// stale result can never be spliced in after a re-toggle.
+#[derive(Debug, Clone)]
+struct PendingExpand {
+    seq: u64,
+    cell: Arc<Mutex<Option<Vec<FileTreeEntry>>>>,
+}
+
 /// Mutable state for the file-tree pane.
 #[derive(Debug, Clone)]
 pub struct FileTreeState {
@@ -51,13 +60,32 @@ pub struct FileTreeState {
     pub is_loading: bool,
     /// Shared cell for async tree-building results (#399 S3).
     loading_cell: Option<Arc<Mutex<Option<Vec<FileTreeEntry>>>>>,
+    /// In-flight expand walks keyed by normalised directory path (#3900).
+    pending_expands: HashMap<PathBuf, PendingExpand>,
+    /// Monotonic counter identifying the latest expand walk per directory.
+    expand_seq: u64,
 }
 
 impl FileTreeState {
     /// Build a fresh tree state by walking `workspace`.
-    /// Spawns the initial walk on a background thread (#399 S3).
+    /// Spawns the initial walk on a background thread (#399 S3); without a
+    /// tokio runtime (plain unit tests) the walk runs synchronously.
     pub fn new(workspace: &Path) -> Self {
         let expanded_dirs = HashSet::new();
+        if tokio::runtime::Handle::try_current().is_err() {
+            let entries = build_file_tree_inner(workspace, &expanded_dirs, None);
+            return Self {
+                entries,
+                cursor: 0,
+                scroll_offset: 0,
+                expanded_dirs,
+                workspace: workspace.to_path_buf(),
+                is_loading: false,
+                loading_cell: None,
+                pending_expands: HashMap::new(),
+                expand_seq: 0,
+            };
+        }
         let loading_cell = Arc::new(Mutex::new(None));
         let cell = loading_cell.clone();
         let ws = workspace.to_path_buf();
@@ -75,6 +103,8 @@ impl FileTreeState {
             workspace: workspace.to_path_buf(),
             is_loading: true,
             loading_cell: Some(loading_cell),
+            pending_expands: HashMap::new(),
+            expand_seq: 0,
         }
     }
 
@@ -103,15 +133,23 @@ impl FileTreeState {
         }
     }
 
-    /// Rebuild the flat entry list from the current `expanded_dirs` set.
-    /// When loading is in progress, the rebuild is deferred.
-    pub fn rebuild(&mut self) {
-        if self.is_loading {
-            // Defer rebuild until async load completes
+    /// Poll for background expand-walk results and splice them in.
+    /// Call from the render loop, after [`Self::poll_loading`] (#3900).
+    pub fn poll_pending_expands(&mut self) {
+        if self.pending_expands.is_empty() {
             return;
         }
-        self.entries = build_file_tree_inner(&self.workspace, &self.expanded_dirs, None);
-        self.clamp_cursor();
+        let mut ready: Vec<(PathBuf, u64, Vec<FileTreeEntry>)> = Vec::new();
+        for (dir, pending) in &self.pending_expands {
+            if let Ok(mut guard) = pending.cell.lock()
+                && let Some(children) = guard.take()
+            {
+                ready.push((dir.clone(), pending.seq, children));
+            }
+        }
+        for (dir, seq, children) in ready {
+            self.apply_expand_result(&dir, seq, children);
+        }
     }
 
     /// Move the cursor up by one.
@@ -140,11 +178,10 @@ impl FileTreeState {
         if entry.is_dir {
             let norm = normalize_path(&entry.path);
             if self.expanded_dirs.contains(&norm) {
-                self.expanded_dirs.remove(&norm);
+                self.collapse_dir_at(self.cursor);
             } else {
-                self.expanded_dirs.insert(norm);
+                self.expand_dir_at(self.cursor);
             }
-            self.rebuild();
             None
         } else {
             // Return the path relative to workspace.
@@ -156,6 +193,125 @@ impl FileTreeState {
                 p
             })
         }
+    }
+
+    /// Collapse the directory at `idx` by splicing its visible descendants
+    /// out of the flat entry list — no filesystem I/O at all (#3900).
+    ///
+    /// Descendant directories stay in `expanded_dirs` so re-expanding the
+    /// parent restores their expanded state, matching the previous
+    /// full-rebuild behavior.
+    fn collapse_dir_at(&mut self, idx: usize) {
+        let Some(entry) = self.entries.get_mut(idx) else {
+            return;
+        };
+        if !entry.is_dir {
+            return;
+        }
+        let depth = entry.depth;
+        entry.expanded = false;
+        let norm = normalize_path(&entry.path);
+        self.expanded_dirs.remove(&norm);
+        // Drop any in-flight expand walk for this directory; its result must
+        // not splice into a collapsed node.
+        self.pending_expands.remove(&norm);
+
+        let end = self.entries[idx + 1..]
+            .iter()
+            .position(|e| e.depth <= depth)
+            .map_or(self.entries.len(), |offset| idx + 1 + offset);
+        let removed = end - (idx + 1);
+        self.entries.drain(idx + 1..end);
+        if self.cursor > idx {
+            self.cursor = if self.cursor < end {
+                idx
+            } else {
+                self.cursor - removed
+            };
+        }
+        self.clamp_cursor();
+        self.clamp_scroll();
+    }
+
+    /// Expand the directory at `idx`. The subtree walk runs on a background
+    /// thread and is spliced in by [`Self::poll_pending_expands`] (#3900);
+    /// without a tokio runtime (plain unit tests) it runs synchronously.
+    ///
+    /// The entry is marked expanded immediately (▼) so the keypress is
+    /// acknowledged; children appear when the walk completes.
+    fn expand_dir_at(&mut self, idx: usize) {
+        let Some(entry) = self.entries.get_mut(idx) else {
+            return;
+        };
+        if !entry.is_dir {
+            return;
+        }
+        entry.expanded = true;
+        let dir = entry.path.clone();
+        let norm = normalize_path(&dir);
+        self.expanded_dirs.insert(norm.clone());
+        self.expand_seq = self.expand_seq.wrapping_add(1);
+        let seq = self.expand_seq;
+        let ws = self.workspace.clone();
+        let expanded_snapshot = self.expanded_dirs.clone();
+
+        let cell = Arc::new(Mutex::new(None));
+        self.pending_expands.insert(
+            norm.clone(),
+            PendingExpand {
+                seq,
+                cell: cell.clone(),
+            },
+        );
+        if tokio::runtime::Handle::try_current().is_ok() {
+            crate::utils::spawn_blocking_supervised("file-tree-expand", move || {
+                let children = build_file_tree_inner(&ws, &expanded_snapshot, Some(&dir));
+                if let Ok(mut guard) = cell.lock() {
+                    *guard = Some(children);
+                }
+            });
+        } else {
+            let children = build_file_tree_inner(&ws, &expanded_snapshot, Some(&dir));
+            self.apply_expand_result(&norm, seq, children);
+        }
+    }
+
+    /// Splice a completed expand walk into the entry list, unless it has
+    /// been superseded (newer walk for the same directory), the directory
+    /// was collapsed while the walk was in flight, or the directory is no
+    /// longer visible (an ancestor collapsed).
+    fn apply_expand_result(&mut self, dir: &Path, seq: u64, children: Vec<FileTreeEntry>) {
+        let is_current = self
+            .pending_expands
+            .get(dir)
+            .is_some_and(|pending| pending.seq == seq);
+        if !is_current {
+            return;
+        }
+        self.pending_expands.remove(dir);
+        if !self.expanded_dirs.contains(dir) {
+            return;
+        }
+        let Some(idx) = self
+            .entries
+            .iter()
+            .position(|e| e.is_dir && normalize_path(&e.path) == *dir)
+        else {
+            return;
+        };
+        let depth = self.entries[idx].depth;
+        // Defensive: never splice a subtree in twice.
+        if self.entries.get(idx + 1).is_some_and(|e| e.depth > depth) {
+            return;
+        }
+        self.entries[idx].expanded = true;
+        let inserted = children.len();
+        self.entries.splice(idx + 1..idx + 1, children);
+        if self.cursor > idx {
+            self.cursor += inserted;
+        }
+        self.clamp_cursor();
+        self.clamp_scroll();
     }
 
     /// Ensure the cursor is within bounds.
@@ -307,6 +463,7 @@ pub fn render_file_tree(
     mode: palette::PaletteMode,
 ) {
     state.poll_loading();
+    state.poll_pending_expands();
     if area.width < FILE_TREE_MIN_WIDTH || area.height < 3 {
         return;
     }
@@ -382,4 +539,221 @@ pub fn render_file_tree(
     );
 
     f.render_widget(section, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn fixture_workspace() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src/nested")).expect("mkdir src/nested");
+        std::fs::create_dir_all(root.join("docs")).expect("mkdir docs");
+        std::fs::create_dir_all(root.join("node_modules/pkg")).expect("mkdir node_modules");
+        std::fs::write(root.join("README.md"), "readme").expect("write README.md");
+        std::fs::write(root.join("src/main.rs"), "fn main() {}").expect("write main.rs");
+        std::fs::write(root.join("src/Lib.rs"), "").expect("write Lib.rs");
+        std::fs::write(root.join("src/nested/mod.rs"), "").expect("write mod.rs");
+        std::fs::write(root.join("docs/guide.md"), "").expect("write guide.md");
+        dir
+    }
+
+    fn index_of(state: &FileTreeState, name: &str) -> usize {
+        state
+            .entries
+            .iter()
+            .position(|e| e.name == name)
+            .unwrap_or_else(|| panic!("entry {name} missing: {:?}", entry_names(state)))
+    }
+
+    fn entry_names(state: &FileTreeState) -> Vec<String> {
+        state.entries.iter().map(|e| e.name.clone()).collect()
+    }
+
+    fn expand_by_name(state: &mut FileTreeState, name: &str) {
+        state.cursor = index_of(state, name);
+        assert!(state.activate().is_none(), "expanding {name} returns None");
+    }
+
+    /// The incremental expand path (splice) must produce exactly the flat
+    /// list the old full rebuild produced, for several expansion orders.
+    #[test]
+    fn incremental_expand_matches_full_rebuild() {
+        let ws = fixture_workspace();
+        for order in [["src", "nested", "docs"], ["docs", "src", "nested"]] {
+            // Plain test: no tokio runtime, so expand walks run synchronously.
+            let mut state = FileTreeState::new(ws.path());
+            assert!(!state.is_loading, "sync fallback builds immediately");
+            for name in order {
+                expand_by_name(&mut state, name);
+            }
+
+            let oracle = build_file_tree_inner(ws.path(), &state.expanded_dirs, None);
+            assert_eq!(
+                state.entries.len(),
+                oracle.len(),
+                "entry count parity for order {order:?}: {:?}",
+                entry_names(&state)
+            );
+            for (spliced, rebuilt) in state.entries.iter().zip(oracle.iter()) {
+                assert_eq!(spliced.name, rebuilt.name);
+                assert_eq!(spliced.path, rebuilt.path);
+                assert_eq!(spliced.is_dir, rebuilt.is_dir);
+                assert_eq!(spliced.depth, rebuilt.depth);
+                assert_eq!(spliced.expanded, rebuilt.expanded);
+            }
+        }
+    }
+
+    #[test]
+    fn collapse_splices_out_subtree_without_io() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        expand_by_name(&mut state, "src");
+        expand_by_name(&mut state, "nested");
+        assert!(state.entries.iter().any(|e| e.name == "mod.rs"));
+
+        // Collapse src: descendants leave the list, nested stays remembered.
+        let src_idx = index_of(&state, "src");
+        state.cursor = src_idx;
+        assert!(state.activate().is_none());
+
+        assert!(!state.entries[src_idx].expanded);
+        assert!(!state.entries.iter().any(|e| e.name == "main.rs"));
+        assert!(!state.entries.iter().any(|e| e.name == "mod.rs"));
+        assert_eq!(state.cursor, src_idx, "cursor stays on the collapsed dir");
+        let nested_norm = normalize_path(&ws.path().join("src/nested"));
+        assert!(
+            state.expanded_dirs.contains(&nested_norm),
+            "collapsing a parent keeps descendant expansion state"
+        );
+    }
+
+    #[test]
+    fn re_expand_restores_descendant_expansion() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        expand_by_name(&mut state, "src");
+        expand_by_name(&mut state, "nested");
+        state.cursor = index_of(&state, "src");
+        assert!(state.activate().is_none()); // collapse
+        assert!(state.activate().is_none()); // re-expand
+
+        let nested_idx = index_of(&state, "nested");
+        assert!(state.entries[nested_idx].expanded);
+        assert!(
+            state.entries.iter().any(|e| e.name == "mod.rs"),
+            "re-expanding the parent restores the expanded child subtree: {:?}",
+            entry_names(&state)
+        );
+    }
+
+    #[test]
+    fn stale_expand_results_are_discarded() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        expand_by_name(&mut state, "src");
+        let src_norm = normalize_path(&ws.path().join("src"));
+
+        // Collapse removes the pending walk; a result landing afterwards is
+        // dropped instead of splicing into the collapsed node.
+        state.cursor = index_of(&state, "src");
+        assert!(state.activate().is_none());
+        let ghost = vec![FileTreeEntry {
+            name: "ghost.rs".to_string(),
+            path: ws.path().join("src/ghost.rs"),
+            is_dir: false,
+            depth: 1,
+            expanded: false,
+        }];
+        state.apply_expand_result(&src_norm, state.expand_seq, ghost.clone());
+        assert!(!state.entries.iter().any(|e| e.name == "ghost.rs"));
+
+        // A superseded sequence number is also dropped, and the newer
+        // pending walk stays registered.
+        state.pending_expands.insert(
+            src_norm.clone(),
+            PendingExpand {
+                seq: 7,
+                cell: Arc::new(Mutex::new(None)),
+            },
+        );
+        state.expanded_dirs.insert(src_norm.clone());
+        state.apply_expand_result(&src_norm, 6, ghost);
+        assert!(!state.entries.iter().any(|e| e.name == "ghost.rs"));
+        assert!(
+            state.pending_expands.contains_key(&src_norm),
+            "a stale result must not clear the newer pending walk"
+        );
+    }
+
+    #[test]
+    fn splice_shifts_cursor_positioned_after_the_expanded_dir() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        let src_norm = normalize_path(&ws.path().join("src"));
+        let src_idx = index_of(&state, "src");
+        let readme_idx = index_of(&state, "README.md");
+        assert!(readme_idx > src_idx);
+
+        state.expanded_dirs.insert(src_norm.clone());
+        state.entries[src_idx].expanded = true;
+        state.pending_expands.insert(
+            src_norm.clone(),
+            PendingExpand {
+                seq: 1,
+                cell: Arc::new(Mutex::new(None)),
+            },
+        );
+        state.cursor = readme_idx;
+        let children = build_file_tree_inner(
+            ws.path(),
+            &state.expanded_dirs,
+            Some(&ws.path().join("src")),
+        );
+        let inserted = children.len();
+        assert!(inserted > 0);
+
+        state.apply_expand_result(&src_norm, 1, children);
+
+        assert_eq!(state.cursor, readme_idx + inserted);
+        assert_eq!(state.entries[state.cursor].name, "README.md");
+    }
+
+    #[tokio::test]
+    async fn async_expand_splices_children_after_poll() {
+        let ws = fixture_workspace();
+        let mut state = FileTreeState::new(ws.path());
+        for _ in 0..500 {
+            state.poll_loading();
+            if !state.is_loading {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(!state.is_loading, "initial async build completes");
+
+        state.cursor = index_of(&state, "src");
+        assert!(state.activate().is_none());
+        assert!(
+            state.entries[state.cursor].expanded,
+            "expand acknowledges the keypress immediately"
+        );
+
+        for _ in 0..500 {
+            state.poll_pending_expands();
+            if state.entries.iter().any(|e| e.name == "main.rs") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            state.entries.iter().any(|e| e.name == "main.rs"),
+            "background walk results are spliced in on poll: {:?}",
+            entry_names(&state)
+        );
+        assert!(state.pending_expands.is_empty());
+    }
 }

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -1262,9 +1262,11 @@ fn render_sidebar_tasks(f: &mut Frame, area: Rect, app: &mut App) {
 
     let content_width = area.width.saturating_sub(4) as usize;
     let usable_rows = area.height.saturating_sub(3) as usize;
-    let (lines, row_actions) = task_panel_rows(app, content_width.max(1), usable_rows.max(1));
+    let row_sets = task_panel_row_sets(app);
+    let (lines, row_actions) =
+        task_panel_rows(app, &row_sets, content_width.max(1), usable_rows.max(1));
 
-    let full_texts = task_panel_hover_texts(app, usable_rows.max(1));
+    let full_texts = task_panel_hover_texts(app, &row_sets, usable_rows.max(1));
     // #4147: This panel renders live tools / background jobs, not durable task
     // state, so the user-facing label is "Activity" to match its contents and
     // avoid colliding with durable tasks. The internal identifiers keep the
@@ -1280,9 +1282,43 @@ struct SidebarToolRow {
     duration_ms: Option<u64>,
 }
 
+/// Row sets shared by the Tasks panel line renderer and hover-text builder.
+///
+/// Computed once per frame in `render_sidebar_tasks` (#3898): both consumers
+/// previously recomputed `active_tool_rows` / `reasoning_task_rows` /
+/// `background_task_rows` (a clone+sort of `app.task_panel`) independently,
+/// doubling the work and risking the two passes disagreeing across an
+/// `Instant::elapsed` TTL boundary within the same frame.
+struct TaskPanelRowSets {
+    active: Vec<SidebarToolRow>,
+    reasoning: Vec<TaskPanelEntry>,
+    background: Vec<TaskPanelEntry>,
+    recent: Vec<SidebarToolRow>,
+}
+
+fn task_panel_row_sets(app: &App) -> TaskPanelRowSets {
+    let explicit_tasks_focus = app.sidebar_focus == SidebarFocus::Tasks;
+    let active = active_tool_rows(app);
+    let reasoning = reasoning_task_rows(app);
+    // Auto/Pinned mode deliberately skips live-tool dedup (passes an empty
+    // slice), matching the previous per-consumer call sites.
+    let background = background_task_rows(app, if explicit_tasks_focus { &active } else { &[] });
+    let recent = if explicit_tasks_focus {
+        recent_tool_rows(app, 4)
+    } else {
+        Vec::new()
+    };
+    TaskPanelRowSets {
+        active,
+        reasoning,
+        background,
+        recent,
+    }
+}
+
 #[cfg(test)]
 fn task_panel_lines(app: &App, content_width: usize, max_rows: usize) -> Vec<Line<'static>> {
-    task_panel_rows(app, content_width, max_rows).0
+    task_panel_rows(app, &task_panel_row_sets(app), content_width, max_rows).0
 }
 
 /// Build the Activity panel lines together with a parallel per-line click-action
@@ -1290,6 +1326,7 @@ fn task_panel_lines(app: &App, content_width: usize, max_rows: usize) -> Vec<Lin
 /// aligned with the rendered lines no matter how the layout evolves.
 fn task_panel_rows(
     app: &App,
+    row_sets: &TaskPanelRowSets,
     content_width: usize,
     max_rows: usize,
 ) -> (Vec<Line<'static>>, Vec<Option<SidebarRowAction>>) {
@@ -1318,26 +1355,19 @@ fn task_panel_rows(
         )));
     }
 
-    let active_rows = active_tool_rows(app);
+    let active_rows = &row_sets.active;
     if explicit_tasks_focus && !active_rows.is_empty() && lines.len() < max_rows {
         push_sidebar_label_theme(&mut lines, "Live tools", theme);
-        push_tool_rows(&mut lines, &active_rows, content_width, max_rows, theme);
+        push_tool_rows(&mut lines, active_rows, content_width, max_rows, theme);
     }
 
-    let reasoning_rows = reasoning_task_rows(app);
+    let reasoning_rows = &row_sets.reasoning;
     if explicit_tasks_focus && !reasoning_rows.is_empty() && lines.len() < max_rows {
         push_sidebar_label_theme(&mut lines, "Model reasoning", theme);
-        push_reasoning_rows(&mut lines, &reasoning_rows, content_width, max_rows, theme);
+        push_reasoning_rows(&mut lines, reasoning_rows, content_width, max_rows, theme);
     }
 
-    let background_rows = background_task_rows(
-        app,
-        if explicit_tasks_focus {
-            &active_rows
-        } else {
-            &[]
-        },
-    );
+    let background_rows = &row_sets.background;
     // Lines pushed so far (turn label, Live tools header, live tool rows)
     // are not clickable — backfill their action slots.
     actions.resize(lines.len(), None);
@@ -1436,10 +1466,10 @@ fn task_panel_rows(
     }
 
     if explicit_tasks_focus && lines.len() < max_rows {
-        let recent_rows = recent_tool_rows(app, 4);
+        let recent_rows = &row_sets.recent;
         if !recent_rows.is_empty() {
             push_sidebar_label_theme(&mut lines, "Recent tools", theme);
-            push_tool_rows(&mut lines, &recent_rows, content_width, max_rows, theme);
+            push_tool_rows(&mut lines, recent_rows, content_width, max_rows, theme);
         }
     }
 
@@ -1475,7 +1505,7 @@ fn task_panel_rows(
     (lines, actions)
 }
 
-fn task_panel_hover_texts(app: &App, max_rows: usize) -> Vec<String> {
+fn task_panel_hover_texts(app: &App, row_sets: &TaskPanelRowSets, max_rows: usize) -> Vec<String> {
     let mut texts = Vec::with_capacity(max_rows.max(4));
     let explicit_tasks_focus = app.sidebar_focus == SidebarFocus::Tasks;
 
@@ -1484,26 +1514,19 @@ fn task_panel_hover_texts(app: &App, max_rows: usize) -> Vec<String> {
         texts.push(format!("turn {turn_id} ({status})"));
     }
 
-    let active_rows = active_tool_rows(app);
+    let active_rows = &row_sets.active;
     if explicit_tasks_focus && !active_rows.is_empty() && texts.len() < max_rows {
         texts.push("Live tools".to_string());
-        push_tool_row_hover_texts(&mut texts, &active_rows, max_rows);
+        push_tool_row_hover_texts(&mut texts, active_rows, max_rows);
     }
 
-    let reasoning_rows = reasoning_task_rows(app);
+    let reasoning_rows = &row_sets.reasoning;
     if explicit_tasks_focus && !reasoning_rows.is_empty() && texts.len() < max_rows {
         texts.push("Model reasoning".to_string());
-        push_reasoning_row_hover_texts(&mut texts, &reasoning_rows, max_rows);
+        push_reasoning_row_hover_texts(&mut texts, reasoning_rows, max_rows);
     }
 
-    let background_rows = background_task_rows(
-        app,
-        if explicit_tasks_focus {
-            &active_rows
-        } else {
-            &[]
-        },
-    );
+    let background_rows = &row_sets.background;
     if !background_rows.is_empty() && texts.len() < max_rows {
         let running = background_rows
             .iter()
@@ -1555,10 +1578,10 @@ fn task_panel_hover_texts(app: &App, max_rows: usize) -> Vec<String> {
     }
 
     if explicit_tasks_focus && texts.len() < max_rows {
-        let recent_rows = recent_tool_rows(app, 4);
+        let recent_rows = &row_sets.recent;
         if !recent_rows.is_empty() {
             texts.push("Recent tools".to_string());
-            push_tool_row_hover_texts(&mut texts, &recent_rows, max_rows);
+            push_tool_row_hover_texts(&mut texts, recent_rows, max_rows);
         }
     }
 
@@ -2668,28 +2691,36 @@ fn sort_sidebar_agent_rows_as_tree(rows: Vec<SidebarAgentRow>) -> Vec<SidebarAge
         rows: &[SidebarAgentRow],
         children: &std::collections::HashMap<String, Vec<usize>>,
         seen: &mut std::collections::HashSet<usize>,
-        out: &mut Vec<SidebarAgentRow>,
+        order: &mut Vec<usize>,
     ) {
         if !seen.insert(idx) {
             return;
         }
-        out.push(rows[idx].clone());
+        order.push(idx);
         if let Some(child_indices) = children.get(&rows[idx].id) {
             for child_idx in child_indices {
-                push_tree(*child_idx, rows, children, seen, out);
+                push_tree(*child_idx, rows, children, seen, order);
             }
         }
     }
 
-    let mut out = Vec::with_capacity(rows.len());
+    let mut order = Vec::with_capacity(rows.len());
     let mut seen = std::collections::HashSet::new();
     for idx in roots {
-        push_tree(idx, &rows, &children, &mut seen, &mut out);
+        push_tree(idx, &rows, &children, &mut seen, &mut order);
     }
     for idx in 0..rows.len() {
-        push_tree(idx, &rows, &children, &mut seen, &mut out);
+        push_tree(idx, &rows, &children, &mut seen, &mut order);
     }
-    out
+
+    // Materialize by move instead of cloning each row a second time (#3898):
+    // `seen` guarantees every index lands in `order` exactly once, so each
+    // slot is taken exactly once and no row is dropped.
+    let mut slots: Vec<Option<SidebarAgentRow>> = rows.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .map(|idx| slots[idx].take().expect("each row emitted exactly once"))
+        .collect()
 }
 
 fn subagent_status_text(status: &SubAgentStatus) -> &'static str {
@@ -3471,8 +3502,8 @@ mod tests {
         normalize_activity_text, render_sidebar, sidebar_agent_rows, sidebar_hover_rows,
         sidebar_work_summary, sort_sidebar_agent_rows_as_tree, subagent_output_handle,
         subagent_panel_hover_texts, subagent_panel_lines, subagent_panel_rows,
-        task_panel_hover_texts, task_panel_lines, task_panel_rows, work_panel_empty_hint,
-        work_panel_hover_texts, work_panel_lines,
+        task_panel_hover_texts, task_panel_lines, task_panel_row_sets, task_panel_rows,
+        work_panel_empty_hint, work_panel_hover_texts, work_panel_lines,
     };
     use crate::config::Config;
     use crate::localization::Locale;
@@ -4651,6 +4682,98 @@ mod tests {
     }
 
     #[test]
+    fn task_panel_row_sets_dedup_background_only_when_tasks_focused() {
+        let mut app = create_test_app();
+        let mut active = ActiveCell::new();
+        active.push_tool(
+            "tool-1",
+            HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+                name: "rlm_search".to_string(),
+                status: ToolStatus::Running,
+                input_summary: Some("scanning workspace".to_string()),
+                output: None,
+                prompts: None,
+                spillover_path: None,
+                output_summary: None,
+                is_diff: false,
+            })),
+        );
+        app.active_cell = Some(active);
+        app.task_panel.push(TaskPanelEntry {
+            id: "rlm-123".to_string(),
+            status: "running".to_string(),
+            prompt_summary: "RLM: scanning workspace".to_string(),
+            duration_ms: Some(1_000),
+            kind: TaskPanelEntryKind::Background,
+            stale: false,
+            elapsed_since_output_ms: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+        });
+
+        app.sidebar_focus = SidebarFocus::Tasks;
+        let focused = task_panel_row_sets(&app);
+        assert!(
+            focused.background.is_empty(),
+            "Tasks focus dedups background jobs against live tools: {:?}",
+            focused.background
+        );
+
+        app.sidebar_focus = SidebarFocus::Auto;
+        let auto = task_panel_row_sets(&app);
+        assert_eq!(
+            auto.background.len(),
+            1,
+            "Auto mode keeps background jobs even when a live tool matches"
+        );
+    }
+
+    #[test]
+    fn task_panel_rows_and_hover_share_one_snapshot() {
+        let mut app = create_test_app();
+        app.sidebar_focus = SidebarFocus::Tasks;
+        app.runtime_turn_id = Some("turn_abcdef123456".to_string());
+        app.runtime_turn_status = Some("in_progress".to_string());
+        app.turn_counter = 3;
+        app.task_panel.push(TaskPanelEntry {
+            id: "job_123".to_string(),
+            status: "running".to_string(),
+            prompt_summary: "shell: cargo test --workspace".to_string(),
+            duration_ms: Some(12_000),
+            kind: TaskPanelEntryKind::Background,
+            stale: false,
+            elapsed_since_output_ms: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+        });
+
+        let row_sets = task_panel_row_sets(&app);
+        let (lines, actions) = task_panel_rows(&app, &row_sets, 80, 12);
+        let hover = task_panel_hover_texts(&app, &row_sets, 12);
+        let text = lines_to_text(&lines);
+
+        assert_eq!(lines.len(), actions.len(), "actions align with lines");
+        let job_idx = text
+            .iter()
+            .position(|line| line.contains("Bash running"))
+            .unwrap_or_else(|| panic!("bash job row missing: {text:?}"));
+        assert!(
+            hover[job_idx].contains("cargo test --workspace"),
+            "hover text at the job row index carries the full command: {hover:?}"
+        );
+        assert!(
+            text[0].starts_with("Turn 3"),
+            "line shows stable turn label: {:?}",
+            text[0]
+        );
+        assert!(
+            hover[0].contains("turn_abcdef123456"),
+            "hover carries the full turn id: {:?}",
+            hover[0]
+        );
+    }
+
+    #[test]
     fn tasks_panel_collapses_stale_running_tool_rows() {
         let mut app = create_test_app();
         app.sidebar_focus = SidebarFocus::Tasks;
@@ -4971,7 +5094,7 @@ mod tests {
             owner_agent_name: None,
         });
 
-        let (lines, actions) = task_panel_rows(&app, 80, 12);
+        let (lines, actions) = task_panel_rows(&app, &task_panel_row_sets(&app), 80, 12);
         let text = lines_to_text(&lines);
         assert_eq!(lines.len(), actions.len());
 
@@ -5011,7 +5134,7 @@ mod tests {
             owner_agent_name: None,
         });
 
-        let (lines, actions) = task_panel_rows(&app, 80, 12);
+        let (lines, actions) = task_panel_rows(&app, &task_panel_row_sets(&app), 80, 12);
         let text = lines_to_text(&lines);
 
         assert!(
@@ -5065,7 +5188,7 @@ mod tests {
             owner_agent_name: None,
         });
 
-        let (lines, actions) = task_panel_rows(&app, 96, 16);
+        let (lines, actions) = task_panel_rows(&app, &task_panel_row_sets(&app), 96, 16);
         let text = lines_to_text(&lines);
         assert_eq!(lines.len(), actions.len());
 
@@ -5132,7 +5255,7 @@ mod tests {
             owner_agent_name: None,
         });
 
-        let (lines, actions) = task_panel_rows(&app, 80, 12);
+        let (lines, actions) = task_panel_rows(&app, &task_panel_row_sets(&app), 80, 12);
         let text = lines_to_text(&lines);
 
         let label_idx = text
@@ -5186,7 +5309,7 @@ mod tests {
             owner_agent_name: None,
         });
 
-        let (lines, actions) = task_panel_rows(&app, 96, 16);
+        let (lines, actions) = task_panel_rows(&app, &task_panel_row_sets(&app), 96, 16);
         let text = lines_to_text(&lines);
         assert_eq!(
             lines.len(),
@@ -5422,6 +5545,50 @@ mod tests {
     }
 
     #[test]
+    fn sort_sidebar_agent_rows_as_tree_emits_each_row_exactly_once() {
+        let agent_row = |id: &str, parent: Option<&str>| SidebarAgentRow {
+            id: id.to_string(),
+            parent_run_id: parent.map(str::to_string),
+            spawn_depth: 1,
+            name: id.to_string(),
+            role: "explore".to_string(),
+            status: "running".to_string(),
+            objective: None,
+            git_branch: None,
+            progress: None,
+            steps_taken: 1,
+            duration_ms: None,
+        };
+        // Parent + child + a two-node parent cycle: the cycle has no root, so
+        // only the orphan sweep reaches it. Every row must still come out
+        // exactly once (the move-based materialization panics on a double
+        // take and this pins the drop case too).
+        let rows = vec![
+            agent_row("agent_parent", None),
+            agent_row("agent_child", Some("agent_parent")),
+            agent_row("agent_cycle_a", Some("agent_cycle_b")),
+            agent_row("agent_cycle_b", Some("agent_cycle_a")),
+        ];
+
+        let sorted = sort_sidebar_agent_rows_as_tree(rows);
+
+        assert_eq!(sorted.len(), 4, "no rows dropped or duplicated");
+        let mut ids: Vec<&str> = sorted.iter().map(|row| row.id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![
+                "agent_child",
+                "agent_cycle_a",
+                "agent_cycle_b",
+                "agent_parent"
+            ]
+        );
+        assert_eq!(sorted[0].id, "agent_parent");
+        assert_eq!(sorted[1].id, "agent_child");
+    }
+
+    #[test]
     fn subagent_sidebar_orders_and_indents_nested_children() {
         let rows = vec![
             SidebarAgentRow {
@@ -5458,6 +5625,7 @@ mod tests {
         let sorted = sort_sidebar_agent_rows_as_tree(rows);
         assert_eq!(sorted[0].id, "agent_parent");
         assert_eq!(sorted[1].id, "agent_grandchild");
+        assert_eq!(sorted.len(), 2, "tree sort must not drop or duplicate rows");
 
         let summary = SidebarSubagentSummary {
             cached_total: 2,
@@ -6843,7 +7011,7 @@ mod tests {
             "raw turn UUID must stay out of the compact row: {text:?}"
         );
 
-        let hover = task_panel_hover_texts(&app, 8);
+        let hover = task_panel_hover_texts(&app, &task_panel_row_sets(&app), 8);
         assert!(
             hover[0].contains("0196f0a3-1111-2222-3333-444455556666"),
             "full turn UUID must remain available in hover text: {hover:?}"

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -5552,12 +5552,14 @@ mod tests {
             spawn_depth: 1,
             name: id.to_string(),
             role: "explore".to_string(),
+            model: None,
             status: "running".to_string(),
             objective: None,
             git_branch: None,
             progress: None,
             steps_taken: 1,
             duration_ms: None,
+            expanded: false,
         };
         // Parent + child + a two-node parent cycle: the cycle has no root, so
         // only the orphan sweep reaches it. Every row must still come out

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -159,7 +159,56 @@ impl TranscriptViewCache {
         original_index_map: Option<&[usize]>,
     ) {
         let total_cells: usize = cell_shards.iter().map(|s| s.len()).sum();
+        self.ensure_iter(
+            total_cells,
+            cell_shards.iter().flat_map(|shard| shard.iter()),
+            cell_revisions,
+            width,
+            options,
+            folded_cells,
+            original_index_map,
+        );
+    }
 
+    /// `ensure_split` over an already-filtered list of borrowed cells.
+    ///
+    /// The collapse path substitutes synthetic tool-run summary cells and
+    /// skips collapsed cells, so it cannot hand over contiguous shard
+    /// slices. Accepting `&[&HistoryCell]` lets it pass borrows instead of
+    /// deep-cloning every visible cell into a fresh `Vec<HistoryCell>` each
+    /// frame (#3896).
+    #[allow(clippy::too_many_arguments)]
+    pub fn ensure_filtered(
+        &mut self,
+        cells: &[&HistoryCell],
+        cell_revisions: &[u64],
+        width: u16,
+        options: TranscriptRenderOptions,
+        folded_cells: &HashSet<usize>,
+        original_index_map: Option<&[usize]>,
+    ) {
+        self.ensure_iter(
+            cells.len(),
+            cells.iter().copied(),
+            cell_revisions,
+            width,
+            options,
+            folded_cells,
+            original_index_map,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn ensure_iter<'a>(
+        &mut self,
+        total_cells: usize,
+        cells: impl Iterator<Item = &'a HistoryCell>,
+        cell_revisions: &[u64],
+        width: u16,
+        options: TranscriptRenderOptions,
+        folded_cells: &HashSet<usize>,
+        original_index_map: Option<&[usize]>,
+    ) {
         let layout_changed = self.width != width || self.options != options;
         let folded_changed = self.folded_cells != *folded_cells;
         if layout_changed || folded_changed {
@@ -183,71 +232,69 @@ impl TranscriptViewCache {
         let revisions_match = cell_revisions.len() == total_cells;
 
         let mut idx: usize = 0;
-        for shard in cell_shards {
-            for cell in *shard {
-                let current_rev = if revisions_match {
-                    cell_revisions[idx]
-                } else {
-                    // No matching revisions — force a re-render this cycle.
-                    u64::MAX
-                };
+        for cell in cells {
+            let current_rev = if revisions_match {
+                cell_revisions[idx]
+            } else {
+                // No matching revisions — force a re-render this cycle.
+                u64::MAX
+            };
 
-                // Reuse cached entry if the revision matches AND it's at the
-                // same index (cells can shift on insert/remove, so we only
-                // reuse when the index is identical — a stricter invariant
-                // codex also uses for its active-cell tail).
-                if let Some(prev) = self.per_cell.get(idx)
-                    && !layout_changed
-                    && prev.revision == current_rev
-                    && revisions_match
-                {
-                    new_per_cell.push(prev.clone());
-                    idx += 1;
-                    continue;
-                }
-
-                any_dirty = true;
-                first_dirty = Some(first_dirty.map_or(idx, |current| current.min(idx)));
-                let is_tool_groupable = matches!(cell, HistoryCell::Tool(_));
-                let render_width = if is_tool_groupable {
-                    width.saturating_sub(2).max(1)
-                } else {
-                    width
-                };
-                let original_idx = original_index_map
-                    .map(|m| *m.get(idx).unwrap_or(&idx))
-                    .unwrap_or(idx);
-                let folded = folded_cells.contains(&original_idx);
-                let rendered = cell.lines_with_copy_metadata_folded(render_width, options, folded);
-                let mut lines = Vec::with_capacity(rendered.len());
-                let mut copy_separators = Vec::with_capacity(rendered.len());
-                let mut copy_prefix_widths = Vec::with_capacity(rendered.len());
-                for rendered_line in rendered {
-                    lines.push(rendered_line.line);
-                    copy_prefix_widths.push(rendered_line.copy_prefix_width);
-                    copy_separators.push(rendered_line.copy_separator_after);
-                }
-                let is_empty = lines.is_empty();
-                new_per_cell.push(CachedCell {
-                    revision: current_rev,
-                    lines: Arc::new(lines),
-                    copy_separators: Arc::new(copy_separators),
-                    copy_prefix_widths: Arc::new(copy_prefix_widths),
-                    is_empty,
-                    is_stream_continuation: cell.is_stream_continuation(),
-                    is_conversational: cell.is_conversational(),
-                    is_system_or_tool: matches!(
-                        cell,
-                        HistoryCell::System { .. }
-                            | HistoryCell::Error { .. }
-                            | HistoryCell::Tool(_)
-                            | HistoryCell::SubAgent(_)
-                            | HistoryCell::ArchivedContext { .. }
-                    ),
-                    is_tool_groupable,
-                });
+            // Reuse cached entry if the revision matches AND it's at the
+            // same index (cells can shift on insert/remove, so we only
+            // reuse when the index is identical — a stricter invariant
+            // codex also uses for its active-cell tail).
+            if let Some(prev) = self.per_cell.get(idx)
+                && !layout_changed
+                && prev.revision == current_rev
+                && revisions_match
+            {
+                new_per_cell.push(prev.clone());
                 idx += 1;
+                continue;
             }
+
+            any_dirty = true;
+            first_dirty = Some(first_dirty.map_or(idx, |current| current.min(idx)));
+            let is_tool_groupable = matches!(cell, HistoryCell::Tool(_));
+            let render_width = if is_tool_groupable {
+                width.saturating_sub(2).max(1)
+            } else {
+                width
+            };
+            let original_idx = original_index_map
+                .map(|m| *m.get(idx).unwrap_or(&idx))
+                .unwrap_or(idx);
+            let folded = folded_cells.contains(&original_idx);
+            let rendered = cell.lines_with_copy_metadata_folded(render_width, options, folded);
+            let mut lines = Vec::with_capacity(rendered.len());
+            let mut copy_separators = Vec::with_capacity(rendered.len());
+            let mut copy_prefix_widths = Vec::with_capacity(rendered.len());
+            for rendered_line in rendered {
+                lines.push(rendered_line.line);
+                copy_prefix_widths.push(rendered_line.copy_prefix_width);
+                copy_separators.push(rendered_line.copy_separator_after);
+            }
+            let is_empty = lines.is_empty();
+            new_per_cell.push(CachedCell {
+                revision: current_rev,
+                lines: Arc::new(lines),
+                copy_separators: Arc::new(copy_separators),
+                copy_prefix_widths: Arc::new(copy_prefix_widths),
+                is_empty,
+                is_stream_continuation: cell.is_stream_continuation(),
+                is_conversational: cell.is_conversational(),
+                is_system_or_tool: matches!(
+                    cell,
+                    HistoryCell::System { .. }
+                        | HistoryCell::Error { .. }
+                        | HistoryCell::Tool(_)
+                        | HistoryCell::SubAgent(_)
+                        | HistoryCell::ArchivedContext { .. }
+                ),
+                is_tool_groupable,
+            });
+            idx += 1;
         }
 
         self.per_cell = new_per_cell;
@@ -1058,6 +1105,97 @@ mod tests {
             "rail_prefix_widths memory unexpectedly large: {memory_kb:.1} KB"
         );
         eprintln!("  ✓ well under 1 MB even for very long sessions");
+    }
+
+    #[test]
+    fn ensure_filtered_matches_ensure_split_output() {
+        let cells = vec![
+            user_cell("hello"),
+            assistant_cell("some **markdown** body", false),
+            exec_tool_cell("cargo test"),
+            user_cell("again"),
+        ];
+        let revisions = vec![1u64, 2, 3, 4];
+        let index_map: Vec<usize> = vec![0, 1, 2, 3];
+
+        let mut split_cache = TranscriptViewCache::new();
+        split_cache.ensure_split(
+            &[&cells],
+            &revisions,
+            40,
+            TranscriptRenderOptions::default(),
+            &HashSet::new(),
+            Some(&index_map),
+        );
+
+        let refs: Vec<&HistoryCell> = cells.iter().collect();
+        let mut filtered_cache = TranscriptViewCache::new();
+        filtered_cache.ensure_filtered(
+            &refs,
+            &revisions,
+            40,
+            TranscriptRenderOptions::default(),
+            &HashSet::new(),
+            Some(&index_map),
+        );
+
+        assert_eq!(plain_lines(&split_cache), plain_lines(&filtered_cache));
+        assert_eq!(
+            split_cache.line_meta().len(),
+            filtered_cache.line_meta().len()
+        );
+    }
+
+    #[test]
+    fn ensure_filtered_reuses_unchanged_cells() {
+        let cells = vec![
+            user_cell("hello"),
+            assistant_cell("streaming", true),
+            user_cell("again"),
+        ];
+        let mut revisions = vec![1u64, 1, 1];
+        let refs: Vec<&HistoryCell> = cells.iter().collect();
+
+        let mut cache = TranscriptViewCache::new();
+        cache.ensure_filtered(
+            &refs,
+            &revisions,
+            80,
+            TranscriptRenderOptions::default(),
+            &HashSet::new(),
+            None,
+        );
+        let first = plain_lines(&cache);
+
+        cache.ensure_filtered(
+            &refs,
+            &revisions,
+            80,
+            TranscriptRenderOptions::default(),
+            &HashSet::new(),
+            None,
+        );
+        assert_eq!(first, plain_lines(&cache));
+        for (idx, cached) in cache.per_cell.iter().enumerate() {
+            assert_eq!(
+                cached.revision, 1,
+                "cell {idx} must be reused, not re-rendered"
+            );
+        }
+
+        // Bump one revision: only that entry re-renders.
+        revisions[1] = 2;
+        cache.ensure_filtered(
+            &refs,
+            &revisions,
+            80,
+            TranscriptRenderOptions::default(),
+            &HashSet::new(),
+            None,
+        );
+        assert_eq!(cache.per_cell[0].revision, 1);
+        assert_eq!(cache.per_cell[1].revision, 2);
+        assert_eq!(cache.per_cell[2].revision, 1);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -3635,6 +3635,13 @@ async fn run_event_loop(
             app.accrue_subagent_cost_estimate(pending_bg_cost);
             app.needs_redraw = true;
         }
+        // Drain completed file-tree walks (initial build / expands) so the
+        // spliced children repaint without waiting for an input event (#3900).
+        if let Some(tree) = app.file_tree.as_mut()
+            && tree.poll_background()
+        {
+            app.needs_redraw = true;
+        }
         // Expire the "Press Ctrl+C again to quit" prompt silently after its
         // window. Triggers a redraw if the prompt was visible.
         app.tick_quit_armed();

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -187,10 +187,26 @@ impl ChatWidget {
                 None,
             );
         } else {
-            // Slow path: clone non-collapsed cells into filtered vecs so
-            // collapsed cells are excluded from rendering. Build the
-            // filtered→original index mapping.
-            let mut filtered_cells: Vec<HistoryCell> =
+            // Slow path: borrow non-collapsed cells into a filtered ref list
+            // so collapsed cells are excluded from rendering, and build the
+            // filtered→original index mapping. Collapsed run starts render a
+            // synthetic summary cell; those few summaries are materialized
+            // up front so the ref list can borrow from a stable Vec —
+            // avoiding the per-frame deep clone of every visible cell that
+            // this path used to pay (#3896).
+            let summary_cells: Vec<(usize, HistoryCell)> = tool_runs
+                .iter()
+                .filter(|run| collapsed_run_starts.contains(&run.start))
+                .map(|run| (run.start, tool_run_summary_cell(run)))
+                .collect();
+            let summary_cell_for = |idx: usize| -> Option<&HistoryCell> {
+                summary_cells
+                    .iter()
+                    .find(|(start, _)| *start == idx)
+                    .map(|(_, cell)| cell)
+            };
+
+            let mut filtered_cells: Vec<&HistoryCell> =
                 Vec::with_capacity(history_len + active_entries.len());
             let mut filtered_revs: Vec<u64> =
                 Vec::with_capacity(history_len + active_entries.len());
@@ -208,7 +224,7 @@ impl ChatWidget {
                     .iter()
                     .find(|run| run.start == idx && collapsed_run_starts.contains(&idx))
                 {
-                    filtered_cells.push(tool_run_summary_cell(run));
+                    filtered_cells.push(summary_cell_for(idx).expect("summary cell materialized"));
                     filtered_revs.push(tool_run_summary_revision(
                         run,
                         &app.history_revisions,
@@ -218,7 +234,7 @@ impl ChatWidget {
                     filtered_to_original.push(idx);
                     continue;
                 }
-                filtered_cells.push(cell.clone());
+                filtered_cells.push(cell);
                 filtered_revs.push(app.history_revisions[idx]);
                 filtered_to_original.push(idx);
             }
@@ -236,7 +252,8 @@ impl ChatWidget {
                     if let Some(run) = tool_runs.iter().find(|run| {
                         run.start == original_idx && collapsed_run_starts.contains(&original_idx)
                     }) {
-                        filtered_cells.push(tool_run_summary_cell(run));
+                        filtered_cells
+                            .push(summary_cell_for(original_idx).expect("summary materialized"));
                         filtered_revs.push(tool_run_summary_revision(
                             run,
                             &app.history_revisions,
@@ -246,7 +263,7 @@ impl ChatWidget {
                         filtered_to_original.push(original_idx);
                         continue;
                     }
-                    filtered_cells.push(cell.clone());
+                    filtered_cells.push(cell);
                     let salt = (i as u64).wrapping_add(1);
                     filtered_revs.push(active_entry_revision(active_rev, salt));
                     filtered_to_original.push(original_idx);
@@ -255,9 +272,8 @@ impl ChatWidget {
 
             app.collapsed_cell_map = filtered_to_original;
 
-            let shards: [&[HistoryCell]; 1] = [&filtered_cells];
-            app.viewport.transcript_cache.ensure_split(
-                &shards,
+            app.viewport.transcript_cache.ensure_filtered(
+                &filtered_cells,
                 &filtered_revs,
                 content_area.width.max(1),
                 render_options,
@@ -3611,6 +3627,80 @@ mod tests {
         let _widget = ChatWidget::new(&mut app, area);
 
         assert_eq!(app.collapsed_cell_map, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn chat_widget_collapse_path_stable_across_frames() {
+        let mut app = create_test_app();
+        app.tool_collapse_mode = ToolCollapseMode::Compact;
+        app.tool_collapse_threshold = 3;
+        add_dense_tool_run(&mut app);
+        app.add_message(HistoryCell::User {
+            content: "trailing prompt".to_string(),
+        });
+
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 10,
+        };
+
+        let mut first_buf = Buffer::empty(area);
+        ChatWidget::new(&mut app, area).render(area, &mut first_buf);
+        let first = buffer_text(&first_buf, area);
+        let first_map = app.collapsed_cell_map.clone();
+        let first_total = app.viewport.last_transcript_total;
+
+        // Second frame without any app mutation: the borrowed filtered path
+        // must reproduce the identical output and index map.
+        let mut second_buf = Buffer::empty(area);
+        ChatWidget::new(&mut app, area).render(area, &mut second_buf);
+        let second = buffer_text(&second_buf, area);
+
+        assert_eq!(first, second, "collapse path is frame-stable");
+        assert_eq!(first_map, app.collapsed_cell_map);
+        assert_eq!(first_total, app.viewport.last_transcript_total);
+        assert!(first.contains("Explored 2 files, 1 search"), "{first}");
+        assert!(first.contains("trailing prompt"), "{first}");
+    }
+
+    #[test]
+    fn chat_widget_collapses_run_spanning_history_and_active_entries() {
+        let mut app = create_test_app();
+        app.tool_collapse_mode = ToolCollapseMode::Compact;
+        app.tool_collapse_threshold = 3;
+        app.add_message(success_tool_cell("read_file"));
+        app.add_message(success_tool_cell("list_dir"));
+        let active = app.active_cell.get_or_insert_with(ActiveCell::new);
+        active.push_untracked(success_tool_cell("web_search"));
+        app.bump_active_cell_revision();
+
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 8,
+        };
+        let mut buf = Buffer::empty(area);
+        ChatWidget::new(&mut app, area).render(area, &mut buf);
+        let rendered = buffer_text(&buf, area);
+
+        assert_eq!(app.collapsed_cell_map, vec![0]);
+        assert!(
+            rendered.contains("Explored 2 files, 1 search"),
+            "run spanning the history/active boundary renders one summary: {rendered}"
+        );
+
+        // Mutating the active tail must re-render the summary (its revision
+        // folds in the covered active entries).
+        let rev_before = app.active_cell_revision;
+        app.bump_active_cell_revision();
+        assert_ne!(rev_before, app.active_cell_revision);
+        let mut second_buf = Buffer::empty(area);
+        ChatWidget::new(&mut app, area).render(area, &mut second_buf);
+        let second = buffer_text(&second_buf, area);
+        assert!(second.contains("Explored 2 files, 1 search"), "{second}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Measure-first partial harvest of draft PR **#3902** (`perf(tui): five render/input hot paths`) rebased onto current `main` for **#4014**.

### Landed slices (smallest green subset)

| Issue | Change | Status vs full #3902 |
|---|---|---|
| **#3896** | Collapse path borrows cells via `TranscriptViewCache::ensure_filtered` — zero deep-clones of visible transcript cells per frame | Cherry-picked cleanly |
| **#3898** | `TaskPanelRowSets` computed once per frame; shared by rows + hover; agent tree sort avoids double clone | Rebased (kept #4147 "Activity" label) |
| **#3900** | File-tree expand/collapse off UI thread + `poll_background()` drain so idle loops repaint | Cherry-picked + event-loop drain ported |

### Deferred (still CONFLICTING / large)

| Issue | Why deferred |
|---|---|
| **#3899** @mention background walk | Conflicts with #3757 candidate cache + app/ui keypath; needs careful recompose |
| **#3897** incremental streaming markdown | Conflicts in `markdown_render.rs` (main moved 4 commits) |

### Measurement notes (from #3902 + structural analysis; no new wall-clock bench harness yet)

**#3896 — collapse clone path**
- Before: with tool-run auto-collapse active, every frame deep-cloned every visible `HistoryCell` into a filtered `Vec` even when nothing changed.
- After: filter builds `Vec<&HistoryCell>`; cache entry point is borrow-based; existing per-cell revision reuse still applies.
- Relevance to #4014: sub-agent cards are `HistoryCell::SubAgent` — high fan-out + collapse multiplies clone cost.

**#3898 — Activity/Tasks panel double compute**
- Before: `task_panel_rows` and `task_panel_hover_texts` each rebuilt active/reasoning/background/recent row sets per frame.
- After: one `task_panel_row_sets(app)` snapshot shared by both.
- Relevance to #4014: fan-out fills `task_panel` / agent tree; double clone+sort is pure waste under redraw storms.

**#3900 — file-tree expand**
- Before: expand/collapse rebuilt via full workspace walk on UI thread.
- After: collapse is pure splice; expand walks only the new subtree on a background thread; event loop drains and sets `needs_redraw`.

**Not claimed:** 30+ agent typing-latency AC of #4014. Companion #4217 worker-record retention PR addresses unbounded state growth.

### Source credit

Rebased from draft PR #3902 by **@Hmbown** / Claude performance branch `claude/performance-improvement-issues-bjknbf`. Original issue authors on #3896–#3900.

## Testing

- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked ensure_filtered`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked task_panel_row_sets`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked task_panel_rows_and_hover`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked sort_sidebar_agent_rows_as_tree_emits`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked poll_background_reports`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked file_tree`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked collapse_path`
- [x] `cargo fmt --all`

## Checklist

- [x] No version bump / no tags
- [x] Leaves #4014 open (partial lever only)
- [x] Closes #3896 #3898 #3900 when merged

Fixes #3896
Fixes #3898
Fixes #3900
Related to #4014
Partial harvest of #3902
