### PR TITLE
feat(workflow): dispatch durable lanes without root model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "codewhale-config",
+ "fd-lock",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -17,7 +17,8 @@ use codewhale_app_server::{
     AppServerOptions, run as run_app_server, run_stdio as run_app_server_stdio,
 };
 use codewhale_config::{
-    CliRuntimeOverrides, ConfigStore, ProviderKind, ResolvedRuntimeOptions, RuntimeApiKeySource,
+    CliRuntimeOverrides, ConfigStore, ProviderKind, ProviderSource, ResolvedRuntimeOptions,
+    RuntimeApiKeySource,
 };
 use codewhale_execpolicy::{AskForApproval, ExecPolicyContext, ExecPolicyEngine};
 use codewhale_mcp::{McpServerDefinition, run_stdio_server};
@@ -229,6 +230,12 @@ path used by stream-json wrappers.
     Exec(TuiPassthroughArgs),
     /// Manage durable Agent Fleet runs via the TUI runtime.
     Fleet(TuiPassthroughArgs),
+    /// Internal model-free Workflow tool dispatcher used by Lane Runtime.
+    #[command(name = "workflow-tool", hide = true)]
+    WorkflowTool(TuiPassthroughArgs),
+    /// Internal detached-runtime output/receipt supervisor.
+    #[command(name = "lane-log-proxy", hide = true)]
+    LaneLogProxy(LaneLogProxyArgs),
     /// Run checked-in Workflows through a Lane Runtime backend.
     #[command(after_help = "\
 Examples:
@@ -236,8 +243,8 @@ Examples:
   codewhale workflow run stopship --fleet v0868-stopship --runtime inline --verify
 
 `workflow run` validates the checked-in Workflow source and named Fleet roster,
-creates a Lane record, then starts the existing headless Workflow tool through
-the selected Runtime backend.
+creates a Lane record, then dispatches the Workflow tool directly through the
+selected Runtime backend without an operator model turn.
 ")]
     Workflow(WorkflowArgs),
     /// Manage running workflow instances (Lanes) and Runtime backends (#4176).
@@ -385,6 +392,22 @@ struct TuiPassthroughArgs {
     args: Vec<String>,
 }
 
+#[derive(Debug, Args)]
+struct LaneLogProxyArgs {
+    #[arg(long, value_name = "PATH")]
+    log_path: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    receipt_path: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    receipt_tmp_path: PathBuf,
+    #[arg(long, value_name = "PATH")]
+    environment_path: Option<PathBuf>,
+    #[arg(long)]
+    lane_id: String,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+    command: Vec<String>,
+}
+
 /// `codewhale lane …` — running workflow instances (#4176).
 #[derive(Debug, Args)]
 struct LaneArgs {
@@ -510,7 +533,6 @@ enum WorkflowCommand {
     },
 }
 
-#[derive(Debug)]
 struct LaneStartRequest {
     workflow: Option<String>,
     fleet: Option<String>,
@@ -522,6 +544,8 @@ struct LaneStartRequest {
     worktree_path: Option<PathBuf>,
     worktree_ttl_secs: Option<u64>,
     command: Vec<String>,
+    environment: Vec<(String, String)>,
+    cwd: Option<PathBuf>,
 }
 
 fn start_lane(request: LaneStartRequest) -> Result<()> {
@@ -540,6 +564,8 @@ fn start_lane(request: LaneStartRequest) -> Result<()> {
         worktree_path,
         worktree_ttl_secs,
         command,
+        environment,
+        cwd,
     } = request;
     let kind = RuntimeBackendKind::parse(&runtime)?;
     let reg = LaneRegistry::open_default()?;
@@ -569,7 +595,12 @@ fn start_lane(request: LaneStartRequest) -> Result<()> {
     };
     let spec = LaneStartSpec {
         command: cmd,
-        cwd: None,
+        cwd,
+        environment,
+        log_proxy: (kind == RuntimeBackendKind::Tmux)
+            .then(std::env::current_exe)
+            .transpose()
+            .context("resolve current Codewhale executable for tmux log proxy")?,
         worktree,
     };
     let backend = resolve_backend(kind);
@@ -594,7 +625,12 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
     match args.command {
         LaneCommand::List { json } => {
             let reg = LaneRegistry::open_default()?;
-            let lanes = reg.list()?;
+            let mut lanes = reg.list()?;
+            for lane in &mut lanes {
+                if let Err(err) = backend_for(lane).reconcile(&reg, lane) {
+                    eprintln!("warning: could not reconcile lane `{}`: {err:#}", lane.id);
+                }
+            }
             if json {
                 println!("{}", serde_json::to_string_pretty(&lanes)?);
             } else if lanes.is_empty() {
@@ -620,7 +656,8 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
         }
         LaneCommand::Status { lane_id, json } => {
             let reg = LaneRegistry::open_default()?;
-            let lane = reg.load(&lane_id)?;
+            let mut lane = reg.load(&lane_id)?;
+            backend_for(&lane).reconcile(&reg, &mut lane)?;
             if json {
                 println!("{}", serde_json::to_string_pretty(&lane)?);
             } else {
@@ -642,6 +679,13 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
                 );
                 println!("branch:   {}", lane.branch.as_deref().unwrap_or("-"));
                 println!("tmux:     {}", lane.tmux_session.as_deref().unwrap_or("-"));
+                println!(
+                    "socket:   {}",
+                    lane.tmux_socket
+                        .as_ref()
+                        .map(|path| path.display().to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                );
                 println!("attach:   {}", lane.attach_target.as_deref().unwrap_or("-"));
                 println!("log:      {}", lane.log_path.display());
             }
@@ -649,9 +693,16 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
         }
         LaneCommand::Attach { lane_id, print } => {
             let reg = LaneRegistry::open_default()?;
-            let lane = reg.load(&lane_id)?;
+            let mut lane = reg.load(&lane_id)?;
             let backend = backend_for(&lane);
+            backend.reconcile(&reg, &mut lane)?;
             let Some(attach) = backend.attach_command(&lane) else {
+                if !lane.status.is_active() {
+                    bail!(
+                        "lane `{lane_id}` is {} and has no active attach target",
+                        lane.status.as_str()
+                    );
+                }
                 bail!(
                     "lane `{lane_id}` runtime `{}` has no attach target",
                     lane.runtime.as_str()
@@ -662,7 +713,13 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
                 return Ok(());
             }
             if let Some(session) = lane.tmux_session.as_deref() {
+                let socket = lane
+                    .tmux_socket
+                    .as_deref()
+                    .context("tmux lane is missing its pinned server socket")?;
                 let status = Command::new("tmux")
+                    .arg("-S")
+                    .arg(socket)
                     .args(["attach", "-t", session])
                     .status();
                 match status {
@@ -690,12 +747,18 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
             if !path.exists() {
                 bail!("log file missing: {}", path.display());
             }
-            let content = std::fs::read_to_string(&path)?;
-            let lines: Vec<&str> = content.lines().collect();
+            let content = std::fs::read(&path)?;
+            let lines: Vec<&[u8]> = content
+                .split(|byte| *byte == b'\n')
+                .filter(|line| !line.is_empty())
+                .collect();
             let start = lines.len().saturating_sub(tail);
+            let mut stdout = std::io::stdout().lock();
             for line in &lines[start..] {
-                println!("{line}");
+                stdout.write_all(String::from_utf8_lossy(line).as_bytes())?;
+                stdout.write_all(b"\n")?;
             }
+            stdout.flush()?;
             if !follow {
                 return Ok(());
             }
@@ -703,15 +766,16 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
             file.seek(std::io::SeekFrom::End(0))?;
             let mut reader = std::io::BufReader::new(file);
             loop {
-                let mut line = String::new();
-                match reader.read_line(&mut line) {
+                let mut line = Vec::new();
+                match reader.read_until(b'\n', &mut line) {
                     Ok(0) => {
                         thread::sleep(Duration::from_millis(200));
                         continue;
                     }
                     Ok(_) => {
-                        print!("{line}");
-                        let _ = std::io::stdout().flush();
+                        let mut stdout = std::io::stdout().lock();
+                        stdout.write_all(String::from_utf8_lossy(&line).as_bytes())?;
+                        stdout.flush()?;
                     }
                     Err(err) => return Err(err.into()),
                 }
@@ -747,11 +811,30 @@ fn run_lane_command(args: LaneArgs) -> Result<()> {
             worktree_path,
             worktree_ttl_secs,
             command,
+            environment: Vec::new(),
+            cwd: None,
         }),
     }
 }
 
-fn run_workflow_command(args: WorkflowArgs) -> Result<()> {
+fn run_lane_log_proxy_command(args: LaneLogProxyArgs) -> Result<()> {
+    let exit_code = codewhale_lane::run_lane_log_proxy(codewhale_lane::LaneLogProxySpec {
+        command: args.command,
+        log_path: args.log_path,
+        receipt_path: args.receipt_path,
+        receipt_tmp_path: args.receipt_tmp_path,
+        environment_path: args.environment_path,
+        lane_id: args.lane_id,
+    })?;
+    std::process::exit(exit_code);
+}
+
+fn run_workflow_command(
+    cli: &Cli,
+    resolved_runtime: &ResolvedRuntimeOptions,
+    config_path: &Path,
+    args: WorkflowArgs,
+) -> Result<()> {
     match args.command {
         WorkflowCommand::Run {
             workflow,
@@ -767,10 +850,17 @@ fn run_workflow_command(args: WorkflowArgs) -> Result<()> {
             worktree_path,
             worktree_ttl_secs,
         } => {
-            let workspace = workflow_workspace_root()?;
+            let workspace = workflow_workspace_root(cli.workspace.as_deref())?;
             let source_path =
                 resolve_workflow_source_path(&workflow, source_path.as_ref(), &workspace)?;
             validate_workflow_source_file(&source_path)?;
+
+            let source_root = if let Some(repo) = worktree_repo.as_deref() {
+                repo.canonicalize()
+                    .with_context(|| format!("resolve --worktree-repo {}", repo.display()))?
+            } else {
+                workspace.clone()
+            };
 
             let roots = named_fleet_search_roots(&workspace);
             let named_fleet = codewhale_workflow::load_named_fleet(&fleet, &roots)
@@ -781,16 +871,19 @@ fn run_workflow_command(args: WorkflowArgs) -> Result<()> {
                     .with_context(|| format!("validate stopship roles in fleet `{fleet}`"))?;
             }
 
-            let command = workflow_exec_command(
-                &workspace,
-                &source_path,
-                &workflow,
-                &fleet,
-                issue.as_deref(),
-                goal.as_deref(),
+            let process = workflow_exec_command(WorkflowExecSpec {
+                cli,
+                resolved_runtime,
+                config_path,
+                source_root: &source_root,
+                source_path: &source_path,
+                workflow: &workflow,
+                fleet: &fleet,
+                issue: issue.as_deref(),
+                goal: goal.as_deref(),
                 token_budget,
                 verify,
-            )?;
+            })?;
             start_lane(LaneStartRequest {
                 workflow: Some(workflow),
                 fleet: Some(fleet),
@@ -801,13 +894,20 @@ fn run_workflow_command(args: WorkflowArgs) -> Result<()> {
                 branch,
                 worktree_path,
                 worktree_ttl_secs,
-                command,
+                command: process.command,
+                environment: process.environment,
+                cwd: Some(workspace),
             })
         }
     }
 }
 
-fn workflow_workspace_root() -> Result<PathBuf> {
+fn workflow_workspace_root(explicit: Option<&Path>) -> Result<PathBuf> {
+    if let Some(path) = explicit {
+        return path
+            .canonicalize()
+            .with_context(|| format!("resolve workflow workspace {}", path.display()));
+    }
     let cwd = std::env::current_dir().context("resolve current directory")?;
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
@@ -819,7 +919,8 @@ fn workflow_workspace_root() -> Result<PathBuf> {
         let text = String::from_utf8_lossy(&output.stdout);
         let root = text.trim();
         if !root.is_empty() {
-            return Ok(PathBuf::from(root));
+            let root = PathBuf::from(root);
+            return Ok(root.canonicalize().unwrap_or(root));
         }
     }
     Ok(cwd)
@@ -923,23 +1024,48 @@ fn display_roots(roots: &[PathBuf]) -> String {
         .join(", ")
 }
 
-fn workflow_exec_command(
-    workspace: &Path,
-    source_path: &Path,
-    workflow: &str,
-    fleet: &str,
-    issue: Option<&str>,
-    goal: Option<&str>,
+struct WorkflowExecSpec<'a> {
+    cli: &'a Cli,
+    resolved_runtime: &'a ResolvedRuntimeOptions,
+    config_path: &'a Path,
+    source_root: &'a Path,
+    source_path: &'a Path,
+    workflow: &'a str,
+    fleet: &'a str,
+    issue: Option<&'a str>,
+    goal: Option<&'a str>,
     token_budget: Option<u64>,
     verify: bool,
-) -> Result<Vec<String>> {
-    let dispatcher = std::env::current_exe()
-        .ok()
-        .filter(|path| path.is_file())
-        .unwrap_or_else(|| PathBuf::from("codewhale"));
+}
+
+struct WorkflowProcessSpec {
+    command: Vec<String>,
+    environment: Vec<(String, String)>,
+}
+
+fn workflow_exec_command(spec: WorkflowExecSpec<'_>) -> Result<WorkflowProcessSpec> {
+    let WorkflowExecSpec {
+        cli,
+        resolved_runtime,
+        config_path,
+        source_root,
+        source_path,
+        workflow,
+        fleet,
+        issue,
+        goal,
+        token_budget,
+        verify,
+    } = spec;
     let source_arg = source_path
-        .strip_prefix(workspace)
-        .unwrap_or(source_path)
+        .strip_prefix(source_root)
+        .with_context(|| {
+            format!(
+                "workflow source {} must be inside execution root {}",
+                source_path.display(),
+                source_root.display()
+            )
+        })?
         .display()
         .to_string();
     let mut payload = serde_json::json!({
@@ -957,20 +1083,72 @@ fn workflow_exec_command(
     if let Some(token_budget) = token_budget {
         payload["token_budget"] = serde_json::json!(token_budget);
     }
-    let prompt = format!(
-        "Run the CodeWhale `workflow` tool with this exact JSON input, wait for completion, and report the resulting run_id/status. Do not describe the workflow instead of running it.\n\n```json\n{}\n```",
-        serde_json::to_string_pretty(&payload)?
+    let input_json = serde_json::to_string(&payload)?;
+    let passthrough = vec![
+        "workflow-tool".to_string(),
+        "--approval-source".to_string(),
+        "explicit-workflow-command".to_string(),
+        "--input-json".to_string(),
+        input_json,
+    ];
+    let command =
+        build_tui_command_with_paths(cli, resolved_runtime, passthrough, Some(config_path), None)?;
+    lane_process_spec_from_command(&command)
+}
+
+fn valid_lane_environment_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn shell_owned_lane_environment(key: &str) -> bool {
+    matches!(
+        key,
+        "PWD" | "OLDPWD" | "SHLVL" | "_" | "TERM" | "TMUX" | "TMUX_PANE"
+    )
+}
+
+fn lane_process_spec_from_command(command: &Command) -> Result<WorkflowProcessSpec> {
+    let mut argv = Vec::new();
+    argv.push(command.get_program().to_string_lossy().into_owned());
+    argv.extend(
+        command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned()),
     );
-    Ok(vec![
-        dispatcher.display().to_string(),
-        "--workspace".to_string(),
-        workspace.display().to_string(),
-        "exec".to_string(),
-        "--auto".to_string(),
-        "--output-format".to_string(),
-        "stream-json".to_string(),
-        prompt,
-    ])
+    let mut environment = std::collections::BTreeMap::new();
+    for (key, value) in std::env::vars_os() {
+        let (Some(key), Some(value)) = (key.to_str(), value.to_str()) else {
+            continue;
+        };
+        if valid_lane_environment_key(key) && !shell_owned_lane_environment(key) {
+            environment.insert(key.to_string(), value.to_string());
+        }
+    }
+    for (key, value) in command.get_envs() {
+        let key = key
+            .to_str()
+            .context("workflow runtime environment key is not UTF-8")?
+            .to_string();
+        if let Some(value) = value {
+            environment.insert(
+                key,
+                value
+                    .to_str()
+                    .context("workflow runtime environment value is not UTF-8")?
+                    .to_string(),
+            );
+        } else {
+            environment.remove(&key);
+        }
+    }
+    Ok(WorkflowProcessSpec {
+        command: argv,
+        environment: environment.into_iter().collect(),
+    })
 }
 
 /// Flags for `codewhale remote-setup`. Forwarded to the TUI binary, which owns
@@ -1279,8 +1457,25 @@ pub fn run_cli() -> std::process::ExitCode {
     }
 }
 
+fn split_lane_log_proxy_command(
+    command: Option<Commands>,
+) -> (Option<LaneLogProxyArgs>, Option<Commands>) {
+    match command {
+        Some(Commands::LaneLogProxy(args)) => (Some(args), None),
+        command => (None, command),
+    }
+}
+
 fn run() -> Result<()> {
     let mut cli = Cli::parse();
+
+    // The detached log proxy must not depend on user config parsing: its job
+    // is to frame child output and publish a terminal receipt even when the
+    // delegated command's own config is malformed.
+    let (proxy, command) = split_lane_log_proxy_command(cli.command.take());
+    if let Some(args) = proxy {
+        return run_lane_log_proxy_command(args);
+    }
 
     let mut store = ConfigStore::load(cli.config.clone())?;
     let runtime_overrides = CliRuntimeOverrides {
@@ -1297,8 +1492,6 @@ fn run() -> Result<()> {
         yolo: Some(cli.yolo),
         verbosity: cli.verbosity.clone(),
     };
-    let command = cli.command.take();
-
     match command {
         Some(Commands::Run(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
@@ -1349,7 +1542,16 @@ fn run() -> Result<()> {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("fleet", args))
         }
-        Some(Commands::Workflow(args)) => run_workflow_command(args),
+        Some(Commands::WorkflowTool(args)) => {
+            let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
+            delegate_to_tui(&cli, &resolved_runtime, tui_args("workflow-tool", args))
+        }
+        Some(Commands::LaneLogProxy(_)) => unreachable!("lane log proxy dispatched above"),
+        Some(Commands::Workflow(args)) => {
+            let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
+            let config_path = store.path().to_path_buf();
+            run_workflow_command(&cli, &resolved_runtime, &config_path, args)
+        }
         Some(Commands::Lane(args)) => run_lane_command(args),
         Some(Commands::Review(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
@@ -2799,8 +3001,28 @@ fn build_tui_command(
     resolved_runtime: &ResolvedRuntimeOptions,
     passthrough: Vec<String>,
 ) -> Result<Command> {
+    build_tui_command_with_paths(
+        cli,
+        resolved_runtime,
+        passthrough,
+        cli.config.as_deref(),
+        cli.workspace.as_deref(),
+    )
+}
+
+fn build_tui_command_with_paths(
+    cli: &Cli,
+    resolved_runtime: &ResolvedRuntimeOptions,
+    passthrough: Vec<String>,
+    config_path: Option<&Path>,
+    workspace_path: Option<&Path>,
+) -> Result<Command> {
     let tui = locate_sibling_tui_binary()?;
-    let mut verbosity = resolved_runtime.verbosity.clone();
+    let mut verbosity = if cli.profile.is_some() {
+        cli.verbosity.clone()
+    } else {
+        resolved_runtime.verbosity.clone()
+    };
     if verbosity.is_none()
         && passthrough
             .iter()
@@ -2810,13 +3032,13 @@ fn build_tui_command(
     }
 
     let mut cmd = Command::new(&tui);
-    if let Some(config) = cli.config.as_ref() {
+    if let Some(config) = config_path {
         cmd.arg("--config").arg(config);
     }
     if let Some(profile) = cli.profile.as_ref() {
         cmd.arg("--profile").arg(profile);
     }
-    if let Some(workspace) = cli.workspace.as_ref() {
+    if let Some(workspace) = workspace_path {
         cmd.arg("--workspace").arg(workspace);
     }
     // Accepted for older scripts, but no longer forwarded: the interactive TUI
@@ -2840,7 +3062,9 @@ fn build_tui_command(
     if let Some(provider) = cli.provider.map(ProviderKind::from) {
         cmd.env("DEEPSEEK_PROVIDER", provider.as_str());
     }
-    if matches!(keyring_bridge_source, Some(RuntimeApiKeySource::Keyring))
+    if !(cli.profile.is_some()
+        && matches!(resolved_runtime.provider_source, ProviderSource::Config))
+        && matches!(keyring_bridge_source, Some(RuntimeApiKeySource::Keyring))
         && let Some(api_key) = keyring_bridge_api_key
     {
         // TUI reloads auth_mode from config/profile, but it does not re-query the
@@ -2884,10 +3108,19 @@ fn build_tui_command(
         cmd.env("DEEPSEEK_YOLO", "true");
     }
     if let Some(api_key) = cli.api_key.as_ref() {
-        cmd.env("DEEPSEEK_API_KEY", api_key);
-        for var in provider_env_vars(resolved_runtime.provider) {
-            if *var != "DEEPSEEK_API_KEY" {
-                cmd.env(var, api_key);
+        // `--profile` is resolved by the TUI after this facade starts it, so
+        // the base ConfigStore provider may not be the effective provider.
+        // Carry the explicit secret through a provider-neutral, source-marked
+        // slot; the TUI applies it after profile/OAuth resolution and before
+        // saved API-key slots. Preserve legacy provider envs only when their
+        // identity is already unambiguous here.
+        cmd.env("CODEWHALE_CLI_API_KEY", api_key);
+        if cli.profile.is_none() || cli.provider.is_some() {
+            cmd.env("DEEPSEEK_API_KEY", api_key);
+            for var in provider_env_vars(resolved_runtime.provider) {
+                if *var != "DEEPSEEK_API_KEY" {
+                    cmd.env(var, api_key);
+                }
             }
         }
         cmd.env("DEEPSEEK_API_KEY_SOURCE", "cli");
@@ -3089,6 +3322,14 @@ mod tests {
             // Safety: tests using this helper serialize with env_lock() and
             // restore the original value in Drop.
             unsafe { std::env::set_var(name, value) };
+            Self { name, previous }
+        }
+
+        fn remove(name: &'static str) -> Self {
+            let previous = std::env::var_os(name);
+            // Safety: tests using this helper serialize with env_lock() and
+            // restore the original value in Drop.
+            unsafe { std::env::remove_var(name) };
             Self { name, previous }
         }
     }
@@ -3655,31 +3896,143 @@ mod tests {
     }
 
     #[test]
+    fn hidden_lane_log_proxy_parses_child_argv_and_preserves_other_commands() {
+        let cli = parse_ok(&[
+            "codewhale",
+            "lane-log-proxy",
+            "--log-path",
+            "/tmp/lane.ndjson",
+            "--receipt-path",
+            "/tmp/lane.exit.json",
+            "--receipt-tmp-path",
+            "/tmp/lane.exit.json.tmp",
+            "--environment-path",
+            "/tmp/lane.env.json",
+            "--lane-id",
+            "lane-proof",
+            "--",
+            "/bin/echo",
+            "--child-flag",
+            "hello",
+        ]);
+        let (proxy, command) = split_lane_log_proxy_command(cli.command);
+        assert!(command.is_none());
+        let proxy = proxy.expect("proxy args");
+        assert_eq!(proxy.lane_id, "lane-proof");
+        assert_eq!(
+            proxy.command,
+            ["/bin/echo", "--child-flag", "hello"].map(str::to_string)
+        );
+
+        let cli = parse_ok(&["codewhale", "lane", "list", "--json"]);
+        let (proxy, command) = split_lane_log_proxy_command(cli.command);
+        assert!(proxy.is_none());
+        assert!(matches!(
+            command,
+            Some(Commands::Lane(LaneArgs {
+                command: LaneCommand::List { json: true }
+            }))
+        ));
+    }
+
+    #[test]
     fn workflow_run_resolves_stopship_alias_and_payload() {
+        let _lock = env_lock();
+        let (_dir, _tui) = install_fake_tui_binary();
+        let _provider = ScopedEnvVar::remove("DEEPSEEK_PROVIDER");
+        let _model = ScopedEnvVar::remove("DEEPSEEK_MODEL");
+        let _base_url = ScopedEnvVar::remove("DEEPSEEK_BASE_URL");
+        let _api_key = ScopedEnvVar::remove("DEEPSEEK_API_KEY");
+        let _cli_api_key = ScopedEnvVar::remove("CODEWHALE_CLI_API_KEY");
         let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("..");
+        let cli = parse_ok(&[
+            "codewhale",
+            "--profile",
+            "workflow-profile",
+            "--model",
+            "explicit-workflow-model",
+            "--api-key",
+            "explicit-profile-key",
+            "--workspace",
+            workspace.to_str().expect("workspace UTF-8"),
+        ]);
+        let resolved = resolved_runtime_for_test(ProviderKind::Deepseek, ProviderSource::Config);
         let source = resolve_workflow_source_path("stopship", None, &workspace)
             .expect("stopship workflow source");
         assert!(source.ends_with("workflows/v0868_stopship_lane.workflow.js"));
 
-        let command = workflow_exec_command(
-            &workspace,
-            &source,
-            "stopship",
-            "v0868-stopship",
-            Some("4090"),
-            Some("fix stopship"),
-            Some(25_000),
-            true,
-        )
+        let process = workflow_exec_command(WorkflowExecSpec {
+            cli: &cli,
+            resolved_runtime: &resolved,
+            config_path: &workspace.join("config.toml"),
+            source_root: &workspace,
+            source_path: &source,
+            workflow: "stopship",
+            fleet: "v0868-stopship",
+            issue: Some("4090"),
+            goal: Some("fix stopship"),
+            token_budget: Some(25_000),
+            verify: true,
+        })
         .expect("command");
-        let joined = command.join("\n");
-        assert!(joined.contains("\"source_path\": \"workflows/v0868_stopship_lane.workflow.js\""));
-        assert!(joined.contains("\"fleet\": \"v0868-stopship\""));
-        assert!(joined.contains("\"issue\": \"4090\""));
-        assert!(joined.contains("\"token_budget\": 25000"));
-        assert!(joined.contains("\"verify\": true"));
+        let joined = process.command.join("\n");
+        assert!(joined.contains("workflow-tool"));
+        assert!(joined.contains("explicit-workflow-command"));
+        assert!(joined.contains("--input-json"));
+        assert!(!process.command.iter().any(|arg| arg == "exec"));
+        assert!(!process.command.iter().any(|arg| arg == "--workspace"));
+        assert!(
+            process
+                .command
+                .windows(2)
+                .any(|pair| pair == ["--profile", "workflow-profile"])
+        );
+        assert!(!joined.contains("Run the CodeWhale"));
+        assert!(joined.contains("\"source_path\":\"workflows/v0868_stopship_lane.workflow.js\""));
+        assert!(joined.contains("\"fleet\":\"v0868-stopship\""));
+        assert!(joined.contains("\"issue\":\"4090\""));
+        assert!(joined.contains("\"token_budget\":25000"));
+        assert!(joined.contains("\"verify\":true"));
+        assert!(
+            process.environment.iter().any(|(key, value)| {
+                key == "DEEPSEEK_MODEL" && value == "explicit-workflow-model"
+            })
+        );
+        assert!(
+            !process
+                .environment
+                .iter()
+                .any(|(key, _)| key == "DEEPSEEK_PROVIDER")
+        );
+        assert!(
+            !process
+                .environment
+                .iter()
+                .any(|(key, _)| key == "DEEPSEEK_BASE_URL")
+        );
+        assert!(
+            !process
+                .environment
+                .iter()
+                .any(|(key, _)| key == "DEEPSEEK_API_KEY")
+        );
+        assert!(process.environment.iter().any(|(key, value)| {
+            key == "CODEWHALE_CLI_API_KEY" && value == "explicit-profile-key"
+        }));
+        assert!(
+            !process
+                .command
+                .iter()
+                .any(|argument| argument.contains("explicit-profile-key"))
+        );
+        assert!(
+            process
+                .environment
+                .iter()
+                .all(|(_, value)| value != "test-model")
+        );
     }
 
     #[test]
@@ -4881,7 +5234,7 @@ mod tests {
             approval_policy: None,
             sandbox_mode: None,
             yolo: None,
-            verbosity: None,
+            verbosity: Some("normal".to_string()),
             http_headers: resolved_headers,
         };
 
@@ -4894,6 +5247,8 @@ mod tests {
         assert_eq!(command_env(&cmd, "DEEPSEEK_API_KEY_SOURCE"), None);
         assert_eq!(command_env(&cmd, "DEEPSEEK_AUTH_MODE"), None);
         assert_eq!(command_env(&cmd, "DEEPSEEK_HTTP_HEADERS"), None);
+        assert_eq!(command_env(&cmd, "CODEWHALE_VERBOSITY"), None);
+        assert_eq!(command_env(&cmd, "DEEPSEEK_VERBOSITY"), None);
         let args: Vec<String> = cmd
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())

--- a/crates/lane/Cargo.toml
+++ b/crates/lane/Cargo.toml
@@ -10,6 +10,7 @@ description = "Lane registry and Runtime backends for CodeWhale workflow instanc
 anyhow.workspace = true
 chrono.workspace = true
 codewhale-config = { path = "../config", version = "0.8.68" }
+fd-lock = "4.0.4"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/lane/src/lib.rs
+++ b/crates/lane/src/lib.rs
@@ -12,7 +12,7 @@ mod worktree;
 
 pub use registry::{LaneRecord, LaneRegistry, LaneStatus, lanes_dir};
 pub use runtime::{
-    InlineRuntime, LaneStartSpec, RuntimeBackend, RuntimeBackendKind, TmuxRuntime, backend_for,
-    resolve_backend,
+    InlineRuntime, LaneLogProxySpec, LaneStartSpec, RuntimeBackend, RuntimeBackendKind,
+    TmuxRuntime, backend_for, resolve_backend, run_lane_log_proxy,
 };
 pub use worktree::{WorktreeProvision, provision_worktree, remove_worktree_if_expired};

--- a/crates/lane/src/registry.rs
+++ b/crates/lane/src/registry.rs
@@ -1,6 +1,6 @@
 //! Durable lane registry under `$CODEWHALE_HOME/lanes/`.
 
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -60,6 +60,11 @@ pub struct LaneRecord {
     /// tmux session name when `runtime == tmux`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tmux_session: Option<String>,
+    /// Explicit tmux server socket used for this Lane. Pinning the socket keeps
+    /// start/attach/stop/reconcile in the same server namespace even when
+    /// `TMUX_TMPDIR` or the caller environment changes between commands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmux_socket: Option<PathBuf>,
     /// Absolute path to the stream-json / NDJSON journal for this lane.
     pub log_path: PathBuf,
     pub started_at: String,
@@ -198,6 +203,7 @@ impl LaneRegistry {
             worktree_path: None,
             branch: None,
             tmux_session: None,
+            tmux_socket: None,
             log_path,
             started_at: LaneRecord::now_rfc3339(),
             stopped_at: None,
@@ -208,21 +214,140 @@ impl LaneRegistry {
         Ok(record)
     }
 
-    pub fn mark_running(&self, record: &mut LaneRecord) -> Result<()> {
-        record.status = LaneStatus::Running;
-        self.save(record)
+    /// Atomically promote a Pending Lane to Running.
+    ///
+    /// A concurrent `lane stop` is allowed to win while a backend is still
+    /// launching. In that case this returns `false`, reloads the terminal
+    /// record, and the backend must tear down any process it just created.
+    pub fn mark_running_if_pending(&self, record: &mut LaneRecord) -> Result<bool> {
+        self.mark_running_if_pending_with(record, || Ok(()), || Ok(()))
     }
 
-    pub fn mark_stopped(&self, record: &mut LaneRecord, status: LaneStatus) -> Result<()> {
-        record.status = status;
-        record.stopped_at = Some(LaneRecord::now_rfc3339());
-        self.save(record)
+    /// Atomically launch backend state and promote a Pending Lane to Running.
+    ///
+    /// The per-Lane lock spans the durable Pending check, `before_transition`,
+    /// and the Running save. A concurrent stop therefore either wins before
+    /// launch (and this returns `false` without calling the closure) or waits
+    /// until the Running record is visible. Backend metadata is first saved in
+    /// the Pending record so a failed final save still leaves enough data for
+    /// a later stop. `rollback` is attempted if that final save fails.
+    pub fn mark_running_if_pending_with<Start, Rollback>(
+        &self,
+        record: &mut LaneRecord,
+        before_transition: Start,
+        rollback: Rollback,
+    ) -> Result<bool>
+    where
+        Start: FnOnce() -> Result<()>,
+        Rollback: FnOnce() -> Result<()>,
+    {
+        let lock_path = self.root.join(format!("{}.lock", record.id));
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .with_context(|| format!("open lane lock {}", lock_path.display()))?;
+        let mut lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock
+            .write()
+            .with_context(|| format!("lock lane record {}", record.id))?;
+
+        let current = self.load(&record.id)?;
+        if current.status != LaneStatus::Pending {
+            *record = current;
+            return Ok(false);
+        }
+
+        // `record` carries backend metadata (tmux session, worktree, attach
+        // target) populated during launch. Persist it while still Pending so
+        // a failed launch/final save remains discoverable and stoppable.
+        record.status = LaneStatus::Pending;
+        record.stopped_at = None;
+        self.save(record)?;
+
+        before_transition()?;
+        record.status = LaneStatus::Running;
+        record.stopped_at = None;
+        if let Err(save_error) = self.save(record) {
+            record.status = LaneStatus::Pending;
+            if let Err(rollback_error) = rollback() {
+                return Err(save_error).context(format!(
+                    "persist running Lane; backend rollback also failed: {rollback_error:#}"
+                ));
+            }
+            return Err(save_error).context("persist running Lane after backend launch");
+        }
+        Ok(true)
+    }
+
+    /// Atomically transition an active Lane to a terminal state.
+    ///
+    /// Detached tmux reconciliation, an explicit stop, and a second status
+    /// reader can race in separate CLI processes. Serialize those terminal
+    /// decisions on a per-Lane advisory lock, reload the live record under the
+    /// lock, and only let the first active -> terminal transition win.
+    pub fn mark_terminal_if_active(
+        &self,
+        record: &mut LaneRecord,
+        status: LaneStatus,
+    ) -> Result<bool> {
+        self.mark_terminal_if_active_with(record, status, |_| Ok(()))
+    }
+
+    /// Atomically perform backend teardown and transition an active Lane.
+    ///
+    /// `before_transition` runs while holding the per-Lane lifecycle lock.
+    /// If teardown fails, the record remains active. This keeps a failed tmux
+    /// kill from being persisted as Stopped and prevents cleanup racing a
+    /// concurrent reconciliation decision.
+    pub fn mark_terminal_if_active_with<F>(
+        &self,
+        record: &mut LaneRecord,
+        status: LaneStatus,
+        before_transition: F,
+    ) -> Result<bool>
+    where
+        F: FnOnce(&LaneRecord) -> Result<()>,
+    {
+        if status.is_active() {
+            bail!("terminal lane transition requires a terminal status");
+        }
+
+        let lock_path = self.root.join(format!("{}.lock", record.id));
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .with_context(|| format!("open lane lock {}", lock_path.display()))?;
+        let mut lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock
+            .write()
+            .with_context(|| format!("lock lane record {}", record.id))?;
+
+        let mut current = self.load(&record.id)?;
+        if !current.status.is_active() {
+            *record = current;
+            return Ok(false);
+        }
+        before_transition(&current)?;
+        current.status = status;
+        current.stopped_at = Some(LaneRecord::now_rfc3339());
+        current.attach_target = None;
+        self.save(&current)?;
+        *record = current;
+        Ok(true)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, mpsc};
     use tempfile::tempdir;
 
     #[test]
@@ -253,5 +378,112 @@ mod tests {
         let listed = reg2.list().unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, id);
+    }
+
+    #[test]
+    fn terminal_lane_cannot_launch_after_stop_wins() {
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let mut record = reg
+            .create_pending(None, None, None, None, RuntimeBackendKind::Tmux, None)
+            .unwrap();
+        assert!(
+            reg.mark_terminal_if_active(&mut record, LaneStatus::Stopped)
+                .unwrap()
+        );
+        let starts = AtomicUsize::new(0);
+        assert!(
+            !reg.mark_running_if_pending_with(
+                &mut record,
+                || {
+                    starts.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                || Ok(()),
+            )
+            .unwrap()
+        );
+        assert_eq!(starts.load(Ordering::SeqCst), 0);
+        assert_eq!(record.status, LaneStatus::Stopped);
+        assert_eq!(reg.load(&record.id).unwrap().status, LaneStatus::Stopped);
+    }
+
+    #[test]
+    fn start_and_stop_are_serialized_across_backend_launch() {
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let record = reg
+            .create_pending(None, None, None, None, RuntimeBackendKind::Tmux, None)
+            .unwrap();
+        let id = record.id.clone();
+        let starts = Arc::new(AtomicUsize::new(0));
+        let teardowns = Arc::new(AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let start_reg = reg.clone();
+        let start_count = Arc::clone(&starts);
+        let start_thread = std::thread::spawn(move || {
+            let mut record = record;
+            let started = start_reg
+                .mark_running_if_pending_with(
+                    &mut record,
+                    || {
+                        start_count.fetch_add(1, Ordering::SeqCst);
+                        entered_tx.send(()).unwrap();
+                        release_rx.recv().unwrap();
+                        Ok(())
+                    },
+                    || Ok(()),
+                )
+                .unwrap();
+            assert!(started);
+        });
+        entered_rx.recv().unwrap();
+
+        let stop_reg = reg.clone();
+        let stop_id = id.clone();
+        let teardown_count = Arc::clone(&teardowns);
+        let (stopped_tx, stopped_rx) = mpsc::channel();
+        let stop_thread = std::thread::spawn(move || {
+            let mut record = stop_reg.load(&stop_id).unwrap();
+            let stopped = stop_reg
+                .mark_terminal_if_active_with(&mut record, LaneStatus::Stopped, |_| {
+                    teardown_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .unwrap();
+            stopped_tx.send(stopped).unwrap();
+        });
+        assert!(matches!(
+            stopped_rx.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+        release_tx.send(()).unwrap();
+        start_thread.join().unwrap();
+        assert!(stopped_rx.recv().unwrap());
+        stop_thread.join().unwrap();
+
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+        assert_eq!(teardowns.load(Ordering::SeqCst), 1);
+        assert_eq!(reg.load(&id).unwrap().status, LaneStatus::Stopped);
+    }
+
+    #[test]
+    fn teardown_failure_keeps_durable_lane_active() {
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let mut record = reg
+            .create_pending(None, None, None, None, RuntimeBackendKind::Tmux, None)
+            .unwrap();
+        assert!(reg.mark_running_if_pending(&mut record).unwrap());
+        let error = reg
+            .mark_terminal_if_active_with(&mut record, LaneStatus::Stopped, |_| {
+                bail!("backend still alive")
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("backend still alive"));
+        assert_eq!(record.status, LaneStatus::Running);
+        assert_eq!(reg.load(&record.id).unwrap().status, LaneStatus::Running);
     }
 }

--- a/crates/lane/src/runtime.rs
+++ b/crates/lane/src/runtime.rs
@@ -1094,23 +1094,22 @@ fn shell_join(args: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(unix)]
     use std::ffi::OsString;
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
 
     fn tmux_env_lock() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    #[cfg(unix)]
     struct ScopedEnvVar {
         name: &'static str,
         previous: Option<OsString>,
     }
 
-    #[cfg(unix)]
     impl ScopedEnvVar {
         fn set(name: &'static str, value: &std::ffi::OsStr) -> Self {
             let previous = std::env::var_os(name);
@@ -1120,6 +1119,7 @@ mod tests {
             Self { name, previous }
         }
 
+        #[cfg(unix)]
         fn remove(name: &'static str) -> Self {
             let previous = std::env::var_os(name);
             // SAFETY: tmux environment tests hold `tmux_env_lock` and restore
@@ -1129,7 +1129,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     impl Drop for ScopedEnvVar {
         fn drop(&mut self) {
             // SAFETY: paired with the serialized mutation above.
@@ -1146,10 +1145,7 @@ mod tests {
     #[test]
     fn tmux_dry_run_start_attach_stop_roundtrip() {
         let _env_guard = tmux_env_lock();
-        // SAFETY: test-only env toggle for tmux dry-run; single-threaded unit test.
-        unsafe {
-            std::env::set_var("CODEWHALE_LANE_TMUX_DRY_RUN", "1");
-        }
+        let _dry_run = ScopedEnvVar::set("CODEWHALE_LANE_TMUX_DRY_RUN", std::ffi::OsStr::new("1"));
         let dir = tempdir().unwrap();
         let reg = LaneRegistry::open(dir.path()).unwrap();
         let mut record = reg
@@ -1194,10 +1190,6 @@ mod tests {
         assert_eq!(record.status, LaneStatus::Stopped);
         let reloaded = reg.load(&record.id).unwrap();
         assert_eq!(reloaded.status, LaneStatus::Stopped);
-        // SAFETY: paired cleanup of the test-only dry-run flag.
-        unsafe {
-            std::env::remove_var("CODEWHALE_LANE_TMUX_DRY_RUN");
-        }
     }
 
     #[cfg(unix)]
@@ -1580,8 +1572,29 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn tmux_reconcile_marks_vanished_session_failed_without_receipt() {
+        use std::os::unix::fs::PermissionsExt;
+
         let _env_guard = tmux_env_lock();
         let dir = tempdir().unwrap();
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir(&bin_dir).unwrap();
+        let tmux = bin_dir.join("tmux");
+        fs::write(
+            &tmux,
+            "#!/bin/sh\nprintf '%s\\n' 'no server running on /tmp/codewhale-test.sock' >&2\nexit 1\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+        let prior_path = std::env::var_os("PATH").unwrap_or_default();
+        let combined_path = std::env::join_paths(
+            std::iter::once(bin_dir).chain(std::env::split_paths(&prior_path)),
+        )
+        .unwrap();
+        let _path = ScopedEnvVar::set("PATH", &combined_path);
+        let _dry_run = ScopedEnvVar::remove("CODEWHALE_LANE_TMUX_DRY_RUN");
+
         let reg = LaneRegistry::open(dir.path()).unwrap();
         let mut record = reg
             .create_pending(

--- a/crates/lane/src/runtime.rs
+++ b/crates/lane/src/runtime.rs
@@ -1094,6 +1094,7 @@ fn shell_join(args: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::ffi::OsString;
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
@@ -1103,11 +1104,13 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
     }
 
+    #[cfg(unix)]
     struct ScopedEnvVar {
         name: &'static str,
         previous: Option<OsString>,
     }
 
+    #[cfg(unix)]
     impl ScopedEnvVar {
         fn set(name: &'static str, value: &std::ffi::OsStr) -> Self {
             let previous = std::env::var_os(name);
@@ -1126,6 +1129,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for ScopedEnvVar {
         fn drop(&mut self) {
             // SAFETY: paired with the serialized mutation above.

--- a/crates/lane/src/runtime.rs
+++ b/crates/lane/src/runtime.rs
@@ -1577,6 +1577,7 @@ mod tests {
         assert!(worktree.exists());
     }
 
+    #[cfg(unix)]
     #[test]
     fn tmux_reconcile_marks_vanished_session_failed_without_receipt() {
         let _env_guard = tmux_env_lock();

--- a/crates/lane/src/runtime.rs
+++ b/crates/lane/src/runtime.rs
@@ -3,10 +3,11 @@
 //! Runtime owns process/session lifecycle and stream-json log capture.
 //! Fleet modules must not import this module.
 
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus, Stdio};
+use std::thread;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -46,14 +47,41 @@ impl RuntimeBackendKind {
 }
 
 /// Inputs for starting a lane under a runtime backend.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LaneStartSpec {
     /// Command argv to run inside the backend (e.g. `codewhale exec …`).
     pub command: Vec<String>,
     /// Working directory for the command (defaults to worktree or cwd).
     pub cwd: Option<PathBuf>,
+    /// Process-local runtime overrides. Values are never written into the
+    /// Lane record or command argv; tmux bridges them through a private 0600
+    /// environment file that the detached shell removes before execution.
+    pub environment: Vec<(String, String)>,
+    /// Executable that exposes Codewhale's hidden `lane-log-proxy` command.
+    /// Required by tmux so arbitrary/binary child output is framed as valid
+    /// NDJSON without trusting a shell pipeline.
+    pub log_proxy: Option<PathBuf>,
     /// When set, provision an isolated git worktree + branch under this repo.
     pub worktree: Option<WorktreeProvision>,
+}
+
+impl std::fmt::Debug for LaneStartSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LaneStartSpec")
+            .field("command", &self.command)
+            .field("cwd", &self.cwd)
+            .field(
+                "environment_keys",
+                &self
+                    .environment
+                    .iter()
+                    .map(|(key, _)| key)
+                    .collect::<Vec<_>>(),
+            )
+            .field("log_proxy", &self.log_proxy)
+            .field("worktree", &self.worktree)
+            .finish()
+    }
 }
 
 /// Runtime adapter contract.
@@ -73,6 +101,14 @@ pub trait RuntimeBackend {
 
     /// Stop the running session/process.
     fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()>;
+
+    /// Reconcile durable backend state into the Lane record before display.
+    /// Most backends update synchronously and need no refresh; tmux records
+    /// the detached process exit in a private sidecar and folds it in on the
+    /// next read.
+    fn reconcile(&self, _registry: &LaneRegistry, _record: &mut LaneRecord) -> Result<()> {
+        Ok(())
+    }
 
     /// Optional worktree TTL cleanup after stop.
     fn cleanup_worktree(&self, record: &LaneRecord) -> Result<()> {
@@ -110,8 +146,486 @@ fn append_log_event(log_path: &Path, event: serde_json::Value) -> Result<()> {
         .append(true)
         .open(log_path)
         .with_context(|| format!("open lane log {}", log_path.display()))?;
-    writeln!(file, "{event}").with_context(|| format!("write lane log {}", log_path.display()))?;
+    let mut encoded = serde_json::to_vec(&event).context("serialize lane log event")?;
+    encoded.push(b'\n');
+    file.write_all(&encoded)
+        .with_context(|| format!("write lane log {}", log_path.display()))?;
     Ok(())
+}
+
+const MAX_EXIT_RECEIPT_BYTES: u64 = 4 * 1024;
+const MAX_ENVIRONMENT_BYTES: u64 = 1024 * 1024;
+const MAX_CHILD_LOG_FRAME_BYTES: usize = 64 * 1024;
+const LANE_PROXY_FAILURE_EXIT_CODE: i32 = 125;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LaneExitReceipt {
+    lane_id: String,
+    exit_code: i32,
+}
+
+/// Inputs to the hidden Rust log proxy used by detached runtimes.
+///
+/// The proxy is deliberately exposed by the Lane crate so the thin CLI
+/// facade can invoke it before loading user configuration. Secrets travel in
+/// the private environment file, never in argv or the Lane record.
+#[derive(Debug, Clone)]
+pub struct LaneLogProxySpec {
+    pub command: Vec<String>,
+    pub log_path: PathBuf,
+    pub receipt_path: PathBuf,
+    pub receipt_tmp_path: PathBuf,
+    pub environment_path: Option<PathBuf>,
+    pub lane_id: String,
+}
+
+fn lane_exit_receipt_path(log_path: &Path) -> PathBuf {
+    log_path.with_extension("exit.json")
+}
+
+fn lane_exit_receipt_tmp_path(log_path: &Path) -> PathBuf {
+    log_path.with_extension("exit.json.tmp")
+}
+
+fn lane_environment_path(log_path: &Path) -> PathBuf {
+    log_path.with_extension("env.json")
+}
+
+fn lane_environment_tmp_path(path: &Path) -> PathBuf {
+    path.with_extension("json.tmp")
+}
+
+fn remove_file_if_present(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+fn valid_environment_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn write_lane_environment(path: &Path, environment: &[(String, String)]) -> Result<()> {
+    for (key, _) in environment {
+        if !valid_environment_key(key) {
+            bail!("invalid lane environment key {key:?}");
+        }
+    }
+    let encoded = serde_json::to_vec(environment).context("serialize private lane environment")?;
+    if encoded.len() as u64 > MAX_ENVIRONMENT_BYTES {
+        bail!(
+            "private lane environment exceeds {} bytes",
+            MAX_ENVIRONMENT_BYTES
+        );
+    }
+
+    let tmp_path = lane_environment_tmp_path(path);
+    remove_file_if_present(path)?;
+    remove_file_if_present(&tmp_path)?;
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let result = (|| {
+        let mut file = options
+            .open(&tmp_path)
+            .with_context(|| format!("create private lane environment {}", tmp_path.display()))?;
+        file.write_all(&encoded)
+            .with_context(|| format!("write private lane environment {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync private lane environment {}", tmp_path.display()))?;
+        fs::rename(&tmp_path, path)
+            .with_context(|| format!("publish private lane environment {}", path.display()))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = remove_file_if_present(&tmp_path);
+        let _ = remove_file_if_present(path);
+    }
+    result
+}
+
+fn append_child_output(log_path: &Path, stream: &str, bytes: &[u8]) -> Result<()> {
+    let mut line = bytes;
+    if let Some(stripped) = line.strip_suffix(b"\n") {
+        line = stripped;
+    }
+    if let Some(stripped) = line.strip_suffix(b"\r") {
+        line = stripped;
+    }
+    if line.is_empty() {
+        return Ok(());
+    }
+    if let Ok(event) = serde_json::from_slice::<serde_json::Value>(line) {
+        append_log_event(log_path, event)
+    } else {
+        append_log_event(
+            log_path,
+            serde_json::json!({
+                "type": "lane_log",
+                "stream": stream,
+                "message": String::from_utf8_lossy(line),
+            }),
+        )
+    }
+}
+
+fn stream_child_output(
+    reader: impl std::io::Read,
+    log_path: PathBuf,
+    stream: &'static str,
+) -> Result<()> {
+    let mut reader = BufReader::new(reader);
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let mut reached_eof = false;
+        while line.len() < MAX_CHILD_LOG_FRAME_BYTES {
+            let buffer = reader
+                .fill_buf()
+                .with_context(|| format!("read lane child {stream}"))?;
+            if buffer.is_empty() {
+                reached_eof = true;
+                break;
+            }
+            let available = buffer
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(buffer.len(), |position| position + 1);
+            let take = available.min(MAX_CHILD_LOG_FRAME_BYTES - line.len());
+            let ended_line = buffer.get(take.saturating_sub(1)) == Some(&b'\n');
+            line.extend_from_slice(&buffer[..take]);
+            reader.consume(take);
+            if ended_line {
+                break;
+            }
+        }
+        if line.is_empty() && reached_eof {
+            return Ok(());
+        }
+        append_child_output(&log_path, stream, &line)?;
+        if reached_eof {
+            return Ok(());
+        }
+    }
+}
+
+fn read_lane_environment(path: &Path) -> Result<Vec<(String, String)>> {
+    let metadata = fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
+    if metadata.len() > MAX_ENVIRONMENT_BYTES {
+        bail!(
+            "private lane environment {} exceeds {} bytes",
+            path.display(),
+            MAX_ENVIRONMENT_BYTES
+        );
+    }
+    let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    if bytes.len() as u64 > MAX_ENVIRONMENT_BYTES {
+        bail!(
+            "private lane environment {} exceeds {} bytes",
+            path.display(),
+            MAX_ENVIRONMENT_BYTES
+        );
+    }
+    let environment: Vec<(String, String)> =
+        serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
+    for (key, _) in &environment {
+        if !valid_environment_key(key) {
+            bail!("invalid lane environment key {key:?}");
+        }
+    }
+    Ok(environment)
+}
+
+fn write_lane_exit_receipt(
+    receipt_path: &Path,
+    receipt_tmp_path: &Path,
+    lane_id: &str,
+    exit_code: i32,
+) -> Result<()> {
+    let encoded = serde_json::to_vec(&LaneExitReceipt {
+        lane_id: lane_id.to_string(),
+        exit_code,
+    })
+    .context("serialize lane exit receipt")?;
+    if encoded.len() as u64 > MAX_EXIT_RECEIPT_BYTES {
+        bail!("serialized lane exit receipt exceeds size bound");
+    }
+    remove_file_if_present(receipt_tmp_path)?;
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let result = (|| {
+        let mut file = options
+            .open(receipt_tmp_path)
+            .with_context(|| format!("create {}", receipt_tmp_path.display()))?;
+        file.write_all(&encoded)
+            .with_context(|| format!("write {}", receipt_tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync {}", receipt_tmp_path.display()))?;
+        fs::rename(receipt_tmp_path, receipt_path)
+            .with_context(|| format!("publish {}", receipt_path.display()))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = remove_file_if_present(receipt_tmp_path);
+    }
+    result
+}
+
+fn exit_status_code(status: ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+    LANE_PROXY_FAILURE_EXIT_CODE
+}
+
+fn append_proxy_failure(log_path: &Path, lane_id: &str, error: &anyhow::Error) -> Result<()> {
+    append_log_event(
+        log_path,
+        serde_json::json!({
+            "type": "lane_proxy_error",
+            "lane_id": lane_id,
+            "error": format!("{error:#}"),
+        }),
+    )
+}
+
+/// Run a child command while framing all output as NDJSON and atomically
+/// publishing a private exit receipt. Returns the process-style exit code the
+/// hidden CLI should propagate to tmux.
+pub fn run_lane_log_proxy(spec: LaneLogProxySpec) -> Result<i32> {
+    let LaneLogProxySpec {
+        command,
+        log_path,
+        receipt_path,
+        receipt_tmp_path,
+        environment_path,
+        lane_id,
+    } = spec;
+
+    let fail = |error: anyhow::Error, exit_code: i32| -> Result<i32> {
+        append_proxy_failure(&log_path, &lane_id, &error)?;
+        write_lane_exit_receipt(&receipt_path, &receipt_tmp_path, &lane_id, exit_code)?;
+        Ok(exit_code)
+    };
+
+    if command.is_empty() {
+        return fail(anyhow::anyhow!("lane log proxy requires a command"), 127);
+    }
+
+    let environment = if let Some(path) = environment_path.as_deref() {
+        let loaded = read_lane_environment(path);
+        let removed = remove_file_if_present(path);
+        match (loaded, removed) {
+            (Ok(environment), Ok(())) => environment,
+            (Err(error), Ok(())) => return fail(error, LANE_PROXY_FAILURE_EXIT_CODE),
+            (Ok(_), Err(error)) | (Err(_), Err(error)) => return Err(error),
+        }
+    } else {
+        Vec::new()
+    };
+
+    let mut child_command = Command::new(&command[0]);
+    child_command.args(&command[1..]);
+    child_command.envs(environment);
+    child_command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = match child_command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return fail(
+                anyhow::Error::from(error).context(format!("spawn lane child command {command:?}")),
+                127,
+            );
+        }
+    };
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => return fail(anyhow::anyhow!("lane child stdout was not piped"), 125),
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => return fail(anyhow::anyhow!("lane child stderr was not piped"), 125),
+    };
+    let stdout_log = log_path.clone();
+    let stderr_log = log_path.clone();
+    let stdout_thread = thread::spawn(move || stream_child_output(stdout, stdout_log, "stdout"));
+    let stderr_thread = thread::spawn(move || stream_child_output(stderr, stderr_log, "stderr"));
+
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(error) => {
+            return fail(
+                anyhow::Error::from(error).context(format!("wait for lane child {command:?}")),
+                LANE_PROXY_FAILURE_EXIT_CODE,
+            );
+        }
+    };
+    let stdout_result = stdout_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("lane proxy stdout logger panicked"))?;
+    let stderr_result = stderr_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("lane proxy stderr logger panicked"))?;
+    let mut exit_code = exit_status_code(status);
+    if let Some(error) = stdout_result.err().or_else(|| stderr_result.err()) {
+        append_proxy_failure(&log_path, &lane_id, &error)?;
+        exit_code = LANE_PROXY_FAILURE_EXIT_CODE;
+    }
+    write_lane_exit_receipt(&receipt_path, &receipt_tmp_path, &lane_id, exit_code)?;
+    Ok(exit_code)
+}
+
+fn read_lane_exit_receipt(log_path: &Path, lane_id: &str) -> Result<Option<LaneExitReceipt>> {
+    let path = lane_exit_receipt_path(log_path);
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).with_context(|| format!("stat {}", path.display())),
+    };
+    if metadata.len() > MAX_EXIT_RECEIPT_BYTES {
+        bail!(
+            "lane exit receipt {} exceeds {} bytes",
+            path.display(),
+            MAX_EXIT_RECEIPT_BYTES
+        );
+    }
+    let bytes = std::fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+    let receipt: LaneExitReceipt =
+        serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
+    if receipt.lane_id != lane_id {
+        bail!(
+            "lane exit receipt {} belongs to {}, expected {}",
+            path.display(),
+            receipt.lane_id,
+            lane_id
+        );
+    }
+    Ok(Some(receipt))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TmuxSessionState {
+    Present,
+    Absent,
+}
+
+fn tmux_command(socket: &Path) -> Command {
+    let mut command = Command::new("tmux");
+    command.arg("-S").arg(socket);
+    command
+}
+
+fn ensure_tmux_available() -> Result<()> {
+    let output = Command::new("tmux")
+        .arg("-V")
+        .output()
+        .context("tmux runtime requires the `tmux` executable")?;
+    if !output.status.success() {
+        bail!(
+            "tmux runtime is unavailable: `tmux -V` failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn tmux_session_state(socket: &Path, session: &str) -> Result<TmuxSessionState> {
+    let output = tmux_command(socket)
+        .args(["has-session", "-t", session])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("query tmux session {session}"))?;
+    if output.status.success() {
+        return Ok(TmuxSessionState::Present);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    if stderr.contains("can't find session:")
+        || stderr.contains("no server running on")
+        || (stderr.contains("error connecting to") && stderr.contains("no such file or directory"))
+    {
+        return Ok(TmuxSessionState::Absent);
+    }
+    bail!(
+        "tmux has-session for {session} failed with {}: {}",
+        output.status,
+        stderr.trim()
+    )
+}
+
+fn stop_tmux_session(socket: &Path, session: &str) -> Result<()> {
+    let status = tmux_command(socket)
+        .args(["kill-session", "-t", session])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .with_context(|| format!("kill tmux session {session}"))?;
+    match tmux_session_state(socket, session).with_context(|| {
+        format!(
+            "confirm tmux session {session} on {} stopped after kill-session ({status})",
+            socket.display()
+        )
+    })? {
+        TmuxSessionState::Absent => {}
+        TmuxSessionState::Present => {
+            bail!("tmux session {session} remains active after kill-session ({status})")
+        }
+    }
+    // A nonzero kill can be benign when the process and session exited in the
+    // same instant. The explicit absence check above is the source of truth.
+    Ok(())
+}
+
+fn tmux_log_proxy_command(
+    proxy: &Path,
+    command: &[String],
+    log_path: &Path,
+    receipt_path: &Path,
+    receipt_tmp_path: &Path,
+    environment_path: Option<&Path>,
+    lane_id: &str,
+) -> String {
+    let mut argv = vec![
+        proxy.display().to_string(),
+        "lane-log-proxy".to_string(),
+        "--log-path".to_string(),
+        log_path.display().to_string(),
+        "--receipt-path".to_string(),
+        receipt_path.display().to_string(),
+        "--receipt-tmp-path".to_string(),
+        receipt_tmp_path.display().to_string(),
+        "--lane-id".to_string(),
+        lane_id.to_string(),
+    ];
+    if let Some(path) = environment_path {
+        argv.push("--environment-path".to_string());
+        argv.push(path.display().to_string());
+    }
+    argv.push("--".to_string());
+    argv.extend(command.iter().cloned());
+    format!("exec {}", shell_join(&argv))
 }
 
 fn apply_worktree(record: &mut LaneRecord, spec: &LaneStartSpec) -> Result<Option<PathBuf>> {
@@ -142,19 +656,33 @@ impl RuntimeBackend for TmuxRuntime {
         if spec.command.is_empty() {
             bail!("tmux runtime requires a non-empty command");
         }
-        // tmux may be absent in CI; fall back to a dry-run session record when
-        // CODEWHALE_LANE_TMUX_DRY_RUN=1 or tmux is missing (tests).
-        let dry_run = std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some()
-            || Command::new("tmux")
-                .arg("-V")
-                .output()
-                .map(|o| !o.status.success())
-                .unwrap_or(true);
+        // Dry-run is an explicit test hook only. A missing/broken tmux binary
+        // must fail closed rather than persisting a fictional Running Lane.
+        let dry_run = std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some();
+        if !dry_run && let Err(error) = ensure_tmux_available() {
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({
+                    "type": "lane_failed",
+                    "lane_id": record.id,
+                    "runtime": "tmux",
+                    "error": error.to_string(),
+                }),
+            )?;
+            let _ = registry.mark_terminal_if_active(record, LaneStatus::Failed)?;
+            return Err(error);
+        }
 
         let cwd = apply_worktree(record, spec)?;
         let session = format!("cw-{}", record.id);
+        let socket = registry.root().join("tmux.sock");
         record.tmux_session = Some(session.clone());
-        record.attach_target = Some(format!("tmux attach -t {session}"));
+        record.tmux_socket = Some(socket.clone());
+        record.attach_target = Some(format!(
+            "tmux -S {} attach -t {}",
+            shell_escape(&socket.display().to_string()),
+            shell_escape(&session)
+        ));
 
         append_log_event(
             &record.log_path,
@@ -180,65 +708,202 @@ impl RuntimeBackend for TmuxRuntime {
                     "cwd": cwd.as_ref().map(|p| p.display().to_string()),
                 }),
             )?;
-            registry.mark_running(record)?;
+            if !registry.mark_running_if_pending(record)? {
+                bail!(
+                    "lane `{}` was stopped before tmux dry-run start completed",
+                    record.id
+                );
+            }
             return Ok(());
         }
 
-        // Detached session: run command, tee stdout into the lane log.
-        let log_path = record.log_path.display().to_string();
-        let shell_cmd = format!(
-            "({}) 2>&1 | while IFS= read -r line; do printf '%s\\n' \"$line\" >> {}; done",
-            shell_join(&spec.command),
-            shell_escape(&log_path)
+        let log_proxy = spec
+            .log_proxy
+            .as_deref()
+            .context("tmux runtime requires a lane log proxy executable")?;
+
+        // Detached session: child output remains an operator journal only.
+        // Terminal control state goes through a separate bounded, atomically
+        // renamed receipt so child stdout cannot forge Lane completion.
+        let receipt_path = lane_exit_receipt_path(&record.log_path);
+        let receipt_tmp_path = lane_exit_receipt_tmp_path(&record.log_path);
+        let environment_path = lane_environment_path(&record.log_path);
+        remove_file_if_present(&receipt_path)?;
+        remove_file_if_present(&receipt_tmp_path)?;
+        remove_file_if_present(&environment_path)?;
+        let environment_path = if spec.environment.is_empty() {
+            None
+        } else {
+            write_lane_environment(&environment_path, &spec.environment)?;
+            Some(environment_path)
+        };
+        let shell_cmd = tmux_log_proxy_command(
+            log_proxy,
+            &spec.command,
+            &record.log_path,
+            &receipt_path,
+            &receipt_tmp_path,
+            environment_path.as_deref(),
+            &record.id,
         );
 
-        let mut cmd = Command::new("tmux");
+        let mut cmd = tmux_command(&socket);
         cmd.args(["new-session", "-d", "-s", &session]);
         if let Some(cwd) = cwd.as_ref() {
             cmd.arg("-c").arg(cwd);
         }
         cmd.arg(shell_cmd);
-        let status = cmd
-            .status()
-            .with_context(|| format!("spawn tmux session {session}"))?;
-        if !status.success() {
-            record.status = LaneStatus::Failed;
-            registry.save(record)?;
-            bail!("tmux new-session failed with {status}");
+        let proposed_record = record.clone();
+        let spawned = std::cell::Cell::new(false);
+        let rolled_back = std::cell::Cell::new(false);
+        match registry.mark_running_if_pending_with(
+            record,
+            || {
+                let status = cmd
+                    .status()
+                    .with_context(|| format!("spawn tmux session {session}"))?;
+                if !status.success() {
+                    bail!("tmux new-session failed with {status}");
+                }
+                spawned.set(true);
+                Ok(())
+            },
+            || {
+                stop_tmux_session(&socket, &session)?;
+                rolled_back.set(true);
+                Ok(())
+            },
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                if let Some(path) = environment_path.as_deref() {
+                    remove_file_if_present(path)?;
+                }
+                let mut stopped_record = proposed_record;
+                stopped_record.stopped_at = record.stopped_at.clone();
+                self.cleanup_worktree(&stopped_record)?;
+                bail!("lane `{}` was stopped before tmux launch", record.id);
+            }
+            Err(error) => {
+                if let Some(path) = environment_path.as_deref() {
+                    let _ = remove_file_if_present(path);
+                }
+                if !spawned.get() || rolled_back.get() {
+                    let _ = registry.mark_terminal_if_active(record, LaneStatus::Failed)?;
+                    let mut failed_record = proposed_record;
+                    failed_record.stopped_at = record.stopped_at.clone();
+                    self.cleanup_worktree(&failed_record)?;
+                }
+                return Err(error);
+            }
         }
-
-        registry.mark_running(record)?;
         Ok(())
     }
 
     fn attach_command(&self, record: &LaneRecord) -> Option<String> {
-        record.attach_target.clone().or_else(|| {
-            record
-                .tmux_session
-                .as_ref()
-                .map(|s| format!("tmux attach -t {s}"))
-        })
+        if record.status != LaneStatus::Running {
+            return None;
+        }
+        let socket = record.tmux_socket.as_ref()?;
+        let session = record.tmux_session.as_deref()?;
+        Some(format!(
+            "tmux -S {} attach -t {}",
+            shell_escape(&socket.display().to_string()),
+            shell_escape(session)
+        ))
     }
 
     fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
-        if let Some(session) = record.tmux_session.as_deref() {
-            let dry_run = std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some();
+        let dry_run = std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some();
+        if registry.mark_terminal_if_active_with(record, LaneStatus::Stopped, |current| {
             if !dry_run {
-                let _ = Command::new("tmux")
-                    .args(["kill-session", "-t", session])
-                    .status();
+                match (
+                    current.tmux_socket.as_deref(),
+                    current.tmux_session.as_deref(),
+                ) {
+                    (Some(socket), Some(session)) => stop_tmux_session(socket, session)?,
+                    _ if current.status == LaneStatus::Running => {
+                        bail!(
+                            "running tmux lane `{}` has incomplete pinned session metadata; refusing unsafe stop",
+                            current.id
+                        );
+                    }
+                    _ => {}
+                }
             }
+            Ok(())
+        })? {
             append_log_event(
                 &record.log_path,
                 serde_json::json!({
                     "type": "lane_stopped",
                     "lane_id": record.id,
-                    "session": session,
+                    "session": record.tmux_session,
                 }),
             )?;
+            remove_file_if_present(&lane_environment_path(&record.log_path))?;
+            self.cleanup_worktree(record)?;
         }
-        registry.mark_stopped(record, LaneStatus::Stopped)?;
-        self.cleanup_worktree(record)?;
+        Ok(())
+    }
+
+    fn reconcile(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
+        // Pending is the pre-launch state. Never reconcile it: a concurrent
+        // status read must not race a fast `tmux new-session` and overwrite
+        // the start path's later Running transition.
+        if record.status != LaneStatus::Running {
+            return Ok(());
+        }
+
+        let receipt = read_lane_exit_receipt(&record.log_path, &record.id)?;
+        let (lane_status, exit_code, reason) = if let Some(receipt) = receipt {
+            (
+                if receipt.exit_code == 0 {
+                    LaneStatus::Completed
+                } else {
+                    LaneStatus::Failed
+                },
+                Some(receipt.exit_code),
+                "process_exit_receipt",
+            )
+        } else {
+            if std::env::var_os("CODEWHALE_LANE_TMUX_DRY_RUN").is_some() {
+                return Ok(());
+            }
+            let (Some(socket), Some(session)) = (
+                record.tmux_socket.as_deref(),
+                record.tmux_session.as_deref(),
+            ) else {
+                bail!(
+                    "running tmux lane `{}` lacks pinned socket/session metadata; refusing unsafe reconciliation",
+                    record.id
+                );
+            };
+            match tmux_session_state(socket, session)? {
+                TmuxSessionState::Present => return Ok(()),
+                TmuxSessionState::Absent => {}
+            }
+            (
+                LaneStatus::Failed,
+                None,
+                "tmux_session_missing_without_exit_receipt",
+            )
+        };
+
+        if registry.mark_terminal_if_active(record, lane_status)? {
+            append_log_event(
+                &record.log_path,
+                serde_json::json!({
+                    "type": "lane_reconciled",
+                    "lane_id": record.id,
+                    "exit_code": exit_code,
+                    "status": lane_status.as_str(),
+                    "reason": reason,
+                }),
+            )?;
+            remove_file_if_present(&lane_environment_path(&record.log_path))?;
+            self.cleanup_worktree(record)?;
+        }
         Ok(())
     }
 }
@@ -271,6 +936,12 @@ impl RuntimeBackend for InlineRuntime {
                 "command": spec.command,
             }),
         )?;
+        if !registry.mark_running_if_pending(record)? {
+            bail!(
+                "lane `{}` was stopped before inline start completed",
+                record.id
+            );
+        }
 
         let mut cmd = Command::new(&spec.command[0]);
         if spec.command.len() > 1 {
@@ -279,33 +950,68 @@ impl RuntimeBackend for InlineRuntime {
         if let Some(cwd) = cwd.as_ref() {
             cmd.current_dir(cwd);
         }
-        let output = cmd
-            .output()
-            .with_context(|| format!("run inline command {:?}", spec.command))?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        for line in stdout.lines().chain(stderr.lines()) {
-            append_log_event(
-                &record.log_path,
-                serde_json::json!({"type": "lane_log", "message": line}),
-            )?;
-        }
-        if output.status.success() {
+        cmd.envs(spec.environment.iter().map(|(key, value)| (key, value)));
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                append_log_event(
+                    &record.log_path,
+                    serde_json::json!({
+                        "type": "lane_failed",
+                        "lane_id": record.id,
+                        "error": err.to_string(),
+                    }),
+                )?;
+                let _ = registry.mark_terminal_if_active(record, LaneStatus::Failed)?;
+                return Err(err).with_context(|| format!("run inline command {:?}", spec.command));
+            }
+        };
+        let stdout = child
+            .stdout
+            .take()
+            .context("inline lane child stdout was not piped")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("inline lane child stderr was not piped")?;
+        let stdout_log = record.log_path.clone();
+        let stderr_log = record.log_path.clone();
+        let stdout_thread =
+            thread::spawn(move || stream_child_output(stdout, stdout_log, "stdout"));
+        let stderr_thread =
+            thread::spawn(move || stream_child_output(stderr, stderr_log, "stderr"));
+        let status = child
+            .wait()
+            .with_context(|| format!("wait for inline command {:?}", spec.command))?;
+        let stdout_result = stdout_thread
+            .join()
+            .map_err(|_| anyhow::anyhow!("inline stdout logger panicked"))?;
+        let stderr_result = stderr_thread
+            .join()
+            .map_err(|_| anyhow::anyhow!("inline stderr logger panicked"))?;
+        let logging_error = stdout_result.err().or_else(|| stderr_result.err());
+
+        if status.success() && logging_error.is_none() {
             append_log_event(
                 &record.log_path,
                 serde_json::json!({"type": "lane_completed", "lane_id": record.id}),
             )?;
-            registry.mark_stopped(record, LaneStatus::Completed)?;
+            let _ = registry.mark_terminal_if_active(record, LaneStatus::Completed)?;
         } else {
             append_log_event(
                 &record.log_path,
                 serde_json::json!({
                     "type": "lane_failed",
                     "lane_id": record.id,
-                    "status": format!("{}", output.status),
+                    "status": format!("{status}"),
+                    "logging_error": logging_error.as_ref().map(ToString::to_string),
                 }),
             )?;
-            registry.mark_stopped(record, LaneStatus::Failed)?;
+            let _ = registry.mark_terminal_if_active(record, LaneStatus::Failed)?;
+        }
+        if let Some(err) = logging_error {
+            return Err(err).context("stream inline lane output");
         }
         Ok(())
     }
@@ -315,10 +1021,17 @@ impl RuntimeBackend for InlineRuntime {
     }
 
     fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
-        if record.status.is_active() {
-            registry.mark_stopped(record, LaneStatus::Stopped)?;
+        if registry.mark_terminal_if_active_with(record, LaneStatus::Stopped, |current| {
+            if current.status == LaneStatus::Running {
+                bail!(
+                    "inline lane `{}` cannot be stopped safely from another process",
+                    current.id
+                );
+            }
+            Ok(())
+        })? {
+            self.cleanup_worktree(record)?;
         }
-        self.cleanup_worktree(record)?;
         Ok(())
     }
 }
@@ -340,17 +1053,21 @@ impl RuntimeBackend for StubRuntime {
         record: &mut LaneRecord,
         _spec: &LaneStartSpec,
     ) -> Result<()> {
+        let error = format!(
+            "{} runtime is not implemented; use tmux or inline",
+            self.kind.as_str()
+        );
         append_log_event(
             &record.log_path,
             serde_json::json!({
-                "type": "lane_started",
+                "type": "lane_failed",
                 "lane_id": record.id,
                 "runtime": self.kind.as_str(),
-                "message": format!("{} runtime is a Phase 1 stub", self.kind.as_str()),
+                "error": &error,
             }),
         )?;
-        registry.mark_running(record)?;
-        Ok(())
+        let _ = registry.mark_terminal_if_active(record, LaneStatus::Failed)?;
+        bail!("{error}")
     }
 
     fn attach_command(&self, _record: &LaneRecord) -> Option<String> {
@@ -358,7 +1075,7 @@ impl RuntimeBackend for StubRuntime {
     }
 
     fn stop(&self, registry: &LaneRegistry, record: &mut LaneRecord) -> Result<()> {
-        registry.mark_stopped(record, LaneStatus::Stopped)?;
+        let _ = registry.mark_terminal_if_active(record, LaneStatus::Stopped)?;
         Ok(())
     }
 }
@@ -377,10 +1094,54 @@ fn shell_join(args: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
+
+    fn tmux_env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct ScopedEnvVar {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(name: &'static str, value: &std::ffi::OsStr) -> Self {
+            let previous = std::env::var_os(name);
+            // SAFETY: tmux environment tests hold `tmux_env_lock` and restore
+            // the process environment in Drop.
+            unsafe { std::env::set_var(name, value) };
+            Self { name, previous }
+        }
+
+        fn remove(name: &'static str) -> Self {
+            let previous = std::env::var_os(name);
+            // SAFETY: tmux environment tests hold `tmux_env_lock` and restore
+            // the process environment in Drop.
+            unsafe { std::env::remove_var(name) };
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            // SAFETY: paired with the serialized mutation above.
+            unsafe {
+                if let Some(previous) = self.previous.take() {
+                    std::env::set_var(self.name, previous);
+                } else {
+                    std::env::remove_var(self.name);
+                }
+            }
+        }
+    }
 
     #[test]
     fn tmux_dry_run_start_attach_stop_roundtrip() {
+        let _env_guard = tmux_env_lock();
         // SAFETY: test-only env toggle for tmux dry-run; single-threaded unit test.
         unsafe {
             std::env::set_var("CODEWHALE_LANE_TMUX_DRY_RUN", "1");
@@ -405,14 +1166,23 @@ mod tests {
                 &LaneStartSpec {
                     command: vec!["echo".into(), "hello-lane".into()],
                     cwd: None,
+                    environment: Vec::new(),
+                    log_proxy: None,
                     worktree: None,
                 },
             )
             .unwrap();
         assert_eq!(record.status, LaneStatus::Running);
         assert!(record.tmux_session.is_some());
+        let expected_socket = reg.root().join("tmux.sock");
+        assert_eq!(
+            record.tmux_socket.as_deref(),
+            Some(expected_socket.as_path())
+        );
         let attach = backend.attach_command(&record).expect("attach");
-        assert!(attach.contains("tmux attach"));
+        assert!(attach.contains("tmux -S"));
+        assert!(attach.contains(&expected_socket.display().to_string()));
+        assert!(attach.contains("attach -t"));
         let log = std::fs::read_to_string(&record.log_path).unwrap();
         assert!(log.contains("lane_started"));
 
@@ -423,6 +1193,76 @@ mod tests {
         // SAFETY: paired cleanup of the test-only dry-run flag.
         unsafe {
             std::env::remove_var("CODEWHALE_LANE_TMUX_DRY_RUN");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unavailable_tmux_fails_lane_instead_of_faking_running() {
+        use std::os::unix::fs::symlink;
+
+        let _env_guard = tmux_env_lock();
+        let dir = tempdir().unwrap();
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir(&bin_dir).unwrap();
+        symlink("/usr/bin/false", bin_dir.join("tmux")).unwrap();
+        let prior_path = std::env::var_os("PATH").unwrap_or_default();
+        let combined_path = std::env::join_paths(
+            std::iter::once(bin_dir).chain(std::env::split_paths(&prior_path)),
+        )
+        .unwrap();
+        let _path = ScopedEnvVar::set("PATH", &combined_path);
+        let _dry_run = ScopedEnvVar::remove("CODEWHALE_LANE_TMUX_DRY_RUN");
+
+        let reg = LaneRegistry::open(dir.path().join("registry")).unwrap();
+        let mut record = reg
+            .create_pending(None, None, None, None, RuntimeBackendKind::Tmux, None)
+            .unwrap();
+        let error = TmuxRuntime
+            .start(
+                &reg,
+                &mut record,
+                &LaneStartSpec {
+                    command: vec!["/bin/true".to_string()],
+                    cwd: None,
+                    environment: Vec::new(),
+                    log_proxy: Some(PathBuf::from("/bin/true")),
+                    worktree: None,
+                },
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("tmux runtime is unavailable"));
+        assert_eq!(record.status, LaneStatus::Failed);
+        assert_eq!(reg.load(&record.id).unwrap().status, LaneStatus::Failed);
+        assert!(
+            String::from_utf8_lossy(&fs::read(&record.log_path).unwrap()).contains("lane_failed")
+        );
+    }
+
+    #[test]
+    fn unimplemented_remote_runtimes_fail_terminally() {
+        for kind in [RuntimeBackendKind::Vm, RuntimeBackendKind::Ci] {
+            let dir = tempdir().unwrap();
+            let reg = LaneRegistry::open(dir.path()).unwrap();
+            let mut record = reg
+                .create_pending(None, None, None, None, kind, None)
+                .unwrap();
+            let error = resolve_backend(kind)
+                .start(
+                    &reg,
+                    &mut record,
+                    &LaneStartSpec {
+                        command: vec!["/bin/true".to_string()],
+                        cwd: None,
+                        environment: Vec::new(),
+                        log_proxy: None,
+                        worktree: None,
+                    },
+                )
+                .unwrap_err();
+            assert!(error.to_string().contains("runtime is not implemented"));
+            assert_eq!(record.status, LaneStatus::Failed);
+            assert_eq!(reg.load(&record.id).unwrap().status, LaneStatus::Failed);
         }
     }
 
@@ -447,6 +1287,8 @@ mod tests {
                 &LaneStartSpec {
                     command: vec!["echo".into(), "inline-ok".into()],
                     cwd: None,
+                    environment: Vec::new(),
+                    log_proxy: None,
                     worktree: None,
                 },
             )
@@ -455,5 +1297,305 @@ mod tests {
         let log = std::fs::read_to_string(&record.log_path).unwrap();
         assert!(log.contains("inline-ok"), "log={log}");
         assert!(log.contains("lane_completed"));
+    }
+
+    #[test]
+    fn lane_start_spec_debug_redacts_environment_values() {
+        let spec = LaneStartSpec {
+            command: vec!["codewhale-tui".into()],
+            cwd: None,
+            environment: vec![("DEEPSEEK_API_KEY".into(), "secret-value".into())],
+            log_proxy: None,
+            worktree: None,
+        };
+        let rendered = format!("{spec:?}");
+        assert!(rendered.contains("DEEPSEEK_API_KEY"));
+        assert!(!rendered.contains("secret-value"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inline_runtime_persists_typed_receipts_before_process_exit() {
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let record = reg
+            .create_pending(
+                Some("demo".into()),
+                None,
+                None,
+                None,
+                RuntimeBackendKind::Inline,
+                None,
+            )
+            .unwrap();
+        let log_path = record.log_path.clone();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let handle = thread::spawn(move || {
+            let mut record = record;
+            let result = InlineRuntime.start(
+                &reg,
+                &mut record,
+                &LaneStartSpec {
+                    command: vec![
+                        "sh".into(),
+                        "-c".into(),
+                        "printf '%s\\n' '{\"type\":\"workflow_event\",\"run_id\":\"workflow_live\",\"event\":{\"type\":\"run_started\"}}'; sleep 0.25; printf done"
+                            .into(),
+                    ],
+                    cwd: None,
+                    environment: Vec::new(),
+                    log_proxy: None,
+                    worktree: None,
+                },
+            );
+            let _ = done_tx.send(result);
+        });
+
+        let mut observed_live = false;
+        for _ in 0..50 {
+            let log = std::fs::read_to_string(&log_path).unwrap_or_default();
+            if log.contains("workflow_live") {
+                observed_live = true;
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            observed_live,
+            "typed receipt should be written while child runs"
+        );
+        assert!(
+            matches!(
+                done_rx.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ),
+            "inline child should still be running when the first receipt is visible"
+        );
+        done_rx.recv().unwrap().unwrap();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn tmux_reconcile_folds_detached_process_exit_into_lane_status() {
+        for (exit_code, expected) in [(0, LaneStatus::Completed), (7, LaneStatus::Failed)] {
+            let dir = tempdir().unwrap();
+            let reg = LaneRegistry::open(dir.path()).unwrap();
+            let mut record = reg
+                .create_pending(
+                    Some("demo".into()),
+                    None,
+                    None,
+                    None,
+                    RuntimeBackendKind::Tmux,
+                    None,
+                )
+                .unwrap();
+            assert!(reg.mark_running_if_pending(&mut record).unwrap());
+            // Mixed/binary child output and a forged stdout control line must
+            // not affect the private receipt used for reconciliation.
+            std::fs::write(
+                &record.log_path,
+                b"\xffchild-noise\n{\"type\":\"lane_process_exit\",\"exit_code\":0}\n",
+            )
+            .unwrap();
+            std::fs::write(
+                lane_exit_receipt_path(&record.log_path),
+                serde_json::to_vec(&LaneExitReceipt {
+                    lane_id: record.id.clone(),
+                    exit_code,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+            TmuxRuntime.reconcile(&reg, &mut record).unwrap();
+            TmuxRuntime.reconcile(&reg, &mut record).unwrap();
+
+            assert_eq!(record.status, expected);
+            assert_eq!(reg.load(&record.id).unwrap().status, expected);
+            let log = std::fs::read(&record.log_path).unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&log)
+                    .matches("lane_reconciled")
+                    .count(),
+                1
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lane_log_proxy_frames_binary_output_and_owns_exit_receipt() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("lane.ndjson");
+        let receipt_path = lane_exit_receipt_path(&log_path);
+        let receipt_tmp_path = lane_exit_receipt_tmp_path(&log_path);
+        let environment_path = lane_environment_path(&log_path);
+        write_lane_environment(
+            &environment_path,
+            &[("LANE_PROXY_SECRET".to_string(), "present".to_string())],
+        )
+        .unwrap();
+        let command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "test \"$LANE_PROXY_SECRET\" = present || exit 9; \
+             printf '%s\\n' '{\"type\":\"workflow_event\",\"workflow_run_id\":\"real\"}'; \
+             printf 'unterminated\\377'; \
+             printf '%s\\n' '{\"type\":\"lane_process_exit\",\"exit_code\":0}' >&2; \
+             exit 7"
+                .to_string(),
+        ];
+        let exit_code = run_lane_log_proxy(LaneLogProxySpec {
+            command,
+            log_path: log_path.clone(),
+            receipt_path: receipt_path.clone(),
+            receipt_tmp_path,
+            environment_path: Some(environment_path.clone()),
+            lane_id: "lane-proof".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(exit_code, 7);
+        assert!(!environment_path.exists());
+        let log = std::fs::read(&log_path).unwrap();
+        let lines = log
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>();
+        assert!(lines.len() >= 3, "log={}", String::from_utf8_lossy(&log));
+        for line in &lines {
+            serde_json::from_slice::<serde_json::Value>(line)
+                .unwrap_or_else(|error| panic!("invalid NDJSON {line:?}: {error}"));
+        }
+        let rendered = String::from_utf8_lossy(&log);
+        assert!(rendered.contains("workflow_event"));
+        assert!(rendered.contains("lane_process_exit"));
+        assert!(rendered.contains("lane_log"));
+        let receipt = read_lane_exit_receipt(&log_path, "lane-proof")
+            .unwrap()
+            .expect("private receipt");
+        assert_eq!(receipt.exit_code, 7);
+    }
+
+    #[test]
+    fn invalid_environment_key_never_leaves_a_partial_secret_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("lane.env.json");
+        let result = write_lane_environment(
+            &path,
+            &[
+                ("VALID_KEY".to_string(), "first-secret".to_string()),
+                ("INVALID-KEY".to_string(), "second-secret".to_string()),
+            ],
+        );
+        assert!(result.is_err());
+        assert!(!path.exists());
+        assert!(!lane_environment_tmp_path(&path).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_environment_is_mode_0600_and_malformed_input_is_removed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("lane.env.json");
+        write_lane_environment(&path, &[("SECRET".to_string(), "sensitive".to_string())]).unwrap();
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        fs::write(&path, b"{malformed").unwrap();
+        let log_path = dir.path().join("lane.ndjson");
+        let exit_code = run_lane_log_proxy(LaneLogProxySpec {
+            command: vec!["/bin/true".to_string()],
+            receipt_path: lane_exit_receipt_path(&log_path),
+            receipt_tmp_path: lane_exit_receipt_tmp_path(&log_path),
+            environment_path: Some(path.clone()),
+            lane_id: "lane-malformed-env".to_string(),
+            log_path: log_path.clone(),
+        })
+        .unwrap();
+        assert_eq!(exit_code, LANE_PROXY_FAILURE_EXIT_CODE);
+        assert!(!path.exists());
+        assert!(String::from_utf8_lossy(&fs::read(log_path).unwrap()).contains("lane_proxy_error"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tmux_stop_failure_keeps_lane_running_and_preserves_cleanup_targets() {
+        use std::os::unix::fs::symlink;
+
+        let _env_guard = tmux_env_lock();
+        let dir = tempdir().unwrap();
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir(&bin_dir).unwrap();
+        symlink("/usr/bin/false", bin_dir.join("tmux")).unwrap();
+        let prior_path = std::env::var_os("PATH").unwrap_or_default();
+        let combined_path = std::env::join_paths(
+            std::iter::once(bin_dir.clone()).chain(std::env::split_paths(&prior_path)),
+        )
+        .unwrap();
+        let _path = ScopedEnvVar::set("PATH", &combined_path);
+        let _dry_run = ScopedEnvVar::remove("CODEWHALE_LANE_TMUX_DRY_RUN");
+
+        let reg = LaneRegistry::open(dir.path().join("registry")).unwrap();
+        let mut record = reg
+            .create_pending(
+                Some("demo".into()),
+                None,
+                None,
+                None,
+                RuntimeBackendKind::Tmux,
+                Some(0),
+            )
+            .unwrap();
+        record.tmux_session = Some(format!("cw-{}", record.id));
+        record.tmux_socket = Some(reg.root().join("tmux.sock"));
+        let worktree = dir.path().join("worktree");
+        fs::create_dir(&worktree).unwrap();
+        record.worktree_path = Some(worktree.clone());
+        let environment_path = lane_environment_path(&record.log_path);
+        write_lane_environment(
+            &environment_path,
+            &[("SECRET".to_string(), "still-private".to_string())],
+        )
+        .unwrap();
+        assert!(reg.mark_running_if_pending(&mut record).unwrap());
+
+        let error = TmuxRuntime.stop(&reg, &mut record).unwrap_err();
+        assert!(format!("{error:#}").contains("tmux has-session"));
+        assert_eq!(record.status, LaneStatus::Running);
+        assert_eq!(reg.load(&record.id).unwrap().status, LaneStatus::Running);
+        assert!(environment_path.exists());
+        assert!(worktree.exists());
+    }
+
+    #[test]
+    fn tmux_reconcile_marks_vanished_session_failed_without_receipt() {
+        let _env_guard = tmux_env_lock();
+        let dir = tempdir().unwrap();
+        let reg = LaneRegistry::open(dir.path()).unwrap();
+        let mut record = reg
+            .create_pending(
+                Some("demo".into()),
+                None,
+                None,
+                None,
+                RuntimeBackendKind::Tmux,
+                None,
+            )
+            .unwrap();
+        record.tmux_session = Some(format!("missing-{}", record.id));
+        record.tmux_socket = Some(reg.root().join("tmux.sock"));
+        assert!(reg.mark_running_if_pending(&mut record).unwrap());
+
+        TmuxRuntime.reconcile(&reg, &mut record).unwrap();
+
+        assert_eq!(record.status, LaneStatus::Failed);
+        let log = std::fs::read_to_string(&record.log_path).unwrap();
+        assert!(log.contains("tmux_session_missing_without_exit_receipt"));
     }
 }

--- a/crates/protocol/src/fleet.rs
+++ b/crates/protocol/src/fleet.rs
@@ -673,6 +673,13 @@ pub enum FleetWorkerEventPayload {
         #[serde(skip_serializing_if = "Option::is_none")]
         call_id: Option<String>,
     },
+    /// Typed receipt emitted by a Workflow running inside this worker.
+    WorkflowEvent {
+        /// Inner Workflow run id. Named distinctly from the outer Fleet run id
+        /// because payloads are flattened into `FleetWorkerEvent`.
+        workflow_run_id: String,
+        event: Value,
+    },
     Heartbeat {
         #[serde(default)]
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -1158,6 +1165,33 @@ mod tests {
         assert!(matches!(
             back[2].payload,
             FleetWorkerEventPayload::Completed { .. }
+        ));
+    }
+
+    #[test]
+    fn workflow_receipt_round_trip_keeps_outer_and_inner_run_ids_distinct() {
+        let event = FleetWorkerEvent {
+            seq: 3,
+            run_id: FleetRunId::from("fleet-run-1"),
+            worker_id: "worker-a".to_string(),
+            task_id: "task-1".to_string(),
+            timestamp: "2026-07-10T00:00:00Z".to_string(),
+            payload: FleetWorkerEventPayload::WorkflowEvent {
+                workflow_run_id: "workflow_1".to_string(),
+                event: serde_json::json!({"type": "task_completed"}),
+            },
+            extra: BTreeMap::new(),
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["run_id"], "fleet-run-1");
+        assert_eq!(value["workflow_run_id"], "workflow_1");
+        let back: FleetWorkerEvent = serde_json::from_value(value).unwrap();
+        assert!(matches!(
+            back.payload,
+            FleetWorkerEventPayload::WorkflowEvent {
+                workflow_run_id,
+                ref event,
+            } if workflow_run_id == "workflow_1" && event["type"] == "task_completed"
         ));
     }
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3454,14 +3454,15 @@ impl Config {
 
     /// Read the API key.
     ///
-    /// Precedence: **explicit in-memory override → provider/root config
-    /// → environment**.
+    /// Precedence: **route-specific OAuth → source-marked explicit CLI key →
+    /// provider/root config → ambient provider environment**.
     ///
     /// The in-memory `self.api_key` override is only honored when the user
     /// explicitly set the field (not the legacy `API_KEYRING_SENTINEL`
     /// placeholder, not empty whitespace).
     pub fn deepseek_api_key(&self) -> Result<String> {
         let provider = self.api_provider();
+        let explicit_cli_key = explicit_cli_api_key_override();
 
         // 0. DeepSeek compatibility slot. The legacy top-level `api_key`
         // belongs to DeepSeek only; provider-specific keys below must win for
@@ -3475,7 +3476,10 @@ impl Config {
         //   codewhale --provider deepseek --api-key ark-... --base-url ... --model auto
         if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN)
             && std::env::var("DEEPSEEK_API_KEY_SOURCE").as_deref() == Ok("cli")
-            && let Some(env_key) = provider_env_api_key(provider)
+            && let Some(env_key) = explicit_cli_key
+                .as_ref()
+                .cloned()
+                .or_else(|| provider_env_api_key(provider))
             && !env_key.trim().is_empty()
         {
             return Ok(env_key);
@@ -3514,6 +3518,14 @@ impl Config {
         // `get_credentials`.
         if provider == ApiProvider::OpenaiCodex {
             return Ok(crate::oauth::get_credentials()?.access_token);
+        }
+
+        // The dispatcher cannot know the effective provider until the TUI
+        // applies `--profile`. A provider-neutral, source-marked CLI override
+        // therefore wins over saved API-key slots here, after OAuth routes
+        // have made their own credential decision.
+        if let Some(value) = explicit_cli_key {
+            return Ok(value);
         }
 
         // 1. Config file (provider-scoped slot). This intentionally wins
@@ -6289,6 +6301,18 @@ pub fn has_api_key(config: &Config) -> bool {
     has_api_key_for(config, config.api_provider())
 }
 
+fn provider_uses_oauth_credentials(config: &Config, provider: ApiProvider) -> bool {
+    provider == ApiProvider::OpenaiCodex
+        || (provider == ApiProvider::Moonshot
+            && config
+                .provider_config_for(provider)
+                .is_some_and(provider_config_uses_kimi_oauth))
+        || (provider == ApiProvider::Xai
+            && config
+                .provider_config_for(provider)
+                .is_some_and(provider_config_uses_xai_oauth))
+}
+
 #[must_use]
 pub fn active_provider_has_config_api_key(config: &Config) -> bool {
     let provider = config.api_provider();
@@ -6337,7 +6361,10 @@ pub fn active_provider_has_config_api_key(config: &Config) -> bool {
 
 #[must_use]
 pub fn active_provider_has_env_api_key(config: &Config) -> bool {
-    provider_env_api_key(config.api_provider()).is_some()
+    let provider = config.api_provider();
+    (!provider_uses_oauth_credentials(config, provider)
+        && explicit_cli_api_key_override().is_some())
+        || provider_env_api_key(provider).is_some()
 }
 
 #[must_use]
@@ -6350,6 +6377,12 @@ pub fn active_provider_uses_env_only_api_key(config: &Config) -> bool {
 /// prompt for a key inline.
 #[must_use]
 pub fn has_api_key_for(config: &Config, provider: ApiProvider) -> bool {
+    if provider == config.api_provider()
+        && !provider_uses_oauth_credentials(config, provider)
+        && explicit_cli_api_key_override().is_some()
+    {
+        return true;
+    }
     if provider
         .env_vars()
         .iter()
@@ -6626,6 +6659,16 @@ fn provider_env_api_key(provider: ApiProvider) -> Option<String> {
             .ok()
             .filter(|value| !value.trim().is_empty())
     })
+}
+
+fn explicit_cli_api_key_override() -> Option<String> {
+    (std::env::var("DEEPSEEK_API_KEY_SOURCE").as_deref() == Ok("cli"))
+        .then(|| {
+            std::env::var("CODEWHALE_CLI_API_KEY")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .flatten()
 }
 
 fn missing_provider_api_key_message(provider: ApiProvider) -> Result<String> {

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -2453,6 +2453,44 @@ fn deepseek_dispatcher_env_key_overrides_config_key() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn provider_neutral_cli_key_wins_after_profile_provider_switch() -> Result<()> {
+    let _lock = lock_test_env();
+    let _source = EnvVarGuard::set("DEEPSEEK_API_KEY_SOURCE", "cli");
+    let _cli_key = EnvVarGuard::set("CODEWHALE_CLI_API_KEY", "explicit-profile-key");
+    let _anthropic_env = EnvVarGuard::remove("ANTHROPIC_API_KEY");
+    let mut providers = ProvidersConfig::default();
+    providers.anthropic.api_key = Some("saved-anthropic-key".to_string());
+    let config = Config {
+        provider: Some("anthropic".to_string()),
+        providers: Some(providers),
+        ..Default::default()
+    };
+
+    assert_eq!(config.deepseek_api_key()?, "explicit-profile-key");
+    assert!(has_api_key(&config));
+    assert!(active_provider_has_env_api_key(&config));
+    Ok(())
+}
+
+#[test]
+fn provider_neutral_cli_key_requires_dispatcher_source_marker() -> Result<()> {
+    let _lock = lock_test_env();
+    let _source = EnvVarGuard::remove("DEEPSEEK_API_KEY_SOURCE");
+    let _cli_key = EnvVarGuard::set("CODEWHALE_CLI_API_KEY", "untrusted-generic-key");
+    let _anthropic_env = EnvVarGuard::remove("ANTHROPIC_API_KEY");
+    let mut providers = ProvidersConfig::default();
+    providers.anthropic.api_key = Some("saved-anthropic-key".to_string());
+    let config = Config {
+        provider: Some("anthropic".to_string()),
+        providers: Some(providers),
+        ..Default::default()
+    };
+
+    assert_eq!(config.deepseek_api_key()?, "saved-anthropic-key");
+    Ok(())
+}
+
 fn config_with_provider_scoped_key(provider: &str, api_key: &str) -> Config {
     let mut providers = ProvidersConfig::default();
     match provider {

--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -172,6 +172,10 @@ pub fn map_exec_stream_line(line: &str) -> Option<FleetWorkerEventPayload> {
                 .map(str::to_string);
             Some(FleetWorkerEventPayload::RunningTool { tool, call_id })
         }
+        "workflow_event" => Some(FleetWorkerEventPayload::WorkflowEvent {
+            workflow_run_id: value.get("run_id")?.as_str()?.to_string(),
+            event: value.get("event")?.clone(),
+        }),
         // Streaming model output / tool results mean the worker is alive and
         // making progress; surface a coarse Running heartbeat.
         "content" | "tool_result" => Some(FleetWorkerEventPayload::Running),
@@ -721,6 +725,22 @@ mod tests {
         match map_exec_stream_line(r#"{"type":"error","error":"boom"}"#) {
             Some(FleetWorkerEventPayload::Failed { reason, .. }) => assert_eq!(reason, "boom"),
             other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_line_maps_workflow_receipt_to_typed_event() {
+        let line =
+            r#"{"type":"workflow_event","run_id":"workflow_1","event":{"type":"task_completed"}}"#;
+        match map_exec_stream_line(line) {
+            Some(FleetWorkerEventPayload::WorkflowEvent {
+                workflow_run_id,
+                event,
+            }) => {
+                assert_eq!(workflow_run_id, "workflow_1");
+                assert_eq!(event["type"], "task_completed");
+            }
+            other => panic!("expected typed workflow receipt, got {other:?}"),
         }
     }
 

--- a/crates/tui/src/fleet/ledger.rs
+++ b/crates/tui/src/fleet/ledger.rs
@@ -551,6 +551,7 @@ fn apply_record(state: &mut FleetLedgerState, record: FleetLedgerRecord) {
                 | FleetWorkerEventPayload::Restarted { .. }
                 | FleetWorkerEventPayload::ModelWait { .. }
                 | FleetWorkerEventPayload::RunningTool { .. }
+                | FleetWorkerEventPayload::WorkflowEvent { .. }
                 | FleetWorkerEventPayload::Heartbeat { .. }
                 | FleetWorkerEventPayload::Starting
                 | FleetWorkerEventPayload::Running => {
@@ -822,6 +823,48 @@ mod tests {
         let state = ledger.rebuild_state().unwrap();
         assert_eq!(state.workers["worker-1"], FleetWorkerStatus::Busy);
         assert_eq!(state.heartbeats["worker-1"].cpu_percent, Some(12.5));
+    }
+
+    #[test]
+    fn fleet_ledger_replays_typed_workflow_receipt_with_distinct_run_ids() {
+        let tmp = TempDir::new().unwrap();
+        let ledger = FleetLedger::open(tmp.path()).unwrap();
+        ledger.create_run(&sample_run("fleet-run-1")).unwrap();
+        ledger
+            .enqueue(sample_entry("fleet-run-1", "task-a"))
+            .unwrap();
+        ledger
+            .append_event(FleetWorkerEvent {
+                seq: 1,
+                run_id: FleetRunId::from("fleet-run-1"),
+                worker_id: "worker-1".to_string(),
+                task_id: "task-a".to_string(),
+                timestamp: "2026-07-10T00:00:00Z".to_string(),
+                payload: FleetWorkerEventPayload::WorkflowEvent {
+                    workflow_run_id: "workflow_1".to_string(),
+                    event: serde_json::json!({"type": "task_completed"}),
+                },
+                extra: BTreeMap::new(),
+            })
+            .unwrap();
+
+        let state = ledger.rebuild_state().unwrap();
+        let event = &state.latest_events["worker-1:fleet-run-1:task-a"];
+        assert!(matches!(
+            &event.payload,
+            FleetWorkerEventPayload::WorkflowEvent {
+                workflow_run_id,
+                event,
+            } if workflow_run_id == "workflow_1" && event["type"] == "task_completed"
+        ));
+        let last_line = std::fs::read_to_string(ledger.path())
+            .unwrap()
+            .lines()
+            .last()
+            .unwrap()
+            .to_string();
+        assert_eq!(last_line.matches("\"run_id\"").count(), 1);
+        assert_eq!(last_line.matches("\"workflow_run_id\"").count(), 1);
     }
 
     #[test]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -276,6 +276,9 @@ enum Commands {
     Exec(ExecArgs),
     /// Manage local Agent Fleet runs and workers
     Fleet(FleetArgs),
+    /// Internal model-free Workflow tool dispatcher used by Lane Runtime.
+    #[command(name = "workflow-tool", hide = true)]
+    WorkflowTool(WorkflowToolArgs),
     /// Run a code review over a git diff
     Review(ReviewArgs),
     /// Open the TUI pre-seeded with a GitHub PR's title, body, and diff
@@ -396,6 +399,16 @@ struct ExecArgs {
         allow_hyphen_values = true
     )]
     prompt: Vec<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+struct WorkflowToolArgs {
+    /// Authority provenance stamped by the public `workflow run` command.
+    #[arg(long, value_name = "SOURCE")]
+    approval_source: String,
+    /// Exact Workflow tool input serialized as one JSON object.
+    #[arg(long, value_name = "JSON")]
+    input_json: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -1398,6 +1411,7 @@ async fn main() -> Result<()> {
                 let workspace = resolve_workspace(&cli);
                 run_fleet_command(&workspace, &config, args).await
             }
+            Commands::WorkflowTool(args) => run_workflow_tool_command(&cli, args).await,
             Commands::Review(args) => {
                 let config = load_config_from_cli(&cli)?;
                 run_review(&config, args).await
@@ -1706,6 +1720,14 @@ async fn run_fleet_command(workspace: &Path, config: &Config, args: FleetArgs) -
                 .as_ref()
                 .map(|call_id| format!("running_tool tool={tool} call_id={call_id}"))
                 .unwrap_or_else(|| format!("running_tool tool={tool}")),
+            FleetWorkerEventPayload::WorkflowEvent {
+                workflow_run_id,
+                event,
+            } => event
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .map(|kind| format!("workflow_event run_id={workflow_run_id} type={kind}"))
+                .unwrap_or_else(|| format!("workflow_event run_id={workflow_run_id}")),
             FleetWorkerEventPayload::Heartbeat { .. } => "heartbeat".to_string(),
             FleetWorkerEventPayload::Artifact(artifact) => {
                 format!("artifact kind={}", artifact_kind_label(&artifact.kind))
@@ -7535,6 +7557,11 @@ enum ExecStreamEvent {
         output: String,
         status: String,
     },
+    #[serde(rename = "workflow_event")]
+    WorkflowEvent {
+        run_id: String,
+        event: serde_json::Value,
+    },
     #[serde(rename = "session_capture")]
     SessionCapture { content: String },
     #[serde(rename = "metadata")]
@@ -7548,6 +7575,381 @@ enum ExecStreamEvent {
 fn emit_exec_stream_event(event: &ExecStreamEvent) -> Result<()> {
     println!("{}", serde_json::to_string(event)?);
     Ok(())
+}
+
+async fn run_workflow_tool_command(cli: &Cli, args: WorkflowToolArgs) -> Result<()> {
+    match run_workflow_tool_command_inner(cli, args).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = emit_exec_stream_event(&ExecStreamEvent::Error {
+                error: format!("{error:#}"),
+            });
+            exit_workflow_tool_failure();
+        }
+    }
+}
+
+async fn run_workflow_tool_command_inner(cli: &Cli, args: WorkflowToolArgs) -> Result<()> {
+    use crate::tools::spec::ToolSpec;
+
+    if args.approval_source != "explicit-workflow-command" {
+        bail!("workflow-tool requires --approval-source explicit-workflow-command");
+    }
+    let input: serde_json::Value = serde_json::from_str(&args.input_json)
+        .context("--input-json must be a valid Workflow tool input object")?;
+    if !input.is_object() {
+        bail!("--input-json must be a JSON object");
+    }
+    if !input
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|action| action.eq_ignore_ascii_case("run"))
+    {
+        bail!("workflow-tool accepts only action=run");
+    }
+
+    let workspace = resolve_workspace(cli);
+    let mut config = load_config_from_cli(cli)?;
+    merge_user_workspace_config(&mut config, cli.config.clone(), &workspace);
+    if let Ok(env_url) = std::env::var("DEEPSEEK_BASE_URL") {
+        let trimmed = env_url.trim();
+        if !trimmed.is_empty() {
+            config.base_url = Some(trimmed.to_string());
+        }
+    }
+
+    let model = resolve_exec_model(&config, None);
+    let route = resolve_cli_auto_route(
+        &config,
+        &model,
+        "Run a checked-in Workflow through the host runtime",
+    )
+    .await?;
+    let execution_config = config_for_cli_route(&config, &route);
+    let tool_id = format!("workflow_host_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    emit_exec_stream_event(&ExecStreamEvent::ToolUse {
+        name: "workflow".to_string(),
+        id: tool_id.clone(),
+        input: input.clone(),
+    })?;
+
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel(1024);
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+    let event_forwarder = tokio::spawn(forward_direct_workflow_events(event_rx, stop_rx));
+    let (tool, context) =
+        match build_direct_workflow_tool(&execution_config, &route, &workspace, event_tx).await {
+            Ok(built) => built,
+            Err(err) => {
+                let _ = stop_tx.send(());
+                let _ = event_forwarder.await;
+                exit_workflow_tool_error(&tool_id, err.to_string());
+            }
+        };
+
+    let result = tool.execute(input, &context).await;
+    drop(tool);
+    let _ = stop_tx.send(());
+    event_forwarder
+        .await
+        .context("workflow event forwarder task failed")??;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(err) => {
+            let error = err.to_string();
+            exit_workflow_tool_error(&tool_id, error);
+        }
+    };
+
+    let workflow_status =
+        direct_workflow_status(&result.content).unwrap_or_else(|| "unknown".to_string());
+    let completed = result.success && workflow_status == "completed";
+    emit_exec_stream_event(&ExecStreamEvent::ToolResult {
+        id: tool_id,
+        output: result.content.clone(),
+        status: if completed { "success" } else { "error" }.to_string(),
+    })?;
+    emit_exec_stream_event(&ExecStreamEvent::Metadata {
+        meta: ExecStreamMeta {
+            // No parent/operator model call occurs on this host-owned path;
+            // child model/provider usage remains attributable in typed task
+            // receipts rather than being misreported as one root model.
+            model: "host-workflow".to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            input_analysis: ExecStreamInputAnalysis::default(),
+            visible_final_answer_chars: result.content.chars().count(),
+            session_id: String::new(),
+            resume_command: String::new(),
+            workspace: workspace.display().to_string(),
+            message_count: 0,
+            status: Some(workflow_status.clone()),
+        },
+    })?;
+    if !completed {
+        let error = format!("workflow run ended with terminal status {workflow_status}");
+        emit_exec_stream_event(&ExecStreamEvent::Error {
+            error: error.clone(),
+        })?;
+        exit_workflow_tool_failure();
+    }
+    emit_exec_stream_event(&ExecStreamEvent::Done)?;
+    Ok(())
+}
+
+fn exit_workflow_tool_failure() -> ! {
+    let _ = io::stdout().flush();
+    std::process::exit(1)
+}
+
+fn exit_workflow_tool_error(tool_id: &str, error: String) -> ! {
+    let _ = emit_exec_stream_event(&ExecStreamEvent::ToolResult {
+        id: tool_id.to_string(),
+        output: error.clone(),
+        status: "error".to_string(),
+    });
+    let _ = emit_exec_stream_event(&ExecStreamEvent::Error { error });
+    exit_workflow_tool_failure()
+}
+
+async fn initialize_direct_workflow_mcp_pool(
+    config: &Config,
+    workspace: &Path,
+    network_policy: Option<crate::network_policy::NetworkPolicyDecider>,
+) -> Option<(
+    std::sync::Arc<tokio::sync::Mutex<crate::mcp::McpPool>>,
+    Vec<(String, String)>,
+)> {
+    if !config.features().enabled(Feature::Mcp) {
+        return None;
+    }
+    let mut pool =
+        crate::mcp::McpPool::from_config_path_with_workspace(&config.mcp_config_path(), workspace)
+            .unwrap_or_else(|error| {
+                tracing::debug!("No MCP config for direct Workflow runtime: {error:#}");
+                crate::mcp::McpPool::new(crate::mcp::McpConfig::default())
+            });
+    if let Some(policy) = network_policy {
+        pool = pool.with_network_policy(policy);
+    }
+    let failures = pool
+        .connect_all()
+        .await
+        .into_iter()
+        .map(|(server, error)| (server, format!("{error:#}")))
+        .collect();
+    Some((std::sync::Arc::new(tokio::sync::Mutex::new(pool)), failures))
+}
+
+async fn build_direct_workflow_tool(
+    config: &Config,
+    route: &CliAutoRoute,
+    workspace: &Path,
+    event_tx: tokio::sync::mpsc::Sender<crate::core::events::Event>,
+) -> Result<(
+    crate::tools::workflow::WorkflowTool,
+    crate::tools::ToolContext,
+)> {
+    use std::sync::Arc;
+
+    use crate::client::DeepSeekClient;
+    use crate::core::authority::shell_policy_for_mode;
+    use crate::fleet::roster::FleetRoster;
+    use crate::tools::AgentToolSurfaceOptions;
+    use crate::tools::goal::new_shared_goal_state;
+    use crate::tools::subagent::{SubAgentRuntime, new_shared_subagent_manager_with_timeout};
+    use crate::tools::todo::new_shared_todo_list;
+    use crate::tui::app::AppMode;
+
+    let provider = config.api_provider();
+    if !config.subagents_enabled_for_provider(provider) {
+        bail!(
+            "Workflow dispatch requires sub-agents for provider {} ({})",
+            provider.as_str(),
+            config
+                .subagents_disabled_reason()
+                .unwrap_or("provider-specific sub-agent configuration disabled it")
+        );
+    }
+
+    let yolo = config.yolo.unwrap_or(false);
+    let mode = if yolo {
+        AppMode::Yolo
+    } else {
+        AppMode::Operate
+    };
+    let allow_shell = yolo || config.allow_shell();
+    let shell_policy = shell_policy_for_mode(mode, allow_shell);
+    let trusted = crate::workspace_trust::WorkspaceTrust::load_for(workspace);
+    let mut context = crate::tools::ToolContext::with_auto_approve(
+        workspace.to_path_buf(),
+        yolo,
+        config.notes_path(),
+        config.mcp_config_path(),
+        yolo,
+    )
+    .with_features(config.features())
+    .with_skills_config(
+        config.skills_dir(),
+        config.skills_config().scan_codewhale_only(),
+    )
+    .with_shell_policy(shell_policy)
+    .with_trusted_external_paths(trusted.paths().to_vec())
+    .with_elevated_sandbox_policy(workflow_host_sandbox_policy(config, mode, workspace));
+    let network_policy = config.network.clone().map(|network| {
+        crate::network_policy::NetworkPolicyDecider::with_default_audit(network.into_runtime())
+    });
+    if let Some(policy) = network_policy.as_ref() {
+        context = context.with_network_policy(policy.clone());
+    }
+    if config.memory_enabled() {
+        context.memory_path = Some(config.memory_path());
+    }
+    context.search_provider = config.search_provider();
+    context.search_api_key = config
+        .search
+        .as_ref()
+        .and_then(|search| search.api_key.clone());
+    context.search_base_url = config
+        .search
+        .as_ref()
+        .and_then(|search| search.base_url.clone());
+    if let Some(backend) = crate::sandbox::backend::create_backend(config)? {
+        context = context.with_sandbox_backend(Arc::from(backend));
+    }
+
+    let max_subagents = config.max_subagents_for_provider(provider);
+    let manager = new_shared_subagent_manager_with_timeout(
+        workspace.to_path_buf(),
+        max_subagents,
+        config
+            .max_admitted_subagents_for_provider(provider)
+            .max(max_subagents),
+        Duration::from_secs(config.subagent_heartbeat_timeout_secs_for_provider(provider)),
+        config.launch_concurrency_for_provider(provider),
+        config.subagent_token_budget_for_provider(provider),
+    );
+    let roster = Arc::new(FleetRoster::load(&config.fleet_config(), workspace));
+    let mut role_models = roster.model_overrides();
+    role_models.extend(config.subagent_model_overrides());
+
+    let features = config.features();
+    let mut surface = AgentToolSurfaceOptions::new(shell_policy);
+    surface.apply_patch_enabled = features.enabled(Feature::ApplyPatch);
+    surface.web_search_enabled = features.enabled(Feature::WebSearch);
+    surface.memory_tool_enabled = config.memory_enabled() && !config.moraine_fallback();
+    surface.vision_config = features
+        .enabled(Feature::VisionModel)
+        .then(|| config.vision_model_config())
+        .flatten();
+    surface.speech_output_dir = config.speech_output_dir();
+    surface.goal_state = Some(new_shared_goal_state());
+
+    let client = DeepSeekClient::new(config)?;
+    let reasoning_effort = route
+        .reasoning_effort
+        .and_then(|effort| cli_reasoning_effort_value(config, effort));
+    let mcp_pool = if let Some((pool, failures)) =
+        initialize_direct_workflow_mcp_pool(config, workspace, network_policy).await
+    {
+        for (server, error) in failures {
+            tracing::warn!(
+                server = %server,
+                error = %error,
+                "direct Workflow runtime could not connect MCP server"
+            );
+        }
+        Some(pool)
+    } else {
+        None
+    };
+    let runtime = SubAgentRuntime::new(
+        client,
+        route.model.clone(),
+        context.clone(),
+        allow_shell,
+        Some(event_tx),
+        manager.clone(),
+    )
+    .with_role_models(role_models)
+    .with_api_config(config.clone())
+    .with_fleet_roster(roster)
+    .with_auto_model(route.auto_model)
+    .with_reasoning_effort(reasoning_effort, route.auto_model)
+    .with_agent_tool_surface_options(surface)
+    .with_max_spawn_depth(config.subagent_max_spawn_depth_for_provider(provider))
+    .with_step_api_timeout(Duration::from_secs(
+        config.subagent_api_timeout_secs_for_provider(provider),
+    ))
+    .with_speech_output_dir(config.speech_output_dir())
+    .with_mcp_pool(mcp_pool)
+    .with_todos(new_shared_todo_list())
+    .with_parent_mode(mode);
+
+    Ok((
+        crate::tools::workflow::WorkflowTool::new(manager, runtime).with_explicit_cli_approval(),
+        context,
+    ))
+}
+
+fn workflow_host_sandbox_policy(
+    config: &Config,
+    mode: crate::tui::app::AppMode,
+    workspace: &Path,
+) -> crate::sandbox::SandboxPolicy {
+    use crate::sandbox::SandboxPolicy;
+
+    match config.sandbox_mode.as_deref() {
+        Some("read-only") => SandboxPolicy::ReadOnly,
+        Some("workspace-write") => SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![workspace.to_path_buf()],
+            network_access: true,
+            exclude_tmpdir: false,
+            exclude_slash_tmp: false,
+        },
+        Some("danger-full-access") => SandboxPolicy::DangerFullAccess,
+        Some("external-sandbox") => SandboxPolicy::ExternalSandbox {
+            network_access: true,
+        },
+        _ => crate::core::authority::sandbox_policy_for_mode(mode, workspace),
+    }
+}
+
+async fn forward_direct_workflow_events(
+    mut event_rx: tokio::sync::mpsc::Receiver<crate::core::events::Event>,
+    mut stop_rx: tokio::sync::oneshot::Receiver<()>,
+) -> Result<()> {
+    loop {
+        tokio::select! {
+            biased;
+            event = event_rx.recv() => match event {
+                Some(event) => emit_direct_workflow_event(event)?,
+                None => return Ok(()),
+            },
+            _ = &mut stop_rx => {
+                while let Ok(event) = event_rx.try_recv() {
+                    emit_direct_workflow_event(event)?;
+                }
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn emit_direct_workflow_event(event: crate::core::events::Event) -> Result<()> {
+    if let crate::core::events::Event::WorkflowUi { run_id, event } = event {
+        emit_exec_stream_event(&ExecStreamEvent::WorkflowEvent { run_id, event })?;
+    }
+    Ok(())
+}
+
+fn direct_workflow_status(content: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(content)
+        .ok()?
+        .get("status")?
+        .as_str()
+        .map(str::to_ascii_lowercase)
 }
 
 fn exec_stream_input_analysis(
@@ -8124,6 +8526,11 @@ async fn run_exec_agent(
             Event::AgentSpawned { .. }
             | Event::AgentProgress { .. }
             | Event::AgentComplete { .. } => {}
+            Event::WorkflowUi { run_id, event }
+                if output_format == ExecOutputFormat::StreamJson =>
+            {
+                emit_exec_stream_event(&ExecStreamEvent::WorkflowEvent { run_id, event })?;
+            }
             Event::ApprovalRequired { id, .. } => {
                 if auto_approve {
                     let _ = engine_handle.approve_tool_call(id).await;
@@ -9327,6 +9734,138 @@ mod terminal_mode_tests {
     }
 
     #[test]
+    fn workflow_tool_internal_subcommand_parses_exact_json() {
+        let cli = parse_cli(&[
+            "codewhale-tui",
+            "workflow-tool",
+            "--approval-source",
+            "explicit-workflow-command",
+            "--input-json",
+            r#"{"action":"run","source_path":"workflows/demo.js"}"#,
+        ]);
+        let Some(Commands::WorkflowTool(args)) = cli.command else {
+            panic!("expected workflow-tool command");
+        };
+        assert!(args.input_json.contains("\"action\":\"run\""));
+    }
+
+    #[tokio::test]
+    async fn direct_workflow_tool_runs_without_an_operator_model_turn() {
+        use crate::tools::spec::ToolSpec;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let config = Config {
+            provider: Some("vllm".to_string()),
+            mcp_config_path: Some(
+                workspace
+                    .path()
+                    .join("missing-mcp.json")
+                    .display()
+                    .to_string(),
+            ),
+            providers: Some(crate::config::ProvidersConfig {
+                vllm: crate::config::ProviderConfig {
+                    base_url: Some("http://127.0.0.1:9/v1".to_string()),
+                    model: Some("offline-test-model".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let route = CliAutoRoute {
+            provider: crate::config::ApiProvider::Vllm,
+            model: "offline-test-model".to_string(),
+            reasoning_effort: None,
+            auto_model: false,
+        };
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+        let (tool, context) =
+            build_direct_workflow_tool(&config, &route, workspace.path(), event_tx)
+                .await
+                .expect("build direct workflow runtime");
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "action": "run",
+                    "script": "phase('offline'); return { ok: true };",
+                    "token_budget": 1_000_000
+                }),
+                &context,
+            )
+            .await
+            .expect("model-free workflow run");
+        let payload: serde_json::Value =
+            serde_json::from_str(&result.content).expect("workflow JSON");
+
+        assert_eq!(payload["status"], "completed");
+        assert_eq!(payload["result"]["ok"], true);
+        assert_eq!(payload["child_ids"].as_array().map(Vec::len), Some(0));
+        assert_eq!(
+            payload["plan_approval"]["decision"],
+            "approved_explicit_cli_command"
+        );
+        assert!(!context.auto_approve);
+        assert!(!context.trust_mode);
+        assert_eq!(
+            context.shell_policy,
+            crate::worker_profile::ShellPolicy::None
+        );
+        assert!(matches!(
+            context.elevated_sandbox_policy,
+            Some(crate::sandbox::SandboxPolicy::WorkspaceWrite { .. })
+        ));
+        let mut event_types = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            if let crate::core::events::Event::WorkflowUi { event, .. } = event
+                && let Some(kind) = event["type"].as_str()
+            {
+                event_types.push(kind.to_string());
+            }
+        }
+        assert!(event_types.iter().any(|kind| kind == "run_started"));
+        assert!(event_types.iter().any(|kind| kind == "run_completed"));
+    }
+
+    #[tokio::test]
+    async fn direct_workflow_mcp_pool_applies_network_policy_before_connect() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let mcp_path = workspace.path().join("mcp.json");
+        std::fs::write(
+            &mcp_path,
+            r#"{
+                "mcpServers": {
+                    "blocked": { "url": "https://blocked.invalid/mcp" }
+                }
+            }"#,
+        )
+        .expect("write MCP config");
+        let config = Config {
+            mcp_config_path: Some(mcp_path.display().to_string()),
+            ..Default::default()
+        };
+        let policy = crate::network_policy::NetworkPolicyDecider::new(
+            crate::network_policy::NetworkPolicy {
+                default: crate::network_policy::DecisionToml::Deny,
+                allow: Vec::new(),
+                deny: Vec::new(),
+                proxy: Vec::new(),
+                audit: false,
+            },
+            None,
+        );
+
+        let (_pool, failures) =
+            initialize_direct_workflow_mcp_pool(&config, workspace.path(), Some(policy))
+                .await
+                .expect("MCP feature enabled");
+        assert_eq!(failures.len(), 1, "failures={failures:?}");
+        assert_eq!(failures[0].0, "blocked");
+        assert!(failures[0].1.contains("blocked by network policy"));
+    }
+
+    #[test]
     fn exec_model_resolution_uses_provider_scoped_default() {
         let _env_lock = crate::test_support::lock_test_env();
         let _codewhale_model = crate::test_support::EnvVarGuard::remove("CODEWHALE_MODEL");
@@ -9787,6 +10326,25 @@ mod terminal_mode_tests {
         assert!(!json.contains('\n'));
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
         assert_eq!(parsed["type"], "tool_result");
+    }
+
+    #[test]
+    fn workflow_receipt_stream_event_is_one_json_line() {
+        let event = ExecStreamEvent::WorkflowEvent {
+            run_id: "workflow_1234".to_string(),
+            event: serde_json::json!({
+                "type": "task_completed",
+                "task_id": "agent_1",
+                "status": "succeeded"
+            }),
+        };
+
+        let json = serde_json::to_string(&event).expect("serializes");
+        assert!(!json.contains('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["type"], "workflow_event");
+        assert_eq!(parsed["run_id"], "workflow_1234");
+        assert_eq!(parsed["event"]["type"], "task_completed");
     }
 
     #[test]

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1231,6 +1231,14 @@ fn fleet_event_label(payload: &FleetWorkerEventPayload) -> String {
             .as_ref()
             .map(|call_id| format!("running_tool tool={tool} call_id={call_id}"))
             .unwrap_or_else(|| format!("running_tool tool={tool}")),
+        FleetWorkerEventPayload::WorkflowEvent {
+            workflow_run_id,
+            event,
+        } => event
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .map(|kind| format!("workflow_event run_id={workflow_run_id} type={kind}"))
+            .unwrap_or_else(|| format!("workflow_event run_id={workflow_run_id}")),
         FleetWorkerEventPayload::Heartbeat { .. } => "heartbeat".to_string(),
         FleetWorkerEventPayload::Artifact(artifact) => {
             format!("artifact kind={}", artifact_kind_label(&artifact.kind))

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -4361,24 +4361,11 @@ async fn spawn_subagent_from_input(
             }
         }
     }
-    // #4193 seam 2: normalize/validate the requested model against the CHILD's
-    // (pinned) provider, not the session provider. `child_runtime` carries the
-    // provider-B client set above, so a profile-less/`inherit` member still
-    // sees the session provider here (no regression).
-    let configured_model = match spawn_request.model.clone() {
-        Some(model) => Some(normalize_requested_subagent_model(
-            &model,
-            "model",
-            child_runtime.client.api_provider(),
-        )?),
-        None => configured_model_for_role_or_type(
-            &child_runtime,
-            spawn_request.assignment.role.as_deref(),
-            &spawn_request.agent_type,
-        )?,
-    };
-    // Resolved before the prompt is moved out of the request below.
-    let requested_model_route = spawn_model_route(&spawn_request, profile_member.as_ref());
+    // Resolve the model once against the CHILD's (possibly profile-pinned)
+    // provider. The typed selection carries both precedence and provenance so
+    // a role default cannot override a saved AgentProfile model (#4177).
+    let model_selection =
+        resolve_spawn_model_selection(&child_runtime, &spawn_request, profile_member.as_ref())?;
     let (effective_prompt, _resident_conflict) = if let Some(ref file_path) =
         spawn_request.resident_file
     {
@@ -4417,10 +4404,10 @@ async fn spawn_subagent_from_input(
     // fixed-model validation then all resolve against provider B.
     let route = resolve_subagent_assignment_route(
         &child_runtime,
-        configured_model,
+        None,
         &effective_prompt,
         &spawn_request.agent_type,
-        requested_model_route,
+        model_selection.model_route,
         spawn_request.thinking,
     )
     .await;
@@ -4442,7 +4429,7 @@ async fn spawn_subagent_from_input(
     let spawn_metadata = WorkflowTaskSpawnMetadata {
         resolved_provider: child_runtime.client.api_provider().as_str().to_string(),
         resolved_model: effective_model.clone(),
-        route_source: route_source_label(&model_route),
+        route_source: model_selection.source.as_str().to_string(),
         resolved_role,
         resolved_profile,
         parent_task_id: child_runtime.parent_agent_id.clone(),
@@ -6351,6 +6338,7 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
     // roster role / member id (scout, release_lead). Type aliases still set
     // agent_type; non-alias roles defer to fleet profile resolution (#4177).
     let parsed_role_type = role_input.and_then(SubAgentType::from_str);
+    let role_is_type_alias = parsed_role_type.is_some();
 
     if let (Some(type_kind), Some(role_kind)) = (&parsed_type, &parsed_role_type)
         && type_kind != role_kind
@@ -6370,14 +6358,15 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
         .or_else(|| type_input.and_then(normalize_role_alias))
         .map(str::to_string);
 
-    // Fleet role token: either the raw role when it is not a type alias, or
-    // the alias form (e.g. implementer) used as a roster lookup key.
+    // Fleet role token: the raw role only when it is not a descriptive type
+    // alias. Type aliases remain local SubAgentType vocabulary and must not be
+    // promoted into roster lookup keys.
     let fleet_role_token = match role_input {
-        Some(raw) => {
+        Some(raw) if !role_is_type_alias => {
             let token = validate_role_name(raw)?;
             Some(token)
         }
-        None => None,
+        _ => None,
     };
 
     let role = role_alias.or_else(|| fleet_role_token.clone()).or_else(|| {
@@ -6389,8 +6378,11 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
     let mut profile = optional_input_str(input, &["profile", "fleet_profile", "roster_profile"])
         .map(validate_profile_name)
         .transpose()?;
-    // When the caller only declared a fleet role, use it as the profile key
-    // so `apply_spawn_profile` is the single roster resolution path (#4177).
+    // When the caller declared a non-type Fleet role, use it as the profile
+    // key so `apply_spawn_profile` is the single roster resolution path.
+    // Descriptive SubAgentType aliases (worker/review/plan/verify/...) keep
+    // profile=None; promoting those aliases to roster ids made valid direct
+    // agent calls fail because several are not member ids (#4177).
     if profile.is_none() {
         profile = fleet_role_token.clone();
     }
@@ -6671,39 +6663,111 @@ fn spawn_profile_prompt_overlay(member: &crate::fleet::profile::AgentProfile) ->
     Some(overlay)
 }
 
-/// Requested model route for a spawn, honoring fleet profile precedence:
-/// explicit `model` param > explicit `model_strength` param > member model
-/// pin (Fixed) > member loadout > parse-time default. An explicit `model`
-/// still wins downstream via the configured-model path (which turns it into
-/// a Fixed route), as does a `role_models` override where one matches today.
-fn spawn_model_route(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpawnRouteSource {
+    TaskModel,
+    TaskModelStrength,
+    AgentProfileModel,
+    AgentProfileLoadout,
+    RoleDefault,
+    RunModel,
+}
+
+impl SpawnRouteSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TaskModel => "task.model",
+            Self::TaskModelStrength => "task.model_strength",
+            Self::AgentProfileModel => "agent_profile.model",
+            Self::AgentProfileLoadout => "agent_profile.loadout",
+            Self::RoleDefault => "role.default",
+            Self::RunModel => "run.model",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SpawnModelSelection {
+    model_route: ModelRoute,
+    source: SpawnRouteSource,
+}
+
+/// Resolve the child model once, with receipt-grade precedence provenance:
+/// explicit task field > saved AgentProfile > configured role/type default >
+/// operator run model. Keeping the route and its source together prevents a
+/// later configured-model lookup from silently overriding a profile pin.
+fn resolve_spawn_model_selection(
+    runtime: &SubAgentRuntime,
     request: &SpawnRequest,
     member: Option<&crate::fleet::profile::AgentProfile>,
-) -> ModelRoute {
-    let Some(member) = member else {
-        return request.model_strength.model_route();
-    };
-    if request.model.is_some() || request.model_strength_explicit {
-        return request.model_strength.model_route();
+) -> Result<SpawnModelSelection, ToolError> {
+    if let Some(model) = request.model.as_deref() {
+        let model =
+            normalize_requested_subagent_model(model, "model", runtime.client.api_provider())?;
+        return Ok(SpawnModelSelection {
+            model_route: ModelRoute::Fixed(model),
+            source: SpawnRouteSource::TaskModel,
+        });
     }
-    if let Some(model) = member
-        .profile
-        .model
-        .as_deref()
-        .map(str::trim)
-        .filter(|model| !model.is_empty() && !model.eq_ignore_ascii_case("auto"))
-    {
-        return ModelRoute::Fixed(model.to_string());
+    if request.model_strength_explicit {
+        return Ok(SpawnModelSelection {
+            model_route: request.model_strength.model_route(),
+            source: SpawnRouteSource::TaskModelStrength,
+        });
     }
-    match member.profile.loadout {
-        codewhale_config::FleetLoadout::Fast => ModelRoute::Faster,
-        // Inherit and the richer loadout classes (strong/balanced/...) all
-        // inherit the parent model here. The fleet dispatcher maps those
-        // classes to Auto, but in this seam Auto routes to the cheap sibling —
-        // a silent downgrade for e.g. a "strong" member. Inheriting keeps the
-        // existing non-profile default behavior.
-        _ => ModelRoute::Inherit,
+    if let Some(member) = member {
+        if let Some(model) = member
+            .profile
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty() && !model.eq_ignore_ascii_case("auto"))
+        {
+            let model = normalize_requested_subagent_model(
+                model,
+                &format!("fleet.profiles.{}.model", member.id),
+                runtime.client.api_provider(),
+            )?;
+            return Ok(SpawnModelSelection {
+                model_route: ModelRoute::Fixed(model),
+                source: SpawnRouteSource::AgentProfileModel,
+            });
+        }
+        if member.profile.loadout == codewhale_config::FleetLoadout::Fast {
+            return Ok(SpawnModelSelection {
+                model_route: ModelRoute::Faster,
+                source: SpawnRouteSource::AgentProfileLoadout,
+            });
+        }
+        // Richer custom loadouts (strong/balanced/...) have no exact
+        // ModelRoute equivalent here. Auto means "cheap sibling" in the
+        // sub-agent router, so those and explicit Inherit both preserve the
+        // operator run model and report that model's actual source.
+        return Ok(SpawnModelSelection {
+            model_route: ModelRoute::Inherit,
+            source: SpawnRouteSource::RunModel,
+        });
     }
+    if let Some(model) = configured_model_for_role_or_type(
+        runtime,
+        request.assignment.role.as_deref(),
+        &request.agent_type,
+    )? {
+        return Ok(SpawnModelSelection {
+            model_route: ModelRoute::Fixed(model),
+            source: SpawnRouteSource::RoleDefault,
+        });
+    }
+    if request.model_strength == SubAgentModelStrength::Faster {
+        return Ok(SpawnModelSelection {
+            model_route: ModelRoute::Faster,
+            source: SpawnRouteSource::RoleDefault,
+        });
+    }
+    Ok(SpawnModelSelection {
+        model_route: ModelRoute::Inherit,
+        source: SpawnRouteSource::RunModel,
+    })
 }
 
 /// Effective absolute `max_spawn_depth` for a child, combining the inherited

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1242,11 +1242,14 @@ fn test_apply_spawn_profile_scout_yields_explore_type_and_faster_route() {
         .expect("scout should resolve")
         .expect("member resolved");
     assert_eq!(request.agent_type, SubAgentType::Explore);
+    let selected = resolve_spawn_model_selection(&stub_runtime(), &request, Some(&member))
+        .expect("scout model selection");
     assert_eq!(
-        spawn_model_route(&request, Some(&member)),
+        selected.model_route,
         ModelRoute::Faster,
         "scout's fast loadout routes to the faster sibling"
     );
+    assert_eq!(selected.source, SpawnRouteSource::AgentProfileLoadout);
 }
 
 #[test]
@@ -1260,65 +1263,87 @@ fn test_apply_spawn_profile_synthesizer_yields_plan_type() {
 }
 
 #[test]
-fn test_spawn_model_route_profile_precedence() {
+fn spawn_model_selection_has_stable_four_tier_precedence_and_source() {
+    let mut runtime = stub_runtime();
+    runtime.model = "deepseek-v4-flash".to_string();
+    runtime
+        .role_models
+        .insert("reviewer".to_string(), "deepseek-v4-flash".to_string());
+
     let mut profile = custom_fleet_profile("reviewer");
     profile.model = Some("deepseek-v4-pro".to_string());
-    profile.loadout = codewhale_config::FleetLoadout::Fast;
     let roster = fleet_roster_with("auditor", profile);
-    let member = roster.get("auditor").expect("member").clone();
+    let member = roster.get("auditor").expect("auditor profile");
 
-    // Member model pin beats loadout.
-    let request =
-        parse_spawn_request(&json!({"prompt": "x", "profile": "auditor"})).expect("parse");
-    assert_eq!(
-        spawn_model_route(&request, Some(&member)),
-        ModelRoute::Fixed("deepseek-v4-pro".to_string())
-    );
-
-    // Explicit model_strength beats the member model pin.
     let request = parse_spawn_request(&json!({
         "prompt": "x",
-        "profile": "auditor",
-        "model_strength": "same"
-    }))
-    .expect("parse");
-    assert_eq!(
-        spawn_model_route(&request, Some(&member)),
-        ModelRoute::Inherit
-    );
-
-    // Explicit model beats the member model pin: the requested route steps
-    // aside and the configured-model path fixes the explicit id.
-    let request = parse_spawn_request(&json!({
-        "prompt": "x",
-        "profile": "auditor",
+        "role": "review",
         "model": "deepseek-v4-flash"
     }))
-    .expect("parse");
-    let requested_route = spawn_model_route(&request, Some(&member));
+    .expect("task model request");
+    let selected = resolve_spawn_model_selection(&runtime, &request, Some(member))
+        .expect("task model selection");
     assert_eq!(
-        assignment_model_route(Some("deepseek-v4-flash"), requested_route),
+        selected,
+        SpawnModelSelection {
+            model_route: ModelRoute::Fixed("deepseek-v4-flash".to_string()),
+            source: SpawnRouteSource::TaskModel,
+        }
+    );
+
+    let request = parse_spawn_request(&json!({
+        "prompt": "x",
+        "role": "review",
+        "model_strength": "faster"
+    }))
+    .expect("task strength request");
+    let selected = resolve_spawn_model_selection(&runtime, &request, Some(member))
+        .expect("task strength selection");
+    assert_eq!(selected.model_route, ModelRoute::Faster);
+    assert_eq!(selected.source, SpawnRouteSource::TaskModelStrength);
+
+    let request =
+        parse_spawn_request(&json!({"prompt": "x", "role": "review"})).expect("profile request");
+    let selected =
+        resolve_spawn_model_selection(&runtime, &request, Some(member)).expect("profile selection");
+    assert_eq!(
+        selected.model_route,
+        ModelRoute::Fixed("deepseek-v4-pro".to_string()),
+        "saved AgentProfile model must beat the configured role default"
+    );
+    assert_eq!(selected.source, SpawnRouteSource::AgentProfileModel);
+
+    let mut strong_profile = custom_fleet_profile("reviewer");
+    strong_profile.loadout = codewhale_config::FleetLoadout::Custom("strong".to_string());
+    let strong_roster = fleet_roster_with("architect", strong_profile);
+    let selected =
+        resolve_spawn_model_selection(&runtime, &request, strong_roster.get("architect"))
+            .expect("custom profile selection");
+    assert_eq!(selected.model_route, ModelRoute::Inherit);
+    assert_eq!(selected.source, SpawnRouteSource::RunModel);
+
+    let mut fast_profile = custom_fleet_profile("reviewer");
+    fast_profile.loadout = codewhale_config::FleetLoadout::Fast;
+    let fast_roster = fleet_roster_with("fast-reviewer", fast_profile);
+    let selected =
+        resolve_spawn_model_selection(&runtime, &request, fast_roster.get("fast-reviewer"))
+            .expect("fast profile selection");
+    assert_eq!(selected.model_route, ModelRoute::Faster);
+    assert_eq!(selected.source, SpawnRouteSource::AgentProfileLoadout);
+
+    let selected =
+        resolve_spawn_model_selection(&runtime, &request, None).expect("role default selection");
+    assert_eq!(
+        selected.model_route,
         ModelRoute::Fixed("deepseek-v4-flash".to_string())
     );
+    assert_eq!(selected.source, SpawnRouteSource::RoleDefault);
 
-    // Without a model pin, the loadout decides: fast -> Faster, other
-    // loadouts inherit rather than auto-downgrade to the cheap sibling.
-    let mut fast = custom_fleet_profile("scout");
-    fast.loadout = codewhale_config::FleetLoadout::Fast;
-    let roster = fleet_roster_with("recon", fast);
-    let request = parse_spawn_request(&json!({"prompt": "x", "profile": "recon"})).expect("parse");
-    assert_eq!(
-        spawn_model_route(&request, roster.get("recon")),
-        ModelRoute::Faster
-    );
-
-    let mut strong = custom_fleet_profile("builder");
-    strong.loadout = codewhale_config::FleetLoadout::Custom("strong".to_string());
-    let roster = fleet_roster_with("architect", strong);
-    assert_eq!(
-        spawn_model_route(&request, roster.get("architect")),
-        ModelRoute::Inherit
-    );
+    runtime.role_models.clear();
+    let selected =
+        resolve_spawn_model_selection(&runtime, &request, None).expect("run model selection");
+    assert_eq!(selected.model_route, ModelRoute::Inherit);
+    assert_eq!(selected.source, SpawnRouteSource::RunModel);
 }
 
 #[test]
@@ -1643,6 +1668,22 @@ fn test_parse_spawn_request_accepts_fleet_role_token_for_runtime_resolution() {
     assert!(!parsed.agent_type_explicit);
     assert_eq!(parsed.assignment.role.as_deref(), Some("release_lead"));
     assert_eq!(parsed.profile.as_deref(), Some("release_lead"));
+
+    let roster = FleetRoster::built_ins_only();
+    let mut parsed = parsed;
+    let member = apply_spawn_profile(&mut parsed, &roster)
+        .expect("release_lead should resolve")
+        .expect("release_lead should select a roster member");
+    assert_eq!(member.id, "manager");
+    assert_eq!(parsed.profile.as_deref(), Some("manager"));
+
+    let mut scout =
+        parse_spawn_request(&json!({"prompt": "map it", "role": "scout"})).expect("scout");
+    let member = apply_spawn_profile(&mut scout, &roster)
+        .expect("scout should resolve")
+        .expect("scout should select a roster member");
+    assert_eq!(member.id, "scout");
+    assert_eq!(scout.agent_type, SubAgentType::Explore);
 }
 
 #[test]
@@ -1690,13 +1731,23 @@ fn test_parse_spawn_request_accepts_full_role_vocabulary() {
         );
 
         let input = json!({ "prompt": "do work", "role": role });
-        let parsed = parse_spawn_request(&input)
+        let mut parsed = parse_spawn_request(&input)
             .unwrap_or_else(|e| panic!("role {role:?} should parse, got {e}"));
         assert_eq!(parsed.agent_type, expected_type, "type for role {role:?}");
         assert_eq!(
             parsed.assignment.role.as_deref(),
             Some(expected_role),
             "canonical role for {role:?}"
+        );
+        assert!(
+            parsed.profile.is_none(),
+            "descriptive role alias {role:?} must not become a roster profile"
+        );
+        assert!(
+            apply_spawn_profile(&mut parsed, &FleetRoster::built_ins_only())
+                .unwrap_or_else(|e| panic!("role {role:?} should apply without a profile: {e}"))
+                .is_none(),
+            "descriptive role alias {role:?} should not require roster resolution"
         );
     }
 }

--- a/crates/tui/src/tools/workflow.rs
+++ b/crates/tui/src/tools/workflow.rs
@@ -48,12 +48,25 @@ use crate::utils::spawn_supervised;
 pub struct WorkflowTool {
     manager: SharedSubAgentManager,
     runtime: SubAgentRuntime,
+    approval_decision: &'static str,
 }
 
 impl WorkflowTool {
     #[must_use]
     pub fn new(manager: SharedSubAgentManager, runtime: SubAgentRuntime) -> Self {
-        Self { manager, runtime }
+        Self {
+            manager,
+            runtime,
+            approval_decision: "approved",
+        }
+    }
+
+    /// Mark execution as approved by the user's explicit `workflow run`
+    /// command rather than by an Engine tool-call approval gate.
+    #[must_use]
+    pub(crate) fn with_explicit_cli_approval(mut self) -> Self {
+        self.approval_decision = "approved_explicit_cli_command";
+        self
     }
 }
 
@@ -506,6 +519,7 @@ impl ToolSpec for WorkflowTool {
                     self.runtime.clone(),
                     state,
                     wait,
+                    self.approval_decision,
                 )
                 .await
             }
@@ -517,6 +531,7 @@ impl ToolSpec for WorkflowTool {
                     self.runtime.clone(),
                     state,
                     true,
+                    self.approval_decision,
                 )
                 .await
             }
@@ -534,6 +549,7 @@ async fn start_workflow(
     runtime: SubAgentRuntime,
     state: Arc<WorkflowWorkspaceState>,
     wait: bool,
+    approval_decision: &str,
 ) -> Result<ToolResult, ToolError> {
     let source = workflow_source(&input, context)?;
     let args = input.get("args").cloned().unwrap_or(Value::Null);
@@ -559,7 +575,7 @@ async fn start_workflow(
     let approval_decision = if summary.is_read_only_envelope() {
         "auto_read_only"
     } else {
-        "approved"
+        approval_decision
     };
     let plan_approval = summary.to_receipt(approval_decision, now_ms());
 
@@ -3660,13 +3676,7 @@ export default workflow({
         assert_eq!(task_started["thinking"], "low");
         assert_eq!(task_started["resolved_provider"], "deepseek");
         assert_eq!(task_started["resolved_model"], "deepseek-v4-flash");
-        assert!(
-            task_started["route_source"]
-                .as_str()
-                .is_some_and(|source| source.contains("explicit model id")),
-            "{}",
-            task_started["route_source"]
-        );
+        assert_eq!(task_started["route_source"], "task.model");
         assert_eq!(task_started["worktree"], false);
         assert!(task_started["parent_task_id"].is_null());
         assert_eq!(task_started["depth"], 1);
@@ -3691,6 +3701,95 @@ export default workflow({
             .expect("child result");
         assert_eq!(child.status, SubAgentStatus::Completed);
         assert_eq!(child.result.as_deref(), Some("child done"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn named_fleet_run_emits_role_resolved_receipt_and_rejects_unknown_before_provider() {
+        let _retry_guard = workflow_test_retry_guard();
+        let _env_lock = crate::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", tmp.path());
+        std::fs::create_dir_all(tmp.path().join("fleets")).expect("fleets dir");
+        std::fs::write(
+            tmp.path().join("fleets/offline.toml"),
+            r#"
+name = "offline"
+[roles]
+reviewer = "reviewer"
+"#,
+        )
+        .expect("named fleet fixture");
+
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 2);
+        let (client, calls) = fake_chat_client("role-resolved child").await;
+        let runtime = SubAgentRuntime::new(
+            client,
+            "deepseek-v4-flash".to_string(),
+            ctx.clone(),
+            true,
+            None,
+            manager.clone(),
+        );
+        let tool = WorkflowTool::new(manager, runtime);
+
+        let completed = tool
+            .execute(
+                json!({
+                    "action": "run",
+                    "fleet": "offline",
+                    "script": "return await task({ description: 'review it', type: 'review', role: 'reviewer', label: 'offline-review' });"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("named fleet workflow");
+        let payload: Value = serde_json::from_str(&completed.content).expect("workflow JSON");
+        assert_eq!(payload["status"], "completed", "{payload}");
+        assert_eq!(payload["result"], "role-resolved child");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let started = payload["events"]
+            .as_array()
+            .and_then(|events| events.iter().find(|event| event["type"] == "task_started"))
+            .expect("task_started receipt");
+        assert_eq!(started["role"], "reviewer");
+        assert_eq!(started["profile"], "reviewer");
+        assert_eq!(started["resolved_role"], "reviewer");
+        assert_eq!(started["resolved_profile"], "reviewer");
+        assert_eq!(started["resolved_provider"], "deepseek");
+        assert_eq!(started["resolved_model"], "deepseek-v4-flash");
+        assert_eq!(started["route_source"], "run.model");
+        assert!(
+            payload["events"]
+                .as_array()
+                .is_some_and(|events| events.iter().any(|event| event["type"] == "task_completed"))
+        );
+
+        let rejected = tool
+            .execute(
+                json!({
+                    "action": "run",
+                    "fleet": "offline",
+                    "script": "return await task({ description: 'must not launch', type: 'review', role: 'wizard' });"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("rejected workflow still returns its terminal record");
+        let rejected: Value = serde_json::from_str(&rejected.content).expect("rejected JSON");
+        assert_eq!(rejected["status"], "failed", "{rejected}");
+        assert!(
+            rejected["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("unknown fleet role `wizard`")),
+            "{rejected}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "unknown role must fail before a second provider call"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -2200,8 +2200,10 @@ mod tests {
             "---\nname: hotbar-demo-skill\ndescription: Demo skill for hotbar tests\n---\n\nFollow the demo instructions.\n",
         )
         .expect("write SKILL.md");
-        let mut config = Config::default();
-        config.skills_dir = Some(skills_dir.path().to_string_lossy().into_owned());
+        let config = Config {
+            skills_dir: Some(skills_dir.path().to_string_lossy().into_owned()),
+            ..Config::default()
+        };
         let mut app = test_app_with_paths_and_config(
             workspace.path().to_path_buf(),
             skills_dir.path().to_path_buf(),

--- a/crates/tui/tests/workflow_tool_stream_acceptance.rs
+++ b/crates/tui/tests/workflow_tool_stream_acceptance.rs
@@ -1,0 +1,145 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn codewhale_tui_binary() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_codewhale-tui") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_codewhale-tui") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("current test executable path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("codewhale-tui{}", std::env::consts::EXE_SUFFIX));
+    path
+}
+
+fn assert_terminal_stream_error(output: Output, expected_fragment: &str) {
+    assert!(
+        !output.status.success(),
+        "workflow-tool unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("workflow-tool stdout is UTF-8");
+    let events = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|error| panic!("invalid stream JSON {line:?}: {error}"))
+        })
+        .collect::<Vec<_>>();
+    let terminal = events.last().expect("terminal error event");
+    assert_eq!(terminal["type"], "error", "events={events:?}");
+    assert!(
+        terminal["error"]
+            .as_str()
+            .is_some_and(|error| error.contains(expected_fragment)),
+        "events={events:?}"
+    );
+    assert!(
+        events.iter().all(|event| event["type"] != "tool_use"),
+        "setup failure must happen before tool_use: {events:?}"
+    );
+}
+
+#[test]
+fn invalid_workflow_input_is_terminal_ndjson() {
+    let output = Command::new(codewhale_tui_binary())
+        .args([
+            "workflow-tool",
+            "--approval-source",
+            "explicit-workflow-command",
+            "--input-json",
+            "{not-json",
+        ])
+        .output()
+        .expect("run workflow-tool");
+    assert_terminal_stream_error(output, "valid Workflow tool input object");
+}
+
+#[test]
+fn missing_profile_is_terminal_ndjson() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = dir.path().join("config.toml");
+    std::fs::write(&config, "provider = \"vllm\"\n").expect("write config");
+    let output = Command::new(codewhale_tui_binary())
+        .arg("--config")
+        .arg(&config)
+        .args([
+            "--profile",
+            "missing-profile",
+            "workflow-tool",
+            "--approval-source",
+            "explicit-workflow-command",
+            "--input-json",
+            r#"{"action":"run"}"#,
+        ])
+        .env("CODEWHALE_HOME", dir.path().join("codewhale-home"))
+        .output()
+        .expect("run workflow-tool with missing profile");
+    assert_terminal_stream_error(output, "Profile 'missing-profile' not found");
+}
+
+#[test]
+fn profile_provider_switch_accepts_source_marked_cli_key_offline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = dir.path().join("config.toml");
+    std::fs::write(
+        &config,
+        r#"
+provider = "deepseek"
+
+[features]
+mcp = false
+
+[profiles.anthropic]
+provider = "anthropic"
+"#,
+    )
+    .expect("write profile config");
+    let output = Command::new(codewhale_tui_binary())
+        .arg("--config")
+        .arg(&config)
+        .args([
+            "--profile",
+            "anthropic",
+            "workflow-tool",
+            "--approval-source",
+            "explicit-workflow-command",
+            "--input-json",
+            r#"{"action":"run","script":"phase('offline'); return { ok: true };"}"#,
+        ])
+        .env("CODEWHALE_HOME", dir.path().join("codewhale-home"))
+        .env("DEEPSEEK_API_KEY_SOURCE", "cli")
+        .env("CODEWHALE_CLI_API_KEY", "profile-switch-secret")
+        .output()
+        .expect("run profile-switched workflow-tool");
+
+    assert!(
+        output.status.success(),
+        "workflow-tool failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("workflow-tool stdout is UTF-8");
+    let event_types = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|error| panic!("invalid stream JSON {line:?}: {error}"))
+        })
+        .map(|event| event["type"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+    assert!(event_types.iter().any(|kind| kind == "tool_use"));
+    assert!(event_types.iter().any(|kind| kind == "tool_result"));
+    assert_eq!(event_types.last().map(String::as_str), Some("done"));
+    assert!(!stdout.contains("profile-switch-secret"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("profile-switch-secret"));
+}

--- a/docs/AGENT_RUNTIME.md
+++ b/docs/AGENT_RUNTIME.md
@@ -123,10 +123,13 @@ delegation. The default affords at least three nested levels.
 
 The fleet ledger persists the worker's own event stream rather than a separate,
 simulated taxonomy. `codewhale exec --output-format stream-json` emits
-`{"type": "content" | "tool_use" | "tool_result" | "metadata" | "done" |
-"error"}` lines, which map onto the fleet ledger's `FleetWorkerEventPayload`
-(`RunningTool`, `Running`, `Completed`, `Failed`, …). One vocabulary, two
-surfaces.
+`{"type": "content" | "tool_use" | "tool_result" | "workflow_event" |
+"metadata" | "done" | "error"}` lines, which map onto the fleet ledger's
+`FleetWorkerEventPayload` (`RunningTool`, `WorkflowEvent`, `Running`,
+`Completed`, `Failed`, …). `workflow_event` carries the typed
+run/phase/task/gate receipt while a Workflow is in flight and is retained as a
+typed `WorkflowEvent` in the Fleet ledger; the enclosing worker still owns the
+terminal `done` or `error`. One vocabulary, two surfaces.
 
 ## Convergence with Claude Code (#2972)
 

--- a/docs/AGENT_WORKFLOWS_0868.md
+++ b/docs/AGENT_WORKFLOWS_0868.md
@@ -130,15 +130,41 @@ codewhale workflow run stopship \
   --goal "Fix #4090, #4093, #4094. Branch implementation from main."
 
 codewhale lane list
+codewhale lane status <lane-id>          # reconciles a finished tmux process
 codewhale lane attach <lane-id>          # or: codewhale lane attach <lane-id> --print
 codewhale lane logs <lane-id>
 codewhale lane stop <lane-id>
 ```
 
 `workflow run` validates the checked-in Workflow source and named Fleet roster,
-creates the Lane record, and starts the existing headless Workflow tool via the
-selected Runtime backend. The Workflow driver resolves each `task({ role })`
-through the named fleet before spawning sub-agents.
+creates the Lane record, and invokes the existing Workflow tool directly via
+the selected Runtime backend. It does not spend an operator-model turn asking a
+model to choose the tool. The Workflow driver resolves each `task({ role })`
+through the named fleet before spawning sub-agents and emits live
+`workflow_event` NDJSON receipts for run, phase, task, gate, and terminal state.
+Inline writes each receipt to the Lane journal as it arrives. The tmux backend
+launches a hidden Rust supervisor that frames arbitrary or binary child output
+as valid NDJSON, removes its private 0600 JSON environment sidecar before the
+child starts, and atomically publishes a separate bounded exit receipt.
+`lane status` and `lane list` reconcile that receipt to `completed` or `failed`,
+and fail a Lane closed when its tmux session vanished without a receipt. Start,
+stop, and reconciliation transitions share a per-Lane lock; a failed or
+unverifiable tmux kill leaves the Lane active and never triggers worktree
+cleanup. Every tmux Lane also persists an explicit registry-owned server socket
+and uses it for start, attach, liveness, and kill operations, so later changes
+to `TMUX_TMPDIR` cannot redirect lifecycle commands to the wrong server.
+Missing tmux and the not-yet-implemented VM/CI backends fail terminally instead
+of reporting a fictional Running Lane.
+
+The public `workflow run` command is the explicit approval of the Workflow
+plan envelope and records `approved_explicit_cli_command` in the durable plan
+receipt. That approval does not silently grant child shell or full-disk
+authority: the host runner preserves the resolved profile/provider/model,
+configured `allow_shell`, sandbox, external sandbox, network, and MCP posture.
+Only a global `--yolo` request selects bypass/full-authority behavior. Runtime
+secrets are bridged outside persisted Lane argv, and an isolated worktree run
+resolves its workspace from the Runtime-owned worktree cwd rather than the
+original checkout.
 
 Validate fleet role resolution without launching agents:
 
@@ -149,12 +175,14 @@ cargo test -p codewhale-workflow --lib named_fleet
 
 ### Direct tool paths
 
-From CodeWhale TUI or headless exec:
+From CodeWhale TUI or the direct headless Workflow entrypoint:
 
 ```bash
-# Headless stopship lane (preferred for CI/VM agents today)
-codewhale exec --auto --output-format stream-json \
-  "Run workflows/v0868_stopship_lane.workflow.js on branch codex/v0868-stopship. Fix #4090, #4093, #4094. Branch from main. Use fleet profiles scout/builder/reviewer/verifier from fleets/v0868-stopship.toml."
+# Headless stopship lane (deterministic host dispatch)
+codewhale workflow run stopship \
+  --fleet v0868-stopship \
+  --runtime inline \
+  --goal "Fix #4090, #4093, #4094. Branch implementation from main."
 
 # Per-issue headless (single stopship issue)
 codewhale exec --auto --output-format stream-json \
@@ -165,7 +193,10 @@ codewhale exec --auto --output-format stream-json \
 ```
 
 Workflows use read-only scouts first, then implementation agents in sequence.
-Write agents require approval in default modes; use `--auto` for headless VM runs.
+`workflow run` is an explicit execution command and approves that checked-in
+plan envelope; its children still inherit the configured durable-task
+permission and sandbox posture. Interactive `/workflow` runs retain their
+normal approval surfaces.
 Do **not** close #4090/#4093/#4094 until human-verified on `main`.
 
 ## Per-issue implementation (single issue)


### PR DESCRIPTION
## Summary

- dispatch `codewhale workflow run` directly through the host-owned Workflow tool, without an operator-model turn
- preserve profile/provider/model, approval, sandbox, network, MCP, environment, and keyring precedence across the hidden runner
- restore named Fleet role resolution and persist typed Workflow receipts with distinct Fleet and Workflow run IDs
- harden Lane tmux execution with a Rust log proxy, bounded atomic receipts, per-Lane lifecycle locks, pinned tmux sockets, and fail-closed backend behavior

## Release issues

- Advances #4177
- Advances #4178
- Advances #4179

## Verification

- `cargo test -p codewhale-protocol --quiet`: 43 unit + 13 parity passed
- `cargo test -p codewhale-workflow --quiet`: 102 passed
- `cargo test -p codewhale-lane --quiet`: 17 passed
- `cargo test -p codewhale-cli --quiet`: 130 library + 1 shim passed
- `cargo test -p codewhale-tui --test workflow_tool_stream_acceptance --quiet`: 3 passed
- full default-feature `codewhale-tui` suite with only `GROK_HOME` isolated: 6,310 passed, 0 failed, 2 ignored
- `GROK_HOME`-isolated `cargo test --workspace --all-features --locked --quiet`: all workspace, acceptance, and doctest targets passed; the all-feature TUI binary reported 6,325 passed, 0 failed, 2 ignored
- exact release-workflow all-target/all-feature Clippy command, formatting, diff hygiene, debug CLI/TUI build, and `scripts/release/check-versions.sh` passed
- `cargo check -p codewhale-lane --target x86_64-pc-windows-gnu --locked` passed
- `cargo check -p codewhale-lane --target aarch64-linux-android --locked` passed
- live tmux proofs covered binary and unterminated output, 200 KB newline-free framing, failed-kill rollback, terminal reconciliation, missing tmux, VM fail-closed behavior, and `TMUX_TMPDIR` drift
- final GitHub matrix on `e021d2cae`: 18 successful, 4 intentionally skipped, 0 failed/pending; Windows passed in 9m59s and macOS plus offline eval passed in 11m21s

The ambient full TUI run inherited a live Grok OAuth catalog and reproduced seven model-picker fixture failures on the clean base. Isolating only `GROK_HOME` preserved the normal Codewhale/Codex catalogs and produced the clean results above. The local host lacks `x86_64-w64-mingw32-gcc`, but the complete GitHub Windows workspace run is green.

## Release boundary

- no paid model or inference calls were made
- `scripts/release/check-published.sh 0.8.68` truthfully reports that npm and the release crates are not published yet
- this draft does not merge, tag, publish, deploy, close issues, or create paid resources
- VM and CI Runtime backends remain explicit terminal failures until implemented
