### PR TITLE
chore: approve @SparkofSpike for PR contributions

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -63,3 +63,4 @@ all:chnjames
 all:ChaceLyee2101
 all:AresNing
 pr:dmitri-0
+pr:sparkofspike


### PR DESCRIPTION
Adds SparkofSpike to the scoped PR contributor allowlist, as requested during review of #4477.