### PR TITLE
fix: sanitize tool input_schema for Anthropic adapter

### DIFF
--- a/crates/tui/src/client/anthropic.rs
+++ b/crates/tui/src/client/anthropic.rs
@@ -29,6 +29,7 @@ use serde_json::{Value, json};
 use crate::llm_client::StreamEventBox;
 use crate::logging;
 use crate::models::{ContentBlock, MessageRequest, MessageResponse, StreamEvent, Usage};
+use crate::tools::schema_sanitize;
 
 use super::{DeepSeekClient, ERROR_BODY_MAX_BYTES, bounded_error_text};
 
@@ -80,10 +81,23 @@ impl DeepSeekClient {
                 tools
                     .iter()
                     .map(|tool| {
+                        // Sanitize the tool's input_schema the same way the
+                        // OpenAI Responses adapter does: strip top-level
+                        // oneOf/anyOf/allOf (which Anthropic rejects), merge
+                        // alternative properties into the root, and surface
+                        // the dropped constraint as a description note so the
+                        // model still knows which parameters are expected.
+                        let mut schema = tool.input_schema.clone();
+                        let constraint_note = schema_sanitize::sanitize_for_responses(&mut schema);
+                        let description = match constraint_note {
+                            Some(note) if tool.description.trim().is_empty() => note,
+                            Some(note) => format!("{}\n\n{}", tool.description.trim(), note),
+                            None => tool.description.clone(),
+                        };
                         let mut value = json!({
                             "name": tool.name,
-                            "description": tool.description,
-                            "input_schema": tool.input_schema,
+                            "description": description,
+                            "input_schema": schema,
                         });
                         if let Some(strict) = tool.strict {
                             value["strict"] = json!(strict);


### PR DESCRIPTION
## Summary

When using Anthropic as the provider, any tool whose `input_schema`
contains a top-level `oneOf`/`anyOf`/`allOf` causes the API to reject
the entire request with HTTP 400:

```
Anthropic API error (HTTP 400 Bad Request invalid_request_error):
tools.1.custom.input_schema: input_schema does not support oneOf,
allOf, or anyOf at the top level
```

This makes the Anthropic provider completely unusable whenever a tool
definition includes composition constraints - which is the case for
several built-in tools.

**Root cause:** The Anthropic adapter (`crates/tui/src/client/anthropic.rs`)
passes `tool.input_schema` to the API as-is, without sanitizing
top-level composition keywords. The OpenAI Responses adapter
(`crates/tui/src/client/responses.rs:596-611`) already solves this by
calling `schema_sanitize::sanitize_for_responses`, which:

1. Strips root-level `oneOf`/`anyOf`/`allOf`
2. Merges alternative properties into the root object
3. Surfaces dropped constraints as a description note so the model
   still knows which parameters are expected

**Fix:** Apply the same `sanitize_for_responses` call in the Anthropic
adapter before sending tool definitions, aligning both adapters for
consistent schema handling across providers.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
