### PR TITLE
fix(pricing): apply 2026-07-09 pricing freshness audit (Parts A-C)

### DIFF
--- a/crates/config/assets/models_dev.bundled.json
+++ b/crates/config/assets/models_dev.bundled.json
@@ -4,7 +4,7 @@
     "schema": "Matches crates/config/src/models_dev.rs ModelsDevCatalog ({ models, providers }).",
     "role": "NOT a competing source of truth. Preferred metadata is the live Models.dev catalog published into ProviderLake (#4187). This asset is used only when live/cache rows are unavailable (offline startup, failed refresh, or empty cache).",
     "source": "Compact offline seed of verified in-repo defaults (context/output from crates/tui/src/models.rs; USD pricing from crates/tui/src/pricing.rs) for providers CodeWhale ships with. It is intentionally smaller than a full Models.dev dump; live refresh supersedes these rows on (provider, wire_model_id) identity.",
-    "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), Anthropic rows (no in-repo per-token table), and Xiaomi MiMo Token-Plan rows (credit/quota based). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
+    "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), and Xiaomi MiMo rows (published PAYG rates apply only to sk- pay-as-you-go keys; the catalog cannot distinguish that billing surface from credit/quota Token Plan keys, so MiMo stays unpriced). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
     "default_rows": "Each provider's `default: true` wire id equals that provider's built-in DEFAULT_*_MODEL so RouteResolver::new() and the descriptor stay in agreement when offline.",
     "coverage": "14 providers, 38 chat offerings (offline seed only)."
   },
@@ -77,7 +77,8 @@
           "reasoning_options": [{ "type": "effort", "values": ["high", "max"] }],
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "limit": { "context": 1000000, "output": 131072 }
+          "limit": { "context": 1000000, "output": 131072 },
+          "cost": { "input": 1.40, "output": 4.40, "cache_read": 0.26 }
         },
         "glm-5.1": {
           "id": "glm-5.1",
@@ -87,7 +88,7 @@
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 202752, "output": 131072 },
-          "cost": { "input": 0.98, "output": 3.08, "cache_read": 0.182 }
+          "cost": { "input": 1.40, "output": 4.40, "cache_read": 0.26 }
         },
         "GLM-5-Turbo": {
           "id": "GLM-5-Turbo",
@@ -96,7 +97,8 @@
           "reasoning": true,
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "limit": { "context": 202752, "output": 131072 }
+          "limit": { "context": 202752, "output": 131072 },
+          "cost": { "input": 1.20, "output": 4.00, "cache_read": 0.24 }
         }
       }
     },
@@ -115,7 +117,8 @@
           "reasoning": true,
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "limit": { "context": 262144, "output": 262144 }
+          "limit": { "context": 262144, "output": 262144 },
+          "cost": { "input": 0.95, "output": 4.00, "cache_read": 0.19 }
         },
         "kimi-k2.6": {
           "id": "kimi-k2.6",
@@ -125,7 +128,7 @@
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 262144, "output": 262144 },
-          "cost": { "input": 0.68, "output": 3.41, "cache_read": 0.34 }
+          "cost": { "input": 0.95, "output": 4.00, "cache_read": 0.16 }
         }
       }
     },
@@ -288,7 +291,8 @@
           "reasoning": true,
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "limit": { "context": 1000000, "output": 64000 }
+          "limit": { "context": 1000000, "output": 128000 },
+          "cost": { "input": 3.00, "output": 15.00, "cache_read": 0.30, "cache_write": 3.75 }
         },
         "claude-opus-4-8": {
           "id": "claude-opus-4-8",
@@ -297,7 +301,8 @@
           "reasoning": true,
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "limit": { "context": 1000000, "output": 128000 }
+          "limit": { "context": 1000000, "output": 128000 },
+          "cost": { "input": 5.00, "output": 25.00, "cache_read": 0.50, "cache_write": 6.25 }
         },
         "claude-haiku-4-5": {
           "id": "claude-haiku-4-5",
@@ -306,7 +311,8 @@
           "reasoning": true,
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
-          "limit": { "context": 200000, "output": 64000 }
+          "limit": { "context": 200000, "output": 64000 },
+          "cost": { "input": 1.00, "output": 5.00, "cache_read": 0.10, "cache_write": 1.25 }
         }
       }
     },
@@ -366,7 +372,7 @@
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 262144, "output": 262140 },
-          "cost": { "input": 0.15, "output": 1.00, "cache_read": 0.05 }
+          "cost": { "input": 0.14, "output": 1.00, "cache_read": 0.05 }
         },
         "minimax/minimax-m3": {
           "id": "minimax/minimax-m3",
@@ -442,7 +448,7 @@
     "novita": {
       "id": "novita",
       "name": "Novita AI",
-      "api": "https://api.novita.ai/v3/openai",
+      "api": "https://api.novita.ai/openai/v1",
       "npm": "@ai-sdk/openai-compatible",
       "env": ["NOVITA_API_KEY"],
       "models": {
@@ -515,7 +521,7 @@
           "tool_call": true,
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 262144, "output": 262144 },
-          "cost": { "input": 0.22, "output": 0.85, "cache_read": 0.06 }
+          "cost": { "input": 0.25, "output": 0.80 }
         },
         "trinity-mini": {
           "id": "trinity-mini",

--- a/crates/config/assets/models_dev.bundled.json
+++ b/crates/config/assets/models_dev.bundled.json
@@ -6,7 +6,7 @@
     "source": "Compact offline seed of verified in-repo defaults (context/output from crates/tui/src/models.rs; USD pricing from crates/tui/src/pricing.rs) for providers CodeWhale ships with. It is intentionally smaller than a full Models.dev dump; live refresh supersedes these rows on (provider, wire_model_id) identity.",
     "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), and Xiaomi MiMo rows (published PAYG rates apply only to sk- pay-as-you-go keys; the catalog cannot distinguish that billing surface from credit/quota Token Plan keys, so MiMo stays unpriced). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
     "default_rows": "Each provider's `default: true` wire id equals that provider's built-in DEFAULT_*_MODEL so RouteResolver::new() and the descriptor stay in agreement when offline.",
-    "coverage": "14 providers, 38 chat offerings (offline seed only)."
+    "coverage": "14 providers, 42 chat offerings (offline seed only)."
   },
   "models": {
     "deepseek-v4-pro": {
@@ -273,6 +273,16 @@
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "limit": { "context": 1050000, "input": 922000, "output": 128000 },
           "cost": { "input": 1.00, "output": 6.00, "cache_read": 0.10, "cache_write": 1.25 }
+        },
+        "gpt-5.3-codex": {
+          "id": "gpt-5.3-codex",
+          "name": "GPT-5.3 Codex",
+          "family": "gpt-codex",
+          "reasoning": true,
+          "tool_call": true,
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "limit": { "context": 400000, "output": 128000 },
+          "cost": { "input": 1.75, "output": 14.00, "cache_read": 0.175 }
         }
       }
     },
@@ -313,6 +323,26 @@
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 200000, "output": 64000 },
           "cost": { "input": 1.00, "output": 5.00, "cache_read": 0.10, "cache_write": 1.25 }
+        },
+        "claude-sonnet-5": {
+          "id": "claude-sonnet-5",
+          "name": "Claude Sonnet 5",
+          "family": "claude",
+          "reasoning": true,
+          "tool_call": true,
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "limit": { "context": 1000000, "output": 128000 },
+          "cost": { "input": 3.00, "output": 15.00, "cache_read": 0.30 }
+        },
+        "claude-fable-5": {
+          "id": "claude-fable-5",
+          "name": "Claude Fable 5",
+          "family": "claude",
+          "reasoning": true,
+          "tool_call": true,
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "limit": { "context": 1000000, "output": 128000 },
+          "cost": { "input": 10.00, "output": 50.00, "cache_read": 1.00, "cache_write": 12.50 }
         }
       }
     },
@@ -373,6 +403,15 @@
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 262144, "output": 262140 },
           "cost": { "input": 0.14, "output": 1.00, "cache_read": 0.05 }
+        },
+        "qwen/qwen3.7-plus": {
+          "id": "qwen/qwen3.7-plus",
+          "name": "Qwen3.7 Plus",
+          "family": "qwen",
+          "reasoning": true,
+          "tool_call": true,
+          "modalities": { "input": ["text"], "output": ["text"] },
+          "cost": { "input": 0.32, "output": 1.28, "cache_read": 0.064, "cache_write": 0.40 }
         },
         "minimax/minimax-m3": {
           "id": "minimax/minimax-m3",

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -622,11 +622,13 @@ fn bundled_asset_pricing_is_honest() {
         }
     }
 
-    // A sampled priced row matches the in-repo USD table (crates/tui pricing).
+    // A sampled priced row matches the in-repo USD table (crates/tui pricing):
+    // GLM-5.1 at the 2026-07-09 Z.ai published rates.
     let glm51 = find(&rows, "zai", "glm-5.1");
     let cost = glm51.cost.as_ref().expect("glm-5.1 is priced");
-    assert_eq!(cost.input, Some(0.98));
-    assert_eq!(cost.output, Some(3.08));
+    assert_eq!(cost.input, Some(1.40));
+    assert_eq!(cost.output, Some(4.40));
+    assert_eq!(cost.cache_read, Some(0.26));
 }
 
 #[test]

--- a/crates/tui/assets/model_catalog.bundled.json
+++ b/crates/tui/assets/model_catalog.bundled.json
@@ -27,6 +27,8 @@
       "context_window": 400000,
       "max_output": 128000,
       "supports_reasoning": true,
+      "input_usd_per_million": 1.25,
+      "output_usd_per_million": 10.0,
       "modalities": ["text"],
       "supported_parameters": ["reasoning"],
       "provenance": "bundled"
@@ -206,7 +208,7 @@
     "claude-sonnet-4-6": {
       "id": "claude-sonnet-4-6",
       "context_window": 1000000,
-      "max_output": 64000,
+      "max_output": 128000,
       "supports_reasoning": true,
       "input_usd_per_million": 3.0,
       "output_usd_per_million": 15.0,
@@ -228,7 +230,7 @@
     "step-3.7-flash": {
       "id": "step-3.7-flash",
       "context_window": 256000,
-      "max_output": 32000,
+      "max_output": 256000,
       "supports_reasoning": false,
       "input_usd_per_million": 0.2,
       "output_usd_per_million": 1.15,
@@ -238,8 +240,8 @@
     },
     "fugu-ultra-20260615": {
       "id": "fugu-ultra-20260615",
-      "context_window": 200000,
-      "max_output": 64000,
+      "context_window": 1000000,
+      "max_output": 131000,
       "supports_reasoning": true,
       "input_usd_per_million": 5.0,
       "output_usd_per_million": 30.0,
@@ -249,8 +251,8 @@
     },
     "fugu-ultra": {
       "id": "fugu-ultra",
-      "context_window": 200000,
-      "max_output": 64000,
+      "context_window": 1000000,
+      "max_output": 131000,
       "supports_reasoning": true,
       "input_usd_per_million": 5.0,
       "output_usd_per_million": 30.0,

--- a/crates/tui/assets/model_catalog.bundled.json
+++ b/crates/tui/assets/model_catalog.bundled.json
@@ -33,6 +33,17 @@
       "supported_parameters": ["reasoning"],
       "provenance": "bundled"
     },
+    "gpt-5.3-codex": {
+      "id": "gpt-5.3-codex",
+      "context_window": 400000,
+      "max_output": 128000,
+      "supports_reasoning": true,
+      "input_usd_per_million": 1.75,
+      "output_usd_per_million": 14.0,
+      "modalities": ["text"],
+      "supported_parameters": ["reasoning"],
+      "provenance": "bundled"
+    },
     "gpt-5.6": {
       "id": "gpt-5.6",
       "context_window": 1050000,
@@ -201,6 +212,28 @@
       "supports_reasoning": true,
       "input_usd_per_million": 5.0,
       "output_usd_per_million": 25.0,
+      "modalities": ["text"],
+      "supported_parameters": ["reasoning"],
+      "provenance": "bundled"
+    },
+    "claude-sonnet-5": {
+      "id": "claude-sonnet-5",
+      "context_window": 1000000,
+      "max_output": 128000,
+      "supports_reasoning": true,
+      "input_usd_per_million": 3.0,
+      "output_usd_per_million": 15.0,
+      "modalities": ["text"],
+      "supported_parameters": ["reasoning"],
+      "provenance": "bundled"
+    },
+    "claude-fable-5": {
+      "id": "claude-fable-5",
+      "context_window": 1000000,
+      "max_output": 128000,
+      "supports_reasoning": true,
+      "input_usd_per_million": 10.0,
+      "output_usd_per_million": 50.0,
       "modalities": ["text"],
       "supported_parameters": ["reasoning"],
       "provenance": "bundled"

--- a/crates/tui/src/model_registry.rs
+++ b/crates/tui/src/model_registry.rs
@@ -134,6 +134,8 @@ const SEED_MODEL_IDS: &[(&str, ModelProvider)] = &[
     // --- Anthropic (config DEFAULT_ANTHROPIC_MODEL + models.rs rows) ---
     ("claude-opus-4-8", ModelProvider::Anthropic),
     ("claude-sonnet-4-6", ModelProvider::Anthropic),
+    ("claude-sonnet-5", ModelProvider::Anthropic),
+    ("claude-fable-5", ModelProvider::Anthropic),
     ("claude-haiku-4-5", ModelProvider::Anthropic),
     // --- OpenAI public API + Codex (config DEFAULT_OPENAI_CODEX_MODEL) ---
     ("gpt-5.5", ModelProvider::OpenAi),
@@ -264,6 +266,8 @@ mod tests {
             ("deepseek-coder:1.3b", Some(128_000)),
             ("claude-opus-4-8", Some(1_000_000)),
             ("claude-sonnet-4-6", Some(1_000_000)),
+            ("claude-sonnet-5", Some(1_000_000)),
+            ("claude-fable-5", Some(1_000_000)),
             ("claude-haiku-4-5", Some(200_000)),
             ("gpt-5.5", Some(1_050_000)),
             ("gpt-5.6", Some(1_050_000)),

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -350,8 +350,11 @@ pub fn max_output_tokens_for_model(model: &str) -> Option<u32> {
     }
     match lower.as_str() {
         "gpt-5-codex" | "gpt-5.3-codex" => Some(128_000),
-        "claude-opus-4-8" => Some(128_000),
-        "claude-sonnet-4-6" | "claude-haiku-4-5" => Some(64_000),
+        // claude-sonnet-4-6 max output raised 64K -> 128K per
+        // https://platform.claude.com/docs/en/about-claude/models/overview
+        // (2026-07-09 audit).
+        "claude-opus-4-8" | "claude-sonnet-4-6" => Some(128_000),
+        "claude-haiku-4-5" => Some(64_000),
         "arcee-ai/trinity-large-thinking"
         | "trinity-large-thinking"
         | "moonshotai/kimi-k2.7-code"
@@ -776,6 +779,33 @@ mod tests {
         assert_eq!(context_window_for_model("gpt-5.5-nano"), None);
         assert_eq!(max_output_tokens_for_model("gpt-5.5-nano"), None);
         assert!(!model_supports_reasoning("gpt-5.5-nano"));
+    }
+
+    #[test]
+    fn anthropic_stepfun_and_sakana_limits_match_2026_07_09_audit() {
+        // Sonnet 4.6 output cap raised 64K -> 128K per
+        // https://platform.claude.com/docs/en/about-claude/models/overview;
+        // Haiku stays at 64K.
+        assert_eq!(
+            max_output_tokens_for_model("claude-sonnet-4-6"),
+            Some(128_000)
+        );
+        assert_eq!(
+            max_output_tokens_for_model("claude-haiku-4-5"),
+            Some(64_000)
+        );
+        // step-3.7-flash max output is third-party sourced (models.dev +
+        // Artificial Analysis; the official StepFun page is silent):
+        // https://models.dev/models/stepfun/step-3.7-flash/
+        assert_eq!(max_output_tokens_for_model("step-3.7-flash"), Some(256_000));
+        assert_eq!(context_window_for_model("step-3.7-flash"), Some(256_000));
+        // fugu-ultra limits are third-party sourced (Requesty; Sakana's own
+        // >272K price tier at https://console.sakana.ai/pricing confirms the
+        // context window exceeds 272K).
+        for model in ["fugu-ultra", "fugu-ultra-20260615"] {
+            assert_eq!(context_window_for_model(model), Some(1_000_000), "{model}");
+            assert_eq!(max_output_tokens_for_model(model), Some(131_000), "{model}");
+        }
     }
 
     #[test]

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -275,7 +275,9 @@ fn known_context_window_for_model(model_lower: &str) -> Option<u32> {
         // https://developers.openai.com/api/docs/models/gpt-5.3-codex
         "gpt-5-codex" | "gpt-5.3-codex" => Some(400_000),
         // Anthropic 4.6+ models carry a 1M window; Haiku stays at 200K (#3014).
-        "claude-opus-4-8" | "claude-sonnet-4-6" => Some(1_000_000),
+        "claude-opus-4-8" | "claude-sonnet-4-6" | "claude-sonnet-5" | "claude-fable-5" => {
+            Some(1_000_000)
+        }
         "claude-haiku-4-5" => Some(200_000),
         "trinity-mini" => Some(128_000),
         "arcee-ai/trinity-large-thinking" | "trinity-large-thinking" | "trinity-large-preview" => {
@@ -353,7 +355,9 @@ pub fn max_output_tokens_for_model(model: &str) -> Option<u32> {
         // claude-sonnet-4-6 max output raised 64K -> 128K per
         // https://platform.claude.com/docs/en/about-claude/models/overview
         // (2026-07-09 audit).
-        "claude-opus-4-8" | "claude-sonnet-4-6" => Some(128_000),
+        "claude-opus-4-8" | "claude-sonnet-4-6" | "claude-sonnet-5" | "claude-fable-5" => {
+            Some(128_000)
+        }
         "claude-haiku-4-5" => Some(64_000),
         "arcee-ai/trinity-large-thinking"
         | "trinity-large-thinking"
@@ -406,6 +410,8 @@ pub fn model_supports_reasoning(model: &str) -> bool {
         lower.as_str(),
         "claude-opus-4-8"
             | "claude-sonnet-4-6"
+            | "claude-sonnet-5"
+            | "claude-fable-5"
             | "gpt-5-codex"
             | "gpt-5.3-codex"
             | "arcee-ai/trinity-large-thinking"
@@ -805,6 +811,17 @@ mod tests {
         for model in ["fugu-ultra", "fugu-ultra-20260615"] {
             assert_eq!(context_window_for_model(model), Some(1_000_000), "{model}");
             assert_eq!(max_output_tokens_for_model(model), Some(131_000), "{model}");
+        }
+    }
+
+    #[test]
+    fn claude_fable_5_and_sonnet_5_have_verified_metadata() {
+        // 1M context / 128K output per
+        // https://platform.claude.com/docs/en/about-claude/pricing (2026-07-09).
+        for model in ["claude-fable-5", "claude-sonnet-5"] {
+            assert_eq!(context_window_for_model(model), Some(1_000_000), "{model}");
+            assert_eq!(max_output_tokens_for_model(model), Some(128_000), "{model}");
+            assert!(model_supports_reasoning(model), "{model}");
         }
     }
 

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -153,6 +153,25 @@ fn known_pricing_for_model(model_lower: &str) -> Option<ModelPricing> {
         "openai/gpt-5.6-terra" | "gpt-5.6-terra" => Some(usd_only_pricing(0.25, 2.50, 15.00)),
         "openai/gpt-5.6-luna" | "gpt-5.6-luna" => Some(usd_only_pricing(0.10, 1.00, 6.00)),
         "meta/muse-spark-1.1" | "muse-spark-1.1" => Some(usd_only_pricing(1.25, 1.25, 4.25)),
+        // Anthropic first-party rates including the published cache-read
+        // discounts (2026-07-09 audit,
+        // https://platform.claude.com/docs/en/about-claude/pricing). These sit
+        // above the catalog lookup because the bundled catalog cannot carry a
+        // cache-read rate yet. Cache-write rates (1.25x-2x input) exist
+        // upstream but `CurrencyPricing` has no cache-write field.
+        "claude-opus-4-8" => Some(usd_only_pricing(0.50, 5.00, 25.00)),
+        "claude-sonnet-4-6" => Some(usd_only_pricing(0.30, 3.00, 15.00)),
+        "claude-haiku-4-5" => Some(usd_only_pricing(0.10, 1.00, 5.00)),
+        // Z.ai GLM-5.2 cache-read rate per https://docs.z.ai/guides/overview/pricing
+        // (cache storage limited-time free).
+        "z-ai/glm-5.2" | "glm-5.2" => Some(usd_only_pricing(0.26, 1.40, 4.40)),
+        // Moonshot K2.7 Code cache-read rate per
+        // https://platform.kimi.ai/docs/pricing/chat-k27-code
+        "moonshotai/kimi-k2.7-code" | "kimi-k2.7-code" => Some(usd_only_pricing(0.19, 0.95, 4.00)),
+        // gpt-5-codex is deprecated upstream on the ChatGPT-OAuth path
+        // (successor: gpt-5.3-codex); API usage is still billed at these rates.
+        // https://developers.openai.com/api/docs/models/gpt-5.3-codex
+        "openai/gpt-5-codex" | "gpt-5-codex" => Some(usd_only_pricing(0.125, 1.25, 10.00)),
         _ => None,
     };
     if explicit.is_some() {
@@ -168,19 +187,27 @@ fn known_pricing_for_model(model_lower: &str) -> Option<ModelPricing> {
         ));
     }
     match model_lower {
-        "moonshotai/kimi-k2.6" | "kimi-k2.6" => Some(usd_only_pricing(0.34, 0.68, 3.41)),
-        "z-ai/glm-5.1" | "glm-5.1" => Some(usd_only_pricing(0.182, 0.98, 3.08)),
+        "moonshotai/kimi-k2.6" | "kimi-k2.6" => Some(usd_only_pricing(0.16, 0.95, 4.00)),
+        "z-ai/glm-5.1" | "glm-5.1" => Some(usd_only_pricing(0.26, 1.40, 4.40)),
+        // GLM-5 Turbo pricing per https://docs.z.ai/guides/overview/pricing
+        "z-ai/glm-5-turbo" | "glm-5-turbo" => Some(usd_only_pricing(0.24, 1.20, 4.00)),
         "minimax/minimax-m3" | "minimax-m3" => Some(usd_only_pricing(0.06, 0.30, 1.20)),
+        // Arcee publishes no cache rate for Trinity Large Thinking, so the
+        // cache-hit rate equals the input rate (no-discount representation).
+        // https://docs.arcee.ai/get-started/pricing
         "arcee-ai/trinity-large-thinking" | "trinity-large-thinking" => {
-            Some(usd_only_pricing(0.06, 0.22, 0.85))
+            Some(usd_only_pricing(0.25, 0.25, 0.80))
         }
         "openai/gpt-5.5" | "gpt-5.5" => Some(usd_only_pricing(0.50, 5.00, 30.00)),
+        // GPT-5.5 Pro does not offer a cached input discount, so the cache-hit
+        // rate equals the input rate.
+        // https://developers.openai.com/api/docs/models/gpt-5.5-pro
         "openai/gpt-5.5-pro" | "gpt-5.5-pro" => Some(usd_only_pricing(30.00, 30.00, 180.00)),
 
         "qwen/qwen3.6-flash" => Some(usd_only_pricing(0.1875, 0.1875, 1.125)),
-        "qwen/qwen3.6-35b-a3b" => Some(usd_only_pricing(0.05, 0.15, 1.00)),
+        "qwen/qwen3.6-35b-a3b" => Some(usd_only_pricing(0.05, 0.14, 1.00)),
         "qwen/qwen3.6-max-preview" => Some(usd_only_pricing(1.04, 1.04, 6.24)),
-        "qwen/qwen3.6-27b" => Some(usd_only_pricing(0.2885, 0.2885, 3.17)),
+        "qwen/qwen3.6-27b" => Some(usd_only_pricing(0.15, 0.285, 2.40)),
         "qwen/qwen3.6-plus" => Some(usd_only_pricing(0.325, 0.325, 1.95)),
         "qwen/qwen3.7-max" => Some(usd_only_pricing(0.25, 1.25, 3.75)),
 
@@ -188,7 +215,7 @@ fn known_pricing_for_model(model_lower: &str) -> Option<ModelPricing> {
         "google/gemma-4-26b-a4b-it" => Some(usd_only_pricing(0.06, 0.06, 0.33)),
         "tencent/hy3-preview" => Some(usd_only_pricing(0.021, 0.063, 0.21)),
         "nvidia/nemotron-3-ultra-550b-a55b" | "nvidia/nemotron-3-ultra" => {
-            Some(usd_only_pricing(0.15, 0.50, 2.50))
+            Some(usd_only_pricing(0.10, 0.50, 2.20))
         }
         _ => None,
     }
@@ -388,17 +415,10 @@ mod tests {
     #[test]
     fn catalog_sourced_models_have_usd_pricing() {
         for (model, input, output) in [
-            ("glm-5.2", 1.4, 4.4),
-            ("z-ai/glm-5.2", 1.4, 4.4),
-            ("kimi-k2.7-code", 0.95, 4.0),
-            ("moonshotai/kimi-k2.7-code", 0.95, 4.0),
             ("minimax-m2.7", 0.3, 1.2),
             ("minimax/minimax-m2.7", 0.3, 1.2),
             ("trinity-mini", 0.045, 0.15),
             ("arcee-ai/trinity-mini", 0.045, 0.15),
-            ("claude-opus-4-8", 5.0, 25.0),
-            ("claude-sonnet-4-6", 3.0, 15.0),
-            ("claude-haiku-4-5", 1.0, 5.0),
             ("step-3.7-flash", 0.2, 1.15),
             ("fugu-ultra-20260615", 5.0, 30.0),
             ("fugu-ultra", 5.0, 30.0),
@@ -420,14 +440,30 @@ mod tests {
             ..Default::default()
         };
         for (model, hit, miss, output) in [
-            ("kimi-k2.6", 0.34, 0.68, 3.41),
-            ("z-ai/glm-5.1", 0.182, 0.98, 3.08),
+            ("kimi-k2.6", 0.16, 0.95, 4.00),
+            ("kimi-k2.7-code", 0.19, 0.95, 4.00),
+            ("moonshotai/kimi-k2.7-code", 0.19, 0.95, 4.00),
+            ("z-ai/glm-5.1", 0.26, 1.40, 4.40),
+            ("glm-5.2", 0.26, 1.40, 4.40),
+            ("z-ai/glm-5.2", 0.26, 1.40, 4.40),
+            ("glm-5-turbo", 0.24, 1.20, 4.00),
+            ("z-ai/glm-5-turbo", 0.24, 1.20, 4.00),
             ("qwen/qwen3.6-plus", 0.325, 0.325, 1.95),
-            ("trinity-large-thinking", 0.06, 0.22, 0.85),
+            ("qwen/qwen3.6-35b-a3b", 0.05, 0.14, 1.00),
+            ("qwen/qwen3.6-27b", 0.15, 0.285, 2.40),
+            // No published cache rate: cache-hit billed at the input rate.
+            ("trinity-large-thinking", 0.25, 0.25, 0.80),
+            ("nvidia/nemotron-3-ultra-550b-a55b", 0.10, 0.50, 2.20),
+            ("claude-opus-4-8", 0.50, 5.00, 25.00),
+            ("claude-sonnet-4-6", 0.30, 3.00, 15.00),
+            ("claude-haiku-4-5", 0.10, 1.00, 5.00),
             ("gpt-5.5", 0.50, 5.00, 30.00),
+            // GPT-5.5 Pro has no cached-input discount: cache-hit == input.
+            ("gpt-5.5-pro", 30.00, 30.00, 180.00),
             ("gpt-5.6-sol", 0.50, 5.00, 30.00),
             ("gpt-5.6-terra", 0.25, 2.50, 15.00),
             ("gpt-5.6-luna", 0.10, 1.00, 6.00),
+            ("gpt-5-codex", 0.125, 1.25, 10.00),
             ("muse-spark-1.1", 1.25, 1.25, 4.25),
         ] {
             let pricing = pricing_for_model_at(model, Utc::now()).expect(model);

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -5,9 +5,7 @@
 //! Plan usage is credit/quota based and is intentionally left unknown until a
 //! reliable balance endpoint exists.
 
-#[cfg(test)]
-use chrono::TimeZone;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use codewhale_config::pricing::TokenUsage;
 
 use crate::config::ApiProvider;
@@ -121,12 +119,18 @@ pub fn has_pricing_for_model(model: &str) -> bool {
     pricing_for_model(model).is_some()
 }
 
-fn pricing_for_model_at(model: &str, _now: DateTime<Utc>) -> Option<ModelPricing> {
+fn pricing_for_model_at(model: &str, now: DateTime<Utc>) -> Option<ModelPricing> {
     let lower = model.to_lowercase();
     if lower.starts_with("deepseek-ai/") {
         // NVIDIA NIM-hosted DeepSeek uses NVIDIA's catalog/account terms, not
         // DeepSeek Platform pricing. Avoid showing misleading DeepSeek costs.
         return None;
+    }
+    if lower == "claude-sonnet-5" {
+        // Time-aware introductory pricing; resolved ahead of the catalog so
+        // the intro rate is honored while it lasts (same pattern as
+        // deepseek_v4_pro_pricing() / #2489).
+        return Some(claude_sonnet_5_pricing(now));
     }
     if let Some(pricing) = known_pricing_for_model(&lower) {
         return Some(pricing);
@@ -162,6 +166,11 @@ fn known_pricing_for_model(model_lower: &str) -> Option<ModelPricing> {
         "claude-opus-4-8" => Some(usd_only_pricing(0.50, 5.00, 25.00)),
         "claude-sonnet-4-6" => Some(usd_only_pricing(0.30, 3.00, 15.00)),
         "claude-haiku-4-5" => Some(usd_only_pricing(0.10, 1.00, 5.00)),
+        // Claude Fable 5 (GA 2026-06-09). Its newer tokenizer produces ~30%
+        // more tokens for the same text than prior Claude models, so raw
+        // per-token rate comparisons against other Claude rows undercount its
+        // effective cost. Cache-write is 12.50 (5m) / 20.00 (1h) upstream.
+        "claude-fable-5" => Some(usd_only_pricing(1.00, 10.00, 50.00)),
         // Z.ai GLM-5.2 cache-read rate per https://docs.z.ai/guides/overview/pricing
         // (cache storage limited-time free).
         "z-ai/glm-5.2" | "glm-5.2" => Some(usd_only_pricing(0.26, 1.40, 4.40)),
@@ -172,6 +181,7 @@ fn known_pricing_for_model(model_lower: &str) -> Option<ModelPricing> {
         // (successor: gpt-5.3-codex); API usage is still billed at these rates.
         // https://developers.openai.com/api/docs/models/gpt-5.3-codex
         "openai/gpt-5-codex" | "gpt-5-codex" => Some(usd_only_pricing(0.125, 1.25, 10.00)),
+        "openai/gpt-5.3-codex" | "gpt-5.3-codex" => Some(usd_only_pricing(0.175, 1.75, 14.00)),
         _ => None,
     };
     if explicit.is_some() {
@@ -209,6 +219,8 @@ fn known_pricing_for_model(model_lower: &str) -> Option<ModelPricing> {
         "qwen/qwen3.6-max-preview" => Some(usd_only_pricing(1.04, 1.04, 6.24)),
         "qwen/qwen3.6-27b" => Some(usd_only_pricing(0.15, 0.285, 2.40)),
         "qwen/qwen3.6-plus" => Some(usd_only_pricing(0.325, 0.325, 1.95)),
+        // Cache-write is 0.40 upstream; CurrencyPricing has no cache-write field.
+        "qwen/qwen3.7-plus" => Some(usd_only_pricing(0.064, 0.32, 1.28)),
         "qwen/qwen3.7-max" => Some(usd_only_pricing(0.25, 1.25, 3.75)),
 
         "google/gemma-4-31b-it" => Some(usd_only_pricing(0.09, 0.12, 0.35)),
@@ -233,6 +245,21 @@ fn usd_only_pricing(
             output_per_million,
         },
         cny: None,
+    }
+}
+
+/// Claude Sonnet 5 pricing (https://platform.claude.com/docs/en/about-claude/pricing):
+/// introductory 2.00 / 10.00 (cache-read 0.20) through 2026-08-31 UTC, then
+/// the standard 3.00 / 15.00 (cache-read 0.30).
+fn claude_sonnet_5_pricing(now: DateTime<Utc>) -> ModelPricing {
+    let intro_ends = Utc
+        .with_ymd_and_hms(2026, 9, 1, 0, 0, 0)
+        .single()
+        .expect("valid intro-pricing cutoff");
+    if now < intro_ends {
+        usd_only_pricing(0.20, 2.00, 10.00)
+    } else {
+        usd_only_pricing(0.30, 3.00, 15.00)
     }
 }
 
@@ -457,6 +484,7 @@ mod tests {
             ("claude-opus-4-8", 0.50, 5.00, 25.00),
             ("claude-sonnet-4-6", 0.30, 3.00, 15.00),
             ("claude-haiku-4-5", 0.10, 1.00, 5.00),
+            ("claude-fable-5", 1.00, 10.00, 50.00),
             ("gpt-5.5", 0.50, 5.00, 30.00),
             // GPT-5.5 Pro has no cached-input discount: cache-hit == input.
             ("gpt-5.5-pro", 30.00, 30.00, 180.00),
@@ -464,6 +492,8 @@ mod tests {
             ("gpt-5.6-terra", 0.25, 2.50, 15.00),
             ("gpt-5.6-luna", 0.10, 1.00, 6.00),
             ("gpt-5-codex", 0.125, 1.25, 10.00),
+            ("gpt-5.3-codex", 0.175, 1.75, 14.00),
+            ("qwen/qwen3.7-plus", 0.064, 0.32, 1.28),
             ("muse-spark-1.1", 1.25, 1.25, 4.25),
         ] {
             let pricing = pricing_for_model_at(model, Utc::now()).expect(model);
@@ -575,6 +605,32 @@ mod tests {
         assert_eq!(pricing.usd.input_cache_miss_per_million, 0.25);
         assert_eq!(pricing.usd.output_per_million, 1.25);
         assert!(pricing.cny.is_none());
+    }
+
+    #[test]
+    fn sonnet_5_uses_intro_pricing_before_2026_08_31_expiry() {
+        let before_expiry = Utc
+            .with_ymd_and_hms(2026, 8, 31, 23, 59, 59)
+            .single()
+            .unwrap();
+        let pricing = pricing_for_model_at("claude-sonnet-5", before_expiry).unwrap();
+
+        assert_eq!(pricing.usd.input_cache_hit_per_million, 0.20);
+        assert_eq!(pricing.usd.input_cache_miss_per_million, 2.00);
+        assert_eq!(pricing.usd.output_per_million, 10.00);
+        assert!(pricing.cny.is_none());
+    }
+
+    #[test]
+    fn sonnet_5_uses_standard_pricing_after_intro_window() {
+        let after_expiry = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).single().unwrap();
+        let pricing = pricing_for_model_at("claude-sonnet-5", after_expiry).unwrap();
+
+        assert_eq!(pricing.usd.input_cache_hit_per_million, 0.30);
+        assert_eq!(pricing.usd.input_cache_miss_per_million, 3.00);
+        assert_eq!(pricing.usd.output_per_million, 15.00);
+        assert!(pricing.cny.is_none());
+        assert!(has_pricing_for_model("claude-sonnet-5"));
     }
 
     #[test]

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -571,7 +571,9 @@ fn cny_cache_savings_falls_back_to_usd_for_usd_only_models() {
     app.model = "kimi-k2.6".to_string();
     app.session.last_prompt_cache_hit_tokens = Some(1_000_000);
 
-    assert_eq!(app.last_turn_cache_savings(), Some(0.34));
+    // 1M cache-hit tokens save (input 0.95 - cache-read 0.16) = $0.79.
+    let savings = app.last_turn_cache_savings().expect("kimi-k2.6 is priced");
+    assert!((savings - 0.79).abs() < 1e-9, "got {savings}");
 }
 
 #[test]


### PR DESCRIPTION
## What

Applies `PRICING_FRESHNESS_HANDOFF_2026-07-09.md` (multi-agent audit verified against official provider pages + the OpenRouter public models API) as two data-fix commits:

**Parts A+B — corrections and published gaps** ([details in commit](../commits)): glm-5.1 → 1.40/4.40/cache 0.26; kimi-k2.6 → 0.95/4.00/0.16; trinity-large-thinking → 0.25/0.80 (unsourced cache removed); qwen3.6-27b/-35b-a3b, nemotron-3-ultra OpenRouter corrections; claude-sonnet-4-6 max output 64K→128K; novita base-URL path fix in models_dev.bundled.json; step-3.7-flash + fugu-ultra limit fixes (third-party sources commented); Anthropic cache-read rates (0.50/0.30/0.10) added; glm-5.2/kimi-k2.7-code cache rates; glm-5-turbo now priced; gpt-5-codex priced + deprecated-upstream note.

**Part C — missing frontier models**: `claude-fable-5` (10/50/cache 1.00, 1M/128K, tokenizer note), `claude-sonnet-5` with **time-aware intro pricing** (2.00/10.00 through 2026-08-31, then 3.00/15.00 — same pattern as the DeepSeek V4-Pro cutover, tests on both sides), `gpt-5.3-codex` (1.75/14.00, 400K/128K), `qwen/qwen3.7-plus`. GPT-5.6 family and Muse Spark are already on the base branch (#4311). `claude-mythos-5` deliberately not added (invite-only).

## Honesty decisions

- **Xiaomi MiMo stays unpriced**: the pricing lookup only sees `(provider, model)` and cannot distinguish PAYG (`sk-`) from Token Plan (`tp-`) billing surfaces; pricing it would misprice Token Plan sessions. Documented in the bundled JSON honesty note; follow-up issue filed.
- **Z.ai casing (A10)**: no rename — `canonical_zai_model_id()` is case-insensitive end-to-end; lowercase aliases already resolve. Wire ids untouched to avoid breaking existing configs without live verification.
- **Skipped**: Qianfan default-model bump and Kimi K2.7 Code HighSpeed (both need live-endpoint/console id verification); `DEFAULT_OPENAI_CODEX_MODEL` unchanged per handoff rule.
- Anthropic in/out rates confirmed against the pre-existing bundled catalog (only the handoff's cache rates are new).

## Verification

- `cargo test -p codewhale-config --locked` → 366 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked -- pricing models model_registry model_catalog` → 112 passed
- Full tui bin suite: 6292 passed, 1 pre-existing failure (`skill_hotbar_action_activates_skill_through_dollar_alias`, fails identically on the clean branch; fixed separately by #4316's isolation commit)
- `cargo fmt --all --check` + `git diff --check` clean

Part D schema extensions tracked in #4317–#4319; DeepSeek alias deadline audit in #4320.