### PR TITLE
release: v0.8.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.68] - 2026-07-10
+
 ### Changed
 
 - Make the advertised Android/Termux release target buildable by generating
@@ -3054,7 +3056,8 @@ overflow report and `/theme` picker edge-wrapping patch in #1814.
 
 Older releases (v0.8.39 and earlier) are archived in [docs/CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).
 
-[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.67...HEAD
+[Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.8.68...HEAD
+[0.8.68]: https://github.com/Hmbown/CodeWhale/compare/v0.8.67...v0.8.68
 [0.8.67]: https://github.com/Hmbown/CodeWhale/compare/v0.8.66...v0.8.67
 [0.8.66]: https://github.com/Hmbown/CodeWhale/compare/v0.8.65...v0.8.66
 [0.8.65]: https://github.com/Hmbown/CodeWhale/compare/v0.8.64...v0.8.65

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codewhale-agent"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "codewhale-config",
  "serde",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-app-server"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "axum",
@@ -833,11 +833,11 @@ dependencies = [
 
 [[package]]
 name = "codewhale-build-support"
-version = "0.8.67"
+version = "0.8.68"
 
 [[package]]
 name = "codewhale-cli"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-config"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "codewhale-execpolicy",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-core"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-execpolicy"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "codewhale-protocol",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-hooks"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-lane"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-mcp"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "serde",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-protocol"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "chrono",
  "serde",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-release"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-secrets"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "dirs",
  "keyring",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-state"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tools"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-tui"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-workflow"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "codewhale-workflow-js"
-version = "0.8.67"
+version = "0.8.68"
 dependencies = [
  "async-trait",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = ["crates/cli", "crates/app-server", "crates/tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.67"
+version = "0.8.68"
 edition = "2024"
 # Rust 1.88 stabilized `let_chains` in `if`/`while` conditions, which the
 # codebase relies on extensively. Cargo enforces this so users on older

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -17,7 +17,7 @@ Rust 製の TUI と CLI、25 のプロバイダ。DeepSeek、OpenRouter、Huggin
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.67
+codewhale --version   # 0.8.68
 ```
 
 npm wrapper（Node 18+）は GitHub Releases から SHA-256 検証済みのバイナリをダウンロードし、`codewhale`、`codew`、`codewhale-tui` をインストールします。ソースからビルドしたい場合は cargo（Rust 1.88+）で:
@@ -44,8 +44,8 @@ nix run github:Hmbown/CodeWhale
 scoop install codewhale        # または GitHub Releases の NSIS インストーラ
 
 # GitHub に安定して到達できない場合の CNB ミラー
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-tui --locked --force
 
 # 旧 Homebrew 互換。formula の改名が完了するまで deepseek-tui 名のままです
 brew tap Hmbown/deepseek-tui

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -35,7 +35,7 @@ CodeWhale이 실제 라우트를 해석해 실행합니다.
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.67
+codewhale --version   # 0.8.68
 ```
 
 npm 래퍼(Node 18+)는 GitHub Releases에서 SHA-256으로 검증된 바이너리를
@@ -64,8 +64,8 @@ nix run github:Hmbown/CodeWhale
 scoop install codewhale        # or the NSIS installer from GitHub Releases
 
 # CNB mirror for users who cannot reliably reach GitHub
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-tui --locked --force
 
 # Legacy Homebrew compatibility while the formula is renamed
 brew tap Hmbown/deepseek-tui

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ open an issue — that's how the project grows.
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.67
+codewhale --version   # 0.8.68
 ```
 
 The npm wrapper (Node 18+) downloads SHA-256-verified binaries from GitHub
@@ -62,8 +62,8 @@ nix run github:Hmbown/CodeWhale
 scoop install codewhale        # or the NSIS installer from GitHub Releases
 
 # CNB mirror for users who cannot reliably reach GitHub
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-tui --locked --force
 
 # Legacy Homebrew compatibility while the formula is renamed
 brew tap Hmbown/deepseek-tui
@@ -191,13 +191,30 @@ setup view. Loadouts express model intent as a class — `strong`, `balanced`, o
 is the same headless runtime that backs in-session sub-agents; Fleet is the
 durable layer on top. See [docs/FLEET.md](docs/FLEET.md).
 
+### Workflow
+
+Workflow is the resumable, inspectable layer for larger jobs. It plans a goal
+into bounded steps, can fan those steps out through Fleet workers, and records
+progress and verification in `.codewhale/workflow-runs.jsonl`:
+
+```bash
+codewhale workflow run my-workflow.js --verify
+codewhale workflow status
+codewhale workflow logs <run-id>
+```
+
+Workflow is an overlay, not another permission mode: Plan / Act / Operate and
+the Ask / Auto-Review / Full Access posture stay orthogonal to orchestration.
+
 ## Safety
 
 CodeWhale edits files and runs commands, so the safety posture is part of the
 product, not an afterthought.
 
-- **Three modes.** Plan (read-only investigation), Agent (executes, asks per
-  action), and YOLO (auto-approve). Switch with `Tab` or `/mode`.
+- **Three modes.** Plan (read-only investigation), Act (multi-step execution),
+  and Operate (Fleet/Workflow orchestration). Switch with `Tab` or `/mode`.
+  `Shift+Tab` independently cycles Ask, Auto-Review, and Full Access approval
+  posture; legacy YOLO remains a compatibility alias for Act + Full Access.
 - **Approval-gated tools.** A `.codewhale/hooks.toml` hook system can allow,
   deny, or ask before any tool call, and the exec policy decides whether a
   command runs, needs approval, or is forbidden outright.
@@ -288,7 +305,7 @@ The README is the short version. The rest is in docs and on
 
 - [User guide](docs/GUIDE.md) · [Install guide](docs/INSTALL.md) ·
   [Configuration](docs/CONFIGURATION.md) · [Provider registry](docs/PROVIDERS.md)
-- [Modes](docs/MODES.md) — Agent, Plan, and YOLO.
+- [Modes](docs/MODES.md) — Plan, Act, Operate, and orthogonal approval posture.
 - [Fleet](docs/FLEET.md) · [Sub-agents](docs/SUBAGENTS.md) — roles, lifecycle,
   output contract, and recovery behavior.
 - [Architecture](docs/ARCHITECTURE.md) — crate layout, runtime flow, tool system,

--- a/README.vi.md
+++ b/README.vi.md
@@ -21,7 +21,7 @@ bằng `/restore` cho mọi lượt.
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.67
+codewhale --version   # 0.8.68
 ```
 
 Wrapper npm (Node 18+) tải binary đã xác minh SHA-256 từ GitHub Releases và
@@ -50,8 +50,8 @@ nix run github:Hmbown/CodeWhale
 scoop install codewhale        # hoặc trình cài NSIS từ GitHub Releases
 
 # CNB mirror cho người dùng khó truy cập GitHub ổn định
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-tui --locked --force
 
 # Homebrew legacy trong lúc formula đang được đổi tên
 brew tap Hmbown/deepseek-tui

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@ DeepInfra 以及本地 vLLM/SGLang/Ollama 都是一等路由；当你手里是 A
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.67
+codewhale --version   # 0.8.68
 ```
 
 npm wrapper（Node 18+）会从 GitHub Releases 下载经 SHA-256 校验的二进制，并安装
@@ -49,8 +49,8 @@ nix run github:Hmbown/CodeWhale
 scoop install codewhale        # 或使用 GitHub Releases 中的 NSIS 安装包
 
 # CNB 镜像：适合无法稳定访问 GitHub 的用户
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-cli --locked --force
-cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.67 codewhale-tui --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-cli --locked --force
+cargo install --git https://cnb.cool/codewhale.net/codewhale --tag v0.8.68 codewhale-tui --locked --force
 
 # 旧 Homebrew 兼容路径：formula 改名期间仍沿用 deepseek-tui
 brew tap Hmbown/deepseek-tui

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 description = "Model/provider registry and fallback strategy for CodeWhale"
 
 [dependencies]
-codewhale-config = { path = "../config", version = "0.8.67" }
+codewhale-config = { path = "../config", version = "0.8.68" }
 serde.workspace = true

--- a/crates/app-server/Cargo.toml
+++ b/crates/app-server/Cargo.toml
@@ -12,16 +12,16 @@ autobins = false
 anyhow.workspace = true
 axum.workspace = true
 clap.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.67" }
-codewhale-config = { path = "../config", version = "0.8.67" }
-codewhale-core = { path = "../core", version = "0.8.67" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
-codewhale-hooks = { path = "../hooks", version = "0.8.67" }
-codewhale-mcp = { path = "../mcp", version = "0.8.67" }
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
-codewhale-release = { path = "../release", version = "0.8.67" }
-codewhale-state = { path = "../state", version = "0.8.67" }
-codewhale-tools = { path = "../tools", version = "0.8.67" }
+codewhale-agent = { path = "../agent", version = "0.8.68" }
+codewhale-config = { path = "../config", version = "0.8.68" }
+codewhale-core = { path = "../core", version = "0.8.68" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.68" }
+codewhale-hooks = { path = "../hooks", version = "0.8.68" }
+codewhale-mcp = { path = "../mcp", version = "0.8.68" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
+codewhale-release = { path = "../release", version = "0.8.68" }
+codewhale-state = { path = "../state", version = "0.8.68" }
+codewhale-tools = { path = "../tools", version = "0.8.68" }
 serde.workspace = true
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,16 +19,16 @@ path = "src/bin/codew_legacy_shim.rs"
 anyhow.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.67" }
-codewhale-app-server = { path = "../app-server", version = "0.8.67" }
-codewhale-config = { path = "../config", version = "0.8.67" }
-codewhale-lane = { path = "../lane", version = "0.8.67" }
-codewhale-workflow = { path = "../workflow", version = "0.8.67" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
-codewhale-mcp = { path = "../mcp", version = "0.8.67" }
-codewhale-release = { path = "../release", version = "0.8.67" }
-codewhale-secrets = { path = "../secrets", version = "0.8.67" }
-codewhale-state = { path = "../state", version = "0.8.67" }
+codewhale-agent = { path = "../agent", version = "0.8.68" }
+codewhale-app-server = { path = "../app-server", version = "0.8.68" }
+codewhale-config = { path = "../config", version = "0.8.68" }
+codewhale-lane = { path = "../lane", version = "0.8.68" }
+codewhale-workflow = { path = "../workflow", version = "0.8.68" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.68" }
+codewhale-mcp = { path = "../mcp", version = "0.8.68" }
+codewhale-release = { path = "../release", version = "0.8.68" }
+codewhale-secrets = { path = "../secrets", version = "0.8.68" }
+codewhale-state = { path = "../state", version = "0.8.68" }
 chrono.workspace = true
 dirs.workspace = true
 serde.workspace = true
@@ -43,7 +43,7 @@ tempfile.workspace = true
 tracing.workspace = true
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.8.67" }
+codewhale-build-support = { path = "../build-support", version = "0.8.68" }
 
 # Parent-death cleanup for delegated server children (#3259): on Linux the
 # dispatcher sets PR_SET_PDEATHSIG so the child is signalled if the dispatcher

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,8 +8,8 @@ description = "Config schema and precedence model for CodeWhale"
 
 [dependencies]
 anyhow.workspace = true
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
-codewhale-secrets = { path = "../secrets", version = "0.8.67" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.68" }
+codewhale-secrets = { path = "../secrets", version = "0.8.68" }
 dirs.workspace = true
 libc = "0.2"
 serde.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,14 +9,14 @@ description = "Core runtime boundaries for CodeWhale"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-agent = { path = "../agent", version = "0.8.67" }
-codewhale-config = { path = "../config", version = "0.8.67" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
-codewhale-hooks = { path = "../hooks", version = "0.8.67" }
-codewhale-mcp = { path = "../mcp", version = "0.8.67" }
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
-codewhale-state = { path = "../state", version = "0.8.67" }
-codewhale-tools = { path = "../tools", version = "0.8.67" }
+codewhale-agent = { path = "../agent", version = "0.8.68" }
+codewhale-config = { path = "../config", version = "0.8.68" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.68" }
+codewhale-hooks = { path = "../hooks", version = "0.8.68" }
+codewhale-mcp = { path = "../mcp", version = "0.8.68" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
+codewhale-state = { path = "../state", version = "0.8.68" }
+codewhale-tools = { path = "../tools", version = "0.8.68" }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true

--- a/crates/execpolicy/Cargo.toml
+++ b/crates/execpolicy/Cargo.toml
@@ -8,5 +8,5 @@ description = "Execution policy and approval model for CodeWhale"
 
 [dependencies]
 anyhow.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
 serde.workspace = true

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -10,8 +10,8 @@ description = "Hook dispatch and notifications support for CodeWhale"
 anyhow.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
-codewhale-release = { path = "../release", version = "0.8.67" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
+codewhale-release = { path = "../release", version = "0.8.68" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -9,7 +9,7 @@ description = "Lane registry and Runtime backends for CodeWhale workflow instanc
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-config = { path = "../config", version = "0.8.67" }
+codewhale-config = { path = "../config", version = "0.8.68" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -9,7 +9,7 @@ description = "Session/thread persistence and recovery model for CodeWhale"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
 dirs.workspace = true
 rusqlite.workspace = true
 serde.workspace = true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tool invocation lifecycle, schema validation, and scheduler paral
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.68] - 2026-07-10
+
 ### Changed
 
 - Make the advertised Android/Termux release target buildable by generating
@@ -2004,31 +2006,6 @@ documentation (#2756, #2735). Additional thanks to **@Implementist** for Plan
 prompt scrolling, wrapping, and display-width fixes, **@jrcjrcc** for the
 Windows sub-agent completion render-width fix, and **@punkcanyang** for the
 original `/init` implementation harvested through #2771/#2745.
-
-## [0.8.53] - 2026-06-03
-
-### Added
-
-- **Hugging Face Inference Providers.** Added `huggingface` as a native
-  provider route (`/provider huggingface`). Supports `HUGGINGFACE_API_KEY`
-  or `HF_TOKEN` for auth, `HUGGINGFACE_BASE_URL` and `HUGGINGFACE_MODEL`
-  for overrides, and `deepseek-ai/DeepSeek-V4-Pro` / `deepseek-ai/DeepSeek-V4-Flash`
-  as default models. Org-prefixed model IDs pass through.
-
-### Fixed
-
-- **Agent-mode shell error copy.** The missing-tool error for shell tools
-  now directs users to `allow_shell = true` instead of nudging toward YOLO
-  mode. `/config` surfaces `allow_shell` in the Permissions section.
-- **Provider description.** `/provider` command description is now neutral
-  instead of recommending specific providers.
-
-### Community
-
-Thanks to **@xyuai** for provider persistence, `/logout` scope clarification,
-provider picker key replacement, and MiMo auth cleanup work (#2714, #2715,
-#2717, #2718), and **@RefuseOdd** for configurable `path_suffix` support on
-OpenAI-compatible endpoints (#2558).
 
 ---
 

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -23,14 +23,14 @@ path = "src/main.rs"
 [dependencies]
 ahash = "0.8"
 anyhow.workspace = true
-codewhale-config = { path = "../config", version = "0.8.67" }
-codewhale-execpolicy = { path = "../execpolicy", version = "0.8.67" }
-codewhale-protocol = { path = "../protocol", version = "0.8.67" }
-codewhale-release = { path = "../release", version = "0.8.67" }
-codewhale-secrets = { path = "../secrets", version = "0.8.67" }
-codewhale-tools = { path = "../tools", version = "0.8.67" }
-codewhale-workflow = { path = "../workflow", version = "0.8.67" }
-codewhale-workflow-js = { path = "../workflow-js", version = "0.8.67" }
+codewhale-config = { path = "../config", version = "0.8.68" }
+codewhale-execpolicy = { path = "../execpolicy", version = "0.8.68" }
+codewhale-protocol = { path = "../protocol", version = "0.8.68" }
+codewhale-release = { path = "../release", version = "0.8.68" }
+codewhale-secrets = { path = "../secrets", version = "0.8.68" }
+codewhale-tools = { path = "../tools", version = "0.8.68" }
+codewhale-workflow = { path = "../workflow", version = "0.8.68" }
+codewhale-workflow-js = { path = "../workflow-js", version = "0.8.68" }
 schemaui = { version = "0.12.0", default-features = false, optional = true }
 async-stream = "0.3.6"
 async-trait.workspace = true
@@ -88,7 +88,7 @@ shell-words = "1.1.1"
 mimalloc.workspace = true
 
 [build-dependencies]
-codewhale-build-support = { path = "../build-support", version = "0.8.67" }
+codewhale-build-support = { path = "../build-support", version = "0.8.68" }
 
 [dev-dependencies]
 cucumber = "0.23.0"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -215,11 +215,11 @@ a download sourced from an impersonating repository or mirror.
 ## 3. Install via npm
 
 npm is the recommended install path. The `codewhale` wrapper is published at
-v0.8.67 (Node 18+; wrapper available for v0.8.56 and later).
+v0.8.68 (Node 18+; wrapper available for v0.8.56 and later).
 
 ```bash
 npm install -g codewhale
-codewhale --version   # 0.8.67
+codewhale --version   # 0.8.68
 ```
 
 `postinstall` downloads the right pair of binaries from the matching GitHub

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -2,8 +2,8 @@
 
 codewhale has two related concepts:
 
-- **TUI mode**: what kind of visible interaction you're in (Plan/Agent/YOLO).
-- **Approval mode**: how aggressively the UI asks before executing tools.
+- **TUI mode**: what kind of visible interaction you're in (Plan/Act/Operate).
+- **Approval posture**: how aggressively the UI asks before executing tools.
 - **Workflow overlay**: optional long-running orchestration that can
   run on top of any TUI mode when a task needs many coordinated workers.
 
@@ -22,16 +22,14 @@ into a resumable workflow with its own progress view.
 
 Press `Tab` to complete composer menus, queue a draft as a next-turn follow-up
 while a turn is running, or cycle through the visible modes when the composer is
-otherwise idle: **Plan → Act → Multitask → Operate → Plan**.
+otherwise idle: **Plan → Act → Operate → Plan**.
 Press `Shift+Tab` to cycle permission posture (Ask → Auto-Review → Full Access).
 Press `Ctrl+T` to cycle reasoning effort.
 Run `/mode` to open the mode picker, or switch directly with `/mode act`,
-`/mode plan`, `/mode multitask`, `/mode operate`, `/mode yolo` (deprecated shim),
-`/mode 1`, `/mode 2`, `/mode 3`, `/mode 5`, or `/mode 4`.
+`/mode plan`, `/mode operate`, or `/mode yolo` (deprecated compatibility shim).
 
 - **Plan**: design-first prompting. Read-only investigation tools stay available; shell and patch execution stay off. Use this when you want to think out loud and produce a plan to hand to a human (yourself later, or a reviewer).
 - **Act** (Agent): multi-step tool use. In interactive TUI sessions, shell tools (`exec_shell`, `task_shell_start`, `task_shell_wait`) are available by default and approval prompts gate each call. Set top-level `allow_shell = false` to hide shell tools for a workspace/profile. File writes are allowed without a prompt.
-- **Multitask**: lighter delegation posture — spawn background sub-agents in parallel, start workflows non-blocking, and keep the operator turn responsive.
 - **Operate**: conductor posture — prefer Fleet roster + `/workflow` orchestration over solo inline tool chains; delegate by default.
 - **YOLO** (deprecated): maps to Act + Full Access permissions (`Shift+Tab` to Bypass). Use only in trusted repos.
 
@@ -39,7 +37,7 @@ Run `/mode` to open the mode picker, or switch directly with `/mode act`,
 
 ### Tool availability by mode
 
-| Tool family | Plan | Agent | YOLO |
+| Tool family | Plan | Act | Operate |
 |:---|:---:|:---:|:---:|
 | Read-only file, search, and diagnostic tools | yes | yes | yes |
 | File write and patch tools | no | yes | yes |

--- a/npm/codewhale/package.json
+++ b/npm/codewhale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codewhale",
-  "version": "0.8.67",
-  "codewhaleBinaryVersion": "0.8.67",
+  "version": "0.8.68",
+  "codewhaleBinaryVersion": "0.8.68",
   "description": "Install and run CodeWhale, the agentic terminal for open-source and open-weight coding models, from GitHub release artifacts.",
   "author": "Hmbown",
   "license": "MIT",

--- a/web/app/[locale]/constitution/page.tsx
+++ b/web/app/[locale]/constitution/page.tsx
@@ -69,9 +69,9 @@ export default async function ConstitutionPage({ params }: { params: Promise<{ l
             : "As a project ages, instructions pile up and conflict: the original spec, a refactor that contradicts it, stale memory, a previous agent's handoff, your current request, fresh test output that doesn't match what the handoff claimed. A flat system prompt makes the model resolve that by guess. CodeWhale uses a nested constitution so there is a defined rank instead of vibes — the order is enforced in the harness, with tests asserting it can't drift, and it stays intact when you swap models."}
         </p>
 
-        {/* v0.8.67 flagship framing */}
+        {/* v0.8.68 flagship framing */}
         <div className="mt-7 max-w-2xl px-4 py-3 hairline-t hairline-b hairline-l hairline-r">
-          <span className="pill pill-new mr-2">{isZh ? "v0.8.67 新增" : "New in v0.8.67"}</span>
+          <span className="pill pill-new mr-2">{isZh ? "v0.8.68 新增" : "New in v0.8.68"}</span>
           <span className={`text-sm text-ink-soft ${isZh ? "leading-[1.9] tracking-wide" : "leading-relaxed"}`}>
             {isZh
               ? "宪法优先的初始设置——首次启动依次引导语言、模型、安全姿态和你的宪法；之后随时 /setup。模型可以起草，由你批准。"

--- a/web/app/[locale]/docs/modes/page.tsx
+++ b/web/app/[locale]/docs/modes/page.tsx
@@ -8,8 +8,8 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     locale,
     title: isZh ? "模式 · CodeWhale 文档" : "Modes · CodeWhale Docs",
     description: isZh
-      ? "Plan、Agent、YOLO 三种运行模式与正交审批策略。"
-      : "Plan, Agent, YOLO operating modes and orthogonal approval policies.",
+      ? "Plan、Act、Operate 三种运行模式与正交审批姿态。"
+      : "Plan, Act, Operate modes and orthogonal approval posture.",
   });
 }
 

--- a/web/app/[locale]/faq/page.tsx
+++ b/web/app/[locale]/faq/page.tsx
@@ -163,7 +163,7 @@ default_text_model = "openrouter/deepseek/deepseek-v4-pro"`}
     sources: ["#574", "#1303", "docs/CONFIGURATION.md"],
   },
   {
-    q: "What are Plan, Agent, and YOLO modes?",
+    q: "What are Plan, Act, and Operate modes?",
     a: (
       <>
         <ul className="list-disc pl-5 space-y-2 text-sm text-ink-soft">
@@ -203,7 +203,7 @@ default_text_model = "openrouter/deepseek/deepseek-v4-pro"`}
         <code className="inline">/goal</code> sets a goal for the current TUI session.
         App-server clients can also persist a thread-scoped goal through the
         <code className="inline">thread/goal/*</code> methods. It does not add another
-        app mode; the mode switcher remains Plan, Agent, and YOLO.
+        app mode; the mode switcher remains Plan, Act, and Operate, while approval posture is selected independently.
         Track progress in <a href="https://github.com/Hmbown/CodeWhale/issues/891" className="body-link">#891</a>.
       </>
     ),
@@ -507,7 +507,7 @@ default_text_model = "openrouter/deepseek/deepseek-v4-pro"`}
     sources: ["#574", "#1303", "docs/CONFIGURATION.md"],
   },
   {
-    q: "Plan、Agent、YOLO 三种模式有什么区别？",
+    q: "Plan、Act、Operate 三种模式有什么区别？",
     a: (
       <>
         <ul className="list-disc pl-5 space-y-2 text-sm text-ink-soft">
@@ -546,7 +546,7 @@ default_text_model = "openrouter/deepseek/deepseek-v4-pro"`}
       <>
         <code className="inline">/goal</code> 为当前 TUI 会话设置目标，支持 <code className="inline">pause</code>、<code className="inline">resume</code>、<code className="inline">complete</code>、<code className="inline">blocked</code> 和 <code className="inline">clear</code> 控制。
         App-server 客户端也可以通过 <code className="inline">thread/goal/*</code> 方法持久化线程范围的目标，支持 <code className="inline">set</code>、<code className="inline">get</code> 和 <code className="inline">clear</code>。
-        它不会新增一个应用模式；模式切换器仍然是 Plan、Agent 和 YOLO。
+        它不会新增一个应用模式；模式切换器仍然是 Plan、Act 和 Operate，审批姿态独立选择。
         跟踪进展：<a href="https://github.com/Hmbown/CodeWhale/issues/891" className="body-link">#891</a>。
       </>
     ),

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       : "CodeWhale — the terminal coding agent for any model, open models first",
     description: isZh
       ? "开源终端编程智能体：适配任意模型，开放模型优先。从 DeepSeek、本地 vLLM/Ollama 到原生 Claude 与 OpenAI，内置审批制工具、沙箱隔离与 /restore 回滚。"
-      : "Open-source terminal coding agent for any model, open models first: broad provider support from DeepSeek and local vLLM/Ollama to native Claude and OpenAI, with approval-gated tools, sandboxing, and /restore rollback.",
+      : "Open-source terminal coding agent for any model, open models first: provider-honest routing from DeepSeek and local vLLM/Ollama to native Claude and OpenAI, with approval-gated tools, sandboxing, rollback, and durable Fleet/Workflow runs.",
   });
 }
 

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -169,7 +169,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           <Seal char="法" />
           <h2 className="font-display">{isZh ? "三层法" : "Three layers of law"}</h2>
           <span className="pill pill-new">
-            {isZh ? "v0.8.67 新增：宪法优先设置" : "New in v0.8.67: constitution-first setup"}
+            {isZh ? "v0.8.68 新增：宪法优先设置" : "New in v0.8.68: constitution-first setup"}
           </span>
         </div>
 
@@ -233,12 +233,12 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
             ? [
                 { n: "01", t: "安装", d: "npm 一行装好，或用 Cargo / Homebrew / 直接下载二进制。中国大陆网络有 CNB 与清华 Tuna 镜像。", cta: "安装指南 →", href: isZh ? "/zh/install" : "/install" },
                 { n: "02", t: "配密钥", d: "codewhale auth set --provider deepseek（或 openrouter、anthropic、zai 等）。本地 vLLM / Ollama 无需密钥。", cta: "提供商列表 →", href: isZh ? "/zh/docs#providers" : "/docs#providers" },
-                { n: "03", t: "运行", d: "在项目目录里敲 codewhale。默认 Plan 只读调查；按 Tab 切到 Agent 执行。", cta: "文档 →", href: isZh ? "/zh/docs" : "/docs" },
+                { n: "03", t: "运行", d: "在项目目录里敲 codewhale。默认 Plan 只读调查；按 Tab 切到 Act 执行，或切到 Operate 编排 Fleet/Workflow。", cta: "文档 →", href: isZh ? "/zh/docs" : "/docs" },
               ]
             : [
                 { n: "01", t: "Install", d: "One npm line, or Cargo / Homebrew / a direct binary. On mainland China networks, the CNB and Tsinghua Tuna mirrors route around GitHub.", cta: "Install guide →", href: "/install" },
                 { n: "02", t: "Add a key", d: "codewhale auth set --provider deepseek (or openrouter, anthropic, zai, …). A local vLLM or Ollama box needs no key at all.", cta: "Provider list →", href: "/docs#providers" },
-                { n: "03", t: "Run it", d: "Type codewhale in a project. Plan mode is read-only by default; press Tab for Agent mode.", cta: "Docs →", href: "/docs" },
+                { n: "03", t: "Run it", d: "Type codewhale in a project. Plan is read-only; press Tab for Act, or choose Operate when the job needs durable Fleet/Workflow orchestration.", cta: "Docs →", href: "/docs" },
               ]
           ).map((item) => (
             <Link key={item.n} href={item.href} className="block p-6 hover:bg-paper-deep transition-colors">

--- a/web/app/[locale]/roadmap/page.tsx
+++ b/web/app/[locale]/roadmap/page.tsx
@@ -25,7 +25,7 @@ const tracksEn = [
       { title: "Typed tool surface", note: "read, write, edit, patch, grep, shell, git, web search — plus sub-agents, RLM, and MCP" },
       { title: "Sub-agent parallel execution", note: "agent; up to 10 concurrent sessions with bounded result handles" },
       { title: "RLM batched processing", note: "Persistent sandboxed Python REPL with 1–16 cheap parallel children for long-input analysis" },
-      { title: "Three operating modes", note: "Plan (read-only), Agent (default), YOLO (auto-approved); orthogonal suggest / auto / never approval" },
+      { title: "Three operating modes", note: "Plan (read-only), Act (execution), Operate (Fleet/Workflow orchestration); orthogonal Ask / Auto-Review / Full Access posture" },
       { title: "Per-platform sandbox", note: "seatbelt (macOS), landlock (Linux); Windows containment via restricted tokens (limited)" },
       { title: "Durable sessions + tasks", note: "Save, resume, rollback; background task queue with replayable timelines under ~/.codewhale/tasks/" },
       { title: "Bidirectional MCP", note: "Consume tools from external servers; expose as server via `codewhale mcp`; ~/.codewhale/mcp.json" },

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -94,8 +94,8 @@ export const DOC_TOPICS: DocTopic[] = [
     slug: "modes",
     label: { en: "Modes", zh: "模式" },
     description: {
-      en: "Plan, Agent, YOLO modes and orthogonal approval policies.",
-      zh: "Plan、Agent、YOLO 三种模式与正交审批策略。",
+      en: "Plan, Act, Operate modes and orthogonal approval posture.",
+      zh: "Plan、Act、Operate 三种模式与正交审批姿态。",
     },
     repoSource: "docs/MODES.md",
     hasPage: true,

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -18,8 +18,8 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-07-09T21:10:21.620Z",
-  "version": "0.8.67",
+  "generatedAt": "2026-07-10T00:34:57.187Z",
+  "version": "0.8.68",
   "crates": [
     "agent",
     "app-server",

--- a/web/lib/page-meta.ts
+++ b/web/lib/page-meta.ts
@@ -7,7 +7,7 @@ export const SITE_NAME = "CodeWhale";
 
 /** The one-line product identity, used as the default OG image alt text. */
 export const IDENTITY_PHRASE =
-  "The terminal coding agent for any model — open models first.";
+  "The calm, provider-honest terminal coding agent for any model — open models first.";
 
 /** Shared OG card rendered by app/opengraph-image.tsx (1200×630 PNG). */
 const OG_IMAGE = {

--- a/workflows/v0868_catalog_lane.workflow.js
+++ b/workflows/v0868_catalog_lane.workflow.js
@@ -50,7 +50,7 @@ export default workflow({
               "id": "impl-refresh-policy",
               "prompt": "Implement catalog refresh policy (#4114) per scout-openrouter findings: manual `/model refresh` or `/provider refresh`, background TTL refresh, stale chip, fail-closed on auth errors, secret-free cache persistence. Touch `client.rs` and `catalog.rs`. Add tests. Run `cargo test -p codewhale-config catalog` and `cargo test -p codewhale-tui provider_lake`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/client.rs", "crates/config/src/catalog.rs"],
               "budget": { "max_steps": 24, "timeout_secs": 1800 }
             }
@@ -60,7 +60,7 @@ export default workflow({
               "id": "impl-picker-views",
               "prompt": "Implement model picker catalog views (#4115, #4139-4141) per scout-picker-views: Configured/Catalog/Recent/Coding/Cheap/Long-context views, metadata rows, cross-field search on provider+model. Minimal diff matching existing picker patterns. Tests in `cargo test -p codewhale-tui model_picker`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tui/model_picker.rs", "crates/tui/src/tui/provider_picker.rs"],
               "budget": { "max_steps": 24, "timeout_secs": 1800 }
             }
@@ -70,7 +70,7 @@ export default workflow({
               "id": "impl-migrate-consumers",
               "prompt": "Migrate remaining legacy model source consumers to ProviderLake (#4116). Replace `model_completion_names_for_provider` at each scout-legacy-sources call site. Keep bundled fallback for unconfigured providers. Run `cargo test -p codewhale-tui model_inventory hotbar subagent`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tui/hotbar/", "crates/tui/src/tools/subagent/mod.rs"],
               "budget": { "max_steps": 20, "timeout_secs": 1200 }
             }

--- a/workflows/v0868_issue_implement.workflow.js
+++ b/workflows/v0868_issue_implement.workflow.js
@@ -27,7 +27,7 @@ export default workflow({
         "id": "implement-fix",
         "prompt": "Implement the issue per scout-code plan. Branch from main (`git checkout main && git pull && git checkout -b codex/v0868-fix-<N>`). Stay within OUT_OF_SCOPE. Smallest correct diff. Run VERIFICATION commands from ISSUE_BRIEF. If blocked, report blocker clearly instead of guessing.",
         "agent_type": "implementer",
-        "mode": "write",
+        "mode": "read_write",
         "file_scope": ["crates/"],
         "budget": { "max_steps": 24, "timeout_secs": 1800 }
       }

--- a/workflows/v0868_stopship_lane.workflow.js
+++ b/workflows/v0868_stopship_lane.workflow.js
@@ -54,7 +54,7 @@ export default workflow({
               "prompt": "Fix #4090 using scout-ctrl-c findings. Branch from main (git checkout main && git pull && git checkout -b codex/v0868-fix-4090). Implement minimal fix so double Ctrl+C exits cleanly in PTY/raw-mode while preserving cancel/copy behavior. Add regression test or PTY/key-path trace. Run: `cargo test -p codewhale-tui` for touched modules and `cargo clippy -p codewhale-tui -- -D warnings`. Do not close the issue; report files changed and test output.",
               "agent_type": "implementer",
               "role": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tui/app.rs", "crates/tui/src/tui/ui.rs"],
               "budget": { "max_steps": 20, "timeout_secs": 1200 }
             }
@@ -65,7 +65,7 @@ export default workflow({
               "prompt": "Using scout findings, fix #4093 and/or #4094 if root causes are clear and independent. Branch from main (separate branches per issue if needed: codex/v0868-fix-4093, codex/v0868-fix-4094). Prefer smallest correct diffs. For #4093: Fleet setup should edit role/profile roster not provider scope. For #4094: sub-agent detail panel must render and not freeze TUI. Add tests where feasible. Run targeted `cargo test -p codewhale-tui fleet sidebar`. Report per-issue status: fixed/partial/blocked.",
               "agent_type": "implementer",
               "role": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tui/views/fleet_setup.rs", "crates/tui/src/tui/sidebar.rs"],
               "budget": { "max_steps": 24, "timeout_secs": 1800 }
             }
@@ -73,10 +73,10 @@ export default workflow({
           {
             "agent": {
               "id": "verify-dogfood",
-              "prompt": "Re-verify dogfood fixes for #3986 (API-key onboarding copy shows CODEWHALE_HOME path) and #3990 (slash autocomplete alias duplication). Read issue bodies via `gh issue view`. Check if fixes exist on current branch; if missing, implement minimal fixes. Run verification gate subset: `cargo fmt --all --check`, `cargo test -p codewhale-tui -- onboarding slash`. Report done/partial/missing per issue.",
+              "prompt": "Re-verify dogfood fixes for #3986 (API-key onboarding copy shows CODEWHALE_HOME path) and #3990 (slash autocomplete alias duplication). Read issue bodies via `gh issue view`. Check if fixes exist on current branch; if missing, report them as missing rather than editing. Run verification gate subset: `cargo fmt --all --check`, `cargo test -p codewhale-tui -- onboarding slash`. Report done/partial/missing per issue.",
               "agent_type": "verifier",
               "role": "verifier",
-              "mode": "write",
+              "mode": "read_only",
               "file_scope": ["crates/tui/src/tui/", "crates/tui/locales/en.json"],
               "budget": { "max_steps": 16, "timeout_secs": 900 }
             }

--- a/workflows/v0868_tui_copy_lane.workflow.js
+++ b/workflows/v0868_tui_copy_lane.workflow.js
@@ -50,7 +50,7 @@ export default workflow({
               "id": "impl-copy-dedupe",
               "prompt": "Implement copy dedupe batch (#4142-#4148, #4112) per scout findings. Rules: disclose once not thrice; header OR footer OR sidebar owns each fact. Touch `en.json`, `mode_picker.rs`, `history.rs`, `sidebar.rs` as needed. Add/adjust tests. `cargo test -p codewhale-tui history mode_picker`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/locales/en.json", "crates/tui/src/tui/history.rs"],
               "budget": { "max_steps": 20, "timeout_secs": 1200 }
             }
@@ -60,7 +60,7 @@ export default workflow({
               "id": "impl-compact-default",
               "prompt": "If scout-compact-mode recommends it, make compact presentation the default (#4095) with safe migration for existing users. Minimal config/default change. Document in CHANGELOG snippet. `cargo test -p codewhale-tui config`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/config.rs"],
               "budget": { "max_steps": 12, "timeout_secs": 900 }
             }

--- a/workflows/v0868_workflow_ui_lane.workflow.js
+++ b/workflows/v0868_workflow_ui_lane.workflow.js
@@ -50,7 +50,7 @@ export default workflow({
               "id": "impl-typed-events",
               "prompt": "Implement typed WorkflowUiEvent stream (#4118) per scout findings. Replace string progress where needed; add resolution fields (provider, model, route_source). Wire sub-agent spawn metadata (#4119). Default parallel write children to worktree (#4120). Tests: `cargo test -p codewhale-tui workflow`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tools/workflow.rs", "crates/tui/src/tools/subagent/mod.rs"],
               "budget": { "max_steps": 28, "timeout_secs": 2400 }
             }
@@ -60,7 +60,7 @@ export default workflow({
               "id": "impl-workflow-panel",
               "prompt": "Implement WorkflowPanel unified activity surface (#4121, #4122, #4125) and history card routing (#4122). Create or extend `workflow_panel.rs`. Panel: collapsed/expanded, phase list, child rows, cancel. History card: phase summary, failure details. Tests for state transitions (#4123). `cargo test -p codewhale-tui workflow_panel history`.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tui/history.rs"],
               "budget": { "max_steps": 28, "timeout_secs": 2400 }
             }
@@ -70,7 +70,7 @@ export default workflow({
               "id": "impl-auto-launch",
               "prompt": "Implement automatic launch pieces (#4127-4129): planner-to-workflow structured launch (#4124), parent prompt update (#4125), approval card for elevated plans (#4126), trigger suppression (#4127), config defaults (#4128), sandbox regression tests (#4129). Prioritize config keys + suppression + prompt; defer full dogfood (#4131) if timeboxed.",
               "agent_type": "implementer",
-              "mode": "write",
+              "mode": "read_write",
               "file_scope": ["crates/tui/src/tools/workflow.rs", "crates/workflow-js/src/vm.rs", "config.example.toml"],
               "budget": { "max_steps": 28, "timeout_secs": 2400 }
             }


### PR DESCRIPTION
## v0.8.68 release preparation

This release PR is intentionally last: all feature work and CI-speed work are already merged, and this branch only carries the release version/changelog plus final public docs/site language.

### Included
- Bump workspace crates, Cargo.lock, npm wrapper, README/install snippets, and generated web facts to `0.8.68`.
- Add the dated `CHANGELOG.md` / `crates/tui/CHANGELOG.md` entries and compare link.
- Align public docs/site copy with the shipped Plan / Act / Operate modes, orthogonal approval posture, and durable Fleet/Workflow overlay.
- Keep the provider-honest/open-model-first positioning and no hosted-account/inference-markup claims.

### Verification
- `./scripts/release/check-versions.sh`
- `cargo build --release --locked --bin codewhale`
- `./target/release/codewhale --version` → `codewhale 0.8.68 (5dbd47739b82)`
- Website `npm run build` → Next.js production build, 39 static pages
- `git diff --check`

The local npm install generated an uncommitted lockfile normalization in the worktree only; it is intentionally not part of this PR.
