### PR TITLE
fix(web): give content-watch drafts canonical identities

### DIFF
--- a/web/AGENT.md
+++ b/web/AGENT.md
@@ -12,12 +12,19 @@ Cloudflare Cron Triggers
        ├─ weekly    → digest (Mon 09:00 UTC)
        └─ 6h       → curate (Today's Dispatch — pre-existing)
 
-Drafts stored in Workers KV:
+Drafts stored in Workers KV (keys always derived via `draftStorageKey` in `lib/community-agent.ts`):
   draft:triage:<issue-number>
   draft:pr-review:<pr-number>
   draft:stale:<issue-number>
   draft:dupes:<issue-number>
   draft:digest:<year>-W<week>
+  draft:linkcheck:<slug>-<sha256-16>          (identity: full broken URL)
+  draft:semantic-drift:<slug>-<sha256-16>     (identity: page+claim+evidence+replacement)
+
+Watcher draft IDs are deterministic — readable slug plus a 64-bit SHA-256
+suffix over the finding's full identity, max 80 chars — so unchanged findings
+dedup and changed findings land as new drafts. Semantic-drift model output is
+validated and capped (10 drafts/run) before any KV writes.
 
 Usage logged to:
   usage:<YYYY-MM-DD>

--- a/web/app/[locale]/admin/admin-client.tsx
+++ b/web/app/[locale]/admin/admin-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { AgentDraft } from "@/lib/community-agent";
+import { draftStorageKey, type AgentDraft } from "@/lib/community-agent";
 
 interface Props {
   drafts: AgentDraft[];
@@ -28,11 +28,11 @@ export function AdminClient({ drafts, posted, isZh, typeLabels }: Props) {
       const data = await res.json();
       if (data.ok) {
         if (action === "discard") {
-          setItems((prev) => prev.filter((d) => `draft:${d.type}:${d.id}` !== draftKey));
+          setItems((prev) => prev.filter((d) => draftStorageKey(d) !== draftKey));
         } else if (action === "post") {
-          const posted = items.find((d) => `draft:${d.type}:${d.id}` === draftKey);
+          const posted = items.find((d) => draftStorageKey(d) === draftKey);
           if (posted) {
-            setItems((prev) => prev.filter((d) => `draft:${d.type}:${d.id}` !== draftKey));
+            setItems((prev) => prev.filter((d) => draftStorageKey(d) !== draftKey));
             setPostedItems((prev) => [{ ...posted, posted: true }, ...prev]);
           }
         }
@@ -48,7 +48,7 @@ export function AdminClient({ drafts, posted, isZh, typeLabels }: Props) {
   };
 
   const startEdit = (draft: AgentDraft) => {
-    const key = `draft:${draft.type}:${draft.id}`;
+    const key = draftStorageKey(draft);
     setEditing(key);
     setEditBody(draft.bodyEn);
   };
@@ -62,7 +62,7 @@ export function AdminClient({ drafts, posted, isZh, typeLabels }: Props) {
             {isZh ? "待审阅" : "Pending"} <span className="font-mono text-sm text-ink-mute ml-2">({items.length})</span>
           </h2>
           {items.map((draft) => {
-            const key = `draft:${draft.type}:${draft.id}`;
+            const key = draftStorageKey(draft);
             const label = typeLabels[draft.type] ?? { en: draft.type, zh: draft.type };
             return (
               <div key={key} className="hairline-t hairline-b hairline-l hairline-r bg-paper">
@@ -147,7 +147,7 @@ export function AdminClient({ drafts, posted, isZh, typeLabels }: Props) {
             {isZh ? "已发布" : "Posted"} <span className="font-mono text-sm text-ink-mute ml-2">({postedItems.length})</span>
           </h2>
           {postedItems.map((draft) => {
-            const key = `draft:${draft.type}:${draft.id}`;
+            const key = draftStorageKey(draft);
             const label = typeLabels[draft.type] ?? { en: draft.type, zh: draft.type };
             return (
               <div key={key} className="hairline-t py-3 px-4 opacity-60">

--- a/web/app/[locale]/admin/page.tsx
+++ b/web/app/[locale]/admin/page.tsx
@@ -17,6 +17,8 @@ const TYPE_LABELS: Record<string, { en: string; zh: string }> = {
   stale: { en: "Stale Nudge", zh: "过期提醒" },
   dupes: { en: "Duplicate", zh: "重复检测" },
   digest: { en: "Weekly Digest", zh: "每周摘要" },
+  linkcheck: { en: "Broken Link", zh: "失效链接" },
+  "semantic-drift": { en: "Content Drift", zh: "内容漂移" },
 };
 
 function LoginForm({ locale, error }: { locale: string; error: boolean }) {

--- a/web/lib/community-agent-tasks.ts
+++ b/web/lib/community-agent-tasks.ts
@@ -98,7 +98,7 @@ export async function runTriage(env: AgentEnv): Promise<Record<string, unknown>>
     let skipped = 0;
 
     for (const issue of newIssues) {
-      if (await hasFreshDraft(env.CURATED_KV, "issue", String(issue.number), issue.updated_at)) {
+      if (await hasFreshDraft(env.CURATED_KV, "triage", String(issue.number), issue.updated_at)) {
         skipped++;
         continue;
       }
@@ -163,7 +163,7 @@ export async function runPrReview(env: AgentEnv): Promise<Record<string, unknown
     let skipped = 0;
 
     for (const pr of prs.slice(0, 10)) {
-      if (await hasFreshDraft(env.CURATED_KV, "pr", String(pr.number), pr.updated_at)) {
+      if (await hasFreshDraft(env.CURATED_KV, "pr-review", String(pr.number), pr.updated_at)) {
         skipped++;
         continue;
       }

--- a/web/lib/community-agent.ts
+++ b/web/lib/community-agent.ts
@@ -25,7 +25,7 @@ interface ChatResponse {
 
 export interface AgentDraft {
   id: string;
-  type: "triage" | "pr-review" | "stale" | "dupes" | "digest";
+  type: "triage" | "pr-review" | "stale" | "dupes" | "digest" | "linkcheck" | "semantic-drift";
   targetNumber?: number;
   targetUrl?: string;
   bodyEn: string;
@@ -221,8 +221,17 @@ export async function getAgentEnv(): Promise<CommunityAgentEnv> {
 
 export async function saveDraft(kv: KVNamespace | undefined, draft: AgentDraft): Promise<void> {
   if (!kv) return;
-  const key = `draft:${draft.type}:${draft.id}`;
-  await kv.put(key, JSON.stringify(draft), { expirationTtl: 60 * 60 * 24 * 30 }); // 30 days
+  await kv.put(draftStorageKey(draft), JSON.stringify(draft), { expirationTtl: 60 * 60 * 24 * 30 }); // 30 days
+}
+
+/**
+ * The one canonical KV key for a draft. Writers (saveDraft), dedup lookups
+ * (hasFreshDraft, the content watchers), and the /admin review surface must
+ * all derive keys through this helper so a draft's identity can never drift
+ * between the key that is checked and the key that is written.
+ */
+export function draftStorageKey(draft: Pick<AgentDraft, "type" | "id">): string {
+  return `draft:${draft.type}:${draft.id}`;
 }
 
 export async function getDraft(kv: KVNamespace | undefined, key: string): Promise<AgentDraft | null> {
@@ -319,13 +328,12 @@ export async function logUsage(
 
 export async function hasFreshDraft(
   kv: KVNamespace | undefined,
-  type: string,
+  type: AgentDraft["type"],
   id: string,
   updatedAt: string
 ): Promise<boolean> {
   if (!kv) return false;
-  const key = `draft:${type}:${id}`;
-  const existing = await getDraft(kv, key);
+  const existing = await getDraft(kv, draftStorageKey({ type, id }));
   if (!existing) return false;
   // Skip if draft is newer than the item's last update
   return new Date(existing.generatedAt) > new Date(updatedAt);

--- a/web/lib/content-watch.test.ts
+++ b/web/lib/content-watch.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+
+vi.mock("./community-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./community-agent")>();
+  return { ...actual, agentChat: vi.fn() };
+});
+
+import { runLinkCheck, runSemanticDrift, watchDraftId } from "./content-watch";
+import { agentChat, draftStorageKey, type AgentDraft } from "./community-agent";
+
+const agentChatMock = agentChat as Mock;
+
+function createFakeKV() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(key: string): Promise<string | null> {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string): Promise<void> {
+      store.set(key, value);
+    },
+    async list(opts?: { prefix?: string; limit?: number }): Promise<{ keys: { name: string }[] }> {
+      const prefix = opts?.prefix ?? "";
+      const limit = opts?.limit ?? 100;
+      return {
+        keys: [...store.keys()]
+          .filter((k) => k.startsWith(prefix))
+          .slice(0, limit)
+          .map((name) => ({ name })),
+      };
+    },
+    async delete(key: string): Promise<void> {
+      store.delete(key);
+    },
+  };
+}
+
+type FakeKV = ReturnType<typeof createFakeKV>;
+
+function draftEntries(kv: FakeKV): [string, AgentDraft][] {
+  return [...kv.store.entries()]
+    .filter(([key]) => key.startsWith("draft:"))
+    .map(([key, value]) => [key, JSON.parse(value) as AgentDraft] as [string, AgentDraft]);
+}
+
+function okResponse(body = ""): Response {
+  return new Response(body, { status: 200 });
+}
+
+describe("runLinkCheck draft identity", () => {
+  let kv: FakeKV;
+
+  beforeEach(() => {
+    kv = createFakeKV();
+    // Break exactly one target; everything else answers 200 to HEAD.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        return url === "https://buymeacoffee.com/hmbown"
+          ? new Response("broken", { status: 500 })
+          : okResponse();
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates a linkcheck draft under the canonical key on first run", async () => {
+    const result = await runLinkCheck({ CURATED_KV: kv });
+
+    expect(result.ok).toBe(true);
+    expect(result.broken).toBe(1);
+
+    const drafts = draftEntries(kv);
+    expect(drafts).toHaveLength(1);
+    const [key, draft] = drafts[0];
+    expect(draft.type).toBe("linkcheck");
+    expect(draft.targetUrl).toBe("https://buymeacoffee.com/hmbown");
+    expect(key).toBe(draftStorageKey(draft));
+    expect(key.startsWith("draft:linkcheck:")).toBe(true);
+    expect(draft.id.length).toBeLessThanOrEqual(80);
+  });
+
+  it("creates no duplicate when the same breakage is seen again", async () => {
+    await runLinkCheck({ CURATED_KV: kv });
+    const second = await runLinkCheck({ CURATED_KV: kv });
+
+    expect(second.broken).toBe(1); // still broken…
+    expect(draftEntries(kv)).toHaveLength(1); // …but not re-drafted
+  });
+});
+
+describe("runSemanticDrift draft identity", () => {
+  let kv: FakeKV;
+
+  const env = () => ({ CURATED_KV: kv, DEEPSEEK_API_KEY: "test-key" });
+
+  function mockSources() {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const { hostname } = new URL(String(input));
+        if (hostname === "api.github.com") return new Response("[]", { status: 200 });
+        if (hostname === "raw.githubusercontent.com") return okResponse("# Changelog\n- things");
+        return okResponse("<html><body>site copy</body></html>");
+      })
+    );
+  }
+
+  function mockDrifts(drifts: unknown) {
+    agentChatMock.mockResolvedValue({
+      content: JSON.stringify({ drifts }),
+      usage: { input: 0, output: 0 },
+    });
+  }
+
+  const finding = {
+    page: "homepage",
+    claim: "Codewhale supports three modes",
+    evidence: "CHANGELOG: modes renamed in 0.9.0",
+    suggested_replacement: "Codewhale supports Plan / Act / Operate",
+  };
+
+  beforeEach(() => {
+    kv = createFakeKV();
+    agentChatMock.mockReset();
+    mockSources();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates a semantic-drift draft under the canonical key on first run", async () => {
+    mockDrifts([finding]);
+    const result = await runSemanticDrift(env());
+
+    expect(result).toEqual({ ok: true, drafted: 1 });
+    const drafts = draftEntries(kv);
+    expect(drafts).toHaveLength(1);
+    const [key, draft] = drafts[0];
+    expect(draft.type).toBe("semantic-drift");
+    expect(key).toBe(draftStorageKey(draft));
+    expect(key.startsWith("draft:semantic-drift:")).toBe(true);
+  });
+
+  it("creates no duplicate when the same finding is reported again", async () => {
+    mockDrifts([finding]);
+    await runSemanticDrift(env());
+    const second = await runSemanticDrift(env());
+
+    expect(second).toEqual({ ok: true, drafted: 0 });
+    expect(draftEntries(kv)).toHaveLength(1);
+  });
+
+  it("creates a new draft when the finding's evidence changes", async () => {
+    mockDrifts([finding]);
+    await runSemanticDrift(env());
+
+    mockDrifts([{ ...finding, evidence: "CHANGELOG: modes renamed in 0.9.1" }]);
+    const second = await runSemanticDrift(env());
+
+    expect(second).toEqual({ ok: true, drafted: 1 });
+    expect(draftEntries(kv)).toHaveLength(2);
+  });
+
+  it("does not collide findings whose truncated slug prefixes are identical", async () => {
+    const sharedPrefix = "a".repeat(120);
+    const first = { ...finding, claim: `${sharedPrefix}-first-variant` };
+    const second = { ...finding, claim: `${sharedPrefix}-second-variant` };
+    mockDrifts([first, second]);
+
+    const result = await runSemanticDrift(env());
+
+    expect(result).toEqual({ ok: true, drafted: 2 });
+    const drafts = draftEntries(kv);
+    expect(drafts).toHaveLength(2);
+    const keys = drafts.map(([key]) => key);
+    expect(new Set(keys).size).toBe(2);
+    for (const [, draft] of drafts) {
+      expect(draft.id.length).toBeLessThanOrEqual(80);
+    }
+  });
+
+  it("bounds excessive model output and skips malformed entries", async () => {
+    const flood = Array.from({ length: 500 }, (_, i) => ({
+      ...finding,
+      claim: `claim number ${i}`,
+    }));
+    const malformed = [
+      { page: "evil-page", claim: "x", evidence: "y", suggested_replacement: "z" },
+      { page: "homepage", claim: "", evidence: "y", suggested_replacement: "z" },
+      { page: "homepage", claim: "x", evidence: 42, suggested_replacement: "z" },
+      "not-an-object",
+      null,
+    ];
+    mockDrifts([...malformed, ...flood]);
+
+    const result = await runSemanticDrift(env());
+
+    expect(result.ok).toBe(true);
+    expect(result.drafted).toBe(10); // MAX_DRIFT_DRAFTS_PER_RUN
+    expect(draftEntries(kv)).toHaveLength(10);
+  });
+
+  it("treats a non-array drifts payload as empty", async () => {
+    mockDrifts(undefined);
+    const result = await runSemanticDrift(env());
+    expect(result).toEqual({ ok: true, drafted: 0 });
+  });
+});
+
+describe("watchDraftId", () => {
+  it("is deterministic for the same identity", async () => {
+    const a = await watchDraftId("some-slug", "identity");
+    const b = await watchDraftId("some-slug", "identity");
+    expect(a).toBe(b);
+  });
+
+  it("separates identities that share a long slug prefix", async () => {
+    const prefix = `https://example.com/${"a".repeat(120)}`;
+    const a = await watchDraftId(prefix, `linkcheck\n${prefix}?x=1`);
+    const b = await watchDraftId(prefix, `linkcheck\n${prefix}?x=2`);
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(80);
+    expect(b.length).toBeLessThanOrEqual(80);
+  });
+});

--- a/web/lib/content-watch.ts
+++ b/web/lib/content-watch.ts
@@ -13,13 +13,39 @@
  * Both surface as drafts in CURATED_KV under `draft:linkcheck:<...>` and
  * `draft:semantic-drift:<...>`, picked up by the existing /admin listing.
  */
-import { agentChat, saveDraft, type AgentDraft, type DeepSeekEnv, VOICE_CONSTRAINTS } from "./community-agent";
+import { agentChat, draftStorageKey, getDraft, saveDraft, type AgentDraft, type DeepSeekEnv, VOICE_CONSTRAINTS } from "./community-agent";
 
 interface KVNamespace {
   get(k: string): Promise<string | null>;
   put(k: string, v: string, o?: { expirationTtl?: number }): Promise<void>;
   list(o?: { prefix?: string; limit?: number }): Promise<{ keys: { name: string }[] }>;
   delete(k: string): Promise<void>;
+}
+
+// --- Canonical draft identities ---
+//
+// Watcher draft IDs are deterministic: a readable slug plus a ~64-bit
+// SHA-256 suffix over the finding's full identity, capped at 80 characters.
+// Re-running a watcher over an unchanged finding reproduces the same key (so
+// the open-draft dedup check skips it); any change to the finding's identity
+// produces a new key (so changed findings are drafted again instead of being
+// silently swallowed by a truncated-prefix collision).
+const WATCH_DRAFT_ID_MAX = 80;
+const WATCH_DRAFT_HASH_HEX = 16; // 64 bits of SHA-256
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function slugify(input: string): string {
+  return input.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase();
+}
+
+export async function watchDraftId(slugSource: string, identity: string): Promise<string> {
+  const hash = (await sha256Hex(identity)).slice(0, WATCH_DRAFT_HASH_HEX);
+  const slug = slugify(slugSource).slice(0, WATCH_DRAFT_ID_MAX - WATCH_DRAFT_HASH_HEX - 1);
+  return `${slug}-${hash}`;
 }
 
 interface WatchEnv {
@@ -98,22 +124,23 @@ export async function runLinkCheck(env: WatchEnv): Promise<{ ok: boolean; checke
     results,
   }), { expirationTtl: 60 * 60 * 24 * 14 });
 
-  // Write drafts ONLY for new breakages — dedup by URL on the open-draft list.
+  // Write drafts ONLY for new breakages — dedup on the canonical draft key,
+  // derived from the full URL identity (the hash suffix keeps long URLs with
+  // identical slug prefixes distinct).
   for (const b of broken) {
-    const id = b.url.replace(/[^a-z0-9]+/gi, "-").slice(0, 80);
-    const key = `draft:linkcheck:${id}`;
-    const existing = await env.CURATED_KV.get(key);
-    if (existing) continue; // already flagged; don't churn
-
+    const id = await watchDraftId(b.url, `linkcheck\n${b.url}`);
     const draft: AgentDraft = {
       id,
-      type: "triage", // reuse existing draft type so /admin renders it
+      type: "linkcheck",
       targetUrl: b.url,
       bodyEn: `**Broken link** (auto-detected by daily watch cron)\n\n- Label: **${b.label}**\n- URL: ${b.url}\n- HTTP status: ${b.status}\n- Latency: ${b.ms}ms\n\nThis URL is referenced in codewhale.net copy. Update the source page or fix the destination.\n\n— drafted by community assistant, pending maintainer review`,
       bodyZh: `**链接失效**（每日巡检自动发现）\n\n- 名称：**${b.label}**\n- 地址：${b.url}\n- HTTP 状态：${b.status}\n- 延迟：${b.ms}ms\n\n该地址被 codewhale.net 文案引用，请更新源页面或修复目标。\n\n— 由社区助理草拟，待维护者审阅`,
       generatedAt: new Date().toISOString(),
       posted: false,
     };
+    const existing = await getDraft(env.CURATED_KV, draftStorageKey(draft));
+    if (existing) continue; // already flagged; don't churn
+
     await saveDraft(env.CURATED_KV, draft);
   }
 
@@ -216,6 +243,41 @@ function stripHtmlForPrompt(input: string): string {
   return collapseWhitespace(out).slice(0, 8000);
 }
 
+// The model's drift list is untrusted input: bound it before any KV fanout so
+// a runaway or hostile response cannot flood the draft queue, and drop entries
+// whose shape does not match the prompt's contract.
+const MAX_DRIFT_DRAFTS_PER_RUN = 10;
+const DRIFT_FIELD_MAX = 2_000;
+const DRIFT_PAGES = new Set(["homepage", "docs", "install", "contribute", "roadmap"]);
+
+interface DriftFinding {
+  page: string;
+  claim: string;
+  evidence: string;
+  suggested_replacement: string;
+}
+
+function validateDriftFindings(raw: unknown): DriftFinding[] {
+  if (!Array.isArray(raw)) return [];
+  const findings: DriftFinding[] = [];
+  for (const entry of raw) {
+    if (findings.length >= MAX_DRIFT_DRAFTS_PER_RUN) break;
+    if (typeof entry !== "object" || entry === null) continue;
+    const { page, claim, evidence, suggested_replacement } = entry as Record<string, unknown>;
+    if (typeof page !== "string" || !DRIFT_PAGES.has(page)) continue;
+    if (typeof claim !== "string" || !claim.trim()) continue;
+    if (typeof evidence !== "string" || !evidence.trim()) continue;
+    if (typeof suggested_replacement !== "string" || !suggested_replacement.trim()) continue;
+    findings.push({
+      page,
+      claim: claim.slice(0, DRIFT_FIELD_MAX),
+      evidence: evidence.slice(0, DRIFT_FIELD_MAX),
+      suggested_replacement: suggested_replacement.slice(0, DRIFT_FIELD_MAX),
+    });
+  }
+  return findings;
+}
+
 export async function runSemanticDrift(env: WatchEnv): Promise<{ ok: boolean; drafted: number; reason?: string }> {
   if (!env.CURATED_KV || !env.DEEPSEEK_API_KEY) {
     return { ok: false, drafted: 0, reason: "missing CURATED_KV or DEEPSEEK_API_KEY" };
@@ -272,7 +334,7 @@ ${docsText}`;
   }
 
   // Extract JSON (jsonMode usually returns clean JSON, but defend against fences)
-  let parsed: { drifts?: { page: string; claim: string; evidence: string; suggested_replacement: string }[] };
+  let parsed: { drifts?: unknown };
   try {
     const trimmed = response.content.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/i, "").trim();
     parsed = JSON.parse(trimmed);
@@ -280,24 +342,27 @@ ${docsText}`;
     return { ok: false, drafted: 0, reason: "LLM returned non-JSON" };
   }
 
-  const drifts = parsed.drifts ?? [];
+  const drifts = validateDriftFindings(parsed.drifts);
   let drafted = 0;
   for (const d of drifts) {
-    const id = `${d.page}-${d.claim.slice(0, 40).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`.slice(0, 80);
-    const key = `draft:semantic-drift:${id}`;
-    const existing = await env.CURATED_KV.get(key);
-    if (existing) continue;
-
+    // Identity covers the full finding — page, claim, evidence, and
+    // replacement — so a re-run over an unchanged finding dedups, while a
+    // changed finding lands under a new key as a fresh draft.
+    const identity = [d.page, d.claim, d.evidence, d.suggested_replacement].join("\n");
+    const id = await watchDraftId(`${d.page}-${d.claim.slice(0, 40)}`, `semantic-drift\n${identity}`);
     const body = `Page: **${d.page}**\n\nClaim that may be drifted:\n> ${d.claim}\n\nEvidence:\n> ${d.evidence}\n\nSuggested replacement:\n> ${d.suggested_replacement}\n\n— drafted by community assistant, pending maintainer review`;
     const draft: AgentDraft = {
       id,
-      type: "triage",
+      type: "semantic-drift",
       targetUrl: `https://codewhale.net/en/${d.page === "homepage" ? "" : d.page}`,
       bodyEn: body,
       bodyZh: body,
       generatedAt: new Date().toISOString(),
       posted: false,
     };
+    const existing = await getDraft(env.CURATED_KV, draftStorageKey(draft));
+    if (existing) continue;
+
     await saveDraft(env.CURATED_KV, draft);
     drafted++;
   }


### PR DESCRIPTION
## What

Fixes #4453. The content watchers (`runLinkCheck`, `runSemanticDrift`) looked drafts up under `draft:linkcheck:*` / `draft:semantic-drift:*` but `saveDraft` wrote them under `draft:triage:*` (the hardcoded `AgentDraft.type`), so the dedup check was dead code: every cron run re-drafted every known finding, and /admin mislabeled watcher drafts as issue triage. Draft IDs were also truncated slugs that collide at 80 chars, and the semantic-drift model output was fanned out to KV with no bound or validation.

## Changes

- **Canonical key**: `draftStorageKey(Pick<AgentDraft, "type" | "id">)` in `web/lib/community-agent.ts`, now used by `saveDraft`, `hasFreshDraft`, both watchers, and the /admin client. `AgentDraft.type` gains `"linkcheck" | "semantic-drift"`.
- **Deterministic IDs**: readable slug + 64-bit SHA-256 suffix over the finding's full identity, max 80 chars. Linkcheck identity = full URL; semantic-drift identity = page + claim + evidence + replacement. Unchanged findings dedup, changed findings land as new drafts, and long IDs with identical slug prefixes no longer collide.
- **Bounded model output**: semantic-drift findings are validated (page allowlist, non-empty string fields, 2000-char caps) and capped at 10 drafts/run before any KV writes.
- **Truthful admin labels**: "Broken Link" / "Content Drift" (en+zh) instead of mislabeled "Issue Triage".
- **Same-class fix in tasks**: `hasFreshDraft` in triage/pr-review was called with `"issue"`/`"pr"` while drafts save as `"triage"`/`"pr-review"` — those dedup checks never matched either; now aligned.

Review/post/discard behavior is unchanged — the post route treats `draftKey` as opaque.

## Tests

New `web/lib/content-watch.test.ts` (fake KV, 10 tests): first-run creation, unchanged re-run dedup, changed-finding re-draft, truncated-prefix collision separation, bounded flood input, malformed entries, non-array payload, ID determinism/length.

## Gates

- `npm test` — 73 passed (9 files)
- `npm run check:facts` — OK
- `npm run check:docs` — OK
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — OK

## Coordination note

Touches `community-agent.ts` / `community-agent-tasks.ts`, which overlap with a separately staged patch; the key-derivation seam (`draftStorageKey`) is the only shared surface and is additive.