### PR TITLE
🧪 Add tests for repair_json_text_once and fix array extraction bug

### DIFF
--- a/crates/workflow/src/model_policy.rs
+++ b/crates/workflow/src/model_policy.rs
@@ -293,25 +293,9 @@ pub fn repair_json_text_once(raw: &str) -> String {
         .map(str::trim)
         .unwrap_or(trimmed);
 
-    let obj_candidate = slice_json_payload(without_fence, '{', '}');
-    let arr_candidate = slice_json_payload(without_fence, '[', ']');
-
-    match (obj_candidate, arr_candidate) {
-        (Some(obj), Some(arr)) => {
-            // Find which one starts first in the original string
-            // slice_json_payload already validates they have matching open/close
-            let obj_start = without_fence.find(obj).unwrap_or(usize::MAX);
-            let arr_start = without_fence.find(arr).unwrap_or(usize::MAX);
-            if obj_start < arr_start {
-                obj.to_string()
-            } else {
-                arr.to_string()
-            }
-        }
-        (Some(obj), None) => obj.to_string(),
-        (None, Some(arr)) => arr.to_string(),
-        (None, None) => without_fence.to_string(),
-    }
+    first_valid_json_payload(without_fence)
+        .unwrap_or(without_fence)
+        .to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -360,10 +344,66 @@ fn model_key(provider: &str, model: &str) -> String {
     format!("{provider}/{model}")
 }
 
-fn slice_json_payload(raw: &str, open: char, close: char) -> Option<&str> {
-    let start = raw.find(open)?;
-    let end = raw.rfind(close)?;
-    (end >= start).then_some(&raw[start..=end])
+// Repair scans untrusted model text once per possible container start. Keep the
+// fallback bounded when malformed output contains a long delimiter flood.
+const JSON_REPAIR_CANDIDATE_LIMIT: usize = 64;
+
+fn first_valid_json_payload(raw: &str) -> Option<&str> {
+    let mut attempted = 0;
+    for (start, open) in raw.char_indices() {
+        if !matches!(open, '{' | '[') {
+            continue;
+        }
+        attempted += 1;
+        if attempted > JSON_REPAIR_CANDIDATE_LIMIT {
+            break;
+        }
+
+        let Some(candidate) = balanced_json_payload(&raw[start..]) else {
+            continue;
+        };
+        if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn balanced_json_payload(raw: &str) -> Option<&str> {
+    let mut stack = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (offset, character) in raw.char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else {
+                match character {
+                    '\\' => escaped = true,
+                    '"' => in_string = false,
+                    _ => {}
+                }
+            }
+            continue;
+        }
+
+        match character {
+            '"' => in_string = true,
+            '{' | '[' => stack.push(character),
+            '}' | ']' => {
+                let expected_open = if character == '}' { '{' } else { '[' };
+                if stack.pop() != Some(expected_open) {
+                    return None;
+                }
+                if stack.is_empty() {
+                    return Some(&raw[..offset + character.len_utf8()]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -509,8 +549,9 @@ mod tests {
         assert_eq!(provider.model(), "fast");
         assert_eq!(response.text, "mock response");
     }
+
     #[test]
-    fn test_repair_json_text_once() {
+    fn repair_json_text_once_extracts_supported_payloads() {
         // Plain JSON object
         assert_eq!(
             repair_json_text_once(r#"{"key": "value"}"#),
@@ -580,15 +621,34 @@ mod tests {
             "Just some plain text"
         );
 
-        // REGRESSION FIX: Unmatched opening bracket should not block finding a balanced one
+        // An unmatched opening bracket must not block a later valid object.
         assert_eq!(repair_json_text_once("[note {\"ok\":1}"), r#"{"ok":1}"#);
 
-        // Control: Nested inside string escapes should be preserved correctly if balanced
-        // (This tests we don't just grab the first '{' without considering the full payload,
-        // though `slice_json_payload` is simple rfind/find right now)
+        // Delimiters inside strings must not terminate the outer object.
         assert_eq!(
             repair_json_text_once(r#"Prefix text {"data": "[nested]"} postfix text"#),
             r#"{"data": "[nested]"}"#
+        );
+
+        // The earliest balanced candidate may still be invalid JSON. Keep scanning
+        // until a balanced candidate also parses successfully.
+        assert_eq!(
+            repair_json_text_once(r#"[not-json] then {"ok":true}"#),
+            r#"{"ok":true}"#
+        );
+
+        // Escaped quotes and backslashes stay inside the JSON string.
+        assert_eq!(
+            repair_json_text_once(
+                r#"prefix {"value":"a \"quoted\" [item]","path":"C:\\tmp"} suffix"#
+            ),
+            r#"{"value":"a \"quoted\" [item]","path":"C:\\tmp"}"#
+        );
+
+        // A mismatched outer delimiter must not consume a later valid payload.
+        assert_eq!(
+            repair_json_text_once(r#"[broken} then [1,{"ok":true}]"#),
+            r#"[1,{"ok":true}]"#
         );
     }
 }

--- a/crates/workflow/src/model_policy.rs
+++ b/crates/workflow/src/model_policy.rs
@@ -292,9 +292,19 @@ pub fn repair_json_text_once(raw: &str) -> String {
         .and_then(|value| value.strip_suffix("```"))
         .map(str::trim)
         .unwrap_or(trimmed);
-    let object = slice_json_payload(without_fence, '{', '}');
-    let array = slice_json_payload(without_fence, '[', ']');
-    object.or(array).unwrap_or(without_fence).to_string()
+
+    let obj_start = without_fence.find('{');
+    let arr_start = without_fence.find('[');
+
+    match (obj_start, arr_start) {
+        (Some(o), Some(a)) if o < a => slice_json_payload(without_fence, '{', '}'),
+        (Some(_), Some(_)) => slice_json_payload(without_fence, '[', ']'),
+        (Some(_), None) => slice_json_payload(without_fence, '{', '}'),
+        (None, Some(_)) => slice_json_payload(without_fence, '[', ']'),
+        (None, None) => None,
+    }
+    .unwrap_or(without_fence)
+    .to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -491,5 +501,74 @@ mod tests {
         assert_eq!(provider.provider(), "mock");
         assert_eq!(provider.model(), "fast");
         assert_eq!(response.text, "mock response");
+    }
+
+    #[test]
+    fn test_repair_json_text_once() {
+        // Plain JSON object
+        assert_eq!(repair_json_text_once(r#"{"key": "value"}"#), r#"{"key": "value"}"#);
+
+        // Plain JSON array
+        assert_eq!(repair_json_text_once(r#"[1, 2, 3]"#), r#"[1, 2, 3]"#);
+
+        // Markdown fenced JSON object
+        assert_eq!(
+            repair_json_text_once("```json\n{\"key\": \"value\"}\n```"),
+            r#"{"key": "value"}"#
+        );
+
+        // Markdown fenced JSON array
+        assert_eq!(
+            repair_json_text_once("```json\n[1, 2, 3]\n```"),
+            r#"[1, 2, 3]"#
+        );
+
+        // Generic markdown fence
+        assert_eq!(
+            repair_json_text_once("```\n{\"key\": \"value\"}\n```"),
+            r#"{"key": "value"}"#
+        );
+
+        // JSON object embedded in text
+        assert_eq!(
+            repair_json_text_once("Here is the JSON:\n\n{\"key\": \"value\"}\n\nHope this helps!"),
+            r#"{"key": "value"}"#
+        );
+
+        // JSON array embedded in text
+        assert_eq!(
+            repair_json_text_once("Some text before [1, 2, 3] and some text after"),
+            r#"[1, 2, 3]"#
+        );
+
+        // Nested structures (object containing array)
+        assert_eq!(
+            repair_json_text_once(r#"{"key": [1, 2, 3]}"#),
+            r#"{"key": [1, 2, 3]}"#
+        );
+
+        // Nested structures (array containing object)
+        assert_eq!(
+            repair_json_text_once(r#"[{"key": "value"}]"#),
+            r#"[{"key": "value"}]"#
+        );
+
+        // Fenced JSON embedded in text (strips fence first, then slices if needed)
+        assert_eq!(
+            repair_json_text_once("Here is the JSON:\n```json\n{\"key\": \"value\"}\n```\nDone."),
+            r#"{"key": "value"}"#
+        );
+
+        // No valid JSON, fallback to trimmed text
+        assert_eq!(
+            repair_json_text_once("Just some plain text without json"),
+            "Just some plain text without json"
+        );
+
+        // Fenced plain text, falls back to stripped and trimmed text
+        assert_eq!(
+            repair_json_text_once("```json\nJust some plain text\n```"),
+            "Just some plain text"
+        );
     }
 }

--- a/crates/workflow/src/model_policy.rs
+++ b/crates/workflow/src/model_policy.rs
@@ -293,18 +293,25 @@ pub fn repair_json_text_once(raw: &str) -> String {
         .map(str::trim)
         .unwrap_or(trimmed);
 
-    let obj_start = without_fence.find('{');
-    let arr_start = without_fence.find('[');
+    let obj_candidate = slice_json_payload(without_fence, '{', '}');
+    let arr_candidate = slice_json_payload(without_fence, '[', ']');
 
-    match (obj_start, arr_start) {
-        (Some(o), Some(a)) if o < a => slice_json_payload(without_fence, '{', '}'),
-        (Some(_), Some(_)) => slice_json_payload(without_fence, '[', ']'),
-        (Some(_), None) => slice_json_payload(without_fence, '{', '}'),
-        (None, Some(_)) => slice_json_payload(without_fence, '[', ']'),
-        (None, None) => None,
+    match (obj_candidate, arr_candidate) {
+        (Some(obj), Some(arr)) => {
+            // Find which one starts first in the original string
+            // slice_json_payload already validates they have matching open/close
+            let obj_start = without_fence.find(obj).unwrap_or(usize::MAX);
+            let arr_start = without_fence.find(arr).unwrap_or(usize::MAX);
+            if obj_start < arr_start {
+                obj.to_string()
+            } else {
+                arr.to_string()
+            }
+        }
+        (Some(obj), None) => obj.to_string(),
+        (None, Some(arr)) => arr.to_string(),
+        (None, None) => without_fence.to_string(),
     }
-    .unwrap_or(without_fence)
-    .to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -502,11 +509,13 @@ mod tests {
         assert_eq!(provider.model(), "fast");
         assert_eq!(response.text, "mock response");
     }
-
     #[test]
     fn test_repair_json_text_once() {
         // Plain JSON object
-        assert_eq!(repair_json_text_once(r#"{"key": "value"}"#), r#"{"key": "value"}"#);
+        assert_eq!(
+            repair_json_text_once(r#"{"key": "value"}"#),
+            r#"{"key": "value"}"#
+        );
 
         // Plain JSON array
         assert_eq!(repair_json_text_once(r#"[1, 2, 3]"#), r#"[1, 2, 3]"#);
@@ -553,7 +562,7 @@ mod tests {
             r#"[{"key": "value"}]"#
         );
 
-        // Fenced JSON embedded in text (strips fence first, then slices if needed)
+        // Fenced JSON embedded in text
         assert_eq!(
             repair_json_text_once("Here is the JSON:\n```json\n{\"key\": \"value\"}\n```\nDone."),
             r#"{"key": "value"}"#
@@ -569,6 +578,17 @@ mod tests {
         assert_eq!(
             repair_json_text_once("```json\nJust some plain text\n```"),
             "Just some plain text"
+        );
+
+        // REGRESSION FIX: Unmatched opening bracket should not block finding a balanced one
+        assert_eq!(repair_json_text_once("[note {\"ok\":1}"), r#"{"ok":1}"#);
+
+        // Control: Nested inside string escapes should be preserved correctly if balanced
+        // (This tests we don't just grab the first '{' without considering the full payload,
+        // though `slice_json_payload` is simple rfind/find right now)
+        assert_eq!(
+            repair_json_text_once(r#"Prefix text {"data": "[nested]"} postfix text"#),
+            r#"{"data": "[nested]"}"#
         );
     }
 }


### PR DESCRIPTION
## What

Adds regression coverage for `repair_json_text_once` and fixes extraction of
JSON arrays, nested payloads, and text containing malformed delimiter prefixes.
The previous object-first repair could reduce an array of objects to the inner
object or select an unmatched opening delimiter.

## Repair contract

- Strip optional Markdown fences before scanning.
- Consider object and array openings in source order.
- Match nested delimiters while respecting quoted strings and escapes.
- Return the earliest balanced candidate that parses as a `serde_json::Value`.
- Skip invalid or unmatched candidates and continue looking for a valid payload.
- Cap the scan at 64 candidate openings so hostile delimiter-heavy text remains
  bounded.

## Coverage

- Plain and fenced objects and arrays
- Objects containing arrays and arrays containing objects
- Unstructured text surrounding JSON
- Unmatched and mismatched delimiter prefixes
- An invalid earlier balanced candidate followed by valid JSON
- Escaped quotes and backslashes inside strings

## Verification

- Focused repair tests
- Full `codewhale-workflow` test suite
- Strict workflow clippy
- Formatting and diff checks
- Independent review of exact head `25026a1af8dcabfff887b7fdd0c79a664ff64aef`

Milestone: v0.9.1.

---

PR created automatically by Jules for task
[6338106765321311427](https://jules.google.com/task/6338106765321311427)
started by @Hmbown, then hardened during maintainer review.
