### PR TITLE
fix(tools): make apply_patch replacement explicit and compatible

### DIFF
--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -1140,11 +1140,11 @@ mod tests {
                 "type": "object",
                 "properties": {
                     "patch": {"type": "string"},
-                    "changes": {"type": "array"}
+                    "replace": {"type": "array"}
                 },
                 "oneOf": [
                     {"required": ["patch"]},
-                    {"required": ["changes"]}
+                    {"required": ["replace"]}
                 ]
             }),
             allowed_callers: None,
@@ -1165,10 +1165,10 @@ mod tests {
         assert!(parameters.get("enum").is_none());
         assert!(parameters.get("not").is_none());
         assert!(parameters["properties"].get("patch").is_some());
-        assert!(parameters["properties"].get("changes").is_some());
+        assert!(parameters["properties"].get("replace").is_some());
         assert_eq!(
             payload["description"],
-            "Apply patch\n\nExactly one of these parameter groups must be provided: `changes` | `patch`."
+            "Apply patch\n\nExactly one of these parameter groups must be provided: `patch` | `replace`."
         );
         assert!(tool.input_schema.get("oneOf").is_some());
     }
@@ -1183,11 +1183,11 @@ mod tests {
                 "type": "object",
                 "properties": {
                     "patch": {"type": "string"},
-                    "changes": {"type": "array"}
+                    "replace": {"type": "array"}
                 },
                 "oneOf": [
                     {"required": ["patch"]},
-                    {"required": ["changes"]}
+                    {"required": ["replace"]}
                 ]
             }),
             allowed_callers: None,
@@ -1201,7 +1201,7 @@ mod tests {
 
         assert_eq!(
             payload["description"],
-            "Apply patch\n\nExactly one of these parameter groups must be provided: `changes` | `patch`."
+            "Apply patch\n\nExactly one of these parameter groups must be provided: `patch` | `replace`."
         );
     }
 

--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -1140,11 +1140,13 @@ mod tests {
                 "type": "object",
                 "properties": {
                     "patch": {"type": "string"},
-                    "replace": {"type": "array"}
+                    "replace": {"type": "array"},
+                    "changes": {"type": "array"}
                 },
                 "oneOf": [
                     {"required": ["patch"]},
-                    {"required": ["replace"]}
+                    {"required": ["replace"]},
+                    {"required": ["changes"]}
                 ]
             }),
             allowed_callers: None,
@@ -1166,9 +1168,10 @@ mod tests {
         assert!(parameters.get("not").is_none());
         assert!(parameters["properties"].get("patch").is_some());
         assert!(parameters["properties"].get("replace").is_some());
+        assert!(parameters["properties"].get("changes").is_some());
         assert_eq!(
             payload["description"],
-            "Apply patch\n\nExactly one of these parameter groups must be provided: `patch` | `replace`."
+            "Apply patch\n\nExactly one of these parameter groups must be provided: `changes` | `patch` | `replace`."
         );
         assert!(tool.input_schema.get("oneOf").is_some());
     }
@@ -1183,11 +1186,13 @@ mod tests {
                 "type": "object",
                 "properties": {
                     "patch": {"type": "string"},
-                    "replace": {"type": "array"}
+                    "replace": {"type": "array"},
+                    "changes": {"type": "array"}
                 },
                 "oneOf": [
                     {"required": ["patch"]},
-                    {"required": ["replace"]}
+                    {"required": ["replace"]},
+                    {"required": ["changes"]}
                 ]
             }),
             allowed_callers: None,
@@ -1201,7 +1206,7 @@ mod tests {
 
         assert_eq!(
             payload["description"],
-            "Apply patch\n\nExactly one of these parameter groups must be provided: `patch` | `replace`."
+            "Apply patch\n\nExactly one of these parameter groups must be provided: `changes` | `patch` | `replace`."
         );
     }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -8237,7 +8237,7 @@ fn edited_paths_for_write_file_returns_path() {
 #[test]
 fn edited_paths_for_apply_patch_with_changes_returns_each_path() {
     let input = json!({
-        "changes": [
+        "replace": [
             { "path": "a.rs", "content": "" },
             { "path": "b.rs", "content": "" }
         ]

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -8235,9 +8235,21 @@ fn edited_paths_for_write_file_returns_path() {
 }
 
 #[test]
-fn edited_paths_for_apply_patch_with_changes_returns_each_path() {
+fn edited_paths_for_apply_patch_with_replace_returns_each_path() {
     let input = json!({
         "replace": [
+            { "path": "a.rs", "content": "" },
+            { "path": "b.rs", "content": "" }
+        ]
+    });
+    let paths = edited_paths_for_tool("apply_patch", &input);
+    assert_eq!(paths, vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")]);
+}
+
+#[test]
+fn edited_paths_for_apply_patch_with_legacy_changes_returns_each_path() {
+    let input = json!({
+        "changes": [
             { "path": "a.rs", "content": "" },
             { "path": "b.rs", "content": "" }
         ]

--- a/crates/tui/src/repo_law.rs
+++ b/crates/tui/src/repo_law.rs
@@ -99,7 +99,7 @@ fn write_target_paths(workspace: &Path, input: &Value) -> Vec<String> {
             push_normalized(&mut targets, workspace, path);
         }
     }
-    if let Some(changes) = input.get("changes").and_then(Value::as_array) {
+    if let Some(changes) = input.get("replace").and_then(Value::as_array) {
         for change in changes {
             if let Some(path) = change.get("path").and_then(Value::as_str) {
                 push_normalized(&mut targets, workspace, path);
@@ -298,7 +298,7 @@ mod tests {
         let decision = repo_law_plan_decision(
             tmp.path(),
             "apply_patch",
-            &json!({"changes": [{"path": "crates/protocol/msg.rs"}]}),
+            &json!({"replace": [{"path": "crates/protocol/msg.rs"}]}),
         );
         assert!(matches!(decision, Some(RepoLawPlanDecision::Block(_))));
         // unified diff shape

--- a/crates/tui/src/repo_law.rs
+++ b/crates/tui/src/repo_law.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 use serde_json::Value;
 
 use crate::project_context::{RepoLawAction, RepoLawRule, load_repo_law_rules};
+use crate::tools::apply_patch::{NormalizedApplyPatchInput, normalize_apply_patch_input};
 
 /// Tools whose inputs name filesystem write targets we can hold. Any
 /// write-capable tool MUST be listed here — the gate fails open for tools it
@@ -86,7 +87,8 @@ pub(crate) fn repo_law_plan_decision(
 }
 
 /// Extract workspace-relative write targets from a tool input. Covers the
-/// `path`/`target`/`destination`/`file_path` params, `changes[].path`, and
+/// `path`/`target`/`destination`/`file_path` params, canonical
+/// `replace[].path`, legacy `changes[].path`, and
 /// every unified-diff / codex-envelope header shape the patch tools accept —
 /// old (`--- `) and new (`+++ `) paths, with or without an `a/`/`b/` prefix,
 /// tab-timestamp suffixes stripped, and `/dev/null` (deletion) falling back
@@ -99,41 +101,44 @@ fn write_target_paths(workspace: &Path, input: &Value) -> Vec<String> {
             push_normalized(&mut targets, workspace, path);
         }
     }
-    if let Some(changes) = input.get("replace").and_then(Value::as_array) {
-        for change in changes {
-            if let Some(path) = change.get("path").and_then(Value::as_str) {
-                push_normalized(&mut targets, workspace, path);
+    match normalize_apply_patch_input(input) {
+        Ok(NormalizedApplyPatchInput::Replacement { entries, .. }) => {
+            for change in entries {
+                if let Some(path) = change.get("path").and_then(Value::as_str) {
+                    push_normalized(&mut targets, workspace, path);
+                }
             }
         }
-    }
-    if let Some(patch) = input.get("patch").and_then(Value::as_str) {
-        let mut pending_old: Option<String> = None;
-        for line in patch.lines() {
-            if let Some(rest) = line.strip_prefix("*** Update File: ") {
-                push_normalized(&mut targets, workspace, rest.trim());
-            } else if let Some(rest) = line.strip_prefix("*** Add File: ") {
-                push_normalized(&mut targets, workspace, rest.trim());
-            } else if let Some(rest) = line.strip_prefix("*** Delete File: ") {
-                push_normalized(&mut targets, workspace, rest.trim());
-            } else if let Some(rest) = line.strip_prefix("--- ") {
-                // Old path: remember it so a `+++ /dev/null` deletion still
-                // holds the file being removed.
-                pending_old = diff_header_path(rest);
-                if let Some(ref p) = pending_old {
-                    push_normalized(&mut targets, workspace, p);
-                }
-            } else if let Some(rest) = line.strip_prefix("+++ ") {
-                match diff_header_path(rest) {
-                    Some(new_path) => push_normalized(&mut targets, workspace, &new_path),
-                    // `+++ /dev/null` → deletion; the target is the old path.
-                    None => {
-                        if let Some(old) = pending_old.take() {
-                            push_normalized(&mut targets, workspace, &old);
+        Ok(NormalizedApplyPatchInput::Patch(patch)) => {
+            let mut pending_old: Option<String> = None;
+            for line in patch.lines() {
+                if let Some(rest) = line.strip_prefix("*** Update File: ") {
+                    push_normalized(&mut targets, workspace, rest.trim());
+                } else if let Some(rest) = line.strip_prefix("*** Add File: ") {
+                    push_normalized(&mut targets, workspace, rest.trim());
+                } else if let Some(rest) = line.strip_prefix("*** Delete File: ") {
+                    push_normalized(&mut targets, workspace, rest.trim());
+                } else if let Some(rest) = line.strip_prefix("--- ") {
+                    // Old path: remember it so a `+++ /dev/null` deletion still
+                    // holds the file being removed.
+                    pending_old = diff_header_path(rest);
+                    if let Some(ref p) = pending_old {
+                        push_normalized(&mut targets, workspace, p);
+                    }
+                } else if let Some(rest) = line.strip_prefix("+++ ") {
+                    match diff_header_path(rest) {
+                        Some(new_path) => push_normalized(&mut targets, workspace, &new_path),
+                        // `+++ /dev/null` → deletion; the target is the old path.
+                        None => {
+                            if let Some(old) = pending_old.take() {
+                                push_normalized(&mut targets, workspace, &old);
+                            }
                         }
                     }
                 }
             }
         }
+        Err(_) => {}
     }
     targets.sort();
     targets.dedup();
@@ -294,11 +299,18 @@ mod tests {
     fn apply_patch_targets_are_extracted_from_all_shapes() {
         let tmp = TempDir::new().unwrap();
         write_law(tmp.path(), LAW);
-        // changes[].path shape
+        // Canonical replace[].path shape.
         let decision = repo_law_plan_decision(
             tmp.path(),
             "apply_patch",
             &json!({"replace": [{"path": "crates/protocol/msg.rs"}]}),
+        );
+        assert!(matches!(decision, Some(RepoLawPlanDecision::Block(_))));
+        // Legacy changes[].path shape must receive the same hold.
+        let decision = repo_law_plan_decision(
+            tmp.path(),
+            "apply_patch",
+            &json!({"changes": [{"path": "crates/protocol/msg.rs"}]}),
         );
         assert!(matches!(decision, Some(RepoLawPlanDecision::Block(_))));
         // unified diff shape

--- a/crates/tui/src/tools/apply_patch.rs
+++ b/crates/tui/src/tools/apply_patch.rs
@@ -179,7 +179,7 @@ struct HunkApplyStats {
 
 #[derive(Debug, Clone)]
 enum ApplyPatchPreflightKind {
-    Changes,
+    Replace,
     PathOverride { path: String, hunks: Vec<Hunk> },
     FilePatches(Vec<FilePatch>),
 }
@@ -226,7 +226,7 @@ impl ToolSpec for ApplyPatchTool {
                     "type": "string",
                     "description": "Unified diff patch content"
                 },
-                "changes": {
+                "replace": {
                     "type": "array",
                     "description": "Optional full file replacements (path + content).",
                     "items": {
@@ -249,7 +249,7 @@ impl ToolSpec for ApplyPatchTool {
             },
             "oneOf": [
                 { "required": ["patch"] },
-                { "required": ["changes"] }
+                { "required": ["replace"] }
             ]
         })
     }
@@ -269,11 +269,19 @@ impl ToolSpec for ApplyPatchTool {
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let fuzz = optional_u64(&input, "fuzz", DEFAULT_FUZZ as u64).min(MAX_FUZZ as u64);
         let fuzz = usize::try_from(fuzz).unwrap_or(DEFAULT_FUZZ);
+
+        // Reject ambiguous input: model may pass both 'patch' and 'replace' when it intends only one
+        if input.get("patch").is_some() && input.get("replace").is_some() {
+            return Err(ToolError::execution_failed(
+                "Cannot use both 'patch' and 'replace' simultaneously. Choose one.",
+            ));
+        }
+
         let create_if_missing = optional_bool(&input, "create_if_missing", false);
         let preflight = preflight_apply_patch_plan(&input)?;
 
-        if let Some(changes_value) = input.get("changes") {
-            let (pending, stats) = build_pending_writes_from_changes(changes_value, context)?;
+        if let Some(replace_value) = input.get("replace") {
+            let (pending, stats) = build_pending_writes_from_replace(replace_value, context)?;
             apply_pending_writes(&pending)?;
             // Resolve absolute paths for LSP diagnostics query.
             let abs_paths: Vec<PathBuf> = pending.iter().map(|p| p.path.clone()).collect();
@@ -302,8 +310,8 @@ impl ToolSpec for ApplyPatchTool {
         }
 
         let file_patches = match preflight.kind {
-            ApplyPatchPreflightKind::Changes => {
-                unreachable!("changes input returned before patch execution")
+            ApplyPatchPreflightKind::Replace => {
+                unreachable!("replace input returned before patch execution")
             }
             ApplyPatchPreflightKind::PathOverride { path, hunks } => vec![FilePatch {
                 path,
@@ -359,10 +367,10 @@ pub fn preflight_apply_patch(input: &Value) -> Result<ApplyPatchPreflight, ToolE
 fn preflight_apply_patch_plan(input: &Value) -> Result<ApplyPatchPreflightPlan, ToolError> {
     let create_if_missing = optional_bool(input, "create_if_missing", false);
 
-    if let Some(changes_value) = input.get("changes") {
+    if let Some(replace_value) = input.get("replace") {
         return Ok(ApplyPatchPreflightPlan {
-            summary: preflight_changes(changes_value)?,
-            kind: ApplyPatchPreflightKind::Changes,
+            summary: preflight_replace(replace_value)?,
+            kind: ApplyPatchPreflightKind::Replace,
         });
     }
 
@@ -443,12 +451,12 @@ fn preflight_apply_patch_plan(input: &Value) -> Result<ApplyPatchPreflightPlan, 
     })
 }
 
-fn preflight_changes(changes_value: &Value) -> Result<ApplyPatchPreflight, ToolError> {
-    let changes = changes_value.as_array().ok_or_else(|| {
-        ToolError::invalid_input("`changes` must be an array of objects like {path, content}")
+fn preflight_replace(replace_value: &Value) -> Result<ApplyPatchPreflight, ToolError> {
+    let changes = replace_value.as_array().ok_or_else(|| {
+        ToolError::invalid_input("`replace` must be an array of objects like {path, content}")
     })?;
     if changes.is_empty() {
-        return Err(ToolError::invalid_input("`changes` cannot be empty"));
+        return Err(ToolError::invalid_input("`replace` cannot be empty"));
     }
 
     let mut touched_files = Vec::new();
@@ -456,11 +464,11 @@ fn preflight_changes(changes_value: &Value) -> Result<ApplyPatchPreflight, ToolE
         let path = change
             .get("path")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("changes[].path"))?;
+            .ok_or_else(|| ToolError::missing_field("replace[].path"))?;
         let _content = change
             .get("content")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("changes[].content"))?;
+            .ok_or_else(|| ToolError::missing_field("replace[].content"))?;
         push_unique(&mut touched_files, path.to_string());
     }
 
@@ -849,15 +857,15 @@ fn push_unique(target: &mut Vec<String>, value: String) {
     }
 }
 
-fn build_pending_writes_from_changes(
-    changes_value: &Value,
+fn build_pending_writes_from_replace(
+    replace_value: &Value,
     context: &ToolContext,
 ) -> Result<(Vec<PendingWrite>, PatchStatsExt), ToolError> {
-    let changes = changes_value.as_array().ok_or_else(|| {
-        ToolError::invalid_input("`changes` must be an array of objects like {path, content}")
+    let changes = replace_value.as_array().ok_or_else(|| {
+        ToolError::invalid_input("`replace` must be an array of objects like {path, content}")
     })?;
     if changes.is_empty() {
-        return Err(ToolError::invalid_input("`changes` cannot be empty"));
+        return Err(ToolError::invalid_input("`replace` cannot be empty"));
     }
 
     let mut pending = Vec::new();
@@ -866,11 +874,11 @@ fn build_pending_writes_from_changes(
         let path = change
             .get("path")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("changes[].path"))?;
+            .ok_or_else(|| ToolError::missing_field("replace[].path"))?;
         let content = change
             .get("content")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("changes[].content"))?;
+            .ok_or_else(|| ToolError::missing_field("replace[].content"))?;
 
         let resolved = context.resolve_path(path)?;
         let original = if resolved.exists() {
@@ -1368,7 +1376,7 @@ diff --git a/old.rs b/old.rs
     #[test]
     fn test_preflight_apply_patch_changes_list() {
         let preflight = preflight_apply_patch(&json!({
-            "changes": [
+            "replace": [
                 { "path": "one.txt", "content": "one" },
                 { "path": "two.txt", "content": "two" }
             ]
@@ -1383,7 +1391,7 @@ diff --git a/old.rs b/old.rs
     #[test]
     fn test_preflight_changes_files_total_counts_entries() {
         let preflight = preflight_apply_patch(&json!({
-            "changes": [
+            "replace": [
                 { "path": "same.txt", "content": "one" },
                 { "path": "same.txt", "content": "two" }
             ]
@@ -1663,7 +1671,7 @@ diff --git a/same.txt b/same.txt
         let result = tool
             .execute(
                 json!({
-                    "changes": [
+                    "replace": [
                         { "path": "one.txt", "content": "new\n" },
                         { "path": "two.txt", "content": "second\n" }
                     ]
@@ -1707,7 +1715,7 @@ diff --git a/same.txt b/same.txt
         let err = tool
             .execute(
                 json!({
-                    "changes": [
+                    "replace": [
                         { "path": "one.txt", "content": "new\n" },
                         { "path": "blocked/two.txt", "content": "second\n" }
                     ]

--- a/crates/tui/src/tools/apply_patch.rs
+++ b/crates/tui/src/tools/apply_patch.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
-    lsp_diagnostics_for_paths, optional_bool, optional_str, optional_u64, required_str,
+    lsp_diagnostics_for_paths, optional_bool, optional_str, optional_u64,
 };
 
 /// Maximum lines of context for fuzzy matching (increased for better tolerance)
@@ -184,6 +184,74 @@ enum ApplyPatchPreflightKind {
     FilePatches(Vec<FilePatch>),
 }
 
+/// Canonicalized `apply_patch` payload mode.
+///
+/// `replace` is the preferred spelling for full-file replacements. `changes`
+/// remains a compatibility alias for callers that learned the original tool
+/// schema before the clearer name was introduced.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum NormalizedApplyPatchInput<'a> {
+    Patch(&'a str),
+    Replacement {
+        entries: &'a [Value],
+        source_field: &'static str,
+    },
+}
+
+/// Validate mutual exclusivity and normalize the legacy `changes` alias.
+///
+/// This is the single parser used by execution, preflight, policy, approval,
+/// and UI consumers so every surface agrees on the accepted input contract.
+pub(crate) fn normalize_apply_patch_input(
+    input: &Value,
+) -> Result<NormalizedApplyPatchInput<'_>, ToolError> {
+    let provided: Vec<&'static str> = ["patch", "replace", "changes"]
+        .into_iter()
+        .filter(|field| input.get(*field).is_some())
+        .collect();
+
+    if provided.len() > 1 {
+        let fields = provided
+            .iter()
+            .map(|field| format!("`{field}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(ToolError::invalid_input(format!(
+            "Cannot use {fields} simultaneously. Choose exactly one of `patch`, `replace`, or the deprecated `changes` alias."
+        )));
+    }
+
+    let Some(field) = provided.first().copied() else {
+        return Err(ToolError::missing_field(
+            "patch, replace, or deprecated changes",
+        ));
+    };
+
+    if field == "patch" {
+        let patch = input
+            .get(field)
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::invalid_input("`patch` must be a string"))?;
+        return Ok(NormalizedApplyPatchInput::Patch(patch));
+    }
+
+    let entries = input.get(field).and_then(Value::as_array).ok_or_else(|| {
+        ToolError::invalid_input(format!(
+            "`{field}` must be an array of objects like {{path, content}}"
+        ))
+    })?;
+    if entries.is_empty() {
+        return Err(ToolError::invalid_input(format!(
+            "`{field}` cannot be empty"
+        )));
+    }
+
+    Ok(NormalizedApplyPatchInput::Replacement {
+        entries,
+        source_field: field,
+    })
+}
+
 #[derive(Debug, Clone)]
 struct ApplyPatchPreflightPlan {
     summary: ApplyPatchPreflight,
@@ -238,6 +306,18 @@ impl ToolSpec for ApplyPatchTool {
                         "required": ["path", "content"]
                     }
                 },
+                "changes": {
+                    "type": "array",
+                    "description": "Deprecated compatibility alias for `replace` (full file replacements by path + content).",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string" },
+                            "content": { "type": "string" }
+                        },
+                        "required": ["path", "content"]
+                    }
+                },
                 "fuzz": {
                     "type": "integer",
                     "description": "Maximum fuzz factor for fuzzy matching (default: 3)"
@@ -249,7 +329,8 @@ impl ToolSpec for ApplyPatchTool {
             },
             "oneOf": [
                 { "required": ["patch"] },
-                { "required": ["replace"] }
+                { "required": ["replace"] },
+                { "required": ["changes"] }
             ]
         })
     }
@@ -269,19 +350,17 @@ impl ToolSpec for ApplyPatchTool {
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
         let fuzz = optional_u64(&input, "fuzz", DEFAULT_FUZZ as u64).min(MAX_FUZZ as u64);
         let fuzz = usize::try_from(fuzz).unwrap_or(DEFAULT_FUZZ);
-
-        // Reject ambiguous input: model may pass both 'patch' and 'replace' when it intends only one
-        if input.get("patch").is_some() && input.get("replace").is_some() {
-            return Err(ToolError::execution_failed(
-                "Cannot use both 'patch' and 'replace' simultaneously. Choose one.",
-            ));
-        }
-
+        let normalized = normalize_apply_patch_input(&input)?;
         let create_if_missing = optional_bool(&input, "create_if_missing", false);
-        let preflight = preflight_apply_patch_plan(&input)?;
+        let preflight = preflight_apply_patch_plan(&input, normalized)?;
 
-        if let Some(replace_value) = input.get("replace") {
-            let (pending, stats) = build_pending_writes_from_replace(replace_value, context)?;
+        if let NormalizedApplyPatchInput::Replacement {
+            entries,
+            source_field,
+        } = normalized
+        {
+            let (pending, stats) =
+                build_pending_writes_from_replace(entries, source_field, context)?;
             apply_pending_writes(&pending)?;
             // Resolve absolute paths for LSP diagnostics query.
             let abs_paths: Vec<PathBuf> = pending.iter().map(|p| p.path.clone()).collect();
@@ -361,20 +440,30 @@ impl ToolSpec for ApplyPatchTool {
 /// suitable for policy checks, audit logs, diagnostics hooks, and future undo
 /// planning that must know the target files before mutation.
 pub fn preflight_apply_patch(input: &Value) -> Result<ApplyPatchPreflight, ToolError> {
-    Ok(preflight_apply_patch_plan(input)?.summary)
+    let normalized = normalize_apply_patch_input(input)?;
+    Ok(preflight_apply_patch_plan(input, normalized)?.summary)
 }
 
-fn preflight_apply_patch_plan(input: &Value) -> Result<ApplyPatchPreflightPlan, ToolError> {
+fn preflight_apply_patch_plan(
+    input: &Value,
+    normalized: NormalizedApplyPatchInput<'_>,
+) -> Result<ApplyPatchPreflightPlan, ToolError> {
     let create_if_missing = optional_bool(input, "create_if_missing", false);
 
-    if let Some(replace_value) = input.get("replace") {
+    if let NormalizedApplyPatchInput::Replacement {
+        entries,
+        source_field,
+    } = normalized
+    {
         return Ok(ApplyPatchPreflightPlan {
-            summary: preflight_replace(replace_value)?,
+            summary: preflight_replace(entries, source_field)?,
             kind: ApplyPatchPreflightKind::Replace,
         });
     }
 
-    let patch_text = required_str(input, "patch")?;
+    let NormalizedApplyPatchInput::Patch(patch_text) = normalized else {
+        unreachable!("replacement input returned before patch parsing")
+    };
     let path_override = optional_str(input, "path");
     let patch_shape = inspect_patch_shape(patch_text);
     validate_patch_shape(&patch_shape, path_override)?;
@@ -451,24 +540,20 @@ fn preflight_apply_patch_plan(input: &Value) -> Result<ApplyPatchPreflightPlan, 
     })
 }
 
-fn preflight_replace(replace_value: &Value) -> Result<ApplyPatchPreflight, ToolError> {
-    let changes = replace_value.as_array().ok_or_else(|| {
-        ToolError::invalid_input("`replace` must be an array of objects like {path, content}")
-    })?;
-    if changes.is_empty() {
-        return Err(ToolError::invalid_input("`replace` cannot be empty"));
-    }
-
+fn preflight_replace(
+    changes: &[Value],
+    source_field: &str,
+) -> Result<ApplyPatchPreflight, ToolError> {
     let mut touched_files = Vec::new();
     for change in changes {
         let path = change
             .get("path")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("replace[].path"))?;
+            .ok_or_else(|| ToolError::missing_field(format!("{source_field}[].path")))?;
         let _content = change
             .get("content")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("replace[].content"))?;
+            .ok_or_else(|| ToolError::missing_field(format!("{source_field}[].content")))?;
         push_unique(&mut touched_files, path.to_string());
     }
 
@@ -858,27 +943,21 @@ fn push_unique(target: &mut Vec<String>, value: String) {
 }
 
 fn build_pending_writes_from_replace(
-    replace_value: &Value,
+    changes: &[Value],
+    source_field: &str,
     context: &ToolContext,
 ) -> Result<(Vec<PendingWrite>, PatchStatsExt), ToolError> {
-    let changes = replace_value.as_array().ok_or_else(|| {
-        ToolError::invalid_input("`replace` must be an array of objects like {path, content}")
-    })?;
-    if changes.is_empty() {
-        return Err(ToolError::invalid_input("`replace` cannot be empty"));
-    }
-
     let mut pending = Vec::new();
     let mut stats = PatchStatsExt::default();
     for change in changes {
         let path = change
             .get("path")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("replace[].path"))?;
+            .ok_or_else(|| ToolError::missing_field(format!("{source_field}[].path")))?;
         let content = change
             .get("content")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::missing_field("replace[].content"))?;
+            .ok_or_else(|| ToolError::missing_field(format!("{source_field}[].content")))?;
 
         let resolved = context.resolve_path(path)?;
         let original = if resolved.exists() {
@@ -1294,6 +1373,27 @@ mod tests {
     }
 
     #[test]
+    fn input_schema_exposes_replace_and_deprecated_changes_alias() {
+        let schema = ApplyPatchTool.input_schema();
+
+        assert_eq!(schema["properties"]["replace"]["type"], "array");
+        assert_eq!(schema["properties"]["changes"]["type"], "array");
+        assert!(
+            schema["properties"]["changes"]["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("Deprecated"))
+        );
+        assert_eq!(
+            schema["oneOf"],
+            json!([
+                { "required": ["patch"] },
+                { "required": ["replace"] },
+                { "required": ["changes"] }
+            ])
+        );
+    }
+
+    #[test]
     fn test_preflight_apply_patch_with_path_override() {
         let patch = r"@@ -1,2 +1,2 @@
  old
@@ -1374,8 +1474,8 @@ diff --git a/old.rs b/old.rs
     }
 
     #[test]
-    fn test_preflight_apply_patch_changes_list() {
-        let preflight = preflight_apply_patch(&json!({
+    fn test_preflight_apply_patch_replace_list() {
+        let canonical = preflight_apply_patch(&json!({
             "replace": [
                 { "path": "one.txt", "content": "one" },
                 { "path": "two.txt", "content": "two" }
@@ -1383,13 +1483,22 @@ diff --git a/old.rs b/old.rs
         }))
         .expect("preflight");
 
-        assert_eq!(preflight.touched_files, vec!["one.txt", "two.txt"]);
-        assert_eq!(preflight.files_total, 2);
-        assert_eq!(preflight.hunks_total, 0);
+        let legacy = preflight_apply_patch(&json!({
+            "changes": [
+                { "path": "one.txt", "content": "one" },
+                { "path": "two.txt", "content": "two" }
+            ]
+        }))
+        .expect("legacy preflight");
+
+        assert_eq!(canonical.touched_files, vec!["one.txt", "two.txt"]);
+        assert_eq!(canonical.files_total, 2);
+        assert_eq!(canonical.hunks_total, 0);
+        assert_eq!(legacy, canonical);
     }
 
     #[test]
-    fn test_preflight_changes_files_total_counts_entries() {
+    fn test_preflight_replace_files_total_counts_entries() {
         let preflight = preflight_apply_patch(&json!({
             "replace": [
                 { "path": "same.txt", "content": "one" },
@@ -1661,7 +1770,7 @@ diff --git a/same.txt b/same.txt
     }
 
     #[tokio::test]
-    async fn test_apply_patch_changes_list() {
+    async fn test_apply_patch_replace_list() {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
 
@@ -1704,7 +1813,80 @@ diff --git a/same.txt b/same.txt
     }
 
     #[tokio::test]
-    async fn test_apply_patch_changes_list_rolls_back_on_write_failure() {
+    async fn test_apply_patch_legacy_changes_list() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        fs::write(tmp.path().join("legacy.txt"), "old\n").expect("write");
+
+        let result = ApplyPatchTool
+            .execute(
+                json!({
+                    "changes": [
+                        { "path": "legacy.txt", "content": "new\n" }
+                    ]
+                }),
+                &ctx,
+            )
+            .await
+            .expect("legacy changes alias should execute");
+
+        assert!(result.success);
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("legacy.txt")).unwrap(),
+            "new\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_patch_rejects_every_mixed_mode_before_writing() {
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        fs::write(tmp.path().join("guard.txt"), "old\n").expect("write");
+        let patch = "--- a/guard.txt\n+++ b/guard.txt\n@@ -1 +1 @@\n-old\n+patched\n";
+        let replacement = json!([{
+            "path": "guard.txt",
+            "content": "replaced\n"
+        }]);
+        let cases = [
+            (
+                ["patch", "replace"],
+                json!({"patch": patch, "replace": replacement.clone()}),
+            ),
+            (
+                ["patch", "changes"],
+                json!({"patch": patch, "changes": replacement.clone()}),
+            ),
+            (
+                ["replace", "changes"],
+                json!({
+                    "replace": replacement.clone(),
+                    "changes": replacement.clone()
+                }),
+            ),
+        ];
+
+        for (fields, input) in cases {
+            let err = ApplyPatchTool
+                .execute(input, &ctx)
+                .await
+                .expect_err("mixed modes must be rejected");
+            let ToolError::InvalidInput { message } = err else {
+                panic!("mixed modes should be invalid input, got: {err}");
+            };
+            assert!(message.contains("simultaneously"), "{message}");
+            for field in fields {
+                assert!(message.contains(field), "{message}");
+            }
+            assert_eq!(
+                fs::read_to_string(tmp.path().join("guard.txt")).unwrap(),
+                "old\n",
+                "mixed modes must be rejected before the first write"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_apply_patch_replace_list_rolls_back_on_write_failure() {
         let tmp = tempdir().expect("tempdir");
         let ctx = ToolContext::new(tmp.path().to_path_buf());
 

--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -123,7 +123,7 @@ fn hash_patch_paths(input: &serde_json::Value) -> String {
 
     let mut paths: Vec<&str> = Vec::new();
 
-    if let Some(changes) = input.get("changes").and_then(|v| v.as_array()) {
+    if let Some(changes) = input.get("replace").and_then(|v| v.as_array()) {
         for change in changes {
             if let Some(path) = change.get("path").and_then(|v| v.as_str()) {
                 paths.push(path);
@@ -291,11 +291,11 @@ mod tests {
     fn grouping_key_collapses_patch_body_for_same_path() {
         let key_a = build_approval_grouping_key(
             "apply_patch",
-            &json!({"changes": [{"path": "a.rs", "content": "x"}]}),
+            &json!({"replace": [{"path": "a.rs", "content": "x"}]}),
         );
         let key_b = build_approval_grouping_key(
             "apply_patch",
-            &json!({"changes": [{"path": "a.rs", "content": "y"}]}),
+            &json!({"replace": [{"path": "a.rs", "content": "y"}]}),
         );
         assert_eq!(
             key_a, key_b,
@@ -320,11 +320,11 @@ mod tests {
     fn patch_keys_differ_by_path() {
         let key_a = build_approval_key(
             "apply_patch",
-            &json!({"changes": [{"path": "a.rs", "content": "x"}]}),
+            &json!({"replace": [{"path": "a.rs", "content": "x"}]}),
         );
         let key_b = build_approval_key(
             "apply_patch",
-            &json!({"changes": [{"path": "b.rs", "content": "x"}]}),
+            &json!({"replace": [{"path": "b.rs", "content": "x"}]}),
         );
         assert_ne!(key_a, key_b);
     }
@@ -333,11 +333,11 @@ mod tests {
     fn patch_keys_differ_by_body_for_same_path() {
         let key_a = build_approval_key(
             "apply_patch",
-            &json!({"changes": [{"path": "a.rs", "content": "x"}]}),
+            &json!({"replace": [{"path": "a.rs", "content": "x"}]}),
         );
         let key_b = build_approval_key(
             "apply_patch",
-            &json!({"changes": [{"path": "a.rs", "content": "y"}]}),
+            &json!({"replace": [{"path": "a.rs", "content": "y"}]}),
         );
         assert_ne!(key_a, key_b);
     }

--- a/crates/tui/src/tools/approval_cache.rs
+++ b/crates/tui/src/tools/approval_cache.rs
@@ -37,6 +37,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::command_safety::classify_command;
+use crate::tools::apply_patch::{NormalizedApplyPatchInput, normalize_apply_patch_input};
 
 /// The fingerprint of a tool call — stable enough to match repeated
 /// calls but specific enough to avoid privilege confusion.
@@ -123,18 +124,22 @@ fn hash_patch_paths(input: &serde_json::Value) -> String {
 
     let mut paths: Vec<&str> = Vec::new();
 
-    if let Some(changes) = input.get("replace").and_then(|v| v.as_array()) {
-        for change in changes {
-            if let Some(path) = change.get("path").and_then(|v| v.as_str()) {
-                paths.push(path);
+    match normalize_apply_patch_input(input) {
+        Ok(NormalizedApplyPatchInput::Replacement { entries, .. }) => {
+            for change in entries {
+                if let Some(path) = change.get("path").and_then(|v| v.as_str()) {
+                    paths.push(path);
+                }
             }
         }
-    } else if let Some(patch_text) = input.get("patch").and_then(|v| v.as_str()) {
-        for line in patch_text.lines() {
-            if let Some(rest) = line.strip_prefix("+++ b/") {
-                paths.push(rest.trim());
+        Ok(NormalizedApplyPatchInput::Patch(patch_text)) => {
+            for line in patch_text.lines() {
+                if let Some(rest) = line.strip_prefix("+++ b/") {
+                    paths.push(rest.trim());
+                }
             }
         }
+        Err(_) => {}
     }
 
     paths.sort();
@@ -301,6 +306,20 @@ mod tests {
             key_a, key_b,
             "approving a patch family must cover later edits to the same path"
         );
+    }
+
+    #[test]
+    fn grouping_key_treats_replace_and_legacy_changes_as_the_same_path_set() {
+        let canonical = build_approval_grouping_key(
+            "apply_patch",
+            &json!({"replace": [{"path": "a.rs", "content": "new"}]}),
+        );
+        let legacy = build_approval_grouping_key(
+            "apply_patch",
+            &json!({"changes": [{"path": "a.rs", "content": "new"}]}),
+        );
+
+        assert_eq!(canonical, legacy);
     }
 
     #[test]

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -825,7 +825,7 @@ mod tests {
             "properties": {
                 "path": {"type": "string"},
                 "patch": {"type": "string"},
-                "changes": {
+                "replace": {
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -839,7 +839,7 @@ mod tests {
             },
             "oneOf": [
                 {"required": ["patch"]},
-                {"required": ["changes"]}
+                {"required": ["replace"]}
             ]
         });
 
@@ -852,10 +852,10 @@ mod tests {
         assert!(schema.get("enum").is_none());
         assert!(schema.get("not").is_none());
         assert!(schema["properties"].get("patch").is_some());
-        assert!(schema["properties"].get("changes").is_some());
+        assert!(schema["properties"].get("replace").is_some());
         assert_eq!(
             note.as_deref(),
-            Some("Exactly one of these parameter groups must be provided: `changes` | `patch`.")
+            Some("Exactly one of these parameter groups must be provided: `patch` | `replace`.")
         );
     }
 

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -835,11 +835,23 @@ mod tests {
                         },
                         "required": ["path", "content"]
                     }
+                },
+                "changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "content": {"type": "string"}
+                        },
+                        "required": ["path", "content"]
+                    }
                 }
             },
             "oneOf": [
                 {"required": ["patch"]},
-                {"required": ["replace"]}
+                {"required": ["replace"]},
+                {"required": ["changes"]}
             ]
         });
 
@@ -853,9 +865,12 @@ mod tests {
         assert!(schema.get("not").is_none());
         assert!(schema["properties"].get("patch").is_some());
         assert!(schema["properties"].get("replace").is_some());
+        assert!(schema["properties"].get("changes").is_some());
         assert_eq!(
             note.as_deref(),
-            Some("Exactly one of these parameter groups must be provided: `patch` | `replace`.")
+            Some(
+                "Exactly one of these parameter groups must be provided: `changes` | `patch` | `replace`."
+            )
         );
     }
 

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -790,7 +790,7 @@ fn file_write_preview_lines(tool_name: &str, params: &Value) -> Option<Vec<Strin
             .and_then(apply_patch_preview_lines)
             .or_else(|| {
                 params
-                    .get("changes")
+                    .get("replace")
                     .and_then(Value::as_array)
                     .and_then(|changes| changes_preview_lines(changes))
             }),
@@ -2161,7 +2161,7 @@ mod tests {
             "apply_patch",
             "Apply a patch",
             &json!({
-                "changes": [
+                "replace": [
                     {
                         "path": "src/lib.rs",
                         "content": "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight"
@@ -2204,7 +2204,7 @@ mod tests {
             "apply_patch",
             "Apply a patch",
             &json!({
-                "changes": [
+                "replace": [
                     {
                         "path": "src/lib.rs",
                         "content": "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight"
@@ -2538,7 +2538,7 @@ diff --git a/src/b.rs b/src/b.rs
             "apply_patch",
             "Apply a patch",
             &json!({
-                "changes": [
+                "replace": [
                     { "path": "src/a.rs", "content": "one" },
                     { "path": "/workspace/src/a.rs", "content": "two" }
                 ]
@@ -2607,7 +2607,7 @@ diff --git a/src/b.rs b/src/b.rs
             "apply_patch",
             "Apply a patch",
             &json!({
-                "changes": [
+                "replace": [
                     { "path": "src/a.rs", "content": "safe" },
                     { "path": "../escape.rs", "content": "unsafe" }
                 ]

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -29,6 +29,7 @@
 
 use crate::localization::{Locale, MessageId, tr};
 use crate::sandbox::SandboxPolicy;
+use crate::tools::apply_patch::{NormalizedApplyPatchInput, normalize_apply_patch_input};
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 use crate::tui::widgets::{ApprovalWidget, ElevationWidget, Renderable};
 use codewhale_config::ToolAskRule;
@@ -784,16 +785,13 @@ fn file_write_preview_lines(tool_name: &str, params: &Value) -> Option<Vec<Strin
             lines.extend(prefixed_preview_lines("with this", "+ ", &replace, 3));
             Some(lines)
         }
-        "apply_patch" => params
-            .get("patch")
-            .and_then(Value::as_str)
-            .and_then(apply_patch_preview_lines)
-            .or_else(|| {
-                params
-                    .get("replace")
-                    .and_then(Value::as_array)
-                    .and_then(|changes| changes_preview_lines(changes))
-            }),
+        "apply_patch" => match normalize_apply_patch_input(params) {
+            Ok(NormalizedApplyPatchInput::Patch(patch)) => apply_patch_preview_lines(patch),
+            Ok(NormalizedApplyPatchInput::Replacement { entries, .. }) => {
+                changes_preview_lines(entries)
+            }
+            Err(_) => None,
+        },
         _ => None,
     }
     .filter(|lines| !lines.is_empty())
@@ -2195,6 +2193,32 @@ mod tests {
             preview.last().map(String::as_str),
             Some("... (+2 more files)")
         );
+    }
+
+    #[test]
+    fn prominent_details_apply_patch_legacy_changes_includes_preview() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "apply_patch",
+            "Apply a patch",
+            &json!({
+                "changes": [{
+                    "path": "src/lib.rs",
+                    "content": "fn legacy() {}\n"
+                }]
+            }),
+            "tool:apply_patch",
+        );
+
+        let details = request.prominent_detail_items(Locale::En);
+        let preview = details
+            .iter()
+            .find(|detail| detail.label == "Preview")
+            .and_then(|detail| detail.shell_lines.as_ref())
+            .expect("legacy changes preview");
+
+        assert!(preview.iter().any(|line| line == "file: src/lib.rs"));
+        assert!(preview.iter().any(|line| line == "+ fn legacy() {}"));
     }
 
     #[test]

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -1317,7 +1317,7 @@ fn parse_plan_input(input: &serde_json::Value) -> PlanSnapshot {
 }
 
 fn parse_patch_summary(input: &serde_json::Value) -> (String, String) {
-    if let Some(changes) = input.get("changes").and_then(|v| v.as_array()) {
+    if let Some(changes) = input.get("replace").and_then(|v| v.as_array()) {
         let count = changes.len();
         let path = changes
             .first()
@@ -1399,7 +1399,7 @@ pub(super) fn maybe_add_patch_preview(app: &mut App, input: &serde_json::Value) 
         return;
     }
 
-    if let Some(changes) = input.get("changes").and_then(|v| v.as_array()) {
+    if let Some(changes) = input.get("replace").and_then(|v| v.as_array()) {
         let preview = format_changes_preview(changes);
         if !preview.trim().is_empty() {
             app.add_message(HistoryCell::Tool(ToolCell::DiffPreview(DiffPreviewCell {

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use crate::hooks::HookEvent;
 use crate::tools::ReviewOutput;
+use crate::tools::apply_patch::{NormalizedApplyPatchInput, normalize_apply_patch_input};
 use crate::tools::plan::PlanSnapshot;
 use crate::tools::spec::{ToolError, ToolResult};
 use crate::tui::active_cell::ActiveCell;
@@ -1317,24 +1318,28 @@ fn parse_plan_input(input: &serde_json::Value) -> PlanSnapshot {
 }
 
 fn parse_patch_summary(input: &serde_json::Value) -> (String, String) {
-    if let Some(changes) = input.get("replace").and_then(|v| v.as_array()) {
-        let count = changes.len();
-        let path = changes
-            .first()
-            .and_then(|c| c.get("path"))
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .unwrap_or_else(|| "<file>".to_string());
-        let label = if count <= 1 {
-            path
-        } else {
-            format!("{count} files")
-        };
-        let summary = format!("Changes: {count} file(s)");
-        return (label, summary);
-    }
-
-    let patch_text = input.get("patch").and_then(|v| v.as_str()).unwrap_or("");
+    let patch_text = match normalize_apply_patch_input(input) {
+        Ok(NormalizedApplyPatchInput::Replacement {
+            entries: changes, ..
+        }) => {
+            let count = changes.len();
+            let path = changes
+                .first()
+                .and_then(|c| c.get("path"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| "<file>".to_string());
+            let label = if count <= 1 {
+                path
+            } else {
+                format!("{count} files")
+            };
+            let summary = format!("Changes: {count} file(s)");
+            return (label, summary);
+        }
+        Ok(NormalizedApplyPatchInput::Patch(patch)) => patch,
+        Err(_) => "",
+    };
     let paths = extract_patch_paths(patch_text);
     let path = input
         .get("path")
@@ -1390,24 +1395,25 @@ fn extract_patch_paths(patch: &str) -> Vec<String> {
 }
 
 pub(super) fn maybe_add_patch_preview(app: &mut App, input: &serde_json::Value) {
-    if let Some(patch) = input.get("patch").and_then(|v| v.as_str()) {
-        app.add_message(HistoryCell::Tool(ToolCell::DiffPreview(DiffPreviewCell {
-            title: "Patch Preview".to_string(),
-            diff: patch.to_string(),
-        })));
-        app.mark_history_updated();
-        return;
-    }
-
-    if let Some(changes) = input.get("replace").and_then(|v| v.as_array()) {
-        let preview = format_changes_preview(changes);
-        if !preview.trim().is_empty() {
+    match normalize_apply_patch_input(input) {
+        Ok(NormalizedApplyPatchInput::Patch(patch)) => {
             app.add_message(HistoryCell::Tool(ToolCell::DiffPreview(DiffPreviewCell {
-                title: "Changes Preview".to_string(),
-                diff: preview,
+                title: "Patch Preview".to_string(),
+                diff: patch.to_string(),
             })));
             app.mark_history_updated();
         }
+        Ok(NormalizedApplyPatchInput::Replacement { entries, .. }) => {
+            let preview = format_changes_preview(entries);
+            if !preview.trim().is_empty() {
+                app.add_message(HistoryCell::Tool(ToolCell::DiffPreview(DiffPreviewCell {
+                    title: "Changes Preview".to_string(),
+                    diff: preview,
+                })));
+                app.mark_history_updated();
+            }
+        }
+        Err(_) => {}
     }
 }
 
@@ -1598,6 +1604,19 @@ mod tests {
         assert_eq!(snapshot.items.len(), 1);
         assert_eq!(snapshot.items[0].step, "render all fields");
         assert_eq!(snapshot.items[0].status, StepStatus::Pending);
+    }
+
+    #[test]
+    fn parse_patch_summary_treats_replace_and_legacy_changes_equally() {
+        let replacements = json!([{
+            "path": "src/lib.rs",
+            "content": "fn replacement() {}\n"
+        }]);
+
+        let canonical = parse_patch_summary(&json!({"replace": replacements.clone()}));
+        let legacy = parse_patch_summary(&json!({"changes": replacements}));
+
+        assert_eq!(canonical, legacy);
     }
 
     // ── #3031: "(no output)" placeholder must not defeat compact rendering ─

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -6792,7 +6792,7 @@ diff --git a/src/b.rs b/src/b.rs\n\
             "apply_patch",
             "Apply a patch",
             &serde_json::json!({
-                "changes": [
+                "replace": [
                     { "path": "src/a.rs", "content": "a" },
                     { "path": "src/b.rs", "content": "b" },
                     { "path": "src/c.rs", "content": "c" },


### PR DESCRIPTION
## Summary

`apply_patch` accepts a `changes` parameter that performs full file replacement, not patching. The name is easily confused with the `patch` parameter (which applies a unified diff). When both are passed simultaneously, `changes` silently takes precedence and `patch` is discarded — no error, no warning, and the file is overwritten with only the `changes` content.

## Root cause

In `execute()`, the `changes` branch returns immediately if present, making the `patch` branch unreachable. The JSON schema declares `oneOf` mutual exclusivity, but this is advisory — the Rust handler enforces precedence, not rejection.

## Fix

- Rename `changes` to `replace` across JSON schema, code, function names, enum variants, error messages, and tests
- Add explicit conflict detection: if both `patch` and `replace` are present, return an error telling the model to choose one

## Testing

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p codewhale-tui` (zero warnings)
- [x] `cargo check -p codewhale-tui`
- [x] `cargo test -p codewhale-tui -- tools::apply_patch` (26/26 passed)

## Checklist

- [x] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address