### PR TITLE
fix(workflow): run documented scripts and harden cancellation

### DIFF
--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -586,16 +586,16 @@ async fn start_workflow(
         state.record_snapshot(&record);
         // #4122: emit RunStarted immediately so the panel + history card open
         // before the first task/phase (including wait:false fire-and-forget).
-        if let Some(tx) = runtime.event_tx.as_ref() {
-            if let Ok(mut value) = serde_json::to_value(&started) {
-                if let Some(obj) = value.as_object_mut() {
-                    obj.insert("run_id".to_string(), json!(run_id));
-                }
-                let _ = tx.try_send(Event::WorkflowUi {
-                    run_id: run_id.clone(),
-                    event: value,
-                });
+        if let Some(tx) = runtime.event_tx.as_ref()
+            && let Ok(mut value) = serde_json::to_value(&started)
+        {
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert("run_id".to_string(), json!(run_id));
             }
+            let _ = tx.try_send(Event::WorkflowUi {
+                run_id: run_id.clone(),
+                event: value,
+            });
         }
     }
 
@@ -1796,6 +1796,7 @@ struct SubAgentWorkflowDriver {
 }
 
 impl SubAgentWorkflowDriver {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         run_id: String,
         manager: SharedSubAgentManager,

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -4360,12 +4360,15 @@ export default workflow({
             .and_then(Value::as_str)
             .expect("run_id metadata");
 
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            while calls.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("workflow should spawn at least one child before cancel");
         let calls_before_cancel = calls.load(Ordering::SeqCst);
-        assert!(
-            calls_before_cancel >= 1,
-            "workflow should spawn at least one child before cancel"
-        );
+        assert!(calls_before_cancel >= 1);
 
         let cancelled = tool
             .execute(json!({"action": "cancel", "run_id": run_id}), &ctx)

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -672,9 +672,22 @@ async fn cancel_workflow(
         let mut controllers_guard = lock_mutex(&state.controllers)?;
         controllers_guard.remove(run_id)
     };
-    if let Some(controller) = controller {
+    let already_cancelled = {
+        let runs_guard = lock_mutex(&state.runs)?;
+        let record = runs_guard.get(run_id).ok_or_else(|| {
+            ToolError::invalid_input(format!("Unknown workflow run_id '{run_id}'"))
+        })?;
+        record.status == WorkflowRunStatus::Cancelled
+    };
+    if already_cancelled {
+        return workflow_result_for(run_id, state);
+    }
+    if let Some(controller) = controller.as_ref() {
         controller.cancel();
     }
+    let cancelled_event = WorkflowUiEvent::new(WorkflowUiEventKind::RunCancelled {
+        reason: "cancelled by workflow tool".to_string(),
+    });
     let snapshot = {
         let mut runs_guard = lock_mutex(&state.runs)?;
         let record = runs_guard.get_mut(run_id).ok_or_else(|| {
@@ -683,15 +696,17 @@ async fn cancel_workflow(
         record.status = WorkflowRunStatus::Cancelled;
         record.completed_at_ms = Some(now_ms());
         let reason = "cancelled by workflow tool".to_string();
-        record.error = Some(reason.clone());
-        record
-            .events
-            .push(WorkflowUiEvent::new(WorkflowUiEventKind::RunCancelled {
-                reason,
-            }));
+        record.error = Some(reason);
+        record.events.push(cancelled_event.clone());
         record.clone()
     };
     state.record_snapshot(&snapshot);
+    // The VM may publish its terminal `run_completed` event while cancellation
+    // is racing it. Always stream the authoritative cancellation afterward so
+    // the live panel finalizes running rows and cannot remain visually failed.
+    if let Some(controller) = controller.as_ref() {
+        controller.driver.emit_ui_event(&cancelled_event);
+    }
     workflow_result_for(run_id, state)
 }
 
@@ -1824,6 +1839,9 @@ impl SubAgentWorkflowDriver {
             .lock()
             .map(|ids| ids.clone())
             .unwrap_or_default();
+        for id in &ids {
+            self.record_task_completion(id, &TaskCompletion::Cancelled);
+        }
         if let Ok(mut permits) = self.spawn_permits.lock() {
             permits.clear();
         }
@@ -4306,12 +4324,13 @@ export default workflow({
         let ctx = ToolContext::new(tmp.path().to_path_buf());
         let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 4);
         let (client, calls) = fake_chat_client("child done").await;
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(256);
         let runtime = SubAgentRuntime::new(
             client,
             "deepseek-v4-flash".to_string(),
             ctx.clone(),
             true,
-            None,
+            Some(event_tx),
             manager.clone(),
         );
         let tool = WorkflowTool::new(manager.clone(), runtime);
@@ -4354,6 +4373,48 @@ export default workflow({
         let cancelled_payload: Value =
             serde_json::from_str(&cancelled.content).expect("cancel json");
         assert_eq!(cancelled_payload["status"], "cancelled");
+        assert!(
+            cancelled_payload["events"]
+                .as_array()
+                .is_some_and(|events| events.iter().any(|event| event["type"] == "run_cancelled")),
+            "cancel receipt must include the authoritative terminal event: {cancelled_payload}"
+        );
+        let mut streamed_cancel = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if let Event::WorkflowUi { event, .. } = event
+                && event["type"] == "run_cancelled"
+            {
+                streamed_cancel = true;
+            }
+        }
+        assert!(
+            streamed_cancel,
+            "cancel must stream a terminal UI event after any racing completion"
+        );
+        let first_event_count = cancelled_payload["events"]
+            .as_array()
+            .expect("events")
+            .len();
+        let first_completed_at = cancelled_payload["completed_at_ms"].clone();
+        let cancelled_again = tool
+            .execute(json!({"action": "cancel", "run_id": run_id}), &ctx)
+            .await
+            .expect("second workflow cancel is a no-op");
+        let cancelled_again_payload: Value =
+            serde_json::from_str(&cancelled_again.content).expect("second cancel json");
+        assert_eq!(cancelled_again_payload["status"], "cancelled");
+        assert_eq!(
+            cancelled_again_payload["events"]
+                .as_array()
+                .expect("events")
+                .len(),
+            first_event_count,
+            "second cancel must not append a duplicate terminal event"
+        );
+        assert_eq!(
+            cancelled_again_payload["completed_at_ms"], first_completed_at,
+            "second cancel must preserve the original completion time"
+        );
 
         tokio::time::sleep(std::time::Duration::from_millis(700)).await;
         let calls_after_cancel = calls.load(Ordering::SeqCst);

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -83,6 +83,7 @@ impl WorkflowRunController {
 
     fn cancel(&self) {
         self.vm_cancel.cancel();
+        self.driver.finalize_running_tasks_cancelled();
         self.driver.force_cancel_all();
         if let Ok(mut guard) = self.run_handle.lock()
             && let Some(handle) = guard.take()
@@ -1840,9 +1841,6 @@ impl SubAgentWorkflowDriver {
             .lock()
             .map(|ids| ids.clone())
             .unwrap_or_default();
-        for id in &ids {
-            self.record_task_completion(id, &TaskCompletion::Cancelled);
-        }
         if let Ok(mut permits) = self.spawn_permits.lock() {
             permits.clear();
         }
@@ -1851,6 +1849,17 @@ impl SubAgentWorkflowDriver {
             for (_, waiter) in state.waiters.drain() {
                 let _ = waiter.send(TaskCompletion::Cancelled);
             }
+        }
+    }
+
+    fn finalize_running_tasks_cancelled(&self) {
+        let ids = self
+            .child_ids
+            .lock()
+            .map(|ids| ids.clone())
+            .unwrap_or_default();
+        for id in &ids {
+            self.record_task_completion(id, &TaskCompletion::Cancelled);
         }
     }
 

--- a/crates/tui/src/tui/mouse_ui.rs
+++ b/crates/tui/src/tui/mouse_ui.rs
@@ -236,13 +236,14 @@ fn handle_workflow_panel_mouse(app: &mut App, mouse: MouseEvent) -> bool {
         .as_ref()
         .is_some_and(|panel| panel.lifecycle.is_running());
 
-    if in_cancel_zone && running {
-        if let Some(run_id) = app.request_workflow_panel_cancel() {
-            app.status_message = Some(format!(
-                "Cancelling workflow {run_id}… (dispatch via /workflow cancel {run_id})"
-            ));
-            return true;
-        }
+    if in_cancel_zone
+        && running
+        && let Some(run_id) = app.request_workflow_panel_cancel()
+    {
+        app.status_message = Some(format!(
+            "Cancelling workflow {run_id}… (dispatch via /workflow cancel {run_id})"
+        ));
+        return true;
     }
 
     // Any other click on the panel toggles expand/collapse.

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -1238,19 +1238,17 @@ impl ProviderPickerView {
         if memory.catalog_view {
             self.view = ProviderListView::Catalog;
         }
-        if let Some(remembered_id) = memory.selected_provider_id.as_deref() {
-            if let Some(idx) = self
+        if let Some(remembered_id) = memory.selected_provider_id.as_deref()
+            && let Some(idx) = self
                 .rows
                 .iter()
                 .position(|row| row.provider_id == remembered_id)
-            {
-                if self.row_visible(idx) || memory.catalog_view {
-                    if memory.catalog_view {
-                        self.view = ProviderListView::Catalog;
-                    }
-                    self.selected_idx = idx;
-                }
+            && (self.row_visible(idx) || memory.catalog_view)
+        {
+            if memory.catalog_view {
+                self.view = ProviderListView::Catalog;
             }
+            self.selected_idx = idx;
         }
         if !self.rows.is_empty() && !self.row_visible(self.selected_idx) {
             self.selected_idx = (0..self.rows.len())

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -1007,7 +1007,7 @@ fn sync_workflow_history_card_from_panel(app: &mut App) {
                     value
                         .get("events")
                         .and_then(|e| e.as_array())
-                        .map_or(true, |e| e.is_empty())
+                        .is_none_or(|e| e.is_empty())
                 }
             }
         };

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4057,18 +4057,18 @@ async fn run_event_loop(
                         if key.modifiers == KeyModifiers::NONE
                             || key.modifiers == KeyModifiers::SHIFT =>
                     {
-                        if let Some(panel) = app.workflow_panel.as_mut() {
-                            if panel.handle_key(ch) {
-                                if matches!(ch, 'c' | 'C' | 'x' | 'X') {
-                                    if let Some(run_id) = panel.take_cancel_emit() {
-                                        app.status_message = Some(format!(
-                                            "Cancelling workflow {run_id}… (dispatch via /workflow cancel {run_id})"
-                                        ));
-                                    }
-                                }
-                                app.needs_redraw = true;
-                                handled = true;
+                        if let Some(panel) = app.workflow_panel.as_mut()
+                            && panel.handle_key(ch)
+                        {
+                            if matches!(ch, 'c' | 'C' | 'x' | 'X')
+                                && let Some(run_id) = panel.take_cancel_emit()
+                            {
+                                app.status_message = Some(format!(
+                                    "Cancelling workflow {run_id}… (dispatch via /workflow cancel {run_id})"
+                                ));
                             }
+                            app.needs_redraw = true;
+                            handled = true;
                         }
                     }
                     _ => {}

--- a/crates/workflow-js/src/driver.rs
+++ b/crates/workflow-js/src/driver.rs
@@ -34,7 +34,7 @@ use crate::error::DriverError;
 /// Provider/model remain optional overrides, not required identity fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskRequest {
-    /// The child prompt (JS `description` or `prompt`; required).
+    /// The child prompt (JS `prompt`, falling back to `description`; required).
     pub description: String,
     /// Subagent type (JS `subagentType` or `type`); `None` lets the driver
     /// apply its default (`general`).

--- a/crates/workflow-js/src/vm.rs
+++ b/crates/workflow-js/src/vm.rs
@@ -708,8 +708,8 @@ async fn task_host_inner(
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TaskOptions {
-    #[serde(alias = "prompt")]
     description: Option<String>,
+    prompt: Option<String>,
     #[serde(alias = "type")]
     subagent_type: Option<String>,
     /// Fleet role name (#4177). Preferred step identity field.
@@ -732,7 +732,8 @@ fn parse_task_options(opts_json: &str) -> Result<TaskRequest, String> {
     let options: TaskOptions =
         serde_json::from_str(opts_json).map_err(|err| format!("task(): invalid options: {err}"))?;
     let description = options
-        .description
+        .prompt
+        .or(options.description)
         .filter(|description| !description.trim().is_empty())
         .ok_or_else(|| "task(): 'description' (or 'prompt') is required".to_string())?;
     let role = options
@@ -796,7 +797,11 @@ const PRELUDE_TEMPLATE: &str = r#""use strict";
   const hostBudgetRemaining = __workflow_budget_remaining;
 
   const MAX_ITEMS = __MAX_ITEMS__;
-  const isResponseSchemaError = (err) => String(err && err.message !== undefined ? err.message : err).includes("responseSchema");
+  const taskErrorText = (err) => String(err && err.message !== undefined ? err.message : err);
+  const isFatalTaskError = (err) => {
+    const text = taskErrorText(err);
+    return text.includes("responseSchema") || text.includes("run cancelled");
+  };
 
   globalThis.task = async (opts) => {
     if (opts === null || typeof opts !== "object") {
@@ -819,12 +824,12 @@ const PRELUDE_TEMPLATE: &str = r#""use strict";
     return Promise.all(thunks.map((thunk) => {
       try {
         return Promise.resolve(typeof thunk === "function" ? thunk() : thunk).catch((err) => {
-          if (isResponseSchemaError(err)) throw err;
+          if (isFatalTaskError(err)) throw err;
           hostLog("parallel(): dropped a failed slot as null: " + String((err && err.message) || err));
           return null;
         });
       } catch (err) {
-        if (isResponseSchemaError(err)) return Promise.reject(err);
+        if (isFatalTaskError(err)) return Promise.reject(err);
         hostLog("parallel(): dropped a failed slot as null: " + String((err && err.message) || err));
         return null;
       }
@@ -844,7 +849,7 @@ const PRELUDE_TEMPLATE: &str = r#""use strict";
         try {
           value = await stage(value, item, index);
         } catch (err) {
-          if (isResponseSchemaError(err)) throw err;
+          if (isFatalTaskError(err)) throw err;
           hostLog("pipeline(): dropped item " + index + " as null: " + String((err && err.message) || err));
           return null;
         }

--- a/crates/workflow-js/src/vm.rs
+++ b/crates/workflow-js/src/vm.rs
@@ -359,7 +359,8 @@ async fn run_in_ctx(
         .catch(&ctx)
         .map_err(|err| WorkflowJsError::VmInit(format!("prelude failed: {err}")))?;
 
-    let wrapped = format!("(async () => {{\n{source}\n}})()");
+    let desugared = desugar_export_default(&source);
+    let wrapped = format!("(async () => {{\n{desugared}\n}})()");
     let promise = ctx
         .eval::<Promise, _>(wrapped)
         .catch(&ctx)
@@ -370,6 +371,39 @@ async fn run_in_ctx(
         .catch(&ctx)
         .map_err(|err| script_error(&cancel, err))?;
     js_value_to_json(&ctx, value)
+}
+
+/// Rewrite the documented module-style authoring shape
+/// (`export default async function (args) { ... }`) into the script form the
+/// VM actually evals. Sources are wrapped in an async IIFE, where the
+/// module-only `export` keyword is a syntax error, so without this every
+/// imperative `export default` workflow (including the #4131 dogfood
+/// fixtures) failed to parse. The default export is captured, invoked with
+/// the `args` global when it is a function, and its result becomes the run
+/// result; a non-function default export is returned as-is.
+fn desugar_export_default(source: &str) -> String {
+    let Some(line_idx) = source
+        .lines()
+        .position(|line| line.trim_start().starts_with("export default"))
+    else {
+        return source.to_string();
+    };
+    let mut lines: Vec<&str> = source.lines().collect();
+    let rewritten =
+        lines[line_idx].replacen("export default", "globalThis.__workflow_default =", 1);
+    let mut out = String::new();
+    for (idx, line) in lines.iter_mut().enumerate() {
+        if idx == line_idx {
+            out.push_str(&rewritten);
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out.push_str(
+        ";{\n  const __wf_default = globalThis.__workflow_default;\n  delete globalThis.__workflow_default;\n  if (typeof __wf_default === \"function\") {\n    return await __wf_default(args);\n  }\n  if (__wf_default !== undefined) {\n    return __wf_default;\n  }\n}\n",
+    );
+    out
 }
 
 fn script_error(cancel: &CancelHandle, err: CaughtError<'_>) -> WorkflowJsError {

--- a/crates/workflow-js/src/vm.rs
+++ b/crates/workflow-js/src/vm.rs
@@ -382,28 +382,113 @@ async fn run_in_ctx(
 /// the `args` global when it is a function, and its result becomes the run
 /// result; a non-function default export is returned as-is.
 fn desugar_export_default(source: &str) -> String {
-    let Some(line_idx) = source
-        .lines()
-        .position(|line| line.trim_start().starts_with("export default"))
-    else {
+    const EXPORT_DEFAULT: &str = "export default";
+    let Some(offset) = line_leading_export_default(source) else {
         return source.to_string();
     };
-    let mut lines: Vec<&str> = source.lines().collect();
-    let rewritten =
-        lines[line_idx].replacen("export default", "globalThis.__workflow_default =", 1);
-    let mut out = String::new();
-    for (idx, line) in lines.iter_mut().enumerate() {
-        if idx == line_idx {
-            out.push_str(&rewritten);
-        } else {
-            out.push_str(line);
-        }
-        out.push('\n');
-    }
+    let mut out = source.to_string();
+    out.replace_range(
+        offset..offset + EXPORT_DEFAULT.len(),
+        "globalThis.__workflow_default =",
+    );
+    out.push('\n');
     out.push_str(
         ";{\n  const __wf_default = globalThis.__workflow_default;\n  delete globalThis.__workflow_default;\n  if (typeof __wf_default === \"function\") {\n    return await __wf_default(args);\n  }\n  if (__wf_default !== undefined) {\n    return __wf_default;\n  }\n}\n",
     );
     out
+}
+
+/// Return the byte offset of a line-leading `export default` token that is
+/// actual JavaScript syntax, not text inside a string, template literal, or
+/// comment. This intentionally recognizes only the documented authoring shape
+/// instead of attempting to implement a general JavaScript module parser.
+fn line_leading_export_default(source: &str) -> Option<usize> {
+    const EXPORT_DEFAULT: &[u8] = b"export default";
+    let bytes = source.as_bytes();
+    let mut idx = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut line_has_only_whitespace = true;
+
+    while idx < bytes.len() {
+        let byte = bytes[idx];
+
+        if line_comment {
+            if byte == b'\n' {
+                line_comment = false;
+                line_has_only_whitespace = true;
+            }
+            idx += 1;
+            continue;
+        }
+
+        if block_comment {
+            if byte == b'*' && bytes.get(idx + 1) == Some(&b'/') {
+                block_comment = false;
+                line_has_only_whitespace = false;
+                idx += 2;
+                continue;
+            }
+            if byte == b'\n' {
+                line_has_only_whitespace = true;
+            } else if !byte.is_ascii_whitespace() {
+                line_has_only_whitespace = false;
+            }
+            idx += 1;
+            continue;
+        }
+
+        if let Some(active_quote) = quote {
+            if byte == b'\n' {
+                line_has_only_whitespace = true;
+                escaped = false;
+            } else {
+                if !byte.is_ascii_whitespace() {
+                    line_has_only_whitespace = false;
+                }
+                if escaped {
+                    escaped = false;
+                } else if byte == b'\\' {
+                    escaped = true;
+                } else if byte == active_quote {
+                    quote = None;
+                }
+            }
+            idx += 1;
+            continue;
+        }
+
+        if byte == b'\n' {
+            line_has_only_whitespace = true;
+            idx += 1;
+            continue;
+        }
+        if line_has_only_whitespace && byte.is_ascii_whitespace() {
+            idx += 1;
+            continue;
+        }
+        if line_has_only_whitespace && bytes[idx..].starts_with(EXPORT_DEFAULT) {
+            return Some(idx);
+        }
+
+        line_has_only_whitespace = false;
+        if byte == b'/' && bytes.get(idx + 1) == Some(&b'/') {
+            line_comment = true;
+            idx += 2;
+        } else if byte == b'/' && bytes.get(idx + 1) == Some(&b'*') {
+            block_comment = true;
+            idx += 2;
+        } else {
+            if matches!(byte, b'\'' | b'"' | b'`') {
+                quote = Some(byte);
+            }
+            idx += 1;
+        }
+    }
+
+    None
 }
 
 fn script_error(cancel: &CancelHandle, err: CaughtError<'_>) -> WorkflowJsError {

--- a/crates/workflow-js/tests/vm_tests.rs
+++ b/crates/workflow-js/tests/vm_tests.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use codewhale_workflow_js::testing::{FakeDriver, FakeReply};
-use codewhale_workflow_js::{ProgressEvent, WORKFLOW_LIFETIME_CAP, WorkflowJsError, WorkflowVm};
+use codewhale_workflow_js::{
+    ProgressEvent, WORKFLOW_LIFETIME_CAP, WorkflowJsError, WorkflowRunCancel, WorkflowVm,
+};
 use serde_json::json;
 
 async fn run(
@@ -116,6 +118,25 @@ async fn task_accepts_prompt_and_type_aliases() {
     let request = &driver.requests()[0];
     assert_eq!(request.description, "aliased");
     assert_eq!(request.subagent_type.as_deref(), Some("verifier"));
+}
+
+#[tokio::test]
+async fn task_prompt_takes_precedence_over_short_description() {
+    let driver = Arc::new(FakeDriver::new());
+    run(
+        &driver,
+        r#"return await task({
+            description: "Short progress summary",
+            prompt: "Detailed child instructions",
+            label: "fixture-compatible"
+        });"#,
+        json!(null),
+    )
+    .await
+    .unwrap();
+    let request = &driver.requests()[0];
+    assert_eq!(request.description, "Detailed child instructions");
+    assert_eq!(request.label.as_deref(), Some("fixture-compatible"));
 }
 
 #[tokio::test]
@@ -852,6 +873,51 @@ async fn dropping_the_run_future_cancels_outstanding_tasks() {
         "dropping the run future must cancel outstanding driver tasks"
     );
     assert_eq!(driver.spawn_count(), 1);
+}
+
+#[tokio::test]
+async fn parallel_does_not_continue_after_external_run_cancellation() {
+    let driver = Arc::new(FakeDriver::new());
+    driver.on("hang", FakeReply::Never);
+    let cancel = WorkflowRunCancel::new();
+    let run_cancel = cancel.clone();
+    let run_driver = driver.clone();
+    let handle = tokio::spawn(async move {
+        WorkflowVm::new()
+            .run_script_with_cancel(
+                r#"
+                await parallel([() => task({ description: "hang" })]);
+                phase("unreachable after cancellation");
+                return "wrong";
+                "#,
+                json!(null),
+                run_driver as Arc<dyn codewhale_workflow_js::WorkflowDriver>,
+                run_cancel,
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while driver.spawn_count() == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("task should start");
+    cancel.cancel();
+
+    let result = handle.await.expect("VM task should join");
+    assert!(
+        matches!(result, Err(WorkflowJsError::Cancelled)),
+        "{result:?}"
+    );
+    assert!(
+        !driver.events().iter().any(|event| matches!(
+            event,
+            ProgressEvent::Phase { title } if title == "unreachable after cancellation"
+        )),
+        "parallel() must not downgrade run cancellation into a null slot"
+    );
 }
 
 #[tokio::test]

--- a/crates/workflow-js/tests/vm_tests.rs
+++ b/crates/workflow-js/tests/vm_tests.rs
@@ -947,3 +947,54 @@ async fn promise_all_of_tasks_resolves_concurrently() {
     );
     assert_eq!(driver.spawn_count(), 2);
 }
+
+#[tokio::test]
+async fn export_default_async_function_runs_with_args() {
+    let driver = Arc::new(FakeDriver::new());
+    let source = r#"
+export default async function (args) {
+  return { doubled: args.n * 2 };
+}
+"#;
+    let value = run(&driver, source, json!({ "n": 21 })).await.unwrap();
+    assert_eq!(value, json!({ "doubled": 42 }));
+}
+
+#[tokio::test]
+async fn export_default_function_result_becomes_run_result() {
+    let driver = Arc::new(FakeDriver::new());
+    let source = r#"
+function helper() {
+  return "from-helper";
+}
+export default function () {
+  return helper();
+}
+"#;
+    let value = run(&driver, source, json!(null)).await.unwrap();
+    assert_eq!(value, json!("from-helper"));
+}
+
+#[tokio::test]
+async fn export_default_non_function_value_is_returned() {
+    let driver = Arc::new(FakeDriver::new());
+    let value = run(&driver, "export default 7;", json!(null))
+        .await
+        .unwrap();
+    assert_eq!(value, json!(7));
+}
+
+#[tokio::test]
+async fn plain_scripts_are_untouched_by_export_desugaring() {
+    let driver = Arc::new(FakeDriver::new());
+    // A string literal mentioning `export default` must not trigger the
+    // module desugaring path.
+    let value = run(
+        &driver,
+        "const note = \"export default docs\";\nreturn note.length;",
+        json!(null),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value, json!(19));
+}

--- a/crates/workflow-js/tests/vm_tests.rs
+++ b/crates/workflow-js/tests/vm_tests.rs
@@ -998,3 +998,28 @@ async fn plain_scripts_are_untouched_by_export_desugaring() {
     .unwrap();
     assert_eq!(value, json!(19));
 }
+
+#[tokio::test]
+async fn export_default_examples_inside_multiline_text_are_not_desugared() {
+    let driver = Arc::new(FakeDriver::new());
+    let value = run(
+        &driver,
+        r#"
+const template = `
+export default async function (args) {
+  return args;
+}
+`;
+/*
+export default function () {
+  return "comment example";
+}
+*/
+return template.includes("export default async function");
+"#,
+        json!(null),
+    )
+    .await
+    .unwrap();
+    assert_eq!(value, json!(true));
+}

--- a/docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md
+++ b/docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md
@@ -19,7 +19,7 @@ Related:
 cargo build -p codewhale-tui --locked
 # Optional headless/runtime checks used by the scenarios below
 cargo test -p codewhale-tui --locked dogfood_ -- --nocapture
-cargo test -p codewhale-workflow-js --locked parallel_ fan_out cancel -- --nocapture
+cargo test -p codewhale-workflow-js --locked
 ```
 
 Isolate config so dogfood does not touch your real home:
@@ -141,6 +141,8 @@ Or run:
 - Panel phases resemble: Implement → Verify (or equivalent labels).
 - Implementer child row shows `wt` (worktree) isolation.
 - Verifier child completes with a short confirmation summary.
+- Verifier evaluates the implementer's returned worktree handoff; it does not
+  expect the unmerged edit to appear in the parent workspace.
 - One artifact / card per delegated unit (no duplicate delegate spam).
 
 ### Pass / fail notes
@@ -151,6 +153,7 @@ Or run:
 | Implementer row marks worktree | | |
 | Verifier runs after implementer | | |
 | Main workspace untouched until merge/apply | | |
+| Verifier validates isolated handoff rather than parent file | | |
 | Compact history card summarizes phases | | |
 
 Automated:
@@ -217,10 +220,11 @@ cargo test -p codewhale-workflow-js --locked parallel_fan_out_maps_one_failure_t
 
 ### Reproducible steps
 
-1. Start a long-running multi-child workflow:
+1. Start a long-running multi-child workflow without blocking the parent turn:
 
 ```text
-/workflow run docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
+Use the workflow tool with exactly
+{"action":"start","source_path":"docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js"}.
 ```
 
 Or a natural long audit with several scouts.
@@ -269,30 +273,45 @@ File or link bugs found during dogfood here (do not silently absorb them):
 
 | Date | Scenario | Symptom | Issue / PR |
 |------|----------|---------|------------|
-| | | | |
+| 2026-07-09 | WF-A1 | Documented `export default async function` fixtures were rejected by the runtime desugaring path. | Fixed with regression coverage in #4325. |
+| 2026-07-09 | WF-A1 | Fixture options containing both `description` and `prompt` failed serde decoding as a duplicate field. | Fixed with prompt-precedence coverage in #4325. |
+| 2026-07-09 | WF-A3 | A refusal is a successful child completion, so it cannot deterministically exercise a nullable failed slot. | Fixture now uses a one-token child budget; #4325. |
+| 2026-07-09 | WF-A4 | Run cancellation was downgraded to a nullable parallel slot, allowing the script to enter its unreachable next phase. | Fixed with external-cancel regression in #4325. |
+| 2026-07-09 | WF-A4 | A racing `run_completed: failed` event left the live panel failed with running rows even though the receipt was cancelled. | Fixed by terminal row finalization + authoritative `run_cancelled` streaming in #4325. |
 
 ---
 
 ## Interactive results log (copy per pass)
 
-```
-Tree / binary: _______________
-Operator: _______________
-Date: _______________
+Tree / binary: `codex/v0868-workflow-export-default`, debug `codewhale-tui`
+Operator: release dogfood session
+Date: 2026-07-09
 
-WF-A1: PASS / FAIL — notes:
-WF-A2: PASS / FAIL — notes:
-WF-A3: PASS / FAIL — notes:
-WF-A4: PASS / FAIL — notes:
+- WF-A1: PASS — `workflow_dd5de6d0`; 3 labeled read-only scouts then one
+  synthesizer, 4/4 completed across two phases. A checked-in `source_path`
+  conservatively requested approval because its capabilities are unknown
+  before execution; no workspace files changed.
+- WF-A2: PASS — `workflow_97ae14dc`; isolated implementer worktree followed by
+  main-workspace verifier, 2/2 across Implement/Verify in 1m31s. The verifier
+  confirmed the intended handoff and that the unmerged edit remained absent
+  from the parent, treating isolation as success instead of expecting
+  cross-worktree mutation.
+- WF-A3: PASS — `workflow_2f590eec`; one child visibly exhausted its one-token
+  budget, header showed one failure, `parallel()` supplied a null slot, and the
+  synthesizer completed from two survivors (`surviving_count=2`).
+- WF-A4: PASS — `workflow_45629ac6`; nonblocking start followed by explicit
+  cancel produced lifecycle `cancelled`, preserved one completed child,
+  finalized two running children as cancelled, did not enter the unreachable
+  phase, and returned no result. Repeated cancel is covered as a no-op by the
+  tool regression test.
 
-New bugs filed:
-Follow-ups:
-```
+New bugs filed: none; all reproducible defects above were fixed in #4325.
+Follow-ups: run the fleet-backed stopship lane from #4178/#4179 after landing.
 
 ### CI / PR gate (non-interactive)
 
 ```bash
 cargo fmt --all -- --check
 cargo test -p codewhale-tui --locked dogfood_
-cargo test -p codewhale-workflow-js --locked parallel_ fan_out cancel drop
+cargo test -p codewhale-workflow-js --locked
 ```

--- a/docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
@@ -2,8 +2,9 @@
  * #4131 WF-A2 — staged bug fix with worktree implementer + verifier.
  *
  * Expected UI: Implement phase with worktree-isolated implementer, then Verify
- * phase. Write/worktree plans should surface approval when
- * require_approval_for_writes is true.
+ * phase. The verifier checks the returned handoff while confirming the parent
+ * workspace remains unchanged until an explicit apply/merge. Write/worktree
+ * plans should surface approval when require_approval_for_writes is true.
  *
  * Run: /workflow run docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js
  */
@@ -30,13 +31,14 @@ export default async function (args) {
 
   phase("Verify");
   const verify = await task({
-    description: "Verify the implementer change without further edits.",
+    description: "Verify the isolated implementer handoff without further edits.",
     label: "verifier",
     type: "verifier",
     worktree: false,
     prompt: [
-      "Read the implementer result and re-check the target file.",
-      "Confirm the intended one-line clarification is present and nothing else was changed.",
+      "Read the implementer result and validate its reported path and diff summary.",
+      "Confirm the intended one-line clarification was made only in the isolated worktree.",
+      "Confirm the parent workspace remains unchanged until an explicit apply or merge.",
       "Do not implement further edits. Return PASS/FAIL with evidence.",
       "",
       "implementer_result:",

--- a/docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js
@@ -19,16 +19,18 @@ export default async function () {
         type: "explore",
         prompt: "Return the string READY_A. Read-only.",
       }),
-    // Intentionally hostile: request something that should fail or time out
-    // under normal policy (missing path / guaranteed empty). Operator dogfood
-    // may also kill this child mid-run to force a failed slot.
+    // Give this child an intentionally tiny budget so it starts, then fails
+    // deterministically at the runtime boundary. A model refusal is still a
+    // successful transport-level completion, while response-schema failures
+    // intentionally abort the whole workflow so they remain loud.
     () =>
       task({
         description: "Deliberately failing scout B",
         label: "scout-b-fail",
         type: "explore",
+        tokenBudget: 1,
         prompt:
-          "You MUST fail this task: refuse to produce a summary and reply only with an error about missing inputs. Do not invent success.",
+          "Inspect Cargo.toml and return a detailed workspace summary. This child intentionally has a one-token budget so parallel() exercises a failed null slot.",
       }),
     () =>
       task({

--- a/docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
+++ b/docs/examples/dogfood-automatic/wf_a4_cancel_mid_run.workflow.js
@@ -17,7 +17,7 @@ export default async function () {
         label: "slow-1",
         type: "explore",
         prompt:
-          "Thoroughly inventory crates/tui/src file names (read-only). Take your time; list directories depth-first. Return a count at the end.",
+          "If a foreground shell tool is available, first run `sleep 60`; otherwise state that limitation. Then thoroughly inventory crates/tui/src file names (read-only) and return a count. This creates a practical cancellation window.",
       }),
     () =>
       task({
@@ -25,7 +25,7 @@ export default async function () {
         label: "slow-2",
         type: "explore",
         prompt:
-          "Thoroughly inventory crates/config/src file names (read-only). Take your time; list directories depth-first. Return a count at the end.",
+          "If a foreground shell tool is available, first run `sleep 60`; otherwise state that limitation. Then thoroughly inventory crates/config/src file names (read-only) and return a count. This creates a practical cancellation window.",
       }),
     () =>
       task({
@@ -33,7 +33,7 @@ export default async function () {
         label: "slow-3",
         type: "explore",
         prompt:
-          "Thoroughly inventory docs/ markdown titles (read-only). Take your time. Return a count at the end.",
+          "If a foreground shell tool is available, first run `sleep 60`; otherwise state that limitation. Then thoroughly inventory docs/ markdown titles (read-only) and return a count. This creates a practical cancellation window.",
       }),
   ]);
 


### PR DESCRIPTION
## What

The #4131 live dogfood pass found that every checked-in imperative Workflow fixture was unrunnable: the VM accepted plain scripts and declarative `export default workflow({...})`, but not the documented `export default async function (args) {...}` shape.

This PR now closes the full live-dogfood chain:

- safely desugars line-leading `export default` without matching examples inside strings, templates, or comments;
- accepts fixtures that provide both a short `description` and the actual `prompt` (`prompt` wins);
- makes WF-A3 deterministic with a real one-token child failure and nullable `parallel()` slot;
- treats run cancellation as fatal control flow instead of a partial-success null;
- finalizes running child rows and streams authoritative `run_cancelled` state after racing completion events;
- makes repeated cancellation an idempotent no-op;
- updates the WF-A1..A4 fixtures and records the live results in `docs/DOGFOOD_AUTOMATIC_WORKFLOWS.md`;
- clears the Rust 1.97 all-target lint findings in the touched Workflow/TUI paths.

## Live evidence

- WF-A1 `workflow_dd5de6d0`: 4/4 children, two phases, read-only audit plus synthesis.
- WF-A2 `workflow_97ae14dc`: isolated implementer then parent verifier, 2/2, isolation confirmed.
- WF-A3 `workflow_2f590eec`: one visible budget failure, one null slot, synthesis from two survivors.
- WF-A4 `workflow_45629ac6`: one completed + two cancelled children, lifecycle `cancelled`, no unreachable phase, no result.

## Verification

- `cargo test -p codewhale-workflow-js --locked` — 42 VM integration tests + 8 unit tests passed.
- `cargo test -p codewhale-tui --locked dogfood_` — 5 dogfood tests passed.
- `cargo test -p codewhale-tui --locked workflow_cancel_interrupts_vm_and_blocks_further_spawns` — passed twice after replacing a fixed sleep with a bounded first-child wait.
- `cargo clippy -p codewhale-tui -p codewhale-workflow-js --all-targets --locked -- -D warnings` — passed on Rust stable 1.97 after merging current `main` / #4322.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

Blocks completion of #4131 and supplies release evidence for #4110, #4175, #4177, and #4179. Part of the v0.8.68 milestone.
