### PR TITLE
chore(release): credit v0.9.1 late landings in all three credit surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,15 @@ Thank you to the contributors whose code, reports, and reviews shaped v0.9.1:
 - [@seanthefuturegorilla](https://github.com/seanthefuturegorilla) — the
   canonical OpenCode Go/Zen provider request and acceptance direction
   (#1481).
+- [@nightt5879](https://github.com/nightt5879) — the Solarized Light
+  background preservation fix (PR #4471).
+- [@AiurArtanis](https://github.com/AiurArtanis) — the Solarized Light
+  regression report and reproduction (#4457).
+- [@shenjackyuanjie](https://github.com/shenjackyuanjie) — the HarmonyOS
+  workflow-js bindgen, portable-pty gating, and SDK environment work
+  (PR #4470).
+- [@shenyongqing](https://github.com/shenyongqing) — the original HarmonyOS
+  bindgen approach (PR #4384), carried into the landed implementation.
 
 ## [0.9.0] - 2026-07-16
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -105,6 +105,15 @@ Thank you to the contributors whose code, reports, and reviews shaped v0.9.1:
 - [@seanthefuturegorilla](https://github.com/seanthefuturegorilla) — the
   canonical OpenCode Go/Zen provider request and acceptance direction
   (#1481).
+- [@nightt5879](https://github.com/nightt5879) — the Solarized Light
+  background preservation fix (PR #4471).
+- [@AiurArtanis](https://github.com/AiurArtanis) — the Solarized Light
+  regression report and reproduction (#4457).
+- [@shenjackyuanjie](https://github.com/shenjackyuanjie) — the HarmonyOS
+  workflow-js bindgen, portable-pty gating, and SDK environment work
+  (PR #4470).
+- [@shenyongqing](https://github.com/shenyongqing) — the original HarmonyOS
+  bindgen approach (PR #4384), carried into the landed implementation.
 
 ## [0.9.0] - 2026-07-16
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -40,6 +40,16 @@ notes, and relevant issue/PR comments.
 - **[Sean Tse / seanthefuturegorilla](https://github.com/seanthefuturegorilla)**
   — the canonical OpenCode Go/Zen provider request and acceptance direction in
   #1481
+- **[nightt5879](https://github.com/nightt5879)** — the Solarized Light
+  background preservation fix for the underwater shell (PR #4471)
+- **[AiurArtanis](https://github.com/AiurArtanis)** — the Solarized Light
+  v0.9.0 regression report and reproduction (#4457)
+- **[shenjackyuanjie](https://github.com/shenjackyuanjie)** — the HarmonyOS
+  workflow-js bindgen, portable-pty gating, and SDK environment work
+  (PR #4470)
+- **[shenyongqing](https://github.com/shenyongqing)** — the original HarmonyOS
+  workflow-js bindgen approach (PR #4384), carried into the landed
+  implementation with credit
 
 </details>
 

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -21,11 +21,15 @@
 /** Contributors whose PRs were merged or harvested into this release. */
 export const RELEASE_CONTRIBUTORS: string[] = [
   "@h3c-hexin",
+  "@shenjackyuanjie",
+  "@shenyongqing",
   "@sternelee",
+  "@nightt5879",
   "@zhangweiii",
 ];
 
 /** Contributors who helped with reports, reproductions, and verification. */
 export const RELEASE_HELPERS: string[] = [
+  "@AiurArtanis",
   "@seanthefuturegorilla",
 ];


### PR DESCRIPTION
Keeps the three credit surfaces in exact parity after #4471 and #4470 merged post-RC: CHANGELOG.md Contributors, docs/CONTRIBUTORS.md v0.9.1 band, and web/lib/release-credits.ts.

Adds: @nightt5879 (#4471), @shenjackyuanjie (#4470), @AiurArtanis (#4457 report), @shenyongqing (original OHOS bindgen approach, #4384).

Verified: sync-changelog --check OK; web tests 73/73 incl. the exact-parity contract.