### PR TITLE
fix(tui): clear clippy 1.97 useless_borrows_in_formatting

### DIFF
--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -544,7 +544,7 @@ fn push_plan_snapshot_lines(
                 StepStatus::InProgress => "\u{25b6}",
                 StepStatus::Completed => "\u{2713}",
             };
-            let step_text = format!("  {status_mark} {}. {}", i + 1, &item.step);
+            let step_text = format!("  {status_mark} {}. {}", i + 1, item.step);
             for line in wrap_text(&step_text, content_width) {
                 lines.push(Line::from(Span::styled(
                     line,
@@ -589,7 +589,7 @@ fn push_todo_snapshot_lines(
             TodoStatus::InProgress => "\u{25b6}",
             TodoStatus::Completed => "\u{2713}",
         };
-        let item_text = format!("  {status_mark} {}. {}", i + 1, &item.content);
+        let item_text = format!("  {status_mark} {}. {}", i + 1, item.content);
         let style = if matches!(item.status, TodoStatus::Completed) {
             Style::default().fg(palette::TEXT_MUTED)
         } else {


### PR DESCRIPTION
## What

Rust stable 1.97.0 (released 2026-07-07) added the `useless_borrows_in_formatting` lint, and CI's `-D warnings` promotes it to an error. Every Lint run on current main now fails on two redundant `&` in `format!` arguments in `crates/tui/src/tui/plan_prompt.rs` (this — not the sccache 504 — is why the Lint job also failed on main-push run 29032827574 and on #4310's first run).

Two-line fix: drop the redundant references.

## Verification

- `cargo clippy --workspace --all-features --locked` with the repo's full `-D/-A` flag set exits **0** under `rustc 1.97.0 (2d8144b78 2026-07-07)` on this branch — so these two sites are the *only* new-lint instances in the workspace with `--all-features`.

## Urgency

This unblocks Lint for every open PR (including #4310 and #4311). Suggest landing first.

Part of the v0.8.68 milestone.