### PR TITLE
fix(runtime): contain hooks and preserve Windows PTY status

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -170,6 +170,7 @@ heloanc = heloanc <61081755+heloanc@users.noreply.github.com>
 heloanc@users.noreply.github.com = heloanc <61081755+heloanc@users.noreply.github.com>
 bistack = Sun Zhenyuan <9128763+bistack@users.noreply.github.com>
 zhenyuan.sun@163.com = Sun Zhenyuan <9128763+bistack@users.noreply.github.com>
+luismateusvargas = Luis Mateus Vargas <289766246+luismateusvargas@users.noreply.github.com>
 
 # v0.8.68 underwater-lane harvests.
 moduvoice = moduvoice <291867022+moduvoice@users.noreply.github.com>

--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -171,6 +171,7 @@ heloanc@users.noreply.github.com = heloanc <61081755+heloanc@users.noreply.githu
 bistack = Sun Zhenyuan <9128763+bistack@users.noreply.github.com>
 zhenyuan.sun@163.com = Sun Zhenyuan <9128763+bistack@users.noreply.github.com>
 luismateusvargas = Luis Mateus Vargas <289766246+luismateusvargas@users.noreply.github.com>
+redjade75723 = redjade75723 <263730355+redjade75723@users.noreply.github.com>
 
 # v0.8.68 underwater-lane harvests.
 moduvoice = moduvoice <291867022+moduvoice@users.noreply.github.com>

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -114,4 +114,4 @@ objc2 = "0.6.3"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSDictionary", "NSError", "NSObject", "NSString", "NSURL"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Media_Audio", "Win32_Security", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_Environment", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Media_Audio", "Win32_Security", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Environment", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }

--- a/crates/tui/src/hooks.rs
+++ b/crates/tui/src/hooks.rs
@@ -20,10 +20,30 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use wait_timeout::ChildExt;
+
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+#[cfg(windows)]
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+#[cfg(windows)]
+use windows::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+};
+#[cfg(windows)]
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject,
+};
+#[cfg(windows)]
+use windows::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+#[cfg(windows)]
+use windows::core::PCWSTR;
 
 /// Events that can trigger hook execution
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -629,6 +649,227 @@ pub struct TurnEndPayloadInput<'a> {
     pub queued_message_count: usize,
 }
 
+/// Owns the process tree created for one hook invocation.
+///
+/// Hooks run through a shell, so killing only the immediate `sh`/`cmd.exe`
+/// child can leave the actual hook runtime alive. Unix hooks get their own
+/// process group and Windows hooks are attached to a kill-on-close Job Object.
+/// Dropping this guard after the shell exits also closes inherited stdout and
+/// stderr pipes held by any lingering descendants.
+struct HookProcessTree {
+    #[cfg(unix)]
+    pgid: libc::pid_t,
+    #[cfg(windows)]
+    job: WindowsHookJob,
+}
+
+impl HookProcessTree {
+    fn attach(child: &Child) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            Ok(Self {
+                pgid: child.id() as libc::pid_t,
+            })
+        }
+
+        #[cfg(windows)]
+        {
+            Ok(Self {
+                job: WindowsHookJob::attach(child)?,
+            })
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            Ok(Self {})
+        }
+    }
+
+    fn terminate(&self, child: &mut Child) {
+        #[cfg(unix)]
+        {
+            let result = unsafe { libc::kill(-self.pgid, libc::SIGKILL) };
+            if result != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    tracing::warn!(?error, "failed to terminate hook process group");
+                    let _ = child.kill();
+                }
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            let result = self
+                .job
+                .terminate()
+                .or_else(|_| kill_windows_process_tree(child.id()));
+            if let Err(error) = result {
+                tracing::warn!(
+                    ?error,
+                    "failed to terminate hook process tree; killing immediate child"
+                );
+                let _ = child.kill();
+            }
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = child.kill();
+        }
+    }
+}
+
+impl Drop for HookProcessTree {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            // The shell may have exited while one of its descendants still
+            // holds a captured pipe. Reaping the process group keeps hook
+            // lifetimes bounded and lets the reader threads finish.
+            let _ = libc::kill(-self.pgid, libc::SIGKILL);
+        }
+        // On Windows, dropping WindowsHookJob closes a Job Object configured
+        // with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.
+    }
+}
+
+#[cfg(windows)]
+struct WindowsHookJob {
+    handle: HANDLE,
+}
+
+#[cfg(windows)]
+impl WindowsHookJob {
+    fn attach(child: &Child) -> std::io::Result<Self> {
+        let handle = unsafe { CreateJobObjectW(None, PCWSTR::null()).map_err(windows_io_error)? };
+        let job = Self { handle };
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        unsafe {
+            SetInformationJobObject(
+                job.handle,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+            .map_err(windows_io_error)?;
+            AssignProcessToJobObject(job.handle, HANDLE(child.as_raw_handle()))
+                .map_err(windows_io_error)?;
+        }
+        Ok(job)
+    }
+
+    fn terminate(&self) -> std::io::Result<()> {
+        unsafe { TerminateJobObject(self.handle, 1).map_err(windows_io_error) }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsHookJob {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_io_error(error: windows::core::Error) -> std::io::Error {
+    std::io::Error::other(error)
+}
+
+#[cfg(windows)]
+fn resume_windows_process(child: &Child) -> std::io::Result<()> {
+    let snapshot =
+        unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0).map_err(windows_io_error)? };
+    let result = (|| {
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            ..Default::default()
+        };
+        let mut next = unsafe { Thread32First(snapshot, &mut entry) };
+        let mut resumed = 0usize;
+        while next.is_ok() {
+            if entry.th32OwnerProcessID == child.id() {
+                let thread = unsafe {
+                    OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID)
+                        .map_err(windows_io_error)?
+                };
+                let resume_result = unsafe { ResumeThread(thread) };
+                let close_result = unsafe { CloseHandle(thread).map_err(windows_io_error) };
+                if resume_result == u32::MAX {
+                    return Err(std::io::Error::last_os_error());
+                }
+                close_result?;
+                resumed += 1;
+            }
+            next = unsafe { Thread32Next(snapshot, &mut entry) };
+        }
+        if resumed == 0 {
+            return Err(std::io::Error::other(
+                "suspended hook process had no resumable thread",
+            ));
+        }
+        Ok(())
+    })();
+    let close_result = unsafe { CloseHandle(snapshot).map_err(windows_io_error) };
+    result?;
+    close_result
+}
+
+#[cfg(windows)]
+fn kill_windows_process_tree(pid: u32) -> std::io::Result<()> {
+    let mut command = Command::new("taskkill");
+    crate::utils::suppress_console_window(&mut command);
+    let pid = pid.to_string();
+    let status = command
+        .args(["/F", "/T", "/PID", pid.as_str()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "taskkill exited with {status}"
+        )))
+    }
+}
+
+fn spawn_hook_child(
+    command: &mut Command,
+    hook_command: &str,
+) -> std::io::Result<(Child, HookProcessTree)> {
+    let mut child = command.spawn()?;
+    let process_tree = match HookProcessTree::attach(&child) {
+        Ok(process_tree) => process_tree,
+        Err(error) => {
+            // Windows hooks are created suspended, so a containment failure
+            // cannot race with a descendant spawn. Fail closed without ever
+            // running the uncontained hook.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(std::io::Error::other(format!(
+                "failed to contain hook process tree for `{hook_command}`: {error}"
+            )));
+        }
+    };
+
+    #[cfg(windows)]
+    if let Err(error) = resume_windows_process(&child) {
+        process_tree.terminate(&mut child);
+        let _ = child.wait();
+        return Err(std::io::Error::other(format!(
+            "failed to resume contained hook process for `{hook_command}`: {error}"
+        )));
+    }
+
+    Ok((child, process_tree))
+}
+
 /// Executor for running hooks
 #[derive(Debug, Clone)]
 pub struct HookExecutor {
@@ -643,7 +884,9 @@ impl HookExecutor {
         {
             use std::os::windows::process::CommandExt as _;
             let mut cmd = Command::new("cmd");
-            crate::utils::suppress_console_window(&mut cmd);
+            const CREATE_SUSPENDED: u32 = 0x0000_0004;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_SUSPENDED | CREATE_NO_WINDOW);
             // raw_arg: cmd.exe does not parse the CRT-style \" escapes that
             // Command::arg would insert, so pass the command line verbatim.
             cmd.arg("/C").raw_arg(command);
@@ -653,6 +896,11 @@ impl HookExecutor {
         {
             let mut cmd = Command::new("sh");
             cmd.arg("-c").arg(command);
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::CommandExt as _;
+                cmd.process_group(0);
+            }
             cmd
         }
     }
@@ -1107,12 +1355,14 @@ impl HookExecutor {
             .current_dir(&working_dir)
             .envs(env_vars)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        if stdin_bytes.is_some() {
-            command.stdin(Stdio::piped());
-        }
+            .stderr(Stdio::piped())
+            .stdin(if stdin_bytes.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            });
 
-        let mut child = match command.spawn() {
+        let (mut child, process_tree) = match spawn_hook_child(&mut command, &hook.command) {
             Ok(child) => child,
             Err(e) => {
                 return HookResult {
@@ -1122,7 +1372,7 @@ impl HookExecutor {
                     stdout: String::new(),
                     stderr: String::new(),
                     duration: started.elapsed(),
-                    error: Some(format!("Failed to spawn hook: {e}")),
+                    error: Some(format!("Failed to start hook: {e}")),
                 };
             }
         };
@@ -1135,21 +1385,24 @@ impl HookExecutor {
         };
 
         match child.wait_timeout(timeout) {
-            Ok(Some(status)) => HookResult {
-                name: hook.name.clone(),
-                success: status.success(),
-                exit_code: status.code(),
-                stdout: join_reader(stdout_reader),
-                stderr: join_reader(stderr_reader),
-                duration: started.elapsed(),
-                error: None,
-            },
+            Ok(Some(status)) => {
+                drop(process_tree);
+                HookResult {
+                    name: hook.name.clone(),
+                    success: status.success(),
+                    exit_code: status.code(),
+                    stdout: collect_reader(stdout_reader, HOOK_PIPE_DRAIN_TIMEOUT),
+                    stderr: collect_reader(stderr_reader, HOOK_PIPE_DRAIN_TIMEOUT),
+                    duration: started.elapsed(),
+                    error: None,
+                }
+            }
             Ok(None) => {
-                let _ = child.kill();
+                process_tree.terminate(&mut child);
                 let _ = child.wait();
-                // Do not join pipe threads on timeout: descendant processes can
-                // inherit pipe fds, and waiting for those threads would defeat
-                // the hook timeout we just enforced.
+                drop(process_tree);
+                let _ = collect_reader(stdout_reader, HOOK_PIPE_SHUTDOWN_TIMEOUT);
+                let _ = collect_reader(stderr_reader, HOOK_PIPE_SHUTDOWN_TIMEOUT);
                 HookResult {
                     name: hook.name.clone(),
                     success: false,
@@ -1161,8 +1414,11 @@ impl HookExecutor {
                 }
             }
             Err(e) => {
-                let _ = child.kill();
+                process_tree.terminate(&mut child);
                 let _ = child.wait();
+                drop(process_tree);
+                let _ = collect_reader(stdout_reader, HOOK_PIPE_SHUTDOWN_TIMEOUT);
+                let _ = collect_reader(stderr_reader, HOOK_PIPE_SHUTDOWN_TIMEOUT);
                 HookResult {
                     name: hook.name.clone(),
                     success: false,
@@ -1228,13 +1484,19 @@ impl HookExecutor {
                 .current_dir(&wd)
                 .envs(&env)
                 .stdout(Stdio::null())
-                .stderr(Stdio::null());
-            if stdin_bytes.is_some() {
-                command.stdin(Stdio::piped());
-            }
+                .stderr(Stdio::null())
+                .stdin(if stdin_bytes.is_some() {
+                    Stdio::piped()
+                } else {
+                    Stdio::null()
+                });
 
-            let Ok(mut child) = command.spawn() else {
-                return;
+            let (mut child, process_tree) = match spawn_hook_child(&mut command, &cmd) {
+                Ok(child) => child,
+                Err(error) => {
+                    tracing::warn!(?error, command = cmd, "failed to start background hook");
+                    return;
+                }
             };
             if let (Some(mut bytes), Some(mut stdin)) = (stdin_bytes, child.stdin.take()) {
                 bytes.push(b'\n');
@@ -1242,6 +1504,7 @@ impl HookExecutor {
                 let _ = stdin.flush();
             }
             let _ = child.wait();
+            drop(process_tree);
         });
 
         // Return immediately with success (background execution is fire-and-forget)
@@ -1257,18 +1520,34 @@ impl HookExecutor {
     }
 }
 
-fn spawn_pipe_reader(mut pipe: impl Read + Send + 'static) -> JoinHandle<String> {
+const HOOK_PIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+const HOOK_PIPE_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
+
+fn spawn_pipe_reader(mut pipe: impl Read + Send + 'static) -> Receiver<String> {
+    let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         let mut buf = String::new();
         let _ = pipe.read_to_string(&mut buf);
-        buf
-    })
+        let _ = tx.send(buf);
+    });
+    rx
 }
 
-fn join_reader(reader: Option<JoinHandle<String>>) -> String {
-    reader
-        .and_then(|handle| handle.join().ok())
-        .unwrap_or_default()
+fn collect_reader(reader: Option<Receiver<String>>, timeout: Duration) -> String {
+    let Some(reader) = reader else {
+        return String::new();
+    };
+    match reader.recv_timeout(timeout) {
+        Ok(output) => output,
+        Err(RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                ?timeout,
+                "hook pipe reader did not finish after process cleanup"
+            );
+            String::new()
+        }
+        Err(RecvTimeoutError::Disconnected) => String::new(),
+    }
 }
 
 fn spawn_stdin_writer(mut stdin: std::process::ChildStdin, mut bytes: Vec<u8>) -> JoinHandle<()> {
@@ -1762,6 +2041,130 @@ NOEQUAL line dropped
                 .error
                 .as_ref()
                 .is_some_and(|e| e.contains("timed out"))
+        );
+    }
+
+    #[test]
+    fn observer_hook_receives_eof_instead_of_inheriting_terminal_stdin() {
+        const INNER_ENV: &str = "CODEWHALE_TEST_HOOK_EOF_INNER";
+        const TEST_NAME: &str =
+            "hooks::tests::observer_hook_receives_eof_instead_of_inheriting_terminal_stdin";
+
+        if std::env::var_os(INNER_ENV).is_some() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            #[cfg(not(windows))]
+            let command = write_hook_script(
+                &dir,
+                "read_to_eof.sh",
+                r#"#!/bin/sh
+payload=$(cat)
+printf 'stdin-bytes=%s\n' "${#payload}"
+"#,
+            );
+            #[cfg(windows)]
+            let command = "powershell -NoProfile -Command \"$value = [Console]::In.ReadToEnd(); [Console]::Out.WriteLine(('stdin-bytes=' + $value.Length))\"".to_string();
+            let hook = Hook::new(HookEvent::ToolCallBefore, &command).with_timeout(2);
+            let executor = HookExecutor::new(HooksConfig::default(), dir.path().to_path_buf());
+
+            let result = executor.execute_sync(&hook, &HashMap::new());
+            assert!(result.success, "stdin-less hook should finish: {result:?}");
+            assert_eq!(result.stdout.trim(), "stdin-bytes=0");
+            return;
+        }
+
+        // Keep this subprocess's stdin pipe deliberately open. Before #4489,
+        // the hook inherited that live pipe and blocked instead of receiving
+        // EOF. The inner test can only finish when HookExecutor uses null stdin.
+        let mut child = Command::new(std::env::current_exe().expect("current test binary"))
+            .args(["--exact", TEST_NAME, "--nocapture", "--test-threads=1"])
+            .env(INNER_ENV, "1")
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("spawn isolated hook EOF test");
+        let held_open_stdin = child.stdin.take().expect("piped child stdin");
+        let status = match child
+            .wait_timeout(Duration::from_secs(10))
+            .expect("wait for isolated hook EOF test")
+        {
+            Some(status) => status,
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("isolated hook EOF test hung with parent stdin open");
+            }
+        };
+        drop(held_open_stdin);
+        assert!(status.success(), "isolated hook EOF test failed: {status}");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn timed_out_hook_kills_descendant_process_group() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let marker = dir.path().join("descendant-survived");
+        let command = write_hook_script(
+            &dir,
+            "spawn_descendant.sh",
+            &format!(
+                "#!/bin/sh\n(sleep 2; printf leaked > '{}') &\nsleep 5\n",
+                marker.display()
+            ),
+        );
+        let hook = Hook::new(HookEvent::ToolCallBefore, &command).with_timeout(1);
+        let executor = HookExecutor::new(HooksConfig::default(), dir.path().to_path_buf());
+
+        let result = executor.execute_sync(&hook, &HashMap::new());
+        assert!(
+            result
+                .error
+                .as_ref()
+                .is_some_and(|error| error.contains("timed out")),
+            "hook should time out: {result:?}"
+        );
+        std::thread::sleep(Duration::from_millis(1_500));
+        assert!(
+            !marker.exists(),
+            "the timed-out hook's descendant escaped its process group"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn timed_out_hook_kills_windows_descendant_job() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let started = dir.path().join("descendant-started.txt");
+        let survived = dir.path().join("descendant-survived.txt");
+        let descendant = dir.path().join("descendant.cmd");
+        std::fs::write(
+            &descendant,
+            "@echo off\r\necho started>descendant-started.txt\r\nping -n 5 127.0.0.1 > nul\r\necho survived>descendant-survived.txt\r\n",
+        )
+        .expect("write descendant script");
+        let parent = dir.path().join("parent.cmd");
+        std::fs::write(
+            &parent,
+            "@echo off\r\nstart \"\" /b cmd.exe /d /c descendant.cmd\r\n:wait_for_child\r\nif exist descendant-started.txt goto child_started\r\nping -n 2 127.0.0.1 > nul\r\ngoto wait_for_child\r\n:child_started\r\nping -n 10 127.0.0.1 > nul\r\n",
+        )
+        .expect("write parent script");
+        let hook = Hook::new(HookEvent::ToolCallBefore, "call parent.cmd").with_timeout(3);
+        let executor = HookExecutor::new(HooksConfig::default(), dir.path().to_path_buf());
+
+        let result = executor.execute_sync(&hook, &HashMap::new());
+        assert!(
+            result
+                .error
+                .as_ref()
+                .is_some_and(|error| error.contains("timed out")),
+            "hook should time out: {result:?}"
+        );
+        assert!(
+            started.exists(),
+            "descendant never reached its start handshake"
+        );
+        std::thread::sleep(Duration::from_secs(5));
+        assert!(
+            !survived.exists(),
+            "the timed-out hook's descendant escaped its Job Object"
         );
     }
 

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -67,7 +67,9 @@ pub enum ShellStatus {
 pub struct ShellResult {
     pub task_id: Option<String>,
     pub status: ShellStatus,
-    pub exit_code: Option<i32>,
+    /// Lossless process exit status. Windows exception/NTSTATUS values use
+    /// the full unsigned 32-bit range, so an i32 would corrupt them.
+    pub exit_code: Option<i64>,
     pub stdout: String,
     pub stderr: String,
     pub duration_ms: u64,
@@ -108,7 +110,7 @@ pub struct ShellJobSnapshot {
     pub command: String,
     pub cwd: PathBuf,
     pub status: ShellStatus,
-    pub exit_code: Option<i32>,
+    pub exit_code: Option<i64>,
     pub elapsed_ms: u64,
     pub stdout_tail: String,
     pub stderr_tail: String,
@@ -131,7 +133,7 @@ pub struct ShellCompletionEvent {
     pub task_id: String,
     pub command: String,
     pub status: ShellStatus,
-    pub exit_code: Option<i32>,
+    pub exit_code: Option<i64>,
     pub duration_ms: u64,
     pub stdout_tail: String,
     pub stderr_tail: String,
@@ -388,26 +390,38 @@ fn attach_windows_job(child: &Child, command: &str) -> Option<WindowsJob> {
 
 #[derive(Clone, Copy, Debug)]
 struct ShellExitStatus {
-    code: Option<i32>,
+    code: Option<i64>,
     success: bool,
 }
 
 impl ShellExitStatus {
     fn from_std(status: std::process::ExitStatus) -> Self {
         Self {
-            code: status.code(),
+            code: status.code().map(std_exit_code_i64),
             success: status.success(),
         }
     }
 
     #[cfg(not(target_env = "ohos"))]
     fn from_pty(status: portable_pty::ExitStatus) -> Self {
-        let code = i32::try_from(status.exit_code()).unwrap_or(i32::MAX);
         Self {
-            code: Some(code),
+            code: Some(i64::from(status.exit_code())),
             success: status.success(),
         }
     }
+}
+
+#[cfg(windows)]
+fn std_exit_code_i64(code: i32) -> i64 {
+    // std exposes Windows DWORD process statuses through i32. Reinterpret
+    // negative values as their original unsigned bit pattern so codes such
+    // as 0xC0000005 survive JSON, persistence, and diagnostics unchanged.
+    i64::from(code as u32)
+}
+
+#[cfg(not(windows))]
+fn std_exit_code_i64(code: i32) -> i64 {
+    i64::from(code)
 }
 
 impl ShellChild {
@@ -514,7 +528,7 @@ pub struct BackgroundShell {
     pub command: String,
     pub working_dir: PathBuf,
     pub status: ShellStatus,
-    pub exit_code: Option<i32>,
+    pub exit_code: Option<i64>,
     pub started_at: Instant,
     last_output_at: Instant,
     last_observed_output_len: usize,
@@ -695,7 +709,9 @@ impl BackgroundShell {
         let (_, stderr_full, _, _) = self.full_output();
         SandboxManager::was_denied(
             self.sandbox_type,
-            self.exit_code.unwrap_or(-1),
+            self.exit_code
+                .and_then(|code| i32::try_from(code).ok())
+                .unwrap_or(-1),
             &stderr_full,
         )
     }
@@ -1237,6 +1253,7 @@ impl ShellManager {
 
         // Wait with timeout
         if let Some(status) = child.wait_timeout(timeout)? {
+            let status = ShellExitStatus::from_std(status);
             #[cfg(unix)]
             let _ = kill_child_process_group(&mut child);
             #[cfg(windows)]
@@ -1245,7 +1262,10 @@ impl ShellManager {
             let stderr = recv_sync_reader_output(&stderr_rx);
             let stdout_str = String::from_utf8_lossy(&stdout).to_string();
             let stderr_str = String::from_utf8_lossy(&stderr).to_string();
-            let exit_code = status.code().unwrap_or(-1);
+            let exit_code = status
+                .code
+                .and_then(|code| i32::try_from(code).ok())
+                .unwrap_or(-1);
 
             // Check if sandbox denied the operation
             let sandbox_denied = SandboxManager::was_denied(sandbox_type, exit_code, &stderr_str);
@@ -1254,12 +1274,12 @@ impl ShellManager {
 
             Ok(ShellResult {
                 task_id: None,
-                status: if status.success() {
+                status: if status.success {
                     ShellStatus::Completed
                 } else {
                     ShellStatus::Failed
                 },
-                exit_code: status.code(),
+                exit_code: status.code,
                 stdout,
                 stderr,
                 duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
@@ -1296,7 +1316,9 @@ impl ShellManager {
             Ok(ShellResult {
                 task_id: None,
                 status: ShellStatus::TimedOut,
-                exit_code: status.and_then(|s| s.code()),
+                exit_code: status
+                    .map(ShellExitStatus::from_std)
+                    .and_then(|status| status.code),
                 stdout,
                 stderr,
                 duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
@@ -1374,16 +1396,17 @@ impl ShellManager {
         let windows_job = attach_windows_job(&child, original_command);
 
         if let Some(status) = child.wait_timeout(timeout)? {
+            let status = ShellExitStatus::from_std(status);
             #[cfg(windows)]
             terminate_and_close_windows_job(windows_job);
             Ok(ShellResult {
                 task_id: None,
-                status: if status.success() {
+                status: if status.success {
                     ShellStatus::Completed
                 } else {
                     ShellStatus::Failed
                 },
-                exit_code: status.code(),
+                exit_code: status.code,
                 stdout: String::new(),
                 stderr: String::new(),
                 duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
@@ -1413,7 +1436,9 @@ impl ShellManager {
             Ok(ShellResult {
                 task_id: None,
                 status: ShellStatus::TimedOut,
-                exit_code: status.and_then(|s| s.code()),
+                exit_code: status
+                    .map(ShellExitStatus::from_std)
+                    .and_then(|status| status.code),
                 stdout: String::new(),
                 stderr: String::new(),
                 duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
@@ -1923,11 +1948,17 @@ use RUN --mount directives).";
 /// Human-readable exit status for a shell result: the numeric code when the
 /// process returned one, or "terminated by signal" when it did not (rather
 /// than leaking `Some(127)` / `None` Debug output to the user).
-fn exit_code_label(code: Option<i32>) -> String {
-    match code {
-        Some(code) => format!("exit code {code}"),
-        None => "terminated by signal".to_string(),
+fn exit_code_label(code: Option<i64>) -> String {
+    match (code, exit_code_hex(code)) {
+        (Some(code), Some(hex)) => format!("exit code {code} ({hex})"),
+        (Some(code), None) => format!("exit code {code}"),
+        (None, _) => "terminated by signal".to_string(),
     }
+}
+
+fn exit_code_hex(code: Option<i64>) -> Option<String> {
+    code.filter(|code| *code > i64::from(i32::MAX) && *code <= i64::from(u32::MAX))
+        .map(|code| format!("0x{code:08X}"))
 }
 const PYTHON_BUILD_DEPENDENCY_HINT: &str = "Python build dependency missing: setuptools is not \
 available in the active environment. Install the declared build requirements first, for example \
@@ -1938,9 +1969,12 @@ fn attach_cargo_failure_summary(
     command: &str,
     result: &ShellResult,
 ) {
-    if let Some(summary) =
-        summarize_cargo_failure(command, &result.stdout, &result.stderr, result.exit_code)
-    {
+    if let Some(summary) = summarize_cargo_failure(
+        command,
+        &result.stdout,
+        &result.stderr,
+        result.exit_code.and_then(|code| i32::try_from(code).ok()),
+    ) {
         metadata["cargo_failure_summary"] = summary.to_metadata_value();
     }
 }
@@ -2507,7 +2541,7 @@ impl ToolSpec for ExecShellTool {
                         } else {
                             ShellStatus::Failed
                         },
-                        exit_code: Some(output.exit_code),
+                        exit_code: Some(i64::from(output.exit_code)),
                         stdout,
                         stderr,
                         duration_ms: u64::try_from(started.elapsed().as_millis())
@@ -2550,6 +2584,7 @@ impl ToolSpec for ExecShellTool {
 
             let mut metadata = json!({
                 "exit_code": result.exit_code,
+                "exit_code_hex": exit_code_hex(result.exit_code),
                 "status": format!("{:?}", result.status),
                 "duration_ms": result.duration_ms,
                 "sandboxed": true,
@@ -2705,6 +2740,7 @@ impl ToolSpec for ExecShellTool {
 
                 let mut metadata = json!({
                     "exit_code": result.exit_code,
+                    "exit_code_hex": exit_code_hex(result.exit_code),
                     "status": format!("{:?}", result.status),
                     "duration_ms": result.duration_ms,
                     "sandboxed": result.sandboxed,
@@ -2850,6 +2886,7 @@ fn build_shell_delta_tool_result(delta: ShellDeltaResult, context: &ToolContext)
 
     let mut metadata = json!({
         "exit_code": result.exit_code,
+        "exit_code_hex": exit_code_hex(result.exit_code),
         "status": format!("{:?}", result.status),
         "duration_ms": result.duration_ms,
         "sandboxed": result.sandboxed,
@@ -3110,6 +3147,7 @@ impl ToolSpec for ShellCancelTool {
                 "status": format!("{:?}", result.status),
                 "task_id": task_id,
                 "exit_code": result.exit_code,
+                "exit_code_hex": exit_code_hex(result.exit_code),
                 "duration_ms": result.duration_ms,
             })),
         })

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -21,6 +21,37 @@ fn env_lock() -> &'static Mutex<()> {
 
 const BACKGROUND_COMPLETION_WAIT_MS: u64 = 30_000;
 
+#[cfg(not(target_env = "ohos"))]
+#[test]
+fn pty_exit_status_preserves_high_windows_code_losslessly() {
+    let raw = 0xC000_0005;
+    let status = ShellExitStatus::from_pty(portable_pty::ExitStatus::with_exit_code(raw));
+
+    assert!(!status.success);
+    assert_eq!(status.code, Some(i64::from(raw)));
+    assert_eq!(
+        exit_code_label(status.code),
+        "exit code 3221225477 (0xC0000005)"
+    );
+    assert_eq!(exit_code_hex(status.code).as_deref(), Some("0xC0000005"));
+}
+
+#[cfg(not(target_env = "ohos"))]
+#[test]
+fn ordinary_pty_exit_status_keeps_concise_label() {
+    let status = ShellExitStatus::from_pty(portable_pty::ExitStatus::with_exit_code(127));
+
+    assert_eq!(status.code, Some(127));
+    assert_eq!(exit_code_label(status.code), "exit code 127");
+    assert_eq!(exit_code_hex(status.code), None);
+}
+
+#[cfg(windows)]
+#[test]
+fn std_windows_exit_status_reinterprets_signed_dword() {
+    assert_eq!(std_exit_code_i64(0xC000_0005_u32 as i32), 0xC000_0005);
+}
+
 #[cfg(windows)]
 const JOB_OBJECT_QUERY_ACCESS: u32 = 0x0004;
 
@@ -884,6 +915,35 @@ fn shell_delta_result_surfaces_network_restricted_hint() {
             .and_then(Value::as_bool),
         Some(true)
     );
+}
+
+#[test]
+fn shell_delta_result_exposes_lossless_high_exit_code_and_hex() {
+    let tmp = tempdir().expect("tempdir");
+    let ctx = ToolContext::new(tmp.path());
+    let mut result = failed_network_shell_result("", "");
+    result.exit_code = Some(0xC000_0005);
+
+    let tool_result = build_shell_delta_tool_result(
+        ShellDeltaResult {
+            command: "echo probe".to_string(),
+            result,
+            stdout_total_len: 0,
+            stderr_total_len: 0,
+        },
+        &ctx,
+    );
+
+    assert!(
+        tool_result
+            .content
+            .contains("exit code 3221225477 (0xC0000005)"),
+        "{}",
+        tool_result.content
+    );
+    let metadata = tool_result.metadata.expect("metadata");
+    assert_eq!(metadata["exit_code"], json!(3221225477_i64));
+    assert_eq!(metadata["exit_code_hex"], json!("0xC0000005"));
 }
 
 #[test]

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -50,6 +50,9 @@ notes, and relevant issue/PR comments.
 - **[shenyongqing](https://github.com/shenyongqing)** — the original HarmonyOS
   workflow-js bindgen approach (PR #4384), carried into the landed
   implementation with credit
+- **[Luis Mateus Vargas / luismateusvargas](https://github.com/luismateusvargas)**
+  — the Windows hook-process leak reproduction, process-tree analysis, and EOF
+  fix direction (#4489)
 
 </details>
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -53,6 +53,8 @@ notes, and relevant issue/PR comments.
 - **[Luis Mateus Vargas / luismateusvargas](https://github.com/luismateusvargas)**
   — the Windows hook-process leak reproduction, process-tree analysis, and EOF
   fix direction (#4489)
+- **[redjade75723](https://github.com/redjade75723)** — the persistent Windows
+  PTY failure report that exposed lossy high-bit exit-status handling (#4100)
 
 </details>
 


### PR DESCRIPTION
## v0.9.1 runtime-reliability bundle

This draft publishes two related Windows/runtime reliability fixes from the restored v0.9.1 workdown. It addresses the verified hook leak in #4489 and removes the lossy exit-status sentinel that blocked diagnosis of #4100.

### Root causes

- Observer hooks without structured input inherited interactive stdin. Scripts waiting for EOF hung, and timeout cleanup could terminate only the shell while leaving descendant hook processes and pipe readers alive.
- portable-pty returns an unsigned 32-bit process status, but CodeWhale converted it to i32 and saturated every high Windows exception/NTSTATUS to 2147483647. Distinct failures therefore looked identical and persisted in tool/session evidence as a false code.

### Changes

- give stdin-less foreground/background hooks immediate EOF
- start Windows hook shells suspended, attach a kill-on-close Job Object before hook code runs, and fail closed if containment/resume fails
- use Unix process groups, complete process-tree termination, and bounded pipe draining
- preserve the full unsigned Windows PTY/std process status as i64
- show high statuses in decimal plus hexadecimal and expose exit_code_hex in tool metadata
- add stdin-open, descendant-cleanup, high-status, ordinary-status, and metadata regressions
- preserve machine-readable/prose/commit credit for @luismateusvargas (#4489) and @redjade75723 (#4100)

### Local verification on 8f376dd99f126a3402001da94af07508334e76f4

- hook suite: 63 passed
- shell suite: 50 passed
- focused lossless metadata regression passed
- cargo check -p codewhale-tui --bin codewhale-tui --locked
- cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- co-author/author-map gate

### Before ready

GitHub CI must rerun on this exact head, including windows-latest. Issue #4100 remains open after merge until a reporter/device retest returns the real decimal/hex status and establishes whether a separate ConPTY recovery fix is needed; this PR deliberately does not claim diagnostics alone repair the underlying process failure.

Refs #4489.
Refs #4100.