### PR TITLE
fix: correct Moonshot Kimi max_output so the input budget stops collapsing to ~1024

### DIFF
--- a/crates/tui/assets/model_catalog.bundled.json
+++ b/crates/tui/assets/model_catalog.bundled.json
@@ -34,7 +34,7 @@
     "kimi-k2.7-code": {
       "id": "kimi-k2.7-code",
       "context_window": 262144,
-      "max_output": 262144,
+      "max_output": 32768,
       "supports_reasoning": true,
       "modalities": ["text"],
       "supported_parameters": ["reasoning"],
@@ -43,7 +43,7 @@
     "moonshotai/kimi-k2.7-code": {
       "id": "moonshotai/kimi-k2.7-code",
       "context_window": 262144,
-      "max_output": 262144,
+      "max_output": 32768,
       "supports_reasoning": true,
       "modalities": ["text"],
       "supported_parameters": ["reasoning"],

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -343,13 +343,14 @@ pub fn max_output_tokens_for_model(model: &str) -> Option<u32> {
         "gpt-5-codex" | "gpt-5.3-codex" => Some(128_000),
         "claude-opus-4-8" => Some(128_000),
         "claude-sonnet-4-6" | "claude-haiku-4-5" => Some(64_000),
-        "arcee-ai/trinity-large-thinking"
-        | "trinity-large-thinking"
-        | "moonshotai/kimi-k2.7-code"
+        "arcee-ai/trinity-large-thinking" | "trinity-large-thinking" => Some(262_144),
+        // Moonshot publishes a 32K output cap beside Kimi's 256K context
+        // window; do not mirror the context window here (#4368).
+        "moonshotai/kimi-k2.7-code"
         | "moonshotai/kimi-k2.6"
         | "kimi-k2.7-code"
         | "kimi-k2.6"
-        | "kimi-for-coding" => Some(262_144),
+        | "kimi-for-coding" => Some(32_768),
         "minimax/minimax-m3" | "minimax-m3" => Some(524_288),
         "qwen/qwen3.6-35b-a3b" | "qwen/qwen3.6-27b" => Some(262_140),
         "qwen/qwen3.6-flash" | "qwen/qwen3.6-max-preview" | "qwen/qwen3.6-plus" => Some(65_536),
@@ -874,12 +875,13 @@ mod tests {
         // vision model): same compact window as 5.1 but reasoning-capable.
         assert_eq!(context_window_for_model("z-ai/glm-5-turbo"), Some(202_752));
         assert!(model_supports_reasoning("z-ai/glm-5-turbo"));
-        assert_eq!(max_output_tokens_for_model("kimi-k2.7-code"), Some(262_144));
-        assert_eq!(max_output_tokens_for_model("kimi-k2.6"), Some(262_144));
         assert_eq!(
-            max_output_tokens_for_model("kimi-for-coding"),
-            Some(262_144)
+            crate::model_catalog::resolved_max_output("kimi-k2.7-code"),
+            Some(32_768)
         );
+        assert_eq!(max_output_tokens_for_model("kimi-k2.7-code"), Some(32_768));
+        assert_eq!(max_output_tokens_for_model("kimi-k2.6"), Some(32_768));
+        assert_eq!(max_output_tokens_for_model("kimi-for-coding"), Some(32_768));
         assert_eq!(max_output_tokens_for_model("minimax-m3"), Some(524_288));
         assert_eq!(max_output_tokens_for_model("glm-5.1"), Some(131_072));
         assert_eq!(max_output_tokens_for_model("glm-5.2"), Some(131_072));


### PR DESCRIPTION
## Summary
The budget math in `core/engine/context.rs` reserves the model's `max_output` from the window when the window is under 500K (`route_output_reservation_for_window`). For `kimi-k2.7-code` it resolves window=262144 and output reservation=262144, so `window - reserved_output - headroom` = `262144 - 262144 - 1024` underflows and clamps to the `MIN_INPUT_BUDGET_TOKENS`/`CONTEXT_HEADROOM_TOKENS` floor of 1024 - exactly the reported budget.

## Why this matters
On Moonshot's Kimi coding plan (model `kimi-k2.7-code`, base_url overridden to the coding endpoint), every turn shows "Emergency context compaction failed to reduce request below model limit (estimate ~21179 tokens, budget ~1024)" even though the conversation still runs. The conversation is far from full, yet the internal input budget is being computed as only ~1024 tokens. The root cause is model metadata: the Kimi K2 entries declare `max_output = 262144`, which mirrors the context window instead of the real (much smaller) output cap. This is the identical "data-entry smell" the codebase already flagged and corrected for Qwen at `models.rs` (MODEL_PROVIDER_AUDIT A2/D-7, where 262,140 wrongly mirrored the window and was fixed to 65,536).

## Testing
- Happy path: `max_output_tokens_for_model("kimi-k2.7-code")` and `max_output_tokens_for_model("kimi-k2.6")`/`"kimi-for-coding"` return the corrected vendor cap (not 262144), and `resolved_max_output("kimi-k2.7-code")` from the bundled catalog returns the same corrected value.
- Regression guard: `context_window_for_model("kimi-k2.7-code")` still returns `Some(262_144)` (window unchanged), and the bundled catalog still parses (`bundled_snapshot_parses_and_is_nonempty`).
- Budget behavior: with the corrected max_output, `context_input_budget_for_route(Moonshot, "kimi-k2.7-code", None, 0)` yields a large input budget (window minus the small output reservation minus headroom) instead of flooring at 1024, so a ~21K-token request no longer trips the emergency-compaction failure warning.

Fixes #4368

AI was used for assistance.