### PR TITLE
fix: keep the remember tool active instead of deferred from the native catalog

### DIFF
--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -57,6 +57,7 @@ pub(super) const DEFAULT_ACTIVE_NATIVE_TOOLS: &[&str] = &[
     "grep_files",
     "list_dir",
     "read_file",
+    "remember",
     "run_tests",
     "run_verifiers",
     "task_create",
@@ -1036,4 +1037,61 @@ pub(super) async fn execute_code_execution_tool(
         success,
         metadata: Some(payload),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRE_REMEMBER_DEFAULT_ACTIVE_TOOL_COUNT: usize = 27;
+
+    fn api_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: None,
+            name: name.to_string(),
+            description: format!("{name} description"),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {}
+            }),
+            allowed_callers: None,
+            defer_loading: None,
+            input_examples: None,
+            strict: None,
+            cache_control: None,
+        }
+    }
+
+    #[test]
+    fn remember_stays_active_in_the_native_tool_catalog() {
+        let default_active_tools = DEFAULT_ACTIVE_NATIVE_TOOLS
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            DEFAULT_ACTIVE_NATIVE_TOOLS.len(),
+            PRE_REMEMBER_DEFAULT_ACTIVE_TOOL_COUNT + 1
+        );
+        assert_eq!(
+            default_active_tools.len(),
+            DEFAULT_ACTIVE_NATIVE_TOOLS.len(),
+            "default-active tool names should be unique"
+        );
+        assert!(DEFAULT_ACTIVE_NATIVE_TOOLS.contains(&"remember"));
+        assert!(default_active_tools.contains("remember"));
+
+        let always_load = HashSet::new();
+        assert!(!should_default_defer_tool("remember", &always_load));
+        assert!(should_default_defer_tool("project_map", &always_load));
+
+        let mut catalog = vec![api_tool("remember"), api_tool("project_map")];
+        apply_native_tool_deferral(&mut catalog, &always_load);
+        assert_eq!(catalog[0].defer_loading, Some(false));
+        assert_eq!(catalog[1].defer_loading, Some(true));
+
+        let mut catalog_without_remember = vec![api_tool("project_map")];
+        apply_native_tool_deferral(&mut catalog_without_remember, &always_load);
+        assert_eq!(catalog_without_remember[0].defer_loading, Some(true));
+    }
 }


### PR DESCRIPTION
## Summary
Add `"remember"` to the `DEFAULT_ACTIVE_NATIVE_TOOLS` constant slice in `tool_catalog.rs` (line 42), inserted in alphabetical order between `"read_file"` and `"run_tests"` to match the existing sorted style. This makes `should_default_defer_tool("remember", ...)` return `false`, so `apply_native_tool_deferral` leaves `remember` active and model-visible in the initial catalog.

## Why this matters
The `remember` tool (user-memory auto-capture) is registered correctly when `[memory] enabled = true`, but `apply_native_tool_deferral` in `crates/tui/src/core/engine/tool_catalog.rs` unconditionally overwrites `defer_loading` for every native tool via `should_default_defer_tool`. That helper only keeps a tool active when it is in `always_load`, is `tool_search` itself, or is a member of the `DEFAULT_ACTIVE_NATIVE_TOOLS` whitelist (lines 42-70). `"remember"` is in none of those, so it is deferred out of the model-visible catalog even though the tool's own `defer_loading()` returns `false` and `model_visible()` returns `true`. The result: the model never sees `remember` in the initial catalog and never auto-captures durable preferences, since it would only find it via an explicit `tool_search` it has no reason to run. Reproduced on v0.8.67.

## Testing
- Happy path: `should_default_defer_tool("remember", &HashSet::new())` returns `false`, and after `apply_native_tool_deferral` runs over a catalog containing a `remember` tool, that tool's `defer_loading` is `Some(false)` (model-visible in the initial catalog).
- Whitelist membership: `DEFAULT_ACTIVE_NATIVE_TOOLS` contains `"remember"`, and the derived `DEFAULT_ACTIVE_NATIVE_TOOLS_SET` reports it as a member.
- Regression / no collateral change: other native tools' deferral verdicts are unchanged (e.g. a genuinely deferred tool still returns `true`), and the active-set count increases by exactly one.
- Edge case: when `[memory] enabled = false` and no `remember` tool is present in the catalog, `apply_native_tool_deferral` still runs without panicking and produces the same result as before (the whitelist entry is inert when the tool is absent).

Fixes #4373

AI was used for assistance.