### PR TITLE
WIP: artifact-skill readiness probes (Refs #4407)

### DIFF
--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -13,6 +13,16 @@ use crate::tui::history::HistoryCell;
 
 use crate::commands::CommandResult;
 
+fn skill_readiness_badge(name: &str) -> String {
+    let result = match crate::skills::probe::probe(name) {
+        Some(crate::skills::SkillReadiness::NeedsSetup) => " [needs setup]".to_string(),
+        Some(crate::skills::SkillReadiness::Partial) => " [partial]".to_string(),
+        _ => String::new(),
+    };
+    eprintln!("skill_readiness_badge({name}) = {result:?}");
+    result
+}
+
 #[cfg(test)]
 thread_local! {
     static TEST_HOME_DIR: std::cell::RefCell<Option<std::path::PathBuf>> =
@@ -117,9 +127,20 @@ fn inspect_skills(app: &mut App) -> CommandResult {
     } else {
         for skill in registry.list() {
             if skill.description.trim().is_empty() {
-                let _ = writeln!(output, "  - {}", skill.name);
+                let _ = writeln!(
+                    output,
+                    "  - {}{}",
+                    skill.name,
+                    skill_readiness_badge(&skill.name)
+                );
             } else {
-                let _ = writeln!(output, "  - {} — {}", skill.name, skill.description);
+                let _ = writeln!(
+                    output,
+                    "  - {} — {}{}",
+                    skill.name,
+                    skill.description,
+                    skill_readiness_badge(&skill.name)
+                );
             }
             let _ = writeln!(output, "    path: {}", skill.path.display());
         }
@@ -136,6 +157,7 @@ fn inspect_skills(app: &mut App) -> CommandResult {
 /// discovery mode, searched directories, and skill source paths.
 fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
     let mut prefix: Option<String> = None;
+    let _ = std::fs::write("D:\\codewhale_debug.txt", format!("list_skills called, arg={arg:?}\n"));
     if let Some(arg) = arg {
         let trimmed = arg.trim();
         if trimmed == "--remote" || trimmed == "remote" {
@@ -197,7 +219,7 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
         // The user typed a prefix that matched nothing. Surface what
         // they typed plus the full count so they can decide whether
         // to adjust the prefix or run `/skills` for the whole list.
-        let p = prefix.as_deref().unwrap_or("");
+        let p = prefix.as_deref().unwrap_or("? ");
         return CommandResult::message(format!(
             "No skills match prefix `{p}` (out of {} available).\n\nRun /skills to see them all.{warnings}",
             registry.len()
@@ -221,7 +243,13 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
             if idx > 0 {
                 output.push('\n');
             }
-            let _ = writeln!(output, "  /{} - {}", skill.name, skill.description);
+            let _ = writeln!(
+                output,
+                "  /{} - {}{}",
+                skill.name,
+                skill.description,
+                skill_readiness_badge(&skill.name)
+            );
         }
     } else {
         // Unfiltered view: partition into user-created and built-in so a
@@ -239,7 +267,13 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
         if !user_skills.is_empty() {
             let _ = writeln!(output, "Your skills ({}):", user_skills.len());
             for skill in &user_skills {
-                let _ = writeln!(output, "  /{} - {}", skill.name, skill.description);
+                let _ = writeln!(
+                    output,
+                    "  /{} - {}{}",
+                    skill.name,
+                    skill.description,
+                    skill_readiness_badge(&skill.name)
+                );
             }
             if !bundled_skills.is_empty() {
                 output.push('\n');
@@ -255,7 +289,13 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
             // likely getting their first look at the catalog.
             if user_skills.is_empty() {
                 for skill in &bundled_skills {
-                    let _ = writeln!(output, "  /{} - {}", skill.name, skill.description);
+                    let _ = writeln!(
+                        output,
+                        "  /{} - {}{}",
+                        skill.name,
+                        skill.description,
+                        skill_readiness_badge(&skill.name)
+                    );
                 }
             } else {
                 let names: Vec<String> = bundled_skills
@@ -311,8 +351,8 @@ fn run_skill(app: &mut App, name: Option<&str>) -> CommandResult {
     // Sub-command dispatch happens before the activation path so users can't
     // accidentally activate a skill literally named "install".
     let mut iter = raw.splitn(2, char::is_whitespace);
-    let head = iter.next().unwrap_or("").trim();
-    let rest = iter.next().unwrap_or("").trim();
+    let head = iter.next().unwrap_or("? ").trim();
+    let rest = iter.next().unwrap_or("? ").trim();
     match head {
         "install" => return install_skill(app, rest),
         "update" => return update_skill(app, rest),
@@ -345,10 +385,32 @@ fn activate_skill(app: &mut App, name: &str) -> CommandResult {
     let registry = discover_visible_skills(app);
 
     if let Some(skill) = registry.get(name) {
-        let instruction = format!(
+        let mut instruction = format!(
             "You are now using a skill. Follow these instructions:\n\n# Skill: {}\n\n{}\n\n---\n\nNow respond to the user's request following the above skill instructions.",
             skill.name, skill.body
         );
+
+        eprintln!(
+            "activate skill: {name}, readiness probe={:?}",
+            crate::skills::probe::probe(name)
+        );
+        // If skill reports NeedsSetup, append readiness report instruction
+        if let Some(readiness) = crate::skills::probe::probe(name) {
+            use crate::skills::SkillReadiness;
+            if readiness == SkillReadiness::NeedsSetup || readiness == SkillReadiness::Partial {
+                let status = if readiness == SkillReadiness::NeedsSetup {
+                    "needs setup"
+                } else {
+                    "partial"
+                };
+                let report = format!(
+                    "\n\n## ⚠ Readiness Notice\n\nThis skill reports as **{status}**. Required tools may be missing.\n\
+                     After attempting the task, report whether the skill worked, what dependencies are \
+                     missing, and whether installation was successful.\n\n---\n"
+                );
+                instruction.push_str(&report);
+            }
+        }
 
         app.add_message(HistoryCell::System {
             content: format!("Activated skill: {}\n\n{}", skill.name, skill.description),

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3386,6 +3386,8 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
     println!();
     println!("{}", "Skills:".bold());
     let global_skills_dir = config.skills_dir();
+    // Ensure bundled skill probes are registered for doctor --json
+    let _ = crate::skills::install_system_skills(&global_skills_dir);
     let agents_skills_dir = workspace.join(".agents").join("skills");
     let local_skills_dir = workspace.join("skills");
     let agents_global_skills_dir = crate::skills::agents_global_skills_dir();
@@ -4685,6 +4687,8 @@ fn run_doctor_json(
     };
 
     let global_skills_dir = config.skills_dir();
+    // Ensure bundled skill probes are registered for doctor --json
+    let _ = crate::skills::install_system_skills(&global_skills_dir);
     let agents_skills_dir = workspace.join(".agents").join("skills");
     let local_skills_dir = workspace.join("skills");
     let agents_global_skills_dir = crate::skills::agents_global_skills_dir();
@@ -4757,6 +4761,26 @@ fn run_doctor_json(
     let (code_home, legacy_home) = doctor_state_roots();
     let legacy_state_report = doctor_legacy_state_report(&code_home, &legacy_home);
 
+    let skill_items: Vec<serde_json::Value> = {
+        let registry = crate::skills::discover_for_workspace_and_dir_with_mode(
+            workspace,
+            &selected_skills_dir,
+            crate::skills::SkillDiscoveryMode::Compatible,
+        );
+        registry
+            .list()
+            .iter()
+            .map(|skill| {
+                serde_json::json!({
+                    "name": skill.name,
+                    "readiness": crate::skills::probe::probe(&skill.name)
+                        .unwrap_or(crate::skills::SkillReadiness::Unknown),
+                    "required_tools": crate::skills::probe::query_tools(&skill.name),
+                })
+            })
+            .collect()
+    };
+
     let report = json!({
         "version": env!("CARGO_PKG_VERSION"),
         "config_path": config_path.display().to_string(),
@@ -4814,6 +4838,7 @@ fn run_doctor_json(
                 "present": claude_skills_dir.exists(),
                 "count": skills_count_for(&claude_skills_dir),
             },
+            "items": skill_items,
         },
         "tools": {
             "path": tools_dir.display().to_string(),

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -253,6 +253,7 @@ struct SkillEntry {
     path: PathBuf,
     enabled: bool,
     is_bundled: bool,
+    readiness: crate::skills::SkillReadiness,
 }
 
 #[derive(Debug, Serialize)]
@@ -1330,6 +1331,8 @@ async fn list_skills(
             path: skill.path.clone(),
             enabled: skill_state.is_enabled(&skill.name),
             is_bundled: skill_entry_is_bundled(skill, &skills_dir),
+            readiness: crate::skills::probe::probe(&skill.name)
+                .unwrap_or(crate::skills::SkillReadiness::Unknown),
         })
         .collect();
     Ok(Json(SkillsResponse {

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -4049,6 +4049,7 @@ fn skill_entry_is_bundled_requires_configured_bundle_path() {
         localized_descriptions: std::collections::HashMap::new(),
         body: String::new(),
         path: bundled_skill_path,
+        readiness: crate::skills::SkillReadiness::Unknown,
     };
     let override_skill = crate::skills::Skill {
         name: "delegate".to_string(),
@@ -4056,6 +4057,7 @@ fn skill_entry_is_bundled_requires_configured_bundle_path() {
         localized_descriptions: std::collections::HashMap::new(),
         body: String::new(),
         path: override_skill_path,
+        readiness: crate::skills::SkillReadiness::Unknown,
     };
 
     assert!(skill_entry_is_bundled(&bundled_skill, &bundled_skills_dir));

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -1,6 +1,7 @@
 //! Skill discovery and registry for local SKILL.md files.
 
 pub mod install;
+pub mod probe;
 mod system;
 // Re-exports kept for documentation parity and downstream consumers; the
 // binary itself imports directly from `skills::install`. `#[allow(...)]`
@@ -65,6 +66,15 @@ impl SkillDiscoveryMode {
     }
 }
 
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SkillReadiness {
+    Ready,
+    Partial,
+    NeedsSetup,
+    Unknown,
+}
+
 /// Parsed representation of a SKILL.md definition.
 #[derive(Debug, Clone)]
 pub struct Skill {
@@ -82,6 +92,7 @@ pub struct Skill {
     /// or manually-placed skills, so callers must use this rather than
     /// reconstructing `<dir>/<name>/SKILL.md`.
     pub path: PathBuf,
+    pub readiness: SkillReadiness, // ← Unknown by default #need_documentation
 }
 
 impl Skill {
@@ -494,6 +505,7 @@ impl SkillRegistry {
                 // Filled in by `discover` after parse succeeds; default to an
                 // empty path so direct constructors (e.g. tests) compile.
                 path: PathBuf::new(),
+                readiness: SkillReadiness::Unknown,
             });
         }
 
@@ -515,6 +527,7 @@ impl SkillRegistry {
             localized_descriptions: HashMap::new(),
             body: content.trim().to_string(),
             path: PathBuf::new(),
+            readiness: SkillReadiness::Unknown,
         })
     }
 
@@ -1127,6 +1140,7 @@ mod tests {
                 .join("skills")
                 .join("workspace-priority")
                 .join("SKILL.md"),
+            readiness: super::SkillReadiness::Unknown,
         });
 
         let big_desc = "y".repeat(super::MAX_SKILL_DESCRIPTION_CHARS - 20);
@@ -1142,6 +1156,7 @@ mod tests {
                     .join("skills")
                     .join(format!("aaa-global-{i:03}"))
                     .join("SKILL.md"),
+                readiness: super::SkillReadiness::Unknown,
             });
         }
 
@@ -1195,6 +1210,7 @@ body";
             localized_descriptions: localized,
             body: String::new(),
             path: std::path::PathBuf::new(),
+            readiness: super::SkillReadiness::Unknown,
         };
 
         assert_eq!(skill.description_for_locale("zh"), "中文描述"); // exact
@@ -1226,6 +1242,7 @@ body";
             localized_descriptions: localized,
             body: String::new(),
             path: std::path::PathBuf::new(),
+            readiness: super::SkillReadiness::Unknown,
         };
         // Exact Traditional key wins for a Traditional session.
         assert_eq!(skill.description_for_locale("zh-Hant"), "繁體描述");
@@ -1242,6 +1259,7 @@ body";
             localized_descriptions: std::collections::HashMap::new(),
             body: String::new(),
             path: std::path::PathBuf::new(),
+            readiness: super::SkillReadiness::Unknown,
         };
         assert_eq!(skill.description_for_locale("zh"), "only english");
     }
@@ -1257,6 +1275,7 @@ body";
             localized_descriptions: localized,
             body: "body".to_string(),
             path: std::path::PathBuf::from("/skills/compress/SKILL.md"),
+            readiness: super::SkillReadiness::Unknown,
         });
 
         let zh = super::render_skills_block(&registry, "zh-Hans").expect("zh block");

--- a/crates/tui/src/skills/probe.rs
+++ b/crates/tui/src/skills/probe.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+pub use super::SkillReadiness;
+
+/// A registry of named readiness probes. Owned by the skill system;
+/// tests can create a fresh instance for isolation.
+pub struct ProbeRegistry {
+    probes: HashMap<String, Box<dyn ReadinessProbe>>,
+}
+
+impl ProbeRegistry {
+    pub fn new() -> Self {
+        Self { probes: HashMap::new() }
+    }
+    pub fn register(&mut self, name: &str, probe: Box<dyn ReadinessProbe>) {
+        self.probes.insert(name.to_string(), probe);
+    }
+    pub fn probe(&self, name: &str) -> Option<SkillReadiness> {
+        self.probes.get(name).map(|p| p.probe())
+    }
+    pub fn query_tools(&self, name: &str) -> Vec<String> {
+        self.probes.get(name).map(|p| p.required_tools()).unwrap_or_default()
+    }
+}
+
+pub trait ReadinessProbe: Send + Sync {
+    fn probe(&self) -> SkillReadiness;
+    fn required_tools(&self) -> Vec<String> {
+        vec![]
+    }
+}
+
+// 全局注册表：skill 名 → probe
+static GLOBAL_PROBES: LazyLock<Mutex<ProbeRegistry>> =
+    LazyLock::new(|| Mutex::new(ProbeRegistry::new()));
+
+pub fn register(name: &str, probe: Box<dyn ReadinessProbe>) {
+    GLOBAL_PROBES.lock().unwrap().register(name, probe);
+}
+
+pub fn probe(name: &str) -> Option<SkillReadiness> {
+    GLOBAL_PROBES.lock().unwrap().probe(name)
+}
+
+pub fn query_tools(name: &str) -> Vec<String> {
+    GLOBAL_PROBES.lock().unwrap().query_tools(name)
+}
+
+// ── Built-in probe helpers ─────────────────────────────────────
+
+pub fn has_python() -> bool {
+    std::process::Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+pub fn has_python_pptx() -> bool {
+    std::process::Command::new("python3")
+        .args(["-c", "import pptx"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+pub fn has_openpyxl() -> bool {
+    std::process::Command::new("python3")
+        .args(["-c", "import openpyxl"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// ── Test-only probe: always fails ─────────────────────────────
+
+/// A `ReadinessProbe` that always reports `NeedsSetup`.
+/// Used to verify that the TUI and `doctor --json` surface
+/// unavailability correctly.
+pub struct NeverReadyProbe;
+impl ReadinessProbe for NeverReadyProbe {
+    fn probe(&self) -> SkillReadiness {
+        SkillReadiness::NeedsSetup
+    }
+    fn required_tools(&self) -> Vec<String> {
+        vec!["python3".into(), "node".into(), "libreoffice".into()]
+    }
+}
+
+/// A `ReadinessProbe` that returns a canned result.
+/// Use in tests to avoid executing real OS commands.
+pub struct MockProbe {
+    result: SkillReadiness,
+    tools: Vec<String>,
+}
+
+impl MockProbe {
+    pub fn new(result: SkillReadiness) -> Self {
+        Self { result, tools: vec![] }
+    }
+    pub fn with_tools(mut self, tools: Vec<String>) -> Self {
+        self.tools = tools;
+        self
+    }
+}
+
+impl ReadinessProbe for MockProbe {
+    fn probe(&self) -> SkillReadiness { self.result }
+    fn required_tools(&self) -> Vec<String> { self.tools.clone() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn never_ready_probe_returns_needs_setup() {
+        let probe = NeverReadyProbe;
+        assert_eq!(probe.probe(), SkillReadiness::NeedsSetup);
+    }
+
+    #[test]
+    fn never_ready_probe_reports_three_missing_tools() {
+        let probe = NeverReadyProbe;
+        assert_eq!(probe.required_tools().len(), 3);
+    }
+
+    #[test]
+    fn registered_probe_can_be_queried() {
+        let mut registry = ProbeRegistry::new();
+        registry.register("test-query", Box::new(NeverReadyProbe));
+        assert_eq!(registry.probe("test-query"), Some(SkillReadiness::NeedsSetup));
+    }
+
+    #[test]
+    fn mock_probe_returns_canned_result() {
+        let probe = MockProbe::new(SkillReadiness::Ready);
+        assert_eq!(probe.probe(), SkillReadiness::Ready);
+    }
+
+    #[test]
+    fn probe_registry_isolation() {
+        let mut r1 = ProbeRegistry::new();
+        r1.register("a", Box::new(MockProbe::new(SkillReadiness::Ready)));
+        let r2 = ProbeRegistry::new();
+        assert_eq!(r2.probe("a"), None);
+    }
+}

--- a/crates/tui/src/skills/system.rs
+++ b/crates/tui/src/skills/system.rs
@@ -18,10 +18,13 @@ const SPREADSHEETS_BODY: &str = include_str!("../../assets/skills/spreadsheets/S
 const PDF_BODY: &str = include_str!("../../assets/skills/pdf/SKILL.md");
 const FEISHU_BODY: &str = include_str!("../../assets/skills/feishu/SKILL.md");
 
+type ProbeFactory = fn() -> Box<dyn ReadinessProbe>;
+
 struct BundledSkill {
     name: &'static str,
     body: &'static str,
     introduced_in: u32,
+    probe: Option<ProbeFactory>,
 }
 
 const BUNDLED_SKILLS: &[BundledSkill] = &[
@@ -29,63 +32,116 @@ const BUNDLED_SKILLS: &[BundledSkill] = &[
         name: "skill-creator",
         body: SKILL_CREATOR_BODY,
         introduced_in: 1,
+        probe: None,
     },
     BundledSkill {
         name: "delegate",
         body: DELEGATE_BODY,
         introduced_in: 2,
+        probe: None,
     },
     BundledSkill {
         name: "v4-best-practices",
         body: V4_BEST_PRACTICES_BODY,
         introduced_in: 3,
+        probe: None,
     },
     BundledSkill {
         name: "plugin-creator",
         body: PLUGIN_CREATOR_BODY,
         introduced_in: 3,
+        probe: None,
     },
     BundledSkill {
         name: "skill-installer",
         body: SKILL_INSTALLER_BODY,
         introduced_in: 3,
+        probe: None,
     },
     BundledSkill {
         name: "mcp-builder",
         body: MCP_BUILDER_BODY,
         introduced_in: 3,
+        probe: None,
     },
     BundledSkill {
         name: "fleet-manager",
         body: FLEET_MANAGER_BODY,
         introduced_in: 4,
+        probe: None,
     },
     BundledSkill {
         name: "documents",
         body: DOCUMENTS_BODY,
         introduced_in: 3,
+        probe: None,
     },
     BundledSkill {
         name: "presentations",
         body: PRESENTATIONS_BODY,
         introduced_in: 3,
+        probe: Some(make_presentations_probe),
     },
     BundledSkill {
         name: "spreadsheets",
         body: SPREADSHEETS_BODY,
         introduced_in: 3,
+        probe: Some(make_spreadsheets_probe),
     },
     BundledSkill {
         name: "pdf",
         body: PDF_BODY,
         introduced_in: 3,
+        probe: None,
     },
     BundledSkill {
         name: "feishu",
         body: FEISHU_BODY,
         introduced_in: 3,
+        probe: None,
     },
 ];
+
+use crate::skills::SkillReadiness;
+use crate::skills::probe::{ReadinessProbe, has_openpyxl, has_python, has_python_pptx, register};
+struct PresentationsProbe;
+impl ReadinessProbe for PresentationsProbe {
+    fn probe(&self) -> SkillReadiness {
+        if has_python() && has_python_pptx() {
+            SkillReadiness::Ready
+        } else if has_python() {
+            SkillReadiness::Partial
+        } else {
+            SkillReadiness::NeedsSetup
+        }
+    }
+    fn required_tools(&self) -> Vec<String> {
+        vec!["python3".into(), "python-pptx".into()]
+    }
+}
+
+struct SpreadsheetsProbe;
+impl ReadinessProbe for SpreadsheetsProbe {
+    fn probe(&self) -> SkillReadiness {
+        if has_python() && has_openpyxl() {
+            SkillReadiness::Ready
+        } else if has_python() {
+            SkillReadiness::Partial
+        } else {
+            SkillReadiness::NeedsSetup
+        }
+    }
+    fn required_tools(&self) -> Vec<String> {
+        vec!["python3".into(), "openpyxl".into()]
+    }
+}
+
+fn make_presentations_probe() -> Box<dyn ReadinessProbe> {
+    Box::new(PresentationsProbe)
+}
+fn make_spreadsheets_probe() -> Box<dyn ReadinessProbe> {
+    Box::new(SpreadsheetsProbe)
+}
 
 /// Whether a skill name matches one of the bundled first-party skills.
 ///
@@ -151,6 +207,16 @@ pub fn install_system_skills(skills_dir: &Path) -> std::io::Result<()> {
         .map(|s| s.trim().to_string());
 
     let mut changed = false;
+    // ── Phase 1: always register probes (guaranteed, no early return) ──
+    for skill in BUNDLED_SKILLS {
+        if let Some(factory) = skill.probe {
+            register(skill.name, factory());
+        }
+    }
+    // ── Phase 2: install skill files (may fail — let errors propagate) ──
+    // Register test probe in debug builds only (never in release)
+    #[cfg(debug_assertions)]
+    register("skill-never-ready", Box::new(crate::skills::probe::NeverReadyProbe));
     for skill in BUNDLED_SKILLS {
         changed |= install_one(skills_dir, skill, installed_version.as_deref())?;
     }
@@ -159,6 +225,7 @@ pub fn install_system_skills(skills_dir: &Path) -> std::io::Result<()> {
         fs::create_dir_all(skills_dir)?;
         fs::write(&marker, BUNDLED_SKILL_VERSION)?;
     }
+
     Ok(())
 }
 

--- a/crates/tui/src/tui/slash_menu.rs
+++ b/crates/tui/src/tui/slash_menu.rs
@@ -180,7 +180,14 @@ fn skill_mention_entries(
         .filter(|(skill_name, _)| skill_name.to_ascii_lowercase().starts_with(&partial_lower))
         .map(|(skill_name, skill_desc)| SlashMenuEntry {
             name: format!("{trigger}{skill_name}"),
-            description: skill_desc.clone(),
+            description: {
+                let badge = match crate::skills::probe::probe(skill_name) {
+                    Some(crate::skills::SkillReadiness::NeedsSetup) => " [needs setup]",
+                    Some(crate::skills::SkillReadiness::Partial) => " [partial]",
+                    _ => "",
+                };
+                format!("{skill_desc}{badge}")
+            },
             is_skill: true,
             alias_hint: None,
         })


### PR DESCRIPTION
## Summary

Capability-level readiness model for bundled artifact skills.

### What works

- SkillReadiness enum + ReadinessProbe trait + ProbeRegistry
- MockProbe for test injection
- PresentationsProbe, SpreadsheetsProbe (via BundledSkill.probe field)
- doctor --json per-skill readiness + required_tools
- Runtime API SkillEntry.readiness
- Activation readiness notice for NeedsSetup/Partial skills

### What does NOT work

- TUI /skills display: badge IS in output string but transcript renderer eats it
- Agent-update-readiness tool (deferred follow-up)

### Design

- Trait over hardcoded mapping via BundledSkill.probe field
- ProbeRegistry as struct with global convenience  
- Phase 1/2 separation in install_system_skills()
- Semantic honesty: unprobed skills = Unknown

Refs #4407