### PR TITLE
feat(tui): ship a first-class local web client over the Runtime API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `codewhale web [--port 7878]`, a first-class loopback-only browser
+  client over the canonical Runtime API. The dependency-free embedded shell
+  supports thread lifecycle, snapshot-then-SSE transcripts, turn start/steer/
+  interrupt, approvals, and user questions, including pending-request recovery
+  across tab reloads, while leaving unsupported managed,
+  files, PTY, model-selection, and Fleet controls absent. Browser auth uses a
+  short-lived one-time loopback capability exchanged for an opaque, bounded,
+  process-local HttpOnly, SameSite=Strict session cookie with a same-origin
+  mutation guard; Runtime tokens never enter URLs, HTML, browser storage, logs,
+  or browser-launch arguments (#4423).
 - Add OpenCode Go as a first-class, subscription-backed Chat Completions
   provider with `[providers.opencode_go]`, `OPENCODE_GO_API_KEY`, and the eight
   models currently documented on its `/v1/chat/completions` endpoint. Models

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -307,6 +307,7 @@ Forwarded serve options:
       --mcp                 Start MCP server over stdio
       --http                Start runtime HTTP/SSE API server
       --mobile              Start runtime HTTP/SSE API server with the mobile control page
+      --web                 Start the embedded loopback-only browser client
       --qr                  Show a QR code for the mobile URL (requires --mobile)
       --acp                 Start ACP server over stdio for editor clients
       --host <HOST>         Bind host (default 127.0.0.1; --mobile defaults to 0.0.0.0)
@@ -320,6 +321,11 @@ Forwarded serve options:
 aliases for `codewhale app-server --http` and `codewhale app-server --mobile`.
 New integrations should prefer `codewhale app-server`.")]
     Serve(TuiPassthroughArgs),
+    /// Open the first-class local browser client over the canonical Runtime API.
+    #[command(
+        after_help = "The browser receives a one-time loopback bootstrap capability, never the Runtime token.\nThe capability is exchanged for a bounded, process-local HttpOnly, SameSite=Strict web session and then invalidated."
+    )]
+    Web(WebArgs),
     /// Generate shell completions for the TUI binary.
     Completions(TuiPassthroughArgs),
     /// Configure provider credentials.
@@ -477,6 +483,13 @@ struct RunArgs {
 struct TuiPassthroughArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     args: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+struct WebArgs {
+    /// Loopback port for the local Runtime API and embedded client.
+    #[arg(long, default_value_t = 7878)]
+    port: u16,
 }
 
 #[derive(Debug, Args)]
@@ -1677,6 +1690,10 @@ fn run() -> Result<()> {
             // delegated child so it is torn down with the dispatcher (#3259).
             delegate_server_to_tui(&cli, &resolved_runtime, tui_args("serve", args))
         }
+        Some(Commands::Web(args)) => {
+            let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
+            delegate_server_to_tui(&cli, &resolved_runtime, web_serve_passthrough(&args))
+        }
         Some(Commands::Completions(args)) => {
             let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("completions", args))
@@ -2695,6 +2712,15 @@ fn app_server_serve_passthrough(args: &AppServerArgs) -> Vec<String> {
         forwarded.push("--qr".to_string());
     }
     forwarded
+}
+
+fn web_serve_passthrough(args: &WebArgs) -> Vec<String> {
+    vec![
+        "serve".to_string(),
+        "--web".to_string(),
+        "--port".to_string(),
+        args.port.to_string(),
+    ]
 }
 
 fn app_server_token_from_env() -> Option<String> {
@@ -3920,9 +3946,35 @@ mod tests {
     }
 
     #[test]
+    fn web_command_is_typed_and_delegates_without_auth_material() {
+        let cli = parse_ok(&["codewhale", "web", "--port", "9091"]);
+        let args = match cli.command {
+            Some(Commands::Web(args)) => args,
+            other => panic!("expected web command, got {other:?}"),
+        };
+        assert_eq!(args.port, 9091);
+        let forwarded = web_serve_passthrough(&args);
+        assert_eq!(forwarded, ["serve", "--web", "--port", "9091"]);
+        assert!(!forwarded.iter().any(|arg| arg.contains("token")));
+    }
+
+    #[test]
+    fn web_command_defaults_to_runtime_port_and_documents_bootstrap_boundary() {
+        let cli = parse_ok(&["codewhale", "web"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Web(WebArgs { port: 7878 }))
+        ));
+        let help = help_for(&["codewhale", "web", "--help"]);
+        assert!(help.contains("--port"));
+        assert!(help.contains("one-time loopback bootstrap"));
+        assert!(!help.contains("--auth-token"));
+    }
+
+    #[test]
     fn serve_help_documents_forwarded_runtime_modes() {
         let help = help_for(&["codewhale", "serve", "--help"]);
-        for flag in ["--http", "--mobile", "--mcp", "--acp"] {
+        for flag in ["--http", "--mobile", "--web", "--mcp", "--acp"] {
             assert!(
                 help.contains(flag),
                 "serve help should document forwarded flag {flag}; help was:\n{help}"

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `codewhale web [--port 7878]`, a first-class loopback-only browser
+  client over the canonical Runtime API. The dependency-free embedded shell
+  supports thread lifecycle, snapshot-then-SSE transcripts, turn start/steer/
+  interrupt, approvals, and user questions, including pending-request recovery
+  across tab reloads, while leaving unsupported managed,
+  files, PTY, model-selection, and Fleet controls absent. Browser auth uses a
+  short-lived one-time loopback capability exchanged for an opaque, bounded,
+  process-local HttpOnly, SameSite=Strict session cookie with a same-origin
+  mutation guard; Runtime tokens never enter URLs, HTML, browser storage, logs,
+  or browser-launch arguments (#4423).
 - Add OpenCode Go as a first-class, subscription-backed Chat Completions
   provider with `[providers.opencode_go]`, `OPENCODE_GO_API_KEY`, and the eight
   models currently documented on its `/v1/chat/completions` endpoint. Models

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -4121,6 +4121,7 @@ pub(crate) struct MockEngineHandle {
     pub handle: EngineHandle,
     pub rx_op: mpsc::Receiver<Op>,
     rx_approval: mpsc::Receiver<ApprovalDecision>,
+    rx_user_input: mpsc::Receiver<UserInputDecision>,
     pub rx_steer: mpsc::Receiver<String>,
     pub tx_event: mpsc::Sender<Event>,
     pub cancel_token: CancellationToken,
@@ -4152,6 +4153,22 @@ impl MockEngineHandle {
             }
         }
     }
+
+    pub(crate) async fn recv_user_input_submission(
+        &mut self,
+    ) -> Option<(String, UserInputResponse)> {
+        match self.rx_user_input.recv().await? {
+            UserInputDecision::Submitted { id, response } => Some((id, response)),
+            UserInputDecision::Cancelled { .. } => None,
+        }
+    }
+
+    pub(crate) async fn recv_user_input_cancellation(&mut self) -> Option<String> {
+        match self.rx_user_input.recv().await? {
+            UserInputDecision::Cancelled { id } => Some(id),
+            UserInputDecision::Submitted { .. } => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -4159,7 +4176,7 @@ pub(crate) fn mock_engine_handle() -> MockEngineHandle {
     let (tx_op, rx_op) = mpsc::channel(32);
     let (tx_event, rx_event) = mpsc::channel(256);
     let (tx_approval, rx_approval) = mpsc::channel(64);
-    let (tx_user_input, _rx_user_input) = mpsc::channel(32);
+    let (tx_user_input, rx_user_input) = mpsc::channel(32);
     let (tx_steer, rx_steer) = mpsc::channel(64);
     let cancel_token = CancellationToken::new();
     let shared_cancel_token = Arc::new(StdMutex::new(cancel_token.clone()));
@@ -4181,6 +4198,7 @@ pub(crate) fn mock_engine_handle() -> MockEngineHandle {
         handle,
         rx_op,
         rx_approval,
+        rx_user_input,
         rx_steer,
         tx_event,
         cancel_token,

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -4169,6 +4169,13 @@ impl MockEngineHandle {
             UserInputDecision::Submitted { .. } => None,
         }
     }
+
+    /// Close the engine event stream without moving fields out of the handle,
+    /// so failure-path tests can keep using the receiver helpers afterwards.
+    pub(crate) fn close_event_stream(&mut self) {
+        let (tx_event, _rx_event) = mpsc::channel(1);
+        self.tx_event = tx_event;
+    }
 }
 
 #[cfg(test)]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1029,6 +1029,9 @@ struct ServeArgs {
     /// Start runtime HTTP/SSE API server with the built-in mobile control page
     #[arg(long)]
     mobile: bool,
+    /// Start the embedded loopback-only browser client and open it
+    #[arg(long)]
+    web: bool,
     /// Show a QR code for the mobile URL in the terminal (requires --mobile)
     #[arg(long, requires = "mobile")]
     qr: bool,
@@ -1084,17 +1087,26 @@ fn resolve_serve_bind_host(mobile: bool, host: Option<String>) -> ServeBindHost 
     }
 }
 
-fn validate_serve_mode_selection(mcp: bool, http: bool, mobile: bool, acp: bool) -> Result<bool> {
+fn validate_serve_mode_selection(
+    mcp: bool,
+    http: bool,
+    mobile: bool,
+    web: bool,
+    acp: bool,
+) -> Result<bool> {
     if http && mobile {
         bail!("--http and --mobile are mutually exclusive; choose one");
     }
-    let http_selected = http || mobile;
+    if web && (http || mobile) {
+        bail!("--web is mutually exclusive with --http and --mobile");
+    }
+    let http_selected = http || mobile || web;
     let selected_modes = [mcp, http_selected, acp]
         .into_iter()
         .filter(|selected| *selected)
         .count();
     if selected_modes != 1 {
-        bail!("Choose exactly one server mode: --mcp, --http/--mobile, or --acp");
+        bail!("Choose exactly one server mode: --mcp, --http/--mobile/--web, or --acp");
     }
     Ok(http_selected)
 }
@@ -1582,8 +1594,13 @@ async fn run_async_main() -> Result<()> {
                 let workspace = cli.workspace.clone().unwrap_or_else(|| {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
-                let http_selected =
-                    validate_serve_mode_selection(args.mcp, args.http, args.mobile, args.acp)?;
+                let http_selected = validate_serve_mode_selection(
+                    args.mcp,
+                    args.http,
+                    args.mobile,
+                    args.web,
+                    args.acp,
+                )?;
                 if args.mcp {
                     tokio::task::block_in_place(|| mcp_server::run_mcp_server(workspace))
                 } else if http_selected {
@@ -1591,6 +1608,9 @@ async fn run_async_main() -> Result<()> {
                         load_config_from_cli_with_effective_profile(&cli)?;
                     let cors_origins = resolve_cors_origins(&config, &args.cors_origin);
                     let bind_host = resolve_serve_bind_host(args.mobile, args.host);
+                    if args.web && bind_host.host != "127.0.0.1" {
+                        bail!("Codewhale web is loopback-only and must bind to 127.0.0.1");
+                    }
                     if bind_host.mobile_rebound_to_lan {
                         println!(
                             "WARNING: --mobile is binding to 0.0.0.0 so LAN devices can reach the mobile control page. Use --host 127.0.0.1 to keep mobile loopback-only."
@@ -1607,6 +1627,7 @@ async fn run_async_main() -> Result<()> {
                             auth_token: args.auth_token,
                             insecure_no_auth: args.insecure_no_auth,
                             mobile: args.mobile,
+                            web: args.web,
                             show_qr: args.qr,
                             config_path: cli.config.clone(),
                             config_profile,
@@ -9422,10 +9443,24 @@ mod serve_bind_host_tests {
 
     #[test]
     fn http_and_mobile_are_mutually_exclusive() {
-        let err = validate_serve_mode_selection(false, true, true, false).unwrap_err();
+        let err = validate_serve_mode_selection(false, true, true, false, false).unwrap_err();
         assert!(
             err.to_string()
                 .contains("--http and --mobile are mutually exclusive")
+        );
+    }
+
+    #[test]
+    fn web_is_a_distinct_loopback_runtime_mode() {
+        assert!(validate_serve_mode_selection(false, false, false, true, false).unwrap());
+        let err = validate_serve_mode_selection(false, true, false, true, false).unwrap_err();
+        assert!(err.to_string().contains("--web is mutually exclusive"));
+        assert_eq!(
+            resolve_serve_bind_host(false, None),
+            ServeBindHost {
+                host: "127.0.0.1".to_string(),
+                mobile_rebound_to_lan: false,
+            }
         );
     }
 }

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -73,6 +73,7 @@ use codewhale_protocol::fleet::{
 
 mod auth;
 mod sessions;
+mod web;
 mod workspace;
 #[cfg(test)]
 use self::auth::{ResolvedRuntimeAuth, token_from_cookie_header};
@@ -111,6 +112,7 @@ pub struct RuntimeApiState {
     bind_host: String,
     bind_port: u16,
     mobile_enabled: bool,
+    web: Option<web::RuntimeWebState>,
     /// Executable used by Runtime API-owned Fleet manager loops. Stored on
     /// state so tests and embedded callers can provide a hermetic worker.
     fleet_codewhale_binary: String,
@@ -142,6 +144,10 @@ pub struct RuntimeApiOptions {
     pub insecure_no_auth: bool,
     /// Enables the built-in mobile control page at `/mobile`.
     pub mobile: bool,
+    /// Enables the embedded local browser client and opens it after binding.
+    /// Web mode is always loopback-only and uses a one-time bootstrap cookie
+    /// exchange rather than exposing the Runtime token to the browser URL.
+    pub web: bool,
     /// Show a QR code for the mobile URL in the terminal.
     pub show_qr: bool,
     /// Original `--config` path used to load the initial config. When
@@ -162,6 +168,7 @@ impl Default for RuntimeApiOptions {
             auth_token: None,
             insecure_no_auth: false,
             mobile: false,
+            web: false,
             show_qr: false,
             config_path: None,
             config_profile: None,
@@ -418,6 +425,12 @@ pub async fn run_http_server(
     if options.port == 0 {
         bail!("Port must be > 0");
     }
+    if options.web && options.host != "127.0.0.1" {
+        bail!("Codewhale web is loopback-only and must bind to 127.0.0.1");
+    }
+    if options.web && options.insecure_no_auth {
+        bail!("Codewhale web requires Runtime authentication; remove --insecure");
+    }
 
     let task_cfg = TaskManagerConfig::from_runtime(
         &config,
@@ -458,6 +471,15 @@ pub async fn run_http_server(
     );
     let runtime_token = resolved_auth.token.clone();
     let auth_enabled = runtime_token.is_some();
+    let (web, web_bootstrap) = if options.web {
+        runtime_token
+            .as_ref()
+            .context("Codewhale web requires a Runtime authentication token")?;
+        let (web, bootstrap) = web::RuntimeWebState::new();
+        (Some(web), Some(bootstrap))
+    } else {
+        (None, None)
+    };
     let skill_state = SkillStateStore::load_default().unwrap_or_else(|err| {
         tracing::warn!(
             "Failed to load skills_state.toml ({}); treating all skills as enabled",
@@ -483,6 +505,7 @@ pub async fn run_http_server(
         bind_host: options.host.clone(),
         bind_port: options.port,
         mobile_enabled: options.mobile,
+        web,
         fleet_codewhale_binary: configured_codewhale_binary(),
         mcp_pool: Arc::new(Mutex::new(None)),
     };
@@ -495,12 +518,30 @@ pub async fn run_http_server(
         .await
         .with_context(|| format!("Failed to bind {addr}"))?;
 
-    println!("Runtime API listening on http://{addr}");
+    let bound_addr = listener
+        .local_addr()
+        .context("Failed to read Runtime API listener address")?;
+    println!("Runtime API listening on http://{bound_addr}");
     for line in runtime_auth_status_lines(&resolved_auth) {
         println!("{line}");
     }
     if options.mobile {
-        print_mobile_urls(addr, auth_enabled, resolved_auth.generated, options.show_qr);
+        print_mobile_urls(
+            bound_addr,
+            auth_enabled,
+            resolved_auth.generated,
+            options.show_qr,
+        );
+    }
+    if let Some(bootstrap) = web_bootstrap {
+        println!("Codewhale web enabled at http://{bound_addr}/");
+        let bootstrap_url = web::bootstrap_url(bound_addr, &bootstrap);
+        if let Err(error) = crate::utils::open_url(&bootstrap_url) {
+            scheduler_cancel.cancel();
+            scheduler_handle.abort();
+            return Err(error)
+                .context("Failed to open the Codewhale web client in the default browser");
+        }
     }
     let is_loopback = options.host == "127.0.0.1" || options.host == "::1";
     if is_loopback {
@@ -522,9 +563,12 @@ pub async fn run_http_server(
             auth = auth_enabled,
         );
     }
-    let serve_result = axum::serve(listener, app)
-        .await
-        .map_err(|e| anyhow!("Runtime API server error: {e}"));
+    let serve_result = axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .map_err(|e| anyhow!("Runtime API server error: {e}"));
     scheduler_cancel.cancel();
     scheduler_handle.abort();
     serve_result
@@ -623,6 +667,13 @@ pub fn build_router(state: RuntimeApiState) -> Router {
         ));
 
     Router::new()
+        .route("/", get(web::web_page))
+        .route("/assets/codewhale-web.css", get(web::web_styles))
+        .route("/assets/codewhale-web.js", get(web::web_script))
+        .route(
+            "/__codewhale/bootstrap/{nonce}",
+            get(web::exchange_bootstrap),
+        )
         .route("/health", get(health))
         .route("/mobile", get(mobile_page))
         .route("/mobile/", get(mobile_page))

--- a/crates/tui/src/runtime_api/auth.rs
+++ b/crates/tui/src/runtime_api/auth.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Request, State};
-use axum::http::{StatusCode, header};
+use axum::http::{Method, StatusCode, header};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use serde_json::json;
@@ -74,7 +74,16 @@ pub(super) async fn require_runtime_token(
     let Some(expected) = state.runtime_token.as_deref() else {
         return next.run(req).await;
     };
-    let authorized = request_has_runtime_token(&req, expected);
+    let cookie_authorized = request_has_runtime_cookie(&req, expected)
+        || state.web.as_ref().is_some_and(|web| {
+            web.matches_session_cookie(
+                req.headers()
+                    .get(header::COOKIE)
+                    .and_then(|value| value.to_str().ok()),
+            )
+        });
+    let authorized = request_has_header_runtime_token(&req, expected)
+        || (cookie_authorized && web_cookie_request_is_same_origin(&req, &state));
 
     if authorized {
         next.run(req).await
@@ -83,7 +92,7 @@ pub(super) async fn require_runtime_token(
     }
 }
 
-fn request_has_runtime_token(req: &Request, expected: &str) -> bool {
+fn request_has_header_runtime_token(req: &Request, expected: &str) -> bool {
     req.headers()
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
@@ -99,12 +108,51 @@ fn request_has_runtime_token(req: &Request, expected: &str) -> bool {
             .get("x-deepseek-runtime-token")
             .and_then(|value| value.to_str().ok())
             .is_some_and(|token| token == expected)
-        || token_from_cookie_header(
-            req.headers()
-                .get(header::COOKIE)
-                .and_then(|value| value.to_str().ok()),
-        )
-        .is_some_and(|token| token == expected)
+}
+
+fn request_has_runtime_cookie(req: &Request, expected: &str) -> bool {
+    token_from_cookie_header(
+        req.headers()
+            .get(header::COOKIE)
+            .and_then(|value| value.to_str().ok()),
+    )
+    .is_some_and(|token| token == expected)
+}
+
+/// The web bootstrap adds cookie authentication to the existing bearer/header
+/// boundary. SameSite is site-scoped rather than origin-scoped, so a sibling
+/// loopback port can still receive the cookie. Require browser-origin evidence
+/// for unsafe methods and reject Fetch Metadata that identifies any
+/// cross-origin cookie request. Bearer and explicit runtime-token headers keep
+/// their existing behavior.
+fn web_cookie_request_is_same_origin(req: &Request, state: &RuntimeApiState) -> bool {
+    if state.web.is_none() {
+        return true;
+    }
+
+    if req
+        .headers()
+        .get("sec-fetch-site")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|site| !site.eq_ignore_ascii_case("same-origin"))
+    {
+        return false;
+    }
+
+    let expected_origin = if state.bind_port == 80 {
+        format!("http://{}", state.bind_host)
+    } else {
+        format!("http://{}:{}", state.bind_host, state.bind_port)
+    };
+    if let Some(origin) = req
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    {
+        return origin == expected_origin;
+    }
+
+    matches!(*req.method(), Method::GET | Method::HEAD | Method::OPTIONS)
 }
 
 fn runtime_token_required_response() -> Response {

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -1172,6 +1172,158 @@ async fn runtime_token_guard_protects_v1_routes() -> Result<()> {
 }
 
 #[tokio::test]
+async fn web_bootstrap_sets_strict_cookie_once_and_preserves_v1_auth() -> Result<()> {
+    let root = std::env::temp_dir().join(format!("codewhale-web-api-{}", Uuid::new_v4()));
+    let sessions_dir = root.join("sessions");
+    let workspace = root.join("workspace");
+    let token = "cwrt_runtime_secret_never_in_browser_storage".to_string();
+    let (web, nonce) = web::RuntimeWebState::new();
+    let Some((addr, _runtime_threads, handle)) =
+        spawn_test_server_with_root_token_mobile_workspace_and_overrides(
+            root,
+            sessions_dir,
+            Some(token.clone()),
+            false,
+            workspace,
+            TestServerOverrides {
+                web: Some(web),
+                ..TestServerOverrides::default()
+            },
+        )
+        .await?
+    else {
+        return Ok(());
+    };
+    let client = crate::tls::reqwest_client_builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+
+    let page = client.get(format!("http://{addr}/")).send().await?;
+    assert_eq!(page.status(), StatusCode::OK);
+    assert_eq!(
+        page.headers()
+            .get(header::CONTENT_SECURITY_POLICY)
+            .and_then(|value| value.to_str().ok()),
+        Some(
+            "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
+        )
+    );
+    let page_body = page.text().await?;
+    assert!(!page_body.contains(&token));
+    assert!(!page_body.contains(&nonce));
+
+    let wrong = client
+        .get(format!(
+            "http://{addr}/__codewhale/bootstrap/cwwb_00000000000000000000000000000000"
+        ))
+        .send()
+        .await?;
+    assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+    let exchange = client
+        .get(format!("http://{addr}/__codewhale/bootstrap/{nonce}"))
+        .send()
+        .await?;
+    assert_eq!(exchange.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        exchange
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("/")
+    );
+    let set_cookie = exchange
+        .headers()
+        .get(header::SET_COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .context("missing bootstrap Set-Cookie")?
+        .to_string();
+    assert!(set_cookie.starts_with("codewhale_web_session=cwws_"));
+    assert!(set_cookie.ends_with("; HttpOnly; SameSite=Strict; Path=/"));
+    assert!(!set_cookie.contains(&token));
+
+    let unauthorized = client
+        .get(format!("http://{addr}/v1/threads/summary"))
+        .send()
+        .await?;
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    let cookie_pair = set_cookie
+        .split(';')
+        .next()
+        .context("missing web session cookie pair")?;
+    let authorized = client
+        .get(format!("http://{addr}/v1/threads/summary"))
+        .header(header::COOKIE, cookie_pair)
+        .send()
+        .await?;
+    assert_eq!(authorized.status(), StatusCode::OK);
+
+    let same_origin_cookie_post = client
+        .post(format!("http://{addr}/v1/threads"))
+        .header(header::COOKIE, cookie_pair)
+        .header(header::ORIGIN, format!("http://{addr}"))
+        .header("sec-fetch-site", "same-origin")
+        .json(&json!({}))
+        .send()
+        .await?;
+    assert_eq!(same_origin_cookie_post.status(), StatusCode::CREATED);
+
+    let cross_origin_cookie_post = client
+        .post(format!("http://{addr}/v1/threads"))
+        .header(header::COOKIE, cookie_pair)
+        .header(header::ORIGIN, "http://127.0.0.1:3000")
+        .header("sec-fetch-site", "same-site")
+        .json(&json!({}))
+        .send()
+        .await?;
+    assert_eq!(cross_origin_cookie_post.status(), StatusCode::UNAUTHORIZED);
+
+    let originless_cookie_post = client
+        .post(format!("http://{addr}/v1/threads"))
+        .header(header::COOKIE, cookie_pair)
+        .json(&json!({}))
+        .send()
+        .await?;
+    assert_eq!(originless_cookie_post.status(), StatusCode::UNAUTHORIZED);
+
+    let bearer_post = client
+        .post(format!("http://{addr}/v1/threads"))
+        .bearer_auth(&token)
+        .header(header::ORIGIN, "http://127.0.0.1:3000")
+        .json(&json!({}))
+        .send()
+        .await?;
+    assert_eq!(bearer_post.status(), StatusCode::CREATED);
+
+    let reused = client
+        .get(format!("http://{addr}/__codewhale/bootstrap/{nonce}"))
+        .send()
+        .await?;
+    assert_eq!(reused.status(), StatusCode::UNAUTHORIZED);
+
+    let mobile = client.get(format!("http://{addr}/mobile")).send().await?;
+    assert_eq!(mobile.status(), StatusCode::NOT_FOUND);
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn web_assets_are_absent_outside_web_mode() -> Result<()> {
+    let Some((addr, _runtime_threads, handle)) = spawn_test_server().await? else {
+        return Ok(());
+    };
+    let client = crate::tls::reqwest_client();
+    for path in ["/", "/assets/codewhale-web.css", "/assets/codewhale-web.js"] {
+        let response = client.get(format!("http://{addr}{path}")).send().await?;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "path={path}");
+    }
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_summary_includes_workspace_branch_metadata() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let root = tmp.path().join("runtime");
@@ -5054,7 +5206,7 @@ async fn set_config_response_contains_all_expected_fields() -> Result<()> {
 }
 
 #[tokio::test]
-async fn cors_layer_advertises_only_supported_request_headers() -> Result<()> {
+async fn cors_layer_advertises_exact_supported_headers_and_never_an_extra() -> Result<()> {
     let layer = cors_layer(&[]);
     let router: Router = Router::new()
         .route("/probe", get(|| async { "ok" }))
@@ -5072,19 +5224,26 @@ async fn cors_layer_advertises_only_supported_request_headers() -> Result<()> {
 
     let client = crate::tls::reqwest_client();
 
-    let resp = client
+    let allowed = client
         .request(reqwest::Method::OPTIONS, format!("http://{addr}/probe"))
         .header("Origin", "http://localhost:1420")
-        .header("Access-Control-Request-Method", "GET")
+        .header("Access-Control-Request-Method", "POST")
         .header(
             "Access-Control-Request-Headers",
-            "authorization, content-type, accept, x-codewhale-runtime-token, x-deepseek-runtime-token, x-malicious-header",
+            "authorization, content-type, accept, x-codewhale-runtime-token, x-deepseek-runtime-token",
         )
         .send()
         .await?;
 
-    assert!(resp.status().is_success());
-    let allow_headers = resp
+    assert!(allowed.status().is_success());
+    assert_eq!(
+        allowed
+            .headers()
+            .get("access-control-allow-origin")
+            .and_then(|value| value.to_str().ok()),
+        Some("http://localhost:1420")
+    );
+    let allow_headers = allowed
         .headers()
         .get("access-control-allow-headers")
         .and_then(|v| v.to_str().ok())
@@ -5106,6 +5265,27 @@ async fn cors_layer_advertises_only_supported_request_headers() -> Result<()> {
     .collect::<std::collections::BTreeSet<_>>();
 
     assert_eq!(advertised, expected);
+
+    let unapproved = client
+        .request(reqwest::Method::OPTIONS, format!("http://{addr}/probe"))
+        .header("Origin", "http://localhost:1420")
+        .header("Access-Control-Request-Method", "POST")
+        .header(
+            "Access-Control-Request-Headers",
+            "authorization, x-malicious-header",
+        )
+        .send()
+        .await?;
+    let unapproved_headers = unapproved
+        .headers()
+        .get("access-control-allow-headers")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    assert!(
+        !unapproved_headers.contains("x-malicious-header"),
+        "an unapproved request header must never be advertised to the browser"
+    );
 
     handle.abort();
     Ok(())

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -345,6 +345,8 @@ fn messages_from_thread_detail_batches_tool_results() {
             ),
         ],
         latest_seq: 0,
+        pending_approvals: Vec::new(),
+        pending_user_inputs: Vec::new(),
     };
 
     let messages = messages_from_thread_detail(&detail);
@@ -418,6 +420,8 @@ fn legacy_exact_thread_export_normalizes_provider_kind_and_id() {
         turns: Vec::new(),
         items: Vec::new(),
         latest_seq: 0,
+        pending_approvals: Vec::new(),
+        pending_user_inputs: Vec::new(),
     };
     let config = Config {
         provider: Some("lm-studio".to_string()),

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -616,6 +616,7 @@ struct TestServerOverrides {
     fleet_codewhale_binary: Option<String>,
     config_path: Option<PathBuf>,
     config_profile: Option<String>,
+    web: Option<web::RuntimeWebState>,
 }
 
 async fn spawn_test_server_with_root_token_mobile_workspace_and_subagents(
@@ -702,6 +703,12 @@ async fn spawn_test_server_with_root_token_mobile_workspace_and_overrides(
     let sub_agent_manager = overrides
         .sub_agent_manager
         .unwrap_or_else(|| runtime_api_sub_agent_manager(&workspace, 2));
+    let listener = match TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let addr = listener.local_addr()?;
     let state = RuntimeApiState {
         config: Arc::new(parking_lot::RwLock::new(config)),
         workspace,
@@ -720,21 +727,20 @@ async fn spawn_test_server_with_root_token_mobile_workspace_and_overrides(
         )),
         auth_required,
         bind_host: "127.0.0.1".to_string(),
-        bind_port: 0,
+        bind_port: addr.port(),
         mobile_enabled,
+        web: overrides.web,
         fleet_codewhale_binary: overrides
             .fleet_codewhale_binary
             .unwrap_or_else(configured_codewhale_binary),
     };
     let app = build_router(state);
-    let listener = match TcpListener::bind("127.0.0.1:0").await {
-        Ok(listener) => listener,
-        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return Ok(None),
-        Err(err) => return Err(err.into()),
-    };
-    let addr = listener.local_addr()?;
     let handle = tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
+        let _ = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await;
     });
     Ok(Some((addr, runtime_threads, handle)))
 }

--- a/crates/tui/src/runtime_api/web.rs
+++ b/crates/tui/src/runtime_api/web.rs
@@ -308,12 +308,12 @@ mod tests {
 
     #[test]
     fn cookie_has_exact_security_attributes_without_the_runtime_bearer() {
-        let session_token = "cwws_0123456789abcdef0123456789abcdef";
+        let session_token = format!("{WEB_SESSION_PREFIX}{}", "01".repeat(16));
         let runtime_bearer = "cwrt_runtime_secret_never_in_browser_storage";
-        let cookie = web_session_cookie(session_token);
+        let cookie = web_session_cookie(&session_token);
         assert_eq!(
             cookie,
-            "codewhale_web_session=cwws_0123456789abcdef0123456789abcdef; HttpOnly; SameSite=Strict; Path=/"
+            format!("codewhale_web_session={session_token}; HttpOnly; SameSite=Strict; Path=/")
         );
         assert!(!cookie.contains(runtime_bearer));
         assert!(!cookie.contains("Domain="));
@@ -322,9 +322,9 @@ mod tests {
     #[test]
     fn launcher_url_contains_only_the_one_time_capability() {
         let token = "cwrt_runtime_secret_never_in_browser_arguments";
-        let nonce = "cwwb_0123456789abcdef0123456789abcdef";
-        let url = bootstrap_url("127.0.0.1:7878".parse().unwrap(), nonce);
-        assert!(url.ends_with(nonce));
+        let nonce = format!("{BOOTSTRAP_PREFIX}{}", "01".repeat(16));
+        let url = bootstrap_url("127.0.0.1:7878".parse().unwrap(), &nonce);
+        assert!(url.ends_with(&nonce));
         assert!(!url.contains(token));
         assert!(!url.contains('?'));
         assert!(!url.contains('#'));

--- a/crates/tui/src/runtime_api/web.rs
+++ b/crates/tui/src/runtime_api/web.rs
@@ -1,0 +1,344 @@
+//! Embedded, loopback-only browser client for the Runtime API.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::extract::{ConnectInfo, Path, State};
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use uuid::Uuid;
+
+use super::RuntimeApiState;
+
+const WEB_HTML: &str = include_str!("../runtime_web/index.html");
+const WEB_CSS: &str = include_str!("../runtime_web/styles.css");
+const WEB_JS: &str = include_str!("../runtime_web/app.mjs");
+const BOOTSTRAP_TTL: Duration = Duration::from_secs(120);
+const WEB_SESSION_TTL: Duration = Duration::from_secs(12 * 60 * 60);
+const BOOTSTRAP_PREFIX: &str = "cwwb_";
+const WEB_SESSION_PREFIX: &str = "cwws_";
+const WEB_SESSION_COOKIE_NAME: &str = "codewhale_web_session";
+const CONTENT_SECURITY_POLICY: &str = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; object-src 'none'";
+
+#[derive(Clone)]
+pub(super) struct RuntimeWebState {
+    bootstrap: Arc<Mutex<Option<BootstrapCapability>>>,
+    session_token: Arc<str>,
+    session_expires_at: Instant,
+}
+
+struct BootstrapCapability {
+    nonce: String,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BootstrapError {
+    Invalid,
+    Expired,
+    NonLoopback,
+}
+
+impl RuntimeWebState {
+    pub(super) fn new() -> (Self, String) {
+        Self::new_with_ttls(BOOTSTRAP_TTL, WEB_SESSION_TTL)
+    }
+
+    fn new_with_ttls(bootstrap_ttl: Duration, session_ttl: Duration) -> (Self, String) {
+        let nonce = format!("{BOOTSTRAP_PREFIX}{}", Uuid::new_v4().simple());
+        let session_token = format!(
+            "{WEB_SESSION_PREFIX}{}{}",
+            Uuid::new_v4().simple(),
+            Uuid::new_v4().simple()
+        );
+        let state = Self {
+            bootstrap: Arc::new(Mutex::new(Some(BootstrapCapability {
+                nonce: nonce.clone(),
+                expires_at: Instant::now() + bootstrap_ttl,
+            }))),
+            session_token: session_token.into(),
+            session_expires_at: Instant::now() + session_ttl,
+        };
+        (state, nonce)
+    }
+
+    fn consume(&self, nonce: &str, peer_ip: IpAddr) -> Result<String, BootstrapError> {
+        if !peer_ip.is_loopback() {
+            return Err(BootstrapError::NonLoopback);
+        }
+        if !valid_bootstrap_nonce(nonce) {
+            return Err(BootstrapError::Invalid);
+        }
+
+        let mut slot = self
+            .bootstrap
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(capability) = slot.as_ref() else {
+            return Err(BootstrapError::Invalid);
+        };
+        if Instant::now() >= capability.expires_at {
+            *slot = None;
+            return Err(BootstrapError::Expired);
+        }
+        if !constant_time_eq(nonce.as_bytes(), capability.nonce.as_bytes()) {
+            return Err(BootstrapError::Invalid);
+        }
+
+        let _capability = slot.take().expect("bootstrap capability checked above");
+        Ok(self.session_token.to_string())
+    }
+
+    pub(super) fn matches_session_cookie(&self, cookie_header: Option<&str>) -> bool {
+        let presented = cookie_value(cookie_header, WEB_SESSION_COOKIE_NAME).unwrap_or_default();
+        let token_matches = constant_time_eq(presented.as_bytes(), self.session_token.as_bytes());
+        token_matches & (Instant::now() < self.session_expires_at)
+    }
+}
+
+pub(super) fn bootstrap_url(addr: SocketAddr, nonce: &str) -> String {
+    format!("http://{addr}/__codewhale/bootstrap/{nonce}")
+}
+
+pub(super) async fn exchange_bootstrap(
+    State(state): State<RuntimeApiState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Path(nonce): Path<String>,
+) -> Response {
+    let Some(web) = state.web.as_ref() else {
+        return not_found();
+    };
+    let session_token = match web.consume(&nonce, peer.ip()) {
+        Ok(token) => token,
+        Err(BootstrapError::NonLoopback) => {
+            return secured_text(StatusCode::FORBIDDEN, "bootstrap unavailable");
+        }
+        Err(BootstrapError::Invalid | BootstrapError::Expired) => {
+            return secured_text(StatusCode::UNAUTHORIZED, "bootstrap unavailable");
+        }
+    };
+
+    let cookie = web_session_cookie(&session_token);
+    let mut response = (StatusCode::SEE_OTHER, "").into_response();
+    response
+        .headers_mut()
+        .insert(header::LOCATION, HeaderValue::from_static("/"));
+    response.headers_mut().insert(
+        header::SET_COOKIE,
+        HeaderValue::from_str(&cookie).expect("percent-encoded Runtime cookie is a valid header"),
+    );
+    secure_headers(&mut response, "text/plain; charset=utf-8");
+    response
+}
+
+pub(super) async fn web_page(State(state): State<RuntimeApiState>) -> Response {
+    if state.web.is_none() {
+        return not_found();
+    }
+    secured_asset("text/html; charset=utf-8", WEB_HTML)
+}
+
+pub(super) async fn web_styles(State(state): State<RuntimeApiState>) -> Response {
+    if state.web.is_none() {
+        return not_found();
+    }
+    secured_asset("text/css; charset=utf-8", WEB_CSS)
+}
+
+pub(super) async fn web_script(State(state): State<RuntimeApiState>) -> Response {
+    if state.web.is_none() {
+        return not_found();
+    }
+    secured_asset("text/javascript; charset=utf-8", WEB_JS)
+}
+
+fn web_session_cookie(session_token: &str) -> String {
+    format!("{WEB_SESSION_COOKIE_NAME}={session_token}; HttpOnly; SameSite=Strict; Path=/")
+}
+
+fn cookie_value<'a>(cookie_header: Option<&'a str>, name: &str) -> Option<&'a str> {
+    cookie_header.and_then(|cookie| {
+        cookie.split(';').find_map(|pair| {
+            let (key, value) = pair.trim().split_once('=')?;
+            (key == name).then_some(value.trim())
+        })
+    })
+}
+
+fn valid_bootstrap_nonce(value: &str) -> bool {
+    value.strip_prefix(BOOTSTRAP_PREFIX).is_some_and(|random| {
+        random.len() == 32 && random.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+fn secured_asset(content_type: &'static str, body: &'static str) -> Response {
+    let mut response = body.into_response();
+    secure_headers(&mut response, content_type);
+    response
+}
+
+fn secured_text(status: StatusCode, body: &'static str) -> Response {
+    let mut response = (status, body).into_response();
+    secure_headers(&mut response, "text/plain; charset=utf-8");
+    response
+}
+
+fn not_found() -> Response {
+    secured_text(StatusCode::NOT_FOUND, "not found")
+}
+
+fn secure_headers(response: &mut Response, content_type: &'static str) {
+    let headers = response.headers_mut();
+    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(CONTENT_SECURITY_POLICY),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        "permissions-policy",
+        HeaderValue::from_static("camera=(), microphone=(), geolocation=()"),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_is_loopback_only_one_time_and_expires() {
+        let (state, nonce) =
+            RuntimeWebState::new_with_ttls(Duration::from_secs(60), Duration::from_secs(60));
+        assert_eq!(
+            state.consume(&nonce, "192.0.2.4".parse().unwrap()),
+            Err(BootstrapError::NonLoopback)
+        );
+        let session_token = state
+            .consume(&nonce, "127.0.0.1".parse().unwrap())
+            .expect("valid loopback bootstrap");
+        assert!(session_token.starts_with(WEB_SESSION_PREFIX));
+        assert!(state.matches_session_cookie(Some(&format!(
+            "theme=dark; {WEB_SESSION_COOKIE_NAME}={session_token}"
+        ))));
+        assert_eq!(
+            state.consume(&nonce, "127.0.0.1".parse().unwrap()),
+            Err(BootstrapError::Invalid)
+        );
+
+        let (expired, expired_nonce) =
+            RuntimeWebState::new_with_ttls(Duration::ZERO, Duration::from_secs(60));
+        assert_eq!(
+            expired.consume(&expired_nonce, "::1".parse().unwrap()),
+            Err(BootstrapError::Expired)
+        );
+    }
+
+    #[test]
+    fn web_session_survives_reload_then_expires_and_rejects_wrong_tokens() {
+        let (state, nonce) =
+            RuntimeWebState::new_with_ttls(Duration::from_secs(60), Duration::from_secs(60));
+        let session_token = state
+            .consume(&nonce, "127.0.0.1".parse().unwrap())
+            .expect("valid loopback bootstrap");
+        let cookie = format!("{WEB_SESSION_COOKIE_NAME}={session_token}");
+        assert!(state.matches_session_cookie(Some(&cookie)));
+        assert!(
+            state.matches_session_cookie(Some(&cookie)),
+            "the same process-local session remains valid across a page reload"
+        );
+        assert!(!state.matches_session_cookie(Some(
+            "codewhale_web_session=cwws_0000000000000000000000000000000000000000000000000000000000000000"
+        )));
+
+        let (expired, _nonce) =
+            RuntimeWebState::new_with_ttls(Duration::from_secs(60), Duration::ZERO);
+        let expired_cookie = format!(
+            "{WEB_SESSION_COOKIE_NAME}={}",
+            expired.session_token.as_ref()
+        );
+        assert!(!expired.matches_session_cookie(Some(&expired_cookie)));
+    }
+
+    #[test]
+    fn bootstrap_rejects_malformed_or_wrong_capabilities_without_consuming() {
+        let (state, nonce) = RuntimeWebState::new();
+        for invalid in ["", "cwwb_short", "cwwb_gggggggggggggggggggggggggggggggg"] {
+            assert_eq!(
+                state.consume(invalid, "127.0.0.1".parse().unwrap()),
+                Err(BootstrapError::Invalid)
+            );
+        }
+        let mut wrong = nonce.clone();
+        wrong.replace_range(wrong.len() - 1.., "0");
+        if wrong == nonce {
+            wrong.replace_range(wrong.len() - 1.., "1");
+        }
+        assert_eq!(
+            state.consume(&wrong, "127.0.0.1".parse().unwrap()),
+            Err(BootstrapError::Invalid)
+        );
+        assert!(
+            state
+                .consume(&nonce, "127.0.0.1".parse().unwrap())
+                .expect("valid bootstrap remains available")
+                .starts_with(WEB_SESSION_PREFIX)
+        );
+    }
+
+    #[test]
+    fn cookie_has_exact_security_attributes_without_the_runtime_bearer() {
+        let session_token = "cwws_0123456789abcdef0123456789abcdef";
+        let runtime_bearer = "cwrt_runtime_secret_never_in_browser_storage";
+        let cookie = web_session_cookie(session_token);
+        assert_eq!(
+            cookie,
+            "codewhale_web_session=cwws_0123456789abcdef0123456789abcdef; HttpOnly; SameSite=Strict; Path=/"
+        );
+        assert!(!cookie.contains(runtime_bearer));
+        assert!(!cookie.contains("Domain="));
+    }
+
+    #[test]
+    fn launcher_url_contains_only_the_one_time_capability() {
+        let token = "cwrt_runtime_secret_never_in_browser_arguments";
+        let nonce = "cwwb_0123456789abcdef0123456789abcdef";
+        let url = bootstrap_url("127.0.0.1:7878".parse().unwrap(), nonce);
+        assert!(url.ends_with(nonce));
+        assert!(!url.contains(token));
+        assert!(!url.contains('?'));
+        assert!(!url.contains('#'));
+    }
+
+    #[test]
+    fn embedded_client_has_no_secret_storage_or_unsafe_dynamic_html_sink() {
+        for asset in [WEB_HTML, WEB_JS] {
+            assert!(!asset.contains("localStorage"));
+            assert!(!asset.contains("sessionStorage"));
+            assert!(!asset.contains("codewhale_runtime_token"));
+            assert!(!asset.contains("innerHTML"));
+            assert!(!asset.contains("http://"));
+            assert!(!asset.contains("https://"));
+        }
+    }
+}

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -863,6 +863,32 @@ pub struct ThreadDetail {
     pub turns: Vec<TurnRecord>,
     pub items: Vec<TurnItemRecord>,
     pub latest_seq: u64,
+    /// Approval prompts that are still waiting for a decision. These are part
+    /// of the canonical snapshot so clients can recover attention UI after a
+    /// tab reload without replaying events older than `latest_seq`.
+    #[serde(default)]
+    pub pending_approvals: Vec<PendingApprovalRequest>,
+    /// User-input prompts that are still waiting for answers. As with
+    /// approvals, the snapshot is authoritative across client reconnects.
+    #[serde(default)]
+    pub pending_user_inputs: Vec<PendingUserInputRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingApprovalRequest {
+    pub id: String,
+    pub turn_id: String,
+    pub tool_name: String,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingUserInputRequest {
+    pub id: String,
+    pub turn_id: String,
+    pub request: crate::tools::user_input::UserInputRequest,
 }
 
 /// Aggregation key for `aggregate_usage`. Whalescale#261 / #564.
@@ -1026,8 +1052,9 @@ pub struct RuntimeThreadManager {
     task_manager: Arc<parking_lot::Mutex<Option<crate::task_manager::SharedTaskManager>>>,
     automations:
         Arc<parking_lot::Mutex<Option<crate::automation_manager::SharedAutomationManager>>>,
-    pending_approvals:
-        Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<ExternalApprovalDecision>>>>,
+    pending_approvals: Arc<parking_lot::Mutex<HashMap<String, PendingApprovalEntry>>>,
+    pending_user_inputs:
+        Arc<parking_lot::Mutex<HashMap<(String, String), PendingUserInputRequest>>>,
     pending_dynamic_tools:
         Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<DynamicToolCallResult>>>>,
 }
@@ -1069,6 +1096,12 @@ enum RuntimeApprovalDecision {
 pub enum ExternalApprovalDecision {
     Allow { remember: bool },
     Deny { remember: bool },
+}
+
+struct PendingApprovalEntry {
+    thread_id: String,
+    request: PendingApprovalRequest,
+    sender: oneshot::Sender<ExternalApprovalDecision>,
 }
 
 impl RuntimeThreadManager {
@@ -1256,6 +1289,7 @@ impl RuntimeThreadManager {
             task_manager: Arc::new(parking_lot::Mutex::new(None)),
             automations: Arc::new(parking_lot::Mutex::new(None)),
             pending_approvals: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            pending_user_inputs: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_dynamic_tools: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         };
         manager.recover_interrupted_state()?;
@@ -1280,6 +1314,7 @@ impl RuntimeThreadManager {
     pub fn shutdown(&self) {
         self.cancel_token.cancel();
         self.pending_approvals.lock().clear();
+        self.pending_user_inputs.lock().clear();
         self.pending_dynamic_tools.lock().clear();
     }
 
@@ -1290,17 +1325,89 @@ impl RuntimeThreadManager {
 
     fn register_pending_approval(
         &self,
-        approval_id: &str,
+        thread_id: &str,
+        request: PendingApprovalRequest,
     ) -> oneshot::Receiver<ExternalApprovalDecision> {
         let (tx, rx) = oneshot::channel();
-        self.pending_approvals
-            .lock()
-            .insert(approval_id.to_string(), tx);
+        self.pending_approvals.lock().insert(
+            request.id.clone(),
+            PendingApprovalEntry {
+                thread_id: thread_id.to_string(),
+                request,
+                sender: tx,
+            },
+        );
         rx
     }
 
     fn cancel_pending_approval(&self, approval_id: &str) {
         self.pending_approvals.lock().remove(approval_id);
+    }
+
+    fn register_pending_user_input(&self, thread_id: &str, request: PendingUserInputRequest) {
+        self.pending_user_inputs
+            .lock()
+            .insert((thread_id.to_string(), request.id.clone()), request);
+    }
+
+    fn take_pending_user_input(
+        &self,
+        thread_id: &str,
+        input_id: &str,
+    ) -> Option<PendingUserInputRequest> {
+        self.pending_user_inputs
+            .lock()
+            .remove(&(thread_id.to_string(), input_id.to_string()))
+    }
+
+    fn pending_requests_for_thread(
+        &self,
+        thread_id: &str,
+    ) -> (Vec<PendingApprovalRequest>, Vec<PendingUserInputRequest>) {
+        let mut approvals = self
+            .pending_approvals
+            .lock()
+            .values()
+            .filter(|entry| entry.thread_id == thread_id)
+            .map(|entry| entry.request.clone())
+            .collect::<Vec<_>>();
+        approvals.sort_by(|left, right| {
+            left.turn_id
+                .cmp(&right.turn_id)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        let mut user_inputs = self
+            .pending_user_inputs
+            .lock()
+            .iter()
+            .filter(|((pending_thread_id, _), _)| pending_thread_id == thread_id)
+            .map(|(_, request)| request.clone())
+            .collect::<Vec<_>>();
+        user_inputs.sort_by(|left, right| {
+            left.turn_id
+                .cmp(&right.turn_id)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        (approvals, user_inputs)
+    }
+
+    fn clear_pending_user_inputs_for_turn(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Vec<PendingUserInputRequest> {
+        let mut pending = self.pending_user_inputs.lock();
+        let keys = pending
+            .iter()
+            .filter(|((pending_thread_id, _), request)| {
+                pending_thread_id == thread_id && request.turn_id == turn_id
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        keys.into_iter()
+            .filter_map(|key| pending.remove(&key))
+            .collect()
     }
 
     fn register_pending_dynamic_tool(
@@ -1323,9 +1430,9 @@ impl RuntimeThreadManager {
         approval_id: &str,
         decision: ExternalApprovalDecision,
     ) -> bool {
-        let sender = self.pending_approvals.lock().remove(approval_id);
-        match sender {
-            Some(tx) => tx.send(decision).is_ok(),
+        let entry = self.pending_approvals.lock().remove(approval_id);
+        match entry {
+            Some(entry) => entry.sender.send(decision).is_ok(),
             None => false,
         }
     }
@@ -1348,21 +1455,47 @@ impl RuntimeThreadManager {
         input_id: &str,
         response: crate::tools::user_input::UserInputResponse,
     ) -> Result<bool> {
-        let active = self.active.lock().await;
-        let Some(state) = active.engines.get(thread_id) else {
-            bail!("thread '{thread_id}' not found");
+        let engine = {
+            let active = self.active.lock().await;
+            let Some(state) = active.engines.get(thread_id) else {
+                bail!("thread '{thread_id}' not found");
+            };
+            state.engine.clone()
         };
-        state.engine.submit_user_input(input_id, response).await?;
+        engine.submit_user_input(input_id, response).await?;
+        if let Some(pending) = self.take_pending_user_input(thread_id, input_id) {
+            self.emit_event(
+                thread_id,
+                Some(&pending.turn_id),
+                None,
+                "user_input.answered",
+                json!({ "id": input_id, "input_id": input_id }),
+            )
+            .await?;
+        }
         Ok(true)
     }
 
     #[allow(dead_code)]
     pub async fn cancel_user_input(&self, thread_id: &str, input_id: &str) -> Result<bool> {
-        let active = self.active.lock().await;
-        let Some(state) = active.engines.get(thread_id) else {
-            bail!("thread '{thread_id}' not found");
+        let engine = {
+            let active = self.active.lock().await;
+            let Some(state) = active.engines.get(thread_id) else {
+                bail!("thread '{thread_id}' not found");
+            };
+            state.engine.clone()
         };
-        state.engine.cancel_user_input(input_id).await?;
+        engine.cancel_user_input(input_id).await?;
+        if let Some(pending) = self.take_pending_user_input(thread_id, input_id) {
+            self.emit_event(
+                thread_id,
+                Some(&pending.turn_id),
+                None,
+                "user_input.canceled",
+                json!({ "id": input_id, "input_id": input_id }),
+            )
+            .await?;
+        }
         Ok(true)
     }
 
@@ -1381,7 +1514,16 @@ impl RuntimeThreadManager {
         &self,
         approval_id: &str,
     ) -> oneshot::Receiver<ExternalApprovalDecision> {
-        self.register_pending_approval(approval_id)
+        self.register_pending_approval(
+            "test-thread",
+            PendingApprovalRequest {
+                id: approval_id.to_string(),
+                turn_id: "test-turn".to_string(),
+                tool_name: "test-tool".to_string(),
+                description: "test approval".to_string(),
+                intent_summary: None,
+            },
+        )
     }
 
     #[cfg(test)]
@@ -1854,11 +1996,19 @@ impl RuntimeThreadManager {
             }
         }
         let latest_seq = self.store.current_seq().await;
+        // Read attention state after the replay cursor. If a request is
+        // registered concurrently after this point, its required event will
+        // have a sequence newer than `latest_seq`; if its event was already
+        // sequenced, registration necessarily happened first and it appears
+        // in this snapshot unless it has already been resolved.
+        let (pending_approvals, pending_user_inputs) = self.pending_requests_for_thread(id);
         Ok(ThreadDetail {
             thread,
             turns,
             items,
             latest_seq,
+            pending_approvals,
+            pending_user_inputs,
         })
     }
 
@@ -4182,29 +4332,36 @@ impl RuntimeThreadManager {
                     intent_summary,
                     ..
                 } => {
-                    self.emit_event(
-                        &thread_id,
-                        Some(&turn_id),
-                        None,
-                        "approval.required",
-                        json!({
-                            "id": id,
-                            "approval_id": id,
-                            "tool_name": tool_name,
-                            "description": description,
-                            "intent_summary": intent_summary,
-                        }),
-                    )
-                    .await?;
-
                     let Some((auto_approve, trust_mode)) =
                         self.active_turn_flags(&thread_id, &turn_id).await
                     else {
-                        let _ = engine.deny_tool_call(id).await;
+                        let _ = engine.deny_tool_call(&id).await;
                         continue;
                     };
 
+                    let pending_request = PendingApprovalRequest {
+                        id: id.clone(),
+                        turn_id: turn_id.clone(),
+                        tool_name: tool_name.clone(),
+                        description: description.clone(),
+                        intent_summary: intent_summary.clone(),
+                    };
+
                     if auto_approve {
+                        self.emit_event(
+                            &thread_id,
+                            Some(&turn_id),
+                            None,
+                            "approval.required",
+                            json!({
+                                "id": id,
+                                "approval_id": id,
+                                "tool_name": tool_name,
+                                "description": description,
+                                "intent_summary": intent_summary,
+                            }),
+                        )
+                        .await?;
                         let auto_decision =
                             Self::approval_decision(auto_approve, trust_mode, false);
                         let (dec_str, approved) = match auto_decision {
@@ -4239,7 +4396,30 @@ impl RuntimeThreadManager {
                         continue;
                     }
 
-                    let rx = self.register_pending_approval(&id);
+                    // Register before sequencing the event. A snapshot racing
+                    // this branch therefore either contains the request or
+                    // subscribes from an older cursor that will replay it.
+                    let rx = self.register_pending_approval(&thread_id, pending_request);
+                    if let Err(err) = self
+                        .emit_event(
+                            &thread_id,
+                            Some(&turn_id),
+                            None,
+                            "approval.required",
+                            json!({
+                                "id": id,
+                                "approval_id": id,
+                                "tool_name": tool_name,
+                                "description": description,
+                                "intent_summary": intent_summary,
+                            }),
+                        )
+                        .await
+                    {
+                        self.cancel_pending_approval(&id);
+                        let _ = engine.deny_tool_call(&id).await;
+                        return Err(err);
+                    }
                     let approval_timeout = approval_decision_timeout();
                     match tokio::time::timeout(approval_timeout, rx).await {
                         Ok(Ok(ExternalApprovalDecision::Allow { remember })) => {
@@ -4351,17 +4531,31 @@ impl RuntimeThreadManager {
                     }
                 }
                 EngineEvent::UserInputRequired { id, request } => {
-                    self.emit_event(
+                    self.register_pending_user_input(
                         &thread_id,
-                        Some(&turn_id),
-                        None,
-                        "user_input.required",
-                        json!({
-                            "id": id,
-                            "request": request,
-                        }),
-                    )
-                    .await?;
+                        PendingUserInputRequest {
+                            id: id.clone(),
+                            turn_id: turn_id.clone(),
+                            request: request.clone(),
+                        },
+                    );
+                    if let Err(err) = self
+                        .emit_event(
+                            &thread_id,
+                            Some(&turn_id),
+                            None,
+                            "user_input.required",
+                            json!({
+                                "id": id,
+                                "request": request,
+                            }),
+                        )
+                        .await
+                    {
+                        self.take_pending_user_input(&thread_id, &id);
+                        let _ = engine.cancel_user_input(&id).await;
+                        return Err(err);
+                    }
                 }
                 EngineEvent::Status { message } => {
                     let item = TurnItemRecord {
@@ -4568,6 +4762,21 @@ impl RuntimeThreadManager {
             thread.latest_turn_id = Some(turn_id.clone());
             thread.updated_at = Utc::now();
             self.store.save_thread(&thread)?;
+        }
+
+        // A terminal turn can no longer answer an outstanding prompt. Clear
+        // it before publishing completion so fresh snapshots never resurrect
+        // stale attention UI, and notify already-connected clients as well.
+        for pending in self.clear_pending_user_inputs_for_turn(&thread_id, &turn_id) {
+            let _ = engine.cancel_user_input(&pending.id).await;
+            self.emit_event(
+                &thread_id,
+                Some(&turn_id),
+                None,
+                "user_input.canceled",
+                json!({ "id": pending.id, "input_id": pending.id, "terminal": true }),
+            )
+            .await?;
         }
 
         self.emit_event(

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -2721,6 +2721,41 @@ impl RuntimeThreadManager {
             }
         }
 
+        // A failed turn can no longer answer an outstanding prompt. Mirror the
+        // happy terminal path: clear pending user inputs before publishing the
+        // terminal receipt so fresh snapshots never resurrect stale attention
+        // UI, and notify already-connected clients as well.
+        let engine_for_cancel = {
+            let active = self.active.lock().await;
+            active
+                .engines
+                .get(thread_id)
+                .map(|state| state.engine.clone())
+        };
+        if let Some(engine) = engine_for_cancel {
+            for pending in self.clear_pending_user_inputs_for_turn(thread_id, turn_id) {
+                let _ = engine.cancel_user_input(&pending.id).await;
+                if let Err(err) = self
+                    .emit_event(
+                        thread_id,
+                        Some(turn_id),
+                        None,
+                        "user_input.canceled",
+                        json!({ "id": pending.id, "input_id": pending.id, "terminal": true }),
+                    )
+                    .await
+                {
+                    tracing::error!(
+                        "Failed to emit user-input cancellation after monitor failure: {err}"
+                    );
+                }
+            }
+        } else {
+            // The engine is already gone; still drop the registrations so
+            // snapshots stop advertising prompts nobody can answer.
+            let _ = self.clear_pending_user_inputs_for_turn(thread_id, turn_id);
+        }
+
         if let Some(turn) = terminal_turn
             && let Err(err) = self
                 .emit_event(

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -3358,6 +3358,13 @@ async fn approval_required_awaits_external_decision_allow() -> Result<()> {
     }
     assert_eq!(manager.pending_approvals_count(), 1);
 
+    let detail = manager.get_thread_detail(&thread.id).await?;
+    assert_eq!(detail.pending_approvals.len(), 1);
+    assert_eq!(detail.pending_approvals[0].id, "tool_external_allow");
+    assert_eq!(detail.pending_approvals[0].turn_id, _turn.id);
+    assert_eq!(detail.pending_approvals[0].tool_name, "exec_command");
+    assert_eq!(detail.pending_user_inputs.len(), 0);
+
     let events = manager.events_since(&thread.id, None)?;
     let approval_event = events
         .iter()
@@ -3383,6 +3390,13 @@ async fn approval_required_awaits_external_decision_allow() -> Result<()> {
         })
     );
     assert_eq!(manager.pending_approvals_count(), 0);
+    assert!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_approvals
+            .is_empty()
+    );
 
     harness
         .tx_event
@@ -3394,6 +3408,216 @@ async fn approval_required_awaits_external_decision_allow() -> Result<()> {
             base_url: None,
         })
         .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn user_input_snapshot_survives_reload_and_clears_after_submission() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "needs a choice".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+
+    harness
+        .tx_event
+        .send(EngineEvent::UserInputRequired {
+            id: "input_reload".to_string(),
+            request: crate::tools::user_input::UserInputRequest {
+                questions: vec![crate::tools::user_input::UserInputQuestion {
+                    header: "Continue".to_string(),
+                    id: "continue".to_string(),
+                    question: "Continue with the check?".to_string(),
+                    options: vec![
+                        crate::tools::user_input::UserInputOption {
+                            label: "Yes".to_string(),
+                            description: "Continue now".to_string(),
+                        },
+                        crate::tools::user_input::UserInputOption {
+                            label: "No".to_string(),
+                            description: "Stop here".to_string(),
+                        },
+                    ],
+                    allow_free_text: false,
+                    multi_select: false,
+                }],
+            },
+        })
+        .await?;
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let detail = loop {
+        let detail = manager.get_thread_detail(&thread.id).await?;
+        if !detail.pending_user_inputs.is_empty() {
+            break detail;
+        }
+        if Instant::now() >= deadline {
+            bail!("pending user input did not reach the canonical snapshot");
+        }
+        sleep(Duration::from_millis(20)).await;
+    };
+    assert_eq!(detail.pending_approvals.len(), 0);
+    assert_eq!(detail.pending_user_inputs.len(), 1);
+    assert_eq!(detail.pending_user_inputs[0].id, "input_reload");
+    assert_eq!(detail.pending_user_inputs[0].turn_id, turn.id);
+    assert_eq!(
+        detail.pending_user_inputs[0].request.questions[0].question,
+        "Continue with the check?"
+    );
+
+    manager
+        .submit_user_input(
+            &thread.id,
+            "input_reload",
+            crate::tools::user_input::UserInputResponse {
+                answers: vec![crate::tools::user_input::UserInputAnswer {
+                    id: "continue".to_string(),
+                    label: "Yes".to_string(),
+                    value: "Yes".to_string(),
+                }],
+            },
+        )
+        .await?;
+    match harness.recv_user_input_submission().await {
+        Some((id, response)) => {
+            assert_eq!(id, "input_reload");
+            assert_eq!(response.answers[0].id, "continue");
+        }
+        other => panic!("expected submitted user input, got {other:?}"),
+    }
+    assert!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_user_inputs
+            .is_empty()
+    );
+    assert!(manager.events_since(&thread.id, None)?.iter().any(|event| {
+        event.event == "user_input.answered"
+            && event.payload.get("input_id").and_then(Value::as_str) == Some("input_reload")
+    }));
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn terminal_turn_cancels_pending_user_input_and_clears_snapshot() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "needs input before completion".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+    harness
+        .tx_event
+        .send(EngineEvent::UserInputRequired {
+            id: "input_terminal".to_string(),
+            request: crate::tools::user_input::UserInputRequest {
+                questions: vec![crate::tools::user_input::UserInputQuestion {
+                    header: "Continue".to_string(),
+                    id: "continue".to_string(),
+                    question: "Continue?".to_string(),
+                    options: vec![crate::tools::user_input::UserInputOption {
+                        label: "Yes".to_string(),
+                        description: "Continue now".to_string(),
+                    }],
+                    allow_free_text: false,
+                    multi_select: false,
+                }],
+            },
+        })
+        .await?;
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if !manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_user_inputs
+            .is_empty()
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            bail!("pending user input did not reach the canonical snapshot");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    let canceled = tokio::time::timeout(
+        Duration::from_secs(2),
+        harness.recv_user_input_cancellation(),
+    )
+    .await
+    .expect("terminal user-input cancellation timed out");
+    assert_eq!(canceled.as_deref(), Some("input_terminal"));
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let detail = manager.get_thread_detail(&thread.id).await?;
+        if detail.pending_user_inputs.is_empty()
+            && manager.events_since(&thread.id, None)?.iter().any(|event| {
+                event.event == "user_input.canceled"
+                    && event.turn_id.as_deref() == Some(turn.id.as_str())
+                    && event.payload.get("input_id").and_then(Value::as_str)
+                        == Some("input_terminal")
+                    && event.payload.get("terminal").and_then(Value::as_bool) == Some(true)
+            })
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "terminal user input was not cleared from the snapshot with a cancellation event"
+            );
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
     Ok(())
 }
 

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -4531,6 +4531,99 @@ async fn closed_engine_event_stream_fails_turn_items_and_evicts_engine() -> Resu
 }
 
 #[tokio::test]
+async fn failed_turn_cancels_pending_user_input_and_clears_snapshot() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "input required, then the engine stream closes".to_string(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+    harness
+        .tx_event
+        .send(EngineEvent::UserInputRequired {
+            id: "input_failed_turn".to_string(),
+            request: crate::tools::user_input::UserInputRequest {
+                questions: vec![crate::tools::user_input::UserInputQuestion {
+                    header: "Continue".to_string(),
+                    id: "continue".to_string(),
+                    question: "Continue?".to_string(),
+                    options: vec![crate::tools::user_input::UserInputOption {
+                        label: "Yes".to_string(),
+                        description: "Continue now".to_string(),
+                    }],
+                    allow_free_text: false,
+                    multi_select: false,
+                }],
+            },
+        })
+        .await?;
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if !manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_user_inputs
+            .is_empty()
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            bail!("pending user input did not reach the canonical snapshot");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    // Fail the turn mid-prompt: closing the event stream settles the turn as
+    // failed through the monitor-failure path.
+    harness.close_event_stream();
+
+    let canceled = tokio::time::timeout(
+        Duration::from_secs(2),
+        harness.recv_user_input_cancellation(),
+    )
+    .await
+    .expect("failure-path user-input cancellation timed out");
+    assert_eq!(canceled.as_deref(), Some("input_failed_turn"));
+
+    let terminal = wait_for_terminal_turn(&manager, &turn.id, Duration::from_secs(2)).await?;
+    assert_eq!(terminal.status, RuntimeTurnStatus::Failed);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let detail = manager.get_thread_detail(&thread.id).await?;
+        if detail.pending_user_inputs.is_empty()
+            && manager.events_since(&thread.id, None)?.iter().any(|event| {
+                event.event == "user_input.canceled"
+                    && event.turn_id.as_deref() == Some(turn.id.as_str())
+                    && event.payload.get("input_id").and_then(Value::as_str)
+                        == Some("input_failed_turn")
+                    && event.payload.get("terminal").and_then(Value::as_bool) == Some(true)
+            })
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            bail!("failed turn left a stale pending user input in the snapshot");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn compaction_lifecycle_emits_item_events_with_compaction_counts() -> Result<()> {
     let manager = test_manager(test_runtime_dir())?;
     let thread = manager

--- a/crates/tui/src/runtime_web/app.mjs
+++ b/crates/tui/src/runtime_web/app.mjs
@@ -1,0 +1,836 @@
+const STREAM_EVENT_NAMES = [
+  "thread.created",
+  "thread.updated",
+  "turn.started",
+  "turn.lifecycle",
+  "turn.steered",
+  "turn.interrupt_requested",
+  "turn.completed",
+  "item.started",
+  "item.delta",
+  "item.completed",
+  "item.failed",
+  "approval.required",
+  "approval.decided",
+  "approval.timeout",
+  "user_input.required",
+  "user_input.answered",
+  "user_input.canceled",
+  "sandbox.denied",
+  "agent.spawned",
+  "agent.progress",
+  "agent.completed",
+  "agent.list",
+];
+
+export function createThreadState(threadId = "") {
+  return {
+    threadId,
+    thread: null,
+    turns: new Map(),
+    turnOrder: [],
+    items: new Map(),
+    itemOrder: [],
+    latestSeq: 0,
+    approvals: new Map(),
+    userInputs: new Map(),
+  };
+}
+
+export function applySnapshot(state, detail, expectedThreadId = state.threadId) {
+  if (!detail || !detail.thread || detail.thread.id !== expectedThreadId) {
+    return false;
+  }
+  state.threadId = expectedThreadId;
+  state.thread = detail.thread;
+  state.turns = new Map();
+  state.turnOrder = [];
+  for (const turn of Array.isArray(detail.turns) ? detail.turns : []) {
+    if (!turn || !turn.id) continue;
+    state.turns.set(turn.id, turn);
+    state.turnOrder.push(turn.id);
+  }
+  state.items = new Map();
+  state.itemOrder = [];
+  for (const item of Array.isArray(detail.items) ? detail.items : []) {
+    if (!item || !item.id) continue;
+    state.items.set(item.id, item);
+    state.itemOrder.push(item.id);
+  }
+  state.latestSeq = normalizedSequence(detail.latest_seq);
+  state.approvals = new Map();
+  for (const approval of Array.isArray(detail.pending_approvals) ? detail.pending_approvals : []) {
+    const approvalId = approval?.approval_id || approval?.id;
+    if (approvalId) state.approvals.set(approvalId, approval);
+  }
+  state.userInputs = new Map();
+  for (const input of Array.isArray(detail.pending_user_inputs) ? detail.pending_user_inputs : []) {
+    const inputId = input?.input_id || input?.id;
+    if (inputId) state.userInputs.set(inputId, input);
+  }
+  return true;
+}
+
+export function applyRuntimeEvent(state, envelope) {
+  if (!envelope || envelope.thread_id !== state.threadId) {
+    return false;
+  }
+  const sequence = normalizedSequence(envelope.seq);
+  if (sequence <= state.latestSeq) {
+    return false;
+  }
+  state.latestSeq = sequence;
+
+  const eventName = envelope.event || envelope.kind || "";
+  const payload = envelope.payload && typeof envelope.payload === "object"
+    ? envelope.payload
+    : {};
+
+  if (eventName === "thread.updated" && payload.thread) {
+    state.thread = payload.thread;
+  } else if (eventName === "turn.started" || eventName === "turn.completed") {
+    if (payload.turn) upsertTurn(state, payload.turn);
+  } else if (eventName === "turn.lifecycle") {
+    const turnId = envelope.turn_id;
+    const turn = turnId ? state.turns.get(turnId) : null;
+    if (turn && payload.status) {
+      state.turns.set(turnId, { ...turn, status: payload.status });
+    }
+  } else if (eventName === "turn.interrupt_requested") {
+    const turnId = envelope.turn_id;
+    const turn = turnId ? state.turns.get(turnId) : null;
+    if (turn) state.turns.set(turnId, { ...turn, status: "in_progress" });
+  } else if (eventName === "item.started" || eventName === "item.completed" || eventName === "item.failed") {
+    if (payload.item) upsertItem(state, payload.item);
+  } else if (eventName === "item.delta") {
+    appendItemDelta(state, envelope.item_id, payload);
+  } else if (eventName === "approval.required") {
+    const approvalId = payload.approval_id || payload.id;
+    if (approvalId) state.approvals.set(approvalId, payload);
+  } else if (eventName === "approval.decided" || eventName === "approval.timeout") {
+    const approvalId = payload.approval_id || payload.id;
+    if (approvalId) state.approvals.delete(approvalId);
+  } else if (eventName === "user_input.required") {
+    const inputId = payload.id;
+    if (inputId) state.userInputs.set(inputId, payload);
+  } else if (eventName === "user_input.answered" || eventName === "user_input.canceled") {
+    const inputId = payload.input_id || payload.id;
+    if (inputId) state.userInputs.delete(inputId);
+  }
+  return true;
+}
+
+export async function snapshotThenSubscribe({
+  state,
+  threadId,
+  loadSnapshot,
+  subscribe,
+  isCurrent = () => true,
+}) {
+  const detail = await loadSnapshot(threadId);
+  if (!isCurrent() || !applySnapshot(state, detail, threadId)) {
+    return false;
+  }
+  if (!isCurrent()) return false;
+  subscribe(threadId, state.latestSeq);
+  return true;
+}
+
+export function eventStreamUrl(threadId, latestSeq) {
+  return `/v1/threads/${encodeURIComponent(threadId)}/events?since_seq=${normalizedSequence(latestSeq)}`;
+}
+
+export function saveDraft(drafts, threadId, value) {
+  if (!threadId) return;
+  if (value) drafts.set(threadId, value);
+  else drafts.delete(threadId);
+}
+
+export function restoreDraft(drafts, threadId) {
+  return drafts.get(threadId) || "";
+}
+
+export function setSafeText(element, value) {
+  element.textContent = value == null ? "" : String(value);
+  return element;
+}
+
+function normalizedSequence(value) {
+  const sequence = Number(value);
+  return Number.isSafeInteger(sequence) && sequence > 0 ? sequence : 0;
+}
+
+function upsertTurn(state, turn) {
+  if (!turn || !turn.id) return;
+  if (!state.turns.has(turn.id)) state.turnOrder.push(turn.id);
+  state.turns.set(turn.id, turn);
+}
+
+function upsertItem(state, item) {
+  if (!item || !item.id) return;
+  if (!state.items.has(item.id)) state.itemOrder.push(item.id);
+  state.items.set(item.id, item);
+}
+
+function appendItemDelta(state, itemId, payload) {
+  if (!itemId) return;
+  const delta = typeof payload.delta === "string" ? payload.delta : "";
+  const existing = state.items.get(itemId) || {
+    id: itemId,
+    turn_id: "",
+    kind: payload.kind || "agent_message",
+    status: "in_progress",
+    summary: "",
+    detail: "",
+  };
+  if (!state.items.has(itemId)) state.itemOrder.push(itemId);
+  state.items.set(itemId, {
+    ...existing,
+    status: "in_progress",
+    detail: `${existing.detail || ""}${delta}`,
+  });
+}
+
+function startBrowserClient() {
+  const dom = {
+    shell: document.querySelector("#app-shell"),
+    railOpen: document.querySelector("#rail-open"),
+    railClose: document.querySelector("#rail-close"),
+    railScrim: document.querySelector("#rail-scrim"),
+    search: document.querySelector("#thread-search"),
+    threadList: document.querySelector("#thread-list"),
+    newThread: document.querySelector("#new-thread"),
+    connectionDot: document.querySelector("#connection-dot"),
+    connectionLabel: document.querySelector("#connection-label"),
+    kicker: document.querySelector("#session-kicker"),
+    title: document.querySelector("#session-title"),
+    facts: document.querySelector("#session-facts"),
+    rename: document.querySelector("#rename-thread"),
+    archive: document.querySelector("#archive-thread"),
+    status: document.querySelector("#status-banner"),
+    transcript: document.querySelector("#transcript"),
+    attention: document.querySelector("#attention"),
+    composer: document.querySelector("#composer"),
+    composerInput: document.querySelector("#composer-input"),
+    send: document.querySelector("#send-message"),
+    interrupt: document.querySelector("#interrupt-turn"),
+    renameDialog: document.querySelector("#rename-dialog"),
+    renameForm: document.querySelector("#rename-form"),
+    renameInput: document.querySelector("#rename-input"),
+  };
+
+  const app = {
+    summaries: [],
+    selectedThreadId: "",
+    threadState: createThreadState(),
+    workspace: null,
+    runtimeInfo: null,
+    drafts: new Map(),
+    stream: null,
+    reconnectTimer: null,
+    generation: 0,
+    searchTimer: null,
+  };
+
+  function element(tag, className, text) {
+    const created = document.createElement(tag);
+    if (className) created.className = className;
+    if (text != null) setSafeText(created, text);
+    return created;
+  }
+
+  function closeRail() {
+    dom.shell.classList.remove("rail-visible");
+    dom.railOpen.focus({ preventScroll: true });
+  }
+
+  function setConnection(kind, message) {
+    dom.connectionDot.className = `connection-dot ${kind || ""}`.trim();
+    setSafeText(dom.connectionLabel, message);
+  }
+
+  function showStatus(message) {
+    setSafeText(dom.status, message || "");
+    dom.status.hidden = !message;
+  }
+
+  async function api(path, options = {}) {
+    const headers = new Headers(options.headers || {});
+    if (options.body != null && !headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
+    const response = await fetch(path, {
+      ...options,
+      headers,
+      credentials: "same-origin",
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      let message = `${response.status} ${response.statusText}`.trim();
+      try {
+        const body = await response.json();
+        message = body?.error?.message || body?.message || message;
+      } catch (_error) {
+        // The status line is enough when the response is not JSON.
+      }
+      if (response.status === 401) {
+        message = "This browser session is not authenticated. Restart `codewhale web` to open a fresh one-time session.";
+      }
+      throw new Error(message);
+    }
+    if (response.status === 204) return null;
+    const contentType = response.headers.get("content-type") || "";
+    return contentType.includes("application/json") ? response.json() : response.text();
+  }
+
+  function renderThreadList() {
+    dom.threadList.replaceChildren();
+    if (app.summaries.length === 0) {
+      const empty = element("p", "thread-preview", "No matching threads");
+      empty.style.padding = "8px 10px";
+      dom.threadList.append(empty);
+      return;
+    }
+    for (const summary of app.summaries) {
+      const row = element("button", "thread-row");
+      row.type = "button";
+      row.dataset.threadId = summary.id;
+      row.setAttribute("aria-current", summary.id === app.selectedThreadId ? "true" : "false");
+      const titleRow = element("span", "thread-title-row");
+      titleRow.append(element("span", "thread-title", summary.title || "New thread"));
+      const status = element("span", `status-pip ${summary.latest_turn_status === "inprogress" || summary.latest_turn_status === "in_progress" ? "running" : summary.latest_turn_status === "failed" ? "failed" : ""}`);
+      status.setAttribute("aria-label", summary.latest_turn_status || "idle");
+      titleRow.append(status);
+      row.append(titleRow);
+      row.append(element("span", "thread-preview", summary.preview || "No messages yet"));
+      const branch = summary.branch || basename(summary.workspace) || "local";
+      row.append(element("span", "thread-meta", `${branch} · ${relativeTime(summary.updated_at)}`));
+      row.addEventListener("click", () => selectThread(summary.id));
+      dom.threadList.append(row);
+    }
+  }
+
+  async function loadThreads(search = dom.search.value.trim()) {
+    const query = new URLSearchParams({ limit: "100" });
+    if (search) query.set("search", search);
+    app.summaries = await api(`/v1/threads/summary?${query.toString()}`);
+    renderThreadList();
+    return app.summaries;
+  }
+
+  function stopStream() {
+    if (app.stream) app.stream.close();
+    app.stream = null;
+    if (app.reconnectTimer) clearTimeout(app.reconnectTimer);
+    app.reconnectTimer = null;
+  }
+
+  async function selectThread(threadId) {
+    if (!threadId) return;
+    saveDraft(app.drafts, app.selectedThreadId, dom.composerInput.value);
+    stopStream();
+    app.selectedThreadId = threadId;
+    app.threadState = createThreadState(threadId);
+    app.generation += 1;
+    const generation = app.generation;
+    dom.composerInput.value = restoreDraft(app.drafts, threadId);
+    resizeComposer();
+    renderThreadList();
+    renderAll();
+    closeRailIfNarrow();
+    setConnection("", "Loading thread snapshot…");
+    showStatus("");
+
+    try {
+      const subscribed = await snapshotThenSubscribe({
+        state: app.threadState,
+        threadId,
+        loadSnapshot: (id) => api(`/v1/threads/${encodeURIComponent(id)}`),
+        subscribe: (id, sequence) => connectStream(id, sequence, generation),
+        isCurrent: () => generation === app.generation && threadId === app.selectedThreadId,
+      });
+      if (!subscribed) return;
+      renderAll();
+      setConnection("ready", "Local runtime connected");
+    } catch (error) {
+      if (generation !== app.generation) return;
+      showStatus(error.message);
+      setConnection("error", "Runtime connection failed");
+    }
+  }
+
+  function connectStream(threadId, sequence, generation) {
+    if (generation !== app.generation || threadId !== app.selectedThreadId) return;
+    if (app.stream) app.stream.close();
+    const stream = new EventSource(eventStreamUrl(threadId, sequence), { withCredentials: true });
+    app.stream = stream;
+    stream.onopen = () => setConnection("ready", "Local runtime connected");
+    const receive = (message) => {
+      if (generation !== app.generation || threadId !== app.selectedThreadId) return;
+      try {
+        const envelope = JSON.parse(message.data);
+        if (!applyRuntimeEvent(app.threadState, envelope)) return;
+        renderAll(true);
+        if (envelope.event === "turn.completed" || envelope.event === "thread.updated") {
+          loadThreads().catch((error) => showStatus(error.message));
+        }
+      } catch (error) {
+        showStatus(`Could not read a Runtime event: ${error.message}`);
+      }
+    };
+    for (const name of STREAM_EVENT_NAMES) stream.addEventListener(name, receive);
+    stream.onerror = () => {
+      stream.close();
+      if (app.stream === stream) app.stream = null;
+      if (generation !== app.generation || threadId !== app.selectedThreadId) return;
+      setConnection("", "Reconnecting to local runtime…");
+      app.reconnectTimer = setTimeout(
+        () => connectStream(threadId, app.threadState.latestSeq, generation),
+        900,
+      );
+    };
+  }
+
+  function renderAll(preserveScroll = false) {
+    renderHeader();
+    renderTranscript(preserveScroll);
+    renderAttention();
+    renderComposer();
+    renderThreadList();
+  }
+
+  function renderHeader() {
+    const thread = app.threadState.thread;
+    const summary = app.summaries.find((item) => item.id === app.selectedThreadId);
+    const title = thread?.title || summary?.title || (thread ? "New thread" : "Choose a thread");
+    setSafeText(dom.title, title);
+    setSafeText(dom.kicker, thread ? "Local Runtime thread" : "Local Runtime");
+    dom.rename.disabled = !thread;
+    dom.archive.disabled = !thread;
+    dom.facts.replaceChildren();
+    if (!thread) return;
+
+    const workspace = summary?.workspace || thread.workspace || app.workspace?.workspace;
+    const branch = summary?.branch || app.workspace?.branch;
+    dom.facts.append(factChip("Workspace", basename(workspace) || "local"));
+    if (branch) dom.facts.append(factChip("Branch", branch));
+    dom.facts.append(factChip("Model", thread.model || "Runtime default"));
+    dom.facts.append(factChip("Mode", modeLabel(thread.mode)));
+    dom.facts.append(factChip("Permission", permissionLabel(thread)));
+  }
+
+  function factChip(label, value) {
+    const chip = element("span", "fact-chip");
+    chip.append(element("span", "", label));
+    chip.append(element("strong", "", value));
+    return chip;
+  }
+
+  function renderTranscript(preserveScroll) {
+    const wasNearBottom = dom.transcript.scrollHeight - dom.transcript.scrollTop - dom.transcript.clientHeight < 120;
+    dom.transcript.replaceChildren();
+    if (!app.threadState.thread) {
+      dom.transcript.append(emptyState("Your local agent, in the browser.", "Create a thread or choose one from the rail. This client uses the same Runtime as the terminal."));
+      return;
+    }
+    if (app.threadState.itemOrder.length === 0) {
+      dom.transcript.append(emptyState("Ready for a task.", "Send a message below. Model, mode, and permission posture come from the Runtime and are shown read-only above."));
+      return;
+    }
+    for (const itemId of app.threadState.itemOrder) {
+      const item = app.threadState.items.get(itemId);
+      if (!item) continue;
+      dom.transcript.append(renderItem(item));
+    }
+    if (!preserveScroll || wasNearBottom) {
+      requestAnimationFrame(() => {
+        dom.transcript.scrollTop = dom.transcript.scrollHeight;
+      });
+    }
+  }
+
+  function emptyState(title, description) {
+    const empty = element("div", "empty-state");
+    empty.append(element("div", "empty-orbit", "◌"));
+    empty.append(element("h2", "", title));
+    empty.append(element("p", "", description));
+    return empty;
+  }
+
+  function renderItem(item) {
+    const detail = item.detail || item.summary || "";
+    if (item.kind === "user_message" || item.kind === "agent_message") {
+      const role = item.kind === "user_message" ? "user" : "agent";
+      const card = element("article", `message ${role} ${item.status === "in_progress" ? "in-progress" : ""}`.trim());
+      card.append(element("div", "message-label", role === "user" ? "You" : "Codewhale"));
+      card.append(element("div", "message-body", detail));
+      return card;
+    }
+    if (item.kind === "agent_reasoning") {
+      const reasoning = element("article", "reasoning");
+      const disclosure = element("details");
+      disclosure.append(element("summary", "", item.status === "in_progress" ? "Reasoning…" : "Reasoning"));
+      disclosure.append(element("pre", "", detail));
+      reasoning.append(disclosure);
+      return reasoning;
+    }
+
+    const receipt = element("article", `receipt ${item.status === "failed" ? "failed" : ""}`.trim());
+    receipt.append(element("div", "receipt-label", `${humanize(item.kind)} · ${humanize(item.status)}`));
+    receipt.append(element("div", "receipt-summary", item.summary || detail || humanize(item.kind)));
+    if (detail && detail !== item.summary) {
+      const disclosure = element("details");
+      disclosure.append(element("summary", "", "Show receipt"));
+      disclosure.append(element("pre", "", detail));
+      receipt.append(disclosure);
+    }
+    return receipt;
+  }
+
+  function renderAttention() {
+    dom.attention.replaceChildren();
+    for (const [approvalId, approval] of app.threadState.approvals) {
+      dom.attention.append(renderApproval(approvalId, approval));
+    }
+    for (const [inputId, input] of app.threadState.userInputs) {
+      dom.attention.append(renderUserInput(inputId, input));
+    }
+    dom.attention.hidden = dom.attention.childElementCount === 0;
+  }
+
+  function renderApproval(approvalId, approval) {
+    const card = element("article", "attention-card");
+    card.append(element("p", "eyebrow", "Approval required"));
+    card.append(element("h2", "", approval.tool_name || "Tool request"));
+    card.append(element("p", "", approval.intent_summary || approval.description || "Codewhale is waiting for permission."));
+    const actions = element("div", "attention-actions");
+    const rememberLabel = element("label", "remember-field");
+    const remember = document.createElement("input");
+    remember.type = "checkbox";
+    rememberLabel.append(remember, document.createTextNode("Remember for this thread"));
+    const deny = element("button", "quiet-button danger", "Deny");
+    deny.type = "button";
+    deny.addEventListener("click", () => resolveApproval(approvalId, "deny", remember.checked));
+    const allow = element("button", "primary-button", "Allow");
+    allow.type = "button";
+    allow.addEventListener("click", () => resolveApproval(approvalId, "allow", remember.checked));
+    actions.append(rememberLabel, deny, allow);
+    card.append(actions);
+    return card;
+  }
+
+  async function resolveApproval(approvalId, decision, remember) {
+    try {
+      await api(`/v1/approvals/${encodeURIComponent(approvalId)}`, {
+        method: "POST",
+        body: JSON.stringify({ decision, remember }),
+      });
+      app.threadState.approvals.delete(approvalId);
+      renderAttention();
+    } catch (error) {
+      showStatus(error.message);
+    }
+  }
+
+  function renderUserInput(inputId, envelope) {
+    const card = element("form", "attention-card");
+    card.append(element("p", "eyebrow", "Input required"));
+    card.append(element("h2", "", "Codewhale has a question"));
+    const questions = Array.isArray(envelope.request?.questions) ? envelope.request.questions : [];
+    const groups = [];
+    for (const question of questions) {
+      const fieldset = element("fieldset", "question-fieldset");
+      fieldset.append(element("legend", "", question.question || question.header || "Choose an option"));
+      const controls = [];
+      for (const option of Array.isArray(question.options) ? question.options : []) {
+        const label = element("label", "answer-option");
+        const input = document.createElement("input");
+        input.type = question.multi_select ? "checkbox" : "radio";
+        input.name = `question-${inputId}-${question.id}`;
+        input.value = option.label || "";
+        label.append(input);
+        const copy = element("span", "", option.label || "Option");
+        if (option.description) copy.append(element("small", "", option.description));
+        label.append(copy);
+        fieldset.append(label);
+        controls.push({ input, label: option.label || "", value: option.label || "" });
+      }
+      let other = null;
+      if (question.allow_free_text) {
+        other = document.createElement("input");
+        other.className = "other-answer";
+        other.type = "text";
+        other.placeholder = "Other response";
+        other.setAttribute("aria-label", `${question.header || "Question"} other response`);
+        fieldset.append(other);
+      }
+      card.append(fieldset);
+      groups.push({ question, controls, other });
+    }
+    const actions = element("div", "attention-actions");
+    const submit = element("button", "primary-button", "Submit answers");
+    submit.type = "submit";
+    actions.append(submit);
+    card.append(actions);
+    card.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const answers = [];
+      for (const group of groups) {
+        for (const control of group.controls) {
+          if (control.input.checked) {
+            answers.push({ id: group.question.id, label: control.label, value: control.value });
+          }
+        }
+        const otherValue = group.other?.value.trim();
+        if (otherValue) answers.push({ id: group.question.id, label: "Other", value: otherValue });
+        if (!answers.some((answer) => answer.id === group.question.id)) {
+          showStatus(`Choose an answer for ${group.question.header || group.question.question || "each question"}.`);
+          return;
+        }
+      }
+      try {
+        await api(`/v1/user-input/${encodeURIComponent(app.selectedThreadId)}/${encodeURIComponent(inputId)}`, {
+          method: "POST",
+          body: JSON.stringify({ answers }),
+        });
+        app.threadState.userInputs.delete(inputId);
+        showStatus("");
+        renderAttention();
+      } catch (error) {
+        showStatus(error.message);
+      }
+    });
+    return card;
+  }
+
+  function latestTurn() {
+    const id = app.threadState.turnOrder.at(-1);
+    return id ? app.threadState.turns.get(id) : null;
+  }
+
+  function activeTurn() {
+    const turn = latestTurn();
+    return turn && (turn.status === "in_progress" || turn.status === "queued") ? turn : null;
+  }
+
+  function renderComposer() {
+    const ready = Boolean(app.threadState.thread);
+    const active = activeTurn();
+    dom.composerInput.disabled = !ready;
+    dom.send.disabled = !ready || !dom.composerInput.value.trim();
+    dom.interrupt.hidden = !active;
+    setSafeText(dom.send, active ? "Steer" : "Send");
+  }
+
+  async function createThread() {
+    showStatus("");
+    try {
+      const thread = await api("/v1/threads", { method: "POST", body: "{}" });
+      await loadThreads("");
+      await selectThread(thread.id);
+      dom.composerInput.focus();
+      return thread;
+    } catch (error) {
+      showStatus(error.message);
+      return null;
+    }
+  }
+
+  async function sendMessage() {
+    const prompt = dom.composerInput.value.trim();
+    if (!prompt) return;
+    let threadId = app.selectedThreadId;
+    if (!threadId) {
+      const thread = await createThread();
+      if (!thread) return;
+      threadId = thread.id;
+    }
+    const turn = activeTurn();
+    dom.send.disabled = true;
+    showStatus("");
+    try {
+      if (turn) {
+        await api(`/v1/threads/${encodeURIComponent(threadId)}/turns/${encodeURIComponent(turn.id)}/steer`, {
+          method: "POST",
+          body: JSON.stringify({ prompt }),
+        });
+      } else {
+        await api(`/v1/threads/${encodeURIComponent(threadId)}/turns`, {
+          method: "POST",
+          body: JSON.stringify({ prompt }),
+        });
+      }
+      saveDraft(app.drafts, threadId, "");
+      dom.composerInput.value = "";
+      resizeComposer();
+      renderComposer();
+      loadThreads().catch((error) => showStatus(error.message));
+    } catch (error) {
+      showStatus(error.message);
+      renderComposer();
+    }
+  }
+
+  async function interruptTurn() {
+    const turn = activeTurn();
+    if (!turn || !app.selectedThreadId) return;
+    dom.interrupt.disabled = true;
+    try {
+      await api(`/v1/threads/${encodeURIComponent(app.selectedThreadId)}/turns/${encodeURIComponent(turn.id)}/interrupt`, { method: "POST" });
+    } catch (error) {
+      showStatus(error.message);
+    } finally {
+      dom.interrupt.disabled = false;
+    }
+  }
+
+  async function archiveThread() {
+    if (!app.selectedThreadId) return;
+    if (!globalThis.confirm("Archive this thread? You can still access it through the Runtime API.")) return;
+    try {
+      await api(`/v1/threads/${encodeURIComponent(app.selectedThreadId)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ archived: true }),
+      });
+      saveDraft(app.drafts, app.selectedThreadId, "");
+      stopStream();
+      app.selectedThreadId = "";
+      app.threadState = createThreadState();
+      await loadThreads();
+      if (app.summaries[0]) await selectThread(app.summaries[0].id);
+      else renderAll();
+    } catch (error) {
+      showStatus(error.message);
+    }
+  }
+
+  function openRenameDialog() {
+    if (!app.threadState.thread) return;
+    dom.renameInput.value = app.threadState.thread.title || "";
+    dom.renameDialog.showModal();
+    dom.renameInput.focus();
+    dom.renameInput.select();
+  }
+
+  async function submitRename(event) {
+    event.preventDefault();
+    const action = event.submitter?.value;
+    if (action !== "save") {
+      dom.renameDialog.close();
+      return;
+    }
+    const title = dom.renameInput.value.trim();
+    if (!title || !app.selectedThreadId) return;
+    try {
+      const thread = await api(`/v1/threads/${encodeURIComponent(app.selectedThreadId)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ title }),
+      });
+      app.threadState.thread = thread;
+      dom.renameDialog.close();
+      await loadThreads();
+      renderHeader();
+    } catch (error) {
+      showStatus(error.message);
+    }
+  }
+
+  function resizeComposer() {
+    dom.composerInput.style.height = "auto";
+    dom.composerInput.style.height = `${Math.min(dom.composerInput.scrollHeight, 180)}px`;
+  }
+
+  function closeRailIfNarrow() {
+    if (globalThis.matchMedia("(max-width: 800px)").matches) closeRail();
+  }
+
+  dom.railOpen.addEventListener("click", () => dom.shell.classList.add("rail-visible"));
+  dom.railClose.addEventListener("click", closeRail);
+  dom.railScrim.addEventListener("click", closeRail);
+  dom.newThread.addEventListener("click", createThread);
+  dom.rename.addEventListener("click", openRenameDialog);
+  dom.archive.addEventListener("click", archiveThread);
+  dom.renameForm.addEventListener("submit", submitRename);
+  dom.interrupt.addEventListener("click", interruptTurn);
+  dom.composer.addEventListener("submit", (event) => {
+    event.preventDefault();
+    sendMessage();
+  });
+  dom.composerInput.addEventListener("input", () => {
+    saveDraft(app.drafts, app.selectedThreadId, dom.composerInput.value);
+    resizeComposer();
+    renderComposer();
+  });
+  dom.composerInput.addEventListener("keydown", (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      sendMessage();
+    }
+  });
+  dom.search.addEventListener("input", () => {
+    if (app.searchTimer) clearTimeout(app.searchTimer);
+    app.searchTimer = setTimeout(() => {
+      loadThreads().catch((error) => showStatus(error.message));
+    }, 180);
+  });
+  globalThis.addEventListener("beforeunload", stopStream);
+
+  async function initialize() {
+    try {
+      [app.runtimeInfo, app.workspace] = await Promise.all([
+        api("/v1/runtime/info"),
+        api("/v1/workspace/status"),
+      ]);
+      setConnection("ready", "Local runtime connected");
+      await loadThreads();
+      if (app.summaries[0]) await selectThread(app.summaries[0].id);
+      else renderAll();
+    } catch (error) {
+      setConnection("error", "Runtime connection failed");
+      showStatus(error.message);
+      renderAll();
+    }
+  }
+
+  initialize();
+}
+
+function basename(path) {
+  if (!path) return "";
+  const normalized = String(path).replaceAll("\\", "/").replace(/\/$/, "");
+  return normalized.split("/").at(-1) || normalized;
+}
+
+function humanize(value) {
+  if (!value) return "Status";
+  return String(value)
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function modeLabel(mode) {
+  if (mode === "agent") return "Act";
+  if (mode === "plan") return "Plan";
+  if (mode === "operate") return "Operate";
+  return humanize(mode || "Runtime default");
+}
+
+function permissionLabel(thread) {
+  if (thread.trust_mode) return "Full Access";
+  if (thread.auto_approve) return "Auto-Review";
+  return "Ask";
+}
+
+function relativeTime(value) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return "recent";
+  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return "now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+if (typeof document !== "undefined") {
+  startBrowserClient();
+}

--- a/crates/tui/src/runtime_web/index.html
+++ b/crates/tui/src/runtime_web/index.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <meta name="theme-color" content="#081316">
+    <title>Codewhale</title>
+    <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/assets/codewhale-web.css">
+    <script type="module" src="/assets/codewhale-web.js"></script>
+  </head>
+  <body>
+    <div class="shell" id="app-shell">
+      <aside class="rail" id="thread-rail" aria-label="Threads">
+        <div class="rail-brand">
+          <div class="brand-mark" aria-hidden="true">CW</div>
+          <div>
+            <p class="eyebrow">Shannon Labs</p>
+            <p class="brand-name">Codewhale</p>
+          </div>
+          <button class="icon-button rail-close" id="rail-close" type="button" aria-label="Close threads">×</button>
+        </div>
+
+        <button class="primary-button new-thread" id="new-thread" type="button">
+          <span aria-hidden="true">＋</span>
+          New thread
+        </button>
+
+        <label class="search-field">
+          <span class="sr-only">Search threads</span>
+          <span aria-hidden="true">⌕</span>
+          <input id="thread-search" type="search" autocomplete="off" placeholder="Search threads">
+        </label>
+
+        <nav class="thread-list" id="thread-list" aria-label="Recent threads"></nav>
+
+        <div class="rail-footer">
+          <span class="connection-dot" id="connection-dot" aria-hidden="true"></span>
+          <span id="connection-label">Connecting to local runtime…</span>
+        </div>
+      </aside>
+
+      <button class="rail-scrim" id="rail-scrim" type="button" aria-label="Close threads"></button>
+
+      <main class="session">
+        <header class="session-header">
+          <div class="session-heading">
+            <button class="icon-button rail-open" id="rail-open" type="button" aria-label="Open threads">☰</button>
+            <div class="title-stack">
+              <p class="eyebrow" id="session-kicker">Local runtime</p>
+              <h1 id="session-title">Choose a thread</h1>
+            </div>
+          </div>
+          <div class="header-actions">
+            <button class="quiet-button" id="rename-thread" type="button" disabled>Rename</button>
+            <button class="quiet-button danger" id="archive-thread" type="button" disabled>Archive</button>
+          </div>
+          <div class="session-facts" id="session-facts" aria-label="Session details"></div>
+        </header>
+
+        <div class="status-banner" id="status-banner" role="status" aria-live="polite" hidden></div>
+
+        <section class="transcript" id="transcript" aria-label="Conversation" aria-live="polite">
+          <div class="empty-state">
+            <div class="empty-orbit" aria-hidden="true">◌</div>
+            <h2>Your local agent, in the browser.</h2>
+            <p>Create a thread or choose one from the rail. This client uses the same Runtime as the terminal.</p>
+          </div>
+        </section>
+
+        <section class="attention" id="attention" aria-label="Items requiring attention" hidden></section>
+
+        <footer class="composer-wrap">
+          <form class="composer" id="composer">
+            <label class="sr-only" for="composer-input">Message Codewhale</label>
+            <textarea id="composer-input" rows="1" placeholder="Ask Codewhale to work in this repository…" disabled></textarea>
+            <div class="composer-bar">
+              <span class="composer-hint">⌘↵ send</span>
+              <div class="composer-actions">
+                <button class="quiet-button" id="interrupt-turn" type="button" hidden>Stop</button>
+                <button class="send-button" id="send-message" type="submit" disabled>Send</button>
+              </div>
+            </div>
+          </form>
+        </footer>
+      </main>
+    </div>
+
+    <dialog class="rename-dialog" id="rename-dialog">
+      <form method="dialog" id="rename-form">
+        <p class="eyebrow">Thread title</p>
+        <h2>Rename this thread</h2>
+        <label>
+          <span class="sr-only">New thread title</span>
+          <input id="rename-input" type="text" maxlength="160" required autocomplete="off">
+        </label>
+        <div class="dialog-actions">
+          <button class="quiet-button" value="cancel" type="submit">Cancel</button>
+          <button class="primary-button" value="save" type="submit">Save title</button>
+        </div>
+      </form>
+    </dialog>
+
+    <noscript>Codewhale web requires JavaScript to connect to the local Runtime API.</noscript>
+  </body>
+</html>

--- a/crates/tui/src/runtime_web/styles.css
+++ b/crates/tui/src/runtime_web/styles.css
@@ -1,0 +1,906 @@
+:root {
+  color-scheme: dark;
+  --ink-0: #061012;
+  --ink-1: #081619;
+  --ink-2: #0d1d20;
+  --ink-3: #14282b;
+  --line: rgba(184, 218, 215, 0.14);
+  --line-strong: rgba(184, 218, 215, 0.25);
+  --text: #edf5f2;
+  --text-soft: #adc0bd;
+  --text-dim: #718985;
+  --gold: #e6b84f;
+  --gold-strong: #f1c768;
+  --gold-wash: rgba(230, 184, 79, 0.11);
+  --aqua: #72c7be;
+  --danger: #f08b83;
+  --ok: #75c49a;
+  --rail: 248px;
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  min-width: 280px;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--ink-0);
+  color: var(--text);
+}
+
+button,
+input,
+textarea {
+  color: inherit;
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled,
+textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--gold-strong);
+  outline-offset: 2px;
+}
+
+.shell {
+  display: grid;
+  grid-template-columns: var(--rail) minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 73% -20%, rgba(53, 126, 124, 0.12), transparent 42%),
+    var(--ink-0);
+}
+
+.rail {
+  position: relative;
+  z-index: 20;
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  gap: 14px;
+  min-width: 0;
+  min-height: 0;
+  padding: 18px 14px 12px;
+  border-right: 1px solid var(--line);
+  background: rgba(8, 22, 25, 0.96);
+}
+
+.rail-brand,
+.session-heading,
+.header-actions,
+.composer-bar,
+.composer-actions,
+.rail-footer,
+.fact-chip,
+.thread-title-row,
+.attention-actions,
+.dialog-actions {
+  display: flex;
+  align-items: center;
+}
+
+.rail-brand {
+  min-width: 0;
+  gap: 10px;
+}
+
+.brand-mark {
+  display: grid;
+  flex: 0 0 34px;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid rgba(230, 184, 79, 0.42);
+  border-radius: 10px;
+  background: var(--gold-wash);
+  color: var(--gold-strong);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.brand-name {
+  margin: 2px 0 0;
+  font-size: 15px;
+  font-weight: 680;
+  letter-spacing: -0.01em;
+}
+
+.primary-button,
+.quiet-button,
+.send-button,
+.icon-button {
+  min-height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--ink-2);
+  color: var(--text-soft);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.primary-button,
+.send-button {
+  border-color: rgba(230, 184, 79, 0.4);
+  background: var(--gold);
+  color: #171204;
+}
+
+.primary-button:hover,
+.send-button:hover {
+  background: var(--gold-strong);
+}
+
+.quiet-button {
+  padding: 0 11px;
+}
+
+.quiet-button:hover,
+.icon-button:hover {
+  border-color: var(--line-strong);
+  background: var(--ink-3);
+  color: var(--text);
+}
+
+.quiet-button.danger:hover {
+  border-color: rgba(240, 139, 131, 0.42);
+  color: var(--danger);
+}
+
+.icon-button {
+  display: inline-grid;
+  width: 34px;
+  min-width: 34px;
+  padding: 0;
+  place-items: center;
+}
+
+.new-thread {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+}
+
+.search-field {
+  display: flex;
+  min-width: 0;
+  height: 36px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: rgba(5, 14, 16, 0.55);
+  color: var(--text-dim);
+}
+
+.search-field:focus-within {
+  border-color: rgba(230, 184, 79, 0.42);
+}
+
+.search-field input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.search-field input::placeholder,
+textarea::placeholder {
+  color: var(--text-dim);
+}
+
+.thread-list {
+  min-height: 0;
+  margin: 0 -4px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--ink-3) transparent;
+}
+
+.thread-row {
+  display: block;
+  width: 100%;
+  margin: 2px 0;
+  padding: 10px;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-soft);
+  text-align: left;
+}
+
+.thread-row:hover {
+  background: rgba(20, 40, 43, 0.62);
+  color: var(--text);
+}
+
+.thread-row[aria-current="true"] {
+  border-color: rgba(230, 184, 79, 0.24);
+  background: var(--gold-wash);
+  color: var(--text);
+}
+
+.thread-title-row {
+  min-width: 0;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.thread-title {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-preview {
+  display: -webkit-box;
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-size: 10px;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.thread-meta {
+  margin-top: 7px;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-pip {
+  flex: 0 0 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+
+.status-pip.running {
+  background: var(--gold-strong);
+  box-shadow: 0 0 0 3px var(--gold-wash);
+}
+
+.status-pip.failed {
+  background: var(--danger);
+}
+
+.rail-footer {
+  min-width: 0;
+  gap: 8px;
+  padding: 9px 4px 0;
+  border-top: 1px solid var(--line);
+  color: var(--text-dim);
+  font-size: 10px;
+}
+
+.connection-dot {
+  flex: 0 0 7px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--gold);
+}
+
+.connection-dot.ready {
+  background: var(--ok);
+}
+
+.connection-dot.error {
+  background: var(--danger);
+}
+
+.session {
+  display: grid;
+  grid-template-areas:
+    "header"
+    "status"
+    "transcript"
+    "attention"
+    "composer";
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+.session-header {
+  display: grid;
+  grid-area: header;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px 20px;
+  padding: 15px 24px 13px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(6, 16, 18, 0.72);
+  backdrop-filter: blur(14px);
+}
+
+.session-heading {
+  min-width: 0;
+  gap: 10px;
+}
+
+.title-stack {
+  min-width: 0;
+}
+
+.session-header h1 {
+  margin: 3px 0 0;
+  overflow: hidden;
+  font-size: 16px;
+  font-weight: 680;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-actions {
+  align-self: center;
+  gap: 7px;
+}
+
+.session-facts {
+  display: flex;
+  grid-column: 1 / -1;
+  min-width: 0;
+  gap: 6px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.session-facts::-webkit-scrollbar {
+  display: none;
+}
+
+.fact-chip {
+  flex: 0 0 auto;
+  min-height: 23px;
+  gap: 5px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text-dim);
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.fact-chip strong {
+  color: var(--text-soft);
+  font-weight: 650;
+}
+
+.rail-open,
+.rail-close,
+.rail-scrim {
+  display: none;
+}
+
+.status-banner {
+  grid-area: status;
+  margin: 12px auto 0;
+  width: min(760px, calc(100% - 32px));
+  padding: 9px 12px;
+  border: 1px solid rgba(240, 139, 131, 0.28);
+  border-radius: 9px;
+  background: rgba(91, 31, 28, 0.24);
+  color: #ffc0bb;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.transcript {
+  grid-area: transcript;
+  min-height: 0;
+  padding: 30px max(16px, calc((100% - 760px) / 2)) 48px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-behavior: smooth;
+  scrollbar-color: var(--ink-3) transparent;
+}
+
+.empty-state {
+  display: grid;
+  min-height: 100%;
+  place-content: center;
+  justify-items: center;
+  padding: 32px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+.empty-state h2 {
+  margin: 14px 0 7px;
+  color: var(--text);
+  font-size: 19px;
+  letter-spacing: -0.02em;
+}
+
+.empty-state p {
+  max-width: 430px;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.empty-orbit {
+  color: var(--gold);
+  font-size: 34px;
+}
+
+.message,
+.receipt,
+.reasoning {
+  width: 100%;
+  margin: 0 0 14px;
+}
+
+.message-label,
+.receipt-label {
+  margin-bottom: 6px;
+  color: var(--text-dim);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.message-body {
+  max-width: 100%;
+  padding: 13px 15px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(13, 29, 32, 0.74);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.message.user .message-body {
+  margin-left: clamp(0px, 8vw, 72px);
+  border-color: rgba(230, 184, 79, 0.19);
+  background: rgba(230, 184, 79, 0.07);
+}
+
+.message.in-progress .message-body::after {
+  content: "";
+  display: inline-block;
+  width: 5px;
+  height: 12px;
+  margin-left: 4px;
+  background: var(--gold);
+  vertical-align: -1px;
+  animation: cursor-pulse 1s steps(2, end) infinite;
+}
+
+@keyframes cursor-pulse {
+  50% { opacity: 0; }
+}
+
+.receipt {
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(8, 22, 25, 0.54);
+}
+
+.receipt.failed {
+  border-color: rgba(240, 139, 131, 0.28);
+}
+
+.receipt-summary {
+  color: var(--text-soft);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.receipt details,
+.reasoning details {
+  margin-top: 7px;
+}
+
+.receipt summary,
+.reasoning summary {
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 10px;
+}
+
+.receipt pre,
+.reasoning pre {
+  max-height: 280px;
+  margin: 8px 0 0;
+  padding: 10px;
+  overflow: auto;
+  border-radius: 7px;
+  background: var(--ink-0);
+  color: var(--text-soft);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.reasoning {
+  padding-left: 12px;
+  border-left: 1px solid var(--line);
+}
+
+.attention {
+  grid-area: attention;
+  width: min(760px, calc(100% - 32px));
+  max-height: 42vh;
+  margin: 0 auto 10px;
+  overflow-y: auto;
+}
+
+.attention-card {
+  margin-top: 8px;
+  padding: 13px;
+  border: 1px solid rgba(230, 184, 79, 0.31);
+  border-radius: 11px;
+  background: rgba(45, 36, 13, 0.42);
+}
+
+.attention-card h2 {
+  margin: 4px 0 5px;
+  font-size: 13px;
+}
+
+.attention-card p {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.attention-actions {
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.remember-field,
+.answer-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: var(--text-soft);
+  font-size: 10px;
+}
+
+.question-fieldset {
+  margin: 12px 0 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+
+.question-fieldset legend {
+  padding: 0 5px;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.answer-option {
+  margin: 7px 0;
+}
+
+.answer-option small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.other-answer,
+.rename-dialog input {
+  width: 100%;
+  min-height: 36px;
+  margin-top: 7px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  outline: 0;
+  background: var(--ink-0);
+}
+
+.composer-wrap {
+  grid-area: composer;
+  padding: 0 max(16px, calc((100% - 760px) / 2)) 18px;
+  background: linear-gradient(transparent, var(--ink-0) 24%);
+}
+
+.composer {
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 13px;
+  background: rgba(13, 29, 32, 0.96);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.3);
+}
+
+.composer:focus-within {
+  border-color: rgba(230, 184, 79, 0.42);
+}
+
+.composer textarea {
+  display: block;
+  width: 100%;
+  min-height: 54px;
+  max-height: 180px;
+  padding: 13px 14px 6px;
+  resize: none;
+  overflow-y: auto;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.composer-bar {
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 7px 7px 13px;
+}
+
+.composer-hint {
+  color: var(--text-dim);
+  font-size: 9px;
+}
+
+.composer-actions {
+  gap: 7px;
+}
+
+.send-button {
+  min-width: 68px;
+  padding: 0 13px;
+}
+
+.rename-dialog {
+  width: min(420px, calc(100% - 28px));
+  padding: 0;
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  background: var(--ink-2);
+  color: var(--text);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+}
+
+.rename-dialog::backdrop {
+  background: rgba(2, 8, 9, 0.74);
+}
+
+.rename-dialog form {
+  padding: 20px;
+}
+
+.rename-dialog h2 {
+  margin: 5px 0 15px;
+  font-size: 17px;
+}
+
+.dialog-actions {
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.dialog-actions .primary-button {
+  padding: 0 13px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+noscript {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--ink-0);
+  color: var(--text);
+}
+
+@media (max-width: 800px) {
+  .shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .rail {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(86vw, 320px);
+    transform: translateX(-102%);
+    box-shadow: 24px 0 70px rgba(0, 0, 0, 0.45);
+    transition: transform 160ms ease-out;
+  }
+
+  .rail-open,
+  .rail-close {
+    display: inline-grid;
+  }
+
+  .rail-close {
+    margin-left: auto;
+  }
+
+  .rail-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 15;
+    display: block;
+    visibility: hidden;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    opacity: 0;
+    background: rgba(2, 8, 9, 0.64);
+    transition: opacity 160ms ease-out, visibility 160ms step-end;
+  }
+
+  .rail-visible .rail {
+    transform: translateX(0);
+  }
+
+  .rail-visible .rail-scrim {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 160ms ease-out;
+  }
+
+  .session-header {
+    padding: 12px 14px 10px;
+  }
+
+  .session-header h1 {
+    font-size: 14px;
+  }
+
+  .header-actions {
+    gap: 4px;
+  }
+
+  .header-actions .quiet-button {
+    padding: 0 8px;
+  }
+
+  .transcript {
+    padding-top: 20px;
+    padding-bottom: 34px;
+  }
+
+  .composer-wrap {
+    padding-bottom: max(10px, env(safe-area-inset-bottom));
+  }
+
+  .message.user .message-body {
+    margin-left: 20px;
+  }
+}
+
+@media (max-width: 430px) {
+  .session-header {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .header-actions {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+
+  .header-actions .quiet-button {
+    width: 34px;
+    padding: 0;
+    overflow: hidden;
+    color: transparent;
+    font-size: 0;
+  }
+
+  #rename-thread::after {
+    content: "✎";
+    color: var(--text-soft);
+    font-size: 13px;
+  }
+
+  #archive-thread::after {
+    content: "⌫";
+    color: var(--danger);
+    font-size: 13px;
+  }
+
+  .session-heading {
+    padding-right: 78px;
+  }
+
+  .session-facts {
+    grid-column: 1;
+  }
+
+  .composer-hint {
+    display: none;
+  }
+
+  .composer-bar {
+    justify-content: flex-end;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -1,0 +1,228 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import {
+  applyRuntimeEvent,
+  applySnapshot,
+  createThreadState,
+  eventStreamUrl,
+  restoreDraft,
+  saveDraft,
+  setSafeText,
+  snapshotThenSubscribe,
+} from "../src/runtime_web/app.mjs";
+
+function snapshot(threadId = "thread-a", latestSeq = 7) {
+  return {
+    thread: { id: threadId, title: "Test", model: "test", mode: "agent" },
+    turns: [{ id: "turn-1", status: "in_progress" }],
+    items: [
+      {
+        id: "item-1",
+        turn_id: "turn-1",
+        kind: "agent_message",
+        status: "in_progress",
+        summary: "",
+        detail: "Hello",
+      },
+    ],
+    latest_seq: latestSeq,
+  };
+}
+
+function runtimeEvent(sequence, event, payload = {}, overrides = {}) {
+  return {
+    schema_version: 1,
+    seq: sequence,
+    event,
+    kind: event,
+    thread_id: "thread-a",
+    turn_id: "turn-1",
+    item_id: null,
+    payload,
+    ...overrides,
+  };
+}
+
+test("loads a consistent snapshot before subscribing from latest_seq", async () => {
+  const state = createThreadState("thread-a");
+  const order = [];
+  const subscribed = await snapshotThenSubscribe({
+    state,
+    threadId: "thread-a",
+    loadSnapshot: async () => {
+      order.push("snapshot");
+      return snapshot("thread-a", 42);
+    },
+    subscribe: (threadId, sequence) => order.push(`subscribe:${threadId}:${sequence}`),
+  });
+
+  assert.equal(subscribed, true);
+  assert.deepEqual(order, ["snapshot", "subscribe:thread-a:42"]);
+  assert.equal(state.latestSeq, 42);
+});
+
+test("drops a stale snapshot selection without opening an event stream", async () => {
+  const state = createThreadState("thread-a");
+  let current = true;
+  let subscribed = false;
+  const result = await snapshotThenSubscribe({
+    state,
+    threadId: "thread-a",
+    loadSnapshot: async () => {
+      current = false;
+      return snapshot();
+    },
+    subscribe: () => {
+      subscribed = true;
+    },
+    isCurrent: () => current,
+  });
+  assert.equal(result, false);
+  assert.equal(subscribed, false);
+});
+
+test("reconnect cursor advances monotonically and duplicate or stale-thread events are ignored", () => {
+  const state = createThreadState("thread-a");
+  assert.equal(applySnapshot(state, snapshot("thread-a", 7)), true);
+
+  assert.equal(
+    applyRuntimeEvent(
+      state,
+      runtimeEvent(8, "item.delta", { delta: " world", kind: "agent_message" }, { item_id: "item-1" }),
+    ),
+    true,
+  );
+  assert.equal(
+    applyRuntimeEvent(
+      state,
+      runtimeEvent(8, "item.delta", { delta: " duplicate", kind: "agent_message" }, { item_id: "item-1" }),
+    ),
+    false,
+  );
+  assert.equal(
+    applyRuntimeEvent(state, runtimeEvent(99, "turn.completed", {}, { thread_id: "thread-b" })),
+    false,
+  );
+  assert.equal(state.items.get("item-1").detail, "Hello world");
+  assert.equal(state.latestSeq, 8);
+  assert.equal(eventStreamUrl("thread-a", state.latestSeq), "/v1/threads/thread-a/events?since_seq=8");
+});
+
+test("assembles deltas and replaces the live item with its settled receipt", () => {
+  const state = createThreadState("thread-a");
+  applySnapshot(state, { ...snapshot(), items: [], latest_seq: 1 });
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(2, "item.delta", { delta: "one", kind: "agent_message" }, { item_id: "item-new" }),
+  );
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(3, "item.delta", { delta: " two", kind: "agent_message" }, { item_id: "item-new" }),
+  );
+  assert.equal(state.items.get("item-new").detail, "one two");
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(
+      4,
+      "item.completed",
+      {
+        item: {
+          id: "item-new",
+          turn_id: "turn-1",
+          kind: "agent_message",
+          status: "completed",
+          summary: "one two",
+          detail: "one two",
+        },
+      },
+      { item_id: "item-new" },
+    ),
+  );
+  assert.equal(state.items.get("item-new").status, "completed");
+  assert.deepEqual(state.itemOrder, ["item-new"]);
+});
+
+test("tracks approval and user-input attention until each is resolved", () => {
+  const state = createThreadState("thread-a");
+  applySnapshot(state, snapshot());
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(8, "approval.required", { approval_id: "approval-1", tool_name: "exec_shell" }),
+  );
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(9, "user_input.required", {
+      id: "input-1",
+      request: { questions: [{ id: "choice", question: "Choose?", options: [] }] },
+    }),
+  );
+  assert.equal(state.approvals.has("approval-1"), true);
+  assert.equal(state.userInputs.has("input-1"), true);
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(10, "approval.decided", { approval_id: "approval-1", decision: "allow" }),
+  );
+  assert.equal(state.approvals.has("approval-1"), false);
+  assert.equal(state.userInputs.has("input-1"), true);
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(11, "user_input.answered", { input_id: "input-1" }),
+  );
+  assert.equal(state.userInputs.has("input-1"), false);
+});
+
+test("hydrates pending attention from a reload snapshot and clears cancellation events", () => {
+  const state = createThreadState("thread-a");
+  const detail = {
+    ...snapshot(),
+    pending_approvals: [{
+      id: "approval-reload",
+      turn_id: "turn-1",
+      tool_name: "exec_command",
+      description: "Run a local check",
+    }],
+    pending_user_inputs: [{
+      id: "input-reload",
+      turn_id: "turn-1",
+      request: { questions: [{ id: "choice", question: "Continue?", options: [] }] },
+    }],
+  };
+
+  assert.equal(applySnapshot(state, detail), true);
+  assert.equal(state.approvals.get("approval-reload").tool_name, "exec_command");
+  assert.equal(state.userInputs.get("input-reload").turn_id, "turn-1");
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(8, "user_input.canceled", { id: "input-reload", terminal: true }),
+  );
+  assert.equal(state.userInputs.has("input-reload"), false);
+});
+
+test("preserves drafts per thread without browser storage", () => {
+  const drafts = new Map();
+  saveDraft(drafts, "thread-a", "draft A");
+  saveDraft(drafts, "thread-b", "draft B");
+  assert.equal(restoreDraft(drafts, "thread-a"), "draft A");
+  assert.equal(restoreDraft(drafts, "thread-b"), "draft B");
+  saveDraft(drafts, "thread-a", "");
+  assert.equal(restoreDraft(drafts, "thread-a"), "");
+});
+
+test("renders hostile Runtime text only through the textContent sink", async () => {
+  const hostile = `<img src=x onerror=alert(1)><script>alert(2)</script>`;
+  const fakeElement = { textContent: "" };
+  setSafeText(fakeElement, hostile);
+  assert.equal(fakeElement.textContent, hostile);
+
+  const source = await readFile(new URL("../src/runtime_web/app.mjs", import.meta.url), "utf8");
+  assert.equal(source.includes("inner" + "HTML"), false);
+  assert.equal(source.includes("insertAdjacent" + "HTML"), false);
+  assert.equal(source.includes("local" + "Storage"), false);
+  assert.equal(source.includes("session" + "Storage"), false);
+});

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -46,6 +46,7 @@ CLI/API surfaces are not implemented yet.
 
 | Entry | Transport | Use |
 |---|---|---|
+| `codewhale web [--port 7878]` | HTTP/SSE on `127.0.0.1:7878` + embedded client | First-class loopback-only browser client; opens the default browser |
 | `codewhale app-server --http` | HTTP/SSE on `127.0.0.1:7878` | Full `/v1/*` runtime API (canonical) |
 | `codewhale app-server --mobile` | HTTP/SSE on `0.0.0.0:7878` + `/mobile` | Runtime API + phone control page |
 | `codewhale app-server --stdio` | JSON-RPC 2.0 over stdio | Local SDK / control probe (no listener) |
@@ -230,6 +231,7 @@ codewhale doctor --json
 codewhale app-server --http [--host 127.0.0.1] [--port 7878] [--workers 2] [--auth-token TOKEN] [--insecure-no-auth]
 codewhale app-server --mobile [--host 0.0.0.0] [--port 7878] [--auth-token TOKEN]
 codewhale app-server --mobile --host 127.0.0.1 [--port 7878] [--insecure-no-auth]
+codewhale web [--port 7878]
 
 # Compatibility aliases — identical server, serve flag names:
 codewhale serve --http   [...] [--insecure]
@@ -247,27 +249,68 @@ no-auth mode with the `--mobile` default host `0.0.0.0`; use a token for LAN
 mobile access, or add `--host 127.0.0.1` for local-only no-auth testing. The
 `codewhale serve` compatibility aliases use `--insecure` for the same loopback
 escape hatch.
-Pass `--auth-token TOKEN` or set `DEEPSEEK_RUNTIME_TOKEN=TOKEN` before starting
-the server. If neither is set, the process generates a one-time token and prints
-it at startup. `/health` and `/v1/runtime/info` remain public for local
-supervision and bootstrap. `/mobile` returns 404 when mobile mode is disabled;
-when mobile mode is enabled and auth is enabled, `/mobile` returns 401 unless
-the request supplies the runtime token.
+Pass `--auth-token TOKEN` or set `CODEWHALE_RUNTIME_TOKEN=TOKEN` before starting
+the server; `DEEPSEEK_RUNTIME_TOKEN` remains a compatibility alias. If neither
+is set, the process generates a Runtime token for that process and does **not**
+print it. `/health`, `/v1/runtime/info`, and an enabled static client shell
+remain public; Runtime mutations and thread data stay behind `/v1/*`
+authentication. `/mobile` returns 404 when mobile mode is disabled and serves
+the unchanged static shell when it is enabled.
 
 Authenticated clients can provide the token as `Authorization: Bearer TOKEN`,
-`X-DeepSeek-Runtime-Token: TOKEN`, or `?token=TOKEN` for EventSource-style
-clients that cannot set custom headers.
+`X-Codewhale-Runtime-Token: TOKEN`, the legacy
+`X-DeepSeek-Runtime-Token: TOKEN`, or the `codewhale_runtime_token` cookie.
+Query-string authentication is not supported.
+
+### Local browser client
+
+`codewhale web` starts the canonical Runtime API on `127.0.0.1`, serves
+dependency-free assets embedded in the binary, and opens the default browser.
+It cannot bind to a non-loopback host and cannot run with Runtime auth disabled.
+
+The browser-launch URL contains a random, short-lived, one-time bootstrap
+capability, never the Runtime token. A loopback request exchanges that
+capability for a
+`codewhale_web_session=…; HttpOnly; SameSite=Strict; Path=/` cookie backed by a
+single process-local server session that expires after 12 hours, consumes the
+capability immediately, and redirects to `/`. Reused, expired, malformed, or
+non-loopback bootstrap attempts fail closed. The Runtime bearer token is not
+placed in rendered HTML, browser storage, logs, URL queries/fragments, or
+browser-launch arguments.
+Existing bearer/header/cookie authorization for `/v1/*` is unchanged outside
+web mode. In web mode, cookie-authenticated unsafe requests must also carry the
+exact local web origin, and Fetch Metadata identifying a cross-origin cookie
+request is rejected. Explicit bearer and Runtime-token header clients keep
+their existing behavior.
+
+The v0.9.1 client provides a responsive thread/search rail, Runtime-owned
+session facts, transcript and tool receipts, and a bottom composer. It can
+create, select, rename, and archive threads; start or steer turns; interrupt
+work; resolve approvals; and answer Runtime user-input requests. Selection
+loads `GET /v1/threads/{id}` first, then opens the replayable event stream with
+`since_seq=latest_seq`; reconnection advances from the newest accepted sequence
+and drops duplicates or events from a stale selection. The thread detail
+snapshot includes `pending_approvals` and `pending_user_inputs`; clients must
+hydrate those fields before subscribing so a reload cannot strand a prompt
+whose `*.required` event is at or before `latest_seq`. Resolution is also
+published as `approval.decided`, `user_input.answered`, or
+`user_input.canceled` for already-connected clients.
+
+Model, mode, permission posture, workspace, and branch are display-only in this
+client. Files/Changes, PTY/terminal, preview, artifacts, provider login/model
+selection, Fleet creation, and undo/retry/restore controls are intentionally
+absent until the Runtime publishes explicit contracts for them.
 
 ### Mobile control page
 
 `codewhale serve --mobile` starts the same HTTP/SSE runtime API and serves a
 phone-friendly control page at `/mobile`. When the bind host is left at the
 default, mobile mode binds to `0.0.0.0`, prints a warning, and prints local/LAN
-URLs. Pass `--host 127.0.0.1` to keep the mobile page loopback-only. If a
-runtime token is generated or supplied, the printed mobile URL includes it as a
-query parameter; the page stores it locally and removes it from the address bar.
-The static HTML page contains no secrets, but it is still token-gated when auth
-is enabled so unauthenticated LAN clients cannot fingerprint the mobile surface.
+URLs. Pass `--host 127.0.0.1` to keep the mobile page loopback-only. The static
+HTML page contains no secrets and is not itself token-gated. Its calls to
+`/v1/*` are authenticated: for LAN use, start with an explicit Runtime token
+and enter it in the page. Generated Runtime tokens are deliberately unprinted,
+so they cannot be copied into another device.
 
 The mobile page can list/create threads, send prompts, follow live SSE events,
 steer or interrupt an active turn, and resolve normal tool approvals through
@@ -362,6 +405,10 @@ accept an empty string to clear a previously-set value. Added in v0.8.10 (#562):
 **Approvals**
 - `POST /v1/approvals/{approval_id}` with body
   `{ "decision": "allow" | "deny", "remember": false }`
+
+**User input**
+- `POST /v1/user-input/{thread_id}/{input_id}` with body
+  `{ "answers": [{ "id": "question-id", "label": "Choice", "value": "Choice" }] }`
 
 **Events** (SSE replay + live stream)
 - `GET /v1/threads/{id}/events?since_seq=<u64>`
@@ -528,7 +575,8 @@ Common event names: `thread.started`, `thread.forked`, `turn.started`,
 `turn.lifecycle`, `turn.steered`, `turn.interrupt_requested`,
 `turn.completed`, `item.started`, `item.delta`, `item.completed`,
 `item.failed`, `item.interrupted`, `approval.required`, `approval.decided`,
-`approval.timeout`, `sandbox.denied`.
+`approval.timeout`, `user_input.required`, `user_input.answered`,
+`user_input.canceled`, `sandbox.denied`.
 
 `approval.required` events may include a `matched_rule` string when an
 execution-policy rule caused the prompt. This field is explanatory metadata for
@@ -571,7 +619,10 @@ when developing a UI on Vite's default `:5173`), use any of:
 
 User-supplied origins **stack on top of** the built-in defaults; they do not
 replace them. Wildcard origins are not supported — the explicit allow-list
-model is preserved. Added in v0.8.10 (#561).
+model is preserved. Cross-origin preflights advertise only `Authorization`,
+`Content-Type`, `Accept`, `X-Codewhale-Runtime-Token`, and the compatibility
+`X-DeepSeek-Runtime-Token` request header; custom request headers are not
+allowed. Added in v0.8.10 (#561), tightened in v0.9.1 (#4454).
 
 ## Runtime SDK Fleet Helpers
 

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -272,11 +272,17 @@ The browser-launch URL contains a random, short-lived, one-time bootstrap
 capability, never the Runtime token. A loopback request exchanges that
 capability for a
 `codewhale_web_session=…; HttpOnly; SameSite=Strict; Path=/` cookie backed by a
-single process-local server session that expires after 12 hours, consumes the
-capability immediately, and redirects to `/`. Reused, expired, malformed, or
+single process-local server session that expires 12 hours after the server
+process starts, consumes the capability immediately, and redirects to `/`.
+Reused, expired, malformed, or
 non-loopback bootstrap attempts fail closed. The Runtime bearer token is not
 placed in rendered HTML, browser storage, logs, URL queries/fragments, or
-browser-launch arguments.
+browser-launch arguments. The one-time bootstrap capability does transit the
+OS browser launcher's argument list for a sub-second window; a same-user
+process scraping the process table in that window could race the browser to
+the exchange, which is why the capability is single-use, loopback-only, and
+expiring — and why a same-user attacker has strictly easier local avenues
+than this race.
 Existing bearer/header/cookie authorization for `/v1/*` is unchanged outside
 web mode. In web mode, cookie-authenticated unsafe requests must also carry the
 exact local web origin, and Fetch Metadata identifying a cross-origin cookie


### PR DESCRIPTION
## What

Closes #4423. `codewhale web` starts the canonical Runtime API on `127.0.0.1`, serves a dependency-free responsive client embedded in the binary, and opens the default browser — thread rail with search, Runtime-owned session facts, transcript + tool receipts, composer, SSE updates, approvals, and user-input handling.

## Session boundary contract

- **Loopback-only by construction**: web mode refuses any bind host other than literal `127.0.0.1` at two layers, and refuses to run with Runtime auth disabled.
- **One-time bootstrap**: the browser-launch URL carries a random 128-bit one-time capability (120s TTL, loopback-only exchange, single-use), never the Runtime bearer. The exchange sets `codewhale_web_session=…; HttpOnly; SameSite=Strict; Path=/` backed by one process-local `cwws_` session credential (2×UUIDv4, 12h expiry from process start, constant-time comparison).
- **The browser never receives the real runtime bearer** — not in HTML, JS, storage, logs, redirects, or errors (compile-time-constant assets; asserted by tests).
- **CSRF**: cookie-authenticated unsafe methods require the exact local web origin (server-config-derived, no Host-header trust) and `sec-fetch-site: same-origin`; no GET mutations exist. CORS stays as landed in #4454 (different layer — same-origin client needs no exception; the lane's stricter test replaces the old one with identical enforcement).
- **Strict CSP** (`default-src 'none'`, self-only script/style/connect), `no-store`, `nosniff`, `no-referrer`, zero DOM sinks beyond `textContent`.
- Legacy bearer/header/cookie behavior for non-web clients is byte-for-byte unchanged (early-return when web mode is off).

## Lifecycle completeness (one contract)

Create/select/rename/archive threads, start/steer turns, interrupt, resolve approvals, answer user input — all recover across page reloads: the canonical thread snapshot now carries `pending_approvals` and `pending_user_inputs`, and the client hydrates before subscribing with `since_seq=latest_seq`. Terminal turns cancel outstanding prompts; **the monitor-failure path now does the same** (independent-review finding — previously a failed turn left a stale, unanswerable input card until process restart). Truthful empty/error states throughout; capabilities absent from the local runtime (managed files, PTY, model selection, Fleet controls) are documented as absent in the changelog, not hinted at in the UI.

## Reviews

- Steward review of `web.rs`/`auth.rs`/router/client assets: SHIP.
- Independent adversarial review (fresh agent, read-only): **SHIP-WITH-NITS**, no critical/high/medium findings. The one low lifecycle finding is fixed in `0872e641d` with a regression test; the bootstrap-argv race is documented in `docs/RUNTIME_API.md`. Remaining nits (no-`Secure` cookie = correct loopback tradeoff, 12h-from-start, legacy bearer `==` comparison pre-existing, submit-after-deliver error wart) are documented or left as follow-ups.

## Gates (at exact head 0872e641d)

- `cargo test -p codewhale-tui --bin codewhale-tui --locked -- runtime_api runtime_threads` — **187 passed** (incl. new failure-path cancellation regression test)
- `node crates/tui/tests/runtime_web_client.test.mjs` — **8/8** (lifecycle, XSS sink, storage isolation)
- `cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all --check` — clean; `./scripts/release/check-versions.sh` — OK
- Smoke: `codewhale web --help`, `codewhale-tui serve --help` surface correctly

Note: `cargo clippy -p codewhale-cli` has a pre-existing `collapsible_if` failure under clippy 1.97.0 at `crates/cli/src/lib.rs:1912`, byte-identical on main (new lint, not this PR).