### PR TITLE
fix: close v0.9.1 MCP and Fleet truth gaps

### DIFF
--- a/crates/tui/src/commands/groups/core/acceptance.rs
+++ b/crates/tui/src/commands/groups/core/acceptance.rs
@@ -108,7 +108,7 @@ async fn clear_replaces_prior_transcript_with_visible_confirmation() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn persistent_work_commands_report_visible_dispatch_requests() {
-    run_scenario(PERSISTENT_WORK_SCENARIO, 7).await;
+    run_scenario(PERSISTENT_WORK_SCENARIO, 8).await;
 }
 
 async fn run_scenario(name: &'static str, expected_steps: usize) {

--- a/crates/tui/src/commands/groups/core/fleet.rs
+++ b/crates/tui/src/commands/groups/core/fleet.rs
@@ -31,7 +31,7 @@ impl RegisterCommand for FleetCmd {
                 super::core::subagents(app)
             }
             Some("help" | "?") => CommandResult::message(
-                "Usage: /fleet [roster|setup|status]\n\n/fleet (or /fleet roster) opens Fleet workers and orchestration state — each member's posture, routing, and origin. Use Operate mode when managing delegated work. /fleet setup opens the authoring wizard for a new or overriding profile. /fleet status shows live Fleet worker status; /subagents is a compatibility shortcut for the same status view.",
+                "Usage: /fleet [roster|setup|status]\n\n/fleet (or /fleet roster) opens Fleet workers and orchestration state — each member's posture, routing, and origin. Use Operate mode when managing delegated work. /fleet setup opens the authoring wizard for a new or overriding profile. /fleet status shows sub-agents in the current TUI session; /subagents is a compatibility shortcut for that view. To inspect the persistent .codewhale/fleet.jsonl ledger, run codewhale fleet status in your shell.",
             ),
             Some(other) => CommandResult::error(format!(
                 "Unknown /fleet target '{other}'. Use `/fleet roster`, `/fleet setup`, or `/fleet status`."
@@ -131,6 +131,13 @@ mod tests {
         let message = result.message.as_deref().unwrap_or_default();
         for surface in ["/fleet roster", "/fleet setup", "/fleet status"] {
             assert!(message.contains(surface), "help must describe {surface}");
+        }
+        for truth in [
+            "current TUI session",
+            "codewhale fleet status",
+            ".codewhale/fleet.jsonl",
+        ] {
+            assert!(message.contains(truth), "help must distinguish {truth}");
         }
     }
 

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -1262,6 +1262,17 @@ struct McpToolAdapter {
     pool: std::sync::Arc<tokio::sync::Mutex<crate::mcp::McpPool>>,
 }
 
+fn is_mcp_read_helper(name: &str) -> bool {
+    matches!(
+        name,
+        "list_mcp_resources"
+            | "list_mcp_resource_templates"
+            | "mcp_read_resource"
+            | "read_mcp_resource"
+            | "mcp_get_prompt"
+    )
+}
+
 #[async_trait::async_trait]
 impl ToolSpec for McpToolAdapter {
     fn name(&self) -> &str {
@@ -1281,29 +1292,24 @@ impl ToolSpec for McpToolAdapter {
     fn capabilities(&self) -> Vec<ToolCapability> {
         // Conservatively treat MCP tools as requiring approval and
         // network access unless they're known discovery helpers.
-        let name_lower = self.name.to_lowercase();
-        if name_lower.contains("list_mcp")
-            || name_lower.contains("read_mcp")
-            || name_lower.contains("mcp_read")
-            || name_lower.contains("mcp_get_prompt")
-        {
+        if is_mcp_read_helper(&self.name) {
             vec![ToolCapability::ReadOnly]
         } else {
             vec![ToolCapability::Network, ToolCapability::RequiresApproval]
         }
     }
 
+    fn approval_requirement(&self) -> ApprovalRequirement {
+        if is_mcp_read_helper(&self.name) {
+            ApprovalRequirement::Auto
+        } else {
+            ApprovalRequirement::Required
+        }
+    }
+
     fn defer_loading(&self) -> bool {
         // Discovery helpers stay loaded; everything else is deferred.
-        let keep_loaded = matches!(
-            self.name.as_str(),
-            "list_mcp_resources"
-                | "list_mcp_resource_templates"
-                | "mcp_read_resource"
-                | "read_mcp_resource"
-                | "mcp_get_prompt"
-        );
-        !keep_loaded
+        !is_mcp_read_helper(&self.name)
     }
 
     async fn execute(&self, input: Value, _context: &ToolContext) -> Result<ToolResult, ToolError> {
@@ -1315,6 +1321,21 @@ impl ToolSpec for McpToolAdapter {
         let content = serde_json::to_string(&result).unwrap_or_else(|_| result.to_string());
         Ok(ToolResult::success(content))
     }
+}
+
+#[cfg(test)]
+pub(super) fn mcp_tool_adapter_for_test(name: &str) -> Arc<dyn ToolSpec> {
+    Arc::new(McpToolAdapter {
+        name: name.to_string(),
+        tool: crate::mcp::McpTool {
+            name: name.to_string(),
+            description: None,
+            input_schema: serde_json::json!({"type": "object"}),
+        },
+        pool: Arc::new(tokio::sync::Mutex::new(crate::mcp::McpPool::new(
+            crate::mcp::McpConfig::default(),
+        ))),
+    })
 }
 
 // === Unit Tests ===
@@ -1330,10 +1351,11 @@ mod tests {
     use crate::config::ToolOverride;
     use crate::tools::ToolRegistryBuilder;
     use crate::tools::spec::{
-        ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, required_str,
+        ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
+        required_str,
     };
 
-    use super::ToolRegistry;
+    use super::{ToolRegistry, mcp_tool_adapter_for_test};
 
     /// A simple test tool for unit testing
     struct TestTool {
@@ -1380,6 +1402,49 @@ mod tests {
             name: name.to_string(),
             description: "A test tool".to_string(),
         })
+    }
+
+    #[test]
+    fn mcp_read_helpers_remain_auto_and_eagerly_loaded() {
+        for name in [
+            "list_mcp_resources",
+            "list_mcp_resource_templates",
+            "mcp_read_resource",
+            "read_mcp_resource",
+            "mcp_get_prompt",
+        ] {
+            let adapter = mcp_tool_adapter_for_test(name);
+            assert_eq!(
+                adapter.approval_requirement(),
+                ApprovalRequirement::Auto,
+                "{name} should remain an automatic read helper"
+            );
+            assert!(adapter.is_read_only(), "{name} should remain read-only");
+            assert!(!adapter.defer_loading(), "{name} should remain loaded");
+        }
+    }
+
+    #[test]
+    fn mcp_actions_require_approval_with_exact_helper_matching() {
+        for name in [
+            "mcp_github_create_pull_request",
+            "mcp_github_list_mcp_resources_export",
+            "read_mcp_resource_and_delete",
+        ] {
+            let adapter = mcp_tool_adapter_for_test(name);
+            assert_eq!(
+                adapter.approval_requirement(),
+                ApprovalRequirement::Required,
+                "{name} must not inherit read-helper approval"
+            );
+            assert!(
+                adapter
+                    .capabilities()
+                    .contains(&ToolCapability::RequiresApproval),
+                "{name} should advertise approval gating"
+            );
+            assert!(adapter.defer_loading(), "{name} should remain deferred");
+        }
     }
 
     #[test]

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -5285,6 +5285,62 @@ async fn subagent_registry_blocks_approval_tools_without_parent_auto_approve() {
     );
 }
 
+const MCP_ACTION_TOOL: &str = "mcp_github_create_pull_request";
+
+fn subagent_registry_with_mcp_action(auto_approve: bool) -> SubAgentToolRegistry {
+    let mut runtime = stub_runtime();
+    runtime.context.auto_approve = auto_approve;
+    let mut registry = SubAgentToolRegistry::new(
+        runtime,
+        SubAgentType::General,
+        Some(vec![MCP_ACTION_TOOL.to_string()]),
+        Arc::new(Mutex::new(TodoList::new())),
+        Arc::new(Mutex::new(PlanState::default())),
+    );
+    registry
+        .registry
+        .register(crate::tools::registry::mcp_tool_adapter_for_test(
+            MCP_ACTION_TOOL,
+        ));
+    registry
+}
+
+#[tokio::test]
+async fn subagent_blocks_mcp_action_without_parent_auto_approve() {
+    let registry = subagent_registry_with_mcp_action(false);
+
+    let err = registry
+        .execute("agent_test", MCP_ACTION_TOOL, json!({}))
+        .await
+        .expect_err("non-read MCP actions must require parent auto approval");
+
+    assert!(
+        err.to_string().contains(
+            "requires approval and cannot run inside this sub-agent unless the parent session is auto-approved"
+        ),
+        "unexpected MCP approval error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn auto_approved_subagent_passes_mcp_action_approval_gate() {
+    let registry = subagent_registry_with_mcp_action(true);
+
+    let err = registry
+        .execute("agent_test", MCP_ACTION_TOOL, json!({}))
+        .await
+        .expect_err("the empty test MCP pool should reject execution after the approval gate");
+    let message = err.to_string();
+    assert!(
+        message.contains("MCP tool failed"),
+        "auto approval should reach the MCP adapter, got: {message}"
+    );
+    assert!(
+        !message.contains("requires approval"),
+        "auto-approved MCP actions must not stop at the approval gate: {message}"
+    );
+}
+
 #[tokio::test]
 async fn implementer_delegation_allows_suggest_write_without_parent_auto_approve() {
     // Issue #1828: implementer agents could not write files even when their

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -1116,14 +1116,7 @@ impl FleetSetupView {
                 codewhale_config::MAX_SPAWN_DEPTH_CEILING,
             ),
         );
-        section(
-            &mut lines,
-            "Review policy",
-            format!(
-                "Workers run without a token cap by default · {}s api, {}s heartbeat. Fleet -> exec runs the workers; /fleet status (or /subagents) inspects the ledger.",
-                self.snapshot.api_timeout_secs, self.snapshot.heartbeat_timeout_secs
-            ),
-        );
+        section(&mut lines, "Review policy", self.review_policy_summary());
         section(
             &mut lines,
             "Profile",
@@ -1148,6 +1141,13 @@ impl FleetSetupView {
             .wrap(Wrap { trim: true })
             .scroll((scroll as u16, 0))
             .render(area, buf);
+    }
+
+    fn review_policy_summary(&self) -> String {
+        format!(
+            "Workers run without a token cap by default · {}s api, {}s heartbeat. Fleet -> exec runs the workers. /fleet status (or /subagents) shows sub-agents in the current interactive session; codewhale fleet status reads the persistent .codewhale/fleet.jsonl ledger.",
+            self.snapshot.api_timeout_secs, self.snapshot.heartbeat_timeout_secs
+        )
     }
 }
 
@@ -2296,5 +2296,18 @@ mod tests {
         for needle in ["Workspace", "Review policy", "until you save"] {
             assert!(bottom.contains(needle), "scrolled review missing: {needle}");
         }
+
+        let policy = FleetSetupView::from_snapshot(snapshot()).review_policy_summary();
+        for truth in [
+            "current interactive session",
+            "codewhale fleet status",
+            ".codewhale/fleet.jsonl",
+        ] {
+            assert!(policy.contains(truth), "review policy missing: {truth}");
+        }
+        assert!(
+            !policy.contains("inspects the ledger"),
+            "the interactive status command must not claim to inspect the durable ledger: {policy}"
+        );
     }
 }

--- a/crates/tui/tests/features/core_command_surfaces.feature
+++ b/crates/tui/tests/features/core_command_surfaces.feature
@@ -39,4 +39,5 @@ Feature: Core command visible surfaces
     When the user runs the core command "/rlm 1 inspect command extraction"
     Then the message window should include "Opening persistent RLM context at depth 1"
     When the user runs the core command "/fleet help"
-    Then the message window should include "/fleet status shows live Fleet worker status"
+    Then the message window should include "/fleet status shows sub-agents in the current TUI session"
+    And the message window should include "run codewhale fleet status in your shell"

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -39,13 +39,24 @@ Fleet state is stored under the workspace in `.codewhale/fleet.jsonl`. Worker
 logs and adapter logs are stored under `.codewhale/fleet/` and
 `.codewhale/fleet-host/`.
 
+### Interactive and persistent status
+
+CodeWhale has two similarly named status surfaces with different scopes:
+
+- In the TUI, `/fleet status` (or `/subagents`) shows the sub-agents attached
+  to the current interactive session. It does not read the persistent Fleet
+  ledger.
+- In a shell, `codewhale fleet status` reads durable Fleet run history from
+  the workspace's `.codewhale/fleet.jsonl` ledger.
+
 ## Authoring agent profiles (`/fleet setup`)
 
 `/fleet setup` (also `/fleet setup edit` / `new`) opens an in-TUI wizard for
 authoring a reusable agent-team profile. Bare `/fleet` and the
 `roster`/`roles`/`profiles`/`party` aliases open the roster (the saved profiles).
-`/fleet status` opens the worker-status view; `/subagents` is a
-compatibility shortcut for that status view.
+`/fleet status` opens the current-session worker view; `/subagents` is a
+compatibility shortcut for that view. For durable run history, use the shell
+command `codewhale fleet status` described above.
 
 The wizard is progressive: you make one focused choice at a time — a **role**,
 then a **model** (`inherit`, or a concrete model from *any configured


### PR DESCRIPTION
## What

This v0.9.1 control/truth bundle closes two remaining release gaps in two reviewable commits:

1. `d88772a699004e4133fdb1a09f9530902486cd94` — make MCP adapter approval semantics exact and enforceable in sub-agents.
2. `286f0299297f21fd691698c443a026a70080c47e` — distinguish current-session Fleet status from the persistent Fleet ledger across the setup UI, command help, docs, and tests.

Base: `c75ad62b1eb5f4a0abf6eff4b9fbf7d346992285`  
Head: `286f0299297f21fd691698c443a026a70080c47e`

## Why

### MCP approval control

`McpToolAdapter` advertised `RequiresApproval` for non-read MCP tools but inherited the generic `ToolSpec` default, which mapped those tools to `Auto`. Sub-agent execution consults the adapter's approval requirement, so a non-auto child could otherwise treat an MCP action as automatic.

The adapter now uses one exact allowlist for the five discovery/read helpers across capabilities, deferred loading, and approval. Those helpers remain `Auto`; every other MCP adapter is `Required`. Exact matching also prevents action tools with read-like substrings from being misclassified.

The existing root YOLO behavior is preserved: ordinary MCP actions still pass the generic approval gate when the parent is auto-approved. The explicit `start_mcp_server` safety floor is unchanged.

### Fleet status truth

The profile-writing and validation flow already exists on `main`. The remaining issue was stale copy that conflated `/fleet status` (sub-agents in the current interactive TUI session) with `codewhale fleet status` (persistent history in `.codewhale/fleet.jsonl`). The Review card, `/fleet help`, and `docs/FLEET.md` now state the two scopes directly.

## Verification

- `cargo fmt --all -- --check` — pass
- `git diff --check origin/main...HEAD` — pass
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mcp` — 212 passed, 1 ignored (pre-marked flaky live TCP test)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_setup` — 28 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked fleet_help_arg_returns_usage` — 1 passed
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings` — pass
- Existing root regression `yolo_mode_does_not_prompt_for_mcp_action` passed inside the MCP suite.
- New sub-agent regressions prove `auto_approve=false` blocks the MCP action before execution and `auto_approve=true` reaches the MCP adapter.

## Known base gate / remaining scope

`cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings` currently stops on two pre-existing warnings in untouched base files: `clippy::needless_return` at `crates/tui/src/config/paths.rs:89` and `clippy::items_after_test_module` in `crates/tui/src/test_support.rs`. This branch does not alter either file; the production-bin clippy target is clean.

This bundle intentionally does not change the global `ToolSpec` default, broaden MCP policy beyond the adapter, add Fleet persistence behavior, or rework already-landed Fleet profile authoring.

Closes #3835  
Closes #3935
