### PR TITLE
fix(web): expose OpenCode Go in derived facts

### DIFF
--- a/web/lib/facts-drift.ts
+++ b/web/lib/facts-drift.ts
@@ -99,6 +99,7 @@ function deriveProvidersFromConfig(cfg: string): ProviderFact[] {
     Together: { id: "together", label: "Together AI", env: "TOGETHER_API_KEY" },
     Qianfan: { id: "qianfan", label: "Baidu Qianfan", env: "QIANFAN_API_KEY / BAIDU_QIANFAN_API_KEY" },
     OpenaiCodex: { id: "openai-codex", label: "OpenAI Codex", env: "ChatGPT/Codex OAuth via `codex login` (OPENAI_CODEX_ACCESS_TOKEN / CODEX_ACCESS_TOKEN override)" },
+    OpencodeGo: { id: "opencode-go", label: "OpenCode Go", env: "OPENCODE_GO_API_KEY" },
     Anthropic: { id: "anthropic", label: "Anthropic", env: "ANTHROPIC_API_KEY" },
     Zai: { id: "zai", label: "Z.ai", env: "ZAI_API_KEY / Z_AI_API_KEY" },
     Stepfun: { id: "stepfun", label: "StepFun", env: "STEPFUN_API_KEY / STEP_API_KEY" },

--- a/web/lib/facts.generated.ts
+++ b/web/lib/facts.generated.ts
@@ -18,7 +18,7 @@ export interface RepoFacts {
 }
 
 export const FACTS: RepoFacts = {
-  "generatedAt": "2026-07-16T00:26:51.854Z",
+  "generatedAt": "2026-07-17T01:28:05.532Z",
   "version": "0.9.0",
   "crates": [
     "agent",
@@ -202,6 +202,11 @@ export const FACTS: RepoFacts = {
       "id": "longcat",
       "label": "Meituan LongCat",
       "env": "LONGCAT_API_KEY"
+    },
+    {
+      "id": "opencode-go",
+      "label": "OpenCode Go",
+      "env": "OPENCODE_GO_API_KEY"
     },
     {
       "id": "meta",

--- a/web/scripts/facts-lib.mjs
+++ b/web/scripts/facts-lib.mjs
@@ -83,6 +83,7 @@ const PROVIDER_LABEL_MAP = {
   Together: { id: "together", label: "Together AI", env: "TOGETHER_API_KEY" },
   Qianfan: { id: "qianfan", label: "Baidu Qianfan", env: "QIANFAN_API_KEY / BAIDU_QIANFAN_API_KEY" },
   OpenaiCodex: { id: "openai-codex", label: "OpenAI Codex", env: "ChatGPT/Codex OAuth via `codex login` (OPENAI_CODEX_ACCESS_TOKEN / CODEX_ACCESS_TOKEN override)" },
+  OpencodeGo: { id: "opencode-go", label: "OpenCode Go", env: "OPENCODE_GO_API_KEY" },
   Anthropic: { id: "anthropic", label: "Anthropic", env: "ANTHROPIC_API_KEY" },
   Zai: { id: "zai", label: "Z.ai", env: "ZAI_API_KEY / Z_AI_API_KEY" },
   Stepfun: { id: "stepfun", label: "StepFun", env: "STEPFUN_API_KEY / STEP_API_KEY" },


### PR DESCRIPTION
## Summary

- map the new `OpencodeGo` runtime provider into both website facts derivation paths
- regenerate the committed provider inventory with `OpenCode Go` / `OPENCODE_GO_API_KEY`
- restore the provider drift gate broken after the first-class OpenCode Go merge

## Verification

- `cd web && npm run check:facts`
- `cd web && npm test -- --run lib/check-facts.test.ts`
- `cd web && npm run lint`
- `cd web && npx tsc --noEmit`
- `git diff --check`

Follow-up to #4420. Contributes to #1481.
