### PR TITLE
🧪 [testing] Add test for ProviderRegistry::new

### DIFF
--- a/crates/workflow/src/model_policy.rs
+++ b/crates/workflow/src/model_policy.rs
@@ -362,6 +362,13 @@ mod tests {
     }
 
     #[test]
+    fn provider_registry_new_is_empty() {
+        let registry = ProviderRegistry::new();
+        assert!(registry.models.is_empty());
+        assert!(registry.role_policies.is_empty());
+    }
+
+    #[test]
     fn provider_capability_fallback() {
         let registry = ProviderRegistry::new()
             .with_model(model("mock", "plain", ModelCapabilities::default()))


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify the initialization of `ProviderRegistry::new()`.
📊 **Coverage:** Tests the `ProviderRegistry::new()` function to ensure that a newly instantiated registry initializes its `models` and `role_policies` as empty `BTreeMap`s.
✨ **Result:** Improved test coverage and reliability for `ProviderRegistry` initialization by explicitly validating its empty state upon creation, guarding against unintended default behavior in future refactors.

---
*PR created automatically by Jules for task [11479245860780325280](https://jules.google.com/task/11479245860780325280) started by @Hmbown*