### PR TITLE
fix(skills): preserve inline task text

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -50,6 +50,7 @@ zlh124 = zlh124 <56312993+zlh124@users.noreply.github.com>
 LeoLin990405 = LeoLin990405 <101193087+LeoLin990405@users.noreply.github.com>
 THINKER-ONLY = THINKER-ONLY <181556007+THINKER-ONLY@users.noreply.github.com>
 nightt5879 = nightt5879 <87569709+nightt5879@users.noreply.github.com>
+CCChisato = Fushimi Rio <158128433+CCChisato@users.noreply.github.com>
 aznikline = aznikline <27564626+aznikline@users.noreply.github.com>
 Aznable = aznikline <27564626+aznikline@users.noreply.github.com>
 anikline@gmail.com = aznikline <27564626+aznikline@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve the trailing task in inline skill invocations: `$<skill> do X`,
+  `/<skill> do X`, and `/skill <skill> do X` now dispatch `do X` immediately
+  with the selected skill instructions attached, while a bare `$<skill>` still
+  arms the next message. A skill literally named `install` remains callable
+  through `$install` and `/install` without shadowing the existing `/skill
+  install` management path (#3915, with fix direction from @CCChisato).
 - Make offline `scorecard` pricing provider-aware: `turn_end` records carry the
   effective route and a non-secret billing surface, runtime exports and
   supported aliases ingest cleanly, legacy/unknown routes remain explicitly

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve the trailing task in inline skill invocations: `$<skill> do X`,
+  `/<skill> do X`, and `/skill <skill> do X` now dispatch `do X` immediately
+  with the selected skill instructions attached, while a bare `$<skill>` still
+  arms the next message. A skill literally named `install` remains callable
+  through `$install` and `/install` without shadowing the existing `/skill
+  install` management path (#3915, with fix direction from @CCChisato).
 - Make offline `scorecard` pricing provider-aware: `turn_end` records carry the
   effective route and a non-secret billing surface, runtime exports and
   supported aliases ingest cleanly, legacy/unknown routes remain explicitly

--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -8,7 +8,7 @@ use crate::skills::install::{
     self, DEFAULT_MAX_SIZE_BYTES, DEFAULT_REGISTRY_URL, InstallOutcome, InstallSource,
     RegistryFetchResult, SkillSyncOutcome, SyncResult, UpdateResult,
 };
-use crate::tui::app::App;
+use crate::tui::app::{App, AppAction};
 use crate::tui::history::HistoryCell;
 
 use crate::commands::CommandResult;
@@ -280,18 +280,17 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
     CommandResult::message(output)
 }
 
-/// Run a specific skill — activates skill for next user message, or
-/// dispatches a sub-command (`install`, `update`, `uninstall`, `trust`).
 /// Try to run a skill by exact name (used for unified slash-command namespace, #435).
+/// A trailing request is dispatched immediately; a bare invocation arms the next message.
 /// Returns None when no skill with that name exists, so the caller can try other sources.
 pub(in crate::commands) fn run_skill_by_name(
     app: &mut App,
     name: &str,
-    _arg: Option<&str>,
+    request: Option<&str>,
 ) -> Option<CommandResult> {
     let registry = discover_visible_skills(app);
     if registry.get(name).is_some() {
-        Some(activate_skill(app, name))
+        Some(activate_skill_for_request(app, name, request))
     } else {
         None
     }
@@ -312,6 +311,8 @@ fn run_skill(app: &mut App, name: Option<&str>) -> CommandResult {
     let mut iter = raw.splitn(2, char::is_whitespace);
     let head = iter.next().unwrap_or("").trim();
     let rest = iter.next().unwrap_or("").trim();
+    let request = (!rest.is_empty()).then_some(rest);
+
     match head {
         "install" => return install_skill(app, rest),
         "update" => return update_skill(app, rest),
@@ -320,7 +321,21 @@ fn run_skill(app: &mut App, name: Option<&str>) -> CommandResult {
         _ => {}
     }
 
-    activate_skill(app, raw)
+    activate_skill_for_request(app, head, request)
+}
+
+fn activate_skill_for_request(app: &mut App, name: &str, request: Option<&str>) -> CommandResult {
+    let mut result = activate_skill(app, name);
+    if result.is_error {
+        return result;
+    }
+
+    if let Some(request) = request {
+        result.action = Some(AppAction::SendMessage(request.to_string()));
+    } else if let Some(message) = result.message.as_mut() {
+        message.push_str("\n\nType your request and the skill instructions will be applied.");
+    }
+    result
 }
 
 fn activate_skill(app: &mut App, name: &str) -> CommandResult {
@@ -342,7 +357,7 @@ fn activate_skill(app: &mut App, name: &str) -> CommandResult {
         app.active_skill = Some(instruction);
 
         CommandResult::message(format!(
-            "Skill '{}' activated.\n\nDescription: {}\n\nType your request and the skill instructions will be applied.",
+            "Skill '{}' activated.\n\nDescription: {}",
             skill.name, skill.description
         ))
     } else {
@@ -747,7 +762,7 @@ impl crate::commands::traits::RegisterCommand for SkillCmd {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::tui::app::{App, TuiOptions};
+    use crate::tui::app::{App, AppAction, TuiOptions};
     use std::ffi::OsString;
     use tempfile::TempDir;
 
@@ -1223,6 +1238,99 @@ mod tests {
         let result = run_skill(&mut app, Some("install"));
         let msg = result.message.unwrap();
         assert!(msg.contains("/skill install"), "got: {msg}");
+    }
+
+    #[test]
+    fn inline_skill_invocations_preserve_task_text() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        create_skill_dir(
+            &tmpdir,
+            "test-skill",
+            "---\nname: test-skill\ndescription: A test skill\n---\nDo something special",
+        );
+
+        for input in [
+            "$test-skill do X",
+            "/test-skill do X",
+            "/skill test-skill do X",
+        ] {
+            let mut app = create_test_app_with_tmpdir(&tmpdir);
+            let result = crate::commands::execute(input, &mut app);
+
+            assert!(!result.is_error, "{input} failed: {result:?}");
+            assert!(
+                matches!(result.action, Some(AppAction::SendMessage(ref task)) if task == "do X"),
+                "{input} did not send the trailing task: {result:?}"
+            );
+            assert!(
+                app.active_skill
+                    .as_deref()
+                    .is_some_and(|instruction| instruction.contains("Do something special")),
+                "{input} did not retain the skill instruction"
+            );
+        }
+    }
+
+    #[test]
+    fn bare_dollar_skill_still_arms_the_next_message() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        create_skill_dir(
+            &tmpdir,
+            "test-skill",
+            "---\nname: test-skill\ndescription: A test skill\n---\nDo something special",
+        );
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+
+        let result = crate::commands::execute("$test-skill", &mut app);
+
+        assert!(!result.is_error, "unexpected activation error: {result:?}");
+        assert!(result.action.is_none(), "bare invocation sent a request");
+        assert!(
+            app.active_skill
+                .as_deref()
+                .is_some_and(|instruction| instruction.contains("Do something special"))
+        );
+    }
+
+    #[test]
+    fn install_skill_uses_unified_namespaces_without_shadowing_management() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        create_skill_dir(
+            &tmpdir,
+            "install",
+            "---\nname: install\ndescription: Install review skill\n---\nReview installs safely",
+        );
+
+        for input in ["$install audit this", "/install audit this"] {
+            let mut app = create_test_app_with_tmpdir(&tmpdir);
+            let result = crate::commands::execute(input, &mut app);
+
+            assert!(!result.is_error, "{input} failed: {result:?}");
+            assert!(
+                matches!(result.action, Some(AppAction::SendMessage(ref task)) if task == "audit this"),
+                "{input} did not send the skill task: {result:?}"
+            );
+            assert!(
+                app.active_skill
+                    .as_deref()
+                    .is_some_and(|instruction| instruction.contains("Review installs safely")),
+                "{input} did not activate the installed skill"
+            );
+        }
+
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        let management = crate::commands::execute("/skill install", &mut app);
+        assert!(management.is_error, "management command was shadowed");
+        assert!(
+            management
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("/skill install <"))
+        );
+        assert!(app.active_skill.is_none());
     }
 
     #[test]

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -8391,6 +8391,29 @@ async fn streaming_enter_queue_pushes_visible_toast() {
 }
 
 #[tokio::test]
+async fn inline_skill_request_keeps_instruction_when_busy_queueing() {
+    let mut app = create_test_app();
+    app.is_loading = true;
+    app.streaming_message_index = Some(0);
+    app.active_skill = Some("Use the test skill".to_string());
+    let config = Config::default();
+    let engine = crate::core::engine::mock_engine_handle();
+
+    let queued = build_queued_message(&mut app, "do X".to_string());
+    assert!(app.active_skill.is_none(), "skill must be consumed once");
+    submit_or_steer_message(&mut app, &config, &engine.handle, queued)
+        .await
+        .expect("streaming skill request queues");
+
+    let queued = app.queued_messages.front().expect("queued skill request");
+    assert_eq!(queued.display, "do X");
+    assert_eq!(
+        queued.skill_instruction.as_deref(),
+        Some("Use the test skill")
+    );
+}
+
+#[tokio::test]
 async fn numeric_plan_choice_still_queues_follow_up_when_busy() {
     let mut app = create_test_app();
     app.mode = AppMode::Plan;

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -44,6 +44,9 @@ and dead-code removal landed alongside Cursor dogfood evidence for v0.8.67.
   bindgen support for codewhale-workflow-js (PR #4349)
 - **[eugenicum](https://github.com/eugenicum)** — copy-paste rail-pollution
   report with code-aware fix direction (#4208)
+- **[Fushimi Rio / CCChisato](https://github.com/CCChisato)** — inline skill
+  task pass-through fix direction and the exact-name `install` skill collision
+  identified in #3915
 
 - **[Jeffrey Luna / Mr-Moon121](https://github.com/Mr-Moon121)** — anti-polling
   constitution for sub-agent waiting (harvested into #4097 / PR #4229 from


### PR DESCRIPTION
## Summary

- dispatch trailing task text in the same turn for `$<skill> do X`, `/<skill> do X`, and `/skill <skill> do X`
- keep bare `$<skill>` activation armed for the next user message
- preserve `/skill install` as the management command while allowing a literal `install` skill through `$install ...` and `/install ...`
- carry the active skill through immediate, queued, and steer message paths exactly once

## Root cause

The unified skill command path accepted trailing arguments but discarded them before activation. The `/skill <name> <task>` path also treated the whole raw argument string as the skill name, so it could not both select the skill and dispatch the task.

## Impact

Inline skill invocations now behave as a single request instead of silently dropping the user's task. Existing bare activation and skill-management behavior remain compatible.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked commands::groups::skills::skills::tests -- --test-threads=1` (27 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked inline_skill_request_keeps_instruction_when_busy_queueing -- --test-threads=1` (1 passed)
- CI-equivalent `cargo clippy --workspace --all-features --locked -- -D warnings ...` passed
- `cargo test --workspace --all-features --locked` reached 6667 passed / 3 parallel-state failures; all three failures passed individually with `--test-threads=1`
- `cargo build --release --locked -p codewhale-cli -p codewhale-tui`; both binaries start and report version 0.8.68
- offline eval harness succeeded (6 steps, 0 tool errors)
- version drift, provider registry, changelog sync, diff, Cargo.lock, and co-author credit checks passed

Closes #3915
