### PR TITLE
Update Cargo.toml to allow build under NetBSD

### DIFF
--- a/crates/workflow-js/Cargo.toml
+++ b/crates/workflow-js/Cargo.toml
@@ -21,5 +21,11 @@ tokio.workspace = true
 [target.'cfg(target_os = "android")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
 
+# rquickjs does not ship pre-generated bindings for NetBSD. Generate them
+# against the NDK sysroot so the advertised Termux/Android release target can
+# compile instead of trying to include a nonexistent bindings file.
+[target.'cfg(target_os = "netbsd")'.dependencies]
+rquickjs = { workspace = true, features = ["bindgen"] }
+
 [dev-dependencies]
 serde_json.workspace = true


### PR DESCRIPTION
rquickjs does not ship pre-generated bindings for NetBSD. Generate them.

Same true for FreeBSD, OpenBSD and DragonFly.

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
