### PR TITLE
🧪 Add test for URL parsing error in install script

### DIFF
--- a/npm/codewhale/scripts/install.js
+++ b/npm/codewhale/scripts/install.js
@@ -1159,6 +1159,7 @@ module.exports = {
     adoptExistingBinaryIfValid,
     shouldIgnoreInstallFailure,
     shouldSkipOptionalPostinstall,
+    httpRequest,
     defaultTimeoutMs,
     defaultStallMs,
     ensureBinary,

--- a/npm/codewhale/test/install.test.js
+++ b/npm/codewhale/test/install.test.js
@@ -263,3 +263,15 @@ test("resolvePackageVersion honors codewhaleBinaryVersion precedence (#3769)", (
     "8.8.8",
   );
 });
+
+test("httpRequest handles invalid URL parsing errors", async () => {
+  const { httpRequest } = _internal;
+  const invalidUrl = "not-a-valid-url";
+  try {
+    await httpRequest(invalidUrl);
+    assert.fail("httpRequest should throw for an invalid URL");
+  } catch (err) {
+    assert.equal(err.name, "NonRetryableError");
+    assert.match(err.message, /Invalid URL: not-a-valid-url/);
+  }
+});


### PR DESCRIPTION
🎯 **What:** Adds a test case to cover the URL parsing error path in the `httpRequest` function of `install.js`.
📊 **Coverage:** Validates that `httpRequest` throws a `NonRetryableError` with the correct error message ("Invalid URL: ...") when provided with an invalid URL string.
✨ **Result:** Improved test coverage for HTTP request utility and ensured reliable error handling logic for invalid URLs.

---
*PR created automatically by Jules for task [18295944675874892323](https://jules.google.com/task/18295944675874892323) started by @Hmbown*