### PR TITLE
Update workflow-js Cargo.toml for HarmonyOS build

### DIFF
--- a/crates/workflow-js/Cargo.toml
+++ b/crates/workflow-js/Cargo.toml
@@ -27,5 +27,11 @@ rquickjs = { workspace = true, features = ["bindgen"] }
 [target.'cfg(target_os = "netbsd")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
 
+# rquickjs does not ship pre-generated bindings for OpenHarmony/OpenHarmony.
+# Generate them at build time so the crate compiles there instead of trying
+# to include a nonexistent bindings file.
+[target.'cfg(target_env = "ohos")'.dependencies]
+rquickjs = { workspace = true, features = ["bindgen"] }
+
 [dev-dependencies]
 serde_json.workspace = true


### PR DESCRIPTION
rquickjs doesn't ship pre-generated bindings for HarmonyOS/OpenHarmony, need to generate there.

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
