### PR TITLE
🧪 Add test for createRuntimeClient

### DIFF
--- a/npm/runtime-sdk/test/fleet-client.test.mjs
+++ b/npm/runtime-sdk/test/fleet-client.test.mjs
@@ -24,6 +24,14 @@ function fakeFetch(responseFactory) {
   return fetch;
 }
 
+test("createRuntimeClient returns CodeWhaleRuntimeClient instance", () => {
+  const fetch = fakeFetch(() => jsonResponse({}));
+  const client = createRuntimeClient({ fetch });
+
+  assert.ok(client instanceof CodeWhaleRuntimeClient);
+  assert.equal(client.baseUrl, "http://127.0.0.1:7878/");
+});
+
 test("listFleetRuns calls the Runtime API with bearer auth", async () => {
   const fetch = fakeFetch(() =>
     jsonResponse({


### PR DESCRIPTION
🎯 **What:** The `createRuntimeClient` instantiation wrapper function in `npm/runtime-sdk/index.js` lacked direct test coverage.
📊 **Coverage:** Added a test covering the happy path for `createRuntimeClient()`. The test explicitly mocks the `fetch` API, calls the instantiation wrapper, and checks that the returned client object is an instance of `CodeWhaleRuntimeClient` with the correct `baseUrl` property.
✨ **Result:** Increased testing confidence on the main exported client wrapper, ensuring basic client instantiation won't silently break or return unexpected objects without a test failure.

---
*PR created automatically by Jules for task [7488924168698692105](https://jules.google.com/task/7488924168698692105) started by @Hmbown*