### PR TITLE
test: isolate hotbar skill cache and automate live TUI QA targets

### DIFF
--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1604,7 +1604,10 @@ async fn approval_required_awaits_external_decision_allow() -> Result<()> {
         })
         .await?;
 
-    let deadline = Instant::now() + Duration::from_secs(2);
+    // A busy or constrained runner can be quiet for more than one 200 ms poll
+    // even though the engine is still making progress. Keep polling until the
+    // actual deadline instead of treating the first quiet interval as failure.
+    let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline && manager.pending_approvals_count() == 0 {
         sleep(Duration::from_millis(20)).await;
     }
@@ -1943,7 +1946,8 @@ async fn thinking_delta_emits_agent_reasoning_item() -> Result<()> {
                     completed_seen = true;
                 }
             }
-            _ => break,
+            Ok(Err(_)) => break,
+            Err(_) => continue,
         }
     }
     assert!(delta_seen, "expected item.delta with kind=agent_reasoning");

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1604,10 +1604,7 @@ async fn approval_required_awaits_external_decision_allow() -> Result<()> {
         })
         .await?;
 
-    // A busy or constrained runner can be quiet for more than one 200 ms poll
-    // even though the engine is still making progress. Keep polling until the
-    // actual deadline instead of treating the first quiet interval as failure.
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline && manager.pending_approvals_count() == 0 {
         sleep(Duration::from_millis(20)).await;
     }
@@ -1705,7 +1702,10 @@ async fn approval_required_external_deny_is_denied() -> Result<()> {
         })
         .await?;
 
-    let deadline = Instant::now() + Duration::from_secs(2);
+    // A busy or constrained runner can be quiet for more than one 200 ms poll
+    // even though the engine is still making progress. Keep polling until the
+    // actual deadline instead of treating the first quiet interval as failure.
+    let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline && manager.pending_approvals_count() == 0 {
         sleep(Duration::from_millis(20)).await;
     }

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1702,10 +1702,7 @@ async fn approval_required_external_deny_is_denied() -> Result<()> {
         })
         .await?;
 
-    // A busy or constrained runner can be quiet for more than one 200 ms poll
-    // even though the engine is still making progress. Keep polling until the
-    // actual deadline instead of treating the first quiet interval as failure.
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline && manager.pending_approvals_count() == 0 {
         sleep(Duration::from_millis(20)).await;
     }
@@ -1919,7 +1916,10 @@ async fn thinking_delta_emits_agent_reasoning_item() -> Result<()> {
         })
         .await?;
 
-    let deadline = Instant::now() + Duration::from_secs(2);
+    // A busy or constrained runner can be quiet for more than one 200 ms poll
+    // even though the engine is still making progress. Keep polling until the
+    // actual deadline instead of treating the first quiet interval as failure.
+    let deadline = Instant::now() + Duration::from_secs(5);
     let mut delta_seen = false;
     let mut completed_seen = false;
     while Instant::now() < deadline && (!delta_seen || !completed_seen) {

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -1446,7 +1446,11 @@ mod tests {
 
     use super::*;
 
-    fn test_app_with_paths(workspace: PathBuf, skills_dir: PathBuf) -> App {
+    fn test_app_with_paths_and_config(
+        workspace: PathBuf,
+        skills_dir: PathBuf,
+        config: &Config,
+    ) -> App {
         let options = TuiOptions {
             model: "deepseek-v4-pro".to_string(),
             workspace,
@@ -1468,9 +1472,13 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        let mut app = App::new(options, &Config::default());
+        let mut app = App::new(options, config);
         app.ui_locale = crate::localization::Locale::En;
         app
+    }
+
+    fn test_app_with_paths(workspace: PathBuf, skills_dir: PathBuf) -> App {
+        test_app_with_paths_and_config(workspace, skills_dir, &Config::default())
     }
 
     fn test_app() -> App {
@@ -2192,9 +2200,12 @@ mod tests {
             "---\nname: hotbar-demo-skill\ndescription: Demo skill for hotbar tests\n---\n\nFollow the demo instructions.\n",
         )
         .expect("write SKILL.md");
-        let mut app = test_app_with_paths(
+        let mut config = Config::default();
+        config.skills_dir = Some(skills_dir.path().to_string_lossy().into_owned());
+        let mut app = test_app_with_paths_and_config(
             workspace.path().to_path_buf(),
             skills_dir.path().to_path_buf(),
+            &config,
         );
 
         let action = app

--- a/crates/tui/tests/release_runtime_qa.rs
+++ b/crates/tui/tests/release_runtime_qa.rs
@@ -1,0 +1,478 @@
+//! Local-only release runtime QA through real pseudo-terminals.
+//!
+//! These scenarios cover the live TUI checks that unit tests cannot prove:
+//! six-worker fanout liveness/cancellation, multi-terminal route isolation,
+//! and queued steering via Ctrl+S. Every provider is a loopback wiremock
+//! server and every process receives a sealed HOME.
+
+#![cfg(unix)]
+
+#[path = "support/qa_harness/mod.rs"]
+mod qa_harness;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow};
+use qa_harness::harness::{Harness, SealedWorkspace, make_sealed_workspace};
+use qa_harness::keys;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+const BOOT_TIMEOUT: Duration = Duration::from_secs(20);
+const INTERACTION_TIMEOUT: Duration = Duration::from_secs(15);
+const COMPOSER_READY_TEXT: &str = "Write a task";
+const MUSE_MODEL: &str = "muse-spark-1.1";
+const GPT_MODEL: &str = "gpt-5.6-terra";
+const DEEPSEEK_TEST_MODEL: &str = "deepseek-v4-pro";
+static RELEASE_RUNTIME_QA_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn sse_chunk(value: Value) -> String {
+    format!(
+        "data: {}\n\n",
+        serde_json::to_string(&value).expect("SSE JSON")
+    )
+}
+
+fn text_sse(model: &str, text: &str) -> String {
+    [
+        sse_chunk(json!({
+            "id": "chatcmpl-local-qa",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": { "content": text },
+                "finish_reason": null
+            }]
+        })),
+        sse_chunk(json!({
+            "id": "chatcmpl-local-qa",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 4,
+                "total_tokens": 16
+            }
+        })),
+        "data: [DONE]\n\n".to_string(),
+    ]
+    .join("")
+}
+
+fn fanout_tool_call_sse() -> String {
+    let tool_calls = (1..=6)
+        .map(|worker| {
+            json!({
+                "index": worker - 1,
+                "id": format!("call_agent_{worker}"),
+                "type": "function",
+                "function": {
+                    "name": "agent",
+                    "arguments": serde_json::to_string(&json!({
+                        "message": format!("stay busy worker {worker} until the parent QA turn is cancelled"),
+                        "agent_type": "explorer",
+                        "session_name": format!("qa-worker-{worker}")
+                    }))
+                    .expect("agent arguments")
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    [
+        sse_chunk(json!({
+            "id": "chatcmpl-fanout",
+            "object": "chat.completion.chunk",
+            "model": DEEPSEEK_TEST_MODEL,
+            "choices": [{
+                "index": 0,
+                "delta": { "tool_calls": tool_calls },
+                "finish_reason": null
+            }]
+        })),
+        sse_chunk(json!({
+            "id": "chatcmpl-fanout",
+            "object": "chat.completion.chunk",
+            "model": DEEPSEEK_TEST_MODEL,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {
+                "prompt_tokens": 20,
+                "completion_tokens": 12,
+                "total_tokens": 32
+            }
+        })),
+        "data: [DONE]\n\n".to_string(),
+    ]
+    .join("")
+}
+
+fn sse_response(body: String) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .insert_header("content-type", "text/event-stream")
+        .insert_header("cache-control", "no-cache")
+        .set_body_string(body)
+}
+
+fn json_response(value: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .insert_header("content-type", "application/json")
+        .set_body_json(value)
+}
+
+async fn mount_models(server: &MockServer, models: &[&str]) {
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(json_response(json!({
+            "object": "list",
+            "data": models
+                .iter()
+                .map(|model| json!({ "id": model, "object": "model" }))
+                .collect::<Vec<_>>()
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_text_model(server: &MockServer, model: &str, answer: &str) {
+    mount_models(server, &[model]).await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(sse_response(text_sse(model, answer)))
+        .mount(server)
+        .await;
+}
+
+fn common_tui_builder(ws: &SealedWorkspace) -> qa_harness::harness::HarnessBuilder {
+    Harness::builder(Harness::cargo_bin("codewhale-tui"))
+        .cwd(ws.workspace())
+        .clear_env()
+        .seal_home(ws.home())
+        .env("RUST_LOG", "warn")
+        .args([
+            "--workspace",
+            ws.workspace().to_str().expect("utf-8 workspace path"),
+            "--no-project-config",
+            "--skip-onboarding",
+        ])
+        .size(42, 150)
+}
+
+fn wait_for_counter(
+    harness: &mut Harness,
+    counter: &AtomicUsize,
+    expected: usize,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        harness.pump();
+        if counter.load(Ordering::SeqCst) >= expected {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "counter did not reach {expected} within {timeout:?}; observed {}\n{}",
+                counter.load(Ordering::SeqCst),
+                harness.debug_dump()
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(40));
+    }
+}
+
+fn type_and_submit(harness: &mut Harness, text: &str) -> Result<()> {
+    harness.send(keys::key::text(text))?;
+    harness.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    harness.send(keys::key::enter())?;
+    Ok(())
+}
+
+fn type_and_tab(harness: &mut Harness, text: &str) -> Result<()> {
+    harness.send(keys::key::text(text))?;
+    harness.wait_for_text(text, Duration::from_secs(3))?;
+    harness.send(b"\t")?;
+    Ok(())
+}
+
+fn chat_requests(requests: &[Request]) -> Vec<Value> {
+    requests
+        .iter()
+        .filter(|request| request.url.path().ends_with("/chat/completions"))
+        .map(|request| request.body_json().expect("chat body JSON"))
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn release_multi_terminal_muse_and_gpt_routes_stay_isolated() -> Result<()> {
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let meta_server = MockServer::start().await;
+    let openai_server = MockServer::start().await;
+    mount_text_model(&meta_server, MUSE_MODEL, "meta-route-ok").await;
+    mount_models(&openai_server, &["gpt-5.6-luna", GPT_MODEL]).await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(sse_response(text_sse(GPT_MODEL, "openai-route-ok")))
+        .mount(&openai_server)
+        .await;
+
+    let ws = make_sealed_workspace()?;
+    let openai_base_url = openai_server.uri();
+    let meta_base_url = meta_server.uri();
+    let shared_openai_env = [
+        ("OPENAI_API_KEY", "openai-local-test-key"),
+        ("OPENAI_BASE_URL", openai_base_url.as_str()),
+        ("OPENAI_MODEL", "gpt-5.6-luna"),
+    ];
+    let shared_meta_env = [
+        ("META_MODEL_API_KEY", "meta-local-test-key"),
+        ("MODEL_API_KEY", "meta-local-test-key"),
+        ("META_MODEL_API_BASE_URL", meta_base_url.as_str()),
+        ("META_MODEL_API_MODEL", MUSE_MODEL),
+    ];
+
+    let mut meta_builder = common_tui_builder(&ws).env("CODEWHALE_PROVIDER", "meta");
+    let mut openai_builder = common_tui_builder(&ws).env("CODEWHALE_PROVIDER", "openai");
+    for (key, value) in shared_openai_env.into_iter().chain(shared_meta_env) {
+        meta_builder = meta_builder.env(key, value);
+        openai_builder = openai_builder.env(key, value);
+    }
+
+    let mut meta_tui = meta_builder.spawn()?;
+    let mut openai_tui = openai_builder.spawn()?;
+    meta_tui.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
+    openai_tui.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
+
+    // Change terminal B's model through the live command path while terminal A
+    // remains open on Meta. Both processes share one sealed settings file.
+    type_and_submit(&mut openai_tui, "/model gpt-5.6-terra")?;
+    openai_tui.wait_for(
+        |frame| frame.row(0).contains(GPT_MODEL),
+        INTERACTION_TIMEOUT,
+    )?;
+    assert!(
+        meta_tui.frame().contains(MUSE_MODEL),
+        "terminal A route changed when terminal B selected a model:\n{}",
+        meta_tui.debug_dump()
+    );
+
+    type_and_submit(&mut meta_tui, "route probe from meta terminal")?;
+    type_and_submit(&mut openai_tui, "route probe from openai terminal")?;
+    meta_tui.wait_for_text("meta-route-ok", INTERACTION_TIMEOUT)?;
+    openai_tui.wait_for_text("openai-route-ok", INTERACTION_TIMEOUT)?;
+
+    let meta_requests = meta_server.received_requests().await.unwrap_or_default();
+    let openai_requests = openai_server.received_requests().await.unwrap_or_default();
+    let meta_chat = chat_requests(&meta_requests);
+    let openai_chat = chat_requests(&openai_requests);
+    assert_eq!(
+        meta_chat.len(),
+        1,
+        "unexpected Meta chat requests: {meta_chat:#?}"
+    );
+    assert_eq!(
+        openai_chat.len(),
+        1,
+        "unexpected OpenAI chat requests: {openai_chat:#?}"
+    );
+    assert_eq!(meta_chat[0]["model"], MUSE_MODEL);
+    assert_eq!(openai_chat[0]["model"], GPT_MODEL);
+    assert!(
+        meta_chat[0]
+            .to_string()
+            .contains("route probe from meta terminal")
+    );
+    assert!(!meta_chat[0].to_string().contains("openai terminal"));
+    assert!(
+        openai_chat[0]
+            .to_string()
+            .contains("route probe from openai terminal")
+    );
+    assert!(!openai_chat[0].to_string().contains("meta terminal"));
+
+    let _ = meta_tui.shutdown();
+    let _ = openai_tui.shutdown();
+    Ok(())
+}
+
+#[derive(Clone)]
+struct FanoutResponder {
+    child_requests: Arc<AtomicUsize>,
+}
+
+impl Respond for FanoutResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body = request.body_json::<Value>().unwrap_or(Value::Null);
+        let raw = body.to_string();
+
+        if raw.contains("stay busy worker") && !raw.contains("launch six QA workers") {
+            self.child_requests.fetch_add(1, Ordering::SeqCst);
+            return sse_response(text_sse(DEEPSEEK_TEST_MODEL, "child-finished-too-soon"))
+                .set_delay(Duration::from_secs(20));
+        }
+
+        if raw.contains("launch six QA workers") {
+            return sse_response(fanout_tool_call_sse());
+        }
+
+        sse_response(text_sse(DEEPSEEK_TEST_MODEL, "unexpected-request"))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn release_six_worker_fanout_keeps_typing_render_and_esc_cancel_live() -> Result<()> {
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let server = MockServer::start().await;
+    mount_models(&server, &[DEEPSEEK_TEST_MODEL]).await;
+    let child_requests = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(FanoutResponder {
+            child_requests: Arc::clone(&child_requests),
+        })
+        .mount(&server)
+        .await;
+
+    let ws = make_sealed_workspace()?;
+    std::fs::write(
+        ws.home().join(".codewhale").join("config.toml"),
+        "[subagents]\nmax_concurrent = 6\nlaunch_concurrency = 6\nmax_admitted = 6\n",
+    )?;
+    let mut tui = common_tui_builder(&ws)
+        .env("CODEWHALE_PROVIDER", "deepseek")
+        .env("DEEPSEEK_API_KEY", "deepseek-local-test-key")
+        .env("DEEPSEEK_BASE_URL", server.uri())
+        .env("DEEPSEEK_MODEL", DEEPSEEK_TEST_MODEL)
+        .args(["--yolo", "--max-subagents", "6"])
+        .spawn()?;
+    tui.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
+
+    type_and_submit(
+        &mut tui,
+        "launch six QA workers and keep the parent turn open",
+    )?;
+    wait_for_counter(&mut tui, &child_requests, 6, INTERACTION_TIMEOUT)?;
+    tui.wait_for_text("6 running / 6", Duration::from_secs(5))?;
+
+    let fanout_frame = tui.debug_dump();
+    assert!(
+        fanout_frame.contains("6 running / 6"),
+        "all six workers were not visible in the sidebar:\n{fanout_frame}"
+    );
+
+    // The provider is deliberately holding every child open. Prove keyboard
+    // input and rendering remain live during the storm, then interrupt the
+    // still-live orchestration turn directly with Esc.
+    tui.send(keys::key::text("fanout-live-marker"))?;
+    tui.wait_for_text("fanout-live-marker", Duration::from_secs(3))?;
+    let before_cancel = tui.debug_dump();
+    assert!(
+        before_cancel.contains("Agent") || before_cancel.contains("agent"),
+        "fanout UI did not expose agent activity:\n{before_cancel}"
+    );
+
+    let cancel_started = Instant::now();
+    tui.send(b"\x1b")?;
+    tui.wait_for(
+        |frame| {
+            let text = frame.text().to_ascii_lowercase();
+            text.contains("cancelled") || text.contains("interrupted")
+        },
+        Duration::from_secs(5),
+    )?;
+    assert!(
+        cancel_started.elapsed() < Duration::from_secs(5),
+        "Esc cancellation exceeded the five-second liveness budget"
+    );
+
+    tui.send(keys::key::text("post-cancel-live"))?;
+    tui.wait_for_text("post-cancel-live", Duration::from_secs(3))?;
+    assert_eq!(child_requests.load(Ordering::SeqCst), 6);
+
+    let _ = tui.shutdown();
+    Ok(())
+}
+
+#[derive(Clone)]
+struct SteeringResponder {
+    initial_requests: Arc<AtomicUsize>,
+    steer_requests: Arc<AtomicUsize>,
+}
+
+impl Respond for SteeringResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body = request.body_json::<Value>().unwrap_or(Value::Null);
+        let raw = body.to_string();
+        if raw.contains("queued steering from ctrl-s") {
+            self.steer_requests.fetch_add(1, Ordering::SeqCst);
+            return sse_response(text_sse(DEEPSEEK_TEST_MODEL, "steering-applied"));
+        }
+        if raw.contains("initial slow turn") {
+            self.initial_requests.fetch_add(1, Ordering::SeqCst);
+            return sse_response(text_sse(DEEPSEEK_TEST_MODEL, "initial-turn-output"))
+                .set_delay(Duration::from_secs(3));
+        }
+        sse_response(text_sse(DEEPSEEK_TEST_MODEL, "unexpected-request"))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn release_queued_steering_ctrl_s_sends_now_with_clear_status() -> Result<()> {
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let server = MockServer::start().await;
+    mount_models(&server, &[DEEPSEEK_TEST_MODEL]).await;
+    let initial_requests = Arc::new(AtomicUsize::new(0));
+    let steer_requests = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(SteeringResponder {
+            initial_requests: Arc::clone(&initial_requests),
+            steer_requests: Arc::clone(&steer_requests),
+        })
+        .mount(&server)
+        .await;
+
+    let ws = make_sealed_workspace()?;
+    let mut tui = common_tui_builder(&ws)
+        .env("CODEWHALE_PROVIDER", "deepseek")
+        .env("DEEPSEEK_API_KEY", "deepseek-local-test-key")
+        .env("DEEPSEEK_BASE_URL", server.uri())
+        .env("DEEPSEEK_MODEL", DEEPSEEK_TEST_MODEL)
+        .spawn()?;
+    tui.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
+
+    type_and_submit(&mut tui, "initial slow turn")?;
+    wait_for_counter(&mut tui, &initial_requests, 1, Duration::from_secs(3))?;
+
+    type_and_tab(&mut tui, "queued steering from ctrl-s")?;
+    tui.wait_for_text("Ctrl+S send now", Duration::from_secs(5))?;
+    assert!(
+        tui.frame().contains("queued steering from ctrl-s"),
+        "queued steering preview was not readable:\n{}",
+        tui.debug_dump()
+    );
+
+    let steer_started = Instant::now();
+    tui.send(b"\x13")?;
+    wait_for_counter(&mut tui, &steer_requests, 1, INTERACTION_TIMEOUT)?;
+    tui.wait_for_text("steering-applied", INTERACTION_TIMEOUT)?;
+    assert!(
+        steer_started.elapsed() < Duration::from_secs(10),
+        "Ctrl+S steering was not incorporated promptly"
+    );
+
+    let _ = tui.shutdown();
+    Ok(())
+}

--- a/crates/tui/tests/release_runtime_qa.rs
+++ b/crates/tui/tests/release_runtime_qa.rs
@@ -69,7 +69,11 @@ fn text_sse(model: &str, text: &str) -> String {
 }
 
 fn fanout_tool_call_sse() -> String {
-    let tool_calls = (1..=6)
+    fanout_tool_call_sse_n(6)
+}
+
+fn fanout_tool_call_sse_n(count: usize) -> String {
+    let tool_calls = (1..=count)
         .map(|worker| {
             json!({
                 "index": worker - 1,
@@ -472,6 +476,144 @@ async fn release_queued_steering_ctrl_s_sends_now_with_clear_status() -> Result<
         steer_started.elapsed() < Duration::from_secs(10),
         "Ctrl+S steering was not incorporated promptly"
     );
+
+    let _ = tui.shutdown();
+    Ok(())
+}
+
+#[derive(Clone)]
+struct BenchFanoutResponder {
+    child_requests: Arc<AtomicUsize>,
+    workers: usize,
+}
+
+impl Respond for BenchFanoutResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body = request.body_json::<Value>().unwrap_or(Value::Null);
+        let raw = body.to_string();
+
+        if raw.contains("stay busy worker") && !raw.contains("launch benchmark QA workers") {
+            self.child_requests.fetch_add(1, Ordering::SeqCst);
+            return sse_response(text_sse(DEEPSEEK_TEST_MODEL, "child-finished-too-soon"))
+                .set_delay(Duration::from_secs(60));
+        }
+
+        if raw.contains("launch benchmark QA workers") {
+            return sse_response(fanout_tool_call_sse_n(self.workers));
+        }
+
+        sse_response(text_sse(DEEPSEEK_TEST_MODEL, "unexpected-request"))
+    }
+}
+
+fn rss_kib(pid: u32) -> Option<u64> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout).trim().parse().ok()
+}
+
+/// #4014 acceptance benchmark: 32 concurrent loopback workers must keep the
+/// TUI live. Ignored by default (heavy storm); run explicitly with
+/// `cargo test -p codewhale-tui --test release_runtime_qa --locked -- \
+///  --ignored bench_thirty_two --nocapture --test-threads=1`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "heavy 32-worker storm; run explicitly for #4014 evidence"]
+async fn release_bench_thirty_two_worker_fanout_stays_live() -> Result<()> {
+    const WORKERS: usize = 32;
+    let _guard = RELEASE_RUNTIME_QA_LOCK.lock().await;
+    let server = MockServer::start().await;
+    mount_models(&server, &[DEEPSEEK_TEST_MODEL]).await;
+    let child_requests = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(BenchFanoutResponder {
+            child_requests: Arc::clone(&child_requests),
+            workers: WORKERS,
+        })
+        .mount(&server)
+        .await;
+
+    let ws = make_sealed_workspace()?;
+    std::fs::write(
+        ws.home().join(".codewhale").join("config.toml"),
+        format!(
+            "[subagents]\nmax_concurrent = {WORKERS}\nlaunch_concurrency = {WORKERS}\nmax_admitted = {WORKERS}\n"
+        ),
+    )?;
+    let mut tui = common_tui_builder(&ws)
+        .env("CODEWHALE_PROVIDER", "deepseek")
+        .env("DEEPSEEK_API_KEY", "deepseek-local-test-key")
+        .env("DEEPSEEK_BASE_URL", server.uri())
+        .env("DEEPSEEK_MODEL", DEEPSEEK_TEST_MODEL)
+        .args(["--yolo", "--max-subagents", &WORKERS.to_string()])
+        .spawn()?;
+    tui.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
+    let pid = tui.pid();
+    let rss_idle = pid.and_then(rss_kib);
+
+    let spawn_started = Instant::now();
+    type_and_submit(
+        &mut tui,
+        "launch benchmark QA workers and keep the parent turn open",
+    )?;
+    wait_for_counter(&mut tui, &child_requests, WORKERS, Duration::from_secs(60))?;
+    let all_children_live = spawn_started.elapsed();
+    tui.wait_for_text(&format!("{WORKERS} running"), Duration::from_secs(10))?;
+    let sidebar_visible = spawn_started.elapsed();
+    let rss_storm = pid.and_then(rss_kib);
+
+    // Echo latency under storm: three samples.
+    let mut echo_samples = Vec::new();
+    for i in 0..3 {
+        let marker = format!("bench-live-marker-{i}");
+        let t = Instant::now();
+        tui.send(keys::key::text(&marker))?;
+        tui.wait_for_text(&marker, Duration::from_secs(5))?;
+        echo_samples.push(t.elapsed());
+        // Clear the composer for the next sample.
+        for _ in 0..marker.len() {
+            tui.send(b"\x7f")?;
+        }
+    }
+
+    let cancel_started = Instant::now();
+    tui.send(b"\x1b")?;
+    tui.wait_for(
+        |frame| {
+            let text = frame.text().to_ascii_lowercase();
+            text.contains("cancelled") || text.contains("interrupted")
+        },
+        Duration::from_secs(10),
+    )?;
+    let cancel_latency = cancel_started.elapsed();
+
+    tui.send(keys::key::text("post-cancel-live"))?;
+    tui.wait_for_text("post-cancel-live", Duration::from_secs(5))?;
+    let rss_after = pid.and_then(rss_kib);
+
+    println!(
+        "BENCH32: children_live={all_children_live:?} sidebar={sidebar_visible:?} \
+         echo={echo_samples:?} cancel={cancel_latency:?} \
+         rss_idle_kib={rss_idle:?} rss_storm_kib={rss_storm:?} rss_after_kib={rss_after:?}"
+    );
+
+    let worst_echo = echo_samples.iter().max().copied().unwrap_or_default();
+    assert!(
+        worst_echo < Duration::from_secs(2),
+        "typing echo exceeded 2s under a {WORKERS}-worker storm: {echo_samples:?}"
+    );
+    assert!(
+        cancel_latency < Duration::from_secs(5),
+        "Esc cancellation exceeded 5s under a {WORKERS}-worker storm: {cancel_latency:?}"
+    );
+    if let (Some(idle), Some(storm)) = (rss_idle, rss_storm) {
+        assert!(
+            storm < idle.saturating_mul(6).max(idle + 1_500_000),
+            "RSS exploded under storm: idle={idle} KiB storm={storm} KiB"
+        );
+    }
 
     let _ = tui.shutdown();
     Ok(())

--- a/crates/tui/tests/support/qa_harness/harness.rs
+++ b/crates/tui/tests/support/qa_harness/harness.rs
@@ -123,6 +123,10 @@ impl Harness {
         HarnessBuilder::new(program)
     }
 
+    pub fn pid(&self) -> Option<u32> {
+        self.pty.pid()
+    }
+
     pub fn send(&mut self, bytes: impl AsRef<[u8]>) -> Result<()> {
         self.pty.write_bytes(bytes.as_ref())
     }

--- a/crates/tui/tests/support/qa_harness/pty.rs
+++ b/crates/tui/tests/support/qa_harness/pty.rs
@@ -155,6 +155,10 @@ impl PtySession {
         PtySessionBuilder::new(program)
     }
 
+    pub fn pid(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
     pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<()> {
         self.writer.write_all(bytes).context("pty write")?;
         self.writer.flush().context("pty flush")?;

--- a/docs/skills/codew-release-qa-sweep/SKILL.md
+++ b/docs/skills/codew-release-qa-sweep/SKILL.md
@@ -37,16 +37,19 @@ cargo test -p codewhale-config -p codewhale-protocol -p codewhale-cli \
 # 3. TUI test binaries, locked
 cargo test -p codewhale-tui --bins --locked
 
-# 4. TUI debug build, locked
+# 4. Real-PTY release runtime QA (sealed HOME + loopback providers)
+cargo test -p codewhale-tui --test release_runtime_qa --locked -- --test-threads=1
+
+# 5. TUI debug build, locked
 cargo build -p codewhale-tui --locked
 
-# 5. Release build for the shipped binaries, locked
+# 6. Release build for the shipped binaries, locked
 cargo build --release --locked -p codewhale-cli -p codewhale-tui
 
-# 6. Version-drift gate (workspace ↔ npm ↔ Cargo.lock ↔ changelog ↔ README)
+# 7. Version-drift gate (workspace ↔ npm ↔ Cargo.lock ↔ changelog ↔ README)
 ./scripts/release/check-versions.sh
 
-# 7. Binary smoke
+# 8. Binary smoke
 ./target/release/codewhale --version
 ```
 
@@ -61,7 +64,12 @@ A PR that is clean against `main` can still conflict with the release branch.
 
 ## Manual QA targets
 
-Automated gates do not cover the live TUI. Exercise all three and record what you saw:
+Unit/build gates do not cover the live TUI. Exercise all three and record what you saw:
+
+The repeatable local baseline is `release_runtime_qa`: it boots real TUI
+processes in pseudo-terminals with sealed homes and loopback mock providers,
+then asserts each scenario below. Run it even when doing a separate hands-on
+visual pass; the test leaves no provider traffic or credentials behind.
 
 1. **Six-worker fanout liveness (#3216/#2211).** Spawn 6 sub-agents. Confirm
    typing, render, cancel, and the sidebar stay live throughout, and that **Esc


### PR DESCRIPTION
## What

Two test-hardening commits from the local v0.8.68 lane, authorship preserved:

- `test(hotbar): isolate configured skill cache` — the hotbar skill activation test now sets `Config.skills_dir` explicitly, matching production startup semantics and preventing a developer's global `~/.agents/skills` from shadowing the temporary fixture.
- `test(release): automate live TUI QA targets` — new `crates/tui/tests/release_runtime_qa.rs` drives the shipped TUI through real pseudo-terminals with sealed homes and loopback providers: six-worker fanout liveness + Esc cancellation (#3216/#2211), concurrent Muse/GPT route isolation (#3227), and queued Ctrl+S steering (#3203). Wired into the release-sweep skill as an explicit gate.

## Why base = codex/v0868-models

The route-isolation scenario drives `CODEWHALE_PROVIDER=meta` / `muse-spark-1.1` and `gpt-5.6-terra`, which only exist with #4311's provider metadata. This PR retargets to main automatically when #4311 merges.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui --locked -- hotbar` → 86 passed
- Release QA suite verified green in the source worktree before split (release_runtime_qa, three PTY scenarios); will re-verify in CI and in the final release sweep.

Part of the v0.8.68 milestone.