### PR TITLE
docs(release): align v0.8.68 mode FAQ and workflow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ into bounded steps, can fan those steps out through Fleet workers, and records
 progress and verification in `.codewhale/workflow-runs.jsonl`:
 
 ```bash
-codewhale workflow run my-workflow.js --verify
-codewhale workflow status
-codewhale workflow logs <run-id>
+codewhale workflow run my-workflow.js --fleet <fleet-name> --runtime tmux --verify
+codewhale lane status <lane-id>
+codewhale lane logs <lane-id>
 ```
 
 Workflow is an overlay, not another permission mode: Plan / Act / Operate and

--- a/web/app/[locale]/faq/page.tsx
+++ b/web/app/[locale]/faq/page.tsx
@@ -168,12 +168,12 @@ default_text_model = "openrouter/deepseek/deepseek-v4-pro"`}
       <>
         <ul className="list-disc pl-5 space-y-2 text-sm text-ink-soft">
           <li><strong>Plan</strong> — Read-only investigation. Can grep, read files, list directories, fetch URLs. Cannot write or execute shell.</li>
-          <li><strong>Agent</strong> — Default mode. Multi-step tool calling. Shell and side-effect tools require approval based on your approval_mode setting.</li>
-          <li><strong>YOLO</strong> — Auto-approves all operations and enables trust mode. Workspace boundaries lift. Use carefully.</li>
+          <li><strong>Act</strong> — Multi-step execution. Shell and side-effect tools require approval based on your approval_mode setting.</li>
+          <li><strong>Operate</strong> — Durable Fleet/Workflow orchestration for larger, staged jobs. It is still governed by the same approval posture.</li>
         </ul>
         <p className="mt-2">
           Press <kbd className="font-mono text-xs px-1.5 py-0.5 hairline-t hairline-b hairline-l hairline-r">Tab</kbd> to cycle modes.
-          Approval mode (suggest / auto / never) is orthogonal — you can be in Agent mode with auto-approval, for example.
+          Approval mode (suggest / auto / never) is orthogonal — you can be in Act mode with auto-approval, for example.
         </p>
       </>
     ),
@@ -512,12 +512,12 @@ default_text_model = "openrouter/deepseek/deepseek-v4-pro"`}
       <>
         <ul className="list-disc pl-5 space-y-2 text-sm text-ink-soft">
           <li><strong>Plan（计划）</strong> — 只读调查。可以 grep、读文件、列目录、抓取 URL。不能写入或执行 Shell。</li>
-          <li><strong>Agent（代理）</strong> — 默认模式。多步工具调用。Shell 和有副作用的工具根据 approval_mode 设置审批。</li>
-          <li><strong>YOLO（全权）</strong> — 自动批准所有操作并启用信任模式。工作区边界解除。请谨慎使用。</li>
+          <li><strong>Act（执行）</strong> — 多步执行。Shell 和有副作用的工具根据 approval_mode 设置审批。</li>
+          <li><strong>Operate（编排）</strong> — 面向较大、分阶段任务的持久 Fleet/Workflow 编排，仍受同一审批模式约束。</li>
         </ul>
         <p className="mt-2">
           按 <kbd className="font-mono text-xs px-1.5 py-0.5 hairline-t hairline-b hairline-l hairline-r">Tab</kbd> 切换模式。
-          审批模式（建议 / 自动 / 拒绝）是独立的——例如你可以在 Agent 模式下使用自动审批。
+          审批模式（建议 / 自动 / 拒绝）是独立的——例如你可以在 Act 模式下使用自动审批。
         </p>
       </>
     ),


### PR DESCRIPTION
## Summary

- align the English and Chinese FAQ with the shipped Plan / Act / Operate mode contract
- replace nonexistent `codewhale workflow status` / `workflow logs` README examples with the real `lane status` / `lane logs` commands
- add the required `--fleet` argument to the workflow run example

## Why

Claude review of merged release PR #4327 caught both inconsistencies. This keeps the v0.8.68 public docs executable and consistent with the CLI on `main` @ `7e18d5a2fe260a39258b85c5d1de394c1609b03a`.

## Verification

- `./scripts/release/check-versions.sh`
- `git diff --check`
- `npm --prefix web run check:docs`
- `npm --prefix web run lint` could not run because this worktree has no `eslint` binary installed

No release tag, GitHub Release, registry publish, or deploy was performed.