### PR TITLE
chore: approve @dmitri-0 for PR contributions

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -62,3 +62,4 @@ all:CrepuscularIRIS
 all:chnjames
 all:ChaceLyee2101
 all:AresNing
+pr:dmitri-0


### PR DESCRIPTION
Adds dmitri-0 to the scoped PR contributor allowlist, as requested during review of #4474.