### PR TITLE
fix(tui): clear stable 1.96 Clippy blockers

### DIFF
--- a/crates/tui/src/config/paths.rs
+++ b/crates/tui/src/config/paths.rs
@@ -86,7 +86,7 @@ pub(crate) fn canonicalize_or_keep(path: &Path) -> PathBuf {
 pub(crate) fn env_config_path() -> Option<PathBuf> {
     #[cfg(test)]
     {
-        return crate::test_support::with_test_env_lock(env_config_path_unlocked);
+        crate::test_support::with_test_env_lock(env_config_path_unlocked)
     }
     #[cfg(not(test))]
     {

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -141,46 +141,6 @@ impl EnvVarGuard {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::mpsc;
-    use std::time::Duration;
-
-    #[test]
-    fn config_path_read_waits_for_foreign_env_redirect_to_restore() {
-        let (tx, rx) = mpsc::channel();
-        let redirected = std::env::temp_dir().join(format!(
-            "codewhale-config-path-read-barrier-{}",
-            std::process::id()
-        ));
-
-        let reader = {
-            let lock = lock_test_env();
-            let redirect = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &redirected);
-            let reader = std::thread::spawn(move || {
-                tx.send(crate::config_persistence::config_toml_path(None))
-                    .expect("send resolved config path");
-            });
-
-            assert!(
-                rx.recv_timeout(Duration::from_millis(50)).is_err(),
-                "a foreign reader observed the temporary config redirect"
-            );
-            drop(redirect);
-            drop(lock);
-            reader
-        };
-
-        let resolved = rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("reader resumed after the redirect was restored")
-            .expect("resolve config path");
-        reader.join().expect("reader thread");
-        assert_ne!(resolved, redirected);
-    }
-}
-
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // SAFETY: callers hold the process-wide test env mutex until after this
@@ -234,5 +194,45 @@ pub(crate) fn assert_byte_identical(label: &str, a: &str, b: &str) {
             "{label}: prompt construction is non-deterministic — first diff at byte {pos}\n\
              ── side A (±32B) ──\n{a_ctx:?}\n── side B (±32B) ──\n{b_ctx:?}",
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn config_path_read_waits_for_foreign_env_redirect_to_restore() {
+        let (tx, rx) = mpsc::channel();
+        let redirected = std::env::temp_dir().join(format!(
+            "codewhale-config-path-read-barrier-{}",
+            std::process::id()
+        ));
+
+        let reader = {
+            let lock = lock_test_env();
+            let redirect = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &redirected);
+            let reader = std::thread::spawn(move || {
+                tx.send(crate::config_persistence::config_toml_path(None))
+                    .expect("send resolved config path");
+            });
+
+            assert!(
+                rx.recv_timeout(Duration::from_millis(50)).is_err(),
+                "a foreign reader observed the temporary config redirect"
+            );
+            drop(redirect);
+            drop(lock);
+            reader
+        };
+
+        let resolved = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader resumed after the redirect was restored")
+            .expect("resolve config path");
+        reader.join().expect("reader thread");
+        assert_ne!(resolved, redirected);
     }
 }


### PR DESCRIPTION
## Summary

- remove the redundant `return` in the test-only `env_config_path` branch
- move the existing `test_support` test module below all helper items
- restore the stable Rust 1.96 all-target Clippy release gate without changing behavior

## Root cause

Rust/Clippy 1.96 reports `clippy::needless_return` for the test-only config-path expression and `clippy::items_after_test_module` because helper definitions followed the in-file test module. With warnings denied, those two pre-existing lints blocked the exact v0.9.1 release gate.

## Impact

This is a mechanical source-order and expression-style cleanup. Runtime config resolution and test behavior are unchanged.

## Verification

- `rustc 1.96.0 (ac68faa20 2026-05-25)`
- `clippy 0.1.96 (ac68faa20c 2026-05-25)`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked config_path_read_waits_for_foreign_env_redirect_to_restore` — 1 passed
