### PR TITLE
fix(fleet): reject retired profile loadout aliases (#4065)

### DIFF
--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -48,10 +48,6 @@ struct AgentProfileToml {
     #[serde(default)]
     persona: Option<String>,
     #[serde(default)]
-    model_class_hint: Option<String>,
-    #[serde(default)]
-    route_tier: Option<String>,
-    #[serde(default)]
     loadout: Option<String>,
     #[serde(default, alias = "model_hint", alias = "model_id")]
     model: Option<String>,
@@ -165,13 +161,9 @@ fn agent_profile_from_toml(path: &Path, parsed: AgentProfileToml) -> Result<Agen
     .to_string();
     validate_agent_profile_token(path, "base_role/role_hint", &role_name)?;
 
-    let loadout = first_present([
-        parsed.model_class_hint.as_deref(),
-        parsed.route_tier.as_deref(),
-        parsed.loadout.as_deref(),
-    ])
-    .map(FleetLoadout::from_name)
-    .unwrap_or_default();
+    let loadout = first_present([parsed.loadout.as_deref()])
+        .map(FleetLoadout::from_name)
+        .unwrap_or_default();
     let model = non_empty_trimmed(parsed.model.as_deref()).map(str::to_string);
     validate_agent_profile_model_hint(path, model.as_deref())?;
 
@@ -534,10 +526,7 @@ impl FleetProfileDraft {
             toml::Value::String(self.role_hint.clone()),
         );
         if let Some(ref hint) = self.model_class_hint {
-            root.insert(
-                "model_class_hint".to_string(),
-                toml::Value::String(hint.clone()),
-            );
+            root.insert("loadout".to_string(), toml::Value::String(hint.clone()));
         }
         if let Some(ref model) = self.model {
             root.insert("model".to_string(), toml::Value::String(model.clone()));
@@ -953,7 +942,7 @@ name = "adversarial_reviewer"
 display_name = "Adversarial Reviewer"
 description = "Skeptical read-only review posture"
 role_hint = "reviewer"
-model_class_hint = "balanced"
+loadout = "balanced"
 model = "deepseek-v4-pro"
 
 [instructions]
@@ -993,6 +982,33 @@ posture = "read-only"
             FleetProfilePermissions::default()
         );
         assert_eq!(profile.source, source);
+    }
+
+    #[test]
+    fn agent_profile_loader_rejects_retired_model_policy_aliases() {
+        for (field, value) in [("model_class_hint", "balanced"), ("route_tier", "fast")] {
+            let tmp = TempDir::new().unwrap();
+            write_profile(
+                tmp.path(),
+                "reviewer.toml",
+                &format!(
+                    r#"
+name = "reviewer"
+role_hint = "reviewer"
+{field} = "{value}"
+"#
+                ),
+            );
+
+            let err = load_agent_profiles_from_dir(tmp.path())
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                err.contains(field) || err.contains("unknown field"),
+                "unexpected error for {field}: {err}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Rebased harvest of draft PR **#4084** by **@cyq1017** onto current `main`.

Remove retired workspace profile TOML inputs `model_class_hint` and `route_tier` so agent profile files use the canonical `loadout` field. The draft profile renderer now writes loadout intent as `loadout`, keeping generated profiles round-trippable through the stricter loader.

Conflict resolution notes:
- Kept main's #4093 first-class `provider` field and its round-trip tests
- Dropped the PR's obsolete "hidden provider policy fields" rejection test (provider is now valid)
- Added the retired-alias rejection test from the contributor PR

Refs #4065
Closes contributor draft after merge: #4084

## Credit

Thanks **@cyq1017** for the original change.

## Testing

- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked agent_profile_loader_rejects_retired`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet::profile` (22 passed)

## Checklist

- [x] No version bump / no tags
- [x] Single-file change