### PR TITLE
fix(mcp): align configured command health with spawn

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -131,7 +131,10 @@ use crate::config::{Config, DEFAULT_TEXT_MODEL, MAX_SUBAGENTS, effective_home_di
 use crate::eval::{EvalHarness, EvalHarnessConfig, ScenarioStepKind};
 use crate::features::{Feature, render_feature_table};
 use crate::llm_client::LlmClient;
-use crate::mcp::{McpConfig, McpPool, McpServerConfig, McpServerOAuthConfig};
+use crate::mcp::{
+    McpCommandAvailability, McpConfig, McpPool, McpServerConfig, McpServerOAuthConfig,
+    is_relative_stdio_path_arg, static_mcp_command_availability,
+};
 use crate::models::{ContentBlock, Message, MessageRequest, SystemPrompt};
 use crate::session_manager::{SessionManager, create_saved_session, truncate_id};
 use crate::tui::history::{summarize_tool_args, summarize_tool_output};
@@ -6759,78 +6762,9 @@ impl McpServerDoctorStatus {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum McpCommandDoctorStatus {
-    Available,
-    Missing,
-    NotApplicable,
-    NotChecked,
-}
-
-impl McpCommandDoctorStatus {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Available => "available",
-            Self::Missing => "missing",
-            Self::NotApplicable => "not_applicable",
-            Self::NotChecked => "not_checked",
-        }
-    }
-}
-
-fn is_relative_stdio_path_arg(value: &str) -> bool {
-    if value.is_empty() || value.starts_with('-') || value.contains("://") || value.starts_with('~')
-    {
-        return false;
-    }
-    let looks_like_path = value.contains('/') || value.contains('\\');
-    if !looks_like_path {
-        return false;
-    }
-    let bytes = value.as_bytes();
-    let windows_absolute = value.starts_with("\\\\")
-        || (bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/'));
-    !Path::new(value).is_absolute() && !windows_absolute
-}
-
 /// Inspect command availability without starting the configured MCP server.
-fn doctor_mcp_command_status(server: &McpServerConfig) -> McpCommandDoctorStatus {
-    if server.url.is_some() {
-        return McpCommandDoctorStatus::NotApplicable;
-    }
-    let Some(cmd) = server.command.as_deref().map(str::trim) else {
-        return McpCommandDoctorStatus::NotChecked;
-    };
-    if cmd.is_empty() {
-        return McpCommandDoctorStatus::Missing;
-    }
-
-    let path = Path::new(cmd);
-    let is_absolute = path.is_absolute() || cmd.starts_with('/');
-    if is_absolute {
-        return if path.is_file() {
-            McpCommandDoctorStatus::Available
-        } else {
-            McpCommandDoctorStatus::Missing
-        };
-    }
-
-    if is_relative_stdio_path_arg(cmd) {
-        let Some(cwd) = server.cwd.as_deref() else {
-            return McpCommandDoctorStatus::NotChecked;
-        };
-        return if cwd.join(path).is_file() {
-            McpCommandDoctorStatus::Available
-        } else {
-            McpCommandDoctorStatus::Missing
-        };
-    }
-
-    if is_command_available(cmd) {
-        McpCommandDoctorStatus::Available
-    } else {
-        McpCommandDoctorStatus::Missing
-    }
+fn doctor_mcp_command_status(server: &McpServerConfig) -> Result<McpCommandAvailability> {
+    static_mcp_command_availability(server)
 }
 
 fn doctor_mcp_server_json(name: &str, server: &McpServerConfig) -> serde_json::Value {
@@ -6851,7 +6785,9 @@ fn doctor_mcp_server_json(name: &str, server: &McpServerConfig) -> serde_json::V
                 "detail": status.detail(),
             },
             "command": {
-                "status": doctor_mcp_command_status(server).as_str(),
+                "status": doctor_mcp_command_status(server)
+                    .map(McpCommandAvailability::as_str)
+                    .unwrap_or("invalid_environment"),
             },
             "process_reachable": {
                 "status": "not_checked",
@@ -6884,9 +6820,17 @@ fn doctor_check_mcp_server(server: &McpServerConfig) -> McpServerDoctorStatus {
         return McpServerDoctorStatus::Error("empty command".to_string());
     }
 
-    if doctor_mcp_command_status(server) == McpCommandDoctorStatus::Missing {
-        return McpServerDoctorStatus::Error(format!("command not found: {cmd}"));
-    }
+    let command_availability = match doctor_mcp_command_status(server) {
+        Ok(McpCommandAvailability::Missing) => {
+            return McpServerDoctorStatus::Error(format!("command not found: {cmd}"));
+        }
+        Err(error) => {
+            return McpServerDoctorStatus::Error(format!(
+                "invalid MCP stdio environment: {error:#}"
+            ));
+        }
+        Ok(status) => status,
+    };
 
     let cmd_path = Path::new(cmd);
     // Also accept Unix-style `/` prefix on Windows, where Path::is_absolute()
@@ -6908,6 +6852,12 @@ fn doctor_check_mcp_server(server: &McpServerConfig) -> McpServerDoctorStatus {
                 "stdio server uses relative path argument \"{arg}\" without cwd; set cwd so headless exec and UI status checks resolve the same path"
             ));
         }
+    }
+
+    if command_availability == McpCommandAvailability::NotChecked {
+        return McpServerDoctorStatus::Warning(format!(
+            "stdio command availability could not be confirmed without starting \"{cmd}\""
+        ));
     }
 
     // Detect self-hosted DeepSeek server entries.
@@ -12900,6 +12850,28 @@ mod doctor_mcp_tests {
         }
     }
 
+    fn write_path_only_command(dir: &Path) -> String {
+        let command = "codewhale-doctor-mcp-path-only-test";
+        #[cfg(windows)]
+        let file_name = format!("{command}.exe");
+        #[cfg(not(windows))]
+        let file_name = command.to_string();
+        let path = dir.join(file_name);
+        std::fs::write(&path, b"test executable").expect("write path-only command");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&path)
+                .expect("path-only command metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions)
+                .expect("make path-only command executable");
+        }
+        command.to_string()
+    }
+
     #[test]
     fn test_no_command_or_url_is_error() {
         let server = make_server(None, &[], None);
@@ -12927,6 +12899,73 @@ mod doctor_mcp_tests {
             McpServerDoctorStatus::Ok(detail) => assert!(detail.contains("stdio")),
             other => panic!("Expected Ok, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn doctor_uses_server_path_for_bare_command_availability() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let command = write_path_only_command(temp.path());
+        let mut server = make_server(Some(&command), &[], None);
+        server.env.insert(
+            "PATH".to_string(),
+            temp.path().to_string_lossy().into_owned(),
+        );
+
+        assert!(matches!(
+            doctor_check_mcp_server(&server),
+            McpServerDoctorStatus::Ok(_)
+        ));
+        assert_eq!(
+            doctor_mcp_server_json("path-only", &server)["checks"]["command"]["status"],
+            "available"
+        );
+
+        server.command = Some("codewhale-doctor-mcp-command-that-does-not-exist".to_string());
+        #[cfg(not(windows))]
+        assert!(matches!(
+            doctor_check_mcp_server(&server),
+            McpServerDoctorStatus::Error(detail) if detail.contains("command not found")
+        ));
+        #[cfg(windows)]
+        assert!(matches!(
+            doctor_check_mcp_server(&server),
+            McpServerDoctorStatus::Warning(detail) if detail.contains("could not be confirmed")
+        ));
+        #[cfg(not(windows))]
+        assert_eq!(
+            doctor_mcp_server_json("missing", &server)["checks"]["command"]["status"],
+            "missing"
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            doctor_mcp_server_json("missing", &server)["checks"]["command"]["status"],
+            "not_checked"
+        );
+    }
+
+    #[test]
+    fn doctor_reports_path_expansion_errors_without_leaking_values() {
+        let _lock = crate::test_support::lock_test_env();
+        let _missing =
+            crate::test_support::EnvVarGuard::remove("CODEWHALE_DOCTOR_MCP_MISSING_PATH");
+        let mut server = make_server(Some("codewhale-mcp-command"), &[], None);
+        server.env.insert(
+            "PATH".to_string(),
+            "do-not-leak-${CODEWHALE_DOCTOR_MCP_MISSING_PATH}-also-secret".to_string(),
+        );
+
+        match doctor_check_mcp_server(&server) {
+            McpServerDoctorStatus::Error(detail) => {
+                assert!(detail.contains("CODEWHALE_DOCTOR_MCP_MISSING_PATH"));
+                assert!(!detail.contains("do-not-leak"));
+                assert!(!detail.contains("also-secret"));
+            }
+            other => panic!("Expected invalid environment error, got {other:?}"),
+        }
+        assert_eq!(
+            doctor_mcp_server_json("invalid-env", &server)["checks"]["command"]["status"],
+            "invalid_environment"
+        );
     }
 
     #[test]

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -6,6 +6,7 @@
 //! - Configurable timeouts per-server and globally
 
 use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::future::Future;
 use std::io::Read;
@@ -98,6 +99,184 @@ fn expand_env_placeholders_map(
         );
     }
     Ok(expanded)
+}
+
+fn expanded_mcp_stdio_env(config: &McpServerConfig) -> Result<HashMap<String, String>> {
+    expand_env_placeholders_map(&config.env, "env")
+}
+
+/// Mirror the exact expanded and sanitized environment applied by the MCP
+/// stdio spawn path, without constructing or starting a process.
+fn mcp_stdio_child_env(config: &McpServerConfig) -> Result<Vec<(OsString, OsString)>> {
+    let expanded_env = expanded_mcp_stdio_env(config)?;
+    Ok(crate::child_env::sanitized_mcp_env(
+        crate::child_env::string_map_env(&expanded_env),
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpCommandAvailability {
+    Available,
+    Missing,
+    NotApplicable,
+    NotChecked,
+}
+
+impl McpCommandAvailability {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Missing => "missing",
+            Self::NotApplicable => "not_applicable",
+            Self::NotChecked => "not_checked",
+        }
+    }
+}
+
+pub(crate) fn is_relative_stdio_path_arg(value: &str) -> bool {
+    if value.is_empty() || value.starts_with('-') || value.contains("://") || value.starts_with('~')
+    {
+        return false;
+    }
+    let looks_like_path = value.contains('/') || value.contains('\\');
+    if !looks_like_path {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    let windows_absolute = value.starts_with("\\\\")
+        || (bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/'));
+    !Path::new(value).is_absolute() && !windows_absolute
+}
+
+fn env_value<'a>(env: &'a [(OsString, OsString)], name: &str) -> Option<&'a OsStr> {
+    env.iter()
+        .rev()
+        .find(|(key, _)| {
+            #[cfg(windows)]
+            {
+                key.to_string_lossy().eq_ignore_ascii_case(name)
+            }
+            #[cfg(not(windows))]
+            {
+                key == OsStr::new(name)
+            }
+        })
+        .map(|(_, value)| value.as_os_str())
+}
+
+#[cfg(unix)]
+fn spawnable_command_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.is_file()
+        && fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn spawnable_command_file(path: &Path) -> bool {
+    path.is_file() || (path.extension().is_none() && path.with_extension("exe").is_file())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn spawnable_command_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn path_candidate(dir: &Path, name: &str, cwd: Option<&Path>) -> PathBuf {
+    #[cfg(unix)]
+    {
+        // Unix performs PATH lookup after applying Command::current_dir. That
+        // includes empty PATH entries, which mean the child's current dir.
+        if dir.is_relative()
+            && let Some(cwd) = cwd
+        {
+            return cwd.join(dir).join(name);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = cwd;
+    dir.join(name)
+}
+
+fn command_availability_on_path(
+    name: &str,
+    env: &[(OsString, OsString)],
+    cwd: Option<&Path>,
+) -> McpCommandAvailability {
+    let Some(path) = env_value(env, "PATH") else {
+        // On Unix execvp falls back to an OS-defined path. On Windows Rust's
+        // resolver still checks system and parent locations. We cannot prove a
+        // miss without reproducing platform internals, so remain conservative.
+        return McpCommandAvailability::NotChecked;
+    };
+    for dir in std::env::split_paths(path) {
+        let candidate = path_candidate(&dir, name, cwd);
+        if spawnable_command_file(&candidate) {
+            return McpCommandAvailability::Available;
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows Command resolution also checks the running executable's
+        // directory, system directories, and the parent PATH after an explicit
+        // child PATH. A static miss in the child PATH is therefore not proof
+        // that spawn will fail. PATHEXT is intentionally not consulted: Rust
+        // only supplies an omitted `.exe`; `.cmd`/`.bat` must be explicit.
+        return McpCommandAvailability::NotChecked;
+    }
+    #[cfg(not(windows))]
+    {
+        McpCommandAvailability::Missing
+    }
+}
+
+/// Inspect an MCP stdio command using the same expanded, sanitized environment
+/// as the real spawn path, without starting the configured process.
+pub(crate) fn static_mcp_command_availability(
+    server: &McpServerConfig,
+) -> Result<McpCommandAvailability> {
+    if server.url.is_some() {
+        return Ok(McpCommandAvailability::NotApplicable);
+    }
+    let Some(cmd) = server.command.as_deref() else {
+        return Ok(McpCommandAvailability::NotChecked);
+    };
+    if cmd.is_empty() {
+        return Ok(McpCommandAvailability::Missing);
+    }
+
+    // StdioTransport expands every configured env value before spawning, even
+    // when the command itself is absolute. Mirror that failure boundary here.
+    let child_env = mcp_stdio_child_env(server)?;
+    let path = Path::new(cmd);
+    let is_absolute = path.is_absolute() || cmd.starts_with('/');
+    if is_absolute {
+        return Ok(if spawnable_command_file(path) {
+            McpCommandAvailability::Available
+        } else {
+            McpCommandAvailability::Missing
+        });
+    }
+
+    if is_relative_stdio_path_arg(cmd) {
+        let Some(cwd) = server.cwd.as_deref() else {
+            return Ok(McpCommandAvailability::NotChecked);
+        };
+        return Ok(if spawnable_command_file(&cwd.join(path)) {
+            McpCommandAvailability::Available
+        } else {
+            McpCommandAvailability::Missing
+        });
+    }
+
+    Ok(command_availability_on_path(
+        cmd,
+        &child_env,
+        server.cwd.as_deref(),
+    ))
 }
 
 /// Mask a URL so any embedded credentials in the userinfo portion (e.g.

--- a/crates/tui/src/mcp/stdio.rs
+++ b/crates/tui/src/mcp/stdio.rs
@@ -80,7 +80,7 @@ impl StdioTransport {
         // from the process environment instead of being stored in cleartext
         // in the MCP config. The child env is allowlist-sanitized below, so
         // these vars would not otherwise be inherited by the child.
-        let expanded_env = super::expand_env_placeholders_map(&config.env, "env")
+        let expanded_env = super::expanded_mcp_stdio_env(config)
             .with_context(|| format!("MCP server '{server_name}' env expansion failed"))?;
 
         // MCP stdio servers are user-configured integrations. Use the

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -266,6 +266,251 @@ fn expand_env_placeholders_reports_missing_variable_without_secret_value() {
     assert!(!err.contains("Bearer "));
 }
 
+fn write_path_only_test_command(dir: &Path) -> String {
+    let command = "codewhale-mcp-path-only-test";
+    #[cfg(windows)]
+    let file_name = format!("{command}.exe");
+    #[cfg(not(windows))]
+    let file_name = command.to_string();
+    let path = dir.join(file_name);
+    fs::write(&path, b"test executable").expect("write path-only test command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&path)
+            .expect("path-only command metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("make path-only test command executable");
+    }
+    command.to_string()
+}
+
+#[test]
+fn static_mcp_command_uses_expanded_sanitized_stdio_path() {
+    let _lock = crate::test_support::lock_test_env();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let command = write_path_only_test_command(temp.path());
+    let _path = crate::test_support::EnvVarGuard::set(
+        "CODEWHALE_MCP_PATH_ONLY_DIR",
+        temp.path().as_os_str(),
+    );
+    let _secret = crate::test_support::EnvVarGuard::set(
+        "CODEWHALE_MCP_STATIC_TEST_SECRET",
+        "must-not-reach-child",
+    );
+    let mut server = test_server_config();
+    server.command = Some(command);
+    server.env.insert(
+        "PATH".to_string(),
+        "${CODEWHALE_MCP_PATH_ONLY_DIR}".to_string(),
+    );
+
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("static command check"),
+        McpCommandAvailability::Available
+    );
+
+    let child_env = mcp_stdio_child_env(&server).expect("stdio child env");
+    assert_eq!(
+        env_value(&child_env, "PATH"),
+        Some(temp.path().as_os_str()),
+        "expanded server PATH must override the inherited PATH"
+    );
+    assert!(
+        child_env
+            .iter()
+            .all(|(key, _)| key != "CODEWHALE_MCP_STATIC_TEST_SECRET"),
+        "static lookup must use the same sanitized parent environment as spawn"
+    );
+
+    let expanded_env = expand_env_placeholders_map(&server.env, "env").expect("expanded env");
+    let mut old_spawn_command = tokio::process::Command::new("unused-test-command");
+    crate::child_env::apply_to_tokio_command_mcp(
+        &mut old_spawn_command,
+        crate::child_env::string_map_env(&expanded_env),
+    );
+    let old_spawn_env = old_spawn_command
+        .as_std()
+        .get_envs()
+        .map(|(key, value)| {
+            (
+                key.to_os_string(),
+                value.expect("spawn env value").to_os_string(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let static_env = child_env.into_iter().collect::<HashMap<_, _>>();
+    assert_eq!(
+        static_env, old_spawn_env,
+        "static lookup and the pre-fix spawn helper must receive identical environments"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn static_mcp_command_reports_missing_with_server_path_override() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut server = test_server_config();
+    server.command = Some("codewhale-mcp-command-that-does-not-exist".to_string());
+    server.env.insert(
+        "PATH".to_string(),
+        temp.path().to_string_lossy().into_owned(),
+    );
+
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("static command check"),
+        McpCommandAvailability::Missing
+    );
+}
+
+#[test]
+fn static_mcp_command_reports_invalid_path_expansion() {
+    let _lock = crate::test_support::lock_test_env();
+    let _missing = crate::test_support::EnvVarGuard::remove("CODEWHALE_MCP_MISSING_PATH_DIR");
+    let mut server = test_server_config();
+    server.command = Some("codewhale-mcp-command".to_string());
+    server.env.insert(
+        "PATH".to_string(),
+        "do-not-leak-${CODEWHALE_MCP_MISSING_PATH_DIR}-also-secret".to_string(),
+    );
+
+    let error = static_mcp_command_availability(&server)
+        .expect_err("missing PATH placeholder must fail static validation");
+    let error = format!("{error:#}");
+    assert!(error.contains("CODEWHALE_MCP_MISSING_PATH_DIR"));
+    assert!(!error.contains("codewhale-mcp-command"));
+    assert!(!error.contains("do-not-leak"));
+    assert!(!error.contains("also-secret"));
+}
+
+#[cfg(unix)]
+fn write_unix_test_command(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, b"#!/bin/sh\nexit 0\n").expect("write Unix test command");
+    let mut permissions = fs::metadata(path)
+        .expect("Unix test command metadata")
+        .permissions();
+    permissions.set_mode(mode);
+    fs::set_permissions(path, permissions).expect("set Unix test command mode");
+}
+
+#[cfg(unix)]
+#[test]
+fn static_mcp_command_anchors_relative_and_empty_path_to_server_cwd() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cwd = temp.path().join("server-cwd");
+    let bin = cwd.join("relative-bin");
+    fs::create_dir_all(&bin).expect("relative bin dir");
+    let relative_command = "codewhale-mcp-relative-path-test";
+    write_unix_test_command(&bin.join(relative_command), 0o755);
+
+    let mut server = test_server_config();
+    server.command = Some(relative_command.to_string());
+    server.cwd = Some(cwd.clone());
+    server
+        .env
+        .insert("PATH".to_string(), "relative-bin".to_string());
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("relative PATH check"),
+        McpCommandAvailability::Available
+    );
+
+    let empty_path_command = "codewhale-mcp-empty-path-test";
+    write_unix_test_command(&cwd.join(empty_path_command), 0o755);
+    server.command = Some(empty_path_command.to_string());
+    server.env.insert("PATH".to_string(), String::new());
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("empty PATH check"),
+        McpCommandAvailability::Available,
+        "an empty Unix PATH entry resolves from the child's cwd"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn static_mcp_command_preserves_literal_name_and_requires_execute_bits() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let literal_command = " codewhale-mcp-literal-command-test ";
+    write_unix_test_command(&temp.path().join(literal_command), 0o755);
+
+    let mut server = test_server_config();
+    server.command = Some(literal_command.to_string());
+    server.env.insert(
+        "PATH".to_string(),
+        temp.path().to_string_lossy().into_owned(),
+    );
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("literal command check"),
+        McpCommandAvailability::Available,
+        "static validation must not trim the command passed to Command::new"
+    );
+
+    let non_executable = temp.path().join("codewhale-mcp-non-executable-test");
+    write_unix_test_command(&non_executable, 0o644);
+    server.command = Some("codewhale-mcp-non-executable-test".to_string());
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("PATH execute-bit check"),
+        McpCommandAvailability::Missing
+    );
+    server.command = Some(non_executable.to_string_lossy().into_owned());
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("absolute execute-bit check"),
+        McpCommandAvailability::Missing
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn static_mcp_command_matches_windows_path_and_extension_rules() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let command = write_path_only_test_command(temp.path());
+    let mut server = test_server_config();
+    server.command = Some(command);
+    server.env.insert(
+        "Path".to_string(),
+        temp.path().to_string_lossy().into_owned(),
+    );
+
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("case-insensitive PATH check"),
+        McpCommandAvailability::Available
+    );
+
+    server.command = Some(
+        temp.path()
+            .join("codewhale-mcp-path-only-test")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("absolute omitted .exe check"),
+        McpCommandAvailability::Available
+    );
+
+    let pathext_command = "codewhale-mcp-pathext-only-test";
+    fs::write(
+        temp.path().join(format!("{pathext_command}.cmd")),
+        b"@exit /b 0\r\n",
+    )
+    .expect("write PATHEXT-only command");
+    server.command = Some(pathext_command.to_string());
+    server.env.insert("PATHEXT".to_string(), ".CMD".to_string());
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("PATHEXT command check"),
+        McpCommandAvailability::NotChecked,
+        "a child-PATH miss is conservative because Windows still searches implicit fallbacks"
+    );
+    server.command = Some(format!("{pathext_command}.cmd"));
+    assert_eq!(
+        static_mcp_command_availability(&server).expect("explicit .cmd command check"),
+        McpCommandAvailability::Available,
+        "Rust requires non-.exe extensions to be explicit"
+    );
+}
+
 #[tokio::test]
 async fn mcp_http_auth_prefers_static_authorization_over_bearer_env() {
     let mut headers = HashMap::new();

--- a/crates/tui/src/tui/setup/tools_mcp.rs
+++ b/crates/tui/src/tui/setup/tools_mcp.rs
@@ -9,7 +9,10 @@ use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::localization::{Locale, MessageId, tr};
-use crate::mcp::{McpConfig, McpManagerSnapshot, McpServerConfig, McpServerSnapshot};
+use crate::mcp::{
+    McpCommandAvailability, McpConfig, McpManagerSnapshot, McpServerConfig, McpServerSnapshot,
+    static_mcp_command_availability,
+};
 use crate::tui::app::App;
 use crate::tui::hotbar::actions::HotbarActionCategory;
 use crate::utils::display_path;
@@ -391,15 +394,11 @@ fn classify_config_server(server: &McpServerConfig) -> InventoryStatus {
     if server.command.is_none() && server.url.is_none() {
         return InventoryStatus::NeedsConfig;
     }
-    if let Some(cmd) = server.command.as_deref() {
-        if cmd.trim().is_empty() {
-            return InventoryStatus::NeedsConfig;
-        }
-        let path = Path::new(cmd);
-        let is_absolute = path.is_absolute() || cmd.starts_with('/');
-        if is_absolute && !path.exists() {
-            return InventoryStatus::NeedsConfig;
-        }
+    if matches!(
+        static_mcp_command_availability(server),
+        Ok(McpCommandAvailability::Missing) | Ok(McpCommandAvailability::NotChecked) | Err(_)
+    ) {
+        return InventoryStatus::NeedsConfig;
     }
     // Env-backed bearer tokens: missing env is needs_config when URL-based.
     if server.url.is_some()
@@ -670,6 +669,36 @@ mod tests {
         app
     }
 
+    fn write_path_only_command(dir: &Path) -> String {
+        let command = "codewhale-setup-mcp-path-only-test";
+        #[cfg(windows)]
+        let file_name = format!("{command}.exe");
+        #[cfg(not(windows))]
+        let file_name = command.to_string();
+        let path = dir.join(file_name);
+        std::fs::write(&path, b"test executable").expect("write path-only command");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&path)
+                .expect("path-only command metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions)
+                .expect("make path-only command executable");
+        }
+        command.to_string()
+    }
+
+    fn path_server(command: &str, path: &Path) -> McpServerConfig {
+        serde_json::from_value(serde_json::json!({
+            "command": command,
+            "env": {"PATH": path},
+        }))
+        .expect("stdio server config")
+    }
+
     #[test]
     fn empty_inventory_is_off_not_error() {
         let tmp = TempDir::new().expect("tempdir");
@@ -714,18 +743,20 @@ mod tests {
         let home = tmp.path().join("cw-home");
         std::fs::create_dir_all(&home).expect("home");
         let mcp_path = tmp.path().join("mcp.json");
+        let executable = std::env::current_exe().expect("current test executable");
+        let mcp_config = serde_json::json!({
+            "servers": {
+                "docs": {
+                    "command": executable,
+                    "args": ["-y", "secret-mcp-package"],
+                    "env": {"API_KEY": "sk-mcp-secret-token"},
+                    "headers": {"Authorization": "Bearer sk-header-secret"}
+                }
+            }
+        });
         std::fs::write(
             &mcp_path,
-            r#"{
-              "servers": {
-                "docs": {
-                  "command": "npx",
-                  "args": ["-y", "secret-mcp-package"],
-                  "env": {"API_KEY": "sk-mcp-secret-token"},
-                  "headers": {"Authorization": "Bearer sk-header-secret"}
-                }
-              }
-            }"#,
+            serde_json::to_vec(&mcp_config).expect("serialize mcp config"),
         )
         .expect("write mcp");
 
@@ -790,6 +821,29 @@ mod tests {
         assert!(!blob.contains("secret-mcp-package"));
         assert!(!blob.contains("API_KEY"));
         assert!(!blob.contains("Bearer"));
+    }
+
+    #[test]
+    fn setup_and_doctor_share_static_server_path_classification() {
+        let temp = TempDir::new().expect("tempdir");
+        let command = write_path_only_command(temp.path());
+        let mut server = path_server(&command, temp.path());
+
+        assert_eq!(classify_config_server(&server), InventoryStatus::Healthy);
+        assert!(matches!(
+            crate::doctor_check_mcp_server(&server),
+            crate::McpServerDoctorStatus::Ok(_)
+        ));
+
+        server.command = Some("codewhale-setup-mcp-command-that-does-not-exist".to_string());
+        assert_eq!(
+            classify_config_server(&server),
+            InventoryStatus::NeedsConfig
+        );
+        assert!(matches!(
+            crate::doctor_check_mcp_server(&server),
+            crate::McpServerDoctorStatus::Error(_) | crate::McpServerDoctorStatus::Warning(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- resolve bare MCP stdio commands against the same expanded and sanitized per-server environment used by the real spawn path
- preserve literal command names, Unix child-`cwd` PATH behavior and execute-bit checks, plus conservative Windows extension and fallback semantics
- make `codewhale doctor` and the setup inventory consume the same static command evidence without starting configured servers
- report missing environment placeholders safely without leaking surrounding configured values

## Why

This follows up on the two unresolved review findings from #4485. Doctor previously searched only its own process PATH, so a valid MCP server relying on `server.env.PATH` could be reported as missing. Setup used a separate, weaker classifier and could call that same entry configured.

The shared resolver now mirrors stdio spawn expansion and sanitization while remaining side-effect free. This is a partial health-evidence slice for #4406; it does not claim that a configured server is live or healthy.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked static_mcp_command` — 5 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked doctor_mcp_tests` — 13 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::setup::tools_mcp::tests` — 10 passed
- `cargo check -p codewhale-tui --all-targets --locked`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`

An additional all-target clippy run reaches two existing Rust 1.96 test-target lints in `crates/tui/src/config/paths.rs:89` and `crates/tui/src/test_support.rs:145`; neither file is changed here, and the production-bin clippy gate above is clean.

## Remaining #4406 scope

- opt-in live MCP process reachability and initialization evidence
- protocol and backend-tool health without conflating it with static configuration
- provider endpoint, credential, and model-readiness evidence
- broader local-provider probe coverage and actionable remediation
