### PR TITLE
🧪 Add unit test for ModelRegistry::new alias map building

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1391,6 +1391,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn model_registry_new_builds_alias_map_correctly() {
+        let models = vec![
+            ModelInfo {
+                id: "Model-A".to_string(),
+                provider: ProviderKind::Deepseek,
+                aliases: vec!["alias-1".to_string(), " ALIAS-2 ".to_string()],
+                supports_tools: true,
+                supports_reasoning: false,
+            },
+            ModelInfo {
+                id: "model-b".to_string(),
+                provider: ProviderKind::Deepseek,
+                aliases: vec!["alias-1".to_string()], // Duplicate alias, should not override
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+        ];
+
+        let registry = ModelRegistry::new(models);
+
+        assert_eq!(registry.alias_map.len(), 4); // "model-a", "alias-1", "alias-2", "model-b"
+        assert_eq!(registry.alias_map.get("model-a"), Some(&0));
+        assert_eq!(registry.alias_map.get("alias-1"), Some(&0)); // First one wins
+        assert_eq!(registry.alias_map.get("alias-2"), Some(&0)); // Normalized
+        assert_eq!(registry.alias_map.get("model-b"), Some(&1));
+    }
+
+    #[test]
     fn deepseek_v4_pro_alias_stays_deepseek_by_default() {
         let registry = ModelRegistry::default();
         let resolved = registry.resolve(Some("deepseek-v4-pro"), None);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a unit test for `ModelRegistry::new` in `crates/agent/src/lib.rs` to verify that its internal alias map building properly normalizes strings and deduplicates them using `.or_insert` correctly.

📊 **Coverage:** What scenarios are now tested
- Ensuring all aliases and model IDs are populated.
- Proper normalization (spaces are trimmed, casing is ignored).
- Duplicate handling (the first registered alias has priority).

✨ **Result:** The improvement in test coverage
We now explicitly verify that the internal `alias_map` used for fast model lookup is assembled correctly during initialization.

---
*PR created automatically by Jules for task [17626795792512689544](https://jules.google.com/task/17626795792512689544) started by @Hmbown*