### PR TITLE
fix(tui): isolate prior-session work receipts

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1732,51 +1732,35 @@ fn build_app_system_prompt_with_goal(
     )
 }
 
-/// How long after a task finishes it should still appear in the Work
-/// sidebar even if its `ended_at` predates the current TUI session.
-///
-/// Tasks completing during the current session always show (until the
-/// next session boundary). Tasks that completed shortly before the
-/// session also show, so users coming back to a terminal see "you just
-/// finished X". Anything older than this window is hidden — preventing
-/// the sidebar from accumulating indefinitely (bug #1913).
-const WORK_SIDEBAR_RECENT_COMPLETED_TTL: chrono::Duration = chrono::Duration::hours(2);
-
 /// Choose which durable-task summaries should appear in the Work
 /// sidebar's Tasks panel.
 ///
 /// Active tasks (`Queued`/`Running`) are always included. Terminal
-/// tasks (`Completed`/`Failed`/`Canceled`) are kept only if their
-/// `ended_at` falls within the "recent" window — defined as either:
+/// tasks (`Completed`/`Failed`/`Canceled`) are session-local receipts: both
+/// their creation and completion must fall within this TUI session. Durable
+/// tasks are stored per user rather than per TUI process, and startup recovery
+/// can stamp an old running record with a fresh `ended_at`. Treating that as a
+/// current receipt makes a new same-workspace instance look failed (#4416).
+/// Shared and older task history remains available explicitly through
+/// `/tasks`; it does not belong on the fresh live-work surface by default.
 ///
-/// - within the current TUI session (`ended_at >= session_started_at`), or
-/// - within `recent_ttl` of `now` (so a task that finished a few
-///   minutes before the session started still shows).
-///
-/// Anything older than that — including the multi-day-old completed
-/// tasks reported in bug #1913 — is excluded so the sidebar does not
-/// accumulate indefinitely across sessions.
-///
-/// A terminal task missing `ended_at` is treated as not-recent and
+/// A terminal task missing `ended_at` is treated as not current and
 /// dropped: durable tasks always stamp `ended_at` when they reach a
 /// terminal state, so absence of it indicates a record from a much
 /// older schema and isn't worth surfacing.
 pub(crate) fn select_work_sidebar_tasks(
     tasks: Vec<TaskSummary>,
     session_started_at: chrono::DateTime<chrono::Utc>,
-    now: chrono::DateTime<chrono::Utc>,
-    recent_ttl: chrono::Duration,
 ) -> Vec<TaskSummary> {
-    let recent_cutoff = now - recent_ttl;
     tasks
         .into_iter()
         .filter(|task| match task.status {
             TaskStatus::Queued | TaskStatus::Running => true,
             TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Canceled => {
-                match task.ended_at {
-                    Some(ended_at) => ended_at >= session_started_at || ended_at >= recent_cutoff,
-                    None => false,
-                }
+                task.created_at >= session_started_at
+                    && task
+                        .ended_at
+                        .is_some_and(|ended_at| ended_at >= session_started_at)
             }
         })
         .collect()
@@ -1785,16 +1769,10 @@ pub(crate) fn select_work_sidebar_tasks(
 async fn refresh_active_task_panel(app: &mut App, task_manager: &SharedTaskManager) -> bool {
     let tasks = task_manager.list_tasks(None).await;
     let session_started_at = app.session_started_at;
-    let now = chrono::Utc::now();
-    let mut entries: Vec<TaskPanelEntry> = select_work_sidebar_tasks(
-        tasks,
-        session_started_at,
-        now,
-        WORK_SIDEBAR_RECENT_COMPLETED_TTL,
-    )
-    .into_iter()
-    .map(task_summary_to_panel_entry)
-    .collect();
+    let mut entries: Vec<TaskPanelEntry> = select_work_sidebar_tasks(tasks, session_started_at)
+        .into_iter()
+        .map(task_summary_to_panel_entry)
+        .collect();
 
     entries.extend(active_rlm_task_entries(app));
 

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -15811,13 +15811,15 @@ fn toast_stack_overlay_respects_composer_boundary() {
     );
 }
 
-// === Bug #1913: Work sidebar should hide stale completed tasks ============
+// === Bugs #1913/#4416: Work sidebar session ownership =====================
 //
 // The Work sidebar reads `~/.deepseek/tasks/` on startup, which holds every
 // durable task the user has ever run. Without filtering, completed tasks
-// from prior sessions persist indefinitely. The projection helper keeps
-// active tasks, keeps tasks that finished during this session, keeps tasks
-// that finished within the last `recent_ttl`, and drops everything older.
+// from prior sessions persist indefinitely. Worse, startup recovery can mark
+// an old running task failed *during* a new TUI session. The projection helper
+// keeps active durable tasks, but only renders terminal receipts that were
+// created and completed during this TUI session. Shared history stays in
+// `/tasks` instead of making a fresh Work surface look failed.
 
 mod work_sidebar_projection_tests {
     use super::*;
@@ -15827,6 +15829,7 @@ mod work_sidebar_projection_tests {
     fn sample_task(
         id: &str,
         status: TaskStatus,
+        created_at: chrono::DateTime<Utc>,
         ended_at: Option<chrono::DateTime<Utc>>,
     ) -> TaskSummary {
         TaskSummary {
@@ -15835,8 +15838,8 @@ mod work_sidebar_projection_tests {
             prompt_summary: format!("task {id}"),
             model: "deepseek-v4-flash".to_string(),
             mode: "agent".to_string(),
-            created_at: Utc.with_ymd_and_hms(2026, 5, 16, 12, 0, 0).unwrap(),
-            started_at: Some(Utc.with_ymd_and_hms(2026, 5, 16, 12, 1, 0).unwrap()),
+            created_at,
+            started_at: Some(created_at + Duration::seconds(1)),
             ended_at,
             duration_ms: ended_at.map(|_| 1_234),
             hunt_verdict: None,
@@ -15847,29 +15850,48 @@ mod work_sidebar_projection_tests {
     }
 
     #[test]
-    fn work_sidebar_hides_stale_completed_tasks_but_keeps_active_and_recent() {
-        // Pretend the TUI session started on 2026-05-23T10:00:00Z. "Now"
-        // is one minute into the session.
+    fn work_sidebar_hides_other_session_terminals_but_keeps_current_and_active() {
+        // Pretend the TUI session started on 2026-05-23T10:00:00Z.
         let session_started_at = Utc.with_ymd_and_hms(2026, 5, 23, 10, 0, 0).unwrap();
-        let now = session_started_at + Duration::minutes(1);
-        let recent_ttl = Duration::hours(2);
 
-        let active_running = sample_task("active_run", TaskStatus::Running, None);
-        let active_queued = sample_task("active_q", TaskStatus::Queued, None);
+        let active_running = sample_task(
+            "active_run",
+            TaskStatus::Running,
+            session_started_at - Duration::minutes(30),
+            None,
+        );
+        let active_queued = sample_task(
+            "active_q",
+            TaskStatus::Queued,
+            session_started_at - Duration::minutes(20),
+            None,
+        );
 
-        // Completed during the current session — must show.
+        // Created and completed during the current session — must show.
         let just_finished = sample_task(
             "just_done",
             TaskStatus::Completed,
+            session_started_at + Duration::seconds(5),
             Some(session_started_at + Duration::seconds(30)),
         );
 
-        // Completed shortly before the session started, inside the
-        // recent-TTL window — must show.
+        // Completed shortly before the session started — shared history, not
+        // this session's live-work receipt.
         let recently_finished_before_session = sample_task(
             "recent_done",
             TaskStatus::Failed,
+            session_started_at - Duration::minutes(20),
             Some(session_started_at - Duration::minutes(15)),
+        );
+
+        // Exact restart regression: a prior-session running record is marked
+        // failed by TaskManager startup and gets a fresh ended_at. Its old
+        // creation time keeps it off the fresh Work surface.
+        let recovered_after_restart = sample_task(
+            "recovered_old_run",
+            TaskStatus::Failed,
+            session_started_at - Duration::minutes(30),
+            Some(session_started_at + Duration::seconds(1)),
         );
 
         // Stale completed from 6 days ago (the exact scenario in #1913) —
@@ -15877,34 +15899,43 @@ mod work_sidebar_projection_tests {
         let stale_completed = sample_task(
             "stale_done",
             TaskStatus::Completed,
+            session_started_at - Duration::days(6) - Duration::minutes(1),
             Some(session_started_at - Duration::days(6)),
         );
         let stale_canceled = sample_task(
             "stale_cancel",
             TaskStatus::Canceled,
+            session_started_at - Duration::days(7) - Duration::minutes(1),
             Some(session_started_at - Duration::days(7)),
         );
         let stale_failed = sample_task(
             "stale_fail",
             TaskStatus::Failed,
+            session_started_at - Duration::days(3) - Duration::minutes(1),
             Some(session_started_at - Duration::days(3)),
         );
 
         // A terminal task without `ended_at` shouldn't sneak through.
-        let terminal_no_timestamp = sample_task("ghost", TaskStatus::Completed, None);
+        let terminal_no_timestamp = sample_task(
+            "ghost",
+            TaskStatus::Completed,
+            session_started_at + Duration::seconds(1),
+            None,
+        );
 
         let tasks = vec![
             active_running.clone(),
             active_queued.clone(),
             just_finished.clone(),
             recently_finished_before_session.clone(),
+            recovered_after_restart.clone(),
             stale_completed.clone(),
             stale_canceled.clone(),
             stale_failed.clone(),
             terminal_no_timestamp.clone(),
         ];
 
-        let kept = select_work_sidebar_tasks(tasks, session_started_at, now, recent_ttl);
+        let kept = select_work_sidebar_tasks(tasks, session_started_at);
         let kept_ids: Vec<&str> = kept.iter().map(|t| t.id.as_str()).collect();
 
         assert!(
@@ -15920,9 +15951,13 @@ mod work_sidebar_projection_tests {
             "task completed during the current session must show: {kept_ids:?}"
         );
         assert!(
-            kept_ids.contains(&"recent_done"),
-            "task completed within the recent TTL before session start must show: \
+            !kept_ids.contains(&"recent_done"),
+            "prior-session terminal task must stay in explicit history: \
              {kept_ids:?}"
+        );
+        assert!(
+            !kept_ids.contains(&"recovered_old_run"),
+            "startup recovery must not turn an old task into a fresh red row: {kept_ids:?}"
         );
 
         assert!(
@@ -15948,13 +15983,14 @@ mod work_sidebar_projection_tests {
         // Edge case: a task that finished at exactly the same instant the
         // session started should still be visible (>= comparison).
         let session_started_at = Utc.with_ymd_and_hms(2026, 5, 23, 10, 0, 0).unwrap();
-        let now = session_started_at + Duration::seconds(1);
-        let recent_ttl = Duration::hours(2);
+        let at_boundary = sample_task(
+            "boundary",
+            TaskStatus::Completed,
+            session_started_at,
+            Some(session_started_at),
+        );
 
-        let at_boundary = sample_task("boundary", TaskStatus::Completed, Some(session_started_at));
-
-        let kept =
-            select_work_sidebar_tasks(vec![at_boundary], session_started_at, now, recent_ttl);
+        let kept = select_work_sidebar_tasks(vec![at_boundary], session_started_at);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0].id, "boundary");
     }

--- a/crates/tui/src/tui/work_surface/live_projection.rs
+++ b/crates/tui/src/tui/work_surface/live_projection.rs
@@ -63,13 +63,23 @@ impl LiveWorkProjection {
     #[must_use]
     pub(super) fn from_app(app: &App) -> Self {
         let mut by_identity = HashMap::new();
+        // `subagent_cache` is shared by several views. AgentList normally
+        // removes prior-session snapshots before updating it, but the Work
+        // surface is the final owner of the "live work" claim and must defend
+        // that boundary itself. Other-session workers remain available through
+        // the explicit archived agent listing; they are not live rows here.
+        let current_session_agents = app
+            .subagent_cache
+            .iter()
+            .filter(|agent| !agent.from_prior_session)
+            .collect::<Vec<_>>();
         let cached_worker_ids = app
             .subagent_cache
             .iter()
             .map(|agent| agent.agent_id.as_str())
             .collect::<std::collections::HashSet<_>>();
         let worker_display_names = localized_whale_display_names(
-            app.subagent_cache
+            current_session_agents
                 .iter()
                 .map(|agent| (agent.agent_id.as_str(), agent.nickname.as_deref())),
             app.ui_locale.tag(),
@@ -134,7 +144,7 @@ impl LiveWorkProjection {
             }
         }
 
-        for agent in &app.subagent_cache {
+        for agent in current_session_agents {
             let status = agent
                 .worker_status
                 .map(worker_status)
@@ -352,8 +362,48 @@ mod tests {
             checkpoint: None,
             needs_input: None,
             duration_ms: 100,
-            from_prior_session: true,
+            from_prior_session: false,
         }
+    }
+
+    #[test]
+    fn fresh_session_hides_prior_terminal_and_active_sibling_workers() {
+        let mut app = test_app();
+        let mut failed = cached_agent("agent_prior_failed", "Prior failed");
+        failed.status = SubAgentStatus::Failed("old failure".to_string());
+        failed.worker_status = Some(AgentWorkerStatus::Failed);
+        failed.from_prior_session = true;
+
+        let mut running = cached_agent("agent_active_sibling", "Sibling");
+        running.from_prior_session = true;
+        app.agent_progress.insert(
+            running.agent_id.clone(),
+            "running in another session".to_string(),
+        );
+        app.subagent_cache = vec![failed, running];
+
+        let projection = LiveWorkProjection::from_app(&app);
+        assert!(
+            projection.rows.is_empty(),
+            "other-session workers must not become fresh live-work rows: {:?}",
+            projection.rows
+        );
+        assert_eq!(projection.counts, LiveWorkCounts::default());
+    }
+
+    #[test]
+    fn current_session_terminal_worker_remains_a_settled_receipt() {
+        let mut app = test_app();
+        let mut failed = cached_agent("agent_current_failed", "Current failed");
+        failed.status = SubAgentStatus::Failed("current failure".to_string());
+        failed.worker_status = Some(AgentWorkerStatus::Failed);
+        app.subagent_cache = vec![failed];
+
+        let projection = LiveWorkProjection::from_app(&app);
+        assert_eq!(projection.rows.len(), 1);
+        assert_eq!(projection.rows[0].state, LiveWorkState::Settled);
+        assert_eq!(projection.rows[0].status, "failed");
+        assert_eq!(projection.counts.active, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Draft handoff: narrow #4416 slice

This preserves the release-safe projection fix for another agent/device.

- hide prior-session worker snapshots from the live Work surface at the final projection owner
- show terminal durable-task receipts only when both creation and completion belong to the current TUI session
- keep active tasks visible
- keep shared history available through /tasks and archived agent views

This intentionally references rather than resolves #4416. Durable task/run/worker owner or lease identity is still missing, and a second TaskManager can still rewrite a shared persisted Running task to Failed during startup reconciliation.

Verification:

- cargo fmt --all -- --check
- git diff --check
- cargo check -p codewhale-tui --locked
- Work-sidebar tests: 5 passed
- Work-surface tests: 27 passed
- prior-session tests: 2 passed
- restart regression: 1 passed
- pre-rebase full TUI binary suite: 7,123 passed, 2 ignored
- strict clippy and build passed

Refs #4416