### PR TITLE
fix: update cargo-deny advisory ignore list

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,36 @@
+name: cargo-deny
+
+permissions: {}
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/cargo-deny.yml'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+  push:
+    branches: [main, master]
+  schedule:
+    # Run weekly on Monday at 06:31 UTC
+    - cron: '31 6 * * 1'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent sudden announcement of a new advisory from failing CI
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check ${{ matrix.checks }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,31 @@
+name: Security audit
+
+permissions: {}
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/security-audit.yml'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/audit.toml'
+  push:
+    branches: [main, master]
+  schedule:
+    # Run weekly on Monday at 06:31 UTC
+    - cron: '31 6 * * 1'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  self-audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Run cargo audit
+        run: cargo audit

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ open an issue — that's how the project grows.
 [简体中文 README](README.zh-CN.md) · [日本語 README](README.ja-JP.md) · [Tiếng Việt README](README.vi.md) · [한국어 README](README.ko-KR.md) · [codewhale.net](https://codewhale.net/) · [Install guide](docs/INSTALL.md) · [Provider registry](docs/PROVIDERS.md) · [Changelog](CHANGELOG.md)
 
 [![CI](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/ci.yml)
+[![Security audit](https://github.com/Hmbown/CodeWhale/actions/workflows/security-audit.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/security-audit.yml)
+[![cargo-deny](https://github.com/Hmbown/CodeWhale/actions/workflows/cargo-deny.yml/badge.svg)](https://github.com/Hmbown/CodeWhale/actions/workflows/cargo-deny.yml)
 [![crates.io](https://img.shields.io/crates/v/codewhale-cli?label=crates.io)](https://crates.io/crates/codewhale-cli)
 [![npm](https://img.shields.io/npm/v/codewhale?label=npm)](https://www.npmjs.com/package/codewhale)
 [![DeepWiki project index](https://img.shields.io/badge/DeepWiki-project-blue)](https://deepwiki.com/Hmbown/CodeWhale)

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration for CodeWhale
+# https://github.com/rustsec/rustsec/blob/main/cargo-audit/audit.toml.example
+
+[advisories]
+# Ignore specific advisories if needed (add RUSTSEC-XXXX-XXXXX)
+# ignore = []
+
+[database]
+# Path to a local advisory database (optional)
+# path = ""
+
+# URL to fetch advisory database from
+# url = ""

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,56 @@
+# cargo-deny configuration for CodeWhale
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Scan all workspace members with all features
+all-features = true
+
+[advisories]
+# Deny unmaintained and unsound crates
+unmaintained = "all"
+unsound = "all"
+# Ignore specific advisories (known issues in dependencies)
+ignore = [
+    "RUSTSEC-2026-0187",  # lopdf stack overflow - no safe upgrade
+    "RUSTSEC-2024-0436",  # paste unmaintained - no safe upgrade
+    "RUSTSEC-2026-0192",  # ttf-parser unmaintained - no safe upgrade
+]
+
+[bans]
+# Deny multiple versions of the same crate
+multiple-versions = "warn"
+# Deny wildcard version requirements
+wildcards = "deny"
+
+[sources]
+# Deny unknown registries and git sources
+unknown-registry = "deny"
+unknown-git = "deny"
+# Allow only crates.io
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Allow git sources used by the project (add as needed)
+allow-git = []
+
+[licenses]
+# Confidence threshold for license inference from text
+confidence-threshold = 0.93
+# Allowed licenses (MIT for CodeWhale, plus common transitive deps)
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "MPL-2.0",
+    "CC0-1.0",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+]
+# License exceptions for specific crates if needed
+exceptions = []

--- a/deny.toml
+++ b/deny.toml
@@ -11,9 +11,10 @@ unmaintained = "all"
 unsound = "all"
 # Ignore specific advisories (known issues in dependencies)
 ignore = [
-    "RUSTSEC-2026-0187",  # lopdf stack overflow - no safe upgrade
     "RUSTSEC-2024-0436",  # paste unmaintained - no safe upgrade
     "RUSTSEC-2026-0192",  # ttf-parser unmaintained - no safe upgrade
+    "RUSTSEC-2024-0388",  # derivative unmaintained - transitive via starlark
+    "RUSTSEC-2025-0057",  # fxhash unmaintained - transitive via starlark
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Update cargo-deny advisory ignore list:

- Remove RUSTSEC-2026-0187 (lopdf fixed in PR #4328)
- Add RUSTSEC-2024-0388 (derivative unmaintained, transitive via starlark)
- Add RUSTSEC-2025-0057 (fxhash unmaintained, transitive via starlark)

## Context

Both  and  are transitive dependencies via , which is used by . No safe upgrade path exists for these crates.