### PR TITLE
fix(auth): isolate xAI device login from Tokio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,10 @@ site's draft, feed, login, and content-watch boundaries.
 - Restore xAI/Grok device-code OAuth login against the live xAI OIDC
   contract: discovery with issuer/endpoint validation and documented
   fallbacks, user-principal scope set, RFC 8628 `slow_down` backoff capped at
-  code expiry, and bounded, sanitized error reporting for denial, expiry, and
-  malformed responses (#4410).
+  code expiry, bounded, sanitized error reporting for denial, expiry, and
+  malformed responses, and a shared blocking-worker boundary for both CLI and
+  TUI login so reqwest's blocking client never creates or drops its private
+  runtime inside Codewhale's Tokio runtime (#4410).
 - Anchor `FREQ=HOURLY` automations with `BYHOUR`/`BYMINUTE` to persisted
   local-calendar slots so intervals keep their wall-clock phase across DST,
   restart, resume, RRULE updates, duplicate-slot recovery, and post-run

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -54,8 +54,10 @@ site's draft, feed, login, and content-watch boundaries.
 - Restore xAI/Grok device-code OAuth login against the live xAI OIDC
   contract: discovery with issuer/endpoint validation and documented
   fallbacks, user-principal scope set, RFC 8628 `slow_down` backoff capped at
-  code expiry, and bounded, sanitized error reporting for denial, expiry, and
-  malformed responses (#4410).
+  code expiry, bounded, sanitized error reporting for denial, expiry, and
+  malformed responses, and a shared blocking-worker boundary for both CLI and
+  TUI login so reqwest's blocking client never creates or drops its private
+  runtime inside Codewhale's Tokio runtime (#4410).
 - Anchor `FREQ=HOURLY` automations with `BYHOUR`/`BYMINUTE` to persisted
   local-calendar slots so intervals keep their wall-clock phase across DST,
   restart, resume, RRULE updates, duplicate-slot recovery, and post-run

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1425,7 +1425,7 @@ async fn run_async_main() -> Result<()> {
             Commands::Login { api_key } => run_login(api_key),
             Commands::Logout => run_logout(),
             Commands::Auth(args) => match args.command {
-                TuiAuthCommand::XaiDevice => run_xai_device_auth(cli.config.as_deref()),
+                TuiAuthCommand::XaiDevice => run_xai_device_auth(cli.config.as_deref()).await,
             },
             Commands::Models(args) => {
                 let config = load_config_from_cli(&cli)?;
@@ -5734,8 +5734,8 @@ fn run_logout() -> Result<()> {
     Ok(())
 }
 
-fn run_xai_device_auth(config_path: Option<&Path>) -> Result<()> {
-    let _credentials = xai_oauth::device_code_login()?;
+async fn run_xai_device_auth(config_path: Option<&Path>) -> Result<()> {
+    let _credentials = xai_oauth::device_code_login().await?;
     let saved =
         config::save_provider_auth_mode_for_at(config::ApiProvider::Xai, "oauth", config_path)?;
     println!(

--- a/crates/tui/src/tools/terminal_session.rs
+++ b/crates/tui/src/tools/terminal_session.rs
@@ -39,6 +39,10 @@ const OUTPUT_LIMIT: usize = 12 * 1024;
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
 #[cfg(unix)]
 const MAX_TIMEOUT_SECS: u64 = 600;
+#[cfg(unix)]
+const CANCEL_CONFIRM_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(unix)]
+const CANCEL_SENTINEL_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 #[cfg(unix)]
 struct TerminalSession {
@@ -471,6 +475,51 @@ fn wait_shared_session(
     }
 }
 
+/// Interrupt a foreground command and wait until the persistent shell confirms
+/// that it is ready again.
+///
+/// Canonical PTYs may flush queued input when they process ETX. Resubmit the
+/// completion sentinel until the shell acknowledges it so a busy host cannot
+/// strand the session merely because the one post-interrupt write raced that
+/// flush.
+#[cfg(unix)]
+fn cancel_shared_session(session: &SharedSession) -> Result<(i32, String), ToolError> {
+    let marker = {
+        let session = session
+            .lock()
+            .map_err(|_| ToolError::execution_failed("terminal session lock poisoned"))?;
+        if session.command.is_none() || completion(&session).is_some() {
+            return Err(ToolError::execution_failed(
+                "terminal session has no running foreground command",
+            ));
+        }
+        write_bytes(&session, &[3]).map_err(ToolError::execution_failed)?;
+        session
+            .command
+            .as_ref()
+            .expect("running command checked above")
+            .marker
+            .clone()
+    };
+    let deadline = Instant::now() + CANCEL_CONFIRM_TIMEOUT;
+
+    loop {
+        std::thread::sleep(CANCEL_SENTINEL_RETRY_INTERVAL);
+        let session = session
+            .lock()
+            .map_err(|_| ToolError::execution_failed("terminal session lock poisoned"))?;
+        if let Some(done) = completion(&session) {
+            return Ok(done);
+        }
+        if Instant::now() >= deadline {
+            return Err(ToolError::execution_failed(
+                "terminal interrupt was sent, but cancellation was not confirmed within 2 seconds",
+            ));
+        }
+        write_completion_sentinel(&session, &marker, 130).map_err(ToolError::execution_failed)?;
+    }
+}
+
 #[cfg(unix)]
 fn session_result(
     session: &mut TerminalSession,
@@ -729,40 +778,11 @@ impl ToolSpec for TerminalCancelTool {
             let name = session_name(&input, true)?.to_string();
             let session = find(&name, &context.workspace).map_err(ToolError::execution_failed)?;
             return tokio::task::spawn_blocking(move || {
-                let marker = {
-                    let session = session.lock().map_err(|_| {
-                        ToolError::execution_failed("terminal session lock poisoned")
-                    })?;
-                    if session.command.is_none() || completion(&session).is_some() {
-                        return Err(ToolError::execution_failed(
-                            "terminal session has no running foreground command",
-                        ));
-                    }
-                    write_bytes(&session, &[3]).map_err(ToolError::execution_failed)?;
-                    session
-                        .command
-                        .as_ref()
-                        .expect("running command checked above")
-                        .marker
-                        .clone()
-                };
-                // Canonical-mode terminals flush queued input on ETX. That can
-                // discard the sentinel originally queued behind the foreground
-                // command, so enqueue it again after the interrupt has reached
-                // the process group. A duplicate sentinel is harmless.
-                std::thread::sleep(Duration::from_millis(50));
-                {
-                    let session = session.lock().map_err(|_| {
-                        ToolError::execution_failed("terminal session lock poisoned")
-                    })?;
-                    write_completion_sentinel(&session, &marker, 130)
-                        .map_err(ToolError::execution_failed)?;
-                }
-                let (done, _) = wait_shared_session(&session, Duration::from_secs(2))?;
+                let done = cancel_shared_session(&session)?;
                 let mut session = session
                     .lock()
                     .map_err(|_| ToolError::execution_failed("terminal session lock poisoned"))?;
-                let mut result = session_result(&mut session, done, false);
+                let mut result = session_result(&mut session, Some(done), false);
                 result.success = true;
                 if let Some(metadata) = result.metadata.as_mut() {
                     metadata["status"] = json!("canceled");
@@ -945,25 +965,16 @@ mod tests {
             let mut guard = worker.lock().unwrap();
             start_command(&mut guard, "sleep 10").unwrap();
         }
-        let started = Instant::now();
         let handle = std::thread::spawn(move || {
             let (done, timed_out) = wait_shared_session(&worker, Duration::from_secs(30)).unwrap();
             let mut guard = worker.lock().unwrap();
             session_result(&mut guard, done, timed_out)
         });
         std::thread::sleep(Duration::from_millis(150));
-        let marker = {
-            let guard = session.lock().unwrap();
-            write_bytes(&guard, &[3]).unwrap();
-            guard.command.as_ref().unwrap().marker.clone()
-        };
-        std::thread::sleep(Duration::from_millis(50));
-        write_completion_sentinel(&session.lock().unwrap(), &marker, 130).unwrap();
-        let _ = handle.join().unwrap();
-        assert!(
-            started.elapsed() < Duration::from_secs(3),
-            "cancel was blocked behind the foreground waiter"
-        );
+        let done = cancel_shared_session(&session).unwrap();
+        let result = handle.join().unwrap();
+        assert_eq!(done.0, 130);
+        assert_eq!(result.metadata.as_ref().unwrap()["exit_code"], 130);
         assert!(
             run(&session, "printf alive", Duration::from_secs(3))
                 .content

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -13179,7 +13179,7 @@ async fn run_xai_device_login_from_tui(
         app.use_mouse_capture,
         app.use_bracketed_paste,
     )?;
-    let login_result = tokio::task::block_in_place(crate::xai_oauth::device_code_login);
+    let login_result = crate::xai_oauth::device_code_login().await;
     resume_terminal(
         terminal,
         app.use_alt_screen,

--- a/crates/tui/src/xai_oauth.rs
+++ b/crates/tui/src/xai_oauth.rs
@@ -261,7 +261,7 @@ pub fn get_credentials() -> Result<XaiOAuthCredentials> {
 /// Public residual entry point for CLI/TUI wiring (`codewhale auth` /
 /// slash command). Call from a headless or TUI surface that can print the
 /// verification URL.
-pub fn device_code_login() -> Result<XaiOAuthCredentials> {
+pub async fn device_code_login() -> Result<XaiOAuthCredentials> {
     let issuer = std::env::var("GROK_OIDC_ISSUER")
         .or_else(|_| std::env::var("XAI_OIDC_ISSUER"))
         .unwrap_or_else(|_| XAI_OIDC_ISSUER.to_string());
@@ -274,7 +274,21 @@ pub fn device_code_login() -> Result<XaiOAuthCredentials> {
     let auth_path = auth_file_path();
     let open_browser = std::env::var_os("CODEWHALE_XAI_OAUTH_NO_BROWSER").is_none();
 
-    device_code_login_with(&issuer, &client_id, &scopes, &auth_path, open_browser)
+    device_code_login_on_blocking_thread(issuer, client_id, scopes, auth_path, open_browser).await
+}
+
+async fn device_code_login_on_blocking_thread(
+    issuer: String,
+    client_id: String,
+    scopes: String,
+    auth_path: PathBuf,
+    open_browser: bool,
+) -> Result<XaiOAuthCredentials> {
+    tokio::task::spawn_blocking(move || {
+        device_code_login_with(&issuer, &client_id, &scopes, &auth_path, open_browser)
+    })
+    .await
+    .context("xAI device-code login worker failed")?
 }
 
 fn device_code_login_with(
@@ -986,7 +1000,7 @@ mod tests {
         assert_eq!(XAI_OIDC_ISSUER, "https://auth.x.ai");
         assert_eq!(GROK_OIDC_CLIENT_ID.len(), 36);
         // Keep device_code_login referenced so the residual entry point stays linked.
-        let _ = device_code_login as fn() -> Result<XaiOAuthCredentials>;
+        let _ = device_code_login;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1014,6 +1028,47 @@ mod tests {
                 token_endpoint: format!("{}/oauth2/token-advertised", server.uri()),
             }
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn device_login_discovery_request_is_safe_inside_tokio_runtime() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "issuer": server.uri(),
+                "device_authorization_endpoint": format!("{}/oauth2/device-advertised", server.uri()),
+                "token_endpoint": format!("{}/oauth2/token-advertised", server.uri())
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/device-advertised"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "invalid_scope",
+                "error_description": "mock refusal before browser or polling"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let auth_dir = TempDir::new().unwrap();
+        let auth_path = auth_dir.path().join("unused-auth.json");
+        let error = device_code_login_on_blocking_thread(
+            server.uri(),
+            "test-public-client".to_string(),
+            "openid".to_string(),
+            auth_path.clone(),
+            false,
+        )
+        .await
+        .expect_err("mock device request must fail without a runtime-drop panic");
+        let message = format!("{error:#}");
+
+        assert!(message.contains("invalid_scope"), "{message}");
+        assert!(message.contains("HTTP 400"), "{message}");
+        assert!(!auth_path.exists());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- run the synchronous reqwest device discovery, request, browser handoff, polling, and persistence flow on Tokio's blocking pool behind one async xAI login entry point
- make both `codewhale auth xai-device` and the TUI provider flow await that shared boundary
- add a multi-thread Tokio regression that reaches loopback OIDC discovery and the advertised device endpoint, then fails before browser/polling/persistence
- extend the existing v0.9.1 #4410 changelog entry without replacing its provenance

## Root cause

reqwest 0.13's blocking client owns a private Tokio runtime. The CLI previously built and dropped that client directly inside Codewhale's `#[tokio::main]` runtime, so the live command panicked before it could display a device code. The TUI had a separate `block_in_place` workaround. A single `spawn_blocking` boundary now owns the complete synchronous workflow for both callers.

## Exact-head verification

Head: `31b148878b9600c78cd988c76cc6afd5b6966aaf`
Base: `8ab67a0bc03ac78406677339f3e4e3714e138885`

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features --locked`
- terminal cancellation regression stress — 100/100 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked xai_oauth -- --nocapture` — 26 passed
- `cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings`
- `./scripts/release/check-versions.sh`
- `./scripts/release/check-ohos-deps.sh`
- `python3 scripts/check-coauthor-trailers.py --range origin/main..HEAD --check-authors`
- actual `cargo run -p codewhale-tui --bin codewhale-tui --locked -- auth xai-device` against a process-local OIDC server: discovery GET and advertised device POST completed; the CLI returned the mock HTTP 400 `invalid_scope` error with no panic

The exact head also hardens the pre-existing macOS PTY cancellation race exposed by CI: cancellation confirmation is retried within the existing two-second contract and fails closed if the shell never acknowledges it. This was also observed in CI runs `29604840054` and `29544532601`.

No real xAI login or endpoint was used. The dogfood server refused the device request before any browser launch, token polling, or auth-file write.

Fixes #4410