### PR TITLE
feat(workflow): lane-backed workflow run entrypoint (#4177/#4178)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "codewhale-release",
  "codewhale-secrets",
  "codewhale-state",
+ "codewhale-workflow",
  "dirs",
  "libc",
  "mimalloc",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ codewhale-agent = { path = "../agent", version = "0.8.67" }
 codewhale-app-server = { path = "../app-server", version = "0.8.67" }
 codewhale-config = { path = "../config", version = "0.8.67" }
 codewhale-lane = { path = "../lane", version = "0.8.67" }
+codewhale-workflow = { path = "../workflow", version = "0.8.67" }
 codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
 codewhale-mcp = { path = "../mcp", version = "0.8.67" }
 codewhale-release = { path = "../release", version = "0.8.67" }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -220,6 +220,17 @@ path used by stream-json wrappers.
     Exec(TuiPassthroughArgs),
     /// Manage durable Agent Fleet runs via the TUI runtime.
     Fleet(TuiPassthroughArgs),
+    /// Run checked-in Workflows through a Lane Runtime backend.
+    #[command(after_help = "\
+Examples:
+  codewhale workflow run stopship --issue 4090 --fleet v0868-stopship --runtime tmux
+  codewhale workflow run stopship --fleet v0868-stopship --runtime inline --verify
+
+`workflow run` validates the checked-in Workflow source and named Fleet roster,
+creates a Lane record, then starts the existing headless Workflow tool through
+the selected Runtime backend.
+")]
+    Workflow(WorkflowArgs),
     /// Manage running workflow instances (Lanes) and Runtime backends (#4176).
     #[command(after_help = "\
 Examples:
@@ -441,11 +452,131 @@ enum LaneCommand {
     },
 }
 
-fn run_lane_command(args: LaneArgs) -> Result<()> {
+/// `codewhale workflow …` — Workflow entrypoints backed by Lanes (#4177/#4178).
+#[derive(Debug, Args)]
+struct WorkflowArgs {
+    #[command(subcommand)]
+    command: WorkflowCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum WorkflowCommand {
+    /// Run a checked-in Workflow through a Runtime-backed Lane.
+    Run {
+        /// Workflow name or path. `stopship` maps to workflows/v0868_stopship_lane.workflow.js.
+        workflow: String,
+        /// Named Fleet roster (e.g. v0868-stopship). Required for role-resolved Workflow runs.
+        #[arg(long)]
+        fleet: String,
+        /// Issue id binding recorded on the Lane and passed into workflow args.
+        #[arg(long)]
+        issue: Option<String>,
+        /// Free-form goal text recorded on the Lane and passed into workflow args.
+        #[arg(long)]
+        goal: Option<String>,
+        /// Runtime backend: tmux, inline, vm, or ci.
+        #[arg(long, default_value = "tmux")]
+        runtime: String,
+        /// Explicit Workflow source path, overriding name-based resolution.
+        #[arg(long, value_name = "PATH")]
+        source_path: Option<PathBuf>,
+        /// Optional shared Workflow token budget.
+        #[arg(long)]
+        token_budget: Option<u64>,
+        /// Run verifier gates after a successful Workflow completion.
+        #[arg(long, default_value_t = false)]
+        verify: bool,
+        /// Create an isolated worktree under this repo root.
+        #[arg(long, value_name = "DIR")]
+        worktree_repo: Option<PathBuf>,
+        /// Branch name for the worktree (requires `--worktree-repo`).
+        #[arg(long)]
+        branch: Option<String>,
+        /// Worktree path (defaults to `<repo>/.codewhale/lanes/<lane-id>`).
+        #[arg(long, value_name = "DIR")]
+        worktree_path: Option<PathBuf>,
+        /// Worktree cleanup TTL seconds after stop (0 = immediate on stop).
+        #[arg(long)]
+        worktree_ttl_secs: Option<u64>,
+    },
+}
+
+#[derive(Debug)]
+struct LaneStartRequest {
+    workflow: Option<String>,
+    fleet: Option<String>,
+    issue: Option<String>,
+    goal: Option<String>,
+    runtime: String,
+    worktree_repo: Option<PathBuf>,
+    branch: Option<String>,
+    worktree_path: Option<PathBuf>,
+    worktree_ttl_secs: Option<u64>,
+    command: Vec<String>,
+}
+
+fn start_lane(request: LaneStartRequest) -> Result<()> {
     use codewhale_lane::{
-        LaneRegistry, LaneStartSpec, RuntimeBackendKind, WorktreeProvision, backend_for,
-        resolve_backend,
+        LaneRegistry, LaneStartSpec, RuntimeBackendKind, WorktreeProvision, resolve_backend,
     };
+
+    let LaneStartRequest {
+        workflow,
+        fleet,
+        issue,
+        goal,
+        runtime,
+        worktree_repo,
+        branch,
+        worktree_path,
+        worktree_ttl_secs,
+        command,
+    } = request;
+    let kind = RuntimeBackendKind::parse(&runtime)?;
+    let reg = LaneRegistry::open_default()?;
+    let mut record = reg.create_pending(workflow, fleet, issue, goal, kind, worktree_ttl_secs)?;
+    let worktree = match (worktree_repo, branch) {
+        (Some(repo_root), Some(branch_name)) => {
+            let path = worktree_path
+                .unwrap_or_else(|| repo_root.join(".codewhale").join("lanes").join(&record.id));
+            Some(WorktreeProvision {
+                repo_root,
+                branch: branch_name,
+                path,
+                base_ref: None,
+            })
+        }
+        (None, None) => None,
+        _ => bail!("--worktree-repo and --branch must be provided together"),
+    };
+    let cmd = if command.is_empty() {
+        vec![
+            "sh".into(),
+            "-c".into(),
+            format!("echo lane {} started", record.id),
+        ]
+    } else {
+        command
+    };
+    let spec = LaneStartSpec {
+        command: cmd,
+        cwd: None,
+        worktree,
+    };
+    let backend = resolve_backend(kind);
+    backend.start(&reg, &mut record, &spec)?;
+    println!("started {}", record.id);
+    println!("status:  {}", record.status.as_str());
+    println!("runtime: {}", record.runtime.as_str());
+    println!("log:     {}", record.log_path.display());
+    if let Some(attach) = backend.attach_command(&record) {
+        println!("attach:  {attach}");
+    }
+    Ok(())
+}
+
+fn run_lane_command(args: LaneArgs) -> Result<()> {
+    use codewhale_lane::{LaneRegistry, backend_for};
     use std::io::{BufRead, Seek, Write};
     use std::process::Command;
     use std::thread;
@@ -596,52 +727,241 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
             worktree_path,
             worktree_ttl_secs,
             command,
+        } => start_lane(LaneStartRequest {
+            workflow,
+            fleet,
+            issue,
+            goal,
+            runtime,
+            worktree_repo,
+            branch,
+            worktree_path,
+            worktree_ttl_secs,
+            command,
+        }),
+    }
+}
+
+fn run_workflow_command(args: WorkflowArgs) -> Result<()> {
+    match args.command {
+        WorkflowCommand::Run {
+            workflow,
+            fleet,
+            issue,
+            goal,
+            runtime,
+            source_path,
+            token_budget,
+            verify,
+            worktree_repo,
+            branch,
+            worktree_path,
+            worktree_ttl_secs,
         } => {
-            let kind = RuntimeBackendKind::parse(&runtime)?;
-            let reg = LaneRegistry::open_default()?;
-            let mut record =
-                reg.create_pending(workflow, fleet, issue, goal, kind, worktree_ttl_secs)?;
-            let worktree = match (worktree_repo, branch) {
-                (Some(repo_root), Some(branch_name)) => {
-                    let path = worktree_path.unwrap_or_else(|| {
-                        repo_root.join(".codewhale").join("lanes").join(&record.id)
-                    });
-                    Some(WorktreeProvision {
-                        repo_root,
-                        branch: branch_name,
-                        path,
-                        base_ref: None,
-                    })
-                }
-                (None, None) => None,
-                _ => bail!("--worktree-repo and --branch must be provided together"),
-            };
-            let cmd = if command.is_empty() {
-                vec![
-                    "sh".into(),
-                    "-c".into(),
-                    format!("echo lane {} started", record.id),
-                ]
-            } else {
-                command
-            };
-            let spec = LaneStartSpec {
-                command: cmd,
-                cwd: None,
-                worktree,
-            };
-            let backend = resolve_backend(kind);
-            backend.start(&reg, &mut record, &spec)?;
-            println!("started {}", record.id);
-            println!("status:  {}", record.status.as_str());
-            println!("runtime: {}", record.runtime.as_str());
-            println!("log:     {}", record.log_path.display());
-            if let Some(attach) = backend.attach_command(&record) {
-                println!("attach:  {attach}");
+            let workspace = workflow_workspace_root()?;
+            let source_path =
+                resolve_workflow_source_path(&workflow, source_path.as_ref(), &workspace)?;
+            validate_workflow_source_file(&source_path)?;
+
+            let roots = named_fleet_search_roots(&workspace);
+            let named_fleet = codewhale_workflow::load_named_fleet(&fleet, &roots)
+                .with_context(|| format!("load fleet `{fleet}` from {}", display_roots(&roots)))?;
+            if workflow == "stopship" || fleet == "v0868-stopship" {
+                named_fleet
+                    .validate_stopship_roles()
+                    .with_context(|| format!("validate stopship roles in fleet `{fleet}`"))?;
             }
-            Ok(())
+
+            let command = workflow_exec_command(
+                &workspace,
+                &source_path,
+                &workflow,
+                &fleet,
+                issue.as_deref(),
+                goal.as_deref(),
+                token_budget,
+                verify,
+            )?;
+            start_lane(LaneStartRequest {
+                workflow: Some(workflow),
+                fleet: Some(fleet),
+                issue,
+                goal,
+                runtime,
+                worktree_repo,
+                branch,
+                worktree_path,
+                worktree_ttl_secs,
+                command,
+            })
         }
     }
+}
+
+fn workflow_workspace_root() -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("resolve current directory")?;
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&cwd)
+        .output();
+    if let Ok(output) = output
+        && output.status.success()
+    {
+        let text = String::from_utf8_lossy(&output.stdout);
+        let root = text.trim();
+        if !root.is_empty() {
+            return Ok(PathBuf::from(root));
+        }
+    }
+    Ok(cwd)
+}
+
+fn resolve_workflow_source_path(
+    workflow: &str,
+    source_path: Option<&PathBuf>,
+    workspace: &Path,
+) -> Result<PathBuf> {
+    let candidates = workflow_source_candidates(workflow, source_path, workspace);
+    for candidate in &candidates {
+        if candidate.is_file() {
+            return Ok(candidate.clone());
+        }
+    }
+    bail!(
+        "workflow source for `{workflow}` not found; tried {}",
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn workflow_source_candidates(
+    workflow: &str,
+    source_path: Option<&PathBuf>,
+    workspace: &Path,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = source_path {
+        candidates.push(resolve_against_workspace(path, workspace));
+        return candidates;
+    }
+
+    let raw = workflow.trim();
+    let workflow_path = PathBuf::from(raw);
+    if raw.contains('/') || raw.contains('\\') || raw.ends_with(".js") || raw.ends_with(".ts") {
+        candidates.push(resolve_against_workspace(&workflow_path, workspace));
+        return candidates;
+    }
+
+    let normalized = raw.replace('-', "_");
+    for rel in [
+        format!("workflows/{raw}.workflow.js"),
+        format!("workflows/{normalized}.workflow.js"),
+        format!("workflows/v0868_{normalized}_lane.workflow.js"),
+        format!("workflows/v0868_{normalized}.workflow.js"),
+    ] {
+        let path = workspace.join(rel);
+        if !candidates.iter().any(|existing| existing == &path) {
+            candidates.push(path);
+        }
+    }
+    candidates
+}
+
+fn resolve_against_workspace(path: &Path, workspace: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workspace.join(path)
+    }
+}
+
+fn validate_workflow_source_file(path: &Path) -> Result<()> {
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    if source.trim_start().starts_with("export default workflow(")
+        || source.trim_start().starts_with("workflow(")
+        || source.contains("\nworkflow(")
+    {
+        let identifier = path.display().to_string();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("ts") {
+            codewhale_workflow::compile_typescript_workflow(&identifier, &source)
+                .with_context(|| format!("parse declarative Workflow {}", path.display()))?;
+        } else {
+            codewhale_workflow::compile_javascript_workflow(&identifier, &source)
+                .with_context(|| format!("parse declarative Workflow {}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn named_fleet_search_roots(workspace: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(home) = codewhale_config::codewhale_home() {
+        roots.push(home);
+    }
+    roots.push(workspace.to_path_buf());
+    roots
+}
+
+fn display_roots(roots: &[PathBuf]) -> String {
+    roots
+        .iter()
+        .map(|root| root.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn workflow_exec_command(
+    workspace: &Path,
+    source_path: &Path,
+    workflow: &str,
+    fleet: &str,
+    issue: Option<&str>,
+    goal: Option<&str>,
+    token_budget: Option<u64>,
+    verify: bool,
+) -> Result<Vec<String>> {
+    let dispatcher = std::env::current_exe()
+        .ok()
+        .filter(|path| path.is_file())
+        .unwrap_or_else(|| PathBuf::from("codewhale"));
+    let source_arg = source_path
+        .strip_prefix(workspace)
+        .unwrap_or(source_path)
+        .display()
+        .to_string();
+    let mut payload = serde_json::json!({
+        "action": "run",
+        "source_path": source_arg,
+        "fleet": fleet,
+        "args": {
+            "workflow": workflow,
+            "fleet": fleet,
+            "issue": issue,
+            "goal": goal,
+        },
+        "verify": verify,
+    });
+    if let Some(token_budget) = token_budget {
+        payload["token_budget"] = serde_json::json!(token_budget);
+    }
+    let prompt = format!(
+        "Run the CodeWhale `workflow` tool with this exact JSON input, wait for completion, and report the resulting run_id/status. Do not describe the workflow instead of running it.\n\n```json\n{}\n```",
+        serde_json::to_string_pretty(&payload)?
+    );
+    Ok(vec![
+        dispatcher.display().to_string(),
+        "--workspace".to_string(),
+        workspace.display().to_string(),
+        "exec".to_string(),
+        "--auto".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        prompt,
+    ])
 }
 
 /// Flags for `codewhale remote-setup`. Forwarded to the TUI binary, which owns
@@ -1017,6 +1337,7 @@ fn run() -> Result<()> {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("fleet", args))
         }
+        Some(Commands::Workflow(args)) => run_workflow_command(args),
         Some(Commands::Lane(args)) => run_lane_command(args),
         Some(Commands::Review(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
@@ -3278,6 +3599,62 @@ mod tests {
             Some(Commands::Fleet(TuiPassthroughArgs { ref args }))
                 if args == &["run", "tasks.json", "--max-workers", "2"]
         ));
+
+        let cli = parse_ok(&[
+            "codewhale",
+            "workflow",
+            "run",
+            "stopship",
+            "--fleet",
+            "v0868-stopship",
+            "--runtime",
+            "tmux",
+            "--issue",
+            "4090",
+        ]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Workflow(WorkflowArgs {
+                command: WorkflowCommand::Run {
+                    ref workflow,
+                    ref fleet,
+                    ref runtime,
+                    ref issue,
+                    ..
+                }
+            })) if workflow == "stopship"
+                && fleet == "v0868-stopship"
+                && runtime == "tmux"
+                && issue.as_deref() == Some("4090")
+        ));
+    }
+
+    #[test]
+    fn workflow_run_resolves_stopship_alias_and_payload() {
+        let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..");
+        let source = resolve_workflow_source_path("stopship", None, &workspace)
+            .expect("stopship workflow source");
+        assert!(source.ends_with("workflows/v0868_stopship_lane.workflow.js"));
+
+        let command = workflow_exec_command(
+            &workspace,
+            &source,
+            "stopship",
+            "v0868-stopship",
+            Some("4090"),
+            Some("fix stopship"),
+            Some(25_000),
+            true,
+        )
+        .expect("command");
+        let joined = command.join("\n");
+        assert!(joined.contains("\"source_path\": \"workflows/v0868_stopship_lane.workflow.js\""));
+        assert!(joined.contains("\"fleet\": \"v0868-stopship\""));
+        assert!(joined.contains("\"issue\": \"4090\""));
+        assert!(joined.contains("\"token_budget\": 25000"));
+        assert!(joined.contains("\"verify\": true"));
     }
 
     #[test]

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -12,10 +12,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use codewhale_workflow::{
     AgentType, BranchResult, BranchSpec, BudgetSpec, ControlNodeKind, ControlNodeResult,
-    LeafResult, LeafSpec, ReduceSpec, SequenceSpec, TaskMode,
+    FleetRoleMap, LeafResult, LeafSpec, ReduceSpec, SequenceSpec, TaskMode,
     WorkflowExecution as IrWorkflowExecution, WorkflowMemoUsage, WorkflowNode,
     WorkflowRunStatus as IrWorkflowRunStatus, WorkflowSpec, WorkflowUsage,
     compile_javascript_workflow, compile_typescript_workflow, leaf_wants_worktree,
+    load_named_fleet, resolve_workflow_agent,
 };
 use codewhale_workflow_js::{
     BudgetSnapshot, DriverError, ProgressEvent, SpawnedTask, TaskCompletion, TaskRequest,
@@ -392,6 +393,10 @@ impl ToolSpec for WorkflowTool {
                     "type": "string",
                     "description": "Path to a .workflow.js script inside the workspace. Use instead of script for checked-in workflows."
                 },
+                "fleet": {
+                    "type": "string",
+                    "description": "Named Fleet roster to resolve task({ role }) declarations, loaded from $CODEWHALE_HOME/fleets/ or workspace fleets/."
+                },
                 "plan": {
                     "type": "object",
                     "description": "Structured planner plan JSON (#4124). Alternative to script/source_path. Accepts goal, risk, max_children, token_budget, phases[], and/or children[] (or IR nodes). Lowered to Workflow JS with parallel() partial-success semantics."
@@ -498,6 +503,7 @@ async fn start_workflow(
     let token_budget = optional_u64(&input, "token_budget", 0);
     let token_budget = (token_budget > 0).then_some(token_budget);
     let verify_on_complete = optional_bool(&input, "verify", false);
+    let (fleet_name, fleet_roles) = workflow_fleet_roles(&input, context)?;
     let run_id = format!("workflow_{}", &Uuid::new_v4().to_string()[..8]);
 
     // Capture the approved plan envelope for audit/receipt (#4126). Reaching
@@ -558,6 +564,8 @@ async fn start_workflow(
         runtime,
         state.clone(),
         token_budget,
+        fleet_name,
+        fleet_roles,
     );
     let vm_cancel = WorkflowRunCancel::new();
     let controller = Arc::new(WorkflowRunController::new(
@@ -643,6 +651,74 @@ async fn cancel_workflow(
     };
     state.record_snapshot(&snapshot);
     workflow_result_for(run_id, state)
+}
+
+fn workflow_fleet_name(input: &Value) -> Option<String> {
+    optional_str(input, "fleet")
+        .or_else(|| {
+            input
+                .get("args")
+                .and_then(|args| optional_str(args, "fleet"))
+        })
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn workflow_fleet_roles(
+    input: &Value,
+    context: &ToolContext,
+) -> Result<(Option<String>, Option<FleetRoleMap>), ToolError> {
+    let Some(name) = workflow_fleet_name(input) else {
+        return Ok((None, None));
+    };
+    let roots = workflow_fleet_search_roots(&context.workspace);
+    let fleet = load_named_fleet(&name, &roots).map_err(|err| {
+        ToolError::invalid_input(format!(
+            "Failed to load workflow fleet '{name}' from {}: {err}",
+            roots
+                .iter()
+                .map(|root| root.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    })?;
+    let roles = FleetRoleMap::from_pairs(
+        fleet
+            .roles
+            .iter()
+            .map(|(role, profile)| (role.as_str(), profile.as_str())),
+    )
+    .map_err(|err| ToolError::invalid_input(err.to_string()))?;
+    Ok((Some(name), Some(roles)))
+}
+
+fn workflow_fleet_search_roots(workspace: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(home) = codewhale_config::codewhale_home() {
+        roots.push(home);
+    }
+    roots.push(workspace.to_path_buf());
+    roots
+}
+
+fn apply_named_fleet_to_task_request(
+    fleet_roles: Option<&FleetRoleMap>,
+    request: &mut TaskRequest,
+) -> Result<(), DriverError> {
+    let Some(fleet_roles) = fleet_roles else {
+        return Ok(());
+    };
+    let resolved = resolve_workflow_agent(
+        request.role.as_deref(),
+        request.profile.as_deref(),
+        fleet_roles,
+        true,
+    )
+    .map_err(|err| DriverError::Rejected(err.to_string()))?;
+    request.role = resolved.resolved_role;
+    request.profile = Some(resolved.resolved_profile);
+    Ok(())
 }
 
 // Pre-existing spawn signature that grew `vm_cancel` for the cancel-interrupt
@@ -1645,6 +1721,9 @@ struct SubAgentWorkflowDriver {
     concurrent_gate: Arc<Semaphore>,
     /// Held permits for in-flight children; released on completion/cancel.
     spawn_permits: Mutex<HashMap<String, OwnedSemaphorePermit>>,
+    /// Optional named Fleet roster for resolving Workflow task roles (#4177/#4178).
+    fleet_name: Option<String>,
+    fleet_roles: Option<FleetRoleMap>,
 }
 
 impl SubAgentWorkflowDriver {
@@ -1654,6 +1733,8 @@ impl SubAgentWorkflowDriver {
         runtime: SubAgentRuntime,
         state: Arc<WorkflowWorkspaceState>,
         total_budget: Option<u64>,
+        fleet_name: Option<String>,
+        fleet_roles: Option<FleetRoleMap>,
     ) -> Arc<Self> {
         let (completion_tx, completion_rx) = mpsc::unbounded_channel();
         let driver = Arc::new(Self {
@@ -1671,6 +1752,8 @@ impl SubAgentWorkflowDriver {
             last_budget_event: Arc::new(Mutex::new(None)),
             concurrent_gate: Arc::new(Semaphore::new(WORKFLOW_MAX_CONCURRENT.max(1))),
             spawn_permits: Mutex::new(HashMap::new()),
+            fleet_name,
+            fleet_roles,
         });
         spawn_completion_pump(driver.clone(), completion_rx);
         driver
@@ -1915,7 +1998,16 @@ struct CompletionState {
 
 #[async_trait]
 impl WorkflowDriver for SubAgentWorkflowDriver {
-    async fn spawn_task(&self, request: TaskRequest) -> Result<SpawnedTask, DriverError> {
+    async fn spawn_task(&self, mut request: TaskRequest) -> Result<SpawnedTask, DriverError> {
+        apply_named_fleet_to_task_request(self.fleet_roles.as_ref(), &mut request).map_err(
+            |err| {
+                if let Some(fleet) = self.fleet_name.as_deref() {
+                    DriverError::Rejected(format!("fleet `{fleet}` role resolution failed: {err}"))
+                } else {
+                    err
+                }
+            },
+        )?;
         // Wait for a concurrent slot (max 16 live children per run).
         let permit = self
             .concurrent_gate
@@ -2743,6 +2835,67 @@ mod tests {
         assert_eq!(
             parse_workflow_action(&json!({"action": "run"})).unwrap(),
             WorkflowAction::Run
+        );
+    }
+
+    #[test]
+    fn named_fleet_maps_workflow_role_to_profile_before_spawn() {
+        let fleet = FleetRoleMap::from_pairs([
+            ("scout", "scout"),
+            ("implementer", "builder"),
+            ("reviewer", "reviewer"),
+            ("verifier", "verifier"),
+            ("release_lead", "manager"),
+        ])
+        .expect("fleet");
+        let mut request = TaskRequest {
+            description: "fix it".to_string(),
+            subagent_type: None,
+            role: Some("implementer".to_string()),
+            profile: None,
+            model: None,
+            model_strength: None,
+            thinking: None,
+            worktree: true,
+            allowed_tools: None,
+            max_depth: None,
+            token_budget: None,
+            response_schema: None,
+            label: Some("fix".to_string()),
+            phase: Some("implement".to_string()),
+        };
+
+        apply_named_fleet_to_task_request(Some(&fleet), &mut request).expect("resolve");
+
+        assert_eq!(request.role.as_deref(), Some("implementer"));
+        assert_eq!(request.profile.as_deref(), Some("builder"));
+    }
+
+    #[test]
+    fn named_fleet_rejects_unknown_workflow_role_before_spawn() {
+        let fleet = FleetRoleMap::from_pairs([("scout", "scout")]).expect("fleet");
+        let mut request = TaskRequest {
+            description: "fix it".to_string(),
+            subagent_type: None,
+            role: Some("wizard".to_string()),
+            profile: None,
+            model: None,
+            model_strength: None,
+            thinking: None,
+            worktree: false,
+            allowed_tools: None,
+            max_depth: None,
+            token_budget: None,
+            response_schema: None,
+            label: None,
+            phase: None,
+        };
+
+        let err = apply_named_fleet_to_task_request(Some(&fleet), &mut request)
+            .expect_err("unknown role should fail");
+        assert!(
+            err.to_string().contains("unknown fleet role `wizard`"),
+            "{err}"
         );
     }
 

--- a/docs/AGENT_WORKFLOWS_0868.md
+++ b/docs/AGENT_WORKFLOWS_0868.md
@@ -116,26 +116,29 @@ git checkout -b codex/v0868-stopship-<issue>
 
 Named fleet file: [`fleets/v0868-stopship.toml`](../fleets/v0868-stopship.toml)
 (roles: `scout`, `implementer`, `reviewer`, `verifier`, `release_lead`).
-Workflow: `workflows/v0868_stopship_lane.workflow.js` (steps bind
-`profile` / fleet roles — not raw provider/model identity).
+Workflow: `workflows/v0868_stopship_lane.workflow.js` (steps bind fleet
+`role` — not raw provider/model identity).
 
-**Target shape** (requires Phase 1 Lane CLI #4176 + Phase 2 role resolution #4177):
+**Target shape** (Phase 1 Lane CLI #4176 + Phase 2 role resolution #4177):
 
 ```bash
-# Create a durable tmux-backed lane bound to stopship + fleet
-codewhale lane start \
-  --workflow stopship \
+# Create a durable tmux-backed lane bound to stopship + fleet and launch Workflow
+codewhale workflow run stopship \
+  --issue 4090 \
   --fleet v0868-stopship \
   --runtime tmux \
-  --issue 4090 \
-  -- codewhale exec --auto --output-format stream-json \
-    "Run workflows/v0868_stopship_lane.workflow.js with fleet v0868-stopship. Fix #4090, #4093, #4094. Branch from main."
+  --goal "Fix #4090, #4093, #4094. Branch implementation from main."
 
 codewhale lane list
 codewhale lane attach <lane-id>          # or: codewhale lane attach <lane-id> --print
 codewhale lane logs <lane-id>
 codewhale lane stop <lane-id>
 ```
+
+`workflow run` validates the checked-in Workflow source and named Fleet roster,
+creates the Lane record, and starts the existing headless Workflow tool via the
+selected Runtime backend. The Workflow driver resolves each `task({ role })`
+through the named fleet before spawning sub-agents.
 
 Validate fleet role resolution without launching agents:
 
@@ -144,7 +147,7 @@ Validate fleet role resolution without launching agents:
 cargo test -p codewhale-workflow --lib named_fleet
 ```
 
-### Interim paths (until `workflow run --fleet` lands)
+### Direct tool paths
 
 From CodeWhale TUI or headless exec:
 

--- a/workflows/v0868_stopship_lane.workflow.js
+++ b/workflows/v0868_stopship_lane.workflow.js
@@ -13,7 +13,7 @@ export default workflow({
               "id": "scout-ctrl-c",
               "prompt": "Investigate GitHub issue #4090 (repeated Ctrl+C re-prompts in PTY/raw-mode). Run: `gh issue view 4090 -R Hmbown/CodeWhale`. Then search `crates/tui/src/` for Ctrl+C handling, raw mode teardown, and exit confirmation paths. Report: repro hypothesis, exact files/functions, whether a regression test or PTY trace exists, minimal fix approach. Read-only.",
               "agent_type": "explore",
-              "profile": "scout",
+              "role": "scout",
               "mode": "read_only",
               "file_scope": ["crates/tui/src/tui/app.rs", "crates/tui/src/tui/ui.rs", "crates/tui/src/main.rs"],
               "budget": { "max_steps": 12, "timeout_secs": 600 }
@@ -24,7 +24,7 @@ export default workflow({
               "id": "scout-fleet-modal",
               "prompt": "Investigate release-blocker #4093 (Fleet setup modal provider-scoped instead of role/profile roster). Run: `gh issue view 4093 -R Hmbown/CodeWhale`. Inspect `crates/tui/src/tui/views/fleet_setup.rs`, `crates/tui/src/fleet/roster.rs`, and related Fleet UI. Report current vs expected behavior, root cause, files to change, test strategy. Read-only.",
               "agent_type": "explore",
-              "profile": "scout",
+              "role": "scout",
               "mode": "read_only",
               "file_scope": ["crates/tui/src/tui/views/fleet_setup.rs", "crates/tui/src/fleet/"],
               "budget": { "max_steps": 12, "timeout_secs": 600 }
@@ -35,7 +35,7 @@ export default workflow({
               "id": "scout-subagent-panel",
               "prompt": "Investigate release-blocker #4094 (sub-agent detail panel empty / TUI freeze). Run: `gh issue view 4094 -R Hmbown/CodeWhale`. Inspect sidebar agents panel, sub-agent detail rendering, and redraw paths under load. Report root cause hypothesis, files, whether throttle or empty-state bug, severity. Read-only.",
               "agent_type": "explore",
-              "profile": "scout",
+              "role": "scout",
               "mode": "read_only",
               "file_scope": ["crates/tui/src/tui/sidebar.rs", "crates/tui/src/tui/widgets/agent_card.rs"],
               "budget": { "max_steps": 12, "timeout_secs": 600 }
@@ -53,7 +53,7 @@ export default workflow({
               "id": "fix-4090",
               "prompt": "Fix #4090 using scout-ctrl-c findings. Branch from main (git checkout main && git pull && git checkout -b codex/v0868-fix-4090). Implement minimal fix so double Ctrl+C exits cleanly in PTY/raw-mode while preserving cancel/copy behavior. Add regression test or PTY/key-path trace. Run: `cargo test -p codewhale-tui` for touched modules and `cargo clippy -p codewhale-tui -- -D warnings`. Do not close the issue; report files changed and test output.",
               "agent_type": "implementer",
-              "profile": "builder",
+              "role": "implementer",
               "mode": "write",
               "file_scope": ["crates/tui/src/tui/app.rs", "crates/tui/src/tui/ui.rs"],
               "budget": { "max_steps": 20, "timeout_secs": 1200 }
@@ -64,7 +64,7 @@ export default workflow({
               "id": "fix-4093-4094",
               "prompt": "Using scout findings, fix #4093 and/or #4094 if root causes are clear and independent. Branch from main (separate branches per issue if needed: codex/v0868-fix-4093, codex/v0868-fix-4094). Prefer smallest correct diffs. For #4093: Fleet setup should edit role/profile roster not provider scope. For #4094: sub-agent detail panel must render and not freeze TUI. Add tests where feasible. Run targeted `cargo test -p codewhale-tui fleet sidebar`. Report per-issue status: fixed/partial/blocked.",
               "agent_type": "implementer",
-              "profile": "builder",
+              "role": "implementer",
               "mode": "write",
               "file_scope": ["crates/tui/src/tui/views/fleet_setup.rs", "crates/tui/src/tui/sidebar.rs"],
               "budget": { "max_steps": 24, "timeout_secs": 1800 }
@@ -75,7 +75,7 @@ export default workflow({
               "id": "verify-dogfood",
               "prompt": "Re-verify dogfood fixes for #3986 (API-key onboarding copy shows CODEWHALE_HOME path) and #3990 (slash autocomplete alias duplication). Read issue bodies via `gh issue view`. Check if fixes exist on current branch; if missing, implement minimal fixes. Run verification gate subset: `cargo fmt --all --check`, `cargo test -p codewhale-tui -- onboarding slash`. Report done/partial/missing per issue.",
               "agent_type": "verifier",
-              "profile": "verifier",
+              "role": "verifier",
               "mode": "write",
               "file_scope": ["crates/tui/src/tui/", "crates/tui/locales/en.json"],
               "budget": { "max_steps": 16, "timeout_secs": 900 }


### PR DESCRIPTION
## Summary

- Adds `codewhale workflow run <name> --fleet <fleet> --runtime <backend>` as a Lane-backed entrypoint that validates the checked-in Workflow source and named Fleet roster before starting a Runtime-backed Lane.
- Wires named Fleet role maps into the TUI Workflow driver so `task({ role })` resolves to the fleet-selected profile before the existing sub-agent spawn path runs.
- Converts the v0.8.68 stopship dogfood workflow to declare fleet `role` values and updates the playbook target command.

Refs #4177 and #4178. This is progress toward the full e2e stopship lane; it does not complete issues 4177 or 4178 until a live `workflow run --fleet --runtime tmux` dogfood run is proven.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-cli --lib --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`
- [x] `cargo test -p codewhale-cli --lib workflow_run --locked -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked named_fleet -- --nocapture`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked workflow_run_dispatches_task_through_subagent_manager -- --nocapture`
- [x] `cargo test -p codewhale-workflow --lib named_fleet --locked -- --nocapture`
- [x] `git diff --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (no harvested/co-authored credit in this PR)

