### PR TITLE
fix(models): restore Kimi K3 1M context

### DIFF
--- a/crates/config/assets/models_dev.bundled.json
+++ b/crates/config/assets/models_dev.bundled.json
@@ -6,7 +6,7 @@
     "source": "Compact offline seed of verified in-repo defaults (context/output from crates/tui/src/models.rs; USD pricing from crates/tui/src/pricing.rs) for providers Codewhale ships with. It is intentionally smaller than a full Models.dev dump; live refresh supersedes these rows on (provider, wire_model_id) identity.",
     "honesty": "Pricing is intentionally OMITTED where the repo does not publish a trustworthy per-token rate: DeepSeek-native rows (priced via the time-aware DeepSeek table elsewhere, kept UnknownOrStale at the route layer), aggregator-hosted DeepSeek rows (aggregator account terms, not DeepSeek Platform pricing), and Xiaomi MiMo rows (published PAYG rates apply only to sk- pay-as-you-go keys; the catalog cannot distinguish that billing surface from credit/quota Token Plan keys, so MiMo stays unpriced). Absent pricing surfaces as PricingSku::UnknownOrStale, never a fabricated zero.",
     "default_rows": "Each provider's `default: true` wire id equals that provider's built-in DEFAULT_*_MODEL so RouteResolver::new() and the descriptor stay in agreement when offline.",
-    "coverage": "15 providers, 44 chat offerings (offline seed only)."
+    "coverage": "15 providers, 45 chat offerings (offline seed only)."
   },
   "models": {
     "deepseek-v4-pro": {
@@ -109,6 +109,15 @@
       "npm": "@ai-sdk/openai-compatible",
       "env": ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
       "models": {
+        "kimi-k3": {
+          "id": "kimi-k3",
+          "name": "Kimi K3",
+          "family": "kimi-k3",
+          "reasoning": true,
+          "tool_call": true,
+          "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+          "limit": { "context": 1048576, "output": 131072 }
+        },
         "kimi-k2.7-code": {
           "id": "kimi-k2.7-code",
           "name": "Kimi K2.7 Code",

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -584,8 +584,27 @@ fn bundled_asset_yields_real_chat_offerings_for_key_models() {
     assert_eq!(glm.limit.as_ref().and_then(|l| l.context), Some(1_000_000));
     assert!(glm.default_for_provider);
 
-    let kimi = find(&rows, "moonshot", "kimi-k2.7-code");
-    assert_eq!(kimi.limit.as_ref().and_then(|l| l.context), Some(262_144));
+    let kimi_k27 = find(&rows, "moonshot", "kimi-k2.7-code");
+    assert_eq!(
+        kimi_k27.limit.as_ref().and_then(|l| l.context),
+        Some(262_144)
+    );
+
+    let kimi_k3 = find(&rows, "moonshot", "kimi-k3");
+    assert_eq!(
+        kimi_k3.limit.as_ref().and_then(|l| l.context),
+        Some(1_048_576)
+    );
+    assert_eq!(kimi_k3.limit.as_ref().and_then(|l| l.output), Some(131_072));
+    let kimi_k3_input_modalities = kimi_k3
+        .modalities
+        .as_ref()
+        .expect("K3 modalities")
+        .input
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(kimi_k3_input_modalities, ["text", "image", "video"]);
 
     let minimax_m3 = find(&rows, "minimax-anthropic", "MiniMax-M3");
     assert_eq!(

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -547,11 +547,17 @@ fn default_resolver_yields_real_facts_from_bundled_catalog() {
 
     // A Kimi row (Moonshot) likewise resolves with its real window — a model
     // the 4-row seam never knew about at all.
-    let kimi = r
+    let kimi_k27 = r
         .resolve(&req(Some(ProviderKind::Moonshot), Some("kimi-k2.7-code")))
         .expect("Moonshot kimi-k2.7-code should resolve from the bundled catalog");
-    assert_eq!(kimi.limits.context_tokens, Some(262_144));
-    assert_eq!(kimi.limits.output_tokens, Some(262_144));
+    assert_eq!(kimi_k27.limits.context_tokens, Some(262_144));
+    assert_eq!(kimi_k27.limits.output_tokens, Some(262_144));
+
+    let kimi_k3 = r
+        .resolve(&req(Some(ProviderKind::Moonshot), Some("kimi-k3")))
+        .expect("Moonshot kimi-k3 should resolve from the bundled catalog");
+    assert_eq!(kimi_k3.limits.context_tokens, Some(1_048_576));
+    assert_eq!(kimi_k3.limits.output_tokens, Some(131_072));
 
     // With the #3085 pricing keystone present on the release branch, the asset's
     // provider-scoped `cost` now projects onto the candidate via

--- a/crates/tui/assets/model_catalog.bundled.json
+++ b/crates/tui/assets/model_catalog.bundled.json
@@ -90,6 +90,15 @@
       "supported_parameters": ["reasoning"],
       "provenance": "bundled"
     },
+    "kimi-k3": {
+      "id": "kimi-k3",
+      "context_window": 1048576,
+      "max_output": 131072,
+      "supports_reasoning": true,
+      "modalities": ["text", "image", "video"],
+      "supported_parameters": ["reasoning"],
+      "provenance": "bundled"
+    },
     "kimi-k2.7-code": {
       "id": "kimi-k2.7-code",
       "context_window": 262144,

--- a/crates/tui/src/models.rs
+++ b/crates/tui/src/models.rs
@@ -986,6 +986,7 @@ mod tests {
         // ids without the OpenRouter vendor prefix; both spellings must
         // resolve identical metadata (#1310 ride-along on #3023).
         for (model, expected_window) in [
+            ("kimi-k3", 1_048_576),
             ("kimi-k2.7-code", 262_144),
             ("kimi-k2.6", 262_144),
             ("minimax-m3", 1_000_000),
@@ -1014,6 +1015,7 @@ mod tests {
         assert_eq!(max_output_tokens_for_model("kimi-k2.7-code"), Some(32_768));
         assert_eq!(max_output_tokens_for_model("kimi-k2.6"), Some(32_768));
         assert_eq!(max_output_tokens_for_model("kimi-for-coding"), Some(32_768));
+        assert_eq!(max_output_tokens_for_model("kimi-k3"), Some(131_072));
         assert_eq!(max_output_tokens_for_model("minimax-m3"), Some(524_288));
         assert_eq!(max_output_tokens_for_model("glm-5.1"), Some(131_072));
         assert_eq!(max_output_tokens_for_model("glm-5.2"), Some(131_072));

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -323,6 +323,25 @@ mod tests {
     }
 
     #[test]
+    fn moonshot_k3_route_uses_bundled_1m_context() {
+        let candidate =
+            resolve_route_candidate(ApiProvider::Moonshot, Some("kimi-k3"), None, None, None)
+                .expect("Moonshot Kimi K3 route");
+
+        assert_eq!(candidate.wire_model_id.as_str(), "kimi-k3");
+        assert_eq!(candidate.limits.context_tokens, Some(1_048_576));
+        assert_eq!(candidate.limits.output_tokens, Some(131_072));
+        assert_eq!(
+            crate::route_budget::route_context_window_tokens(
+                ApiProvider::Moonshot,
+                "kimi-k3",
+                Some(candidate.limits),
+            ),
+            1_048_576
+        );
+    }
+
+    #[test]
     fn runtime_route_without_model_uses_target_provider_default() {
         let config = Config {
             provider: Some("openrouter".to_string()),


### PR DESCRIPTION
## Summary

- add the direct Moonshot `kimi-k3` model to both bundled offline catalogs
- carry its 1,048,576-token context and 131,072-token output limit into runtime route budgeting
- keep the tier-dependent Kimi Code `k3` identity and OAuth compatibility path separate

This closes the current mismatch where live model discovery can display K3 at 1M context, but the runtime resolver falls back to the unknown-model 128K floor.

Official model reference: https://platform.kimi.ai/docs/guide/kimi-k3-quickstart

## Verification

- JSON parsing and bundled snapshot validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p codewhale-config` (386 passed)
- focused TUI model metadata test (1 passed)
- focused TUI route-runtime tests (8 passed)

Only the known macOS `__eh_frame` linker warning appeared.

## Checklist

- [x] Added regression coverage for bundled catalog hydration and runtime budgeting
- [x] Kept provider/model identity boundaries explicit
- [x] No publishing or deployment performed
