### PR TITLE
🔒 Restrict overly permissive CORS headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).
 
+### Security
+
+- Restrict cross-origin Runtime API browser preflights to the documented
+  authentication and content headers, explicitly allowing `Authorization`
+  instead of relying on a wildcard (#4454).
+
 ## [0.9.0] - 2026-07-16
 
 Codewhale v0.9.0 replaces the default terminal shell with the underwater

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).
 
+### Security
+
+- Restrict cross-origin Runtime API browser preflights to the documented
+  authentication and content headers, explicitly allowing `Authorization`
+  instead of relying on a wildcard (#4454).
+
 ## [0.9.0] - 2026-07-16
 
 Codewhale v0.9.0 replaces the default terminal shell with the underwater

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -10,9 +10,8 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow, bail};
 use async_stream::stream;
 use axum::extract::{Path, Query, Request, State};
-#[cfg(test)]
 use axum::http::header;
-use axum::http::{HeaderValue, Method, StatusCode};
+use axum::http::{HeaderName, HeaderValue, Method, StatusCode};
 use axum::middleware;
 use axum::response::Html;
 use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
@@ -29,7 +28,7 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::CorsLayer;
 
 #[cfg(test)]
 use crate::dependencies::ExternalTool;
@@ -2949,7 +2948,13 @@ fn cors_layer(extra_origins: &[String]) -> CorsLayer {
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers(Any)
+        .allow_headers([
+            header::AUTHORIZATION,
+            header::CONTENT_TYPE,
+            header::ACCEPT,
+            HeaderName::from_static("x-codewhale-runtime-token"),
+            HeaderName::from_static("x-deepseek-runtime-token"),
+        ])
 }
 
 fn map_task_err(err: anyhow::Error) -> ApiError {

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -5044,7 +5044,7 @@ async fn set_config_response_contains_all_expected_fields() -> Result<()> {
 }
 
 #[tokio::test]
-async fn cors_layer_restricts_headers() -> Result<()> {
+async fn cors_layer_advertises_only_supported_request_headers() -> Result<()> {
     let layer = cors_layer(&[]);
     let router: Router = Router::new()
         .route("/probe", get(|| async { "ok" }))
@@ -5073,18 +5073,29 @@ async fn cors_layer_restricts_headers() -> Result<()> {
         .send()
         .await?;
 
+    assert!(resp.status().is_success());
     let allow_headers = resp
         .headers()
         .get("access-control-allow-headers")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
+    let advertised = allow_headers
+        .split(',')
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .collect::<std::collections::BTreeSet<_>>();
+    let expected = [
+        "accept",
+        "authorization",
+        "content-type",
+        "x-codewhale-runtime-token",
+        "x-deepseek-runtime-token",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<std::collections::BTreeSet<_>>();
 
-    assert!(allow_headers.contains("authorization"));
-    assert!(allow_headers.contains("content-type"));
-    assert!(allow_headers.contains("accept"));
-    assert!(allow_headers.contains("x-codewhale-runtime-token"));
-    assert!(allow_headers.contains("x-deepseek-runtime-token"));
-    assert!(!allow_headers.contains("x-malicious-header"));
+    assert_eq!(advertised, expected);
 
     handle.abort();
     Ok(())

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -5042,3 +5042,50 @@ async fn set_config_response_contains_all_expected_fields() -> Result<()> {
     handle.abort();
     Ok(())
 }
+
+#[tokio::test]
+async fn cors_layer_restricts_headers() -> Result<()> {
+    let layer = cors_layer(&[]);
+    let router: Router = Router::new()
+        .route("/probe", get(|| async { "ok" }))
+        .layer(layer);
+
+    let listener = match TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    let addr = listener.local_addr()?;
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    let client = crate::tls::reqwest_client();
+
+    let resp = client
+        .request(reqwest::Method::OPTIONS, format!("http://{addr}/probe"))
+        .header("Origin", "http://localhost:1420")
+        .header("Access-Control-Request-Method", "GET")
+        .header(
+            "Access-Control-Request-Headers",
+            "authorization, content-type, accept, x-codewhale-runtime-token, x-deepseek-runtime-token, x-malicious-header",
+        )
+        .send()
+        .await?;
+
+    let allow_headers = resp
+        .headers()
+        .get("access-control-allow-headers")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    assert!(allow_headers.contains("authorization"));
+    assert!(allow_headers.contains("content-type"));
+    assert!(allow_headers.contains("accept"));
+    assert!(allow_headers.contains("x-codewhale-runtime-token"));
+    assert!(allow_headers.contains("x-deepseek-runtime-token"));
+    assert!(!allow_headers.contains("x-malicious-header"));
+
+    handle.abort();
+    Ok(())
+}


### PR DESCRIPTION
## What

Replace wildcard Runtime API CORS request-header permission with the explicit headers used by first-party browser clients:

- `Authorization`
- `Content-Type`
- `Accept`
- `X-Codewhale-Runtime-Token`
- `X-DeepSeek-Runtime-Token`

## Why

This is least-privilege and compatibility hardening for origins already allowed by `--cors-origin`. In particular, browser Fetch treats `Authorization` as a non-wildcard request header, so naming it explicitly is more reliable than returning `Access-Control-Allow-Headers: *`.

This does not make the server reject arbitrary headers from non-browser clients, and it is not a standalone vulnerability claim: CORS is enforced by browsers, origins remain explicitly allowlisted, credentials are not enabled, and Runtime API routes retain their token authentication.

## Verification

- Adds a real OPTIONS preflight integration test.
- Proves the five supported headers are permitted and an unknown request header is not advertised to the browser.
- Full CI is required on the rebased head before merge.

---
Original implementation generated by Jules for task [12670987091699450534](https://jules.google.com/task/12670987091699450534) started by @Hmbown.
