### PR TITLE
fix(tui): project subagent handoffs on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Convert persisted sub-agent completion and still-running control events into
+  concise, non-authoritative resume checkpoints, keeping their raw runtime
+  envelopes, sentinels, and retry instructions out of restored model and TUI
+  conversation state (#4409).
 - Keep the Hotbar Setup action list synchronized with keyboard focus when the
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Convert persisted sub-agent completion and still-running control events into
+  concise, non-authoritative resume checkpoints, keeping their raw runtime
+  envelopes, sentinels, and retry instructions out of restored model and TUI
+  conversation state (#4409).
 - Keep the Hotbar Setup action list synchronized with keyboard focus when the
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1914,7 +1914,8 @@ impl Engine {
                         } else if messages.is_empty() && system_prompt.is_none() {
                             self.session.id = uuid::Uuid::new_v4().to_string();
                         }
-                        self.session.messages = messages.into();
+                        self.session.messages =
+                            crate::runtime_handoff::project_messages_for_restore(&messages).into();
                         self.session.compaction_summary_prompt =
                             extract_compaction_summary_prompt(system_prompt.clone());
                         self.session.system_prompt = system_prompt;
@@ -2415,7 +2416,9 @@ impl Engine {
         let count = completions.len();
         let content = completions
             .iter()
-            .map(|completion| turn_loop::subagent_completion_runtime_text(&completion.payload))
+            .map(|completion| {
+                crate::runtime_handoff::subagent_completion_runtime_text(&completion.payload)
+            })
             .collect::<Vec<_>>()
             .join("\n\n");
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -5680,6 +5680,73 @@ async fn sync_session_restores_current_mode() {
 }
 
 #[tokio::test]
+async fn sync_session_projects_persisted_subagent_handoff_for_headless_restore() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        model: "deepseek-v4-pro".to_string(),
+        ..Default::default()
+    };
+    let (engine, handle) = Engine::new(config, &Config::default());
+    let payload = concat!(
+        "Child result retained.\nCheckpoint: engine restore is covered.\n",
+        "<codewhale:subagent.done>{\"agent_id\":\"agent_headless\",",
+        "\"status\":\"completed\",\"summary_location\":\"previous_line\"}",
+        "</codewhale:subagent.done>",
+    );
+    let messages = vec![
+        Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Keep the original task".to_string(),
+                cache_control: None,
+            }],
+        },
+        crate::runtime_handoff::subagent_completion_runtime_message(payload),
+    ];
+
+    let run = tokio::spawn(engine.run());
+    handle
+        .send(Op::SyncSession {
+            session_id: Some("headless-resume".to_string()),
+            messages,
+            system_prompt: None,
+            system_prompt_override: false,
+            model: "deepseek-v4-pro".to_string(),
+            workspace: tmp.path().to_path_buf(),
+            mode: AppMode::Agent,
+        })
+        .await
+        .expect("sync session");
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(tx))),
+        })
+        .await
+        .expect("request snapshot");
+    let snapshot = tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("snapshot response")
+        .expect("snapshot");
+
+    assert_eq!(snapshot.messages.len(), 2);
+    assert!(snapshot.messages[0].content.iter().any(
+        |block| matches!(block, ContentBlock::Text { text, .. } if text == "Keep the original task")
+    ));
+    let restored =
+        crate::runtime_handoff::restored_subagent_checkpoint_display(&snapshot.messages[1])
+            .expect("projected headless checkpoint");
+    assert!(restored.contains("agent_headless"));
+    assert!(restored.contains("Checkpoint: engine restore is covered."));
+    assert!(!restored.contains("runtime_event"));
+    assert!(!restored.contains("subagent.done"));
+
+    run.abort();
+}
+
+#[tokio::test]
 async fn session_snapshot_omits_id_for_legacy_root_custom_route() {
     let tmp = tempdir().expect("tempdir");
     let api_config = Config {

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -11,6 +11,9 @@ use super::stuck_guard::{
 use super::*;
 use crate::core::ops::UserInputProvenance;
 use crate::prompt_zones::PinnedPrefix;
+use crate::runtime_handoff::{
+    subagent_completion_runtime_message, waiting_for_subagents_runtime_message,
+};
 
 const MAX_APPROVAL_INTENT_SUMMARY_CHARS: usize = 2_000;
 const TOOL_ERROR_DEGRADATION_THRESHOLD: u32 = 2;
@@ -2850,71 +2853,6 @@ impl Engine {
 
     pub(super) fn messages_with_turn_metadata(&self) -> Vec<Message> {
         self.session.messages.clone().into()
-    }
-}
-
-pub(super) fn subagent_completion_runtime_text(payload: &str) -> String {
-    format!(
-        "<codewhale:runtime_event kind=\"subagent_completion\" visibility=\"internal\">\n\
-This is an internal runtime event, not user input. Use the sub-agent completion \
-data below to continue coordinating the current task. Do not tell the user they \
-pasted sentinels, do not explain the sentinel protocol, and do not quote the raw \
-XML unless the user explicitly asks to debug sub-agent internals.\n\n\
-{payload}\n\
-</codewhale:runtime_event>"
-    )
-}
-
-fn waiting_for_subagents_runtime_message(running: usize) -> Message {
-    Message {
-        role: "user".to_string(),
-        content: vec![
-            ContentBlock::Text {
-                text: format!(
-                    "<codewhale:runtime_event kind=\"waiting_for_subagents\" visibility=\"internal\">\n\
-This is an internal runtime event, not user input. Your {running} sub-agent(s) \
-are still running. Do NOT poll them with agent(action=\"peek\") or \
-agent(action=\"status\"). Do NOT use sleep or any shell blocking primitive as a \
-waiting strategy. The runtime will deliver <codewhale:subagent.done> sentinels \
-automatically when each child finishes — polling will never make that happen \
-sooner. Stop immediately: emit zero tool calls and end the turn.\n\
-</codewhale:runtime_event>"
-                ),
-                cache_control: None,
-            },
-            runtime_event_turn_metadata_block(UserInputProvenance::SubAgentHandoff),
-        ],
-    }
-}
-
-fn subagent_completion_runtime_message(payload: &str) -> Message {
-    // Role is "user", not "system": some OpenAI-compatible backends apply a
-    // strict chat template (e.g. vLLM serving Qwen3) that requires any system
-    // message to be messages[0]. A system message appended mid-conversation
-    // makes the template raise "System message must be at the beginning",
-    // which surfaces as a 400 BadRequest and breaks the whole sub-agent
-    // hand-off in the parent turn. The `visibility="internal"` tag already
-    // tells the model this is a runtime event rather than user input, so the
-    // role carries no semantic weight here — only template-compatibility cost.
-    Message {
-        role: "user".to_string(),
-        content: vec![
-            ContentBlock::Text {
-                text: subagent_completion_runtime_text(payload),
-                cache_control: None,
-            },
-            runtime_event_turn_metadata_block(UserInputProvenance::SubAgentHandoff),
-        ],
-    }
-}
-
-fn runtime_event_turn_metadata_block(provenance: UserInputProvenance) -> ContentBlock {
-    ContentBlock::Text {
-        text: format!(
-            "<turn_meta>\nInput provenance: {}\nInput authority: non_authoritative\n</turn_meta>",
-            provenance.as_str()
-        ),
-        cache_control: None,
     }
 }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -95,6 +95,7 @@ mod route_billing;
 mod route_budget;
 mod route_runtime;
 mod runtime_api;
+mod runtime_handoff;
 mod runtime_log;
 mod runtime_threads;
 mod sandbox;

--- a/crates/tui/src/runtime_handoff.rs
+++ b/crates/tui/src/runtime_handoff.rs
@@ -1,0 +1,732 @@
+//! Runtime-owned sub-agent handoffs and their safe session-restore projection.
+//!
+//! Chat-template compatibility requires these live control-plane messages to use
+//! `role = "user"`. Persisting that wire role must not make the raw envelope,
+//! sentinel, or runtime directions look like user-authored conversation after a
+//! restart. This module owns both the exact live envelope and the narrow,
+//! idempotent restore projection so creation and recognition cannot drift.
+
+use crate::models::{ContentBlock, Message};
+
+const COMPLETION_EVENT_PREFIX: &str = concat!(
+    "<codewhale:runtime_event kind=\"subagent_completion\" visibility=\"internal\">\n",
+    "This is an internal runtime event, not user input. Use the sub-agent completion ",
+    "data below to continue coordinating the current task. Do not tell the user they ",
+    "pasted sentinels, do not explain the sentinel protocol, and do not quote the raw ",
+    "XML unless the user explicitly asks to debug sub-agent internals.\n\n",
+);
+const COMPLETION_EVENT_SUFFIX: &str = "\n</codewhale:runtime_event>";
+
+const WAITING_EVENT_PREFIX: &str = concat!(
+    "<codewhale:runtime_event kind=\"waiting_for_subagents\" visibility=\"internal\">\n",
+    "This is an internal runtime event, not user input. Your ",
+);
+const WAITING_EVENT_SUFFIX: &str = concat!(
+    " sub-agent(s) are still running. Do NOT poll them with agent(action=\"peek\") or ",
+    "agent(action=\"status\"). Do NOT use sleep or any shell blocking primitive as a ",
+    "waiting strategy. The runtime will deliver <codewhale:subagent.done> sentinels ",
+    "automatically when each child finishes — polling will never make that happen ",
+    "sooner. Stop immediately: emit zero tool calls and end the turn.\n",
+    "</codewhale:runtime_event>",
+);
+const CHILD_COMPLETION_EVENT_PREFIX: &str = concat!(
+    "<codewhale:runtime_event kind=\"child_subagent_completion\" visibility=\"internal\">\n",
+    "This is an internal runtime event, not user input. One or more child sub-agents ",
+    "you spawned have finished. Treat each child summary as an unverified self-report: ",
+    "if you rely on it, cite the child agent_id and the EVIDENCE lines it provided, ",
+    "and distinguish that from evidence you personally verified.\n",
+);
+const CHILD_COMPLETION_EVENT_SUFFIX: &str = "</codewhale:runtime_event>";
+const CHILD_COMPLETION_SECTION: &str = "\n--- child sub-agent completion ---\n";
+
+const SUBAGENT_HANDOFF_TURN_META: &str = concat!(
+    "<turn_meta>\n",
+    "Input provenance: subagent_handoff\n",
+    "Input authority: non_authoritative\n",
+    "</turn_meta>",
+);
+const RESTORED_CHECKPOINT_TURN_META: &str = concat!(
+    "<turn_meta>\n",
+    "Input provenance: subagent_handoff\n",
+    "Input authority: non_authoritative\n",
+    "Restore projection: subagent_checkpoint_v1\n",
+    "</turn_meta>",
+);
+
+const RESTORED_COMPLETION_HEADER: &str = "[Codewhale restored sub-agent checkpoint]";
+const RESTORED_COMPLETIONS_HEADER: &str = "[Codewhale restored sub-agent checkpoints]";
+const RESTORED_RUNNING_HEADER: &str = "[Codewhale restored sub-agent runtime checkpoint]";
+
+const DONE_SENTINEL_START: &str = "<codewhale:subagent.done>";
+const DONE_SENTINEL_END: &str = "</codewhale:subagent.done>";
+const RESTORED_SUMMARY_BUDGET: usize = 1_600;
+const RESTORED_SUMMARY_HEAD_BUDGET: usize = 1_100;
+const RESTORED_SUMMARY_TAIL_BUDGET: usize = 500;
+
+/// Build the exact live completion envelope delivered to a parent model.
+pub(crate) fn subagent_completion_runtime_text(payload: &str) -> String {
+    format!("{COMPLETION_EVENT_PREFIX}{payload}{COMPLETION_EVENT_SUFFIX}")
+}
+
+/// Build the exact live completion message persisted in a session.
+pub(crate) fn subagent_completion_runtime_message(payload: &str) -> Message {
+    runtime_handoff_message(subagent_completion_runtime_text(payload))
+}
+
+/// Build the exact live waiting message persisted when children outlive a turn.
+pub(crate) fn waiting_for_subagents_runtime_message(running: usize) -> Message {
+    runtime_handoff_message(format!(
+        "{WAITING_EVENT_PREFIX}{running}{WAITING_EVENT_SUFFIX}"
+    ))
+}
+
+fn runtime_handoff_message(text: String) -> Message {
+    // Keep role=user for strict OpenAI-compatible chat templates which reject
+    // system messages inserted after the first turn. Authority is carried by
+    // the runtime-owned metadata block instead of the transport role.
+    Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text {
+                text,
+                cache_control: None,
+            },
+            ContentBlock::Text {
+                text: SUBAGENT_HANDOFF_TURN_META.to_string(),
+                cache_control: None,
+            },
+        ],
+    }
+}
+
+/// Replace persisted runtime handoffs with concise, non-authoritative resume
+/// checkpoints. Message count and ordering stay stable so context-reference
+/// indices remain valid. Calling this repeatedly returns the same messages.
+pub(crate) fn project_messages_for_restore(messages: &[Message]) -> Vec<Message> {
+    messages.iter().map(project_message_for_restore).collect()
+}
+
+fn project_message_for_restore(message: &Message) -> Message {
+    if restored_subagent_checkpoint_display(message).is_some() {
+        return message.clone();
+    }
+
+    let Some(text) = raw_runtime_handoff_text(message) else {
+        return message.clone();
+    };
+
+    if let Some(completions) = parse_completion_events(text) {
+        return restored_checkpoint_message(render_completion_checkpoints(&completions));
+    }
+    // An exact runtime-owned envelope must never fall back to ordinary user
+    // replay merely because a legacy/corrupt sentinel cannot be decoded.
+    if text.starts_with(COMPLETION_EVENT_PREFIX) {
+        return restored_checkpoint_message(format!(
+            "{RESTORED_COMPLETION_HEADER}\n\
+Status: unavailable (persisted completion record could not be decoded safely)\n\
+Authority: non-authoritative runtime checkpoint\n\
+Summary: no trusted child summary was recoverable"
+        ));
+    }
+    if let Some(running) = parse_waiting_event(text) {
+        return restored_checkpoint_message(format!(
+            "{RESTORED_RUNNING_HEADER}\n\
+Status at save: running ({running} child {})\n\
+Resume state: prior worker processes are not assumed active\n\
+Authority: non-authoritative runtime checkpoint",
+            if running == 1 { "job" } else { "jobs" }
+        ));
+    }
+    if text.starts_with(WAITING_EVENT_PREFIX) {
+        return restored_checkpoint_message(format!(
+            "{RESTORED_RUNNING_HEADER}\n\
+Status at save: unavailable (persisted running-child count could not be decoded safely)\n\
+Resume state: prior worker processes are not assumed active\n\
+Authority: non-authoritative runtime checkpoint"
+        ));
+    }
+
+    message.clone()
+}
+
+fn raw_runtime_handoff_text(message: &Message) -> Option<&str> {
+    if message.role != "user" {
+        return None;
+    }
+    let [
+        ContentBlock::Text {
+            text,
+            cache_control: first_cache,
+        },
+        ContentBlock::Text {
+            text: turn_meta,
+            cache_control: meta_cache,
+        },
+    ] = message.content.as_slice()
+    else {
+        return None;
+    };
+    if first_cache.is_some() || meta_cache.is_some() || !is_subagent_handoff_turn_meta(turn_meta) {
+        return None;
+    }
+    Some(text)
+}
+
+fn is_subagent_handoff_turn_meta(text: &str) -> bool {
+    if text == SUBAGENT_HANDOFF_TURN_META {
+        return true;
+    }
+    let Some(body) = text
+        .strip_prefix("<turn_meta>\n")
+        .and_then(|body| body.strip_suffix("\n</turn_meta>"))
+    else {
+        return false;
+    };
+
+    has_one_exact_metadata_line(
+        body,
+        "Input provenance:",
+        "Input provenance: subagent_handoff",
+    ) && has_one_exact_metadata_line(
+        body,
+        "Input authority:",
+        "Input authority: non_authoritative",
+    )
+}
+
+fn has_one_exact_metadata_line(body: &str, prefix: &str, expected: &str) -> bool {
+    let mut matching = body.lines().filter(|line| line.starts_with(prefix));
+    matching.next() == Some(expected) && matching.next().is_none()
+}
+
+#[derive(Debug)]
+struct RestoredCompletion {
+    agent_id: String,
+    name: Option<String>,
+    agent_type: Option<String>,
+    status: String,
+    summary: String,
+}
+
+fn parse_completion_events(mut text: &str) -> Option<Vec<RestoredCompletion>> {
+    let mut completions = Vec::new();
+    loop {
+        let after_prefix = text.strip_prefix(COMPLETION_EVENT_PREFIX)?;
+        let (completion, remainder) = parse_one_completion_event(after_prefix)?;
+        completions.push(completion);
+        if remainder.is_empty() {
+            break;
+        }
+        text = remainder.strip_prefix("\n\n")?;
+    }
+    (!completions.is_empty()).then_some(completions)
+}
+
+fn parse_one_completion_event(text: &str) -> Option<(RestoredCompletion, &str)> {
+    let mut search_from = 0;
+    while let Some(relative_end) = text[search_from..].find(COMPLETION_EVENT_SUFFIX) {
+        let event_end = search_from + relative_end;
+        let payload = &text[..event_end];
+        let remainder = &text[event_end + COMPLETION_EVENT_SUFFIX.len()..];
+        if (remainder.is_empty() || remainder.starts_with("\n\n"))
+            && let Some(completion) = parse_completion_payload(payload)
+        {
+            return Some((completion, remainder));
+        }
+        search_from = event_end.saturating_add(1);
+    }
+    None
+}
+
+fn parse_completion_payload(payload: &str) -> Option<RestoredCompletion> {
+    let sentinel_start = payload.rfind(DONE_SENTINEL_START)?;
+    let json_start = sentinel_start + DONE_SENTINEL_START.len();
+    let relative_end = payload[json_start..].find(DONE_SENTINEL_END)?;
+    let json_end = json_start + relative_end;
+    if !payload[json_end + DONE_SENTINEL_END.len()..]
+        .trim()
+        .is_empty()
+    {
+        return None;
+    }
+
+    let sentinel: serde_json::Value = serde_json::from_str(&payload[json_start..json_end]).ok()?;
+    let agent_id = sentinel
+        .get("agent_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    let status =
+        normalize_terminal_status(sentinel.get("status").and_then(serde_json::Value::as_str)?)?
+            .to_string();
+    let name = sentinel
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let agent_type = sentinel
+        .get("agent_type")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let summary = sanitize_nested_child_completion_events(&payload[..sentinel_start]);
+    let summary = strip_done_sentinels(&summary);
+    let summary = if summary.trim().is_empty() {
+        "No child summary was persisted.".to_string()
+    } else {
+        concise_summary(summary.trim())
+    };
+
+    Some(RestoredCompletion {
+        agent_id,
+        name,
+        agent_type,
+        status,
+        summary,
+    })
+}
+
+fn normalize_terminal_status(status: &str) -> Option<&'static str> {
+    match status.trim().to_ascii_lowercase().as_str() {
+        "completed" => Some("completed"),
+        "failed" => Some("failed"),
+        "cancelled" | "canceled" => Some("cancelled"),
+        "interrupted" => Some("interrupted"),
+        "budget_exhausted" => Some("budget exhausted"),
+        _ => None,
+    }
+}
+
+fn strip_done_sentinels(text: &str) -> String {
+    let mut remaining = text;
+    let mut clean = String::with_capacity(text.len());
+    while let Some(start) = remaining.find(DONE_SENTINEL_START) {
+        clean.push_str(&remaining[..start]);
+        let after_start = &remaining[start + DONE_SENTINEL_START.len()..];
+        let Some(end) = after_start.find(DONE_SENTINEL_END) else {
+            remaining = &remaining[start + DONE_SENTINEL_START.len()..];
+            continue;
+        };
+        remaining = &after_start[end + DONE_SENTINEL_END.len()..];
+    }
+    clean.push_str(remaining);
+    clean
+}
+
+fn sanitize_nested_child_completion_events(text: &str) -> String {
+    let mut remaining = text;
+    let mut safe = String::with_capacity(text.len());
+    while let Some(start) = remaining.find(CHILD_COMPLETION_EVENT_PREFIX) {
+        safe.push_str(&remaining[..start]);
+        let after_prefix = &remaining[start + CHILD_COMPLETION_EVENT_PREFIX.len()..];
+        let Some(end) = after_prefix.find(CHILD_COMPLETION_EVENT_SUFFIX) else {
+            safe.push_str(
+                "[Nested child completion checkpoint unavailable: persisted control record was incomplete.]",
+            );
+            return safe;
+        };
+        let body = &after_prefix[..end];
+        safe.push_str(
+            &parse_nested_child_completion_body(body).unwrap_or_else(|| {
+                "[Nested child completion checkpoint unavailable: persisted control record could not be decoded safely.]".to_string()
+            }),
+        );
+        remaining = &after_prefix[end + CHILD_COMPLETION_EVENT_SUFFIX.len()..];
+    }
+    safe.push_str(remaining);
+    safe
+}
+
+fn parse_nested_child_completion_body(body: &str) -> Option<String> {
+    let body = body.strip_prefix(CHILD_COMPLETION_SECTION)?;
+    let mut completions = Vec::new();
+    for section in body.split(CHILD_COMPLETION_SECTION) {
+        let section = section.strip_prefix("agent_id: ")?;
+        let (declared_agent_id, payload) = section.split_once('\n')?;
+        let completion = parse_completion_payload(payload.trim())?;
+        if declared_agent_id.trim() != completion.agent_id {
+            return None;
+        }
+        completions.push(completion);
+    }
+    if completions.is_empty() {
+        return None;
+    }
+
+    let mut rendered = String::new();
+    for (index, completion) in completions.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str("\n\n");
+        }
+        rendered.push_str("[Restored nested sub-agent checkpoint]");
+        append_completion_details(&mut rendered, completion);
+    }
+    Some(rendered)
+}
+
+fn concise_summary(summary: &str) -> String {
+    let char_count = summary.chars().count();
+    if char_count <= RESTORED_SUMMARY_BUDGET {
+        return summary.to_string();
+    }
+    let head = summary
+        .chars()
+        .take(RESTORED_SUMMARY_HEAD_BUDGET)
+        .collect::<String>();
+    let tail = summary
+        .chars()
+        .skip(char_count.saturating_sub(RESTORED_SUMMARY_TAIL_BUDGET))
+        .collect::<String>();
+    let omitted = char_count
+        .saturating_sub(RESTORED_SUMMARY_HEAD_BUDGET)
+        .saturating_sub(RESTORED_SUMMARY_TAIL_BUDGET);
+    format!("{head}\n\n[... {omitted} child-report characters omitted on resume ...]\n\n{tail}")
+}
+
+fn render_completion_checkpoints(completions: &[RestoredCompletion]) -> String {
+    let header = if completions.len() == 1 {
+        RESTORED_COMPLETION_HEADER
+    } else {
+        RESTORED_COMPLETIONS_HEADER
+    };
+    let mut rendered = String::from(header);
+    for (index, completion) in completions.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str("\n\n---\n");
+        }
+        append_completion_details(&mut rendered, completion);
+    }
+    rendered
+}
+
+fn append_completion_details(rendered: &mut String, completion: &RestoredCompletion) {
+    rendered.push_str("\nAgent: ");
+    if let Some(name) = &completion.name {
+        rendered.push_str(name);
+        rendered.push_str(" (");
+        rendered.push_str(&completion.agent_id);
+        rendered.push(')');
+    } else {
+        rendered.push_str(&completion.agent_id);
+    }
+    if let Some(agent_type) = &completion.agent_type {
+        rendered.push_str("\nRole: ");
+        rendered.push_str(agent_type);
+    }
+    rendered.push_str("\nStatus: ");
+    rendered.push_str(&completion.status);
+    rendered.push_str("\nAuthority: non-authoritative child self-report\nSummary:\n");
+    rendered.push_str(&completion.summary);
+}
+
+fn parse_waiting_event(text: &str) -> Option<usize> {
+    let running = text
+        .strip_prefix(WAITING_EVENT_PREFIX)?
+        .strip_suffix(WAITING_EVENT_SUFFIX)?
+        .parse::<usize>()
+        .ok()?;
+    (running > 0).then_some(running)
+}
+
+fn restored_checkpoint_message(display: String) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text {
+                text: display,
+                cache_control: None,
+            },
+            ContentBlock::Text {
+                text: RESTORED_CHECKPOINT_TURN_META.to_string(),
+                cache_control: None,
+            },
+        ],
+    }
+}
+
+/// Return the user-safe display body for an already projected checkpoint.
+/// The exact metadata marker keeps arbitrary user-authored text on the normal
+/// conversation path.
+pub(crate) fn restored_subagent_checkpoint_display(message: &Message) -> Option<&str> {
+    if message.role != "user" {
+        return None;
+    }
+    let [
+        ContentBlock::Text {
+            text,
+            cache_control: first_cache,
+        },
+        ContentBlock::Text {
+            text: turn_meta,
+            cache_control: meta_cache,
+        },
+    ] = message.content.as_slice()
+    else {
+        return None;
+    };
+    if first_cache.is_some()
+        || meta_cache.is_some()
+        || turn_meta != RESTORED_CHECKPOINT_TURN_META
+        || ![
+            RESTORED_COMPLETION_HEADER,
+            RESTORED_COMPLETIONS_HEADER,
+            RESTORED_RUNNING_HEADER,
+        ]
+        .iter()
+        .any(|header| text.starts_with(header))
+    {
+        return None;
+    }
+    Some(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn completion_payload(agent_id: &str, status: &str, summary: &str) -> String {
+        format!(
+            "{summary}\n<codewhale:subagent.done>{{\"agent_id\":\"{agent_id}\",\"name\":\"Tide\",\"agent_type\":\"implementer\",\"status\":\"{status}\",\"summary_location\":\"previous_line\"}}</codewhale:subagent.done>"
+        )
+    }
+
+    #[test]
+    fn restore_projection_replaces_completion_control_plane_and_is_idempotent() {
+        let user_task = Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Fix the resume regression".to_string(),
+                cache_control: None,
+            }],
+        };
+        let raw = subagent_completion_runtime_message(&completion_payload(
+            "agent_abc",
+            "completed",
+            "Implemented the shared restore projection.\nCheckpoint: focused tests pass.",
+        ));
+
+        let projected = project_messages_for_restore(&[user_task.clone(), raw]);
+        assert_eq!(projected[0], user_task);
+        let display = restored_subagent_checkpoint_display(&projected[1])
+            .expect("restored checkpoint display");
+        assert!(display.contains("Agent: Tide (agent_abc)"));
+        assert!(display.contains("Status: completed"));
+        assert!(display.contains("Implemented the shared restore projection."));
+        assert!(display.contains("Checkpoint: focused tests pass."));
+        assert!(display.contains("Authority: non-authoritative child self-report"));
+        assert!(!display.contains("<codewhale:runtime_event"));
+        assert!(!display.contains("<codewhale:subagent.done>"));
+        assert!(!display.contains("Do not tell the user"));
+        assert_eq!(project_messages_for_restore(&projected), projected);
+    }
+
+    #[test]
+    fn restore_projection_preserves_terminal_statuses() {
+        for (persisted, displayed) in [
+            ("failed", "failed"),
+            ("cancelled", "cancelled"),
+            ("interrupted", "interrupted"),
+            ("budget_exhausted", "budget exhausted"),
+        ] {
+            let raw = subagent_completion_runtime_message(&completion_payload(
+                "agent_state",
+                persisted,
+                "Terminal checkpoint",
+            ));
+            let projected = project_messages_for_restore(&[raw]);
+            let display = restored_subagent_checkpoint_display(&projected[0])
+                .expect("restored checkpoint display");
+            assert!(
+                display.contains(&format!("Status: {displayed}")),
+                "display was {display:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn restore_projection_accepts_failed_error_location_sentinel() {
+        let raw = subagent_completion_runtime_message(concat!(
+            "Failed: child tool timed out\n",
+            "<codewhale:subagent.done>{\"agent_id\":\"agent_failed\",",
+            "\"status\":\"failed\",\"error_location\":\"previous_line\"}",
+            "</codewhale:subagent.done>",
+        ));
+
+        let projected = project_messages_for_restore(&[raw]);
+        let display = restored_subagent_checkpoint_display(&projected[0])
+            .expect("restored failed checkpoint display");
+        assert!(display.contains("Agent: agent_failed"));
+        assert!(display.contains("Status: failed"));
+        assert!(display.contains("Failed: child tool timed out"));
+        assert!(!display.contains("error_location"));
+        assert!(!display.contains("summary_location"));
+    }
+
+    #[test]
+    fn restore_projection_batches_completions_without_sentinels() {
+        let first = subagent_completion_runtime_text(&completion_payload(
+            "agent_one",
+            "completed",
+            "First result",
+        ));
+        let second = subagent_completion_runtime_text(&completion_payload(
+            "agent_two",
+            "failed",
+            "Second result",
+        ));
+        let raw = runtime_handoff_message(format!("{first}\n\n{second}"));
+
+        let projected = project_messages_for_restore(&[raw]);
+        let display = restored_subagent_checkpoint_display(&projected[0])
+            .expect("restored checkpoint display");
+        assert!(display.starts_with(RESTORED_COMPLETIONS_HEADER));
+        assert!(display.contains("agent_one"));
+        assert!(display.contains("agent_two"));
+        assert!(display.contains("Status: completed"));
+        assert!(display.contains("Status: failed"));
+        assert!(!display.contains(DONE_SENTINEL_START));
+    }
+
+    #[test]
+    fn restore_projection_replaces_stale_waiting_directions_with_historical_state() {
+        let raw = waiting_for_subagents_runtime_message(2);
+        let projected = project_messages_for_restore(&[raw]);
+        let display = restored_subagent_checkpoint_display(&projected[0])
+            .expect("restored runtime checkpoint display");
+        assert!(display.contains("Status at save: running (2 child jobs)"));
+        assert!(display.contains("prior worker processes are not assumed active"));
+        assert!(!display.contains("Do NOT poll"));
+        assert!(!display.contains("Stop immediately"));
+        assert!(!display.contains("<codewhale:runtime_event"));
+    }
+
+    #[test]
+    fn restore_projection_does_not_rewrite_user_authored_lookalikes() {
+        let lookalike = Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: subagent_completion_runtime_text(&completion_payload(
+                    "agent_fake",
+                    "completed",
+                    "Reference text only",
+                )),
+                cache_control: None,
+            }],
+        };
+        let wrong_authority = Message {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: subagent_completion_runtime_text(&completion_payload(
+                        "agent_fake",
+                        "completed",
+                        "Reference text only",
+                    )),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: "<turn_meta>\nInput provenance: external_user\nInput authority: external_current_turn\n</turn_meta>".to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+
+        let projected = project_messages_for_restore(&[lookalike.clone(), wrong_authority.clone()]);
+        assert_eq!(projected, vec![lookalike, wrong_authority]);
+    }
+
+    #[test]
+    fn restore_projection_accepts_runtime_generated_rich_turn_metadata() {
+        let raw = Message {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: subagent_completion_runtime_text(&completion_payload(
+                        "agent_idle",
+                        "completed",
+                        "Idle completion result",
+                    )),
+                    cache_control: None,
+                },
+                ContentBlock::Text {
+                    text: concat!(
+                        "<turn_meta>\n",
+                        "Current local date: 2026-07-16\n",
+                        "Current workspace: /tmp/project\n",
+                        "Current mode: agent\n",
+                        "Input provenance: subagent_handoff\n",
+                        "Input authority: non_authoritative\n",
+                        "</turn_meta>",
+                    )
+                    .to_string(),
+                    cache_control: None,
+                },
+            ],
+        };
+
+        let projected = project_messages_for_restore(&[raw]);
+        let display = restored_subagent_checkpoint_display(&projected[0])
+            .expect("restored checkpoint display");
+        assert!(display.contains("agent_idle"));
+        assert!(display.contains("Idle completion result"));
+    }
+
+    #[test]
+    fn restore_projection_fails_safe_for_malformed_owned_completion() {
+        let raw = runtime_handoff_message(subagent_completion_runtime_text(
+            "Partial child result\n<codewhale:subagent.done>{not-json}</codewhale:subagent.done>",
+        ));
+
+        let projected = project_messages_for_restore(&[raw]);
+        let display = restored_subagent_checkpoint_display(&projected[0])
+            .expect("restored fallback checkpoint display");
+        assert!(display.contains("Status: unavailable"));
+        assert!(display.contains("no trusted child summary was recoverable"));
+        assert!(!display.contains("runtime_event"));
+        assert!(!display.contains("subagent.done"));
+        assert!(!display.contains("not-json"));
+    }
+
+    #[test]
+    fn restore_projection_sanitizes_nested_child_completion_envelope() {
+        let nested = concat!(
+            "Parent checkpoint before nested result.\n",
+            "<codewhale:runtime_event kind=\"child_subagent_completion\" visibility=\"internal\">\n",
+            "This is an internal runtime event, not user input. One or more child sub-agents ",
+            "you spawned have finished. Treat each child summary as an unverified self-report: ",
+            "if you rely on it, cite the child agent_id and the EVIDENCE lines it provided, ",
+            "and distinguish that from evidence you personally verified.\n",
+            "\n--- child sub-agent completion ---\n",
+            "agent_id: agent_nested\n",
+            "Nested child verified the focused test.\nEVIDENCE: cargo test passed.\n",
+            "<codewhale:subagent.done>{\"agent_id\":\"agent_nested\",",
+            "\"agent_type\":\"verifier\",\"status\":\"completed\",",
+            "\"summary_location\":\"previous_line\"}</codewhale:subagent.done>\n",
+            "</codewhale:runtime_event>\n",
+            "Parent checkpoint after nested result.",
+        );
+        let raw = subagent_completion_runtime_message(&completion_payload(
+            "agent_parent",
+            "completed",
+            nested,
+        ));
+
+        let projected = project_messages_for_restore(&[raw]);
+        let display = restored_subagent_checkpoint_display(&projected[0])
+            .expect("restored nested checkpoint display");
+        assert!(display.contains("Parent checkpoint before nested result."));
+        assert!(display.contains("[Restored nested sub-agent checkpoint]"));
+        assert!(display.contains("Agent: agent_nested"));
+        assert!(display.contains("Role: verifier"));
+        assert!(display.contains("Status: completed"));
+        assert!(display.contains("Nested child verified the focused test."));
+        assert!(display.contains("EVIDENCE: cargo test passed."));
+        assert!(display.contains("Parent checkpoint after nested result."));
+        assert!(!display.contains("child_subagent_completion"));
+        assert!(!display.contains("Treat each child summary"));
+        assert!(!display.contains(DONE_SENTINEL_START));
+    }
+}

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -447,6 +447,12 @@ impl HistoryCell {
 /// Convert a message into history cells for rendering.
 #[must_use]
 pub fn history_cells_from_message(msg: &Message) -> Vec<HistoryCell> {
+    if let Some(display) = crate::runtime_handoff::restored_subagent_checkpoint_display(msg) {
+        return vec![HistoryCell::System {
+            content: display.to_string(),
+        }];
+    }
+
     let mut cells = Vec::new();
 
     for block in &msg.content {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -13303,7 +13303,9 @@ fn apply_loaded_session(
     // wholly intact.
     app.restore_work_state(session.work_state.as_ref())?;
     *config = *restored_route.config;
-    let (messages, recovered_draft) = recover_interrupted_user_tail(&session.messages);
+    let projected_messages =
+        crate::runtime_handoff::project_messages_for_restore(&session.messages);
+    let (messages, recovered_draft) = recover_interrupted_user_tail(&projected_messages);
     app.api_messages = messages;
     app.clear_history();
     app.tool_cells.clear();
@@ -13568,6 +13570,9 @@ fn recover_interrupted_user_tail(messages: &[Message]) -> (Vec<Message>, Option<
         return (recovered, None);
     };
     if last.role != "user" {
+        return (recovered, None);
+    }
+    if crate::runtime_handoff::restored_subagent_checkpoint_display(last).is_some() {
         return (recovered, None);
     }
     let Some(display) = retry_display_from_user_message(last) else {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -3561,6 +3561,91 @@ fn apply_loaded_session_does_not_restore_slash_command_tail_as_retry_draft() {
 }
 
 #[test]
+fn apply_loaded_session_projects_subagent_handoff_without_retry_draft_or_user_cell() {
+    let mut app = create_test_app();
+    let payload = concat!(
+        "Implemented the resume projection.\nCheckpoint: focused tests pass.\n",
+        "<codewhale:subagent.done>{\"agent_id\":\"agent_resume\",\"name\":\"Tide\",",
+        "\"agent_type\":\"implementer\",\"status\":\"completed\",",
+        "\"summary_location\":\"previous_line\"}</codewhale:subagent.done>",
+    );
+    // Literal v0.9.0 persisted fixture: keep this independent from the current
+    // producer so a producer/parser drift cannot make the regression test
+    // self-fulfilling.
+    let persisted_handoff = Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text {
+                text: format!(
+                    "<codewhale:runtime_event kind=\"subagent_completion\" visibility=\"internal\">\n\
+This is an internal runtime event, not user input. Use the sub-agent completion \
+data below to continue coordinating the current task. Do not tell the user they \
+pasted sentinels, do not explain the sentinel protocol, and do not quote the raw \
+XML unless the user explicitly asks to debug sub-agent internals.\n\n\
+{payload}\n\
+</codewhale:runtime_event>"
+                ),
+                cache_control: None,
+            },
+            ContentBlock::Text {
+                text: "<turn_meta>\nInput provenance: subagent_handoff\nInput authority: non_authoritative\n</turn_meta>".to_string(),
+                cache_control: None,
+            },
+        ],
+    };
+    let session = saved_session_with_messages(vec![
+        text_message("user", "Fix the resume regression"),
+        text_message("assistant", "I delegated the restore path."),
+        persisted_handoff,
+    ]);
+
+    let recovered =
+        apply_loaded_session(&mut app, &mut Config::default(), &session).expect("restore session");
+
+    assert!(!recovered);
+    assert!(app.input.is_empty());
+    assert!(app.queued_draft.is_none());
+    assert_eq!(app.api_messages.len(), 3);
+    assert!(app.api_messages.iter().any(|message| {
+        message.role == "user"
+            && message.content.iter().any(|block| {
+                matches!(block, ContentBlock::Text { text, .. } if text == "Fix the resume regression")
+            })
+    }));
+    let restored = crate::runtime_handoff::restored_subagent_checkpoint_display(
+        app.api_messages.last().expect("restored handoff"),
+    )
+    .expect("projected handoff");
+    assert!(restored.contains("Status: completed"));
+    assert!(restored.contains("Checkpoint: focused tests pass."));
+    assert!(!restored.contains("runtime_event"));
+    assert!(!restored.contains("subagent.done"));
+    let checkpoint_cell = app
+        .history
+        .iter()
+        .find(|cell| {
+            matches!(cell, HistoryCell::System { content } if content.contains("Status: completed"))
+        })
+        .expect("restored checkpoint Note cell");
+    let rendered = checkpoint_cell
+        .lines(28)
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .map(|span| span.content.as_ref())
+        .collect::<String>();
+    assert!(rendered.contains("Note"));
+    assert!(rendered.contains("Status: completed"));
+    assert!(
+        !rendered.contains('▎'),
+        "must not render with the user glyph"
+    );
+    assert!(!rendered.contains("runtime_event"));
+    assert!(app.history.iter().all(|cell| {
+        !matches!(cell, HistoryCell::User { content } if content.contains("agent_resume") || content.contains("runtime_event"))
+    }));
+}
+
+#[test]
 fn apply_loaded_session_resets_unpersisted_telemetry() {
     let mut app = create_test_app();
     app.session.session_cost = 1.25;


### PR DESCRIPTION
## Summary

- centralize live subagent completion/waiting envelopes with an idempotent restore projection
- keep restored child status, summaries, evidence, ordering, and non-authoritative provenance
- exclude raw runtime directions, sentinels, malformed control records, and retry-draft recovery from model and TUI restore paths
- render restored checkpoints as Note cells and cover headless SyncSession restore

Targets v0.9.1.

Fixes #4409

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

Additional gates:

- full `codewhale-tui` binary suite: 7,062 passed, 2 ignored, 0 failed
- focused restore projection: 9 passed
- focused TUI loaded-session restore: passed
- focused headless `SyncSession` restore: passed
- `scripts/release/check-versions.sh`: passed
- `git diff --check`: passed

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address

The UI behavior is covered by a narrow-width render regression; no manual provider session was required. No harvested or co-authored commit is present.
