### PR TITLE
fix(tui): preserve Solarized Light background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve Solarized Light's canonical Base3 (`#fdf6e3`) shell background
+  instead of tinting it green-grey through the default underwater Ombre
+  treatment, while retaining foreground ambient life (#4457 by
+  @AiurArtanis).
+
 ## [0.9.1] - 2026-07-17
 
 Codewhale v0.9.1 ships a first-class local web client over the Runtime API,

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve Solarized Light's canonical Base3 (`#fdf6e3`) shell background
+  instead of tinting it green-grey through the default underwater Ombre
+  treatment, while retaining foreground ambient life (#4457 by
+  @AiurArtanis).
+
 ## [0.9.1] - 2026-07-17
 
 Codewhale v0.9.1 ships a first-class local web client over the Runtime API,

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -1840,6 +1840,10 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
         "theme" | "ui_theme" | "background_color" | "background" | "bg" => {
             app.theme_id = crate::palette::ThemeId::from_name(&settings.theme)
                 .unwrap_or(crate::palette::ThemeId::System);
+            app.background_color_override = settings
+                .background_color
+                .as_deref()
+                .and_then(crate::palette::parse_hex_rgb_color);
             app.ui_theme = crate::palette::ui_theme_from_settings(
                 &settings.theme,
                 settings.background_color.as_deref(),
@@ -3799,6 +3803,40 @@ max_concurrent = 4
         assert_eq!(app.theme_id, crate::palette::ThemeId::Grayscale);
         assert_eq!(app.ui_theme.mode, crate::palette::PaletteMode::Grayscale);
         assert!(app.needs_redraw);
+    }
+
+    #[test]
+    fn explicit_default_background_override_survives_theme_preview() {
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-background-override-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(temp_root.join(".deepseek")).expect("settings dir");
+        let _guard = EnvGuard::new(&temp_root);
+        fs::write(
+            temp_root.join(".deepseek").join("settings.toml"),
+            "theme = \"solarized-light\"\nbackground_color = \"#fdf6e3\"\n",
+        )
+        .expect("seed settings");
+
+        let mut app = create_test_app();
+        let explicit_base3 = ratatui::style::Color::Rgb(0xfd, 0xf6, 0xe3);
+        assert_eq!(app.background_color_override, Some(explicit_base3));
+
+        let result = set_config_value(&mut app, "theme", "dark", false);
+
+        assert!(!result.is_error, "{:?}", result.message);
+        assert_eq!(app.theme_id, crate::palette::ThemeId::Whale);
+        assert_eq!(app.background_color_override, Some(explicit_base3));
+        assert_eq!(app.ui_theme.surface_bg, explicit_base3);
+        assert!(
+            crate::tui::ocean::OceanRamp::for_theme(&app.ui_theme).is_some(),
+            "the explicit surface must retain ombre when previewing another theme"
+        );
     }
 
     #[test]

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -1840,13 +1840,23 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
         "theme" | "ui_theme" | "background_color" | "background" | "bg" => {
             app.theme_id = crate::palette::ThemeId::from_name(&settings.theme)
                 .unwrap_or(crate::palette::ThemeId::System);
-            app.background_color_override = settings
-                .background_color
-                .as_deref()
-                .and_then(crate::palette::parse_hex_rgb_color);
+            // Theme previews reload persisted settings for each cursor move.
+            // Keep a session-only background overlay live unless this command
+            // is itself updating (or clearing) the background.
+            let background_color_override = if matches!(key.as_str(), "theme" | "ui_theme") {
+                app.background_color_override
+            } else {
+                settings
+                    .background_color
+                    .as_deref()
+                    .and_then(crate::palette::parse_hex_rgb_color)
+            };
+            app.background_color_override = background_color_override;
+            let background_setting =
+                background_color_override.and_then(crate::palette::hex_rgb_string);
             app.ui_theme = crate::palette::ui_theme_from_settings(
                 &settings.theme,
-                settings.background_color.as_deref(),
+                background_setting.as_deref(),
             );
             app.needs_redraw = true;
         }
@@ -3836,6 +3846,57 @@ max_concurrent = 4
         assert!(
             crate::tui::ocean::OceanRamp::for_theme(&app.ui_theme).is_some(),
             "the explicit surface must retain ombre when previewing another theme"
+        );
+    }
+
+    #[test]
+    fn session_only_background_override_survives_theme_preview() {
+        let temp_root = env::temp_dir().join(format!(
+            "codewhale-tui-session-background-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(temp_root.join(".deepseek")).expect("settings dir");
+        let _guard = EnvGuard::new(&temp_root);
+        fs::write(
+            temp_root.join(".deepseek").join("settings.toml"),
+            "theme = \"solarized-light\"\n",
+        )
+        .expect("seed settings");
+
+        let mut app = create_test_app();
+        let custom = ratatui::style::Color::Rgb(0x1a, 0x1b, 0x26);
+        let background = set_config_value(&mut app, "background_color", "#1a1b26", false);
+        assert!(!background.is_error, "{:?}", background.message);
+        assert_eq!(app.background_color_override, Some(custom));
+
+        let preview = set_config_value(&mut app, "theme", "dark", false);
+        assert!(!preview.is_error, "{:?}", preview.message);
+        assert_eq!(app.background_color_override, Some(custom));
+        assert_eq!(app.ui_theme.surface_bg, custom);
+
+        let solarized_preview = set_config_value(&mut app, "theme", "solarized-light", false);
+        assert!(
+            !solarized_preview.is_error,
+            "{:?}",
+            solarized_preview.message
+        );
+        assert_eq!(app.background_color_override, Some(custom));
+        assert_eq!(app.ui_theme.surface_bg, custom);
+        assert!(crate::tui::ocean::OceanRamp::for_theme(&app.ui_theme).is_some());
+
+        let saved_theme = set_config_value(&mut app, "theme", "dark", true);
+        assert!(!saved_theme.is_error, "{:?}", saved_theme.message);
+        assert_eq!(app.background_color_override, Some(custom));
+        assert_eq!(app.ui_theme.surface_bg, custom);
+        let persisted = Settings::load_persisted().expect("persisted settings");
+        assert_eq!(persisted.theme, "dark");
+        assert_eq!(
+            persisted.background_color, None,
+            "saving a theme must not persist the session-only background"
         );
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -2032,6 +2033,11 @@ pub struct App {
     /// budget-only chatter is paced under fan-out (#4095 residual).
     pub last_workflow_budget_redraw: Option<Instant>,
     pub ui_theme: UiTheme,
+    /// Parsed `background_color` setting, kept separately from `ui_theme` so
+    /// an explicit override remains distinguishable even when it happens to
+    /// equal the current named theme's default surface and can still carry
+    /// into previews of other themes.
+    pub background_color_override: Option<Color>,
     /// Active named theme. Drives the cell-level color remap in
     /// `tui::color_compat::ColorCompatBackend` so community presets
     /// (Catppuccin, Tokyo Night, Dracula, Gruvbox) propagate to every
@@ -2767,11 +2773,11 @@ impl App {
         let theme_id =
             palette::ThemeId::from_name(&settings.theme).unwrap_or(palette::ThemeId::System);
         let mut ui_theme = theme_id.ui_theme();
-        if let Some(background) = settings
+        let background_color_override = settings
             .background_color
             .as_deref()
-            .and_then(palette::parse_hex_rgb_color)
-        {
+            .and_then(palette::parse_hex_rgb_color);
+        if let Some(background) = background_color_override {
             ui_theme = ui_theme.with_background_color(background);
         }
         let provider_models = settings.provider_models.clone().unwrap_or_default();
@@ -3143,6 +3149,7 @@ impl App {
             last_agent_progress_redraw: None,
             last_workflow_budget_redraw: None,
             ui_theme,
+            background_color_override,
             theme_id,
             onboarding,
             onboarding_needs_api_key: needs_api_key,

--- a/crates/tui/src/tui/ocean.rs
+++ b/crates/tui/src/tui/ocean.rs
@@ -167,11 +167,20 @@ impl OceanColumn {
 impl OceanRamp {
     #[must_use]
     pub fn for_theme(theme: &UiTheme) -> Option<Self> {
+        // Solarized Light's Base3 (#fdf6e3) background is part of the named
+        // palette's contract. Tinting it with the underwater field turns the
+        // shell green-grey and no longer renders Solarized Light (#4457).
+        // Keep foreground ambient life, just as the flat treatment does, but
+        // leave the canonical background untouched.
+        if theme.mode == PaletteMode::SolarizedLight {
+            return None;
+        }
+
         let base = rgb(theme.surface_bg)?;
         let seafoam = rgb(theme.accent_secondary).unwrap_or((79, 209, 197));
 
         let (surface, middle, deep) = match theme.mode {
-            PaletteMode::Light | PaletteMode::SolarizedLight => (
+            PaletteMode::Light => (
                 mix(base, seafoam, 0.07),
                 mix(base, seafoam, 0.13),
                 mix(base, (70, 139, 196), 0.18),
@@ -181,6 +190,7 @@ impl OceanRamp {
                 mix(base, (7, 30, 54), 0.40),
                 mix(base, (2, 9, 24), 0.64),
             ),
+            PaletteMode::SolarizedLight => unreachable!("handled above"),
         };
 
         Some(Self {
@@ -333,13 +343,26 @@ mod tests {
     }
 
     #[test]
+    fn solarized_light_preserves_its_canonical_base3_background() {
+        let theme = crate::palette::SOLARIZED_LIGHT_UI_THEME;
+
+        assert_eq!(theme.surface_bg, Color::Rgb(0xfd, 0xf6, 0xe3));
+        assert_eq!(OceanRamp::for_theme(&theme), None);
+    }
+
+    #[test]
     fn every_shipped_theme_has_an_intentional_ocean_treatment() {
         use crate::palette::{SELECTABLE_THEMES, ThemeId};
 
         for id in SELECTABLE_THEMES {
             let ramp = OceanRamp::for_theme(&id.ui_theme());
-            if matches!(id, ThemeId::Terminal) {
-                assert_eq!(ramp, None, "Terminal must keep its inherited background");
+            if matches!(id, ThemeId::Terminal | ThemeId::SolarizedLight) {
+                assert_eq!(
+                    ramp,
+                    None,
+                    "{} must keep its canonical background",
+                    id.name()
+                );
             } else {
                 let ramp = ramp.unwrap_or_else(|| panic!("{} has no ocean ramp", id.name()));
                 assert_ne!(

--- a/crates/tui/src/tui/ocean.rs
+++ b/crates/tui/src/tui/ocean.rs
@@ -167,12 +167,14 @@ impl OceanColumn {
 impl OceanRamp {
     #[must_use]
     pub fn for_theme(theme: &UiTheme) -> Option<Self> {
-        // Solarized Light's Base3 (#fdf6e3) background is part of the named
-        // palette's contract. Tinting it with the underwater field turns the
-        // shell green-grey and no longer renders Solarized Light (#4457).
-        // Keep foreground ambient life, just as the flat treatment does, but
-        // leave the canonical background untouched.
-        if theme.mode == PaletteMode::SolarizedLight {
+        // Solarized Light's canonical Base3 (#fdf6e3) background is part of
+        // the named palette's contract. Tinting it with the underwater field
+        // turns the shell green-grey and no longer renders Solarized Light
+        // (#4457). A non-canonical user-supplied background is a separate
+        // contract and must keep the configured ombre treatment.
+        if theme.mode == PaletteMode::SolarizedLight
+            && theme.surface_bg == crate::palette::SOLARIZED_LIGHT_UI_THEME.surface_bg
+        {
             return None;
         }
 
@@ -180,7 +182,7 @@ impl OceanRamp {
         let seafoam = rgb(theme.accent_secondary).unwrap_or((79, 209, 197));
 
         let (surface, middle, deep) = match theme.mode {
-            PaletteMode::Light => (
+            PaletteMode::Light | PaletteMode::SolarizedLight => (
                 mix(base, seafoam, 0.07),
                 mix(base, seafoam, 0.13),
                 mix(base, (70, 139, 196), 0.18),
@@ -190,7 +192,6 @@ impl OceanRamp {
                 mix(base, (7, 30, 54), 0.40),
                 mix(base, (2, 9, 24), 0.64),
             ),
-            PaletteMode::SolarizedLight => unreachable!("handled above"),
         };
 
         Some(Self {
@@ -348,6 +349,16 @@ mod tests {
 
         assert_eq!(theme.surface_bg, Color::Rgb(0xfd, 0xf6, 0xe3));
         assert_eq!(OceanRamp::for_theme(&theme), None);
+    }
+
+    #[test]
+    fn solarized_light_custom_background_preserves_ombre() {
+        let custom = Color::Rgb(0x1a, 0x1b, 0x26);
+        let theme = crate::palette::SOLARIZED_LIGHT_UI_THEME.with_background_color(custom);
+        let ramp = OceanRamp::for_theme(&theme).expect("custom backgrounds retain ombre");
+
+        assert_ne!(ramp.surface, custom);
+        assert_ne!(ramp.surface, ramp.deep);
     }
 
     #[test]

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -281,7 +281,9 @@ impl ModalView for ThemePickerView {
 
         let treatment = if matches!(self.current(), ThemeId::Terminal) {
             tr(self.locale, MessageId::ThemeTreatmentOmbreUnavailable)
-        } else if self.ocean_treatment.is_flat() {
+        } else if self.ocean_treatment.is_flat()
+            || crate::tui::ocean::OceanRamp::for_theme(&live).is_none()
+        {
             tr(self.locale, MessageId::ThemeTreatmentFlatActive)
         } else {
             tr(self.locale, MessageId::ThemeTreatmentOmbreActive)
@@ -587,6 +589,21 @@ mod tests {
             .collect::<String>();
         assert!(terminal_text.contains("Ombre unavailable"));
         assert!(terminal_text.contains("Terminal owns the background"));
+
+        let solarized = ThemePickerView::new_with_treatment(
+            "solarized-light".to_string(),
+            crate::tui::ocean::OceanTreatment::Ombre,
+            Locale::En,
+        );
+        let mut solarized_buf = ratatui::buffer::Buffer::empty(area);
+        solarized.render(area, &mut solarized_buf);
+        let solarized_text = solarized_buf
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(solarized_text.contains("Treatment  Flat — active"));
+        assert!(!solarized_text.contains("Treatment  Ombre — active"));
     }
 
     #[test]

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -19,7 +19,7 @@ use crossterm::event::{KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Paragraph, Widget},
 };
@@ -44,6 +44,10 @@ pub struct ThemePickerView {
     /// Effective session treatment, reported separately from theme so the
     /// picker never claims an ombre is active under Terminal or Flat.
     ocean_treatment: crate::tui::ocean::OceanTreatment,
+    /// User-configured background applied on top of every named-theme preview.
+    /// Without carrying this into the picker, a customized Solarized Light
+    /// session would render ombre behind the modal but report Flat inside it.
+    background_override: Option<Color>,
     row_hitboxes: RefCell<Vec<(Rect, usize)>>,
     last_mouse_selected: Option<usize>,
     /// UI locale captured from the app at construction (#4057 wave 2).
@@ -85,11 +89,21 @@ impl ThemePickerView {
         )
     }
 
+    #[cfg(test)]
     #[must_use]
     pub fn new_with_treatment(
         original_name: String,
         ocean_treatment: crate::tui::ocean::OceanTreatment,
         locale: Locale,
+    ) -> Self {
+        Self::new_with_treatment_and_background(original_name, ocean_treatment, locale, None)
+    }
+
+    fn new_with_treatment_and_background(
+        original_name: String,
+        ocean_treatment: crate::tui::ocean::OceanTreatment,
+        locale: Locale,
+        background_override: Option<Color>,
     ) -> Self {
         let options = theme_options(&original_name);
         let mut controller = SettingsPickerController::new(options, original_name.clone());
@@ -105,6 +119,7 @@ impl ThemePickerView {
             controller,
             system_ui_theme: UiTheme::detect(),
             ocean_treatment,
+            background_override,
             row_hitboxes: RefCell::new(Vec::new()),
             last_mouse_selected: None,
             locale,
@@ -119,11 +134,13 @@ impl ThemePickerView {
         original_name: String,
         ocean_treatment: crate::tui::ocean::OceanTreatment,
         locale: Locale,
+        background_override: Option<Color>,
     ) -> Box<dyn ModalView> {
-        Box::new(Self::new_with_treatment(
+        Box::new(Self::new_with_treatment_and_background(
             original_name,
             ocean_treatment,
             locale,
+            background_override,
         ))
     }
 
@@ -147,11 +164,13 @@ impl ThemePickerView {
     /// Resolve a theme to a `UiTheme`, returning the cached `System`
     /// resolution to avoid repeated env-var reads inside `render`.
     fn ui_theme_for(&self, id: ThemeId) -> UiTheme {
-        if matches!(id, ThemeId::System) {
+        let theme = if matches!(id, ThemeId::System) {
             self.system_ui_theme
         } else {
             id.ui_theme()
-        }
+        };
+        self.background_override
+            .map_or(theme, |background| theme.with_background_color(background))
     }
 
     fn preview_event(&self) -> ViewAction {
@@ -604,6 +623,22 @@ mod tests {
             .collect::<String>();
         assert!(solarized_text.contains("Treatment  Flat — active"));
         assert!(!solarized_text.contains("Treatment  Ombre — active"));
+
+        let solarized_custom = ThemePickerView::new_with_treatment_and_background(
+            "solarized-light".to_string(),
+            crate::tui::ocean::OceanTreatment::Ombre,
+            Locale::En,
+            Some(Color::Rgb(0x1a, 0x1b, 0x26)),
+        );
+        let mut solarized_custom_buf = ratatui::buffer::Buffer::empty(area);
+        solarized_custom.render(area, &mut solarized_custom_buf);
+        let solarized_custom_text = solarized_custom_buf
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(solarized_custom_text.contains("Treatment  Ombre — active"));
+        assert!(!solarized_custom_text.contains("Treatment  Flat — active"));
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -9583,6 +9583,7 @@ async fn apply_command_result(
                             original,
                             app.ocean_treatment,
                             app.ui_locale,
+                            app.background_color_override,
                         ),
                     );
                 }

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -5910,6 +5910,25 @@ mod tests {
     }
 
     #[test]
+    fn solarized_light_custom_background_keeps_ombre() {
+        let mut app = create_test_app();
+        let custom = Color::Rgb(0x1a, 0x1b, 0x26);
+        app.ui_theme = crate::palette::SOLARIZED_LIGHT_UI_THEME.with_background_color(custom);
+        app.ocean_treatment = crate::tui::ocean::OceanTreatment::Ombre;
+
+        let area = Rect::new(0, 0, 100, 30);
+        let mut buf = Buffer::empty(area);
+        ChatWidget::new(&mut app, area).render(area, &mut buf);
+
+        assert_ne!(buf[(0, 0)].bg, custom);
+        assert_ne!(
+            buf[(0, 0)].bg,
+            buf[(0, 29)].bg,
+            "custom Solarized Light backgrounds must retain ombre depth"
+        );
+    }
+
+    #[test]
     fn terminal_owned_background_still_carries_foreground_life() {
         let mut app = create_test_app();
         app.ui_theme = crate::palette::TERMINAL_UI_THEME;

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -728,8 +728,9 @@ impl Renderable for ChatWidget {
 impl ChatWidget {
     /// Paint the underwater field. The water column belongs to ombre;
     /// ambient life belongs to every underwater treatment. Flat keeps the
-    /// theme surface and Terminal keeps its inherited background, but
-    /// neither means a lifeless ocean.
+    /// theme surface, Solarized Light keeps canonical Base3, and Terminal
+    /// keeps its inherited background, but none of those means a lifeless
+    /// ocean.
     fn render_underwater_field(&self, area: Rect, buf: &mut Buffer) {
         if let Some(column) = self.ocean_column {
             for local_y in 0..area.height {
@@ -5873,6 +5874,38 @@ mod tests {
         assert!(
             (0..area.height).any(|y| (0..area.width).any(|x| buf[(x, y)].symbol() == "F")),
             "Fleet setup remains available in flat mode"
+        );
+    }
+
+    #[test]
+    fn solarized_light_ombre_keeps_canonical_surface_and_ambient_life() {
+        let mut app = create_test_app();
+        app.ui_theme = crate::palette::SOLARIZED_LIGHT_UI_THEME;
+        app.ocean_treatment = crate::tui::ocean::OceanTreatment::Ombre;
+        app.low_motion = false;
+        app.fancy_animations = true;
+        // The old cyan-tinted ramp produced the reported #e1e9da at row 16
+        // of a common 30-row viewport.
+        let area = Rect::new(0, 0, 100, 30);
+        let canonical_base3 = Color::Rgb(0xfd, 0xf6, 0xe3);
+        let mut buf = Buffer::empty(area);
+        ChatWidget::new(&mut app, area).render(area, &mut buf);
+
+        assert_eq!(buf[(0, 0)].bg, canonical_base3);
+        assert_eq!(
+            buf[(0, 16)].bg,
+            canonical_base3,
+            "Solarized Light must not regress to the reported #e1e9da tint"
+        );
+        assert_eq!(
+            buf[(0, 29)].bg,
+            canonical_base3,
+            "Solarized Light must keep canonical Base3 through the viewport"
+        );
+        let rendered = buffer_text(&buf, area);
+        assert!(
+            rendered.contains("><>") || rendered.contains("<><"),
+            "preserving the background must not remove ambient life:\n{rendered}"
         );
     }
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -437,7 +437,8 @@ patches, and TUI fixes landed alongside first-time and returning contributor wor
 - **[lihuan215](https://github.com/lihuan215)** — Unix socket hook sink design harvested into the opt-in hook event path (#2333, #2430)
 - **[AdityaVG13](https://github.com/AdityaVG13)** — Xiaomi MiMo provider support (#2246)
 - **[New2Niu](https://github.com/New2Niu)** — macOS display notifications (#2260)
-- **[AiurArtanis](https://github.com/AiurArtanis)** — Solarized Light theme (#2270)
+- **[AiurArtanis](https://github.com/AiurArtanis)** — Solarized Light theme and
+  canonical-background regression report (#2270, #4457)
 - **[Lee-take](https://github.com/Lee-take)** — task migration and session environment isolation fixes (#2272)
 - **[LeoAlex0](https://github.com/LeoAlex0)** — session persistence fixes for message counts and tool-output cache preservation (#2388, #2395)
 - **[jimmyzhuu](https://github.com/jimmyzhuu)** — Baidu AI Search backend for `web_search` (#2371)


### PR DESCRIPTION
## Summary

- preserve Solarized Light's canonical Base3 (`#fdf6e3`) shell background
- keep foreground fish/bubble ambient life even though the theme skips the Ombre water column
- report the effective Flat treatment truthfully in `/theme`
- credit the original theme author and regression reporter

Fixes #4457.

## Root cause

v0.9.0 made the underwater Ombre treatment the default. `OceanRamp::for_theme` grouped Solarized Light with the generic light theme and mixed Base3 with cyan/blue. On a 30-row viewport that produced the reported `#e1e9da` at row 16, even though the Solarized theme token itself remained `#fdf6e3`.

Solarized Light now opts out of the background water column, just like Flat rendering, while its independently rendered foreground ambient life remains available. Other themes and the global Ombre default are unchanged.

## Tests

- `cargo fmt --all --check`
- `git diff --check upstream/main...HEAD`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked solarized_light -- --nocapture` (5 passed, exact rebased head)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::theme_picker::tests::treatment_report_names_effective_appearance -- --exact --nocapture` (passed, exact rebased head)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::ocean::tests -- --nocapture` (12 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::theme_picker::tests -- --nocapture` (16 passed)
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `cargo test --workspace --exclude codewhale-tui --exclude codewhale-lane --locked`
- `cargo build --release -p codewhale-cli -p codewhale-tui --locked`

The full Windows TUI run reached 7015 passed / 5 failed / 2 ignored. All new theme tests passed. One shell test passed in isolation; the remaining failures reproduce independently in untouched provider/setup code or depend on unavailable Unix `printf`. The separately excluded lane test likewise invokes an unavailable standalone `echo` binary on Windows. CI remains the authoritative clean-platform gate.

## Self-review

Two independent read-only reviews traced every `OceanRamp` consumer (transcript, header, work strip, composer, and footer), verified ambient-life scheduling remains intact, checked the effective treatment copy, and found no remaining behavior issue. One review requested the missing reporter credit in `docs/CONTRIBUTORS.md`; this PR includes that correction.
