### PR TITLE
feat(release): publish native Windows ARM64 artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:1.7.7
+        uses: docker://rhysd/actionlint:1.7.12
         with:
           # SC2129 (grouped redirects) is style-only and endemic to the
           # existing GITHUB_ENV/GITHUB_OUTPUT append pattern; SC2221/SC2222

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: Nightly
 
 # Scheduled nightly artifact build. This used to run on every push to main,
-# rebuilding five release targets per merge; PR CI already builds/tests the
+# rebuilding six release targets per merge; PR CI already builds/tests the
 # same commits on macOS/Windows and CNB covers Linux, so a daily cadence
 # keeps the artifact stream fresh without burning ~28 runner-minutes per
 # merge. Use workflow_dispatch for an on-demand build.
@@ -34,6 +34,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             platform: linux-x64
             cli_binary: codewhale
+            shim_binary: codew
             tui_binary: codewhale-tui
             cli_artifact: codewhale-linux-x64
             tui_artifact: codewhale-tui-linux-x64
@@ -41,6 +42,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64
             cli_binary: codewhale
+            shim_binary: codew
             tui_binary: codewhale-tui
             cli_artifact: codewhale-linux-arm64
             tui_artifact: codewhale-tui-linux-arm64
@@ -48,6 +50,7 @@ jobs:
             target: x86_64-apple-darwin
             platform: macos-x64
             cli_binary: codewhale
+            shim_binary: codew
             tui_binary: codewhale-tui
             cli_artifact: codewhale-macos-x64
             tui_artifact: codewhale-tui-macos-x64
@@ -55,6 +58,7 @@ jobs:
             target: aarch64-apple-darwin
             platform: macos-arm64
             cli_binary: codewhale
+            shim_binary: codew
             tui_binary: codewhale-tui
             cli_artifact: codewhale-macos-arm64
             tui_artifact: codewhale-tui-macos-arm64
@@ -62,9 +66,18 @@ jobs:
             target: x86_64-pc-windows-msvc
             platform: windows-x64
             cli_binary: codewhale.exe
+            shim_binary: codew.exe
             tui_binary: codewhale-tui.exe
             cli_artifact: codewhale-windows-x64.exe
             tui_artifact: codewhale-tui-windows-x64.exe
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            platform: windows-arm64
+            cli_binary: codewhale.exe
+            shim_binary: codew.exe
+            tui_binary: codewhale-tui.exe
+            cli_artifact: codewhale-windows-arm64.exe
+            tui_artifact: codewhale-tui-windows-arm64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -72,8 +85,6 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - name: Install Rust target
-        run: rustup target add --toolchain stable ${{ matrix.target }}
       - uses: mozilla-actions/sccache-action@v0.0.10
         id: sccache
         continue-on-error: true
@@ -116,6 +127,14 @@ jobs:
           done
           echo "Build failed after 3 attempts" >&2
           exit 1
+      - name: Smoke native ARM binaries
+        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-pc-windows-msvc'
+        shell: bash
+        run: |
+          bin_dir="target/${{ matrix.target }}/release"
+          "${bin_dir}/${{ matrix.cli_binary }}" --version
+          "${bin_dir}/${{ matrix.shim_binary }}" --version
+          "${bin_dir}/${{ matrix.tui_binary }}" --version
       - name: Stage artifact
         id: stage
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
             cli_artifact: codewhale-linux-x64
             shim_artifact: codew-linux-x64
             tui_artifact: codewhale-tui-linux-x64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platform: linux-arm64
             cli_binary: codewhale
@@ -221,6 +221,15 @@ jobs:
             cli_artifact: codewhale-windows-x64.exe
             shim_artifact: codew-windows-x64.exe
             tui_artifact: codewhale-tui-windows-x64.exe
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            platform: windows-arm64
+            cli_binary: codewhale.exe
+            shim_binary: codew.exe
+            tui_binary: codewhale-tui.exe
+            cli_artifact: codewhale-windows-arm64.exe
+            shim_artifact: codew-windows-arm64.exe
+            tui_artifact: codewhale-tui-windows-arm64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -230,8 +239,6 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - name: Install Rust target
-        run: rustup target add --toolchain stable ${{ matrix.target }}
       - uses: mozilla-actions/sccache-action@v0.0.10
         id: sccache
         # A cache bootstrap failure must degrade to an uncached build, never
@@ -247,8 +254,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-bin: false
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install Linux ARM64 system dependencies
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           for i in 1 2 3 4 5; do
             sudo apt-get update && break
@@ -264,21 +271,6 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add --toolchain stable x86_64-unknown-linux-musl
           cargo build --release --locked --target x86_64-unknown-linux-musl -p codewhale-cli -p codewhale-tui
-      - name: Install AArch64 cross-compilation toolchain
-        if: matrix.target == 'aarch64-unknown-linux-gnu' && runner.os == 'Linux'
-        run: |
-          . /etc/os-release
-          sudo tee /etc/apt/sources.list.d/arm64.sources <<SRC
-          Types: deb
-          URIs: http://ports.ubuntu.com/ubuntu-ports/
-          Suites: ${UBUNTU_CODENAME} ${UBUNTU_CODENAME}-updates ${UBUNTU_CODENAME}-security
-          Components: main universe
-          Architectures: arm64
-          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          SRC
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/arm64.sources -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0
-          sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross libdbus-1-dev:arm64 pkg-config
       - name: Configure Android NDK linker
         if: matrix.target == 'aarch64-linux-android' && runner.os == 'Linux'
         shell: bash
@@ -328,11 +320,15 @@ jobs:
         shell: bash
         env:
           DEEPSEEK_BUILD_SHA: ${{ needs.resolve.outputs.sha }}
-          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          PKG_CONFIG_ALLOW_CROSS: 1
-          PKG_CONFIG_LIBDIR_aarch64_unknown_linux_gnu: /usr/lib/aarch64-linux-gnu/pkgconfig
         run: cargo build --release --locked --target ${{ matrix.target }} -p codewhale-cli -p codewhale-tui
+      - name: Smoke native ARM binaries
+        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-pc-windows-msvc'
+        shell: bash
+        run: |
+          bin_dir="target/${{ matrix.target }}/release"
+          "${bin_dir}/${{ matrix.cli_binary }}" --version
+          "${bin_dir}/${{ matrix.shim_binary }}" --version
+          "${bin_dir}/${{ matrix.tui_binary }}" --version
       - name: Stage binaries
         shell: bash
         run: |
@@ -388,7 +384,7 @@ jobs:
           : > "$MANIFEST"
 
           bundle() {
-            local platform="$1"   # linux-x64, linux-arm64, android-arm64, macos-x64, macos-arm64, windows-x64
+            local platform="$1"   # linux-x64, linux-arm64, android-arm64, macos-x64, macos-arm64, windows-x64, windows-arm64
             local cli_src="$2"    # artifact name for codewhale binary
             local shim_src="$3"   # artifact name for codew shim
             local tui_src="$4"    # artifact name for codewhale-tui binary
@@ -465,6 +461,12 @@ jobs:
             codewhale-windows-x64.exe codew-windows-x64.exe codewhale-tui-windows-x64.exe zip ""
           bundle windows-x64 \
             codewhale-windows-x64.exe codew-windows-x64.exe codewhale-tui-windows-x64.exe zip "portable"
+
+          # Platform: windows-arm64 (standard + portable)
+          bundle windows-arm64 \
+            codewhale-windows-arm64.exe codew-windows-arm64.exe codewhale-tui-windows-arm64.exe zip ""
+          bundle windows-arm64 \
+            codewhale-windows-arm64.exe codew-windows-arm64.exe codewhale-tui-windows-arm64.exe zip "portable"
 
           echo ""
           echo "=== Archive checksums ==="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ site's draft, feed, login, and content-watch boundaries.
   of this narrow route until Codewhale supports per-model wire selection
   (#1481 by @seanthefuturegorilla; implementation harvested from PR #773 by
   @zhangweiii and PR #1050 by @sternelee).
+- Publish native Windows ARM64 `codewhale`, `codew`, and `codewhale-tui`
+  binaries, npm selection, updater support, and standard/portable release
+  archives. Build and smoke them on GitHub's native Windows 11 ARM runner,
+  and move Linux ARM64 release builds to the native Ubuntu ARM runner to
+  remove the slower multi-arch cross-link setup (#4267 by @w1w218).
 
 ### Fixed
 
@@ -85,6 +90,13 @@ site's draft, feed, login, and content-watch boundaries.
   (#4380).
 - Avoid blocked reader joins after Windows process kills so terminated shell
   sessions cannot hang their readers (#4383).
+- Give stdin-less observer hooks immediate EOF and contain timed-out hook
+  process trees so descendants and pipe readers cannot leak after the parent
+  shell exits (#4489 by @luismateusvargas).
+- Preserve the full unsigned Windows PTY process status instead of collapsing
+  every high-bit exception or NTSTATUS to `2147483647`, including decimal and
+  hexadecimal diagnostic metadata for device retests (#4100 by
+  @redjade75723).
 - Keep the Hotbar Setup action list synchronized with keyboard focus when the
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).
@@ -128,6 +140,13 @@ Thank you to the contributors whose code, reports, and reviews shaped v0.9.1:
   (PR #4470).
 - [@shenyongqing](https://github.com/shenyongqing) — the original HarmonyOS
   bindgen approach (PR #4384), carried into the landed implementation.
+- [@luismateusvargas](https://github.com/luismateusvargas) — the Windows hook
+  process-leak reproduction, process-tree analysis, and EOF fix direction
+  (#4489).
+- [@redjade75723](https://github.com/redjade75723) — the persistent Windows PTY
+  report that exposed lossy high-bit process-status handling (#4100).
+- [@w1w218](https://github.com/w1w218) — the Windows ARM64 release request and
+  real-device motivation (#4267).
 
 ## [0.9.0] - 2026-07-16
 

--- a/crates/cli/src/update.rs
+++ b/crates/cli/src/update.rs
@@ -2078,6 +2078,7 @@ mod tests {
             ("codewhale", "macos", "x86_64", "codewhale-macos-x64"),
             ("codewhale", "linux", "x86_64", "codewhale-linux-x64"),
             ("codewhale", "windows", "x86_64", "codewhale-windows-x64"),
+            ("codewhale", "windows", "aarch64", "codewhale-windows-arm64"),
             (
                 "codewhale-tui",
                 "macos",
@@ -2337,10 +2338,12 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
             { "name": "codewhale-macos-arm64",        "browser_download_url": "https://example.invalid/codewhale-macos-arm64" },
             { "name": "codewhale-windows-x64.exe",    "browser_download_url": "https://example.invalid/codewhale-windows-x64.exe" },
             { "name": "codewhale-windows-x64.exe.sha256", "browser_download_url": "https://example.invalid/codewhale-windows-x64.exe.sha256" },
+            { "name": "codewhale-windows-arm64.exe",  "browser_download_url": "https://example.invalid/codewhale-windows-arm64.exe" },
             { "name": "codewhale-tui-linux-x64",      "browser_download_url": "https://example.invalid/codewhale-tui-linux-x64" },
             { "name": "codewhale-tui-macos-x64",      "browser_download_url": "https://example.invalid/codewhale-tui-macos-x64" },
             { "name": "codewhale-tui-macos-arm64",    "browser_download_url": "https://example.invalid/codewhale-tui-macos-arm64" },
-            { "name": "codewhale-tui-windows-x64.exe","browser_download_url": "https://example.invalid/codewhale-tui-windows-x64.exe" }
+            { "name": "codewhale-tui-windows-x64.exe","browser_download_url": "https://example.invalid/codewhale-tui-windows-x64.exe" },
+            { "name": "codewhale-tui-windows-arm64.exe","browser_download_url": "https://example.invalid/codewhale-tui-windows-arm64.exe" }
           ]
         }"#;
         serde_json::from_str(json).expect("mock release JSON")
@@ -2354,6 +2357,7 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
             ("macos", "x86_64", "codewhale-macos-x64"),
             ("linux", "x86_64", "codewhale-linux-x64"),
             ("windows", "x86_64", "codewhale-windows-x64.exe"),
+            ("windows", "aarch64", "codewhale-windows-arm64.exe"),
         ];
 
         for (os, arch, expected) in cases {
@@ -2374,6 +2378,12 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
         );
         let asset = select_platform_asset(&release, &stem).expect("TUI platform asset");
         assert_eq!(asset.name, "codewhale-tui-macos-arm64");
+
+        let windows_stem =
+            release_asset_stem_for(Path::new("C:\\codewhale-tui.exe"), "windows", "aarch64");
+        let windows_asset =
+            select_platform_asset(&release, &windows_stem).expect("Windows ARM64 TUI asset");
+        assert_eq!(windows_asset.name, "codewhale-tui-windows-arm64.exe");
     }
 
     #[test]
@@ -2458,6 +2468,17 @@ E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855  *codewhale-win
         assert!(
             select_platform_asset(&release, "codewhale-tui-windows-x64")
                 .is_some_and(|asset| asset.name == "codewhale-tui-windows-x64.exe")
+        );
+
+        let arm_release = release_from_mirror_base_url(
+            "https://mirror.example/releases/v0.9.1",
+            "v0.9.1",
+            "windows",
+            "aarch64",
+        );
+        assert!(
+            select_platform_asset(&arm_release, "codewhale-windows-arm64")
+                .is_some_and(|asset| asset.name == "codewhale-windows-arm64.exe")
         );
     }
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -40,6 +40,11 @@ site's draft, feed, login, and content-watch boundaries.
   of this narrow route until Codewhale supports per-model wire selection
   (#1481 by @seanthefuturegorilla; implementation harvested from PR #773 by
   @zhangweiii and PR #1050 by @sternelee).
+- Publish native Windows ARM64 `codewhale`, `codew`, and `codewhale-tui`
+  binaries, npm selection, updater support, and standard/portable release
+  archives. Build and smoke them on GitHub's native Windows 11 ARM runner,
+  and move Linux ARM64 release builds to the native Ubuntu ARM runner to
+  remove the slower multi-arch cross-link setup (#4267 by @w1w218).
 
 ### Fixed
 
@@ -85,6 +90,13 @@ site's draft, feed, login, and content-watch boundaries.
   (#4380).
 - Avoid blocked reader joins after Windows process kills so terminated shell
   sessions cannot hang their readers (#4383).
+- Give stdin-less observer hooks immediate EOF and contain timed-out hook
+  process trees so descendants and pipe readers cannot leak after the parent
+  shell exits (#4489 by @luismateusvargas).
+- Preserve the full unsigned Windows PTY process status instead of collapsing
+  every high-bit exception or NTSTATUS to `2147483647`, including decimal and
+  hexadecimal diagnostic metadata for device retests (#4100 by
+  @redjade75723).
 - Keep the Hotbar Setup action list synchronized with keyboard focus when the
   selection moves beyond the visible rows, including Down past `/export`
   (#4418).
@@ -128,6 +140,13 @@ Thank you to the contributors whose code, reports, and reviews shaped v0.9.1:
   (PR #4470).
 - [@shenyongqing](https://github.com/shenyongqing) — the original HarmonyOS
   bindgen approach (PR #4384), carried into the landed implementation.
+- [@luismateusvargas](https://github.com/luismateusvargas) — the Windows hook
+  process-leak reproduction, process-tree analysis, and EOF fix direction
+  (#4489).
+- [@redjade75723](https://github.com/redjade75723) — the persistent Windows PTY
+  report that exposed lossy high-bit process-status handling (#4100).
+- [@w1w218](https://github.com/w1w218) — the Windows ARM64 release request and
+  real-device motivation (#4267).
 
 ## [0.9.0] - 2026-07-16
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -245,6 +245,11 @@ const REQUIRED_RELEASE_ASSETS: &[&str] = &[
     "codewhale-windows-x64.exe",
     "codewhale-windows-x64-portable.zip",
     "codewhale-windows-x64.zip",
+    "codew-windows-arm64.exe",
+    "codewhale-tui-windows-arm64.exe",
+    "codewhale-windows-arm64.exe",
+    "codewhale-windows-arm64-portable.zip",
+    "codewhale-windows-arm64.zip",
 ];
 
 fn is_session_approved_for_tool(app: &App, tool_name: &str, grouping_key: &str) -> bool {

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -55,6 +55,9 @@ notes, and relevant issue/PR comments.
   fix direction (#4489)
 - **[redjade75723](https://github.com/redjade75723)** — the persistent Windows
   PTY failure report that exposed lossy high-bit exit-status handling (#4100)
+- **[w1w218](https://github.com/w1w218)** — the Windows ARM64 release request
+  and cross-compilation report that led to native release, npm, updater, and
+  archive support (#4267)
 
 </details>
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,6 +37,7 @@ onward. Linux RISC-V prebuilts are temporarily paused because the locked
 | macOS        | x64          |     ✅      |       ✅        | `codewhale-macos-x64`, `codew-macos-x64`, `codewhale-tui-macos-x64`        |
 | macOS        | arm64 (M-series) | ✅      |       ✅        | `codewhale-macos-arm64`, `codew-macos-arm64`, `codewhale-tui-macos-arm64`    |
 | Windows      | x64          |     ✅      |       ✅        | `codewhale-windows-x64.exe`, `codew-windows-x64.exe`, `codewhale-tui-windows-x64.exe` |
+| Windows      | arm64        |     ✅      |       ✅        | `codewhale-windows-arm64.exe`, `codew-windows-arm64.exe`, `codewhale-tui-windows-arm64.exe` |
 | Linux x64 on musl (Alpine) | ✅ (static) |    ✅      |       ✅        | static `codewhale-tui-linux-x64` (musl) asset           |
 | Other Linux (musl non-x64, other arches) | — | ❌¹ | ✅² | build from source                                     |
 | FreeBSD / OpenBSD              | — |   ❌      |       ✅²       | build from source                                     |
@@ -510,6 +511,11 @@ when you need the newest version immediately.
 A standalone NSIS-based installer is available starting with v0.8.50 for
 Windows users who prefer a traditional double-click setup (no npm, no Scoop, no
 Cargo required).
+
+The NSIS installer currently contains the Windows x64 binaries. Windows ARM64
+users should install through npm running under native ARM64 Node.js or download
+`codewhale-windows-arm64.zip` from the same release; both paths then use native
+ARM64 binaries.
 
 **Download** `CodeWhaleSetup.exe` from the
 [Releases page](https://github.com/Hmbown/CodeWhale/releases/latest).

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -232,7 +232,7 @@ The publish helper is idempotent for reruns: already-published crate versions ar
 `.github/workflows/release.yml` builds these binaries:
 
 - `codewhale-*` CLI binaries for Linux x64/arm64, Android arm64, macOS
-  x64/arm64, and Windows x64
+  x64/arm64, and Windows x64/arm64
 - `codewhale-tui-*` TUI binaries for the same target matrix
 - `codew-*` shortcut binaries for the same target matrix
 - `codewhale.bat` for the Windows npm launcher

--- a/npm/codewhale/README.md
+++ b/npm/codewhale/README.md
@@ -67,7 +67,7 @@ Prebuilt binaries for the GitHub release are downloaded automatically:
 - Linux arm64
 - Android arm64 (Termux)
 - macOS x64 / arm64
-- Windows x64
+- Windows x64 / arm64
 
 HarmonyOS PC (`openharmony`) is treated as `linux`, so it gets the Linux
 binaries matching your CPU architecture (x64 or arm64). Linux riscv64 prebuilts

--- a/npm/codewhale/scripts/artifacts.js
+++ b/npm/codewhale/scripts/artifacts.js
@@ -23,6 +23,8 @@ const BUNDLE_ASSET_NAMES = [
   "codewhale-macos-arm64.tar.gz",
   "codewhale-windows-x64.zip",
   "codewhale-windows-x64-portable.zip",
+  "codewhale-windows-arm64.zip",
+  "codewhale-windows-arm64-portable.zip",
 ];
 
 const ASSET_MATRIX = {
@@ -39,6 +41,7 @@ const ASSET_MATRIX = {
   },
   win32: {
     x64: ["codewhale-windows-x64.exe", "codewhale-tui-windows-x64.exe", "codew-windows-x64.exe", "codewhale.bat"],
+    arm64: ["codewhale-windows-arm64.exe", "codewhale-tui-windows-arm64.exe", "codew-windows-arm64.exe"],
   },
 };
 

--- a/npm/codewhale/test/artifacts.test.js
+++ b/npm/codewhale/test/artifacts.test.js
@@ -68,6 +68,7 @@ test("known platforms are unaffected by alias map", () => {
     ["linux", "x64", "codewhale-linux-x64"],
     ["darwin", "arm64", "codewhale-macos-arm64"],
     ["win32", "x64", "codewhale-windows-x64.exe"],
+    ["win32", "arm64", "codewhale-windows-arm64.exe"],
   ]) {
     withMockedOs(platform, arch, () => {
       const { detectBinaryNames } = require(ARTIFACTS_PATH);
@@ -75,6 +76,19 @@ test("known platforms are unaffected by alias map", () => {
       assert.equal(result.codewhale, expectedCodeWhale);
     });
   }
+});
+
+test("Windows arm64 resolves the complete native binary family", () => {
+  withMockedOs("win32", "arm64", () => {
+    const { detectBinaryNames } = require(ARTIFACTS_PATH);
+    assert.deepEqual(detectBinaryNames(), {
+      platform: "win32",
+      arch: "arm64",
+      codewhale: "codewhale-windows-arm64.exe",
+      tui: "codewhale-tui-windows-arm64.exe",
+      codew: "codew-windows-arm64.exe",
+    });
+  });
 });
 
 test("linux riscv64 reports the temporary upstream binding blocker", () => {
@@ -108,12 +122,16 @@ test("release asset inventory includes binaries, archives, installer, and manife
   assert.ok(assetNames.includes("codewhale-tui-windows-x64.exe"));
   assert.ok(assetNames.includes("codew-windows-x64.exe"));
   assert.ok(assetNames.includes("codewhale.bat"));
+  assert.ok(assetNames.includes("codewhale-windows-arm64.exe"));
+  assert.ok(assetNames.includes("codewhale-tui-windows-arm64.exe"));
+  assert.ok(assetNames.includes("codew-windows-arm64.exe"));
   assert.ok(assetNames.includes("codewhale-android-arm64"));
   assert.ok(assetNames.includes("codewhale-tui-android-arm64"));
   assert.ok(assetNames.includes("codew-android-arm64"));
   assert.ok(!assetNames.includes("codewhale-linux-riscv64"));
   assert.ok(releaseAssetNames.includes("codew-windows-x64.exe"));
   assert.ok(releaseAssetNames.includes("codewhale.bat"));
+  assert.ok(releaseAssetNames.includes("codew-windows-arm64.exe"));
   assert.ok(releaseAssetNames.includes("codew-android-arm64"));
   for (const bundle of BUNDLE_ASSET_NAMES) {
     assert.ok(releaseAssetNames.includes(bundle));

--- a/scripts/release/generate-release-body.sh
+++ b/scripts/release/generate-release-body.sh
@@ -80,6 +80,8 @@ Each archive below contains the \`codewhale\` dispatcher, \`codew\` shim, and \`
 | Windows x64 (installer) | \`CodeWhaleSetup.exe\` | NSIS setup |
 | Windows x64 | \`codewhale-windows-x64.zip\` | \`install.bat\` |
 | Windows x64 (portable) | \`codewhale-windows-x64-portable.zip\` | — |
+| Windows ARM64 | \`codewhale-windows-arm64.zip\` | \`install.bat\` |
+| Windows ARM64 (portable) | \`codewhale-windows-arm64-portable.zip\` | — |
 
 **Unix (Linux / macOS):**
 \`\`\`bash
@@ -90,7 +92,8 @@ cd codewhale-<platform>
 
 **Windows:**
 - For the installer path, run \`CodeWhaleSetup.exe\`; it installs \`codewhale.exe\`, \`codew.exe\`, and \`codewhale-tui.exe\` under \`%LOCALAPPDATA%\\Programs\\CodeWhale\\bin\` and adds that directory to the current-user PATH.
-- Extract \`codewhale-windows-x64.zip\`
+- Extract the archive for your machine: \`codewhale-windows-x64.zip\` or
+  \`codewhale-windows-arm64.zip\`
 - Run \`install.bat\` (copies to \`%USERPROFILE%\\bin\`)
 - Add \`%USERPROFILE%\\bin\` to your PATH
 

--- a/scripts/release/generate-release-body.test.sh
+++ b/scripts/release/generate-release-body.test.sh
@@ -28,6 +28,7 @@ grep -Fq -- "## Contributors" <<<"${body}"
 grep -Fq -- "[@example](https://github.com/example)" <<<"${body}"
 grep -Fq -- 'codewhale-home:/home/codewhale/.codewhale' <<<"${body}"
 grep -Fq -- 'codewhale-android-arm64.tar.gz' <<<"${body}"
+grep -Fq -- 'codewhale-windows-arm64.zip' <<<"${body}"
 grep -Fq -- 'The image ships the `codewhale` dispatcher, `codew` shim, and `codewhale-tui` runtime.' <<<"${body}"
 if grep -Fq -- "### Contributors" <<<"${body}"; then
   echo "nested contributor heading leaked into generated release body" >&2

--- a/web/components/install-binary.tsx
+++ b/web/components/install-binary.tsx
@@ -1,9 +1,49 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import {
+  detectFromBrowserSignals,
+  type Arch,
+  type UserAgentArchitecture,
+} from "@/lib/install-platform";
 import { InstallCodeBlock } from "./install-code-block";
 
-type Arch = "macos-arm64" | "macos-x64" | "linux-x64" | "linux-arm64" | "windows-x64";
+function windowsSnippet(arch: "x64" | "arm64"): string {
+  return `# PowerShell
+$ErrorActionPreference = "Stop"
+$dest = "$Env:USERPROFILE\\bin"
+New-Item -ItemType Directory -Force $dest | Out-Null
+$manifest = Invoke-WebRequest https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+
+Invoke-WebRequest \`
+  -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-windows-${arch}.exe \`
+  -OutFile "$dest\\codewhale.exe"
+Invoke-WebRequest \`
+  -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-windows-${arch}.exe \`
+  -OutFile "$dest\\codewhale-tui.exe"
+
+$expected = @{}
+$manifest.Content -split "\`n" | ForEach-Object {
+  $parts = $_.Trim() -split "\\s+"
+  if ($parts.Length -ge 2) { $expected[$parts[1]] = $parts[0].ToUpperInvariant() }
+}
+if ((Get-FileHash "$dest\\codewhale.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-windows-${arch}.exe"]) { throw "codewhale.exe checksum mismatch" }
+if ((Get-FileHash "$dest\\codewhale-tui.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-tui-windows-${arch}.exe"]) { throw "codewhale-tui.exe checksum mismatch" }
+
+$Env:Path = "$dest;$Env:Path"`;
+}
+
+function windowsVerify(arch: "x64" | "arm64"): string {
+  return `# PowerShell
+$manifest = Invoke-WebRequest https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
+$expected = @{}
+$manifest.Content -split "\`n" | ForEach-Object {
+  $parts = $_.Trim() -split "\\s+"
+  if ($parts.Length -ge 2) { $expected[$parts[1]] = $parts[0].ToUpperInvariant() }
+}
+if ((Get-FileHash "$Env:USERPROFILE\\bin\\codewhale.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-windows-${arch}.exe"]) { throw "codewhale.exe checksum mismatch" }
+if ((Get-FileHash "$Env:USERPROFILE\\bin\\codewhale-tui.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-tui-windows-${arch}.exe"]) { throw "codewhale-tui.exe checksum mismatch" }`;
+}
 
 const SNIPPETS: Record<Arch, string> = {
   "macos-arm64": `curl -fsSL -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
@@ -40,28 +80,8 @@ curl -fsSL -o codewhale-tui \\
 grep -E ' (codewhale|codewhale-tui)-linux-arm64$' codewhale-artifacts-sha256.txt | sha256sum -c -
 chmod +x codewhale codewhale-tui
 sudo mv codewhale codewhale-tui /usr/local/bin/`,
-  "windows-x64": `# PowerShell
-$ErrorActionPreference = "Stop"
-$dest = "$Env:USERPROFILE\\bin"
-New-Item -ItemType Directory -Force $dest | Out-Null
-$manifest = Invoke-WebRequest https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
-
-Invoke-WebRequest \`
-  -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-windows-x64.exe \`
-  -OutFile "$dest\\codewhale.exe"
-Invoke-WebRequest \`
-  -Uri https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-tui-windows-x64.exe \`
-  -OutFile "$dest\\codewhale-tui.exe"
-
-$expected = @{}
-$manifest.Content -split "\`n" | ForEach-Object {
-  $parts = $_.Trim() -split "\\s+"
-  if ($parts.Length -ge 2) { $expected[$parts[1]] = $parts[0].ToUpperInvariant() }
-}
-if ((Get-FileHash "$dest\\codewhale.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-windows-x64.exe"]) { throw "codewhale.exe checksum mismatch" }
-if ((Get-FileHash "$dest\\codewhale-tui.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-tui-windows-x64.exe"]) { throw "codewhale-tui.exe checksum mismatch" }
-
-$Env:Path = "$dest;$Env:Path"`,
+  "windows-x64": windowsSnippet("x64"),
+  "windows-arm64": windowsSnippet("arm64"),
 };
 
 const VERIFY: Record<Arch, string> = {
@@ -69,15 +89,8 @@ const VERIFY: Record<Arch, string> = {
   "macos-x64": `grep -E ' (codewhale|codewhale-tui)-macos-x64$' codewhale-artifacts-sha256.txt | shasum -a 256 -c -`,
   "linux-x64": `grep -E ' (codewhale|codewhale-tui)-linux-x64$' codewhale-artifacts-sha256.txt | sha256sum -c -`,
   "linux-arm64": `grep -E ' (codewhale|codewhale-tui)-linux-arm64$' codewhale-artifacts-sha256.txt | sha256sum -c -`,
-  "windows-x64": `# PowerShell
-$manifest = Invoke-WebRequest https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhale-artifacts-sha256.txt
-$expected = @{}
-$manifest.Content -split "\`n" | ForEach-Object {
-  $parts = $_.Trim() -split "\\s+"
-  if ($parts.Length -ge 2) { $expected[$parts[1]] = $parts[0].ToUpperInvariant() }
-}
-if ((Get-FileHash "$Env:USERPROFILE\\bin\\codewhale.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-windows-x64.exe"]) { throw "codewhale.exe checksum mismatch" }
-if ((Get-FileHash "$Env:USERPROFILE\\bin\\codewhale-tui.exe" -Algorithm SHA256).Hash -ne $expected["codewhale-tui-windows-x64.exe"]) { throw "codewhale-tui.exe checksum mismatch" }`,
+  "windows-x64": windowsVerify("x64"),
+  "windows-arm64": windowsVerify("arm64"),
 };
 
 const LABELS: Record<Arch, string> = {
@@ -86,17 +99,30 @@ const LABELS: Record<Arch, string> = {
   "linux-x64": "Linux · x64",
   "linux-arm64": "Linux · arm64",
   "windows-x64": "Windows · x64",
+  "windows-arm64": "Windows · arm64",
 };
 
-function detect(): Arch {
+interface NavigatorWithUserAgentData extends Navigator {
+  userAgentData?: {
+    getHighEntropyValues(hints: string[]): Promise<UserAgentArchitecture>;
+  };
+}
+
+async function detect(): Promise<Arch> {
   if (typeof navigator === "undefined") return "macos-arm64";
-  const ua = navigator.userAgent.toLowerCase();
-  if (ua.includes("win")) return "windows-x64";
-  if (ua.includes("linux")) {
-    if (ua.includes("aarch64") || ua.includes("arm64")) return "linux-arm64";
-    return "linux-x64";
+  const browserNavigator = navigator as NavigatorWithUserAgentData;
+  let architecture: UserAgentArchitecture | undefined;
+  if (navigator.userAgent.toLowerCase().includes("win")) {
+    try {
+      architecture = await browserNavigator.userAgentData?.getHighEntropyValues([
+        "architecture",
+        "bitness",
+      ]);
+    } catch {
+      // The manual platform buttons and frozen-UA fallback remain available.
+    }
   }
-  return "macos-arm64";
+  return detectFromBrowserSignals(navigator.userAgent, architecture);
 }
 
 interface Props {
@@ -108,7 +134,15 @@ interface Props {
 export function InstallBinary({ copyLabel, copiedLabel, verifyHeading = "Verify checksum" }: Props) {
   const [arch, setArch] = useState<Arch>("macos-arm64");
 
-  useEffect(() => { setArch(detect()); }, []);
+  useEffect(() => {
+    let active = true;
+    void detect().then((detected) => {
+      if (active) setArch(detected);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   return (
     <div>

--- a/web/lib/install-platform.test.ts
+++ b/web/lib/install-platform.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { detectFromBrowserSignals } from "./install-platform";
+
+describe("install platform detection", () => {
+  const frozenWindowsUa =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+
+  it("uses User-Agent Client Hints for native Windows ARM64", () => {
+    expect(
+      detectFromBrowserSignals(frozenWindowsUa, {
+        architecture: "arm",
+        bitness: "64",
+      }),
+    ).toBe("windows-arm64");
+  });
+
+  it("keeps frozen Windows user agents on x64 without an ARM hint", () => {
+    expect(detectFromBrowserSignals(frozenWindowsUa)).toBe("windows-x64");
+  });
+
+  it("retains the legacy ARM token fallback", () => {
+    expect(detectFromBrowserSignals("Mozilla/5.0 (Windows NT 10.0; ARM64)")).toBe(
+      "windows-arm64",
+    );
+  });
+});

--- a/web/lib/install-platform.ts
+++ b/web/lib/install-platform.ts
@@ -1,0 +1,37 @@
+export type Arch =
+  | "macos-arm64"
+  | "macos-x64"
+  | "linux-x64"
+  | "linux-arm64"
+  | "windows-x64"
+  | "windows-arm64";
+
+export interface UserAgentArchitecture {
+  architecture?: string;
+  bitness?: string;
+}
+
+export function detectFromBrowserSignals(
+  userAgent: string,
+  userAgentArchitecture?: UserAgentArchitecture,
+): Arch {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("win")) {
+    const architecture = userAgentArchitecture?.architecture?.toLowerCase();
+    const bitness = userAgentArchitecture?.bitness;
+    if (
+      architecture === "arm64" ||
+      (architecture === "arm" && bitness === "64") ||
+      ua.includes("aarch64") ||
+      ua.includes("arm64")
+    ) {
+      return "windows-arm64";
+    }
+    return "windows-x64";
+  }
+  if (ua.includes("linux")) {
+    if (ua.includes("aarch64") || ua.includes("arm64")) return "linux-arm64";
+    return "linux-x64";
+  }
+  return "macos-arm64";
+}

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -25,6 +25,9 @@ export const RELEASE_CONTRIBUTORS: string[] = [
   "@shenyongqing",
   "@sternelee",
   "@nightt5879",
+  "@luismateusvargas",
+  "@redjade75723",
+  "@w1w218",
   "@zhangweiii",
 ];
 


### PR DESCRIPTION
## Summary

- publish native Windows ARM64 `codewhale`, `codew`, and `codewhale-tui` binaries plus standard and portable ZIPs
- select and update the ARM64 binary family through npm, the built-in updater, release inventory, docs, and website install UI
- build and smoke Windows ARM64 and Linux ARM64 on GitHub native hosted runners
- replace the slower Linux ARM cross-link setup, remove redundant matrix target installs, and update actionlint for the hosted ARM runner label
- preserve @w1w218 credit from the originating request

Closes #4267.

## Exact local gates

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui version_hint_requires_complete_release_assets --locked`
- `cargo test -p codewhale-cli update::tests --locked` (64 passed)
- npm wrapper tests (43 passed)
- release-body fixture test
- web tests (76 passed), facts/docs checks, ESLint, and production build
- actionlint 1.7.12 across all workflows
- `git diff --check`

The PR remains draft until exact-head hosted CI and an on-demand Nightly run prove the native Windows and Linux ARM jobs and uploaded artifacts.