### PR TITLE
fix: don't let Vim Normal mode swallow Space for thinking block expan…

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6028,7 +6028,12 @@ async fn run_event_loop(
                         && key.modifiers.is_empty()
                         && !slash_menu_open
                         && !mention_menu_open
-                        && app.view_stack.is_empty() =>
+                        && app.view_stack.is_empty()
+                        // When the input is empty, Space expands the focused
+                        // thinking block (#1972).  Don't let Vim Normal mode
+                        // swallow it — let it fall through to the global
+                        // Space binding.
+                        && !(c == ' ' && app.input.is_empty()) =>
                 {
                     vim_mode::handle_vim_normal_key(app, c);
                     continue;


### PR DESCRIPTION
…sion

When composer_vim_mode is 'normal', pressing Space with an empty input should expand/fold the focused thinking block (per #1972). Previously, Vim Normal mode's catch-all _ => {} silently discarded Space before the global Space binding could reach it. This adds an explicit exception so Space passes through when the input is empty.

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
