### PR TITLE
docs: add Cursor Cloud dev-environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,37 @@
   (`gh issue list --repo Hmbown/CodeWhale --milestone "<current milestone>"`) and
   refresh state before acting. Older per-version triage docs under `docs/` are
   historical reference only.
+
+## Cursor Cloud specific instructions
+
+Standard build/test/run commands are already documented above and in
+`CONTRIBUTING.md`; this section only records the non-obvious cloud-VM caveats.
+
+- **System build dep:** the build needs `libdbus-1-dev` (pulled in by
+  `crates/secrets` for the OS keyring). It is installed by the startup update
+  script; if a `cargo build` fails with a `dbus`/`pkg-config` error, that dep is
+  missing.
+- **`rustup default` must be set:** some tests and runtime paths spawn shells in
+  temp dirs *outside* this checkout (e.g. `run_verifiers_background_*`, sub-agent
+  worktrees). Those spawned shells only see the repo's `rust-toolchain.toml`
+  override while inside `/workspace`, so without a global default they fail with
+  "rustup could not choose a version of rustc to run". The update script runs
+  `rustup default stable` to fix this.
+- **Known env-specific test failures at `/workspace` (not code bugs):** because
+  the checkout sits directly under `/`, two `codewhale-tui` subagent tests fail
+  here — `git_repo_root_reports_attempted_paths_when_no_repo_found` (cannot
+  create a temp dir in the unwritable parent `/`) and
+  `create_isolated_worktree_reports_friendly_error_when_no_repo_found` (walking
+  up to `/` discovers `/workspace` itself as a repo). Both pass when the repo is
+  checked out under a normal, writable parent. `run_verifiers_background_*` is
+  the separate pre-existing flake already noted above. Everything else in
+  `cargo test --workspace` passes (~6384 tests).
+- **Running the agent without provider API keys:** point CodeWhale at any local
+  OpenAI-compatible endpoint via the keyless `vllm`/`ollama`/`sglang` providers,
+  e.g. `CODEWHALE_PROVIDER=vllm VLLM_BASE_URL=http://127.0.0.1:8000/v1
+  VLLM_MODEL=<id> codewhale exec --auto "..."`. `codewhale exec` (add `--auto`
+  for tool use) is the non-interactive path to exercise the full agent loop.
+- **Dispatcher needs its sibling:** the `codewhale` binary shells out to a
+  sibling `codewhale-tui` in the same directory (both land in `target/debug`
+  after a build). If they are not co-located, set `DEEPSEEK_TUI_BIN` to the
+  `codewhale-tui` path.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the CodeWhale development environment for Cursor Cloud agents, and records the non-obvious cloud-VM caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section. No product code changed — only `AGENTS.md`.

Key learnings captured:
- `libdbus-1-dev` is a required system build dep (`crates/secrets` OS keyring).
- `rustup default stable` must be set so shells spawned outside the checkout (verifier background jobs, sub-agent worktrees) can find `rustc`.
- Two `codewhale-tui` subagent tests fail only because the checkout sits directly under `/` (unwritable parent; `/workspace` gets discovered as a nested repo when walking up). Not code bugs.
- How to run the agent without provider API keys via keyless `vllm`/`ollama` pointed at a local OpenAI-compatible endpoint.
- The `codewhale` dispatcher needs its sibling `codewhale-tui` co-located.

## Environment verification

- Rust `1.97.0` stable (satisfies MSRV 1.88); installed `libdbus-1-dev`.
- Built the workspace (`cargo build`), both binaries report `0.8.68`.
- Ran the agent end-to-end against a keyless local OpenAI-compatible mock LLM: plain one-shot `codewhale exec`, and the full agentic loop `codewhale exec --auto` (model → `exec_shell` tool call → shell execution → tool result → final streamed answer).

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo test --workspace` — 6384 passed; 3 failures are env-specific (repo at `/workspace`) / the documented `run_verifiers_background_*` flake, all explained in the new AGENTS.md section.

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d779faaf-0c7b-4c92-819a-ade4fb134b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d779faaf-0c7b-4c92-819a-ade4fb134b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

