### PR TITLE
test: isolate config-path readers from env redirects

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -2324,7 +2324,7 @@ mod tests {
         no_animations: Option<OsString>,
         term_program: Option<OsString>,
         ptyxis_version: Option<OsString>,
-        _lock: std::sync::MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl EnvGuard {

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -718,7 +718,7 @@ mod tests {
     struct SettingsPathGuard {
         _tmp: TempDir,
         previous: Option<OsString>,
-        _lock: std::sync::MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl SettingsPathGuard {

--- a/crates/tui/src/commands/groups/debug/tests.rs
+++ b/crates/tui/src/commands/groups/debug/tests.rs
@@ -835,12 +835,11 @@ fn test_retry_truncates_long_input() {
 fn test_patch_undo_requests_session_resync_after_restore() {
     use crate::snapshot::SnapshotRepo;
     use crate::test_support::lock_test_env;
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     struct HomeGuard {
         prev: Option<std::ffi::OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl Drop for HomeGuard {
@@ -903,12 +902,11 @@ fn test_patch_undo_requests_session_resync_after_restore() {
 fn test_patch_undo_walks_back_to_older_snapshot_on_repeat() {
     use crate::snapshot::SnapshotRepo;
     use crate::test_support::lock_test_env;
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     struct HomeGuard {
         prev: Option<std::ffi::OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl Drop for HomeGuard {
@@ -962,12 +960,11 @@ fn test_patch_undo_walks_back_to_older_snapshot_on_repeat() {
 fn test_patch_undo_prunes_tool_turn_context() {
     use crate::snapshot::SnapshotRepo;
     use crate::test_support::lock_test_env;
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     struct HomeGuard {
         prev: Option<std::ffi::OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl Drop for HomeGuard {
@@ -1093,12 +1090,11 @@ fn test_patch_undo_prunes_tool_turn_context() {
 fn test_patch_undo_prunes_pre_turn_context() {
     use crate::snapshot::SnapshotRepo;
     use crate::test_support::lock_test_env;
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     struct HomeGuard {
         prev: Option<std::ffi::OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl Drop for HomeGuard {

--- a/crates/tui/src/commands/groups/skills/restore.rs
+++ b/crates/tui/src/commands/groups/skills/restore.rs
@@ -197,7 +197,6 @@ mod tests {
     use crate::config::Config;
     use crate::test_support::lock_test_env;
     use crate::tui::app::TuiOptions;
-    use std::sync::MutexGuard;
     use tempfile::TempDir;
 
     fn make_app(tmp: &TempDir, yolo: bool) -> App {
@@ -231,7 +230,7 @@ mod tests {
     struct ScopedHome {
         prev: Option<std::ffi::OsString>,
         _home: TempDir,
-        _guard: MutexGuard<'static, ()>,
+        _guard: crate::test_support::TestEnvLock,
     }
     impl Drop for ScopedHome {
         fn drop(&mut self) {

--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -767,7 +767,7 @@ mod tests {
     use tempfile::TempDir;
 
     struct IsolatedHome {
-        _lock: std::sync::MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
         home_prev: Option<OsString>,
         userprofile_prev: Option<OsString>,
         test_home_prev: Option<std::path::PathBuf>,

--- a/crates/tui/src/commands/groups/utility/network.rs
+++ b/crates/tui/src/commands/groups/utility/network.rs
@@ -300,7 +300,7 @@ mod tests {
         home: Option<OsString>,
         userprofile: Option<OsString>,
         deepseek_config_path: Option<OsString>,
-        _lock: std::sync::MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl EnvGuard {

--- a/crates/tui/src/commands/mod.rs
+++ b/crates/tui/src/commands/mod.rs
@@ -311,7 +311,6 @@ mod tests {
     use crate::tui::app::{App, AppAction, SidebarFocus, TuiOptions};
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     fn create_test_app() -> App {
@@ -1104,7 +1103,7 @@ mod tests {
 
     struct ConfigPathGuard {
         previous: Option<OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl ConfigPathGuard {

--- a/crates/tui/src/config/paths.rs
+++ b/crates/tui/src/config/paths.rs
@@ -84,6 +84,17 @@ pub(crate) fn canonicalize_or_keep(path: &Path) -> PathBuf {
 }
 
 pub(crate) fn env_config_path() -> Option<PathBuf> {
+    #[cfg(test)]
+    {
+        return crate::test_support::with_test_env_lock(env_config_path_unlocked);
+    }
+    #[cfg(not(test))]
+    {
+        env_config_path_unlocked()
+    }
+}
+
+fn env_config_path_unlocked() -> Option<PathBuf> {
     if let Ok(path) = std::env::var("CODEWHALE_CONFIG_PATH") {
         let trimmed = path.trim();
         if !trimmed.is_empty() {

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -585,7 +585,7 @@ mod tests {
         codewhale_home: Option<OsString>,
         codewhale_config_path: Option<OsString>,
         deepseek_config_path: Option<OsString>,
-        _lock: std::sync::MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl EnvGuard {

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -23,7 +23,7 @@ struct WorkspaceTrustConfigGuard {
     config_path: PathBuf,
     _codewhale_config_path: crate::test_support::EnvVarGuard,
     _deepseek_config_path: crate::test_support::EnvVarGuard,
-    _env_lock: std::sync::MutexGuard<'static, ()>,
+    _env_lock: crate::test_support::TestEnvLock,
 }
 
 fn workspace_trust_config_guard(workspace: &Path) -> WorkspaceTrustConfigGuard {

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -102,14 +102,8 @@ impl TuiPrefs {
     pub fn path() -> Result<PathBuf> {
         // Honour the same env-var escape hatch used by Settings::path so that
         // integration tests can redirect all config I/O to a temp directory.
-        if let Ok(config_path) = std::env::var("DEEPSEEK_CONFIG_PATH") {
-            let config_path = config_path.trim();
-            if !config_path.is_empty() {
-                let p = expand_path(config_path);
-                if let Some(parent) = p.parent() {
-                    return Ok(parent.join("tui.toml"));
-                }
-            }
+        if let Some(parent) = legacy_config_override_parent() {
+            return Ok(parent.join("tui.toml"));
         }
 
         let primary = codewhale_config::codewhale_home()
@@ -1381,14 +1375,8 @@ fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathB
     // Allow tests to override the settings directory via the same env var
     // used for config (DEEPSEEK_CONFIG_PATH points at config.toml; the
     // settings file lives as a sibling in the same directory).
-    if let Ok(config_path) = std::env::var("DEEPSEEK_CONFIG_PATH") {
-        let config_path = config_path.trim();
-        if !config_path.is_empty() {
-            let p = expand_path(config_path);
-            if let Some(parent) = p.parent() {
-                return (Some(parent.join(SETTINGS_FILE_NAME)), None, None);
-            }
-        }
+    if let Some(parent) = legacy_config_override_parent() {
+        return (Some(parent.join(SETTINGS_FILE_NAME)), None, None);
     }
 
     let primary = codewhale_config::codewhale_home()
@@ -1404,6 +1392,26 @@ fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathB
         dirs::config_dir().map(|dir| dir.join("deepseek").join(SETTINGS_FILE_NAME));
 
     (primary, legacy_home, legacy_config_dir)
+}
+
+fn legacy_config_override_parent() -> Option<PathBuf> {
+    fn read() -> Option<PathBuf> {
+        let config_path = std::env::var("DEEPSEEK_CONFIG_PATH").ok()?;
+        let config_path = config_path.trim();
+        if config_path.is_empty() {
+            return None;
+        }
+        expand_path(config_path).parent().map(Path::to_path_buf)
+    }
+
+    #[cfg(test)]
+    {
+        crate::test_support::with_test_env_lock(read)
+    }
+    #[cfg(not(test))]
+    {
+        read()
+    }
 }
 
 fn migrate_settings_file_to_primary_if_needed(primary: &Path, active_read_path: &Path) {
@@ -2168,7 +2176,7 @@ mod tests {
     /// otherwise a `NO_ANIMATIONS=1` leak from this test family can
     /// flip a concurrent `TERM_PROGRAM=iTerm` test's `low_motion`
     /// assertion through the shared `apply_env_overrides` path.
-    fn no_animations_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    fn no_animations_test_guard() -> crate::test_support::TestEnvLock {
         crate::test_support::lock_test_env()
     }
 
@@ -2319,7 +2327,7 @@ mod tests {
     /// — otherwise a concurrent test that calls `animated_settings()`
     /// can read whatever value our two `set_var`s have raced into the
     /// env at that instant.
-    fn term_program_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    fn term_program_test_guard() -> crate::test_support::TestEnvLock {
         crate::test_support::lock_test_env()
     }
 
@@ -2988,7 +2996,7 @@ mod tests {
 
     /// Serialise tests that mutate `DEEPSEEK_CONFIG_PATH` through this guard
     /// so the parallel test runner doesn't observe interleaved env values.
-    fn config_path_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    fn config_path_test_guard() -> crate::test_support::TestEnvLock {
         crate::test_support::lock_test_env()
     }
 

--- a/crates/tui/src/snapshot/prune.rs
+++ b/crates/tui/src/snapshot/prune.rs
@@ -38,14 +38,13 @@ pub fn prune_older_than(workspace: &Path, max_age: Duration) -> io::Result<usize
 mod tests {
     use super::*;
     use crate::test_support::lock_test_env;
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     /// Same guard shape as in `repo::tests` — pins HOME for the lifetime
     /// of one test under the process-wide env mutex.
     struct ScopedHome {
         prev: Option<std::ffi::OsString>,
-        _guard: MutexGuard<'static, ()>,
+        _guard: crate::test_support::TestEnvLock,
     }
     impl Drop for ScopedHome {
         fn drop(&mut self) {

--- a/crates/tui/src/snapshot/repo.rs
+++ b/crates/tui/src/snapshot/repo.rs
@@ -958,7 +958,6 @@ mod tests {
     use super::*;
     use crate::test_support::lock_test_env;
     use std::fs::{File, FileTimes};
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     /// Holds the home directory pinned to a tempdir for the lifetime of a test. Also
@@ -966,7 +965,7 @@ mod tests {
     /// don't trample each other's home env vars.
     pub(super) struct ScopedHome {
         prev_vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
-        _guard: MutexGuard<'static, ()>,
+        _guard: crate::test_support::TestEnvLock,
     }
     impl Drop for ScopedHome {
         fn drop(&mut self) {

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -1,21 +1,106 @@
 //! Shared test-only helpers.
 
 use std::ffi::{OsStr, OsString};
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock, TryLockError};
+use std::thread::ThreadId;
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn env_lock_owner() -> &'static Mutex<Option<ThreadId>> {
+    static OWNER: OnceLock<Mutex<Option<ThreadId>>> = OnceLock::new();
+    OWNER.get_or_init(|| Mutex::new(None))
+}
+
+fn record_env_lock_owner() {
+    let mut owner = match env_lock_owner().lock() {
+        Ok(owner) => owner,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *owner = Some(std::thread::current().id());
+}
+
+fn current_thread_owns_contended_env_lock() -> bool {
+    let owner = match env_lock_owner().lock() {
+        Ok(owner) => owner,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    owner.as_ref() == Some(&std::thread::current().id())
+}
+
+/// Owned process-wide test-environment lock.
+///
+/// Clearing the owner before the underlying mutex unlocks keeps re-entrant
+/// reader detection exact; a stale thread id could otherwise let the previous
+/// owner bypass a newly acquired lock during its tiny owner-registration
+/// window.
+pub(crate) struct TestEnvLock {
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl Drop for TestEnvLock {
+    fn drop(&mut self) {
+        let mut owner = match env_lock_owner().lock() {
+            Ok(owner) => owner,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if owner.as_ref() == Some(&std::thread::current().id()) {
+            *owner = None;
+        }
+    }
+}
+
 /// Acquire the process-wide env-var mutex.
 ///
 /// If a prior test panicked while holding the lock, recover the guard instead
 /// of cascading failures across unrelated tests.
-pub(crate) fn lock_test_env() -> MutexGuard<'static, ()> {
-    match env_lock().lock() {
+pub(crate) fn lock_test_env() -> TestEnvLock {
+    let guard = match env_lock().lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
+    };
+    record_env_lock_owner();
+    TestEnvLock { _guard: guard }
+}
+
+/// Read process-global test environment while respecting [`lock_test_env`].
+///
+/// Config-path writers hold the mutex for their whole test. Production path
+/// resolution normally only reads the environment, but those reads still have
+/// to wait or they can resolve another test's temporary config and later write
+/// into it. The owner check makes the barrier re-entrant for a test that reads
+/// its own guarded override.
+pub(crate) fn with_test_env_lock<T>(read: impl FnOnce() -> T) -> T {
+    match env_lock().try_lock() {
+        Ok(_guard) => read(),
+        Err(TryLockError::Poisoned(poisoned)) => {
+            let _guard = poisoned.into_inner();
+            read()
+        }
+        Err(TryLockError::WouldBlock) if current_thread_owns_contended_env_lock() => read(),
+        Err(TryLockError::WouldBlock) => {
+            let _guard = match env_lock().lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            read()
+        }
+    }
+}
+
+fn current_thread_holds_test_env_lock() -> bool {
+    match env_lock().try_lock() {
+        Ok(guard) => {
+            drop(guard);
+            false
+        }
+        Err(TryLockError::Poisoned(poisoned)) => {
+            drop(poisoned.into_inner());
+            false
+        }
+        Err(TryLockError::WouldBlock) => current_thread_owns_contended_env_lock(),
     }
 }
 
@@ -30,6 +115,10 @@ pub(crate) struct EnvVarGuard {
 
 impl EnvVarGuard {
     pub(crate) fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        debug_assert!(
+            current_thread_holds_test_env_lock(),
+            "EnvVarGuard::set({key}) requires lock_test_env()"
+        );
         let previous = std::env::var_os(key);
         // SAFETY: callers hold the process-wide test env mutex.
         unsafe { std::env::set_var(key, value) };
@@ -37,6 +126,10 @@ impl EnvVarGuard {
     }
 
     pub(crate) fn remove(key: &'static str) -> Self {
+        debug_assert!(
+            current_thread_holds_test_env_lock(),
+            "EnvVarGuard::remove({key}) requires lock_test_env()"
+        );
         let previous = std::env::var_os(key);
         // SAFETY: callers hold the process-wide test env mutex.
         unsafe { std::env::remove_var(key) };
@@ -45,6 +138,46 @@ impl EnvVarGuard {
 
     pub(crate) fn previous(&self) -> Option<OsString> {
         self.previous.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn config_path_read_waits_for_foreign_env_redirect_to_restore() {
+        let (tx, rx) = mpsc::channel();
+        let redirected = std::env::temp_dir().join(format!(
+            "codewhale-config-path-read-barrier-{}",
+            std::process::id()
+        ));
+
+        let reader = {
+            let lock = lock_test_env();
+            let redirect = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &redirected);
+            let reader = std::thread::spawn(move || {
+                tx.send(crate::config_persistence::config_toml_path(None))
+                    .expect("send resolved config path");
+            });
+
+            assert!(
+                rx.recv_timeout(Duration::from_millis(50)).is_err(),
+                "a foreign reader observed the temporary config redirect"
+            );
+            drop(redirect);
+            drop(lock);
+            reader
+        };
+
+        let resolved = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader resumed after the redirect was restored")
+            .expect("resolve config path");
+        reader.join().expect("reader thread");
+        assert_ne!(resolved, redirected);
     }
 }
 

--- a/crates/tui/src/tools/revert_turn.rs
+++ b/crates/tui/src/tools/revert_turn.rs
@@ -134,14 +134,13 @@ fn short_sha(sha: &str) -> &str {
 mod tests {
     use super::*;
     use crate::test_support::lock_test_env;
-    use std::sync::MutexGuard;
     use tempfile::tempdir;
 
     /// Pins HOME to a tempdir for the duration of the test under the
     /// process-wide env mutex (`crate::test_support::lock_test_env`).
     struct HomeGuard {
         prev: Option<std::ffi::OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
     impl Drop for HomeGuard {
         fn drop(&mut self) {

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -1828,7 +1828,7 @@ mod tests {
         Config,
         (
             Vec<crate::test_support::EnvVarGuard>,
-            std::sync::MutexGuard<'static, ()>,
+            crate::test_support::TestEnvLock,
         ),
     ) {
         let lock = crate::test_support::lock_test_env();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -14638,13 +14638,12 @@ mod provider_key_validation_tests {
     use crate::core::engine::mock_engine_handle;
     use ratatui::{buffer::Buffer, layout::Rect};
     use std::ffi::OsString;
-    use std::sync::MutexGuard;
     use tempfile::TempDir;
 
     struct ConfigPathEnvGuard {
         _tmp: TempDir,
         previous: Option<OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl ConfigPathEnvGuard {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -31,7 +31,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::MutexGuard;
 use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthStr;
 
@@ -406,7 +405,7 @@ fn workflow_panel_uses_non_text_keys_for_controls() {
 struct ConfigPathEnvGuard {
     _tmp: TempDir,
     previous: Option<OsString>,
-    _lock: MutexGuard<'static, ()>,
+    _lock: crate::test_support::TestEnvLock,
 }
 
 impl ConfigPathEnvGuard {
@@ -452,7 +451,7 @@ struct SettingsHomeGuard {
     previous_xdg_config_home: Option<OsString>,
     previous_appdata: Option<OsString>,
     previous_localappdata: Option<OsString>,
-    _lock: MutexGuard<'static, ()>,
+    _lock: crate::test_support::TestEnvLock,
 }
 
 impl SettingsHomeGuard {

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -3835,7 +3835,6 @@ mod tests {
     use std::ffi::OsString;
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::MutexGuard;
     use tempfile::TempDir;
     use unicode_width::UnicodeWidthStr;
 
@@ -4033,7 +4032,7 @@ mod tests {
     struct ConfigSettingsEnvGuard {
         _tmp: TempDir,
         previous_config_path: Option<OsString>,
-        _lock: MutexGuard<'static, ()>,
+        _lock: crate::test_support::TestEnvLock,
     }
 
     impl ConfigSettingsEnvGuard {


### PR DESCRIPTION
## Summary

Fixes the test-environment reader race behind the intermittent Windows provider-persistence failures in #4463.

- serialize test-only `CODEWHALE_CONFIG_PATH` and `DEEPSEEK_CONFIG_PATH` readers with the existing process-wide environment lock
- preserve same-thread reentrant reads for tests that own a temporary redirect
- make `EnvVarGuard` assert that callers actually hold the lock
- add a cross-thread regression proving a reader cannot observe another test temporary path

Production config-path behavior is unchanged; the synchronization is `cfg(test)` only.

Closes #4463

## Verification

- full `codewhale-tui` suite: 7,111 passed, 0 failed, 2 ignored
- both historical provider-persistence flake tests passed
- new regression fails before this fix and passes after it
- `cargo check -p codewhale-tui`
- `cargo check -p codewhale-tui --tests`
- formatting and diff checks

The remaining acceptance gate is native `windows-latest` CI. Local cross-compilation on macOS stopped in `ring` because the Windows SDK header `assert.h` is unavailable, before Codewhale code compiled.
