### PR TITLE
fix(ohos): wrap Windows final links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ site's draft, feed, login, and content-watch boundaries.
 - Keep the Hotbar Setup action list synchronized with keyboard focus when the
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).
+- Route Windows OpenHarmony Cargo links through the repository's target-aware
+  clang launcher so the final Rust link keeps its target, sysroot, and MUSL
+  flags, and extend the no-SDK release guard to protect that contract. This
+  completes [@shenjackyuanjie](https://github.com/shenjackyuanjie)'s PR #4470
+  setup alongside [@shenyongqing](https://github.com/shenyongqing)'s original
+  bindgen approach in PR #4384.
 - Reconcile the website roadmap with reality: the retired share-link
   direction is now an explicit non-goal, Workrooms is the considered
   direction, and the local web client appears as underway, in English and

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -80,6 +80,12 @@ site's draft, feed, login, and content-watch boundaries.
 - Keep the Hotbar Setup action list synchronized with keyboard focus when the
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).
+- Route Windows OpenHarmony Cargo links through the repository's target-aware
+  clang launcher so the final Rust link keeps its target, sysroot, and MUSL
+  flags, and extend the no-SDK release guard to protect that contract. This
+  completes [@shenjackyuanjie](https://github.com/shenjackyuanjie)'s PR #4470
+  setup alongside [@shenyongqing](https://github.com/shenyongqing)'s original
+  bindgen approach in PR #4384.
 - Reconcile the website roadmap with reality: the retired share-link
   direction is now an explicit non-goal, Workrooms is the considered
   direction, and the local web client appears as underway, in English and

--- a/docs/HarmonyOS.md
+++ b/docs/HarmonyOS.md
@@ -46,6 +46,12 @@ CMake toolchain variables for `aarch64-unknown-linux-ohos`. They also point
 `bindgen` at the SDK's `libclang` and sysroot so `rquickjs-sys` can generate
 the OpenHarmony bindings that it does not ship pre-generated.
 
+On Windows, `ohos-env.ps1` points Cargo at the repository's
+`ohos-clang.cmd` launcher. The launcher delegates to `ohos-clang.ps1`, so the
+final Rust link—not only C/C++ compilation and bindgen—always carries
+`-target aarch64-linux-ohos`, the SDK sysroot, and `-D__MUSL__` while preserving
+Cargo's linker arguments and exit status.
+
 ## Compiler Wrappers
 
 For ad-hoc compiler calls, use the wrappers in `scripts/ohos/`. They read the same
@@ -87,11 +93,13 @@ Release prep runs a no-SDK dependency check:
 ./scripts/release/check-ohos-deps.sh
 ```
 
-The guard resolves the `codewhale-tui` dependency graph for
-`aarch64-unknown-linux-ohos` and fails if unsupported host/UI crates re-enter
-the target graph: `nix` 0.28/0.29, `portable-pty`, `starlark`, `arboard`, or
-`keyring`. This does not replace a real SDK/sysroot build, but it catches the
-known `starlark -> rustyline -> nix` and PTY/keyring regressions before release.
+The guard asserts the Windows final-link wrapper contract, proves that OHOS
+activates the `rquickjs-sys` bindgen feature, resolves the `codewhale-tui`
+dependency graph for `aarch64-unknown-linux-ohos`, and fails if unsupported
+host/UI crates re-enter that graph: `nix` 0.28/0.29, `portable-pty`, `starlark`,
+`arboard`, or `keyring`. This no-SDK check does not replace a real SDK/sysroot
+build, but it catches the known linker, bindgen, `starlark -> rustyline -> nix`,
+and PTY/keyring regressions before release.
 
 Because `portable-pty` is intentionally absent from the OpenHarmony graph, the
 persistent `terminal/*` PTY tools are not registered on that target. The

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -72,8 +72,10 @@ generic checklist does not enumerate.
 - [ ] `./scripts/release/check-versions.sh` reports
       `Version state OK: workspace=X.Y.Z, npm=X.Y.Z, lockfile in sync.`
 - [ ] `./scripts/release/check-ohos-deps.sh` reports that the OpenHarmony
-      target graph does not pull the unsupported `nix` 0.28/0.29,
-      `portable-pty`, `starlark`, `arboard`, or `keyring` crates.
+      Windows linker keeps the target/sysroot flags, the target enables the
+      `rquickjs-sys` bindgen edge, and its graph does not pull the unsupported
+      `nix` 0.28/0.29, `portable-pty`, `starlark`, `arboard`, or `keyring`
+      crates.
 
 ## 3. Preflight gates
 

--- a/scripts/ohos-env.ps1
+++ b/scripts/ohos-env.ps1
@@ -16,18 +16,24 @@ if (-not (Test-Path -LiteralPath $env:OHOS_NATIVE_SDK -PathType Container -Error
 }
 
 $sdk = (Resolve-Path -LiteralPath $env:OHOS_NATIVE_SDK -ErrorAction Stop).Path
+$env:OHOS_NATIVE_SDK = $sdk
 $clang = [System.IO.Path]::Combine($sdk, "llvm", "bin", "clang.exe")
 $clangxx = [System.IO.Path]::Combine($sdk, "llvm", "bin", "clang++.exe")
 $ar = [System.IO.Path]::Combine($sdk, "llvm", "bin", "llvm-ar.exe")
 $libclang = [System.IO.Path]::Combine($sdk, "llvm", "bin", "libclang.dll")
 $sysroot = [System.IO.Path]::Combine($sdk, "sysroot")
 $cmakeToolchain = [System.IO.Path]::Combine($sdk, "build", "cmake", "ohos.toolchain.cmake")
+$linker = [System.IO.Path]::Combine($PSScriptRoot, "ohos", "ohos-clang.cmd")
 
 $requiredFiles = @($clang, $clangxx, $ar, $libclang, $cmakeToolchain)
 foreach ($path in $requiredFiles) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf -ErrorAction SilentlyContinue)) {
         Stop-OhosEnv "required OpenHarmony SDK file is missing: $path"
     }
+}
+
+if (-not (Test-Path -LiteralPath $linker -PathType Leaf -ErrorAction SilentlyContinue)) {
+    Stop-OhosEnv "required repository linker wrapper is missing: $linker"
 }
 
 if (-not (Test-Path -LiteralPath $sysroot -PathType Container -ErrorAction SilentlyContinue)) {
@@ -38,7 +44,7 @@ $target = "aarch64_unknown_linux_ohos"
 $targetUpper = "AARCH64_UNKNOWN_LINUX_OHOS"
 $commonFlags = "-target aarch64-linux-ohos --sysroot=`"$sysroot`" -D__MUSL__"
 
-$env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = $clang
+$env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = $linker
 $env:AR_aarch64_unknown_linux_ohos = $ar
 $env:CC_aarch64_unknown_linux_ohos = $clang
 $env:CXX_aarch64_unknown_linux_ohos = $clangxx

--- a/scripts/ohos/ohos-clang.cmd
+++ b/scripts/ohos/ohos-clang.cmd
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+
+set "OHOS_LINKER_SCRIPT=%~dp0ohos-clang.ps1"
+if not exist "%OHOS_LINKER_SCRIPT%" (
+    echo error: OpenHarmony linker script is missing: %OHOS_LINKER_SCRIPT% 1>&2
+    exit /b 1
+)
+
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%OHOS_LINKER_SCRIPT%" %*
+exit /b %ERRORLEVEL%

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -15,6 +15,51 @@ target="${1:-aarch64-unknown-linux-ohos}"
 package="${CODEWHALE_OHOS_DEP_PACKAGE:-codewhale-tui}"
 workflow_js_package="${CODEWHALE_OHOS_WORKFLOW_JS_PACKAGE:-codewhale-workflow-js}"
 
+require_literal() {
+  local file="$1"
+  local literal="$2"
+  local description="$3"
+
+  if ! grep -qF -- "${literal}" "${file}"; then
+    echo "::error::OHOS Windows linker contract lost ${description}: ${file}" >&2
+    return 1
+  fi
+}
+
+# Cargo invokes its configured linker directly. On Windows that entry point
+# must be the repository launcher, not the SDK's bare clang.exe, so the final
+# Rust link receives the OHOS target, sysroot, and musl flags as reliably as C,
+# C++, and bindgen invocations do. This is a static, no-SDK contract check; the
+# launcher delegates to the PowerShell compiler wrapper that validates the SDK
+# and preserves Cargo's linker arguments and exit status.
+require_literal \
+  scripts/ohos-env.ps1 \
+  '$linker = [System.IO.Path]::Combine($PSScriptRoot, "ohos", "ohos-clang.cmd")' \
+  "the repository-local linker launcher"
+require_literal \
+  scripts/ohos-env.ps1 \
+  '$env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = $linker' \
+  "Cargo's target-specific linker assignment"
+require_literal \
+  scripts/ohos/ohos-clang.cmd \
+  'ohos-clang.ps1' \
+  "the cmd-to-PowerShell delegation"
+require_literal \
+  scripts/ohos/ohos-clang.cmd \
+  '-File "%OHOS_LINKER_SCRIPT%" %*' \
+  "linker argument forwarding"
+require_literal \
+  scripts/ohos/ohos-clang.ps1 \
+  '& $clang -target aarch64-linux-ohos "--sysroot=$sysroot" -D__MUSL__ @args' \
+  "the target/sysroot/musl linker flags"
+
+if grep -qF -- '$env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = $clang' scripts/ohos-env.ps1; then
+  echo "::error::OHOS Windows Cargo linker points directly at clang.exe instead of the target-aware wrapper." >&2
+  exit 1
+fi
+
+echo "OHOS Windows linker wrapper contract OK."
+
 cargo_tree_with_retry() {
   local package="$1"
   shift

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -41,6 +41,10 @@ require_literal \
   '$env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = $linker' \
   "Cargo's target-specific linker assignment"
 require_literal \
+  scripts/ohos-env.ps1 \
+  '$env:OHOS_NATIVE_SDK = $sdk' \
+  "the absolute SDK path inherited by Cargo"
+require_literal \
   scripts/ohos/ohos-clang.cmd \
   'ohos-clang.ps1' \
   "the cmd-to-PowerShell delegation"
@@ -49,9 +53,17 @@ require_literal \
   '-File "%OHOS_LINKER_SCRIPT%" %*' \
   "linker argument forwarding"
 require_literal \
+  scripts/ohos/ohos-clang.cmd \
+  'exit /b %ERRORLEVEL%' \
+  "PowerShell exit-status propagation"
+require_literal \
   scripts/ohos/ohos-clang.ps1 \
   '& $clang -target aarch64-linux-ohos "--sysroot=$sysroot" -D__MUSL__ @args' \
   "the target/sysroot/musl linker flags"
+require_literal \
+  scripts/ohos/ohos-clang.ps1 \
+  'exit $LASTEXITCODE' \
+  "native linker exit-status propagation"
 
 if grep -qF -- '$env:CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = $clang' scripts/ohos-env.ps1; then
   echo "::error::OHOS Windows Cargo linker points directly at clang.exe instead of the target-aware wrapper." >&2


### PR DESCRIPTION
## Summary

- point `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER` at a repository-local Windows launcher instead of the SDK's bare `clang.exe`
- delegate that launcher to the existing `ohos-clang.ps1` wrapper so every final Rust link receives `-target aarch64-linux-ohos`, the configured SDK sysroot, and `-D__MUSL__`
- normalize `OHOS_NATIVE_SDK` before Cargo can invoke the wrapper from another working directory
- extend the no-SDK release gate to assert the Windows launcher, argument forwarding, both native exit-status handoffs, SDK-path normalization, rquickjs bindgen feature edge, and dependency graph together
- document the linker path and mirror the credited v0.9.1 changelog entry

## Contributor lineage

This is a follow-up to @shenjackyuanjie's OHOS implementation and validation in #4470, prompted by their Windows final-link review. It preserves @shenyongqing's credit for the original `rquickjs-sys` bindgen approach in #4384. The implementation commit carries @shenjackyuanjie as a GitHub-mappable co-author.

## Exact-head verification

Head: `d4d07abc3ed03d53a9a3bef346e697aa4c151ca4`

- `cargo fmt --all -- --check`
- `bash -n scripts/release/check-ohos-deps.sh`
- `./scripts/release/check-ohos-deps.sh`
  - Windows linker wrapper contract OK
  - OHOS dependency graph OK
  - OHOS `rquickjs-sys` bindgen feature edge OK
- `./scripts/release/check-versions.sh`
- `python3 scripts/check-coauthor-trailers.py --range origin/main..HEAD --check-authors`
- `git diff --check`

## Evidence boundary

This checkout does not have a Windows OpenHarmony SDK or device, so this PR does **not** claim a new live Windows link or device run. The gate statically asserts the complete final-link configuration chain without an SDK; #4470 remains the existing real OHOS build/ELF validation trail. A Windows SDK link of this exact draft head is still welcome before making it ready.