### PR TITLE
fix(ohos): generate QuickJS bindings and gate unsupported PTY tools

### DIFF
--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -53,6 +53,7 @@ pub mod spec;
 pub mod speech;
 pub mod subagent;
 pub mod tasks;
+#[cfg(not(target_env = "ohos"))]
 pub mod terminal_session;
 pub mod test_runner;
 pub mod todo;

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -578,6 +578,7 @@ impl ToolRegistryBuilder {
 
     /// Include the stateful PTY terminal tools. Like `exec_shell`, these are
     /// only exposed when the active shell policy allows shell access.
+    #[cfg(not(target_env = "ohos"))]
     #[must_use]
     pub fn with_terminal_tools(self) -> Self {
         use super::terminal_session::{
@@ -589,6 +590,14 @@ impl ToolRegistryBuilder {
             .with_tool(Arc::new(TerminalWaitTool))
             .with_tool(Arc::new(TerminalCancelTool))
             .with_tool(Arc::new(TerminalResetTool))
+    }
+
+    /// OpenHarmony does not include the `portable-pty` dependency, so keep the
+    /// ordinary shell tools without advertising unavailable persistent PTYs.
+    #[cfg(target_env = "ohos")]
+    #[must_use]
+    pub fn with_terminal_tools(self) -> Self {
+        self
     }
 
     /// Include search tools (`grep_files`).

--- a/crates/workflow-js/Cargo.toml
+++ b/crates/workflow-js/Cargo.toml
@@ -28,5 +28,10 @@ rquickjs = { workspace = true, features = ["bindgen"] }
 [target.'cfg(target_os = "netbsd")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
 
+# rquickjs does not ship pre-generated bindings for OpenHarmony. Generate them
+# against the native SDK sysroot configured by scripts/ohos-env.*.
+[target.'cfg(target_env = "ohos")'.dependencies]
+rquickjs = { workspace = true, features = ["bindgen"] }
+
 [dev-dependencies]
 serde_json.workspace = true

--- a/docs/HarmonyOS.md
+++ b/docs/HarmonyOS.md
@@ -42,7 +42,9 @@ cargo build --target aarch64-unknown-linux-ohos -p codewhale-cli
 
 The setup scripts export Cargo's target-specific `linker`, `AR`, `CC`, `CXX`,
 `CFLAGS`, `CXXFLAGS`, `CARGO_ENCODED_RUSTFLAGS`, `CC_SHELL_ESCAPED_FLAGS`, and
-CMake toolchain variables for `aarch64-unknown-linux-ohos`.
+CMake toolchain variables for `aarch64-unknown-linux-ohos`. They also point
+`bindgen` at the SDK's `libclang` and sysroot so `rquickjs-sys` can generate
+the OpenHarmony bindings that it does not ship pre-generated.
 
 ## Compiler Wrappers
 
@@ -90,3 +92,8 @@ The guard resolves the `codewhale-tui` dependency graph for
 the target graph: `nix` 0.28/0.29, `portable-pty`, `starlark`, `arboard`, or
 `keyring`. This does not replace a real SDK/sysroot build, but it catches the
 known `starlark -> rustyline -> nix` and PTY/keyring regressions before release.
+
+Because `portable-pty` is intentionally absent from the OpenHarmony graph, the
+persistent `terminal/*` PTY tools are not registered on that target. The
+ordinary `exec_shell` tools remain available through their non-PTY process
+implementation.

--- a/scripts/ohos-env.ps1
+++ b/scripts/ohos-env.ps1
@@ -19,10 +19,11 @@ $sdk = (Resolve-Path -LiteralPath $env:OHOS_NATIVE_SDK -ErrorAction Stop).Path
 $clang = [System.IO.Path]::Combine($sdk, "llvm", "bin", "clang.exe")
 $clangxx = [System.IO.Path]::Combine($sdk, "llvm", "bin", "clang++.exe")
 $ar = [System.IO.Path]::Combine($sdk, "llvm", "bin", "llvm-ar.exe")
+$libclang = [System.IO.Path]::Combine($sdk, "llvm", "bin", "libclang.dll")
 $sysroot = [System.IO.Path]::Combine($sdk, "sysroot")
 $cmakeToolchain = [System.IO.Path]::Combine($sdk, "build", "cmake", "ohos.toolchain.cmake")
 
-$requiredFiles = @($clang, $clangxx, $ar, $cmakeToolchain)
+$requiredFiles = @($clang, $clangxx, $ar, $libclang, $cmakeToolchain)
 foreach ($path in $requiredFiles) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf -ErrorAction SilentlyContinue)) {
         Stop-OhosEnv "required OpenHarmony SDK file is missing: $path"
@@ -45,6 +46,8 @@ $env:CC_SHELL_ESCAPED_FLAGS = "1"
 Set-Item -Path "Env:CFLAGS_$target" -Value $commonFlags
 Set-Item -Path "Env:CXXFLAGS_$target" -Value $commonFlags
 Set-Item -Path "Env:CMAKE_TOOLCHAIN_FILE_$target" -Value $cmakeToolchain
+$env:LIBCLANG_PATH = [System.IO.Path]::GetDirectoryName($libclang)
+Set-Item -Path "Env:BINDGEN_EXTRA_CLANG_ARGS_$target" -Value $commonFlags
 
 $separator = [char]0x1f
 $env:CARGO_ENCODED_RUSTFLAGS = @(

--- a/scripts/ohos-env.sh
+++ b/scripts/ohos-env.sh
@@ -29,6 +29,19 @@ if [ ! -d "$sysroot" ]; then
     return 1 2>/dev/null || exit 1
 fi
 
+libclang_path=
+for directory in "$sdk/llvm/lib" "$sdk/llvm/lib64" "$sdk/llvm/bin"; do
+    if [ -f "$directory/libclang.so" ] || [ -f "$directory/libclang.dylib" ]; then
+        libclang_path=$directory
+        break
+    fi
+done
+
+if [ -z "$libclang_path" ]; then
+    echo "error: required OpenHarmony SDK libclang shared library is missing under: $sdk/llvm" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER=$clang
 export AR_aarch64_unknown_linux_ohos=$ar
 export CC_aarch64_unknown_linux_ohos=$clang
@@ -37,6 +50,8 @@ export CC_SHELL_ESCAPED_FLAGS=1
 export CFLAGS_aarch64_unknown_linux_ohos="-target aarch64-linux-ohos --sysroot=\"$sysroot\" -D__MUSL__"
 export CXXFLAGS_aarch64_unknown_linux_ohos="-target aarch64-linux-ohos --sysroot=\"$sysroot\" -D__MUSL__"
 export CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_ohos=$cmake_toolchain
+export LIBCLANG_PATH=$libclang_path
+export BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos="-target aarch64-linux-ohos --sysroot=\"$sysroot\" -D__MUSL__"
 
 sep=$(printf '\037')
 export CARGO_ENCODED_RUSTFLAGS="-Clink-arg=-target${sep}-Clink-arg=aarch64-linux-ohos${sep}-Clink-arg=--sysroot=$sysroot${sep}-Clink-arg=-D__MUSL__"


### PR DESCRIPTION
## Summary

- enable `rquickjs` bindgen for `target_env = "ohos"` and configure the OpenHarmony SDK libclang/sysroot in both environment setup scripts
- keep `portable-pty` out of the OHOS dependency graph by omitting persistent `terminal/*` tools while retaining the non-PTY `exec_shell` path
- document the bindgen setup and PTY capability difference in the HarmonyOS guide

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p codewhale-tui --bin codewhale-tui --target aarch64-unknown-linux-ohos --locked`
- verified the OHOS all-features dependency graph contains no portable-pty/starlark/arboard/keyring/nix 0.28-0.29 chain
- `cargo test -p codewhale-tui --bin codewhale-tui --locked terminal_session`
- `cargo build --release -p codewhale-cli -p codewhale-tui --target aarch64-unknown-linux-ohos --locked`
- validated both release outputs as AArch64 ELF64 binaries using `/lib/ld-musl-aarch64.so.1`