### PR TITLE
fix: make v0.8.68 TUI state and routing truthful

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -50,13 +50,23 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const PERMISSIONS_FILE_NAME: &str = "permissions.toml";
 
+fn http_headers_are_effectively_empty(headers: &BTreeMap<String, String>) -> bool {
+    !headers
+        .iter()
+        .any(|(name, value)| !name.trim().is_empty() && !value.trim().is_empty())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProviderConfigToml {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(
         default,
+        skip_serializing_if = "Option::is_none",
         alias = "contextWindow",
         alias = "context_window_tokens",
         alias = "contextWindowTokens",
@@ -64,66 +74,101 @@ pub struct ProviderConfigToml {
         alias = "contextLength"
     )]
     pub context_window: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub insecure_skip_tls_verify: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "http_headers_are_effectively_empty")]
     pub http_headers: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_suffix: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<ProviderAuthSourceToml>,
 }
 
+impl ProviderConfigToml {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        let blank = |value: Option<&String>| value.is_none_or(|value| value.trim().is_empty());
+
+        blank(self.api_key.as_ref())
+            && blank(self.base_url.as_ref())
+            && blank(self.model.as_ref())
+            && self.context_window.is_none()
+            && blank(self.mode.as_ref())
+            && blank(self.auth_mode.as_ref())
+            && self.insecure_skip_tls_verify.is_none()
+            && http_headers_are_effectively_empty(&self.http_headers)
+            && blank(self.path_suffix.as_ref())
+            && self.auth.is_none()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProvidersToml {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub deepseek: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "deepseek-anthropic",
         alias = "deepseekAnthropic",
         alias = "deepseek-claude",
         alias = "deepseek_claude"
     )]
     pub deepseek_anthropic: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub nvidia_nim: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub openai: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub atlascloud: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub wanjie_ark: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub volcengine: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub openrouter: ProviderConfigToml,
-    #[serde(default, alias = "xiaomi", alias = "mimo", alias = "xiaomimimo")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "xiaomi",
+        alias = "mimo",
+        alias = "xiaomimimo"
+    )]
     pub xiaomi_mimo: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub novita: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub fireworks: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub siliconflow: ProviderConfigToml,
-    #[serde(default, alias = "siliconflow-CN", alias = "siliconflow-cn")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "siliconflow-CN",
+        alias = "siliconflow-cn"
+    )]
     pub siliconflow_cn: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub arcee: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub moonshot: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub sglang: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub vllm: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub ollama: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub huggingface: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub together: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "baidu-qianfan",
         alias = "baidu_qianfan",
         alias = "baidu"
@@ -131,6 +176,7 @@ pub struct ProvidersToml {
     pub qianfan: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "openai-codex",
         alias = "openai_codex",
         alias = "codex",
@@ -138,12 +184,18 @@ pub struct ProvidersToml {
         alias = "chatgpt-codex"
     )]
     pub openai_codex: ProviderConfigToml,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub anthropic: ProviderConfigToml,
-    #[serde(default, alias = "open-model", alias = "open_model")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "open-model",
+        alias = "open_model"
+    )]
     pub openmodel: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "z-ai",
         alias = "z_ai",
         alias = "z.ai",
@@ -155,6 +207,7 @@ pub struct ProvidersToml {
     pub zai: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "step-fun",
         alias = "step_fun",
         alias = "stepfun",
@@ -163,14 +216,32 @@ pub struct ProvidersToml {
         alias = "step_flash"
     )]
     pub stepfun: ProviderConfigToml,
-    #[serde(default, alias = "mini-max", alias = "mini_max", alias = "minimax")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "mini-max",
+        alias = "mini_max",
+        alias = "minimax"
+    )]
     pub minimax: ProviderConfigToml,
-    #[serde(default, alias = "deep-infra", alias = "deep_infra")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "deep-infra",
+        alias = "deep_infra"
+    )]
     pub deepinfra: ProviderConfigToml,
-    #[serde(default, alias = "sakana-ai", alias = "sakana_ai", alias = "fugu")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "sakana-ai",
+        alias = "sakana_ai",
+        alias = "fugu"
+    )]
     pub sakana: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "long-cat",
         alias = "meituan-longcat",
         alias = "meituan"
@@ -178,6 +249,7 @@ pub struct ProvidersToml {
     pub longcat: ProviderConfigToml,
     #[serde(
         default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "meta-ai",
         alias = "meta_ai",
         alias = "meta-model-api",
@@ -186,14 +258,20 @@ pub struct ProvidersToml {
         alias = "muse-spark"
     )]
     pub meta: ProviderConfigToml,
-    #[serde(default, alias = "x-ai", alias = "x_ai", alias = "grok")]
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "x-ai",
+        alias = "x_ai",
+        alias = "grok"
+    )]
     pub xai: ProviderConfigToml,
     /// Catch-all table for the dynamic OpenAI-compatible custom provider
     /// identity (#1519). Arbitrary `[providers.<name>]` tables are handled by
     /// the tui-side flatten map; this named slot keeps the canonical
     /// `ProviderKind::Custom` lookups total without leaking into another
     /// provider's config.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProviderConfigToml::is_empty")]
     pub custom: ProviderConfigToml,
 }
 
@@ -254,6 +332,13 @@ impl PermissionsToml {
 }
 
 impl ProvidersToml {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        ProviderKind::all()
+            .iter()
+            .all(|provider| self.for_provider(*provider).is_empty())
+    }
+
     #[must_use]
     pub fn for_provider(&self, provider: ProviderKind) -> &ProviderConfigToml {
         match provider {
@@ -340,7 +425,7 @@ pub struct ConfigToml {
     /// TUI-compatible DeepSeek base URL.
     pub base_url: Option<String>,
     /// Optional extra HTTP headers forwarded to model API requests.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "http_headers_are_effectively_empty")]
     pub http_headers: BTreeMap<String, String>,
     /// TUI-compatible default DeepSeek model.
     pub default_text_model: Option<String>,
@@ -357,7 +442,7 @@ pub struct ConfigToml {
     /// Native tool catalog controls shared with `codewhale-tui`.
     #[serde(default)]
     pub tools: Option<ToolsToml>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ProvidersToml::is_empty")]
     pub providers: ProvidersToml,
     /// Provider fallback chain (#2574). TUI runtime code may advance through
     /// these providers after recoverable provider errors; config resolution

--- a/crates/config/src/setup_state.rs
+++ b/crates/config/src/setup_state.rs
@@ -307,6 +307,12 @@ pub struct SetupState {
     #[serde(default)]
     pub runtime_posture_source: RuntimePostureSource,
 
+    /// Host-enforced Workflow dispatch and terminal receipts have been proven
+    /// for this installation. Older records did not carry this proof and must
+    /// deserialize false even if their Operate/Fleet card was marked Verified.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub operate_receipts_verified: bool,
+
     /// True when this record was *derived* from existing config rather than
     /// persisted by an explicit setup run. Lets `/setup` and `doctor` explain
     /// why an updating user is not treated as a broken fresh install.
@@ -333,6 +339,7 @@ impl Default for SetupState {
             constitution_preview_hash: None,
             constitution_preview_version: 0,
             runtime_posture_source: RuntimePostureSource::default(),
+            operate_receipts_verified: false,
             inherited: false,
         }
     }
@@ -413,6 +420,7 @@ impl SetupState {
         self.first_run_ready()
             && self.step_verified(SetupStep::ProviderModel)
             && self.step_verified(SetupStep::OperateFleet)
+            && self.operate_receipts_verified
     }
 
     /// Update "ready" for `version`: the constitution checkpoint for that lane is
@@ -621,7 +629,30 @@ mod tests {
         assert!(!state.operate_ready());
 
         state.set_step(SetupStep::OperateFleet, verified("0.8.67"));
+        assert!(
+            !state.operate_ready(),
+            "a legacy Verified card is not receipt proof"
+        );
+        state.operate_receipts_verified = true;
         assert!(state.operate_ready());
+    }
+
+    #[test]
+    fn legacy_verified_operate_card_without_receipt_proof_fails_closed() {
+        let mut legacy = SetupState::default();
+        legacy.set_step(SetupStep::Language, verified("0.8.67"));
+        legacy.set_step(SetupStep::ProviderModel, verified("0.8.67"));
+        legacy.set_step(SetupStep::OperateFleet, verified("0.8.67"));
+        legacy.runtime_posture_source = RuntimePostureSource::Confirmed;
+        legacy.constitution_choice = ConstitutionChoice::Bundled;
+        let raw = serde_json::to_string(&legacy).expect("serialize legacy-style state");
+        assert!(!raw.contains("operate_receipts_verified"), "{raw}");
+
+        let loaded: SetupState = serde_json::from_str(&raw).expect("load legacy-style state");
+
+        assert_eq!(loaded.status(SetupStep::OperateFleet), StepStatus::Verified);
+        assert!(!loaded.operate_receipts_verified);
+        assert!(!loaded.operate_ready());
     }
 
     #[test]

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -5516,6 +5516,46 @@ fn empty_fallback_providers_do_not_serialize() {
 }
 
 #[test]
+fn empty_provider_header_tables_do_not_survive_round_trip() {
+    let polluted = r#"
+[http_headers]
+
+[providers.anthropic.http_headers]
+" " = "ignored"
+"X-Blank" = "   "
+
+[providers.openrouter.http_headers]
+
+[providers.xai]
+model = "   "
+"#;
+    let config: ConfigToml = toml::from_str(polluted).expect("polluted config parses");
+    let serialized = toml::to_string_pretty(&config).expect("config serializes");
+
+    assert!(
+        !serialized.contains("[http_headers]"),
+        "empty root headers must not be serialized:\n{serialized}"
+    );
+    assert!(
+        !serialized.contains("[providers.anthropic"),
+        "empty Anthropic provider state must not be serialized:\n{serialized}"
+    );
+    assert!(
+        !serialized.contains("[providers.openrouter"),
+        "empty OpenRouter provider state must not be serialized:\n{serialized}"
+    );
+    assert!(
+        !serialized.contains("[providers.xai"),
+        "blank provider fields must not be serialized:\n{serialized}"
+    );
+
+    let round_tripped: ConfigToml = toml::from_str(&serialized).expect("canonical config parses");
+    assert!(round_tripped.http_headers.is_empty());
+    assert!(round_tripped.providers.anthropic.http_headers.is_empty());
+    assert!(round_tripped.providers.openrouter.http_headers.is_empty());
+}
+
+#[test]
 fn workflow_config_defaults_match_product_surface() {
     // #4128 / Section 2.11: omitted `[workflow]` keys resolve to the
     // documented product defaults so launch/approval/persist share one model.

--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -278,7 +278,7 @@
     "SettingsTitle": "Settings:",
     "SettingsConfigFile": "Config file:",
     "ClearConversation": "Conversation cleared",
-    "ClearConversationBusy": "Conversation cleared (plan state busy; run /clear again if needed)",
+    "ClearConversationBusy": "Nothing cleared (Work state or runtime work busy; wait, then try /clear again)",
     "ModelChanged": "Model changed: {old} →, {new}",
     "LinksTitle": "Provider Links:",
     "LinksDashboard": "Dashboard:",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -276,7 +276,7 @@
     "SettingsTitle": "Configuraciones:",
     "SettingsConfigFile": "Archivo de configuración:",
     "ClearConversation": "Conversación limpia",
-    "ClearConversationBusy": "Conversación limpia (estado del plan ocupado; ejecuta /clear de nuevo si es necesario)",
+    "ClearConversationBusy": "No se borró nada (el estado de Trabajo o la ejecución está ocupada; espera y vuelve a intentar /clear)",
     "ModelChanged": "Modelo cambiado: {old} →, {new}",
     "LinksTitle": "Enlaces de proveedores:",
     "LinksDashboard": "Panel:",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -276,7 +276,7 @@
     "SettingsTitle": "設定：",
     "SettingsConfigFile": "設定ファイル：",
     "ClearConversation": "会話履歴をクリアしました",
-    "ClearConversationBusy": "会話履歴をクリアしました（plan 状態が忙しい；必要なら /clear を再度実行）",
+    "ClearConversationBusy": "何もクリアされませんでした（Work 状態またはランタイム処理が実行中です。待ってから /clear を再実行してください）",
     "ModelChanged": "モデルを変更しました: {old} → {new}",
     "LinksTitle": "プロバイダーリンク：",
     "LinksDashboard": "ダッシュボード：",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -276,7 +276,7 @@
     "SettingsTitle": "Configurações:",
     "SettingsConfigFile": "Arquivo de configuração:",
     "ClearConversation": "Conversa limpa",
-    "ClearConversationBusy": "Conversa limpa (estado do plano ocupado; execute /clear novamente se necessário)",
+    "ClearConversationBusy": "Nada foi limpo (estado de Trabalho ou execução ativa ocupada; aguarde e tente /clear novamente)",
     "ModelChanged": "Modelo alterado: {old} →, {new}",
     "LinksTitle": "Links dos provedores:",
     "LinksDashboard": "Painel:",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -276,7 +276,7 @@
     "SettingsTitle": "Cài đặt:",
     "SettingsConfigFile": "Tệp cấu hình:",
     "ClearConversation": "Đã xóa cuộc trò chuyện",
-    "ClearConversationBusy": "Đã xóa cuộc trò chuyện (trạng thái plan đang bận; chạy lại /clear nếu cần)",
+    "ClearConversationBusy": "Chưa xóa nội dung nào (trạng thái Công việc hoặc tác vụ thời gian chạy đang bận; hãy chờ rồi thử lại /clear)",
     "ModelChanged": "Đã thay đổi mô hình: {old} → {new}",
     "LinksTitle": "Liên kết nhà cung cấp:",
     "LinksDashboard": "Bảng điều khiển:",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -276,7 +276,7 @@
     "SettingsTitle": "设置：",
     "SettingsConfigFile": "配置文件：",
     "ClearConversation": "对话已清空",
-    "ClearConversationBusy": "对话已清空（Plan 状态忙碌；如需再次清空请运行 /clear）",
+    "ClearConversationBusy": "未清空任何内容（工作状态或运行时任务正忙；请等待后重试 /clear）",
     "ModelChanged": "模型已切换：{old} → {new}",
     "LinksTitle": "服务商链接：",
     "LinksDashboard": "控制台：",

--- a/crates/tui/src/codex_model_cache.rs
+++ b/crates/tui/src/codex_model_cache.rs
@@ -1,0 +1,371 @@
+//! Secret-free OpenAI Codex / ChatGPT OAuth model roster discovery.
+//!
+//! The Codex CLI keeps its account-scoped roster in `models_cache.json`.
+//! CodeWhale reads only the cache timestamp and model identifiers; it never
+//! opens the adjacent OAuth credential file and never logs cache contents.
+
+use std::collections::HashSet;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::Deserialize;
+
+use crate::config::DEFAULT_OPENAI_CODEX_MODEL;
+
+const MODEL_CACHE_FILE: &str = "models_cache.json";
+const MAX_MODEL_CACHE_BYTES: u64 = 4 * 1024 * 1024;
+/// Codex refreshes its own cache much more frequently. CodeWhale is an offline
+/// consumer, so it accepts a last-known account roster for one day before
+/// falling back to the single conservative compatibility model.
+const MODEL_CACHE_MAX_AGE: Duration = Duration::hours(24);
+const MAX_FUTURE_CLOCK_SKEW: Duration = Duration::minutes(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CodexModelCacheFreshness {
+    Fresh,
+    Missing,
+    Stale,
+    Invalid,
+}
+
+impl CodexModelCacheFreshness {
+    #[must_use]
+    pub(crate) const fn picker_label(self) -> &'static str {
+        match self {
+            Self::Fresh => "ChatGPT OAuth",
+            Self::Missing => "OAuth roster missing · fallback",
+            Self::Stale => "OAuth roster stale · fallback",
+            Self::Invalid => "OAuth roster invalid · fallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodexModelRoster {
+    pub(crate) models: Vec<CodexModelMetadata>,
+    pub(crate) freshness: CodexModelCacheFreshness,
+    pub(crate) fetched_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodexModelMetadata {
+    pub(crate) id: String,
+    pub(crate) context_window: Option<u32>,
+    pub(crate) reasoning: Option<bool>,
+}
+
+impl CodexModelRoster {
+    fn fallback(freshness: CodexModelCacheFreshness, fetched_at: Option<DateTime<Utc>>) -> Self {
+        Self {
+            models: vec![CodexModelMetadata {
+                id: DEFAULT_OPENAI_CODEX_MODEL.to_string(),
+                context_window: None,
+                reasoning: None,
+            }],
+            freshness,
+            fetched_at,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn model_ids(&self) -> Vec<String> {
+        self.models.iter().map(|model| model.id.clone()).collect()
+    }
+
+    #[must_use]
+    pub(crate) fn metadata_for(&self, id: &str) -> Option<&CodexModelMetadata> {
+        self.models
+            .iter()
+            .find(|model| model.id.eq_ignore_ascii_case(id.trim()))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheFile {
+    fetched_at: DateTime<Utc>,
+    #[serde(default)]
+    models: Vec<CacheModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheModel {
+    slug: String,
+    #[serde(default)]
+    priority: Option<i64>,
+    #[serde(default)]
+    context_window: Option<u32>,
+    #[serde(default)]
+    supported_reasoning_levels: Option<Vec<CacheReasoningLevel>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheReasoningLevel {}
+
+/// Resolve the Codex home without consulting OAuth-file overrides.
+///
+/// `OPENAI_CODEX_AUTH_FILE` intentionally does not participate: it may point
+/// at a standalone test/credential file while the model roster still belongs
+/// to `$CODEX_HOME` (or the default `~/.codex`).
+#[must_use]
+pub(crate) fn codex_home_path() -> PathBuf {
+    std::env::var_os("CODEX_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".codex")
+        })
+}
+
+#[must_use]
+pub(crate) fn model_roster() -> CodexModelRoster {
+    load_model_roster_from_home_at(&codex_home_path(), Utc::now())
+}
+
+fn load_model_roster_from_home_at(home: &Path, now: DateTime<Utc>) -> CodexModelRoster {
+    let path = home.join(MODEL_CACHE_FILE);
+    let path_metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return CodexModelRoster::fallback(CodexModelCacheFreshness::Missing, None);
+        }
+        Err(_) => return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None),
+    };
+    if !path_metadata.file_type().is_file() || path_metadata.len() > MAX_MODEL_CACHE_BYTES {
+        return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None);
+    }
+    let mut file = match open_cache_file(&path) {
+        Ok(file) => file,
+        Err(_) => return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None),
+    };
+    let metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(_) => return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None),
+    };
+    if !metadata.file_type().is_file() || metadata.len() > MAX_MODEL_CACHE_BYTES {
+        return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None);
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len().min(MAX_MODEL_CACHE_BYTES) as usize);
+    if file
+        .by_ref()
+        .take(MAX_MODEL_CACHE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > MAX_MODEL_CACHE_BYTES
+    {
+        return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None);
+    }
+    let cache: CacheFile = match serde_json::from_slice(&bytes) {
+        Ok(cache) => cache,
+        Err(_) => return CodexModelRoster::fallback(CodexModelCacheFreshness::Invalid, None),
+    };
+
+    let age = now.signed_duration_since(cache.fetched_at);
+    if age < -MAX_FUTURE_CLOCK_SKEW {
+        return CodexModelRoster::fallback(
+            CodexModelCacheFreshness::Invalid,
+            Some(cache.fetched_at),
+        );
+    }
+    if age > MODEL_CACHE_MAX_AGE {
+        return CodexModelRoster::fallback(CodexModelCacheFreshness::Stale, Some(cache.fetched_at));
+    }
+
+    let mut indexed: Vec<_> = cache.models.into_iter().enumerate().collect();
+    indexed.sort_by_key(|(index, model)| (model.priority.unwrap_or(i64::MAX), *index));
+
+    let mut seen = HashSet::new();
+    let mut models = Vec::new();
+    for (_, model) in indexed {
+        let slug = model.slug.trim();
+        if !valid_model_id(slug) {
+            continue;
+        }
+        let identity = slug.to_ascii_lowercase();
+        if seen.insert(identity) {
+            models.push(CodexModelMetadata {
+                id: slug.to_string(),
+                context_window: model
+                    .context_window
+                    .filter(|window| (1..=16_000_000).contains(window)),
+                reasoning: model
+                    .supported_reasoning_levels
+                    .map(|levels| !levels.is_empty()),
+            });
+        }
+    }
+    if models.is_empty() {
+        return CodexModelRoster::fallback(
+            CodexModelCacheFreshness::Invalid,
+            Some(cache.fetched_at),
+        );
+    }
+
+    CodexModelRoster {
+        models,
+        freshness: CodexModelCacheFreshness::Fresh,
+        fetched_at: Some(cache.fetched_at),
+    }
+}
+
+fn open_cache_file(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    options.open(path)
+}
+
+fn valid_model_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value.bytes().any(|byte| byte.is_ascii_alphanumeric())
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'/' | b'-')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = include_str!("../tests/fixtures/codex_models_cache.json");
+    const FIXTURE_TIME: &str = "2030-01-02T03:04:05Z";
+
+    fn fixture_time() -> DateTime<Utc> {
+        FIXTURE_TIME.parse().expect("fixture timestamp")
+    }
+
+    fn write_fixture(home: &Path) {
+        std::fs::write(home.join(MODEL_CACHE_FILE), FIXTURE).expect("write fixture");
+    }
+
+    #[test]
+    fn valid_cache_uses_priority_order_and_keeps_route_available_rows() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        write_fixture(home.path());
+
+        let roster =
+            load_model_roster_from_home_at(home.path(), fixture_time() + Duration::minutes(30));
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Fresh);
+        assert_eq!(roster.fetched_at, Some(fixture_time()));
+        assert_eq!(
+            roster.model_ids(),
+            [
+                "gpt-test-primary",
+                "gpt-test-secondary",
+                "codex-test-review"
+            ]
+        );
+        let primary = roster
+            .metadata_for("gpt-test-primary")
+            .expect("primary metadata");
+        assert_eq!(primary.context_window, Some(372_000));
+        assert_eq!(primary.reasoning, Some(true));
+        let secondary = roster
+            .metadata_for("gpt-test-secondary")
+            .expect("secondary metadata");
+        assert_eq!(secondary.context_window, Some(128_000));
+    }
+
+    #[test]
+    fn missing_cache_falls_back_conservatively() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        let roster = load_model_roster_from_home_at(home.path(), fixture_time());
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Missing);
+        assert_eq!(roster.model_ids(), [DEFAULT_OPENAI_CODEX_MODEL]);
+    }
+
+    #[test]
+    fn malformed_cache_falls_back_conservatively() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        std::fs::write(home.path().join(MODEL_CACHE_FILE), b"{not-json")
+            .expect("write malformed cache");
+
+        let roster = load_model_roster_from_home_at(home.path(), fixture_time());
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Invalid);
+        assert_eq!(roster.model_ids(), [DEFAULT_OPENAI_CODEX_MODEL]);
+    }
+
+    #[test]
+    fn oversized_cache_is_rejected_without_unbounded_read() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        let file = std::fs::File::create(home.path().join(MODEL_CACHE_FILE)).expect("cache file");
+        file.set_len(MAX_MODEL_CACHE_BYTES + 1)
+            .expect("sparse oversized cache");
+
+        let roster = load_model_roster_from_home_at(home.path(), fixture_time());
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Invalid);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_cache_is_rejected_as_non_regular_input() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        let target = home.path().join("target.json");
+        std::fs::write(&target, FIXTURE).expect("target fixture");
+        std::os::unix::fs::symlink(&target, home.path().join(MODEL_CACHE_FILE))
+            .expect("cache symlink");
+
+        let roster = load_model_roster_from_home_at(home.path(), fixture_time());
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Invalid);
+    }
+
+    #[test]
+    fn stale_cache_falls_back_conservatively() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        write_fixture(home.path());
+
+        let roster =
+            load_model_roster_from_home_at(home.path(), fixture_time() + Duration::hours(25));
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Stale);
+        assert_eq!(roster.model_ids(), [DEFAULT_OPENAI_CODEX_MODEL]);
+        assert_eq!(roster.fetched_at, Some(fixture_time()));
+    }
+
+    #[test]
+    fn invalid_and_duplicate_model_ids_are_filtered() {
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        let cache = format!(
+            r#"{{
+  "fetched_at": "{FIXTURE_TIME}",
+  "models": [
+    {{"slug": "gpt-good", "priority": 3}},
+    {{"slug": "GPT-GOOD", "priority": 4}},
+    {{"slug": "bad model", "priority": 1}},
+    {{"slug": "../bad\\path", "priority": 2}}
+  ]
+}}"#
+        );
+        std::fs::write(home.path().join(MODEL_CACHE_FILE), cache).expect("write cache");
+
+        let roster = load_model_roster_from_home_at(home.path(), fixture_time());
+
+        assert_eq!(roster.freshness, CodexModelCacheFreshness::Fresh);
+        assert_eq!(roster.model_ids(), ["gpt-good"]);
+    }
+
+    #[test]
+    fn codex_home_respects_environment_override() {
+        let lock = crate::test_support::lock_test_env();
+        let home = tempfile::tempdir().expect("temp CODEX_HOME");
+        let guard = crate::test_support::EnvVarGuard::set("CODEX_HOME", home.path());
+
+        assert_eq!(codex_home_path(), home.path());
+
+        drop(guard);
+        drop(lock);
+    }
+}

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -726,6 +726,19 @@ fn config_editability_audit(app: &App) -> CommandResult {
     } else {
         app.model.clone()
     };
+    let saved_permission_posture = Settings::load()
+        .ok()
+        .and_then(|settings| settings.permission_posture)
+        .unwrap_or_else(|| "(unset)".to_string());
+    let configured_approval_policy = config
+        .approval_policy
+        .clone()
+        .unwrap_or_else(|| "(unset)".to_string());
+    let effective_permissions = if app.mode == AppMode::Plan {
+        "Read Only"
+    } else {
+        app.approval_mode.permission_chip_label()
+    };
 
     let rows = [
         (
@@ -743,11 +756,25 @@ fn config_editability_audit(app: &App) -> CommandResult {
             "Switches the active model now; use default_text_model in config.toml for startup default.",
         ),
         (
+            "effective_permissions",
+            effective_permissions.to_string(),
+            "runtime",
+            "Shift+Tab",
+            "Shows the effective Act/Operate posture; Plan remains Read Only.",
+        ),
+        (
+            "permission_posture",
+            saved_permission_posture,
+            "TUI settings",
+            "Shift+Tab",
+            "Saved in settings.toml and ignored when config/requirements manage approval policy.",
+        ),
+        (
             "approval_policy",
-            approval_mode_config_value(app.approval_mode).to_string(),
-            "runtime+persisted",
+            configured_approval_policy,
+            "persisted config",
             "/config approval_mode <auto|on-request|never> --save",
-            "Writes top-level approval_policy and updates the current session.",
+            "Top-level managed policy; Full Access is not a valid value here.",
         ),
         (
             "allow_shell",
@@ -1421,8 +1448,13 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
         "approval_mode" | "approval" => {
             let mode = ApprovalMode::from_config_value(value);
             return match mode {
+                Some(_) if app.approval_policy_requirements_managed() => CommandResult::error(
+                    "Approval posture is controlled by managed requirements; edit the controlling policy source.",
+                ),
+                Some(ApprovalMode::Bypass) if persist => CommandResult::error(
+                    "Full Access is not a valid top-level approval_policy. Use Shift+Tab to save the TUI-only posture.",
+                ),
                 Some(m) => {
-                    app.approval_mode = m;
                     if persist {
                         let saved = approval_mode_config_value(m);
                         match persist_root_string_key(
@@ -1430,23 +1462,34 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
                             "approval_policy",
                             saved,
                         ) {
-                            Ok(path) => CommandResult::message(format!(
-                                "approval_mode = {} (saved to {} as approval_policy = \"{}\")",
-                                m.label(),
-                                path.display(),
-                                saved
-                            )),
+                            Ok(path) => {
+                                app.set_agent_approval_posture(m);
+                                app.mark_approval_policy_locked();
+                                CommandResult::with_message_and_action(
+                                    format!(
+                                        "approval_mode = {} (saved to {} as approval_policy = \"{}\")",
+                                        m.label(),
+                                        path.display(),
+                                        saved
+                                    ),
+                                    AppAction::ModeChanged(app.mode),
+                                )
+                            }
                             Err(err) => CommandResult::error(format!("Failed to save: {err}")),
                         }
                     } else {
-                        CommandResult::message(format!(
-                            "approval_mode = {} (session only, add --save to persist)",
-                            m.label()
-                        ))
+                        app.set_agent_approval_posture(m);
+                        CommandResult::with_message_and_action(
+                            format!(
+                                "approval_mode = {} (session only, add --save to persist)",
+                                m.label()
+                            ),
+                            AppAction::ModeChanged(app.mode),
+                        )
                     }
                 }
                 None => CommandResult::error(
-                    "Invalid approval_mode. Use: auto, suggest/on-request/untrusted, never/deny",
+                    "Invalid approval_mode. Use: auto, suggest/on-request/untrusted, bypass/full-access, never/deny",
                 ),
             };
         }
@@ -2194,7 +2237,7 @@ mod tests {
         }
     }
 
-    fn create_test_app() -> App {
+    fn create_test_app_with_config(config: &Config) -> App {
         let options = TuiOptions {
             model: "test-model".to_string(),
             workspace: PathBuf::from("."),
@@ -2220,7 +2263,7 @@ mod tests {
             resume_session_id: None,
             initial_input: None,
         };
-        let mut app = App::new(options, &Config::default());
+        let mut app = App::new(options, config);
         // App::new folds in saved TUI settings from the developer machine.
         // Pin command tests back to DeepSeek semantics so model aliases are
         // not normalized through a provider selected in an interactive run.
@@ -2229,6 +2272,10 @@ mod tests {
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
         app
+    }
+
+    fn create_test_app() -> App {
+        create_test_app_with_config(&Config::default())
     }
 
     #[test]
@@ -2470,7 +2517,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
     fn sidebar_config_command_reports_width_suppression() {
         let mut app = create_test_app();
         app.sidebar_focus = SidebarFocus::Hidden;
-        app.last_sidebar_host_width = Some(63);
+        app.last_sidebar_host_width = Some(59);
 
         let result = sidebar(&mut app, Some("on"));
 
@@ -2479,7 +2526,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
         assert_eq!(
             result.message.as_deref(),
             Some(
-                "Sidebar is on, but hidden because the terminal is too narrow (63 cols; needs at least 64)"
+                "Sidebar is on, but hidden because the terminal is too narrow (59 cols; needs at least 60)"
             )
         );
     }
@@ -2488,7 +2535,7 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
     fn sidebar_config_command_is_visible_at_minimum_width() {
         let mut app = create_test_app();
         app.sidebar_focus = SidebarFocus::Hidden;
-        app.last_sidebar_host_width = Some(64);
+        app.last_sidebar_host_width = Some(60);
 
         let result = sidebar(&mut app, Some("on"));
 
@@ -3029,13 +3076,24 @@ max_concurrent = 4
         assert!(!result.is_error);
         assert!(msg.contains("Config editability audit"));
         assert!(msg.contains(&format!("Config path: {}", config_path.display())));
-        assert!(msg.contains("approval_policy | never | runtime+persisted"));
+        assert!(msg.contains("effective_permissions | Never | runtime"));
+        assert!(msg.contains("permission_posture | (unset) | TUI settings"));
+        assert!(msg.contains("approval_policy | (unset) | persisted config"));
         assert!(msg.contains("stream_chunk_timeout_secs | 45 | runtime+persisted"));
         assert!(msg.contains("subagents.enabled | false | runtime+persisted"));
         assert!(msg.contains("subagents.max_concurrent | 4 | runtime+persisted"));
         assert!(msg.contains("base_url | https://api.from-config.local/v1 | persisted restart"));
         assert!(msg.contains("instructions | configured | file-only restart"));
         assert!(msg.contains("network | unset | file-only"));
+
+        app.mode = AppMode::Plan;
+        let plan_msg = config_command(&mut app, Some("audit"))
+            .message
+            .expect("Plan audit message");
+        assert!(
+            plan_msg.contains("effective_permissions | Read Only | runtime"),
+            "{plan_msg}"
+        );
     }
 
     #[test]
@@ -3358,6 +3416,7 @@ max_concurrent = 4
             std::process::id()
         ));
         fs::create_dir_all(&temp_root).unwrap();
+        let _guard = EnvGuard::new(&temp_root);
         let config_path = temp_root.join("custom-config.toml");
 
         let mut app = create_test_app();
@@ -3377,8 +3436,19 @@ max_concurrent = 4
         );
         assert!(saved.contains("approval_policy = \"on-request\""));
 
-        let loaded = Config::load(Some(config_path), None).unwrap();
+        let loaded = Config::load(Some(config_path.clone()), None).unwrap();
         assert_eq!(loaded.approval_policy.as_deref(), Some("on-request"));
+
+        let mut restarted = create_test_app_with_config(&loaded);
+        restarted.config_path = Some(config_path.clone());
+        assert!(restarted.approval_policy_locked());
+        assert!(!restarted.approval_policy_requirements_managed());
+        let changed = config_command(&mut restarted, Some("approval_mode auto --save"));
+        assert!(!changed.is_error, "{:?}", changed.message);
+        assert!(matches!(changed.action, Some(AppAction::ModeChanged(_))));
+        assert_eq!(restarted.approval_mode, ApprovalMode::Auto);
+        let reloaded = Config::load(Some(config_path), None).unwrap();
+        assert_eq!(reloaded.approval_policy.as_deref(), Some("auto"));
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -50,14 +50,21 @@ pub fn help(app: &mut App, topic: Option<&str>) -> CommandResult {
 
 /// Clear conversation history
 pub fn clear(app: &mut App) -> CommandResult {
-    let todos_cleared = reset_conversation_state(app);
+    if app.session_transition_blocked() {
+        return CommandResult::error(
+            tr(app.ui_locale, MessageId::ClearConversationBusy).to_string(),
+        );
+    }
+    if !reset_conversation_state(app) {
+        return CommandResult::error(
+            tr(app.ui_locale, MessageId::ClearConversationBusy).to_string(),
+        );
+    }
     app.current_session_id = None;
+    app.current_session_metadata = None;
+    app.session_title = None;
     let locale = app.ui_locale;
-    let message = if todos_cleared {
-        tr(locale, MessageId::ClearConversation).to_string()
-    } else {
-        tr(locale, MessageId::ClearConversationBusy).to_string()
-    };
+    let message = tr(locale, MessageId::ClearConversation).to_string();
     CommandResult::with_message_and_action(
         message,
         AppAction::SyncSession {
@@ -73,6 +80,12 @@ pub fn clear(app: &mut App) -> CommandResult {
 
 /// Reset the active conversation without choosing the next session id.
 pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
+    // Work state is the only contended portion. Acquire and clear it first so
+    // `/clear` and `/new` are all-or-nothing rather than losing conversation
+    // state while leaving an old To-do attached to the next session.
+    if !app.clear_todos() {
+        return false;
+    }
     app.clear_history();
     app.mark_history_updated();
     app.api_messages.clear();
@@ -90,7 +103,6 @@ pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
     app.session.subagent_cost_event_seqs.clear();
     app.session.displayed_cost_high_water = 0.0;
     app.session.displayed_cost_high_water_cny = 0.0;
-    let todos_cleared = app.clear_todos();
     app.tool_log.clear();
     app.tool_cells.clear();
     app.tool_details_by_cell.clear();
@@ -109,7 +121,7 @@ pub(crate) fn reset_conversation_state(app: &mut App) -> bool {
     app.session.last_warmup_key = None;
     app.session.last_tool_catalog = None;
     app.session.last_base_url = None;
-    todos_cleared
+    true
 }
 
 /// Exit the application
@@ -835,6 +847,55 @@ mod tests {
         assert!(app.session_artifacts.is_empty());
         assert!(app.current_session_id.is_none());
         assert!(matches!(result.action, Some(AppAction::SyncSession { .. })));
+    }
+
+    #[test]
+    fn clear_is_all_or_nothing_when_work_state_is_busy() {
+        let mut app = create_test_app();
+        app.history.push(HistoryCell::User {
+            content: "keep me".to_string(),
+        });
+        app.api_messages.push(Message {
+            role: "user".to_string(),
+            content: vec![],
+        });
+        app.current_session_id = Some("current-session".to_string());
+        let plan_state = app.plan_state.clone();
+        let _held = plan_state.try_lock().expect("hold plan lock");
+
+        let result = clear(&mut app);
+
+        assert!(result.is_error);
+        assert!(result.action.is_none());
+        assert_eq!(app.history.len(), 1);
+        assert_eq!(app.api_messages.len(), 1);
+        assert_eq!(app.current_session_id.as_deref(), Some("current-session"));
+        assert!(result.message.as_deref().is_some_and(|message| {
+            message.contains("Nothing cleared") && message.contains("busy")
+        }));
+    }
+
+    #[test]
+    fn clear_rejects_an_active_turn_without_mutating_session_state() {
+        let mut app = create_test_app();
+        app.history.push(HistoryCell::User {
+            content: "keep active turn".to_string(),
+        });
+        app.api_messages.push(Message {
+            role: "user".to_string(),
+            content: vec![],
+        });
+        app.current_session_id = Some("active-session".to_string());
+        app.is_loading = true;
+        app.runtime_turn_status = Some("in_progress".to_string());
+
+        let result = clear(&mut app);
+
+        assert!(result.is_error);
+        assert!(result.action.is_none());
+        assert_eq!(app.history.len(), 1);
+        assert_eq!(app.api_messages.len(), 1);
+        assert_eq!(app.current_session_id.as_deref(), Some("active-session"));
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/debug/tests.rs
+++ b/crates/tui/src/commands/groups/debug/tests.rs
@@ -94,6 +94,23 @@ fn test_tokens_shows_usage_info() {
 }
 
 #[test]
+fn tokens_report_uses_codex_oauth_route_context() {
+    let mut app = create_test_app();
+    app.api_provider = crate::config::ApiProvider::OpenaiCodex;
+    app.set_model_selection("gpt-5.5".to_string());
+    app.active_route_limits = Some(codewhale_config::route::RouteLimits {
+        context_tokens: Some(272_000),
+        input_tokens: None,
+        output_tokens: None,
+    });
+
+    let message = tokens(&mut app).message.expect("tokens report");
+
+    assert!(message.contains("/ 272000"), "{message}");
+    assert!(!message.contains("1050000"), "{message}");
+}
+
+#[test]
 fn test_cost_shows_spending_info() {
     let mut app = create_test_app();
     app.session.session_cost = 0.1234;

--- a/crates/tui/src/commands/groups/debug/tokens.rs
+++ b/crates/tui/src/commands/groups/debug/tokens.rs
@@ -2,7 +2,7 @@
 
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::localization::{Locale, MessageId, tr};
-use crate::models::{SystemPrompt, context_window_for_model};
+use crate::models::SystemPrompt;
 use crate::tui::app::{App, AppAction};
 
 use super::CommandResult;
@@ -17,18 +17,17 @@ fn token_count(value: Option<u32>, locale: Locale) -> String {
 fn active_context_summary(app: &App, locale: Locale) -> String {
     let estimated =
         estimate_input_tokens_conservative(&app.api_messages, app.system_prompt.as_ref());
-    match context_window_for_model(&app.model) {
-        Some(window) => {
-            let used = estimated.min(window as usize);
-            let percent = (used as f64 / f64::from(window) * 100.0).clamp(0.0, 100.0);
-            tr(locale, MessageId::CmdTokensContextWithWindow)
-                .replace("{used}", &used.to_string())
-                .replace("{window}", &window.to_string())
-                .replace("{percent}", &format!("{percent:.1}"))
-        }
-        None => tr(locale, MessageId::CmdTokensContextUnknownWindow)
-            .replace("{estimated}", &estimated.to_string()),
-    }
+    let window = crate::route_budget::route_context_window_tokens(
+        app.api_provider,
+        app.effective_model_for_budget(),
+        app.active_route_limits,
+    );
+    let used = estimated.min(window as usize);
+    let percent = (used as f64 / f64::from(window) * 100.0).clamp(0.0, 100.0);
+    tr(locale, MessageId::CmdTokensContextWithWindow)
+        .replace("{used}", &used.to_string())
+        .replace("{window}", &window.to_string())
+        .replace("{percent}", &format!("{percent:.1}"))
 }
 
 fn cache_summary(app: &App, locale: Locale) -> String {

--- a/crates/tui/src/commands/groups/session/mod.rs
+++ b/crates/tui/src/commands/groups/session/mod.rs
@@ -11,6 +11,8 @@ mod new;
 mod purge;
 mod relay;
 mod rename;
+#[cfg(test)]
+pub(crate) use rename::rename_with_manager;
 mod save;
 mod sessions;
 // This group dir intentionally has a `session.rs` child module with the same

--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -61,11 +61,11 @@ pub fn rename(app: &mut App, arg: Option<&str>) -> CommandResult {
     rename_with_manager(new_title, &session_id, &manager, app)
 }
 
-fn rename_with_manager(
+pub(crate) fn rename_with_manager(
     new_title: &str,
     session_id: &str,
     manager: &SessionManager,
-    app: &App,
+    app: &mut App,
 ) -> CommandResult {
     let mut session = match manager.load_session(session_id) {
         Ok(s) => s,
@@ -79,11 +79,29 @@ fn rename_with_manager(
         u64::from(app.session.total_tokens),
         app.system_prompt.as_ref(),
     );
+    session.work_state = match app.work_state_snapshot() {
+        Ok(state) => state,
+        Err(err) => {
+            return CommandResult::error(format!(
+                "Could not snapshot Work state before rename: {err}"
+            ));
+        }
+    };
+    session.context_references = app.session_context_references.clone();
+    session.artifacts = app.session_artifacts.clone();
+    session.metadata.model = app.model_selection_for_persistence();
+    session.metadata.model_provider = app.api_provider.as_str().to_string();
+    session.metadata.workspace.clone_from(&app.workspace);
+    session.metadata.mode = Some(app.mode.as_setting().to_string());
     app.sync_cost_to_metadata(&mut session.metadata);
     session.metadata.title = new_title.to_string();
 
     match manager.save_session(&session) {
-        Ok(_) => CommandResult::message(format!("Session renamed to \"{new_title}\"")),
+        Ok(_) => {
+            app.current_session_metadata = Some(session.metadata.clone());
+            app.session_title = Some(new_title.to_string());
+            CommandResult::message(format!("Session renamed to \"{new_title}\""))
+        }
         Err(e) => CommandResult::error(format!("Could not save session: {e}")),
     }
 }
@@ -169,26 +187,58 @@ mod tests {
     fn rename_persists_new_title() {
         let tmp = TempDir::new().unwrap();
         let manager = make_session_manager(&tmp);
-        let app = make_app(&tmp);
+        let mut app = make_app(&tmp);
 
-        let session =
-            create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
+        let stale_prompt = crate::models::SystemPrompt::Text("stale prompt".to_string());
+        let session = create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            Some(&stale_prompt),
+            None,
+        );
         let session_id = session.metadata.id.clone();
         manager.save_session(&session).unwrap();
+        app.set_model_selection("openrouter/new-route".to_string());
+        app.api_provider = crate::config::ApiProvider::Openrouter;
+        app.mode = crate::tui::app::AppMode::Operate;
+        app.system_prompt = None;
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add(
+                "live rename state".to_string(),
+                crate::tools::todo::TodoStatus::InProgress,
+            );
+        }
+        let expected_work_state = app.work_state_snapshot().expect("work snapshot");
 
-        let result = rename_with_manager("Brand New Title", &session_id, &manager, &app);
+        let result = rename_with_manager("Brand New Title", &session_id, &manager, &mut app);
         assert!(!result.is_error);
         assert!(result.message.unwrap().contains("Brand New Title"));
 
         let reloaded = manager.load_session(&session_id).unwrap();
         assert_eq!(reloaded.metadata.title, "Brand New Title");
+        assert_eq!(reloaded.work_state, expected_work_state);
+        assert!(reloaded.system_prompt.is_none());
+        assert_eq!(reloaded.metadata.model, "openrouter/new-route");
+        assert_eq!(reloaded.metadata.model_provider, "openrouter");
+        assert_eq!(reloaded.metadata.workspace, app.workspace);
+        assert_eq!(reloaded.metadata.mode.as_deref(), Some("operate"));
+        assert_eq!(app.session_title.as_deref(), Some("Brand New Title"));
+        assert_eq!(
+            app.current_session_metadata
+                .as_ref()
+                .map(|metadata| metadata.title.as_str()),
+            Some("Brand New Title")
+        );
     }
 
     #[test]
     fn rename_title_at_max_length_succeeds() {
         let tmp = TempDir::new().unwrap();
         let manager = make_session_manager(&tmp);
-        let app = make_app(&tmp);
+        let mut app = make_app(&tmp);
 
         let session =
             create_saved_session_with_mode(&[], "deepseek-v4-pro", tmp.path(), 0, None, None);
@@ -196,7 +246,7 @@ mod tests {
         manager.save_session(&session).unwrap();
 
         let max_title = "中".repeat(MAX_TITLE_LEN);
-        let result = rename_with_manager(&max_title, &session_id, &manager, &app);
+        let result = rename_with_manager(&max_title, &session_id, &manager, &mut app);
         assert!(!result.is_error);
 
         let reloaded = manager.load_session(&session_id).unwrap();

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -20,14 +20,7 @@ use super::CommandResult;
 /// or legacy `~/.deepseek/sessions`) so repo-local `session_*.json`
 /// artifacts are no longer created by default.
 pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
-    let save_path = if let Some(p) = path {
-        PathBuf::from(p)
-    } else {
-        let dir = crate::session_manager::default_sessions_dir()
-            .unwrap_or_else(|_| app.workspace.clone());
-        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-        dir.join(format!("session_{timestamp}.json"))
-    };
+    let explicit_save_path = path.map(PathBuf::from);
 
     let messages = app.api_messages.clone();
     let mut session = create_saved_session_with_mode(
@@ -40,7 +33,17 @@ pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
     );
     session.metadata.model_provider = app.api_provider.as_str().to_string();
     app.sync_cost_to_metadata(&mut session.metadata);
+    session.context_references = app.session_context_references.clone();
     session.artifacts = app.session_artifacts.clone();
+    session.work_state = match app.work_state_snapshot() {
+        Ok(state) => state,
+        Err(err) => return CommandResult::error(format!("Failed to snapshot Work state: {err}")),
+    };
+    let save_path = explicit_save_path.unwrap_or_else(|| {
+        let dir = crate::session_manager::default_sessions_dir()
+            .unwrap_or_else(|_| app.workspace.clone());
+        dir.join(format!("{}.json", session.metadata.id))
+    });
 
     let sessions_dir = save_path
         .parent()
@@ -56,6 +59,8 @@ pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
             match std::fs::write(&save_path, json) {
                 Ok(()) => {
                     app.current_session_id = Some(session.metadata.id.clone());
+                    app.current_session_metadata = Some(session.metadata.clone());
+                    app.session_title = Some(session.metadata.title.clone());
                     CommandResult::message(format!(
                         "Session saved to {} (ID: {})",
                         save_path.display(),
@@ -71,6 +76,11 @@ pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
 
 /// Fork the active conversation into a new saved sibling session and switch to it.
 pub fn fork(app: &mut App) -> CommandResult {
+    if app.session_transition_blocked() {
+        return CommandResult::error(
+            "Cannot fork a session while runtime work is active. Wait for the current turn, maintenance, and background tasks to finish, or cancel that specific work first.",
+        );
+    }
     if app.api_messages.is_empty() {
         return CommandResult::error("Nothing to fork. Send or load a message first.");
     }
@@ -96,8 +106,27 @@ pub fn fork(app: &mut App) -> CommandResult {
         Some(app.mode.label()),
     );
     parent.metadata.model_provider = app.api_provider.as_str().to_string();
+    if let Some(cached) = app
+        .current_session_metadata
+        .as_ref()
+        .filter(|metadata| metadata.id == parent.metadata.id)
+    {
+        parent.metadata.created_at = cached.created_at;
+        parent.metadata.title.clone_from(&cached.title);
+        parent
+            .metadata
+            .parent_session_id
+            .clone_from(&cached.parent_session_id);
+        parent.metadata.forked_from_message_count = cached.forked_from_message_count;
+    }
     app.sync_cost_to_metadata(&mut parent.metadata);
+    parent.context_references = app.session_context_references.clone();
     parent.artifacts = app.session_artifacts.clone();
+    let work_state = match app.work_state_snapshot() {
+        Ok(state) => state,
+        Err(err) => return CommandResult::error(format!("Failed to snapshot Work state: {err}")),
+    };
+    parent.work_state = work_state.clone();
 
     if let Err(err) = manager.save_session(&parent) {
         return CommandResult::error(format!("Failed to save parent session: {err}"));
@@ -114,12 +143,17 @@ pub fn fork(app: &mut App) -> CommandResult {
     forked.metadata.model_provider = app.api_provider.as_str().to_string();
     forked.metadata.copy_cost_from(&parent.metadata);
     forked.metadata.mark_forked_from(&parent.metadata);
+    forked.context_references = app.session_context_references.clone();
+    forked.artifacts = app.session_artifacts.clone();
+    forked.work_state = work_state;
 
     if let Err(err) = manager.save_session(&forked) {
         return CommandResult::error(format!("Failed to save forked session: {err}"));
     }
 
     app.current_session_id = Some(forked.metadata.id.clone());
+    app.current_session_metadata = Some(forked.metadata.clone());
+    app.session_title = Some(forked.metadata.title.clone());
     let fork_id = forked.metadata.id.clone();
     let parent_label = crate::session_manager::truncate_id(&parent.metadata.id).to_string();
     let fork_label = crate::session_manager::truncate_id(&fork_id).to_string();
@@ -149,6 +183,12 @@ pub fn new_session(app: &mut App, arg: Option<&str>) -> CommandResult {
         }
     };
 
+    if app.session_transition_blocked() {
+        return CommandResult::error(
+            "Cannot start a new session while runtime work is active. Wait for the current turn, maintenance, and background tasks to finish, or cancel that specific work. `/new --force` only discards draft or queued input.",
+        );
+    }
+
     if !force {
         let blockers = new_session_blockers(app);
         if !blockers.is_empty() {
@@ -160,12 +200,17 @@ pub fn new_session(app: &mut App, arg: Option<&str>) -> CommandResult {
     }
 
     let new_id = uuid::Uuid::new_v4().to_string();
-    super::super::core::reset_conversation_state(app);
+    if !super::super::core::reset_conversation_state(app) {
+        return CommandResult::error(
+            "Could not start a new session because Work state is busy; retry in a moment.",
+        );
+    }
     app.clear_input();
     app.session_artifacts.clear();
     app.session_context_references.clear();
     app.tool_evidence.clear();
     app.current_session_id = Some(new_id.clone());
+    app.current_session_metadata = None;
     app.session_title = Some("New Session".to_string());
     app.scroll_to_bottom();
 
@@ -193,20 +238,16 @@ fn new_session_blockers(app: &App) -> Vec<&'static str> {
     if !app.queued_messages.is_empty() || app.queued_draft.is_some() {
         blockers.push("queued messages are pending");
     }
-    if app.is_loading || app.runtime_turn_status.as_deref() == Some("in_progress") {
-        blockers.push("a turn is in progress");
-    }
-    if app.is_compacting {
-        blockers.push("context compaction is running");
-    }
-    if app.task_panel.iter().any(|task| task.status == "running") {
-        blockers.push("background tasks are running");
-    }
     blockers
 }
 
 /// Load session from file
 pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
+    if app.session_transition_blocked() {
+        return CommandResult::error(
+            "Cannot load a session while runtime work is active. Wait for the current turn, maintenance, and background tasks to finish, or cancel that specific work first.",
+        );
+    }
     let load_path = if let Some(p) = path {
         if p.contains('/') || p.contains('\\') {
             PathBuf::from(p)
@@ -231,21 +272,56 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
         }
     };
 
+    if let Err(err) = app.restore_work_state(session.work_state.as_ref()) {
+        return CommandResult::error(format!("Failed to restore saved Work state: {err}"));
+    }
+
     app.api_messages.clone_from(&session.messages);
     app.clear_history();
-    let cells_to_add: Vec<_> = app
-        .api_messages
-        .iter()
-        .flat_map(history_cells_from_message)
-        .collect();
-    app.extend_history(cells_to_add);
+    let messages = app.api_messages.clone();
+    let mut message_to_cell = std::collections::HashMap::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        let cells = history_cells_from_message(message);
+        let base = app.history.len();
+        if message.role == "user"
+            && let Some(offset) = cells
+                .iter()
+                .position(|cell| matches!(cell, HistoryCell::User { .. }))
+        {
+            message_to_cell.insert(message_index, base + offset);
+        }
+        app.extend_history(cells);
+    }
+    app.sync_context_references_from_session(&session.context_references, &message_to_cell);
     app.mark_history_updated();
     app.viewport.transcript_selection.clear();
+    let previous_provider = app.api_provider;
     if let Some(provider) = crate::config::ApiProvider::parse(&session.metadata.model_provider) {
         app.api_provider = provider;
         app.reasoning_effort = app.reasoning_effort.normalize_for_provider(provider);
+        if provider != previous_provider {
+            // A context override belongs to the route that supplied it. A
+            // file load can cross providers without the live Config value in
+            // scope, so never leak the previous provider's limit into the
+            // restored route.
+            app.set_active_context_window_override(None);
+        }
     }
     app.set_model_selection(session.metadata.model.clone());
+    app.active_route_limits = if app.auto_model {
+        app.context_window_override_limits()
+    } else {
+        crate::route_runtime::resolve_route_candidate(
+            app.api_provider,
+            Some(&app.model),
+            Some(&session.metadata.model),
+            None,
+            app.active_context_window_override,
+        )
+        .ok()
+        .and_then(|candidate| crate::route_budget::known_route_limits(candidate.limits))
+        .or_else(|| app.context_window_override_limits())
+    };
     app.update_model_compaction_budget();
     app.workspace.clone_from(&session.metadata.workspace);
     if let Some(mode) = session.metadata.mode.as_deref().and_then(AppMode::parse) {
@@ -270,10 +346,13 @@ pub fn load(app: &mut App, path: Option<&str>) -> CommandResult {
     app.session.last_reasoning_replay_tokens = None;
     app.session.turn_cache_history.clear();
     app.current_session_id = Some(session.metadata.id.clone());
+    app.current_session_metadata = Some(session.metadata.clone());
+    app.session_title = Some(session.metadata.title.clone());
     app.session_artifacts = session.artifacts.clone();
-    if let Some(sp) = session.system_prompt {
-        app.system_prompt = Some(crate::models::SystemPrompt::Text(sp));
-    }
+    app.system_prompt = session
+        .system_prompt
+        .clone()
+        .map(crate::models::SystemPrompt::Text);
     app.scroll_to_bottom();
 
     CommandResult::with_message_and_action(
@@ -597,6 +676,22 @@ mod tests {
         let previous_home = home_guard.previous();
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         app.current_session_id = Some("parent-session".to_string());
+        let mut cached_parent = create_saved_session_with_id_and_mode(
+            "parent-session".to_string(),
+            &[],
+            &app.model,
+            &app.workspace,
+            0,
+            None,
+            Some(app.mode.label()),
+        )
+        .metadata;
+        cached_parent.title = "Custom Parent".to_string();
+        cached_parent.created_at = "2026-01-02T03:04:05Z"
+            .parse()
+            .expect("fixed parent timestamp");
+        app.current_session_metadata = Some(cached_parent.clone());
+        app.session_title = Some(cached_parent.title.clone());
         app.api_messages.push(crate::models::Message {
             role: "user".to_string(),
             content: vec![crate::models::ContentBlock::Text {
@@ -619,13 +714,52 @@ mod tests {
             .expect("parent saved");
         let child = manager.load_session(&new_id).expect("child saved");
         assert_eq!(parent.messages.len(), 1);
+        assert_eq!(parent.metadata.title, cached_parent.title);
+        assert_eq!(parent.metadata.created_at, cached_parent.created_at);
         assert_eq!(
             child.metadata.parent_session_id.as_deref(),
             Some("parent-session")
         );
         assert_eq!(child.metadata.forked_from_message_count, Some(1));
+        let cached_child = app
+            .current_session_metadata
+            .as_ref()
+            .expect("child metadata cached");
+        assert_eq!(cached_child.id, child.metadata.id);
+        assert_eq!(cached_child.title, child.metadata.title);
+        assert_eq!(cached_child.created_at, child.metadata.created_at);
+        assert_eq!(
+            cached_child.parent_session_id,
+            child.metadata.parent_session_id
+        );
+        assert_eq!(
+            app.session_title.as_deref(),
+            Some(child.metadata.title.as_str())
+        );
         drop(home_guard);
         assert_eq!(std::env::var_os("HOME"), previous_home);
+    }
+
+    #[test]
+    fn fork_rejects_active_runtime_without_switching_sessions() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("parent-session".to_string());
+        app.api_messages.push(crate::models::Message {
+            role: "user".to_string(),
+            content: vec![crate::models::ContentBlock::Text {
+                text: "still running".to_string(),
+                cache_control: None,
+            }],
+        });
+        app.is_loading = true;
+
+        let result = fork(&mut app);
+
+        assert!(result.is_error);
+        assert!(result.action.is_none());
+        assert_eq!(app.current_session_id.as_deref(), Some("parent-session"));
+        assert_eq!(app.api_messages.len(), 1);
     }
 
     #[test]
@@ -733,6 +867,67 @@ mod tests {
     }
 
     #[test]
+    fn new_session_force_cannot_detach_an_in_flight_turn() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("old-session".to_string());
+        app.api_messages.push(crate::models::Message {
+            role: "user".to_string(),
+            content: vec![],
+        });
+        app.is_loading = true;
+        app.runtime_turn_status = Some("in_progress".to_string());
+
+        let result = new_session(&mut app, Some("--force"));
+
+        assert!(result.is_error);
+        assert!(result.action.is_none());
+        assert_eq!(app.current_session_id.as_deref(), Some("old-session"));
+        assert_eq!(app.api_messages.len(), 1);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("only discards draft or queued input"))
+        );
+    }
+
+    #[test]
+    fn load_rejects_an_active_runtime_before_reading_or_mutating() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.current_session_id = Some("old-session".to_string());
+        app.api_messages.push(crate::models::Message {
+            role: "user".to_string(),
+            content: vec![],
+        });
+        app.task_panel.push(crate::tui::app::TaskPanelEntry {
+            id: "queued-late-producer".to_string(),
+            status: "queued".to_string(),
+            prompt_summary: "queued".to_string(),
+            duration_ms: None,
+            kind: crate::tui::app::TaskPanelEntryKind::Background,
+            stale: false,
+            elapsed_since_output_ms: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+        });
+
+        let result = load(&mut app, Some("does-not-exist.json"));
+
+        assert!(result.is_error);
+        assert!(result.action.is_none());
+        assert_eq!(app.current_session_id.as_deref(), Some("old-session"));
+        assert_eq!(app.api_messages.len(), 1);
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("runtime work is active"))
+        );
+    }
+
+    #[test]
     fn test_save_with_default_path_uses_managed_sessions_dir() {
         let tmpdir = TempDir::new().unwrap();
         let _lock = crate::test_support::lock_test_env();
@@ -754,7 +949,7 @@ mod tests {
             std::fs::read_dir(&sessions_dir)
                 .unwrap()
                 .filter_map(|e| e.ok())
-                .filter(|e| e.file_name().to_string_lossy().starts_with("session_"))
+                .filter(|e| e.file_name().to_string_lossy().ends_with(".json"))
                 .collect()
         } else {
             Vec::new()
@@ -765,6 +960,11 @@ mod tests {
             !entries.is_empty(),
             "expected session file in {sessions_dir:?}, got none; msg: {msg}"
         );
+        let session_id = app
+            .current_session_id
+            .as_deref()
+            .expect("current session id");
+        assert!(sessions_dir.join(format!("{session_id}.json")).exists());
         assert_eq!(std::env::var_os("CODEWHALE_HOME"), previous_codewhale_home);
     }
 
@@ -827,6 +1027,23 @@ mod tests {
 
         // Create new app and load
         let mut app2 = create_test_app_with_tmpdir(&tmpdir);
+        app2.system_prompt = Some(crate::models::SystemPrompt::Text(
+            "stale prompt from prior session".to_string(),
+        ));
+        app2.session_context_references
+            .push(crate::session_manager::SessionContextReference {
+                message_index: 0,
+                reference: crate::tui::file_mention::ContextReference {
+                    kind: crate::tui::file_mention::ContextReferenceKind::File,
+                    source: crate::tui::file_mention::ContextReferenceSource::AtMention,
+                    badge: "file".to_string(),
+                    label: "stale.rs".to_string(),
+                    target: tmpdir.path().join("stale.rs").display().to_string(),
+                    included: true,
+                    expanded: true,
+                    detail: None,
+                },
+            });
         let result = load(&mut app2, Some(save_path.to_str().unwrap()));
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
@@ -837,6 +1054,8 @@ mod tests {
         assert_eq!(app2.session.total_tokens, 500);
         assert_eq!(app2.mode, AppMode::Plan);
         assert!(app2.current_session_id.is_some());
+        assert!(app2.system_prompt.is_none());
+        assert!(app2.session_context_references.is_empty());
         assert!(matches!(
             result.action,
             Some(AppAction::SyncSession {
@@ -844,6 +1063,58 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn explicit_save_and_load_round_trip_work_state() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut saved_app = create_test_app_with_tmpdir(&tmpdir);
+        {
+            let mut todos = saved_app.todos.try_lock().expect("todos lock");
+            todos.add(
+                "persist me".to_string(),
+                crate::tools::todo::TodoStatus::InProgress,
+            );
+        }
+        {
+            let mut plan = saved_app.plan_state.try_lock().expect("plan lock");
+            plan.update(crate::tools::plan::UpdatePlanArgs {
+                objective: Some("Resume exactly".to_string()),
+                ..crate::tools::plan::UpdatePlanArgs::default()
+            });
+        }
+        let expected = saved_app.work_state_snapshot().expect("snapshot");
+        let save_path = tmpdir.path().join("work_state.json");
+        let saved = save(&mut saved_app, Some(save_path.to_str().unwrap()));
+        assert!(!saved.is_error, "{:?}", saved.message);
+
+        let mut loaded_app = create_test_app_with_tmpdir(&tmpdir);
+        let loaded = load(&mut loaded_app, Some(save_path.to_str().unwrap()));
+        assert!(!loaded.is_error, "{:?}", loaded.message);
+        assert_eq!(
+            loaded_app.work_state_snapshot().expect("snapshot"),
+            expected
+        );
+    }
+
+    #[test]
+    fn new_session_is_all_or_nothing_when_work_state_is_busy() {
+        let tmpdir = TempDir::new().unwrap();
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.api_messages.push(crate::models::Message {
+            role: "user".to_string(),
+            content: vec![],
+        });
+        app.current_session_id = Some("current-session".to_string());
+        let todos = app.todos.clone();
+        let _held = todos.try_lock().expect("hold todos lock");
+
+        let result = new_session(&mut app, Some("--force"));
+
+        assert!(result.is_error);
+        assert_eq!(app.api_messages.len(), 1);
+        assert_eq!(app.current_session_id.as_deref(), Some("current-session"));
+        assert!(result.action.is_none());
     }
 
     #[test]

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -17,6 +17,8 @@ pub use traits::CommandInfo;
 
 // Long-standing public paths that predate the group layout.
 pub use groups::project::share;
+#[cfg(test)]
+pub(crate) use groups::session::rename_with_manager as rename_session_with_manager;
 
 // Voice capture plumbing shared with the hotbar and the UI event loop.
 pub use groups::core::voice;

--- a/crates/tui/src/compaction.rs
+++ b/crates/tui/src/compaction.rs
@@ -30,6 +30,9 @@ pub struct CompactionConfig {
     pub enabled: bool,
     pub token_threshold: usize,
     pub model: String,
+    /// Route-effective context window. `None` preserves compatibility for
+    /// callers that have not resolved a provider route yet.
+    pub effective_context_window: Option<u32>,
     pub cache_summary: bool,
 }
 
@@ -54,6 +57,7 @@ impl Default for CompactionConfig {
             // `compaction_threshold_for_model_and_effort`.
             token_threshold: 800_000,
             model: DEFAULT_TEXT_MODEL.to_string(),
+            effective_context_window: None,
             cache_summary: true,
         }
     }
@@ -91,9 +95,13 @@ struct SummaryInputLimits {
     word_limit: usize,
 }
 
-fn summary_input_limits_for_model(model: &str) -> SummaryInputLimits {
-    let is_large_context =
-        context_window_for_model(model).is_some_and(|window| window >= LARGE_CONTEXT_WINDOW_TOKENS);
+fn summary_input_limits_for_model(
+    model: &str,
+    effective_context_window: Option<u32>,
+) -> SummaryInputLimits {
+    let is_large_context = effective_context_window
+        .or_else(|| context_window_for_model(model))
+        .is_some_and(|window| window >= LARGE_CONTEXT_WINDOW_TOKENS);
     if is_large_context {
         SummaryInputLimits {
             text_snippet_chars: LARGE_CONTEXT_SUMMARY_TEXT_SNIPPET_CHARS,
@@ -1127,7 +1135,13 @@ pub async fn compact_messages(
         .collect();
 
     // Create a summary of the unpinned portion of the conversation
-    let summary = create_summary(client, &to_summarize, &config.model).await?;
+    let summary = create_summary(
+        client,
+        &to_summarize,
+        &config.model,
+        config.effective_context_window,
+    )
+    .await?;
 
     // Extract workflow context (files touched, tasks in progress, etc.)
     let workflow_context = extract_workflow_context(&to_summarize, workspace);
@@ -1179,9 +1193,11 @@ async fn create_summary(
     client: &DeepSeekClient,
     messages: &[Message],
     model: &str,
+    effective_context_window: Option<u32>,
 ) -> Result<String> {
-    let limits = summary_input_limits_for_model(model);
-    let used_cache_aligned = should_use_cache_aligned_summary(model, messages);
+    let limits = summary_input_limits_for_model(model, effective_context_window);
+    let used_cache_aligned =
+        should_use_cache_aligned_summary(model, effective_context_window, messages);
     let request = if used_cache_aligned {
         build_cache_aligned_summary_request(model, messages, limits)
     } else {
@@ -1211,7 +1227,7 @@ async fn create_summary(
     // Compaction summary calls are billed by DeepSeek; route the
     // tokens through the side-channel so the dashboard total
     // matches the website (#526).
-    crate::cost_status::report(&response.model, &response.usage);
+    crate::cost_status::report(client.api_provider(), &response.model, &response.usage);
 
     // #584: emit one debug-level event per summary call so the
     // V4 cache-aligned win is observable post-deploy without
@@ -1336,8 +1352,12 @@ fn log_summary_cache_telemetry(used_cache_aligned: bool, usage: &crate::models::
 /// `create_summary` emits a `tracing::debug!` event under
 /// `target = "compaction"` after each call so the path choice and
 /// cache-hit rate are observable post-deploy without UI surface.
-fn should_use_cache_aligned_summary(model: &str, messages: &[Message]) -> bool {
-    let Some(window) = context_window_for_model(model) else {
+fn should_use_cache_aligned_summary(
+    model: &str,
+    effective_context_window: Option<u32>,
+    messages: &[Message],
+) -> bool {
+    let Some(window) = effective_context_window.or_else(|| context_window_for_model(model)) else {
         return false;
     };
     if window < LARGE_CONTEXT_WINDOW_TOKENS {
@@ -1850,12 +1870,27 @@ mod tests {
 
     #[test]
     fn summary_limits_expand_for_v4_context() {
-        let legacy = summary_input_limits_for_model("deepseek-v3.2-128k");
-        let v4 = summary_input_limits_for_model("deepseek-v4-pro");
+        let legacy = summary_input_limits_for_model("deepseek-v3.2-128k", None);
+        let v4 = summary_input_limits_for_model("deepseek-v4-pro", None);
 
         assert!(v4.input_max_chars > legacy.input_max_chars);
         assert!(v4.tool_result_snippet_chars > legacy.tool_result_snippet_chars);
         assert!(v4.max_tokens > legacy.max_tokens);
+    }
+
+    #[test]
+    fn route_effective_window_bounds_same_id_oauth_summary() {
+        let api = summary_input_limits_for_model("gpt-5.5", None);
+        let oauth = summary_input_limits_for_model("gpt-5.5", Some(272_000));
+        let messages = vec![msg("user", "summarize this route")];
+
+        assert!(api.input_max_chars > oauth.input_max_chars);
+        assert!(should_use_cache_aligned_summary("gpt-5.5", None, &messages));
+        assert!(!should_use_cache_aligned_summary(
+            "gpt-5.5",
+            Some(272_000),
+            &messages
+        ));
     }
 
     #[test]
@@ -1864,10 +1899,12 @@ mod tests {
 
         assert!(should_use_cache_aligned_summary(
             "deepseek-v4-flash",
+            None,
             &messages
         ));
         assert!(!should_use_cache_aligned_summary(
             "deepseek-v3.2-128k",
+            None,
             &messages
         ));
     }
@@ -1928,7 +1965,7 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let limits = summary_input_limits_for_model("deepseek-v4-pro");
+        let limits = summary_input_limits_for_model("deepseek-v4-pro", None);
 
         let request = build_formatted_summary_request("deepseek-v4-pro", &messages, limits);
 
@@ -1946,7 +1983,7 @@ mod tests {
             msg("user", "Please edit crates/tui/src/compaction.rs"),
             msg("assistant", "I will inspect the file."),
         ];
-        let limits = summary_input_limits_for_model("deepseek-v4-pro");
+        let limits = summary_input_limits_for_model("deepseek-v4-pro", None);
         let request = build_cache_aligned_summary_request("deepseek-v4-pro", &messages, limits);
 
         assert_eq!(request.system, None);

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -484,7 +484,10 @@ pub fn provider_capability(provider: ApiProvider, resolved_model: &str) -> Provi
             provider,
             resolved_model: resolved_model.to_string(),
             context_window: OPENAI_CODEX_EFFECTIVE_CONTEXT_WINDOW_TOKENS,
-            max_output: crate::models::max_output_tokens_for_model(resolved_model).unwrap_or(4096),
+            // The OAuth cache does not publish an output ceiling. Keep the
+            // compatibility capability conservative instead of inheriting the
+            // public API model's output limit.
+            max_output: 4096,
             thinking_supported: true,
             cache_telemetry_supported: false,
             request_payload_mode: RequestPayloadMode::Responses,
@@ -2745,6 +2748,40 @@ struct RequirementsFile {
 // === Config Loading ===
 
 impl Config {
+    /// Whether an explicit config or requirements file owns approval posture.
+    /// TUI preferences may supply a default only when this is false.
+    #[must_use]
+    pub fn approval_policy_is_managed(&self) -> bool {
+        if self.approval_policy.is_some() {
+            return true;
+        }
+        self.approval_policy_is_requirements_managed()
+    }
+
+    /// Whether organization requirements, rather than a user-editable config
+    /// key, own approval posture. User config still outranks TUI settings, but
+    /// `/config approval_mode ... --save` may edit that user-owned key.
+    #[must_use]
+    pub fn approval_policy_is_requirements_managed(&self) -> bool {
+        let path = self
+            .requirements_path
+            .as_deref()
+            .map(expand_path)
+            .or_else(default_requirements_path);
+        let Some(path) = path else {
+            return false;
+        };
+        if !path.exists() {
+            return false;
+        }
+        // Fail closed if a present requirements file becomes unreadable or
+        // malformed between Config::load and App::new.
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|contents| toml::from_str::<RequirementsFile>(&contents).ok())
+            .is_none_or(|requirements| !requirements.allowed_approval_policies.is_empty())
+    }
+
     #[must_use]
     pub fn search_provider_resolution(&self) -> SearchProviderResolution {
         if let Ok(raw) = std::env::var("DEEPSEEK_SEARCH_PROVIDER")
@@ -6304,7 +6341,7 @@ pub fn active_provider_has_config_api_key(config: &Config) -> bool {
         // The persistent Codex login is the OAuth credential file, analogous to
         // a stored config key. Token env overrides are scored separately by
         // active_provider_has_env_api_key.
-        return crate::oauth::auth_file_path().exists();
+        return crate::oauth::stored_credentials_present();
     }
     if matches!(provider, ApiProvider::Huggingface)
         && std::env::var("HUGGINGFACE_API_KEY")
@@ -6368,7 +6405,7 @@ pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
     if provider == ApiProvider::OpenaiCodex {
         // Token env overrides are checked above; also honor the Codex CLI OAuth
         // login on disk.
-        return crate::oauth::auth_file_path().exists();
+        return crate::oauth::credentials_present();
     }
     if provider == ApiProvider::Xai && crate::xai_oauth::credentials_present() {
         // xAI supports both API keys and OAuth. A Grok-compatible token file is
@@ -6474,18 +6511,29 @@ pub(crate) fn provider_is_configured_for_active(
 /// isn't enough, since untouched providers still resolve to a
 /// `ProviderConfig::default()` there.
 fn provider_config_is_explicit(entry: &ProviderConfig) -> bool {
-    entry.api_key.is_some()
-        || entry.base_url.is_some()
-        || entry.model.is_some()
-        || entry.auth_mode.is_some()
-        || entry.auth.is_some()
+    let non_empty = |value: Option<&String>| value.is_some_and(|value| !value.trim().is_empty());
+
+    non_empty(entry.api_key.as_ref())
+        || non_empty(entry.base_url.as_ref())
+        || non_empty(entry.model.as_ref())
+        || non_empty(entry.auth_mode.as_ref())
+        || entry
+            .auth
+            .as_ref()
+            .is_some_and(|auth| auth.validate().is_ok())
         || entry.context_window.is_some()
-        || entry.mode.is_some()
+        || non_empty(entry.mode.as_ref())
         || entry.max_concurrency.is_some()
-        || entry.http_headers.is_some()
-        || entry.path_suffix.is_some()
-        || entry.reasoning_stream_style.is_some()
+        || entry.http_headers.as_ref().is_some_and(|headers| {
+            headers
+                .iter()
+                .any(|(name, value)| !name.trim().is_empty() && !value.trim().is_empty())
+        })
+        || non_empty(entry.path_suffix.as_ref())
+        || non_empty(entry.reasoning_stream_style.as_ref())
         || entry.insecure_skip_tls_verify.is_some()
+        || non_empty(entry.kind.as_ref())
+        || non_empty(entry.api_key_env.as_ref())
 }
 
 /// Save an API key to the appropriate place for the given provider.

--- a/crates/tui/src/config/models.rs
+++ b/crates/tui/src/config/models.rs
@@ -121,7 +121,9 @@ pub const DEFAULT_QIANFAN_MODEL: &str = "ernie-4.0-turbo-8k";
 pub const DEFAULT_QIANFAN_BASE_URL: &str = "https://api.baiduqianfan.ai/v1";
 pub const DEFAULT_OPENAI_CODEX_MODEL: &str = "gpt-5.5";
 pub const DEFAULT_OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api";
-pub const OPENAI_CODEX_EFFECTIVE_CONTEXT_WINDOW_TOKENS: u32 = 400_000;
+/// Conservative offline floor for an OAuth model absent from a fresh Codex
+/// roster. Fresh account-scoped cache metadata overrides this in route_runtime.
+pub const OPENAI_CODEX_EFFECTIVE_CONTEXT_WINDOW_TOKENS: u32 = 128_000;
 /// Legacy `deepseek-cn` provider alias.
 ///
 /// DeepSeek's official API host is the same worldwide. Keep this alias for

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -6966,10 +6966,25 @@ fn provider_capability_openai_codex_uses_responses_payload() {
         cap.context_window,
         OPENAI_CODEX_EFFECTIVE_CONTEXT_WINDOW_TOKENS
     );
-    assert_eq!(cap.max_output, 128_000);
+    assert_eq!(cap.max_output, 4096);
     assert!(cap.thinking_supported);
     assert!(!cap.cache_telemetry_supported);
     assert_eq!(cap.request_payload_mode, RequestPayloadMode::Responses);
+}
+
+#[test]
+fn invalid_provider_auth_source_is_not_explicit_configuration() {
+    let entry = ProviderConfig {
+        auth: Some(codewhale_config::ProviderAuthSourceToml {
+            source: codewhale_config::AuthSourceKind::Command,
+            command: Vec::new(),
+            timeout_ms: None,
+            secret_id: None,
+        }),
+        ..ProviderConfig::default()
+    };
+
+    assert!(!provider_config_is_explicit(&entry));
 }
 
 #[test]

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -1107,6 +1107,8 @@ mod tests {
         app.auto_model = false;
         app.api_provider = ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
+        app.active_route_limits = None;
+        app.update_model_compaction_budget();
         app
     }
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -56,6 +56,7 @@ use crate::tools::subagent::{
 };
 use crate::tools::todo::{SharedTodoList, TodoListSnapshot, new_shared_todo_list};
 use crate::tools::user_input::{UserInputRequest, UserInputResponse};
+use crate::tools::workflow_trigger::{WorkflowTriggerSignals, evaluate_operate_admission};
 use crate::tools::{ToolContext, ToolRegistryBuilder};
 use crate::tui::app::AppMode;
 use crate::utils::spawn_supervised;
@@ -679,6 +680,45 @@ impl Engine {
             AppMode::Operate => prompts::OPERATE_MODE,
         }
         .trim()
+    }
+
+    /// Fail closed before a provider request when Operate cannot prove it will
+    /// leave the ordinary local Act loop and produce orchestration receipts.
+    fn operate_readiness_blocker(&self, mode: AppMode, content: &str) -> Option<String> {
+        if mode != AppMode::Operate {
+            return None;
+        }
+
+        let mut signals = WorkflowTriggerSignals::product_defaults();
+        signals.auto_start_child_limit = self
+            .api_config
+            .workflow_config()
+            .auto_start_child_limit
+            .try_into()
+            .unwrap_or(usize::MAX);
+        let admission = evaluate_operate_admission(content, &signals);
+        if admission.allows_local_execution() {
+            return None;
+        }
+
+        let readiness_gap = if !self.config.subagents_enabled
+            || !self.config.features.enabled(Feature::Subagents)
+        {
+            "the sub-agent/Workflow runtime is disabled"
+        } else if self.config.max_subagents == 0 || self.config.launch_concurrency == 0 {
+            "the worker runtime has no launch capacity"
+        } else if self.config.max_spawn_depth == 0 {
+            "worker delegation depth is zero"
+        } else if self.deepseek_client.is_none() {
+            "no active provider route is loaded for workers"
+        } else {
+            "this build does not yet host-enforce Workflow dispatch and terminal receipt verification"
+        };
+
+        Some(format!(
+            "Operate readiness blocked: {} requires Fleet/Workflow orchestration, but {readiness_gap}. No provider request or solo tool chain was started. Run `/setup report` and `/setup fleet` to inspect and record the readiness gap. This release cannot start a verified Operate workflow until host-enforced dispatch and terminal receipts are available; switch to Act only for intentionally local execution.",
+            admission.reason()
+        ))
     }
 
     pub(super) async fn emit_compaction_started(
@@ -1350,13 +1390,13 @@ impl Engine {
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) {
         enum EngineRunInput {
-            Operation(Op),
+            Operation(Box<Op>),
             SubAgentCompletion(SubAgentCompletion),
         }
 
         loop {
             let input = tokio::select! {
-                op = self.rx_op.recv() => op.map(EngineRunInput::Operation),
+                op = self.rx_op.recv() => op.map(|op| EngineRunInput::Operation(Box::new(op))),
                 completion = self.rx_subagent_completion.recv() => {
                     completion.map(EngineRunInput::SubAgentCompletion)
                 }
@@ -1369,12 +1409,14 @@ impl Engine {
                 EngineRunInput::SubAgentCompletion(completion) => {
                     self.handle_idle_subagent_completion(completion).await;
                 }
-                EngineRunInput::Operation(op) => match op {
+                EngineRunInput::Operation(op) => match *op {
                     Op::SendMessage {
                         content,
                         mode,
                         provider,
                         model,
+                        route_limits,
+                        compaction,
                         goal_objective,
                         goal_token_budget,
                         goal_status,
@@ -1398,6 +1440,8 @@ impl Engine {
                             mode,
                             provider,
                             model,
+                            route_limits,
+                            *compaction,
                             goal_objective,
                             goal_token_budget,
                             goal_status,
@@ -1845,6 +1889,8 @@ impl Engine {
                             mode,
                             Some(self.api_provider),
                             self.session.model.clone(),
+                            self.active_route_limits,
+                            self.config.compaction.clone(),
                             self.config.goal_objective.clone(),
                             self.config.goal_token_budget,
                             self.config.goal_status,
@@ -2203,6 +2249,8 @@ impl Engine {
             self.current_mode,
             Some(self.api_provider),
             self.session.model.clone(),
+            self.active_route_limits,
+            self.config.compaction.clone(),
             self.config.goal_objective.clone(),
             self.config.goal_token_budget,
             self.config.goal_status,
@@ -2324,6 +2372,8 @@ impl Engine {
         mode: AppMode,
         provider: Option<ApiProvider>,
         model: String,
+        route_limits: Option<codewhale_config::route::RouteLimits>,
+        compaction: CompactionConfig,
         goal_objective: Option<String>,
         goal_token_budget: Option<u32>,
         goal_status: GoalStatus,
@@ -2378,6 +2428,34 @@ impl Engine {
                 turn_id: turn.id.clone(),
             })
             .await;
+
+        // Operate is not allowed to silently fall through to Act for work that
+        // is not provably one-step. Until the host can prove a Workflow/Fleet
+        // dispatch plus terminal receipt, return an actionable blocker before
+        // route activation, snapshots, or any provider request.
+        if let Some(message) = self.operate_readiness_blocker(input_policy.mode, &content) {
+            let _ = self
+                .tx_event
+                .send(Event::error(ErrorEnvelope::transient(message.clone())))
+                .await;
+            let _ = self
+                .tx_event
+                .send(Event::TurnComplete {
+                    usage: turn.usage.clone(),
+                    status: TurnOutcomeStatus::Failed,
+                    error: Some(message),
+                    tool_catalog: None,
+                    base_url: None,
+                })
+                .await;
+            return;
+        }
+
+        // Apply the host-resolved route budget only after admission succeeds.
+        // The model, limits, and compaction policy arrive in one operation so
+        // no provider request can observe a partially updated route.
+        self.active_route_limits = route_limits;
+        self.config.compaction = compaction;
 
         // Snapshot the workspace BEFORE we touch a single tool. Run the git
         // work on the blocking pool so the async runtime stays responsive;
@@ -2799,6 +2877,8 @@ impl Engine {
                     mode,
                     provider,
                     model: self.session.model.clone(),
+                    route_limits: self.active_route_limits,
+                    compaction: Box::new(self.config.compaction.clone()),
                     goal_objective: None,
                     goal_token_budget: None,
                     goal_status: GoalStatus::Active,
@@ -2962,10 +3042,15 @@ impl Engine {
 
         let (status, error) = match run_purge(
             &client,
+            self.api_provider,
             &self.session.messages,
             &self.session.model,
             self.session.reasoning_effort.clone(),
-            effective_max_output_tokens_for_route(&self.session.model, self.active_route_limits),
+            effective_max_output_tokens_for_route(
+                self.api_provider,
+                &self.session.model,
+                self.active_route_limits,
+            ),
         )
         .await
         {
@@ -3894,7 +3979,9 @@ pub(crate) fn mock_engine_handle() -> MockEngineHandle {
 mod approval;
 mod context;
 mod handle;
+#[cfg(test)]
 pub(crate) use context::compact_tool_result_for_context;
+pub(crate) use context::compact_tool_result_for_route;
 /// Public so external hosts/wrappers can reuse the engine's input-budget math
 /// (see `context_input_budget_for_route`'s doc) instead of re-deriving it.
 pub use context::context_input_budget_for_route;

--- a/crates/tui/src/core/engine/context.rs
+++ b/crates/tui/src/core/engine/context.rs
@@ -60,10 +60,12 @@ pub(super) fn effective_max_output_tokens(model: &str) -> u32 {
 }
 
 pub(super) fn effective_max_output_tokens_for_route(
+    provider: ApiProvider,
     model: &str,
     route_limits: Option<RouteLimits>,
 ) -> u32 {
-    let cap = effective_max_output_tokens(model);
+    let cap = effective_max_output_tokens(model)
+        .min(crate::config::provider_capability(provider, model).max_output);
     let cap = crate::route_budget::route_output_limit_tokens(route_limits)
         .map_or(cap, |route_cap| cap.min(route_cap));
     let Some(window) = route_limits
@@ -450,9 +452,8 @@ fn compact_structured_tool_result_for_context(tool_name: &str, raw: &str) -> Opt
     }
 }
 
-fn tool_result_context_limits_for_model(model: &str) -> ToolResultContextLimits {
-    let is_large_context =
-        context_window_for_model(model).is_some_and(|window| window >= LARGE_CONTEXT_WINDOW_TOKENS);
+fn tool_result_context_limits_for_window(context_window: u32) -> ToolResultContextLimits {
+    let is_large_context = context_window >= LARGE_CONTEXT_WINDOW_TOKENS;
 
     if is_large_context {
         ToolResultContextLimits {
@@ -469,8 +470,19 @@ fn tool_result_context_limits_for_model(model: &str) -> ToolResultContextLimits 
     }
 }
 
+#[cfg(test)]
 pub(crate) fn compact_tool_result_for_context(
     model: &str,
+    tool_name: &str,
+    output: &ToolResult,
+) -> String {
+    compact_tool_result_for_route(ApiProvider::Deepseek, model, None, tool_name, output)
+}
+
+pub(crate) fn compact_tool_result_for_route(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<RouteLimits>,
     tool_name: &str,
     output: &ToolResult,
 ) -> String {
@@ -487,7 +499,9 @@ pub(crate) fn compact_tool_result_for_context(
         return summary;
     }
 
-    let limits = tool_result_context_limits_for_model(model);
+    let context_window =
+        crate::route_budget::route_context_window_tokens(provider, model, route_limits);
+    let limits = tool_result_context_limits_for_window(context_window);
     let raw_chars = raw.chars().count();
     let should_compact = raw_chars > limits.hard_limit_chars
         || (tool_result_is_noisy(tool_name) && raw_chars > limits.noisy_soft_limit_chars);
@@ -629,7 +643,7 @@ pub(super) fn route_context_budget_for_route(
     input_tokens: usize,
 ) -> Option<ContextBudget> {
     let window = crate::route_budget::route_context_window_tokens(provider, model, route_limits);
-    let output_cap = route_output_reservation_for_window(model, window, route_limits);
+    let output_cap = route_output_reservation_for_window(provider, model, window, route_limits);
     crate::route_budget::route_context_budget(
         provider,
         model,
@@ -640,6 +654,7 @@ pub(super) fn route_context_budget_for_route(
 }
 
 fn route_output_reservation_for_window(
+    provider: ApiProvider,
     model: &str,
     window_tokens: u32,
     route_limits: Option<RouteLimits>,
@@ -650,7 +665,7 @@ fn route_output_reservation_for_window(
     if window_tokens >= INTERNAL_BUDGET_LARGE_WINDOW_THRESHOLD {
         TURN_MAX_OUTPUT_TOKENS
     } else {
-        effective_max_output_tokens(model)
+        effective_max_output_tokens_for_route(provider, model, route_limits)
     }
 }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -60,6 +60,7 @@ fn subagent_mailbox_keeps_lifecycle_events_reliable() {
     assert!(!subagent_mailbox_message_is_best_effort(
         &MailboxMessage::TokenUsage {
             agent_id: "agent_a".to_string(),
+            provider: ApiProvider::Deepseek,
             model: "model".to_string(),
             usage: Usage::default(),
         }
@@ -146,6 +147,7 @@ fn subagent_mailbox_never_samples_lifecycle_or_usage_events() {
         &mut last_sent_at,
         &MailboxMessage::TokenUsage {
             agent_id: "agent_a".to_string(),
+            provider: ApiProvider::Deepseek,
             model: "model".to_string(),
             usage: Usage::default(),
         },
@@ -465,6 +467,224 @@ fn model_turn_event_timeout() -> Duration {
     } else {
         Duration::from_secs(10)
     }
+}
+
+fn external_user_message_op(content: &str, mode: AppMode) -> Op {
+    Op::SendMessage {
+        content: content.to_string(),
+        mode,
+        provider: None,
+        model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+        route_limits: None,
+        compaction: Box::new(CompactionConfig::default()),
+        goal_objective: None,
+        goal_token_budget: None,
+        goal_status: crate::tools::goal::GoalStatus::Active,
+        reasoning_effort: None,
+        reasoning_effort_auto: false,
+        auto_model: false,
+        allow_shell: true,
+        trust_mode: false,
+        auto_approve: false,
+        approval_mode: crate::tui::approval::ApprovalMode::Suggest,
+        translation_enabled: false,
+        show_thinking: true,
+        allowed_tools: None,
+        dynamic_tools: Vec::new(),
+        hook_executor: None,
+        verbosity: None,
+        provenance: UserInputProvenance::ExternalUser,
+    }
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn operate_admission_blocks_unready_nontrivial_but_allows_act_and_trivial() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let _lock = lock_test_env();
+    let workspace = tempdir().expect("tempdir");
+    let server = MockServer::start().await;
+    let done_sse = concat!(
+        "data: {\"id\":\"chatcmpl-act\",\"choices\":[{\"index\":0,",
+        "\"delta\":{\"content\":\"local Act response\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-act\",\"choices\":[{\"index\":0,",
+        "\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(done_sse),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let api_config = Config {
+        api_key: Some("test-key".to_string()),
+        base_url: Some(server.uri()),
+        ..Config::default()
+    };
+    let engine_config = EngineConfig {
+        workspace: workspace.path().to_path_buf(),
+        snapshots_enabled: false,
+        subagents_enabled: false,
+        ..EngineConfig::default()
+    };
+    let ask = "audit every crate, implement the fixes, then verify independently";
+
+    let (operate_engine, operate_handle) = Engine::new(engine_config.clone(), &api_config);
+    let operate_task = tokio::spawn(operate_engine.run());
+    operate_handle
+        .send(external_user_message_op(ask, AppMode::Operate))
+        .await
+        .expect("send Operate turn");
+
+    let mut saw_blocker = false;
+    let mut saw_operate_complete = false;
+    let mut operate_rx = operate_handle.rx_event.write().await;
+    while let Some(event) = tokio::time::timeout(model_turn_event_timeout(), operate_rx.recv())
+        .await
+        .expect("timed out waiting for Operate blocker")
+    {
+        match event {
+            Event::Error { envelope, .. } => {
+                saw_blocker = true;
+                assert!(
+                    envelope.recoverable,
+                    "readiness blocker must not force offline mode"
+                );
+                assert!(envelope.message.contains("Operate readiness blocked"));
+                assert!(envelope.message.contains("/setup fleet"));
+                assert!(envelope.message.contains("No provider request"));
+                assert!(
+                    envelope
+                        .message
+                        .contains("cannot start a verified Operate workflow")
+                );
+                assert!(!envelope.message.contains("start an explicit `/workflow`"));
+            }
+            Event::TurnComplete { status, error, .. } => {
+                assert_eq!(status, TurnOutcomeStatus::Failed);
+                assert!(
+                    error
+                        .as_deref()
+                        .is_some_and(|message| message.contains("/setup fleet"))
+                );
+                saw_operate_complete = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    drop(operate_rx);
+
+    assert!(
+        saw_blocker,
+        "Operate must surface an actionable readiness blocker"
+    );
+    assert!(
+        saw_operate_complete,
+        "blocked Operate turn must terminate cleanly"
+    );
+    assert!(
+        server
+            .received_requests()
+            .await
+            .expect("recorded requests after Operate")
+            .is_empty(),
+        "blocked Operate must make zero provider requests"
+    );
+    operate_handle
+        .send(Op::Shutdown)
+        .await
+        .expect("shutdown Operate engine");
+    operate_task.await.expect("Operate engine task");
+
+    let (act_engine, act_handle) = Engine::new(engine_config.clone(), &api_config);
+    let act_task = tokio::spawn(act_engine.run());
+    act_handle
+        .send(external_user_message_op(ask, AppMode::Agent))
+        .await
+        .expect("send Act turn");
+
+    let mut saw_act_complete = false;
+    let mut act_rx = act_handle.rx_event.write().await;
+    while let Some(event) = tokio::time::timeout(model_turn_event_timeout(), act_rx.recv())
+        .await
+        .expect("timed out waiting for Act completion")
+    {
+        if let Event::TurnComplete { status, error, .. } = event {
+            assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+            saw_act_complete = true;
+            break;
+        }
+    }
+    drop(act_rx);
+
+    assert!(
+        saw_act_complete,
+        "Act turn must reach provider-backed completion"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("recorded requests after Act");
+    assert_eq!(
+        requests.len(),
+        1,
+        "Act must retain its ordinary local model path"
+    );
+    act_handle
+        .send(Op::Shutdown)
+        .await
+        .expect("shutdown Act engine");
+    act_task.await.expect("Act engine task");
+
+    let (trivial_engine, trivial_handle) = Engine::new(engine_config, &api_config);
+    let trivial_task = tokio::spawn(trivial_engine.run());
+    trivial_handle
+        .send(external_user_message_op("git status", AppMode::Operate))
+        .await
+        .expect("send trivial Operate turn");
+
+    let mut saw_trivial_complete = false;
+    let mut trivial_rx = trivial_handle.rx_event.write().await;
+    while let Some(event) = tokio::time::timeout(model_turn_event_timeout(), trivial_rx.recv())
+        .await
+        .expect("timed out waiting for trivial Operate completion")
+    {
+        if let Event::TurnComplete { status, error, .. } = event {
+            assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+            saw_trivial_complete = true;
+            break;
+        }
+    }
+    drop(trivial_rx);
+
+    assert!(
+        saw_trivial_complete,
+        "provably one-step Operate turn must retain the local path"
+    );
+    let requests = server
+        .received_requests()
+        .await
+        .expect("recorded requests after trivial Operate");
+    assert_eq!(
+        requests.len(),
+        2,
+        "trivial Operate must make the second allowed provider request"
+    );
+    trivial_handle
+        .send(Op::Shutdown)
+        .await
+        .expect("shutdown trivial Operate engine");
+    trivial_task.await.expect("trivial Operate engine task");
 }
 
 #[test]
@@ -2710,6 +2930,8 @@ async fn yolo_mode_does_not_prompt_for_model_driven_typed_ask_rule() {
             mode: AppMode::Yolo,
             provider: None,
             model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            route_limits: None,
+            compaction: Box::new(CompactionConfig::default()),
             goal_objective: None,
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
@@ -2836,6 +3058,8 @@ async fn yolo_mode_still_prompts_for_background_destructive_shell() {
             mode: AppMode::Yolo,
             provider: None,
             model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            route_limits: None,
+            compaction: Box::new(CompactionConfig::default()),
             goal_objective: None,
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
@@ -2990,6 +3214,8 @@ async fn yolo_mode_does_not_prompt_for_background_shell() {
             mode: AppMode::Yolo,
             provider: None,
             model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            route_limits: None,
+            compaction: Box::new(CompactionConfig::default()),
             goal_objective: None,
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
@@ -3124,6 +3350,8 @@ async fn yolo_mode_prompts_for_publish_like_shell_safety_floor() {
             mode: AppMode::Yolo,
             provider: None,
             model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            route_limits: None,
+            compaction: Box::new(CompactionConfig::default()),
             goal_objective: None,
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
@@ -3276,6 +3504,8 @@ async fn yolo_mode_does_not_prompt_for_mcp_action() {
             mode: AppMode::Yolo,
             provider: None,
             model: crate::config::DEFAULT_TEXT_MODEL.to_string(),
+            route_limits: None,
+            compaction: Box::new(CompactionConfig::default()),
             goal_objective: None,
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
@@ -4575,7 +4805,9 @@ fn context_budget_uses_conservative_fallback_for_unknown_models() {
     let _lock = lock_test_env();
     let budget = context_input_budget_for_provider(ApiProvider::Openai, "auto")
         .expect("unknown/auto model ids should still get a conservative hard preflight budget");
-    let expected = 128_000usize - effective_max_output_tokens("auto") as usize - 1_024usize;
+    let expected = 128_000usize
+        - effective_max_output_tokens_for_route(ApiProvider::Openai, "auto", None) as usize
+        - 1_024usize;
     assert_eq!(budget, expected);
 }
 
@@ -4583,8 +4815,12 @@ fn context_budget_uses_conservative_fallback_for_unknown_models() {
 fn context_budget_uses_provider_effective_window_for_openai_codex() {
     let _lock = lock_test_env();
     let budget = context_input_budget_for_provider(ApiProvider::OpenaiCodex, "gpt-5.5")
-        .expect("OpenAI Codex should use the route-effective context window");
-    let expected = 400_000usize - effective_max_output_tokens("gpt-5.5") as usize - 1_024usize;
+        .expect("OpenAI Codex should use a conservative fallback without route metadata");
+    let expected = usize::try_from(crate::config::OPENAI_CODEX_EFFECTIVE_CONTEXT_WINDOW_TOKENS)
+        .expect("context window fits usize")
+        - crate::config::provider_capability(ApiProvider::OpenaiCodex, "gpt-5.5").max_output
+            as usize
+        - 1_024usize;
     assert_eq!(budget, expected);
 }
 
@@ -4594,10 +4830,15 @@ fn route_context_budget_uses_shared_budget_service() {
     let budget = route_context_budget_for_provider(ApiProvider::OpenaiCodex, "gpt-5.5", 380_000)
         .expect("OpenAI Codex should produce a route budget");
 
-    assert_eq!(budget.window_tokens, 400_000);
+    assert_eq!(
+        budget.window_tokens,
+        u64::from(crate::config::OPENAI_CODEX_EFFECTIVE_CONTEXT_WINDOW_TOKENS)
+    );
     assert_eq!(
         budget.output_cap_tokens,
-        u64::from(effective_max_output_tokens("gpt-5.5"))
+        u64::from(
+            crate::config::provider_capability(ApiProvider::OpenaiCodex, "gpt-5.5").max_output
+        )
     );
     assert_eq!(
         budget.pressure,
@@ -4637,7 +4878,11 @@ fn effective_max_output_tokens_for_route_caps_to_route_output_limit() {
     };
 
     assert_eq!(
-        effective_max_output_tokens_for_route("deepseek-v4-pro", Some(limits)),
+        effective_max_output_tokens_for_route(
+            ApiProvider::Deepseek,
+            "deepseek-v4-pro",
+            Some(limits),
+        ),
         8_192
     );
 }
@@ -4651,7 +4896,11 @@ fn effective_max_output_tokens_for_route_caps_to_context_window() {
         output_tokens: None,
     };
 
-    let cap = effective_max_output_tokens_for_route("deepseek-v4-pro", Some(limits));
+    let cap = effective_max_output_tokens_for_route(
+        ApiProvider::Deepseek,
+        "deepseek-v4-pro",
+        Some(limits),
+    );
 
     assert!(cap < 32_000, "request cap must fit the configured window");
     assert!(
@@ -4670,9 +4919,32 @@ fn effective_max_output_tokens_for_route_keeps_tiny_window_positive() {
     };
 
     assert_eq!(
-        effective_max_output_tokens_for_route("deepseek-v4-pro", Some(limits)),
+        effective_max_output_tokens_for_route(
+            ApiProvider::Deepseek,
+            "deepseek-v4-pro",
+            Some(limits),
+        ),
         1
     );
+}
+
+#[test]
+fn codex_route_without_output_metadata_uses_oauth_capability_floor() {
+    let _lock = lock_test_env();
+    let limits = codewhale_config::route::RouteLimits {
+        context_tokens: Some(272_000),
+        input_tokens: None,
+        output_tokens: None,
+    };
+
+    assert_eq!(
+        effective_max_output_tokens_for_route(ApiProvider::OpenaiCodex, "gpt-5.5", Some(limits)),
+        4_096
+    );
+    let budget =
+        route_context_budget_for_route(ApiProvider::OpenaiCodex, "gpt-5.5", Some(limits), 0)
+            .expect("Codex route budget");
+    assert_eq!(budget.output_cap_tokens, 4_096);
 }
 
 #[test]
@@ -4791,7 +5063,8 @@ fn internal_context_budget_tiers_reserved_output_by_window() {
     let small_window_budget =
         context_input_budget_for_provider(ApiProvider::Openai, "qwen3-32b-256k")
             .expect("a 256K-suffix model must yield Some budget via the effective-cap branch");
-    let effective_output = effective_max_output_tokens("qwen3-32b-256k") as usize;
+    let effective_output =
+        effective_max_output_tokens_for_route(ApiProvider::Openai, "qwen3-32b-256k", None) as usize;
     let expected_small = 256_000 - effective_output - 1_024;
     assert_eq!(small_window_budget, expected_small);
 }
@@ -4813,6 +5086,28 @@ fn v4_keeps_large_file_reads_but_compacts_noisy_shell_output() {
         compact_tool_result_for_context("deepseek-v3.2-128k", "read_file", &output);
     assert!(legacy_context.contains("output compacted to protect context"));
     assert!(legacy_context.len() < v4_context.len());
+}
+
+#[test]
+fn codex_tool_retention_uses_oauth_route_window_not_api_model_window() {
+    let content = "route-effective context\n".repeat(900);
+    let output = ToolResult::success(content.clone());
+    let limits = codewhale_config::route::RouteLimits {
+        context_tokens: Some(272_000),
+        input_tokens: None,
+        output_tokens: None,
+    };
+
+    let context = compact_tool_result_for_route(
+        ApiProvider::OpenaiCodex,
+        "gpt-5.5",
+        Some(limits),
+        "read_file",
+        &output,
+    );
+
+    assert!(context.contains("output compacted to protect context"));
+    assert!(context.len() < content.len());
 }
 
 #[test]

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -596,6 +596,7 @@ impl Engine {
                 model: self.session.model.clone(),
                 messages: self.messages_with_turn_metadata(),
                 max_tokens: effective_max_output_tokens_for_route(
+                    self.api_provider,
                     &self.session.model,
                     self.active_route_limits,
                 ),
@@ -2508,8 +2509,10 @@ impl Engine {
                             "tool_name": outcome.name.clone(),
                             "success": output.success,
                         }));
-                        let output_for_context = compact_tool_result_for_context(
+                        let output_for_context = compact_tool_result_for_route(
+                            self.api_provider,
                             &self.session.model,
+                            self.active_route_limits,
                             &outcome.name,
                             &output,
                         );

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -87,6 +87,11 @@ pub enum Op {
         /// different authenticated provider.
         provider: Option<ApiProvider>,
         model: String,
+        /// Provider-route limits resolved by the host for this exact turn.
+        route_limits: Option<codewhale_config::route::RouteLimits>,
+        /// Compaction policy derived from the same provider route. Carrying it
+        /// atomically avoids a model/limit mismatch before `SendMessage`.
+        compaction: Box<CompactionConfig>,
         goal_objective: Option<String>,
         goal_token_budget: Option<u32>,
         goal_status: GoalStatus,

--- a/crates/tui/src/cost_status.rs
+++ b/crates/tui/src/cost_status.rs
@@ -22,6 +22,7 @@
 
 use std::sync::{Mutex, OnceLock};
 
+use crate::config::ApiProvider;
 use crate::models::Usage;
 use crate::pricing::CostEstimate;
 
@@ -32,11 +33,14 @@ fn cell() -> &'static Mutex<CostEstimate> {
 }
 
 /// Background callers report their LLM usage here. Computes the
-/// cost via [`crate::pricing::calculate_turn_cost_estimate_from_usage`] and
+/// cost via [`crate::pricing::calculate_turn_cost_estimate_for_provider`] and
 /// adds it to the pending pool. Cheap; takes a short-lived lock
-/// and returns. No-op on models the pricing table doesn't know.
-pub fn report(model: &str, usage: &Usage) {
-    let Some(cost) = crate::pricing::calculate_turn_cost_estimate_from_usage(model, usage) else {
+/// and returns. No-op when the provider does not expose authoritative runtime
+/// pricing (for example ChatGPT/Codex OAuth) or the model is unknown.
+pub fn report(provider: ApiProvider, model: &str, usage: &Usage) {
+    let Some(cost) =
+        crate::pricing::calculate_turn_cost_estimate_for_provider(provider, model, usage)
+    else {
         return;
     };
     if !cost.is_positive() {
@@ -94,7 +98,7 @@ mod tests {
     fn report_adds_to_pool_and_drain_returns_then_resets() {
         let _g = serial_lock();
         reset_for_tests();
-        report("deepseek-v4-flash", &small_usage());
+        report(ApiProvider::Deepseek, "deepseek-v4-flash", &small_usage());
         let first = drain();
         assert!(first.usd > 0.0, "expected positive USD cost, got {first:?}");
         assert!(first.cny > 0.0, "expected positive CNY cost, got {first:?}");
@@ -107,7 +111,19 @@ mod tests {
         let _g = serial_lock();
         reset_for_tests();
         // NIM-hosted models intentionally have no DeepSeek pricing.
-        report("deepseek-ai/deepseek-v4-pro", &small_usage());
+        report(
+            ApiProvider::NvidiaNim,
+            "deepseek-ai/deepseek-v4-pro",
+            &small_usage(),
+        );
+        assert_eq!(drain(), CostEstimate::default());
+    }
+
+    #[test]
+    fn report_skips_codex_oauth_pricing() {
+        let _g = serial_lock();
+        reset_for_tests();
+        report(ApiProvider::OpenaiCodex, "gpt-5.5", &small_usage());
         assert_eq!(drain(), CostEstimate::default());
     }
 
@@ -115,8 +131,8 @@ mod tests {
     fn report_accumulates_across_multiple_calls() {
         let _g = serial_lock();
         reset_for_tests();
-        report("deepseek-v4-flash", &small_usage());
-        report("deepseek-v4-flash", &small_usage());
+        report(ApiProvider::Deepseek, "deepseek-v4-flash", &small_usage());
+        report(ApiProvider::Deepseek, "deepseek-v4-flash", &small_usage());
         let total = drain();
         // Two equal reports — total must be 2× a single report.
         let single = crate::pricing::calculate_turn_cost_estimate_from_usage(

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -29,6 +29,7 @@ mod auto_reasoning;
 mod automation_manager;
 mod child_env;
 mod client;
+mod codex_model_cache;
 mod command_safety;
 mod commands;
 mod compaction;
@@ -7784,6 +7785,11 @@ async fn run_exec_agent(
     let compaction = CompactionConfig {
         enabled: auto_compact_enabled,
         model: effective_model.clone(),
+        effective_context_window: Some(crate::route_budget::route_context_window_tokens(
+            effective_provider,
+            &effective_model,
+            active_route_limits,
+        )),
         token_threshold: crate::route_budget::compaction_threshold_for_route_at_percent(
             effective_provider,
             &effective_model,
@@ -7837,7 +7843,7 @@ async fn run_exec_agent(
         subagents_enabled: execution_config.subagents_enabled_for_provider(effective_provider),
         features: execution_config.features(),
         auto_review_policy: execution_config.auto_review_policy(),
-        compaction,
+        compaction: compaction.clone(),
         todos: new_shared_todo_list(),
         plan_state: new_shared_plan_state(),
         goal_state: crate::tools::goal::new_shared_goal_state(),
@@ -7946,6 +7952,8 @@ async fn run_exec_agent(
             mode,
             provider: Some(effective_provider),
             model: effective_model.clone(),
+            route_limits: active_route_limits,
+            compaction: Box::new(compaction.clone()),
             goal_objective: None,
             goal_token_budget: None,
             goal_status: crate::tools::goal::GoalStatus::Active,
@@ -8855,7 +8863,7 @@ mod doctor_setup_state_tests {
     }
 
     #[test]
-    fn doctor_setup_report_json_reports_operate_readiness() {
+    fn doctor_setup_report_json_fails_closed_without_operate_receipts() {
         let _guard = crate::test_support::lock_test_env();
         let tmp = TempDir::new().expect("tempdir");
         let (_home_guard, _codewhale_home) = prepare_env(&tmp);
@@ -8899,7 +8907,7 @@ mod doctor_setup_state_tests {
         let report = doctor_setup_report_json(&Config::default(), &workspace);
 
         assert_eq!(report["first_run_ready"], true);
-        assert_eq!(report["operate_ready"], true);
+        assert_eq!(report["operate_ready"], false);
         assert_eq!(
             report["operate_fleet"]["concurrency"]["plan_limit_probed"],
             false

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -14,6 +14,7 @@ pub const DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS: u32 = 1_000_000;
 /// models resolve to their own scaled value via
 /// [`compaction_threshold_for_model`] (#664).
 pub const DEFAULT_COMPACTION_TOKEN_THRESHOLD: usize = 102_400;
+#[cfg(test)]
 const COMPACTION_THRESHOLD_PERCENT: u32 = 80;
 pub const DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS: u32 = DEEPSEEK_V4_CONTEXT_WINDOW_TOKENS;
 
@@ -555,6 +556,7 @@ fn explicit_context_window_hint(model_lower: &str) -> Option<u32> {
 /// Derive a compaction token threshold from model context and a caller-supplied
 /// percentage.
 #[must_use]
+#[cfg(test)]
 pub fn compaction_threshold_for_model_at_percent(model: &str, percent: f64) -> usize {
     let Some(window) = context_window_for_model(model) else {
         return DEFAULT_COMPACTION_TOKEN_THRESHOLD;
@@ -574,6 +576,7 @@ pub fn compaction_threshold_for_model_at_percent(model: &str, percent: f64) -> u
 /// configure it. v0.8.64 defaults automatic continuity on for known model
 /// windows up to the V4 1M class while keeping unknown model ids opt-in.
 #[must_use]
+#[cfg(test)]
 pub fn auto_compact_default_for_model(model: &str) -> bool {
     context_window_for_model(model)
         .is_some_and(|window| window <= DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS)

--- a/crates/tui/src/oauth.rs
+++ b/crates/tui/src/oauth.rs
@@ -129,6 +129,37 @@ pub fn load_credentials() -> Result<Option<CodexCredentials>> {
     }))
 }
 
+/// Prompt-free, non-refreshing readiness check for picker/onboarding surfaces.
+/// It validates stored structure and requires either an unexpired access token
+/// or a nonblank refresh token; no network request is made.
+#[must_use]
+pub fn credentials_present() -> bool {
+    if ["OPENAI_CODEX_ACCESS_TOKEN", "CODEX_ACCESS_TOKEN"]
+        .iter()
+        .any(|name| std::env::var(name).is_ok_and(|token| !token.trim().is_empty()))
+    {
+        return true;
+    }
+
+    stored_credentials_present()
+}
+
+/// Validate only the stored OAuth file, excluding token environment
+/// overrides so config-vs-env provenance remains truthful.
+#[must_use]
+pub fn stored_credentials_present() -> bool {
+    load_credentials()
+        .ok()
+        .flatten()
+        .is_some_and(|credentials| {
+            !token_is_expired(&credentials.access_token)
+                || credentials
+                    .refresh_token
+                    .as_deref()
+                    .is_some_and(|token| !token.trim().is_empty())
+        })
+}
+
 /// Refresh an expired access token using the refresh token.
 ///
 /// Calls the OpenAI token endpoint and returns new credentials.
@@ -362,6 +393,33 @@ mod tests {
         let payload = URL_SAFE_NO_PAD.encode(b"{\"exp\":1000000000}");
         let token = format!("header.{payload}.sig");
         assert!(token_is_expired(&token));
+    }
+
+    #[test]
+    fn credential_presence_rejects_empty_and_malformed_files_without_refresh() {
+        let _lock = crate::test_support::lock_test_env();
+        let home = tempfile::tempdir().expect("temp Codex home");
+        let auth_path = home.path().join("auth.json");
+        let _auth = crate::test_support::EnvVarGuard::set("OPENAI_CODEX_AUTH_FILE", &auth_path);
+        let _access = crate::test_support::EnvVarGuard::remove("OPENAI_CODEX_ACCESS_TOKEN");
+        let _legacy_access = crate::test_support::EnvVarGuard::remove("CODEX_ACCESS_TOKEN");
+
+        std::fs::write(&auth_path, "{}").expect("empty auth");
+        assert!(!credentials_present());
+        std::fs::write(&auth_path, "{not-json").expect("malformed auth");
+        assert!(!credentials_present());
+
+        let payload = URL_SAFE_NO_PAD.encode(b"{\"exp\":9999999999}");
+        let access_token = format!("header.{payload}.signature");
+        std::fs::write(
+            &auth_path,
+            serde_json::to_vec(&serde_json::json!({
+                "tokens": {"access_token": access_token}
+            }))
+            .expect("valid auth json"),
+        )
+        .expect("valid auth");
+        assert!(credentials_present());
     }
 
     #[test]

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -119,6 +119,15 @@ pub fn has_pricing_for_model(model: &str) -> bool {
     pricing_for_model(model).is_some()
 }
 
+/// Return whether the selected provider route exposes authoritative dollar
+/// pricing for this model. ChatGPT/Codex OAuth usage is subscription/account
+/// scoped, so the same model id can be priced on the OpenAI API route while
+/// remaining intentionally unpriced on the OAuth route.
+#[must_use]
+pub fn has_pricing_for_provider(provider: ApiProvider, model: &str) -> bool {
+    provider != ApiProvider::OpenaiCodex && has_pricing_for_model(model)
+}
+
 fn pricing_for_model_at(model: &str, now: DateTime<Utc>) -> Option<ModelPricing> {
     let lower = model.to_lowercase();
     if lower.starts_with("deepseek-ai/") {
@@ -295,6 +304,7 @@ fn deepseek_v4_flash_pricing() -> ModelPricing {
 
 /// Calculate cost from provider usage, honoring DeepSeek context-cache fields.
 #[must_use]
+#[cfg(test)]
 pub fn calculate_turn_cost_from_usage(model: &str, usage: &Usage) -> Option<f64> {
     calculate_turn_cost_estimate_from_usage(model, usage).map(|estimate| estimate.usd)
 }
@@ -542,6 +552,11 @@ mod tests {
         };
 
         assert!(calculate_turn_cost_estimate_from_usage("gpt-5.5", &usage).is_some());
+        assert!(has_pricing_for_provider(ApiProvider::Openai, "gpt-5.5"));
+        assert!(!has_pricing_for_provider(
+            ApiProvider::OpenaiCodex,
+            "gpt-5.5"
+        ));
         assert!(
             calculate_turn_cost_estimate_for_provider(ApiProvider::OpenaiCodex, "gpt-5.5", &usage)
                 .is_none()

--- a/crates/tui/src/provider_lake.rs
+++ b/crates/tui/src/provider_lake.rs
@@ -15,6 +15,7 @@ use std::sync::RwLock;
 
 use codewhale_config::catalog::{CatalogOffering, CatalogSnapshot, bundled_catalog_offerings};
 
+use crate::codex_model_cache;
 use crate::config::{
     ApiProvider, Config, model_completion_names_for_provider, provider_is_configured_for_active,
 };
@@ -124,6 +125,13 @@ fn catalog_models_from_offerings<'a>(
 /// local providers (and gateways not yet in the offline seed) keep defaults.
 #[must_use]
 pub fn all_catalog_models_for_provider(provider: ApiProvider) -> Vec<String> {
+    // ChatGPT OAuth availability is account-scoped. A generic OpenAI or
+    // Models.dev catalog is not evidence that a model can be routed through
+    // the Codex backend, so this provider owns a separate secret-free source.
+    if provider == ApiProvider::OpenaiCodex {
+        return codex_model_cache::model_roster().model_ids();
+    }
+
     let catalog_id = catalog_provider_id(provider);
     let merged = merged_snapshot();
     let mut models = catalog_models_from_offerings(merged.offerings_for_provider(catalog_id));
@@ -146,6 +154,9 @@ pub fn catalog_offering_for_model(
     provider: ApiProvider,
     wire_model_id: &str,
 ) -> Option<CatalogOffering> {
+    if provider == ApiProvider::OpenaiCodex {
+        return None;
+    }
     let catalog_id = catalog_provider_id(provider);
     let needle = wire_model_id.trim();
     if needle.is_empty() {
@@ -234,6 +245,14 @@ mod tests {
 
     #[test]
     fn configured_providers_matches_provider_predicate() {
+        let _env_lock = crate::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _auth_file = crate::test_support::EnvVarGuard::set(
+            "OPENAI_CODEX_AUTH_FILE",
+            tmp.path().join("missing-auth.json"),
+        );
+        let _openai_token = crate::test_support::EnvVarGuard::remove("OPENAI_CODEX_ACCESS_TOKEN");
+        let _codex_token = crate::test_support::EnvVarGuard::remove("CODEX_ACCESS_TOKEN");
         let config = Config::default();
         let active = ApiProvider::Deepseek;
         let expected: Vec<_> = ApiProvider::sorted_for_display()
@@ -279,6 +298,9 @@ mod tests {
     /// `requested_model_for_provider`, not by this list.
     #[test]
     fn catalog_facade_covers_every_provider_with_a_legacy_table() {
+        let _env = crate::test_support::lock_test_env();
+        let codex_home = tempfile::tempdir().expect("temporary CODEX_HOME");
+        let _codex_home = crate::test_support::EnvVarGuard::set("CODEX_HOME", codex_home.path());
         let _live = lock_live_snapshot();
         clear_live_snapshot();
         for &provider in ApiProvider::all() {
@@ -299,6 +321,9 @@ mod tests {
     /// fallback when Models.dev (live or bundled) has no rows for them.
     #[test]
     fn codewhale_only_providers_keep_legacy_defaults() {
+        let _env = crate::test_support::lock_test_env();
+        let codex_home = tempfile::tempdir().expect("temporary CODEX_HOME");
+        let _codex_home = crate::test_support::EnvVarGuard::set("CODEX_HOME", codex_home.path());
         let _live = lock_live_snapshot();
         clear_live_snapshot();
         let openai_codex = all_catalog_models_for_provider(ApiProvider::OpenaiCodex);
@@ -333,6 +358,11 @@ mod tests {
         let merged = merged_snapshot();
         let mut exercised = 0usize;
         for &provider in ApiProvider::all() {
+            // OpenAI Codex deliberately owns an account-scoped cache source;
+            // its fallback behavior is covered separately above.
+            if provider == ApiProvider::OpenaiCodex {
+                continue;
+            }
             let catalog_id = catalog_provider_id(provider);
             let has_catalog_rows = !merged.offerings_for_provider(catalog_id).is_empty();
             let legacy = model_completion_names_for_provider(provider);

--- a/crates/tui/src/purge.rs
+++ b/crates/tui/src/purge.rs
@@ -10,6 +10,7 @@ use regex::Regex;
 use std::fmt::Write;
 use tokio::sync::mpsc::Sender;
 
+use crate::config::ApiProvider;
 use crate::core::events::Event;
 use crate::fast_hash::{FastHashMap, FastHashSet};
 use crate::llm_client::LlmClient;
@@ -532,6 +533,7 @@ pub fn build_purge_tool() -> Tool {
 /// and for replacing the session message list with `PurgeResult.messages`.
 pub async fn run_purge(
     client: &impl LlmClient,
+    provider: ApiProvider,
     messages: &[Message],
     model: &str,
     reasoning_effort: Option<String>,
@@ -573,7 +575,7 @@ pub async fn run_purge(
         .await
         .map_err(|e| format!("Purge API error: {e}"))?;
 
-    crate::cost_status::report(&response.model, &response.usage);
+    crate::cost_status::report(provider, &response.model, &response.usage);
 
     // 5. Find the `purge_context` tool call in the response.
     let tool_input = response.content.iter().find_map(|block| {
@@ -849,7 +851,7 @@ mod tests {
             msg_text("user", "bye"),
         ];
 
-        let result = run_purge(&mock, &messages, "mock", None, 4096)
+        let result = run_purge(&mock, ApiProvider::Deepseek, &messages, "mock", None, 4096)
             .await
             .unwrap();
         assert_eq!(result.removed_count, 1);
@@ -883,7 +885,7 @@ mod tests {
 
         let messages = vec![msg_text("assistant", "this is very long and verbose text")];
 
-        let result = run_purge(&mock, &messages, "mock", None, 4096)
+        let result = run_purge(&mock, ApiProvider::Deepseek, &messages, "mock", None, 4096)
             .await
             .unwrap();
         assert_eq!(result.removed_count, 0);
@@ -905,7 +907,7 @@ mod tests {
         mock.push_message_response(msg_response_without_tool_call("nothing to clean up"));
 
         let messages = vec![msg_text("user", "hi")];
-        let err = run_purge(&mock, &messages, "mock", None, 4096)
+        let err = run_purge(&mock, ApiProvider::Deepseek, &messages, "mock", None, 4096)
             .await
             .unwrap_err();
         assert!(err.contains("did not call purge_context"));
@@ -916,7 +918,7 @@ mod tests {
         // No canned response — MockLlmClient returns an error.
         let mock = MockLlmClient::new(vec![]);
         let messages = vec![msg_text("user", "hi")];
-        let err = run_purge(&mock, &messages, "mock", None, 4096)
+        let err = run_purge(&mock, ApiProvider::Deepseek, &messages, "mock", None, 4096)
             .await
             .unwrap_err();
         assert!(err.contains("Purge API error"));

--- a/crates/tui/src/route_budget.rs
+++ b/crates/tui/src/route_budget.rs
@@ -4,7 +4,6 @@ use crate::config::{ApiProvider, provider_capability};
 use crate::context_budget::ContextBudget;
 use crate::models::{
     DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS, DEFAULT_COMPACTION_TOKEN_THRESHOLD,
-    compaction_threshold_for_model_at_percent,
 };
 
 /// Preserve only route limits that came from a concrete offering.
@@ -63,22 +62,15 @@ pub(crate) fn compaction_threshold_for_route_at_percent(
     route_limits: Option<RouteLimits>,
     percent: f64,
 ) -> usize {
-    if route_limits
-        .and_then(|limits| limits.context_tokens)
-        .is_some()
-    {
-        let window = route_context_window_tokens(provider, model, route_limits);
-        let percent = percent.clamp(10.0, 100.0);
-        let threshold = (f64::from(window) * percent / 100.0).round();
-        let threshold = if threshold.is_finite() && threshold > 0.0 {
-            threshold as u64
-        } else {
-            return DEFAULT_COMPACTION_TOKEN_THRESHOLD;
-        };
-        return usize::try_from(threshold).unwrap_or(DEFAULT_COMPACTION_TOKEN_THRESHOLD);
-    }
-
-    compaction_threshold_for_model_at_percent(model, percent)
+    let window = route_context_window_tokens(provider, model, route_limits);
+    let percent = percent.clamp(10.0, 100.0);
+    let threshold = (f64::from(window) * percent / 100.0).round();
+    let threshold = if threshold.is_finite() && threshold > 0.0 {
+        threshold as u64
+    } else {
+        return DEFAULT_COMPACTION_TOKEN_THRESHOLD;
+    };
+    usize::try_from(threshold).unwrap_or(DEFAULT_COMPACTION_TOKEN_THRESHOLD)
 }
 
 #[must_use]
@@ -87,13 +79,33 @@ pub(crate) fn auto_compact_default_for_route(
     model: &str,
     route_limits: Option<RouteLimits>,
 ) -> bool {
-    if route_limits
-        .and_then(|limits| limits.context_tokens)
-        .is_some()
-    {
-        return route_context_window_tokens(provider, model, route_limits)
-            <= DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS;
-    }
+    route_context_window_tokens(provider, model, route_limits)
+        <= DEFAULT_AUTO_COMPACT_MAX_CONTEXT_WINDOW_TOKENS
+}
 
-    crate::models::auto_compact_default_for_model(model)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_missing_route_metadata_uses_provider_context_floor() {
+        assert_eq!(
+            route_context_window_tokens(ApiProvider::OpenaiCodex, "gpt-5.5", None),
+            128_000
+        );
+        assert_eq!(
+            compaction_threshold_for_route_at_percent(
+                ApiProvider::OpenaiCodex,
+                "gpt-5.5",
+                None,
+                80.0,
+            ),
+            102_400
+        );
+        assert!(auto_compact_default_for_route(
+            ApiProvider::OpenaiCodex,
+            "gpt-5.5",
+            None,
+        ));
+    }
 }

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -2,6 +2,7 @@ use codewhale_config::route::{
     LogicalModelRef, ReadyRouteCandidate, RouteLimits, RouteRequest, RouteResolver, WireModelId,
 };
 
+use crate::codex_model_cache::{CodexModelCacheFreshness, model_roster};
 use crate::config::{ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL};
 
 #[derive(Debug, Clone)]
@@ -29,6 +30,25 @@ pub(crate) fn resolve_route_candidate(
         .resolve(&route_request)
         .map_err(|err| err.to_string())?;
     apply_context_window_override(&mut candidate.limits, context_window_override);
+    if provider == ApiProvider::OpenaiCodex {
+        // Models.dev describes the public API offering, not the account-scoped
+        // ChatGPT OAuth route. Strip API-only limits, then carry the fresh
+        // Codex roster's per-model context into every runtime consumer.
+        candidate.limits.input_tokens = None;
+        candidate.limits.output_tokens = None;
+        if context_window_override.is_none() {
+            let roster = model_roster();
+            candidate.limits.context_tokens = if roster.freshness == CodexModelCacheFreshness::Fresh
+            {
+                roster
+                    .metadata_for(candidate.wire_model_id.as_str())
+                    .and_then(|metadata| metadata.context_window)
+                    .map(u64::from)
+            } else {
+                None
+            };
+        }
+    }
     Ok(candidate)
 }
 
@@ -127,6 +147,48 @@ fn root_base_url_belongs_to_non_deepseek_provider(base_url: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::{DEFAULT_TEXT_MODEL, DEFAULT_ZAI_MODEL, ProviderConfig, ProvidersConfig};
+
+    #[test]
+    fn codex_route_uses_fresh_account_context_and_drops_api_only_limits() {
+        let _lock = crate::test_support::lock_test_env();
+        let codex_home = tempfile::tempdir().expect("Codex home");
+        let _home = crate::test_support::EnvVarGuard::set("CODEX_HOME", codex_home.path());
+        std::fs::write(
+            codex_home.path().join("models_cache.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "fetched_at": chrono::Utc::now(),
+                "models": [{
+                    "slug": crate::config::DEFAULT_OPENAI_CODEX_MODEL,
+                    "priority": 1,
+                    "context_window": 128000,
+                    "supported_reasoning_levels": [{"effort": "high"}]
+                }]
+            }))
+            .expect("serialize cache"),
+        )
+        .expect("write cache");
+
+        let candidate = resolve_route_candidate(
+            ApiProvider::OpenaiCodex,
+            Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL),
+            None,
+            None,
+            None,
+        )
+        .expect("Codex route");
+
+        assert_eq!(candidate.limits.context_tokens, Some(128_000));
+        assert_eq!(candidate.limits.input_tokens, None);
+        assert_eq!(candidate.limits.output_tokens, None);
+        assert_eq!(
+            crate::route_budget::route_context_window_tokens(
+                ApiProvider::OpenaiCodex,
+                crate::config::DEFAULT_OPENAI_CODEX_MODEL,
+                Some(candidate.limits),
+            ),
+            128_000
+        );
+    }
 
     #[test]
     fn runtime_route_without_model_uses_target_provider_default() {

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -67,6 +67,7 @@ fn saved_session_with_blocks(blocks: Vec<crate::models::ContentBlock>) -> SavedS
         system_prompt: None,
         context_references: Vec::new(),
         artifacts: Vec::new(),
+        work_state: None,
     }
 }
 
@@ -198,6 +199,8 @@ fn messages_from_thread_detail_batches_tool_results() {
         ended_at: Some(now),
         duration_ms: Some(0),
         usage: None,
+        effective_provider: None,
+        effective_model: None,
         error: None,
         item_ids: vec![
             "item_user".to_string(),

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1,7 +1,8 @@
 //! Durable thread/turn/item runtime for the HTTP API and background tasks.
 //!
-//! This module keeps DeepSeek-only execution while exposing Codex-like lifecycle
-//! semantics (threads, turns, items, interrupt/steer, and replayable events).
+//! Execution follows the configured provider route while exposing Codex-like
+//! lifecycle semantics (threads, turns, items, interrupt/steer, and replayable
+//! events).
 
 // Background-task runtime — runs alongside the TUI. Raw stdio prints
 // here would still land in the alt-screen on whichever terminal the
@@ -26,14 +27,16 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::compaction::CompactionConfig;
-use crate::config::{Config, DEFAULT_TEXT_MODEL, MAX_SUBAGENTS};
+use crate::config::{ApiProvider, Config, DEFAULT_TEXT_MODEL, MAX_SUBAGENTS};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
 use crate::core::events::{Event as EngineEvent, TurnOutcomeStatus};
 use crate::core::ops::Op;
-use crate::models::{
-    ContentBlock, Message, SystemPrompt, Usage, auto_compact_default_for_model,
-    compaction_threshold_for_model_at_percent,
+use crate::models::{ContentBlock, Message, SystemPrompt, Usage};
+use crate::route_budget::{
+    auto_compact_default_for_route, compaction_threshold_for_route_at_percent, known_route_limits,
+    route_context_window_tokens,
 };
+use crate::route_runtime::resolve_runtime_route;
 use crate::tools::plan::new_shared_plan_state;
 use crate::tools::subagent::SubAgentStatus;
 use crate::tools::todo::new_shared_todo_list;
@@ -243,6 +246,14 @@ pub struct TurnRecord {
     pub duration_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
+    /// Concrete provider selected for this turn. Additive so legacy records
+    /// deserialize without inventing provider provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_provider: Option<String>,
+    /// Concrete wire model selected for this turn (especially important when
+    /// the thread is configured as `auto`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(default)]
@@ -813,18 +824,52 @@ pub struct UsageAggregation {
     pub buckets: Vec<UsageBucket>,
 }
 
-/// Best-effort provider classification from a model name. Used as a grouping
-/// key for `/v1/usage?group_by=provider`. Cost-tracking already runs the
-/// model→pricing→cost path; this only labels the bucket.
-fn provider_label_for_model(model: &str) -> &'static str {
-    if model.starts_with("deepseek-ai/") {
-        "nvidia-nim"
-    } else if model.starts_with("deepseek-") {
-        "deepseek"
-    } else if model.starts_with("openai/") || model.starts_with("anthropic/") {
-        "openrouter"
-    } else {
-        "unknown"
+#[derive(Debug, Clone)]
+struct RuntimeThreadRoute {
+    provider: ApiProvider,
+    model: String,
+    config: Config,
+    limits: Option<codewhale_config::route::RouteLimits>,
+}
+
+fn resolve_runtime_thread_route(
+    config: &Config,
+    provider: ApiProvider,
+    model_selector: Option<&str>,
+) -> Result<RuntimeThreadRoute> {
+    let route = resolve_runtime_route(config, provider, model_selector)
+        .map_err(|reason| anyhow!("Failed to resolve runtime thread route: {reason}"))?;
+    Ok(RuntimeThreadRoute {
+        provider,
+        model: route.model,
+        config: route.config,
+        limits: known_route_limits(route.candidate.limits),
+    })
+}
+
+fn runtime_compaction_config(
+    provider: ApiProvider,
+    model: &str,
+    route_limits: Option<codewhale_config::route::RouteLimits>,
+    auto_compact: bool,
+    auto_compact_explicit: bool,
+    threshold_percent: f64,
+) -> CompactionConfig {
+    CompactionConfig {
+        enabled: if auto_compact_explicit {
+            auto_compact
+        } else {
+            auto_compact_default_for_route(provider, model, route_limits)
+        },
+        model: model.to_string(),
+        token_threshold: compaction_threshold_for_route_at_percent(
+            provider,
+            model,
+            route_limits,
+            threshold_percent,
+        ),
+        effective_context_window: Some(route_context_window_tokens(provider, model, route_limits)),
+        ..Default::default()
     }
 }
 
@@ -840,6 +885,8 @@ struct ActiveTurnState {
 struct ActiveThreadState {
     engine: EngineHandle,
     active_turn: Option<ActiveTurnState>,
+    route_provider: ApiProvider,
+    route_model: String,
 }
 
 #[derive(Default)]
@@ -927,6 +974,38 @@ impl RuntimeThreadManager {
         self.config.read()
     }
 
+    fn resolved_route_for_thread(
+        &self,
+        config: &Config,
+        thread: &ThreadRecord,
+    ) -> Result<RuntimeThreadRoute> {
+        if !thread.model.trim().eq_ignore_ascii_case("auto") {
+            return resolve_runtime_thread_route(
+                config,
+                config.api_provider(),
+                Some(&thread.model),
+            );
+        }
+
+        let restored = self
+            .store
+            .list_turns_for_thread(&thread.id)?
+            .into_iter()
+            .rev()
+            .find_map(|turn| {
+                let provider = turn
+                    .effective_provider
+                    .as_deref()
+                    .and_then(ApiProvider::parse)?;
+                let model = turn.effective_model?.trim().to_string();
+                (!model.is_empty()).then_some((provider, model))
+            });
+        match restored {
+            Some((provider, model)) => resolve_runtime_thread_route(config, provider, Some(&model)),
+            None => resolve_runtime_thread_route(config, config.api_provider(), None),
+        }
+    }
+
     /// Reload config from an updated Config instance (called after /v1/config/reload).
     pub fn reload_config(&self, new_config: Config) {
         let mut guard = self.config.write();
@@ -939,72 +1018,73 @@ impl RuntimeThreadManager {
     /// `apply_model_and_compaction_update` after a config change, ensuring
     /// running engines pick up the new settings without a restart.
     pub async fn sync_engines_with_config(&self) {
-        let (default_model, compaction_template, stream_chunk_timeout_secs, subagent_cfg) = {
+        let (
+            config,
+            auto_compact,
+            auto_compact_explicit,
+            auto_compact_threshold_percent,
+            stream_chunk_timeout_secs,
+        ) = {
             let cfg = self.read_config();
             let settings = crate::settings::Settings::load().unwrap_or_default();
-            let provider = cfg.api_provider();
-            let auto_compact_enabled =
-                if crate::settings::Settings::auto_compact_explicitly_configured() {
-                    settings.auto_compact
-                } else {
-                    auto_compact_default_for_model(
-                        &cfg.default_text_model.clone().unwrap_or_default(),
-                    )
-                };
-            let compaction = crate::compaction::CompactionConfig {
-                enabled: auto_compact_enabled,
-                model: String::new(), // per-engine, filled below
-                token_threshold: compaction_threshold_for_model_at_percent(
-                    &cfg.default_text_model.clone().unwrap_or_default(),
-                    settings.auto_compact_threshold_percent,
-                ),
-                ..Default::default()
-            };
-            let subagent = (
-                cfg.subagents_enabled_for_provider(provider),
-                cfg.max_subagents_for_provider(provider)
-                    .clamp(1, crate::config::MAX_SUBAGENTS),
-                cfg.launch_concurrency_for_provider(provider),
-                cfg.subagent_max_spawn_depth_for_provider(provider),
-                cfg.subagent_api_timeout_secs_for_provider(provider),
-                cfg.subagent_heartbeat_timeout_secs_for_provider(provider),
-            );
             (
-                cfg.default_text_model.clone().unwrap_or_default(),
-                compaction,
+                cfg.clone(),
+                settings.auto_compact,
+                crate::settings::Settings::auto_compact_explicitly_configured(),
+                settings.auto_compact_threshold_percent,
                 cfg.stream_chunk_timeout_secs(),
-                subagent,
             )
         };
 
-        // Collect engine handles and thread IDs, then release the active lock
-        // before doing any async work (sending Ops, loading thread records).
-        let entries: Vec<(String, EngineHandle)> = {
+        // Keep each already-loaded engine on its actual provider/model route.
+        // `SetModel` cannot swap the provider client; the next `SendMessage`
+        // performs provider activation if a turn explicitly selects another
+        // route.
+        let entries: Vec<(String, EngineHandle, ApiProvider, String)> = {
             let active = self.active.lock().await;
             active
                 .engines
                 .iter()
-                .map(|(id, state)| (id.clone(), state.engine.clone()))
+                .map(|(id, state)| {
+                    (
+                        id.clone(),
+                        state.engine.clone(),
+                        state.route_provider,
+                        state.route_model.clone(),
+                    )
+                })
                 .collect()
         };
 
-        for (thread_id, engine) in entries {
-            let engine_model = self
-                .store
-                .load_thread(&thread_id)
-                .ok()
-                .map(|t| t.model)
-                .unwrap_or_else(|| default_model.clone());
-            let engine_compaction = crate::compaction::CompactionConfig {
-                model: engine_model.clone(),
-                ..compaction_template.clone()
+        for (thread_id, engine, provider, engine_model) in entries {
+            let route = match resolve_runtime_thread_route(&config, provider, Some(&engine_model)) {
+                Ok(route) => route,
+                Err(err) => {
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        provider = provider.as_str(),
+                        model = %engine_model,
+                        error = %err,
+                        "Skipped runtime engine route sync"
+                    );
+                    continue;
+                }
             };
+            let route_limits = route.limits;
+            let engine_compaction = runtime_compaction_config(
+                provider,
+                &route.model,
+                route_limits,
+                auto_compact,
+                auto_compact_explicit,
+                auto_compact_threshold_percent,
+            );
 
             let _ = engine
                 .send(Op::SetModel {
-                    model: engine_model,
+                    model: route.model.clone(),
                     mode: crate::tui::app::AppMode::Agent,
-                    route_limits: None,
+                    route_limits,
                 })
                 .await;
             let _ = engine
@@ -1019,14 +1099,21 @@ impl RuntimeThreadManager {
                 .await;
             let _ = engine
                 .send(Op::SetSubagentRuntimeConfig {
-                    enabled: subagent_cfg.0,
-                    max_subagents: subagent_cfg.1,
-                    launch_concurrency: subagent_cfg.2,
-                    max_spawn_depth: subagent_cfg.3,
-                    api_timeout_secs: subagent_cfg.4,
-                    heartbeat_timeout_secs: subagent_cfg.5,
+                    enabled: config.subagents_enabled_for_provider(provider),
+                    max_subagents: config
+                        .max_subagents_for_provider(provider)
+                        .clamp(1, crate::config::MAX_SUBAGENTS),
+                    launch_concurrency: config.launch_concurrency_for_provider(provider),
+                    max_spawn_depth: config.subagent_max_spawn_depth_for_provider(provider),
+                    api_timeout_secs: config.subagent_api_timeout_secs_for_provider(provider),
+                    heartbeat_timeout_secs: config
+                        .subagent_heartbeat_timeout_secs_for_provider(provider),
                 })
                 .await;
+
+            if let Some(state) = self.active.lock().await.engines.get_mut(&thread_id) {
+                state.route_model = route.model;
+            }
 
             tracing::info!(thread_id = %thread_id, "Synced engine with reloaded config");
         }
@@ -1307,8 +1394,10 @@ impl RuntimeThreadManager {
 
     /// Aggregate token + cost usage across all threads/turns inside the time
     /// range `[since, until]`. Each turn's cost is computed via
-    /// `pricing::calculate_turn_cost_from_usage` using the *thread*'s model
-    /// (turns inherit it). Whalescale#261 / #564.
+    /// provider-aware pricing using each turn's persisted concrete route.
+    /// Legacy turns without provider provenance and providers without an
+    /// authoritative runtime price (including ChatGPT/Codex OAuth) accrue
+    /// tokens but no fabricated dollar cost. Whalescale#261 / #564.
     ///
     /// Buckets are sorted by ascending key for deterministic output. Empty
     /// ranges produce empty `buckets` (never an error).
@@ -1322,7 +1411,6 @@ impl RuntimeThreadManager {
 
         let mut buckets: BTreeMap<String, UsageBucket> = BTreeMap::new();
         let mut totals = UsageTotals::default();
-
         for thread in self.store.list_threads()? {
             let turns = self.store.list_turns_for_thread(&thread.id)?;
             for turn in turns {
@@ -1343,7 +1431,24 @@ impl RuntimeThreadManager {
                 let reasoning = usage.reasoning_tokens.unwrap_or(0) as u64;
                 let input = usage.input_tokens as u64;
                 let output = usage.output_tokens as u64;
-                let cost = crate::pricing::calculate_turn_cost_from_usage(&thread.model, usage)
+                let model = turn
+                    .effective_model
+                    .as_deref()
+                    .filter(|model| !model.trim().is_empty())
+                    .unwrap_or(&thread.model);
+                let provider_label = turn
+                    .effective_provider
+                    .as_deref()
+                    .filter(|provider| !provider.trim().is_empty())
+                    .unwrap_or("unknown");
+                let provider = ApiProvider::parse(provider_label);
+                let cost = provider
+                    .and_then(|provider| {
+                        crate::pricing::calculate_turn_cost_estimate_for_provider(
+                            provider, model, usage,
+                        )
+                    })
+                    .map(|estimate| estimate.usd)
                     .unwrap_or(0.0);
 
                 totals.input_tokens += input;
@@ -1355,8 +1460,8 @@ impl RuntimeThreadManager {
 
                 let key = match group_by {
                     UsageGroupBy::Day => turn.created_at.format("%Y-%m-%d").to_string(),
-                    UsageGroupBy::Model => thread.model.clone(),
-                    UsageGroupBy::Provider => provider_label_for_model(&thread.model).to_string(),
+                    UsageGroupBy::Model => model.to_string(),
+                    UsageGroupBy::Provider => provider_label.to_string(),
                     UsageGroupBy::Thread => thread.id.clone(),
                 };
                 let bucket = buckets.entry(key.clone()).or_insert_with(|| UsageBucket {
@@ -2064,6 +2169,8 @@ impl RuntimeThreadManager {
                     ended_at: Some(now),
                     duration_ms: Some(0),
                     usage: None,
+                    effective_provider: None,
+                    effective_model: None,
                     error: None,
                     item_ids,
                     steer_count: 0,
@@ -2104,6 +2211,59 @@ impl RuntimeThreadManager {
             }
         }
 
+        // Resolve the concrete provider/model before persisting a turn. Auto
+        // routing can fail, and such a failure must not leave a zombie
+        // in-progress record behind.
+        let mode = req
+            .mode
+            .as_deref()
+            .and_then(parse_mode_opt)
+            .unwrap_or_else(|| parse_mode(&thread.mode));
+        let requested_model = req.model.as_deref().unwrap_or(&thread.model).to_string();
+        let auto_model = requested_model.trim().eq_ignore_ascii_case("auto");
+        let cfg_snapshot = self.config.read().clone();
+        let (provider, selected_model, reasoning_effort, verbosity) = {
+            let verbosity = cfg_snapshot.verbosity.clone();
+            if auto_model {
+                let selection = crate::model_routing::resolve_auto_route_with_inventory(
+                    &cfg_snapshot,
+                    &prompt,
+                    "",
+                    "auto",
+                    "auto",
+                )
+                .await?;
+                (
+                    selection.provider,
+                    selection.model,
+                    selection
+                        .reasoning_effort
+                        .map(|effort| effort.as_setting().to_string()),
+                    verbosity,
+                )
+            } else {
+                (
+                    cfg_snapshot.api_provider(),
+                    requested_model,
+                    None,
+                    verbosity,
+                )
+            }
+        };
+        let route = resolve_runtime_thread_route(&cfg_snapshot, provider, Some(&selected_model))?;
+        let model = route.model;
+        let route_limits = route.limits;
+        let settings = crate::settings::Settings::load().unwrap_or_default();
+        let compaction = runtime_compaction_config(
+            provider,
+            &model,
+            route_limits,
+            settings.auto_compact,
+            crate::settings::Settings::auto_compact_explicitly_configured(),
+            settings.auto_compact_threshold_percent,
+        );
+        let show_thinking = settings.show_thinking;
+
         let now = Utc::now();
         let turn_id = format!("turn_{}", &Uuid::new_v4().to_string()[..8]);
         let mut turn = TurnRecord {
@@ -2119,6 +2279,8 @@ impl RuntimeThreadManager {
             ended_at: None,
             duration_ms: None,
             usage: None,
+            effective_provider: Some(provider.as_str().to_string()),
+            effective_model: Some(model.clone()),
             error: None,
             item_ids: Vec::new(),
             steer_count: 0,
@@ -2183,52 +2345,13 @@ impl RuntimeThreadManager {
                 auto_approve: req.auto_approve.unwrap_or(thread.auto_approve),
                 trust_mode: req.trust_mode.unwrap_or(thread.trust_mode),
             });
+            state.route_provider = provider;
+            state.route_model.clone_from(&model);
             touch_lru(&mut active.lru, thread_id);
         }
-
-        // A requested mode override only takes effect when it is an explicit,
-        // recognized mode token. An unrecognized override (e.g. a stray prompt
-        // fragment) must NOT silently change the mode: fall back to the
-        // thread's persisted mode rather than coercing to Agent (#3387).
-        let mode = req
-            .mode
-            .as_deref()
-            .and_then(parse_mode_opt)
-            .unwrap_or_else(|| parse_mode(&thread.mode));
-        let requested_model = req.model.unwrap_or_else(|| thread.model.clone());
-        let auto_model = requested_model.trim().eq_ignore_ascii_case("auto");
-        // Snapshot config to avoid holding RwLockReadGuard across await points.
-        let cfg_snapshot = self.config.read().clone();
-        let (provider, model, reasoning_effort, verbosity) = {
-            let verbosity = cfg_snapshot.verbosity.clone();
-            if auto_model {
-                let selection = crate::model_routing::resolve_auto_route_with_inventory(
-                    &cfg_snapshot,
-                    &prompt,
-                    "",
-                    "auto",
-                    "auto",
-                )
-                .await?;
-                (
-                    selection.provider,
-                    selection.model,
-                    selection
-                        .reasoning_effort
-                        .map(|effort| effort.as_setting().to_string()),
-                    verbosity,
-                )
-            } else {
-                let provider = cfg_snapshot.api_provider();
-                (provider, requested_model, None, verbosity)
-            }
-        };
         let allow_shell = req.allow_shell.unwrap_or(thread.allow_shell);
         let trust_mode = req.trust_mode.unwrap_or(thread.trust_mode);
         let auto_approve = req.auto_approve.unwrap_or(thread.auto_approve);
-        let show_thinking = crate::settings::Settings::load()
-            .unwrap_or_default()
-            .show_thinking;
 
         engine
             .send(Op::SendMessage {
@@ -2236,6 +2359,8 @@ impl RuntimeThreadManager {
                 mode,
                 provider: Some(provider),
                 model: model.clone(),
+                route_limits,
+                compaction: Box::new(compaction),
                 goal_objective: None,
                 goal_token_budget: None,
                 goal_status: crate::tools::goal::GoalStatus::Active,
@@ -2417,14 +2542,19 @@ impl RuntimeThreadManager {
         let mut thread = self.get_thread(thread_id).await?;
         let engine = self.ensure_engine_loaded(&thread).await?;
 
-        {
+        let (route_provider, route_model) = {
             let active = self.active.lock().await;
-            if let Some(active_thread) = active.engines.get(thread_id)
-                && active_thread.active_turn.is_some()
-            {
+            let Some(active_thread) = active.engines.get(thread_id) else {
+                bail!("Thread engine not loaded");
+            };
+            if active_thread.active_turn.is_some() {
                 bail!("Thread already has an active turn");
             }
-        }
+            (
+                active_thread.route_provider,
+                active_thread.route_model.clone(),
+            )
+        };
 
         let now = Utc::now();
         let turn_id = format!("turn_{}", &Uuid::new_v4().to_string()[..8]);
@@ -2443,6 +2573,8 @@ impl RuntimeThreadManager {
             ended_at: None,
             duration_ms: None,
             usage: None,
+            effective_provider: Some(route_provider.as_str().to_string()),
+            effective_model: Some(route_model),
             error: None,
             item_ids: Vec::new(),
             steer_count: 0,
@@ -2541,27 +2673,26 @@ impl RuntimeThreadManager {
             }
         }
 
-        // Snapshot config once to avoid holding RwLockReadGuard across await points.
-        let cfg = self.read_config().clone();
+        // Snapshot and prepare the concrete provider route once so the engine,
+        // route limits, compaction budget, and restored session all agree.
+        let base_config = self.read_config().clone();
+        let route = self.resolved_route_for_thread(&base_config, thread)?;
+        let provider = route.provider;
+        let route_model = route.model;
+        let route_limits = route.limits;
+        let cfg = route.config;
 
-        // Resolve the model-aware auto-compaction default unless the user
-        // persisted an explicit preference.
+        // Resolve the provider-route-aware auto-compaction default unless the
+        // user persisted an explicit preference.
         let settings = crate::settings::Settings::load().unwrap_or_default();
-        let auto_compact_enabled =
-            if crate::settings::Settings::auto_compact_explicitly_configured() {
-                settings.auto_compact
-            } else {
-                auto_compact_default_for_model(&thread.model)
-            };
-        let compaction = CompactionConfig {
-            enabled: auto_compact_enabled,
-            model: thread.model.clone(),
-            token_threshold: compaction_threshold_for_model_at_percent(
-                &thread.model,
-                settings.auto_compact_threshold_percent,
-            ),
-            ..Default::default()
-        };
+        let compaction = runtime_compaction_config(
+            provider,
+            &route_model,
+            route_limits,
+            settings.auto_compact,
+            crate::settings::Settings::auto_compact_explicitly_configured(),
+            settings.auto_compact_threshold_percent,
+        );
         let network_policy = cfg.network.clone().map(|toml_cfg| {
             crate::network_policy::NetworkPolicyDecider::with_default_audit(toml_cfg.into_runtime())
         });
@@ -2569,13 +2700,12 @@ impl RuntimeThreadManager {
             .lsp
             .clone()
             .map(crate::config::LspConfigToml::into_runtime);
-        let provider = cfg.api_provider();
         let max_subagents = cfg
             .max_subagents_for_provider(provider)
             .clamp(1, MAX_SUBAGENTS);
         let engine_cfg = EngineConfig {
-            model: thread.model.clone(),
-            active_route_limits: None,
+            model: route_model.clone(),
+            active_route_limits: route_limits,
             workspace: thread.workspace.clone(),
             allow_shell: thread.allow_shell,
             trust_mode: thread.trust_mode,
@@ -2717,7 +2847,7 @@ impl RuntimeThreadManager {
                     messages: session_messages,
                     system_prompt: sys_prompt,
                     system_prompt_override: thread.system_prompt.is_some(),
-                    model: thread.model.clone(),
+                    model: route_model.clone(),
                     workspace: thread.workspace.clone(),
                     mode: parse_mode(&thread.mode),
                 })
@@ -2732,6 +2862,8 @@ impl RuntimeThreadManager {
             ActiveThreadState {
                 engine: engine.clone(),
                 active_turn: None,
+                route_provider: provider,
+                route_model,
             },
         );
         touch_lru(&mut active.lru, &thread.id);
@@ -3863,13 +3995,17 @@ impl RuntimeThreadManager {
         thread_id: &str,
         engine: EngineHandle,
     ) -> Result<()> {
-        let _ = self.get_thread(thread_id).await?;
+        let thread = self.get_thread(thread_id).await?;
+        let config = self.read_config().clone();
+        let route = self.resolved_route_for_thread(&config, &thread)?;
         let mut active = self.active.lock().await;
         active.engines.insert(
             thread_id.to_string(),
             ActiveThreadState {
                 engine,
                 active_turn: None,
+                route_provider: route.provider,
+                route_model: route.model,
             },
         );
         touch_lru(&mut active.lru, thread_id);

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -78,10 +78,94 @@ fn sample_turn(thread_id: &str, turn_id: &str, status: RuntimeTurnStatus) -> Tur
         ended_at: None,
         duration_ms: None,
         usage: None,
+        effective_provider: None,
+        effective_model: None,
         error: None,
         item_ids: Vec::new(),
         steer_count: 0,
     }
+}
+
+#[test]
+fn runtime_compaction_uses_provider_route_context() {
+    let limits = codewhale_config::route::RouteLimits {
+        context_tokens: Some(272_000),
+        input_tokens: None,
+        output_tokens: None,
+    };
+    let config = runtime_compaction_config(
+        ApiProvider::OpenaiCodex,
+        "gpt-5.5",
+        Some(limits),
+        false,
+        false,
+        80.0,
+    );
+
+    assert!(config.enabled);
+    assert_eq!(config.token_threshold, 217_600);
+    assert_eq!(config.effective_context_window, Some(272_000));
+}
+
+#[test]
+fn legacy_turn_record_has_no_invented_route_provenance() {
+    let turn = sample_turn("thr_legacy", "turn_legacy", RuntimeTurnStatus::Completed);
+    let mut value = serde_json::to_value(turn).expect("serialize turn");
+    let object = value.as_object_mut().expect("turn object");
+    object.remove("effective_provider");
+    object.remove("effective_model");
+
+    let restored: TurnRecord = serde_json::from_value(value).expect("deserialize legacy turn");
+    assert_eq!(restored.effective_provider, None);
+    assert_eq!(restored.effective_model, None);
+}
+
+#[tokio::test]
+async fn aggregate_usage_keeps_codex_tokens_without_api_dollar_pricing() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let mut thread = sample_thread("thr_mixed_routes");
+    thread.model = "auto".to_string();
+    manager.store.save_thread(&thread)?;
+
+    let usage = Usage {
+        input_tokens: 10_000,
+        output_tokens: 1_000,
+        ..Usage::default()
+    };
+    let mut deepseek = sample_turn(&thread.id, "turn_deepseek", RuntimeTurnStatus::Completed);
+    deepseek.usage = Some(usage.clone());
+    deepseek.effective_provider = Some(ApiProvider::Deepseek.as_str().to_string());
+    deepseek.effective_model = Some("deepseek-v4-flash".to_string());
+    manager.store.save_turn(&deepseek)?;
+
+    let mut codex = sample_turn(&thread.id, "turn_codex", RuntimeTurnStatus::Completed);
+    codex.usage = Some(usage);
+    codex.effective_provider = Some(ApiProvider::OpenaiCodex.as_str().to_string());
+    codex.effective_model = Some("gpt-5.5".to_string());
+    manager.store.save_turn(&codex)?;
+
+    let report = manager
+        .aggregate_usage(None, None, UsageGroupBy::Provider)
+        .await?;
+    assert_eq!(report.totals.turns, 2);
+    assert_eq!(report.totals.input_tokens, 20_000);
+    assert!(report.totals.cost_usd > 0.0);
+
+    let deepseek_bucket = report
+        .buckets
+        .iter()
+        .find(|bucket| bucket.key == ApiProvider::Deepseek.as_str())
+        .expect("DeepSeek bucket");
+    let codex_bucket = report
+        .buckets
+        .iter()
+        .find(|bucket| bucket.key == ApiProvider::OpenaiCodex.as_str())
+        .expect("Codex bucket");
+    assert!(deepseek_bucket.cost_usd > 0.0);
+    assert_eq!(codex_bucket.cost_usd, 0.0);
+    assert_eq!(codex_bucket.input_tokens, 10_000);
+    assert_eq!(report.totals.cost_usd, deepseek_bucket.cost_usd);
+    Ok(())
 }
 
 fn sample_item(turn_id: &str, item_id: &str, status: TurnItemLifecycleStatus) -> TurnItemRecord {
@@ -111,6 +195,8 @@ async fn install_mock_engine(
         ActiveThreadState {
             engine: harness.handle.clone(),
             active_turn: None,
+            route_provider: ApiProvider::Deepseek,
+            route_model: DEFAULT_TEXT_MODEL.to_string(),
         },
     );
     touch_lru(&mut active.lru, thread_id);
@@ -502,6 +588,8 @@ fn enforce_lru_capacity_does_not_loop_when_all_threads_are_active() {
                 auto_approve: true,
                 trust_mode: false,
             }),
+            route_provider: ApiProvider::Deepseek,
+            route_model: DEFAULT_TEXT_MODEL.to_string(),
         },
     );
     active.engines.insert(
@@ -514,6 +602,8 @@ fn enforce_lru_capacity_does_not_loop_when_all_threads_are_active() {
                 auto_approve: true,
                 trust_mode: false,
             }),
+            route_provider: ApiProvider::Deepseek,
+            route_model: DEFAULT_TEXT_MODEL.to_string(),
         },
     );
     active.lru.push_back("thr_a".to_string());
@@ -2550,6 +2640,8 @@ fn opening_manager_recovers_stale_queued_and_in_progress_work() -> Result<()> {
         ended_at: None,
         duration_ms: None,
         usage: None,
+        effective_provider: None,
+        effective_model: None,
         error: None,
         item_ids: vec![completed_item.id.clone(), in_progress_item.id.clone()],
         steer_count: 0,
@@ -2565,6 +2657,8 @@ fn opening_manager_recovers_stale_queued_and_in_progress_work() -> Result<()> {
         ended_at: None,
         duration_ms: None,
         usage: None,
+        effective_provider: None,
+        effective_model: None,
         error: None,
         item_ids: vec![queued_item.id.clone()],
         steer_count: 0,
@@ -2810,6 +2904,8 @@ fn seed_turns_with_user_messages(
             ended_at: Some(created_at),
             duration_ms: Some(0),
             usage: None,
+            effective_provider: None,
+            effective_model: None,
             error: None,
             item_ids: vec![user_item_id, asst_item_id],
             steer_count: 0,

--- a/crates/tui/src/seam_manager.rs
+++ b/crates/tui/src/seam_manager.rs
@@ -315,7 +315,11 @@ impl SeamManager {
         // Seam recompaction calls are billed; route through the
         // side-channel (#526) so the footer total matches the
         // DeepSeek website.
-        crate::cost_status::report(&response.model, &response.usage);
+        crate::cost_status::report(
+            self.flash_client.api_provider(),
+            &response.model,
+            &response.usage,
+        );
         let summary = response
             .content
             .iter()
@@ -436,7 +440,11 @@ impl SeamManager {
         // Seam recompaction calls are billed; route through the
         // side-channel (#526) so the footer total matches the
         // DeepSeek website.
-        crate::cost_status::report(&response.model, &response.usage);
+        crate::cost_status::report(
+            self.flash_client.api_provider(),
+            &response.model,
+            &response.usage,
+        );
         let summary = response
             .content
             .iter()

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -8,6 +8,8 @@
 
 use crate::artifacts::ArtifactRecord;
 use crate::models::{ContentBlock, Message, SystemPrompt};
+use crate::tools::plan::PlanSnapshot;
+use crate::tools::todo::TodoListSnapshot;
 use crate::tui::file_mention::ContextReference;
 use crate::utils::write_atomic;
 use chrono::{DateTime, Utc};
@@ -192,6 +194,23 @@ impl SessionMetadata {
     }
 }
 
+/// Durable Work-panel state. Optional on [`SavedSession`] so every session
+/// written before v0.8.68 remains loadable without migration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionWorkState {
+    #[serde(default, skip_serializing_if = "TodoListSnapshot::is_empty")]
+    pub todos: TodoListSnapshot,
+    #[serde(default, skip_serializing_if = "PlanSnapshot::is_empty")]
+    pub plan: PlanSnapshot,
+}
+
+impl SessionWorkState {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.todos.is_empty() && self.plan.is_empty()
+    }
+}
+
 /// A saved session containing full conversation history
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedSession {
@@ -212,6 +231,9 @@ pub struct SavedSession {
     /// Artifact contents are stored in the session-owned artifact directory.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<ArtifactRecord>,
+    /// To-do and plan state shown in the Work sidebar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_state: Option<SessionWorkState>,
 }
 
 /// Manager for session persistence operations
@@ -847,6 +869,7 @@ pub fn create_saved_session_with_id_and_mode(
         system_prompt: system_prompt_to_string(system_prompt),
         context_references: Vec::new(),
         artifacts: Vec::new(),
+        work_state: None,
     }
 }
 
@@ -863,9 +886,7 @@ pub fn update_session(
     session.metadata.updated_at = Utc::now();
     session.metadata.message_count = messages.len();
     session.metadata.total_tokens = total_tokens;
-    if system_prompt.is_some() {
-        session.system_prompt = system_prompt_to_string(system_prompt);
-    }
+    session.system_prompt = system_prompt_to_string(system_prompt);
     session
 }
 
@@ -1163,6 +1184,7 @@ mod tests {
             system_prompt: None,
             context_references: Vec::new(),
             artifacts: Vec::new(),
+            work_state: None,
         };
         manager.save_session(&session).expect("save");
     }
@@ -1195,6 +1217,7 @@ mod tests {
             system_prompt: None,
             context_references: Vec::new(),
             artifacts: Vec::new(),
+            work_state: None,
         };
         manager.save_session(&session).expect("save empty");
     }

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -302,6 +302,11 @@ pub struct Settings {
     /// Default reasoning effort selected from the TUI model picker.
     /// `None` falls back to `config.toml` and then the runtime default.
     pub reasoning_effort: Option<String>,
+    /// TUI-only Shift+Tab posture: ask, auto-review, or full-access.
+    /// An explicit/managed `config.toml` approval policy always takes
+    /// precedence, so this preference cannot loosen project requirements.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_posture: Option<String>,
     /// Per-provider model overrides. Key is provider name (e.g. "openai"),
     /// value is the model id. Takes precedence over `default_model`.
     pub provider_models: Option<std::collections::HashMap<String, String>>,
@@ -402,6 +407,7 @@ impl Default for Settings {
             default_provider: None,
             default_model: None,
             reasoning_effort: None,
+            permission_posture: None,
             provider_models: None,
             status_indicator: "whale".to_string(),
             synchronized_output: "auto".to_string(),
@@ -507,6 +513,10 @@ impl Settings {
                 .reasoning_effort
                 .as_deref()
                 .and_then(|value| normalize_reasoning_effort_setting(value).ok().flatten());
+            s.permission_posture = s
+                .permission_posture
+                .as_deref()
+                .and_then(normalize_permission_posture);
             s
         };
         migrate_settings_file_to_primary_if_needed(&write_path, &read_path);
@@ -876,6 +886,14 @@ impl Settings {
             "reasoning_effort" | "effort" => {
                 self.reasoning_effort = normalize_reasoning_effort_setting(value)?;
             }
+            "permission_posture" | "permissions" => {
+                self.permission_posture = normalize_permission_posture(value);
+                if self.permission_posture.is_none() {
+                    anyhow::bail!(
+                        "Failed to update setting: invalid permission posture '{value}'. Expected: ask, auto-review, or full-access."
+                    );
+                }
+            }
             _ => {
                 anyhow::bail!("Failed to update setting: unknown setting '{key}'.");
             }
@@ -974,6 +992,12 @@ impl Settings {
         lines.push(format!(
             "  reasoning_effort:   {}",
             self.reasoning_effort
+                .as_deref()
+                .unwrap_or("(config/default)")
+        ));
+        lines.push(format!(
+            "  permission_posture: {}",
+            self.permission_posture
                 .as_deref()
                 .unwrap_or("(config/default)")
         ));
@@ -1274,6 +1298,15 @@ fn normalize_default_model(value: &str) -> Option<String> {
         Some("auto".to_string())
     } else {
         normalize_model_name(trimmed)
+    }
+}
+
+fn normalize_permission_posture(value: &str) -> Option<String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "ask" | "suggest" | "on-request" | "untrusted" => Some("ask".to_string()),
+        "auto" | "auto-review" | "auto_review" => Some("auto-review".to_string()),
+        "full" | "full-access" | "full_access" | "bypass" => Some("full-access".to_string()),
+        _ => None,
     }
 }
 

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -47,7 +47,7 @@ impl StepStatus {
 }
 
 /// Input representation for a plan item.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanItemArg {
     pub step: String,
     pub status: StepStatus,
@@ -136,7 +136,7 @@ impl PlanStep {
 }
 
 /// Serializable snapshot for display
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -346,6 +346,28 @@ impl PlanState {
                 })
                 .collect(),
         }
+    }
+
+    /// Restore persisted plan data through the same normalization path used by
+    /// `update_plan`. Timing is intentionally session-local and starts fresh.
+    #[must_use]
+    pub fn from_snapshot(snapshot: &PlanSnapshot) -> Self {
+        let mut state = Self::default();
+        state.update(UpdatePlanArgs {
+            title: snapshot.title.clone(),
+            objective: snapshot.objective.clone(),
+            context_summary: snapshot.context_summary.clone(),
+            explanation: snapshot.explanation.clone(),
+            sources_used: snapshot.sources_used.clone(),
+            critical_files: snapshot.critical_files.clone(),
+            constraints: snapshot.constraints.clone(),
+            recommended_approach: snapshot.recommended_approach.clone(),
+            verification_plan: snapshot.verification_plan.clone(),
+            risks_and_unknowns: snapshot.risks_and_unknowns.clone(),
+            handoff_packet: snapshot.handoff_packet.clone(),
+            plan: snapshot.items.clone(),
+        });
+        state
     }
 
     pub fn explanation(&self) -> Option<&str> {
@@ -752,6 +774,27 @@ mod tests {
         assert_eq!(snapshot.items.len(), 1);
         assert_eq!(snapshot.items[0].step, "render sections");
         assert_eq!(snapshot.items[0].status, StepStatus::InProgress);
+    }
+
+    #[test]
+    fn plan_state_restores_from_persisted_snapshot() {
+        let snapshot = PlanSnapshot {
+            objective: Some("Restore Work state".to_string()),
+            items: vec![
+                PlanItemArg {
+                    step: "inspect".to_string(),
+                    status: StepStatus::Completed,
+                },
+                PlanItemArg {
+                    step: "verify".to_string(),
+                    status: StepStatus::InProgress,
+                },
+            ],
+            ..PlanSnapshot::default()
+        };
+
+        let restored = PlanState::from_snapshot(&snapshot);
+        assert_eq!(restored.snapshot(), snapshot);
     }
 
     #[test]

--- a/crates/tui/src/tools/subagent/mailbox.rs
+++ b/crates/tui/src/tools/subagent/mailbox.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
+use crate::config::ApiProvider;
 use crate::models::Usage;
 
 use super::SubAgentType;
@@ -63,6 +64,9 @@ pub enum MailboxMessage {
     /// Published after each turn so the parent's cost counter updates live.
     TokenUsage {
         agent_id: String,
+        /// Effective provider that produced this usage. Pricing and billing
+        /// policy are route-scoped, so model identity alone is insufficient.
+        provider: ApiProvider,
         /// Model that produced this usage, used for pricing.
         model: String,
         /// Provider usage payload, including cache-hit/cache-miss fields.
@@ -105,11 +109,13 @@ impl MailboxMessage {
 
     pub(crate) fn token_usage(
         agent_id: impl Into<String>,
+        provider: ApiProvider,
         model: impl Into<String>,
         usage: Usage,
     ) -> Self {
         Self::TokenUsage {
             agent_id: agent_id.into(),
+            provider,
             model: model.into(),
             usage,
         }
@@ -476,6 +482,7 @@ mod tests {
             (
                 MailboxMessage::TokenUsage {
                     agent_id: "a9".into(),
+                    provider: ApiProvider::Deepseek,
                     model: "deepseek-v4-flash".into(),
                     usage: Usage {
                         input_tokens: 100,

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -5839,6 +5839,7 @@ async fn run_subagent(
         if let Some(mb) = runtime.mailbox.as_ref() {
             let _ = mb.send(MailboxMessage::token_usage(
                 &agent_id,
+                runtime.client.api_provider(),
                 response.model.clone(),
                 response.usage.clone(),
             ));

--- a/crates/tui/src/tools/todo.rs
+++ b/crates/tui/src/tools/todo.rs
@@ -45,7 +45,7 @@ impl TodoStatus {
 }
 
 /// A single todo item.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TodoItem {
     pub id: u32,
     pub content: String,
@@ -53,11 +53,21 @@ pub struct TodoItem {
 }
 
 /// Snapshot of a todo list for display or serialization.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TodoListSnapshot {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub items: Vec<TodoItem>,
+    #[serde(default)]
     pub completion_pct: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub in_progress_id: Option<u32>,
+}
+
+impl TodoListSnapshot {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
 }
 
 /// Mutable list of todo items with helper operations.
@@ -85,6 +95,48 @@ impl TodoList {
             completion_pct: self.completion_percentage(),
             in_progress_id: self.in_progress_id(),
         }
+    }
+
+    /// Rebuild a mutable list from a persisted snapshot.
+    ///
+    /// Derived snapshot fields are deliberately recomputed. IDs and the
+    /// single-in-progress invariant are validated before any live state is
+    /// replaced, so malformed session data cannot leave a half-restored list.
+    pub fn from_snapshot(snapshot: &TodoListSnapshot) -> Result<Self, String> {
+        let mut seen = std::collections::HashSet::with_capacity(snapshot.items.len());
+        let mut in_progress_count = 0usize;
+        let mut max_id = 0u32;
+        let mut items = Vec::with_capacity(snapshot.items.len());
+
+        for item in &snapshot.items {
+            if item.id == 0 {
+                return Err("To-do item IDs must be greater than zero".to_string());
+            }
+            if !seen.insert(item.id) {
+                return Err(format!("Duplicate To-do item ID {}", item.id));
+            }
+            if item.status == TodoStatus::InProgress {
+                in_progress_count += 1;
+                if in_progress_count > 1 {
+                    return Err("Only one To-do item may be in progress".to_string());
+                }
+            }
+            max_id = max_id.max(item.id);
+            items.push(TodoItem {
+                id: item.id,
+                content: item.content.clone(),
+                status: item.status,
+            });
+        }
+
+        let next_id = if items.is_empty() {
+            1
+        } else {
+            max_id
+                .checked_add(1)
+                .ok_or_else(|| "To-do item IDs are exhausted".to_string())?
+        };
+        Ok(Self { items, next_id })
     }
 
     /// Add a new todo item.
@@ -625,6 +677,81 @@ fn work_progress_metadata(snapshot: &TodoListSnapshot, tool_name: &str) -> serde
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn persisted_snapshot_restores_ids_status_and_recomputes_metrics() {
+        let snapshot = TodoListSnapshot {
+            items: vec![
+                TodoItem {
+                    id: 4,
+                    content: " inspect ".to_string(),
+                    status: TodoStatus::Completed,
+                },
+                TodoItem {
+                    id: 9,
+                    content: "patch".to_string(),
+                    status: TodoStatus::InProgress,
+                },
+            ],
+            completion_pct: 0,
+            in_progress_id: None,
+        };
+
+        let mut restored = TodoList::from_snapshot(&snapshot).expect("restore");
+        let restored_snapshot = restored.snapshot();
+        assert_eq!(restored_snapshot.items[0].id, 4);
+        assert_eq!(restored_snapshot.items[0].content, " inspect ");
+        assert_eq!(restored_snapshot.items[1].id, 9);
+        assert_eq!(restored_snapshot.completion_pct, 50);
+        assert_eq!(restored_snapshot.in_progress_id, Some(9));
+        assert_eq!(
+            restored.add("verify".to_string(), TodoStatus::Pending).id,
+            10
+        );
+    }
+
+    #[test]
+    fn malformed_persisted_snapshot_is_rejected_deterministically() {
+        let duplicate = TodoListSnapshot {
+            items: vec![
+                TodoItem {
+                    id: 1,
+                    content: "one".to_string(),
+                    status: TodoStatus::InProgress,
+                },
+                TodoItem {
+                    id: 1,
+                    content: "two".to_string(),
+                    status: TodoStatus::Pending,
+                },
+            ],
+            ..TodoListSnapshot::default()
+        };
+        assert_eq!(
+            TodoList::from_snapshot(&duplicate).unwrap_err(),
+            "Duplicate To-do item ID 1"
+        );
+
+        let multiple_active = TodoListSnapshot {
+            items: vec![
+                TodoItem {
+                    id: 1,
+                    content: "one".to_string(),
+                    status: TodoStatus::InProgress,
+                },
+                TodoItem {
+                    id: 2,
+                    content: "two".to_string(),
+                    status: TodoStatus::InProgress,
+                },
+            ],
+            ..TodoListSnapshot::default()
+        };
+        assert_eq!(
+            TodoList::from_snapshot(&multiple_active).unwrap_err(),
+            "Only one To-do item may be in progress"
+        );
+    }
 
     #[tokio::test]
     async fn work_update_returns_canonical_task_update_metadata() {

--- a/crates/tui/src/tools/workflow_trigger.rs
+++ b/crates/tui/src/tools/workflow_trigger.rs
@@ -6,14 +6,9 @@
 //! ask setup questions via `request_user_input` (TUI modal) before calling
 //! `workflow` / `plan`.
 //!
-//! Pure decision helper; does not start workflows itself. Public API is live for
-//! unit tests and upcoming runtime wiring — keep reachable from non-test builds
-//! via [`soft_auto_policy_is_linked`].
-
-// Soft-auto policy is consulted primarily by the model (prompt) and tests today;
-// runtime auto-launch will call [`evaluate_workflow_trigger`] next. Until then,
-// private helpers trip `dead_code` on bin builds under `-D warnings`.
-#![allow(dead_code)]
+//! Operate admission also consumes this policy at the host boundary. Operate
+//! only keeps a turn local when it is provably one-step; everything else must
+//! produce real Workflow/Fleet activity or an explicit readiness blocker.
 
 /// Signals the parent can supply without full conversation replay.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -26,7 +21,7 @@ pub struct WorkflowTriggerSignals {
     pub risky_writes_unclear_decomposition: bool,
     /// Estimated child count if Workflow launched now.
     pub estimated_children: usize,
-    /// Soft cap from `[workflow].auto_start_child_limit` (default 8).
+    /// Soft cap from `[workflow].auto_start_child_limit` (default 16).
     pub auto_start_child_limit: usize,
     /// Approximate parent context tokens in use (for high-volume signal).
     pub context_tokens: usize,
@@ -42,10 +37,62 @@ impl WorkflowTriggerSignals {
             highly_interactive: false,
             risky_writes_unclear_decomposition: false,
             estimated_children: 0,
-            auto_start_child_limit: 8,
+            auto_start_child_limit: 16,
             context_tokens: 0,
             high_context_token_threshold: 80_000,
         }
+    }
+}
+
+/// Host-level admission decision for an Operate turn.
+///
+/// Unlike the general soft-auto decision, absence of a trigger is not enough to
+/// let Operate behave like Act. Local execution is allowed only for an explicit,
+/// deterministic one-step request; ambiguous work fails closed into the
+/// orchestration path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperateAdmissionDecision {
+    LocalOneStep { reason: &'static str },
+    RequiresOrchestration { reason: &'static str },
+}
+
+impl OperateAdmissionDecision {
+    #[must_use]
+    pub fn allows_local_execution(&self) -> bool {
+        matches!(self, Self::LocalOneStep { .. })
+    }
+
+    #[must_use]
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::LocalOneStep { reason } | Self::RequiresOrchestration { reason } => reason,
+        }
+    }
+}
+
+/// Decide whether an Operate request is safe to keep local.
+///
+/// This intentionally has a stricter fallback than [`evaluate_workflow_trigger`]:
+/// Operate is an orchestration posture, so an unrecognized or ambiguous request
+/// is not silently admitted to the ordinary Act tool loop.
+#[must_use]
+pub fn evaluate_operate_admission(
+    user_text: &str,
+    signals: &WorkflowTriggerSignals,
+) -> OperateAdmissionDecision {
+    let workflow_decision = evaluate_workflow_trigger(user_text, signals);
+    if workflow_decision.should_trigger() {
+        return OperateAdmissionDecision::RequiresOrchestration {
+            reason: workflow_decision.reason(),
+        };
+    }
+
+    if let Some(reason) = explicit_local_one_step_reason(user_text, signals) {
+        return OperateAdmissionDecision::LocalOneStep { reason };
+    }
+
+    OperateAdmissionDecision::RequiresOrchestration {
+        reason: "request is not provably a single local step",
     }
 }
 
@@ -171,6 +218,56 @@ fn child_overhead_exceeds_benefit(lower: &str, signals: &WorkflowTriggerSignals)
     tiny.iter().any(|needle| lower.contains(needle))
 }
 
+fn explicit_local_one_step_reason(
+    user_text: &str,
+    _signals: &WorkflowTriggerSignals,
+) -> Option<&'static str> {
+    let text = user_text.trim();
+    let lower = text.to_ascii_lowercase();
+    let compound = has_compound_or_shell_syntax(&lower);
+    let orchestration_language = has_fanout_language(&lower)
+        || has_staged_work_language(&lower)
+        || has_independent_verification_language(&lower);
+
+    if !compound && !orchestration_language && is_strict_read_only_operate_request(&lower) {
+        return Some("explicit one-step read-only request");
+    }
+    None
+}
+
+fn has_compound_or_shell_syntax(lower: &str) -> bool {
+    lower.lines().count() > 1
+        || [
+            "&&", "||", ";", "`", "$(", " and ", " then ", " also ", " plus ",
+        ]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+fn is_strict_read_only_operate_request(lower: &str) -> bool {
+    matches!(
+        lower.trim_end_matches(['?', '.', '!']).trim(),
+        "git status"
+            | "git status --short"
+            | "git status --porcelain"
+            | "git diff"
+            | "git diff --check"
+            | "git diff --stat"
+            | "git log"
+            | "git log --oneline"
+            | "pwd"
+            | "ls"
+            | "show version"
+            | "print version"
+            | "status"
+            | "ping"
+            | "hello"
+            | "hi"
+            | "thanks"
+            | "thank you"
+    )
+}
+
 fn is_simple_command_or_factual_question(lower: &str, original: &str) -> bool {
     if lower.starts_with('/') {
         // Slash commands are UI routing, not orchestration.
@@ -199,7 +296,7 @@ fn is_simple_command_or_factual_question(lower: &str, original: &str) -> bool {
         "git status",
         "git log",
         "git diff",
-        "ls ",
+        "ls",
         "pwd",
         "show version",
         "print version",
@@ -337,6 +434,45 @@ mod tests {
             let d = evaluate_workflow_trigger(ask, &s);
             assert!(!d.should_trigger(), "expected suppress for {ask:?}: {d:?}");
         }
+    }
+
+    #[test]
+    fn operate_admits_only_explicit_local_one_step_requests() {
+        let s = signals();
+        for ask in ["git status", "git diff --check"] {
+            let decision = evaluate_operate_admission(ask, &s);
+            assert!(
+                decision.allows_local_execution(),
+                "expected explicit local admission for {ask:?}: {decision:?}"
+            );
+        }
+
+        for ask in [
+            "audit every crate for unsafe blocks",
+            "phase 1 inspect then phase 2 implement",
+            "fix the release",
+            "run tests and fix failures",
+            "what is a worktree?",
+            "cargo test --workspace && fix every failure",
+            "rewrite only this file to implement the compiler",
+            "/workflow audit the repository",
+            "What is a worktree? Delete this repository",
+            "What is a worktree: delete this repository?",
+            "Explain the bug — fix it now",
+            "Explain the bug - fix it now",
+            "Explain the bug. Fix it now",
+        ] {
+            let decision = evaluate_operate_admission(ask, &s);
+            assert!(
+                !decision.allows_local_execution(),
+                "Operate must fail closed for {ask:?}: {decision:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn product_defaults_match_workflow_child_limit() {
+        assert_eq!(signals().auto_start_child_limit, 16);
     }
 
     #[test]

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -27,13 +27,13 @@ use crate::models::{Message, SystemPrompt, Tool};
 use crate::palette::{self, UiTheme};
 use crate::pricing::{CostCurrency, CostEstimate};
 use crate::resource_telemetry::TokenThroughput;
-use crate::session_manager::SessionContextReference;
+use crate::session_manager::{SessionContextReference, SessionMetadata, SessionWorkState};
 use crate::settings::Settings;
-use crate::tools::plan::{SharedPlanState, new_shared_plan_state};
+use crate::tools::plan::{PlanState, SharedPlanState, new_shared_plan_state};
 use crate::tools::shell::new_shared_shell_manager;
 use crate::tools::spec::RuntimeToolServices;
 use crate::tools::subagent::SubAgentResult;
-use crate::tools::todo::{SharedTodoList, new_shared_todo_list};
+use crate::tools::todo::{SharedTodoList, TodoList, new_shared_todo_list};
 use crate::tui::active_cell::ActiveCell;
 use crate::tui::approval::ApprovalMode;
 use crate::tui::clipboard::{ClipboardContent, ClipboardHandler};
@@ -1061,12 +1061,6 @@ impl AppMode {
         }
     }
 
-    /// Whether entering this mode should emphasize the Agents sidebar panel.
-    #[must_use]
-    pub fn prefers_agents_sidebar(self) -> bool {
-        matches!(self, Self::Operate)
-    }
-
     /// Localized short name for the mode picker (user-facing surface only).
     #[must_use]
     pub fn display_name_localized(self, locale: Locale) -> Cow<'static, str> {
@@ -1940,6 +1934,12 @@ pub struct App {
     /// restore to (#3386). Refreshed from the live fields whenever the user
     /// leaves Agent mode; see [`base_policy_for_mode`] and `set_mode`.
     mode_prefs: ModeSessionPrefs,
+    /// True when config/requirements supplied an approval policy. In that
+    /// case the TUI-only Shift+Tab preference must not loosen it.
+    approval_policy_locked: bool,
+    /// True only when an organization requirements file owns approval policy.
+    /// Unlike a user-owned config key, this source cannot be edited in-app.
+    approval_policy_requirements_managed: bool,
     // Clipboard handler
     pub clipboard: ClipboardHandler,
     // Tool approval session allowlist
@@ -1961,6 +1961,13 @@ pub struct App {
     pub backtrack: crate::tui::backtrack::BacktrackState,
     /// Current session ID for auto-save updates
     pub current_session_id: Option<String>,
+    /// Last non-contended Work snapshot captured in this App. The outer
+    /// option distinguishes "never captured" from a captured empty state.
+    pub(crate) last_known_work_state: Option<Option<SessionWorkState>>,
+    /// Metadata for the active session, cached in memory so automatic
+    /// checkpoints never synchronously reload and parse a growing JSON file on
+    /// the UI thread.
+    pub(crate) current_session_metadata: Option<SessionMetadata>,
     /// Metadata-only registry of large tool outputs produced in this session.
     pub session_artifacts: Vec<ArtifactRecord>,
     /// Trust mode - allow access outside workspace
@@ -2666,10 +2673,22 @@ impl App {
         // documented, while an explicit `allow_shell = false` still hides it.
         // Trust is never part of the Agent baseline (it is YOLO-only authority).
         // Approval mirrors the configured policy.
-        let configured_approval_mode = config
+        let explicit_approval_mode = config
             .approval_policy
             .as_deref()
-            .and_then(ApprovalMode::from_config_value)
+            .and_then(ApprovalMode::from_config_value);
+        let approval_policy_locked = config.approval_policy_is_managed();
+        let approval_policy_requirements_managed = config.approval_policy_is_requirements_managed();
+        let saved_permission_posture = if approval_policy_locked {
+            None
+        } else {
+            settings
+                .permission_posture
+                .as_deref()
+                .and_then(ApprovalMode::from_config_value)
+        };
+        let configured_approval_mode = explicit_approval_mode
+            .or(saved_permission_posture)
             .unwrap_or_default();
         let mode_prefs = ModeSessionPrefs {
             agent_allow_shell: if yolo_compat || matches!(initial_mode, AppMode::Yolo) {
@@ -2888,22 +2907,22 @@ impl App {
             yolo_compat_notified: false,
             keybinding_migration_notified: false,
             mode_prefs,
+            approval_policy_locked,
+            approval_policy_requirements_managed,
             clipboard: ClipboardHandler::new(),
             approval_session_approved: HashSet::new(),
             approval_session_denied: HashSet::new(),
             approval_mode: if yolo_compat || matches!(initial_mode, AppMode::Yolo) {
                 ApprovalMode::Bypass
             } else {
-                config
-                    .approval_policy
-                    .as_deref()
-                    .and_then(ApprovalMode::from_config_value)
-                    .unwrap_or_default()
+                configured_approval_mode
             },
             view_stack: ViewStack::new(),
             pending_user_input_prompt: None,
             backtrack: crate::tui::backtrack::BacktrackState::new(),
             current_session_id: None,
+            last_known_work_state: None,
+            current_session_metadata: None,
             session_artifacts: Vec::new(),
             trust_mode: yolo_compat || initial_mode == AppMode::Yolo,
             translation_enabled: false,
@@ -3197,10 +3216,6 @@ impl App {
             self.plan_tool_used_in_turn = false;
         }
 
-        if mode.prefers_agents_sidebar() {
-            self.set_sidebar_focus(SidebarFocus::Agents);
-        }
-
         // Execute mode change hooks
         let context = HookContext::new()
             .with_mode(mode.label())
@@ -3307,7 +3322,56 @@ impl App {
         if self.reject_setting_change_while_busy("Permissions") {
             return false;
         }
+        if self.mode == AppMode::Plan {
+            self.push_status_toast(
+                "Plan is Read Only; switch to Act or Operate to change permissions".to_string(),
+                StatusToastLevel::Info,
+                Some(5_000),
+            );
+            self.needs_redraw = true;
+            return false;
+        }
+        if self.approval_policy_locked() {
+            self.push_status_toast(
+                "Permissions are controlled by config or managed requirements".to_string(),
+                StatusToastLevel::Warning,
+                Some(6_000),
+            );
+            self.needs_redraw = true;
+            return false;
+        }
         let next = self.mode_prefs.agent_approval_mode.cycle_permission_next();
+        let persisted = match next {
+            ApprovalMode::Suggest => "ask",
+            ApprovalMode::Auto => "auto-review",
+            ApprovalMode::Bypass => "full-access",
+            ApprovalMode::Never => "never",
+        };
+        let persistence_result = (|| -> anyhow::Result<()> {
+            let mut settings = Settings::load()?;
+            settings.permission_posture = Some(persisted.to_string());
+            settings.save()
+        })();
+        if let Err(err) = persistence_result {
+            self.push_status_toast(
+                format!("Permissions were not changed: could not save TUI posture ({err})"),
+                StatusToastLevel::Warning,
+                Some(8_000),
+            );
+            self.needs_redraw = true;
+            return false;
+        }
+        self.set_agent_approval_posture(next);
+        self.needs_redraw = true;
+        // Footer permission chip is canonical — no status toast for the new
+        // value, only the one-shot rebinding notice.
+        self.notify_keybinding_migration_once();
+        true
+    }
+
+    /// Update the durable Act/Operate baseline and project it onto the live
+    /// runtime when the current mode uses that baseline. Plan remains read-only.
+    pub fn set_agent_approval_posture(&mut self, next: ApprovalMode) {
         self.mode_prefs.agent_approval_mode = next;
         if self.mode.uses_agent_baseline() {
             let policy = base_policy_for_mode(self.mode, &self.mode_prefs);
@@ -3316,11 +3380,35 @@ impl App {
             self.approval_mode = policy.approval_mode;
             self.yolo = matches!(policy.approval_mode, ApprovalMode::Bypass);
         }
-        self.needs_redraw = true;
-        // Footer permission chip is canonical — no status toast for the new
-        // value, only the one-shot rebinding notice.
-        self.notify_keybinding_migration_once();
-        true
+    }
+
+    #[must_use]
+    pub fn approval_policy_locked(&self) -> bool {
+        self.approval_policy_locked
+    }
+
+    #[must_use]
+    pub fn approval_policy_requirements_managed(&self) -> bool {
+        self.approval_policy_requirements_managed
+    }
+
+    /// Session transitions must never detach live runtime producers. Late
+    /// engine, compaction, purge, or background-task events could otherwise
+    /// contaminate the replacement session after clear/load/new.
+    #[must_use]
+    pub fn session_transition_blocked(&self) -> bool {
+        self.is_loading
+            || self.runtime_turn_status.as_deref() == Some("in_progress")
+            || self.is_compacting
+            || self.is_purging
+            || self
+                .task_panel
+                .iter()
+                .any(|task| matches!(task.status.as_str(), "queued" | "running"))
+    }
+
+    pub fn mark_approval_policy_locked(&mut self) {
+        self.approval_policy_locked = true;
     }
 
     /// Execute hooks for a specific event with the given context
@@ -6010,21 +6098,87 @@ impl App {
         None
     }
 
-    pub fn clear_todos(&mut self) -> bool {
-        // Clear the todo list (the sidebar checklist). Retry with try_lock
-        // so /clear always resets todos even when the engine briefly holds
-        // the mutex during tool execution.
-        let todos_cleared = if let Some(mut todos) = Self::retry_lock(&self.todos, 100) {
-            todos.clear();
-            true
-        } else {
-            false
+    /// Capture the durable Work state without ever converting lock contention
+    /// into an empty snapshot.
+    pub fn work_state_snapshot(&self) -> Result<Option<SessionWorkState>, String> {
+        let todos = Self::retry_lock(&self.todos, 100)
+            .ok_or_else(|| "To-do state is busy; try saving again".to_string())?;
+        let plan = Self::retry_lock(&self.plan_state, 100)
+            .ok_or_else(|| "Plan state is busy; try saving again".to_string())?;
+        let state = SessionWorkState {
+            todos: todos.snapshot(),
+            plan: plan.snapshot(),
         };
-        // Also clear the plan state — /clear means a full reset.
-        if let Some(mut plan) = Self::retry_lock(&self.plan_state, 100) {
-            *plan = crate::tools::plan::PlanState::default();
-        }
-        todos_cleared
+        Ok((!state.is_empty()).then_some(state))
+    }
+
+    /// Non-blocking snapshot for the render/event loop. Automatic persistence
+    /// must skip a contended first save instead of pausing the UI or writing a
+    /// false empty state.
+    pub fn try_work_state_snapshot(&mut self) -> Result<Option<SessionWorkState>, String> {
+        let todos = self
+            .todos
+            .try_lock()
+            .map_err(|_| "To-do state is busy".to_string())?;
+        let plan = self
+            .plan_state
+            .try_lock()
+            .map_err(|_| "Plan state is busy".to_string())?;
+        let state = SessionWorkState {
+            todos: todos.snapshot(),
+            plan: plan.snapshot(),
+        };
+        let state = (!state.is_empty()).then_some(state);
+        drop(plan);
+        drop(todos);
+        self.last_known_work_state = Some(state.clone());
+        Ok(state)
+    }
+
+    /// Atomically replace the live Work state from a saved session.
+    pub fn restore_work_state(&mut self, state: Option<&SessionWorkState>) -> Result<(), String> {
+        let (restored_todos, restored_plan) = match state {
+            Some(state) => (
+                TodoList::from_snapshot(&state.todos)?,
+                PlanState::from_snapshot(&state.plan),
+            ),
+            None => (TodoList::new(), PlanState::default()),
+        };
+        let normalized_state = SessionWorkState {
+            todos: restored_todos.snapshot(),
+            plan: restored_plan.snapshot(),
+        };
+
+        let mut todos = Self::retry_lock(&self.todos, 100)
+            .ok_or_else(|| "To-do state is busy; session was not restored".to_string())?;
+        let mut plan = Self::retry_lock(&self.plan_state, 100)
+            .ok_or_else(|| "Plan state is busy; session was not restored".to_string())?;
+        *todos = restored_todos;
+        *plan = restored_plan;
+        drop(plan);
+        drop(todos);
+        self.cached_work_summary = None;
+        self.last_known_work_state =
+            Some((!normalized_state.is_empty()).then_some(normalized_state));
+        Ok(())
+    }
+
+    pub fn clear_todos(&mut self) -> bool {
+        // Acquire both stores before mutating either one. `/clear` must never
+        // report success after clearing only half of the Work surface.
+        let Some(mut todos) = Self::retry_lock(&self.todos, 100) else {
+            return false;
+        };
+        let Some(mut plan) = Self::retry_lock(&self.plan_state, 100) else {
+            return false;
+        };
+        todos.clear();
+        *plan = PlanState::default();
+        drop(plan);
+        drop(todos);
+        self.cached_work_summary = None;
+        self.last_known_work_state = Some(None);
+        true
     }
 
     pub fn update_model_compaction_budget(&mut self) {
@@ -6138,6 +6292,11 @@ impl App {
             enabled: self.auto_compact,
             token_threshold: self.compact_threshold,
             model: self.effective_model_for_budget().to_string(),
+            effective_context_window: Some(crate::route_budget::route_context_window_tokens(
+                self.api_provider,
+                self.effective_model_for_budget(),
+                self.active_route_limits,
+            )),
             ..Default::default()
         }
     }

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -396,6 +396,62 @@ fn app_new_normalizes_saved_codex_reasoning_effort() {
 }
 
 #[test]
+fn codex_startup_threads_fresh_roster_context_into_active_route_limits() {
+    let _lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let codex_home = tmp.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home).expect("Codex home");
+    std::fs::write(
+        codex_home.join("models_cache.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "fetched_at": chrono::Utc::now(),
+            "models": [{
+                "slug": crate::config::DEFAULT_OPENAI_CODEX_MODEL,
+                "priority": 1,
+                "context_window": 128000,
+                "supported_reasoning_levels": [{"effort": "high"}]
+            }]
+        }))
+        .expect("serialize cache"),
+    )
+    .expect("write cache");
+    let _config_path = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let _codex_home = EnvVarGuard::set("CODEX_HOME", &codex_home);
+    let _token = EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "test-codex-startup-token");
+    let config = Config {
+        provider: Some("openai-codex".to_string()),
+        providers: Some(ProvidersConfig {
+            openai_codex: ProviderConfig {
+                model: Some(crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string()),
+                ..ProviderConfig::default()
+            },
+            ..ProvidersConfig::default()
+        }),
+        ..Config::default()
+    };
+
+    let mut options = test_options(false);
+    options.model = crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string();
+    let app = App::new(options, &config);
+
+    assert_eq!(app.api_provider, ApiProvider::OpenaiCodex);
+    assert_eq!(
+        app.active_route_limits
+            .and_then(|limits| limits.context_tokens),
+        Some(128_000)
+    );
+    assert_eq!(
+        crate::route_budget::route_context_window_tokens(
+            app.api_provider,
+            &app.model,
+            app.active_route_limits,
+        ),
+        128_000
+    );
+}
+
+#[test]
 fn settings_default_provider_auth_check_uses_provider_scoped_key() {
     let _lock = lock_test_env();
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -568,6 +624,7 @@ fn cny_display_keeps_cny_when_costs_have_cny_rates() {
 fn cny_cache_savings_falls_back_to_usd_for_usd_only_models() {
     let mut app = App::new(test_options(false), &Config::default());
     app.cost_currency = CostCurrency::Cny;
+    app.api_provider = ApiProvider::Moonshot;
     app.model = "kimi-k2.6".to_string();
     app.session.last_prompt_cache_hit_tokens = Some(1_000_000);
 
@@ -1493,6 +1550,63 @@ fn clear_todos_resets_plan_state() {
 }
 
 #[test]
+fn work_state_snapshot_round_trips_todos_and_plan() {
+    let app = App::new(test_options(false), &Config::default());
+    {
+        let mut todos = app.todos.try_lock().expect("todos lock");
+        todos.add("inspect".to_string(), TodoStatus::Completed);
+        todos.add("patch".to_string(), TodoStatus::InProgress);
+    }
+    {
+        let mut plan = app.plan_state.try_lock().expect("plan lock");
+        plan.update(UpdatePlanArgs {
+            objective: Some("Keep Work durable".to_string()),
+            plan: vec![PlanItemArg {
+                step: "verify".to_string(),
+                status: StepStatus::InProgress,
+            }],
+            ..UpdatePlanArgs::default()
+        });
+    }
+    let state = app
+        .work_state_snapshot()
+        .expect("snapshot locks")
+        .expect("non-empty state");
+
+    let mut restored = App::new(test_options(false), &Config::default());
+    restored
+        .restore_work_state(Some(&state))
+        .expect("restore Work state");
+    assert_eq!(
+        restored.work_state_snapshot().expect("snapshot"),
+        Some(state)
+    );
+}
+
+#[test]
+fn clear_todos_is_atomic_and_invalidates_cached_work_summary() {
+    let mut app = App::new(test_options(false), &Config::default());
+    {
+        let mut todos = app.todos.try_lock().expect("todos lock");
+        todos.add("clear me".to_string(), TodoStatus::Pending);
+    }
+    app.cached_work_summary = Some(SidebarWorkSummary::default());
+
+    assert!(app.clear_todos());
+    assert!(app.cached_work_summary.is_none());
+    assert_eq!(app.work_state_snapshot().expect("snapshot"), None);
+}
+
+#[test]
+fn entering_operate_preserves_user_sidebar_focus() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.sidebar_focus = SidebarFocus::Tasks;
+
+    assert!(app.set_mode(AppMode::Operate));
+    assert_eq!(app.sidebar_focus, SidebarFocus::Tasks);
+}
+
+#[test]
 fn app_mode_helpers_centralize_parse_labels_and_cycle_order() {
     assert_eq!(AppMode::parse("agent"), Some(AppMode::Agent));
     assert_eq!(AppMode::parse("act"), Some(AppMode::Agent));
@@ -1799,8 +1913,13 @@ fn base_policy_for_mode_projects_the_mode_permission_table() {
 
 #[test]
 fn cycle_approval_posture_cycles_suggest_auto_bypass() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
     let mut options = test_options(false);
     options.start_in_agent_mode = true;
+    options.config_path = Some(config_path);
     let mut app = App::new(options, &Config::default());
     app.approval_mode = ApprovalMode::Suggest;
 
@@ -1812,12 +1931,19 @@ fn cycle_approval_posture_cycles_suggest_auto_bypass() {
 
     assert!(app.cycle_approval_posture());
     assert_eq!(app.approval_mode, ApprovalMode::Suggest);
+    let persisted = std::fs::read_to_string(tmp.path().join("settings.toml")).expect("settings");
+    assert!(persisted.contains("permission_posture = \"ask\""));
 }
 
 #[test]
 fn cycle_approval_posture_emits_rebinding_notice_once() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
     let mut options = test_options(false);
     options.start_in_agent_mode = true;
+    options.config_path = Some(config_path);
     let mut app = App::new(options, &Config::default());
 
     assert!(app.cycle_approval_posture());
@@ -1835,6 +1961,118 @@ fn cycle_approval_posture_emits_rebinding_notice_once() {
         .filter(|toast| toast.text.contains("moved to Ctrl+T"))
         .count();
     assert_eq!(notices, 1, "notice is one-shot per session");
+}
+
+#[test]
+fn plan_permission_cycle_is_rejected_without_mutating_agent_baseline() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let mut options = test_options(false);
+    options.config_path = Some(config_path);
+    let mut app = App::new(options, &Config::default());
+    app.set_agent_approval_posture(ApprovalMode::Auto);
+    app.set_mode(AppMode::Plan);
+
+    assert!(!app.cycle_approval_posture());
+    assert_eq!(app.approval_mode, ApprovalMode::Suggest);
+    assert_eq!(app.mode_prefs.agent_approval_mode, ApprovalMode::Auto);
+    assert!(!tmp.path().join("settings.toml").exists());
+    assert!(
+        app.status_toasts
+            .iter()
+            .any(|toast| toast.text.contains("Read Only"))
+    );
+
+    app.set_mode(AppMode::Operate);
+    assert_eq!(app.approval_mode, ApprovalMode::Auto);
+}
+
+#[test]
+fn busy_permission_cycle_changes_neither_runtime_nor_persistence() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let mut options = test_options(false);
+    options.config_path = Some(config_path);
+    let mut app = App::new(options, &Config::default());
+    let before = app.approval_mode;
+    app.is_loading = true;
+
+    assert!(!app.cycle_approval_posture());
+    assert_eq!(app.approval_mode, before);
+    assert_eq!(app.mode_prefs.agent_approval_mode, before);
+    assert!(!tmp.path().join("settings.toml").exists());
+    assert!(
+        app.status_message
+            .as_deref()
+            .is_some_and(|message| message.contains("locked"))
+    );
+}
+
+#[test]
+fn permission_postures_persist_across_restart() {
+    let _env_lock = lock_test_env();
+    for (cycles, expected) in [
+        (1, ApprovalMode::Auto),
+        (2, ApprovalMode::Bypass),
+        (3, ApprovalMode::Suggest),
+    ] {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("config.toml");
+        let config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &path);
+        let mut options = test_options(false);
+        options.start_in_agent_mode = true;
+        options.config_path = Some(path.clone());
+        let mut app = App::new(options.clone(), &Config::default());
+        for _ in 0..cycles {
+            assert!(app.cycle_approval_posture());
+        }
+        assert_eq!(app.approval_mode, expected);
+
+        let restarted = App::new(options, &Config::default());
+        assert_eq!(restarted.approval_mode, expected);
+        assert_eq!(restarted.mode_prefs.agent_approval_mode, expected);
+        drop(config_env);
+    }
+}
+
+#[test]
+fn managed_requirements_ignore_saved_full_access_and_lock_changes() {
+    let _env_lock = lock_test_env();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let requirements_path = tmp.path().join("requirements.toml");
+    std::fs::write(
+        tmp.path().join("settings.toml"),
+        "permission_posture = \"full-access\"\n",
+    )
+    .expect("settings");
+    std::fs::write(
+        &requirements_path,
+        "allowed_approval_policies = [\"on-request\"]\n",
+    )
+    .expect("requirements");
+    let _config_env = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let config = Config {
+        requirements_path: Some(requirements_path.to_string_lossy().into_owned()),
+        ..Config::default()
+    };
+
+    let mut app = App::new(test_options(false), &config);
+
+    assert!(app.approval_policy_locked());
+    assert!(app.approval_policy_requirements_managed());
+    assert_eq!(app.approval_mode, ApprovalMode::Suggest);
+    assert!(!app.cycle_approval_posture());
+    assert_eq!(app.approval_mode, ApprovalMode::Suggest);
+    assert!(
+        app.status_toasts
+            .iter()
+            .any(|toast| toast.text.contains("controlled"))
+    );
 }
 
 #[test]
@@ -1910,6 +2148,8 @@ fn set_mode_captures_agent_edits_as_the_durable_baseline() {
     options.start_in_agent_mode = true;
     let mut app = App::new(options, &Config::default());
     assert_eq!(app.mode, AppMode::Agent);
+    app.allow_shell = false;
+    app.set_agent_approval_posture(ApprovalMode::Suggest);
 
     // Initial baseline restores to no-shell / Suggest.
     app.set_mode(AppMode::Plan);
@@ -2153,6 +2393,7 @@ fn test_update_model_compaction_budget() {
     // depend on the developer's local `auto_compact_threshold_percent`
     // setting (App::new loads real settings) or on auto-model resolution.
     app.auto_model = false;
+    app.api_provider = ApiProvider::Deepseek;
     app.active_route_limits = None;
     app.active_context_window_override = None;
     app.auto_compact_threshold_percent = 80.0;

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -73,10 +73,12 @@ impl ApprovalMode {
 
     pub fn from_config_value(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "auto" => Some(ApprovalMode::Auto),
+            "auto" | "auto-review" | "auto_review" => Some(ApprovalMode::Auto),
             "bypass" | "yolo" | "dontask" | "dont_ask" | "bypass-permissions"
-            | "bypasspermissions" => Some(ApprovalMode::Bypass),
-            "suggest" | "suggested" | "on-request" | "untrusted" => Some(ApprovalMode::Suggest),
+            | "bypasspermissions" | "full-access" | "full" => Some(ApprovalMode::Bypass),
+            "suggest" | "suggested" | "on-request" | "untrusted" | "ask" => {
+                Some(ApprovalMode::Suggest)
+            }
             "never" | "deny" | "denied" => Some(ApprovalMode::Never),
             _ => None,
         }

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -2200,8 +2200,10 @@ mod tests {
             "---\nname: hotbar-demo-skill\ndescription: Demo skill for hotbar tests\n---\n\nFollow the demo instructions.\n",
         )
         .expect("write SKILL.md");
-        let mut config = Config::default();
-        config.skills_dir = Some(skills_dir.path().to_string_lossy().into_owned());
+        let config = Config {
+            skills_dir: Some(skills_dir.path().to_string_lossy().into_owned()),
+            ..Config::default()
+        };
         let mut app = test_app_with_paths_and_config(
             workspace.path().to_path_buf(),
             skills_dir.path().to_path_buf(),

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -21,7 +21,13 @@ use codewhale_config::catalog::CatalogSource;
 use codewhale_config::model_reference::ModelReferenceCard;
 use codewhale_config::pricing::OfferingPricing;
 
+use crate::codex_model_cache::{
+    self, CodexModelCacheFreshness, CodexModelMetadata, CodexModelRoster,
+};
 use crate::config::{ApiProvider, Config};
+use crate::model_profile::{
+    CapabilityOverride, SupportState, resolved_capability_profile_with_overrides,
+};
 use crate::model_registry;
 use crate::models_dev_live::{self, ModelsDevFreshness};
 use crate::palette;
@@ -164,6 +170,26 @@ struct ModelPickerRow {
     id: String,
     provider: Option<ApiProvider>,
     hint: String,
+    metadata: EffectivePickerMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct EffectivePickerMetadata {
+    context_window: Option<u32>,
+    max_output: Option<u32>,
+    tool_calls: Option<bool>,
+    reasoning: bool,
+    pricing: PickerPricing,
+    source: Option<CatalogSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+enum PickerPricing {
+    /// The route explicitly does not expose authoritative token pricing.
+    Unavailable,
+    Known(String),
+    #[default]
+    Unknown,
 }
 
 impl ModelPickerView {
@@ -174,7 +200,7 @@ impl ModelPickerView {
         } else {
             app.model.clone()
         };
-        let model_rows = picker_model_rows_for_app(app);
+        let model_rows = picker_model_rows_for_app(app, config);
         let configured_providers: Vec<_> = configured_providers(config, app.api_provider)
             .into_iter()
             .filter(|provider| *provider != app.api_provider)
@@ -671,20 +697,46 @@ pub(crate) fn provider_scoped_model_completion_ids(app: &App) -> Vec<String> {
     provider_scoped_model_ids_for_app(app, true)
 }
 
-fn picker_model_rows_for_app(app: &App) -> Vec<ModelPickerRow> {
+fn picker_model_rows_for_app(app: &App, config: &Config) -> Vec<ModelPickerRow> {
     let mut rows = Vec::new();
+    // One snapshot supplies both IDs, capabilities, and freshness so a cache
+    // replacement cannot produce mixed-generation picker rows.
+    let codex_roster = codex_model_cache::model_roster();
+    let active_model_ids = if app.api_provider == ApiProvider::OpenaiCodex {
+        let mut models = vec!["auto".to_string()];
+        for id in codex_roster.model_ids() {
+            push_model_id(&mut models, &id);
+        }
+        if let Some(model) = app
+            .provider_models
+            .get(app.api_provider.as_str())
+            .map(|model| model.trim())
+            .filter(|model| !model.is_empty())
+        {
+            push_model_id(&mut models, model);
+        }
+        models
+    } else {
+        provider_scoped_model_ids_for_app(app, false)
+    };
     push_provider_model_rows(
         &mut rows,
         app.api_provider,
-        provider_scoped_model_ids_for_app(app, false),
+        active_model_ids,
         app.api_provider,
+        config,
+        &codex_roster,
     );
 
     for provider in ApiProvider::sorted_for_display() {
         if provider == app.api_provider {
             continue;
         }
-        let mut model_ids = provider_catalog_model_ids(provider);
+        let mut model_ids = if provider == ApiProvider::OpenaiCodex {
+            codex_roster.model_ids()
+        } else {
+            provider_catalog_model_ids(provider)
+        };
         if let Some(model) = app
             .provider_models
             .get(provider.as_str())
@@ -693,7 +745,14 @@ fn picker_model_rows_for_app(app: &App) -> Vec<ModelPickerRow> {
         {
             push_model_id(&mut model_ids, model);
         }
-        push_provider_model_rows(&mut rows, provider, model_ids, app.api_provider);
+        push_provider_model_rows(
+            &mut rows,
+            provider,
+            model_ids,
+            app.api_provider,
+            config,
+            &codex_roster,
+        );
     }
 
     rows
@@ -704,16 +763,34 @@ fn push_provider_model_rows(
     provider: ApiProvider,
     model_ids: Vec<String>,
     active_provider: ApiProvider,
+    config: &Config,
+    codex_roster: &CodexModelRoster,
 ) {
     for id in model_ids {
         if id == "auto" {
-            push_model_row(rows, id, None, picker_model_hint("auto", None));
+            let metadata = effective_picker_metadata(config, None, "auto");
+            let hint = render_picker_model_hint("auto", None, &metadata, None);
+            push_model_row(rows, id, None, hint, metadata);
         } else {
-            let mut hint = picker_model_hint(&id, Some(provider));
+            let roster_entry = if provider == ApiProvider::OpenaiCodex {
+                codex_roster.metadata_for(&id)
+            } else {
+                None
+            };
+            let codex_metadata = if codex_roster.freshness == CodexModelCacheFreshness::Fresh {
+                roster_entry
+            } else {
+                None
+            };
+            let codex_freshness = roster_entry.map(|_| codex_roster.freshness);
+            let metadata =
+                effective_picker_metadata_with_codex(config, Some(provider), &id, codex_metadata);
+            let mut hint =
+                render_picker_model_hint(&id, Some(provider), &metadata, codex_freshness);
             if provider != active_provider {
                 hint = format!("switch route · {hint}");
             }
-            push_model_row(rows, id.clone(), Some(provider), hint);
+            push_model_row(rows, id.clone(), Some(provider), hint, metadata);
         }
     }
 }
@@ -778,6 +855,7 @@ fn push_model_row(
     id: String,
     provider: Option<ApiProvider>,
     hint: String,
+    metadata: EffectivePickerMetadata,
 ) {
     if rows
         .iter()
@@ -785,7 +863,12 @@ fn push_model_row(
     {
         return;
     }
-    rows.push(ModelPickerRow { id, provider, hint });
+    rows.push(ModelPickerRow {
+        id,
+        provider,
+        hint,
+        metadata,
+    });
 }
 
 /// Compact Models.dev freshness chip for the picker chrome (#4139).
@@ -924,19 +1007,13 @@ fn offering_fetched_at(row: &ModelPickerRow) -> u64 {
 }
 
 fn context_tokens(row: &ModelPickerRow) -> u64 {
-    if let Some(ctx) = offering_for_row(row)
-        .and_then(|offering| offering.limit)
-        .and_then(|limit| limit.context)
-    {
-        return ctx;
-    }
-    model_registry::lookup(&row.id)
-        .and_then(|meta| meta.context_window)
-        .map(u64::from)
-        .unwrap_or(0)
+    row.metadata.context_window.map(u64::from).unwrap_or(0)
 }
 
 fn input_price_per_million(row: &ModelPickerRow) -> Option<f64> {
+    if matches!(row.metadata.pricing, PickerPricing::Unavailable) {
+        return None;
+    }
     offering_for_row(row)
         .and_then(|offering| OfferingPricing::from_catalog_offering(&offering))
         .and_then(|pricing| pricing.input_per_million)
@@ -955,94 +1032,194 @@ fn coding_score(row: &ModelPickerRow) -> u32 {
         if text_ok {
             score += 40;
         }
-        if offering.tool_call == Some(true) {
-            score += 40;
-        }
-        if offering.reasoning == Some(true) {
-            score += 10;
-        }
-        if offering
-            .limit
-            .as_ref()
-            .and_then(|limit| limit.context)
-            .unwrap_or(0)
-            >= 100_000
-        {
-            score += 10;
-        }
-    } else if model_registry::lookup(&row.id).is_some_and(|meta| meta.supports_reasoning) {
-        score += 20;
+    }
+    if row.metadata.tool_calls == Some(true) {
+        score += 40;
+    }
+    if row.metadata.reasoning {
+        score += 10;
+    }
+    if row.metadata.context_window.unwrap_or(0) >= 100_000 {
+        score += 10;
     }
     score
 }
 
+#[cfg(test)]
 fn picker_model_hint(id: &str, provider: Option<ApiProvider>) -> String {
+    let config = Config::default();
+    let metadata = effective_picker_metadata(&config, provider, id);
+    let codex_freshness = (provider == Some(ApiProvider::OpenaiCodex))
+        .then(|| codex_model_cache::model_roster().freshness);
+    render_picker_model_hint(id, provider, &metadata, codex_freshness)
+}
+
+fn effective_picker_metadata(
+    config: &Config,
+    provider: Option<ApiProvider>,
+    id: &str,
+) -> EffectivePickerMetadata {
+    effective_picker_metadata_with_codex(config, provider, id, None)
+}
+
+fn effective_picker_metadata_with_codex(
+    config: &Config,
+    provider: Option<ApiProvider>,
+    id: &str,
+    codex_metadata: Option<&CodexModelMetadata>,
+) -> EffectivePickerMetadata {
+    let offering = provider.and_then(|provider| catalog_offering_for_model(provider, id));
+    let card = offering.as_ref().map(ModelReferenceCard::from_offering);
+    let registry = model_registry::lookup(id);
+
+    let Some(provider) = provider else {
+        return EffectivePickerMetadata {
+            context_window: registry.as_ref().and_then(|meta| meta.context_window),
+            max_output: registry.as_ref().and_then(|meta| meta.max_output),
+            tool_calls: None,
+            reasoning: registry
+                .as_ref()
+                .is_some_and(|meta| meta.supports_reasoning),
+            pricing: if crate::pricing::has_pricing_for_model(id) {
+                PickerPricing::Known("priced".to_string())
+            } else {
+                PickerPricing::Unknown
+            },
+            source: None,
+        };
+    };
+
+    let context_override = config.context_window_for_provider_config(provider);
+    let profile = resolved_capability_profile_with_overrides(
+        provider,
+        id,
+        CapabilityOverride {
+            context_window: context_override,
+            ..CapabilityOverride::default()
+        },
+    );
+    let card_context = card
+        .as_ref()
+        .and_then(|card| card.context_window)
+        .map(|tokens| tokens.min(u64::from(u32::MAX)) as u32);
+    let context_window = if context_override.is_some() {
+        profile.context_window
+    } else if provider == ApiProvider::OpenaiCodex {
+        codex_metadata.and_then(|metadata| metadata.context_window)
+    } else {
+        card_context.or(profile.context_window)
+    };
+    let card_output = card
+        .as_ref()
+        .and_then(|card| card.max_output)
+        .map(|tokens| tokens.min(u64::from(u32::MAX)) as u32);
+    // The Codex cache does not publish a route-owned output ceiling. The
+    // profile's current value is inherited from the same-id OpenAI API model,
+    // so omitting it is more truthful than claiming that API limit for OAuth.
+    let max_output = if provider == ApiProvider::OpenaiCodex {
+        None
+    } else {
+        card_output.or(profile.max_output)
+    };
+    let profile_tool_calls = match profile.native_tool_calls {
+        SupportState::Supported => Some(true),
+        SupportState::Unsupported => Some(false),
+        SupportState::Unknown => None,
+    };
+    let tool_calls = if provider == ApiProvider::OpenaiCodex {
+        codex_metadata.and(profile_tool_calls)
+    } else {
+        offering
+            .as_ref()
+            .and_then(|offering| offering.tool_call)
+            .or(profile_tool_calls)
+    };
+    let reasoning = if provider == ApiProvider::OpenaiCodex {
+        codex_metadata
+            .map(|metadata| {
+                metadata
+                    .reasoning
+                    .unwrap_or_else(|| profile.supports_reasoning())
+            })
+            .unwrap_or(false)
+    } else {
+        offering
+            .as_ref()
+            .and_then(|offering| offering.reasoning)
+            .unwrap_or_else(|| profile.supports_reasoning())
+    };
+    let card_price = card.as_ref().and_then(|card| {
+        let label = card.price_label();
+        (label != "unknown").then_some(label)
+    });
+    let pricing = if provider == ApiProvider::OpenaiCodex {
+        PickerPricing::Unavailable
+    } else if let Some(label) = card_price {
+        PickerPricing::Known(label)
+    } else if crate::pricing::has_pricing_for_provider(provider, id) {
+        PickerPricing::Known("priced".to_string())
+    } else {
+        PickerPricing::Unknown
+    };
+
+    EffectivePickerMetadata {
+        context_window,
+        max_output,
+        tool_calls,
+        reasoning,
+        pricing,
+        source: card.map(|card| card.source),
+    }
+}
+
+fn render_picker_model_hint(
+    id: &str,
+    provider: Option<ApiProvider>,
+    metadata: &EffectivePickerMetadata,
+    codex_freshness: Option<CodexModelCacheFreshness>,
+) -> String {
     if id == "auto" {
         return "select per turn".to_string();
     }
 
-    let offering = provider.and_then(|p| catalog_offering_for_model(p, id));
-    let registry = model_registry::lookup(id);
-    let card = offering.as_ref().map(ModelReferenceCard::from_offering);
-
     let mut parts = Vec::new();
 
-    let context = card
-        .as_ref()
-        .and_then(|c| c.context_window)
-        .map(|tokens| tokens.min(u64::from(u32::MAX)) as u32)
-        .or_else(|| registry.as_ref().and_then(|meta| meta.context_window));
-    if let Some(context_window) = context {
+    if let Some(context_window) = metadata.context_window {
         parts.push(format!(
             "{} ctx",
             format_picker_context_window(context_window)
         ));
     }
 
-    let max_output = card
-        .as_ref()
-        .and_then(|c| c.max_output)
-        .map(|tokens| tokens.min(u64::from(u32::MAX)) as u32)
-        .or_else(|| registry.as_ref().and_then(|meta| meta.max_output));
-    if let Some(max_output) = max_output {
+    if let Some(max_output) = metadata.max_output {
         parts.push(format!("{} out", format_picker_context_window(max_output)));
     }
 
-    match offering.as_ref().and_then(|o| o.tool_call) {
+    match metadata.tool_calls {
         Some(true) => parts.push("tools".to_string()),
         Some(false) => parts.push("no tools".to_string()),
         None => {}
     }
 
-    let reasoning = offering
-        .as_ref()
-        .and_then(|o| o.reasoning)
-        .unwrap_or_else(|| {
-            registry
-                .as_ref()
-                .is_some_and(|meta| meta.supports_reasoning)
-        });
-    if reasoning {
+    if metadata.reasoning {
         parts.push("reasoning".to_string());
     }
 
-    if let Some(card) = card.as_ref() {
-        let price = card.price_label();
-        if price != "unknown" {
-            parts.push(price);
-        } else {
-            parts.push("price unknown".to_string());
-        }
-        match &card.source {
-            CatalogSource::Live { .. } => parts.push("live".to_string()),
-            CatalogSource::Bundled => parts.push("bundled".to_string()),
-            CatalogSource::UserOverride => parts.push("override".to_string()),
-        }
-    } else {
-        parts.push(if crate::pricing::has_pricing_for_model(id) {
-            "priced".to_string()
-        } else {
-            "price unknown".to_string()
+    match &metadata.pricing {
+        PickerPricing::Unavailable => {}
+        PickerPricing::Known(label) => parts.push(label.clone()),
+        PickerPricing::Unknown => parts.push("price unknown".to_string()),
+    }
+    match metadata.source.as_ref() {
+        Some(CatalogSource::Live { .. }) => parts.push("live".to_string()),
+        Some(CatalogSource::Bundled) => parts.push("bundled".to_string()),
+        Some(CatalogSource::UserOverride) => parts.push("override".to_string()),
+        None => {}
+    }
+    if provider == Some(ApiProvider::OpenaiCodex) {
+        parts.push(match codex_freshness {
+            Some(freshness) => freshness.picker_label().to_string(),
+            None => "custom · OAuth roster unconfirmed".to_string(),
         });
     }
 
@@ -1368,26 +1545,41 @@ mod tests {
     use std::path::PathBuf;
 
     /// `_lock` bundles the process-wide test-env mutex with a guard that
-    /// neutralizes the real Codex CLI OAuth login on disk (`~/.codex/auth.json`),
-    /// if any — `has_api_key_for` checks `crate::oauth::auth_file_path().exists()`
-    /// unconditionally for `OpenaiCodex` (#3830), so without this, "default view
-    /// shows only configured providers" tests would pass or fail depending on
-    /// whether the machine running them happens to have a prior Codex login.
+    /// neutralizes the real Codex CLI OAuth login and model cache on disk. The
+    /// picker must not inherit either the developer's auth state or live account
+    /// roster unless a test opts into an isolated fixture explicitly.
     /// Declared in this order so the env var is restored (dropped first) while
     /// the mutex is still held, before the mutex itself is released.
     fn create_test_app() -> (
         App,
         Config,
         (
-            crate::test_support::EnvVarGuard,
+            Vec<crate::test_support::EnvVarGuard>,
             std::sync::MutexGuard<'static, ()>,
         ),
     ) {
         let lock = crate::test_support::lock_test_env();
-        let codex_auth_guard = crate::test_support::EnvVarGuard::set(
+        let mut env_guards = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for provider in ApiProvider::sorted_for_display() {
+            for &name in provider.env_vars() {
+                if seen.insert(name) {
+                    env_guards.push(crate::test_support::EnvVarGuard::remove(name));
+                }
+            }
+        }
+        env_guards.push(crate::test_support::EnvVarGuard::set(
             "OPENAI_CODEX_AUTH_FILE",
             "/nonexistent/codewhale-test-codex-auth.json",
-        );
+        ));
+        env_guards.push(crate::test_support::EnvVarGuard::set(
+            "CODEX_HOME",
+            "/nonexistent/codewhale-test-codex-home",
+        ));
+        env_guards.push(crate::test_support::EnvVarGuard::set(
+            "GROK_AUTH_PATH",
+            "/nonexistent/codewhale-test-grok-auth.json",
+        ));
         let options = TuiOptions {
             model: "deepseek-v4-pro".to_string(),
             workspace: PathBuf::from("."),
@@ -1424,7 +1616,7 @@ mod tests {
         app.api_provider = crate::config::ApiProvider::Deepseek;
         app.model_ids_passthrough = false;
         app.provider_models.clear();
-        (app, config, (codex_auth_guard, lock))
+        (app, config, (env_guards, lock))
     }
 
     fn type_model_query(view: &mut ModelPickerView, query: &str) {
@@ -1462,6 +1654,203 @@ mod tests {
             hint.contains("priced") || hint.contains("per Mtok") || hint.contains("$"),
             "hint should include pricing availability: {hint}"
         );
+    }
+
+    #[test]
+    fn same_model_id_uses_route_effective_api_and_oauth_metadata() {
+        let config = Config::default();
+        let api = effective_picker_metadata(&config, Some(ApiProvider::Openai), "gpt-5.5");
+        let codex_cache = CodexModelMetadata {
+            id: "gpt-5.5".to_string(),
+            context_window: Some(272_000),
+            reasoning: Some(true),
+        };
+        let oauth = effective_picker_metadata_with_codex(
+            &config,
+            Some(ApiProvider::OpenaiCodex),
+            "gpt-5.5",
+            Some(&codex_cache),
+        );
+
+        assert_eq!(api.context_window, Some(1_050_000));
+        assert_eq!(api.max_output, Some(128_000));
+        assert!(matches!(api.pricing, PickerPricing::Known(_)));
+        assert_eq!(oauth.context_window, Some(272_000));
+        assert_eq!(oauth.max_output, None);
+        assert_eq!(oauth.pricing, PickerPricing::Unavailable);
+        assert_eq!(oauth.tool_calls, Some(true));
+        assert!(oauth.reasoning);
+
+        let api_hint = render_picker_model_hint("gpt-5.5", Some(ApiProvider::Openai), &api, None);
+        let oauth_hint = render_picker_model_hint(
+            "gpt-5.5",
+            Some(ApiProvider::OpenaiCodex),
+            &oauth,
+            Some(CodexModelCacheFreshness::Fresh),
+        );
+        assert!(api_hint.contains("1.05M ctx"), "{api_hint}");
+        assert!(api_hint.contains("128K out"), "{api_hint}");
+        assert!(
+            api_hint.contains("priced") || api_hint.contains('$') || api_hint.contains("per Mtok"),
+            "{api_hint}"
+        );
+        assert!(oauth_hint.contains("272K ctx"), "{oauth_hint}");
+        assert!(oauth_hint.contains("tools"), "{oauth_hint}");
+        assert!(oauth_hint.contains("ChatGPT OAuth"), "{oauth_hint}");
+        for false_api_fact in ["1.05M", "128K out", "priced", "$", "per Mtok"] {
+            assert!(
+                !oauth_hint.contains(false_api_fact),
+                "OAuth hint inherited API-only fact {false_api_fact:?}: {oauth_hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_context_override_wins_in_picker_metadata() {
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                openai: crate::config::ProviderConfig {
+                    context_window: Some(123_456),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        let metadata = effective_picker_metadata(&config, Some(ApiProvider::Openai), "gpt-5.5");
+
+        assert_eq!(metadata.context_window, Some(123_456));
+    }
+
+    #[test]
+    fn codex_cache_roster_populates_picker_and_preserves_custom_selection() {
+        let (mut app, config, _lock) = create_test_app();
+        let codex_home = tempfile::tempdir().expect("temporary CODEX_HOME");
+        let _home = crate::test_support::EnvVarGuard::set("CODEX_HOME", codex_home.path());
+        let cache = serde_json::json!({
+            "fetched_at": chrono::Utc::now(),
+            "models": [
+                {"slug": "gpt-fixture-secondary", "priority": 20, "visibility": "list", "context_window": 128000, "supports_parallel_tool_calls": true, "supported_reasoning_levels": [{"effort": "medium"}]},
+                {"slug": "gpt-fixture-primary", "priority": 10, "visibility": "list", "context_window": 372000, "supports_parallel_tool_calls": true, "supported_reasoning_levels": [{"effort": "high"}]},
+                {"slug": "codex-fixture-review", "priority": 30, "visibility": "hide", "context_window": 272000, "supports_parallel_tool_calls": true, "supported_reasoning_levels": [{"effort": "medium"}]}
+            ]
+        });
+        std::fs::write(
+            codex_home.path().join("models_cache.json"),
+            serde_json::to_vec_pretty(&cache).expect("serialize cache"),
+        )
+        .expect("write cache");
+        app.api_provider = ApiProvider::OpenaiCodex;
+        app.model = "gpt-private-preview".to_string();
+        app.auto_model = false;
+
+        let view = ModelPickerView::new(&app, &config);
+        let codex_ids: Vec<_> = view
+            .visible_model_rows()
+            .into_iter()
+            .filter(|row| row.provider == Some(ApiProvider::OpenaiCodex))
+            .map(|row| row.id.as_str())
+            .collect();
+
+        assert_eq!(
+            codex_ids,
+            [
+                "gpt-fixture-primary",
+                "gpt-fixture-secondary",
+                "codex-fixture-review"
+            ]
+        );
+        assert!(view.show_custom_model_row);
+        assert_eq!(view.resolved_model(), "gpt-private-preview");
+        assert_eq!(view.selected_model_idx, view.visible_model_rows().len());
+        let primary = view
+            .model_rows
+            .iter()
+            .find(|row| row.id == "gpt-fixture-primary")
+            .expect("primary row");
+        let secondary = view
+            .model_rows
+            .iter()
+            .find(|row| row.id == "gpt-fixture-secondary")
+            .expect("secondary row");
+        assert!(primary.hint.contains("372K ctx"), "{}", primary.hint);
+        assert!(secondary.hint.contains("128K ctx"), "{}", secondary.hint);
+        assert!(
+            !secondary.hint.contains("no tools"),
+            "parallel=false must not be misread as no tool support: {}",
+            secondary.hint
+        );
+    }
+
+    #[test]
+    fn saved_codex_model_outside_fresh_roster_is_explicitly_unconfirmed() {
+        let (mut app, config, _lock) = create_test_app();
+        let codex_home = tempfile::tempdir().expect("Codex home");
+        let _codex_home = crate::test_support::EnvVarGuard::set("CODEX_HOME", codex_home.path());
+        std::fs::write(
+            codex_home.path().join("models_cache.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "fetched_at": chrono::Utc::now(),
+                "models": [{
+                    "slug": "gpt-roster-confirmed",
+                    "priority": 1,
+                    "context_window": 272000,
+                    "supported_reasoning_levels": [{"effort": "high"}]
+                }]
+            }))
+            .expect("serialize cache"),
+        )
+        .expect("write cache");
+        app.provider_models.insert(
+            ApiProvider::OpenaiCodex.as_str().to_string(),
+            "gpt-saved-unconfirmed".to_string(),
+        );
+
+        let view = ModelPickerView::new(&app, &config);
+        let row = view
+            .model_rows
+            .iter()
+            .find(|row| {
+                row.provider == Some(ApiProvider::OpenaiCodex) && row.id == "gpt-saved-unconfirmed"
+            })
+            .expect("saved Codex row");
+
+        assert!(
+            row.hint.contains("OAuth roster unconfirmed"),
+            "{}",
+            row.hint
+        );
+        for unsourced in ["ctx", "tools", "reasoning", "priced", "$", "per Mtok"] {
+            assert!(
+                !row.hint.contains(unsourced),
+                "unconfirmed row inherited {unsourced:?}: {}",
+                row.hint
+            );
+        }
+    }
+
+    #[test]
+    fn cross_provider_codex_row_previews_destination_route_truth() {
+        let (app, config, _lock) = create_test_app();
+        let view = ModelPickerView::new(&app, &config);
+        let row = view
+            .model_rows
+            .iter()
+            .find(|row| row.provider == Some(ApiProvider::OpenaiCodex) && row.id == "gpt-5.5")
+            .expect("Codex fallback row");
+
+        assert!(
+            row.hint
+                .contains("switch route · OAuth roster missing · fallback"),
+            "{}",
+            row.hint
+        );
+        assert!(!row.hint.contains(" ctx"), "{}", row.hint);
+        assert!(!row.hint.contains("tools"), "{}", row.hint);
+        assert!(!row.hint.contains("1.05M"), "{}", row.hint);
+        assert!(!row.hint.contains("128K out"), "{}", row.hint);
+        assert!(!row.hint.contains("priced"), "{}", row.hint);
     }
 
     #[test]
@@ -1577,6 +1966,43 @@ mod tests {
                 .iter()
                 .any(|row| row.provider == Some(crate::config::ApiProvider::Sglang)),
             "searching should still surface unconfigured providers"
+        );
+    }
+
+    #[test]
+    fn picker_configured_view_ignores_empty_anthropic_header_table() {
+        let (mut app, _default_config, _lock) = create_test_app();
+        app.api_provider = crate::config::ApiProvider::Deepseek;
+        app.model = "deepseek-v4-pro".to_string();
+        app.auto_model = false;
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                anthropic: crate::config::ProviderConfig {
+                    http_headers: Some(std::collections::HashMap::new()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+
+        let view = ModelPickerView::new(&app, &config);
+        assert!(
+            !view
+                .visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Anthropic)),
+            "empty persisted headers must not pull Anthropic into Configured"
+        );
+
+        let mut queried = ModelPickerView::new(&app, &config);
+        type_model_query(&mut queried, "anthropic");
+        assert!(
+            queried
+                .visible_model_rows()
+                .iter()
+                .any(|row| row.provider == Some(crate::config::ApiProvider::Anthropic)),
+            "full-catalog search must still discover unconfigured Anthropic routes"
         );
     }
 
@@ -1975,6 +2401,7 @@ mod tests {
             id: "z-ai/glm-5.2".to_string(),
             provider: Some(ApiProvider::Zai),
             hint: "switch route · reasoning".to_string(),
+            metadata: EffectivePickerMetadata::default(),
         }
     }
 

--- a/crates/tui/src/tui/persistence_actor.rs
+++ b/crates/tui/src/tui/persistence_actor.rs
@@ -24,6 +24,7 @@
 //!   naturally backpressures via the spawn pool. A few outstanding
 //!   `SavedSession` values in the channel (< 1 MB) is negligible pressure.
 
+use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use tokio::sync::mpsc;
@@ -112,16 +113,21 @@ pub fn persist(request: PersistRequest) {
 ///
 /// The returned handle should be passed to [`init_actor`] so that the
 /// `persist()` free function can reach it from anywhere in the TUI.
-pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
+pub fn spawn_persistence_actor(
+    manager: SessionManager,
+) -> (PersistActorHandle, tokio::task::JoinHandle<()>) {
     let (tx, mut rx) = mpsc::unbounded_channel::<PersistRequest>();
     let handle = PersistActorHandle { tx };
 
-    spawn_supervised(
+    let task = spawn_supervised(
         "persistence-actor",
         std::panic::Location::caller(),
         async move {
             let mut latest_checkpoint: Option<SavedSession> = None;
-            let mut latest_session: Option<SavedSession> = None;
+            // Latest-wins per session id. Coalescing into one global slot can
+            // drop session A when an immediate `/new` queues session B before
+            // the actor drains.
+            let mut latest_sessions: BTreeMap<String, SavedSession> = BTreeMap::new();
             let mut latest_offline_queue: Option<PendingOfflineQueue> = None;
             let mut should_clear: bool = false;
 
@@ -138,7 +144,7 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
                             should_clear = false;
                         }
                         PersistRequest::SessionSnapshot(session) => {
-                            latest_session = Some(session);
+                            latest_sessions.insert(session.metadata.id.clone(), session);
                         }
                         PersistRequest::OfflineQueue { state, session_id } => {
                             latest_offline_queue =
@@ -156,7 +162,7 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
                             flush_inner(
                                 &manager,
                                 latest_checkpoint.as_ref(),
-                                latest_session.as_ref(),
+                                &latest_sessions,
                                 latest_offline_queue.as_ref(),
                                 should_clear,
                             );
@@ -173,8 +179,8 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
                 if let Some(ref session) = latest_checkpoint.take() {
                     let _ = manager.save_checkpoint(session);
                 }
-                if let Some(ref session) = latest_session.take() {
-                    let _ = manager.save_session(session);
+                for (_, session) in std::mem::take(&mut latest_sessions) {
+                    let _ = manager.save_session(&session);
                 }
                 if let Some(ref request) = latest_offline_queue.take() {
                     apply_offline_queue_request(&manager, request);
@@ -187,7 +193,7 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
                         should_clear = false;
                     }
                     Some(PersistRequest::SessionSnapshot(session)) => {
-                        latest_session = Some(session);
+                        latest_sessions.insert(session.metadata.id.clone(), session);
                     }
                     Some(PersistRequest::OfflineQueue { state, session_id }) => {
                         latest_offline_queue =
@@ -204,7 +210,7 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
                         flush_inner(
                             &manager,
                             latest_checkpoint.as_ref(),
-                            latest_session.as_ref(),
+                            &latest_sessions,
                             latest_offline_queue.as_ref(),
                             should_clear,
                         );
@@ -215,7 +221,7 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
                         flush_inner(
                             &manager,
                             latest_checkpoint.as_ref(),
-                            latest_session.as_ref(),
+                            &latest_sessions,
                             latest_offline_queue.as_ref(),
                             should_clear,
                         );
@@ -226,14 +232,14 @@ pub fn spawn_persistence_actor(manager: SessionManager) -> PersistActorHandle {
         },
     );
 
-    handle
+    (handle, task)
 }
 
 /// Write any pending work to disk (used on shutdown).
 fn flush_inner(
     manager: &SessionManager,
     checkpoint: Option<&SavedSession>,
-    session: Option<&SavedSession>,
+    sessions: &BTreeMap<String, SavedSession>,
     offline_queue: Option<&PendingOfflineQueue>,
     should_clear: bool,
 ) {
@@ -243,7 +249,7 @@ fn flush_inner(
     if let Some(s) = checkpoint {
         let _ = manager.save_checkpoint(s);
     }
-    if let Some(s) = session {
+    for s in sessions.values() {
         let _ = manager.save_session(s);
     }
     if let Some(request) = offline_queue {
@@ -289,7 +295,7 @@ mod tests {
         let sessions_dir = tmp.path().join("sessions");
         let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
         let queue_path = sessions_dir.join("checkpoints").join("offline_queue.json");
-        let handle = spawn_persistence_actor(manager);
+        let (handle, task) = spawn_persistence_actor(manager);
 
         let state = OfflineQueueState {
             messages: vec![QueuedSessionMessage {
@@ -312,5 +318,84 @@ mod tests {
         handle.try_send(PersistRequest::ClearOfflineQueue);
         wait_until(|| !queue_path.exists()).await;
         handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+    }
+
+    #[tokio::test]
+    async fn shutdown_wait_flushes_queued_session_before_returning() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let verification_manager = SessionManager::new(sessions_dir).expect("verification manager");
+        let session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let session_id = session.metadata.id.clone();
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::SessionSnapshot(session));
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+
+        let loaded = verification_manager
+            .load_session(&session_id)
+            .expect("shutdown must flush queued session");
+        assert_eq!(loaded.metadata.id, session_id);
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_latest_snapshot_for_each_session_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let verification_manager = SessionManager::new(sessions_dir).expect("verification manager");
+        let mut first = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        first.metadata.title = "Session A".to_string();
+        let mut second = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        second.metadata.title = "Session B".to_string();
+        let first_id = first.metadata.id.clone();
+        let second_id = second.metadata.id.clone();
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::SessionSnapshot(first));
+        handle.try_send(PersistRequest::SessionSnapshot(second));
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+
+        assert_eq!(
+            verification_manager
+                .load_session(&first_id)
+                .expect("session A flushed")
+                .metadata
+                .title,
+            "Session A"
+        );
+        assert_eq!(
+            verification_manager
+                .load_session(&second_id)
+                .expect("session B flushed")
+                .metadata
+                .title,
+            "Session B"
+        );
     }
 }

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -2925,6 +2925,85 @@ mod tests {
     }
 
     #[test]
+    fn empty_provider_headers_do_not_mark_provider_configured() {
+        let _env = crate::test_support::lock_test_env();
+        let _anthropic_key = crate::test_support::EnvVarGuard::remove("ANTHROPIC_API_KEY");
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                anthropic: crate::config::ProviderConfig {
+                    http_headers: Some(std::collections::HashMap::new()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let anthropic = picker
+            .rows
+            .iter()
+            .find(|row| row.provider == ApiProvider::Anthropic)
+            .expect("anthropic row");
+
+        assert!(
+            !anthropic.is_configured,
+            "an empty deserialized header table is default state, not setup"
+        );
+    }
+
+    #[test]
+    fn non_empty_provider_headers_mark_provider_configured() {
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                anthropic: crate::config::ProviderConfig {
+                    http_headers: Some(std::collections::HashMap::from([(
+                        "X-Route".to_string(),
+                        "custom".to_string(),
+                    )])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        let picker = ProviderPickerView::new(ApiProvider::Deepseek, &config);
+        let anthropic = picker
+            .rows
+            .iter()
+            .find(|row| row.provider == ApiProvider::Anthropic)
+            .expect("anthropic row");
+
+        assert!(
+            anthropic.is_configured,
+            "a user-authored header is meaningful explicit provider setup"
+        );
+    }
+
+    #[test]
+    fn blank_provider_header_entries_do_not_mark_provider_configured() {
+        let _env = crate::test_support::lock_test_env();
+        let _anthropic_key = crate::test_support::EnvVarGuard::remove("ANTHROPIC_API_KEY");
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                anthropic: crate::config::ProviderConfig {
+                    http_headers: Some(std::collections::HashMap::from([
+                        (" ".to_string(), "value".to_string()),
+                        ("X-Blank".to_string(), "   ".to_string()),
+                    ])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Config::default()
+        };
+        assert!(!crate::config::provider_is_configured_for_active(
+            &config,
+            ApiProvider::Anthropic,
+            ApiProvider::Deepseek,
+        ));
+    }
+
+    #[test]
     fn self_hosted_provider_not_auto_configured_without_explicit_setup() {
         // #3830: `has_api_key_for` always reports `true` for self-hosted
         // providers (no auth required to route to them) — that must not, on

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -351,7 +351,9 @@ impl SessionPickerView {
         self.apply_sort_and_filter();
         self.refresh_preview();
         self.status = Some(format!("Renamed to \"{new_title}\""));
-        ViewAction::None
+        ViewAction::Emit(ViewEvent::SessionRenamed {
+            metadata: saved.metadata,
+        })
     }
 
     fn refresh_preview(&mut self) {
@@ -1026,6 +1028,36 @@ mod tests {
         };
         view.apply_sort_and_filter();
         view
+    }
+
+    #[test]
+    fn rename_selected_persists_and_emits_saved_metadata() {
+        let _lock = crate::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", tmp.path());
+        let manager = SessionManager::default_location().expect("session manager");
+        let mut saved = saved_session_with_messages(vec![text_message("user", "hello")]);
+        saved.metadata.id = "session-01".to_string();
+        saved.metadata.title = "Before".to_string();
+        manager.save_session(&saved).expect("save session");
+        let mut view = picker_with(vec![saved.metadata.clone()], None);
+
+        let action = view.rename_selected("After");
+
+        let ViewAction::Emit(ViewEvent::SessionRenamed { metadata }) = action else {
+            panic!("expected SessionRenamed event");
+        };
+        assert_eq!(metadata.id, "session-01");
+        assert_eq!(metadata.title, "After");
+        assert_eq!(view.sessions[0].title, "After");
+        assert_eq!(
+            manager
+                .load_session("session-01")
+                .expect("load renamed session")
+                .metadata
+                .title,
+            "After"
+        );
     }
 
     fn buffer_row_text(buf: &Buffer, area: Rect, y: u16) -> String {

--- a/crates/tui/src/tui/setup/mod.rs
+++ b/crates/tui/src/tui/setup/mod.rs
@@ -539,7 +539,8 @@ impl SetupRuntimePreset {
             Self::AskFirst | Self::NormalAgent => Some("on-request"),
             // YOLO derives bypass approval from `default_mode = "yolo"`.
             // `approval_policy = "bypass"` is intentionally not a persisted
-            // config value in v0.8.67.
+            // config value. Interactive Shift+Tab posture is stored separately
+            // in TUI settings and cannot override managed approval policy.
             Self::HighTrustLocal => None,
         }
     }
@@ -1708,10 +1709,10 @@ impl SetupWizardView {
     }
 
     fn operate_fleet_facts_ready(&self) -> bool {
-        self.state.first_run_ready()
-            && self.facts.provider_ready
-            && self.facts.operate_runtime_ready
-            && self.facts.fleet_roster_ready
+        // Provider, capacity, and roster facts are configuration snapshots,
+        // not proof of dispatch and terminal receipts. This release must never
+        // persist an Operate-ready claim from those facts alone.
+        false
     }
 
     fn commit_operate_fleet_review(&mut self) -> ViewAction {
@@ -5590,7 +5591,7 @@ mod tests {
     }
 
     #[test]
-    fn operate_fleet_review_records_ready_without_plan_probe() {
+    fn operate_fleet_review_records_needs_action_without_receipt_capability() {
         let facts = SetupRuntimeFacts {
             provider_ready: true,
             operate_runtime_ready: true,
@@ -5613,15 +5614,18 @@ mod tests {
         else {
             panic!("expected setup-state commit event");
         };
-        assert_eq!(state.status(SetupStep::OperateFleet), StepStatus::Verified);
-        assert!(state.operate_ready());
+        assert_eq!(
+            state.status(SetupStep::OperateFleet),
+            StepStatus::NeedsAction
+        );
+        assert!(!state.operate_ready());
         let result = state
             .steps
             .get(&SetupStep::OperateFleet)
             .and_then(|entry| entry.result.as_deref())
             .expect("operate result");
         assert!(result.contains("plan limit not probed"), "{result}");
-        assert!(message.contains("Operate/Fleet readiness recorded"));
+        assert!(message.contains("needs action"));
         assert_eq!(view.selected_step(), SetupStep::Hotbar);
     }
 

--- a/crates/tui/src/tui/setup/operate.rs
+++ b/crates/tui/src/tui/setup/operate.rs
@@ -39,12 +39,24 @@ impl SetupOperateFacts {
                     .unwrap_or("disabled for active provider"),
             )
         };
-        let runtime_ready = subagents_enabled && max_subagents > 0 && launch_concurrency > 0;
+        let runtime_configured = subagents_enabled && max_subagents > 0 && launch_concurrency > 0;
+        // Configuration and roster presence are useful facts, but this release
+        // cannot yet prove host-enforced Workflow dispatch plus terminal
+        // receipts. Keep Operate readiness blocked until that capability exists.
+        let runtime_ready = false;
         let runtime_result = if let Some(reason) = runtime_disabled_reason {
             format!("worker runtime disabled ({reason})")
+        } else if runtime_configured {
+            format!(
+                "worker runtime configuration present for {}; max_subagents={}, launch_concurrency={}, admission={}; verified Operate dispatch and terminal receipts unavailable in this release",
+                app.api_provider.as_str(),
+                max_subagents,
+                launch_concurrency,
+                max_admitted
+            )
         } else {
             format!(
-                "worker runtime enabled for {}; max_subagents={}, launch_concurrency={}, admission={}",
+                "worker runtime has no launch capacity for {}; max_subagents={}, launch_concurrency={}, admission={}",
                 app.api_provider.as_str(),
                 max_subagents,
                 launch_concurrency,

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -51,7 +51,7 @@ const HOTBAR_ROW_COLUMNS: usize = 4;
 pub fn render_sidebar(f: &mut Frame, area: Rect, app: &mut App, config: &Config) {
     // Clear hover state at the start of each render
     app.sidebar_hover = SidebarHoverState::default();
-    if area.width < 24 || area.height < 8 {
+    if area.width < 20 || area.height < 3 {
         // Paint a styled block over the area so stale cells from a previous
         // (wider) frame don't persist as bleed-through artifacts (#400).
         Block::default()
@@ -67,15 +67,42 @@ pub fn render_sidebar(f: &mut Frame, area: Rect, app: &mut App, config: &Config)
         return;
     }
 
-    let hotbar_enabled = hotbar_panel_enabled(app, config) && !is_hotbar_disabled(config);
+    let work_has_content = sidebar_work_summary(app).has_useful_content();
+    // At compact heights the durable Work state outranks optional Hotbar
+    // chrome. The Hotbar returns automatically after the terminal grows.
+    let hotbar_enabled = hotbar_panel_enabled(app, config)
+        && !is_hotbar_disabled(config)
+        && !(work_has_content && area.height < 12);
     let (main_area, hotbar_area) = split_sidebar_hotbar_area(area, hotbar_enabled);
-    match app.sidebar_focus {
-        SidebarFocus::Auto => render_sidebar_auto(f, main_area, app),
-        SidebarFocus::Pinned => render_sidebar_pinned(f, main_area, app),
-        SidebarFocus::Tasks => render_sidebar_tasks(f, main_area, app),
-        SidebarFocus::Agents => render_sidebar_subagents(f, main_area, app),
-        SidebarFocus::Context => render_context_panel(f, main_area, app),
-        SidebarFocus::Hidden => unreachable!("hidden sidebar returned before render dispatch"),
+    let fixed_focus = matches!(
+        app.sidebar_focus,
+        SidebarFocus::Tasks | SidebarFocus::Agents | SidebarFocus::Context
+    );
+    if fixed_focus && work_has_content {
+        if main_area.height < 7 {
+            render_sidebar_work_compact(f, main_area, app);
+        } else {
+            let sections = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(3), Constraint::Length(4)])
+                .split(main_area);
+            match app.sidebar_focus {
+                SidebarFocus::Tasks => render_sidebar_tasks(f, sections[0], app),
+                SidebarFocus::Agents => render_sidebar_subagents(f, sections[0], app),
+                SidebarFocus::Context => render_context_panel(f, sections[0], app),
+                _ => unreachable!("fixed focus was checked above"),
+            }
+            render_sidebar_work_compact(f, sections[1], app);
+        }
+    } else {
+        match app.sidebar_focus {
+            SidebarFocus::Auto => render_sidebar_auto(f, main_area, app),
+            SidebarFocus::Pinned => render_sidebar_pinned(f, main_area, app),
+            SidebarFocus::Tasks => render_sidebar_tasks(f, main_area, app),
+            SidebarFocus::Agents => render_sidebar_subagents(f, main_area, app),
+            SidebarFocus::Context => render_context_panel(f, main_area, app),
+            SidebarFocus::Hidden => unreachable!("hidden sidebar returned before render dispatch"),
+        }
     }
     if let Some(hotbar_area) = hotbar_area {
         render_hotbar_panel(f, hotbar_area, app, config);
@@ -136,10 +163,12 @@ fn render_sidebar_panel_stack(
             Constraint::Min(0),
         ],
         4 => vec![
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
-            Constraint::Min(6),
+            // Work is first whenever present. Give it a hard compact floor so
+            // Context cannot starve a live To-do after a resize.
+            Constraint::Length(5),
+            Constraint::Percentage(30),
+            Constraint::Percentage(30),
+            Constraint::Min(3),
         ],
         _ => vec![
             Constraint::Percentage(20),
@@ -528,6 +557,51 @@ impl SidebarWorkSummary {
         let percent = completed.saturating_mul(100) / self.strategy_steps.len();
         u8::try_from(percent).unwrap_or(u8::MAX)
     }
+
+    fn compact_indicator(&self) -> Option<String> {
+        if !self.checklist_items.is_empty() {
+            return Some(format!(
+                "To-do {} · {}%",
+                self.checklist_items.len(),
+                self.checklist_completion_pct
+            ));
+        }
+        if self.has_strategy() {
+            return Some("Work plan active".to_string());
+        }
+        self.goal_objective
+            .as_ref()
+            .map(|_| "Work goal active".to_string())
+    }
+}
+
+/// Compact Work fallback for surfaces used when the sidebar cannot fit.
+/// Reads the live stores first and only falls back to the last rendered
+/// summary during brief lock contention.
+pub(crate) fn compact_work_indicator(app: &App) -> Option<String> {
+    let todos = app.todos.try_lock().ok().map(|todos| todos.snapshot());
+    if let Some(snapshot) = todos.as_ref().filter(|snapshot| !snapshot.is_empty()) {
+        return Some(format!(
+            "To-do {} · {}%",
+            snapshot.items.len(),
+            snapshot.completion_pct
+        ));
+    }
+
+    let plan = app.plan_state.try_lock().ok().map(|plan| !plan.is_empty());
+    if plan == Some(true) {
+        return Some("Work plan active".to_string());
+    }
+    if app.hunt.quarry.is_some() || app.paused_quarry.is_some() {
+        return Some("Work goal active".to_string());
+    }
+    if todos.is_none() || plan.is_none() {
+        return app
+            .cached_work_summary
+            .as_ref()
+            .and_then(SidebarWorkSummary::compact_indicator);
+    }
+    None
 }
 
 fn should_render_strategy_step(
@@ -1211,6 +1285,41 @@ fn render_sidebar_work(f: &mut Frame, area: Rect, app: &mut App) {
 
     let full_texts = work_panel_hover_texts(&summary, content_width.max(1), usable_rows);
     render_sidebar_section(f, area, "To-do", lines, full_texts, Vec::new(), app);
+}
+
+fn render_sidebar_work_compact(f: &mut Frame, area: Rect, app: &mut App) {
+    let summary = sidebar_work_summary(app);
+    let label = if !summary.checklist_items.is_empty() {
+        let count = summary.checklist_items.len();
+        format!(
+            "{count} item{} · {}%",
+            if count == 1 { "" } else { "s" },
+            summary.checklist_completion_pct
+        )
+    } else if summary.has_strategy() {
+        let (pending, in_progress, completed) = summary.strategy_counts();
+        let total = pending + in_progress + completed;
+        if total == 0 {
+            "plan active".to_string()
+        } else {
+            format!("plan {completed}/{total} · {in_progress} active")
+        }
+    } else if summary.goal_objective.is_some() {
+        "goal active".to_string()
+    } else {
+        "Work state updating...".to_string()
+    };
+    let content_width = area.width.saturating_sub(4) as usize;
+    let line = truncate_line_to_width(&label, content_width.max(1));
+    render_sidebar_section(
+        f,
+        area,
+        "To-do",
+        vec![Line::from(line.clone())],
+        vec![label],
+        Vec::new(),
+        app,
+    );
 }
 
 /// Click actions for one background job row pair (#3028).
@@ -3306,7 +3415,9 @@ fn render_context_panel(f: &mut Frame, area: Rect, app: &mut App) {
 
 fn context_panel_cost_line(app: &App) -> String {
     let displayed_total = app.displayed_session_cost_for_currency(app.cost_currency);
-    if displayed_total == 0.0 && !crate::pricing::has_pricing_for_model(&app.model) {
+    if displayed_total == 0.0
+        && !crate::pricing::has_pricing_for_provider(app.api_provider, &app.model)
+    {
         return format!("cost: n/a (no pricing data for {})", app.model);
     }
 
@@ -3582,6 +3693,18 @@ mod tests {
         assert_eq!(
             context_panel_cost_line(&app),
             "cost: n/a (no pricing data for unknown-provider/unknown-model)"
+        );
+    }
+
+    #[test]
+    fn context_panel_cost_line_does_not_inherit_api_pricing_for_codex_oauth() {
+        let mut app = create_test_app();
+        app.api_provider = crate::config::ApiProvider::OpenaiCodex;
+        app.model = "gpt-5.5".to_string();
+
+        assert_eq!(
+            context_panel_cost_line(&app),
+            "cost: n/a (no pricing data for gpt-5.5)"
         );
     }
 
@@ -3945,6 +4068,104 @@ mod tests {
             rendered.contains("Alt4"),
             "active agent-mode slot should render distinctly: {rendered:?}"
         );
+    }
+
+    #[test]
+    fn nonempty_todo_remains_visible_across_release_sizes_and_focuses() {
+        // These sidebar widths are the actual splits produced by 120, 100,
+        // and 80-column terminals (the compact 80-column case is 20 wide).
+        for (sidebar_width, height) in [(33, 32), (28, 30), (20, 24)] {
+            for focus in [
+                SidebarFocus::Auto,
+                SidebarFocus::Pinned,
+                SidebarFocus::Tasks,
+                SidebarFocus::Agents,
+                SidebarFocus::Context,
+            ] {
+                let mut app = create_test_app();
+                app.sidebar_focus = focus;
+                {
+                    let mut todos = app.todos.try_lock().expect("todos lock");
+                    todos.add("inspect".to_string(), TodoStatus::Completed);
+                    todos.add("patch".to_string(), TodoStatus::InProgress);
+                }
+                let config = Config {
+                    hotbar: Some(Vec::new()),
+                    ..Config::default()
+                };
+                let backend = TestBackend::new(sidebar_width, height);
+                let mut terminal = Terminal::new(backend).expect("terminal");
+                terminal
+                    .draw(|frame| render_sidebar(frame, frame.area(), &mut app, &config))
+                    .expect("draw sidebar");
+                let rendered = terminal
+                    .backend()
+                    .buffer()
+                    .content()
+                    .iter()
+                    .map(|cell| cell.symbol())
+                    .collect::<String>();
+
+                assert!(
+                    rendered.contains("To-do"),
+                    "To-do title missing at {sidebar_width}x{height} in {focus:?}: {rendered:?}"
+                );
+                assert!(
+                    rendered.contains("patch") || rendered.contains("2 items"),
+                    "neither full nor compact To-do state rendered at {sidebar_width}x{height} in {focus:?}: {rendered:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hidden_is_the_only_focus_that_suppresses_nonempty_todo() {
+        let mut app = create_test_app();
+        app.sidebar_focus = SidebarFocus::Hidden;
+        app.todos
+            .try_lock()
+            .expect("todos lock")
+            .add("hidden explicitly".to_string(), TodoStatus::InProgress);
+        let backend = TestBackend::new(20, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| render_sidebar(frame, frame.area(), &mut app, &Config::default()))
+            .expect("draw sidebar");
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!rendered.contains("To-do"));
+    }
+
+    #[test]
+    fn compact_metadata_only_plan_reports_active_without_zero_counts() {
+        let mut app = create_test_app();
+        app.sidebar_focus = SidebarFocus::Agents;
+        app.plan_state
+            .try_lock()
+            .expect("plan lock")
+            .update(crate::tools::plan::UpdatePlanArgs {
+                objective: Some("metadata-only release plan".to_string()),
+                ..crate::tools::plan::UpdatePlanArgs::default()
+            });
+        let backend = TestBackend::new(20, 8);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| render_sidebar(frame, frame.area(), &mut app, &Config::default()))
+            .expect("draw sidebar");
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("plan active"), "{rendered:?}");
+        assert!(!rendered.contains("0/0"), "{rendered:?}");
     }
 
     #[test]

--- a/crates/tui/src/tui/subagent_routing.rs
+++ b/crates/tui/src/tui/subagent_routing.rs
@@ -325,13 +325,16 @@ pub(super) fn subagent_message_refreshes_workspace_context(message: &MailboxMess
 /// allocating a `DelegateCard` or `FanoutCard` on first sight (issue #128).
 pub(super) fn handle_subagent_mailbox(app: &mut App, seq: u64, message: &MailboxMessage) -> bool {
     // Accumulate sub-agent token costs for the real-time footer counter (#166).
-    if let MailboxMessage::TokenUsage { model, usage, .. } = message {
+    if let MailboxMessage::TokenUsage {
+        provider,
+        model,
+        usage,
+        ..
+    } = message
+    {
         if app.session.subagent_cost_event_seqs.insert(seq)
-            && let Some(cost) = crate::pricing::calculate_turn_cost_estimate_for_provider(
-                app.api_provider,
-                model,
-                usage,
-            )
+            && let Some(cost) =
+                crate::pricing::calculate_turn_cost_estimate_for_provider(*provider, model, usage)
         {
             app.accrue_subagent_cost_estimate(cost);
         }

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -411,7 +411,15 @@ fn accrue_child_token_cost_if_any(app: &mut App, result: &Result<ToolResult, Too
         reasoning_replay_tokens: None,
         server_tool_use: None,
     };
-    if let Some(cost) = crate::pricing::calculate_turn_cost_estimate_from_usage(model, &usage) {
+    let provider = metadata
+        .get("child_provider")
+        .or_else(|| metadata.get("resolved_provider"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(crate::config::ApiProvider::parse)
+        .unwrap_or(app.api_provider);
+    if let Some(cost) =
+        crate::pricing::calculate_turn_cost_estimate_for_provider(provider, model, &usage)
+    {
         app.accrue_subagent_cost_estimate(cost);
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -52,7 +52,7 @@ use crate::commands;
 use crate::compaction::estimate_input_tokens_conservative;
 use crate::config::{
     ApiProvider, Config, ProviderConfig, ProvidersConfig, StatusItem, UpdateConfig,
-    provider_capability, save_provider_auth_mode_for_at,
+    save_provider_auth_mode_for_at,
 };
 use crate::config_ui::{self, ConfigUiMode, WebConfigSession, WebConfigSessionEvent};
 use crate::core::engine::{EngineConfig, EngineHandle, spawn_engine};
@@ -67,7 +67,7 @@ use crate::prompts;
 use crate::route_runtime::{resolve_route_candidate, resolve_runtime_route};
 use crate::session_manager::{
     OfflineQueueState, QueuedSessionMessage, SavedSession, SessionManager,
-    create_saved_session_with_id_and_mode, create_saved_session_with_mode, update_session,
+    create_saved_session_with_id_and_mode, create_saved_session_with_mode,
 };
 use crate::settings::Settings;
 use crate::task_manager::{
@@ -202,7 +202,9 @@ const TOOL_HANG_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(600);
 // the per-tool spinner pulse — keep this fast enough that the whale-spout
 // braille pattern reads as continuous motion instead of teleport-frames.
 const UI_STATUS_ANIMATION_MS: u64 = crate::tui::spinner::BRAILLE_SPINNER_FRAME_MS;
-pub(crate) const SIDEBAR_VISIBLE_MIN_WIDTH: u16 = 64;
+// At an 80-column terminal the file tree owns 20 columns, leaving a 60-column
+// chat host. Keep a compact 20-column sidebar plus a 40-column transcript.
+pub(crate) const SIDEBAR_VISIBLE_MIN_WIDTH: u16 = 60;
 const DEFAULT_TERMINAL_PROBE_TIMEOUT_MS: u64 = 500;
 const PERIODIC_FULL_REPAINT_EVERY_N: u64 = 50;
 const TURN_META_PREFIX: &str = "<turn_meta>";
@@ -915,15 +917,18 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
             };
 
         match load_result {
-            Ok(Some(saved)) => {
-                let recovered = apply_loaded_session(&mut app, config, &saved);
-                if !recovered {
+            Ok(Some(saved)) => match apply_loaded_session(&mut app, config, &saved) {
+                Ok(false) => {
                     app.status_message = Some(format!(
                         "Resumed session: {}",
                         crate::session_manager::truncate_id(&saved.metadata.id)
                     ));
                 }
-            }
+                Ok(true) => {}
+                Err(err) => {
+                    app.status_message = Some(format!("Failed to restore session: {err}"));
+                }
+            },
             Ok(None) => {
                 app.status_message = Some("No sessions found to resume".to_string());
             }
@@ -1064,10 +1069,13 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     // Spawn the persistence actor so checkpoint/session-save I/O stays off
     // the UI thread.  The actor serialises + writes to disk in a dedicated
     // task; the UI just `try_send`s a request and returns immediately.
-    if let Ok(persist_manager) = SessionManager::default_location() {
-        let handle = persistence_actor::spawn_persistence_actor(persist_manager);
-        persistence_actor::init_actor(handle);
-    }
+    let persistence_runtime = SessionManager::default_location()
+        .ok()
+        .map(|persist_manager| {
+            let (handle, task) = persistence_actor::spawn_persistence_actor(persist_manager);
+            persistence_actor::init_actor(handle.clone());
+            (handle, task)
+        });
 
     submit_initial_input_if_ready(&mut app, config, &engine_handle).await?;
 
@@ -1092,8 +1100,11 @@ pub async fn run_tui(config: &Config, options: TuiOptions) -> Result<()> {
     }
 
     // Flush the persistence actor: clear checkpoint + graceful shutdown.
-    persistence_actor::persist(PersistRequest::ClearCheckpoint);
-    persistence_actor::persist(PersistRequest::Shutdown);
+    if let Some((handle, task)) = persistence_runtime {
+        handle.try_send(PersistRequest::ClearCheckpoint);
+        handle.try_send(PersistRequest::Shutdown);
+        let _ = task.await;
+    }
 
     cleanup_guard.defused = true;
     pop_keyboard_enhancement_flags(terminal.backend_mut());
@@ -1577,9 +1588,11 @@ fn build_app_system_prompt(app: &App, config: &Config) -> SystemPrompt {
             locale_tag: app.ui_locale.tag(),
             translation_enabled: app.translation_enabled,
             model_id: &app.model,
-            context_window_override: Some(
-                provider_capability(app.api_provider, &app.model).context_window,
-            ),
+            context_window_override: Some(crate::route_budget::route_context_window_tokens(
+                app.api_provider,
+                &app.model,
+                app.active_route_limits,
+            )),
             show_thinking: app.show_thinking,
             verbosity: app.verbosity.as_deref(),
             skills_scan_codewhale_only: app.skills_scan_codewhale_only,
@@ -2828,12 +2841,17 @@ async fn run_event_loop(
                         // Auto-save completed turn and clear crash checkpoint.
                         // Offloaded to the persistence actor so the UI
                         // stays responsive.
-                        if let Ok(manager) = SessionManager::default_location() {
-                            let session = build_session_snapshot(app, &manager);
+                        let mut completed_snapshot_queued = false;
+                        if let Ok(manager) = SessionManager::default_location()
+                            && let Ok(session) = build_session_snapshot(app, &manager)
+                        {
                             app.current_session_id = Some(session.metadata.id.clone());
                             persistence_actor::persist(PersistRequest::SessionSnapshot(session));
+                            completed_snapshot_queued = true;
                         }
-                        persistence_actor::persist(PersistRequest::ClearCheckpoint);
+                        if completed_snapshot_queued {
+                            persistence_actor::persist(PersistRequest::ClearCheckpoint);
+                        }
 
                         // Refresh DeepSeek account balance after each completed
                         // turn so the footer balance chip stays current without
@@ -2940,7 +2958,7 @@ async fn run_event_loop(
                         model,
                         workspace,
                     } => {
-                        app.current_session_id = Some(session_id);
+                        app.current_session_id = Some(session_id.clone());
                         app.api_messages = messages;
                         app.system_prompt = system_prompt;
                         if app.auto_model {
@@ -2953,25 +2971,21 @@ async fn run_event_loop(
                         if (app.is_loading || app.is_compacting || app.is_purging)
                             && let Ok(manager) = SessionManager::default_location()
                         {
-                            let session = build_session_snapshot(app, &manager);
-                            app.session_title = Some(session.metadata.title.clone());
-                            persistence_actor::persist(PersistRequest::Checkpoint(session));
+                            if let Ok(session) = build_session_snapshot(app, &manager) {
+                                app.session_title = Some(session.metadata.title.clone());
+                                persistence_actor::persist(PersistRequest::Checkpoint(session));
+                            }
                         } else if app.session_title.is_none() {
-                            // First turn on a brand-new session: persist hasn't fired yet so
-                            // read the title from the session file if it already exists,
-                            // otherwise fall back to deriving from messages.
-                            let persisted = app
-                                .current_session_id
-                                .as_deref()
-                                .and_then(|id| {
-                                    SessionManager::default_location()
-                                        .ok()?
-                                        .load_session(id)
-                                        .ok()
-                                })
-                                .map(|s| s.metadata.title);
+                            // Never synchronously reload the growing session
+                            // JSON on the event-loop task just to recover a
+                            // title. The in-memory metadata cache is authoritative.
+                            let cached = app
+                                .current_session_metadata
+                                .as_ref()
+                                .filter(|metadata| metadata.id == session_id)
+                                .map(|metadata| metadata.title.clone());
                             app.session_title =
-                                persisted.or_else(|| derive_session_title(&app.api_messages));
+                                cached.or_else(|| derive_session_title(&app.api_messages));
                         }
                     }
                     EngineEvent::CompactionStarted { message, .. } => {
@@ -5996,51 +6010,69 @@ fn deliver_fleet_draft_result(
 
 // `format_*` chip/message builders moved to `tui/format_helpers.rs`.
 
-fn build_session_snapshot(app: &App, manager: &SessionManager) -> SavedSession {
+fn build_session_snapshot(
+    app: &mut App,
+    _manager: &SessionManager,
+) -> Result<SavedSession, String> {
     let model = app.model_selection_for_persistence();
-    if let Some(ref existing_id) = app.current_session_id
-        && let Ok(existing) = manager.load_session(existing_id)
-    {
-        let mut updated = update_session(
-            existing,
+    let work_state = match app.try_work_state_snapshot() {
+        Ok(work_state) => work_state,
+        Err(err) => app.last_known_work_state.clone().ok_or_else(|| {
+            format!("automatic session snapshot skipped while Work state is busy: {err}")
+        })?,
+    };
+    let mut session = if let Some(existing_id) = app.current_session_id.as_ref() {
+        create_saved_session_with_id_and_mode(
+            existing_id.clone(),
             &app.api_messages,
+            &model,
+            &app.workspace,
             u64::from(app.session.total_tokens),
             app.system_prompt.as_ref(),
-        );
-        updated.metadata.model = model;
-        updated.metadata.model_provider = app.api_provider.as_str().to_string();
-        updated.metadata.mode = Some(app.mode.as_setting().to_string());
-        app.sync_cost_to_metadata(&mut updated.metadata);
-        updated.context_references = app.session_context_references.clone();
-        updated.artifacts = app.session_artifacts.clone();
-        updated
+            Some(app.mode.as_setting()),
+        )
     } else {
-        let mut session = if let Some(existing_id) = app.current_session_id.as_ref() {
-            create_saved_session_with_id_and_mode(
-                existing_id.clone(),
-                &app.api_messages,
-                &model,
-                &app.workspace,
-                u64::from(app.session.total_tokens),
-                app.system_prompt.as_ref(),
-                Some(app.mode.as_setting()),
-            )
-        } else {
-            create_saved_session_with_mode(
-                &app.api_messages,
-                &model,
-                &app.workspace,
-                u64::from(app.session.total_tokens),
-                app.system_prompt.as_ref(),
-                Some(app.mode.as_setting()),
-            )
-        };
-        session.metadata.model_provider = app.api_provider.as_str().to_string();
-        app.sync_cost_to_metadata(&mut session.metadata);
-        session.context_references = app.session_context_references.clone();
-        session.artifacts = app.session_artifacts.clone();
+        create_saved_session_with_mode(
+            &app.api_messages,
+            &model,
+            &app.workspace,
+            u64::from(app.session.total_tokens),
+            app.system_prompt.as_ref(),
+            Some(app.mode.as_setting()),
+        )
+    };
+    if let Some(cached) = app
+        .current_session_metadata
+        .as_ref()
+        .filter(|cached| cached.id == session.metadata.id)
+    {
+        session.metadata.created_at = cached.created_at;
+        session.metadata.title.clone_from(&cached.title);
         session
+            .metadata
+            .parent_session_id
+            .clone_from(&cached.parent_session_id);
+        session.metadata.forked_from_message_count = cached.forked_from_message_count;
     }
+    session.metadata.model_provider = app.api_provider.as_str().to_string();
+    app.sync_cost_to_metadata(&mut session.metadata);
+    session.context_references = app.session_context_references.clone();
+    session.artifacts = app.session_artifacts.clone();
+    session.work_state = work_state;
+    app.current_session_metadata = Some(session.metadata.clone());
+    Ok(session)
+}
+
+fn apply_picker_session_rename_to_active_app(
+    app: &mut App,
+    metadata: crate::session_manager::SessionMetadata,
+) -> bool {
+    if app.current_session_id.as_deref() != Some(metadata.id.as_str()) {
+        return false;
+    }
+    app.session_title = Some(metadata.title.clone());
+    app.current_session_metadata = Some(metadata);
+    true
 }
 
 fn queued_ui_to_session(msg: &QueuedMessage) -> QueuedSessionMessage {
@@ -6163,13 +6195,27 @@ fn turn_stall_watchdog_timeout(app: &App) -> Duration {
 /// written to disk, so `--continue` loads the *previous* save — effectively
 /// losing the entire in-progress turn.
 fn persist_recovery_snapshot(app: &mut App) {
-    if let Ok(manager) = SessionManager::default_location() {
-        let session = build_session_snapshot(app, &manager);
+    if let Ok(manager) = SessionManager::default_location()
+        && let Ok(session) = build_session_snapshot(app, &manager)
+    {
         if app.current_session_id.is_none() {
             app.current_session_id = Some(session.metadata.id.clone());
         }
         persistence_actor::persist(PersistRequest::SessionSnapshot(session));
     }
+}
+
+fn persist_full_reset_snapshot(app: &mut App) {
+    if let Ok(manager) = SessionManager::default_location()
+        && let Ok(session) = build_session_snapshot(app, &manager)
+    {
+        app.current_session_id = Some(session.metadata.id.clone());
+        persistence_actor::persist(PersistRequest::SessionSnapshot(session));
+    }
+    // `/clear` and `/new` are explicit boundaries. Never let an older
+    // in-flight checkpoint resurrect the session the user just discarded,
+    // even if the replacement snapshot could not be constructed.
+    persistence_actor::persist(PersistRequest::ClearCheckpoint);
 }
 
 fn maybe_throttled_recovery_snapshot(
@@ -6687,7 +6733,13 @@ async fn tool_result_content_for_api_message(
     }
 
     if matches!(name, "run_tests" | "run_verifiers" | "task_gate_run") {
-        return crate::core::engine::compact_tool_result_for_context(&app.model, name, output);
+        return crate::core::engine::compact_tool_result_for_route(
+            app.api_provider,
+            &app.model,
+            app.active_route_limits,
+            name,
+            output,
+        );
     }
 
     if raw.chars().count() > crate::tool_output_receipts::RAW_TOOL_OUTPUT_RECEIPT_THRESHOLD_CHARS {
@@ -6707,7 +6759,13 @@ async fn tool_result_content_for_api_message(
         }
     }
 
-    crate::core::engine::compact_tool_result_for_context(&app.model, name, output)
+    crate::core::engine::compact_tool_result_for_route(
+        app.api_provider,
+        &app.model,
+        app.active_route_limits,
+        name,
+        output,
+    )
 }
 
 fn live_tool_receipt_messages(app: &App, id: &str, raw: &str, success: bool) -> Vec<Message> {
@@ -7204,8 +7262,9 @@ async fn dispatch_user_message(
     app.session.last_reasoning_replay_tokens = None;
     // Persist immediately so abrupt termination can recover this in-flight turn.
     // Offloaded to the persistence actor.
-    if let Ok(manager) = SessionManager::default_location() {
-        let session = build_session_snapshot(app, &manager);
+    if let Ok(manager) = SessionManager::default_location()
+        && let Ok(session) = build_session_snapshot(app, &manager)
+    {
         persistence_actor::persist(PersistRequest::Checkpoint(session));
     }
 
@@ -7269,6 +7328,8 @@ async fn dispatch_user_message(
             mode: app.mode,
             provider: Some(effective_provider),
             model: effective_model,
+            route_limits: app.active_route_limits,
+            compaction: Box::new(app.compaction_config()),
             goal_objective: app.hunt.quarry.clone(),
             goal_token_budget: app.hunt.token_budget,
             goal_status: app.hunt.verdict.goal_status(),
@@ -8137,6 +8198,38 @@ async fn apply_command_result(
                     app.current_session_id = Some(new_session_id.clone());
                     session_id = Some(new_session_id);
                 }
+                let workspace_changed = task_manager.default_workspace().await != workspace;
+                if workspace_changed {
+                    apply_workspace_runtime_state(app, config, workspace.clone());
+                    sync_runtime_workspace_state(task_manager, workspace.clone()).await;
+                }
+                let provider_changed = config.api_provider() != app.api_provider;
+                if provider_changed {
+                    let provider_name = app.api_provider.as_str().to_string();
+                    restore_loaded_session_provider(app, config, &provider_name);
+                    config.provider_config_for_mut(app.api_provider).model = Some(model.clone());
+                }
+                // Re-resolve from the live config even when the provider did
+                // not change. The command layer intentionally has no Config
+                // handle, so its provisional limits cannot include current
+                // provider overrides.
+                resolve_loaded_session_route(app, config);
+                app.update_model_compaction_budget();
+                if provider_changed || workspace_changed {
+                    let _ = engine_handle.send(Op::Shutdown).await;
+                    *engine_handle = spawn_engine(build_engine_config(app, config), config);
+                }
+                // SyncSession carries the conversation but not resolved route
+                // limits. Refresh the engine's model first so a loaded,
+                // forked, or freshly reset session cannot retain the previous
+                // route's context/output facts.
+                let _ = engine_handle
+                    .send(Op::SetModel {
+                        model: model.clone(),
+                        mode,
+                        route_limits: app.active_route_limits,
+                    })
+                    .await;
                 let _ = engine_handle
                     .send(Op::SyncSession {
                         session_id,
@@ -8154,12 +8247,7 @@ async fn apply_command_result(
                     })
                     .await;
                 if is_full_reset {
-                    if let Ok(manager) = SessionManager::default_location() {
-                        let session = build_session_snapshot(app, &manager);
-                        app.current_session_id = Some(session.metadata.id.clone());
-                        persistence_actor::persist(PersistRequest::SessionSnapshot(session));
-                    }
-                    persistence_actor::persist(PersistRequest::ClearCheckpoint);
+                    persist_full_reset_snapshot(app);
                 }
             }
             AppAction::ModeChanged(_mode) => {
@@ -9626,10 +9714,14 @@ fn render(f: &mut Frame, app: &mut App, config: &Config) {
 
     // Render header
     {
-        let sanitized_context_window = context_usage
-            .as_ref()
-            .map(|(_, max, _)| *max)
-            .or_else(|| crate::models::context_window_for_model(&app.model));
+        let sanitized_context_window =
+            context_usage.as_ref().map(|(_, max, _)| *max).or_else(|| {
+                Some(crate::route_budget::route_context_window_tokens(
+                    app.api_provider,
+                    app.effective_model_for_budget(),
+                    app.active_route_limits,
+                ))
+            });
         let sanitized_prompt_tokens = context_usage
             .as_ref()
             .and_then(|(used, _, _)| u32::try_from(*used).ok());
@@ -10415,8 +10507,31 @@ async fn handle_view_events(
 
                 match manager.load_session(&session_id) {
                     Ok(session) => {
-                        let recovered = apply_loaded_session(app, config, &session);
+                        let previous_provider = app.api_provider;
+                        let previous_workspace = app.workspace.clone();
+                        let recovered = match apply_loaded_session(app, config, &session) {
+                            Ok(recovered) => recovered,
+                            Err(err) => {
+                                app.status_message =
+                                    Some(format!("Failed to restore session: {err}"));
+                                continue;
+                            }
+                        };
                         sync_runtime_workspace_state(task_manager, app.workspace.clone()).await;
+                        if app.api_provider != previous_provider
+                            || app.workspace != previous_workspace
+                        {
+                            let _ = engine_handle.send(Op::Shutdown).await;
+                            *engine_handle = spawn_engine(build_engine_config(app, config), config);
+                        } else {
+                            let _ = engine_handle
+                                .send(Op::SetModel {
+                                    model: app.model.clone(),
+                                    mode: app.mode,
+                                    route_limits: app.active_route_limits,
+                                })
+                                .await;
+                        }
                         let _ = engine_handle
                             .send(Op::SyncSession {
                                 session_id: app.current_session_id.clone(),
@@ -10447,6 +10562,31 @@ async fn handle_view_events(
                         ));
                     }
                 }
+            }
+            ViewEvent::SessionRenamed { metadata } => {
+                let session_id = metadata.id.clone();
+                let title = metadata.title.clone();
+                if apply_picker_session_rename_to_active_app(app, metadata)
+                    && let Ok(manager) = SessionManager::default_location()
+                {
+                    match build_session_snapshot(app, &manager) {
+                        Ok(session) => {
+                            persistence_actor::persist(PersistRequest::SessionSnapshot(session))
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                error = %err,
+                                "Could not queue active session rename snapshot"
+                            );
+                        }
+                    }
+                }
+                app.status_message = Some(format!(
+                    "Renamed session {} to \"{}\"",
+                    crate::session_manager::truncate_id(&session_id),
+                    title
+                ));
             }
             ViewEvent::SessionDeleted { session_id, title } => {
                 app.status_message = Some(format!(
@@ -11786,7 +11926,20 @@ fn set_provider_auth_mode_in_memory(config: &mut Config, provider: ApiProvider, 
     entry.auth_mode = Some(auth_mode);
 }
 
-fn apply_loaded_session(app: &mut App, config: &mut Config, session: &SavedSession) -> bool {
+fn apply_loaded_session(
+    app: &mut App,
+    config: &mut Config,
+    session: &SavedSession,
+) -> Result<bool, String> {
+    if app.session_transition_blocked() {
+        return Err(
+            "runtime work is active; wait for the current turn, maintenance, and background tasks to finish, or cancel that specific work before switching sessions".to_string(),
+        );
+    }
+    // Restore/validate the contended state before mutating conversation or
+    // workspace fields. A failed session switch must leave the current session
+    // wholly intact.
+    app.restore_work_state(session.work_state.as_ref())?;
     let (messages, recovered_draft) = recover_interrupted_user_tail(&session.messages);
     app.api_messages = messages;
     app.clear_history();
@@ -11801,7 +11954,6 @@ fn apply_loaded_session(app: &mut App, config: &mut Config, session: &SavedSessi
     app.ignored_tool_calls.clear();
     app.pending_tool_uses.clear();
     app.last_exec_wait_command = None;
-
     let messages = app.api_messages.clone();
     let mut message_to_cell = std::collections::HashMap::new();
     for (message_index, msg) in messages.iter().enumerate() {
@@ -11833,6 +11985,7 @@ fn apply_loaded_session(app: &mut App, config: &mut Config, session: &SavedSessi
     app.viewport.transcript_selection.clear();
     restore_loaded_session_provider(app, config, &session.metadata.model_provider);
     app.set_model_selection(session.metadata.model.clone());
+    resolve_loaded_session_route(app, config);
     app.provider_models.insert(
         app.api_provider.as_str().to_string(),
         app.model_selection_for_persistence(),
@@ -11880,6 +12033,7 @@ fn apply_loaded_session(app: &mut App, config: &mut Config, session: &SavedSessi
     app.cumulative_turn_duration =
         std::time::Duration::from_secs(session.metadata.cumulative_turn_secs);
     app.current_session_id = Some(session.metadata.id.clone());
+    app.current_session_metadata = Some(session.metadata.clone());
     app.session_artifacts = session.artifacts.clone();
     app.session_title = Some(session.metadata.title.clone());
     app.workspace_context = None;
@@ -11896,7 +12050,7 @@ fn apply_loaded_session(app: &mut App, config: &mut Config, session: &SavedSessi
         false
     };
     app.scroll_to_bottom();
-    recovered
+    Ok(recovered)
 }
 
 fn restore_loaded_session_provider(app: &mut App, config: &mut Config, model_provider: &str) {
@@ -11918,6 +12072,29 @@ fn restore_loaded_session_provider(app: &mut App, config: &mut Config, model_pro
     app.reasoning_effort = app.reasoning_effort.normalize_for_provider(provider);
     app.set_active_context_window_override(config.context_window_for_provider_config(provider));
     app.active_route_limits = app.context_window_override_limits();
+}
+
+fn resolve_loaded_session_route(app: &mut App, config: &Config) {
+    let context_override = config.context_window_for_provider_config(app.api_provider);
+    app.set_active_context_window_override(context_override);
+    if app.auto_model {
+        app.active_route_limits = app.context_window_override_limits();
+        return;
+    }
+
+    let saved_provider_model = config
+        .provider_config_for(app.api_provider)
+        .and_then(|provider| provider.model.as_deref());
+    app.active_route_limits = resolve_route_candidate(
+        app.api_provider,
+        Some(&app.model),
+        saved_provider_model,
+        Some(config.deepseek_base_url()),
+        context_override,
+    )
+    .ok()
+    .and_then(|candidate| crate::route_budget::known_route_limits(candidate.limits))
+    .or_else(|| app.context_window_override_limits());
 }
 
 /// Derive a short display title from the API message list.

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -2242,6 +2242,7 @@ fn saved_session_with_messages(messages: Vec<Message>) -> SavedSession {
         system_prompt: None,
         context_references: Vec::new(),
         artifacts: Vec::new(),
+        work_state: None,
     }
 }
 
@@ -2253,7 +2254,8 @@ fn apply_loaded_session_restores_dangling_user_tail_as_retry_draft() {
         "finish the Qthresh proof bundle",
     )]);
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(recovered);
     assert!(app.api_messages.is_empty());
@@ -2283,7 +2285,8 @@ fn apply_loaded_session_does_not_restore_slash_command_tail_as_retry_draft() {
     let mut app = create_test_app();
     let session = saved_session_with_messages(vec![text_message("user", "/sessions")]);
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(!recovered);
     assert_eq!(app.input, "");
@@ -2325,7 +2328,8 @@ fn apply_loaded_session_resets_unpersisted_telemetry() {
     let mut session = saved_session_with_messages(vec![text_message("assistant", "ready")]);
     session.metadata.total_tokens = 500;
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(!recovered);
     assert_eq!(app.session.total_tokens, 500);
@@ -2368,7 +2372,7 @@ async fn apply_loaded_session_resets_workspace_runtime_state() {
     let mut session = saved_session_with_messages(vec![text_message("assistant", "ready")]);
     session.metadata.workspace = TempDir::new().expect("temp dir").path().to_path_buf();
 
-    let recovered = apply_loaded_session(&mut app, &mut config, &session);
+    let recovered = apply_loaded_session(&mut app, &mut config, &session).expect("restore session");
 
     assert!(!recovered);
     assert_eq!(app.workspace, session.metadata.workspace);
@@ -2431,7 +2435,7 @@ fn apply_loaded_session_updates_current_workspace_display() {
     let mut session = saved_session_with_messages(vec![text_message("assistant", "ready")]);
     session.metadata.workspace = workspace.path().to_path_buf();
 
-    let recovered = apply_loaded_session(&mut app, &mut config, &session);
+    let recovered = apply_loaded_session(&mut app, &mut config, &session).expect("restore session");
     let result = commands::execute("/workspace", &mut app);
 
     assert!(!recovered);
@@ -4753,7 +4757,17 @@ fn hidden_sidebar_focus_suppresses_sidebar_split_even_when_wide() {
 }
 
 #[test]
-fn sidebar_width_gate_uses_sixty_four_column_boundary() {
+fn compact_sidebar_split_survives_eighty_column_file_tree_host() {
+    let mut app = create_test_app();
+    app.sidebar_focus = SidebarFocus::Pinned;
+
+    // 80-column body -> 20-column file tree + 60-column chat host.
+    assert_eq!(sidebar_width_for_chat_area(&app, 60), Some(20));
+    assert_eq!(sidebar_width_for_chat_area(&app, 59), None);
+}
+
+#[test]
+fn sidebar_width_gate_uses_compact_sixty_column_boundary() {
     let mut app = create_test_app();
     app.sidebar_focus = SidebarFocus::Pinned;
     app.last_sidebar_host_width = Some(SIDEBAR_VISIBLE_MIN_WIDTH - 1);
@@ -5435,6 +5449,7 @@ fn subagent_token_usage_updates_live_cost_counter_without_card_change() {
         1,
         &crate::tools::subagent::MailboxMessage::TokenUsage {
             agent_id: "agent-a".to_string(),
+            provider: ApiProvider::Deepseek,
             model: "deepseek-v4-flash".to_string(),
             usage: crate::models::Usage {
                 input_tokens: 10_000,
@@ -5452,10 +5467,37 @@ fn subagent_token_usage_updates_live_cost_counter_without_card_change() {
 }
 
 #[test]
+fn subagent_token_usage_prices_the_child_route_not_the_parent_route() {
+    let mut app = create_test_app();
+    assert_eq!(app.api_provider, ApiProvider::Deepseek);
+
+    handle_subagent_mailbox(
+        &mut app,
+        2,
+        &crate::tools::subagent::MailboxMessage::TokenUsage {
+            agent_id: "agent-codex".to_string(),
+            provider: ApiProvider::OpenaiCodex,
+            model: "gpt-5.5".to_string(),
+            usage: crate::models::Usage {
+                input_tokens: 10_000,
+                output_tokens: 1_000,
+                ..Default::default()
+            },
+        },
+    );
+
+    assert_eq!(
+        app.session.subagent_cost, 0.0,
+        "ChatGPT/Codex child usage must not inherit the DeepSeek parent's pricing"
+    );
+}
+
+#[test]
 fn subagent_token_usage_is_deduped_by_mailbox_sequence() {
     let mut app = create_test_app();
     let usage = crate::tools::subagent::MailboxMessage::TokenUsage {
         agent_id: "agent-a".to_string(),
+        provider: ApiProvider::Deepseek,
         model: "deepseek-v4-flash".to_string(),
         usage: crate::models::Usage {
             input_tokens: 10_000,
@@ -6553,7 +6595,7 @@ fn issue_2739_stalled_turn_snapshot_preserves_api_messages() {
     // which in turn calls build_session_snapshot. Since persistence
     // may fail in tests (no real home dir), we verify directly that
     // build_session_snapshot captures the in-progress messages.
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
     assert_eq!(snapshot.messages.len(), 2);
     assert_eq!(snapshot.messages[0].role, "user");
     assert_eq!(snapshot.messages[1].role, "assistant");
@@ -6583,7 +6625,7 @@ fn issue_2739_esc_cancel_preserves_session_messages_before_clear() {
         app.current_session_id.is_some(),
         "local cancel should create a resumable session snapshot"
     );
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
     assert_eq!(snapshot.messages.len(), 2);
     assert_eq!(snapshot.messages[0].role, "user");
     assert_eq!(snapshot.messages[1].role, "assistant");
@@ -6618,7 +6660,7 @@ fn issue_2739_dispatch_timeout_preserves_user_prompt() {
     // #2739: the user's prompt must survive dispatch-timeout recovery so a
     // snapshot (and therefore --continue) still has it instead of loading the
     // previous save.
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
     assert_eq!(snapshot.messages.len(), 1);
     assert_eq!(snapshot.messages[0].role, "user");
 }
@@ -7605,7 +7647,7 @@ fn throttled_recovery_snapshot_persists_during_loading_turns() {
     let t0 = Instant::now();
     maybe_throttled_recovery_snapshot(&mut app, t0, &mut last_snapshot_at);
     assert!(last_snapshot_at.is_some());
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
     assert_eq!(snapshot.messages.len(), 1);
 
     maybe_throttled_recovery_snapshot(
@@ -8948,6 +8990,95 @@ fn tool_child_usage_metadata_updates_live_cost_counter() {
 }
 
 #[test]
+fn picker_renamed_active_title_survives_automatic_snapshot() {
+    let mut app = create_test_app();
+    let manager = SessionManager::new(tempfile::tempdir().expect("tempdir").path().to_path_buf())
+        .expect("session manager");
+    let mut metadata = crate::session_manager::create_saved_session_with_id_and_mode(
+        "session-active".to_string(),
+        &app.api_messages,
+        &app.model,
+        &app.workspace,
+        0,
+        app.system_prompt.as_ref(),
+        Some(app.mode.as_setting()),
+    )
+    .metadata;
+    metadata.title = "Before".to_string();
+    metadata.parent_session_id = Some("session-parent".to_string());
+    metadata.forked_from_message_count = Some(7);
+    let created_at = metadata.created_at;
+    app.current_session_id = Some(metadata.id.clone());
+    app.current_session_metadata = Some(metadata.clone());
+    app.session_title = Some(metadata.title.clone());
+
+    metadata.title = "After".to_string();
+    assert!(apply_picker_session_rename_to_active_app(
+        &mut app, metadata
+    ));
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("snapshot");
+
+    assert_eq!(snapshot.metadata.title, "After");
+    assert_eq!(snapshot.metadata.created_at, created_at);
+    assert_eq!(
+        snapshot.metadata.parent_session_id.as_deref(),
+        Some("session-parent")
+    );
+    assert_eq!(snapshot.metadata.forked_from_message_count, Some(7));
+}
+
+#[test]
+fn picker_rename_of_inactive_session_does_not_touch_active_metadata() {
+    let mut app = create_test_app();
+    let mut active = crate::session_manager::create_saved_session_with_id_and_mode(
+        "session-active".to_string(),
+        &app.api_messages,
+        &app.model,
+        &app.workspace,
+        0,
+        app.system_prompt.as_ref(),
+        Some(app.mode.as_setting()),
+    )
+    .metadata;
+    active.title = "Active".to_string();
+    let mut inactive = active.clone();
+    inactive.id = "session-inactive".to_string();
+    inactive.title = "Renamed inactive".to_string();
+    app.current_session_id = Some(active.id.clone());
+    app.current_session_metadata = Some(active.clone());
+    app.session_title = Some(active.title.clone());
+
+    assert!(!apply_picker_session_rename_to_active_app(
+        &mut app, inactive
+    ));
+    assert_eq!(app.session_title.as_deref(), Some("Active"));
+    assert_eq!(
+        app.current_session_metadata
+            .as_ref()
+            .map(|metadata| metadata.title.as_str()),
+        Some("Active")
+    );
+}
+
+#[test]
+fn codex_tool_child_usage_does_not_inherit_public_api_pricing() {
+    let mut app = create_test_app();
+    app.api_provider = crate::config::ApiProvider::OpenaiCodex;
+    let result = Ok(crate::tools::spec::ToolResult::success("ok").with_metadata(
+        serde_json::json!({
+            "child_model": "gpt-5.5",
+            "child_input_tokens": 10_000,
+            "child_output_tokens": 1_000,
+            "child_provider": "openai-codex",
+        }),
+    ));
+
+    handle_tool_call_complete(&mut app, "review-usage", "review", &result);
+
+    assert_eq!(app.session.subagent_cost, 0.0);
+}
+
+#[test]
 fn spilled_tool_completion_records_session_artifact_metadata() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let spillover_path = tmp.path().join("call-big.txt");
@@ -8984,7 +9115,7 @@ fn spilled_tool_completion_records_session_artifact_metadata() {
 
     let manager =
         crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
     assert_eq!(snapshot.artifacts, app.session_artifacts);
 }
 
@@ -8997,7 +9128,7 @@ fn first_snapshot_preserves_current_session_id_for_artifact_ownership() {
     app.current_session_id = Some("session-123".to_string());
     app.api_messages.push(text_message("user", "hello"));
 
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
 
     assert_eq!(snapshot.metadata.id, "session-123");
 }
@@ -9018,10 +9149,306 @@ fn existing_session_snapshot_updates_model_selection() {
     app.api_messages.push(text_message("user", "hello"));
     app.set_model_selection("deepseek-v4-flash".to_string());
 
-    let snapshot = build_session_snapshot(&app, &manager);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
 
     assert_eq!(snapshot.metadata.id, existing.metadata.id);
     assert_eq!(snapshot.metadata.model, "deepseek-v4-flash");
+}
+
+#[test]
+fn session_snapshot_and_resume_round_trip_work_state() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manager =
+        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let mut app = create_test_app();
+    app.api_messages.push(text_message("user", "keep my work"));
+    app.api_messages
+        .push(text_message("assistant", "continuity captured"));
+    {
+        let mut todos = app.todos.try_lock().expect("todos lock");
+        todos.add(
+            "inspect".to_string(),
+            crate::tools::todo::TodoStatus::Completed,
+        );
+        todos.add(
+            "patch".to_string(),
+            crate::tools::todo::TodoStatus::InProgress,
+        );
+    }
+    {
+        let mut plan = app.plan_state.try_lock().expect("plan lock");
+        plan.update(crate::tools::plan::UpdatePlanArgs {
+            objective: Some("Ship continuity".to_string()),
+            plan: vec![crate::tools::plan::PlanItemArg {
+                step: "verify".to_string(),
+                status: crate::tools::plan::StepStatus::InProgress,
+            }],
+            ..crate::tools::plan::UpdatePlanArgs::default()
+        });
+    }
+
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("session snapshot");
+    let expected = snapshot.work_state.clone().expect("persisted Work state");
+    manager.save_session(&snapshot).expect("save session");
+
+    let loaded = manager
+        .load_session(&snapshot.metadata.id)
+        .expect("load session");
+    let mut restored = create_test_app();
+    let recovered = apply_loaded_session(&mut restored, &mut Config::default(), &loaded)
+        .expect("restore session");
+    assert!(!recovered);
+    assert_eq!(
+        restored.work_state_snapshot().expect("restored snapshot"),
+        Some(expected)
+    );
+}
+
+#[test]
+fn session_snapshot_preserves_last_work_state_when_lock_is_busy() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manager =
+        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let mut app = create_test_app();
+    app.current_session_id = Some("work-lock-session".to_string());
+    app.todos.try_lock().expect("todos lock").add(
+        "durable".to_string(),
+        crate::tools::todo::TodoStatus::InProgress,
+    );
+    let initial = build_session_snapshot(&mut app, &manager).expect("initial snapshot");
+    let expected = initial.work_state.clone();
+    manager.save_session(&initial).expect("save initial");
+
+    let todos = app.todos.clone();
+    let _held = todos.try_lock().expect("hold todos lock");
+    let contended = build_session_snapshot(&mut app, &manager).expect("contended snapshot");
+    assert_eq!(contended.work_state, expected);
+}
+
+#[test]
+fn session_snapshot_prefers_newer_memory_over_stale_disk_when_lock_is_busy() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manager =
+        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let mut app = create_test_app();
+    app.current_session_id = Some("work-cache-newer-than-disk".to_string());
+    app.todos.try_lock().expect("todos lock").add(
+        "disk state".to_string(),
+        crate::tools::todo::TodoStatus::Completed,
+    );
+    let disk_snapshot = build_session_snapshot(&mut app, &manager).expect("disk snapshot");
+    manager
+        .save_session(&disk_snapshot)
+        .expect("save disk snapshot");
+
+    app.todos.try_lock().expect("todos lock").add(
+        "newer memory state".to_string(),
+        crate::tools::todo::TodoStatus::InProgress,
+    );
+    let memory_snapshot = build_session_snapshot(&mut app, &manager).expect("memory snapshot");
+    assert_ne!(memory_snapshot.work_state, disk_snapshot.work_state);
+
+    let todos = app.todos.clone();
+    let _held = todos.try_lock().expect("hold todos lock");
+    let contended = build_session_snapshot(&mut app, &manager).expect("contended snapshot");
+
+    assert_eq!(contended.work_state, memory_snapshot.work_state);
+}
+
+#[test]
+fn automatic_session_snapshot_never_reloads_existing_json_on_ui_thread() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sessions_dir = tmp.path().join("sessions");
+    let manager =
+        crate::session_manager::SessionManager::new(sessions_dir.clone()).expect("manager");
+    let mut app = create_test_app();
+    app.current_session_id = Some("nonblocking-snapshot".to_string());
+    app.api_messages
+        .push(text_message("user", "first in-memory checkpoint"));
+    let initial = build_session_snapshot(&mut app, &manager).expect("initial snapshot");
+    manager.save_session(&initial).expect("save initial");
+    std::fs::write(
+        sessions_dir.join("nonblocking-snapshot.json"),
+        "{ intentionally malformed and never read",
+    )
+    .expect("corrupt disk fixture");
+    app.api_messages
+        .push(text_message("assistant", "newer in-memory state"));
+
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("nonblocking snapshot");
+
+    assert_eq!(snapshot.metadata.id, "nonblocking-snapshot");
+    assert_eq!(snapshot.messages.len(), 2);
+    assert_eq!(snapshot.metadata.created_at, initial.metadata.created_at);
+}
+
+#[test]
+fn renamed_title_survives_next_in_memory_automatic_snapshot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manager =
+        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let mut session = saved_session_with_messages(vec![text_message("user", "original title")]);
+    session.metadata.title = "Original Title".to_string();
+    manager.save_session(&session).expect("save session");
+    let mut app = create_test_app();
+    app.current_session_id = Some(session.metadata.id.clone());
+    app.api_messages.clone_from(&session.messages);
+
+    let renamed = crate::commands::rename_session_with_manager(
+        "Renamed In Memory",
+        &session.metadata.id,
+        &manager,
+        &mut app,
+    );
+    assert!(!renamed.is_error, "{:?}", renamed.message);
+    let snapshot = build_session_snapshot(&mut app, &manager).expect("automatic snapshot");
+
+    assert_eq!(snapshot.metadata.title, "Renamed In Memory");
+}
+
+#[test]
+fn session_snapshot_uses_last_known_work_before_first_file_flush() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manager =
+        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let mut app = create_test_app();
+    app.todos.try_lock().expect("todos lock").add(
+        "queued durable state".to_string(),
+        crate::tools::todo::TodoStatus::InProgress,
+    );
+    let initial = build_session_snapshot(&mut app, &manager).expect("initial snapshot");
+    let expected = initial.work_state.clone();
+    app.current_session_id = Some(initial.metadata.id);
+    app.api_messages
+        .push(text_message("user", "new transcript content"));
+
+    let todos = app.todos.clone();
+    let _held = todos.try_lock().expect("hold todos lock");
+    let contended = build_session_snapshot(&mut app, &manager).expect("cached snapshot");
+
+    assert_eq!(contended.work_state, expected);
+    assert_eq!(contended.messages.len(), 1);
+}
+
+#[test]
+fn first_contended_snapshot_fails_instead_of_serializing_false_empty_work() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manager =
+        crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
+    let mut app = create_test_app();
+    app.todos.try_lock().expect("todos lock").add(
+        "not empty".to_string(),
+        crate::tools::todo::TodoStatus::InProgress,
+    );
+    let todos = app.todos.clone();
+    let _held = todos.try_lock().expect("hold todos lock");
+
+    let err = build_session_snapshot(&mut app, &manager).unwrap_err();
+
+    assert!(err.contains("skipped"), "{err}");
+}
+
+#[test]
+fn legacy_session_without_work_state_clears_previous_todo_on_load() {
+    let mut app = create_test_app();
+    app.todos.try_lock().expect("todos lock").add(
+        "old session".to_string(),
+        crate::tools::todo::TodoStatus::Pending,
+    );
+    let session = saved_session_with_messages(vec![text_message("user", "legacy")]);
+    assert!(session.work_state.is_none());
+
+    apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
+    assert_eq!(app.work_state_snapshot().expect("snapshot"), None);
+}
+
+#[test]
+fn contended_work_restore_leaves_current_session_wholly_unchanged() {
+    let mut app = create_test_app();
+    app.api_messages
+        .push(text_message("user", "current conversation"));
+    app.current_session_id = Some("current-session".to_string());
+    let mut session = saved_session_with_messages(vec![text_message("user", "replacement")]);
+    session.work_state = Some(crate::session_manager::SessionWorkState {
+        todos: crate::tools::todo::TodoListSnapshot {
+            items: vec![crate::tools::todo::TodoItem {
+                id: 1,
+                content: "replacement todo".to_string(),
+                status: crate::tools::todo::TodoStatus::Pending,
+            }],
+            completion_pct: 0,
+            in_progress_id: None,
+        },
+        plan: crate::tools::plan::PlanSnapshot::default(),
+    });
+    let plan_state = app.plan_state.clone();
+    let _held = plan_state.try_lock().expect("hold plan lock");
+
+    let err = apply_loaded_session(&mut app, &mut Config::default(), &session).unwrap_err();
+
+    assert!(err.contains("session was not restored"), "{err}");
+    assert_eq!(app.api_messages.len(), 1);
+    assert_eq!(app.current_session_id.as_deref(), Some("current-session"));
+}
+
+#[test]
+fn session_picker_restore_rejects_active_turn_before_mutating() {
+    let mut app = create_test_app();
+    app.api_messages
+        .push(text_message("user", "current active conversation"));
+    app.current_session_id = Some("current-session".to_string());
+    app.is_loading = true;
+    app.runtime_turn_status = Some("in_progress".to_string());
+    let session = saved_session_with_messages(vec![text_message("user", "replacement")]);
+
+    let err = apply_loaded_session(&mut app, &mut Config::default(), &session).unwrap_err();
+
+    assert!(err.contains("runtime work is active"), "{err}");
+    assert_eq!(app.api_messages.len(), 1);
+    assert_eq!(app.current_session_id.as_deref(), Some("current-session"));
+}
+
+#[test]
+fn session_restore_rebuilds_fresh_codex_route_limits() {
+    let _lock = crate::test_support::lock_test_env();
+    let codex_home = tempfile::tempdir().expect("Codex home");
+    let _codex_home = crate::test_support::EnvVarGuard::set("CODEX_HOME", codex_home.path());
+    std::fs::write(
+        codex_home.path().join("models_cache.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "fetched_at": chrono::Utc::now(),
+            "models": [{
+                "slug": crate::config::DEFAULT_OPENAI_CODEX_MODEL,
+                "priority": 1,
+                "context_window": 272000,
+                "supported_reasoning_levels": [{"effort": "high"}]
+            }]
+        }))
+        .expect("serialize cache"),
+    )
+    .expect("write cache");
+    let mut app = create_test_app();
+    let mut config = Config::default();
+    let mut session = saved_session_with_messages(vec![text_message("user", "resume Codex")]);
+    session.metadata.model_provider = ApiProvider::OpenaiCodex.as_str().to_string();
+    session.metadata.model = crate::config::DEFAULT_OPENAI_CODEX_MODEL.to_string();
+
+    apply_loaded_session(&mut app, &mut config, &session).expect("restore session");
+
+    assert_eq!(app.api_provider, ApiProvider::OpenaiCodex);
+    assert_eq!(app.model, crate::config::DEFAULT_OPENAI_CODEX_MODEL);
+    assert_eq!(
+        app.active_route_limits
+            .and_then(|limits| limits.context_tokens),
+        Some(272_000)
+    );
+    let engine_config = build_engine_config(&app, &config);
+    assert_eq!(
+        engine_config
+            .active_route_limits
+            .and_then(|limits| limits.context_tokens),
+        Some(272_000)
+    );
 }
 
 #[test]
@@ -9034,7 +9461,8 @@ fn apply_loaded_session_restores_concrete_model_mode() {
     ]);
     session.metadata.model = "deepseek-v4-flash".to_string();
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(!recovered);
     assert!(!app.auto_model);
@@ -9055,7 +9483,8 @@ fn apply_loaded_session_restores_auto_model_mode() {
     ]);
     session.metadata.model = "auto".to_string();
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(!recovered);
     assert!(app.auto_model);
@@ -9077,7 +9506,8 @@ fn apply_loaded_session_restores_saved_mode() {
     ]);
     session.metadata.mode = Some("plan".to_string());
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(!recovered);
     assert_eq!(app.mode, crate::tui::app::AppMode::Plan);
@@ -9253,7 +9683,8 @@ fn apply_loaded_session_restores_artifact_registry() {
         storage_path: PathBuf::from("/tmp/tool_outputs/call-big.txt"),
     });
 
-    let recovered = apply_loaded_session(&mut app, &mut Config::default(), &session);
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
 
     assert!(!recovered);
     assert_eq!(app.session_artifacts, session.artifacts);
@@ -11776,6 +12207,7 @@ fn duplicate_mailbox_token_usage_does_not_regress_displayed_cost() {
     let mut app = create_test_app();
     let usage = crate::tools::subagent::MailboxMessage::TokenUsage {
         agent_id: "agent-x".to_string(),
+        provider: ApiProvider::Deepseek,
         model: "deepseek-v4-flash".to_string(),
         usage: crate::models::Usage {
             input_tokens: 10_000,

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -557,6 +557,9 @@ pub enum ViewEvent {
     SessionSelected {
         session_id: String,
     },
+    SessionRenamed {
+        metadata: crate::session_manager::SessionMetadata,
+    },
     SessionDeleted {
         session_id: String,
         title: String,

--- a/crates/tui/src/tui/widgets/footer.rs
+++ b/crates/tui/src/tui/widgets/footer.rs
@@ -14,7 +14,7 @@
 //! | Glance fact | Footer field | Drill-down owner |
 //! |-------------|--------------|------------------|
 //! | state | `state_label` (+ working strip) | transcript / live work strip |
-//! | work count | `agents` | Agents sidebar, `/fleet` |
+//! | work count | `work`, `agents` | To-do/Agents sidebar, `/fleet` |
 //! | mode | `mode_label` | `/mode` picker |
 //! | permission | `permission` | Shift+Tab cycle, `/config` |
 //! | cost/rate | `cost`, `balance`, `cache` | `/tokens`, context inspector |
@@ -34,7 +34,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
-use crate::tui::app::{App, AppMode};
+use crate::tui::app::{App, AppMode, SidebarFocus};
 
 use super::Renderable;
 
@@ -74,6 +74,9 @@ pub struct FooterProps {
     pub mcp: Vec<Span<'static>>,
     /// Permission posture chip (Ask / Auto-Review / Full Access) when visible.
     pub permission: Vec<Span<'static>>,
+    /// Compact nonempty Work indicator when terminal width suppresses the
+    /// sidebar. Empty when Work is visible or explicitly hidden.
+    pub work: Vec<Span<'static>>,
     /// Cumulative model-work chip spans ("worked 3h 12m"). Sums the
     /// elapsed time of completed turns (from `App::cumulative_turn_duration`),
     /// **not** wall-clock since launch — an idle TUI shouldn't claim
@@ -286,6 +289,7 @@ impl FooterProps {
             .map(|s| s.servers.iter().filter(|server| server.connected).count());
         let mcp = footer_mcp_chip(mcp_connected, mcp_configured);
         let permission = footer_permission_chip(app);
+        let work = footer_compact_work_chip(app);
         // #448: cumulative work-time chip. Sums actual turn durations
         // (set on `TurnComplete`) rather than wall-clock uptime — a TUI
         // that's been open and idle for 4 minutes shouldn't claim
@@ -307,6 +311,7 @@ impl FooterProps {
             cache,
             mcp,
             permission,
+            work,
             worked,
             cost,
             balance,
@@ -334,10 +339,11 @@ fn mode_style(app: &App) -> (&'static str, Color) {
 }
 
 pub fn footer_permission_chip(app: &App) -> Vec<Span<'static>> {
-    if !app.mode.uses_agent_baseline() && app.mode != AppMode::Yolo {
-        return Vec::new();
-    }
-    let label = app.approval_mode.permission_chip_label();
+    let label = if app.mode == AppMode::Plan {
+        "Read Only"
+    } else {
+        app.approval_mode.permission_chip_label()
+    };
     vec![
         Span::raw("perm "),
         Span::styled(
@@ -345,6 +351,22 @@ pub fn footer_permission_chip(app: &App) -> Vec<Span<'static>> {
             Style::default().fg(app.ui_theme.text_hint),
         ),
     ]
+}
+
+fn footer_compact_work_chip(app: &App) -> Vec<Span<'static>> {
+    if app.sidebar_focus == SidebarFocus::Hidden
+        || !app
+            .last_sidebar_host_width
+            .is_some_and(|width| width < crate::tui::ui::SIDEBAR_VISIBLE_MIN_WIDTH)
+    {
+        return Vec::new();
+    }
+    crate::tui::sidebar::compact_work_indicator(app).map_or_else(Vec::new, |label| {
+        vec![Span::styled(
+            label,
+            Style::default().fg(palette::WHALE_INFO),
+        )]
+    })
 }
 
 /// Pure-render footer. Build once per frame, then `render(area, buf)`.
@@ -365,6 +387,7 @@ impl FooterWidget {
         // disappear without disturbing the steady mode·model·cost line.
         let parts: Vec<&Vec<Span<'static>>> = [
             &self.props.permission,
+            &self.props.work,
             &self.props.agents,
             &self.props.reasoning_replay,
             &self.props.cache,
@@ -649,7 +672,23 @@ impl Renderable for FooterWidget {
             }
         }
 
-        let preview_left_spans = self.left_spans(available_width);
+        // Permission posture is a safety fact. Reserve it before allowing a
+        // long toast/model label to consume the row, then let lower-priority
+        // auxiliary chips fill whatever remains.
+        let permission_width = span_width(&self.props.permission);
+        let work_width = span_width(&self.props.work);
+        let critical_inner_gap = usize::from(permission_width > 0 && work_width > 0) * 2;
+        let critical_width = permission_width + critical_inner_gap + work_width;
+        let reserved_gap = usize::from(critical_width > 0) * 2;
+        let preview_left_budget = if critical_width > 0 {
+            available_width
+                .saturating_sub(critical_width)
+                .saturating_sub(reserved_gap)
+                .max(1)
+        } else {
+            available_width
+        };
+        let preview_left_spans = self.left_spans(preview_left_budget);
         let preview_left_width = span_width(&preview_left_spans);
         let right_budget = available_width
             .saturating_sub(preview_left_width)
@@ -1230,6 +1269,147 @@ mod tests {
             .collect::<String>()
             .trim_end()
             .to_string()
+    }
+
+    #[test]
+    fn permission_chip_reports_effective_posture_for_every_visible_mode() {
+        let mut app = make_app();
+        app.approval_mode = crate::tui::approval::ApprovalMode::Bypass;
+
+        app.mode = AppMode::Agent;
+        assert_eq!(
+            super::spans_text(&super::footer_permission_chip(&app)),
+            "perm Full Access"
+        );
+        app.mode = AppMode::Operate;
+        assert_eq!(
+            super::spans_text(&super::footer_permission_chip(&app)),
+            "perm Full Access"
+        );
+        app.mode = AppMode::Plan;
+        assert_eq!(
+            super::spans_text(&super::footer_permission_chip(&app)),
+            "perm Read Only"
+        );
+    }
+
+    #[test]
+    fn width_suppressed_sidebar_falls_back_to_compact_work_chip() {
+        let mut app = make_app();
+        app.mode = AppMode::Operate;
+        app.approval_mode = crate::tui::approval::ApprovalMode::Bypass;
+        app.last_sidebar_host_width = Some(59);
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add(
+                "inspect".to_string(),
+                crate::tools::todo::TodoStatus::Completed,
+            );
+            todos.add(
+                "patch".to_string(),
+                crate::tools::todo::TodoStatus::InProgress,
+            );
+        }
+
+        let props = FooterProps::from_app(
+            &app,
+            None,
+            "ready",
+            palette::TEXT_MUTED,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(super::spans_text(&props.work), "To-do 2 · 50%");
+        let line = render_at_width(props, 59);
+        assert!(line.contains("To-do 2 · 50%"), "{line:?}");
+        assert!(line.contains("perm Full Access"), "{line:?}");
+
+        app.sidebar_focus = crate::tui::app::SidebarFocus::Hidden;
+        let hidden = FooterProps::from_app(
+            &app,
+            None,
+            "ready",
+            palette::TEXT_MUTED,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        assert!(hidden.work.is_empty());
+    }
+
+    #[test]
+    fn permission_safety_chip_survives_long_toast_at_release_widths() {
+        let mut app = make_app();
+        app.mode = AppMode::Plan;
+        let props = FooterProps::from_app(
+            &app,
+            Some(super::FooterToast {
+                text:
+                    "Permissions is locked while a turn is running — press Esc to interrupt first"
+                        .to_string(),
+                color: palette::STATUS_WARNING,
+            }),
+            "working",
+            palette::WHALE_INFO,
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+            Vec::<Span<'static>>::new(),
+        );
+
+        for width in [120, 100, 80] {
+            let line = render_at_width(props.clone(), width);
+            assert!(
+                line.contains("perm Read Only"),
+                "effective safety posture missing at {width} cols: {line:?}"
+            );
+            assert!(line.width() <= usize::from(width));
+        }
+    }
+
+    #[test]
+    fn ask_auto_and_full_access_render_at_release_widths() {
+        for (posture, expected) in [
+            (crate::tui::approval::ApprovalMode::Suggest, "perm Ask"),
+            (crate::tui::approval::ApprovalMode::Auto, "perm Auto-Review"),
+            (
+                crate::tui::approval::ApprovalMode::Bypass,
+                "perm Full Access",
+            ),
+        ] {
+            let mut app = make_app();
+            app.mode = AppMode::Operate;
+            app.approval_mode = posture;
+            let props = FooterProps::from_app(
+                &app,
+                Some(super::FooterToast {
+                    text:
+                        "A long runtime status must not displace the effective permission posture"
+                            .to_string(),
+                    color: palette::STATUS_WARNING,
+                }),
+                "working",
+                palette::WHALE_INFO,
+                Vec::<Span<'static>>::new(),
+                Vec::<Span<'static>>::new(),
+                Vec::<Span<'static>>::new(),
+                Vec::<Span<'static>>::new(),
+                Vec::<Span<'static>>::new(),
+            );
+            for width in [120, 100, 80] {
+                let line = render_at_width(props.clone(), width);
+                assert!(
+                    line.contains(expected),
+                    "{expected:?} missing at {width} cols: {line:?}"
+                );
+            }
+        }
     }
 
     fn props_with_status(state: &str) -> FooterProps {

--- a/crates/tui/tests/fixtures/codex_models_cache.json
+++ b/crates/tui/tests/fixtures/codex_models_cache.json
@@ -1,0 +1,40 @@
+{
+  "client_version": "test-client",
+  "etag": "test-etag",
+  "fetched_at": "2030-01-02T03:04:05Z",
+  "models": [
+    {
+      "slug": "gpt-test-secondary",
+      "display_name": "GPT Test Secondary",
+      "priority": 20,
+      "context_window": 128000,
+      "supports_parallel_tool_calls": false,
+      "supported_reasoning_levels": [{"effort": "medium"}],
+      "visibility": "list",
+      "supported_in_api": true,
+      "base_instructions": "ignored by CodeWhale"
+    },
+    {
+      "slug": "gpt-test-primary",
+      "display_name": "GPT Test Primary",
+      "priority": 10,
+      "context_window": 372000,
+      "supports_parallel_tool_calls": true,
+      "supported_reasoning_levels": [{"effort": "high"}],
+      "visibility": "list",
+      "supported_in_api": true,
+      "base_instructions": "ignored by CodeWhale"
+    },
+    {
+      "slug": "codex-test-review",
+      "display_name": "Codex Test Review",
+      "priority": 30,
+      "context_window": 272000,
+      "supports_parallel_tool_calls": true,
+      "supported_reasoning_levels": [{"effort": "medium"}],
+      "visibility": "hide",
+      "supported_in_api": true,
+      "base_instructions": "ignored by CodeWhale"
+    }
+  ]
+}

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -221,6 +221,135 @@ fn smoke_keystroke_reaches_composer() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Release stopship coverage: a real built TUI restores durable Work state and
+/// keeps both To-do and the effective permission posture visible at each
+/// supported compact evidence size. No model turn is sent.
+#[test]
+fn work_and_permission_are_visible_at_release_terminal_sizes() -> anyhow::Result<()> {
+    let _guard = qa_pty_test_lock();
+
+    for (cols, rows) in [(120_u16, 32_u16), (100, 30), (80, 24)] {
+        let ws = make_sealed_workspace()?;
+        let codewhale_home = ws.home().join(".codewhale");
+        let codex_home = ws.home().join(".codex");
+        std::fs::create_dir_all(&codex_home)?;
+        std::fs::write(codewhale_home.join("config.toml"), "allow_shell = true\n")?;
+        std::fs::write(
+            codewhale_home.join("settings.toml"),
+            "permission_posture = \"full-access\"\n",
+        )?;
+        std::fs::write(
+            codex_home.join("models_cache.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "fetched_at": chrono::Utc::now(),
+                "models": [{"slug": "gpt-pty-fixture", "priority": 1}]
+            }))?,
+        )?;
+
+        let session_path = ws.workspace().join("release-work-session.json");
+        std::fs::write(
+            &session_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "metadata": {
+                    "id": format!("pty-{cols}x{rows}"),
+                    "title": "Release Work continuity",
+                    "created_at": "2026-07-10T00:00:00Z",
+                    "updated_at": "2026-07-10T00:00:00Z",
+                    "message_count": 0,
+                    "total_tokens": 0,
+                    "model": "deepseek-v4-pro",
+                    "model_provider": "deepseek",
+                    "workspace": ws.workspace(),
+                    "mode": "operate",
+                    "cost": {},
+                    "cumulative_turn_secs": 0
+                },
+                "messages": [],
+                "system_prompt": null,
+                "work_state": {
+                    "todos": {
+                        "items": [
+                            {"id": 1, "content": "persisted inspect", "status": "completed"},
+                            {"id": 2, "content": "persisted patch", "status": "in_progress"}
+                        ],
+                        "completion_pct": 50,
+                        "in_progress_id": 2
+                    },
+                    "plan": {
+                        "objective": "Keep release Work visible",
+                        "items": [
+                            {"step": "verify PTY", "status": "in_progress"}
+                        ]
+                    }
+                }
+            }))?,
+        )?;
+
+        let mut h = Harness::builder(Harness::cargo_bin("codewhale-tui"))
+            .cwd(ws.workspace())
+            .clear_env()
+            .seal_home(ws.home())
+            .env("CODEWHALE_HOME", codewhale_home.to_string_lossy())
+            .env(
+                "DEEPSEEK_CONFIG_PATH",
+                codewhale_home.join("config.toml").to_string_lossy(),
+            )
+            .env("CODEX_HOME", codex_home.to_string_lossy())
+            .env("DEEPSEEK_API_KEY", "ci-test-key-not-real")
+            .env("DEEPSEEK_BASE_URL", "http://127.0.0.1:1")
+            .env("RUST_LOG", "warn")
+            .args([
+                "--workspace",
+                ws.workspace().to_str().expect("utf-8 workspace path"),
+                "--no-project-config",
+                "--skip-onboarding",
+            ])
+            .size(rows, cols)
+            .spawn()?;
+
+        h.wait_for_text(COMPOSER_READY_TEXT, BOOT_TIMEOUT)?;
+        h.send(keys::key::text(&format!(
+            "/load {}",
+            session_path.to_string_lossy()
+        )))?;
+        h.wait_for_text("/load", KEY_TIMEOUT)?;
+        h.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+        h.send(keys::key::enter())?;
+        h.wait_for_text("To-do", KEY_TIMEOUT)?;
+        h.wait_for_text("Full Access", KEY_TIMEOUT)?;
+        h.wait_for_idle(Duration::from_millis(250), Duration::from_secs(3))?;
+
+        let frame = h.frame();
+        let dump = frame.debug_dump();
+        assert!(
+            frame.contains("To-do"),
+            "To-do missing at {cols}x{rows}:\n{dump}"
+        );
+        assert!(
+            frame.contains("persisted") || frame.contains("2 items"),
+            "Work state missing at {cols}x{rows}:\n{dump}"
+        );
+        assert!(
+            frame.contains("Full Access"),
+            "effective permission missing at {cols}x{rows}:\n{dump}"
+        );
+        assert!(
+            frame.contains("Operate") || frame.contains("operate"),
+            "restored mode missing at {cols}x{rows}:\n{dump}"
+        );
+
+        if let Some(dir) = std::env::var_os("CODEWHALE_QA_EVIDENCE_DIR") {
+            let dir = std::path::PathBuf::from(dir);
+            std::fs::create_dir_all(&dir)?;
+            std::fs::write(dir.join(format!("tui-{cols}x{rows}.txt")), dump)?;
+        }
+
+        let _ = h.shutdown();
+    }
+    Ok(())
+}
+
 /// Regression: `/skills` should reflect the same merged discovery set as the
 /// slash menu and model-visible skills block, not just the first selected
 /// skills directory.


### PR DESCRIPTION
## Summary

This is the v0.8.68 TUI stopship repair batch. It keeps the current `main` TUI and fixes the live regressions without merging the stale replacement branch.

- Treat only meaningful provider configuration as configured; blank fields/maps and malformed auth no longer populate the configured picker, and empty provider/header structures are omitted on serialization.
- Source the OpenAI Codex/ChatGPT OAuth roster from a bounded, validated, fresh local Codex model cache with conservative fallback behavior and no credential reads/logging.
- Make picker/runtime/session/cost facts provider-and-model scoped. Codex drops OpenAI API-only limits and fabricated dollar pricing; effective route facts survive resume, compaction, tool children, and runtime-thread aggregation.
- Fail Operate closed for nontrivial work before snapshots or provider requests until host-enforced Workflow dispatch and terminal receipt verification exist. Exact one-step read-only commands remain local; setup reports the readiness gap.
- Persist To-do + Plan Work state with backward-compatible session records, nonblocking snapshot writes, rename-safe metadata, explicit clear semantics, and compact visibility at narrow widths.
- Persist a truthful Ask / Auto-Review / Full Access posture, show Plan as Read Only, keep the safety chip at release widths, lock managed policy, and show busy-state rejection.

## Root causes

1. Empty `http_headers` tables counted as explicit provider setup.
2. OpenAI Codex used a single built-in fallback instead of the user's local Codex roster.
3. Model metadata, output limits, compaction, and cost often keyed only by model ID.
4. Operate relied on prompt/chrome differences and could fall through to the ordinary Act loop.
5. Work state was in-memory and sidebar auto-allocation could hide a nonempty To-do list.
6. Permission display, mode transitions, managed policy, and persistence did not share one effective posture.

## Local verification

- `cargo test -p codewhale-config --locked`: 368 passed, 0 failed.
- `cargo test -p codewhale-tui --bin codewhale-tui --locked`: 6,378 passed, 0 failed, 2 ignored (6,380 total).
- Focused filters: model_picker 68, provider 459, configured 53, sidebar 157, todo 16, footer 97, permission 20, operate 10, mode 653, session 239, rename 11; all passed, 0 failed.
- `cargo test -p codewhale-tui --test qa_pty --locked -- work_and_permission_are_visible_at_release_terminal_sizes --nocapture`: 1 passed, 0 failed; transcripts captured for 120x32, 100x30, and 80x24.
- `cargo check -p codewhale-tui --locked`: passed.
- `cargo build -p codewhale-tui --bin codewhale-tui --locked`: passed (known nonfatal macOS `__eh_frame` linker warning).
- `cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check 7e18d5a2f..HEAD`: passed.

At all three PTY sizes the nonempty To-do panel remains visible, the session title remains `Release Work continuity`, and the footer retains `perm Full Access`.

## Replacement TUI audit

The local `work/tui-overnight-coherence` branch is 61 commits behind and 44 ahead of current main, changes 66 files, and has merge conflicts. No replacement-branch commit or code was ported. Picker chrome, To-do click/prefill, and Fleet observability work remain candidates for later targeted integration; its permission predicate and current stopship contracts were not sufficient.

## Deliberate boundaries

- No paid model calls.
- No tag, publication, GitHub Release, deployment, merge, or release-artifact push.
- Operate is truthful but remains readiness-blocked for nontrivial orchestration until the host can prove dispatch plus terminal receipts.
- Android/Termux device evidence and the six open v0.8.68 milestone issues remain outside this local TUI proof.
- Offline scorecard provider provenance and restored custom named-provider identity are follow-up seams; active TUI/runtime route accounting now fails closed where provider provenance is available.

## Tracking

- Configured-provider regression: #4333
- Existing Codex OAuth/usage tracker: #2984
- Existing permission tracker: #3211
- Existing Work/session trackers: #3983 and #2934
- Operate/Fleet readiness trackers: #4175 and #4178
- Follow-up custom-provider session identity: #4334
- Follow-up offline scorecard provider provenance: #4335 (preserves @findshan credit from #3388)
