### PR TITLE
🧪 Add test coverage for ToolError::missing_field display format

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -599,7 +599,11 @@ mod tests {
     #[test]
     fn tool_error_missing_field_constructor() {
         let err = ToolError::missing_field("my_field");
-        assert!(matches!(err, ToolError::MissingField { field } if field == "my_field"));
+        assert!(matches!(err, ToolError::MissingField { ref field } if field == "my_field"));
+        assert_eq!(
+            err.to_string(),
+            "Failed to validate input: missing required field 'my_field'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** Improved the testing suite by enhancing the test for `ToolError::missing_field` constructor in `crates/tools/src/lib.rs`.
📊 **Coverage:** The test now verifies not only the state-based construction (`matches!`) but also the exact Display implementation output (using `err.to_string()`). Refactored variable destructuring to prevent partial moves, allowing proper string comparisons.
✨ **Result:** Better error message validation prevents accidental changes to `ToolError` formatting.

---
*PR created automatically by Jules for task [2590320779045522146](https://jules.google.com/task/2590320779045522146) started by @Hmbown*