### PR TITLE
fix(tui): clear clippy 1.97 lints in test targets

### DIFF
--- a/crates/tui/src/purge.rs
+++ b/crates/tui/src/purge.rs
@@ -861,7 +861,7 @@ mod tests {
         } else {
             panic!(
                 "expected text block, got {:?}",
-                &result.messages[0].content[0]
+                result.messages[0].content[0]
             );
         }
         if let ContentBlock::Text { text, .. } = &result.messages[1].content[0] {
@@ -869,7 +869,7 @@ mod tests {
         } else {
             panic!(
                 "expected text block, got {:?}",
-                &result.messages[1].content[0]
+                result.messages[1].content[0]
             );
         }
     }
@@ -894,7 +894,7 @@ mod tests {
         } else {
             panic!(
                 "expected text block, got {:?}",
-                &result.messages[0].content[0]
+                result.messages[0].content[0]
             );
         }
     }

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -1526,13 +1526,14 @@ mod tests {
 
     /// Explicit animated baseline for env-force tests (#4095 flipped defaults to calm).
     fn animated_settings() -> Settings {
-        let mut s = Settings::default();
-        s.calm_mode = false;
-        s.low_motion = false;
-        s.fancy_animations = true;
-        s.show_tool_details = true;
-        s.transcript_spacing = "comfortable".to_string();
-        s
+        Settings {
+            calm_mode: false,
+            low_motion: false,
+            fancy_animations: true,
+            show_tool_details: true,
+            transcript_spacing: "comfortable".to_string(),
+            ..Settings::default()
+        }
     }
 
     #[test]

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -1616,7 +1616,7 @@ mod tests {
         assert!(
             result.content.contains("Recursive Language Models"),
             "pdf-extract should recover the document title; got prefix {:?}",
-            &result.content.chars().take(200).collect::<String>()
+            result.content.chars().take(200).collect::<String>()
         );
     }
 

--- a/crates/tui/src/tools/skill.rs
+++ b/crates/tui/src/tools/skill.rs
@@ -345,7 +345,7 @@ mod tests {
         assert!(
             result.content.contains("# Skill: from-opencode"),
             "body header missing: {}",
-            &result.content
+            result.content
         );
         assert!(result.content.contains("Body content marker."));
 

--- a/crates/tui/src/tui/transcript.rs
+++ b/crates/tui/src/tui/transcript.rs
@@ -1148,7 +1148,7 @@ mod tests {
 
     #[test]
     fn ensure_filtered_reuses_unchanged_cells() {
-        let cells = vec![
+        let cells = [
             user_cell("hello"),
             assistant_cell("streaming", true),
             user_cell("again"),


### PR DESCRIPTION
Re-opened continuation of #4321 (auto-closed when its stacked base branch was deleted after #4312 merged).

The release parity gate runs `--all-targets`, which surfaces seven more Rust 1.97 lint errors in test code beyond #4312's two fixes: redundant references in `panic!`/`assert!` args (`purge.rs` ×3, `tools/file.rs`, `tools/skill.rs`), `field_reassign_with_default` in `settings.rs`, and a useless `vec!` in `transcript.rs`.

Verified locally: `cargo clippy --workspace --all-targets --all-features --locked` with the repo's `-D/-A` set exits **0** under rustc 1.97.0 on this branch — the release-gate clippy is fully green.

Supersedes local-lane commit `63f0b91d9` (its target files are already clean on main). Part of the v0.8.68 milestone.