### PR TITLE
fix(auto): honor cost_saving in inventory routing

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1989,10 +1989,11 @@ pub struct SubagentProviderConfig {
 
 /// `[auto]` table — knobs for the `--model auto` / `/model auto` router.
 ///
-/// `cost_saving` (#1207): when `true`, the auto-mode router prefers
-/// `deepseek-v4-flash` for ambiguous requests, only escalating to
-/// `deepseek-v4-pro` when the task clearly benefits from deeper reasoning.
-/// Default is `false` (balanced — match the existing routing voice).
+/// `cost_saving` (#1207): when `true`, the auto-mode router prefers the
+/// active provider's known fast sibling for ambiguous requests, only using
+/// its strong tier when the task clearly benefits from deeper reasoning.
+/// Providers without a validated sibling stay on the active model. Default
+/// is `false` (balanced — match the existing routing voice).
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct AutoConfig {
     #[serde(default)]
@@ -3391,9 +3392,10 @@ impl Config {
     }
 
     /// Return `true` if the `[auto] cost_saving = true` opt-in is set
-    /// (#1207). When true, the auto-mode router biases toward
-    /// `deepseek-v4-flash` for ambiguous requests instead of escalating to
-    /// `deepseek-v4-pro`. Default: `false` (balanced behaviour).
+    /// (#1207). When true, the auto-mode router biases toward the active
+    /// provider's validated fast sibling for ambiguous requests instead of
+    /// its strong tier. Providers without a known sibling stay on the active
+    /// model. Default: `false` (balanced behaviour).
     #[must_use]
     pub fn auto_cost_saving(&self) -> bool {
         self.auto

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -444,9 +444,14 @@ fn auto_route_from_inventory_heuristic(
         };
     };
     // Use the candidates' cheap/big info for complexity-based routing.
-    let router_candidates = provider_router_candidates(config.api_provider(), &active.model);
+    let router_candidates = provider_router_candidates(active.provider, &active.model);
     let chosen = if router_candidates.cheap.is_some() {
-        auto_model_heuristic_for_candidates(latest_request, &active.model, &router_candidates)
+        auto_model_heuristic_with_bias_for_candidates(
+            latest_request,
+            &active.model,
+            config.auto_cost_saving(),
+            &router_candidates,
+        )
     } else {
         active.model.clone()
     };
@@ -472,7 +477,7 @@ async fn auto_route_inventory_recommendation(
     router_config.default_text_model = Some(inventory.router_model.to_string());
 
     let client = DeepSeekClient::new(&router_config)?;
-    let router_system = inventory_auto_router_system_prompt(inventory);
+    let router_system = inventory_auto_router_system_prompt(inventory, config.auto_cost_saving());
     let request = MessageRequest {
         model: inventory.router_model.to_string(),
         messages: vec![Message {
@@ -508,15 +513,46 @@ async fn auto_route_inventory_recommendation(
     ))
 }
 
-fn inventory_auto_router_system_prompt(inventory: &ModelInventory) -> String {
-    format!(
+fn inventory_auto_router_system_prompt(inventory: &ModelInventory, cost_saving: bool) -> String {
+    let mut prompt = format!(
         "You are the codewhale model-routing classifier. Return only compact JSON: \
 {{\"provider\":\"<provider>\",\"model\":\"<model>\",\"thinking\":\"off|high|max\"}}.\n\
 Choose only provider/model pairs present in the inventory JSON. Use off only for trivial no-tool answers, \
 high for ordinary reasoning, and max for agentic, coding, multi-file, release, architecture, debugging, \
 security, tool-heavy, or uncertain work.\n\nInventory JSON:\n{}",
         inventory.router_context_json()
-    )
+    );
+
+    if cost_saving {
+        let active_pair = inventory.active_default().and_then(|active| {
+            let candidates = provider_router_candidates(active.provider, &active.model);
+            let fast = candidates.cheap.as_deref()?;
+            (inventory
+                .candidate(active.provider, &candidates.big)
+                .is_some()
+                && inventory.candidate(active.provider, fast).is_some())
+            .then_some((active.provider, candidates.big, fast.to_string()))
+        });
+
+        if let Some((provider, strong, fast)) = active_pair {
+            prompt.push_str(&format!(
+                "\n\nCost-saving mode is ON. For the active provider `{}`, `{fast}` is the fast tier \
+and `{strong}` is the strong tier. Prefer `{fast}` for ambiguous, routine, or single-step work. \
+Select `{strong}` only when the request is unmistakably agentic, multi-step, architecture/design, \
+security review, debugging, or otherwise clearly beyond the fast tier. Keep the selected model paired \
+with provider `{}`.",
+                provider.as_str(),
+                provider.as_str()
+            ));
+        } else {
+            prompt.push_str(
+                "\n\nCost-saving mode is ON, but the active provider has no known runnable fast sibling. \
+Do not invent a model or cross-provider downgrade solely to save cost.",
+            );
+        }
+    }
+
+    prompt
 }
 
 fn parse_inventory_auto_route_recommendation(
@@ -667,6 +703,33 @@ mod tests {
         assert!(
             prompt.starts_with("Session mode: plan\n"),
             "auto-route prompt should reflect the active session mode, got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn inventory_auto_router_prompt_names_cost_saving_zai_pair() {
+        let _env_lock = crate::test_support::lock_test_env();
+        let _deepseek = crate::test_support::EnvVarGuard::remove("DEEPSEEK_API_KEY");
+        let _zai = crate::test_support::EnvVarGuard::set("ZAI_API_KEY", "zai-key");
+        let config = Config {
+            provider: Some("zai".to_string()),
+            ..Default::default()
+        };
+        let inventory = ModelInventory::from_config(&config);
+
+        let balanced = inventory_auto_router_system_prompt(&inventory, false);
+        let cost_saving = inventory_auto_router_system_prompt(&inventory, true);
+
+        assert!(!balanced.contains("Cost-saving mode is ON"));
+        assert!(
+            cost_saving.contains(
+                "For the active provider `zai`, `GLM-5-Turbo` is the fast tier and `GLM-5.2` is the strong tier"
+            ),
+            "cost-saving classifier policy must name the provider-safe pair: {cost_saving}"
+        );
+        assert!(
+            cost_saving.contains("Keep the selected model paired with provider `zai`"),
+            "cost-saving policy must preserve provider/model validation: {cost_saving}"
         );
     }
 
@@ -824,6 +887,73 @@ mod tests {
         assert_eq!(route.provider, ApiProvider::Zai);
         assert_eq!(route.model, crate::config::ZAI_GLM_5_TURBO_MODEL);
         assert_eq!(route.source, AutoRouteSource::Heuristic);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn inventory_auto_route_uses_fallback_candidates_from_their_provider() {
+        let _env_lock = crate::test_support::lock_test_env();
+        let _deepseek = crate::test_support::EnvVarGuard::set("DEEPSEEK_API_KEY", "ds-key");
+        let _zai = crate::test_support::EnvVarGuard::remove("ZAI_API_KEY");
+        let config = Config {
+            provider: Some("zai".to_string()),
+            ..Default::default()
+        };
+
+        let route =
+            resolve_auto_route_with_inventory(&config, "quick status check", "", "auto", "auto")
+                .await
+                .expect("inventory route should fall back to an authenticated provider");
+
+        assert_eq!(route.provider, ApiProvider::Deepseek);
+        assert_eq!(route.model, "deepseek-v4-flash");
+        assert_eq!(route.source, AutoRouteSource::Heuristic);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn inventory_auto_route_cost_saving_changes_borderline_zai_route() {
+        let _env_lock = crate::test_support::lock_test_env();
+        let _deepseek = crate::test_support::EnvVarGuard::remove("DEEPSEEK_API_KEY");
+        let _zai = crate::test_support::EnvVarGuard::set("ZAI_API_KEY", "zai-key");
+        let balanced = Config {
+            provider: Some("zai".to_string()),
+            ..Default::default()
+        };
+        let cost_saving = Config {
+            auto: Some(crate::config::AutoConfig {
+                cost_saving: Some(true),
+            }),
+            ..balanced.clone()
+        };
+
+        let balanced_route = resolve_auto_route_with_inventory(
+            &balanced,
+            "Please implement a binary search",
+            "",
+            "auto",
+            "auto",
+        )
+        .await
+        .expect("balanced Auto route should resolve");
+        let cost_saving_route = resolve_auto_route_with_inventory(
+            &cost_saving,
+            "Please implement a binary search",
+            "",
+            "auto",
+            "auto",
+        )
+        .await
+        .expect("cost-saving Auto route should resolve");
+
+        assert_eq!(balanced_route.provider, ApiProvider::Zai);
+        assert_eq!(balanced_route.model, crate::config::ZAI_GLM_5_2_MODEL);
+        assert_eq!(cost_saving_route.provider, ApiProvider::Zai);
+        assert_eq!(
+            cost_saving_route.model,
+            crate::config::ZAI_GLM_5_TURBO_MODEL
+        );
+        assert_eq!(cost_saving_route.source, AutoRouteSource::Heuristic);
     }
 
     #[tokio::test]
@@ -1012,13 +1142,20 @@ mod tests {
             big: "qwen3:32b".to_string(),
             cheap: None,
         };
-        for prompt in [
-            "hi",
-            "please refactor the auth module for security",
-            &"long filler sentence. ".repeat(60),
-        ] {
-            let model = auto_model_heuristic_for_candidates(prompt, "qwen3:32b", &candidates);
-            assert_eq!(model, "qwen3:32b", "prompt {prompt:?}");
+        for cost_saving in [false, true] {
+            for prompt in [
+                "hi",
+                "please refactor the auth module for security",
+                &"long filler sentence. ".repeat(60),
+            ] {
+                let model = auto_model_heuristic_with_bias_for_candidates(
+                    prompt,
+                    "qwen3:32b",
+                    cost_saving,
+                    &candidates,
+                );
+                assert_eq!(model, "qwen3:32b", "prompt {prompt:?}");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- wire the parsed auto.cost_saving opt-in into the provider-aware heuristic
- tell the network classifier the exact validated strong and fast sibling pair
- keep providers without a known fast sibling on their active model
- derive fallback candidates from the fallback provider, preventing cross-provider model invention
- leave default routing and child-agent model-strength policy unchanged

## Verification

- cargo fmt --all -- --check
- git diff --check
- cargo check -p codewhale-tui --locked
- focused model-routing tests: 22 passed
- full TUI binary suite before the final provider-fallback follow-up: 7,123 passed, 2 ignored
- cargo build -p codewhale-tui --locked
- exact fallback-provider regression passed after the follow-up

Refs #4405

This is intentionally a partial fix. Effective-pair diagnostics and per-turn strong versus fast route receipts remain in #4405.