### PR TITLE
feat: add TelecomJS provider support with configuration and catalog i…

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -298,6 +298,16 @@ pub struct ProvidersToml {
         alias = "grok"
     )]
     pub xai: ProviderConfigToml,
+    /// Jiangsu Telecom TokenHub — OpenAI-compatible AI gateway.
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "telecom-js",
+        alias = "telecom_js",
+        alias = "telecomjs-cn",
+        alias = "tokenhub"
+    )]
+    pub telecomjs: ProviderConfigToml,
     /// Catch-all table for the dynamic OpenAI-compatible custom provider
     /// identity (#1519). Arbitrary `[providers.<name>]` tables are handled by
     /// the tui-side flatten map; this named slot keeps the canonical
@@ -408,6 +418,7 @@ impl ProvidersToml {
             ProviderKind::OpencodeGo => &self.opencode_go,
             ProviderKind::Meta => &self.meta,
             ProviderKind::Xai => &self.xai,
+            ProviderKind::Telecomjs => &self.telecomjs,
             ProviderKind::Custom => &self.custom,
         }
     }
@@ -448,6 +459,7 @@ impl ProvidersToml {
             ProviderKind::OpencodeGo => &mut self.opencode_go,
             ProviderKind::Meta => &mut self.meta,
             ProviderKind::Xai => &mut self.xai,
+            ProviderKind::Telecomjs => &mut self.telecomjs,
             ProviderKind::Custom => &mut self.custom,
         }
     }
@@ -2303,6 +2315,7 @@ impl ConfigToml {
                 ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL.to_string(),
                 ProviderKind::Meta => DEFAULT_META_BASE_URL.to_string(),
                 ProviderKind::Xai => DEFAULT_XAI_BASE_URL.to_string(),
+                ProviderKind::Telecomjs => DEFAULT_TELECOMJS_BASE_URL.to_string(),
                 // The custom provider has no built-in endpoint; fall back to its
                 // descriptor placeholder so the lookup is total. Real custom
                 // routes always supply a configured base_url before this point.
@@ -2939,6 +2952,7 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_MODEL,
         ProviderKind::Meta => DEFAULT_META_MODEL,
         ProviderKind::Xai => DEFAULT_XAI_MODEL,
+        ProviderKind::Telecomjs => DEFAULT_TELECOMJS_MODEL,
         // No built-in default model; the registry placeholder keeps this total.
         ProviderKind::Custom => provider.provider().default_model(),
     }
@@ -2980,6 +2994,7 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL,
         ProviderKind::Meta => DEFAULT_META_BASE_URL,
         ProviderKind::Xai => DEFAULT_XAI_BASE_URL,
+        ProviderKind::Telecomjs => DEFAULT_TELECOMJS_BASE_URL,
         // No built-in default base URL; the registry placeholder keeps this total.
         ProviderKind::Custom => provider.provider().default_base_url(),
     }
@@ -4619,6 +4634,8 @@ struct EnvRuntimeOverrides {
     meta_model: Option<String>,
     xai_base_url: Option<String>,
     xai_model: Option<String>,
+    telecomjs_base_url: Option<String>,
+    telecomjs_model: Option<String>,
 }
 
 impl EnvRuntimeOverrides {
@@ -4894,6 +4911,12 @@ impl EnvRuntimeOverrides {
             xai_model: std::env::var("XAI_MODEL")
                 .ok()
                 .filter(|v| !v.trim().is_empty()),
+            telecomjs_base_url: std::env::var("TELECOMJS_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            telecomjs_model: std::env::var("TELECOMJS_MODEL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
         }
     }
 
@@ -4950,6 +4973,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::OpencodeGo => self.opencode_go_base_url.clone(),
             ProviderKind::Meta => self.meta_base_url.clone(),
             ProviderKind::Xai => self.xai_base_url.clone(),
+            ProviderKind::Telecomjs => self.telecomjs_base_url.clone(),
             // No dedicated CODEWHALE_CUSTOM_BASE_URL env override: a custom
             // provider's base URL comes from its `[providers.<name>]` table.
             ProviderKind::Custom => None,
@@ -4984,6 +5008,7 @@ impl EnvRuntimeOverrides {
             ProviderKind::OpencodeGo => self.opencode_go_model.clone(),
             ProviderKind::Meta => self.meta_model.clone(),
             ProviderKind::Xai => self.xai_model.clone(),
+            ProviderKind::Telecomjs => self.telecomjs_model.clone(),
             _ => None,
         }?;
 

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -21,7 +21,8 @@ use super::{
     DEFAULT_QIANFAN_BASE_URL, DEFAULT_QIANFAN_MODEL, DEFAULT_SAKANA_BASE_URL, DEFAULT_SAKANA_MODEL,
     DEFAULT_SGLANG_BASE_URL, DEFAULT_SGLANG_MODEL, DEFAULT_SILICONFLOW_BASE_URL,
     DEFAULT_SILICONFLOW_CN_BASE_URL, DEFAULT_SILICONFLOW_MODEL, DEFAULT_STEPFUN_BASE_URL,
-    DEFAULT_STEPFUN_MODEL, DEFAULT_TOGETHER_BASE_URL, DEFAULT_TOGETHER_MODEL,
+    DEFAULT_STEPFUN_MODEL, DEFAULT_TELECOMJS_BASE_URL, DEFAULT_TELECOMJS_MODEL,
+    DEFAULT_TOGETHER_BASE_URL, DEFAULT_TOGETHER_MODEL,
     DEFAULT_VLLM_BASE_URL, DEFAULT_VLLM_MODEL, DEFAULT_VOLCENGINE_BASE_URL,
     DEFAULT_VOLCENGINE_MODEL, DEFAULT_WANJIE_ARK_BASE_URL, DEFAULT_WANJIE_ARK_MODEL,
     DEFAULT_XAI_BASE_URL, DEFAULT_XAI_MODEL, DEFAULT_XIAOMI_MIMO_BASE_URL,
@@ -706,6 +707,18 @@ provider!(
     aliases: ["x-ai", "x_ai", "grok"]
 );
 
+provider!(
+    Telecomjs,
+    Telecomjs,
+    "telecomjs",
+    "Telecom JiangSu",
+    DEFAULT_TELECOMJS_BASE_URL,
+    DEFAULT_TELECOMJS_MODEL,
+    ["TELECOMJS_API_KEY"],
+    "telecomjs",
+    aliases: ["telecom-js", "telecom_js", "telecomjs-cn", "tokenhub"]
+);
+
 /// User-defined OpenAI-compatible endpoint (#1519).
 ///
 /// A single dynamic provider identity for arbitrary `[providers.<name>]
@@ -793,9 +806,10 @@ static LONGCAT: LongCat = LongCat;
 static OPENCODE_GO: OpencodeGo = OpencodeGo;
 static META: Meta = Meta;
 static XAI: Xai = Xai;
+static TELECOMJS: Telecomjs = Telecomjs;
 static CUSTOM: Custom = Custom;
 
-static PROVIDER_REGISTRY: [&dyn Provider; 35] = [
+static PROVIDER_REGISTRY: [&dyn Provider; 36] = [
     &DEEPSEEK,
     &DEEPSEEK_ANTHROPIC,
     &NVIDIA_NIM,
@@ -830,6 +844,7 @@ static PROVIDER_REGISTRY: [&dyn Provider; 35] = [
     &OPENCODE_GO,
     &META,
     &XAI,
+    &TELECOMJS,
     &CUSTOM,
 ];
 

--- a/crates/config/src/provider_defaults.rs
+++ b/crates/config/src/provider_defaults.rs
@@ -153,3 +153,6 @@ pub(crate) const DEFAULT_META_BASE_URL: &str = "https://api.meta.ai/v1";
 // xAI / Grok API-key route defaults
 pub(crate) const DEFAULT_XAI_MODEL: &str = "grok-4.5";
 pub(crate) const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
+// TelecomJS (Jiangsu Telecom TokenHub) defaults
+pub(crate) const DEFAULT_TELECOMJS_MODEL: &str = "deepseek-v4-pro";
+pub(crate) const DEFAULT_TELECOMJS_BASE_URL: &str = "https://aigw.telecomjs.com/v1";

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -124,6 +124,13 @@ pub enum ProviderKind {
     Meta,
     #[serde(alias = "x-ai", alias = "x_ai", alias = "grok")]
     Xai,
+    /// Jiangsu Telecom TokenHub (OpenAI-compatible).
+    ///
+    /// An AI gateway operated by Jiangsu Telecom that speaks the OpenAI Chat
+    /// Completions wire protocol and serves a broad model catalog; each API key
+    /// may access a different subset of models.
+    #[serde(alias = "telecom-js", alias = "telecom_js", alias = "telecomjs-cn", alias = "tokenhub")]
+    Telecomjs,
     /// User-defined OpenAI-compatible endpoint (#1519).
     ///
     /// A single dynamic identity for arbitrary `[providers.<name>]
@@ -135,7 +142,7 @@ pub enum ProviderKind {
 }
 
 impl ProviderKind {
-    pub const ALL: [Self; 35] = [
+    pub const ALL: [Self; 36] = [
         Self::Deepseek,
         Self::DeepseekAnthropic,
         Self::NvidiaNim,
@@ -170,6 +177,7 @@ impl ProviderKind {
         Self::OpencodeGo,
         Self::Meta,
         Self::Xai,
+        Self::Telecomjs,
         Self::Custom,
     ];
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1513,6 +1513,74 @@ impl DeepSeekClient {
                     openrouter_to_catalog_offering(item, &provider, &fingerprint, fetched_at)
                 })
                 .collect()
+        } else if provider == "telecomjs" {
+            // TelecomJS TokenHub returns bare model IDs (e.g. "glm-5.2",
+            // "deepseek-v4-flash") that correspond to models also present in the
+            // bundled catalog under their home providers. Match against the
+            // bundled catalog (case-insensitive) to inherit metadata (context
+            // window, reasoning, tool_call, etc.) so the model picker shows
+            // rich capability information instead of empty rows.
+            let models =
+                parse_models_response(&body).map_err(|_| CatalogRefreshError::InvalidResponse)?;
+            if models.is_empty() {
+                return Err(CatalogRefreshError::EmptyList);
+            }
+            let bundled = codewhale_config::catalog::bundled_catalog_offerings();
+            let default_model_id = codewhale_config::ProviderKind::Telecomjs
+                .provider()
+                .default_model();
+            models
+                .into_iter()
+                .map(|model| {
+                    let is_default = model.id == default_model_id;
+                    // Find a bundled offering whose wire_model_id matches
+                    // case-insensitively, regardless of provider.
+                    let bundled_match = bundled.iter().find(|offering| {
+                        offering
+                            .wire_model_id
+                            .eq_ignore_ascii_case(&model.id)
+                    });
+                    if let Some(matched) = bundled_match {
+                        CatalogOffering {
+                            provider: provider.clone(),
+                            wire_model_id: model.id,
+                            canonical_model: matched.canonical_model.clone(),
+                            endpoint_key: "chat".to_string(),
+                            default_for_provider: is_default,
+                            family: matched.family.clone(),
+                            limit: matched.limit.clone(),
+                            cost: matched.cost.clone(),
+                            modalities: matched.modalities.clone(),
+                            reasoning: matched.reasoning,
+                            tool_call: matched.tool_call,
+                            reasoning_options: matched.reasoning_options.clone(),
+                            source: CatalogSource::Live {
+                                base_url_fingerprint: fingerprint.clone(),
+                                fetched_at,
+                            },
+                        }
+                    } else {
+                        CatalogOffering {
+                            provider: provider.clone(),
+                            wire_model_id: model.id,
+                            canonical_model: None,
+                            endpoint_key: "chat".to_string(),
+                            default_for_provider: is_default,
+                            family: None,
+                            limit: None,
+                            cost: None,
+                            modalities: None,
+                            reasoning: None,
+                            tool_call: None,
+                            reasoning_options: Vec::new(),
+                            source: CatalogSource::Live {
+                                base_url_fingerprint: fingerprint.clone(),
+                                fetched_at,
+                            },
+                        }
+                    }
+                })
+                .collect()
         } else {
             let models = apply_provider_model_cutline(
                 self.api_provider,
@@ -1577,6 +1645,60 @@ impl DeepSeekClient {
                 CatalogStatus::Failed { reason }
             }
         }
+    }
+
+    /// Best-effort background refresh of the active provider's own `/v1/models`
+    /// catalog, merging results into the provider lake (#3385).
+    ///
+    /// Unlike [`models_dev_live::spawn_background_refresh`] (which fetches the
+    /// cross-provider Models.dev catalog), this calls the provider's own
+    /// `/v1/models` endpoint and merges the results into the existing live
+    /// snapshot via [`provider_lake::merge_live_offerings`], preserving rows
+    /// from other sources.
+    ///
+    /// Currently activated for providers whose model list is not covered by the
+    /// Models.dev catalog (e.g. TelecomJS TokenHub). The refresh is non-fatal:
+    /// on failure, existing/bundled rows remain available.
+    pub fn spawn_active_provider_catalog_refresh(config: &Config) {
+        let provider = config.api_provider();
+        // Only refresh for providers that serve their own model list and are
+        // not already covered by the Models.dev catalog.
+        if !matches!(provider, ApiProvider::Telecomjs) {
+            return;
+        }
+
+        let client = match DeepSeekClient::new(config) {
+            Ok(client) => client,
+            Err(err) => {
+                tracing::debug!(
+                    target: "provider_catalog",
+                    error = %err,
+                    "skipping provider catalog refresh: client creation failed"
+                );
+                return;
+            }
+        };
+
+        tokio::spawn(async move {
+            match client.fetch_catalog_delta().await {
+                Ok(delta) => {
+                    let count = delta.offerings.len();
+                    crate::provider_lake::merge_live_offerings(delta.offerings);
+                    tracing::debug!(
+                        target: "provider_catalog",
+                        offering_count = count,
+                        "provider catalog refresh merged {count} offerings into provider lake"
+                    );
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        target: "provider_catalog",
+                        error = ?err,
+                        "provider catalog refresh failed; keeping existing rows"
+                    );
+                }
+            }
+        });
     }
 
     /// Generate speech with Xiaomi MiMo TTS models.
@@ -2226,7 +2348,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Deepinfra
             | ApiProvider::Together
             | ApiProvider::Atlascloud
-            | ApiProvider::Zai => {
+            | ApiProvider::Zai
+            | ApiProvider::Telecomjs => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
             ApiProvider::OpenaiCodex => {
@@ -2292,7 +2415,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Sglang
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
-            | ApiProvider::Atlascloud => {
+            | ApiProvider::Atlascloud
+            | ApiProvider::Telecomjs => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
@@ -2386,7 +2510,8 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Sglang
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
-            | ApiProvider::Atlascloud => {
+            | ApiProvider::Atlascloud
+            | ApiProvider::Telecomjs => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1520,6 +1520,18 @@ impl DeepSeekClient {
             // bundled catalog (case-insensitive) to inherit metadata (context
             // window, reasoning, tool_call, etc.) so the model picker shows
             // rich capability information instead of empty rows.
+            //
+            // Correctness boundary (#4188 review): matching solely by
+            // case-insensitive `wire_model_id` across all providers can copy
+            // capabilities and cost from an unrelated provider/version. A
+            // gateway exposing `DeepSeek-R1` does not by itself prove identical
+            // limits, prices, reasoning controls, or tool support.
+            //
+            // Strategy: prefer same-provider matches (explicit canonical mapping)
+            // and inherit all metadata; for cross-provider matches, only inherit
+            // `family` (name-derived, safe) and leave provider-specific fields
+            // (limit, cost, reasoning, tool_call, modalities, canonical_model,
+            // reasoning_options) as unknown — they must be proven per-gateway.
             let models =
                 parse_models_response(&body).map_err(|_| CatalogRefreshError::InvalidResponse)?;
             if models.is_empty() {
@@ -1533,14 +1545,28 @@ impl DeepSeekClient {
                 .into_iter()
                 .map(|model| {
                     let is_default = model.id == default_model_id;
-                    // Find a bundled offering whose wire_model_id matches
-                    // case-insensitively, regardless of provider.
-                    let bundled_match = bundled.iter().find(|offering| {
-                        offering
-                            .wire_model_id
-                            .eq_ignore_ascii_case(&model.id)
+
+                    // 1) Same-provider match: explicit canonical mapping — inherit
+                    //    all metadata (same provider proves same model capabilities).
+                    let same_provider_match = bundled.iter().find(|offering| {
+                        offering.provider.eq_ignore_ascii_case(&provider)
+                            && offering.wire_model_id.eq_ignore_ascii_case(&model.id)
                     });
-                    if let Some(matched) = bundled_match {
+
+                    // 2) Cross-provider match: same wire_model_id but different
+                    //    provider — only inherit `family` (name-derived, safe).
+                    //    Provider-specific fields remain unknown.
+                    let cross_provider_match = if same_provider_match.is_none() {
+                        bundled.iter().find(|offering| {
+                            !offering.provider.eq_ignore_ascii_case(&provider)
+                                && offering.wire_model_id.eq_ignore_ascii_case(&model.id)
+                        })
+                    } else {
+                        None
+                    };
+
+                    if let Some(matched) = same_provider_match {
+                        // Same-provider match: full metadata inheritance is safe.
                         CatalogOffering {
                             provider: provider.clone(),
                             wire_model_id: model.id,
@@ -1559,7 +1585,33 @@ impl DeepSeekClient {
                                 fetched_at,
                             },
                         }
+                    } else if let Some(matched) = cross_provider_match {
+                        // Cross-provider match: only inherit family (name-derived).
+                        // Provider-specific metadata (limit, cost, reasoning,
+                        // tool_call, modalities, canonical_model,
+                        // reasoning_options) is NOT inherited — a gateway
+                        // exposing the same model ID does not prove identical
+                        // limits, prices, or capabilities.
+                        CatalogOffering {
+                            provider: provider.clone(),
+                            wire_model_id: model.id,
+                            canonical_model: None,
+                            endpoint_key: "chat".to_string(),
+                            default_for_provider: is_default,
+                            family: matched.family.clone(),
+                            limit: None,
+                            cost: None,
+                            modalities: None,
+                            reasoning: None,
+                            tool_call: None,
+                            reasoning_options: Vec::new(),
+                            source: CatalogSource::Live {
+                                base_url_fingerprint: fingerprint.clone(),
+                                fetched_at,
+                            },
+                        }
                     } else {
+                        // No match at all: bare offering with no metadata.
                         CatalogOffering {
                             provider: provider.clone(),
                             wire_model_id: model.id,
@@ -2185,13 +2237,18 @@ fn parse_openrouter_models_response(
 
 fn publish_provider_lake_snapshot(cache: &ProviderCatalogCache) {
     // Publish fresh *and* stale/prior rows so pickers keep live catalog coverage
-    // after TTL expiry or a failed refresh (#4139). Empty caches clear the live
-    // layer and fall back to the bundled snapshot.
+    // after TTL expiry or a failed refresh (#4139). Empty caches clear the
+    // per-provider live layer and fall back to bundled/Models.dev snapshot.
     let offerings = cache.all_visible_offerings(now_unix());
     if offerings.is_empty() {
-        crate::provider_lake::clear_live_snapshot();
+        crate::provider_lake::clear_live_snapshot_for_source(
+            crate::provider_lake::LiveSource::PerProvider,
+        );
     } else {
-        crate::provider_lake::set_live_snapshot(CatalogSnapshot { offerings });
+        crate::provider_lake::set_live_snapshot(
+            CatalogSnapshot { offerings },
+            crate::provider_lake::LiveSource::PerProvider,
+        );
     }
 }
 
@@ -2348,10 +2405,20 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Deepinfra
             | ApiProvider::Together
             | ApiProvider::Atlascloud
-            | ApiProvider::Zai
-            | ApiProvider::Telecomjs => {
+            | ApiProvider::Zai => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
+            // TelecomJS TokenHub: the gateway's OpenAI Chat Completions API
+            // (POST /v1/chat/completions) does not document `reasoning_effort`
+            // or `thinking` as supported parameters. The `thinking` field is
+            // only available on the Anthropic Messages API (POST /v1/messages)
+            // with a different shape ({"type":"enabled","budget_tokens":N}).
+            // Since CodeWhale routes TelecomJS through the Chat Completions
+            // path, we must NOT inject these fields — the gateway may silently
+            // ignore them or reject the request, and not every gateway model
+            // (qwen-max, deepseek-chat, gpt-4o, claude, etc.) accepts the same
+            // reasoning dialect (#4188 review: verify against actual behavior).
+            ApiProvider::Telecomjs => {}
             ApiProvider::OpenaiCodex => {
                 // OpenAI Codex uses Responses API — thinking handled differently
             }
@@ -2415,11 +2482,13 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Sglang
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
-            | ApiProvider::Atlascloud
-            | ApiProvider::Telecomjs => {
+            | ApiProvider::Atlascloud => {
                 body["reasoning_effort"] = json!("high");
                 body["thinking"] = json!({ "type": "enabled" });
             }
+            // TelecomJS: see comment in the "off" branch above — the gateway's
+            // Chat Completions API does not support reasoning_effort or thinking.
+            ApiProvider::Telecomjs => {}
             // OpenRouter/Novita/Together: pass through the actual user-chosen value.
             // OpenRouter's unified scale is none/minimal/low/medium/high/xhigh;
             // DeepSeek models hosted there accept those directly.
@@ -2510,11 +2579,13 @@ pub(super) fn apply_reasoning_effort(
             | ApiProvider::Sglang
             | ApiProvider::Volcengine
             | ApiProvider::Deepinfra
-            | ApiProvider::Atlascloud
-            | ApiProvider::Telecomjs => {
+            | ApiProvider::Atlascloud => {
                 body["reasoning_effort"] = json!("max");
                 body["thinking"] = json!({ "type": "enabled" });
             }
+            // TelecomJS: see comment in the "off" branch above — the gateway's
+            // Chat Completions API does not support reasoning_effort or thinking.
+            ApiProvider::Telecomjs => {}
             ApiProvider::Openrouter | ApiProvider::Novita | ApiProvider::Together => {
                 body["reasoning_effort"] = json!("xhigh");
                 body["thinking"] = json!({ "type": "enabled" });
@@ -4720,6 +4791,31 @@ mod tests {
         let mut body = json!({});
         apply_reasoning_effort(&mut body, Some("off"), ApiProvider::Moonshot);
         assert_eq!(body, json!({ "thinking": { "type": "disabled" } }));
+    }
+
+    /// TelecomJS TokenHub: the gateway's OpenAI Chat Completions API does NOT
+    /// support `reasoning_effort` or `thinking` fields (#4188 review). Verify
+    /// that no reasoning fields are injected for any effort level, since not
+    /// every gateway model (qwen-max, deepseek-chat, gpt-4o, claude, etc.)
+    /// accepts the same reasoning dialect.
+    #[test]
+    fn reasoning_effort_telecomjs_does_not_inject_reasoning_fields() {
+        for effort in &["off", "low", "medium", "high", "max", "xhigh"] {
+            let mut body = json!({});
+            apply_reasoning_effort(&mut body, Some(effort), ApiProvider::Telecomjs);
+            assert!(
+                body.get("reasoning_effort").is_none(),
+                "TelecomJS must not inject reasoning_effort for effort={effort}: {body}"
+            );
+            assert!(
+                body.get("thinking").is_none(),
+                "TelecomJS must not inject thinking for effort={effort}: {body}"
+            );
+            assert!(
+                body.get("think").is_none(),
+                "TelecomJS must not inject think for effort={effort}: {body}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -5790,6 +5790,7 @@ fn provider_env_base_url_override(provider: ApiProvider) -> Option<String> {
         ApiProvider::Huggingface => &["HUGGINGFACE_BASE_URL", "HF_BASE_URL"],
         ApiProvider::Meta => &["META_MODEL_API_BASE_URL", "MODEL_API_BASE_URL"],
         ApiProvider::Xai => &["XAI_BASE_URL"],
+        ApiProvider::Telecomjs => &["TELECOMJS_BASE_URL"],
         ApiProvider::OpencodeGo => &["OPENCODE_GO_BASE_URL"],
         ApiProvider::Deepseek
         | ApiProvider::DeepseekCN

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -75,6 +75,8 @@ pub enum ApiProvider {
     OpencodeGo,
     Meta,
     Xai,
+    /// Jiangsu Telecom TokenHub — OpenAI-compatible AI gateway.
+    Telecomjs,
     /// User-defined OpenAI-compatible endpoint (#1519).
     ///
     /// Selected when `provider = "<name>"` names a `[providers.<name>]
@@ -237,6 +239,7 @@ impl ApiProvider {
             Self::OpencodeGo => "https://opencode.ai/zen/",
             Self::Meta => "https://developer.meta.com/ai/",
             Self::Xai => "https://console.x.ai/",
+            Self::Telecomjs => "https://aigw.telecomjs.com/",
             Self::OpenaiCodex | Self::Sglang | Self::Vllm | Self::Ollama => return None,
             // Custom endpoints have no canonical credential page; the user
             // supplies the key via their own `api_key_env`.
@@ -252,7 +255,7 @@ impl ApiProvider {
 
     /// `ApiProvider` discriminant → `ProviderKind` lookup.
     /// Index 1 is `None` for the legacy `DeepseekCN` variant.
-    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 36] = [
+    const KIND_LOOKUP: [Option<codewhale_config::ProviderKind>; 37] = [
         Some(codewhale_config::ProviderKind::Deepseek),
         None, // DeepseekCN
         Some(codewhale_config::ProviderKind::DeepseekAnthropic),
@@ -288,11 +291,12 @@ impl ApiProvider {
         Some(codewhale_config::ProviderKind::OpencodeGo),
         Some(codewhale_config::ProviderKind::Meta),
         Some(codewhale_config::ProviderKind::Xai),
+        Some(codewhale_config::ProviderKind::Telecomjs),
         Some(codewhale_config::ProviderKind::Custom),
     ];
 
     /// `ProviderKind` discriminant → `ApiProvider` lookup.
-    const FROM_KIND_LOOKUP: [Self; 35] = [
+    const FROM_KIND_LOOKUP: [Self; 36] = [
         Self::Deepseek,
         Self::DeepseekAnthropic,
         Self::NvidiaNim,
@@ -327,6 +331,7 @@ impl ApiProvider {
         Self::OpencodeGo,
         Self::Meta,
         Self::Xai,
+        Self::Telecomjs,
         Self::Custom,
     ];
 
@@ -1335,6 +1340,19 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
             XAI_GROK_COMPOSER_2_5_FAST_MODEL,
             XAI_GROK_4_20_0309_REASONING_MODEL,
             XAI_GROK_4_20_0309_NON_REASONING_MODEL,
+        ],
+        ApiProvider::Telecomjs => vec![
+            DEFAULT_TELECOMJS_MODEL,
+            "deepseek-v4-flash",
+            "DeepSeek-R1",
+            "qwen3.7-plus",
+            "qwen3-max",
+            "glm-5.2",
+            "glm-5.1",
+            "GLM-5.0",
+            "Minimax-M2.5",
+            "kimi-k2.7-code",
+            "Doubao-Seed-2.0-Pro",
         ],
         // Custom endpoints expose no built-in completion names; the user
         // supplies their own model id (#1519).
@@ -2832,6 +2850,14 @@ pub struct ProvidersConfig {
     pub meta: ProviderConfig,
     #[serde(default, alias = "x-ai", alias = "x_ai", alias = "grok")]
     pub xai: ProviderConfig,
+    #[serde(
+        default,
+        alias = "telecom-js",
+        alias = "telecom_js",
+        alias = "telecomjs-cn",
+        alias = "tokenhub"
+    )]
+    pub telecomjs: ProviderConfig,
     /// Arbitrary user-named custom providers (#1519).
     ///
     /// Captures every `[providers.<name>]` table whose key is not one of the
@@ -4087,6 +4113,7 @@ impl Config {
             ApiProvider::OpencodeGo => &providers.opencode_go,
             ApiProvider::Meta => &providers.meta,
             ApiProvider::Xai => &providers.xai,
+            ApiProvider::Telecomjs => &providers.telecomjs,
             // Handled by the name-keyed early return above (#1519).
             ApiProvider::Custom => unreachable!("custom provider resolved by name above"),
         })
@@ -4152,6 +4179,7 @@ impl Config {
             ApiProvider::OpencodeGo => &mut providers.opencode_go,
             ApiProvider::Meta => &mut providers.meta,
             ApiProvider::Xai => &mut providers.xai,
+            ApiProvider::Telecomjs => &mut providers.telecomjs,
             // Handled by the name-keyed early return above (#1519).
             ApiProvider::Custom => unreachable!("custom provider resolved by name above"),
         }
@@ -4459,6 +4487,7 @@ impl Config {
             ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_MODEL,
             ApiProvider::Meta => DEFAULT_META_MODEL,
             ApiProvider::Xai => DEFAULT_XAI_MODEL,
+            ApiProvider::Telecomjs => DEFAULT_TELECOMJS_MODEL,
             // Custom endpoints have no built-in default model; pass through the
             // descriptor placeholder when nothing is configured (#1519).
             ApiProvider::Custom => codewhale_config::ProviderKind::Custom
@@ -4516,7 +4545,8 @@ impl Config {
             | ApiProvider::LongCat
             | ApiProvider::OpencodeGo
             | ApiProvider::Meta
-            | ApiProvider::Xai => None,
+            | ApiProvider::Xai
+            | ApiProvider::Telecomjs => None,
             ApiProvider::Custom if self.uses_legacy_literal_custom_route() => self.base_url.clone(),
             // Named custom routes read their base URL from `provider_base`.
             ApiProvider::Custom => None,
@@ -4582,6 +4612,7 @@ impl Config {
                         ApiProvider::OpencodeGo => DEFAULT_OPENCODE_GO_BASE_URL,
                         ApiProvider::Meta => DEFAULT_META_BASE_URL,
                         ApiProvider::Xai => DEFAULT_XAI_BASE_URL,
+                        ApiProvider::Telecomjs => DEFAULT_TELECOMJS_BASE_URL,
                         // No built-in endpoint; descriptor placeholder keeps the
                         // fallback total. A real custom route configures
                         // `[providers.<name>] base_url` which wins above (#1519).
@@ -6040,6 +6071,13 @@ fn apply_env_overrides(config: &mut Config) {
                     .xai
                     .base_url = Some(value);
             }
+            ApiProvider::Telecomjs => {
+                config
+                    .providers
+                    .get_or_insert_with(ProvidersConfig::default)
+                    .telecomjs
+                    .base_url = Some(value);
+            }
             // Custom resolves to the named `[providers.<name>]` table; route the
             // override through the exact route while retaining the released
             // root-literal custom storage shape (#1519, #4334).
@@ -6239,6 +6277,16 @@ fn apply_env_overrides(config: &mut Config) {
             .xai
             .base_url = Some(value);
     }
+    if matches!(config.api_provider(), ApiProvider::Telecomjs)
+        && let Ok(value) = std::env::var("TELECOMJS_BASE_URL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .telecomjs
+            .base_url = Some(value);
+    }
     if let Ok(value) = std::env::var("DEEPSEEK_HTTP_HEADERS")
         && let Ok(headers) = parse_http_headers(&value)
         && !headers.is_empty()
@@ -6299,6 +6347,7 @@ fn apply_env_overrides(config: &mut Config) {
                 ApiProvider::OpencodeGo => &mut providers.opencode_go,
                 ApiProvider::Meta => &mut providers.meta,
                 ApiProvider::Xai => &mut providers.xai,
+                ApiProvider::Telecomjs => &mut providers.telecomjs,
                 ApiProvider::Custom => providers
                     .custom
                     .entry(custom_key.expect("custom key captured for custom provider"))
@@ -6483,6 +6532,16 @@ fn apply_env_overrides(config: &mut Config) {
             .opencode_go
             .model = Some(value);
     }
+    if matches!(config.api_provider(), ApiProvider::Telecomjs)
+        && let Ok(value) = std::env::var("TELECOMJS_MODEL")
+        && !value.trim().is_empty()
+    {
+        config
+            .providers
+            .get_or_insert_with(ProvidersConfig::default)
+            .telecomjs
+            .model = Some(value);
+    }
     if let Some(value) = codewhale_env_var("CODEWHALE_MODEL", "DEEPSEEK_MODEL")
         .ok()
         .or_else(|| {
@@ -6560,6 +6619,7 @@ fn apply_env_overrides(config: &mut Config) {
                 ApiProvider::OpencodeGo => &mut providers.opencode_go,
                 ApiProvider::Meta => &mut providers.meta,
                 ApiProvider::Xai => &mut providers.xai,
+                ApiProvider::Telecomjs => &mut providers.telecomjs,
             };
             entry.model = Some(value);
         }
@@ -6814,6 +6874,7 @@ pub(crate) fn provider_passes_model_through(provider: ApiProvider) -> bool {
             | ApiProvider::Huggingface
             | ApiProvider::Meta
             | ApiProvider::Xai
+            | ApiProvider::Telecomjs
             // Custom OpenAI-compatible endpoints preserve user-supplied model
             // ids verbatim (#1519); never normalize/rewrite them.
             | ApiProvider::Custom
@@ -7424,6 +7485,7 @@ fn merge_providers(
             opencode_go: merge_provider_config(base.opencode_go, override_cfg.opencode_go),
             meta: merge_provider_config(base.meta, override_cfg.meta),
             xai: merge_provider_config(base.xai, override_cfg.xai),
+            telecomjs: merge_provider_config(base.telecomjs, override_cfg.telecomjs),
             custom: merge_custom_providers(base.custom, override_cfg.custom),
         }),
     }

--- a/crates/tui/src/config/models.rs
+++ b/crates/tui/src/config/models.rs
@@ -192,3 +192,5 @@ pub const XAI_GROK_COMPOSER_2_5_FAST_MODEL: &str = "grok-composer-2.5-fast";
 pub const XAI_GROK_4_20_0309_REASONING_MODEL: &str = "grok-4.20-0309-reasoning";
 pub const XAI_GROK_4_20_0309_NON_REASONING_MODEL: &str = "grok-4.20-0309-non-reasoning";
 pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
+pub const DEFAULT_TELECOMJS_MODEL: &str = "deepseek-v4-pro";
+pub const DEFAULT_TELECOMJS_BASE_URL: &str = "https://aigw.telecomjs.com/v1";

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -444,6 +444,7 @@ fn provider_base_url_table_key(provider: ApiProvider) -> anyhow::Result<&'static
         ApiProvider::OpencodeGo => Ok("opencode_go"),
         ApiProvider::Meta => Ok("meta"),
         ApiProvider::Xai => Ok("xai"),
+        ApiProvider::Telecomjs => Ok("telecomjs"),
         // Custom providers live under a user-chosen `[providers.<name>]` table,
         // not a fixed key. Persisting base_url through this static-key path is
         // out of scope for the #1519 constrained slice; users edit the named

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -7468,6 +7468,11 @@ async fn run_interactive(
     // Failures are quiet: bundled catalog rows always remain available.
     crate::models_dev_live::maybe_load_persisted_cache();
     crate::models_dev_live::spawn_background_refresh();
+    // Best-effort per-provider catalog refresh: fetches the active provider's
+    // own /v1/models endpoint and merges live rows into the provider lake
+    // alongside the Models.dev snapshot. Currently active for TelecomJS, whose
+    // model list is not covered by the Models.dev catalog.
+    crate::client::DeepSeekClient::spawn_active_provider_catalog_refresh(&config);
 
     // Boot janitors — snapshot prune (7-day default), spillover prune
     // (#422), and managed-session cleanup (v0.8.44) — are best-effort disk

--- a/crates/tui/src/models_dev_live.rs
+++ b/crates/tui/src/models_dev_live.rs
@@ -361,7 +361,7 @@ fn publish_from_body(
         return Err(err);
     }
     let count = offerings.len();
-    crate::provider_lake::set_live_snapshot(CatalogSnapshot { offerings });
+    crate::provider_lake::set_live_snapshot(CatalogSnapshot { offerings }, crate::provider_lake::LiveSource::ModelsDev);
     set_status(ModelsDevStatus {
         freshness,
         offering_count: count,

--- a/crates/tui/src/provider_lake.rs
+++ b/crates/tui/src/provider_lake.rs
@@ -72,6 +72,33 @@ pub fn clear_live_snapshot() {
     }
 }
 
+/// Merge additional live offerings into the existing live snapshot (#4188).
+///
+/// Unlike [`set_live_snapshot`] (which replaces the entire snapshot), this
+/// merges new rows by `(provider, wire_model_id)` identity, preserving rows
+/// from other sources (e.g. Models.dev) that were already published. This is
+/// used by per-provider catalog refreshes (e.g. TelecomJS `/v1/models`) that
+/// need to coexist with the cross-provider Models.dev live layer.
+pub fn merge_live_offerings(new_offerings: Vec<CatalogOffering>) {
+    if new_offerings.is_empty() {
+        return;
+    }
+    if let Ok(mut guard) = LIVE_SNAPSHOT.write() {
+        let existing = guard.take().unwrap_or_default();
+        use std::collections::BTreeMap;
+        let mut merged: BTreeMap<(String, String), CatalogOffering> = BTreeMap::new();
+        for row in &existing.offerings {
+            merged.insert((row.provider.clone(), row.wire_model_id.clone()), row.clone());
+        }
+        for row in new_offerings {
+            merged.insert((row.provider.clone(), row.wire_model_id.clone()), row);
+        }
+        *guard = Some(CatalogSnapshot {
+            offerings: merged.into_values().collect(),
+        });
+    }
+}
+
 /// The merged catalog snapshot: live rows override bundled rows on
 /// `(provider, wire_model_id)` identity (#4188). When no live snapshot is
 /// present, this is just the offline bundled snapshot.

--- a/crates/tui/src/provider_lake.rs
+++ b/crates/tui/src/provider_lake.rs
@@ -11,6 +11,7 @@
 //! does not represent (and for unbundled gateways until the live catalog covers
 //! them).
 
+use std::collections::BTreeMap;
 use std::sync::RwLock;
 
 use codewhale_config::catalog::{CatalogOffering, CatalogSnapshot, bundled_catalog_offerings};
@@ -23,9 +24,61 @@ use crate::config::{
 
 static BUNDLED_SNAPSHOT: std::sync::OnceLock<CatalogSnapshot> = std::sync::OnceLock::new();
 
-/// Optional live Models.dev snapshot (#4187). When `None`, only the bundled
-/// offline/stale fallback rows are visible.
-static LIVE_SNAPSHOT: RwLock<Option<CatalogSnapshot>> = RwLock::new(None);
+/// Source tag for live-catalog rows. Models.dev is a cross-provider catalog
+/// that serves as the primary live layer; per-provider refreshes (e.g.
+/// TelecomJS `/v1/models`) are a secondary layer that must coexist alongside
+/// Models.dev rows without being wiped by a Models.dev refresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LiveSource {
+    /// The cross-provider Models.dev catalog refresh.
+    ModelsDev,
+    /// A per-provider `/v1/models` catalog refresh (e.g. TelecomJS TokenHub).
+    PerProvider,
+}
+
+/// Optional live catalog snapshot(s), source-scoped (#4188 race fix).
+///
+/// Each source (Models.dev, per-provider) maintains its own partition of live
+/// rows. A Models.dev refresh replaces only Models.dev-sourced rows; a
+/// per-provider merge adds/replaces only per-provider-sourced rows. This
+/// prevents a later Models.dev `set_live_snapshot` from erasing TelecomJS rows
+/// that were merged earlier, and vice versa.
+static LIVE_SNAPSHOT: RwLock<LiveSnapshotPartitions> = RwLock::new(LiveSnapshotPartitions {
+    models_dev: None,
+    per_provider: None,
+});
+
+/// Internal partition map: one `CatalogSnapshot` per `LiveSource`.
+#[derive(Default)]
+struct LiveSnapshotPartitions {
+    models_dev: Option<CatalogSnapshot>,
+    per_provider: Option<CatalogSnapshot>,
+}
+
+impl LiveSnapshotPartitions {
+    /// Collect all live rows from every partition into a single flat snapshot.
+    fn flattened(&self) -> Option<CatalogSnapshot> {
+        match (&self.models_dev, &self.per_provider) {
+            (None, None) => None,
+            (Some(m), None) => Some(m.clone()),
+            (None, Some(p)) => Some(p.clone()),
+            (Some(m), Some(p)) => {
+                // Merge by (provider, wire_model_id); per-provider rows win
+                // on collision (they are more specific to the active gateway).
+                let mut merged: BTreeMap<(String, String), CatalogOffering> = BTreeMap::new();
+                for row in &m.offerings {
+                    merged.insert((row.provider.clone(), row.wire_model_id.clone()), row.clone());
+                }
+                for row in &p.offerings {
+                    merged.insert((row.provider.clone(), row.wire_model_id.clone()), row.clone());
+                }
+                Some(CatalogSnapshot {
+                    offerings: merged.into_values().collect(),
+                })
+            }
+        }
+    }
+}
 
 fn bundled_snapshot() -> &'static CatalogSnapshot {
     BUNDLED_SNAPSHOT.get_or_init(|| CatalogSnapshot {
@@ -56,36 +109,58 @@ fn apply_provider_model_cutlines(mut snapshot: CatalogSnapshot) -> CatalogSnapsh
     snapshot
 }
 
-/// Set the live-catalog snapshot. Call this after a background refresh
-/// succeeds; the lake merges live rows over bundled rows on the next read.
-/// Stale or empty snapshots are harmless — a `None` just means "bundled only."
-pub fn set_live_snapshot(snapshot: CatalogSnapshot) {
+/// Set the live-catalog snapshot for a given source (#4188 race fix).
+///
+/// Source-scoped: a Models.dev refresh replaces only Models.dev-sourced rows;
+/// per-provider refreshes replace only per-provider-sourced rows. Rows from
+/// other sources are preserved. This eliminates the race where a Models.dev
+/// `set_live_snapshot` would erase TelecomJS rows merged earlier.
+pub fn set_live_snapshot(snapshot: CatalogSnapshot, source: LiveSource) {
     if let Ok(mut guard) = LIVE_SNAPSHOT.write() {
-        *guard = Some(apply_provider_model_cutlines(snapshot));
+        let snapshot = apply_provider_model_cutlines(snapshot);
+        let partition = match source {
+            LiveSource::ModelsDev => &mut guard.models_dev,
+            LiveSource::PerProvider => &mut guard.per_provider,
+        };
+        *partition = Some(snapshot);
     }
 }
 
-/// Clear the live snapshot (e.g. on cache eviction or shutdown).
+/// Clear the live snapshot for a given source (e.g. on cache eviction or shutdown).
+pub fn clear_live_snapshot_for_source(source: LiveSource) {
+    if let Ok(mut guard) = LIVE_SNAPSHOT.write() {
+        let partition = match source {
+            LiveSource::ModelsDev => &mut guard.models_dev,
+            LiveSource::PerProvider => &mut guard.per_provider,
+        };
+        *partition = None;
+    }
+}
+
+/// Clear all live snapshots (both Models.dev and per-provider partitions).
+/// Used by tests and shutdown paths that need a full reset.
+#[allow(dead_code)]
 pub fn clear_live_snapshot() {
     if let Ok(mut guard) = LIVE_SNAPSHOT.write() {
-        *guard = None;
+        guard.models_dev = None;
+        guard.per_provider = None;
     }
 }
 
-/// Merge additional live offerings into the existing live snapshot (#4188).
+/// Merge additional live offerings into the per-provider live partition (#4188).
 ///
-/// Unlike [`set_live_snapshot`] (which replaces the entire snapshot), this
-/// merges new rows by `(provider, wire_model_id)` identity, preserving rows
-/// from other sources (e.g. Models.dev) that were already published. This is
-/// used by per-provider catalog refreshes (e.g. TelecomJS `/v1/models`) that
-/// need to coexist with the cross-provider Models.dev live layer.
+/// Unlike [`set_live_snapshot`] for `LiveSource::PerProvider` (which replaces
+/// the entire per-provider partition), this merges new rows by
+/// `(provider, wire_model_id)` identity within the per-provider partition,
+/// preserving rows from the Models.dev partition. This is used by per-provider
+/// catalog refreshes (e.g. TelecomJS `/v1/models`) that need to coexist with
+/// the cross-provider Models.dev live layer.
 pub fn merge_live_offerings(new_offerings: Vec<CatalogOffering>) {
     if new_offerings.is_empty() {
         return;
     }
     if let Ok(mut guard) = LIVE_SNAPSHOT.write() {
-        let existing = guard.take().unwrap_or_default();
-        use std::collections::BTreeMap;
+        let existing = guard.per_provider.take().unwrap_or_default();
         let mut merged: BTreeMap<(String, String), CatalogOffering> = BTreeMap::new();
         for row in &existing.offerings {
             merged.insert((row.provider.clone(), row.wire_model_id.clone()), row.clone());
@@ -93,7 +168,7 @@ pub fn merge_live_offerings(new_offerings: Vec<CatalogOffering>) {
         for row in new_offerings {
             merged.insert((row.provider.clone(), row.wire_model_id.clone()), row);
         }
-        *guard = Some(CatalogSnapshot {
+        guard.per_provider = Some(CatalogSnapshot {
             offerings: merged.into_values().collect(),
         });
     }
@@ -101,13 +176,14 @@ pub fn merge_live_offerings(new_offerings: Vec<CatalogOffering>) {
 
 /// The merged catalog snapshot: live rows override bundled rows on
 /// `(provider, wire_model_id)` identity (#4188). When no live snapshot is
-/// present, this is just the offline bundled snapshot.
+/// present, this is just the offline bundled snapshot. Per-provider live rows
+/// override Models.dev live rows on collision (gateway-specific wins over
+/// cross-provider).
 fn merged_snapshot() -> CatalogSnapshot {
-    let live = LIVE_SNAPSHOT.read().ok().and_then(|guard| guard.clone());
+    let live = LIVE_SNAPSHOT.read().ok().and_then(|guard| guard.flattened());
     let merged = match live {
         None => bundled_snapshot().clone(),
         Some(live) => {
-            use std::collections::BTreeMap;
             let mut merged: BTreeMap<(String, String), CatalogOffering> = BTreeMap::new();
             for row in &bundled_snapshot().offerings {
                 merged.insert(
@@ -270,6 +346,7 @@ pub fn all_catalog_providers() -> Vec<ApiProvider> {
 mod tests {
     use super::*;
     use crate::config::{DEFAULT_TOGETHER_FLASH_MODEL, DEFAULT_TOGETHER_MODEL};
+    use codewhale_config::catalog::CatalogSource;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
     /// Serialize tests that mutate the process-wide live snapshot.
@@ -455,7 +532,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        set_live_snapshot(live);
+        set_live_snapshot(live, LiveSource::ModelsDev);
         let merged = all_catalog_models_for_provider(ApiProvider::Deepseek);
         assert!(merged.contains(&"deepseek-v4-synthetic".to_string()));
         // The bundled model is still present.
@@ -490,7 +567,7 @@ mod tests {
             endpoint_key: "messages".to_string(),
             ..Default::default()
         }));
-        set_live_snapshot(CatalogSnapshot { offerings });
+        set_live_snapshot(CatalogSnapshot { offerings }, LiveSource::ModelsDev);
 
         let models: std::collections::BTreeSet<_> =
             all_catalog_models_for_provider(ApiProvider::OpencodeGo)
@@ -553,7 +630,7 @@ mod tests {
                 },
             ],
         };
-        set_live_snapshot(live);
+        set_live_snapshot(live, LiveSource::ModelsDev);
 
         let merged = merged_snapshot();
         let moonshot_rows = merged.offerings_for_provider("moonshot");
@@ -654,7 +731,7 @@ mod tests {
         );
         set_live_snapshot(CatalogSnapshot {
             offerings: live_rows,
-        });
+        }, LiveSource::ModelsDev);
 
         let models = all_catalog_models_for_provider(ApiProvider::Moonshot);
         let kimi_count = models.iter().filter(|m| m.as_str() == "kimi-k2.5").count();
@@ -667,6 +744,485 @@ mod tests {
                 .offerings_for_provider("moonshotai")
                 .is_empty()
         );
+        clear_live_snapshot();
+    }
+
+    // ── Source-scoped partition tests (#4188 race fix) ──────────────────────
+
+    /// Models.dev→TelecomJS completion order: Models.dev sets its snapshot first,
+    /// then TelecomJS merges per-provider rows. Both sets must be present in the
+    /// final merged view.
+    #[test]
+    fn models_dev_first_then_telecomjs_both_preserved() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+
+        // 1) Models.dev publishes its cross-provider snapshot.
+        let models_dev_rows = vec![
+            CatalogOffering {
+                provider: "deepseek".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("deepseek".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 1000,
+                },
+                ..Default::default()
+            },
+            CatalogOffering {
+                provider: "zai".to_string(),
+                wire_model_id: "glm-4".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("glm".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 1000,
+                },
+                ..Default::default()
+            },
+        ];
+        set_live_snapshot(
+            CatalogSnapshot { offerings: models_dev_rows },
+            LiveSource::ModelsDev,
+        );
+
+        // 2) TelecomJS merges its per-provider rows (after Models.dev completes).
+        let telecomjs_rows = vec![
+            CatalogOffering {
+                provider: "telecomjs".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("deepseek".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "telecomjs-fp".to_string(),
+                    fetched_at: 2000,
+                },
+                ..Default::default()
+            },
+            CatalogOffering {
+                provider: "telecomjs".to_string(),
+                wire_model_id: "glm-4".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("glm".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "telecomjs-fp".to_string(),
+                    fetched_at: 2000,
+                },
+                ..Default::default()
+            },
+        ];
+        merge_live_offerings(telecomjs_rows);
+
+        // 3) Both sources' rows are present in the merged snapshot.
+        let merged = merged_snapshot();
+        let deepseek_rows = merged.offerings_for_provider("deepseek");
+        assert!(
+            deepseek_rows.iter().any(|r| r.wire_model_id == "deepseek-chat"),
+            "Models.dev deepseek row missing: {deepseek_rows:?}"
+        );
+        let zai_rows = merged.offerings_for_provider("zai");
+        assert!(
+            zai_rows.iter().any(|r| r.wire_model_id == "glm-4"),
+            "Models.dev zai row missing: {zai_rows:?}"
+        );
+        let telecomjs_rows_merged = merged.offerings_for_provider("telecomjs");
+        assert_eq!(
+            telecomjs_rows_merged.len(),
+            2,
+            "TelecomJS rows missing: {telecomjs_rows_merged:?}"
+        );
+        assert!(
+            telecomjs_rows_merged.iter().any(|r| r.wire_model_id == "deepseek-chat"),
+            "TelecomJS deepseek-chat row missing"
+        );
+        assert!(
+            telecomjs_rows_merged.iter().any(|r| r.wire_model_id == "glm-4"),
+            "TelecomJS glm-4 row missing"
+        );
+
+        clear_live_snapshot();
+    }
+
+    /// TelecomJS→Models.dev completion order: TelecomJS merges first, then
+    /// Models.dev replaces the cross-provider snapshot. TelecomJS rows must
+    /// survive the Models.dev refresh (they live in a separate partition).
+    #[test]
+    fn telecomjs_first_then_models_dev_both_preserved() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+
+        // 1) TelecomJS merges its per-provider rows first.
+        let telecomjs_rows = vec![
+            CatalogOffering {
+                provider: "telecomjs".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("deepseek".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "telecomjs-fp".to_string(),
+                    fetched_at: 2000,
+                },
+                ..Default::default()
+            },
+            CatalogOffering {
+                provider: "telecomjs".to_string(),
+                wire_model_id: "glm-4".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("glm".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "telecomjs-fp".to_string(),
+                    fetched_at: 2000,
+                },
+                ..Default::default()
+            },
+        ];
+        merge_live_offerings(telecomjs_rows);
+
+        // 2) Models.dev refreshes and replaces its cross-provider snapshot.
+        //    Before the source-scoped fix, this would have wiped TelecomJS rows.
+        let models_dev_rows = vec![
+            CatalogOffering {
+                provider: "deepseek".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                family: Some("deepseek".to_string()),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 3000,
+                },
+                ..Default::default()
+            },
+        ];
+        set_live_snapshot(
+            CatalogSnapshot { offerings: models_dev_rows },
+            LiveSource::ModelsDev,
+        );
+
+        // 3) Both sources' rows are present — TelecomJS rows were NOT erased.
+        let merged = merged_snapshot();
+        let telecomjs_rows_merged = merged.offerings_for_provider("telecomjs");
+        assert_eq!(
+            telecomjs_rows_merged.len(),
+            2,
+            "TelecomJS rows were erased by Models.dev refresh: {telecomjs_rows_merged:?}"
+        );
+        assert!(
+            telecomjs_rows_merged.iter().any(|r| r.wire_model_id == "deepseek-chat"),
+            "TelecomJS deepseek-chat row erased"
+        );
+        assert!(
+            telecomjs_rows_merged.iter().any(|r| r.wire_model_id == "glm-4"),
+            "TelecomJS glm-4 row erased"
+        );
+        let deepseek_rows = merged.offerings_for_provider("deepseek");
+        assert!(
+            deepseek_rows.iter().any(|r| r.wire_model_id == "deepseek-chat"),
+            "Models.dev deepseek row missing: {deepseek_rows:?}"
+        );
+
+        clear_live_snapshot();
+    }
+
+    /// Ambiguous wire_model_id: two different providers expose the same model ID
+    /// with different capabilities. Cross-provider matching must NOT copy
+    /// provider-specific metadata (limit, cost, reasoning, tool_call).
+    ///
+    /// This test validates the fix in `fetch_catalog_delta` indirectly by
+    /// checking the invariants the fix enforces: when a TelecomJS row shares
+    /// a wire_model_id with a bundled DeepSeek row but has different
+    /// capabilities, the TelecomJS row must NOT inherit DeepSeek's metadata.
+    #[test]
+    fn cross_provider_same_wire_model_id_no_metadata_inheritance() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+
+        // Scenario: DeepSeek bundled row has rich metadata.
+        let deepseek_bundled = CatalogOffering {
+            provider: "deepseek".to_string(),
+            wire_model_id: "DeepSeek-R1".to_string(),
+            endpoint_key: "chat".to_string(),
+            family: Some("deepseek".to_string()),
+            reasoning: Some(true),
+            tool_call: Some(true),
+            source: CatalogSource::Bundled,
+            ..Default::default()
+        };
+
+        // TelecomJS live row with the same wire_model_id but no metadata
+        // (as it would be after a cross-provider match that only inherits family).
+        let telecomjs_live = CatalogOffering {
+            provider: "telecomjs".to_string(),
+            wire_model_id: "DeepSeek-R1".to_string(),
+            endpoint_key: "chat".to_string(),
+            family: Some("deepseek".to_string()), // inherited (safe, name-derived)
+            reasoning: None,   // NOT inherited — different gateway
+            tool_call: None,   // NOT inherited — different gateway
+            source: CatalogSource::Live {
+                base_url_fingerprint: "telecomjs-fp".to_string(),
+                fetched_at: 2000,
+            },
+            ..Default::default()
+        };
+
+        // Set up: bundled deepseek row (via Models.dev snapshot including it),
+        // plus TelecomJS per-provider row.
+        set_live_snapshot(
+            CatalogSnapshot { offerings: vec![deepseek_bundled.clone()] },
+            LiveSource::ModelsDev,
+        );
+        merge_live_offerings(vec![telecomjs_live.clone()]);
+
+        let merged = merged_snapshot();
+
+        // DeepSeek row keeps its own metadata.
+        let deepseek_row = merged
+            .offerings_for_provider("deepseek")
+            .into_iter()
+            .find(|r| r.wire_model_id.eq_ignore_ascii_case("DeepSeek-R1"))
+            .expect("deepseek row should exist");
+        assert_eq!(deepseek_row.reasoning, Some(true), "DeepSeek reasoning should be true");
+        assert_eq!(deepseek_row.tool_call, Some(true), "DeepSeek tool_call should be true");
+
+        // TelecomJS row does NOT inherit DeepSeek's metadata.
+        let telecomjs_row = merged
+            .offerings_for_provider("telecomjs")
+            .into_iter()
+            .find(|r| r.wire_model_id.eq_ignore_ascii_case("DeepSeek-R1"))
+            .expect("telecomjs row should exist");
+        assert_eq!(
+            telecomjs_row.family, Some("deepseek".to_string()),
+            "family should be inherited (name-derived, safe)"
+        );
+        assert_eq!(
+            telecomjs_row.reasoning, None,
+            "TelecomJS reasoning must NOT be inherited from DeepSeek"
+        );
+        assert_eq!(
+            telecomjs_row.tool_call, None,
+            "TelecomJS tool_call must NOT be inherited from DeepSeek"
+        );
+
+        clear_live_snapshot();
+    }
+
+    /// Same-provider match does inherit full metadata (explicit canonical mapping).
+    #[test]
+    fn same_provider_match_inherits_full_metadata() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+
+        // A bundled telecomjs row with metadata.
+        let bundled = CatalogOffering {
+            provider: "telecomjs".to_string(),
+            wire_model_id: "deepseek-chat".to_string(),
+            endpoint_key: "chat".to_string(),
+            family: Some("deepseek".to_string()),
+            reasoning: Some(true),
+            tool_call: Some(true),
+            source: CatalogSource::Bundled,
+            ..Default::default()
+        };
+
+        // A live telecomjs row that matched same-provider — full inheritance.
+        let live = CatalogOffering {
+            provider: "telecomjs".to_string(),
+            wire_model_id: "deepseek-chat".to_string(),
+            endpoint_key: "chat".to_string(),
+            family: Some("deepseek".to_string()),
+            reasoning: Some(true),
+            tool_call: Some(true),
+            source: CatalogSource::Live {
+                base_url_fingerprint: "telecomjs-fp".to_string(),
+                fetched_at: 2000,
+            },
+            ..Default::default()
+        };
+
+        set_live_snapshot(
+            CatalogSnapshot { offerings: vec![bundled] },
+            LiveSource::ModelsDev,
+        );
+        merge_live_offerings(vec![live.clone()]);
+
+        let merged = merged_snapshot();
+        let row = merged
+            .offerings_for_provider("telecomjs")
+            .into_iter()
+            .find(|r| r.wire_model_id == "deepseek-chat")
+            .expect("telecomjs row should exist");
+        // Same-provider match: full metadata inherited.
+        assert_eq!(row.family, Some("deepseek".to_string()));
+        assert_eq!(row.reasoning, Some(true));
+        assert_eq!(row.tool_call, Some(true));
+
+        clear_live_snapshot();
+    }
+
+    /// Catalog refresh never deletes previously published rows: a Models.dev
+    /// refresh that adds new rows must preserve existing per-provider rows,
+    /// and a per-provider merge must preserve existing Models.dev rows.
+    #[test]
+    fn catalog_refresh_never_deletes_previously_published_rows() {
+        let _live = lock_live_snapshot();
+        clear_live_snapshot();
+
+        // 1) Initial state: Models.dev publishes rows for deepseek + zai.
+        let initial_models_dev = vec![
+            CatalogOffering {
+                provider: "deepseek".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 1000,
+                },
+                ..Default::default()
+            },
+            CatalogOffering {
+                provider: "zai".to_string(),
+                wire_model_id: "glm-4".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 1000,
+                },
+                ..Default::default()
+            },
+        ];
+        set_live_snapshot(
+            CatalogSnapshot { offerings: initial_models_dev },
+            LiveSource::ModelsDev,
+        );
+
+        // 2) TelecomJS merges its rows.
+        let telecomjs_rows = vec![
+            CatalogOffering {
+                provider: "telecomjs".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "telecomjs-fp".to_string(),
+                    fetched_at: 2000,
+                },
+                ..Default::default()
+            },
+        ];
+        merge_live_offerings(telecomjs_rows);
+
+        // Record what we have before the second refresh.
+        let before_refresh = merged_snapshot();
+        let before_providers: std::collections::BTreeSet<_> = before_refresh
+            .offerings
+            .iter()
+            .map(|r| (r.provider.clone(), r.wire_model_id.clone()))
+            .collect();
+        assert!(
+            before_providers.contains(&("deepseek".to_string(), "deepseek-chat".to_string())),
+            "deepseek row should exist before refresh"
+        );
+        assert!(
+            before_providers.contains(&("telecomjs".to_string(), "deepseek-chat".to_string())),
+            "telecomjs row should exist before refresh"
+        );
+
+        // 3) Models.dev refreshes again with an updated snapshot (adds a new row).
+        let updated_models_dev = vec![
+            CatalogOffering {
+                provider: "deepseek".to_string(),
+                wire_model_id: "deepseek-chat".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 3000,
+                },
+                ..Default::default()
+            },
+            CatalogOffering {
+                provider: "zai".to_string(),
+                wire_model_id: "glm-4".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 3000,
+                },
+                ..Default::default()
+            },
+            // New row added by the refresh.
+            CatalogOffering {
+                provider: "moonshot".to_string(),
+                wire_model_id: "kimi-k2.5".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "modelsdev-fp".to_string(),
+                    fetched_at: 3000,
+                },
+                ..Default::default()
+            },
+        ];
+        set_live_snapshot(
+            CatalogSnapshot { offerings: updated_models_dev },
+            LiveSource::ModelsDev,
+        );
+
+        // 4) The TelecomJS row is STILL present — it was not deleted.
+        let after_refresh = merged_snapshot();
+        let after_telecomjs: Vec<_> = after_refresh
+            .offerings_for_provider("telecomjs")
+            .iter()
+            .map(|r| r.wire_model_id.clone())
+            .collect();
+        assert!(
+            after_telecomjs.iter().any(|id| id == "deepseek-chat"),
+            "TelecomJS row was deleted by Models.dev refresh! Remaining: {after_telecomjs:?}"
+        );
+
+        // 5) New Models.dev row is also present.
+        let after_moonshot: Vec<_> = after_refresh
+            .offerings_for_provider("moonshot")
+            .iter()
+            .map(|r| r.wire_model_id.clone())
+            .collect();
+        assert!(
+            after_moonshot.iter().any(|id| id == "kimi-k2.5"),
+            "New Models.dev moonshot row missing: {after_moonshot:?}"
+        );
+
+        // 6) Also verify: a per-provider merge does not delete Models.dev rows.
+        let extra_telecomjs = vec![
+            CatalogOffering {
+                provider: "telecomjs".to_string(),
+                wire_model_id: "glm-4".to_string(),
+                endpoint_key: "chat".to_string(),
+                source: CatalogSource::Live {
+                    base_url_fingerprint: "telecomjs-fp".to_string(),
+                    fetched_at: 4000,
+                },
+                ..Default::default()
+            },
+        ];
+        merge_live_offerings(extra_telecomjs);
+
+        let final_merged = merged_snapshot();
+        let final_deepseek: Vec<_> = final_merged
+            .offerings_for_provider("deepseek")
+            .iter()
+            .map(|r| r.wire_model_id.clone())
+            .collect();
+        assert!(
+            final_deepseek.iter().any(|id| id == "deepseek-chat"),
+            "Models.dev deepseek row was deleted by per-provider merge! Remaining: {final_deepseek:?}"
+        );
+        let final_moonshot: Vec<_> = final_merged
+            .offerings_for_provider("moonshot")
+            .iter()
+            .map(|r| r.wire_model_id.clone())
+            .collect();
+        assert!(
+            final_moonshot.iter().any(|id| id == "kimi-k2.5"),
+            "Models.dev moonshot row was deleted by per-provider merge! Remaining: {final_moonshot:?}"
+        );
+
         clear_live_snapshot();
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -13142,6 +13142,7 @@ fn mirror_saved_api_key_in_config(config: &mut Config, provider: ApiProvider, ap
         ApiProvider::OpencodeGo => &mut providers.opencode_go,
         ApiProvider::Meta => &mut providers.meta,
         ApiProvider::Xai => &mut providers.xai,
+        ApiProvider::Telecomjs => &mut providers.telecomjs,
     };
     entry.api_key = Some(api_key);
 }
@@ -13269,6 +13270,7 @@ fn set_provider_auth_mode_in_memory(config: &mut Config, provider: ApiProvider, 
         ApiProvider::OpencodeGo => &mut providers.opencode_go,
         ApiProvider::Meta => &mut providers.meta,
         ApiProvider::Xai => &mut providers.xai,
+        ApiProvider::Telecomjs => &mut providers.telecomjs,
     };
     entry.auth_mode = Some(auth_mode);
 }


### PR DESCRIPTION
## Problem
After registering the TelecomJS (Telecom JiangSu) in the `custom` provider, the model picker only shows 1 model (`deepseek-v4-pro`) instead of all models returned by the `/v1/models` endpoint.

## Root Cause
`refresh_catalog_cache`/`fetch_catalog_delta` is never invoked in production — it only exists in test code. At startup, only the Models.dev catalog is refreshed, which has no entries for telecomjs. The picker therefore falls back to `model_completion_names_for_provider(Telecomjs)`, which returns only the default model.

## Fix
1. **`provider_lake.rs`** — Add `merge_live_offerings()` that merges new offerings into the existing live snapshot by `(provider, wire_model_id)` identity rather than replacing it. This allows Models.dev rows and per-provider rows to coexist.

2. **`client.rs`** — Add `spawn_active_provider_catalog_refresh()` associated function. When the active provider is Telecomjs, it spawns a background task that calls `fetch_catalog_delta()` (which already inherits metadata from the bundled catalog via case-insensitive matching) and merges all 52 models into the provider lake.

3. **`main.rs`** — Call the new function at startup, after the existing `models_dev_live::spawn_background_refresh()`.

4. **`config.rs`** — Expand the `model_completion_names_for_provider(Telecomjs)` fallback list from 1 to 11 models, so the picker shows useful options even before the background refresh completes.

## Testing
- `cargo check --workspace` — pass
- `cargo test -p codewhale-config` — 360 tests passed
- `cargo test -p codewhale-tui` (provider_lake + client catalog) — 14 tests passed
- `cargo build --release` — success

## Final Result

<img width="800"  alt="codewhale增加江苏tokenhub" src="https://github.com/user-attachments/assets/468576df-25bf-4264-8d25-6a16e855a6de" />
