### PR TITLE
fix(doctor): distinguish configuration from live health

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -848,6 +848,13 @@ struct DoctorArgs {
     /// Emit only the diagnostic context source map as JSON
     #[arg(long, default_value_t = false, conflicts_with = "json")]
     context_json: bool,
+    /// Opt in to probing a local provider endpoint (may start a local service)
+    #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with_all = ["json", "context_json"]
+    )]
+    probe_local: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -1395,7 +1402,7 @@ async fn run_async_main() -> Result<()> {
                 } else if args.json {
                     run_doctor_json(&config, &workspace, cli.config.as_deref())
                 } else {
-                    run_doctor(&config, &workspace, cli.config.as_deref()).await;
+                    run_doctor(&config, &workspace, cli.config.as_deref(), args.probe_local).await;
                     Ok(())
                 }
             }
@@ -2996,8 +3003,25 @@ fn run_session_diagnostics(args: SessionDiagnosticsArgs) -> Result<()> {
     Ok(())
 }
 
+/// Local endpoints require an explicit opt-in because an HTTP request can wake
+/// a desktop-managed daemon (notably Ollama.app). Hosted endpoints preserve the
+/// historical `doctor` connectivity check.
+fn doctor_should_probe_api(
+    provider: crate::config::ApiProvider,
+    base_url: &str,
+    probe_local: bool,
+) -> bool {
+    let local = provider.is_self_hosted() || crate::config::base_url_uses_local_host(base_url);
+    !local || probe_local
+}
+
 /// Run system diagnostics
-async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Option<&Path>) {
+async fn run_doctor(
+    config: &Config,
+    workspace: &Path,
+    config_path_override: Option<&Path>,
+    probe_local: bool,
+) {
     use crate::palette;
     use colored::Colorize;
 
@@ -3248,7 +3272,9 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
             alias.alias, alias.retirement_date, alias.replacement
         );
     }
-    if has_api_key {
+    if has_api_key
+        && doctor_should_probe_api(config.api_provider(), &api_target.base_url, probe_local)
+    {
         print!("  {} Testing connection...", "·".dimmed());
         use std::io::Write;
         std::io::stdout().flush().ok();
@@ -3302,13 +3328,22 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
                 }
             }
         }
+    } else if has_api_key {
+        println!(
+            "  {} Live connectivity not checked for this local endpoint",
+            "·".dimmed()
+        );
+        println!(
+            "    Run `codewhale doctor --probe-local` to opt in; the request may start a local service."
+        );
     } else {
         println!("  {} Skipped (no API key configured)", "·".dimmed());
     }
 
     // MCP configuration
     println!();
-    println!("{}", "MCP Servers:".bold());
+    println!("{}", "MCP Servers (configuration only):".bold());
+    println!("  · Static check only; no server process was started.");
     let features = config.features();
     if features.enabled(Feature::Mcp) {
         println!(
@@ -3366,32 +3401,36 @@ async fn run_doctor(config: &Config, workspace: &Path, config_path_override: Opt
             );
             for (name, server) in &cfg.servers {
                 let status = doctor_check_mcp_server(server);
-                let icon = match status {
-                    McpServerDoctorStatus::Ok(ref detail) => {
+                let icon = match &status {
+                    McpServerDoctorStatus::Ok(detail) => {
                         format!(
-                            "  {} {name}: {}",
+                            "  {} {name}: configuration valid; {}",
                             "✓".truecolor(aqua_r, aqua_g, aqua_b),
                             detail
                         )
                     }
-                    McpServerDoctorStatus::Warning(ref detail) => {
+                    McpServerDoctorStatus::Warning(detail) => {
                         format!(
-                            "  {} {name}: {}",
+                            "  {} {name}: configuration warning; {}",
                             "!".truecolor(sky_r, sky_g, sky_b),
                             detail
                         )
                     }
-                    McpServerDoctorStatus::Error(ref detail) => {
+                    McpServerDoctorStatus::Error(detail) => {
                         format!(
-                            "  {} {name}: {}",
+                            "  {} {name}: configuration invalid; {}",
                             "✗".truecolor(red_r, red_g, red_b),
                             detail
                         )
                     }
                 };
                 println!("{icon}");
-                if !server.enabled {
-                    println!("      (disabled)");
+                if !server.is_enabled() {
+                    println!("      disabled; live health not checked");
+                } else {
+                    println!(
+                        "      process/protocol/backend: not checked; `codewhale mcp validate` explicitly starts and initializes configured servers"
+                    );
                 }
             }
         }
@@ -4673,26 +4712,15 @@ fn run_doctor_json(
             let servers: Vec<serde_json::Value> = cfg
                 .servers
                 .iter()
-                .map(|(name, server)| {
-                    let status = doctor_check_mcp_server(server);
-                    let (kind, detail) = match &status {
-                        McpServerDoctorStatus::Ok(d) => ("ok", d.clone()),
-                        McpServerDoctorStatus::Warning(d) => ("warning", d.clone()),
-                        McpServerDoctorStatus::Error(d) => ("error", d.clone()),
-                    };
-                    json!({
-                        "name": name,
-                        "enabled": server.enabled && !server.disabled,
-                        "status": kind,
-                        "detail": detail,
-                    })
-                })
+                .map(|(name, server)| doctor_mcp_server_json(name, server))
                 .collect();
             json!({
                 "config_path": mcp_config_path.display().to_string(),
                 "present": mcp_present,
                 "project_config_path": project_mcp_config_path.display().to_string(),
                 "project_present": project_mcp_present,
+                "probe_scope": "configuration",
+                "live_health_checked": false,
                 "servers": servers,
             })
         }
@@ -4701,6 +4729,8 @@ fn run_doctor_json(
             "present": mcp_present,
             "project_config_path": project_mcp_config_path.display().to_string(),
             "project_present": project_mcp_present,
+            "probe_scope": "configuration",
+            "live_health_checked": false,
             "servers": [],
             "error": err.to_string(),
         }),
@@ -6705,6 +6735,49 @@ enum McpServerDoctorStatus {
     Error(String),
 }
 
+impl McpServerDoctorStatus {
+    fn legacy_status(&self) -> &'static str {
+        match self {
+            Self::Ok(_) => "ok",
+            Self::Warning(_) => "warning",
+            Self::Error(_) => "error",
+        }
+    }
+
+    fn configuration_status(&self) -> &'static str {
+        match self {
+            Self::Ok(_) => "valid",
+            Self::Warning(_) => "warning",
+            Self::Error(_) => "invalid",
+        }
+    }
+
+    fn detail(&self) -> &str {
+        match self {
+            Self::Ok(detail) | Self::Warning(detail) | Self::Error(detail) => detail,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpCommandDoctorStatus {
+    Available,
+    Missing,
+    NotApplicable,
+    NotChecked,
+}
+
+impl McpCommandDoctorStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Missing => "missing",
+            Self::NotApplicable => "not_applicable",
+            Self::NotChecked => "not_checked",
+        }
+    }
+}
+
 fn is_relative_stdio_path_arg(value: &str) -> bool {
     if value.is_empty() || value.starts_with('-') || value.contains("://") || value.starts_with('~')
     {
@@ -6718,6 +6791,79 @@ fn is_relative_stdio_path_arg(value: &str) -> bool {
     let windows_absolute = value.starts_with("\\\\")
         || (bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/'));
     !Path::new(value).is_absolute() && !windows_absolute
+}
+
+/// Inspect command availability without starting the configured MCP server.
+fn doctor_mcp_command_status(server: &McpServerConfig) -> McpCommandDoctorStatus {
+    if server.url.is_some() {
+        return McpCommandDoctorStatus::NotApplicable;
+    }
+    let Some(cmd) = server.command.as_deref().map(str::trim) else {
+        return McpCommandDoctorStatus::NotChecked;
+    };
+    if cmd.is_empty() {
+        return McpCommandDoctorStatus::Missing;
+    }
+
+    let path = Path::new(cmd);
+    let is_absolute = path.is_absolute() || cmd.starts_with('/');
+    if is_absolute {
+        return if path.is_file() {
+            McpCommandDoctorStatus::Available
+        } else {
+            McpCommandDoctorStatus::Missing
+        };
+    }
+
+    if is_relative_stdio_path_arg(cmd) {
+        let Some(cwd) = server.cwd.as_deref() else {
+            return McpCommandDoctorStatus::NotChecked;
+        };
+        return if cwd.join(path).is_file() {
+            McpCommandDoctorStatus::Available
+        } else {
+            McpCommandDoctorStatus::Missing
+        };
+    }
+
+    if is_command_available(cmd) {
+        McpCommandDoctorStatus::Available
+    } else {
+        McpCommandDoctorStatus::Missing
+    }
+}
+
+fn doctor_mcp_server_json(name: &str, server: &McpServerConfig) -> serde_json::Value {
+    use serde_json::json;
+
+    let status = doctor_check_mcp_server(server);
+    json!({
+        "name": name,
+        "enabled": server.enabled && !server.disabled,
+        // Compatibility field retained for existing doctor JSON consumers.
+        // Its scope is now explicit in `checks.configuration` below.
+        "status": status.legacy_status(),
+        "detail": status.detail(),
+        "check_scope": "configuration",
+        "checks": {
+            "configuration": {
+                "status": status.configuration_status(),
+                "detail": status.detail(),
+            },
+            "command": {
+                "status": doctor_mcp_command_status(server).as_str(),
+            },
+            "process_reachable": {
+                "status": "not_checked",
+            },
+            "protocol_initialized": {
+                "status": "not_checked",
+            },
+            "backend_tool_health": {
+                "status": "not_checked",
+            },
+        },
+    })
 }
 
 /// Check an MCP server config entry for common issues.
@@ -6738,14 +6884,14 @@ fn doctor_check_mcp_server(server: &McpServerConfig) -> McpServerDoctorStatus {
         return McpServerDoctorStatus::Error("empty command".to_string());
     }
 
+    if doctor_mcp_command_status(server) == McpCommandDoctorStatus::Missing {
+        return McpServerDoctorStatus::Error(format!("command not found: {cmd}"));
+    }
+
     let cmd_path = Path::new(cmd);
     // Also accept Unix-style `/` prefix on Windows, where Path::is_absolute()
     // requires a drive letter.
     let is_absolute = cmd_path.is_absolute() || cmd.starts_with('/');
-
-    if is_absolute && !cmd_path.exists() {
-        return McpServerDoctorStatus::Error(format!("command not found: {cmd}"));
-    }
 
     if server.cwd.is_none() {
         if is_relative_stdio_path_arg(cmd) {
@@ -12774,7 +12920,9 @@ mod doctor_mcp_tests {
 
     #[test]
     fn test_command_server_is_ok() {
-        let server = make_server(Some("node"), &["server.js"], None);
+        let executable = std::env::current_exe().expect("current test executable");
+        let executable = executable.to_string_lossy();
+        let server = make_server(Some(&executable), &["server.js"], None);
         match doctor_check_mcp_server(&server) {
             McpServerDoctorStatus::Ok(detail) => assert!(detail.contains("stdio")),
             other => panic!("Expected Ok, got {other:?}"),
@@ -12783,7 +12931,9 @@ mod doctor_mcp_tests {
 
     #[test]
     fn test_relative_stdio_path_arg_without_cwd_warns() {
-        let server = make_server(Some("python"), &["server/mcp_server.py"], None);
+        let executable = std::env::current_exe().expect("current test executable");
+        let executable = executable.to_string_lossy();
+        let server = make_server(Some(&executable), &["server/mcp_server.py"], None);
         match doctor_check_mcp_server(&server) {
             McpServerDoctorStatus::Warning(detail) => {
                 assert!(detail.contains("relative path argument"));
@@ -12795,7 +12945,9 @@ mod doctor_mcp_tests {
 
     #[test]
     fn test_relative_stdio_path_arg_with_cwd_is_ok() {
-        let mut server = make_server(Some("python"), &["server/mcp_server.py"], None);
+        let executable = std::env::current_exe().expect("current test executable");
+        let executable = executable.to_string_lossy();
+        let mut server = make_server(Some(&executable), &["server/mcp_server.py"], None);
         server.cwd = Some(PathBuf::from("/tmp/codewhale-project"));
         match doctor_check_mcp_server(&server) {
             McpServerDoctorStatus::Ok(detail) => assert!(detail.contains("stdio")),
@@ -12835,7 +12987,11 @@ mod doctor_mcp_tests {
 
     #[test]
     fn test_self_hosted_relative_is_warning() {
-        let server = make_server(Some("codewhale"), &["serve", "--mcp"], None);
+        #[cfg(unix)]
+        let command = "sh";
+        #[cfg(windows)]
+        let command = "cmd";
+        let server = make_server(Some(command), &["serve", "--mcp"], None);
         match doctor_check_mcp_server(&server) {
             McpServerDoctorStatus::Warning(detail) => {
                 assert!(detail.contains("relative"));
@@ -12850,6 +13006,94 @@ mod doctor_mcp_tests {
         assert!(matches!(
             doctor_check_mcp_server(&server),
             McpServerDoctorStatus::Error(_)
+        ));
+    }
+
+    #[test]
+    fn doctor_json_separates_configuration_from_live_health() {
+        let server = make_server(None, &[], Some("http://127.0.0.1:3000/mcp"));
+        let report = doctor_mcp_server_json("tools-only", &server);
+
+        assert_eq!(report["check_scope"], "configuration");
+        assert_eq!(report["checks"]["configuration"]["status"], "valid");
+        assert_eq!(report["checks"]["command"]["status"], "not_applicable");
+        assert_eq!(
+            report["checks"]["process_reachable"]["status"],
+            "not_checked"
+        );
+        assert_eq!(
+            report["checks"]["protocol_initialized"]["status"],
+            "not_checked"
+        );
+        assert_eq!(
+            report["checks"]["backend_tool_health"]["status"],
+            "not_checked"
+        );
+        assert!(!report.to_string().contains("healthy"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn static_mcp_check_never_starts_the_configured_command() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = temp.path().join("started");
+        let script = temp.path().join("mcp-server");
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+        )
+        .expect("write test server");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).expect("make script executable");
+
+        let script = script.to_string_lossy();
+        let server = make_server(Some(&script), &[], None);
+        assert!(matches!(
+            doctor_check_mcp_server(&server),
+            McpServerDoctorStatus::Ok(_)
+        ));
+        assert!(!marker.exists(), "static doctor check started MCP server");
+    }
+}
+
+#[cfg(test)]
+mod doctor_live_probe_tests {
+    use super::*;
+
+    #[test]
+    fn local_provider_probe_requires_explicit_opt_in() {
+        assert!(!doctor_should_probe_api(
+            crate::config::ApiProvider::Ollama,
+            "http://127.0.0.1:11434/v1",
+            false,
+        ));
+        assert!(doctor_should_probe_api(
+            crate::config::ApiProvider::Ollama,
+            "http://127.0.0.1:11434/v1",
+            true,
+        ));
+    }
+
+    #[test]
+    fn custom_loopback_probe_also_requires_explicit_opt_in() {
+        assert!(!doctor_should_probe_api(
+            crate::config::ApiProvider::Custom,
+            "http://localhost:8000/v1",
+            false,
+        ));
+    }
+
+    #[test]
+    fn hosted_provider_preserves_the_default_live_check() {
+        assert!(doctor_should_probe_api(
+            crate::config::ApiProvider::Deepseek,
+            "https://api.deepseek.com/beta",
+            false,
         ));
     }
 }

--- a/crates/tui/src/tui/setup/mod.rs
+++ b/crates/tui/src/tui/setup/mod.rs
@@ -5995,7 +5995,7 @@ mod tests {
     #[test]
     fn tools_mcp_detail_lines_show_read_only_inventory_facts() {
         let facts = SetupRuntimeFacts {
-            tools_mcp_servers_result: "healthy — 2 configured (2 healthy, 0 needs_config, 0 off; global present at /tmp/mcp.json; project missing at /tmp/project/.codewhale/mcp.json); healthy: docs, search".to_string(),
+            tools_mcp_servers_result: "configured — 2 configured (2 configuration valid, 0 needs_config, 0 off; global present at /tmp/mcp.json; project missing at /tmp/project/.codewhale/mcp.json); live health not checked — servers not started; configuration valid: docs, search".to_string(),
             tools_mcp_skills_result: "healthy — 3 discovered (hotbar skill sources), 3 on disk at /tmp/skills".to_string(),
             tools_mcp_tools_result: "healthy — 1 entries, 0 script-plugin tools at /tmp/tools".to_string(),
             tools_mcp_plugins_result: "off — nothing configured yet (missing at /tmp/plugins); optional".to_string(),
@@ -6012,7 +6012,8 @@ mod tests {
         let text = lines_to_text(view.tools_mcp_detail_lines());
 
         assert!(text.contains("MCP servers:"));
-        assert!(text.contains("healthy"));
+        assert!(text.contains("configured"));
+        assert!(text.contains("live health not checked"));
         assert!(text.contains("/tmp/mcp.json"));
         assert!(text.contains("/tmp/project/.codewhale/mcp.json"));
         assert!(text.contains("Skills:"));

--- a/crates/tui/src/tui/setup/tools_mcp.rs
+++ b/crates/tui/src/tui/setup/tools_mcp.rs
@@ -58,6 +58,29 @@ struct InventoryRow {
     detail: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpInventoryScope {
+    Configuration,
+    Protocol,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct McpInventoryRow {
+    status: InventoryStatus,
+    detail: String,
+    scope: McpInventoryScope,
+}
+
+impl McpInventoryRow {
+    fn status_label(&self) -> &'static str {
+        match (self.status, self.scope) {
+            (InventoryStatus::Healthy, McpInventoryScope::Configuration) => "configured",
+            (InventoryStatus::Healthy, McpInventoryScope::Protocol) => "protocol_ready",
+            (status, _) => status.as_str(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SetupToolsMcpFacts {
     pub(super) servers_result: String,
@@ -116,7 +139,7 @@ impl SetupToolsMcpFacts {
         let skills_path_display = display_path(&app.skills_dir);
         let plugins_path_display = display_path(&plugins_dir_for(app, config, codewhale_home));
 
-        let servers_result = format!("{} — {}", mcp.status.as_str(), mcp.detail);
+        let servers_result = format!("{} — {}", mcp.status_label(), mcp.detail);
         let skills_result = format!("{} — {}", skills.status.as_str(), skills.detail);
         let tools_result = format!("{} — {}", tools.status.as_str(), tools.detail);
         let plugins_result = format!("{} — {}", plugins.status.as_str(), plugins.detail);
@@ -124,7 +147,7 @@ impl SetupToolsMcpFacts {
 
         let result = format!(
             "mcp={}, skills={}, tools={}, plugins={}, hotbar_sources={}, overall={}, mode=read_only_safe_probe",
-            mcp.status.as_str(),
+            mcp.status_label(),
             skills.status.as_str(),
             tools.status.as_str(),
             plugins.status.as_str(),
@@ -160,20 +183,21 @@ pub(super) fn on_ramp_text(locale: Locale, facts: &SetupToolsMcpFacts) -> String
         .replace("{plugins_path}", &facts.plugins_path_display)
 }
 
-fn mcp_inventory(app: &App, project_mcp_path: &Path) -> InventoryRow {
+fn mcp_inventory(app: &App, project_mcp_path: &Path) -> McpInventoryRow {
     if let Some(snapshot) = app.mcp_snapshot.as_ref() {
         return mcp_snapshot_inventory(snapshot, &app.mcp_config_path, project_mcp_path);
     }
 
     match crate::mcp::load_config_with_workspace(&app.mcp_config_path, &app.workspace) {
         Ok(cfg) => mcp_config_inventory(&app.mcp_config_path, project_mcp_path, &cfg),
-        Err(_) => InventoryRow {
+        Err(_) => McpInventoryRow {
             status: InventoryStatus::NeedsConfig,
             detail: format!(
                 "config unreadable at {} (and project {}); open /mcp or run `codewhale doctor` — secrets not shown",
                 display_path(&app.mcp_config_path),
                 display_path(project_mcp_path)
             ),
+            scope: McpInventoryScope::Configuration,
         },
     }
 }
@@ -200,19 +224,20 @@ fn mcp_snapshot_inventory(
     snapshot: &McpManagerSnapshot,
     global_path: &Path,
     project_path: &Path,
-) -> InventoryRow {
+) -> McpInventoryRow {
     let total = snapshot.servers.len();
     let paths = mcp_path_presence(global_path, project_path);
     if total == 0 {
-        return InventoryRow {
+        return McpInventoryRow {
             status: InventoryStatus::Off,
             detail: format!(
                 "nothing configured yet ({paths}); optional — use /mcp or `codewhale mcp init` later"
             ),
+            scope: McpInventoryScope::Protocol,
         };
     }
 
-    let mut healthy = 0usize;
+    let mut protocol_ready = 0usize;
     let mut needs_config = 0usize;
     let mut off = 0usize;
     let mut names_ok: Vec<&str> = Vec::new();
@@ -222,7 +247,7 @@ fn mcp_snapshot_inventory(
     for server in &snapshot.servers {
         match classify_snapshot_server(server) {
             InventoryStatus::Healthy => {
-                healthy += 1;
+                protocol_ready += 1;
                 if names_ok.len() < 4 {
                     names_ok.push(server.name.as_str());
                 }
@@ -244,17 +269,17 @@ fn mcp_snapshot_inventory(
 
     let status = if needs_config > 0 {
         InventoryStatus::NeedsConfig
-    } else if healthy > 0 {
+    } else if protocol_ready > 0 {
         InventoryStatus::Healthy
     } else {
         InventoryStatus::Off
     };
 
     let mut detail = format!(
-        "{total} configured ({healthy} healthy, {needs_config} needs_config, {off} off; {paths})"
+        "{total} configured ({protocol_ready} protocol_ready, {needs_config} needs_config, {off} off; {paths}); backend/tool health not checked"
     );
     if !names_ok.is_empty() {
-        detail.push_str(&format!("; healthy: {}", names_ok.join(", ")));
+        detail.push_str(&format!("; protocol_ready: {}", names_ok.join(", ")));
     }
     if !names_bad.is_empty() {
         detail.push_str(&format!("; needs_config: {}", names_bad.join(", ")));
@@ -266,7 +291,11 @@ fn mcp_snapshot_inventory(
         detail.push_str("; restart required for live tool list");
     }
     detail.push_str("; /mcp for details (commands/tokens never shown here)");
-    InventoryRow { status, detail }
+    McpInventoryRow {
+        status,
+        detail,
+        scope: McpInventoryScope::Protocol,
+    }
 }
 
 fn classify_snapshot_server(server: &McpServerSnapshot) -> InventoryStatus {
@@ -283,19 +312,20 @@ fn classify_snapshot_server(server: &McpServerSnapshot) -> InventoryStatus {
     }
 }
 
-fn mcp_config_inventory(global: &Path, project: &Path, cfg: &McpConfig) -> InventoryRow {
+fn mcp_config_inventory(global: &Path, project: &Path, cfg: &McpConfig) -> McpInventoryRow {
     let total = cfg.servers.len();
     let paths = mcp_path_presence(global, project);
     if total == 0 {
-        return InventoryRow {
+        return McpInventoryRow {
             status: InventoryStatus::Off,
             detail: format!(
                 "nothing configured yet ({paths}); optional — use /mcp or `codewhale mcp init` later"
             ),
+            scope: McpInventoryScope::Configuration,
         };
     }
 
-    let mut healthy = 0usize;
+    let mut configured = 0usize;
     let mut needs_config = 0usize;
     let mut off = 0usize;
     let mut names_ok: Vec<&str> = Vec::new();
@@ -305,7 +335,7 @@ fn mcp_config_inventory(global: &Path, project: &Path, cfg: &McpConfig) -> Inven
     for (name, server) in &cfg.servers {
         match classify_config_server(server) {
             InventoryStatus::Healthy => {
-                healthy += 1;
+                configured += 1;
                 if names_ok.len() < 4 {
                     names_ok.push(name.as_str());
                 }
@@ -327,17 +357,17 @@ fn mcp_config_inventory(global: &Path, project: &Path, cfg: &McpConfig) -> Inven
 
     let status = if needs_config > 0 {
         InventoryStatus::NeedsConfig
-    } else if healthy > 0 {
+    } else if configured > 0 {
         InventoryStatus::Healthy
     } else {
         InventoryStatus::Off
     };
 
     let mut detail = format!(
-        "{total} configured ({healthy} healthy, {needs_config} needs_config, {off} off; {paths}); static probe only — servers not started"
+        "{total} configured ({configured} configuration valid, {needs_config} needs_config, {off} off; {paths}); live health not checked — servers not started"
     );
     if !names_ok.is_empty() {
-        detail.push_str(&format!("; healthy: {}", names_ok.join(", ")));
+        detail.push_str(&format!("; configuration valid: {}", names_ok.join(", ")));
     }
     if !names_bad.is_empty() {
         detail.push_str(&format!("; needs_config: {}", names_bad.join(", ")));
@@ -346,7 +376,11 @@ fn mcp_config_inventory(global: &Path, project: &Path, cfg: &McpConfig) -> Inven
         detail.push_str(&format!("; off: {}", names_off.join(", ")));
     }
     detail.push_str("; /mcp or `codewhale doctor` for full checks");
-    InventoryRow { status, detail }
+    McpInventoryRow {
+        status,
+        detail,
+        scope: McpInventoryScope::Configuration,
+    }
 }
 
 /// Safe static probe aligned with `doctor_check_mcp_server` without spawning.
@@ -675,7 +709,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_mcp_reports_healthy_without_secret_details() {
+    fn configured_mcp_is_not_reported_as_live_healthy() {
         let tmp = TempDir::new().expect("tempdir");
         let home = tmp.path().join("cw-home");
         std::fs::create_dir_all(&home).expect("home");
@@ -720,10 +754,12 @@ mod tests {
         let facts = SetupToolsMcpFacts::from_app_config(&app, &Config::default(), &home);
 
         assert!(
-            facts.servers_result.contains("healthy"),
-            "configured MCP should be healthy: {}",
+            facts.servers_result.starts_with("configured"),
+            "configured MCP should report configuration evidence: {}",
             facts.servers_result
         );
+        assert!(facts.servers_result.contains("live health not checked"));
+        assert!(!facts.servers_result.contains("healthy"));
         assert!(facts.servers_result.contains("docs"));
         assert!(
             facts.skills_result.contains("healthy"),
@@ -856,6 +892,12 @@ mod tests {
         assert!(facts.servers_result.contains("needs_config"));
         assert!(facts.servers_result.contains("bad"));
         assert!(facts.servers_result.contains("ok"));
+        assert!(facts.servers_result.contains("protocol_ready"));
+        assert!(
+            facts
+                .servers_result
+                .contains("backend/tool health not checked")
+        );
         assert!(facts.needs_action);
         assert!(!facts.servers_result.contains("sk-live-secret"));
         assert!(!facts.servers_result.contains("secret-should-not-appear"));

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1726,12 +1726,24 @@ also run `codewhale-tui setup --skills --local` to create a workspace-local
 `./skills` dir.
 
 `codewhale-tui doctor --json` prints a machine-readable report that skips the
-live API connectivity probe. Top-level keys: `version`, `config_path`,
-`config_present`, `workspace`, `api_key.source`, `base_url`,
+live API connectivity probe. Plain `doctor` keeps the existing hosted-provider
+connectivity check, but it does not contact loopback or self-hosted provider
+endpoints unless `--probe-local` is supplied. That opt-in request may start a
+desktop-managed local service such as Ollama. Top-level keys: `version`,
+`config_path`, `config_present`, `workspace`, `api_key.source`, `base_url`,
 `default_text_model`, `mcp`, `skills`, `tools`, `plugins`, `sandbox`,
 `platform`, `api_connectivity`, `capability`. CI consumers should rely on `api_key.source`
 (`env`/`config`/`missing`) rather than parsing the human-readable `doctor`
 text.
+
+MCP entries are configuration diagnostics unless an explicit MCP command is
+run. `mcp.probe_scope` is `configuration`, `mcp.live_health_checked` is false,
+and each server separates `checks.configuration` / `checks.command` from
+`checks.process_reachable`, `checks.protocol_initialized`, and
+`checks.backend_tool_health`. The latter three remain `not_checked` in doctor
+output. Run `codewhale mcp validate` to explicitly start enabled servers and
+verify protocol initialization/discovery; backend health still requires an
+appropriate explicit tool call.
 
 The `capability` key contains per-provider capability info derived from
 static knowledge (release docs, API guides) rather than live API probes.

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -178,7 +178,9 @@ codewhale doctor --json
 | `memory.file_present` | bool | Whether memory file exists |
 | `mcp.config_path` | string | MCP config file path |
 | `mcp.present` | bool | Whether MCP config exists |
-| `mcp.servers` | array | Per-server health: `{name, enabled, status, detail}` |
+| `mcp.probe_scope` | string | `configuration`; doctor does not start MCP servers |
+| `mcp.live_health_checked` | bool | Always false for doctor JSON |
+| `mcp.servers` | array | Per-server configuration result plus separate `checks` for command availability, process reachability, protocol initialization, and backend/tool health; live stages are `not_checked` |
 | `skills.selected` | string | Resolved skills directory |
 | `skills.global.path` / `.present` / `.count` | — | Codewhale global skills dir (`~/.codewhale/skills`, with legacy `~/.deepseek/skills` support) |
 | `skills.agents.path` / `.present` / `.count` | — | Workspace `.agents/skills/` dir |


### PR DESCRIPTION
## Summary

Advance #4406 by making the diagnostic evidence boundary truthful without introducing a broad or side-effecting deep probe.

- human MCP doctor output now says **configuration only** and explicitly leaves process, protocol, and backend/tool health unchecked
- doctor JSON retains compatibility fields while adding `probe_scope`, `live_health_checked`, and per-stage checks including command availability
- ordinary doctor no longer contacts self-hosted or loopback providers unless `--probe-local` is explicitly supplied, because that request may wake a desktop-managed daemon such as Ollama
- setup inventory calls static MCP entries `configured`; live manager snapshots can say `protocol_ready`; neither is mislabeled as backend healthy
- tools-only MCP servers remain valid without resources or templates

This intentionally references rather than closes #4406. Generic backend/tool invocation, Moraine backend-down versus fully healthy evidence, and inactive-route reporting remain follow-up work.

Refs #4406

## Verification

- doctor MCP tests: 11 passed
- local-provider probe policy: 3 passed
- setup MCP tests: 9 passed
- setup detail regression: 1 passed
- full `codewhale-tui` binary suite: 7,119 passed, 0 failed, 2 ignored
- `cargo build -p codewhale-tui --locked`
- manual built CLI: `doctor --help` and `doctor --json` evidence checked
- formatting and diff checks

Only the known local macOS `__eh_frame section too large` linker warning appeared.
