### PR TITLE
feat(tui): adopt the Blue Stage semantic palette

### DIFF
--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -65,7 +65,7 @@ impl Theme {
             section_border_type: BorderType::Plain,
             section_border_color: palette::BORDER_COLOR,
             section_bg: palette::WHALE_BG,
-            section_title_color: palette::WHALE_ACCENT_PRIMARY,
+            section_title_color: palette::WHALE_ACTION,
             // Horizontal padding only. `Padding::uniform(1)` ate two rows of
             // each sidebar panel — for compact terminals where Work/Tasks/Agents
             // get ~3 rows total via the 25% layout split, that left zero rows
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(theme.variant, Variant::Dark);
         assert_eq!(theme.section_border_color, palette::BORDER_COLOR);
         assert_eq!(theme.section_bg, palette::WHALE_BG);
-        assert_eq!(theme.section_title_color, palette::WHALE_ACCENT_PRIMARY);
+        assert_eq!(theme.section_title_color, palette::WHALE_ACTION);
         assert_eq!(theme.tool_title_color, palette::TEXT_SOFT);
         assert_eq!(theme.tool_value_color, palette::TEXT_MUTED);
         assert_eq!(theme.tool_label_color, palette::TEXT_DIM);

--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -1,9 +1,9 @@
-//! Whale terminal theme tokens (legacy module path).
+//! Codewhale terminal theme tokens (legacy module path).
 //!
 //! A small, deliberately flat module that names the color, border, and
-//! padding choices the TUI is making. Values follow the Blue Stage semantic
-//! grammar exposed by [`crate::palette`], keeping the older module path for
-//! source compatibility.
+//! padding choices the TUI is making. Values follow the semantic grammar
+//! exposed by [`crate::palette`], keeping the older module path for source
+//! compatibility.
 //!
 //! The only consumers today are the plan and tool cell renderers in
 //! [`crate::tui::history`] and the sidebar section chrome in
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn dark_theme_uses_blue_stage_semantic_roles() {
+    fn dark_theme_uses_codewhale_semantic_roles() {
         let theme = Theme::dark();
         assert_eq!(theme.variant, Variant::Dark);
         assert_eq!(theme.section_border_color, palette::BORDER_COLOR);

--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -1,10 +1,9 @@
-//! Whale/DeepSeek terminal theme tokens.
+//! Whale terminal theme tokens (legacy module path).
 //!
 //! A small, deliberately flat module that names the color, border, and
-//! padding choices the TUI is already making. All values match the dark
-//! palette previously hard-coded against [`crate::palette`]; a single
-//! source-of-truth change here can swap the skin later. Visible output
-//! is not changed by introducing this module.
+//! padding choices the TUI is making. Values follow the Blue Stage semantic
+//! grammar exposed by [`crate::palette`], keeping the older module path for
+//! source compatibility.
 //!
 //! The only consumers today are the plan and tool cell renderers in
 //! [`crate::tui::history`] and the sidebar section chrome in
@@ -77,13 +76,13 @@ impl Theme {
             tool_value_color: palette::TEXT_MUTED,
             tool_label_color: palette::TEXT_DIM,
             tool_running_accent: palette::ACCENT_TOOL_LIVE,
-            tool_success_accent: palette::TEXT_DIM,
-            tool_failed_accent: palette::ACCENT_TOOL_ISSUE,
+            tool_success_accent: palette::STATUS_SUCCESS,
+            tool_failed_accent: palette::STATUS_ERROR,
             plan_progress_color: palette::STATUS_SUCCESS,
             plan_summary_color: palette::TEXT_MUTED,
             plan_explanation_color: palette::TEXT_DIM,
             plan_pending_color: palette::TEXT_MUTED,
-            plan_in_progress_color: palette::STATUS_WARNING,
+            plan_in_progress_color: palette::WHALE_HUMAN,
             plan_completed_color: palette::STATUS_SUCCESS,
         }
     }
@@ -97,20 +96,20 @@ impl Theme {
             section_border_type: BorderType::Plain,
             section_border_color: palette::LIGHT_BORDER,
             section_bg: palette::LIGHT_PANEL,
-            section_title_color: palette::WHALE_ACCENT_PRIMARY,
+            section_title_color: palette::LIGHT_ACTION,
             section_padding: Padding::horizontal(1),
             tool_title_color: palette::LIGHT_TEXT_SOFT,
             tool_value_color: palette::LIGHT_TEXT_MUTED,
             tool_label_color: palette::LIGHT_TEXT_HINT,
-            tool_running_accent: palette::WHALE_ACCENT_PRIMARY,
-            tool_success_accent: palette::LIGHT_TEXT_HINT,
-            tool_failed_accent: palette::WHALE_ERROR,
-            plan_progress_color: palette::WHALE_ACCENT_PRIMARY,
+            tool_running_accent: palette::LIGHT_LIVE,
+            tool_success_accent: palette::LIGHT_SUCCESS_FG,
+            tool_failed_accent: palette::LIGHT_DANGER,
+            plan_progress_color: palette::LIGHT_SUCCESS_FG,
             plan_summary_color: palette::LIGHT_TEXT_MUTED,
             plan_explanation_color: palette::LIGHT_TEXT_HINT,
             plan_pending_color: palette::LIGHT_TEXT_MUTED,
-            plan_in_progress_color: Color::Rgb(180, 83, 9),
-            plan_completed_color: palette::WHALE_ACCENT_PRIMARY,
+            plan_in_progress_color: palette::LIGHT_HUMAN,
+            plan_completed_color: palette::LIGHT_SUCCESS_FG,
         }
     }
 
@@ -232,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn dark_theme_matches_existing_palette_choices() {
+    fn dark_theme_uses_blue_stage_semantic_roles() {
         let theme = Theme::dark();
         assert_eq!(theme.variant, Variant::Dark);
         assert_eq!(theme.section_border_color, palette::BORDER_COLOR);
@@ -242,8 +241,9 @@ mod tests {
         assert_eq!(theme.tool_value_color, palette::TEXT_MUTED);
         assert_eq!(theme.tool_label_color, palette::TEXT_DIM);
         assert_eq!(theme.tool_running_accent, palette::ACCENT_TOOL_LIVE);
-        assert_eq!(theme.tool_success_accent, palette::TEXT_DIM);
-        assert_eq!(theme.tool_failed_accent, palette::ACCENT_TOOL_ISSUE);
+        assert_eq!(theme.tool_success_accent, palette::STATUS_SUCCESS);
+        assert_eq!(theme.tool_failed_accent, palette::STATUS_ERROR);
+        assert_eq!(theme.plan_in_progress_color, palette::WHALE_HUMAN);
     }
 
     #[test]
@@ -254,6 +254,9 @@ mod tests {
         assert_eq!(theme.section_border_color, palette::LIGHT_BORDER);
         assert_eq!(theme.tool_title_color, palette::LIGHT_TEXT_SOFT);
         assert_eq!(theme.tool_value_color, palette::LIGHT_TEXT_MUTED);
+        assert_eq!(theme.section_title_color, palette::LIGHT_ACTION);
+        assert_eq!(theme.tool_running_accent, palette::LIGHT_LIVE);
+        assert_eq!(theme.tool_success_accent, palette::LIGHT_SUCCESS_FG);
         assert_eq!(theme.plan_summary_color, palette::LIGHT_TEXT_MUTED);
     }
 

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3028,7 +3028,7 @@ async fn run_doctor(
     use crate::palette;
     use colored::Colorize;
 
-    let (accent_r, accent_g, accent_b) = palette::WHALE_ACCENT_PRIMARY_RGB;
+    let (accent_r, accent_g, accent_b) = palette::WHALE_HUMAN_RGB;
     let (sky_r, sky_g, sky_b) = palette::WHALE_INFO_RGB;
     let (aqua_r, aqua_g, aqua_b) = palette::WHALE_INFO_RGB;
     let (red_r, red_g, red_b) = palette::WHALE_ERROR_RGB;
@@ -5578,7 +5578,8 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     use colored::Colorize;
     use session_manager::{SessionManager, format_session_line};
 
-    let (accent_r, accent_g, accent_b) = palette::WHALE_ACCENT_PRIMARY_RGB;
+    let (action_r, action_g, action_b) = palette::WHALE_ACTION_RGB;
+    let (human_r, human_g, human_b) = palette::WHALE_HUMAN_RGB;
     let (sky_r, sky_g, sky_b) = palette::WHALE_INFO_RGB;
     let (aqua_r, aqua_g, aqua_b) = palette::WHALE_INFO_RGB;
 
@@ -5594,7 +5595,7 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
         println!("{}", "No sessions found.".truecolor(sky_r, sky_g, sky_b));
         println!(
             "Start a new session with: {}",
-            "codewhale".truecolor(accent_r, accent_g, accent_b)
+            "codewhale".truecolor(human_r, human_g, human_b)
         );
         return Ok(());
     }
@@ -5602,7 +5603,7 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     println!(
         "{}",
         "Saved Sessions"
-            .truecolor(accent_r, accent_g, accent_b)
+            .truecolor(action_r, action_g, action_b)
             .bold()
     );
     println!("{}", "==============".truecolor(sky_r, sky_g, sky_b));
@@ -5629,12 +5630,12 @@ fn list_sessions(limit: usize, search: Option<String>) -> Result<()> {
     println!();
     println!(
         "Resume with: {} {}",
-        sessions_resume_command().truecolor(accent_r, accent_g, accent_b),
+        sessions_resume_command().truecolor(action_r, action_g, action_b),
         "<session-id>".dimmed()
     );
     println!(
         "Continue latest in this workspace: {}",
-        "codewhale --continue".truecolor(accent_r, accent_g, accent_b)
+        "codewhale --continue".truecolor(action_r, action_g, action_b)
     );
 
     Ok(())

--- a/crates/tui/src/palette/adapt.rs
+++ b/crates/tui/src/palette/adapt.rs
@@ -41,11 +41,11 @@ fn adapt_fg_for_light_palette(color: Color) -> Color {
         LIGHT_BORDER
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         LIGHT_LIVE
-    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_INFO || color == WHALE_ACTION {
         LIGHT_ACTION
     } else if color == MODE_AGENT {
         LIGHT_UI_THEME.mode_agent
-    } else if color == WHALE_HUMAN {
+    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
         LIGHT_HUMAN
     } else if color == MODE_PLAN {
         LIGHT_UI_THEME.mode_plan
@@ -114,11 +114,11 @@ fn adapt_fg_for_solarized_light_palette(color: Color) -> Color {
         SOLARIZED_BORDER
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         SOLARIZED_CYAN
-    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_INFO || color == WHALE_ACTION {
         SOLARIZED_BLUE
     } else if color == MODE_AGENT {
         SOLARIZED_LIGHT_UI_THEME.mode_agent
-    } else if color == WHALE_HUMAN {
+    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
         SOLARIZED_ORANGE
     } else if color == MODE_PLAN {
         SOLARIZED_LIGHT_UI_THEME.mode_plan
@@ -252,11 +252,11 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
         ui.border
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         ui.status_working
-    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_INFO || color == WHALE_ACTION {
         ui.accent_primary
     } else if color == MODE_AGENT {
         ui.mode_agent
-    } else if color == WHALE_HUMAN {
+    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
         ui.accent_action
     } else if color == MODE_PLAN {
         ui.mode_plan
@@ -542,7 +542,7 @@ fn raw_semantic_foreground_role(color: Color) -> Option<SemanticForegroundRole> 
         Some(SemanticForegroundRole::Action)
     } else if color == WHALE_LIVE || color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         Some(SemanticForegroundRole::Live)
-    } else if color == WHALE_HUMAN {
+    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
         Some(SemanticForegroundRole::Human)
     } else if color == STATUS_WARNING {
         Some(SemanticForegroundRole::Warning)
@@ -572,6 +572,9 @@ fn theme_semantic_foreground_role(color: Color, ui: &UiTheme) -> Option<Semantic
     } else if color == ui.status_working
         || color == ui.accent_secondary
         || color == ui.tool_running
+        // `UiTheme::info` is the sky/worker lane used by ambient and live
+        // surfaces. Several shipped themes intentionally alias it to their
+        // working color, so it must not precede the live buckets.
         || color == ui.info
     {
         Some(SemanticForegroundRole::Live)

--- a/crates/tui/src/palette/adapt.rs
+++ b/crates/tui/src/palette/adapt.rs
@@ -3,7 +3,7 @@
 use ratatui::style::Color;
 
 use super::detect::PaletteMode;
-use super::themes::{ThemeId, UiTheme};
+use super::themes::{LIGHT_UI_THEME, SOLARIZED_LIGHT_UI_THEME, ThemeId, UiTheme};
 use super::tokens::*;
 
 #[must_use]
@@ -41,16 +41,18 @@ fn adapt_fg_for_light_palette(color: Color) -> Color {
         LIGHT_LIVE
     } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
         LIGHT_ACTION
-    } else if color == WHALE_HUMAN || color == MODE_PLAN {
+    } else if color == MODE_AGENT {
+        LIGHT_UI_THEME.mode_agent
+    } else if color == WHALE_HUMAN {
         LIGHT_HUMAN
+    } else if color == MODE_PLAN {
+        LIGHT_UI_THEME.mode_plan
     } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
         Color::Rgb(146, 64, 14)
-    } else if color == ACCENT_TOOL_ISSUE
-        || color == WHALE_ERROR
-        || color == STATUS_ERROR
-        || color == MODE_YOLO
-    {
+    } else if color == ACCENT_TOOL_ISSUE || color == WHALE_ERROR || color == STATUS_ERROR {
         LIGHT_DANGER
+    } else if color == MODE_YOLO {
+        LIGHT_UI_THEME.mode_yolo
     } else if color == STATUS_WARNING {
         LIGHT_WARNING
     } else if color == STATUS_SUCCESS {
@@ -112,19 +114,18 @@ fn adapt_fg_for_solarized_light_palette(color: Color) -> Color {
         SOLARIZED_CYAN
     } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
         SOLARIZED_BLUE
-    } else if color == WHALE_HUMAN
-        || color == MODE_PLAN
-        || color == STATUS_WARNING
-        || color == TEXT_REASONING
-        || color == ACCENT_REASONING_LIVE
-    {
+    } else if color == MODE_AGENT {
+        SOLARIZED_LIGHT_UI_THEME.mode_agent
+    } else if color == WHALE_HUMAN {
         SOLARIZED_ORANGE
-    } else if color == ACCENT_TOOL_ISSUE
-        || color == WHALE_ERROR
-        || color == STATUS_ERROR
-        || color == MODE_YOLO
-    {
+    } else if color == MODE_PLAN {
+        SOLARIZED_LIGHT_UI_THEME.mode_plan
+    } else if color == STATUS_WARNING || color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
+        SOLARIZED_ORANGE
+    } else if color == ACCENT_TOOL_ISSUE || color == WHALE_ERROR || color == STATUS_ERROR {
         SOLARIZED_RED
+    } else if color == MODE_YOLO {
+        SOLARIZED_LIGHT_UI_THEME.mode_yolo
     } else if color == DIFF_ADDED || color == USER_BODY || color == STATUS_SUCCESS {
         SOLARIZED_GREEN
     } else if color == MODE_OPERATE {
@@ -249,22 +250,24 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
         ui.border
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         ui.status_working
-    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY || color == MODE_AGENT {
+    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
         ui.accent_primary
-    } else if color == WHALE_HUMAN || color == MODE_PLAN {
+    } else if color == MODE_AGENT {
+        ui.mode_agent
+    } else if color == WHALE_HUMAN {
         ui.accent_action
+    } else if color == MODE_PLAN {
+        ui.mode_plan
     } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
         if theme == ThemeId::Matrix {
             Color::Rgb(0x00, 0x55, 0x00) // #005500
         } else {
             ui.mode_plan
         }
-    } else if color == ACCENT_TOOL_ISSUE
-        || color == STATUS_ERROR
-        || color == WHALE_ERROR
-        || color == MODE_YOLO
-    {
+    } else if color == ACCENT_TOOL_ISSUE || color == STATUS_ERROR || color == WHALE_ERROR {
         ui.error_fg
+    } else if color == MODE_YOLO {
+        ui.mode_yolo
     } else if color == STATUS_WARNING {
         ui.warning
     } else if color == STATUS_SUCCESS {

--- a/crates/tui/src/palette/adapt.rs
+++ b/crates/tui/src/palette/adapt.rs
@@ -3,7 +3,9 @@
 use ratatui::style::Color;
 
 use super::detect::PaletteMode;
-use super::themes::{LIGHT_UI_THEME, SOLARIZED_LIGHT_UI_THEME, ThemeId, UiTheme};
+use super::themes::{
+    GRAYSCALE_UI_THEME, LIGHT_UI_THEME, SOLARIZED_LIGHT_UI_THEME, ThemeId, UiTheme,
+};
 use super::tokens::*;
 
 #[must_use]
@@ -323,13 +325,29 @@ fn adapt_fg_for_grayscale_palette(color: Color) -> Color {
     if color == Color::Reset {
         return color;
     }
-    if color == TEXT_BODY
+    // Resolved grayscale mode slots are already final palette colors. Keep
+    // this branch ahead of the luma buckets so a direct `UiTheme` call site is
+    // idempotent instead of being adapted a second time.
+    if color == GRAYSCALE_UI_THEME.mode_agent
+        || color == GRAYSCALE_UI_THEME.mode_plan
+        || color == GRAYSCALE_UI_THEME.mode_operate
+        || color == GRAYSCALE_UI_THEME.mode_yolo
+    {
+        color
+    } else if color == MODE_AGENT {
+        GRAYSCALE_UI_THEME.mode_agent
+    } else if color == MODE_PLAN {
+        GRAYSCALE_UI_THEME.mode_plan
+    } else if color == MODE_OPERATE {
+        GRAYSCALE_UI_THEME.mode_operate
+    } else if color == MODE_YOLO {
+        GRAYSCALE_UI_THEME.mode_yolo
+    } else if color == TEXT_BODY
         || color == SELECTION_TEXT
         || color == LIGHT_TEXT_BODY
         || color == Color::White
         || color == WHALE_ERROR
         || color == STATUS_ERROR
-        || color == MODE_YOLO
     {
         GRAYSCALE_TEXT_BODY
     } else if color == TEXT_SOFT
@@ -341,7 +359,6 @@ fn adapt_fg_for_grayscale_palette(color: Color) -> Color {
         || color == ACCENT_TOOL_LIVE
         || color == STATUS_SUCCESS
         || color == STATUS_INFO
-        || color == MODE_AGENT
     {
         GRAYSCALE_TEXT_SOFT
     } else if color == TEXT_SECONDARY
@@ -350,7 +367,6 @@ fn adapt_fg_for_grayscale_palette(color: Color) -> Color {
         || color == TEXT_REASONING
         || color == ACCENT_REASONING_LIVE
         || color == STATUS_WARNING
-        || color == MODE_PLAN
         || color == USER_BODY
         || color == LIGHT_USER_BODY
         || color == DIFF_ADDED
@@ -477,6 +493,122 @@ pub enum ColorDepth {
     TrueColor,
 }
 
+/// Foreground roles that must remain distinct after the terminal reduces the
+/// palette. RGB proximity is deliberately irrelevant here: action and Operate,
+/// or a human ask and a warning, are different product states even when their
+/// source hues happen to share a nearest ANSI color.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SemanticForegroundRole {
+    Action,
+    Live,
+    Human,
+    Warning,
+    Danger,
+    Success,
+    ModeAgent,
+    ModePlan,
+    ModeOperate,
+    ModeYolo,
+}
+
+impl SemanticForegroundRole {
+    #[must_use]
+    const fn ansi16(self) -> Color {
+        match self {
+            Self::Action => Color::LightBlue,
+            Self::Live => Color::LightCyan,
+            Self::Human => Color::LightYellow,
+            Self::Warning => Color::Yellow,
+            Self::Danger => Color::LightRed,
+            Self::Success => Color::LightGreen,
+            Self::ModeAgent => Color::Blue,
+            Self::ModePlan => Color::Magenta,
+            Self::ModeOperate => Color::LightMagenta,
+            Self::ModeYolo => Color::Red,
+        }
+    }
+}
+
+fn raw_semantic_foreground_role(color: Color) -> Option<SemanticForegroundRole> {
+    if color == MODE_AGENT {
+        Some(SemanticForegroundRole::ModeAgent)
+    } else if color == MODE_PLAN {
+        Some(SemanticForegroundRole::ModePlan)
+    } else if color == MODE_OPERATE {
+        Some(SemanticForegroundRole::ModeOperate)
+    } else if color == MODE_YOLO {
+        Some(SemanticForegroundRole::ModeYolo)
+    } else if color == WHALE_ACTION || color == WHALE_INFO || color == STATUS_INFO {
+        Some(SemanticForegroundRole::Action)
+    } else if color == WHALE_LIVE || color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
+        Some(SemanticForegroundRole::Live)
+    } else if color == WHALE_HUMAN {
+        Some(SemanticForegroundRole::Human)
+    } else if color == STATUS_WARNING {
+        Some(SemanticForegroundRole::Warning)
+    } else if color == WHALE_ERROR || color == STATUS_ERROR || color == ACCENT_TOOL_ISSUE {
+        Some(SemanticForegroundRole::Danger)
+    } else if color == STATUS_SUCCESS || color == USER_BODY || color == DIFF_ADDED {
+        Some(SemanticForegroundRole::Success)
+    } else {
+        None
+    }
+}
+
+fn theme_semantic_foreground_role(color: Color, ui: &UiTheme) -> Option<SemanticForegroundRole> {
+    // Mode slots come first. Shipped themes keep these source colors distinct
+    // from the general semantic lanes so direct `app.ui_theme.mode_*` call
+    // sites retain the same identity as raw `MODE_*` call sites.
+    if color == ui.mode_agent {
+        Some(SemanticForegroundRole::ModeAgent)
+    } else if color == ui.mode_plan {
+        Some(SemanticForegroundRole::ModePlan)
+    } else if color == ui.mode_operate {
+        Some(SemanticForegroundRole::ModeOperate)
+    } else if color == ui.mode_yolo {
+        Some(SemanticForegroundRole::ModeYolo)
+    } else if color == ui.accent_primary {
+        Some(SemanticForegroundRole::Action)
+    } else if color == ui.status_working
+        || color == ui.accent_secondary
+        || color == ui.tool_running
+        || color == ui.info
+    {
+        Some(SemanticForegroundRole::Live)
+    } else if color == ui.accent_action {
+        Some(SemanticForegroundRole::Human)
+    } else if color == ui.warning || color == ui.status_warning {
+        Some(SemanticForegroundRole::Warning)
+    } else if color == ui.error_fg || color == ui.tool_failed || color == ui.diff_deleted_fg {
+        Some(SemanticForegroundRole::Danger)
+    } else if color == ui.success || color == ui.tool_success || color == ui.diff_added_fg {
+        Some(SemanticForegroundRole::Success)
+    } else {
+        None
+    }
+}
+
+/// Adapt a resolved foreground to terminal depth while retaining the semantic
+/// role carried by the original cell color. Truecolor and ANSI-256 preserve the
+/// resolved theme value; ANSI-16 uses a fixed, injective role matrix instead of
+/// an arbitrary nearest-color guess.
+#[must_use]
+pub(crate) fn adapt_fg_for_depth(
+    source: Color,
+    resolved: Color,
+    depth: ColorDepth,
+    ui: &UiTheme,
+) -> Color {
+    if depth == ColorDepth::Ansi16
+        && let Some(role) = raw_semantic_foreground_role(source)
+            .or_else(|| theme_semantic_foreground_role(source, ui))
+    {
+        role.ansi16()
+    } else {
+        adapt_color(resolved, depth)
+    }
+}
+
 impl ColorDepth {
     /// Detect the active terminal's color depth. Honors `COLORTERM`
     /// (truecolor / 24bit) first, then falls back to `TERM`. Defaults to
@@ -522,9 +654,10 @@ impl ColorDepth {
 
 /// Adapt a foreground color to the terminal's color depth.
 ///
-/// On TrueColor, `color` passes through. On Ansi256 we let ratatui's renderer
-/// down-convert (it does this already). On Ansi16 we strip RGB to a near
-/// named color so semantic intent survives even on legacy terminals.
+/// On TrueColor, `color` passes through. ANSI-256 uses the stable extended
+/// palette; ANSI-16 uses a generic nearest named color. Rendered semantic
+/// foregrounds must go through [`adapt_fg_for_depth`] so role identity is not
+/// inferred from RGB proximity.
 #[allow(dead_code)]
 #[must_use]
 pub fn adapt_color(color: Color, depth: ColorDepth) -> Color {

--- a/crates/tui/src/palette/adapt.rs
+++ b/crates/tui/src/palette/adapt.rs
@@ -37,12 +37,26 @@ fn adapt_fg_for_light_palette(color: Color) -> Color {
         LIGHT_TEXT_SOFT
     } else if color == BORDER_COLOR {
         LIGHT_BORDER
-    } else if color == TEXT_ACCENT || color == WHALE_INFO || color == ACCENT_TOOL_LIVE {
-        WHALE_ACCENT_PRIMARY
+    } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
+        LIGHT_LIVE
+    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
+        LIGHT_ACTION
+    } else if color == WHALE_HUMAN || color == MODE_PLAN {
+        LIGHT_HUMAN
     } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
         Color::Rgb(146, 64, 14)
-    } else if color == ACCENT_TOOL_ISSUE {
-        Color::Rgb(159, 18, 57)
+    } else if color == ACCENT_TOOL_ISSUE
+        || color == WHALE_ERROR
+        || color == STATUS_ERROR
+        || color == MODE_YOLO
+    {
+        LIGHT_DANGER
+    } else if color == STATUS_WARNING {
+        LIGHT_WARNING
+    } else if color == STATUS_SUCCESS {
+        LIGHT_SUCCESS_FG
+    } else if color == MODE_OPERATE {
+        LIGHT_OPERATE
     } else if color == DIFF_ADDED {
         Color::Rgb(22, 101, 52)
     } else if color == USER_BODY {
@@ -94,14 +108,27 @@ fn adapt_fg_for_solarized_light_palette(color: Color) -> Color {
         SOLARIZED_TEXT_SOFT
     } else if color == BORDER_COLOR {
         SOLARIZED_BORDER
-    } else if color == TEXT_ACCENT || color == WHALE_INFO || color == ACCENT_TOOL_LIVE {
+    } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
+        SOLARIZED_CYAN
+    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY {
         SOLARIZED_BLUE
-    } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
+    } else if color == WHALE_HUMAN
+        || color == MODE_PLAN
+        || color == STATUS_WARNING
+        || color == TEXT_REASONING
+        || color == ACCENT_REASONING_LIVE
+    {
         SOLARIZED_ORANGE
-    } else if color == ACCENT_TOOL_ISSUE {
+    } else if color == ACCENT_TOOL_ISSUE
+        || color == WHALE_ERROR
+        || color == STATUS_ERROR
+        || color == MODE_YOLO
+    {
         SOLARIZED_RED
-    } else if color == DIFF_ADDED || color == USER_BODY {
+    } else if color == DIFF_ADDED || color == USER_BODY || color == STATUS_SUCCESS {
         SOLARIZED_GREEN
+    } else if color == MODE_OPERATE {
+        Color::Rgb(0x6C, 0x71, 0xC4)
     } else {
         color
     }
@@ -220,24 +247,32 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
         ui.text_soft
     } else if color == BORDER_COLOR {
         ui.border
-    } else if color == TEXT_ACCENT || color == WHALE_INFO || color == ACCENT_TOOL_LIVE {
+    } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         ui.status_working
+    } else if color == WHALE_INFO || color == WHALE_ACCENT_PRIMARY || color == MODE_AGENT {
+        ui.accent_primary
+    } else if color == WHALE_HUMAN || color == MODE_PLAN {
+        ui.accent_action
     } else if color == TEXT_REASONING || color == ACCENT_REASONING_LIVE {
         if theme == ThemeId::Matrix {
             Color::Rgb(0x00, 0x55, 0x00) // #005500
         } else {
             ui.mode_plan
         }
-    } else if color == ACCENT_TOOL_ISSUE {
-        ui.mode_yolo
+    } else if color == ACCENT_TOOL_ISSUE
+        || color == STATUS_ERROR
+        || color == WHALE_ERROR
+        || color == MODE_YOLO
+    {
+        ui.error_fg
     } else if color == STATUS_WARNING {
         ui.warning
-    } else if color == STATUS_ERROR || color == WHALE_ERROR {
-        ui.error_fg
+    } else if color == STATUS_SUCCESS {
+        ui.success
+    } else if color == MODE_OPERATE {
+        ui.mode_operate
     } else if color == DIFF_ADDED || color == USER_BODY {
         theme_green(ui)
-    } else if color == WHALE_ACCENT_PRIMARY {
-        ui.mode_agent
     } else {
         color
     }

--- a/crates/tui/src/palette/mod.rs
+++ b/crates/tui/src/palette/mod.rs
@@ -1,4 +1,4 @@
-//! CodeWhale color palette and semantic roles.
+//! Codewhale color palette and semantic roles.
 //!
 //! This module defines the color system for the TUI in three layers:
 //!

--- a/crates/tui/src/palette/mod.rs
+++ b/crates/tui/src/palette/mod.rs
@@ -1,4 +1,4 @@
-//! DeepSeek color palette and semantic roles.
+//! CodeWhale color palette and semantic roles.
 //!
 //! This module defines the color system for the TUI in three layers:
 //!

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -1,13 +1,14 @@
 use super::adapt::{
     ColorDepth, adapt_bg, adapt_bg_for_palette_mode, adapt_bg_for_theme, adapt_color,
-    adapt_fg_for_palette_mode, adapt_fg_for_theme, blend, luma, nearest_ansi16, pulse_brightness,
-    reasoning_surface_tint, rgb_to_ansi256,
+    adapt_fg_for_depth, adapt_fg_for_palette_mode, adapt_fg_for_theme, blend, luma, nearest_ansi16,
+    pulse_brightness, reasoning_surface_tint, rgb_to_ansi256,
 };
 use super::detect::{PaletteMode, palette_mode_from_apple_interface_style};
 use super::themes::{
-    GRAYSCALE_UI_THEME, LIGHT_UI_THEME, MATRIX_UI_THEME, SOLARIZED_LIGHT_UI_THEME,
-    TERMINAL_UI_THEME, TOKYO_NIGHT_UI_THEME, ThemeId, UI_THEME, UiTheme, normalize_hex_rgb_color,
-    normalize_theme_name, parse_hex_rgb_color, theme_label_for_mode, ui_theme_from_settings,
+    CATPPUCCIN_MOCHA_UI_THEME, GRAYSCALE_UI_THEME, LIGHT_UI_THEME, MATRIX_UI_THEME,
+    SELECTABLE_THEMES, SOLARIZED_LIGHT_UI_THEME, TERMINAL_UI_THEME, TOKYO_NIGHT_UI_THEME, ThemeId,
+    UI_THEME, UiTheme, normalize_hex_rgb_color, normalize_theme_name, parse_hex_rgb_color,
+    theme_label_for_mode, ui_theme_from_settings,
 };
 use super::tokens::{
     ACCENT_REASONING_LIVE, DIFF_ADDED, DIFF_ADDED_BG, DIFF_DELETED_BG, GRAYSCALE_BORDER,
@@ -18,9 +19,9 @@ use super::tokens::{
     LIGHT_TEXT_HINT, LIGHT_WARNING, MODE_AGENT, MODE_PLAN, MODE_YOLO, SELECTION_BG,
     SOLARIZED_PANEL, SOLARIZED_SURFACE, SOLARIZED_TEXT_BODY, SOLARIZED_TEXT_HINT, STATUS_ERROR,
     STATUS_WARNING, SURFACE_ERROR, SURFACE_REASONING, SURFACE_REASONING_TINT, SURFACE_TOOL_ACTIVE,
-    TEXT_BODY, TEXT_HINT, TEXT_REASONING, TEXT_TOOL_OUTPUT, WHALE_ACTION, WHALE_BG, WHALE_ERROR,
-    WHALE_HUMAN, WHALE_INFO, WHALE_LIVE, WHALE_PANEL, WHALE_REASONING_TEXT_RGB,
-    WHALE_REASONING_TINT_RGB, WHALE_TEXT_BODY_RGB,
+    TEXT_BODY, TEXT_HINT, TEXT_REASONING, TEXT_TOOL_OUTPUT, WHALE_ACCENT_PRIMARY, WHALE_ACTION,
+    WHALE_BG, WHALE_ERROR, WHALE_HUMAN, WHALE_INFO, WHALE_LIVE, WHALE_PANEL,
+    WHALE_REASONING_TEXT_RGB, WHALE_REASONING_TINT_RGB, WHALE_TEXT_BODY_RGB,
 };
 use ratatui::style::Color;
 
@@ -423,6 +424,69 @@ fn adapt_color_drops_to_named_on_ansi16() {
         adapt_color(WHALE_ERROR, ColorDepth::Ansi16),
         Color::LightRed
     );
+}
+
+#[test]
+fn semantic_tokens_keep_brand_compatibility_distinct_from_action() {
+    assert_eq!(WHALE_ACCENT_PRIMARY, WHALE_HUMAN);
+    assert_eq!(WHALE_ACTION, WHALE_INFO);
+    assert_ne!(WHALE_ACTION, WHALE_HUMAN);
+}
+
+#[test]
+fn community_theme_info_keeps_the_sky_live_role_on_ansi16() {
+    assert_eq!(
+        adapt_fg_for_depth(
+            CATPPUCCIN_MOCHA_UI_THEME.info,
+            CATPPUCCIN_MOCHA_UI_THEME.info,
+            ColorDepth::Ansi16,
+            &CATPPUCCIN_MOCHA_UI_THEME,
+        ),
+        Color::LightCyan,
+    );
+    assert_eq!(
+        adapt_fg_for_depth(
+            CATPPUCCIN_MOCHA_UI_THEME.status_working,
+            CATPPUCCIN_MOCHA_UI_THEME.status_working,
+            ColorDepth::Ansi16,
+            &CATPPUCCIN_MOCHA_UI_THEME,
+        ),
+        Color::LightCyan,
+    );
+}
+
+#[test]
+fn every_selectable_theme_keeps_action_and_working_roles_distinct_on_ansi16() {
+    for theme_id in SELECTABLE_THEMES {
+        // Grayscale deliberately collapses colored semantic lanes to neutral
+        // luminance tiers before terminal-depth adaptation.
+        if *theme_id == ThemeId::Grayscale {
+            continue;
+        }
+        let ui = theme_id.ui_theme();
+        assert_eq!(
+            adapt_fg_for_depth(
+                ui.accent_primary,
+                ui.accent_primary,
+                ColorDepth::Ansi16,
+                &ui,
+            ),
+            Color::LightBlue,
+            "theme '{}' lost the action lane",
+            theme_id.name(),
+        );
+        assert_eq!(
+            adapt_fg_for_depth(
+                ui.status_working,
+                ui.status_working,
+                ColorDepth::Ansi16,
+                &ui,
+            ),
+            Color::LightCyan,
+            "theme '{}' lost the live working lane",
+            theme_id.name(),
+        );
+    }
 }
 
 #[test]

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -5,21 +5,22 @@ use super::adapt::{
 };
 use super::detect::{PaletteMode, palette_mode_from_apple_interface_style};
 use super::themes::{
-    GRAYSCALE_UI_THEME, LIGHT_UI_THEME, SOLARIZED_LIGHT_UI_THEME, TERMINAL_UI_THEME, ThemeId,
-    UI_THEME, UiTheme, normalize_hex_rgb_color, normalize_theme_name, parse_hex_rgb_color,
-    theme_label_for_mode, ui_theme_from_settings,
+    GRAYSCALE_UI_THEME, LIGHT_UI_THEME, MATRIX_UI_THEME, SOLARIZED_LIGHT_UI_THEME,
+    TERMINAL_UI_THEME, TOKYO_NIGHT_UI_THEME, ThemeId, UI_THEME, UiTheme, normalize_hex_rgb_color,
+    normalize_theme_name, parse_hex_rgb_color, theme_label_for_mode, ui_theme_from_settings,
 };
 use super::tokens::{
-    ACCENT_REASONING_LIVE, DIFF_ADDED, DIFF_ADDED_BG, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED,
-    GRAYSCALE_PANEL, GRAYSCALE_REASONING, GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY,
-    GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT, LIGHT_ACTION, LIGHT_BORDER, LIGHT_DANGER,
-    LIGHT_ELEVATED, LIGHT_HUMAN, LIGHT_LIVE, LIGHT_PANEL, LIGHT_REASONING, LIGHT_SUCCESS_FG,
-    LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_BODY_RGB, LIGHT_TEXT_HINT, LIGHT_WARNING,
+    ACCENT_REASONING_LIVE, DIFF_ADDED, DIFF_ADDED_BG, DIFF_DELETED_BG, GRAYSCALE_BORDER,
+    GRAYSCALE_ELEVATED, GRAYSCALE_PANEL, GRAYSCALE_REASONING, GRAYSCALE_SURFACE,
+    GRAYSCALE_TEXT_BODY, GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT, LIGHT_ACTION, LIGHT_BORDER,
+    LIGHT_DANGER, LIGHT_ELEVATED, LIGHT_HUMAN, LIGHT_LIVE, LIGHT_PANEL, LIGHT_REASONING,
+    LIGHT_SELECTION_BG, LIGHT_SUCCESS_FG, LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_BODY_RGB,
+    LIGHT_TEXT_HINT, LIGHT_WARNING, MODE_AGENT, MODE_PLAN, MODE_YOLO, SELECTION_BG,
     SOLARIZED_PANEL, SOLARIZED_SURFACE, SOLARIZED_TEXT_BODY, SOLARIZED_TEXT_HINT, STATUS_ERROR,
-    STATUS_WARNING, SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT,
-    TEXT_REASONING, TEXT_TOOL_OUTPUT, WHALE_ACTION, WHALE_BG, WHALE_ERROR, WHALE_HUMAN, WHALE_INFO,
-    WHALE_LIVE, WHALE_PANEL, WHALE_REASONING_TEXT_RGB, WHALE_REASONING_TINT_RGB,
-    WHALE_TEXT_BODY_RGB,
+    STATUS_WARNING, SURFACE_ERROR, SURFACE_REASONING, SURFACE_REASONING_TINT, SURFACE_TOOL_ACTIVE,
+    TEXT_BODY, TEXT_HINT, TEXT_REASONING, TEXT_TOOL_OUTPUT, WHALE_ACTION, WHALE_BG, WHALE_ERROR,
+    WHALE_HUMAN, WHALE_INFO, WHALE_LIVE, WHALE_PANEL, WHALE_REASONING_TEXT_RGB,
+    WHALE_REASONING_TINT_RGB, WHALE_TEXT_BODY_RGB,
 };
 use ratatui::style::Color;
 
@@ -146,11 +147,59 @@ fn terminal_theme_resets_surfaces_and_remaps_direct_palette_constants() {
 }
 
 #[test]
+fn terminal_and_matrix_preserve_agent_plan_and_full_access_mode_slots() {
+    for (theme_id, theme) in [
+        (ThemeId::Terminal, TERMINAL_UI_THEME),
+        (ThemeId::Matrix, MATRIX_UI_THEME),
+    ] {
+        for (source, expected, role) in [
+            (MODE_AGENT, theme.mode_agent, "agent"),
+            (MODE_PLAN, theme.mode_plan, "plan"),
+            (MODE_YOLO, theme.mode_yolo, "full access"),
+        ] {
+            assert_eq!(
+                adapt_fg_for_theme(source, theme_id, &theme),
+                expected,
+                "theme '{}' must map the raw {role} token to its mode slot",
+                theme_id.name(),
+            );
+        }
+    }
+}
+
+#[test]
+fn community_remap_keeps_selection_tool_and_error_background_domains() {
+    let mut theme = TOKYO_NIGHT_UI_THEME;
+    theme.selection_bg = Color::Rgb(1, 2, 3);
+    theme.elevated_bg = Color::Rgb(4, 5, 6);
+    theme.error_surface = Color::Rgb(7, 8, 9);
+    theme.diff_deleted_bg = Color::Rgb(10, 11, 12);
+
+    assert_eq!(
+        adapt_bg_for_theme(SELECTION_BG, ThemeId::TokyoNight, &theme),
+        theme.selection_bg
+    );
+    assert_eq!(
+        adapt_bg_for_theme(SURFACE_TOOL_ACTIVE, ThemeId::TokyoNight, &theme),
+        theme.elevated_bg
+    );
+    assert_eq!(
+        adapt_bg_for_theme(SURFACE_ERROR, ThemeId::TokyoNight, &theme),
+        theme.error_surface
+    );
+    assert_eq!(
+        adapt_bg_for_theme(DIFF_DELETED_BG, ThemeId::TokyoNight, &theme),
+        theme.diff_deleted_bg
+    );
+}
+
+#[test]
 fn light_palette_has_quiet_layer_separation() {
     assert_eq!(LIGHT_SURFACE, Color::Rgb(244, 247, 251));
     assert_eq!(LIGHT_PANEL, Color::Rgb(255, 253, 248));
     assert_eq!(LIGHT_ELEVATED, Color::Rgb(232, 238, 248));
     assert_eq!(LIGHT_BORDER, Color::Rgb(169, 184, 207));
+    assert_eq!(LIGHT_SELECTION_BG, Color::Rgb(238, 246, 255));
     assert_ne!(LIGHT_SURFACE, LIGHT_PANEL);
     assert_ne!(LIGHT_PANEL, LIGHT_ELEVATED);
 }
@@ -465,14 +514,14 @@ fn pulse_passes_named_colors_unchanged() {
 
 #[test]
 fn nearest_ansi16_routes_known_brand_colors() {
-    // Blue Stage keeps action, live, human, and danger distinct where ANSI-16 allows it.
-    assert_eq!(nearest_ansi16(106, 174, 242), Color::LightBlue); // Blue Devil action
+    // Codewhale keeps action, live, human, and danger distinct where ANSI-16 allows it.
+    assert_eq!(nearest_ansi16(106, 174, 242), Color::LightBlue); // Cobalt action
     assert_eq!(nearest_ansi16(246, 196, 83), Color::LightYellow); // Signal Gold
     assert_eq!(nearest_ansi16(79, 209, 197), Color::LightCyan); // Seafoam
-    assert_eq!(nearest_ansi16(42, 74, 127), Color::Blue); // Border
+    assert_eq!(nearest_ansi16(38, 62, 92), Color::Blue); // Border
     assert_eq!(nearest_ansi16(54, 187, 212), Color::LightCyan); // Aqua
     assert_eq!(nearest_ansi16(255, 134, 178), Color::LightRed); // Rose danger
-    assert_eq!(nearest_ansi16(3, 7, 13), Color::Black); // Stage Black
+    assert_eq!(nearest_ansi16(3, 7, 13), Color::Black); // Deep field
 }
 
 #[test]

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -12,12 +12,14 @@ use super::themes::{
 use super::tokens::{
     ACCENT_REASONING_LIVE, DIFF_ADDED, DIFF_ADDED_BG, GRAYSCALE_BORDER, GRAYSCALE_ELEVATED,
     GRAYSCALE_PANEL, GRAYSCALE_REASONING, GRAYSCALE_SURFACE, GRAYSCALE_TEXT_BODY,
-    GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT, LIGHT_BORDER, LIGHT_ELEVATED, LIGHT_PANEL,
-    LIGHT_REASONING, LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_BODY_RGB, LIGHT_TEXT_HINT,
-    SOLARIZED_PANEL, SOLARIZED_SURFACE, SOLARIZED_TEXT_BODY, SOLARIZED_TEXT_HINT,
-    SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT, TEXT_REASONING,
-    TEXT_TOOL_OUTPUT, WHALE_BG, WHALE_ERROR, WHALE_INFO, WHALE_PANEL, WHALE_REASONING_TEXT_RGB,
-    WHALE_REASONING_TINT_RGB, WHALE_TEXT_BODY_RGB,
+    GRAYSCALE_TEXT_HINT, GRAYSCALE_TEXT_SOFT, LIGHT_ACTION, LIGHT_BORDER, LIGHT_DANGER,
+    LIGHT_ELEVATED, LIGHT_HUMAN, LIGHT_LIVE, LIGHT_PANEL, LIGHT_REASONING, LIGHT_SUCCESS_FG,
+    LIGHT_SURFACE, LIGHT_TEXT_BODY, LIGHT_TEXT_BODY_RGB, LIGHT_TEXT_HINT, LIGHT_WARNING,
+    SOLARIZED_PANEL, SOLARIZED_SURFACE, SOLARIZED_TEXT_BODY, SOLARIZED_TEXT_HINT, STATUS_ERROR,
+    STATUS_WARNING, SURFACE_REASONING, SURFACE_REASONING_TINT, TEXT_BODY, TEXT_HINT,
+    TEXT_REASONING, TEXT_TOOL_OUTPUT, WHALE_ACTION, WHALE_BG, WHALE_ERROR, WHALE_HUMAN, WHALE_INFO,
+    WHALE_LIVE, WHALE_PANEL, WHALE_REASONING_TEXT_RGB, WHALE_REASONING_TINT_RGB,
+    WHALE_TEXT_BODY_RGB,
 };
 use ratatui::style::Color;
 
@@ -145,10 +147,10 @@ fn terminal_theme_resets_surfaces_and_remaps_direct_palette_constants() {
 
 #[test]
 fn light_palette_has_quiet_layer_separation() {
-    assert_eq!(LIGHT_SURFACE, Color::Rgb(246, 248, 251));
-    assert_eq!(LIGHT_PANEL, Color::Rgb(236, 242, 248));
-    assert_eq!(LIGHT_ELEVATED, Color::Rgb(219, 229, 240));
-    assert_eq!(LIGHT_BORDER, Color::Rgb(139, 161, 184));
+    assert_eq!(LIGHT_SURFACE, Color::Rgb(244, 247, 251));
+    assert_eq!(LIGHT_PANEL, Color::Rgb(255, 253, 248));
+    assert_eq!(LIGHT_ELEVATED, Color::Rgb(232, 238, 248));
+    assert_eq!(LIGHT_BORDER, Color::Rgb(169, 184, 207));
     assert_ne!(LIGHT_SURFACE, LIGHT_PANEL);
     assert_ne!(LIGHT_PANEL, LIGHT_ELEVATED);
 }
@@ -240,6 +242,27 @@ fn light_palette_maps_dark_surfaces_and_text() {
         adapt_fg_for_palette_mode(TEXT_HINT, LIGHT_SURFACE, PaletteMode::Light),
         LIGHT_TEXT_HINT
     );
+    assert_eq!(
+        adapt_fg_for_palette_mode(WHALE_ACTION, LIGHT_SURFACE, PaletteMode::Light),
+        LIGHT_ACTION
+    );
+    assert_eq!(
+        adapt_fg_for_palette_mode(WHALE_LIVE, LIGHT_SURFACE, PaletteMode::Light),
+        LIGHT_LIVE
+    );
+    assert_eq!(
+        adapt_fg_for_palette_mode(WHALE_HUMAN, LIGHT_SURFACE, PaletteMode::Light),
+        LIGHT_HUMAN
+    );
+    assert_eq!(
+        adapt_fg_for_palette_mode(STATUS_WARNING, LIGHT_SURFACE, PaletteMode::Light),
+        LIGHT_WARNING
+    );
+    assert_eq!(
+        adapt_fg_for_palette_mode(STATUS_ERROR, LIGHT_SURFACE, PaletteMode::Light),
+        LIGHT_DANGER
+    );
+    assert_ne!(LIGHT_LIVE, LIGHT_SUCCESS_FG);
 }
 
 #[test]
@@ -442,13 +465,14 @@ fn pulse_passes_named_colors_unchanged() {
 
 #[test]
 fn nearest_ansi16_routes_known_brand_colors() {
-    // v0.8.45: accent primary is Signal Gold (#F6C453), secondary is Seafoam.
+    // Blue Stage keeps action, live, human, and danger distinct where ANSI-16 allows it.
+    assert_eq!(nearest_ansi16(106, 174, 242), Color::LightBlue); // Blue Devil action
     assert_eq!(nearest_ansi16(246, 196, 83), Color::LightYellow); // Signal Gold
     assert_eq!(nearest_ansi16(79, 209, 197), Color::LightCyan); // Seafoam
     assert_eq!(nearest_ansi16(42, 74, 127), Color::Blue); // Border
     assert_eq!(nearest_ansi16(54, 187, 212), Color::LightCyan); // Aqua
-    assert_eq!(nearest_ansi16(255, 92, 122), Color::LightRed); // Rose Red
-    assert_eq!(nearest_ansi16(13, 21, 37), Color::Black); // Deep Navy
+    assert_eq!(nearest_ansi16(255, 134, 178), Color::LightRed); // Rose danger
+    assert_eq!(nearest_ansi16(3, 7, 13), Color::Black); // Stage Black
 }
 
 #[test]

--- a/crates/tui/src/palette/themes.rs
+++ b/crates/tui/src/palette/themes.rs
@@ -38,7 +38,11 @@ pub struct UiTheme {
     pub warning: Color,
     pub success: Color,
     pub info: Color,
-    // Mode badge colors (act/plan/operate; mode_yolo kept for legacy theme data)
+    // Mode badge colors (act/plan/operate; mode_yolo kept for legacy theme data).
+    // These must be distinct from one another and from the general accent,
+    // human, warning, danger, and success lanes: the terminal backend receives
+    // only the final `Color` and needs that identity to perform semantic ANSI
+    // adaptation.
     pub mode_agent: Color,
     pub mode_yolo: Color,
     pub mode_plan: Color,
@@ -152,9 +156,9 @@ pub const LIGHT_UI_THEME: UiTheme = UiTheme {
     warning: LIGHT_WARNING,
     success: LIGHT_SUCCESS_FG,
     info: LIGHT_ACTION,
-    mode_agent: LIGHT_ACTION,
-    mode_yolo: LIGHT_DANGER,
-    mode_plan: LIGHT_HUMAN,
+    mode_agent: LIGHT_MODE_AGENT,
+    mode_yolo: LIGHT_MODE_YOLO,
+    mode_plan: LIGHT_MODE_PLAN,
     mode_operate: LIGHT_OPERATE,
     status_ready: LIGHT_TEXT_MUTED,
     status_working: LIGHT_LIVE,
@@ -195,9 +199,9 @@ pub const SOLARIZED_LIGHT_UI_THEME: UiTheme = UiTheme {
     warning: SOLARIZED_YELLOW,
     success: SOLARIZED_GREEN,
     info: SOLARIZED_BLUE,
-    mode_agent: SOLARIZED_BLUE,
-    mode_yolo: SOLARIZED_RED,
-    mode_plan: SOLARIZED_ORANGE,
+    mode_agent: Color::Rgb(0x27, 0x8B, 0xD2),
+    mode_yolo: Color::Rgb(0xDD, 0x32, 0x2F),
+    mode_plan: Color::Rgb(0xCC, 0x4B, 0x16),
     mode_operate: Color::Rgb(0x6C, 0x71, 0xC4), // solarized violet
     status_ready: SOLARIZED_CYAN,
     status_working: SOLARIZED_CYAN,
@@ -239,11 +243,11 @@ pub const GRAYSCALE_UI_THEME: UiTheme = UiTheme {
     success: GRAYSCALE_TEXT_SOFT,
     info: GRAYSCALE_TEXT_MUTED,
     mode_agent: Color::Rgb(200, 200, 200),
-    mode_yolo: GRAYSCALE_TEXT_BODY,
-    mode_plan: GRAYSCALE_TEXT_MUTED,
-    // Monochrome theme: pure white is the one step left above the YOLO
-    // body tone (236) that stays unmistakably distinct.
-    mode_operate: Color::Rgb(255, 255, 255),
+    mode_yolo: Color::Rgb(237, 237, 237),
+    mode_plan: Color::Rgb(181, 181, 181),
+    // Near-white stays unmistakably distinct without claiming arbitrary pure
+    // white content as an already-resolved mode slot.
+    mode_operate: Color::Rgb(250, 250, 250),
     status_ready: GRAYSCALE_TEXT_MUTED,
     status_working: GRAYSCALE_TEXT_SOFT,
     status_warning: GRAYSCALE_TEXT_BODY,
@@ -283,9 +287,9 @@ pub const CATPPUCCIN_MOCHA_UI_THEME: UiTheme = UiTheme {
     warning: Color::Rgb(0xf9, 0xe2, 0xaf),         // yellow
     success: Color::Rgb(0xa6, 0xe3, 0xa1),         // green
     info: Color::Rgb(0x89, 0xd9, 0xeb),            // sky
-    mode_agent: Color::Rgb(0x89, 0xb4, 0xfa),      // blue
-    mode_yolo: Color::Rgb(0xf3, 0x8b, 0xa8),       // red
-    mode_plan: Color::Rgb(0xfa, 0xb3, 0x87),       // peach
+    mode_agent: Color::Rgb(0x8a, 0xb4, 0xfa),      // blue
+    mode_yolo: Color::Rgb(0xf3, 0x8c, 0xa8),       // red
+    mode_plan: Color::Rgb(0xfa, 0xb4, 0x87),       // peach
     mode_operate: Color::Rgb(0xcb, 0xa6, 0xf7),    // mauve
     status_ready: Color::Rgb(0x7f, 0x84, 0x9c),    // overlay1
     status_working: Color::Rgb(0x74, 0xc7, 0xec),  // sapphire
@@ -326,9 +330,9 @@ pub const TOKYO_NIGHT_UI_THEME: UiTheme = UiTheme {
     warning: Color::Rgb(0xe0, 0xaf, 0x68),         // yellow
     success: Color::Rgb(0x9e, 0xce, 0x6a),         // green
     info: Color::Rgb(0x7d, 0xcf, 0xff),            // cyan
-    mode_agent: Color::Rgb(0x7a, 0xa2, 0xf7),      // blue
-    mode_yolo: Color::Rgb(0xf7, 0x76, 0x8e),       // red
-    mode_plan: Color::Rgb(0xff, 0x9e, 0x64),       // orange
+    mode_agent: Color::Rgb(0x7b, 0xa2, 0xf7),      // blue
+    mode_yolo: Color::Rgb(0xf7, 0x77, 0x8e),       // red
+    mode_plan: Color::Rgb(0xff, 0x9f, 0x64),       // orange
     mode_operate: Color::Rgb(0xbb, 0x9a, 0xf7),    // purple
     status_ready: Color::Rgb(0x56, 0x5f, 0x89),    // comment
     status_working: Color::Rgb(0x7d, 0xcf, 0xff),  // cyan
@@ -369,10 +373,10 @@ pub const DRACULA_UI_THEME: UiTheme = UiTheme {
     warning: Color::Rgb(0xf1, 0xfa, 0x8c),         // yellow
     success: Color::Rgb(0x50, 0xfa, 0x7b),         // green
     info: Color::Rgb(0x8b, 0xe9, 0xfd),            // cyan
-    mode_agent: Color::Rgb(0xbd, 0x93, 0xf9),      // purple
-    mode_yolo: Color::Rgb(0xff, 0x55, 0x55),       // red
-    mode_plan: Color::Rgb(0xff, 0xb8, 0x6c),       // orange
-    mode_operate: Color::Rgb(0x8b, 0xe9, 0xfd),    // cyan
+    mode_agent: Color::Rgb(0xbe, 0x93, 0xf9),      // purple
+    mode_yolo: Color::Rgb(0xff, 0x56, 0x55),       // red
+    mode_plan: Color::Rgb(0xff, 0xb9, 0x6c),       // orange
+    mode_operate: Color::Rgb(0x8c, 0xe9, 0xfd),    // cyan
     status_ready: Color::Rgb(0x62, 0x72, 0xa4),    // comment
     status_working: Color::Rgb(0x8b, 0xe9, 0xfd),  // cyan
     status_warning: Color::Rgb(0xf1, 0xfa, 0x8c),  // yellow
@@ -421,13 +425,13 @@ pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
     warning: Color::Yellow,
     success: Color::Green,
     info: Color::Cyan,
-    mode_agent: Color::Blue,
-    mode_yolo: Color::Red,
+    mode_agent: Color::LightBlue,
+    mode_yolo: Color::LightRed,
     // Magenta keeps Plan visually distinct from `status_warning` (yellow)
     // so the mode indicator and warning chip don't collide on themes that
     // render both in the status row.
     mode_plan: Color::Magenta,
-    mode_operate: Color::Cyan,
+    mode_operate: Color::LightCyan,
     // DarkGray gives "Ready" a low-contrast but still distinguishable hue
     // versus default body text (which is `Color::Reset` on this theme).
     status_ready: Color::DarkGray,
@@ -469,9 +473,9 @@ pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
     warning: Color::Rgb(0xfa, 0xbd, 0x2f),         // yellow
     success: Color::Rgb(0x8e, 0xc0, 0x7c),         // green
     info: Color::Rgb(0x83, 0xa5, 0x98),            // blue
-    mode_agent: Color::Rgb(0x83, 0xa5, 0x98),      // blue
-    mode_yolo: Color::Rgb(0xfb, 0x49, 0x34),       // red
-    mode_plan: Color::Rgb(0xfe, 0x80, 0x19),       // orange
+    mode_agent: Color::Rgb(0x84, 0xa5, 0x98),      // blue
+    mode_yolo: Color::Rgb(0xfb, 0x4a, 0x34),       // red
+    mode_plan: Color::Rgb(0xfe, 0x81, 0x19),       // orange
     mode_operate: Color::Rgb(0xd3, 0x86, 0x9b),    // purple
     status_ready: Color::Rgb(0x92, 0x83, 0x74),    // gray
     status_working: Color::Rgb(0x8e, 0xc0, 0x7c),  // aqua
@@ -518,9 +522,9 @@ pub const CLAUDE_UI_THEME: UiTheme = UiTheme {
     success: Color::Rgb(0x5d, 0xb8, 0x72), // green
     info: Color::Rgb(0x5d, 0xb8, 0xa6),    // teal
     // Mode badges
-    mode_agent: Color::Rgb(0xcc, 0x78, 0x5c),   // coral
-    mode_yolo: Color::Rgb(0xc6, 0x45, 0x45),    // red
-    mode_plan: Color::Rgb(0xe8, 0xa5, 0x5a),    // amber
+    mode_agent: Color::Rgb(0xcd, 0x78, 0x5c),   // coral
+    mode_yolo: Color::Rgb(0xc7, 0x45, 0x45),    // red
+    mode_plan: Color::Rgb(0xe8, 0xa6, 0x5a),    // amber
     mode_operate: Color::Rgb(0x8a, 0x63, 0xd2), // violet
     // Footer statusline
     status_ready: Color::Rgb(0xa0, 0x9d, 0x96),
@@ -620,7 +624,7 @@ pub const MATRIX_UI_THEME: UiTheme = UiTheme {
     warning: Color::Rgb(204, 204, 0),
     success: Color::Rgb(0x88, 0xff, 0x88),
     info: Color::Rgb(0, 204, 0),
-    mode_agent: Color::Rgb(0, 153, 0),
+    mode_agent: Color::Rgb(0, 154, 0),
     mode_yolo: Color::Rgb(255, 100, 100),
     mode_plan: Color::Rgb(255, 170, 60),
     mode_operate: Color::Rgb(100, 255, 220),
@@ -924,7 +928,9 @@ mod tests {
     }
 
     /// Dogfood A7 (#4092): every mode must be tellable apart from the footer
-    /// badge alone — Operate must never wear the YOLO red again.
+    /// badge alone — Operate must never wear the full-access red again. Mode
+    /// slots also stay distinct from general semantic lanes so limited-color
+    /// adaptation can identify direct `UiTheme` call sites without guessing.
     #[test]
     fn every_selectable_theme_keeps_mode_badges_distinct() {
         for theme_id in SELECTABLE_THEMES {
@@ -933,6 +939,7 @@ mod tests {
                 ("act", ui.mode_agent),
                 ("plan", ui.mode_plan),
                 ("operate", ui.mode_operate),
+                ("full access", ui.mode_yolo),
             ];
             for (i, (name_a, color_a)) in badges.iter().enumerate() {
                 for (name_b, color_b) in badges.iter().skip(i + 1) {
@@ -940,6 +947,24 @@ mod tests {
                         color_a,
                         color_b,
                         "theme '{}' renders modes '{name_a}' and '{name_b}' with the same badge color",
+                        theme_id.name(),
+                    );
+                }
+            }
+            let semantic_lanes = [
+                ("action", ui.accent_primary),
+                ("live", ui.status_working),
+                ("human", ui.accent_action),
+                ("warning", ui.warning),
+                ("danger", ui.error_fg),
+                ("success", ui.success),
+            ];
+            for (mode_name, mode_color) in badges {
+                for (lane_name, lane_color) in semantic_lanes {
+                    assert_ne!(
+                        mode_color,
+                        lane_color,
+                        "theme '{}' reuses the {lane_name} color for mode '{mode_name}', erasing render-stage identity",
                         theme_id.name(),
                     );
                 }

--- a/crates/tui/src/palette/themes.rs
+++ b/crates/tui/src/palette/themes.rs
@@ -727,8 +727,8 @@ impl ThemeId {
         match self {
             Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
             Self::Terminal => "Inherit terminal colors fully (transparent surfaces, ANSI accents)",
-            Self::Whale => "Blue Stage — Blue Devil focus, seafoam live, Signal Gold asks",
-            Self::WhaleLight => "Blue Stage light — ivory field, cobalt focus",
+            Self::Whale => "Whale dark — deep navy & gold",
+            Self::WhaleLight => "DeepSeek light, paper-ish",
             Self::Grayscale => "Color-minimal high contrast",
             Self::CatppuccinMocha => "Soft pastels on warm dark",
             Self::TokyoNight => "Deep blue/violet night palette",
@@ -881,7 +881,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn blue_stage_refresh_keeps_theme_ids_and_default_compatibility() {
+    fn whale_refresh_keeps_theme_ids_and_default_compatibility() {
         let names = SELECTABLE_THEMES
             .iter()
             .map(|theme| theme.name())
@@ -908,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn whale_pair_uses_blue_stage_semantic_grammar() {
+    fn whale_pair_uses_codewhale_semantic_grammar() {
         assert_eq!(UI_THEME.accent_primary, WHALE_ACTION);
         assert_eq!(UI_THEME.status_working, WHALE_LIVE);
         assert_eq!(UI_THEME.accent_action, WHALE_HUMAN);

--- a/crates/tui/src/palette/themes.rs
+++ b/crates/tui/src/palette/themes.rs
@@ -64,32 +64,20 @@ pub const UI_THEME: UiTheme = UiTheme {
     surface_bg: WHALE_BG,
     panel_bg: WHALE_PANEL,
     elevated_bg: SURFACE_ELEVATED,
-    composer_bg: WHALE_PANEL,
+    composer_bg: WHALE_COMPOSER,
     selection_bg: SELECTION_BG,
-    header_bg: WHALE_BG,
-    footer_bg: WHALE_BG,
+    header_bg: WHALE_CHROME,
+    footer_bg: WHALE_CHROME,
     text_dim: TEXT_DIM,
     text_hint: TEXT_HINT,
     text_muted: TEXT_MUTED,
     text_body: TEXT_BODY,
     text_soft: TEXT_SOFT,
     border: BORDER_COLOR,
-    accent_primary: Color::Rgb(
-        WHALE_ACCENT_PRIMARY_RGB.0,
-        WHALE_ACCENT_PRIMARY_RGB.1,
-        WHALE_ACCENT_PRIMARY_RGB.2,
-    ),
-    accent_secondary: Color::Rgb(
-        WHALE_ACCENT_SECONDARY_RGB.0,
-        WHALE_ACCENT_SECONDARY_RGB.1,
-        WHALE_ACCENT_SECONDARY_RGB.2,
-    ),
-    accent_action: Color::Rgb(
-        WHALE_ACCENT_ACTION_RGB.0,
-        WHALE_ACCENT_ACTION_RGB.1,
-        WHALE_ACCENT_ACTION_RGB.2,
-    ),
-    error_fg: Color::Rgb(WHALE_ERROR_RGB.0, WHALE_ERROR_RGB.1, WHALE_ERROR_RGB.2),
+    accent_primary: WHALE_ACTION,
+    accent_secondary: WHALE_LIVE,
+    accent_action: WHALE_HUMAN,
+    error_fg: WHALE_ERROR,
     error_hover: Color::Rgb(
         WHALE_ERROR_HOVER_RGB.0,
         WHALE_ERROR_HOVER_RGB.1,
@@ -110,39 +98,31 @@ pub const UI_THEME: UiTheme = UiTheme {
         WHALE_ERROR_TEXT_RGB.1,
         WHALE_ERROR_TEXT_RGB.2,
     ),
-    warning: Color::Rgb(
-        WHALE_WARNING_RGB.0,
-        WHALE_WARNING_RGB.1,
-        WHALE_WARNING_RGB.2,
-    ),
+    warning: STATUS_WARNING,
     success: Color::Rgb(
         WHALE_SUCCESS_RGB.0,
         WHALE_SUCCESS_RGB.1,
         WHALE_SUCCESS_RGB.2,
     ),
-    info: Color::Rgb(WHALE_INFO_RGB.0, WHALE_INFO_RGB.1, WHALE_INFO_RGB.2),
+    info: WHALE_ACTION,
     mode_agent: MODE_AGENT,
     mode_yolo: MODE_YOLO,
     mode_plan: MODE_PLAN,
     mode_operate: MODE_OPERATE,
     status_ready: TEXT_MUTED,
-    status_working: Color::Rgb(
-        WHALE_ACCENT_SECONDARY_RGB.0,
-        WHALE_ACCENT_SECONDARY_RGB.1,
-        WHALE_ACCENT_SECONDARY_RGB.2,
-    ),
+    status_working: WHALE_LIVE,
     status_warning: STATUS_WARNING,
     diff_added_fg: DIFF_ADDED,
-    diff_deleted_fg: Color::Rgb(WHALE_ERROR_RGB.0, WHALE_ERROR_RGB.1, WHALE_ERROR_RGB.2),
+    diff_deleted_fg: WHALE_ERROR,
     diff_added_bg: DIFF_ADDED_BG,
     diff_deleted_bg: DIFF_DELETED_BG,
-    tool_running: ACCENT_TOOL_LIVE,
+    tool_running: WHALE_LIVE,
     tool_success: Color::Rgb(
         WHALE_WORKING_GREEN_RGB.0,
         WHALE_WORKING_GREEN_RGB.1,
         WHALE_WORKING_GREEN_RGB.2,
     ),
-    tool_failed: ACCENT_TOOL_ISSUE,
+    tool_failed: WHALE_ERROR,
 };
 
 pub const LIGHT_UI_THEME: UiTheme = UiTheme {
@@ -161,35 +141,31 @@ pub const LIGHT_UI_THEME: UiTheme = UiTheme {
     text_body: LIGHT_TEXT_BODY,
     text_soft: LIGHT_TEXT_SOFT,
     border: LIGHT_BORDER,
-    accent_primary: Color::Rgb(53, 120, 229),   // blue
-    accent_secondary: Color::Rgb(79, 180, 160), // teal
-    accent_action: Color::Rgb(220, 90, 60),     // warm coral
-    error_fg: Color::Rgb(200, 40, 60),          // red
-    error_hover: Color::Rgb(220, 70, 85),
-    error_surface: Color::Rgb(254, 229, 229),
-    error_border: Color::Rgb(240, 120, 130),
-    error_text: Color::Rgb(120, 20, 30),
-    warning: Color::Rgb(180, 83, 9), // amber
-    success: Color::Rgb(
-        LIGHT_SUCCESS_FG_RGB.0,
-        LIGHT_SUCCESS_FG_RGB.1,
-        LIGHT_SUCCESS_FG_RGB.2,
-    ), // readable green foreground
-    info: Color::Rgb(53, 120, 229),  // blue
-    mode_agent: Color::Rgb(53, 120, 229), // blue
-    mode_yolo: Color::Rgb(200, 40, 60), // red
-    mode_plan: Color::Rgb(180, 83, 9), // amber
-    mode_operate: Color::Rgb(124, 58, 237), // violet
+    accent_primary: LIGHT_ACTION,
+    accent_secondary: LIGHT_LIVE,
+    accent_action: LIGHT_HUMAN,
+    error_fg: LIGHT_DANGER,
+    error_hover: Color::Rgb(201, 71, 120), // #C94778
+    error_surface: LIGHT_ERROR,
+    error_border: LIGHT_DANGER,
+    error_text: Color::Rgb(109, 22, 56), // #6D1638
+    warning: LIGHT_WARNING,
+    success: LIGHT_SUCCESS_FG,
+    info: LIGHT_ACTION,
+    mode_agent: LIGHT_ACTION,
+    mode_yolo: LIGHT_DANGER,
+    mode_plan: LIGHT_HUMAN,
+    mode_operate: LIGHT_OPERATE,
     status_ready: LIGHT_TEXT_MUTED,
-    status_working: Color::Rgb(79, 180, 160), // teal live work
-    status_warning: Color::Rgb(180, 83, 9),   // amber
-    diff_added_fg: Color::Rgb(22, 101, 52),   // green
-    diff_deleted_fg: Color::Rgb(200, 40, 60), // red
+    status_working: LIGHT_LIVE,
+    status_warning: LIGHT_WARNING,
+    diff_added_fg: Color::Rgb(22, 101, 52), // green
+    diff_deleted_fg: LIGHT_DANGER,
     diff_added_bg: Color::Rgb(223, 247, 231), // light green
-    diff_deleted_bg: Color::Rgb(254, 229, 229), // light red
-    tool_running: Color::Rgb(53, 120, 229),   // blue
-    tool_success: Color::Rgb(21, 128, 61),
-    tool_failed: Color::Rgb(200, 40, 60), // red
+    diff_deleted_bg: LIGHT_ERROR,
+    tool_running: LIGHT_LIVE,
+    tool_success: LIGHT_SUCCESS_FG,
+    tool_failed: LIGHT_DANGER,
 };
 
 pub const SOLARIZED_LIGHT_UI_THEME: UiTheme = UiTheme {
@@ -751,8 +727,8 @@ impl ThemeId {
         match self {
             Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
             Self::Terminal => "Inherit terminal colors fully (transparent surfaces, ANSI accents)",
-            Self::Whale => "Whale dark — deep navy & gold",
-            Self::WhaleLight => "DeepSeek light, paper-ish",
+            Self::Whale => "Blue Stage — Blue Devil focus, seafoam live, Signal Gold asks",
+            Self::WhaleLight => "Blue Stage light — ivory field, cobalt focus",
             Self::Grayscale => "Color-minimal high contrast",
             Self::CatppuccinMocha => "Soft pastels on warm dark",
             Self::TokyoNight => "Deep blue/violet night palette",
@@ -903,6 +879,49 @@ pub fn hex_rgb_string(color: Color) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn blue_stage_refresh_keeps_theme_ids_and_default_compatibility() {
+        let names = SELECTABLE_THEMES
+            .iter()
+            .map(|theme| theme.name())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                "system",
+                "terminal",
+                "dark",
+                "light",
+                "grayscale",
+                "catppuccin-mocha",
+                "tokyo-night",
+                "dracula",
+                "gruvbox-dark",
+                "claude",
+                "matrix",
+                "solarized-light",
+            ]
+        );
+        assert_eq!(normalize_theme_name("default"), Some("system"));
+        assert_eq!(normalize_theme_name("whale"), Some("dark"));
+    }
+
+    #[test]
+    fn whale_pair_uses_blue_stage_semantic_grammar() {
+        assert_eq!(UI_THEME.accent_primary, WHALE_ACTION);
+        assert_eq!(UI_THEME.status_working, WHALE_LIVE);
+        assert_eq!(UI_THEME.accent_action, WHALE_HUMAN);
+        assert_eq!(UI_THEME.warning, STATUS_WARNING);
+        assert_eq!(UI_THEME.error_fg, WHALE_ERROR);
+        assert_eq!(UI_THEME.mode_operate, MODE_OPERATE);
+        assert_eq!(LIGHT_UI_THEME.accent_primary, LIGHT_ACTION);
+        assert_eq!(LIGHT_UI_THEME.status_working, LIGHT_LIVE);
+        assert_eq!(LIGHT_UI_THEME.accent_action, LIGHT_HUMAN);
+        assert_eq!(LIGHT_UI_THEME.warning, LIGHT_WARNING);
+        assert_eq!(LIGHT_UI_THEME.error_fg, LIGHT_DANGER);
+        assert_eq!(LIGHT_UI_THEME.mode_operate, LIGHT_OPERATE);
+    }
 
     /// Dogfood A7 (#4092): every mode must be tellable apart from the footer
     /// badge alone — Operate must never wear the YOLO red again.

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -16,9 +16,12 @@ pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (132, 145, 170); // #8491AA
 #[allow(dead_code)]
 pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (105, 119, 145); // #697791
 pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Cobalt action blue
-pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
 pub const WHALE_ACCENT_SECONDARY_RGB: (u8, u8, u8) = (79, 209, 197); // #4FD1C5 Seafoam
 pub const WHALE_HUMAN_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
+/// Compatibility name retained for downstream callers that used the original
+/// Codewhale brand accent. New action/focus call sites should use
+/// [`WHALE_ACTION_RGB`] instead.
+pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
 pub const WHALE_WORKING_GREEN_RGB: (u8, u8, u8) = (155, 214, 111); // #9BD66F Working Green
 #[allow(dead_code)]
 pub const WHALE_ACCENT_ACTION_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
@@ -224,7 +227,8 @@ pub const WHALE_ACCENT_PRIMARY: Color = Color::Rgb(
     WHALE_ACCENT_PRIMARY_RGB.1,
     WHALE_ACCENT_PRIMARY_RGB.2,
 );
-pub const WHALE_ACTION: Color = WHALE_ACCENT_PRIMARY;
+pub const WHALE_ACTION: Color =
+    Color::Rgb(WHALE_ACTION_RGB.0, WHALE_ACTION_RGB.1, WHALE_ACTION_RGB.2);
 pub const WHALE_LIVE: Color = Color::Rgb(
     WHALE_ACCENT_SECONDARY_RGB.0,
     WHALE_ACCENT_SECONDARY_RGB.1,

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -2,11 +2,10 @@
 
 use ratatui::style::Color;
 
-// Blue Stage Whale palette. The neutral field follows the Blue Devils-derived
-// stage study; semantic colors below own state, never decoration alone.
-pub const WHALE_BG_RGB: (u8, u8, u8) = (3, 7, 13); // #03070D Stage Black
+// Codewhale Whale palette. Semantic colors own state, never decoration alone.
+pub const WHALE_BG_RGB: (u8, u8, u8) = (3, 7, 13); // #03070D Deep field
 pub const WHALE_CHROME_RGB: (u8, u8, u8) = (8, 17, 28); // #08111C Ink / chrome
-pub const WHALE_PANEL_RGB: (u8, u8, u8) = (14, 23, 41); // #0E1729 Stage surface
+pub const WHALE_PANEL_RGB: (u8, u8, u8) = (14, 23, 41); // #0E1729 Panel surface
 pub const WHALE_COMPOSER_RGB: (u8, u8, u8) = (22, 34, 56); // #162238 Plate
 pub const WHALE_ELEVATED_RGB: (u8, u8, u8) = (24, 39, 66); // #182742 Raised
 pub const WHALE_SELECTION_RGB: (u8, u8, u8) = (31, 50, 77); // #1F324D Action-blue tint
@@ -16,7 +15,7 @@ pub const WHALE_TEXT_MUTED_RGB: (u8, u8, u8) = (147, 160, 184); // #93A0B8
 pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (132, 145, 170); // #8491AA
 #[allow(dead_code)]
 pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (105, 119, 145); // #697791
-pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Blue Devil Sky
+pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Cobalt action blue
 pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
 pub const WHALE_ACCENT_SECONDARY_RGB: (u8, u8, u8) = (79, 209, 197); // #4FD1C5 Seafoam
 pub const WHALE_HUMAN_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
@@ -60,16 +59,19 @@ pub const WHALE_DIFF_ADDED_RGB: (u8, u8, u8) = (87, 199, 133); // #57C785
 #[allow(dead_code)]
 pub const WHALE_DIFF_DELETED_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
 pub const WHALE_DIFF_ADDED_BG_RGB: (u8, u8, u8) = (18, 42, 34); // #122A22
-pub const WHALE_DIFF_DELETED_BG_RGB: (u8, u8, u8) = WHALE_ERROR_SURFACE_RGB;
-pub const WHALE_MODE_AGENT_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
-pub const WHALE_MODE_YOLO_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
-pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
+// Raw colors that are remapped by equality must remain distinct across roles.
+// These stay in the same perceptual families as action, danger, and human asks
+// while preserving mode identity for Terminal and community themes.
+pub const WHALE_DIFF_DELETED_BG_RGB: (u8, u8, u8) = (52, 24, 39); // #341827
+pub const WHALE_MODE_AGENT_RGB: (u8, u8, u8) = (118, 181, 245); // #76B5F5
+pub const WHALE_MODE_YOLO_RGB: (u8, u8, u8) = (255, 112, 160); // #FF70A0
+pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = (255, 208, 106); // #FFD06A
 pub const WHALE_MODE_OPERATE_RGB: (u8, u8, u8) = (173, 136, 255); // #AD88FF
 pub const WHALE_TOOL_LIVE_RGB: (u8, u8, u8) = WHALE_ACCENT_SECONDARY_RGB;
 pub const WHALE_TOOL_ISSUE_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
 pub const WHALE_TOOL_OUTPUT_RGB: (u8, u8, u8) = WHALE_TEXT_SOFT_RGB;
 pub const WHALE_TOOL_SURFACE_RGB: (u8, u8, u8) = (18, 29, 50); // #121D32
-pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = WHALE_SELECTION_RGB;
+pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = (27, 44, 68); // #1B2C44
 
 pub const LIGHT_SURFACE_RGB: (u8, u8, u8) = (244, 247, 251); // #F4F7FB
 pub const LIGHT_PANEL_RGB: (u8, u8, u8) = (255, 253, 248); // #FFFDF8
@@ -183,7 +185,7 @@ pub const SOLARIZED_COMPOSER: Color = Color::Rgb(
 );
 
 pub const LIGHT_BORDER_RGB: (u8, u8, u8) = (169, 184, 207); // #A9B8CF
-pub const LIGHT_SELECTION_RGB: (u8, u8, u8) = (221, 230, 247); // #DDE6F7
+pub const LIGHT_SELECTION_RGB: (u8, u8, u8) = (238, 246, 255); // #EEF6FF
 pub const GRAYSCALE_SURFACE_RGB: (u8, u8, u8) = (10, 10, 10); // #0A0A0A
 pub const GRAYSCALE_PANEL_RGB: (u8, u8, u8) = (18, 18, 18); // #121212
 pub const GRAYSCALE_ELEVATED_RGB: (u8, u8, u8) = (31, 31, 31); // #1F1F1F

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -78,7 +78,7 @@ pub const LIGHT_PANEL_RGB: (u8, u8, u8) = (255, 253, 248); // #FFFDF8
 pub const LIGHT_ELEVATED_RGB: (u8, u8, u8) = (232, 238, 248); // #E8EEF8
 pub const LIGHT_REASONING_RGB: (u8, u8, u8) = (255, 246, 214); // #FFF6D6
 pub const LIGHT_SUCCESS_RGB: (u8, u8, u8) = (223, 247, 231); // #DFF7E7
-pub const LIGHT_SUCCESS_FG_RGB: (u8, u8, u8) = (21, 128, 61); // readable completed / verified foreground
+pub const LIGHT_SUCCESS_FG_RGB: (u8, u8, u8) = (20, 118, 61); // #14763D, readable on every light surface
 pub const LIGHT_ERROR_RGB: (u8, u8, u8) = (252, 235, 242); // #FCEBF2
 pub const LIGHT_TEXT_BODY_RGB: (u8, u8, u8) = (20, 33, 58); // #14213A
 pub const LIGHT_TEXT_MUTED_RGB: (u8, u8, u8) = (91, 103, 128); // #5B6780
@@ -89,6 +89,13 @@ pub const LIGHT_LIVE_RGB: (u8, u8, u8) = (8, 118, 109); // #08766D
 pub const LIGHT_HUMAN_RGB: (u8, u8, u8) = (122, 85, 0); // #7A5500
 pub const LIGHT_WARNING_RGB: (u8, u8, u8) = (169, 71, 36); // #A94724
 pub const LIGHT_DANGER_RGB: (u8, u8, u8) = (180, 35, 90); // #B4235A
+// Mode shades stay in their parent semantic families while remaining distinct
+// inputs to the render backend. A `Cell` carries only a `Color`, so reusing the
+// exact action/human/danger value here would erase the mode role before ANSI
+// adaptation can preserve it.
+pub const LIGHT_MODE_AGENT_RGB: (u8, u8, u8) = (50, 95, 216); // #325FD8
+pub const LIGHT_MODE_YOLO_RGB: (u8, u8, u8) = (181, 35, 90); // #B5235A
+pub const LIGHT_MODE_PLAN_RGB: (u8, u8, u8) = (123, 85, 0); // #7B5500
 pub const LIGHT_OPERATE_RGB: (u8, u8, u8) = (112, 71, 184); // #7047B8
 
 // Solarized Light palette colors
@@ -294,6 +301,21 @@ pub const LIGHT_WARNING: Color = Color::Rgb(
 );
 pub const LIGHT_DANGER: Color =
     Color::Rgb(LIGHT_DANGER_RGB.0, LIGHT_DANGER_RGB.1, LIGHT_DANGER_RGB.2);
+pub const LIGHT_MODE_AGENT: Color = Color::Rgb(
+    LIGHT_MODE_AGENT_RGB.0,
+    LIGHT_MODE_AGENT_RGB.1,
+    LIGHT_MODE_AGENT_RGB.2,
+);
+pub const LIGHT_MODE_YOLO: Color = Color::Rgb(
+    LIGHT_MODE_YOLO_RGB.0,
+    LIGHT_MODE_YOLO_RGB.1,
+    LIGHT_MODE_YOLO_RGB.2,
+);
+pub const LIGHT_MODE_PLAN: Color = Color::Rgb(
+    LIGHT_MODE_PLAN_RGB.0,
+    LIGHT_MODE_PLAN_RGB.1,
+    LIGHT_MODE_PLAN_RGB.2,
+);
 pub const LIGHT_OPERATE: Color = Color::Rgb(
     LIGHT_OPERATE_RGB.0,
     LIGHT_OPERATE_RGB.1,
@@ -408,7 +430,7 @@ pub const TEXT_PRIMARY: Color = TEXT_BODY;
 pub const TEXT_MUTED: Color = TEXT_SECONDARY;
 pub const TEXT_DIM: Color = TEXT_HINT;
 pub const USER_BODY: Color = Color::Rgb(74, 222, 128); // #4ADE80 green
-pub const LIGHT_USER_BODY: Color = Color::Rgb(21, 128, 61); // #15803D green
+pub const LIGHT_USER_BODY: Color = LIGHT_SUCCESS_FG;
 
 // Compatibility semantic colors for UI theming
 pub const BORDER_COLOR: Color =

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -2,30 +2,36 @@
 
 use ratatui::style::Color;
 
-// v0.8.46 Whale dark palette — improved contrast and layer separation.
-pub const WHALE_BG_RGB: (u8, u8, u8) = (10, 17, 32); // #0A1120 Deep Navy
-pub const WHALE_PANEL_RGB: (u8, u8, u8) = (22, 34, 56); // #162238
-pub const WHALE_ELEVATED_RGB: (u8, u8, u8) = (36, 52, 78); // #24344E
-pub const WHALE_SELECTION_RGB: (u8, u8, u8) = (40, 56, 84); // #283854 — darker to avoid bright pop on deep navy
+// Blue Stage Whale palette. The neutral field follows the Blue Devils-derived
+// stage study; semantic colors below own state, never decoration alone.
+pub const WHALE_BG_RGB: (u8, u8, u8) = (3, 7, 13); // #03070D Stage Black
+pub const WHALE_CHROME_RGB: (u8, u8, u8) = (8, 17, 28); // #08111C Ink / chrome
+pub const WHALE_PANEL_RGB: (u8, u8, u8) = (14, 23, 41); // #0E1729 Stage surface
+pub const WHALE_COMPOSER_RGB: (u8, u8, u8) = (22, 34, 56); // #162238 Plate
+pub const WHALE_ELEVATED_RGB: (u8, u8, u8) = (24, 39, 66); // #182742 Raised
+pub const WHALE_SELECTION_RGB: (u8, u8, u8) = (31, 50, 77); // #1F324D Action-blue tint
 pub const WHALE_TEXT_BODY_RGB: (u8, u8, u8) = (246, 242, 232); // #F6F2E8 Whale Ivory
-pub const WHALE_TEXT_SOFT_RGB: (u8, u8, u8) = (217, 224, 234); // #D9E0EA
-pub const WHALE_TEXT_MUTED_RGB: (u8, u8, u8) = (169, 180, 199); // #A9B4C7 Mist Gray
-pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (138, 150, 174); // #8A96AE
+pub const WHALE_TEXT_SOFT_RGB: (u8, u8, u8) = (182, 192, 212); // #B6C0D4
+pub const WHALE_TEXT_MUTED_RGB: (u8, u8, u8) = (147, 160, 184); // #93A0B8
+pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (132, 145, 170); // #8491AA
 #[allow(dead_code)]
-pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (118, 130, 156); // #76829C
-pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
+pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (105, 119, 145); // #697791
+pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Blue Devil Sky
+pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
 pub const WHALE_ACCENT_SECONDARY_RGB: (u8, u8, u8) = (79, 209, 197); // #4FD1C5 Seafoam
+pub const WHALE_HUMAN_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
 pub const WHALE_WORKING_GREEN_RGB: (u8, u8, u8) = (155, 214, 111); // #9BD66F Working Green
-pub const WHALE_ACCENT_ACTION_RGB: (u8, u8, u8) = (255, 122, 89); // #FF7A59 Coral Spark
-pub const WHALE_ERROR_RGB: (u8, u8, u8) = (255, 92, 122); // #FF5C7A Rose Red
-pub const WHALE_ERROR_HOVER_RGB: (u8, u8, u8) = (255, 120, 144); // #FF7890 Rose Hover
-pub const WHALE_ERROR_SURFACE_RGB: (u8, u8, u8) = (42, 18, 26); // #2A121A Error Surface
-pub const WHALE_ERROR_BORDER_RGB: (u8, u8, u8) = (255, 138, 160); // #FF8AA0 Error Border
-pub const WHALE_ERROR_TEXT_RGB: (u8, u8, u8) = (255, 214, 222); // #FFD6DE Error Text
-pub const WHALE_WARNING_RGB: (u8, u8, u8) = (240, 160, 48); // #F0A030
+#[allow(dead_code)]
+pub const WHALE_ACCENT_ACTION_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
+pub const WHALE_ERROR_RGB: (u8, u8, u8) = (255, 134, 178); // #FF86B2 Rose danger
+pub const WHALE_ERROR_HOVER_RGB: (u8, u8, u8) = (255, 156, 194); // #FF9CC2
+pub const WHALE_ERROR_SURFACE_RGB: (u8, u8, u8) = (43, 21, 34); // #2B1522
+pub const WHALE_ERROR_BORDER_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
+pub const WHALE_ERROR_TEXT_RGB: (u8, u8, u8) = (255, 219, 232); // #FFDBE8
+pub const WHALE_WARNING_RGB: (u8, u8, u8) = (255, 122, 89); // #FF7A59 Coral warning
 pub const WHALE_SUCCESS_RGB: (u8, u8, u8) = WHALE_WORKING_GREEN_RGB; // completed / verified
-pub const WHALE_INFO_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Sky
-pub const WHALE_BORDER_RGB: (u8, u8, u8) = (52, 88, 145); // #345891
+pub const WHALE_INFO_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
+pub const WHALE_BORDER_RGB: (u8, u8, u8) = (38, 62, 92); // #263E5C, blue at 25% on stage
 pub const WHALE_REASONING_TEXT_RGB: (u8, u8, u8) = (224, 153, 72); // #E09948
 pub const WHALE_REASONING_SURFACE_RGB: (u8, u8, u8) = (42, 34, 24); // #2A2218
 pub const WHALE_REASONING_TINT_RGB: (u8, u8, u8) = (24, 36, 52); // #182434
@@ -52,30 +58,36 @@ pub const SOLARIZED_SELECT_RGB: (u8, u8, u8) = (0xD6, 0xD2, 0xC9);
 
 pub const WHALE_DIFF_ADDED_RGB: (u8, u8, u8) = (87, 199, 133); // #57C785
 #[allow(dead_code)]
-pub const WHALE_DIFF_DELETED_RGB: (u8, u8, u8) = (255, 92, 122); // #FF5C7A Rose Red
+pub const WHALE_DIFF_DELETED_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
 pub const WHALE_DIFF_ADDED_BG_RGB: (u8, u8, u8) = (18, 42, 34); // #122A22
-pub const WHALE_DIFF_DELETED_BG_RGB: (u8, u8, u8) = (42, 18, 26); // #2A121A
-pub const WHALE_MODE_AGENT_RGB: (u8, u8, u8) = (80, 150, 255); // #5096FF
-pub const WHALE_MODE_YOLO_RGB: (u8, u8, u8) = (255, 100, 100); // #FF6464
-pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
-pub const WHALE_MODE_OPERATE_RGB: (u8, u8, u8) = (178, 132, 255); // #B284FF
-pub const WHALE_TOOL_LIVE_RGB: (u8, u8, u8) = (140, 190, 238); // #8CBEEE
-pub const WHALE_TOOL_ISSUE_RGB: (u8, u8, u8) = (198, 150, 160); // #C696A0
-pub const WHALE_TOOL_OUTPUT_RGB: (u8, u8, u8) = (194, 208, 224); // #C2D0E0
-pub const WHALE_TOOL_SURFACE_RGB: (u8, u8, u8) = (28, 40, 62); // #1C283E
-pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = (38, 54, 80); // #263650
+pub const WHALE_DIFF_DELETED_BG_RGB: (u8, u8, u8) = WHALE_ERROR_SURFACE_RGB;
+pub const WHALE_MODE_AGENT_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
+pub const WHALE_MODE_YOLO_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
+pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
+pub const WHALE_MODE_OPERATE_RGB: (u8, u8, u8) = (173, 136, 255); // #AD88FF
+pub const WHALE_TOOL_LIVE_RGB: (u8, u8, u8) = WHALE_ACCENT_SECONDARY_RGB;
+pub const WHALE_TOOL_ISSUE_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
+pub const WHALE_TOOL_OUTPUT_RGB: (u8, u8, u8) = WHALE_TEXT_SOFT_RGB;
+pub const WHALE_TOOL_SURFACE_RGB: (u8, u8, u8) = (18, 29, 50); // #121D32
+pub const WHALE_TOOL_ACTIVE_RGB: (u8, u8, u8) = WHALE_SELECTION_RGB;
 
-pub const LIGHT_SURFACE_RGB: (u8, u8, u8) = (246, 248, 251); // #F6F8FB
-pub const LIGHT_PANEL_RGB: (u8, u8, u8) = (236, 242, 248); // #ECF2F8
-pub const LIGHT_ELEVATED_RGB: (u8, u8, u8) = (219, 229, 240); // #DBE5F0
+pub const LIGHT_SURFACE_RGB: (u8, u8, u8) = (244, 247, 251); // #F4F7FB
+pub const LIGHT_PANEL_RGB: (u8, u8, u8) = (255, 253, 248); // #FFFDF8
+pub const LIGHT_ELEVATED_RGB: (u8, u8, u8) = (232, 238, 248); // #E8EEF8
 pub const LIGHT_REASONING_RGB: (u8, u8, u8) = (255, 246, 214); // #FFF6D6
 pub const LIGHT_SUCCESS_RGB: (u8, u8, u8) = (223, 247, 231); // #DFF7E7
 pub const LIGHT_SUCCESS_FG_RGB: (u8, u8, u8) = (21, 128, 61); // readable completed / verified foreground
-pub const LIGHT_ERROR_RGB: (u8, u8, u8) = (254, 229, 229); // #FEE5E5
-pub const LIGHT_TEXT_BODY_RGB: (u8, u8, u8) = (15, 23, 42); // #0F172A
-pub const LIGHT_TEXT_MUTED_RGB: (u8, u8, u8) = (51, 65, 85); // #334155
-pub const LIGHT_TEXT_HINT_RGB: (u8, u8, u8) = (100, 116, 139); // #64748B
-pub const LIGHT_TEXT_SOFT_RGB: (u8, u8, u8) = (30, 41, 59); // #1E293B
+pub const LIGHT_ERROR_RGB: (u8, u8, u8) = (252, 235, 242); // #FCEBF2
+pub const LIGHT_TEXT_BODY_RGB: (u8, u8, u8) = (20, 33, 58); // #14213A
+pub const LIGHT_TEXT_MUTED_RGB: (u8, u8, u8) = (91, 103, 128); // #5B6780
+pub const LIGHT_TEXT_HINT_RGB: (u8, u8, u8) = (95, 107, 129); // #5F6B81
+pub const LIGHT_TEXT_SOFT_RGB: (u8, u8, u8) = (69, 81, 104); // #455168
+pub const LIGHT_ACTION_RGB: (u8, u8, u8) = (49, 95, 216); // #315FD8 Cobalt
+pub const LIGHT_LIVE_RGB: (u8, u8, u8) = (8, 118, 109); // #08766D
+pub const LIGHT_HUMAN_RGB: (u8, u8, u8) = (122, 85, 0); // #7A5500
+pub const LIGHT_WARNING_RGB: (u8, u8, u8) = (169, 71, 36); // #A94724
+pub const LIGHT_DANGER_RGB: (u8, u8, u8) = (180, 35, 90); // #B4235A
+pub const LIGHT_OPERATE_RGB: (u8, u8, u8) = (112, 71, 184); // #7047B8
 
 // Solarized Light palette colors
 pub const SOLARIZED_TEXT_DIM: Color = Color::Rgb(
@@ -170,8 +182,8 @@ pub const SOLARIZED_COMPOSER: Color = Color::Rgb(
     SOLARIZED_PANEL_RGB.2,
 );
 
-pub const LIGHT_BORDER_RGB: (u8, u8, u8) = (139, 161, 184); // #8BA1B8
-pub const LIGHT_SELECTION_RGB: (u8, u8, u8) = (207, 224, 247); // #CFE0F7
+pub const LIGHT_BORDER_RGB: (u8, u8, u8) = (169, 184, 207); // #A9B8CF
+pub const LIGHT_SELECTION_RGB: (u8, u8, u8) = (221, 230, 247); // #DDE6F7
 pub const GRAYSCALE_SURFACE_RGB: (u8, u8, u8) = (10, 10, 10); // #0A0A0A
 pub const GRAYSCALE_PANEL_RGB: (u8, u8, u8) = (18, 18, 18); // #121212
 pub const GRAYSCALE_ELEVATED_RGB: (u8, u8, u8) = (31, 31, 31); // #1F1F1F
@@ -195,17 +207,31 @@ pub const MATRIX_TEXT_SOFT_RGB: (u8, u8, u8) = (221, 255, 221); // #DDFFDD
 pub const MATRIX_TEXT_DIM_RGB: (u8, u8, u8) = (0, 68, 0); // #004400
 pub const MATRIX_BORDER_RGB: (u8, u8, u8) = (0, 204, 0); // #00CC00
 
-// New semantic colors
-pub const BORDER_COLOR_RGB: (u8, u8, u8) = WHALE_BORDER_RGB; // #2A4A7F
+// Semantic colors
+pub const BORDER_COLOR_RGB: (u8, u8, u8) = WHALE_BORDER_RGB;
 
 pub const WHALE_ACCENT_PRIMARY: Color = Color::Rgb(
     WHALE_ACCENT_PRIMARY_RGB.0,
     WHALE_ACCENT_PRIMARY_RGB.1,
     WHALE_ACCENT_PRIMARY_RGB.2,
 );
+pub const WHALE_ACTION: Color = WHALE_ACCENT_PRIMARY;
+pub const WHALE_LIVE: Color = Color::Rgb(
+    WHALE_ACCENT_SECONDARY_RGB.0,
+    WHALE_ACCENT_SECONDARY_RGB.1,
+    WHALE_ACCENT_SECONDARY_RGB.2,
+);
+pub const WHALE_HUMAN: Color = Color::Rgb(WHALE_HUMAN_RGB.0, WHALE_HUMAN_RGB.1, WHALE_HUMAN_RGB.2);
 pub const WHALE_INFO: Color = Color::Rgb(WHALE_INFO_RGB.0, WHALE_INFO_RGB.1, WHALE_INFO_RGB.2);
 pub const WHALE_BG: Color = Color::Rgb(WHALE_BG_RGB.0, WHALE_BG_RGB.1, WHALE_BG_RGB.2);
+pub const WHALE_CHROME: Color =
+    Color::Rgb(WHALE_CHROME_RGB.0, WHALE_CHROME_RGB.1, WHALE_CHROME_RGB.2);
 pub const WHALE_PANEL: Color = Color::Rgb(WHALE_PANEL_RGB.0, WHALE_PANEL_RGB.1, WHALE_PANEL_RGB.2);
+pub const WHALE_COMPOSER: Color = Color::Rgb(
+    WHALE_COMPOSER_RGB.0,
+    WHALE_COMPOSER_RGB.1,
+    WHALE_COMPOSER_RGB.2,
+);
 pub const WHALE_ERROR: Color = Color::Rgb(WHALE_ERROR_RGB.0, WHALE_ERROR_RGB.1, WHALE_ERROR_RGB.2);
 
 pub const LIGHT_SURFACE: Color = Color::Rgb(
@@ -229,6 +255,11 @@ pub const LIGHT_SUCCESS: Color = Color::Rgb(
     LIGHT_SUCCESS_RGB.1,
     LIGHT_SUCCESS_RGB.2,
 );
+pub const LIGHT_SUCCESS_FG: Color = Color::Rgb(
+    LIGHT_SUCCESS_FG_RGB.0,
+    LIGHT_SUCCESS_FG_RGB.1,
+    LIGHT_SUCCESS_FG_RGB.2,
+);
 pub const LIGHT_ERROR: Color = Color::Rgb(LIGHT_ERROR_RGB.0, LIGHT_ERROR_RGB.1, LIGHT_ERROR_RGB.2);
 pub const LIGHT_TEXT_BODY: Color = Color::Rgb(
     LIGHT_TEXT_BODY_RGB.0,
@@ -249,6 +280,22 @@ pub const LIGHT_TEXT_SOFT: Color = Color::Rgb(
     LIGHT_TEXT_SOFT_RGB.0,
     LIGHT_TEXT_SOFT_RGB.1,
     LIGHT_TEXT_SOFT_RGB.2,
+);
+pub const LIGHT_ACTION: Color =
+    Color::Rgb(LIGHT_ACTION_RGB.0, LIGHT_ACTION_RGB.1, LIGHT_ACTION_RGB.2);
+pub const LIGHT_LIVE: Color = Color::Rgb(LIGHT_LIVE_RGB.0, LIGHT_LIVE_RGB.1, LIGHT_LIVE_RGB.2);
+pub const LIGHT_HUMAN: Color = Color::Rgb(LIGHT_HUMAN_RGB.0, LIGHT_HUMAN_RGB.1, LIGHT_HUMAN_RGB.2);
+pub const LIGHT_WARNING: Color = Color::Rgb(
+    LIGHT_WARNING_RGB.0,
+    LIGHT_WARNING_RGB.1,
+    LIGHT_WARNING_RGB.2,
+);
+pub const LIGHT_DANGER: Color =
+    Color::Rgb(LIGHT_DANGER_RGB.0, LIGHT_DANGER_RGB.1, LIGHT_DANGER_RGB.2);
+pub const LIGHT_OPERATE: Color = Color::Rgb(
+    LIGHT_OPERATE_RGB.0,
+    LIGHT_OPERATE_RGB.1,
+    LIGHT_OPERATE_RGB.2,
 );
 pub const LIGHT_BORDER: Color =
     Color::Rgb(LIGHT_BORDER_RGB.0, LIGHT_BORDER_RGB.1, LIGHT_BORDER_RGB.2);
@@ -361,7 +408,7 @@ pub const TEXT_DIM: Color = TEXT_HINT;
 pub const USER_BODY: Color = Color::Rgb(74, 222, 128); // #4ADE80 green
 pub const LIGHT_USER_BODY: Color = Color::Rgb(21, 128, 61); // #15803D green
 
-// New semantic colors for UI theming
+// Compatibility semantic colors for UI theming
 pub const BORDER_COLOR: Color =
     Color::Rgb(BORDER_COLOR_RGB.0, BORDER_COLOR_RGB.1, BORDER_COLOR_RGB.2);
 #[allow(dead_code)]
@@ -500,4 +547,4 @@ pub const SELECTION_BG: Color = Color::Rgb(
     WHALE_SELECTION_RGB.2,
 );
 #[allow(dead_code)]
-pub const COMPOSER_BG: Color = WHALE_PANEL;
+pub const COMPOSER_BG: Color = WHALE_COMPOSER;

--- a/crates/tui/src/runtime_web/index.html
+++ b/crates/tui/src/runtime_web/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="dark">
-    <meta name="theme-color" content="#081316">
+    <meta name="theme-color" content="#03070d">
     <title>Codewhale</title>
     <link rel="icon" href="data:,">
     <link rel="stylesheet" href="/assets/codewhale-web.css">

--- a/crates/tui/src/runtime_web/styles.css
+++ b/crates/tui/src/runtime_web/styles.css
@@ -358,7 +358,7 @@ textarea::placeholder {
   gap: 12px 20px;
   padding: 15px 24px 13px;
   border-bottom: 1px solid var(--line);
-  background: rgba(6, 16, 18, 0.72);
+  background: rgba(8, 17, 28, 0.72);
   backdrop-filter: blur(14px);
 }
 
@@ -428,10 +428,10 @@ textarea::placeholder {
   margin: 12px auto 0;
   width: min(760px, calc(100% - 32px));
   padding: 9px 12px;
-  border: 1px solid rgba(255, 134, 178, 0.28);
+  border: 1px solid rgba(255, 122, 89, 0.34);
   border-radius: 9px;
-  background: rgba(43, 21, 34, 0.42);
-  color: #ffdbe8;
+  background: rgba(48, 25, 21, 0.48);
+  color: var(--warning);
   font-size: 11px;
   line-height: 1.45;
 }

--- a/crates/tui/src/runtime_web/styles.css
+++ b/crates/tui/src/runtime_web/styles.css
@@ -1,20 +1,24 @@
 :root {
   color-scheme: dark;
-  --ink-0: #061012;
-  --ink-1: #081619;
-  --ink-2: #0d1d20;
-  --ink-3: #14282b;
-  --line: rgba(184, 218, 215, 0.14);
-  --line-strong: rgba(184, 218, 215, 0.25);
-  --text: #edf5f2;
-  --text-soft: #adc0bd;
-  --text-dim: #718985;
-  --gold: #e6b84f;
-  --gold-strong: #f1c768;
-  --gold-wash: rgba(230, 184, 79, 0.11);
-  --aqua: #72c7be;
-  --danger: #f08b83;
-  --ok: #75c49a;
+  --ink-0: #03070d;
+  --ink-1: #08111c;
+  --ink-2: #0e1729;
+  --ink-3: #182742;
+  --line: rgba(106, 174, 242, 0.18);
+  --line-strong: rgba(106, 174, 242, 0.32);
+  --text: #f6f2e8;
+  --text-soft: #b6c0d4;
+  --text-dim: #93a0b8;
+  --action: #6aaef2;
+  --action-strong: #4f8fe8;
+  --action-wash: rgba(106, 174, 242, 0.11);
+  --human: #f6c453;
+  --human-wash: rgba(246, 196, 83, 0.11);
+  --live: #4fd1c5;
+  --live-wash: rgba(79, 209, 197, 0.12);
+  --warning: #ff7a59;
+  --danger: #ff86b2;
+  --ok: #9bd66f;
   --rail: 248px;
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
@@ -57,7 +61,7 @@ button:focus-visible,
 input:focus-visible,
 textarea:focus-visible,
 summary:focus-visible {
-  outline: 2px solid var(--gold-strong);
+  outline: 2px solid var(--action);
   outline-offset: 2px;
 }
 
@@ -67,7 +71,7 @@ summary:focus-visible {
   width: 100%;
   height: 100%;
   background:
-    radial-gradient(circle at 73% -20%, rgba(53, 126, 124, 0.12), transparent 42%),
+    radial-gradient(circle at 73% -20%, rgba(49, 95, 216, 0.14), transparent 42%),
     var(--ink-0);
 }
 
@@ -81,7 +85,7 @@ summary:focus-visible {
   min-height: 0;
   padding: 18px 14px 12px;
   border-right: 1px solid var(--line);
-  background: rgba(8, 22, 25, 0.96);
+  background: rgba(8, 17, 28, 0.96);
 }
 
 .rail-brand,
@@ -109,10 +113,10 @@ summary:focus-visible {
   width: 34px;
   height: 34px;
   place-items: center;
-  border: 1px solid rgba(230, 184, 79, 0.42);
+  border: 1px solid rgba(246, 196, 83, 0.42);
   border-radius: 10px;
-  background: var(--gold-wash);
-  color: var(--gold-strong);
+  background: var(--human-wash);
+  color: var(--human);
   font-size: 11px;
   font-weight: 800;
   letter-spacing: 0.05em;
@@ -150,14 +154,14 @@ summary:focus-visible {
 
 .primary-button,
 .send-button {
-  border-color: rgba(230, 184, 79, 0.4);
-  background: var(--gold);
-  color: #171204;
+  border-color: rgba(106, 174, 242, 0.46);
+  background: var(--action);
+  color: var(--ink-0);
 }
 
 .primary-button:hover,
 .send-button:hover {
-  background: var(--gold-strong);
+  background: var(--action-strong);
 }
 
 .quiet-button {
@@ -172,7 +176,7 @@ summary:focus-visible {
 }
 
 .quiet-button.danger:hover {
-  border-color: rgba(240, 139, 131, 0.42);
+  border-color: rgba(255, 134, 178, 0.42);
   color: var(--danger);
 }
 
@@ -201,12 +205,12 @@ summary:focus-visible {
   padding: 0 10px;
   border: 1px solid var(--line);
   border-radius: 9px;
-  background: rgba(5, 14, 16, 0.55);
+  background: rgba(3, 7, 13, 0.55);
   color: var(--text-dim);
 }
 
 .search-field:focus-within {
-  border-color: rgba(230, 184, 79, 0.42);
+  border-color: rgba(106, 174, 242, 0.46);
 }
 
 .search-field input {
@@ -247,13 +251,13 @@ textarea::placeholder {
 }
 
 .thread-row:hover {
-  background: rgba(20, 40, 43, 0.62);
+  background: rgba(24, 39, 66, 0.62);
   color: var(--text);
 }
 
 .thread-row[aria-current="true"] {
-  border-color: rgba(230, 184, 79, 0.24);
-  background: var(--gold-wash);
+  border-color: rgba(106, 174, 242, 0.32);
+  background: var(--action-wash);
   color: var(--text);
 }
 
@@ -301,8 +305,8 @@ textarea::placeholder {
 }
 
 .status-pip.running {
-  background: var(--gold-strong);
-  box-shadow: 0 0 0 3px var(--gold-wash);
+  background: var(--live);
+  box-shadow: 0 0 0 3px var(--live-wash);
 }
 
 .status-pip.failed {
@@ -323,11 +327,11 @@ textarea::placeholder {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--gold);
+  background: var(--action);
 }
 
 .connection-dot.ready {
-  background: var(--ok);
+  background: var(--live);
 }
 
 .connection-dot.error {
@@ -424,10 +428,10 @@ textarea::placeholder {
   margin: 12px auto 0;
   width: min(760px, calc(100% - 32px));
   padding: 9px 12px;
-  border: 1px solid rgba(240, 139, 131, 0.28);
+  border: 1px solid rgba(255, 134, 178, 0.28);
   border-radius: 9px;
-  background: rgba(91, 31, 28, 0.24);
-  color: #ffc0bb;
+  background: rgba(43, 21, 34, 0.42);
+  color: #ffdbe8;
   font-size: 11px;
   line-height: 1.45;
 }
@@ -468,7 +472,7 @@ textarea::placeholder {
 }
 
 .empty-orbit {
-  color: var(--gold);
+  color: var(--human);
   font-size: 34px;
 }
 
@@ -494,7 +498,7 @@ textarea::placeholder {
   padding: 13px 15px;
   border: 1px solid var(--line);
   border-radius: 12px;
-  background: rgba(13, 29, 32, 0.74);
+  background: rgba(14, 23, 41, 0.74);
   color: var(--text);
   font-size: 13px;
   line-height: 1.65;
@@ -504,8 +508,8 @@ textarea::placeholder {
 
 .message.user .message-body {
   margin-left: clamp(0px, 8vw, 72px);
-  border-color: rgba(230, 184, 79, 0.19);
-  background: rgba(230, 184, 79, 0.07);
+  border-color: rgba(246, 196, 83, 0.22);
+  background: rgba(246, 196, 83, 0.07);
 }
 
 .message.in-progress .message-body::after {
@@ -514,7 +518,7 @@ textarea::placeholder {
   width: 5px;
   height: 12px;
   margin-left: 4px;
-  background: var(--gold);
+  background: var(--live);
   vertical-align: -1px;
   animation: cursor-pulse 1s steps(2, end) infinite;
 }
@@ -527,11 +531,11 @@ textarea::placeholder {
   padding: 10px 12px;
   border: 1px solid var(--line);
   border-radius: 10px;
-  background: rgba(8, 22, 25, 0.54);
+  background: rgba(8, 17, 28, 0.54);
 }
 
 .receipt.failed {
-  border-color: rgba(240, 139, 131, 0.28);
+  border-color: rgba(255, 134, 178, 0.28);
 }
 
 .receipt-summary {
@@ -585,9 +589,9 @@ textarea::placeholder {
 .attention-card {
   margin-top: 8px;
   padding: 13px;
-  border: 1px solid rgba(230, 184, 79, 0.31);
+  border: 1px solid rgba(246, 196, 83, 0.34);
   border-radius: 11px;
-  background: rgba(45, 36, 13, 0.42);
+  background: rgba(42, 34, 24, 0.56);
 }
 
 .attention-card h2 {
@@ -664,12 +668,12 @@ textarea::placeholder {
   overflow: hidden;
   border: 1px solid var(--line-strong);
   border-radius: 13px;
-  background: rgba(13, 29, 32, 0.96);
+  background: rgba(14, 23, 41, 0.96);
   box-shadow: 0 18px 60px rgba(0, 0, 0, 0.3);
 }
 
 .composer:focus-within {
-  border-color: rgba(230, 184, 79, 0.42);
+  border-color: rgba(106, 174, 242, 0.46);
 }
 
 .composer textarea {
@@ -719,7 +723,7 @@ textarea::placeholder {
 }
 
 .rename-dialog::backdrop {
-  background: rgba(2, 8, 9, 0.74);
+  background: rgba(3, 7, 13, 0.74);
 }
 
 .rename-dialog form {
@@ -801,7 +805,7 @@ noscript {
     padding: 0;
     border: 0;
     opacity: 0;
-    background: rgba(2, 8, 9, 0.64);
+    background: rgba(3, 7, 13, 0.64);
     transition: opacity 160ms ease-out, visibility 160ms step-end;
   }
 

--- a/crates/tui/src/runtime_web/styles.css
+++ b/crates/tui/src/runtime_web/styles.css
@@ -331,7 +331,7 @@ textarea::placeholder {
 }
 
 .connection-dot.ready {
-  background: var(--live);
+  background: var(--ok);
 }
 
 .connection-dot.error {

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -389,6 +389,7 @@ fn adapt_cell_colors(
     theme_id: ThemeId,
     ui_theme: &UiTheme,
 ) {
+    let source_fg = cell.fg;
     // Stage 1: community-theme remap (dark palette → preset slots). No-op
     // for System / Whale / WhaleLight so legacy dark/light flows are
     // untouched. Runs *before* the palette-mode remap so a light terminal
@@ -401,7 +402,7 @@ fn adapt_cell_colors(
     cell.fg = palette::adapt_fg_for_palette_mode(cell.fg, original_bg, palette_mode);
     cell.bg = palette::adapt_bg_for_palette_mode(cell.bg, palette_mode);
     // Stage 3: depth (truecolor / 256 / 16) downsampling.
-    cell.fg = palette::adapt_color(cell.fg, depth);
+    cell.fg = palette::adapt_fg_for_depth(source_fg, cell.fg, depth, ui_theme);
     cell.bg = palette::adapt_bg(cell.bg, depth);
 }
 
@@ -592,6 +593,7 @@ mod tests {
             for (source, expected, role) in [
                 (palette::MODE_AGENT, theme.mode_agent, "agent"),
                 (palette::MODE_PLAN, theme.mode_plan, "plan"),
+                (palette::MODE_OPERATE, theme.mode_operate, "operate"),
                 (palette::MODE_YOLO, theme.mode_yolo, "full access"),
             ] {
                 let mut cell = Cell::default();
@@ -609,6 +611,140 @@ mod tests {
                     "theme '{}' rendered the {role} token through the wrong slot",
                     theme_id.name(),
                 );
+            }
+        }
+    }
+
+    fn rendered_foreground(
+        source: Color,
+        depth: ColorDepth,
+        theme_id: ThemeId,
+        theme: &UiTheme,
+    ) -> Color {
+        let mut cell = Cell::default();
+        cell.set_fg(source);
+        adapt_cell_colors(&mut cell, depth, theme.mode, theme_id, theme);
+        cell.fg
+    }
+
+    #[test]
+    fn grayscale_modes_are_identity_safe_for_raw_and_direct_cells() {
+        let theme = palette::GRAYSCALE_UI_THEME;
+        let roles = [
+            ("act", palette::MODE_AGENT, theme.mode_agent, Color::Blue),
+            ("plan", palette::MODE_PLAN, theme.mode_plan, Color::Magenta),
+            (
+                "operate",
+                palette::MODE_OPERATE,
+                theme.mode_operate,
+                Color::LightMagenta,
+            ),
+            (
+                "full access",
+                palette::MODE_YOLO,
+                theme.mode_yolo,
+                Color::Red,
+            ),
+        ];
+
+        for depth in [
+            ColorDepth::TrueColor,
+            ColorDepth::Ansi256,
+            ColorDepth::Ansi16,
+        ] {
+            let mut outputs = Vec::new();
+            for (name, raw, direct, ansi16) in roles {
+                let expected = if depth == ColorDepth::Ansi16 {
+                    ansi16
+                } else {
+                    palette::adapt_color(direct, depth)
+                };
+                let raw_output = rendered_foreground(raw, depth, ThemeId::Grayscale, &theme);
+                let direct_output = rendered_foreground(direct, depth, ThemeId::Grayscale, &theme);
+                assert_eq!(raw_output, expected, "raw {name} at {depth:?}");
+                assert_eq!(direct_output, expected, "direct {name} at {depth:?}");
+                outputs.push((name, raw_output));
+            }
+            for (index, (left_name, left)) in outputs.iter().enumerate() {
+                for (right_name, right) in outputs.iter().skip(index + 1) {
+                    assert_ne!(
+                        left, right,
+                        "grayscale {depth:?} merged {left_name} and {right_name}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ansi16_uses_complete_semantic_role_matrix_for_whale_dark_and_light() {
+        let expected = [
+            ("action", Color::LightBlue),
+            ("live", Color::LightCyan),
+            ("human", Color::LightYellow),
+            ("warning", Color::Yellow),
+            ("danger", Color::LightRed),
+            ("success", Color::LightGreen),
+            ("act mode", Color::Blue),
+            ("plan mode", Color::Magenta),
+            ("operate mode", Color::LightMagenta),
+            ("full-access mode", Color::Red),
+        ];
+        let raw = [
+            palette::WHALE_ACTION,
+            palette::WHALE_LIVE,
+            palette::WHALE_HUMAN,
+            palette::STATUS_WARNING,
+            palette::WHALE_ERROR,
+            palette::STATUS_SUCCESS,
+            palette::MODE_AGENT,
+            palette::MODE_PLAN,
+            palette::MODE_OPERATE,
+            palette::MODE_YOLO,
+        ];
+
+        for (theme_id, theme) in [
+            (ThemeId::Whale, palette::UI_THEME),
+            (ThemeId::WhaleLight, palette::LIGHT_UI_THEME),
+        ] {
+            let direct = [
+                theme.accent_primary,
+                theme.status_working,
+                theme.accent_action,
+                theme.warning,
+                theme.error_fg,
+                theme.success,
+                theme.mode_agent,
+                theme.mode_plan,
+                theme.mode_operate,
+                theme.mode_yolo,
+            ];
+            for (source_kind, sources) in [("raw", raw), ("direct", direct)] {
+                let outputs = sources
+                    .into_iter()
+                    .zip(expected)
+                    .map(|(source, (name, expected_color))| {
+                        let output =
+                            rendered_foreground(source, ColorDepth::Ansi16, theme_id, &theme);
+                        assert_eq!(
+                            output,
+                            expected_color,
+                            "{} {source_kind} {name}",
+                            theme_id.name(),
+                        );
+                        (name, output)
+                    })
+                    .collect::<Vec<_>>();
+                for (index, (left_name, left)) in outputs.iter().enumerate() {
+                    for (right_name, right) in outputs.iter().skip(index + 1) {
+                        assert_ne!(
+                            left,
+                            right,
+                            "{} {source_kind} matrix merged {left_name} and {right_name}",
+                            theme_id.name(),
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -584,6 +584,36 @@ mod tests {
     }
 
     #[test]
+    fn terminal_and_matrix_cells_keep_effective_mode_colors() {
+        for (theme_id, theme) in [
+            (ThemeId::Terminal, palette::TERMINAL_UI_THEME),
+            (ThemeId::Matrix, palette::MATRIX_UI_THEME),
+        ] {
+            for (source, expected, role) in [
+                (palette::MODE_AGENT, theme.mode_agent, "agent"),
+                (palette::MODE_PLAN, theme.mode_plan, "plan"),
+                (palette::MODE_YOLO, theme.mode_yolo, "full access"),
+            ] {
+                let mut cell = Cell::default();
+                cell.set_fg(source);
+                adapt_cell_colors(
+                    &mut cell,
+                    ColorDepth::TrueColor,
+                    theme.mode,
+                    theme_id,
+                    &theme,
+                );
+                assert_eq!(
+                    cell.fg,
+                    expected,
+                    "theme '{}' rendered the {role} token through the wrong slot",
+                    theme_id.name(),
+                );
+            }
+        }
+    }
+
+    #[test]
     fn backend_palette_mode_can_follow_runtime_theme_changes() {
         let writer = SharedWriter::default();
         let mut backend = ColorCompatBackend::new(writer, ColorDepth::TrueColor, PaletteMode::Dark);

--- a/crates/tui/src/tui/diff_render.rs
+++ b/crates/tui/src/tui/diff_render.rs
@@ -274,7 +274,7 @@ fn render_header_line(line: &str, width: u16) -> Vec<Line<'static>> {
 }
 
 fn render_hunk_header(line: &str, width: u16) -> Vec<Line<'static>> {
-    let style = Style::default().fg(palette::WHALE_ACCENT_PRIMARY);
+    let style = Style::default().fg(palette::WHALE_ACTION);
     wrap_with_style(line, style, width)
 }
 

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1058,7 +1058,7 @@ impl ReviewCell {
         lines.push(Line::from(Span::styled(
             "Issues",
             Style::default()
-                .fg(palette::WHALE_ACCENT_PRIMARY)
+                .fg(palette::WHALE_ACTION)
                 .add_modifier(Modifier::BOLD),
         )));
         if output.issues.is_empty() {
@@ -1092,7 +1092,7 @@ impl ReviewCell {
         lines.push(Line::from(Span::styled(
             "Suggestions",
             Style::default()
-                .fg(palette::WHALE_ACCENT_PRIMARY)
+                .fg(palette::WHALE_ACTION)
                 .add_modifier(Modifier::BOLD),
         )));
         if output.suggestions.is_empty() {
@@ -1880,7 +1880,7 @@ fn is_cycle_boundary(content: &str) -> bool {
 /// horizontal rule above for visual separation.
 fn render_cycle_boundary(content: &str, width: u16) -> Vec<Line<'static>> {
     let style = Style::default()
-        .fg(palette::WHALE_ACCENT_PRIMARY)
+        .fg(palette::WHALE_ACTION)
         .add_modifier(Modifier::BOLD);
     let rule_style = Style::default().fg(palette::TEXT_DIM);
     let content_width = usize::from(width.saturating_sub(2).max(1));

--- a/crates/tui/src/tui/history/tool_output.rs
+++ b/crates/tui/src/tui/history/tool_output.rs
@@ -553,7 +553,7 @@ fn file_line_style(text: &str) -> Option<Style> {
 fn diff_line_style(text: &str) -> Option<Style> {
     let trimmed = text.trim_start();
     if trimmed.starts_with("@@") {
-        Some(Style::default().fg(palette::WHALE_ACCENT_PRIMARY))
+        Some(Style::default().fg(palette::WHALE_ACTION))
     } else if trimmed.starts_with('+') && !trimmed.starts_with("+++") {
         Some(Style::default().fg(palette::DIFF_ADDED))
     } else if trimmed.starts_with('-') && !trimmed.starts_with("---") {

--- a/crates/tui/src/tui/markdown_render.rs
+++ b/crates/tui/src/tui/markdown_render.rs
@@ -293,7 +293,7 @@ pub fn render_parsed_tagged(
             }
             Block::Paragraph { text } => {
                 let link_style = Style::default()
-                    .fg(palette::WHALE_ACCENT_PRIMARY)
+                    .fg(palette::WHALE_ACTION)
                     .add_modifier(Modifier::UNDERLINED);
                 out.extend(render_line_with_links_tagged(
                     text, width, base_style, link_style,
@@ -1261,7 +1261,7 @@ fn render_table_group(blocks: &[Block], width: usize, base_style: Style) -> Vec<
 
 fn link_style() -> Style {
     Style::default()
-        .fg(palette::WHALE_ACCENT_PRIMARY)
+        .fg(palette::WHALE_ACTION)
         .add_modifier(Modifier::UNDERLINED)
 }
 

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -1683,7 +1683,7 @@ impl ModelPickerView {
             Line::from(vec![
                 Span::styled(
                     format!("─ {} ", tr(self.locale, MessageId::RoutePanelHeader)),
-                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+                    Style::default().fg(palette::WHALE_ACTION).bold(),
                 ),
                 Span::styled(
                     "──────────────────────── ",
@@ -3718,7 +3718,7 @@ mod tests {
         );
         assert!(
             !(area.x..area.x.saturating_add(area.width))
-                .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY),
+                .any(|x| buf[(x, y)].bg == palette::WHALE_ACTION),
             "selected /model row should not use the bright accent background"
         );
     }

--- a/crates/tui/src/tui/ocean.rs
+++ b/crates/tui/src/tui/ocean.rs
@@ -404,8 +404,12 @@ mod tests {
             ("human", theme.accent_action),
             ("warning", theme.warning),
             ("danger", theme.error_fg),
+            ("act mode", theme.mode_agent),
+            ("plan mode", theme.mode_plan),
             ("operate", theme.mode_operate),
+            ("full-access mode", theme.mode_yolo),
             ("success", theme.success),
+            ("user", crate::palette::LIGHT_USER_BODY),
         ];
         let backgrounds = [
             ("ocean surface", ramp.surface),

--- a/crates/tui/src/tui/ocean.rs
+++ b/crates/tui/src/tui/ocean.rs
@@ -1,4 +1,4 @@
-//! Terminal-native underwater field for the CodeWhale transcript.
+//! Terminal-native underwater field for the Codewhale transcript.
 //!
 //! The field is atmosphere, never content: ordinary shell cells share its
 //! water column while semantic surfaces such as selections, errors, and code
@@ -178,7 +178,7 @@ impl OceanRamp {
             return None;
         }
 
-        // The canonical Whale pair gets the authored Blue Stage water column.
+        // The canonical Whale pair gets the authored Codewhale water column.
         // Match both name and surface so a user-supplied `background_color`
         // remains the source of truth and still receives the generic ramp.
         if theme.name == crate::palette::UI_THEME.name
@@ -197,7 +197,7 @@ impl OceanRamp {
             return Some(Self {
                 surface: Color::Rgb(0xff, 0xfd, 0xf8),
                 middle: Color::Rgb(0xf4, 0xf7, 0xfb),
-                deep: Color::Rgb(0xdb, 0xe4, 0xf2),
+                deep: Color::Rgb(0xf0, 0xf4, 0xf9),
                 ambient: Color::Rgb(0x9a, 0xb8, 0xe0),
             });
         }
@@ -343,6 +343,30 @@ mod tests {
         ar.abs_diff(br) as u16 + ag.abs_diff(bg) as u16 + ab.abs_diff(bb) as u16
     }
 
+    fn relative_luminance(value: Color) -> f64 {
+        let (r, g, b) = rgb(value).expect("contrast colors must be RGB");
+        let linearize = |component: u8| {
+            let srgb = f64::from(component) / 255.0;
+            if srgb <= 0.04045 {
+                srgb / 12.92
+            } else {
+                ((srgb + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+    }
+
+    fn contrast_ratio(foreground: Color, background: Color) -> f64 {
+        let foreground = relative_luminance(foreground);
+        let background = relative_luminance(background);
+        let (lighter, darker) = if foreground >= background {
+            (foreground, background)
+        } else {
+            (background, foreground)
+        };
+        (lighter + 0.05) / (darker + 0.05)
+    }
+
     #[test]
     fn whale_ramp_is_perceptibly_deep_not_merely_non_equal() {
         let ramp = OceanRamp::for_theme(&crate::palette::UI_THEME).expect("RGB theme");
@@ -361,9 +385,44 @@ mod tests {
         let ramp = OceanRamp::for_theme(&crate::palette::LIGHT_UI_THEME).expect("RGB theme");
         assert_eq!(ramp.surface, Color::Rgb(0xff, 0xfd, 0xf8));
         assert_eq!(ramp.middle, Color::Rgb(0xf4, 0xf7, 0xfb));
-        assert_eq!(ramp.deep, Color::Rgb(0xdb, 0xe4, 0xf2));
+        assert_eq!(ramp.deep, Color::Rgb(0xf0, 0xf4, 0xf9));
         let (r, g, b) = rgb(ramp.deep).expect("RGB color");
         assert!(u16::from(r) + u16::from(g) + u16::from(b) > 420);
+    }
+
+    #[test]
+    fn light_ocean_and_selection_keep_text_and_semantic_roles_readable() {
+        let theme = crate::palette::LIGHT_UI_THEME;
+        let ramp = OceanRamp::for_theme(&theme).expect("RGB theme");
+        let foregrounds = [
+            ("body", theme.text_body),
+            ("soft", theme.text_soft),
+            ("muted", theme.text_muted),
+            ("hint", theme.text_hint),
+            ("action", theme.accent_primary),
+            ("live", theme.status_working),
+            ("human", theme.accent_action),
+            ("warning", theme.warning),
+            ("danger", theme.error_fg),
+            ("operate", theme.mode_operate),
+            ("success", theme.success),
+        ];
+        let backgrounds = [
+            ("ocean surface", ramp.surface),
+            ("ocean middle", ramp.middle),
+            ("ocean deep", ramp.deep),
+            ("selection", theme.selection_bg),
+        ];
+
+        for (background_name, background) in backgrounds {
+            for (foreground_name, foreground) in foregrounds {
+                let ratio = contrast_ratio(foreground, background);
+                assert!(
+                    ratio >= 4.5,
+                    "light {foreground_name} on {background_name} contrast {ratio:.2} is below 4.50"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/ocean.rs
+++ b/crates/tui/src/tui/ocean.rs
@@ -178,6 +178,30 @@ impl OceanRamp {
             return None;
         }
 
+        // The canonical Whale pair gets the authored Blue Stage water column.
+        // Match both name and surface so a user-supplied `background_color`
+        // remains the source of truth and still receives the generic ramp.
+        if theme.name == crate::palette::UI_THEME.name
+            && theme.surface_bg == crate::palette::UI_THEME.surface_bg
+        {
+            return Some(Self {
+                surface: Color::Rgb(0x0e, 0x17, 0x29),
+                middle: Color::Rgb(0x08, 0x11, 0x1c),
+                deep: Color::Rgb(0x03, 0x07, 0x0d),
+                ambient: Color::Rgb(0x26, 0x48, 0x66),
+            });
+        }
+        if theme.name == crate::palette::LIGHT_UI_THEME.name
+            && theme.surface_bg == crate::palette::LIGHT_UI_THEME.surface_bg
+        {
+            return Some(Self {
+                surface: Color::Rgb(0xff, 0xfd, 0xf8),
+                middle: Color::Rgb(0xf4, 0xf7, 0xfb),
+                deep: Color::Rgb(0xdb, 0xe4, 0xf2),
+                ambient: Color::Rgb(0x9a, 0xb8, 0xe0),
+            });
+        }
+
         let base = rgb(theme.surface_bg)?;
         let seafoam = rgb(theme.accent_secondary).unwrap_or((79, 209, 197));
 
@@ -322,6 +346,9 @@ mod tests {
     #[test]
     fn whale_ramp_is_perceptibly_deep_not_merely_non_equal() {
         let ramp = OceanRamp::for_theme(&crate::palette::UI_THEME).expect("RGB theme");
+        assert_eq!(ramp.surface, Color::Rgb(0x0e, 0x17, 0x29));
+        assert_eq!(ramp.middle, Color::Rgb(0x08, 0x11, 0x1c));
+        assert_eq!(ramp.deep, Color::Rgb(0x03, 0x07, 0x0d));
         assert!(
             distance(ramp.surface, ramp.deep) >= 32,
             "the selected underwater treatment must read at a glance"
@@ -332,8 +359,21 @@ mod tests {
     #[test]
     fn light_theme_stays_light_enough_for_light_theme_text() {
         let ramp = OceanRamp::for_theme(&crate::palette::LIGHT_UI_THEME).expect("RGB theme");
+        assert_eq!(ramp.surface, Color::Rgb(0xff, 0xfd, 0xf8));
+        assert_eq!(ramp.middle, Color::Rgb(0xf4, 0xf7, 0xfb));
+        assert_eq!(ramp.deep, Color::Rgb(0xdb, 0xe4, 0xf2));
         let (r, g, b) = rgb(ramp.deep).expect("RGB color");
         assert!(u16::from(r) + u16::from(g) + u16::from(b) > 420);
+    }
+
+    #[test]
+    fn whale_custom_background_uses_the_configured_surface() {
+        let custom = Color::Rgb(0x12, 0x1a, 0x2d);
+        let theme = crate::palette::UI_THEME.with_background_color(custom);
+        let ramp = OceanRamp::for_theme(&theme).expect("custom backgrounds retain ombre");
+
+        assert_ne!(ramp.surface, Color::Rgb(0x0e, 0x17, 0x29));
+        assert_ne!(ramp.surface, ramp.deep);
     }
 
     #[test]

--- a/crates/tui/src/tui/onboarding/language.rs
+++ b/crates/tui/src/tui/onboarding/language.rs
@@ -56,7 +56,7 @@ pub fn lines(app: &App) -> Vec<Line<'static>> {
         let is_current = current == *tag;
         let bullet = if is_current { "●" } else { "○" };
         let bullet_color = if is_current {
-            palette::WHALE_ACCENT_PRIMARY
+            palette::WHALE_ACTION
         } else {
             palette::TEXT_MUTED
         };

--- a/crates/tui/src/tui/onboarding/mod.rs
+++ b/crates/tui/src/tui/onboarding/mod.rs
@@ -63,7 +63,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             .title(Line::from(Span::styled(
                 " Codewhale ",
                 Style::default()
-                    .fg(palette::WHALE_ACCENT_PRIMARY)
+                    .fg(palette::WHALE_HUMAN)
                     .add_modifier(Modifier::BOLD),
             )))
             .borders(Borders::ALL)
@@ -344,7 +344,7 @@ fn provider_lines(app: &App) -> Vec<ratatui::text::Line<'static>> {
         let is_current = app.onboarding_provider == *provider;
         let bullet = if is_current { "●" } else { "○" };
         let bullet_color = if is_current {
-            palette::WHALE_ACCENT_PRIMARY
+            palette::WHALE_ACTION
         } else {
             palette::TEXT_MUTED
         };

--- a/crates/tui/src/tui/onboarding/welcome.rs
+++ b/crates/tui/src/tui/onboarding/welcome.rs
@@ -20,7 +20,7 @@ pub fn lines(app: &App) -> Vec<Line<'static>> {
         Line::from(Span::styled(
             "codewhale",
             Style::default()
-                .fg(palette::WHALE_ACCENT_PRIMARY)
+                .fg(palette::WHALE_HUMAN)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(
@@ -131,6 +131,14 @@ mod tests {
         assert!(body.contains("/constitution"));
         assert!(!body.contains("add an API key"));
         assert!(!body.contains("land in the chat"));
+    }
+
+    #[test]
+    fn welcome_wordmark_uses_the_human_brand_lane() {
+        let app = test_app_with_locale(Locale::En);
+        let welcome = lines(&app);
+        assert_eq!(welcome[0].spans[0].style.fg, Some(palette::WHALE_HUMAN));
+        assert_ne!(palette::WHALE_HUMAN, palette::WHALE_ACTION);
     }
 
     #[test]

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -46,7 +46,7 @@ fn modal_block() -> Block<'static> {
     Block::default()
         .title(Line::from(vec![Span::styled(
             " Plan Confirmation ",
-            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+            Style::default().fg(palette::WHALE_HUMAN).bold(),
         )]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -32,7 +32,7 @@ fn section_block(title: &str) -> Block<'static> {
         .title(Line::from(vec![Span::styled(
             title.to_string(),
             Style::default()
-                .fg(palette::WHALE_ACCENT_PRIMARY)
+                .fg(palette::WHALE_ACTION)
                 .add_modifier(Modifier::BOLD),
         )]))
         .borders(Borders::TOP)
@@ -1337,7 +1337,7 @@ mod tests {
 
         assert_eq!(span.style.fg, Some(palette::SELECTION_TEXT));
         assert_eq!(span.style.bg, Some(palette::SELECTION_BG));
-        assert_ne!(span.style.bg, Some(palette::WHALE_ACCENT_PRIMARY));
+        assert_ne!(span.style.bg, Some(palette::WHALE_ACTION));
         assert!(span.style.add_modifier.contains(Modifier::BOLD));
     }
 
@@ -1376,7 +1376,7 @@ mod tests {
         );
         assert!(
             !(area.x..area.x.saturating_add(area.width))
-                .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY),
+                .any(|x| buf[(x, y)].bg == palette::WHALE_ACTION),
             "selected /sessions row should not use the bright accent background"
         );
     }

--- a/crates/tui/src/tui/setup/mod.rs
+++ b/crates/tui/src/tui/setup/mod.rs
@@ -1627,7 +1627,7 @@ fn freeform_note_line(locale: Locale, note: &str, editing: bool) -> Line<'static
         (_, false, false) => format!("F Own words: {preview}"),
     };
     let style = if editing || !preview.is_empty() {
-        Style::default().fg(palette::WHALE_ACCENT_PRIMARY)
+        Style::default().fg(palette::WHALE_HUMAN)
     } else {
         Style::default().fg(palette::TEXT_MUTED)
     };
@@ -2552,6 +2552,18 @@ impl ModalView for SetupWizardView {
         lines.push(Line::from(""));
         for (idx, step) in STEP_SPECS.iter().enumerate() {
             let selected = idx == self.selected;
+            let status = self.state.status(step.id());
+            let status_color = match status {
+                StepStatus::InProgress => palette::WHALE_LIVE,
+                StepStatus::NeedsAction => palette::WHALE_HUMAN,
+                StepStatus::Verified => palette::STATUS_SUCCESS,
+                StepStatus::Failed => palette::STATUS_ERROR,
+                StepStatus::NotStarted
+                | StepStatus::Recommended
+                | StepStatus::Optional
+                | StepStatus::Deferred
+                | StepStatus::Skipped => palette::TEXT_MUTED,
+            };
             let marker = if selected { ">" } else { " " };
             let style = if selected {
                 Style::default()
@@ -2565,8 +2577,8 @@ impl ModalView for SetupWizardView {
                 Span::styled(tr(self.locale, step.title_id()).to_string(), style),
                 Span::raw("  "),
                 Span::styled(
-                    self.status_label(self.state.status(step.id())).to_string(),
-                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
+                    self.status_label(status).to_string(),
+                    Style::default().fg(status_color),
                 ),
             ]));
         }
@@ -2700,7 +2712,7 @@ impl SetupWizardView {
         if self.facts.constitution_file == SetupConstitutionFileState::Loaded {
             lines.push(Line::from(Span::styled(
                 keep_existing_invitation_line(self.locale),
-                Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
+                Style::default().fg(palette::WHALE_HUMAN),
             )));
         }
         if let Some(label) = self
@@ -2710,12 +2722,12 @@ impl SetupWizardView {
         {
             lines.push(Line::from(Span::styled(
                 model_draft_ready_line(self.locale, label),
-                Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
+                Style::default().fg(palette::STATUS_SUCCESS),
             )));
         } else if self.facts.provider_ready {
             lines.push(Line::from(Span::styled(
                 model_draft_invitation_line(self.locale, &self.facts.model),
-                Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
+                Style::default().fg(palette::WHALE_HUMAN),
             )));
         }
         lines.push(Line::from(Span::styled(

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -904,7 +904,7 @@ pub fn empty_state_lines(app: &App, area: Rect) -> Vec<Line<'static>> {
                 row,
                 elapsed_ms,
                 animated,
-                app.ui_theme.accent_primary,
+                app.ui_theme.accent_action,
                 app.ui_theme.text_body,
                 app.ui_theme.text_body,
             )
@@ -1285,6 +1285,21 @@ mod tests {
         }
         assert_ne!(colors(&moving), colors(&parked));
         assert_eq!(colors(&frozen_a), colors(&frozen_b));
+    }
+
+    #[test]
+    fn idle_whale_uses_the_human_brand_role_not_focus_blue() {
+        let mut app = test_app();
+        app.low_motion = true;
+        let lines = empty_state_lines(&app, Rect::new(0, 0, 100, 30));
+        let colors = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .filter_map(|span| span.style.fg)
+            .collect::<Vec<_>>();
+
+        assert!(colors.contains(&app.ui_theme.accent_action));
+        assert_ne!(app.ui_theme.accent_action, app.ui_theme.accent_primary);
     }
 
     #[test]

--- a/crates/tui/src/tui/user_input.rs
+++ b/crates/tui/src/tui/user_input.rs
@@ -409,7 +409,7 @@ impl ModalView for UserInputView {
                     } else {
                         self.other_input.clone()
                     },
-                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
+                    Style::default().fg(palette::WHALE_HUMAN),
                 ),
             ]));
         }

--- a/crates/tui/src/tui/user_input.rs
+++ b/crates/tui/src/tui/user_input.rs
@@ -15,7 +15,7 @@ fn modal_block(title: &str) -> Block<'static> {
     Block::default()
         .title(Line::from(vec![Span::styled(
             title.to_string(),
-            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+            Style::default().fg(palette::WHALE_HUMAN).bold(),
         )]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -217,7 +217,7 @@ impl ModalView for FleetRosterView {
             Line::from(vec![
                 Span::styled(
                     format!("─ {} ", tr(self.locale, MessageId::FleetRosterHeaderLabel)),
-                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+                    Style::default().fg(palette::WHALE_ACTION).bold(),
                 ),
                 Span::styled(
                     "──────────────────────── ",
@@ -317,7 +317,7 @@ impl FleetRosterView {
                         self.operator.model
                     ),
                     Style::default()
-                        .fg(palette::WHALE_ACCENT_PRIMARY)
+                        .fg(palette::WHALE_ACTION)
                         .add_modifier(Modifier::BOLD),
                 )
             } else {

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -888,7 +888,7 @@ impl ModalView for FleetSetupView {
             .title(Line::from(Span::styled(
                 " Fleet setup — your agent team ",
                 Style::default()
-                    .fg(palette::WHALE_ACCENT_PRIMARY)
+                    .fg(palette::WHALE_ACTION)
                     .add_modifier(Modifier::BOLD),
             )))
             .title_bottom(
@@ -1233,7 +1233,7 @@ fn render_choice_step(
     let mut detail_lines: Vec<Line> = vec![
         Line::from(Span::styled(
             choice.summary.clone(),
-            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+            Style::default().fg(palette::WHALE_ACTION).bold(),
         )),
         Line::from(""),
         Line::from(Span::styled(

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -514,7 +514,7 @@ impl ModalView for HelpView {
                         lines.push(Line::from(Span::styled(
                             format!("  {} ({})", section.label(self.locale), count),
                             Style::default()
-                                .fg(palette::WHALE_ACCENT_PRIMARY)
+                                .fg(palette::WHALE_ACTION)
                                 .add_modifier(Modifier::BOLD),
                         )));
                     }

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -125,7 +125,7 @@ pub(crate) fn render_underwater_surface(
         .title(Line::from(Span::styled(
             format!(" {title} "),
             Style::default()
-                .fg(palette::WHALE_ACCENT_PRIMARY)
+                .fg(palette::WHALE_ACTION)
                 .add_modifier(Modifier::BOLD),
         )))
         .borders(Borders::TOP | Borders::BOTTOM)
@@ -3100,7 +3100,7 @@ impl ModalView for ConfigView {
                     Line::from(vec![
                         Span::styled(
                             self.tr(MessageId::ConfigTitle),
-                            Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+                            Style::default().fg(palette::WHALE_ACTION).bold(),
                         ),
                         Span::styled(
                             format!(" — {}", self.tr(MessageId::ConfigSubtitle)),
@@ -3597,7 +3597,7 @@ impl ModalView for SubAgentsView {
             Line::from(vec![
                 Span::styled(
                     "─ fleet ",
-                    Style::default().fg(palette::WHALE_ACCENT_PRIMARY).bold(),
+                    Style::default().fg(palette::WHALE_ACTION).bold(),
                 ),
                 Span::styled(
                     "──────────────────────── ",
@@ -3766,7 +3766,7 @@ fn format_agent_status(
         SubAgentStatus::Running => ("running", Style::default().fg(palette::WHALE_INFO), None),
         SubAgentStatus::Completed => (
             "completed",
-            Style::default().fg(palette::WHALE_ACCENT_PRIMARY),
+            Style::default().fg(palette::STATUS_SUCCESS),
             None,
         ),
         SubAgentStatus::Interrupted(reason) => (
@@ -4990,7 +4990,7 @@ base_url = "https://api.xiaomimimo.com/v1"
         );
         assert!(
             !(area.x..area.x.saturating_add(area.width))
-                .any(|x| buf[(x, y)].bg == palette::WHALE_ACCENT_PRIMARY),
+                .any(|x| buf[(x, y)].bg == palette::WHALE_ACTION),
             "selected config row should not use the bright accent background"
         );
     }

--- a/crates/tui/src/tui/widgets/header.rs
+++ b/crates/tui/src/tui/widgets/header.rs
@@ -288,7 +288,7 @@ impl<'a> HeaderWidget<'a> {
             return Vec::new();
         };
         let color = if frame == "cw" {
-            palette::WHALE_ACCENT_PRIMARY
+            palette::WHALE_HUMAN
         } else {
             palette::WHALE_INFO
         };
@@ -858,6 +858,36 @@ mod tests {
             whale_idx < max_idx,
             "expected whale to render before effort label, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn cw_indicator_keeps_the_human_brand_lane_distinct_from_live_frames() {
+        let cw = HeaderWidget::new(
+            HeaderData::new(
+                AppMode::Agent,
+                "deepseek-v4-pro",
+                "codewhale-tui",
+                false,
+                palette::WHALE_BG,
+            )
+            .with_status_indicator(Some("cw")),
+        )
+        .status_indicator_spans();
+        let live = HeaderWidget::new(
+            HeaderData::new(
+                AppMode::Agent,
+                "deepseek-v4-pro",
+                "codewhale-tui",
+                false,
+                palette::WHALE_BG,
+            )
+            .with_status_indicator(Some("··")),
+        )
+        .status_indicator_spans();
+
+        assert_eq!(cw[0].style.fg, Some(palette::WHALE_HUMAN));
+        assert_eq!(live[0].style.fg, Some(palette::WHALE_INFO));
+        assert_ne!(cw[0].style.fg, live[0].style.fg);
     }
 
     #[test]

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -2358,13 +2358,13 @@ fn approval_palette(stakes: crate::tui::approval::ApprovalStakes) -> ApprovalCol
     match stakes {
         ApprovalStakes::Routine => ApprovalColors {
             border: palette::BORDER_COLOR,
-            accent: palette::WHALE_INFO,
+            accent: palette::WHALE_HUMAN,
             shortcut: palette::WHALE_INFO,
         },
         // Ordinary state-touching work: a calm ask, not an alarm.
         ApprovalStakes::Elevated => ApprovalColors {
-            border: palette::BORDER_COLOR,
-            accent: palette::STATUS_WARNING,
+            border: palette::WHALE_HUMAN,
+            accent: palette::WHALE_HUMAN,
             shortcut: palette::WHALE_INFO,
         },
         ApprovalStakes::Critical => ApprovalColors {
@@ -4126,7 +4126,7 @@ mod tests {
         ACTIVE_REVISION_DOMAIN, ApprovalWidget, COMPOSER_PANEL_HEIGHT, COMPOSER_PLACEHOLDER,
         ChatWidget, ComposerWidget, Renderable, SlashMenuEntry, active_entry_revision,
         ambient_ping_pong, apply_detail_target_highlight, apply_selection_to_line,
-        apply_send_flash, build_empty_state_lines, composer_content_geometry,
+        apply_send_flash, approval_palette, build_empty_state_lines, composer_content_geometry,
         composer_empty_hint_text, composer_height, composer_max_height, composer_min_input_rows,
         composer_top_padding, cursor_row_col, empty_composer_visual_rows, fish_flee_offset,
         fish_heading, fish_mark, history_entry_revision, layout_input, layout_input_with_scroll,
@@ -4197,6 +4197,21 @@ mod tests {
             text.push('\n');
         }
         text
+    }
+
+    #[test]
+    fn approval_palette_reserves_signal_gold_for_human_decisions() {
+        use crate::tui::approval::ApprovalStakes;
+
+        let routine = approval_palette(ApprovalStakes::Routine);
+        let elevated = approval_palette(ApprovalStakes::Elevated);
+        let critical = approval_palette(ApprovalStakes::Critical);
+
+        assert_eq!(routine.accent, palette::WHALE_HUMAN);
+        assert_eq!(routine.shortcut, palette::WHALE_ACTION);
+        assert_eq!(elevated.border, palette::WHALE_HUMAN);
+        assert_eq!(elevated.accent, palette::WHALE_HUMAN);
+        assert_eq!(critical.accent, palette::WHALE_ERROR);
     }
 
     #[test]

--- a/crates/tui/tests/palette_audit.rs
+++ b/crates/tui/tests/palette_audit.rs
@@ -100,6 +100,12 @@ fn whale_roles_are_pinned_and_non_colliding() {
     assert_eq!(palette::WHALE_MODE_YOLO_RGB, (255, 112, 160));
     assert_eq!(palette::WHALE_MODE_PLAN_RGB, (255, 208, 106));
     assert_eq!(palette::WHALE_MODE_OPERATE_RGB, (173, 136, 255));
+    assert_eq!(palette::LIGHT_SUCCESS_FG_RGB, (20, 118, 61));
+    assert_eq!(palette::LIGHT_MODE_AGENT_RGB, (50, 95, 216));
+    assert_eq!(palette::LIGHT_MODE_PLAN_RGB, (123, 85, 0));
+    assert_eq!(palette::LIGHT_OPERATE_RGB, (112, 71, 184));
+    assert_eq!(palette::LIGHT_MODE_YOLO_RGB, (181, 35, 90));
+    assert_eq!(palette::LIGHT_USER_BODY, palette::LIGHT_SUCCESS_FG);
 
     let ui = palette::UI_THEME;
     assert_eq!(ui.accent_primary, palette::WHALE_ACTION);
@@ -235,12 +241,21 @@ fn contrast_guardrails_for_key_ui_pairs() {
         ("human", palette::LIGHT_UI_THEME.accent_action),
         ("warning", palette::LIGHT_UI_THEME.warning),
         ("danger", palette::LIGHT_UI_THEME.error_fg),
+        ("act mode", palette::LIGHT_UI_THEME.mode_agent),
+        ("plan mode", palette::LIGHT_UI_THEME.mode_plan),
         ("operate", palette::LIGHT_UI_THEME.mode_operate),
+        ("full-access mode", palette::LIGHT_UI_THEME.mode_yolo),
         ("success", palette::LIGHT_UI_THEME.success),
+        ("user", palette::LIGHT_USER_BODY),
     ];
     for (background_name, background) in [
         ("surface", palette::LIGHT_SURFACE),
+        ("panel", palette::LIGHT_PANEL),
+        ("raised", palette::LIGHT_ELEVATED),
         ("selection", palette::LIGHT_SELECTION_BG),
+        ("reasoning", palette::LIGHT_REASONING),
+        ("success tint", palette::LIGHT_SUCCESS),
+        ("error tint", palette::LIGHT_ERROR),
     ] {
         for (foreground_name, foreground) in light_foregrounds {
             assert_min_contrast(
@@ -251,4 +266,16 @@ fn contrast_guardrails_for_key_ui_pairs() {
             );
         }
     }
+    assert_min_contrast(
+        "light user row on raised",
+        palette::LIGHT_USER_BODY,
+        palette::LIGHT_ELEVATED,
+        min_readable,
+    );
+    assert_min_contrast(
+        "light work-surface success hover on raised",
+        palette::LIGHT_UI_THEME.success,
+        palette::LIGHT_UI_THEME.elevated_bg,
+        min_readable,
+    );
 }

--- a/crates/tui/tests/palette_audit.rs
+++ b/crates/tui/tests/palette_audit.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests ensure that deprecated colors are not used directly in
 //! user-visible code. Backward-compatible DeepSeek aliases should point
-//! at the current CodeWhale semantic tokens instead of stale brand RGBs.
+//! at the current Codewhale semantic tokens instead of stale brand RGBs.
 
 use ratatui::style::Color;
 
@@ -87,7 +87,7 @@ fn verify_status_success_uses_success_token() {
 }
 
 #[test]
-fn whale_blue_stage_roles_are_pinned_and_non_colliding() {
+fn whale_roles_are_pinned_and_non_colliding() {
     assert_eq!(palette::WHALE_BG_RGB, (3, 7, 13));
     assert_eq!(palette::WHALE_PANEL_RGB, (14, 23, 41));
     assert_eq!(palette::WHALE_ELEVATED_RGB, (24, 39, 66));
@@ -96,6 +96,9 @@ fn whale_blue_stage_roles_are_pinned_and_non_colliding() {
     assert_eq!(palette::WHALE_HUMAN_RGB, (246, 196, 83));
     assert_eq!(palette::WHALE_WARNING_RGB, (255, 122, 89));
     assert_eq!(palette::WHALE_ERROR_RGB, (255, 134, 178));
+    assert_eq!(palette::WHALE_MODE_AGENT_RGB, (118, 181, 245));
+    assert_eq!(palette::WHALE_MODE_YOLO_RGB, (255, 112, 160));
+    assert_eq!(palette::WHALE_MODE_PLAN_RGB, (255, 208, 106));
     assert_eq!(palette::WHALE_MODE_OPERATE_RGB, (173, 136, 255));
 
     let ui = palette::UI_THEME;
@@ -115,6 +118,54 @@ fn whale_blue_stage_roles_are_pinned_and_non_colliding() {
         ui.warning, ui.error_fg,
         "warning and danger must not collapse"
     );
+
+    let foreground_domains = [
+        ("action", palette::WHALE_ACTION),
+        ("live", palette::WHALE_LIVE),
+        ("human", palette::WHALE_HUMAN),
+        ("success", palette::STATUS_SUCCESS),
+        ("warning", palette::STATUS_WARNING),
+        ("danger", palette::WHALE_ERROR),
+        ("agent mode", palette::MODE_AGENT),
+        ("full-access mode", palette::MODE_YOLO),
+        ("plan mode", palette::MODE_PLAN),
+        ("operate mode", palette::MODE_OPERATE),
+        ("reasoning", palette::TEXT_REASONING),
+        ("diff added", palette::DIFF_ADDED),
+    ];
+    for (index, (left_name, left)) in foreground_domains.iter().enumerate() {
+        for (right_name, right) in foreground_domains.iter().skip(index + 1) {
+            assert_ne!(
+                left, right,
+                "raw foreground adaptation domains '{left_name}' and '{right_name}' collide"
+            );
+        }
+    }
+
+    let background_domains = [
+        ("base", palette::WHALE_BG),
+        ("panel", palette::WHALE_PANEL),
+        ("composer", palette::WHALE_COMPOSER),
+        ("elevated", palette::SURFACE_ELEVATED),
+        ("tool", palette::SURFACE_TOOL),
+        ("tool active", palette::SURFACE_TOOL_ACTIVE),
+        ("reasoning", palette::SURFACE_REASONING),
+        ("reasoning tint", palette::SURFACE_REASONING_TINT),
+        ("reasoning active", palette::SURFACE_REASONING_ACTIVE),
+        ("success", palette::SURFACE_SUCCESS),
+        ("error", palette::SURFACE_ERROR),
+        ("selection", palette::SELECTION_BG),
+        ("diff added", palette::DIFF_ADDED_BG),
+        ("diff deleted", palette::DIFF_DELETED_BG),
+    ];
+    for (index, (left_name, left)) in background_domains.iter().enumerate() {
+        for (right_name, right) in background_domains.iter().skip(index + 1) {
+            assert_ne!(
+                left, right,
+                "raw background adaptation domains '{left_name}' and '{right_name}' collide"
+            );
+        }
+    }
 }
 
 #[test]
@@ -174,33 +225,30 @@ fn contrast_guardrails_for_key_ui_pairs() {
     ] {
         assert_min_contrast(label, foreground, palette::SURFACE_ELEVATED, min_readable);
     }
-    assert_min_contrast(
-        "LIGHT_TEXT_BODY on LIGHT_SURFACE",
-        palette::LIGHT_TEXT_BODY,
-        palette::LIGHT_SURFACE,
-        min_readable,
-    );
-    assert_min_contrast(
-        "LIGHT_TEXT_MUTED on LIGHT_SURFACE",
-        palette::LIGHT_TEXT_MUTED,
-        palette::LIGHT_SURFACE,
-        min_readable,
-    );
-    assert_min_contrast(
-        "LIGHT_TEXT_BODY on LIGHT_SELECTION_BG",
-        palette::LIGHT_TEXT_BODY,
-        palette::LIGHT_SELECTION_BG,
-        min_readable,
-    );
-    for (label, foreground) in [
-        ("light action", palette::LIGHT_UI_THEME.accent_primary),
-        ("light live", palette::LIGHT_UI_THEME.status_working),
-        ("light human", palette::LIGHT_UI_THEME.accent_action),
-        ("light warning", palette::LIGHT_UI_THEME.warning),
-        ("light danger", palette::LIGHT_UI_THEME.error_fg),
-        ("light operate", palette::LIGHT_UI_THEME.mode_operate),
-        ("light success", palette::LIGHT_UI_THEME.success),
+    let light_foregrounds = [
+        ("body", palette::LIGHT_UI_THEME.text_body),
+        ("soft", palette::LIGHT_UI_THEME.text_soft),
+        ("muted", palette::LIGHT_UI_THEME.text_muted),
+        ("hint", palette::LIGHT_UI_THEME.text_hint),
+        ("action", palette::LIGHT_UI_THEME.accent_primary),
+        ("live", palette::LIGHT_UI_THEME.status_working),
+        ("human", palette::LIGHT_UI_THEME.accent_action),
+        ("warning", palette::LIGHT_UI_THEME.warning),
+        ("danger", palette::LIGHT_UI_THEME.error_fg),
+        ("operate", palette::LIGHT_UI_THEME.mode_operate),
+        ("success", palette::LIGHT_UI_THEME.success),
+    ];
+    for (background_name, background) in [
+        ("surface", palette::LIGHT_SURFACE),
+        ("selection", palette::LIGHT_SELECTION_BG),
     ] {
-        assert_min_contrast(label, foreground, palette::LIGHT_SURFACE, min_readable);
+        for (foreground_name, foreground) in light_foregrounds {
+            assert_min_contrast(
+                &format!("light {foreground_name} on {background_name}"),
+                foreground,
+                background,
+                min_readable,
+            );
+        }
     }
 }

--- a/crates/tui/tests/palette_audit.rs
+++ b/crates/tui/tests/palette_audit.rs
@@ -87,23 +87,34 @@ fn verify_status_success_uses_success_token() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn verify_brand_aliases_follow_whale_tokens() {
-    assert_eq!(palette::WHALE_ACCENT_PRIMARY_RGB, (246, 196, 83));
-    assert_eq!(palette::WHALE_INFO_RGB, (106, 174, 242));
-    assert_eq!(palette::WHALE_ERROR_RGB, (255, 92, 122));
-    assert_eq!(
-        color_to_rgb(palette::WHALE_ACCENT_PRIMARY),
-        palette::WHALE_ACCENT_PRIMARY_RGB
-    );
+fn whale_blue_stage_roles_are_pinned_and_non_colliding() {
+    assert_eq!(palette::WHALE_BG_RGB, (3, 7, 13));
+    assert_eq!(palette::WHALE_PANEL_RGB, (14, 23, 41));
+    assert_eq!(palette::WHALE_ELEVATED_RGB, (24, 39, 66));
+    assert_eq!(palette::WHALE_ACTION_RGB, (106, 174, 242));
+    assert_eq!(palette::WHALE_ACCENT_SECONDARY_RGB, (79, 209, 197));
+    assert_eq!(palette::WHALE_HUMAN_RGB, (246, 196, 83));
+    assert_eq!(palette::WHALE_WARNING_RGB, (255, 122, 89));
+    assert_eq!(palette::WHALE_ERROR_RGB, (255, 134, 178));
+    assert_eq!(palette::WHALE_MODE_OPERATE_RGB, (173, 136, 255));
 
-    assert_eq!(
-        palette::WHALE_ACCENT_PRIMARY_RGB,
-        palette::WHALE_ACCENT_PRIMARY_RGB
+    let ui = palette::UI_THEME;
+    assert_eq!(ui.accent_primary, palette::WHALE_ACTION);
+    assert_eq!(ui.info, palette::WHALE_ACTION);
+    assert_eq!(ui.status_working, palette::WHALE_LIVE);
+    assert_eq!(ui.accent_action, palette::WHALE_HUMAN);
+    assert_eq!(ui.warning, palette::STATUS_WARNING);
+    assert_eq!(ui.error_fg, palette::WHALE_ERROR);
+    assert_eq!(ui.mode_operate, palette::MODE_OPERATE);
+    assert_ne!(
+        ui.status_working, ui.success,
+        "live and done need separate ink"
     );
-    assert_eq!(palette::WHALE_ACCENT_PRIMARY, palette::WHALE_ACCENT_PRIMARY);
-    assert_eq!(palette::WHALE_INFO_RGB, palette::WHALE_INFO_RGB);
-    assert_eq!(palette::WHALE_ERROR_RGB, palette::WHALE_ERROR_RGB);
+    assert_ne!(ui.accent_action, ui.warning, "human asks are not warnings");
+    assert_ne!(
+        ui.warning, ui.error_fg,
+        "warning and danger must not collapse"
+    );
 }
 
 #[test]
@@ -152,6 +163,17 @@ fn contrast_guardrails_for_key_ui_pairs() {
         palette::SURFACE_ELEVATED,
         min_readable,
     );
+    for (label, foreground) in [
+        ("action", palette::UI_THEME.accent_primary),
+        ("live", palette::UI_THEME.status_working),
+        ("human", palette::UI_THEME.accent_action),
+        ("warning", palette::UI_THEME.warning),
+        ("danger", palette::UI_THEME.error_fg),
+        ("operate", palette::UI_THEME.mode_operate),
+        ("success", palette::UI_THEME.success),
+    ] {
+        assert_min_contrast(label, foreground, palette::SURFACE_ELEVATED, min_readable);
+    }
     assert_min_contrast(
         "LIGHT_TEXT_BODY on LIGHT_SURFACE",
         palette::LIGHT_TEXT_BODY,
@@ -170,4 +192,15 @@ fn contrast_guardrails_for_key_ui_pairs() {
         palette::LIGHT_SELECTION_BG,
         min_readable,
     );
+    for (label, foreground) in [
+        ("light action", palette::LIGHT_UI_THEME.accent_primary),
+        ("light live", palette::LIGHT_UI_THEME.status_working),
+        ("light human", palette::LIGHT_UI_THEME.accent_action),
+        ("light warning", palette::LIGHT_UI_THEME.warning),
+        ("light danger", palette::LIGHT_UI_THEME.error_fg),
+        ("light operate", palette::LIGHT_UI_THEME.mode_operate),
+        ("light success", palette::LIGHT_UI_THEME.success),
+    ] {
+        assert_min_contrast(label, foreground, palette::LIGHT_SURFACE, min_readable);
+    }
 }

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -45,6 +45,12 @@ function runtimeEvent(sequence, event, payload = {}, overrides = {}) {
   };
 }
 
+function cssDeclarations(styles, selectorPattern) {
+  const match = styles.match(new RegExp(`${selectorPattern}\\s*\\{([^}]*)\\}`));
+  assert.ok(match, `missing CSS rule matching ${selectorPattern}`);
+  return match[1];
+}
+
 test("embedded web client uses the Blue Stage semantic palette", async () => {
   const [styles, html] = await Promise.all([
     readFile(new URL("../src/runtime_web/styles.css", import.meta.url), "utf8"),
@@ -64,10 +70,26 @@ test("embedded web client uses the Blue Stage semantic palette", async () => {
   ]) {
     assert.match(styles, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
-  assert.match(styles, /\.primary-button,[\s\S]*background: var\(--action\)/);
-  assert.match(styles, /\.status-pip\.running[\s\S]*background: var\(--live\)/);
-  assert.match(styles, /\.message\.user \.message-body[\s\S]*rgba\(246, 196, 83/);
-  assert.match(styles, /\.attention-card[\s\S]*rgba\(246, 196, 83/);
+  assert.match(
+    cssDeclarations(styles, "\\.primary-button,\\s*\\.send-button"),
+    /background: var\(--action\)/,
+  );
+  assert.match(
+    cssDeclarations(styles, "\\.status-pip\\.running"),
+    /background: var\(--live\)/,
+  );
+  assert.match(
+    cssDeclarations(styles, "\\.message\\.user \\.message-body"),
+    /background: rgba\(246, 196, 83/,
+  );
+  assert.match(
+    cssDeclarations(styles, "\\.attention-card"),
+    /border: 1px solid rgba\(246, 196, 83/,
+  );
+  assert.match(
+    cssDeclarations(styles, "\\.status-banner"),
+    /color: var\(--warning\)/,
+  );
   assert.match(html, /name="theme-color" content="#03070d"/);
 });
 

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -67,6 +67,7 @@ test("embedded web client uses the Blue Stage semantic palette", async () => {
     "--live: #4fd1c5",
     "--warning: #ff7a59",
     "--danger: #ff86b2",
+    "--ok: #9bd66f",
   ]) {
     assert.match(styles, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
@@ -89,6 +90,10 @@ test("embedded web client uses the Blue Stage semantic palette", async () => {
   assert.match(
     cssDeclarations(styles, "\\.status-banner"),
     /color: var\(--warning\)/,
+  );
+  assert.match(
+    cssDeclarations(styles, "\\.connection-dot\\.ready"),
+    /background: var\(--ok\)/,
   );
   assert.match(html, /name="theme-color" content="#03070d"/);
 });

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -45,6 +45,32 @@ function runtimeEvent(sequence, event, payload = {}, overrides = {}) {
   };
 }
 
+test("embedded web client uses the Blue Stage semantic palette", async () => {
+  const [styles, html] = await Promise.all([
+    readFile(new URL("../src/runtime_web/styles.css", import.meta.url), "utf8"),
+    readFile(new URL("../src/runtime_web/index.html", import.meta.url), "utf8"),
+  ]);
+
+  for (const token of [
+    "--ink-0: #03070d",
+    "--ink-1: #08111c",
+    "--ink-2: #0e1729",
+    "--text: #f6f2e8",
+    "--action: #6aaef2",
+    "--human: #f6c453",
+    "--live: #4fd1c5",
+    "--warning: #ff7a59",
+    "--danger: #ff86b2",
+  ]) {
+    assert.match(styles, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.match(styles, /\.primary-button,[\s\S]*background: var\(--action\)/);
+  assert.match(styles, /\.status-pip\.running[\s\S]*background: var\(--live\)/);
+  assert.match(styles, /\.message\.user \.message-body[\s\S]*rgba\(246, 196, 83/);
+  assert.match(styles, /\.attention-card[\s\S]*rgba\(246, 196, 83/);
+  assert.match(html, /name="theme-color" content="#03070d"/);
+});
+
 test("loads a consistent snapshot before subscribing from latest_seq", async () => {
   const state = createThreadState("thread-a");
   const order = [];

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1115,11 +1115,11 @@ Common settings keys:
 - `theme` (`system`, `terminal`, `dark`, `light`, `grayscale`,
   `catppuccin-mocha`, `tokyo-night`, `dracula`, `gruvbox-dark`, `claude`,
   `matrix`, `solarized-light`; default `system`): `system` follows terminal
-  background detection, `dark`/`light` use the Blue Stage Whale pair,
+  background detection, `dark`/`light` use the Codewhale Whale pair,
   `terminal` inherits the host terminal, `grayscale` is the low-opinion
   black/white theme, and the named community presets apply across the TUI.
   Aliases such as `whale`, `mono`, `black-white`, `tokyonight`, and `gruvbox`
-  are accepted. In Whale, Blue Devil blue owns action/focus, seafoam owns live
+  are accepted. In Whale, cobalt blue owns action/focus, seafoam owns live
   work, Signal Gold owns human decisions and the whale, coral owns warnings,
   rose owns danger, violet owns Operate, and green remains completed/verified.
   Text labels, markers, and motion policy carry the same states when color is

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1112,12 +1112,18 @@ You can inspect or update these from the TUI with `/settings` and `/config`
 
 Common settings keys:
 
-- `theme` (`system`, `dark`, `light`, `grayscale`, `catppuccin-mocha`,
-  `tokyo-night`, `dracula`, `gruvbox-dark`; default `system`): `system`
-  follows terminal background detection, `dark`/`light` use the DeepSeek
-  palettes, `grayscale` is the low-opinion black/white theme, and the named
-  community presets apply across the TUI. Aliases such as `whale`, `mono`,
-  `black-white`, `tokyonight`, and `gruvbox` are accepted.
+- `theme` (`system`, `terminal`, `dark`, `light`, `grayscale`,
+  `catppuccin-mocha`, `tokyo-night`, `dracula`, `gruvbox-dark`, `claude`,
+  `matrix`, `solarized-light`; default `system`): `system` follows terminal
+  background detection, `dark`/`light` use the Blue Stage Whale pair,
+  `terminal` inherits the host terminal, `grayscale` is the low-opinion
+  black/white theme, and the named community presets apply across the TUI.
+  Aliases such as `whale`, `mono`, `black-white`, `tokyonight`, and `gruvbox`
+  are accepted. In Whale, Blue Devil blue owns action/focus, seafoam owns live
+  work, Signal Gold owns human decisions and the whale, coral owns warnings,
+  rose owns danger, violet owns Operate, and green remains completed/verified.
+  Text labels, markers, and motion policy carry the same states when color is
+  unavailable; color is never the only cue.
 - `auto_compact` (on/off, model-aware default on for known context windows
   unless explicitly configured)
 - `auto_compact_threshold_percent` (10-100, default `80`): pre-send


### PR DESCRIPTION
## Summary

- make refreshed Whale dark and light palettes the default Codewhale color grammar while retaining stable theme identifiers and System behavior
- give identity, live work, human decisions, warnings, danger, completion, and Operate distinct semantic roles
- preserve those roles through grayscale, ANSI-16, ANSI-256, TrueColor, terminal, matrix, and community-theme adaptation
- raise Whale Light contrast across every supported surface and keep Ocean endpoints coherent

## Verification

- palette audit: 42 passed
- focused palette and command-palette suite: 60 passed
- Ocean tests: 15 passed
- color-backend tests: 20 passed
- underwater tests: 17 passed
- theme picker tests: 16 passed
- DeepSeek theme tests: 5 passed
- approval, default-theme, responsive, and real-PTY all-theme checks passed
- cargo fmt --all -- --check
- cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings

## Review notes

A separate contrast and backend review caught and this branch fixes light success contrast, grayscale double-adaptation, and ANSI-16 role collisions. No theme ID or persisted configuration key changes.