### PR TITLE
fix(shell): avoid blocked reader joins after Windows kill

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -608,10 +608,10 @@ impl BackgroundShell {
         #[cfg(windows)]
         terminate_and_close_windows_job(self.windows_job.take());
         if let Some(handle) = self.stdout_thread.take() {
-            let _ = handle.join();
+            finish_background_reader(handle, &self.status);
         }
         if let Some(handle) = self.stderr_thread.take() {
-            let _ = handle.join();
+            finish_background_reader(handle, &self.status);
         }
         self.stdin = None;
         self.child = None;
@@ -827,6 +827,23 @@ impl BackgroundShell {
             stderr,
         }
     }
+}
+
+fn finish_background_reader(handle: std::thread::JoinHandle<()>, status: &ShellStatus) {
+    // A killed Windows process can leave a pipe reader blocked even after its
+    // Job Object has been closed. Cancellation must return promptly instead of
+    // waiting for that reader to observe EOF. Other terminal states still join
+    // so their final output is collected before the shell is discarded.
+    #[cfg(windows)]
+    if *status == ShellStatus::Killed {
+        drop(handle);
+        return;
+    }
+
+    #[cfg(not(windows))]
+    let _ = status;
+
+    let _ = handle.join();
 }
 
 impl Drop for BackgroundShell {

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1641,6 +1641,48 @@ fn windows_job_kill_on_close_releases_reader_threads_when_terminate_denied() {
     assert_eq!(done.status, ShellStatus::Completed);
 }
 
+#[cfg(windows)]
+#[test]
+fn killed_shell_does_not_wait_for_blocked_reader_threads() {
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    let stdout_thread = std::thread::spawn(move || {
+        let _ = release_rx.recv();
+    });
+    let now = std::time::Instant::now();
+    let mut shell = BackgroundShell {
+        id: "killed-reader".to_string(),
+        command: "test".to_string(),
+        working_dir: std::path::PathBuf::from("."),
+        status: ShellStatus::Killed,
+        exit_code: None,
+        started_at: now,
+        last_output_at: now,
+        last_observed_output_len: 0,
+        sandbox_type: SandboxType::None,
+        linked_task_id: None,
+        owner_agent: None,
+        stdout_buffer: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        stderr_buffer: None,
+        stdout_cursor: 0,
+        stderr_cursor: 0,
+        completion_reported: false,
+        stdin: None,
+        child: None,
+        windows_job: None,
+        stdout_thread: Some(stdout_thread),
+        stderr_thread: None,
+    };
+
+    let started = std::time::Instant::now();
+    shell.collect_output();
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(1),
+        "killed shell must not synchronously join a blocked reader"
+    );
+    release_tx.send(()).expect("release detached reader");
+}
+
 #[test]
 fn test_list_jobs_cleans_up_completed_old_processes() {
     let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

When a background shell is killed on Windows, do not synchronously join reader threads that can remain blocked on inherited pipe handles. Other terminal states and non-Windows platforms retain the existing join behavior so final output is still collected.

A Windows-only regression test holds a reader thread deliberately and verifies that cleanup returns promptly after `Killed`.

## Testing

- `cargo fmt --check`
- `cargo test -p codewhale-tui --bin codewhale-tui tools::shell::tests::test_orphaned_subprocess_does_not_block_collect_output`
- Windows-only regression test added; this host has no Windows Rust target, so it is left for CI.

## Checklist

- [x] Added a focused regression test
- [x] No behavior change outside Windows cancellation
- [x] No product-specific behavior or branding included