### PR TITLE
feat(build): HarmonyOS workflow-js target support (harvest of #4384)

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -179,3 +179,7 @@ hange = qinlinwang <491831+qinlinwang@users.noreply.github.com>
 atnhan@qq.com = qinlinwang <491831+qinlinwang@users.noreply.github.com>
 knqiufan = knqiufan <34114995+knqiufan@users.noreply.github.com>
 knqiufan@foxmail.com = knqiufan <34114995+knqiufan@users.noreply.github.com>
+
+# v0.9.1 harvests.
+shenyongqing = Shen Yongqing <26758802+shenyongqing@users.noreply.github.com>
+floatinsky@126.com = Shen Yongqing <26758802+shenyongqing@users.noreply.github.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Check release helper contracts
         run: |
           bash .github/scripts/agent-task-metadata.test.sh
+          bash scripts/ohos-env.test.sh
           bash scripts/release/generate-release-body.test.sh
           bash scripts/release/prepare-release.test.sh
           bash scripts/release/require-release-tag-checkout.test.sh
@@ -300,6 +301,10 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
           echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
           echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
+      - name: Check OHOS PowerShell environment helper
+        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'windows-latest'
+        shell: pwsh
+        run: ./scripts/ohos-env.test.ps1
       - uses: Swatinem/rust-cache@v2
         if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restart, resume, RRULE updates, duplicate-slot recovery, and post-run
   advancement. Nonexistent clock slots are skipped and ambiguous slots run at
   their first occurrence (#4381 by @h3c-hexin).
+- Generate QuickJS bindings at build time for the `codewhale-workflow-js`
+  crate on HarmonyOS/OpenHarmony (`target_env = "ohos"`), where rquickjs has
+  no pre-generated bindings (#4384 by @shenyongqing; workflow-js slice of
+  #2970).
 - Convert persisted sub-agent completion and still-running control events into
   concise, non-authoritative resume checkpoints, keeping their raw runtime
   envelopes, sentinels, and retry instructions out of restored model and TUI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   advancement. Nonexistent clock slots are skipped and ambiguous slots run at
   their first occurrence (#4381 by @h3c-hexin).
 - Generate QuickJS bindings at build time for the `codewhale-workflow-js`
-  crate on HarmonyOS/OpenHarmony (`target_env = "ohos"`), where rquickjs has
-  no pre-generated bindings (#4384 by @shenyongqing; workflow-js slice of
-  #2970).
+  crate on HarmonyOS/OpenHarmony (`target_env = "ohos"`), and pass the OHOS
+  target and sysroot to bindgen through the platform environment helpers
+  (#4384 by @shenyongqing; workflow-js slice of #2970).
 - Convert persisted sub-agent completion and still-running control events into
   concise, non-authoritative resume checkpoints, keeping their raw runtime
   envelopes, sentinels, and retry instructions out of restored model and TUI

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restart, resume, RRULE updates, duplicate-slot recovery, and post-run
   advancement. Nonexistent clock slots are skipped and ambiguous slots run at
   their first occurrence (#4381 by @h3c-hexin).
+- Generate QuickJS bindings at build time for the `codewhale-workflow-js`
+  crate on HarmonyOS/OpenHarmony (`target_env = "ohos"`), and pass the OHOS
+  target and sysroot to bindgen through the platform environment helpers
+  (#4384 by @shenyongqing; workflow-js slice of #2970).
 - Convert persisted sub-agent completion and still-running control events into
   concise, non-authoritative resume checkpoints, keeping their raw runtime
   envelopes, sentinels, and retry instructions out of restored model and TUI

--- a/crates/workflow-js/Cargo.toml
+++ b/crates/workflow-js/Cargo.toml
@@ -28,5 +28,11 @@ rquickjs = { workspace = true, features = ["bindgen"] }
 [target.'cfg(target_os = "netbsd")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
 
+# rquickjs does not ship pre-generated bindings for OpenHarmony/OpenHarmony.
+# Generate them at build time so the crate compiles there instead of trying
+# to include a nonexistent bindings file.
+[target.'cfg(target_env = "ohos")'.dependencies]
+rquickjs = { workspace = true, features = ["bindgen"] }
+
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/workflow-js/Cargo.toml
+++ b/crates/workflow-js/Cargo.toml
@@ -28,7 +28,7 @@ rquickjs = { workspace = true, features = ["bindgen"] }
 [target.'cfg(target_os = "netbsd")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
 
-# rquickjs does not ship pre-generated bindings for OpenHarmony/OpenHarmony.
+# rquickjs does not ship pre-generated bindings for HarmonyOS/OpenHarmony.
 # Generate them at build time so the crate compiles there instead of trying
 # to include a nonexistent bindings file.
 [target.'cfg(target_env = "ohos")'.dependencies]

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -32,6 +32,10 @@ notes, and relevant issue/PR comments.
 
 - **[h3c-hexin](https://github.com/h3c-hexin)** — calendar-anchored hourly
   automation recurrence across DST and lifecycle transitions (PR #4381)
+- **[Shen Yongqing / shenyongqing](https://github.com/shenyongqing)** —
+  HarmonyOS/OpenHarmony QuickJS bindgen activation for
+  `codewhale-workflow-js` (PR #4384), covering the workflow-js build slice of
+  #2970
 - **[zhangweiii](https://github.com/zhangweiii)** and
   **[Sterne Lee / sternelee](https://github.com/sternelee)** — the original
   first-class OpenCode Go implementations in PRs #773 and #1050, harvested

--- a/docs/HarmonyOS.md
+++ b/docs/HarmonyOS.md
@@ -40,9 +40,25 @@ rustup target add aarch64-unknown-linux-ohos
 cargo build --target aarch64-unknown-linux-ohos -p codewhale-cli
 ```
 
+For the JavaScript Workflow runtime, which generates QuickJS bindings on OHOS,
+also verify the target crate directly:
+
+```bash
+cargo check --locked --target aarch64-unknown-linux-ohos -p codewhale-workflow-js
+```
+
 The setup scripts export Cargo's target-specific `linker`, `AR`, `CC`, `CXX`,
-`CFLAGS`, `CXXFLAGS`, `CARGO_ENCODED_RUSTFLAGS`, `CC_SHELL_ESCAPED_FLAGS`, and
-CMake toolchain variables for `aarch64-unknown-linux-ohos`.
+`CFLAGS`, `CXXFLAGS`, `BINDGEN_EXTRA_CLANG_ARGS`,
+`CARGO_ENCODED_RUSTFLAGS`, `CC_SHELL_ESCAPED_FLAGS`, and CMake toolchain
+variables for `aarch64-unknown-linux-ohos`. The bindgen variable carries the
+OHOS target and sysroot into rquickjs's build script; compiler flags alone do
+not configure bindgen.
+
+Bindgen runs on the build host and must be able to load a host-compatible
+`libclang`. The setup scripts intentionally do not guess a host LLVM install.
+If bindgen cannot locate `libclang`, install it for the host or set
+`LIBCLANG_PATH` to the directory containing that host library before running
+the Cargo command.
 
 ## Compiler Wrappers
 

--- a/scripts/ohos-env.ps1
+++ b/scripts/ohos-env.ps1
@@ -44,6 +44,7 @@ $env:CXX_aarch64_unknown_linux_ohos = $clangxx
 $env:CC_SHELL_ESCAPED_FLAGS = "1"
 Set-Item -Path "Env:CFLAGS_$target" -Value $commonFlags
 Set-Item -Path "Env:CXXFLAGS_$target" -Value $commonFlags
+Set-Item -Path "Env:BINDGEN_EXTRA_CLANG_ARGS_$target" -Value $commonFlags
 Set-Item -Path "Env:CMAKE_TOOLCHAIN_FILE_$target" -Value $cmakeToolchain
 
 $separator = [char]0x1f

--- a/scripts/ohos-env.sh
+++ b/scripts/ohos-env.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+# The exit fallbacks are reached when this file is executed instead of sourced.
+# shellcheck disable=SC2317
 
 if [ -z "${OHOS_NATIVE_SDK:-}" ]; then
     echo "error: set OHOS_NATIVE_SDK to the OpenHarmony native SDK directory." >&2
@@ -29,14 +31,16 @@ if [ ! -d "$sysroot" ]; then
     return 1 2>/dev/null || exit 1
 fi
 
-export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER=$clang
-export AR_aarch64_unknown_linux_ohos=$ar
-export CC_aarch64_unknown_linux_ohos=$clang
-export CXX_aarch64_unknown_linux_ohos=$clangxx
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER="$clang"
+export AR_aarch64_unknown_linux_ohos="$ar"
+export CC_aarch64_unknown_linux_ohos="$clang"
+export CXX_aarch64_unknown_linux_ohos="$clangxx"
 export CC_SHELL_ESCAPED_FLAGS=1
-export CFLAGS_aarch64_unknown_linux_ohos="-target aarch64-linux-ohos --sysroot=\"$sysroot\" -D__MUSL__"
-export CXXFLAGS_aarch64_unknown_linux_ohos="-target aarch64-linux-ohos --sysroot=\"$sysroot\" -D__MUSL__"
-export CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_ohos=$cmake_toolchain
+common_flags="-target aarch64-linux-ohos --sysroot=\"$sysroot\" -D__MUSL__"
+export CFLAGS_aarch64_unknown_linux_ohos="$common_flags"
+export CXXFLAGS_aarch64_unknown_linux_ohos="$common_flags"
+export BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos="$common_flags"
+export CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_ohos="$cmake_toolchain"
 
 sep=$(printf '\037')
 export CARGO_ENCODED_RUSTFLAGS="-Clink-arg=-target${sep}-Clink-arg=aarch64-linux-ohos${sep}-Clink-arg=--sysroot=$sysroot${sep}-Clink-arg=-D__MUSL__"

--- a/scripts/ohos-env.test.ps1
+++ b/scripts/ohos-env.test.ps1
@@ -1,0 +1,81 @@
+$ErrorActionPreference = "Stop"
+
+function Assert-EnvironmentValue {
+    param(
+        [string]$Name,
+        [string]$Expected
+    )
+
+    $actual = [Environment]::GetEnvironmentVariable($Name, "Process")
+    if ($actual -cne $Expected) {
+        throw "$Name mismatch.`nexpected: $Expected`nactual:   $actual"
+    }
+}
+
+$fixture = [System.IO.Path]::Combine(
+    [System.IO.Path]::GetTempPath(),
+    "Codewhale OHOS Env $([Guid]::NewGuid())"
+)
+
+try {
+    $directories = @(
+        [System.IO.Path]::Combine($fixture, "llvm", "bin"),
+        [System.IO.Path]::Combine($fixture, "sysroot"),
+        [System.IO.Path]::Combine($fixture, "build", "cmake")
+    )
+    foreach ($directory in $directories) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $requiredFiles = @(
+        [System.IO.Path]::Combine($fixture, "llvm", "bin", "clang.exe"),
+        [System.IO.Path]::Combine($fixture, "llvm", "bin", "clang++.exe"),
+        [System.IO.Path]::Combine($fixture, "llvm", "bin", "llvm-ar.exe"),
+        [System.IO.Path]::Combine($fixture, "build", "cmake", "ohos.toolchain.cmake")
+    )
+    foreach ($file in $requiredFiles) {
+        New-Item -ItemType File -Path $file -Force | Out-Null
+    }
+
+    $env:OHOS_NATIVE_SDK = $fixture
+    . "$PSScriptRoot/ohos-env.ps1" | Out-Null
+
+    $sdk = (Resolve-Path -LiteralPath $fixture).Path
+    $target = "aarch64_unknown_linux_ohos"
+    $clang = [System.IO.Path]::Combine($sdk, "llvm", "bin", "clang.exe")
+    $clangxx = [System.IO.Path]::Combine($sdk, "llvm", "bin", "clang++.exe")
+    $ar = [System.IO.Path]::Combine($sdk, "llvm", "bin", "llvm-ar.exe")
+    $sysroot = [System.IO.Path]::Combine($sdk, "sysroot")
+    $cmakeToolchain = [System.IO.Path]::Combine(
+        $sdk,
+        "build",
+        "cmake",
+        "ohos.toolchain.cmake"
+    )
+    $commonFlags = "-target aarch64-linux-ohos --sysroot=`"$sysroot`" -D__MUSL__"
+    $separator = [char]0x1f
+    $encodedRustflags = @(
+        "-Clink-arg=-target",
+        "-Clink-arg=aarch64-linux-ohos",
+        "-Clink-arg=--sysroot=$sysroot",
+        "-Clink-arg=-D__MUSL__"
+    ) -join $separator
+
+    Assert-EnvironmentValue "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER" $clang
+    Assert-EnvironmentValue "AR_$target" $ar
+    Assert-EnvironmentValue "CC_$target" $clang
+    Assert-EnvironmentValue "CXX_$target" $clangxx
+    Assert-EnvironmentValue "CFLAGS_$target" $commonFlags
+    Assert-EnvironmentValue "CXXFLAGS_$target" $commonFlags
+    Assert-EnvironmentValue "BINDGEN_EXTRA_CLANG_ARGS_$target" $commonFlags
+    Assert-EnvironmentValue "CMAKE_TOOLCHAIN_FILE_$target" $cmakeToolchain
+    Assert-EnvironmentValue "CC_SHELL_ESCAPED_FLAGS" "1"
+    Assert-EnvironmentValue "CARGO_ENCODED_RUSTFLAGS" $encodedRustflags
+}
+finally {
+    if (Test-Path -LiteralPath $fixture) {
+        Remove-Item -LiteralPath $fixture -Recurse -Force
+    }
+}
+
+Write-Host "ohos-env.ps1 tests passed"

--- a/scripts/ohos-env.test.sh
+++ b/scripts/ohos-env.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_base="${CODEWHALE_TEST_TMPDIR:-${TMPDIR:-/tmp}}"
+mkdir -p "${tmp_base}"
+tmp_dir="$(mktemp -d "${tmp_base%/}/codewhale-ohos-env.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+assert_equal() {
+  local name="$1"
+  local actual="$2"
+  local expected="$3"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf '%s mismatch\nexpected: %q\nactual:   %q\n' \
+      "${name}" "${expected}" "${actual}" >&2
+    exit 1
+  fi
+}
+
+if env -u OHOS_NATIVE_SDK sh "${repo_root}/scripts/ohos-env.sh" \
+  >"${tmp_dir}/unset.log" 2>&1; then
+  echo "ohos-env.sh unexpectedly accepted an unset OHOS_NATIVE_SDK" >&2
+  exit 1
+fi
+grep -Fq 'set OHOS_NATIVE_SDK' "${tmp_dir}/unset.log"
+
+sdk="${tmp_dir}/OpenHarmony Native SDK"
+mkdir -p \
+  "${sdk}/llvm/bin" \
+  "${sdk}/sysroot" \
+  "${sdk}/build/cmake"
+touch \
+  "${sdk}/llvm/bin/clang" \
+  "${sdk}/llvm/bin/clang++" \
+  "${sdk}/llvm/bin/llvm-ar" \
+  "${sdk}/build/cmake/ohos.toolchain.cmake"
+
+(
+  export OHOS_NATIVE_SDK="${sdk}"
+  # shellcheck source=scripts/ohos-env.sh
+  . "${repo_root}/scripts/ohos-env.sh" >/dev/null
+
+  resolved_sdk="$(cd "${sdk}" && pwd)"
+  sysroot="${resolved_sdk}/sysroot"
+  common_flags="-target aarch64-linux-ohos --sysroot=\"${sysroot}\" -D__MUSL__"
+  separator="$(printf '\037')"
+  encoded_rustflags="-Clink-arg=-target${separator}-Clink-arg=aarch64-linux-ohos${separator}-Clink-arg=--sysroot=${sysroot}${separator}-Clink-arg=-D__MUSL__"
+
+  assert_equal \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER \
+    "${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER}" \
+    "${resolved_sdk}/llvm/bin/clang"
+  assert_equal \
+    AR_aarch64_unknown_linux_ohos \
+    "${AR_aarch64_unknown_linux_ohos}" \
+    "${resolved_sdk}/llvm/bin/llvm-ar"
+  assert_equal \
+    CC_aarch64_unknown_linux_ohos \
+    "${CC_aarch64_unknown_linux_ohos}" \
+    "${resolved_sdk}/llvm/bin/clang"
+  assert_equal \
+    CXX_aarch64_unknown_linux_ohos \
+    "${CXX_aarch64_unknown_linux_ohos}" \
+    "${resolved_sdk}/llvm/bin/clang++"
+  assert_equal CFLAGS_aarch64_unknown_linux_ohos \
+    "${CFLAGS_aarch64_unknown_linux_ohos}" "${common_flags}"
+  assert_equal CXXFLAGS_aarch64_unknown_linux_ohos \
+    "${CXXFLAGS_aarch64_unknown_linux_ohos}" "${common_flags}"
+  assert_equal BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos \
+    "${BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos}" "${common_flags}"
+  assert_equal CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_ohos \
+    "${CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_ohos}" \
+    "${resolved_sdk}/build/cmake/ohos.toolchain.cmake"
+  assert_equal CC_SHELL_ESCAPED_FLAGS "${CC_SHELL_ESCAPED_FLAGS}" "1"
+  assert_equal CARGO_ENCODED_RUSTFLAGS \
+    "${CARGO_ENCODED_RUSTFLAGS}" "${encoded_rustflags}"
+)
+
+echo "ohos-env.sh tests passed"

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -4,15 +4,20 @@
 # This check intentionally does not require an OpenHarmony SDK or sysroot. It
 # only asks Cargo to resolve the codewhale-tui dependency graph for the OHOS
 # target and fails if crates known to break or be unsupported on OHOS re-enter
-# that graph.
+# that graph. It also proves the OHOS target activates the rquickjs-sys
+# `bindgen` feature for codewhale-workflow-js, which is the only reason the
+# crate compiles for a target with no pre-generated QuickJS bindings.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
 target="${1:-aarch64-unknown-linux-ohos}"
 package="${CODEWHALE_OHOS_DEP_PACKAGE:-codewhale-tui}"
+workflow_js_package="${CODEWHALE_OHOS_WORKFLOW_JS_PACKAGE:-codewhale-workflow-js}"
 
 cargo_tree_with_retry() {
+  local package="$1"
+  shift
   local attempt
   local max_attempts="${CODEWHALE_OHOS_DEP_RETRIES:-3}"
   local delay_seconds="${CODEWHALE_OHOS_DEP_RETRY_DELAY_SECONDS:-10}"
@@ -31,10 +36,9 @@ cargo_tree_with_retry() {
       cargo tree \
         --locked \
         --package "${package}" \
-        --all-features \
         --target "${target}" \
         --prefix none \
-        --no-dedupe \
+        "$@" \
         2>"${err_file}"
     )"; then
       rm -f "${err_file}"
@@ -54,7 +58,7 @@ cargo_tree_with_retry() {
   done
 }
 
-tree="$(cargo_tree_with_retry)"
+tree="$(cargo_tree_with_retry "${package}" --all-features --no-dedupe)"
 
 disallowed="$(
   grep -E '^(nix v0\.(28|29)\.|portable-pty v|starlark v|arboard v|keyring v)' <<<"${tree}" || true
@@ -73,3 +77,28 @@ if [[ -n "${disallowed}" ]]; then
 fi
 
 echo "OHOS dependency graph OK for ${package} on ${target}."
+
+# codewhale-workflow-js only compiles for OHOS because its
+# `cfg(target_env = "ohos")` dependency gate activates rquickjs's `bindgen`
+# feature, which forwards to rquickjs-sys so QuickJS bindings are generated at
+# build time. Resolve the feature graph for the OHOS target (pure metadata, no
+# SDK or target toolchain needed) and fail loudly if either feature edge
+# disappears — for example because the target gate was dropped or an rquickjs
+# upgrade renamed the feature.
+workflow_js_features="$(cargo_tree_with_retry "${workflow_js_package}" --edges features)"
+
+if ! grep -qF 'rquickjs feature "bindgen"' <<<"${workflow_js_features}" \
+  || ! grep -qF 'rquickjs-sys feature "bindgen"' <<<"${workflow_js_features}"; then
+  {
+    echo "::error::OHOS target graph for ${workflow_js_package} lost the rquickjs bindgen feature edges:"
+    grep -E '^(rquickjs|rquickjs-sys|rquickjs-core|bindgen)( v| feature)' <<<"${workflow_js_features}" || true
+    echo
+    echo "crates/workflow-js/Cargo.toml must keep activating rquickjs's \`bindgen\`"
+    echo "feature under cfg(target_env = \"ohos\"); rquickjs ships no pre-generated"
+    echo "QuickJS bindings for OpenHarmony, so without that edge the crate cannot"
+    echo "compile for ${target}."
+  } >&2
+  exit 1
+fi
+
+echo "OHOS rquickjs-sys bindgen feature edge OK for ${workflow_js_package} on ${target}."


### PR DESCRIPTION
## Summary

Harvested from #4384 — this is the credited replacement lane for HarmonyOS workflow-js build support, covering the workflow-js slice of #2970 (mentioned only; this PR does **not** close it).

**Why this replacement exists:** the original contributor PR #4384 is not being merged directly. This lane rebases the work onto current `main`, adds an SDK-free guard proving the OHOS target actually activates the `rquickjs-sys` `bindgen` feature, and reruns the focused gates. Contributor authorship is preserved exactly:

- `25da6dea` `fix(workflow-js): generate QuickJS bindings on OHOS` — **Shen Yongqing (@shenyongqing)**, the original PR commit, authorship unchanged
- `63a55bfb` `fix(ohos): pass target sysroot to bindgen` — maintainer follow-up
- `d90f32c6` `test(release): prove OHOS rquickjs-sys bindgen edge without an SDK` — new guard added by this lane

What the lane does:

- Activates rquickjs's `bindgen` feature for `codewhale-workflow-js` under `cfg(target_env = "ohos")` — rquickjs ships no pre-generated QuickJS bindings for OpenHarmony.
- Teaches `scripts/ohos-env.sh` / `scripts/ohos-env.ps1` to pass the OHOS target and sysroot through to bindgen.
- Extends `scripts/release/check-ohos-deps.sh` to fail loudly if the `rquickjs feature "bindgen"` / `rquickjs-sys feature "bindgen"` edges disappear from the OHOS-resolved feature graph — pure `cargo tree` metadata resolution, no OpenHarmony SDK or target toolchain required.

## Draft status

This PR stays **DRAFT** until a real HarmonyOS SDK receipt exists:

```
source scripts/ohos-env.sh && rustup target add aarch64-unknown-linux-ohos && cargo check --locked --target aarch64-unknown-linux-ohos -p codewhale-workflow-js
```

## Testing

- [x] `bash scripts/release/check-ohos-deps.sh` — OHOS dependency graph plus the new bindgen-edge assertion pass; negative path verified against a non-OHOS target, where the assertion fails as designed
- [x] `bash scripts/ohos-env.test.sh` — POSIX helper tests pass
- [x] `shellcheck scripts/ohos-env.sh scripts/ohos-env.test.sh scripts/release/check-ohos-deps.sh` — clean
- [x] `cargo test -p codewhale-workflow-js --locked` — 42 passed, 0 failed
- [x] `cargo clippy -p codewhale-workflow-js --all-targets --locked -- -D warnings` — clean
- [x] `./scripts/release/check-versions.sh` — version state OK
- [x] `python3 scripts/check-coauthor-trailers.py --author-map .github/AUTHOR_MAP --range origin/main..HEAD --check-authors` — 3 commits pass
- [ ] `scripts/ohos-env.test.ps1` — cannot execute on macOS (no `pwsh`); Windows CI (`windows-latest` matrix) must validate it
- [ ] Real HarmonyOS SDK receipt (see Draft status) — still pending, blocks ready-for-review

## Checklist

- [x] Updated docs or comments as needed (`docs/HarmonyOS.md`, CHANGELOG, `docs/CONTRIBUTORS.md`)
- [x] Added or updated tests where relevant
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (`26758802+shenyongqing@users.noreply.github.com`)
