### PR TITLE
🧪 [mcp] Add test coverage for McpManager::call_tool

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1184,6 +1184,47 @@ mod tests {
     }
 
     #[test]
+    fn manager_call_tool_propagates_client_error() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(InMemoryMcpClient::default()),
+        );
+        let err = manager.call_tool("s1", "missing_tool", json!({})).unwrap_err();
+        assert!(err.to_string().contains("tool 'missing_tool' not found"));
+    }
+
+    struct MockArgumentClient;
+    impl McpManagedClient for MockArgumentClient {
+        fn list_tools(&self) -> Result<Vec<McpToolDescriptor>> {
+            Ok(vec![])
+        }
+        fn call_tool(&self, _tool_name: &str, arguments: Value) -> Result<Value> {
+            Ok(arguments) // Just echo the arguments back to test they are passed
+        }
+        fn list_resources(&self) -> Result<Vec<McpResourceDescriptor>> {
+            Ok(vec![])
+        }
+        fn read_resource(&self, _uri: &str) -> Result<Value> {
+            Err(anyhow::anyhow!("not found"))
+        }
+    }
+
+    #[test]
+    fn manager_call_tool_passes_arguments() {
+        let mut manager = McpManager::default();
+        manager.register_server(
+            make_server_config("s1"),
+            ToolFilter::default(),
+            Box::new(MockArgumentClient),
+        );
+        let args = json!({"arg1": "value1", "arg2": 42});
+        let result = manager.call_tool("s1", "t", args.clone()).unwrap();
+        assert_eq!(result, args);
+    }
+
+    #[test]
     fn manager_call_qualified_tool_parses_name() {
         let mut manager = McpManager::default();
         manager.register_server(


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing test coverage for `McpManager::call_tool` in `crates/mcp/src/lib.rs`. While the behavior for the method was clear (delegating to `client.call_tool`), we lacked test coverage to guarantee errors were propagated and arguments were correctly transmitted.

📊 **Coverage:** The PR introduces two tests:
- `manager_call_tool_propagates_client_error` uses an `InMemoryMcpClient` to ensure an error on a missing tool is surfaced.
- `manager_call_tool_passes_arguments` sets up a new `MockArgumentClient` implementing `McpManagedClient` to record/echo arguments passed into it, successfully verifying that `arguments` are appropriately piped down.

✨ **Result:** Test coverage for `McpManager::call_tool` is now complete, assuring regressions don't occur when arguments or client interactions are refactored in the future.

---
*PR created automatically by Jules for task [15673930294980849864](https://jules.google.com/task/15673930294980849864) started by @Hmbown*