### PR TITLE
fix(runtime-web): make replay and interaction recovery lossless

### DIFF
--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2034,7 +2034,7 @@ async fn interrupt_thread_turn(
 
 async fn deliver_dynamic_tool_result(
     State(state): State<RuntimeApiState>,
-    Path((id, _turn_id, call_id)): Path<(String, String, String)>,
+    Path((id, turn_id, call_id)): Path<(String, String, String)>,
     Json(result): Json<DynamicToolCallResult>,
 ) -> Result<StatusCode, ApiError> {
     state
@@ -2044,7 +2044,9 @@ async fn deliver_dynamic_tool_result(
         .map_err(map_thread_err)?;
     if state
         .runtime_threads
-        .deliver_dynamic_tool_result(&call_id, result)
+        .deliver_dynamic_tool_result(&id, &turn_id, &call_id, result)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?
     {
         Ok(StatusCode::ACCEPTED)
     } else {

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2568,9 +2568,99 @@ fn map_compat_stream_event(event: &crate::runtime_threads::RuntimeEventRecord) -
                 None
             }
         }
-        "approval.required" => Some(sse_json("approval.required", payload.clone())),
-        "approval.decided" => Some(sse_json("approval.decided", payload.clone())),
-        "approval.timeout" => Some(sse_json("approval.timeout", payload.clone())),
+        "approval.required" => {
+            let approval_id = payload
+                .get("approval_id")
+                .or_else(|| payload.get("id"))?
+                .clone();
+            Some(sse_json(
+                "approval.required",
+                json!({
+                    "id": approval_id,
+                    "approval_id": approval_id,
+                    "thread_id": event.thread_id,
+                    "turn_id": event.turn_id,
+                    "tool_name": payload.get("tool_name"),
+                    "description": payload.get("description"),
+                    "intent_summary": payload.get("intent_summary"),
+                }),
+            ))
+        }
+        "approval.decided" => {
+            let approval_id = payload
+                .get("approval_id")
+                .or_else(|| payload.get("id"))?
+                .clone();
+            Some(sse_json(
+                "approval.decided",
+                json!({
+                    "id": approval_id,
+                    "approval_id": approval_id,
+                    "thread_id": event.thread_id,
+                    "turn_id": event.turn_id,
+                    "decision": payload.get("decision"),
+                    "remember": payload.get("remember"),
+                    "auto": payload.get("auto"),
+                    "timeout": payload.get("timeout"),
+                }),
+            ))
+        }
+        "approval.timeout" => {
+            let approval_id = payload
+                .get("approval_id")
+                .or_else(|| payload.get("id"))?
+                .clone();
+            Some(sse_json(
+                "approval.timeout",
+                json!({
+                    "id": approval_id,
+                    "approval_id": approval_id,
+                    "thread_id": event.thread_id,
+                    "turn_id": event.turn_id,
+                    "timeout_secs": payload.get("timeout_secs"),
+                }),
+            ))
+        }
+        "user_input.required" => {
+            let input_id = payload
+                .get("input_id")
+                .or_else(|| payload.get("id"))?
+                .clone();
+            let request = payload.get("request")?.clone();
+            Some(sse_json(
+                "user_input.required",
+                json!({
+                    "id": input_id,
+                    "input_id": input_id,
+                    "thread_id": event.thread_id,
+                    "turn_id": event.turn_id,
+                    "status": "required",
+                    "request": request,
+                }),
+            ))
+        }
+        "user_input.answered" | "user_input.canceled" => {
+            let input_id = payload
+                .get("input_id")
+                .or_else(|| payload.get("id"))?
+                .clone();
+            let status = if event.event == "user_input.answered" {
+                "submitted"
+            } else {
+                "canceled"
+            };
+            Some(sse_json(
+                &event.event,
+                json!({
+                    "id": input_id,
+                    "input_id": input_id,
+                    "thread_id": event.thread_id,
+                    "turn_id": event.turn_id,
+                    "status": status,
+                    "terminal": payload.get("terminal").and_then(Value::as_bool).unwrap_or(false),
+                }),
+            ))
+        }
         "sandbox.denied" => Some(sse_json("sandbox.denied", payload.clone())),
         "turn.completed" => {
             let usage = payload

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -122,6 +122,26 @@ pub struct RuntimeApiState {
     /// lazily-initialized slot; slow per-pool work (connect_all) runs under
     /// the inner handle so it cannot block slot reads.
     mcp_pool: Arc<Mutex<Option<Arc<Mutex<McpPool>>>>>,
+    #[cfg(test)]
+    compat_stream_test_hook: Option<tokio::sync::mpsc::UnboundedSender<CompatStreamTestPoint>>,
+}
+
+#[cfg(test)]
+enum CompatStreamTestPoint {
+    ThreadCreated {
+        thread_id: String,
+        resume: tokio::sync::oneshot::Sender<()>,
+    },
+    SubscribedBeforeReplay {
+        thread_id: String,
+        turn_id: String,
+        resume: tokio::sync::oneshot::Sender<()>,
+    },
+    ReplayLoaded {
+        thread_id: String,
+        turn_id: String,
+        resume: tokio::sync::oneshot::Sender<()>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -508,6 +528,8 @@ pub async fn run_http_server(
         web,
         fleet_codewhale_binary: configured_codewhale_binary(),
         mcp_pool: Arc::new(Mutex::new(None)),
+        #[cfg(test)]
+        compat_stream_test_hook: None,
     };
     let app = build_router(state);
 
@@ -2243,6 +2265,19 @@ async fn stream_turn(
         .await
         .map_err(|e| ApiError::internal(format!("Failed to create stream thread: {e}")))?;
 
+    #[cfg(test)]
+    if let Some(hook) = &state.compat_stream_test_hook {
+        let (resume, wait_for_resume) = tokio::sync::oneshot::channel();
+        hook.send(CompatStreamTestPoint::ThreadCreated {
+            thread_id: thread.id.clone(),
+            resume,
+        })
+        .map_err(|_| ApiError::internal("Compatibility stream test hook closed"))?;
+        wait_for_resume
+            .await
+            .map_err(|_| ApiError::internal("Compatibility stream test hook dropped resume"))?;
+    }
+
     let turn = state
         .runtime_threads
         .start_turn(
@@ -2261,15 +2296,48 @@ async fn stream_turn(
         .await
         .map_err(|e| ApiError::internal(format!("Failed to start stream turn: {e}")))?;
 
-    let backlog = state
-        .runtime_threads
-        .events_since(&thread.id, None)
-        .map_err(|e| ApiError::internal(format!("Failed to load stream backlog: {e}")))?;
+    // Subscribe before reading the durable replay. Events produced while the
+    // replay is loaded then exist in at least one source, and the sequence
+    // cursor below removes overlap without dropping the handoff edge.
     let mut live = state.runtime_threads.subscribe_events();
     let thread_id = thread.id.clone();
     let turn_id = turn.id.clone();
 
+    #[cfg(test)]
+    if let Some(hook) = &state.compat_stream_test_hook {
+        let (resume, wait_for_resume) = tokio::sync::oneshot::channel();
+        hook.send(CompatStreamTestPoint::SubscribedBeforeReplay {
+            thread_id: thread_id.clone(),
+            turn_id: turn_id.clone(),
+            resume,
+        })
+        .map_err(|_| ApiError::internal("Compatibility stream test hook closed"))?;
+        wait_for_resume
+            .await
+            .map_err(|_| ApiError::internal("Compatibility stream test hook dropped resume"))?;
+    }
+
+    let backlog = state
+        .runtime_threads
+        .events_since(&thread.id, None)
+        .map_err(|e| ApiError::internal(format!("Failed to load stream backlog: {e}")))?;
+
+    #[cfg(test)]
+    if let Some(hook) = &state.compat_stream_test_hook {
+        let (resume, wait_for_resume) = tokio::sync::oneshot::channel();
+        hook.send(CompatStreamTestPoint::ReplayLoaded {
+            thread_id: thread_id.clone(),
+            turn_id: turn_id.clone(),
+            resume,
+        })
+        .map_err(|_| ApiError::internal("Compatibility stream test hook closed"))?;
+        wait_for_resume
+            .await
+            .map_err(|_| ApiError::internal("Compatibility stream test hook dropped resume"))?;
+    }
+
     let stream = stream! {
+        let mut last_seq = 0;
         yield Ok(sse_json("turn.started", json!({
             "thread_id": thread.id,
             "turn_id": turn.id,
@@ -2279,42 +2347,112 @@ async fn stream_turn(
         })));
 
         for event in backlog {
-            if event.thread_id != thread_id || event.turn_id.as_deref() != Some(&turn_id) {
+            let Some((mapped, terminal)) = take_compat_turn_event(
+                &event,
+                &thread_id,
+                &turn_id,
+                &mut last_seq,
+            ) else {
                 continue;
-            }
-            if let Some(mapped) = map_compat_stream_event(&event) {
+            };
+            if let Some(mapped) = mapped {
                 yield Ok(mapped);
             }
-            if event.event == "turn.completed" {
+            if terminal {
                 yield Ok(sse_json("done", json!({})));
                 return;
             }
         }
 
         loop {
-            let incoming = live.recv().await;
-            let Ok(event) = incoming else {
-                yield Ok(sse_json("error", json!({ "message": "event channel closed" })));
-                break;
-            };
-            if event.thread_id != thread_id || event.turn_id.as_deref() != Some(&turn_id) {
-                continue;
-            }
-            if let Some(mapped) = map_compat_stream_event(&event) {
-                yield Ok(mapped);
-            }
-            if event.event == "turn.completed" {
-                break;
+            match live.recv().await {
+                Ok(event) => {
+                    let Some((mapped, terminal)) = take_compat_turn_event(
+                        &event,
+                        &thread_id,
+                        &turn_id,
+                        &mut last_seq,
+                    ) else {
+                        continue;
+                    };
+                    if let Some(mapped) = mapped {
+                        yield Ok(mapped);
+                    }
+                    if terminal {
+                        yield Ok(sse_json("done", json!({})));
+                        return;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    let recovered = match state.runtime_threads.events_since(
+                        &thread_id,
+                        Some(last_seq),
+                    ) {
+                        Ok(events) => events,
+                        Err(error) => {
+                            tracing::warn!(
+                                thread_id = %thread_id,
+                                turn_id = %turn_id,
+                                last_seq,
+                                skipped,
+                                %error,
+                                "Failed to recover lagged compatibility stream from durable history"
+                            );
+                            yield Ok(sse_json("error", json!({
+                                "message": "failed to recover lagged event stream",
+                            })));
+                            return;
+                        }
+                    };
+                    for event in recovered {
+                        let Some((mapped, terminal)) = take_compat_turn_event(
+                            &event,
+                            &thread_id,
+                            &turn_id,
+                            &mut last_seq,
+                        ) else {
+                            continue;
+                        };
+                        if let Some(mapped) = mapped {
+                            yield Ok(mapped);
+                        }
+                        if terminal {
+                            yield Ok(sse_json("done", json!({})));
+                            return;
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    yield Ok(sse_json("error", json!({ "message": "event channel closed" })));
+                    return;
+                }
             }
         }
-
-        yield Ok(sse_json("done", json!({})));
     };
 
     Ok(Sse::new(stream).keep_alive(
         KeepAlive::new()
             .interval(Duration::from_secs(15))
             .text("keepalive"),
+    ))
+}
+
+fn take_compat_turn_event(
+    event: &crate::runtime_threads::RuntimeEventRecord,
+    thread_id: &str,
+    turn_id: &str,
+    last_seq: &mut u64,
+) -> Option<(Option<SseEvent>, bool)> {
+    if event.thread_id != thread_id
+        || event.turn_id.as_deref() != Some(turn_id)
+        || event.seq <= *last_seq
+    {
+        return None;
+    }
+    *last_seq = event.seq;
+    Some((
+        map_compat_stream_event(event),
+        event.event == "turn.completed",
     ))
 }
 

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -2097,49 +2097,107 @@ async fn stream_thread_events(
         .await
         .map_err(map_thread_err)?;
 
+    // Subscribe before reading durable history. An event emitted while replay
+    // is loaded is then present in both places (and deduped below) or queued
+    // live, never in an uncovered handoff window.
+    let live = state.runtime_threads.subscribe_events();
     let mut backlog = state
         .runtime_threads
         .events_since(&id, query.since_seq)
         .map_err(|e| ApiError::internal(e.to_string()))?;
+    let mut replay_cursor = query.since_seq.unwrap_or(0);
     if let Some(limit) = query.replay_limit
         && backlog.len() > limit
     {
-        backlog = backlog.split_off(backlog.len() - limit);
-    }
-    let mut last_seq = query.since_seq.unwrap_or(0);
-    if let Some(last) = backlog.last() {
-        last_seq = last.seq;
+        let split_at = backlog.len() - limit;
+        replay_cursor = backlog[split_at - 1].seq;
+        backlog = backlog.split_off(split_at);
     }
 
-    let mut live = state.runtime_threads.subscribe_events();
-    let thread_id = id.clone();
-    let stream = stream! {
-        for event in backlog {
-            let event_name = event.event.clone();
-            yield Ok(sse_json(&event_name, runtime_event_payload(event)));
-        }
-        loop {
-            let incoming = live.recv().await;
-            let Ok(event) = incoming else {
-                break;
-            };
-            if event.thread_id != thread_id {
-                continue;
-            }
-            if event.seq <= last_seq {
-                continue;
-            }
-            last_seq = event.seq;
-            let event_name = event.event.clone();
-            yield Ok(sse_json(&event_name, runtime_event_payload(event)));
-        }
-    };
+    let stream = replay_live_thread_events(
+        state.runtime_threads.clone(),
+        id,
+        replay_cursor,
+        backlog,
+        live,
+    );
 
     Ok(Sse::new(stream).keep_alive(
         KeepAlive::new()
             .interval(Duration::from_secs(15))
             .text("keepalive"),
     ))
+}
+
+fn replay_live_thread_events(
+    runtime_threads: SharedRuntimeThreadManager,
+    thread_id: String,
+    mut last_seq: u64,
+    backlog: Vec<crate::runtime_threads::RuntimeEventRecord>,
+    mut live: tokio::sync::broadcast::Receiver<crate::runtime_threads::RuntimeEventRecord>,
+) -> impl futures_util::Stream<Item = Result<SseEvent, Infallible>> {
+    stream! {
+        for event in backlog {
+            if event.thread_id != thread_id || event.seq <= last_seq {
+                continue;
+            }
+            let previous_seq = last_seq;
+            last_seq = event.seq;
+            let event_name = event.event.clone();
+            yield Ok(sse_json(
+                &event_name,
+                runtime_event_payload_with_previous(event, previous_seq),
+            ));
+        }
+
+        loop {
+            match live.recv().await {
+                Ok(event) => {
+                    if event.thread_id != thread_id || event.seq <= last_seq {
+                        continue;
+                    }
+                    let previous_seq = last_seq;
+                    last_seq = event.seq;
+                    let event_name = event.event.clone();
+                    yield Ok(sse_json(
+                        &event_name,
+                        runtime_event_payload_with_previous(event, previous_seq),
+                    ));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    // Broadcast is only a wake-up path; durable history remains
+                    // authoritative. Catch up from the last delivered cursor so
+                    // receiver pressure cannot turn into a silent prompt loss.
+                    let recovered = match runtime_threads.events_since(&thread_id, Some(last_seq)) {
+                        Ok(events) => events,
+                        Err(error) => {
+                            tracing::warn!(
+                                thread_id = %thread_id,
+                                last_seq,
+                                skipped,
+                                %error,
+                                "Failed to recover lagged Runtime web event stream from durable history"
+                            );
+                            break;
+                        }
+                    };
+                    for event in recovered {
+                        if event.thread_id != thread_id || event.seq <= last_seq {
+                            continue;
+                        }
+                        let previous_seq = last_seq;
+                        last_seq = event.seq;
+                        let event_name = event.event.clone();
+                        yield Ok(sse_json(
+                            &event_name,
+                            runtime_event_payload_with_previous(event, previous_seq),
+                        ));
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    }
 }
 
 async fn stream_turn(
@@ -2278,6 +2336,17 @@ fn runtime_event_payload(event: crate::runtime_threads::RuntimeEventRecord) -> s
         extra: Default::default(),
     };
     serde_json::to_value(envelope).expect("serialize runtime event envelope")
+}
+
+fn runtime_event_payload_with_previous(
+    event: crate::runtime_threads::RuntimeEventRecord,
+    previous_seq: u64,
+) -> serde_json::Value {
+    let mut payload = runtime_event_payload(event);
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("previous_seq".to_string(), json!(previous_seq));
+    }
+    payload
 }
 
 fn map_compat_stream_event(event: &crate::runtime_threads::RuntimeEventRecord) -> Option<SseEvent> {

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -49,10 +49,10 @@ use crate::mcp::McpPool;
 #[cfg(test)]
 pub(super) use crate::models::{ContentBlock, Message};
 use crate::runtime_threads::{
-    CompactThreadRequest, CreateThreadRequest, ExternalApprovalDecision, RuntimeThreadManager,
-    RuntimeThreadManagerConfig, SharedRuntimeThreadManager, StartTurnRequest, SteerTurnRequest,
-    ThreadDetail, ThreadListFilter, ThreadRecord, TurnItemKind, TurnRecord, UpdateThreadRequest,
-    UsageGroupBy,
+    CompactThreadRequest, CreateThreadRequest, ExternalApprovalDecision,
+    MAX_RUNTIME_EVENT_REPLAY_TAIL, RuntimeThreadManager, RuntimeThreadManagerConfig,
+    SharedRuntimeThreadManager, StartTurnRequest, SteerTurnRequest, ThreadDetail, ThreadListFilter,
+    ThreadRecord, TurnItemKind, TurnRecord, UpdateThreadRequest, UsageGroupBy,
 };
 #[cfg(test)]
 pub(super) use crate::runtime_threads::{RuntimeTurnStatus, TurnItemLifecycleStatus};
@@ -2130,24 +2130,25 @@ async fn stream_thread_events(
     // is loaded is then present in both places (and deduped below) or queued
     // live, never in an uncovered handoff window.
     let live = state.runtime_threads.subscribe_events();
-    let mut backlog = state
-        .runtime_threads
-        .events_since(&id, query.since_seq)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    let mut replay_cursor = query.since_seq.unwrap_or(0);
-    if let Some(limit) = query.replay_limit
-        && backlog.len() > limit
+    if query
+        .replay_limit
+        .is_some_and(|limit| limit > MAX_RUNTIME_EVENT_REPLAY_TAIL)
     {
-        let split_at = backlog.len() - limit;
-        replay_cursor = backlog[split_at - 1].seq;
-        backlog = backlog.split_off(split_at);
+        return Err(ApiError::bad_request(format!(
+            "replay_limit cannot exceed {MAX_RUNTIME_EVENT_REPLAY_TAIL}"
+        )));
     }
+    let replay = state
+        .runtime_threads
+        .replay_events(&id, query.since_seq, query.replay_limit)
+        .await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
 
     let stream = replay_live_thread_events(
         state.runtime_threads.clone(),
         id,
-        replay_cursor,
-        backlog,
+        replay.base_seq,
+        replay.batches,
         live,
     );
 
@@ -2162,24 +2163,40 @@ fn replay_live_thread_events(
     runtime_threads: SharedRuntimeThreadManager,
     thread_id: String,
     mut last_seq: u64,
-    backlog: Vec<crate::runtime_threads::RuntimeEventRecord>,
+    mut backlog: tokio::sync::mpsc::Receiver<
+        std::result::Result<Vec<crate::runtime_threads::RuntimeEventRecord>, String>,
+    >,
     mut live: tokio::sync::broadcast::Receiver<crate::runtime_threads::RuntimeEventRecord>,
 ) -> impl futures_util::Stream<Item = Result<SseEvent, Infallible>> {
     stream! {
-        for event in backlog {
-            if event.thread_id != thread_id || event.seq <= last_seq {
-                continue;
+        while let Some(batch) = backlog.recv().await {
+            let events = match batch {
+                Ok(events) => events,
+                Err(error) => {
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        last_seq,
+                        %error,
+                        "Failed to replay Runtime web event stream from durable history"
+                    );
+                    return;
+                }
+            };
+            for event in events {
+                if event.thread_id != thread_id || event.seq <= last_seq {
+                    continue;
+                }
+                let previous_seq = last_seq;
+                last_seq = event.seq;
+                let event_name = event.event.clone();
+                yield Ok(sse_json(
+                    &event_name,
+                    runtime_event_payload_with_previous(event, previous_seq),
+                ));
             }
-            let previous_seq = last_seq;
-            last_seq = event.seq;
-            let event_name = event.event.clone();
-            yield Ok(sse_json(
-                &event_name,
-                runtime_event_payload_with_previous(event, previous_seq),
-            ));
         }
 
-        loop {
+        'live: loop {
             match live.recv().await {
                 Ok(event) => {
                     if event.thread_id != thread_id || event.seq <= last_seq {
@@ -2197,8 +2214,11 @@ fn replay_live_thread_events(
                     // Broadcast is only a wake-up path; durable history remains
                     // authoritative. Catch up from the last delivered cursor so
                     // receiver pressure cannot turn into a silent prompt loss.
-                    let recovered = match runtime_threads.events_since(&thread_id, Some(last_seq)) {
-                        Ok(events) => events,
+                    let mut recovered = match runtime_threads
+                        .replay_events(&thread_id, Some(last_seq), None)
+                        .await
+                    {
+                        Ok(replay) => replay.batches,
                         Err(error) => {
                             tracing::warn!(
                                 thread_id = %thread_id,
@@ -2207,20 +2227,35 @@ fn replay_live_thread_events(
                                 %error,
                                 "Failed to recover lagged Runtime web event stream from durable history"
                             );
-                            break;
+                            break 'live;
                         }
                     };
-                    for event in recovered {
-                        if event.thread_id != thread_id || event.seq <= last_seq {
-                            continue;
+                    while let Some(batch) = recovered.recv().await {
+                        let events = match batch {
+                            Ok(events) => events,
+                            Err(error) => {
+                                tracing::warn!(
+                                    thread_id = %thread_id,
+                                    last_seq,
+                                    skipped,
+                                    %error,
+                                    "Failed to recover lagged Runtime web event stream from durable history"
+                                );
+                                break 'live;
+                            }
+                        };
+                        for event in events {
+                            if event.thread_id != thread_id || event.seq <= last_seq {
+                                continue;
+                            }
+                            let previous_seq = last_seq;
+                            last_seq = event.seq;
+                            let event_name = event.event.clone();
+                            yield Ok(sse_json(
+                                &event_name,
+                                runtime_event_payload_with_previous(event, previous_seq),
+                            ));
                         }
-                        let previous_seq = last_seq;
-                        last_seq = event.seq;
-                        let event_name = event.event.clone();
-                        yield Ok(sse_json(
-                            &event_name,
-                            runtime_event_payload_with_previous(event, previous_seq),
-                        ));
                     }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
@@ -2324,9 +2359,10 @@ async fn stream_turn(
             .map_err(|_| ApiError::internal("Compatibility stream test hook dropped resume"))?;
     }
 
-    let backlog = state
+    let mut backlog = state
         .runtime_threads
-        .events_since(&thread.id, None)
+        .replay_events(&thread.id, None, None)
+        .await
         .map_err(|e| ApiError::internal(format!("Failed to load stream backlog: {e}")))?;
 
     #[cfg(test)]
@@ -2353,21 +2389,38 @@ async fn stream_turn(
             "workspace": workspace,
         })));
 
-        for event in backlog {
-            let Some((mapped, terminal)) = take_compat_turn_event(
-                &event,
-                &thread_id,
-                &turn_id,
-                &mut last_seq,
-            ) else {
-                continue;
+        while let Some(batch) = backlog.batches.recv().await {
+            let events = match batch {
+                Ok(events) => events,
+                Err(error) => {
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        turn_id = %turn_id,
+                        %error,
+                        "Failed to replay compatibility stream from durable history"
+                    );
+                    yield Ok(sse_json("error", json!({
+                        "message": "failed to replay durable event stream",
+                    })));
+                    return;
+                }
             };
-            if let Some(mapped) = mapped {
-                yield Ok(mapped);
-            }
-            if terminal {
-                yield Ok(sse_json("done", json!({})));
-                return;
+            for event in events {
+                let Some((mapped, terminal)) = take_compat_turn_event(
+                    &event,
+                    &thread_id,
+                    &turn_id,
+                    &mut last_seq,
+                ) else {
+                    continue;
+                };
+                if let Some(mapped) = mapped {
+                    yield Ok(mapped);
+                }
+                if terminal {
+                    yield Ok(sse_json("done", json!({})));
+                    return;
+                }
             }
         }
 
@@ -2391,11 +2444,11 @@ async fn stream_turn(
                     }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                    let recovered = match state.runtime_threads.events_since(
-                        &thread_id,
-                        Some(last_seq),
-                    ) {
-                        Ok(events) => events,
+                    let mut recovered = match state.runtime_threads
+                        .replay_events(&thread_id, Some(last_seq), None)
+                        .await
+                    {
+                        Ok(replay) => replay.batches,
                         Err(error) => {
                             tracing::warn!(
                                 thread_id = %thread_id,
@@ -2411,21 +2464,40 @@ async fn stream_turn(
                             return;
                         }
                     };
-                    for event in recovered {
-                        let Some((mapped, terminal)) = take_compat_turn_event(
-                            &event,
-                            &thread_id,
-                            &turn_id,
-                            &mut last_seq,
-                        ) else {
-                            continue;
+                    while let Some(batch) = recovered.recv().await {
+                        let events = match batch {
+                            Ok(events) => events,
+                            Err(error) => {
+                                tracing::warn!(
+                                    thread_id = %thread_id,
+                                    turn_id = %turn_id,
+                                    last_seq,
+                                    skipped,
+                                    %error,
+                                    "Failed to recover lagged compatibility stream from durable history"
+                                );
+                                yield Ok(sse_json("error", json!({
+                                    "message": "failed to recover lagged event stream",
+                                })));
+                                return;
+                            }
                         };
-                        if let Some(mapped) = mapped {
-                            yield Ok(mapped);
-                        }
-                        if terminal {
-                            yield Ok(sse_json("done", json!({})));
-                            return;
+                        for event in events {
+                            let Some((mapped, terminal)) = take_compat_turn_event(
+                                &event,
+                                &thread_id,
+                                &turn_id,
+                                &mut last_seq,
+                            ) else {
+                                continue;
+                            };
+                            if let Some(mapped) = mapped {
+                                yield Ok(mapped);
+                            }
+                            if terminal {
+                                yield Ok(sse_json("done", json!({})));
+                                return;
+                            }
                         }
                     }
                 }

--- a/crates/tui/src/runtime_api.rs
+++ b/crates/tui/src/runtime_api.rs
@@ -1502,6 +1502,11 @@ async fn submit_user_input(
         .submit_user_input(&thread_id, &input_id, response)
         .await
         .map_err(map_thread_err)?;
+    if !delivered {
+        return Err(ApiError::not_found(format!(
+            "no pending user-input request with id '{input_id}'"
+        )));
+    }
     Ok(Json(SubmitUserInputResponse {
         ok: true,
         input_id,

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -348,6 +348,7 @@ fn messages_from_thread_detail_batches_tool_results() {
         latest_seq: 0,
         pending_approvals: Vec::new(),
         pending_user_inputs: Vec::new(),
+        pending_dynamic_tool_calls: Vec::new(),
     };
 
     let messages = messages_from_thread_detail(&detail);
@@ -423,6 +424,7 @@ fn legacy_exact_thread_export_normalizes_provider_kind_and_id() {
         latest_seq: 0,
         pending_approvals: Vec::new(),
         pending_user_inputs: Vec::new(),
+        pending_dynamic_tool_calls: Vec::new(),
     };
     let config = Config {
         provider: Some("lm-studio".to_string()),
@@ -2231,7 +2233,7 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
     let (hook_tx, mut hook_rx) = mpsc::unbounded_channel();
     let Some((addr, runtime_threads, handle)) =
         spawn_test_server_with_root_token_mobile_workspace_and_overrides(
-            root,
+            root.clone(),
             sessions_dir,
             None,
             false,
@@ -2288,36 +2290,58 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
                 route: None,
             })
             .await?;
+        let request = crate::tools::user_input::UserInputRequest {
+            questions: vec![crate::tools::user_input::UserInputQuestion {
+                header: "Continue".to_string(),
+                id: "choice".to_string(),
+                question: "Continue the compatibility turn?".to_string(),
+                options: vec![
+                    crate::tools::user_input::UserInputOption {
+                        label: "Continue".to_string(),
+                        description: "Finish the turn".to_string(),
+                    },
+                    crate::tools::user_input::UserInputOption {
+                        label: "Stop".to_string(),
+                        description: "Cancel the turn".to_string(),
+                    },
+                ],
+                allow_free_text: false,
+                multi_select: false,
+            }],
+        };
+        harness
+            .tx_event
+            .send(EngineEvent::ToolCallStarted {
+                id: "input_compat".to_string(),
+                name: "request_user_input".to_string(),
+                input: serde_json::to_value(&request)?,
+            })
+            .await?;
         harness
             .tx_event
             .send(EngineEvent::UserInputRequired {
                 id: "input_compat".to_string(),
-                request: crate::tools::user_input::UserInputRequest {
-                    questions: vec![crate::tools::user_input::UserInputQuestion {
-                        header: "Continue".to_string(),
-                        id: "choice".to_string(),
-                        question: "Continue the compatibility turn?".to_string(),
-                        options: vec![
-                            crate::tools::user_input::UserInputOption {
-                                label: "Continue".to_string(),
-                                description: "Finish the turn".to_string(),
-                            },
-                            crate::tools::user_input::UserInputOption {
-                                label: "Stop".to_string(),
-                                description: "Cancel the turn".to_string(),
-                            },
-                        ],
-                        allow_free_text: false,
-                        multi_select: false,
-                    }],
-                },
+                request,
             })
             .await?;
         let submission = harness.recv_user_input_submission().await;
+        let tool_result = submission
+            .as_ref()
+            .map(|(_, response)| crate::tools::spec::ToolResult::json(response))
+            .transpose()?
+            .context("compatibility user input was canceled before tool completion")?;
         let _ = submission_tx.send(submission);
         wait_for_completion_release
             .await
             .context("compatibility interaction test dropped completion release")?;
+        harness
+            .tx_event
+            .send(EngineEvent::ToolCallComplete {
+                id: "input_compat".to_string(),
+                name: "request_user_input".to_string(),
+                result: Ok(tool_result),
+            })
+            .await?;
         harness
             .tx_event
             .send(EngineEvent::MessageStarted { index: 0 })
@@ -2490,6 +2514,60 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
     assert!(
         !serde_json::to_string(&frames)?.contains(SECRET_ANSWER),
         "submitted answer leaked into compatibility SSE"
+    );
+    let detail = runtime_threads.get_thread_detail(&thread_id).await?;
+    let serialized_detail = serde_json::to_string(&detail)?;
+    assert!(
+        !serialized_detail.contains(SECRET_ANSWER),
+        "submitted answer leaked into the thread snapshot"
+    );
+    let redacted_item = detail
+        .items
+        .iter()
+        .find(|item| {
+            item.metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("tool_name"))
+                .and_then(Value::as_str)
+                == Some("request_user_input")
+        })
+        .context("request_user_input Runtime receipt was not persisted")?;
+    assert_eq!(
+        redacted_item.detail.as_deref(),
+        Some("User input submitted")
+    );
+    assert_eq!(
+        redacted_item
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("response_redacted"))
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    let durable_events = runtime_threads.events_since(&thread_id, None)?;
+    assert!(
+        !serde_json::to_string(&durable_events)?.contains(SECRET_ANSWER),
+        "submitted answer leaked into the durable Runtime event log"
+    );
+    let leaked_file = ignore::WalkBuilder::new(root.join("runtime"))
+        .hidden(false)
+        .build()
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| entry.file_type().is_some_and(|kind| kind.is_file()))
+        .find_map(|entry| {
+            fs::read_to_string(entry.path())
+                .ok()
+                .filter(|contents| contents.contains(SECRET_ANSWER))
+                .map(|_| entry.path().to_path_buf())
+        });
+    assert!(
+        leaked_file.is_none(),
+        "submitted answer leaked into Runtime file {}",
+        leaked_file
+            .as_deref()
+            .map(std::path::Path::display)
+            .map(|path| path.to_string())
+            .unwrap_or_default()
     );
 
     handle.abort();
@@ -4769,7 +4847,17 @@ async fn dynamic_tool_result_endpoint_delivers_to_runtime() -> Result<()> {
         .json()
         .await?;
     let thread_id = thread["id"].as_str().context("thread id")?;
-    let rx = runtime_threads.register_pending_dynamic_tool_for_test("call_1");
+    let rx =
+        runtime_threads.register_pending_dynamic_tool_for_test(thread_id, "turn_1", "call_1")?;
+
+    let wrong_turn = client
+        .post(format!(
+            "http://{addr}/v1/threads/{thread_id}/turns/turn_wrong/tool-calls/call_1/result"
+        ))
+        .json(&json!({ "success": false }))
+        .send()
+        .await?;
+    assert_eq!(wrong_turn.status(), StatusCode::NOT_FOUND);
 
     let resp = client
         .post(format!(
@@ -4786,6 +4874,31 @@ async fn dynamic_tool_result_endpoint_delivers_to_runtime() -> Result<()> {
     let received = tokio::time::timeout(Duration::from_secs(1), rx).await??;
     assert!(received.success);
     assert_eq!(received.content.len(), 1);
+    let resolved = runtime_threads
+        .events_since(thread_id, None)?
+        .into_iter()
+        .filter(|event| event.event == "tool_call.resolved")
+        .collect::<Vec<_>>();
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].payload["call_id"], "call_1");
+    assert!(resolved[0].payload.get("content").is_none());
+
+    let duplicate = client
+        .post(format!(
+            "http://{addr}/v1/threads/{thread_id}/turns/turn_1/tool-calls/call_1/result"
+        ))
+        .json(&json!({ "success": true }))
+        .send()
+        .await?;
+    assert_eq!(duplicate.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        runtime_threads
+            .events_since(thread_id, None)?
+            .iter()
+            .filter(|event| event.event == "tool_call.resolved")
+            .count(),
+        1
+    );
 
     handle.abort();
     Ok(())

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -837,6 +837,49 @@ async fn read_first_sse_frame(resp: reqwest::Response) -> Result<String> {
     }
 }
 
+fn take_complete_sse_frame(buffer: &mut Vec<u8>) -> Result<Option<String>> {
+    let text = String::from_utf8_lossy(buffer);
+    let lf = text.find("\n\n").map(|index| (index, 2));
+    let crlf = text.find("\r\n\r\n").map(|index| (index, 4));
+    let delimiter = match (lf, crlf) {
+        (Some(left), Some(right)) => Some(if left.0 <= right.0 { left } else { right }),
+        (Some(found), None) | (None, Some(found)) => Some(found),
+        (None, None) => None,
+    };
+    let Some((index, delimiter_len)) = delimiter else {
+        return Ok(None);
+    };
+    let frame = String::from_utf8(buffer[..index].to_vec())?;
+    buffer.drain(..index + delimiter_len);
+    Ok(Some(frame))
+}
+
+async fn collect_sse_frames(
+    response: reqwest::Response,
+    frame_tx: mpsc::UnboundedSender<(String, serde_json::Value)>,
+) -> Result<Vec<(String, serde_json::Value)>> {
+    let mut stream = response.bytes_stream();
+    let mut buffer = Vec::new();
+    let mut frames = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        buffer.extend_from_slice(&chunk?);
+        while let Some(raw) = take_complete_sse_frame(&mut buffer)? {
+            if raw.trim().is_empty() || raw.trim_start().starts_with(':') {
+                continue;
+            }
+            let frame = parse_sse_frame(&raw)?;
+            frame_tx
+                .send(frame.clone())
+                .map_err(|_| anyhow::anyhow!("SSE frame observer closed"))?;
+            frames.push(frame);
+        }
+        if buffer.len() > 64 * 1024 {
+            bail!("SSE frame exceeded 64KB without delimiter");
+        }
+    }
+    Ok(frames)
+}
+
 #[cfg(unix)]
 fn write_fake_fleet_binary(root: &Path, marker: &Path) -> Result<PathBuf> {
     use std::os::unix::fs::PermissionsExt;
@@ -2180,6 +2223,280 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
 }
 
 #[tokio::test]
+async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_echo() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let root = temp.path().join("server");
+    let sessions_dir = root.join("sessions");
+    let workspace = root.join("workspace");
+    let (hook_tx, mut hook_rx) = mpsc::unbounded_channel();
+    let Some((addr, runtime_threads, handle)) =
+        spawn_test_server_with_root_token_mobile_workspace_and_overrides(
+            root,
+            sessions_dir,
+            None,
+            false,
+            workspace,
+            TestServerOverrides {
+                compat_stream_test_hook: Some(hook_tx),
+                ..TestServerOverrides::default()
+            },
+        )
+        .await?
+    else {
+        return Ok(());
+    };
+
+    let client = crate::tls::reqwest_client();
+    let stream_client = client.clone();
+    let request_task = tokio::spawn(async move {
+        let response = stream_client
+            .post(format!("http://{addr}/v1/stream"))
+            .json(&json!({ "prompt": "ask before continuing" }))
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok::<_, anyhow::Error>(response)
+    });
+
+    let created = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("compatibility stream did not create its interaction thread")?
+        .context("compatibility stream interaction hook closed")?;
+    let (thread_id, resume_created) = match created {
+        CompatStreamTestPoint::ThreadCreated { thread_id, resume } => (thread_id, resume),
+        CompatStreamTestPoint::SubscribedBeforeReplay { .. }
+        | CompatStreamTestPoint::ReplayLoaded { .. } => {
+            bail!("compatibility interaction stream advanced before engine installation")
+        }
+    };
+
+    let mut harness = crate::core::engine::mock_engine_handle();
+    runtime_threads
+        .install_test_engine(&thread_id, harness.handle.clone())
+        .await?;
+    let (submission_tx, submission_rx) = oneshot::channel();
+    let (release_completion, wait_for_completion_release) = oneshot::channel();
+    let engine_task = tokio::spawn(async move {
+        if !matches!(harness.rx_op.recv().await, Some(Op::SendMessage { .. })) {
+            bail!("compatibility interaction engine did not receive a prompt");
+        }
+        harness
+            .tx_event
+            .send(EngineEvent::TurnStarted {
+                turn_id: "mock_compat_input".to_string(),
+                created_at: chrono::Utc::now(),
+                route: None,
+            })
+            .await?;
+        harness
+            .tx_event
+            .send(EngineEvent::UserInputRequired {
+                id: "input_compat".to_string(),
+                request: crate::tools::user_input::UserInputRequest {
+                    questions: vec![crate::tools::user_input::UserInputQuestion {
+                        header: "Continue".to_string(),
+                        id: "choice".to_string(),
+                        question: "Continue the compatibility turn?".to_string(),
+                        options: vec![
+                            crate::tools::user_input::UserInputOption {
+                                label: "Continue".to_string(),
+                                description: "Finish the turn".to_string(),
+                            },
+                            crate::tools::user_input::UserInputOption {
+                                label: "Stop".to_string(),
+                                description: "Cancel the turn".to_string(),
+                            },
+                        ],
+                        allow_free_text: false,
+                        multi_select: false,
+                    }],
+                },
+            })
+            .await?;
+        let submission = harness.recv_user_input_submission().await;
+        let _ = submission_tx.send(submission);
+        wait_for_completion_release
+            .await
+            .context("compatibility interaction test dropped completion release")?;
+        harness
+            .tx_event
+            .send(EngineEvent::MessageStarted { index: 0 })
+            .await?;
+        harness
+            .tx_event
+            .send(EngineEvent::MessageDelta {
+                index: 0,
+                content: "continued".to_string(),
+            })
+            .await?;
+        harness
+            .tx_event
+            .send(EngineEvent::MessageComplete { index: 0 })
+            .await?;
+        harness
+            .tx_event
+            .send(EngineEvent::TurnComplete {
+                usage: Usage::default(),
+                status: TurnOutcomeStatus::Completed,
+                error: None,
+                tool_catalog: None,
+                base_url: None,
+            })
+            .await?;
+        Ok::<_, anyhow::Error>(())
+    });
+    resume_created
+        .send(())
+        .map_err(|_| anyhow::anyhow!("compatibility interaction stream dropped create hook"))?;
+
+    let subscribed = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("compatibility interaction stream did not subscribe")?
+        .context("compatibility stream interaction hook closed")?;
+    let (subscribed_thread_id, turn_id, resume_subscribed) = match subscribed {
+        CompatStreamTestPoint::SubscribedBeforeReplay {
+            thread_id,
+            turn_id,
+            resume,
+        } => (thread_id, turn_id, resume),
+        CompatStreamTestPoint::ThreadCreated { .. }
+        | CompatStreamTestPoint::ReplayLoaded { .. } => {
+            bail!("compatibility interaction stream missed subscribe-before-replay hook")
+        }
+    };
+    assert_eq!(subscribed_thread_id, thread_id);
+    resume_subscribed
+        .send(())
+        .map_err(|_| anyhow::anyhow!("compatibility interaction stream dropped subscribe hook"))?;
+
+    let replay_loaded = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("compatibility interaction stream did not load replay")?
+        .context("compatibility stream interaction hook closed")?;
+    let (replay_thread_id, replay_turn_id, resume_replay) = match replay_loaded {
+        CompatStreamTestPoint::ReplayLoaded {
+            thread_id,
+            turn_id,
+            resume,
+        } => (thread_id, turn_id, resume),
+        CompatStreamTestPoint::ThreadCreated { .. }
+        | CompatStreamTestPoint::SubscribedBeforeReplay { .. } => {
+            bail!("compatibility interaction stream missed replay-loaded hook")
+        }
+    };
+    assert_eq!(replay_thread_id, thread_id);
+    assert_eq!(replay_turn_id, turn_id);
+    resume_replay
+        .send(())
+        .map_err(|_| anyhow::anyhow!("compatibility interaction stream dropped replay hook"))?;
+
+    let response = tokio::time::timeout(Duration::from_secs(2), request_task)
+        .await
+        .context("compatibility interaction request did not return SSE headers")?
+        .context("compatibility interaction request task panicked")??;
+    let (frame_tx, mut frame_rx) = mpsc::unbounded_channel();
+    let body_task = tokio::spawn(collect_sse_frames(response, frame_tx));
+
+    let required_payload = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let (event, payload) = frame_rx
+                .recv()
+                .await
+                .context("compatibility interaction stream ended before user input")?;
+            if event == "user_input.required" {
+                break Ok::<_, anyhow::Error>(payload);
+            }
+        }
+    })
+    .await
+    .context("compatibility stream did not expose required user input")??;
+    assert_eq!(required_payload["id"], "input_compat");
+    assert_eq!(required_payload["input_id"], "input_compat");
+    assert_eq!(required_payload["thread_id"], thread_id);
+    assert_eq!(required_payload["turn_id"], turn_id);
+    assert_eq!(required_payload["status"], "required");
+    assert_eq!(required_payload["request"]["questions"][0]["id"], "choice");
+    assert!(required_payload.get("answers").is_none());
+
+    const SECRET_ANSWER: &str = "compat-answer-must-not-be-echoed";
+    let submitted: serde_json::Value = client
+        .post(format!(
+            "http://{addr}/v1/user-input/{thread_id}/input_compat"
+        ))
+        .json(&json!({
+            "answers": [{
+                "id": "choice",
+                "label": "Continue",
+                "value": SECRET_ANSWER,
+            }],
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(submitted["delivered"], true);
+    let (submitted_id, submitted_response) =
+        tokio::time::timeout(Duration::from_secs(2), submission_rx)
+            .await
+            .context("mock engine did not receive compatibility user input")?
+            .context("mock engine dropped compatibility user input")?
+            .context("compatibility user input was canceled instead of submitted")?;
+    assert_eq!(submitted_id, "input_compat");
+    assert_eq!(submitted_response.answers[0].value, SECRET_ANSWER);
+    release_completion
+        .send(())
+        .map_err(|_| anyhow::anyhow!("mock interaction engine dropped completion release"))?;
+
+    let frames = tokio::time::timeout(Duration::from_secs(3), body_task)
+        .await
+        .context("compatibility interaction stream did not terminate")?
+        .context("compatibility interaction body task panicked")??;
+    engine_task
+        .await
+        .context("compatibility interaction engine task panicked")??;
+
+    let answered = frames
+        .iter()
+        .find(|(event, _)| event == "user_input.answered")
+        .context("compatibility stream omitted submitted user-input lifecycle")?;
+    assert_eq!(answered.1["id"], "input_compat");
+    assert_eq!(answered.1["status"], "submitted");
+    assert!(answered.1.get("answers").is_none());
+    assert_eq!(
+        frames
+            .iter()
+            .filter(|(event, _)| event == "user_input.required")
+            .count(),
+        1
+    );
+    assert_eq!(
+        frames
+            .iter()
+            .filter(|(event, _)| event == "user_input.answered")
+            .count(),
+        1
+    );
+    assert!(
+        !frames
+            .iter()
+            .any(|(event, _)| event == "user_input.canceled")
+    );
+    assert!(frames.iter().any(|(event, _)| event == "turn.completed"));
+    assert_eq!(
+        frames.iter().filter(|(event, _)| event == "done").count(),
+        1
+    );
+    assert!(
+        !serde_json::to_string(&frames)?.contains(SECRET_ANSWER),
+        "submitted answer leaked into compatibility SSE"
+    );
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_endpoints_expose_lifecycle_contract() -> Result<()> {
     let Some((addr, runtime_threads, handle)) = spawn_test_server().await? else {
         return Ok(());
@@ -2856,9 +3173,148 @@ async fn stream_compat_mapping_handles_expected_runtime_events() -> Result<()> {
     assert!(text.contains("event: tool.completed"));
     assert!(text.contains("\"success\":true"));
 
-    let unknown = RuntimeEventRecord {
+    let user_input_required = RuntimeEventRecord {
         schema_version: 1,
         seq: 4,
+        timestamp: chrono::Utc::now(),
+        thread_id: "thr_test".to_string(),
+        turn_id: Some("turn_test".to_string()),
+        item_id: None,
+        event: "user_input.required".to_string(),
+        payload: json!({
+            "id": "input_test",
+            "request": {
+                "questions": [{
+                    "header": "Continue",
+                    "id": "choice",
+                    "question": "Continue?",
+                    "options": [
+                        { "label": "Yes", "description": "Continue" },
+                        { "label": "No", "description": "Stop" }
+                    ]
+                }]
+            },
+            "internal_secret": "required-secret",
+        }),
+    };
+    let mapped = map_compat_stream_event(&user_input_required)
+        .context("missing user_input.required event")?;
+    let stream = async_stream::stream! {
+        yield Ok::<_, Infallible>(mapped);
+    };
+    let body =
+        axum::body::to_bytes(Sse::new(stream).into_response().into_body(), usize::MAX).await?;
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("event: user_input.required"));
+    assert!(text.contains("\"input_id\":\"input_test\""));
+    assert!(text.contains("\"status\":\"required\""));
+    assert!(!text.contains("required-secret"));
+
+    let user_input_answered = RuntimeEventRecord {
+        schema_version: 1,
+        seq: 5,
+        timestamp: chrono::Utc::now(),
+        thread_id: "thr_test".to_string(),
+        turn_id: Some("turn_test".to_string()),
+        item_id: None,
+        event: "user_input.answered".to_string(),
+        payload: json!({
+            "input_id": "input_test",
+            "answers": [{ "id": "choice", "value": "answer-secret" }],
+        }),
+    };
+    let mapped = map_compat_stream_event(&user_input_answered)
+        .context("missing user_input.answered event")?;
+    let stream = async_stream::stream! {
+        yield Ok::<_, Infallible>(mapped);
+    };
+    let body =
+        axum::body::to_bytes(Sse::new(stream).into_response().into_body(), usize::MAX).await?;
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("event: user_input.answered"));
+    assert!(text.contains("\"status\":\"submitted\""));
+    assert!(!text.contains("answer-secret"));
+    assert!(!text.contains("\"answers\""));
+
+    let user_input_canceled = RuntimeEventRecord {
+        schema_version: 1,
+        seq: 6,
+        timestamp: chrono::Utc::now(),
+        thread_id: "thr_test".to_string(),
+        turn_id: Some("turn_test".to_string()),
+        item_id: None,
+        event: "user_input.canceled".to_string(),
+        payload: json!({ "id": "input_test", "terminal": true }),
+    };
+    let mapped = map_compat_stream_event(&user_input_canceled)
+        .context("missing user_input.canceled event")?;
+    let stream = async_stream::stream! {
+        yield Ok::<_, Infallible>(mapped);
+    };
+    let body =
+        axum::body::to_bytes(Sse::new(stream).into_response().into_body(), usize::MAX).await?;
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("event: user_input.canceled"));
+    assert!(text.contains("\"status\":\"canceled\""));
+    assert!(text.contains("\"terminal\":true"));
+
+    let approval_required = RuntimeEventRecord {
+        schema_version: 1,
+        seq: 7,
+        timestamp: chrono::Utc::now(),
+        thread_id: "thr_test".to_string(),
+        turn_id: Some("turn_test".to_string()),
+        item_id: None,
+        event: "approval.required".to_string(),
+        payload: json!({
+            "approval_id": "approval_test",
+            "tool_name": "exec_command",
+            "description": "Run tests",
+            "input": { "token": "approval-secret" },
+        }),
+    };
+    let mapped =
+        map_compat_stream_event(&approval_required).context("missing approval.required event")?;
+    let stream = async_stream::stream! {
+        yield Ok::<_, Infallible>(mapped);
+    };
+    let body =
+        axum::body::to_bytes(Sse::new(stream).into_response().into_body(), usize::MAX).await?;
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("event: approval.required"));
+    assert!(text.contains("\"approval_id\":\"approval_test\""));
+    assert!(!text.contains("approval-secret"));
+
+    let approval_decided = RuntimeEventRecord {
+        schema_version: 1,
+        seq: 8,
+        timestamp: chrono::Utc::now(),
+        thread_id: "thr_test".to_string(),
+        turn_id: Some("turn_test".to_string()),
+        item_id: None,
+        event: "approval.decided".to_string(),
+        payload: json!({
+            "approval_id": "approval_test",
+            "decision": "allow",
+            "remember": false,
+            "internal_secret": "approval-decision-secret",
+        }),
+    };
+    let mapped =
+        map_compat_stream_event(&approval_decided).context("missing approval.decided event")?;
+    let stream = async_stream::stream! {
+        yield Ok::<_, Infallible>(mapped);
+    };
+    let body =
+        axum::body::to_bytes(Sse::new(stream).into_response().into_body(), usize::MAX).await?;
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("event: approval.decided"));
+    assert!(text.contains("\"decision\":\"allow\""));
+    assert!(!text.contains("approval-decision-secret"));
+
+    let unknown = RuntimeEventRecord {
+        schema_version: 1,
+        seq: 9,
         timestamp: chrono::Utc::now(),
         thread_id: "thr_test".to_string(),
         turn_id: Some("turn_test".to_string()),

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -618,6 +618,7 @@ struct TestServerOverrides {
     config_path: Option<PathBuf>,
     config_profile: Option<String>,
     web: Option<web::RuntimeWebState>,
+    compat_stream_test_hook: Option<mpsc::UnboundedSender<CompatStreamTestPoint>>,
 }
 
 async fn spawn_test_server_with_root_token_mobile_workspace_and_subagents(
@@ -734,6 +735,7 @@ async fn spawn_test_server_with_root_token_mobile_workspace_and_overrides(
         fleet_codewhale_binary: overrides
             .fleet_codewhale_binary
             .unwrap_or_else(configured_codewhale_binary),
+        compat_stream_test_hook: overrides.compat_stream_test_hook,
     };
     let app = build_router(state);
     let handle = tokio::spawn(async move {
@@ -1967,6 +1969,212 @@ async fn stream_requires_prompt() -> Result<()> {
         .send()
         .await?;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let root = temp.path().join("server");
+    let sessions_dir = root.join("sessions");
+    let workspace = root.join("workspace");
+    let (hook_tx, mut hook_rx) = mpsc::unbounded_channel();
+    let Some((addr, runtime_threads, handle)) =
+        spawn_test_server_with_root_token_mobile_workspace_and_overrides(
+            root,
+            sessions_dir,
+            None,
+            false,
+            workspace,
+            TestServerOverrides {
+                compat_stream_test_hook: Some(hook_tx),
+                ..TestServerOverrides::default()
+            },
+        )
+        .await?
+    else {
+        return Ok(());
+    };
+
+    let client = crate::tls::reqwest_client();
+    let stream_client = client.clone();
+    let stream_task = tokio::spawn(async move {
+        let response = stream_client
+            .post(format!("http://{addr}/v1/stream"))
+            .json(&json!({ "prompt": "cross the replay handoff" }))
+            .send()
+            .await?
+            .error_for_status()?;
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let body = response.text().await?;
+        Ok::<_, anyhow::Error>((content_type, body))
+    });
+
+    let created = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("compatibility stream did not create its thread")?
+        .context("compatibility stream test hook closed")?;
+    let (thread_id, resume_created) = match created {
+        CompatStreamTestPoint::ThreadCreated { thread_id, resume } => (thread_id, resume),
+        CompatStreamTestPoint::SubscribedBeforeReplay { .. }
+        | CompatStreamTestPoint::ReplayLoaded { .. } => {
+            bail!("compatibility stream loaded replay before its thread was prepared")
+        }
+    };
+
+    let harness = crate::core::engine::mock_engine_handle();
+    runtime_threads
+        .install_test_engine(&thread_id, harness.handle.clone())
+        .await?;
+    let mut rx_op = harness.rx_op;
+    let tx_event = harness.tx_event;
+    let (release_overlap, wait_for_overlap_release) = oneshot::channel();
+    let (release_terminal, wait_for_terminal_release) = oneshot::channel();
+    let engine_task = tokio::spawn(async move {
+        if !matches!(rx_op.recv().await, Some(Op::SendMessage { .. })) {
+            return;
+        }
+        let _ = wait_for_overlap_release.await;
+        let _ = tx_event
+            .send(EngineEvent::TurnStarted {
+                turn_id: "mock_compat_handoff".to_string(),
+                created_at: chrono::Utc::now(),
+                route: None,
+            })
+            .await;
+        let _ = tx_event
+            .send(EngineEvent::MessageStarted { index: 0 })
+            .await;
+        let _ = tx_event
+            .send(EngineEvent::MessageDelta {
+                index: 0,
+                content: "handoff".to_string(),
+            })
+            .await;
+        let _ = wait_for_terminal_release.await;
+        let _ = tx_event
+            .send(EngineEvent::MessageComplete { index: 0 })
+            .await;
+        let _ = tx_event
+            .send(EngineEvent::TurnComplete {
+                usage: Usage {
+                    input_tokens: 3,
+                    output_tokens: 1,
+                    ..Usage::default()
+                },
+                status: TurnOutcomeStatus::Completed,
+                error: None,
+                tool_catalog: None,
+                base_url: None,
+            })
+            .await;
+    });
+    resume_created
+        .send(())
+        .map_err(|_| anyhow::anyhow!("compatibility stream dropped thread-create handoff"))?;
+
+    let subscribed = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("compatibility stream did not subscribe before replay")?
+        .context("compatibility stream test hook closed")?;
+    let (subscribed_thread_id, subscribed_turn_id, resume_subscribed) = match subscribed {
+        CompatStreamTestPoint::SubscribedBeforeReplay {
+            thread_id,
+            turn_id,
+            resume,
+        } => (thread_id, turn_id, resume),
+        CompatStreamTestPoint::ThreadCreated { .. }
+        | CompatStreamTestPoint::ReplayLoaded { .. } => {
+            bail!("compatibility stream did not expose its subscribe-before-replay boundary")
+        }
+    };
+    assert_eq!(subscribed_thread_id, thread_id);
+
+    release_overlap
+        .send(())
+        .map_err(|_| anyhow::anyhow!("mock engine dropped overlap release"))?;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if runtime_threads
+                .events_since(&thread_id, None)
+                .is_ok_and(|events| {
+                    events.iter().any(|event| {
+                        event.turn_id.as_deref() == Some(&subscribed_turn_id)
+                            && event.event == "item.delta"
+                    })
+                })
+            {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("overlap event was not persisted before compatibility replay")?;
+    resume_subscribed
+        .send(())
+        .map_err(|_| anyhow::anyhow!("compatibility stream dropped subscribe handoff"))?;
+
+    let replay_loaded = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("compatibility stream did not reach its replay/live handoff")?
+        .context("compatibility stream test hook closed")?;
+    let (replay_thread_id, turn_id, resume_replay) = match replay_loaded {
+        CompatStreamTestPoint::ReplayLoaded {
+            thread_id,
+            turn_id,
+            resume,
+        } => (thread_id, turn_id, resume),
+        CompatStreamTestPoint::ThreadCreated { .. }
+        | CompatStreamTestPoint::SubscribedBeforeReplay { .. } => {
+            bail!("compatibility stream created more than one thread")
+        }
+    };
+    assert_eq!(replay_thread_id, thread_id);
+    assert_eq!(turn_id, subscribed_turn_id);
+
+    release_terminal
+        .send(())
+        .map_err(|_| anyhow::anyhow!("mock engine dropped terminal release"))?;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if runtime_threads
+                .events_since(&thread_id, None)
+                .is_ok_and(|events| {
+                    events.iter().any(|event| {
+                        event.turn_id.as_deref() == Some(&turn_id)
+                            && event.event == "turn.completed"
+                    })
+                })
+            {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("terminal event was not persisted during compatibility handoff")?;
+    resume_replay
+        .send(())
+        .map_err(|_| anyhow::anyhow!("compatibility stream dropped replay handoff"))?;
+
+    let (content_type, body) = tokio::time::timeout(Duration::from_secs(3), stream_task)
+        .await
+        .context("compatibility stream hung after its terminal event")?
+        .context("compatibility stream request task panicked")??;
+    engine_task.await.context("mock engine task panicked")?;
+
+    assert!(content_type.starts_with("text/event-stream"));
+    assert_eq!(body.matches("event: message.delta").count(), 1, "{body}");
+    assert_eq!(body.matches("event: turn.completed").count(), 1, "{body}");
+    assert_eq!(body.matches("event: done").count(), 1, "{body}");
+
     handle.abort();
     Ok(())
 }

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -2996,6 +2996,12 @@ async fn event_handoff_replays_and_dedupes_interaction_prompts_without_a_gap() -
         )
         .await?;
     let backlog = runtime_threads.events_since(&thread.id, Some(initial_seq))?;
+    let (backlog_tx, backlog_rx) = mpsc::channel(1);
+    backlog_tx
+        .send(Ok(backlog))
+        .await
+        .map_err(|_| anyhow::anyhow!("failed to seed replay backlog"))?;
+    drop(backlog_tx);
 
     // This request lands after the replay read and is therefore live-only.
     let input = runtime_threads
@@ -3020,7 +3026,7 @@ async fn event_handoff_replays_and_dedupes_interaction_prompts_without_a_gap() -
         runtime_threads.clone(),
         thread.id.clone(),
         initial_seq,
-        backlog,
+        backlog_rx,
         live,
     )
     .take(2);

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -2364,6 +2364,88 @@ async fn events_endpoint_respects_since_seq_cursor() -> Result<()> {
 }
 
 #[tokio::test]
+async fn event_handoff_replays_and_dedupes_interaction_prompts_without_a_gap() -> Result<()> {
+    let Some((_addr, runtime_threads, handle)) = spawn_test_server().await? else {
+        return Ok(());
+    };
+    let thread = runtime_threads
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let initial_seq = runtime_threads
+        .events_since(&thread.id, None)?
+        .last()
+        .context("thread creation should emit an event")?
+        .seq;
+
+    // Deterministically place approval.required in the old vulnerable window:
+    // the receiver exists, but durable replay has not been read yet.
+    let live = runtime_threads.subscribe_events();
+    let approval = runtime_threads
+        .emit_event_for_test(
+            &thread.id,
+            None,
+            "approval.required",
+            json!({
+                "approval_id": "approval-handoff",
+                "tool_name": "exec_command",
+                "description": "Run a local check",
+            }),
+        )
+        .await?;
+    let backlog = runtime_threads.events_since(&thread.id, Some(initial_seq))?;
+
+    // This request lands after the replay read and is therefore live-only.
+    let input = runtime_threads
+        .emit_event_for_test(
+            &thread.id,
+            None,
+            "user_input.required",
+            json!({
+                "id": "input-handoff",
+                "request": {
+                    "questions": [{
+                        "id": "choice",
+                        "question": "Continue?",
+                        "options": [],
+                    }],
+                },
+            }),
+        )
+        .await?;
+
+    let stream = replay_live_thread_events(
+        runtime_threads.clone(),
+        thread.id.clone(),
+        initial_seq,
+        backlog,
+        live,
+    )
+    .take(2);
+    let body =
+        axum::body::to_bytes(Sse::new(stream).into_response().into_body(), usize::MAX).await?;
+    let rendered = String::from_utf8(body.to_vec())?;
+    let frames = rendered
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|frame| !frame.is_empty())
+        .map(parse_sse_frame)
+        .collect::<Result<Vec<_>>>()?;
+
+    assert_eq!(frames.len(), 2, "unexpected SSE frames: {rendered}");
+    assert_eq!(frames[0].0, "approval.required");
+    assert_eq!(frames[0].1["seq"], approval.seq);
+    assert_eq!(frames[0].1["previous_seq"], initial_seq);
+    assert_eq!(frames[1].0, "user_input.required");
+    assert_eq!(frames[1].1["seq"], input.seq);
+    assert_eq!(frames[1].1["previous_seq"], approval.seq);
+    assert_eq!(rendered.matches("approval-handoff").count(), 1);
+    assert_eq!(rendered.matches("input-handoff").count(), 1);
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
 async fn steer_and_interrupt_endpoints_work_on_active_turn() -> Result<()> {
     let Some((addr, runtime_threads, handle)) = spawn_test_server().await? else {
         return Ok(());

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -4793,6 +4793,70 @@ async fn decide_approval_404s_when_nothing_pending() -> Result<()> {
 }
 
 #[tokio::test]
+async fn submit_user_input_404s_without_entering_engine_mailbox_for_unknown_id() -> Result<()> {
+    let Some((addr, runtime_threads, handle)) = spawn_test_server().await? else {
+        return Ok(());
+    };
+    let thread = runtime_threads
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = crate::core::engine::mock_engine_handle();
+    runtime_threads
+        .install_test_engine(&thread.id, harness.handle.clone())
+        .await?;
+
+    let response = crate::tls::reqwest_client()
+        .post(format!(
+            "http://{addr}/v1/user-input/{}/input-missing",
+            thread.id
+        ))
+        .json(&json!({
+            "answers": [{
+                "id": "choice",
+                "label": "Missing",
+                "value": "must-not-enter-engine-mailbox",
+            }],
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            harness.recv_user_input_submission()
+        )
+        .await
+        .is_err(),
+        "unknown user input reached the engine mailbox"
+    );
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn events_endpoint_rejects_unbounded_tail_requests() -> Result<()> {
+    let Some((addr, runtime_threads, handle)) = spawn_test_server().await? else {
+        return Ok(());
+    };
+    let thread = runtime_threads
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let response = crate::tls::reqwest_client()
+        .get(format!(
+            "http://{addr}/v1/threads/{}/events?replay_limit={}",
+            thread.id,
+            MAX_RUNTIME_EVENT_REPLAY_TAIL.saturating_add(1),
+        ))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
 async fn decide_approval_400s_on_bad_decision() -> Result<()> {
     let Some((addr, _runtime_threads, handle)) = spawn_test_server().await? else {
         return Ok(());

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -955,19 +955,7 @@ impl RuntimeThreadStore {
             // with ordinary write authority only on the failure path so the
             // success path remains an atomic append on every platform.
             drop(file);
-            let rollback_result = (|| -> Result<()> {
-                reject_symlinked_store_file(&path)?;
-                let rollback_file = OpenOptions::new()
-                    .write(true)
-                    .open(&path)
-                    .with_context(|| format!("Failed to reopen {} for rollback", path.display()))?;
-                rollback_file
-                    .set_len(original_len)
-                    .with_context(|| format!("Failed to roll back {}", path.display()))?;
-                rollback_file
-                    .sync_all()
-                    .with_context(|| format!("Failed to sync rollback for {}", path.display()))
-            })();
+            let rollback_result = rollback_failed_event_append(&path, original_len);
             let error = match rollback_result {
                 Ok(()) => RuntimeEventAppendError {
                     disposition: EventAppendFailureDisposition::RolledBack,
@@ -6971,6 +6959,20 @@ fn reject_symlinked_store_file(path: &Path) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn rollback_failed_event_append(path: &Path, original_len: u64) -> Result<()> {
+    reject_symlinked_store_file(path)?;
+    let rollback_file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .with_context(|| format!("Failed to reopen {} for rollback", path.display()))?;
+    rollback_file
+        .set_len(original_len)
+        .with_context(|| format!("Failed to roll back {}", path.display()))?;
+    rollback_file
+        .sync_all()
+        .with_context(|| format!("Failed to sync rollback for {}", path.display()))
 }
 
 fn reject_symlinked_store_dir(path: &Path) -> Result<()> {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -955,14 +955,19 @@ impl RuntimeThreadStore {
             // with ordinary write authority only on the failure path so the
             // success path remains an atomic append on every platform.
             drop(file);
-            let rollback_result =
-                OpenOptions::new()
+            let rollback_result = (|| -> Result<()> {
+                reject_symlinked_store_file(&path)?;
+                let rollback_file = OpenOptions::new()
                     .write(true)
                     .open(&path)
-                    .and_then(|rollback_file| {
-                        rollback_file.set_len(original_len)?;
-                        rollback_file.sync_all()
-                    });
+                    .with_context(|| format!("Failed to reopen {} for rollback", path.display()))?;
+                rollback_file
+                    .set_len(original_len)
+                    .with_context(|| format!("Failed to roll back {}", path.display()))?;
+                rollback_file
+                    .sync_all()
+                    .with_context(|| format!("Failed to sync rollback for {}", path.display()))
+            })();
             let error = match rollback_result {
                 Ok(()) => RuntimeEventAppendError {
                     disposition: EventAppendFailureDisposition::RolledBack,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -56,7 +56,10 @@ use codewhale_protocol::runtime::{
 
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const MAX_ACTIVE_THREADS_DEFAULT: usize = 8;
+const MAX_PENDING_DYNAMIC_TOOL_CALLS: usize = 128;
 const SUMMARY_LIMIT: usize = 280;
+const REQUEST_USER_INPUT_TOOL_NAME: &str = "request_user_input";
+const REDACTED_USER_INPUT_RECEIPT: &str = "User input submitted";
 
 /// Sentinel delimiters wrapping the compaction summary section persisted in a
 /// thread record's `system_prompt`. The section carries the engine-rendered
@@ -139,9 +142,14 @@ const CURRENT_RUNTIME_SCHEMA_VERSION: u32 = 2;
 const RUNTIME_RESTART_REASON: &str = "Interrupted by process restart";
 const EMPTY_TURN_REASON: &str = "Turn completed without engine output";
 const APPROVAL_DECISION_TIMEOUT: Duration = Duration::from_secs(300);
+const DYNAMIC_TOOL_RESULT_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[cfg(test)]
 static TEST_APPROVAL_DECISION_TIMEOUT_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+static TEST_DYNAMIC_TOOL_RESULT_TIMEOUT_MS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
 fn approval_decision_timeout() -> Duration {
@@ -155,9 +163,25 @@ fn approval_decision_timeout() -> Duration {
     APPROVAL_DECISION_TIMEOUT
 }
 
+fn dynamic_tool_result_timeout() -> Duration {
+    #[cfg(test)]
+    {
+        let ms = TEST_DYNAMIC_TOOL_RESULT_TIMEOUT_MS.load(std::sync::atomic::Ordering::SeqCst);
+        if ms > 0 {
+            return Duration::from_millis(ms);
+        }
+    }
+    DYNAMIC_TOOL_RESULT_TIMEOUT
+}
+
 #[cfg(test)]
 pub(crate) fn set_test_approval_decision_timeout_ms(ms: u64) -> u64 {
     TEST_APPROVAL_DECISION_TIMEOUT_MS.swap(ms, std::sync::atomic::Ordering::SeqCst)
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_dynamic_tool_result_timeout_ms(ms: u64) -> u64 {
+    TEST_DYNAMIC_TOOL_RESULT_TIMEOUT_MS.swap(ms, std::sync::atomic::Ordering::SeqCst)
 }
 
 const fn default_runtime_schema_version() -> u32 {
@@ -874,6 +898,12 @@ pub struct ThreadDetail {
     /// approvals, the snapshot is authoritative across client reconnects.
     #[serde(default)]
     pub pending_user_inputs: Vec<PendingUserInputRequest>,
+    /// Client-executed dynamic tool calls that are still waiting for a result.
+    /// Keeping the typed request in the canonical snapshot lets an external
+    /// Runtime client reload from `latest_seq` without stranding a call whose
+    /// `tool_call.requested` event is already behind that cursor.
+    #[serde(default)]
+    pub pending_dynamic_tool_calls: Vec<DynamicToolCallParams>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1057,8 +1087,7 @@ pub struct RuntimeThreadManager {
     pending_approvals: Arc<parking_lot::Mutex<HashMap<String, PendingApprovalEntry>>>,
     pending_user_inputs:
         Arc<parking_lot::Mutex<HashMap<(String, String), PendingUserInputRequest>>>,
-    pending_dynamic_tools:
-        Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<DynamicToolCallResult>>>>,
+    pending_dynamic_tools: Arc<parking_lot::Mutex<HashMap<String, PendingDynamicToolEntry>>>,
     #[cfg(test)]
     snapshot_test_hook: Arc<parking_lot::Mutex<Option<mpsc::UnboundedSender<SnapshotTestPoint>>>>,
 }
@@ -1113,6 +1142,11 @@ struct PendingApprovalEntry {
     thread_id: String,
     request: PendingApprovalRequest,
     sender: oneshot::Sender<ExternalApprovalDecision>,
+}
+
+struct PendingDynamicToolEntry {
+    params: DynamicToolCallParams,
+    sender: oneshot::Sender<DynamicToolCallResult>,
 }
 
 impl RuntimeThreadManager {
@@ -1425,17 +1459,71 @@ impl RuntimeThreadManager {
 
     fn register_pending_dynamic_tool(
         &self,
-        call_id: &str,
-    ) -> oneshot::Receiver<DynamicToolCallResult> {
+        params: DynamicToolCallParams,
+    ) -> Result<oneshot::Receiver<DynamicToolCallResult>> {
         let (tx, rx) = oneshot::channel();
-        self.pending_dynamic_tools
-            .lock()
-            .insert(call_id.to_string(), tx);
-        rx
+        let mut pending = self.pending_dynamic_tools.lock();
+        if pending.len() >= MAX_PENDING_DYNAMIC_TOOL_CALLS {
+            bail!(
+                "Runtime has reached the pending dynamic tool call limit ({MAX_PENDING_DYNAMIC_TOOL_CALLS})"
+            );
+        }
+        if pending.contains_key(&params.call_id) {
+            bail!("Dynamic tool call '{}' is already pending", params.call_id);
+        }
+        pending.insert(
+            params.call_id.clone(),
+            PendingDynamicToolEntry { params, sender: tx },
+        );
+        Ok(rx)
     }
 
-    fn cancel_pending_dynamic_tool(&self, call_id: &str) {
-        self.pending_dynamic_tools.lock().remove(call_id);
+    fn take_pending_dynamic_tool(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+        call_id: &str,
+    ) -> Option<PendingDynamicToolEntry> {
+        let mut pending = self.pending_dynamic_tools.lock();
+        let matches_route = pending.get(call_id).is_some_and(|entry| {
+            entry.params.thread_id == thread_id && entry.params.turn_id == turn_id
+        });
+        matches_route.then(|| pending.remove(call_id)).flatten()
+    }
+
+    fn pending_dynamic_tool_calls_for_thread(&self, thread_id: &str) -> Vec<DynamicToolCallParams> {
+        let mut calls = self
+            .pending_dynamic_tools
+            .lock()
+            .values()
+            .filter(|entry| entry.params.thread_id == thread_id)
+            .map(|entry| entry.params.clone())
+            .collect::<Vec<_>>();
+        calls.sort_by(|left, right| {
+            left.turn_id
+                .cmp(&right.turn_id)
+                .then_with(|| left.call_id.cmp(&right.call_id))
+        });
+        calls
+    }
+
+    fn clear_pending_dynamic_tools_for_turn(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Vec<DynamicToolCallParams> {
+        let mut pending = self.pending_dynamic_tools.lock();
+        let call_ids = pending
+            .iter()
+            .filter(|(_, entry)| {
+                entry.params.thread_id == thread_id && entry.params.turn_id == turn_id
+            })
+            .map(|(call_id, _)| call_id.clone())
+            .collect::<Vec<_>>();
+        call_ids
+            .into_iter()
+            .filter_map(|call_id| pending.remove(&call_id).map(|entry| entry.params))
+            .collect()
     }
 
     pub fn deliver_external_approval(
@@ -1450,16 +1538,42 @@ impl RuntimeThreadManager {
         }
     }
 
-    pub fn deliver_dynamic_tool_result(
+    pub async fn deliver_dynamic_tool_result(
         &self,
+        thread_id: &str,
+        turn_id: &str,
         call_id: &str,
         result: DynamicToolCallResult,
-    ) -> bool {
-        let sender = self.pending_dynamic_tools.lock().remove(call_id);
-        match sender {
-            Some(tx) => tx.send(result).is_ok(),
-            None => false,
+    ) -> Result<bool> {
+        let Some(entry) = self.take_pending_dynamic_tool(thread_id, turn_id, call_id) else {
+            return Ok(false);
+        };
+        let success = result.success;
+        if entry.sender.send(result).is_err() {
+            self.emit_event(
+                thread_id,
+                Some(turn_id),
+                None,
+                "tool_call.canceled",
+                dynamic_tool_terminal_payload(
+                    &entry.params,
+                    "canceled",
+                    None,
+                    Some("receiver_closed"),
+                ),
+            )
+            .await?;
+            return Ok(false);
         }
+        self.emit_event(
+            thread_id,
+            Some(turn_id),
+            None,
+            "tool_call.resolved",
+            dynamic_tool_terminal_payload(&entry.params, "resolved", Some(success), None),
+        )
+        .await?;
+        Ok(true)
     }
 
     pub async fn submit_user_input(
@@ -1542,9 +1656,18 @@ impl RuntimeThreadManager {
     #[cfg(test)]
     pub(crate) fn register_pending_dynamic_tool_for_test(
         &self,
+        thread_id: &str,
+        turn_id: &str,
         call_id: &str,
-    ) -> oneshot::Receiver<DynamicToolCallResult> {
-        self.register_pending_dynamic_tool(call_id)
+    ) -> Result<oneshot::Receiver<DynamicToolCallResult>> {
+        self.register_pending_dynamic_tool(DynamicToolCallParams {
+            thread_id: thread_id.to_string(),
+            turn_id: turn_id.to_string(),
+            call_id: call_id.to_string(),
+            namespace: Some("test".to_string()),
+            tool: "test_tool".to_string(),
+            arguments: json!({ "input": "test" }),
+        })
     }
 
     async fn remember_thread_auto_approve(&self, thread_id: &str) {
@@ -2049,6 +2172,7 @@ impl RuntimeThreadManager {
             }
         }
         let (pending_approvals, pending_user_inputs) = self.pending_requests_for_thread(id);
+        let pending_dynamic_tool_calls = self.pending_dynamic_tool_calls_for_thread(id);
         Ok(ThreadDetail {
             thread,
             turns,
@@ -2056,6 +2180,7 @@ impl RuntimeThreadManager {
             latest_seq,
             pending_approvals,
             pending_user_inputs,
+            pending_dynamic_tool_calls,
         })
     }
 
@@ -2801,6 +2926,28 @@ impl RuntimeThreadManager {
             // The engine is already gone; still drop the registrations so
             // snapshots stop advertising prompts nobody can answer.
             let _ = self.clear_pending_user_inputs_for_turn(thread_id, turn_id);
+        }
+
+        for params in self.clear_pending_dynamic_tools_for_turn(thread_id, turn_id) {
+            let mut payload =
+                dynamic_tool_terminal_payload(&params, "canceled", None, Some("turn_terminal"));
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("terminal".to_string(), json!(true));
+            }
+            if let Err(err) = self
+                .emit_event(
+                    thread_id,
+                    Some(turn_id),
+                    None,
+                    "tool_call.canceled",
+                    payload,
+                )
+                .await
+            {
+                tracing::error!(
+                    "Failed to emit dynamic-tool cancellation after monitor failure: {err}"
+                );
+            }
         }
 
         if let Some(turn) = terminal_turn
@@ -4023,6 +4170,14 @@ impl RuntimeThreadManager {
                 EngineEvent::MessageDelta { content, .. } => {
                     if let Some((item_id, text)) = current_message_item.as_mut() {
                         text.push_str(&content);
+                        // Materialize the prefix before sequencing its delta.
+                        // A snapshot whose cursor includes this event must not
+                        // still observe the empty item saved at MessageStarted,
+                        // and restart recovery must retain the partial output.
+                        let mut item = self.store.load_item(item_id)?;
+                        item.summary = summarize_text(text, SUMMARY_LIMIT);
+                        item.detail = Some(text.clone());
+                        self.store.save_item(&item)?;
                         self.emit_event(
                             &thread_id,
                             Some(&turn_id),
@@ -4081,6 +4236,10 @@ impl RuntimeThreadManager {
                 EngineEvent::ThinkingDelta { content, .. } => {
                     if let Some((item_id, text)) = current_reasoning_item.as_mut() {
                         text.push_str(&content);
+                        let mut item = self.store.load_item(item_id)?;
+                        item.summary = summarize_text(text, SUMMARY_LIMIT);
+                        item.detail = Some(text.clone());
+                        self.store.save_item(&item)?;
                         self.emit_event(
                             &thread_id,
                             Some(&turn_id),
@@ -4150,12 +4309,28 @@ impl RuntimeThreadManager {
                                 } else {
                                     TurnItemLifecycleStatus::Failed
                                 };
-                                item.summary = summarize_text(
-                                    &format!("{name}: {}", output.content),
-                                    SUMMARY_LIMIT,
-                                );
-                                item.detail = Some(output.content.clone());
-                                item.metadata = output.metadata.clone();
+                                if name == REQUEST_USER_INPUT_TOOL_NAME {
+                                    // The engine must return the structured
+                                    // answers to the model, but Runtime
+                                    // receipts are durable and fan out to UI
+                                    // clients. Persist only a machine-readable
+                                    // redaction marker, never answer labels or
+                                    // free-text values.
+                                    item.summary = REDACTED_USER_INPUT_RECEIPT.to_string();
+                                    item.detail = Some(REDACTED_USER_INPUT_RECEIPT.to_string());
+                                    item.metadata = Some(json!({
+                                        "tool_call_id": id,
+                                        "tool_name": REQUEST_USER_INPUT_TOOL_NAME,
+                                        "response_redacted": true,
+                                    }));
+                                } else {
+                                    item.summary = summarize_text(
+                                        &format!("{name}: {}", output.content),
+                                        SUMMARY_LIMIT,
+                                    );
+                                    item.detail = Some(output.content.clone());
+                                    item.metadata = output.metadata.clone();
+                                }
                             }
                             Err(err) => {
                                 item.status = TurnItemLifecycleStatus::Failed;
@@ -4861,6 +5036,22 @@ impl RuntimeThreadManager {
             .await?;
         }
 
+        for params in self.clear_pending_dynamic_tools_for_turn(&thread_id, &turn_id) {
+            let mut payload =
+                dynamic_tool_terminal_payload(&params, "canceled", None, Some("turn_terminal"));
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("terminal".to_string(), json!(true));
+            }
+            self.emit_event(
+                &thread_id,
+                Some(&turn_id),
+                None,
+                "tool_call.canceled",
+                payload,
+            )
+            .await?;
+        }
+
         self.emit_event(
             &thread_id,
             Some(&turn_id),
@@ -5042,6 +5233,29 @@ fn dynamic_tool_result_text(content: &[DynamicToolCallContent]) -> String {
         .join("\n")
 }
 
+fn dynamic_tool_terminal_payload(
+    params: &DynamicToolCallParams,
+    status: &str,
+    success: Option<bool>,
+    reason: Option<&str>,
+) -> Value {
+    let mut payload = json!({
+        "thread_id": params.thread_id,
+        "turn_id": params.turn_id,
+        "call_id": params.call_id,
+        "status": status,
+    });
+    if let Some(object) = payload.as_object_mut() {
+        if let Some(success) = success {
+            object.insert("success".to_string(), json!(success));
+        }
+        if let Some(reason) = reason {
+            object.insert("reason".to_string(), json!(reason));
+        }
+    }
+    payload
+}
+
 #[async_trait::async_trait]
 impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
     async fn execute_dynamic_tool(
@@ -5062,8 +5276,6 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             ))
         })?;
         let call_id = format!("call_{}", &Uuid::new_v4().to_string()[..8]);
-        let rx = self.register_pending_dynamic_tool(&call_id);
-
         let params = DynamicToolCallParams {
             thread_id: thread_id.clone(),
             turn_id: turn_id.clone(),
@@ -5072,24 +5284,27 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             tool: name.clone(),
             arguments: input,
         };
+        let rx = self
+            .register_pending_dynamic_tool(params.clone())
+            .map_err(|err| crate::tools::spec::ToolError::execution_failed(err.to_string()))?;
         if let Err(err) = self
             .emit_event(
                 &thread_id,
                 Some(&turn_id),
                 None,
                 "tool_call.requested",
-                json!(params),
+                json!(&params),
             )
             .await
         {
-            self.cancel_pending_dynamic_tool(&call_id);
+            self.take_pending_dynamic_tool(&thread_id, &turn_id, &call_id);
             return Err(crate::tools::spec::ToolError::execution_failed(format!(
                 "failed to emit runtime dynamic tool request for '{name}': {err}"
             )));
         }
 
-        let approval_timeout = approval_decision_timeout();
-        match tokio::time::timeout(approval_timeout, rx).await {
+        let result_timeout = dynamic_tool_result_timeout();
+        match tokio::time::timeout(result_timeout, rx).await {
             Ok(Ok(result)) => {
                 let text = dynamic_tool_result_text(&result.content);
                 if result.success {
@@ -5102,13 +5317,51 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
                     }))
                 }
             }
-            Ok(Err(_recv_err)) => Err(crate::tools::spec::ToolError::execution_failed(format!(
-                "runtime dynamic tool '{name}' result channel closed"
-            ))),
+            Ok(Err(_recv_err)) => {
+                if let Some(entry) = self.take_pending_dynamic_tool(&thread_id, &turn_id, &call_id)
+                {
+                    self.emit_event(
+                        &thread_id,
+                        Some(&turn_id),
+                        None,
+                        "tool_call.canceled",
+                        dynamic_tool_terminal_payload(
+                            &entry.params,
+                            "canceled",
+                            None,
+                            Some("channel_closed"),
+                        ),
+                    )
+                    .await
+                    .map_err(|err| {
+                        crate::tools::spec::ToolError::execution_failed(err.to_string())
+                    })?;
+                }
+                Err(crate::tools::spec::ToolError::execution_failed(format!(
+                    "runtime dynamic tool '{name}' result channel closed"
+                )))
+            }
             Err(_timeout) => {
-                self.cancel_pending_dynamic_tool(&call_id);
+                if let Some(entry) = self.take_pending_dynamic_tool(&thread_id, &turn_id, &call_id)
+                {
+                    self.emit_event(&thread_id, Some(&turn_id), None, "tool_call.timeout", {
+                        let mut payload =
+                            dynamic_tool_terminal_payload(&entry.params, "timeout", None, None);
+                        if let Some(object) = payload.as_object_mut() {
+                            object.insert(
+                                "timeout_secs".to_string(),
+                                json!(result_timeout.as_secs()),
+                            );
+                        }
+                        payload
+                    })
+                    .await
+                    .map_err(|err| {
+                        crate::tools::spec::ToolError::execution_failed(err.to_string())
+                    })?;
+                }
                 Err(crate::tools::spec::ToolError::Timeout {
-                    seconds: approval_timeout.as_secs(),
+                    seconds: result_timeout.as_secs(),
                 })
             }
         }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 #[cfg(test)]
 use tokio::sync::mpsc;
-use tokio::sync::{Mutex, broadcast, oneshot};
+use tokio::sync::{Mutex, broadcast, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -58,8 +58,139 @@ const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const MAX_ACTIVE_THREADS_DEFAULT: usize = 8;
 const MAX_PENDING_DYNAMIC_TOOL_CALLS: usize = 128;
 const SUMMARY_LIMIT: usize = 280;
+const STREAM_DELTA_BATCH_MAX_LATENCY: Duration = Duration::from_millis(32);
+const STREAM_DELTA_BATCH_MAX_BYTES: usize = 16 * 1024;
 const REQUEST_USER_INPUT_TOOL_NAME: &str = "request_user_input";
 const REDACTED_USER_INPUT_RECEIPT: &str = "User input submitted";
+
+#[cfg(test)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EventAppendTestFault {
+    AfterFlush,
+    AfterSync,
+}
+
+#[cfg(test)]
+static TEST_EVENT_APPEND_FAULTS: std::sync::Mutex<Vec<(String, EventAppendTestFault, usize)>> =
+    std::sync::Mutex::new(Vec::new());
+
+#[cfg(test)]
+pub(crate) type EventAppendTestFaultRestore = (String, Option<(EventAppendTestFault, usize)>);
+
+#[cfg(test)]
+pub(crate) fn set_test_event_append_fault(
+    thread_id: &str,
+    fault: EventAppendTestFault,
+    remaining: usize,
+) -> EventAppendTestFaultRestore {
+    assert!(remaining > 0, "event append fault count must be positive");
+    let mut pending = TEST_EVENT_APPEND_FAULTS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let previous = pending
+        .iter()
+        .position(|(target, _, _)| target == thread_id)
+        .map(|index| {
+            let (_, previous_fault, previous_remaining) = pending.remove(index);
+            (previous_fault, previous_remaining)
+        });
+    pending.push((thread_id.to_string(), fault, remaining));
+    (thread_id.to_string(), previous)
+}
+
+#[cfg(test)]
+pub(crate) fn restore_test_event_append_fault(restore: EventAppendTestFaultRestore) {
+    let (thread_id, previous) = restore;
+    let mut pending = TEST_EVENT_APPEND_FAULTS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(index) = pending
+        .iter()
+        .position(|(target, _, _)| target == &thread_id)
+    {
+        pending.remove(index);
+    }
+    if let Some((fault, remaining)) = previous {
+        pending.push((thread_id, fault, remaining));
+    }
+}
+
+#[cfg(test)]
+fn take_test_event_append_fault(thread_id: &str, expected: EventAppendTestFault) -> bool {
+    let mut pending = TEST_EVENT_APPEND_FAULTS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(index) = pending
+        .iter()
+        .position(|(target, fault, _)| target == thread_id && *fault == expected)
+    else {
+        return false;
+    };
+    if pending[index].2 > 1 {
+        pending[index].2 -= 1;
+    } else {
+        pending.remove(index);
+    }
+    true
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StreamDeltaKind {
+    Message,
+    Reasoning,
+}
+
+struct StreamDeltaBatch {
+    content: String,
+    pending_event: Option<EngineEvent>,
+    channel_closed: bool,
+}
+
+async fn coalesce_stream_delta(
+    engine: &EngineHandle,
+    kind: StreamDeltaKind,
+    mut content: String,
+) -> StreamDeltaBatch {
+    let deadline = tokio::time::Instant::now() + STREAM_DELTA_BATCH_MAX_LATENCY;
+    let mut pending_event = None;
+    let mut channel_closed = false;
+    let mut rx = engine.rx_event.write().await;
+
+    while content.len() < STREAM_DELTA_BATCH_MAX_BYTES {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let next = match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Some(event)) => event,
+            Ok(None) => {
+                channel_closed = true;
+                break;
+            }
+            Err(_) => break,
+        };
+        match next {
+            EngineEvent::MessageDelta { content: next, .. } if kind == StreamDeltaKind::Message => {
+                content.push_str(&next);
+            }
+            EngineEvent::ThinkingDelta { content: next, .. }
+                if kind == StreamDeltaKind::Reasoning =>
+            {
+                content.push_str(&next);
+            }
+            event => {
+                pending_event = Some(event);
+                break;
+            }
+        }
+    }
+
+    StreamDeltaBatch {
+        content,
+        pending_event,
+        channel_closed,
+    }
+}
 
 /// Sentinel delimiters wrapping the compaction summary section persisted in a
 /// thread record's `system_prompt`. The section carries the engine-rendered
@@ -391,6 +522,44 @@ impl Default for RuntimeStoreState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventAppendFailureDisposition {
+    RolledBack,
+    Indeterminate,
+}
+
+#[derive(Debug)]
+struct RuntimeEventAppendError {
+    disposition: EventAppendFailureDisposition,
+    append_error: String,
+    rollback_error: Option<String>,
+}
+
+impl RuntimeEventAppendError {
+    const fn retry_safe(&self) -> bool {
+        matches!(self.disposition, EventAppendFailureDisposition::RolledBack)
+    }
+}
+
+impl std::fmt::Display for RuntimeEventAppendError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.rollback_error {
+            Some(rollback_error) => write!(
+                formatter,
+                "Runtime event append is indeterminate after append error ({}) and rollback error ({})",
+                self.append_error, rollback_error
+            ),
+            None => write!(
+                formatter,
+                "Runtime event append failed and was rolled back: {}",
+                self.append_error
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeEventAppendError {}
+
 #[derive(Debug, Clone)]
 pub struct RuntimeThreadStore {
     threads_dir: PathBuf,
@@ -721,12 +890,52 @@ impl RuntimeThreadStore {
             .append(true)
             .open(&path)
             .with_context(|| format!("Failed to open {}", path.display()))?;
-        let line = serde_json::to_string(&record)?;
-        writeln!(file, "{line}").with_context(|| format!("Failed to append {}", path.display()))?;
-        file.flush()
-            .with_context(|| format!("Failed to flush {}", path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("Failed to fsync {}", path.display()))?;
+        let original_len = file
+            .metadata()
+            .with_context(|| format!("Failed to inspect {}", path.display()))?
+            .len();
+        let mut line = serde_json::to_vec(&record)?;
+        line.push(b'\n');
+        let append_result = (|| -> std::io::Result<()> {
+            file.write_all(&line)?;
+            file.flush()?;
+            #[cfg(test)]
+            if take_test_event_append_fault(thread_id, EventAppendTestFault::AfterFlush) {
+                return Err(std::io::Error::other(
+                    "injected Runtime event failure after flush",
+                ));
+            }
+            file.sync_all()?;
+            #[cfg(test)]
+            if take_test_event_append_fault(thread_id, EventAppendTestFault::AfterSync) {
+                return Err(std::io::Error::other(
+                    "injected Runtime event failure after fsync",
+                ));
+            }
+            Ok(())
+        })();
+        if let Err(append_error) = append_result {
+            // A failed flush/fsync can still leave the complete JSONL record
+            // visible (or even durable). Roll back to the exact pre-append
+            // offset and fsync that truncation before reporting a retryable
+            // error. If rollback itself fails, classify the write as
+            // indeterminate so callers never restore/retry and duplicate a
+            // possibly committed terminal receipt.
+            let rollback_result = file.set_len(original_len).and_then(|()| file.sync_all());
+            let error = match rollback_result {
+                Ok(()) => RuntimeEventAppendError {
+                    disposition: EventAppendFailureDisposition::RolledBack,
+                    append_error: append_error.to_string(),
+                    rollback_error: None,
+                },
+                Err(rollback_error) => RuntimeEventAppendError {
+                    disposition: EventAppendFailureDisposition::Indeterminate,
+                    append_error: append_error.to_string(),
+                    rollback_error: Some(rollback_error.to_string()),
+                },
+            };
+            return Err(anyhow!(error));
+        }
         // Keep the global sequence lock through the append so no later event
         // can reach disk or broadcast before this sequence number.
         drop(state);
@@ -1048,15 +1257,26 @@ struct ActiveThreads {
 
 pub type SharedRuntimeThreadManager = Arc<RuntimeThreadManager>;
 
+#[derive(Clone)]
+struct RecoveredTurnReceipt {
+    turn: TurnRecord,
+    unresolved_dynamic_tools: Vec<DynamicToolCallParams>,
+}
+
 /// Manages active engine threads, lifecycle, and event persistence.
 ///
 /// # Lock ordering invariant
 ///
-/// Runtime state uses six locks:
+/// Runtime state uses eight lock classes:
 /// - `RuntimeThreadManager::engine_load` — serializes cache-miss engine builds.
 ///   It may cross awaits and is always acquired before `active`.
 /// - `RuntimeThreadManager::event_emit` — preserves append-to-broadcast event
 ///   order and is only acquired after all record/engine guards are released.
+/// - `RuntimeThreadManager::projection_locks` — one async lock per thread,
+///   held while a streamed item checkpoint and its event are published or
+///   while a snapshot captures its cursor and reads projections.
+/// - `RuntimeThreadManager::recovery_flush` — serializes deferred receipt
+///   reconciliation before it acquires a projection lock and `event_emit`.
 /// - `RuntimeThreadStore::state` — protects the monotonic event sequence counter.
 /// - `RuntimeThreadStore::thread_mutation` — synchronizes short, synchronous
 ///   thread-record load-modify-save transactions and never crosses `.await`.
@@ -1064,8 +1284,10 @@ pub type SharedRuntimeThreadManager = Arc<RuntimeThreadManager>;
 /// - `RuntimeThreadManager::active` — protects the set of loaded engine handles.
 ///
 /// `state` is never held with `active`, either record-mutation guard, or
-/// `engine_load`. Event publication intentionally acquires `event_emit` before
-/// `state`; both guards are released before `emit_event` returns. All
+/// `engine_load`. Streaming projection publication acquires its per-thread
+/// projection lock before `event_emit`, which acquires `state`; snapshots
+/// acquire only the projection lock and then `state`. All guards are released
+/// before returning. All
 /// `emit_event` calls happen after `active`, `thread_mutation`, and
 /// `turn_mutation` have been released. When record and engine state must change
 /// atomically, acquire `active` before the applicable record-mutation guard and
@@ -1078,6 +1300,7 @@ pub struct RuntimeThreadManager {
     engine_load: Arc<Mutex<()>>,
     active: Arc<Mutex<ActiveThreads>>,
     event_emit: Arc<Mutex<()>>,
+    projection_locks: Arc<parking_lot::Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     event_tx: broadcast::Sender<RuntimeEventRecord>,
     manager_cfg: RuntimeThreadManagerConfig,
     cancel_token: CancellationToken,
@@ -1088,6 +1311,8 @@ pub struct RuntimeThreadManager {
     pending_user_inputs:
         Arc<parking_lot::Mutex<HashMap<(String, String), PendingUserInputRequest>>>,
     pending_dynamic_tools: Arc<parking_lot::Mutex<HashMap<String, PendingDynamicToolEntry>>>,
+    recovery_receipts: Arc<parking_lot::Mutex<HashMap<String, Vec<RecoveredTurnReceipt>>>>,
+    recovery_flush: Arc<Mutex<()>>,
     #[cfg(test)]
     snapshot_test_hook: Arc<parking_lot::Mutex<Option<mpsc::UnboundedSender<SnapshotTestPoint>>>>,
 }
@@ -1146,7 +1371,41 @@ struct PendingApprovalEntry {
 
 struct PendingDynamicToolEntry {
     params: DynamicToolCallParams,
+    /// Present while the call can still be claimed by result delivery,
+    /// timeout, or turn termination. The entry remains in the registry after
+    /// the winner takes this sender so snapshots continue to advertise the
+    /// request until its terminal receipt is durably appended.
+    sender: Option<oneshot::Sender<DynamicToolCallResult>>,
+    settlement_tx: watch::Sender<u64>,
+    indeterminate: bool,
+}
+
+struct ClaimedDynamicToolSettlement {
+    params: DynamicToolCallParams,
     sender: oneshot::Sender<DynamicToolCallResult>,
+    settlement_tx: watch::Sender<u64>,
+}
+
+enum PendingDynamicToolClaim {
+    Claimed(ClaimedDynamicToolSettlement),
+    Settling(watch::Receiver<u64>),
+    Indeterminate,
+    Missing,
+}
+
+enum DynamicToolTerminalOutcome {
+    Resolved(DynamicToolCallResult),
+    Canceled {
+        reason: &'static str,
+        terminal: bool,
+    },
+    Timeout {
+        timeout: Duration,
+    },
+}
+
+struct DynamicToolSettlementAck {
+    result_accepted: bool,
 }
 
 impl RuntimeThreadManager {
@@ -1328,6 +1587,7 @@ impl RuntimeThreadManager {
             engine_load: Arc::new(Mutex::new(())),
             active: Arc::new(Mutex::new(ActiveThreads::default())),
             event_emit: Arc::new(Mutex::new(())),
+            projection_locks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             event_tx,
             manager_cfg,
             cancel_token: CancellationToken::new(),
@@ -1336,6 +1596,8 @@ impl RuntimeThreadManager {
             pending_approvals: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_user_inputs: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_dynamic_tools: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            recovery_receipts: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            recovery_flush: Arc::new(Mutex::new(())),
             #[cfg(test)]
             snapshot_test_hook: Arc::new(parking_lot::Mutex::new(None)),
         };
@@ -1462,6 +1724,7 @@ impl RuntimeThreadManager {
         params: DynamicToolCallParams,
     ) -> Result<oneshot::Receiver<DynamicToolCallResult>> {
         let (tx, rx) = oneshot::channel();
+        let (settlement_tx, _settlement_rx) = watch::channel(0);
         let mut pending = self.pending_dynamic_tools.lock();
         if pending.len() >= MAX_PENDING_DYNAMIC_TOOL_CALLS {
             bail!(
@@ -1473,12 +1736,51 @@ impl RuntimeThreadManager {
         }
         pending.insert(
             params.call_id.clone(),
-            PendingDynamicToolEntry { params, sender: tx },
+            PendingDynamicToolEntry {
+                params,
+                sender: Some(tx),
+                settlement_tx,
+                indeterminate: false,
+            },
         );
         Ok(rx)
     }
 
-    fn take_pending_dynamic_tool(
+    /// Atomically select the single terminal owner for a dynamic tool call.
+    ///
+    /// The registry entry intentionally remains present with an empty sender
+    /// while the winner commits its receipt. `get_thread_detail` therefore
+    /// cannot publish a cursor that has neither the pending request nor the
+    /// terminal event, and competing result/timeout/cancel paths cannot claim
+    /// the same call twice.
+    fn claim_pending_dynamic_tool(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+        call_id: &str,
+    ) -> PendingDynamicToolClaim {
+        let mut pending = self.pending_dynamic_tools.lock();
+        let Some(entry) = pending.get_mut(call_id) else {
+            return PendingDynamicToolClaim::Missing;
+        };
+        let matches_route = entry.params.thread_id == thread_id && entry.params.turn_id == turn_id;
+        if !matches_route {
+            return PendingDynamicToolClaim::Missing;
+        }
+        if entry.indeterminate {
+            return PendingDynamicToolClaim::Indeterminate;
+        }
+        match entry.sender.take() {
+            Some(sender) => PendingDynamicToolClaim::Claimed(ClaimedDynamicToolSettlement {
+                params: entry.params.clone(),
+                sender,
+                settlement_tx: entry.settlement_tx.clone(),
+            }),
+            None => PendingDynamicToolClaim::Settling(entry.settlement_tx.subscribe()),
+        }
+    }
+
+    fn remove_pending_dynamic_tool(
         &self,
         thread_id: &str,
         turn_id: &str,
@@ -1507,23 +1809,77 @@ impl RuntimeThreadManager {
         calls
     }
 
-    fn clear_pending_dynamic_tools_for_turn(
+    fn claim_or_watch_pending_dynamic_tools_for_turn(
         &self,
         thread_id: &str,
         turn_id: &str,
-    ) -> Vec<DynamicToolCallParams> {
+    ) -> (
+        Vec<ClaimedDynamicToolSettlement>,
+        Vec<watch::Receiver<u64>>,
+        bool,
+    ) {
         let mut pending = self.pending_dynamic_tools.lock();
-        let call_ids = pending
-            .iter()
-            .filter(|(_, entry)| {
-                entry.params.thread_id == thread_id && entry.params.turn_id == turn_id
-            })
-            .map(|(call_id, _)| call_id.clone())
-            .collect::<Vec<_>>();
-        call_ids
-            .into_iter()
-            .filter_map(|call_id| pending.remove(&call_id).map(|entry| entry.params))
-            .collect()
+        let mut claims = Vec::new();
+        let mut settling = Vec::new();
+        let mut indeterminate = false;
+        for entry in pending
+            .values_mut()
+            .filter(|entry| entry.params.thread_id == thread_id && entry.params.turn_id == turn_id)
+        {
+            if entry.indeterminate {
+                indeterminate = true;
+                continue;
+            }
+            match entry.sender.take() {
+                Some(sender) => claims.push(ClaimedDynamicToolSettlement {
+                    params: entry.params.clone(),
+                    sender,
+                    settlement_tx: entry.settlement_tx.clone(),
+                }),
+                None => settling.push(entry.settlement_tx.subscribe()),
+            }
+        }
+        (claims, settling, indeterminate)
+    }
+
+    fn finish_dynamic_tool_settlement(&self, params: &DynamicToolCallParams) {
+        let mut pending = self.pending_dynamic_tools.lock();
+        let can_remove = pending.get(&params.call_id).is_some_and(|entry| {
+            entry.params.thread_id == params.thread_id
+                && entry.params.turn_id == params.turn_id
+                && entry.sender.is_none()
+        });
+        if can_remove {
+            pending.remove(&params.call_id);
+        }
+    }
+
+    fn restore_dynamic_tool_claim(&self, claim: ClaimedDynamicToolSettlement) {
+        let settlement_tx = claim.settlement_tx.clone();
+        let mut pending = self.pending_dynamic_tools.lock();
+        if let Some(entry) = pending.get_mut(&claim.params.call_id)
+            && entry.params.thread_id == claim.params.thread_id
+            && entry.params.turn_id == claim.params.turn_id
+            && entry.sender.is_none()
+        {
+            entry.sender = Some(claim.sender);
+            entry.indeterminate = false;
+        }
+        settlement_tx.send_modify(|epoch| *epoch = epoch.saturating_add(1));
+    }
+
+    fn mark_dynamic_tool_claim_indeterminate(&self, claim: &ClaimedDynamicToolSettlement) {
+        let mut pending = self.pending_dynamic_tools.lock();
+        if let Some(entry) = pending.get_mut(&claim.params.call_id)
+            && entry.params.thread_id == claim.params.thread_id
+            && entry.params.turn_id == claim.params.turn_id
+            && entry.sender.is_none()
+        {
+            entry.indeterminate = true;
+        }
+        claim
+            .settlement_tx
+            .send_modify(|epoch| *epoch = epoch.saturating_add(1));
     }
 
     pub fn deliver_external_approval(
@@ -1545,35 +1901,22 @@ impl RuntimeThreadManager {
         call_id: &str,
         result: DynamicToolCallResult,
     ) -> Result<bool> {
-        let Some(entry) = self.take_pending_dynamic_tool(thread_id, turn_id, call_id) else {
-            return Ok(false);
+        let claim = match self.claim_pending_dynamic_tool(thread_id, turn_id, call_id) {
+            PendingDynamicToolClaim::Claimed(claim) => claim,
+            PendingDynamicToolClaim::Settling(_) | PendingDynamicToolClaim::Missing => {
+                return Ok(false);
+            }
+            PendingDynamicToolClaim::Indeterminate => {
+                bail!(
+                    "Dynamic tool call '{call_id}' has an indeterminate terminal receipt; inspect Runtime storage before retrying"
+                );
+            }
         };
-        let success = result.success;
-        if entry.sender.send(result).is_err() {
-            self.emit_event(
-                thread_id,
-                Some(turn_id),
-                None,
-                "tool_call.canceled",
-                dynamic_tool_terminal_payload(
-                    &entry.params,
-                    "canceled",
-                    None,
-                    Some("receiver_closed"),
-                ),
-            )
-            .await?;
-            return Ok(false);
-        }
-        self.emit_event(
-            thread_id,
-            Some(turn_id),
-            None,
-            "tool_call.resolved",
-            dynamic_tool_terminal_payload(&entry.params, "resolved", Some(success), None),
-        )
-        .await?;
-        Ok(true)
+        let ack =
+            self.spawn_dynamic_tool_settlement(claim, DynamicToolTerminalOutcome::Resolved(result));
+        Ok(Self::await_dynamic_tool_settlement(ack)
+            .await?
+            .result_accepted)
     }
 
     pub async fn submit_user_input(
@@ -1705,6 +2048,15 @@ impl RuntimeThreadManager {
         self.event_tx.subscribe()
     }
 
+    fn projection_lock(&self, thread_id: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.projection_locks.lock();
+        Arc::clone(
+            locks
+                .entry(thread_id.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        )
+    }
+
     async fn emit_event(
         &self,
         thread_id: &str,
@@ -1714,6 +2066,22 @@ impl RuntimeThreadManager {
         payload: Value,
     ) -> Result<RuntimeEventRecord> {
         let _emit_order = self.event_emit.lock().await;
+        self.append_and_broadcast_event(thread_id, turn_id, item_id, event, payload)
+            .await
+    }
+
+    /// Append and broadcast an event while the caller owns `event_emit`.
+    /// Keeping this primitive separate lets dynamic-tool settlement hold its
+    /// projection boundary through durable append, registry removal, and the
+    /// non-awaiting result send.
+    async fn append_and_broadcast_event(
+        &self,
+        thread_id: &str,
+        turn_id: Option<&str>,
+        item_id: Option<&str>,
+        event: impl Into<String>,
+        payload: Value,
+    ) -> Result<RuntimeEventRecord> {
         let record = self
             .store
             .append_event(thread_id, turn_id, item_id, event, payload)
@@ -1725,6 +2093,381 @@ impl RuntimeThreadManager {
             );
         }
         Ok(record)
+    }
+
+    async fn emit_turn_completed_if_missing(
+        &self,
+        turn: &TurnRecord,
+        recovered: bool,
+    ) -> Result<bool> {
+        let _emit_order = self.event_emit.lock().await;
+        if self
+            .store
+            .events_since(&turn.thread_id, None)?
+            .iter()
+            .any(|event| {
+                event.event == "turn.completed"
+                    && event.turn_id.as_deref() == Some(turn.id.as_str())
+            })
+        {
+            return Ok(false);
+        }
+        let mut payload = json!({ "turn": turn });
+        if recovered && let Some(object) = payload.as_object_mut() {
+            object.insert("recovered".to_string(), json!(true));
+        }
+        self.append_and_broadcast_event(
+            &turn.thread_id,
+            Some(&turn.id),
+            None,
+            "turn.completed",
+            payload,
+        )
+        .await?;
+        Ok(true)
+    }
+
+    async fn emit_recovered_dynamic_cancellation_if_missing(
+        &self,
+        params: &DynamicToolCallParams,
+    ) -> Result<bool> {
+        let _emit_order = self.event_emit.lock().await;
+        if self
+            .store
+            .events_since(&params.thread_id, None)?
+            .iter()
+            .any(|event| {
+                matches!(
+                    event.event.as_str(),
+                    "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
+                ) && event.payload.get("call_id").and_then(Value::as_str)
+                    == Some(params.call_id.as_str())
+            })
+        {
+            return Ok(false);
+        }
+        let mut payload =
+            dynamic_tool_terminal_payload(params, "canceled", None, Some("process_restart"));
+        if let Some(object) = payload.as_object_mut() {
+            object.insert("terminal".to_string(), json!(true));
+            object.insert("recovered".to_string(), json!(true));
+        }
+        self.append_and_broadcast_event(
+            &params.thread_id,
+            Some(&params.turn_id),
+            None,
+            "tool_call.canceled",
+            payload,
+        )
+        .await?;
+        Ok(true)
+    }
+
+    async fn flush_recovery_receipts_for_thread(&self, thread_id: &str) -> Result<()> {
+        if !self.recovery_receipts.lock().contains_key(thread_id) {
+            return Ok(());
+        }
+        let _recovery_flush = self.recovery_flush.lock().await;
+        loop {
+            let next = self
+                .recovery_receipts
+                .lock()
+                .get(thread_id)
+                .and_then(|receipts| receipts.first())
+                .cloned();
+            let Some(receipt) = next else {
+                return Ok(());
+            };
+
+            // An in-process monitor failure may leave retry-safe calls in the
+            // live registry. Retry their supervised cancellation before the
+            // static restart-recovery receipts below. Startup recovery has no
+            // live registry entries, so this is a no-op in that case.
+            self.settle_dynamic_tools_for_terminal_turn(thread_id, &receipt.turn.id)
+                .await?;
+
+            let projection_lock = self.projection_lock(thread_id);
+            let _projection = projection_lock.lock().await;
+            for params in &receipt.unresolved_dynamic_tools {
+                self.emit_recovered_dynamic_cancellation_if_missing(params)
+                    .await?;
+            }
+            self.emit_turn_completed_if_missing(&receipt.turn, true)
+                .await?;
+            drop(_projection);
+
+            let mut queued = self.recovery_receipts.lock();
+            let remove_thread = if let Some(receipts) = queued.get_mut(thread_id) {
+                receipts.retain(|candidate| candidate.turn.id != receipt.turn.id);
+                receipts.is_empty()
+            } else {
+                false
+            };
+            if remove_thread {
+                queued.remove(thread_id);
+            }
+        }
+    }
+
+    fn queue_recovery_receipt(&self, receipt: RecoveredTurnReceipt) {
+        let thread_id = receipt.turn.thread_id.clone();
+        let turn_id = receipt.turn.id.clone();
+        let mut queued = self.recovery_receipts.lock();
+        let receipts = queued.entry(thread_id).or_default();
+        if let Some(existing) = receipts
+            .iter_mut()
+            .find(|candidate| candidate.turn.id == turn_id)
+        {
+            let mut known_calls = existing
+                .unresolved_dynamic_tools
+                .iter()
+                .map(|params| params.call_id.clone())
+                .collect::<HashSet<_>>();
+            existing.unresolved_dynamic_tools.extend(
+                receipt
+                    .unresolved_dynamic_tools
+                    .into_iter()
+                    .filter(|params| known_calls.insert(params.call_id.clone())),
+            );
+            return;
+        }
+        receipts.push(receipt);
+        receipts.sort_by_key(|candidate| candidate.turn.created_at);
+    }
+
+    fn spawn_dynamic_tool_settlement(
+        &self,
+        claim: ClaimedDynamicToolSettlement,
+        outcome: DynamicToolTerminalOutcome,
+    ) -> oneshot::Receiver<std::result::Result<DynamicToolSettlementAck, String>> {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let manager = self.clone();
+        tokio::spawn(async move {
+            use futures_util::FutureExt;
+
+            let mut claim = Some(claim);
+            let mut outcome = Some(outcome);
+            let settlement = std::panic::AssertUnwindSafe(async {
+                let claim_ref = claim
+                    .as_ref()
+                    .ok_or_else(|| "Dynamic tool settlement lost its claim".to_string())?;
+                let outcome_ref = outcome
+                    .as_ref()
+                    .ok_or_else(|| "Dynamic tool settlement lost its outcome".to_string())?;
+                let projection_lock = manager.projection_lock(&claim_ref.params.thread_id);
+                let _projection = projection_lock.lock().await;
+                let emit_order = manager.event_emit.lock().await;
+
+                // `resolved` linearizes durable acceptance by the Runtime. It
+                // deliberately does not claim that the model consumed the
+                // result: the receiver may close at any point before the
+                // post-receipt, non-awaiting send.
+                let (event, payload) = match outcome_ref {
+                    DynamicToolTerminalOutcome::Resolved(result) => {
+                        let mut payload = dynamic_tool_terminal_payload(
+                            &claim_ref.params,
+                            "resolved",
+                            Some(result.success),
+                            None,
+                        );
+                        if let Some(object) = payload.as_object_mut() {
+                            object.insert("result_accepted".to_string(), json!(true));
+                        }
+                        ("tool_call.resolved", payload)
+                    }
+                    DynamicToolTerminalOutcome::Canceled { reason, terminal } => {
+                        let mut payload = dynamic_tool_terminal_payload(
+                            &claim_ref.params,
+                            "canceled",
+                            None,
+                            Some(reason),
+                        );
+                        if *terminal && let Some(object) = payload.as_object_mut() {
+                            object.insert("terminal".to_string(), json!(true));
+                        }
+                        ("tool_call.canceled", payload)
+                    }
+                    DynamicToolTerminalOutcome::Timeout { timeout } => {
+                        let mut payload =
+                            dynamic_tool_terminal_payload(&claim_ref.params, "timeout", None, None);
+                        if let Some(object) = payload.as_object_mut() {
+                            object.insert("timeout_secs".to_string(), json!(timeout.as_secs()));
+                        }
+                        ("tool_call.timeout", payload)
+                    }
+                };
+
+                if let Err(error) = manager
+                    .append_and_broadcast_event(
+                        &claim_ref.params.thread_id,
+                        Some(&claim_ref.params.turn_id),
+                        None,
+                        event,
+                        payload,
+                    )
+                    .await
+                {
+                    drop(emit_order);
+                    if let Some(claim) = claim.take() {
+                        let retry_safe = error
+                            .downcast_ref::<RuntimeEventAppendError>()
+                            .is_none_or(RuntimeEventAppendError::retry_safe);
+                        if retry_safe {
+                            // Definite pre-write failures and transactionally
+                            // rolled-back appends return the call to Awaiting.
+                            manager.restore_dynamic_tool_claim(claim);
+                        } else {
+                            // A failed rollback means the JSONL tail may already
+                            // contain the terminal line. Keep the request
+                            // explicitly indeterminate so neither an API retry
+                            // nor turn timeout can append a duplicate.
+                            manager.mark_dynamic_tool_claim_indeterminate(&claim);
+                            drop(claim);
+                        }
+                    }
+                    return Err(error.to_string());
+                }
+
+                let claim = claim
+                    .take()
+                    .ok_or_else(|| "Dynamic tool settlement lost its claim".to_string())?;
+                let outcome = outcome
+                    .take()
+                    .ok_or_else(|| "Dynamic tool settlement lost its outcome".to_string())?;
+
+                // The snapshot boundary stays held until the request
+                // disappears. The model-facing channel is only woken after the
+                // terminal event is on disk, and send itself cannot suspend or
+                // be caller-canceled.
+                manager.finish_dynamic_tool_settlement(&claim.params);
+                claim
+                    .settlement_tx
+                    .send_modify(|epoch| *epoch = epoch.saturating_add(1));
+                let result_accepted = matches!(&outcome, DynamicToolTerminalOutcome::Resolved(_));
+                match outcome {
+                    DynamicToolTerminalOutcome::Resolved(result) => {
+                        if claim.sender.send(result).is_err() {
+                            tracing::debug!(
+                                call_id = %claim.params.call_id,
+                                "Durably accepted dynamic tool result had no remaining model receiver"
+                            );
+                        }
+                    }
+                    DynamicToolTerminalOutcome::Canceled { .. }
+                    | DynamicToolTerminalOutcome::Timeout { .. } => drop(claim.sender),
+                }
+                Ok(DynamicToolSettlementAck { result_accepted })
+            })
+            .catch_unwind()
+            .await;
+
+            let result = match settlement {
+                Ok(result) => result,
+                Err(payload) => {
+                    // A panic before durable completion must not leave a
+                    // Settling tombstone. Reacquire the same projection
+                    // boundary before returning the sender to Awaiting.
+                    if let Some(claim) = claim.take() {
+                        let projection_lock = manager.projection_lock(&claim.params.thread_id);
+                        let _projection = projection_lock.lock().await;
+                        manager.restore_dynamic_tool_claim(claim);
+                    }
+                    Err(format!(
+                        "Dynamic tool settlement task panicked: {}",
+                        panic_payload_message(&*payload)
+                    ))
+                }
+            };
+            let _ = ack_tx.send(result);
+        });
+        ack_rx
+    }
+
+    async fn await_dynamic_tool_settlement(
+        ack: oneshot::Receiver<std::result::Result<DynamicToolSettlementAck, String>>,
+    ) -> Result<DynamicToolSettlementAck> {
+        match ack.await {
+            Ok(Ok(ack)) => Ok(ack),
+            Ok(Err(error)) => bail!("{error}"),
+            Err(_) => bail!("Dynamic tool settlement task ended before acknowledgement"),
+        }
+    }
+
+    async fn settle_dynamic_tool_timeout(
+        &self,
+        claim: ClaimedDynamicToolSettlement,
+        timeout: Duration,
+    ) -> Result<()> {
+        let ack = self
+            .spawn_dynamic_tool_settlement(claim, DynamicToolTerminalOutcome::Timeout { timeout });
+        Self::await_dynamic_tool_settlement(ack).await?;
+        Ok(())
+    }
+
+    async fn settle_dynamic_tools_for_terminal_turn(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+    ) -> Result<()> {
+        loop {
+            let (claims, mut settling, indeterminate) =
+                self.claim_or_watch_pending_dynamic_tools_for_turn(thread_id, turn_id);
+            if indeterminate {
+                bail!(
+                    "Turn {turn_id} has an indeterminate dynamic-tool receipt; refusing to publish turn completion"
+                );
+            }
+            if claims.is_empty() && settling.is_empty() {
+                return Ok(());
+            }
+
+            let mut first_error = None;
+            for claim in claims {
+                let ack = self.spawn_dynamic_tool_settlement(
+                    claim,
+                    DynamicToolTerminalOutcome::Canceled {
+                        reason: "turn_terminal",
+                        terminal: true,
+                    },
+                );
+                if let Err(error) = Self::await_dynamic_tool_settlement(ack).await
+                    && first_error.is_none()
+                {
+                    first_error = Some(error);
+                }
+            }
+
+            // If result delivery or timeout already owned a call, wait for its
+            // supervised completion/rollback before publishing turn.completed.
+            // On rollback the next iteration claims terminal cancellation; on
+            // success the completed entry is gone.
+            for progress in &mut settling {
+                let _ = progress.changed().await;
+            }
+
+            // Every claim selected above has now either committed, restored
+            // itself to Awaiting, or entered the explicit indeterminate state.
+            // Returning only after supervising the whole batch prevents an
+            // early failure from dropping unstarted senders into permanent
+            // Settling tombstones.
+            if let Some(error) = first_error {
+                return Err(error);
+            }
+        }
+    }
+
+    /// Persist a streaming item without blocking the Tokio worker that drives
+    /// engine events. Each delta must reach the item projection before its
+    /// durable event is sequenced, otherwise a snapshot at that cursor can
+    /// expose stale text. Keeping the full record in memory avoids rereading
+    /// and reparsing the same item for every provider chunk.
+    async fn save_streaming_item(&self, item: &TurnItemRecord) -> Result<()> {
+        let store = self.store.clone();
+        let item = item.clone();
+        tokio::task::spawn_blocking(move || store.save_item(&item))
+            .await
+            .context("Streaming item persistence task failed")??;
+        Ok(())
     }
 
     #[cfg(test)]
@@ -1948,6 +2691,7 @@ impl RuntimeThreadManager {
     }
 
     pub async fn get_thread(&self, id: &str) -> Result<ThreadRecord> {
+        self.flush_recovery_receipts_for_thread(id).await?;
         self.store
             .load_thread(id)
             .with_context(|| format!("Thread not found: {id}"))
@@ -2138,11 +2882,13 @@ impl RuntimeThreadManager {
     }
 
     pub async fn get_thread_detail(&self, id: &str) -> Result<ThreadDetail> {
-        // Treat the cursor as a lower watermark for the projection reads that
-        // follow. A concurrent save+emit can then be represented in both the
-        // snapshot and replay (authoritative records are upserted and event
-        // sequences are deduplicated), or only in replay, but it cannot be
-        // absent from both while the cursor skips its event.
+        self.flush_recovery_receipts_for_thread(id).await?;
+        // Hold the per-thread projection boundary from cursor capture through
+        // item reads. A streamed delta is therefore either entirely before
+        // this snapshot (materialized item + included cursor) or entirely
+        // after it (old item + replayable delta), never both.
+        let projection_lock = self.projection_lock(id);
+        let _projection = projection_lock.lock().await;
         let latest_seq = self.store.current_seq().await;
 
         #[cfg(test)]
@@ -2161,7 +2907,14 @@ impl RuntimeThreadManager {
                 .map_err(|_| anyhow!("snapshot test hook dropped resume"))?;
         }
 
-        let thread = self.get_thread(id).await?;
+        // Recovery was flushed before taking the non-reentrant projection
+        // lock. Do not call `get_thread` here: a receipt queued between that
+        // flush and this read would re-enter recovery and wait forever on the
+        // projection lock held by this snapshot.
+        let thread = self
+            .store
+            .load_thread(id)
+            .with_context(|| format!("Thread not found: {id}"))?;
         let turns = self.store.list_turns_for_thread(id)?;
         let turn_ids: Vec<String> = turns.iter().map(|turn| turn.id.clone()).collect();
         let mut items_by_turn = self.store.list_items_for_turns_map(&turn_ids)?;
@@ -2857,20 +3610,28 @@ impl RuntimeThreadManager {
         let terminal_turn = {
             let _turn_mutation = self.store.turn_mutation.lock();
             match self.store.load_turn(turn_id) {
-                Ok(mut turn) if turn.status == RuntimeTurnStatus::InProgress => {
-                    turn.status = RuntimeTurnStatus::Failed;
-                    turn.ended_at = Some(now);
-                    turn.duration_ms = turn.started_at.map(|start| duration_ms(start, now));
-                    turn.error = Some(reason.to_string());
-                    match self.store.save_turn(&turn) {
-                        Ok(()) => Some(turn),
-                        Err(err) => {
+                Ok(mut turn) => {
+                    let mut persisted = true;
+                    if turn.status == RuntimeTurnStatus::InProgress {
+                        turn.status = RuntimeTurnStatus::Failed;
+                        turn.ended_at = Some(now);
+                        turn.duration_ms = turn.started_at.map(|start| duration_ms(start, now));
+                        turn.error = Some(reason.to_string());
+                        if let Err(err) = self.store.save_turn(&turn) {
                             tracing::error!("Failed to persist terminal monitor failure: {err}");
-                            None
+                            persisted = false;
                         }
                     }
+                    (persisted
+                        && matches!(
+                            turn.status,
+                            RuntimeTurnStatus::Completed
+                                | RuntimeTurnStatus::Failed
+                                | RuntimeTurnStatus::Interrupted
+                                | RuntimeTurnStatus::Canceled
+                        ))
+                    .then_some(turn)
                 }
-                Ok(_) => None,
                 Err(err) => {
                     tracing::error!("Failed to load turn after monitor failure: {err}");
                     None
@@ -2928,40 +3689,33 @@ impl RuntimeThreadManager {
             let _ = self.clear_pending_user_inputs_for_turn(thread_id, turn_id);
         }
 
-        for params in self.clear_pending_dynamic_tools_for_turn(thread_id, turn_id) {
-            let mut payload =
-                dynamic_tool_terminal_payload(&params, "canceled", None, Some("turn_terminal"));
-            if let Some(object) = payload.as_object_mut() {
-                object.insert("terminal".to_string(), json!(true));
+        let dynamic_tools_settled = if let Err(err) = self
+            .settle_dynamic_tools_for_terminal_turn(thread_id, turn_id)
+            .await
+        {
+            tracing::error!(
+                "Failed to emit dynamic-tool cancellation after monitor failure: {err}"
+            );
+            if let Some(turn) = terminal_turn.as_ref() {
+                self.queue_recovery_receipt(RecoveredTurnReceipt {
+                    turn: turn.clone(),
+                    unresolved_dynamic_tools: Vec::new(),
+                });
             }
-            if let Err(err) = self
-                .emit_event(
-                    thread_id,
-                    Some(turn_id),
-                    None,
-                    "tool_call.canceled",
-                    payload,
-                )
-                .await
-            {
-                tracing::error!(
-                    "Failed to emit dynamic-tool cancellation after monitor failure: {err}"
-                );
-            }
-        }
+            false
+        } else {
+            true
+        };
 
-        if let Some(turn) = terminal_turn
-            && let Err(err) = self
-                .emit_event(
-                    thread_id,
-                    Some(turn_id),
-                    None,
-                    "turn.completed",
-                    json!({ "turn": turn }),
-                )
-                .await
+        if dynamic_tools_settled
+            && let Some(turn) = terminal_turn.as_ref()
+            && let Err(err) = self.emit_turn_completed_if_missing(turn, false).await
         {
             tracing::error!("Failed to emit terminal monitor failure: {err}");
+            self.queue_recovery_receipt(RecoveredTurnReceipt {
+                turn: turn.clone(),
+                unresolved_dynamic_tools: Vec::new(),
+            });
         }
 
         // Keep the failed claim in place until its terminal receipts are
@@ -4053,8 +4807,8 @@ impl RuntimeThreadManager {
         turn_id: String,
         engine: EngineHandle,
     ) -> Result<()> {
-        let mut current_message_item: Option<(String, String)> = None;
-        let mut current_reasoning_item: Option<(String, String)> = None;
+        let mut current_message_item: Option<TurnItemRecord> = None;
+        let mut current_reasoning_item: Option<TurnItemRecord> = None;
         let mut tool_items: HashMap<String, String> = HashMap::new();
         let mut compaction_items: HashMap<String, String> = HashMap::new();
         let mut turn_usage: Option<Usage> = None;
@@ -4063,9 +4817,15 @@ impl RuntimeThreadManager {
         let mut turn_error: Option<String> = None;
         let mut saw_engine_activity = false;
         let mut saw_turn_started = false;
+        let mut pending_event: Option<EngineEvent> = None;
+        let mut event_channel_closed = false;
 
         loop {
-            let event = {
+            let event = if let Some(event) = pending_event.take() {
+                Some(event)
+            } else if event_channel_closed {
+                None
+            } else {
                 let mut rx = engine.rx_event.write().await;
                 rx.recv().await
             };
@@ -4162,26 +4922,32 @@ impl RuntimeThreadManager {
                         Some(&turn_id),
                         Some(&item_id),
                         "item.started",
-                        json!({ "item": item }),
+                        json!({ "item": item.clone() }),
                     )
                     .await?;
-                    current_message_item = Some((item_id, String::new()));
+                    current_message_item = Some(item);
                 }
                 EngineEvent::MessageDelta { content, .. } => {
-                    if let Some((item_id, text)) = current_message_item.as_mut() {
+                    let batch =
+                        coalesce_stream_delta(&engine, StreamDeltaKind::Message, content).await;
+                    pending_event = batch.pending_event;
+                    event_channel_closed |= batch.channel_closed;
+                    let content = batch.content;
+                    if let Some(item) = current_message_item.as_mut() {
+                        let text = item.detail.get_or_insert_default();
                         text.push_str(&content);
                         // Materialize the prefix before sequencing its delta.
                         // A snapshot whose cursor includes this event must not
                         // still observe the empty item saved at MessageStarted,
                         // and restart recovery must retain the partial output.
-                        let mut item = self.store.load_item(item_id)?;
                         item.summary = summarize_text(text, SUMMARY_LIMIT);
-                        item.detail = Some(text.clone());
-                        self.store.save_item(&item)?;
+                        let projection_lock = self.projection_lock(&thread_id);
+                        let _projection = projection_lock.lock().await;
+                        self.save_streaming_item(item).await?;
                         self.emit_event(
                             &thread_id,
                             Some(&turn_id),
-                            Some(item_id),
+                            Some(&item.id),
                             "item.delta",
                             json!({ "delta": content, "kind": "agent_message" }),
                         )
@@ -4189,17 +4955,18 @@ impl RuntimeThreadManager {
                     }
                 }
                 EngineEvent::MessageComplete { .. } => {
-                    if let Some((item_id, text)) = current_message_item.take() {
-                        let mut item = self.store.load_item(&item_id)?;
+                    if let Some(mut item) = current_message_item.take() {
                         item.status = TurnItemLifecycleStatus::Completed;
-                        item.summary = summarize_text(&text, SUMMARY_LIMIT);
-                        item.detail = Some(text);
+                        item.summary = summarize_text(
+                            item.detail.as_deref().unwrap_or_default(),
+                            SUMMARY_LIMIT,
+                        );
                         item.ended_at = Some(Utc::now());
-                        self.store.save_item(&item)?;
+                        self.save_streaming_item(&item).await?;
                         self.emit_event(
                             &thread_id,
                             Some(&turn_id),
-                            Some(&item_id),
+                            Some(&item.id),
                             "item.completed",
                             json!({ "item": item }),
                         )
@@ -4228,22 +4995,28 @@ impl RuntimeThreadManager {
                         Some(&turn_id),
                         Some(&item_id),
                         "item.started",
-                        json!({ "item": item }),
+                        json!({ "item": item.clone() }),
                     )
                     .await?;
-                    current_reasoning_item = Some((item_id, String::new()));
+                    current_reasoning_item = Some(item);
                 }
                 EngineEvent::ThinkingDelta { content, .. } => {
-                    if let Some((item_id, text)) = current_reasoning_item.as_mut() {
+                    let batch =
+                        coalesce_stream_delta(&engine, StreamDeltaKind::Reasoning, content).await;
+                    pending_event = batch.pending_event;
+                    event_channel_closed |= batch.channel_closed;
+                    let content = batch.content;
+                    if let Some(item) = current_reasoning_item.as_mut() {
+                        let text = item.detail.get_or_insert_default();
                         text.push_str(&content);
-                        let mut item = self.store.load_item(item_id)?;
                         item.summary = summarize_text(text, SUMMARY_LIMIT);
-                        item.detail = Some(text.clone());
-                        self.store.save_item(&item)?;
+                        let projection_lock = self.projection_lock(&thread_id);
+                        let _projection = projection_lock.lock().await;
+                        self.save_streaming_item(item).await?;
                         self.emit_event(
                             &thread_id,
                             Some(&turn_id),
-                            Some(item_id),
+                            Some(&item.id),
                             "item.delta",
                             json!({ "delta": content, "kind": "agent_reasoning" }),
                         )
@@ -4251,17 +5024,18 @@ impl RuntimeThreadManager {
                     }
                 }
                 EngineEvent::ThinkingComplete { .. } => {
-                    if let Some((item_id, text)) = current_reasoning_item.take() {
-                        let mut item = self.store.load_item(&item_id)?;
+                    if let Some(mut item) = current_reasoning_item.take() {
                         item.status = TurnItemLifecycleStatus::Completed;
-                        item.summary = summarize_text(&text, SUMMARY_LIMIT);
-                        item.detail = Some(text);
+                        item.summary = summarize_text(
+                            item.detail.as_deref().unwrap_or_default(),
+                            SUMMARY_LIMIT,
+                        );
                         item.ended_at = Some(Utc::now());
-                        self.store.save_item(&item)?;
+                        self.save_streaming_item(&item).await?;
                         self.emit_event(
                             &thread_id,
                             Some(&turn_id),
-                            Some(&item_id),
+                            Some(&item.id),
                             "item.completed",
                             json!({ "item": item }),
                         )
@@ -4914,21 +5688,20 @@ impl RuntimeThreadManager {
             turn_status = RuntimeTurnStatus::Interrupted;
         }
 
-        if let Some((item_id, text)) = current_message_item.take() {
-            let mut item = self.store.load_item(&item_id)?;
+        if let Some(mut item) = current_message_item.take() {
             if turn_status == RuntimeTurnStatus::Interrupted {
                 item.status = TurnItemLifecycleStatus::Interrupted;
             } else {
                 item.status = TurnItemLifecycleStatus::Completed;
             }
-            item.summary = summarize_text(&text, SUMMARY_LIMIT);
-            item.detail = Some(text);
+            item.summary =
+                summarize_text(item.detail.as_deref().unwrap_or_default(), SUMMARY_LIMIT);
             item.ended_at = Some(Utc::now());
-            self.store.save_item(&item)?;
+            self.save_streaming_item(&item).await?;
             self.emit_event(
                 &thread_id,
                 Some(&turn_id),
-                Some(&item_id),
+                Some(&item.id),
                 if item.status == TurnItemLifecycleStatus::Interrupted {
                     "item.interrupted"
                 } else {
@@ -4939,21 +5712,20 @@ impl RuntimeThreadManager {
             .await?;
         }
 
-        if let Some((item_id, text)) = current_reasoning_item.take() {
-            let mut item = self.store.load_item(&item_id)?;
+        if let Some(mut item) = current_reasoning_item.take() {
             if turn_status == RuntimeTurnStatus::Interrupted {
                 item.status = TurnItemLifecycleStatus::Interrupted;
             } else {
                 item.status = TurnItemLifecycleStatus::Completed;
             }
-            item.summary = summarize_text(&text, SUMMARY_LIMIT);
-            item.detail = Some(text);
+            item.summary =
+                summarize_text(item.detail.as_deref().unwrap_or_default(), SUMMARY_LIMIT);
             item.ended_at = Some(Utc::now());
-            self.store.save_item(&item)?;
+            self.save_streaming_item(&item).await?;
             self.emit_event(
                 &thread_id,
                 Some(&turn_id),
-                Some(&item_id),
+                Some(&item.id),
                 if item.status == TurnItemLifecycleStatus::Interrupted {
                     "item.interrupted"
                 } else {
@@ -5036,30 +5808,10 @@ impl RuntimeThreadManager {
             .await?;
         }
 
-        for params in self.clear_pending_dynamic_tools_for_turn(&thread_id, &turn_id) {
-            let mut payload =
-                dynamic_tool_terminal_payload(&params, "canceled", None, Some("turn_terminal"));
-            if let Some(object) = payload.as_object_mut() {
-                object.insert("terminal".to_string(), json!(true));
-            }
-            self.emit_event(
-                &thread_id,
-                Some(&turn_id),
-                None,
-                "tool_call.canceled",
-                payload,
-            )
+        self.settle_dynamic_tools_for_terminal_turn(&thread_id, &turn_id)
             .await?;
-        }
 
-        self.emit_event(
-            &thread_id,
-            Some(&turn_id),
-            None,
-            "turn.completed",
-            json!({ "turn": turn.clone() }),
-        )
-        .await?;
+        self.emit_turn_completed_if_missing(&turn, false).await?;
 
         {
             let mut active = self.active.lock().await;
@@ -5139,31 +5891,24 @@ impl RuntimeThreadManager {
 
     fn recover_interrupted_state(&self) -> Result<()> {
         let now = Utc::now();
-        // One scan of the turns store, filtered to the interrupted-candidate
-        // statuses, grouped by thread. The previous shape re-read and
-        // re-parsed every turn file once per thread — O(threads x turns) on
-        // the boot path (#3757).
+        let mut threads = self
+            .store
+            .list_threads()?
+            .into_iter()
+            .map(|thread| (thread.id.clone(), thread))
+            .collect::<HashMap<_, _>>();
         let mut turns_by_thread: HashMap<String, Vec<TurnRecord>> = HashMap::new();
-        for turn in self.store.list_all_turns()? {
+        let mut changed_threads = HashSet::new();
+
+        // First terminalize interrupted candidates. Keep every terminal turn
+        // in the same one-pass grouping so already-terminal records whose
+        // completion append failed are reconciled too.
+        for mut turn in self.store.list_all_turns()? {
+            let mut thread_changed = false;
             if matches!(
                 turn.status,
                 RuntimeTurnStatus::Queued | RuntimeTurnStatus::InProgress
             ) {
-                turns_by_thread
-                    .entry(turn.thread_id.clone())
-                    .or_default()
-                    .push(turn);
-            }
-        }
-        if turns_by_thread.is_empty() {
-            return Ok(());
-        }
-        for mut thread in self.store.list_threads()? {
-            let Some(turns) = turns_by_thread.remove(&thread.id) else {
-                continue;
-            };
-            let mut thread_changed = false;
-            for mut turn in turns {
                 turn.status = RuntimeTurnStatus::Interrupted;
                 turn.error = Some(RUNTIME_RESTART_REASON.to_string());
                 turn.ended_at = Some(now);
@@ -5185,14 +5930,97 @@ impl RuntimeThreadManager {
                     }
                 }
 
-                thread.updated_at = now;
                 thread_changed = true;
             }
-
-            if thread_changed {
-                self.store.save_thread(&thread)?;
+            if thread_changed && let Some(thread) = threads.get_mut(&turn.thread_id) {
+                thread.updated_at = now;
+                changed_threads.insert(thread.id.clone());
+            }
+            if matches!(
+                turn.status,
+                RuntimeTurnStatus::Completed
+                    | RuntimeTurnStatus::Failed
+                    | RuntimeTurnStatus::Interrupted
+                    | RuntimeTurnStatus::Canceled
+            ) {
+                turns_by_thread
+                    .entry(turn.thread_id.clone())
+                    .or_default()
+                    .push(turn);
             }
         }
+
+        for thread_id in changed_threads {
+            if let Some(thread) = threads.get(&thread_id) {
+                self.store.save_thread(thread)?;
+            }
+        }
+
+        let mut recovery_receipts: HashMap<String, Vec<RecoveredTurnReceipt>> = HashMap::new();
+        for (thread_id, mut turns) in turns_by_thread {
+            let events = self.store.events_since(&thread_id, None)?;
+            let completed_turns = events
+                .iter()
+                .filter(|event| event.event == "turn.completed")
+                .filter_map(|event| event.turn_id.clone())
+                .collect::<HashSet<_>>();
+            let terminal_calls = events
+                .iter()
+                .filter(|event| {
+                    matches!(
+                        event.event.as_str(),
+                        "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
+                    )
+                })
+                .filter_map(|event| {
+                    event
+                        .payload
+                        .get("call_id")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string)
+                })
+                .collect::<HashSet<_>>();
+            let mut requests_by_turn: HashMap<String, Vec<DynamicToolCallParams>> = HashMap::new();
+            for event in events
+                .iter()
+                .filter(|event| event.event == "tool_call.requested")
+            {
+                let Ok(params) =
+                    serde_json::from_value::<DynamicToolCallParams>(event.payload.clone())
+                else {
+                    tracing::warn!(
+                        thread_id,
+                        seq = event.seq,
+                        "Ignoring malformed dynamic-tool request during Runtime recovery"
+                    );
+                    continue;
+                };
+                if params.thread_id == thread_id && !terminal_calls.contains(&params.call_id) {
+                    requests_by_turn
+                        .entry(params.turn_id.clone())
+                        .or_default()
+                        .push(params);
+                }
+            }
+
+            turns.sort_by_key(|turn| turn.created_at);
+            for turn in turns {
+                if completed_turns.contains(&turn.id) {
+                    continue;
+                }
+                recovery_receipts
+                    .entry(thread_id.clone())
+                    .or_default()
+                    .push(RecoveredTurnReceipt {
+                        unresolved_dynamic_tools: requests_by_turn
+                            .remove(&turn.id)
+                            .unwrap_or_default(),
+                        turn,
+                    });
+            }
+        }
+
+        *self.recovery_receipts.lock() = recovery_receipts;
 
         Ok(())
     }
@@ -5231,6 +6059,21 @@ fn dynamic_tool_result_text(content: &[DynamicToolCallContent]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn dynamic_tool_result_to_tool_result(
+    result: DynamicToolCallResult,
+) -> crate::tools::spec::ToolResult {
+    let text = dynamic_tool_result_text(&result.content);
+    if result.success {
+        crate::tools::spec::ToolResult::success(text)
+    } else {
+        crate::tools::spec::ToolResult::error(if text.is_empty() {
+            "dynamic tool failed".to_string()
+        } else {
+            text
+        })
+    }
 }
 
 fn dynamic_tool_terminal_payload(
@@ -5284,7 +6127,7 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             tool: name.clone(),
             arguments: input,
         };
-        let rx = self
+        let mut rx = self
             .register_pending_dynamic_tool(params.clone())
             .map_err(|err| crate::tools::spec::ToolError::execution_failed(err.to_string()))?;
         if let Err(err) = self
@@ -5297,72 +6140,111 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             )
             .await
         {
-            self.take_pending_dynamic_tool(&thread_id, &turn_id, &call_id);
+            self.remove_pending_dynamic_tool(&thread_id, &turn_id, &call_id);
             return Err(crate::tools::spec::ToolError::execution_failed(format!(
                 "failed to emit runtime dynamic tool request for '{name}': {err}"
             )));
         }
 
         let result_timeout = dynamic_tool_result_timeout();
-        match tokio::time::timeout(result_timeout, rx).await {
-            Ok(Ok(result)) => {
-                let text = dynamic_tool_result_text(&result.content);
-                if result.success {
-                    Ok(crate::tools::spec::ToolResult::success(text))
-                } else {
-                    Ok(crate::tools::spec::ToolResult::error(if text.is_empty() {
-                        "dynamic tool failed".to_string()
-                    } else {
-                        text
-                    }))
-                }
-            }
-            Ok(Err(_recv_err)) => {
-                if let Some(entry) = self.take_pending_dynamic_tool(&thread_id, &turn_id, &call_id)
-                {
-                    self.emit_event(
-                        &thread_id,
-                        Some(&turn_id),
-                        None,
-                        "tool_call.canceled",
-                        dynamic_tool_terminal_payload(
-                            &entry.params,
-                            "canceled",
-                            None,
-                            Some("channel_closed"),
-                        ),
-                    )
-                    .await
-                    .map_err(|err| {
-                        crate::tools::spec::ToolError::execution_failed(err.to_string())
-                    })?;
-                }
-                Err(crate::tools::spec::ToolError::execution_failed(format!(
-                    "runtime dynamic tool '{name}' result channel closed"
-                )))
-            }
+        match tokio::time::timeout(result_timeout, &mut rx).await {
+            Ok(Ok(result)) => Ok(dynamic_tool_result_to_tool_result(result)),
+            Ok(Err(_recv_err)) => Err(crate::tools::spec::ToolError::execution_failed(format!(
+                "runtime dynamic tool '{name}' result channel closed"
+            ))),
             Err(_timeout) => {
-                if let Some(entry) = self.take_pending_dynamic_tool(&thread_id, &turn_id, &call_id)
+                let mut settlement_progress = match self
+                    .claim_pending_dynamic_tool(&thread_id, &turn_id, &call_id)
                 {
-                    self.emit_event(&thread_id, Some(&turn_id), None, "tool_call.timeout", {
-                        let mut payload =
-                            dynamic_tool_terminal_payload(&entry.params, "timeout", None, None);
-                        if let Some(object) = payload.as_object_mut() {
-                            object.insert(
-                                "timeout_secs".to_string(),
-                                json!(result_timeout.as_secs()),
-                            );
+                    PendingDynamicToolClaim::Claimed(claim) => {
+                        self.settle_dynamic_tool_timeout(claim, result_timeout)
+                            .await
+                            .map_err(|err| {
+                                crate::tools::spec::ToolError::execution_failed(err.to_string())
+                            })?;
+                        return Err(crate::tools::spec::ToolError::Timeout {
+                            seconds: result_timeout.as_secs(),
+                        });
+                    }
+                    PendingDynamicToolClaim::Settling(progress) => progress,
+                    PendingDynamicToolClaim::Indeterminate => {
+                        return Err(crate::tools::spec::ToolError::execution_failed(format!(
+                            "runtime dynamic tool '{name}' has an indeterminate terminal receipt"
+                        )));
+                    }
+                    PendingDynamicToolClaim::Missing => {
+                        return match rx.await {
+                            Ok(result) => Ok(dynamic_tool_result_to_tool_result(result)),
+                            Err(_recv_err) => Err(crate::tools::spec::ToolError::execution_failed(
+                                format!("runtime dynamic tool '{name}' result channel closed"),
+                            )),
+                        };
+                    }
+                };
+
+                // A result or turn cancellation claimed the call just before
+                // the timer fired. Preserve that winner. Its supervised task
+                // notifies this watcher on either durable completion or
+                // rollback, so a panic/persistence error cannot strand this
+                // executor in an unbounded `rx.await`.
+                loop {
+                    tokio::select! {
+                        received = &mut rx => {
+                            return match received {
+                                Ok(result) => Ok(dynamic_tool_result_to_tool_result(result)),
+                                Err(_recv_err) => Err(
+                                    crate::tools::spec::ToolError::execution_failed(format!(
+                                        "runtime dynamic tool '{name}' result channel closed"
+                                    )),
+                                ),
+                            };
                         }
-                        payload
-                    })
-                    .await
-                    .map_err(|err| {
-                        crate::tools::spec::ToolError::execution_failed(err.to_string())
-                    })?;
+                        _ = settlement_progress.changed() => {
+                            match self.claim_pending_dynamic_tool(
+                                &thread_id,
+                                &turn_id,
+                                &call_id,
+                            ) {
+                                PendingDynamicToolClaim::Claimed(claim) => {
+                                    self.settle_dynamic_tool_timeout(claim, result_timeout)
+                                        .await
+                                        .map_err(|err| {
+                                            crate::tools::spec::ToolError::execution_failed(
+                                                err.to_string(),
+                                            )
+                                        })?;
+                                    return Err(crate::tools::spec::ToolError::Timeout {
+                                        seconds: result_timeout.as_secs(),
+                                    });
+                                }
+                                PendingDynamicToolClaim::Settling(progress) => {
+                                    settlement_progress = progress;
+                                }
+                                PendingDynamicToolClaim::Indeterminate => {
+                                    return Err(
+                                        crate::tools::spec::ToolError::execution_failed(format!(
+                                            "runtime dynamic tool '{name}' has an indeterminate terminal receipt"
+                                        )),
+                                    );
+                                }
+                                PendingDynamicToolClaim::Missing => {
+                                    return match rx.await {
+                                        Ok(result) => {
+                                            Ok(dynamic_tool_result_to_tool_result(result))
+                                        }
+                                        Err(_recv_err) => Err(
+                                            crate::tools::spec::ToolError::execution_failed(
+                                                format!(
+                                                    "runtime dynamic tool '{name}' result channel closed"
+                                                ),
+                                            ),
+                                        ),
+                                    };
+                                }
+                            }
+                        }
+                    }
                 }
-                Err(crate::tools::spec::ToolError::Timeout {
-                    seconds: result_timeout.as_secs(),
-                })
             }
         }
     }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -22,6 +22,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+#[cfg(test)]
+use tokio::sync::mpsc;
 use tokio::sync::{Mutex, broadcast, oneshot};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -1057,6 +1059,15 @@ pub struct RuntimeThreadManager {
         Arc<parking_lot::Mutex<HashMap<(String, String), PendingUserInputRequest>>>,
     pending_dynamic_tools:
         Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<DynamicToolCallResult>>>>,
+    #[cfg(test)]
+    snapshot_test_hook: Arc<parking_lot::Mutex<Option<mpsc::UnboundedSender<SnapshotTestPoint>>>>,
+}
+
+#[cfg(test)]
+pub(crate) struct SnapshotTestPoint {
+    pub thread_id: String,
+    pub latest_seq: u64,
+    pub resume: oneshot::Sender<()>,
 }
 
 /// Helper types for `seed_thread_from_messages` — intermediate representation
@@ -1291,6 +1302,8 @@ impl RuntimeThreadManager {
             pending_approvals: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_user_inputs: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_dynamic_tools: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            snapshot_test_hook: Arc::new(parking_lot::Mutex::new(None)),
         };
         manager.recover_interrupted_state()?;
         Ok(manager)
@@ -1601,6 +1614,11 @@ impl RuntimeThreadManager {
     ) -> Result<RuntimeEventRecord> {
         self.emit_event(thread_id, turn_id, None, event, payload)
             .await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_snapshot_test_hook(&self, hook: mpsc::UnboundedSender<SnapshotTestPoint>) {
+        *self.snapshot_test_hook.lock() = Some(hook);
     }
 
     pub async fn create_thread(&self, req: CreateThreadRequest) -> Result<ThreadRecord> {
@@ -1997,6 +2015,29 @@ impl RuntimeThreadManager {
     }
 
     pub async fn get_thread_detail(&self, id: &str) -> Result<ThreadDetail> {
+        // Treat the cursor as a lower watermark for the projection reads that
+        // follow. A concurrent save+emit can then be represented in both the
+        // snapshot and replay (authoritative records are upserted and event
+        // sequences are deduplicated), or only in replay, but it cannot be
+        // absent from both while the cursor skips its event.
+        let latest_seq = self.store.current_seq().await;
+
+        #[cfg(test)]
+        let snapshot_test_hook = { self.snapshot_test_hook.lock().take() };
+        #[cfg(test)]
+        if let Some(hook) = snapshot_test_hook {
+            let (resume, wait_for_resume) = oneshot::channel();
+            hook.send(SnapshotTestPoint {
+                thread_id: id.to_string(),
+                latest_seq,
+                resume,
+            })
+            .map_err(|_| anyhow!("snapshot test hook closed"))?;
+            wait_for_resume
+                .await
+                .map_err(|_| anyhow!("snapshot test hook dropped resume"))?;
+        }
+
         let thread = self.get_thread(id).await?;
         let turns = self.store.list_turns_for_thread(id)?;
         let turn_ids: Vec<String> = turns.iter().map(|turn| turn.id.clone()).collect();
@@ -2007,12 +2048,6 @@ impl RuntimeThreadManager {
                 items.append(&mut turn_items);
             }
         }
-        let latest_seq = self.store.current_seq().await;
-        // Read attention state after the replay cursor. If a request is
-        // registered concurrently after this point, its required event will
-        // have a sequence newer than `latest_seq`; if its event was already
-        // sequenced, registration necessarily happened first and it appears
-        // in this snapshot unless it has already been resolved.
         let (pending_approvals, pending_user_inputs) = self.pending_requests_for_thread(id);
         Ok(ThreadDetail {
             thread,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -949,7 +949,20 @@ impl RuntimeThreadStore {
             // error. If rollback itself fails, classify the write as
             // indeterminate so callers never restore/retry and duplicate a
             // possibly committed terminal receipt.
-            let rollback_result = file.set_len(original_len).and_then(|()| file.sync_all());
+            // Rust intentionally opens append-mode files on Windows without
+            // FILE_WRITE_DATA. That preserves kernel append semantics but
+            // means the append handle cannot truncate. Reopen the exact path
+            // with ordinary write authority only on the failure path so the
+            // success path remains an atomic append on every platform.
+            drop(file);
+            let rollback_result =
+                OpenOptions::new()
+                    .write(true)
+                    .open(&path)
+                    .and_then(|rollback_file| {
+                        rollback_file.set_len(original_len)?;
+                        rollback_file.sync_all()
+                    });
             let error = match rollback_result {
                 Ok(()) => RuntimeEventAppendError {
                     disposition: EventAppendFailureDisposition::RolledBack,

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -13,7 +13,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -588,6 +588,7 @@ impl RuntimeThreadStore {
         ensure_runtime_store_dir(&turns_dir)?;
         ensure_runtime_store_dir(&items_dir)?;
         ensure_runtime_store_dir(&events_dir)?;
+        repair_torn_event_log_tails(&events_dir)?;
 
         let state_path = root.join("state.json");
         reject_symlinked_store_file(&state_path)?;
@@ -2140,8 +2141,9 @@ impl RuntimeThreadManager {
                 matches!(
                     event.event.as_str(),
                     "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
-                ) && event.payload.get("call_id").and_then(Value::as_str)
-                    == Some(params.call_id.as_str())
+                ) && event.turn_id.as_deref() == Some(params.turn_id.as_str())
+                    && event.payload.get("call_id").and_then(Value::as_str)
+                        == Some(params.call_id.as_str())
             })
         {
             return Ok(false);
@@ -5973,11 +5975,9 @@ impl RuntimeThreadManager {
                     )
                 })
                 .filter_map(|event| {
-                    event
-                        .payload
-                        .get("call_id")
-                        .and_then(Value::as_str)
-                        .map(ToString::to_string)
+                    let turn_id = event.turn_id.as_deref()?;
+                    let call_id = event.payload.get("call_id")?.as_str()?;
+                    Some((turn_id.to_string(), call_id.to_string()))
                 })
                 .collect::<HashSet<_>>();
             let mut requests_by_turn: HashMap<String, Vec<DynamicToolCallParams>> = HashMap::new();
@@ -5995,7 +5995,9 @@ impl RuntimeThreadManager {
                     );
                     continue;
                 };
-                if params.thread_id == thread_id && !terminal_calls.contains(&params.call_id) {
+                if params.thread_id == thread_id
+                    && !terminal_calls.contains(&(params.turn_id.clone(), params.call_id.clone()))
+                {
                     requests_by_turn
                         .entry(params.turn_id.clone())
                         .or_default()
@@ -6005,16 +6007,16 @@ impl RuntimeThreadManager {
 
             turns.sort_by_key(|turn| turn.created_at);
             for turn in turns {
-                if completed_turns.contains(&turn.id) {
+                let unresolved_dynamic_tools =
+                    requests_by_turn.remove(&turn.id).unwrap_or_default();
+                if completed_turns.contains(&turn.id) && unresolved_dynamic_tools.is_empty() {
                     continue;
                 }
                 recovery_receipts
                     .entry(thread_id.clone())
                     .or_default()
                     .push(RecoveredTurnReceipt {
-                        unresolved_dynamic_tools: requests_by_turn
-                            .remove(&turn.id)
-                            .unwrap_or_default(),
+                        unresolved_dynamic_tools,
                         turn,
                     });
             }
@@ -6510,6 +6512,86 @@ fn reject_symlinked_store_dir(path: &Path) -> Result<()> {
 fn ensure_runtime_store_dir(path: &Path) -> Result<()> {
     fs::create_dir_all(path).with_context(|| format!("Failed to create {}", path.display()))?;
     reject_symlinked_store_dir(path)
+}
+
+/// Remove only an unterminated final JSONL fragment left by a process or
+/// machine stopping in the middle of `write_all`. A newline-terminated bad
+/// record is not crash debris we can identify safely, so normal replay keeps
+/// rejecting it instead of silently discarding durable data.
+fn repair_torn_event_log_tails(events_dir: &Path) -> Result<()> {
+    let events_dir = checked_existing_runtime_store_dir(events_dir)?;
+    for entry in fs::read_dir(&events_dir)
+        .with_context(|| format!("Failed to read {}", events_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path
+            .extension()
+            .is_none_or(|extension| extension != "jsonl")
+        {
+            continue;
+        }
+        reject_symlinked_store_file(&path)?;
+        if !entry
+            .file_type()
+            .with_context(|| format!("Failed to inspect {}", path.display()))?
+            .is_file()
+        {
+            continue;
+        }
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .with_context(|| format!("Failed to open {} for tail recovery", path.display()))?;
+        let len = file
+            .metadata()
+            .with_context(|| format!("Failed to inspect {}", path.display()))?
+            .len();
+        if len == 0 {
+            continue;
+        }
+
+        file.seek(SeekFrom::End(-1))?;
+        let mut last = [0_u8; 1];
+        file.read_exact(&mut last)?;
+        if last[0] == b'\n' {
+            continue;
+        }
+
+        let mut search_end = len;
+        let mut truncate_at = 0_u64;
+        let mut buffer = [0_u8; 8 * 1024];
+        let buffer_len = u64::try_from(buffer.len()).expect("event recovery buffer fits u64");
+        while search_end > 0 {
+            let chunk_len = usize::try_from(search_end.min(buffer_len))
+                .expect("event recovery chunk length fits usize");
+            let chunk_len_u64 =
+                u64::try_from(chunk_len).expect("event recovery chunk length fits u64");
+            let chunk_start = search_end - chunk_len_u64;
+            file.seek(SeekFrom::Start(chunk_start))?;
+            file.read_exact(&mut buffer[..chunk_len])?;
+            if let Some(index) = buffer[..chunk_len].iter().rposition(|byte| *byte == b'\n') {
+                truncate_at = chunk_start
+                    + u64::try_from(index).expect("event recovery newline index fits u64")
+                    + 1;
+                break;
+            }
+            search_end = chunk_start;
+        }
+
+        file.set_len(truncate_at)
+            .with_context(|| format!("Failed to truncate torn tail in {}", path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("Failed to sync repaired {}", path.display()))?;
+        tracing::warn!(
+            path = %path.display(),
+            removed_bytes = len.saturating_sub(truncate_at),
+            "Recovered an unterminated Runtime event-log tail"
+        );
+    }
+    Ok(())
 }
 
 fn read_store_file(path: &Path) -> Result<String> {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -22,9 +22,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-#[cfg(test)]
-use tokio::sync::mpsc;
-use tokio::sync::{Mutex, broadcast, oneshot, watch};
+use tokio::sync::{Mutex, broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -55,6 +53,8 @@ use codewhale_protocol::runtime::{
 };
 
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
+pub(crate) const RUNTIME_EVENT_REPLAY_BATCH_SIZE: usize = 256;
+pub(crate) const MAX_RUNTIME_EVENT_REPLAY_TAIL: usize = 4096;
 const MAX_ACTIVE_THREADS_DEFAULT: usize = 8;
 const MAX_PENDING_DYNAMIC_TOOL_CALLS: usize = 128;
 const SUMMARY_LIMIT: usize = 280;
@@ -504,6 +504,21 @@ pub struct RuntimeEventRecord {
     pub item_id: Option<String>,
     pub event: String,
     pub payload: Value,
+}
+
+pub(crate) struct RuntimeEventReplay {
+    /// Cursor immediately before the first replayed event. For a tail-limited
+    /// replay this advances past omitted history so continuity remains exact.
+    pub(crate) base_seq: u64,
+    /// Filesystem parsing happens on the blocking pool and publishes bounded
+    /// chunks through this small channel, applying backpressure instead of
+    /// allocating an unbounded backlog on a Tokio worker.
+    pub(crate) batches: mpsc::Receiver<std::result::Result<Vec<RuntimeEventRecord>, String>>,
+}
+
+enum RuntimeEventMatch {
+    TurnCompleted { turn_id: String },
+    DynamicTerminal { turn_id: String, call_id: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -964,15 +979,9 @@ impl RuntimeThreadStore {
         }
         let file =
             File::open(&path).with_context(|| format!("Failed to open {}", path.display()))?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
         let mut out = Vec::new();
-        for line in reader.lines() {
-            let line = line?;
-            if line.trim().is_empty() {
-                continue;
-            }
-            let event: RuntimeEventRecord = serde_json::from_str(&line)
-                .with_context(|| format!("Failed to parse event line in {}", path.display()))?;
+        while let Some(event) = read_complete_event(&mut reader, &path)? {
             if let Some(since) = since_seq
                 && event.seq <= since
             {
@@ -981,6 +990,158 @@ impl RuntimeThreadStore {
             out.push(event);
         }
         Ok(out)
+    }
+
+    fn publish_event_replay(
+        &self,
+        thread_id: &str,
+        since_seq: Option<u64>,
+        tail_limit: Option<usize>,
+        base_tx: oneshot::Sender<std::result::Result<u64, String>>,
+        batch_tx: mpsc::Sender<std::result::Result<Vec<RuntimeEventRecord>, String>>,
+    ) {
+        let mut base_tx = Some(base_tx);
+        let result = match tail_limit {
+            Some(limit) => {
+                self.publish_tail_event_replay(thread_id, since_seq, limit, &mut base_tx, &batch_tx)
+            }
+            None => self.publish_full_event_replay(thread_id, since_seq, &mut base_tx, &batch_tx),
+        };
+        if let Err(error) = result {
+            let message = format!("{error:#}");
+            if let Some(base_tx) = base_tx.take() {
+                let _ = base_tx.send(Err(message));
+            } else {
+                let _ = batch_tx.blocking_send(Err(message));
+            }
+        }
+    }
+
+    fn open_event_reader(&self, thread_id: &str) -> Result<Option<BufReader<File>>> {
+        let path = self.events_path(thread_id)?;
+        reject_symlinked_store_dir(&self.events_dir)?;
+        reject_symlinked_store_file(&path)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        let file =
+            File::open(&path).with_context(|| format!("Failed to open {}", path.display()))?;
+        Ok(Some(BufReader::new(file)))
+    }
+
+    fn contains_event(&self, thread_id: &str, expected: &RuntimeEventMatch) -> Result<bool> {
+        let Some(mut reader) = self.open_event_reader(thread_id)? else {
+            return Ok(false);
+        };
+        let path = self.events_path(thread_id)?;
+        while let Some(event) = read_complete_event(&mut reader, &path)? {
+            let matches = match expected {
+                RuntimeEventMatch::TurnCompleted { turn_id } => {
+                    event.event == "turn.completed"
+                        && event.turn_id.as_deref() == Some(turn_id.as_str())
+                }
+                RuntimeEventMatch::DynamicTerminal { turn_id, call_id } => {
+                    matches!(
+                        event.event.as_str(),
+                        "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
+                    ) && event.turn_id.as_deref() == Some(turn_id.as_str())
+                        && event.payload.get("call_id").and_then(Value::as_str)
+                            == Some(call_id.as_str())
+                }
+            };
+            if matches {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn publish_full_event_replay(
+        &self,
+        thread_id: &str,
+        since_seq: Option<u64>,
+        base_tx: &mut Option<oneshot::Sender<std::result::Result<u64, String>>>,
+        batch_tx: &mpsc::Sender<std::result::Result<Vec<RuntimeEventRecord>, String>>,
+    ) -> Result<()> {
+        let Some(mut reader) = self.open_event_reader(thread_id)? else {
+            if let Some(base_tx) = base_tx.take() {
+                let _ = base_tx.send(Ok(since_seq.unwrap_or(0)));
+            }
+            return Ok(());
+        };
+        if base_tx
+            .take()
+            .is_some_and(|base_tx| base_tx.send(Ok(since_seq.unwrap_or(0))).is_err())
+        {
+            return Ok(());
+        }
+
+        let path = self.events_path(thread_id)?;
+        let mut batch = Vec::with_capacity(RUNTIME_EVENT_REPLAY_BATCH_SIZE);
+        while let Some(event) = read_complete_event(&mut reader, &path)? {
+            if since_seq.is_some_and(|since| event.seq <= since) {
+                continue;
+            }
+            batch.push(event);
+            if batch.len() == RUNTIME_EVENT_REPLAY_BATCH_SIZE {
+                if batch_tx.blocking_send(Ok(batch)).is_err() {
+                    return Ok(());
+                }
+                batch = Vec::with_capacity(RUNTIME_EVENT_REPLAY_BATCH_SIZE);
+            }
+        }
+        if !batch.is_empty() {
+            let _ = batch_tx.blocking_send(Ok(batch));
+        }
+        Ok(())
+    }
+
+    fn publish_tail_event_replay(
+        &self,
+        thread_id: &str,
+        since_seq: Option<u64>,
+        tail_limit: usize,
+        base_tx: &mut Option<oneshot::Sender<std::result::Result<u64, String>>>,
+        batch_tx: &mpsc::Sender<std::result::Result<Vec<RuntimeEventRecord>, String>>,
+    ) -> Result<()> {
+        let Some(mut reader) = self.open_event_reader(thread_id)? else {
+            if let Some(base_tx) = base_tx.take() {
+                let _ = base_tx.send(Ok(since_seq.unwrap_or(0)));
+            }
+            return Ok(());
+        };
+        let path = self.events_path(thread_id)?;
+        let mut base_seq = since_seq.unwrap_or(0);
+        let mut tail = VecDeque::with_capacity(tail_limit.min(RUNTIME_EVENT_REPLAY_BATCH_SIZE));
+        while let Some(event) = read_complete_event(&mut reader, &path)? {
+            if since_seq.is_some_and(|since| event.seq <= since) {
+                continue;
+            }
+            if tail_limit == 0 {
+                base_seq = event.seq;
+                continue;
+            }
+            tail.push_back(event);
+            if tail.len() > tail_limit
+                && let Some(omitted) = tail.pop_front()
+            {
+                base_seq = omitted.seq;
+            }
+        }
+        if base_tx
+            .take()
+            .is_some_and(|base_tx| base_tx.send(Ok(base_seq)).is_err())
+        {
+            return Ok(());
+        }
+        while !tail.is_empty() {
+            let take = tail.len().min(RUNTIME_EVENT_REPLAY_BATCH_SIZE);
+            let batch = tail.drain(..take).collect::<Vec<_>>();
+            if batch_tx.blocking_send(Ok(batch)).is_err() {
+                return Ok(());
+            }
+        }
+        Ok(())
     }
 
     pub async fn current_seq(&self) -> u64 {
@@ -2343,15 +2504,12 @@ impl RuntimeThreadManager {
         recovered: bool,
     ) -> Result<bool> {
         let _emit_order = self.event_emit.lock().await;
-        if self
-            .store
-            .events_since(&turn.thread_id, None)?
-            .iter()
-            .any(|event| {
-                event.event == "turn.completed"
-                    && event.turn_id.as_deref() == Some(turn.id.as_str())
-            })
-        {
+        if self.store.contains_event(
+            &turn.thread_id,
+            &RuntimeEventMatch::TurnCompleted {
+                turn_id: turn.id.clone(),
+            },
+        )? {
             return Ok(false);
         }
         let mut payload = json!({ "turn": turn });
@@ -2374,19 +2532,13 @@ impl RuntimeThreadManager {
         params: &DynamicToolCallParams,
     ) -> Result<bool> {
         let _emit_order = self.event_emit.lock().await;
-        if self
-            .store
-            .events_since(&params.thread_id, None)?
-            .iter()
-            .any(|event| {
-                matches!(
-                    event.event.as_str(),
-                    "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
-                ) && event.turn_id.as_deref() == Some(params.turn_id.as_str())
-                    && event.payload.get("call_id").and_then(Value::as_str)
-                        == Some(params.call_id.as_str())
-            })
-        {
+        if self.store.contains_event(
+            &params.thread_id,
+            &RuntimeEventMatch::DynamicTerminal {
+                turn_id: params.turn_id.clone(),
+                call_id: params.call_id.clone(),
+            },
+        )? {
             return Ok(false);
         }
         let mut payload =
@@ -3163,19 +3315,25 @@ impl RuntimeThreadManager {
         // lock. Do not call `get_thread` here: a receipt queued between that
         // flush and this read would re-enter recovery and wait forever on the
         // projection lock held by this snapshot.
-        let thread = self
-            .store
-            .load_thread(id)
-            .with_context(|| format!("Thread not found: {id}"))?;
-        let turns = self.store.list_turns_for_thread(id)?;
-        let turn_ids: Vec<String> = turns.iter().map(|turn| turn.id.clone()).collect();
-        let mut items_by_turn = self.store.list_items_for_turns_map(&turn_ids)?;
-        let mut items = Vec::new();
-        for turn in &turns {
-            if let Some(mut turn_items) = items_by_turn.remove(&turn.id) {
-                items.append(&mut turn_items);
+        let store = self.store.clone();
+        let snapshot_thread_id = id.to_string();
+        let (thread, turns, items) = tokio::task::spawn_blocking(move || {
+            let thread = store
+                .load_thread(&snapshot_thread_id)
+                .with_context(|| format!("Thread not found: {snapshot_thread_id}"))?;
+            let turns = store.list_turns_for_thread(&snapshot_thread_id)?;
+            let turn_ids: Vec<String> = turns.iter().map(|turn| turn.id.clone()).collect();
+            let mut items_by_turn = store.list_items_for_turns_map(&turn_ids)?;
+            let mut items = Vec::new();
+            for turn in &turns {
+                if let Some(mut turn_items) = items_by_turn.remove(&turn.id) {
+                    items.append(&mut turn_items);
+                }
             }
-        }
+            Ok::<_, anyhow::Error>((thread, turns, items))
+        })
+        .await
+        .context("Runtime thread projection task failed")??;
         let (pending_approvals, pending_user_inputs) = self.pending_requests_for_thread(id);
         let pending_dynamic_tool_calls = self.pending_dynamic_tool_calls_for_thread(id);
         Ok(ThreadDetail {
@@ -3207,7 +3365,7 @@ impl RuntimeThreadManager {
         id: &str,
     ) -> Result<(ThreadRecord, Vec<AgentRebindHint>)> {
         let thread = self.resume_thread(id).await?;
-        let events = self.store.events_since(&thread.id, None)?;
+        let events = self.events_since_offloaded(&thread.id, None).await?;
         let hints = collect_agent_rebind_hints(&events);
         Ok((thread, hints))
     }
@@ -4629,6 +4787,41 @@ impl RuntimeThreadManager {
         self.store.events_since(thread_id, since_seq)
     }
 
+    async fn events_since_offloaded(
+        &self,
+        thread_id: &str,
+        since_seq: Option<u64>,
+    ) -> Result<Vec<RuntimeEventRecord>> {
+        let store = self.store.clone();
+        let thread_id = thread_id.to_string();
+        tokio::task::spawn_blocking(move || store.events_since(&thread_id, since_seq))
+            .await
+            .context("Runtime event history task failed")?
+    }
+
+    pub(crate) async fn replay_events(
+        &self,
+        thread_id: &str,
+        since_seq: Option<u64>,
+        tail_limit: Option<usize>,
+    ) -> Result<RuntimeEventReplay> {
+        if tail_limit.is_some_and(|limit| limit > MAX_RUNTIME_EVENT_REPLAY_TAIL) {
+            bail!("Runtime event replay_limit cannot exceed {MAX_RUNTIME_EVENT_REPLAY_TAIL}");
+        }
+        let (base_tx, base_rx) = oneshot::channel();
+        let (batch_tx, batches) = mpsc::channel(2);
+        let store = self.store.clone();
+        let thread_id = thread_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            store.publish_event_replay(&thread_id, since_seq, tail_limit, base_tx, batch_tx);
+        });
+        let base_seq = base_rx
+            .await
+            .context("Runtime event replay worker ended before initialization")?
+            .map_err(anyhow::Error::msg)?;
+        Ok(RuntimeEventReplay { base_seq, batches })
+    }
+
     async fn ensure_engine_loaded(&self, thread_hint: &ThreadRecord) -> Result<EngineHandle> {
         {
             let mut active = self.active.lock().await;
@@ -5673,6 +5866,8 @@ impl RuntimeThreadManager {
                     // Register before sequencing the event. A snapshot racing
                     // this branch therefore either contains the request or
                     // subscribes from an older cursor that will replay it.
+                    let projection_lock = self.projection_lock(&thread_id);
+                    let projection = projection_lock.lock().await;
                     let rx = self.register_pending_approval(&thread_id, pending_request);
                     if let Err(err) = self
                         .emit_event(
@@ -5691,9 +5886,11 @@ impl RuntimeThreadManager {
                         .await
                     {
                         self.cancel_pending_approval(&id);
+                        drop(projection);
                         let _ = engine.deny_tool_call(&id).await;
                         return Err(err);
                     }
+                    drop(projection);
                     let approval_timeout = approval_decision_timeout();
                     match tokio::time::timeout(approval_timeout, rx).await {
                         Ok(Ok(ExternalApprovalDecision::Allow { remember })) => {
@@ -5805,6 +6002,8 @@ impl RuntimeThreadManager {
                     }
                 }
                 EngineEvent::UserInputRequired { id, request } => {
+                    let projection_lock = self.projection_lock(&thread_id);
+                    let projection = projection_lock.lock().await;
                     self.register_pending_user_input(
                         &thread_id,
                         PendingUserInputRequest {
@@ -5827,9 +6026,11 @@ impl RuntimeThreadManager {
                         .await
                     {
                         self.discard_pending_user_input_registration(&thread_id, &id);
+                        drop(projection);
                         let _ = engine.cancel_user_input(&id).await;
                         return Err(err);
                     }
+                    drop(projection);
                 }
                 EngineEvent::Status { message } => {
                     let item = TurnItemRecord {
@@ -6361,6 +6562,8 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             tool: name.clone(),
             arguments: input,
         };
+        let projection_lock = self.projection_lock(&thread_id);
+        let projection = projection_lock.lock().await;
         let mut rx = self
             .register_pending_dynamic_tool(params.clone())
             .map_err(|err| crate::tools::spec::ToolError::execution_failed(err.to_string()))?;
@@ -6375,10 +6578,12 @@ impl crate::tools::spec::DynamicToolExecutor for RuntimeThreadManager {
             .await
         {
             self.remove_pending_dynamic_tool(&thread_id, &turn_id, &call_id);
+            drop(projection);
             return Err(crate::tools::spec::ToolError::execution_failed(format!(
                 "failed to emit runtime dynamic tool request for '{name}': {err}"
             )));
         }
+        drop(projection);
 
         let result_timeout = dynamic_tool_result_timeout();
         match tokio::time::timeout(result_timeout, &mut rx).await {
@@ -6744,6 +6949,32 @@ fn reject_symlinked_store_dir(path: &Path) -> Result<()> {
 fn ensure_runtime_store_dir(path: &Path) -> Result<()> {
     fs::create_dir_all(path).with_context(|| format!("Failed to create {}", path.display()))?;
     reject_symlinked_store_dir(path)
+}
+
+fn read_complete_event(
+    reader: &mut BufReader<File>,
+    path: &Path,
+) -> Result<Option<RuntimeEventRecord>> {
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        // A concurrent append can be visible before write_all finishes. The
+        // subscribed broadcast path will deliver that event after its durable
+        // append completes, so stop at an unterminated live tail instead of
+        // misclassifying it as durable corruption. Store startup separately
+        // truncates an unterminated tail left by a dead process.
+        if !line.ends_with('\n') {
+            return Ok(None);
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str(&line)
+            .with_context(|| format!("Failed to parse event line in {}", path.display()))?;
+        return Ok(Some(event));
+    }
 }
 
 /// Remove only an unterminated final JSONL fragment left by a process or

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1591,6 +1591,18 @@ impl RuntimeThreadManager {
         Ok(record)
     }
 
+    #[cfg(test)]
+    pub(crate) async fn emit_event_for_test(
+        &self,
+        thread_id: &str,
+        turn_id: Option<&str>,
+        event: &str,
+        payload: Value,
+    ) -> Result<RuntimeEventRecord> {
+        self.emit_event(thread_id, turn_id, None, event, payload)
+            .await
+    }
+
     pub async fn create_thread(&self, req: CreateThreadRequest) -> Result<ThreadRecord> {
         let now = Utc::now();
         let (model_provider, model_provider_id, default_model) = {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -560,6 +560,14 @@ impl std::fmt::Display for RuntimeEventAppendError {
 
 impl std::error::Error for RuntimeEventAppendError {}
 
+fn event_append_is_indeterminate(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<RuntimeEventAppendError>()
+            .is_some_and(|append| !append.retry_safe())
+    })
+}
+
 #[derive(Debug, Clone)]
 pub struct RuntimeThreadStore {
     threads_dir: PathBuf,
@@ -1309,8 +1317,7 @@ pub struct RuntimeThreadManager {
     automations:
         Arc<parking_lot::Mutex<Option<crate::automation_manager::SharedAutomationManager>>>,
     pending_approvals: Arc<parking_lot::Mutex<HashMap<String, PendingApprovalEntry>>>,
-    pending_user_inputs:
-        Arc<parking_lot::Mutex<HashMap<(String, String), PendingUserInputRequest>>>,
+    pending_user_inputs: Arc<parking_lot::Mutex<HashMap<(String, String), PendingUserInputEntry>>>,
     pending_dynamic_tools: Arc<parking_lot::Mutex<HashMap<String, PendingDynamicToolEntry>>>,
     recovery_receipts: Arc<parking_lot::Mutex<HashMap<String, Vec<RecoveredTurnReceipt>>>>,
     recovery_flush: Arc<Mutex<()>>,
@@ -1368,6 +1375,31 @@ struct PendingApprovalEntry {
     thread_id: String,
     request: PendingApprovalRequest,
     sender: oneshot::Sender<ExternalApprovalDecision>,
+}
+
+struct PendingUserInputEntry {
+    request: PendingUserInputRequest,
+    /// A request remains snapshot-visible while its winner appends the
+    /// secret-free terminal receipt. This prevents a snapshot cursor from
+    /// observing neither the pending prompt nor its settlement event.
+    settling: bool,
+    settlement_tx: watch::Sender<u64>,
+    /// An append whose rollback failed may or may not be durable. Never send
+    /// the answer or allow a retry in that state: either could disclose or
+    /// duplicate a response whose receipt cannot be established safely.
+    indeterminate: bool,
+}
+
+enum PendingUserInputClaim {
+    Claimed(PendingUserInputRequest),
+    Settling,
+    Indeterminate,
+    Missing,
+}
+
+enum UserInputTerminalOutcome {
+    Answered(crate::tools::user_input::UserInputResponse),
+    Canceled { terminal: bool },
 }
 
 struct PendingDynamicToolEntry {
@@ -1655,19 +1687,129 @@ impl RuntimeThreadManager {
     }
 
     fn register_pending_user_input(&self, thread_id: &str, request: PendingUserInputRequest) {
-        self.pending_user_inputs
-            .lock()
-            .insert((thread_id.to_string(), request.id.clone()), request);
+        let (settlement_tx, _settlement_rx) = watch::channel(0);
+        self.pending_user_inputs.lock().insert(
+            (thread_id.to_string(), request.id.clone()),
+            PendingUserInputEntry {
+                request,
+                settling: false,
+                settlement_tx,
+                indeterminate: false,
+            },
+        );
     }
 
-    fn take_pending_user_input(
+    fn claim_pending_user_input(&self, thread_id: &str, input_id: &str) -> PendingUserInputClaim {
+        let mut pending = self.pending_user_inputs.lock();
+        let Some(entry) = pending.get_mut(&(thread_id.to_string(), input_id.to_string())) else {
+            return PendingUserInputClaim::Missing;
+        };
+        if entry.indeterminate {
+            return PendingUserInputClaim::Indeterminate;
+        }
+        if entry.settling {
+            return PendingUserInputClaim::Settling;
+        }
+        entry.settling = true;
+        PendingUserInputClaim::Claimed(entry.request.clone())
+    }
+
+    fn discard_pending_user_input_registration(&self, thread_id: &str, input_id: &str) {
+        let key = (thread_id.to_string(), input_id.to_string());
+        let mut pending = self.pending_user_inputs.lock();
+        if pending.get(&key).is_some_and(|entry| !entry.settling) {
+            pending.remove(&key);
+        }
+    }
+
+    fn claim_pending_user_inputs_for_turn(
         &self,
         thread_id: &str,
-        input_id: &str,
-    ) -> Option<PendingUserInputRequest> {
-        self.pending_user_inputs
+        turn_id: &str,
+    ) -> Result<(Vec<PendingUserInputRequest>, Vec<watch::Receiver<u64>>)> {
+        let mut pending = self.pending_user_inputs.lock();
+        if let Some((_, entry)) = pending.iter().find(|((pending_thread_id, _), entry)| {
+            pending_thread_id == thread_id
+                && entry.request.turn_id == turn_id
+                && entry.indeterminate
+        }) {
+            bail!(
+                "User-input request '{}' has an indeterminate terminal receipt; inspect Runtime storage before completing turn '{turn_id}'",
+                entry.request.id
+            );
+        }
+        let mut claims = Vec::new();
+        let mut settling = Vec::new();
+        for ((pending_thread_id, _), entry) in pending.iter_mut() {
+            if pending_thread_id != thread_id || entry.request.turn_id != turn_id {
+                continue;
+            }
+            if entry.settling {
+                settling.push(entry.settlement_tx.subscribe());
+                continue;
+            }
+            entry.settling = true;
+            claims.push(entry.request.clone());
+        }
+        Ok((claims, settling))
+    }
+
+    fn restore_pending_user_input_claim(&self, thread_id: &str, request: &PendingUserInputRequest) {
+        let settlement_tx = if let Some(entry) = self
+            .pending_user_inputs
             .lock()
-            .remove(&(thread_id.to_string(), input_id.to_string()))
+            .get_mut(&(thread_id.to_string(), request.id.clone()))
+            && entry.request.turn_id == request.turn_id
+        {
+            entry.settling = false;
+            entry.indeterminate = false;
+            Some(entry.settlement_tx.clone())
+        } else {
+            None
+        };
+        if let Some(settlement_tx) = settlement_tx {
+            settlement_tx.send_modify(|epoch| *epoch = epoch.saturating_add(1));
+        }
+    }
+
+    fn mark_pending_user_input_indeterminate(
+        &self,
+        thread_id: &str,
+        request: &PendingUserInputRequest,
+    ) {
+        let settlement_tx = if let Some(entry) = self
+            .pending_user_inputs
+            .lock()
+            .get_mut(&(thread_id.to_string(), request.id.clone()))
+            && entry.request.turn_id == request.turn_id
+        {
+            entry.settling = true;
+            entry.indeterminate = true;
+            Some(entry.settlement_tx.clone())
+        } else {
+            None
+        };
+        if let Some(settlement_tx) = settlement_tx {
+            settlement_tx.send_modify(|epoch| *epoch = epoch.saturating_add(1));
+        }
+    }
+
+    fn finish_pending_user_input_settlement(
+        &self,
+        thread_id: &str,
+        request: &PendingUserInputRequest,
+    ) -> Option<watch::Sender<u64>> {
+        let mut pending = self.pending_user_inputs.lock();
+        let key = (thread_id.to_string(), request.id.clone());
+        let settlement_tx = if pending.get(&key).is_some_and(|entry| {
+            entry.request.turn_id == request.turn_id && entry.settling && !entry.indeterminate
+        }) {
+            pending.remove(&key).map(|entry| entry.settlement_tx)
+        } else {
+            None
+        };
+        drop(pending);
+        settlement_tx
     }
 
     fn pending_requests_for_thread(
@@ -1692,7 +1834,7 @@ impl RuntimeThreadManager {
             .lock()
             .iter()
             .filter(|((pending_thread_id, _), _)| pending_thread_id == thread_id)
-            .map(|(_, request)| request.clone())
+            .map(|(_, entry)| entry.request.clone())
             .collect::<Vec<_>>();
         user_inputs.sort_by(|left, right| {
             left.turn_id
@@ -1700,24 +1842,6 @@ impl RuntimeThreadManager {
                 .then_with(|| left.id.cmp(&right.id))
         });
         (approvals, user_inputs)
-    }
-
-    fn clear_pending_user_inputs_for_turn(
-        &self,
-        thread_id: &str,
-        turn_id: &str,
-    ) -> Vec<PendingUserInputRequest> {
-        let mut pending = self.pending_user_inputs.lock();
-        let keys = pending
-            .iter()
-            .filter(|((pending_thread_id, _), request)| {
-                pending_thread_id == thread_id && request.turn_id == turn_id
-            })
-            .map(|(key, _)| key.clone())
-            .collect::<Vec<_>>();
-        keys.into_iter()
-            .filter_map(|key| pending.remove(&key))
-            .collect()
     }
 
     fn register_pending_dynamic_tool(
@@ -1933,18 +2057,35 @@ impl RuntimeThreadManager {
             };
             state.engine.clone()
         };
-        engine.submit_user_input(input_id, response).await?;
-        if let Some(pending) = self.take_pending_user_input(thread_id, input_id) {
-            self.emit_event(
-                thread_id,
-                Some(&pending.turn_id),
-                None,
-                "user_input.answered",
-                json!({ "id": input_id, "input_id": input_id }),
-            )
-            .await?;
-        }
-        Ok(true)
+        let request = match self.claim_pending_user_input(thread_id, input_id) {
+            PendingUserInputClaim::Claimed(request) => request,
+            PendingUserInputClaim::Missing | PendingUserInputClaim::Settling => {
+                return Ok(false);
+            }
+            PendingUserInputClaim::Indeterminate => {
+                bail!(
+                    "User-input request '{input_id}' has an indeterminate terminal receipt; inspect Runtime storage before retrying"
+                );
+            }
+        };
+
+        // This child task deliberately outlives the HTTP future. Once a
+        // request is claimed, client disconnect/cancellation cannot strand it
+        // between durable acceptance and engine delivery.
+        let manager = self.clone();
+        let thread_id = thread_id.to_string();
+        tokio::spawn(async move {
+            manager
+                .settle_claimed_user_input(
+                    &thread_id,
+                    Some(engine),
+                    request,
+                    UserInputTerminalOutcome::Answered(response),
+                )
+                .await
+        })
+        .await
+        .context("User-input settlement task failed")?
     }
 
     #[allow(dead_code)]
@@ -1956,18 +2097,118 @@ impl RuntimeThreadManager {
             };
             state.engine.clone()
         };
-        engine.cancel_user_input(input_id).await?;
-        if let Some(pending) = self.take_pending_user_input(thread_id, input_id) {
-            self.emit_event(
-                thread_id,
-                Some(&pending.turn_id),
-                None,
+        let request = match self.claim_pending_user_input(thread_id, input_id) {
+            PendingUserInputClaim::Claimed(request) => request,
+            PendingUserInputClaim::Missing | PendingUserInputClaim::Settling => {
+                return Ok(false);
+            }
+            PendingUserInputClaim::Indeterminate => {
+                bail!(
+                    "User-input request '{input_id}' has an indeterminate terminal receipt; inspect Runtime storage before retrying"
+                );
+            }
+        };
+        let manager = self.clone();
+        let thread_id = thread_id.to_string();
+        tokio::spawn(async move {
+            manager
+                .settle_claimed_user_input(
+                    &thread_id,
+                    Some(engine),
+                    request,
+                    UserInputTerminalOutcome::Canceled { terminal: false },
+                )
+                .await
+        })
+        .await
+        .context("User-input cancellation task failed")?
+    }
+
+    async fn settle_claimed_user_input(
+        &self,
+        thread_id: &str,
+        engine: Option<EngineHandle>,
+        request: PendingUserInputRequest,
+        outcome: UserInputTerminalOutcome,
+    ) -> Result<bool> {
+        let projection_lock = self.projection_lock(thread_id);
+        let _projection = projection_lock.lock().await;
+        let (event, payload) = match &outcome {
+            UserInputTerminalOutcome::Answered(_) => (
+                "user_input.answered",
+                json!({ "id": &request.id, "input_id": &request.id }),
+            ),
+            UserInputTerminalOutcome::Canceled { terminal } => (
                 "user_input.canceled",
-                json!({ "id": input_id, "input_id": input_id }),
-            )
-            .await?;
+                json!({
+                    "id": &request.id,
+                    "input_id": &request.id,
+                    "terminal": terminal,
+                }),
+            ),
+        };
+        if let Err(error) = self
+            .emit_event(thread_id, Some(&request.turn_id), None, event, payload)
+            .await
+        {
+            if event_append_is_indeterminate(&error) {
+                self.mark_pending_user_input_indeterminate(thread_id, &request);
+            } else {
+                self.restore_pending_user_input_claim(thread_id, &request);
+            }
+            return Err(error);
         }
+        let settlement_tx = self.finish_pending_user_input_settlement(thread_id, &request);
+        drop(_projection);
+
+        let delivery_result = match (engine, outcome) {
+            (Some(engine), UserInputTerminalOutcome::Answered(response)) => {
+                engine.submit_user_input(&request.id, response).await
+            }
+            (Some(engine), UserInputTerminalOutcome::Canceled { .. }) => {
+                if let Err(error) = engine.cancel_user_input(&request.id).await {
+                    tracing::debug!(
+                        thread_id,
+                        input_id = %request.id,
+                        "User-input cancellation was durable after engine mailbox closed: {error}"
+                    );
+                }
+                Ok(())
+            }
+            (None, _) => Ok(()),
+        };
+        if let Some(settlement_tx) = settlement_tx {
+            settlement_tx.send_modify(|epoch| *epoch = epoch.saturating_add(1));
+        }
+        delivery_result?;
         Ok(true)
+    }
+
+    async fn settle_user_inputs_for_terminal_turn(
+        &self,
+        thread_id: &str,
+        turn_id: &str,
+        engine: Option<EngineHandle>,
+    ) -> Result<()> {
+        loop {
+            let (requests, settling) =
+                self.claim_pending_user_inputs_for_turn(thread_id, turn_id)?;
+            for request in requests {
+                self.settle_claimed_user_input(
+                    thread_id,
+                    engine.clone(),
+                    request,
+                    UserInputTerminalOutcome::Canceled { terminal: true },
+                )
+                .await?;
+            }
+            if settling.is_empty() {
+                return Ok(());
+            }
+            for mut progress in settling {
+                let _ = progress.changed().await;
+            }
+        }
     }
 
     #[allow(dead_code)]
@@ -2186,6 +2427,15 @@ impl RuntimeThreadManager {
             // static restart-recovery receipts below. Startup recovery has no
             // live registry entries, so this is a no-op in that case.
             self.settle_dynamic_tools_for_terminal_turn(thread_id, &receipt.turn.id)
+                .await?;
+            let engine = {
+                let active = self.active.lock().await;
+                active
+                    .engines
+                    .get(thread_id)
+                    .map(|state| state.engine.clone())
+            };
+            self.settle_user_inputs_for_terminal_turn(thread_id, &receipt.turn.id, engine)
                 .await?;
 
             let projection_lock = self.projection_lock(thread_id);
@@ -3657,9 +3907,7 @@ impl RuntimeThreadManager {
         }
 
         // A failed turn can no longer answer an outstanding prompt. Mirror the
-        // happy terminal path: clear pending user inputs before publishing the
-        // terminal receipt so fresh snapshots never resurrect stale attention
-        // UI, and notify already-connected clients as well.
+        // happy terminal path's receipt-before-removal ordering.
         let engine_for_cancel = {
             let active = self.active.lock().await;
             active
@@ -3667,29 +3915,21 @@ impl RuntimeThreadManager {
                 .get(thread_id)
                 .map(|state| state.engine.clone())
         };
-        if let Some(engine) = engine_for_cancel {
-            for pending in self.clear_pending_user_inputs_for_turn(thread_id, turn_id) {
-                let _ = engine.cancel_user_input(&pending.id).await;
-                if let Err(err) = self
-                    .emit_event(
-                        thread_id,
-                        Some(turn_id),
-                        None,
-                        "user_input.canceled",
-                        json!({ "id": pending.id, "input_id": pending.id, "terminal": true }),
-                    )
-                    .await
-                {
-                    tracing::error!(
-                        "Failed to emit user-input cancellation after monitor failure: {err}"
-                    );
-                }
+        let user_inputs_settled = if let Err(err) = self
+            .settle_user_inputs_for_terminal_turn(thread_id, turn_id, engine_for_cancel)
+            .await
+        {
+            tracing::error!("Failed to emit user-input cancellation after monitor failure: {err}");
+            if let Some(turn) = terminal_turn.as_ref() {
+                self.queue_recovery_receipt(RecoveredTurnReceipt {
+                    turn: turn.clone(),
+                    unresolved_dynamic_tools: Vec::new(),
+                });
             }
+            false
         } else {
-            // The engine is already gone; still drop the registrations so
-            // snapshots stop advertising prompts nobody can answer.
-            let _ = self.clear_pending_user_inputs_for_turn(thread_id, turn_id);
-        }
+            true
+        };
 
         let dynamic_tools_settled = if let Err(err) = self
             .settle_dynamic_tools_for_terminal_turn(thread_id, turn_id)
@@ -3709,7 +3949,8 @@ impl RuntimeThreadManager {
             true
         };
 
-        if dynamic_tools_settled
+        if user_inputs_settled
+            && dynamic_tools_settled
             && let Some(turn) = terminal_turn.as_ref()
             && let Err(err) = self.emit_turn_completed_if_missing(turn, false).await
         {
@@ -5585,7 +5826,7 @@ impl RuntimeThreadManager {
                         )
                         .await
                     {
-                        self.take_pending_user_input(&thread_id, &id);
+                        self.discard_pending_user_input_registration(&thread_id, &id);
                         let _ = engine.cancel_user_input(&id).await;
                         return Err(err);
                     }
@@ -5795,20 +6036,11 @@ impl RuntimeThreadManager {
             self.store.save_thread(&thread)?;
         }
 
-        // A terminal turn can no longer answer an outstanding prompt. Clear
-        // it before publishing completion so fresh snapshots never resurrect
-        // stale attention UI, and notify already-connected clients as well.
-        for pending in self.clear_pending_user_inputs_for_turn(&thread_id, &turn_id) {
-            let _ = engine.cancel_user_input(&pending.id).await;
-            self.emit_event(
-                &thread_id,
-                Some(&turn_id),
-                None,
-                "user_input.canceled",
-                json!({ "id": pending.id, "input_id": pending.id, "terminal": true }),
-            )
+        // A terminal turn can no longer answer an outstanding prompt. Commit
+        // each cancellation while the request remains snapshot-authoritative,
+        // then remove and notify the engine before publishing completion.
+        self.settle_user_inputs_for_terminal_turn(&thread_id, &turn_id, Some(engine.clone()))
             .await?;
-        }
 
         self.settle_dynamic_tools_for_terminal_turn(&thread_id, &turn_id)
             .await?;

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -919,6 +919,10 @@ impl RuntimeThreadStore {
             .with_context(|| format!("Failed to inspect {}", path.display()))?
             .len();
         let mut line = serde_json::to_vec(&record)?;
+        // The trailing newline is the JSONL transaction's commit marker. A
+        // crash after all JSON bytes reach the file but before this delimiter
+        // is written leaves a parseable yet uncommitted tail; startup removes
+        // that tail and deliberately does not reuse its reserved sequence.
         line.push(b'\n');
         let append_result = (|| -> std::io::Result<()> {
             file.write_all(&line)?;
@@ -1444,7 +1448,8 @@ struct RecoveredTurnReceipt {
 ///   order and is only acquired after all record/engine guards are released.
 /// - `RuntimeThreadManager::projection_locks` — one async lock per thread,
 ///   held while a streamed item checkpoint and its event are published or
-///   while a snapshot captures its cursor and reads projections.
+///   while a terminal turn projection, receipt, and active-claim cleanup are
+///   published, or while a snapshot captures its cursor and reads projections.
 /// - `RuntimeThreadManager::recovery_flush` — serializes deferred receipt
 ///   reconciliation before it acquires a projection lock and `event_emit`.
 /// - `RuntimeThreadStore::state` — protects the monotonic event sequence counter.
@@ -2504,12 +2509,16 @@ impl RuntimeThreadManager {
         recovered: bool,
     ) -> Result<bool> {
         let _emit_order = self.event_emit.lock().await;
-        if self.store.contains_event(
-            &turn.thread_id,
-            &RuntimeEventMatch::TurnCompleted {
-                turn_id: turn.id.clone(),
-            },
-        )? {
+        let store = self.store.clone();
+        let thread_id = turn.thread_id.clone();
+        let expected = RuntimeEventMatch::TurnCompleted {
+            turn_id: turn.id.clone(),
+        };
+        let already_emitted =
+            tokio::task::spawn_blocking(move || store.contains_event(&thread_id, &expected))
+                .await
+                .context("Runtime turn-completion dedupe scan failed")??;
+        if already_emitted {
             return Ok(false);
         }
         let mut payload = json!({ "turn": turn });
@@ -2532,13 +2541,17 @@ impl RuntimeThreadManager {
         params: &DynamicToolCallParams,
     ) -> Result<bool> {
         let _emit_order = self.event_emit.lock().await;
-        if self.store.contains_event(
-            &params.thread_id,
-            &RuntimeEventMatch::DynamicTerminal {
-                turn_id: params.turn_id.clone(),
-                call_id: params.call_id.clone(),
-            },
-        )? {
+        let store = self.store.clone();
+        let thread_id = params.thread_id.clone();
+        let expected = RuntimeEventMatch::DynamicTerminal {
+            turn_id: params.turn_id.clone(),
+            call_id: params.call_id.clone(),
+        };
+        let already_emitted =
+            tokio::task::spawn_blocking(move || store.contains_event(&thread_id, &expected))
+                .await
+                .context("Runtime dynamic-tool terminal dedupe scan failed")??;
+        if already_emitted {
             return Ok(false);
         }
         let mut payload =
@@ -4021,25 +4034,19 @@ impl RuntimeThreadManager {
             let _turn_mutation = self.store.turn_mutation.lock();
             match self.store.load_turn(turn_id) {
                 Ok(mut turn) => {
-                    let mut persisted = true;
                     if turn.status == RuntimeTurnStatus::InProgress {
                         turn.status = RuntimeTurnStatus::Failed;
                         turn.ended_at = Some(now);
                         turn.duration_ms = turn.started_at.map(|start| duration_ms(start, now));
                         turn.error = Some(reason.to_string());
-                        if let Err(err) = self.store.save_turn(&turn) {
-                            tracing::error!("Failed to persist terminal monitor failure: {err}");
-                            persisted = false;
-                        }
                     }
-                    (persisted
-                        && matches!(
-                            turn.status,
-                            RuntimeTurnStatus::Completed
-                                | RuntimeTurnStatus::Failed
-                                | RuntimeTurnStatus::Interrupted
-                                | RuntimeTurnStatus::Canceled
-                        ))
+                    matches!(
+                        turn.status,
+                        RuntimeTurnStatus::Completed
+                            | RuntimeTurnStatus::Failed
+                            | RuntimeTurnStatus::Interrupted
+                            | RuntimeTurnStatus::Canceled
+                    )
                     .then_some(turn)
                 }
                 Err(err) => {
@@ -4078,12 +4085,6 @@ impl RuntimeThreadManager {
             .await
         {
             tracing::error!("Failed to emit user-input cancellation after monitor failure: {err}");
-            if let Some(turn) = terminal_turn.as_ref() {
-                self.queue_recovery_receipt(RecoveredTurnReceipt {
-                    turn: turn.clone(),
-                    unresolved_dynamic_tools: Vec::new(),
-                });
-            }
             false
         } else {
             true
@@ -4096,27 +4097,42 @@ impl RuntimeThreadManager {
             tracing::error!(
                 "Failed to emit dynamic-tool cancellation after monitor failure: {err}"
             );
-            if let Some(turn) = terminal_turn.as_ref() {
-                self.queue_recovery_receipt(RecoveredTurnReceipt {
-                    turn: turn.clone(),
-                    unresolved_dynamic_tools: Vec::new(),
-                });
-            }
             false
         } else {
             true
         };
 
-        if user_inputs_settled
-            && dynamic_tools_settled
-            && let Some(turn) = terminal_turn.as_ref()
-            && let Err(err) = self.emit_turn_completed_if_missing(turn, false).await
-        {
-            tracing::error!("Failed to emit terminal monitor failure: {err}");
-            self.queue_recovery_receipt(RecoveredTurnReceipt {
-                turn: turn.clone(),
-                unresolved_dynamic_tools: Vec::new(),
-            });
+        // A terminal record is the externally visible lifecycle boundary.
+        // Keep snapshots outside that boundary until its terminal receipt and
+        // active-claim cleanup are also ordered. The dedupe scan may yield to
+        // a blocking worker while this projection guard remains held.
+        let projection_lock = self.projection_lock(thread_id);
+        let _projection = projection_lock.lock().await;
+        let terminal_turn = terminal_turn.and_then(|turn| {
+            let _turn_mutation = self.store.turn_mutation.lock();
+            match self.store.save_turn(&turn) {
+                Ok(()) => Some(turn),
+                Err(err) => {
+                    tracing::error!("Failed to persist terminal monitor failure: {err}");
+                    None
+                }
+            }
+        });
+        if let Some(turn) = terminal_turn.as_ref() {
+            if user_inputs_settled && dynamic_tools_settled {
+                if let Err(err) = self.emit_turn_completed_if_missing(turn, false).await {
+                    tracing::error!("Failed to emit terminal monitor failure: {err}");
+                    self.queue_recovery_receipt(RecoveredTurnReceipt {
+                        turn: turn.clone(),
+                        unresolved_dynamic_tools: Vec::new(),
+                    });
+                }
+            } else {
+                self.queue_recovery_receipt(RecoveredTurnReceipt {
+                    turn: turn.clone(),
+                    unresolved_dynamic_tools: Vec::new(),
+                });
+            }
         }
 
         // Keep the failed claim in place until its terminal receipts are
@@ -4137,6 +4153,7 @@ impl RuntimeThreadManager {
             }
         };
         if let Some(engine) = evicted_engine {
+            drop(_projection);
             engine.cancel_with_reason(crate::core::engine::CancelReason::Internal);
             let _ = engine.try_send(Op::Shutdown);
         }
@@ -6225,17 +6242,8 @@ impl RuntimeThreadManager {
                 })
                 .map(str::to_string);
             turn.error = turn_error;
-            self.store.save_turn(&turn)?;
             turn
         };
-
-        {
-            let _thread_mutation = self.store.thread_mutation.lock();
-            let mut thread = self.store.load_thread(&thread_id)?;
-            thread.latest_turn_id = Some(turn_id.clone());
-            thread.updated_at = Utc::now();
-            self.store.save_thread(&thread)?;
-        }
 
         // A terminal turn can no longer answer an outstanding prompt. Commit
         // each cancellation while the request remains snapshot-authoritative,
@@ -6246,6 +6254,23 @@ impl RuntimeThreadManager {
         self.settle_dynamic_tools_for_terminal_turn(&thread_id, &turn_id)
             .await?;
 
+        // Publish the terminal projection as one snapshot boundary. The
+        // duplicate scan is offloaded while this guard is held, so public
+        // readers cannot observe a terminal record before its receipt and
+        // active-claim cleanup are ordered.
+        let projection_lock = self.projection_lock(&thread_id);
+        let _projection = projection_lock.lock().await;
+        {
+            let _turn_mutation = self.store.turn_mutation.lock();
+            self.store.save_turn(&turn)?;
+        }
+        {
+            let _thread_mutation = self.store.thread_mutation.lock();
+            let mut thread = self.store.load_thread(&thread_id)?;
+            thread.latest_turn_id = Some(turn_id.clone());
+            thread.updated_at = Utc::now();
+            self.store.save_thread(&thread)?;
+        }
         self.emit_turn_completed_if_missing(&turn, false).await?;
 
         {
@@ -6978,9 +7003,11 @@ fn read_complete_event(
 }
 
 /// Remove only an unterminated final JSONL fragment left by a process or
-/// machine stopping in the middle of `write_all`. A newline-terminated bad
-/// record is not crash debris we can identify safely, so normal replay keeps
-/// rejecting it instead of silently discarding durable data.
+/// machine stopping before the append's newline commit marker. This includes
+/// an otherwise valid JSON object whose delimiter never reached disk: without
+/// the newline, the append did not commit. A newline-terminated bad record is
+/// not crash debris we can identify safely, so normal replay keeps rejecting
+/// it instead of silently discarding durable data.
 fn repair_torn_event_log_tails(events_dir: &Path) -> Result<()> {
     let events_dir = checked_existing_runtime_store_dir(events_dir)?;
     for entry in fs::read_dir(&events_dir)

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -58,6 +58,30 @@ fn test_dynamic_tool_timeout_ms(ms: u64) -> DynamicToolTimeoutGuard {
     }
 }
 
+struct EventAppendFaultGuard {
+    restore: Option<EventAppendTestFaultRestore>,
+}
+
+impl EventAppendFaultGuard {
+    fn arm(thread_id: &str, fault: EventAppendTestFault) -> Self {
+        Self::arm_repeated(thread_id, fault, 1)
+    }
+
+    fn arm_repeated(thread_id: &str, fault: EventAppendTestFault, count: usize) -> Self {
+        Self {
+            restore: Some(set_test_event_append_fault(thread_id, fault, count)),
+        }
+    }
+}
+
+impl Drop for EventAppendFaultGuard {
+    fn drop(&mut self) {
+        if let Some(restore) = self.restore.take() {
+            restore_test_event_append_fault(restore);
+        }
+    }
+}
+
 fn sample_thread(thread_id: &str) -> ThreadRecord {
     let now = Utc::now();
     ThreadRecord {
@@ -3647,6 +3671,73 @@ async fn thread_detail_cursor_precedes_projection_reads_at_terminal_boundary() -
 }
 
 #[tokio::test]
+async fn thread_detail_does_not_reenter_recovery_while_projection_is_locked() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let turn_id = "turn_recovery_queued_during_snapshot";
+    let mut turn = sample_turn(&thread.id, turn_id, RuntimeTurnStatus::Completed);
+    turn.ended_at = Some(Utc::now());
+    turn.duration_ms = Some(1);
+    manager.store.save_turn(&turn)?;
+    {
+        let _thread_mutation = manager.store.thread_mutation.lock();
+        let mut persisted_thread = manager.store.load_thread(&thread.id)?;
+        persisted_thread.latest_turn_id = Some(turn_id.to_string());
+        manager.store.save_thread(&persisted_thread)?;
+    }
+
+    let (hook_tx, mut hook_rx) = mpsc::unbounded_channel();
+    manager.set_snapshot_test_hook(hook_tx);
+    let snapshot_manager = manager.clone();
+    let snapshot_thread_id = thread.id.clone();
+    let snapshot_task = tokio::spawn(async move {
+        snapshot_manager
+            .get_thread_detail(&snapshot_thread_id)
+            .await
+    });
+    let point = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("snapshot did not acquire its projection boundary")?
+        .context("snapshot test hook closed")?;
+
+    // Queue after get_thread_detail's initial recovery flush, while its
+    // projection lock is held. A nested get_thread call would see this receipt
+    // and deadlock trying to reacquire that same lock.
+    manager.queue_recovery_receipt(RecoveredTurnReceipt {
+        turn: turn.clone(),
+        unresolved_dynamic_tools: Vec::new(),
+    });
+    point
+        .resume
+        .send(())
+        .map_err(|_| anyhow!("snapshot dropped its resume barrier"))?;
+    let detail = tokio::time::timeout(Duration::from_secs(2), snapshot_task)
+        .await
+        .context("snapshot re-entered recovery while holding its projection lock")?
+        .context("snapshot task panicked")??;
+    assert_eq!(detail.thread.id, thread.id);
+    assert_eq!(detail.latest_seq, point.latest_seq);
+    assert!(manager.recovery_receipts.lock().contains_key(&thread.id));
+
+    // The next top-level observation flushes the receipt after the prior
+    // snapshot has released its projection boundary.
+    manager.get_thread(&thread.id).await?;
+    let completed = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .filter(|event| {
+            event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].payload["recovered"], true);
+    assert!(!manager.recovery_receipts.lock().contains_key(&thread.id));
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_detail_materializes_stream_prefixes_before_their_delta_cursor() -> Result<()> {
     let manager = test_manager(test_runtime_dir())?;
     let thread = manager
@@ -3752,6 +3843,144 @@ async fn thread_detail_materializes_stream_prefixes_before_their_delta_cursor() 
             .iter()
             .all(|event| event.event != "item.delta"),
         "the snapshot itself must carry every delta at or before latest_seq"
+    );
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Interrupted,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_detail_delta_boundary_is_replay_idempotent() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "pause a snapshot across streamed deltas".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "delta_boundary".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::MessageStarted { index: 0 })
+        .await?;
+
+    let started = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = manager
+                .events_since(&thread.id, None)?
+                .into_iter()
+                .find(|event| {
+                    event.turn_id.as_deref() == Some(&turn.id)
+                        && event.event == "item.started"
+                        && event.payload.pointer("/item/kind").and_then(Value::as_str)
+                            == Some("agent_message")
+                })
+            {
+                break Ok::<_, anyhow::Error>(event);
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("message item did not start")??;
+    let item_id = started.item_id.context("started event omitted item id")?;
+
+    let (hook_tx, mut hook_rx) = mpsc::unbounded_channel();
+    manager.set_snapshot_test_hook(hook_tx);
+    let snapshot_manager = manager.clone();
+    let snapshot_thread_id = thread.id.clone();
+    let snapshot_task = tokio::spawn(async move {
+        snapshot_manager
+            .get_thread_detail(&snapshot_thread_id)
+            .await
+    });
+    let point = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("snapshot did not capture its replay cursor")?
+        .context("snapshot test hook closed")?;
+    assert!(point.latest_seq >= started.seq);
+
+    for content in ["A", "B"] {
+        harness
+            .tx_event
+            .send(EngineEvent::MessageDelta {
+                index: 0,
+                content: content.to_string(),
+            })
+            .await?;
+    }
+    sleep(STREAM_DELTA_BATCH_MAX_LATENCY + Duration::from_millis(50)).await;
+    assert!(
+        manager
+            .events_since(&thread.id, Some(point.latest_seq))?
+            .iter()
+            .all(|event| event.event != "item.delta"),
+        "a delta must not publish while the snapshot holds its projection boundary"
+    );
+
+    point
+        .resume
+        .send(())
+        .map_err(|_| anyhow!("snapshot dropped its resume barrier"))?;
+    let detail = snapshot_task.await.context("snapshot task panicked")??;
+    let snapshotted = detail
+        .items
+        .iter()
+        .find(|item| item.id == item_id)
+        .context("snapshot omitted the streaming item")?;
+    assert_eq!(snapshotted.detail.as_deref(), Some(""));
+
+    let delta = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = manager
+                .events_since(&thread.id, Some(detail.latest_seq))?
+                .into_iter()
+                .find(|event| {
+                    event.item_id.as_deref() == Some(&item_id) && event.event == "item.delta"
+                })
+            {
+                break Ok::<_, anyhow::Error>(event);
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("batched delta did not publish after snapshot release")??;
+    assert_eq!(
+        delta.payload.get("delta").and_then(Value::as_str),
+        Some("AB")
+    );
+    assert_eq!(
+        manager.store.load_item(&item_id)?.detail.as_deref(),
+        Some("AB")
     );
 
     harness
@@ -4021,6 +4250,774 @@ async fn dynamic_tool_result_settles_snapshot_and_emits_one_safe_resolution() ->
             base_url: None,
         })
         .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dynamic_tool_result_receipt_outlives_canceled_delivery_future() -> Result<()> {
+    use crate::tools::spec::DynamicToolExecutor;
+
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "settle a result after its HTTP future disappears".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "dynamic_detached_settlement".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+
+    const RESULT_SECRET: &str = "detached-dynamic-result-secret";
+    let executor = manager.clone();
+    let executor_thread_id = thread.id.clone();
+    let execution = tokio::spawn(async move {
+        DynamicToolExecutor::execute_dynamic_tool(
+            &executor,
+            Some(executor_thread_id),
+            Some("bench".to_string()),
+            "detached_lookup".to_string(),
+            json!({ "record_id": "record-detached" }),
+        )
+        .await
+    });
+
+    let call = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(call) = manager
+                .get_thread_detail(&thread.id)
+                .await?
+                .pending_dynamic_tool_calls
+                .first()
+                .cloned()
+            {
+                break Ok::<_, anyhow::Error>(call);
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("dynamic tool call did not become pending")??;
+
+    // Stall terminal publication, submit the result, and wait until that path
+    // owns the call. Canceling the API future from this point must not cancel
+    // its detached receipt task or wake the model before the receipt is durable.
+    let emit_guard = manager.event_emit.lock().await;
+    let delivery_manager = manager.clone();
+    let delivery_thread_id = thread.id.clone();
+    let delivery_turn_id = turn.id.clone();
+    let delivery_call_id = call.call_id.clone();
+    let delivery = tokio::spawn(async move {
+        delivery_manager
+            .deliver_dynamic_tool_result(
+                &delivery_thread_id,
+                &delivery_turn_id,
+                &delivery_call_id,
+                DynamicToolCallResult {
+                    success: true,
+                    content: vec![DynamicToolCallContent::InputText {
+                        text: RESULT_SECRET.to_string(),
+                    }],
+                },
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let settling = manager
+                .pending_dynamic_tools
+                .lock()
+                .get(&call.call_id)
+                .is_some_and(|entry| entry.sender.is_none());
+            if settling {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("result delivery never claimed the pending call")?;
+    assert!(
+        !execution.is_finished(),
+        "the model consumed the result before its terminal receipt could commit"
+    );
+    assert!(
+        !manager
+            .deliver_dynamic_tool_result(
+                &thread.id,
+                &turn.id,
+                &call.call_id,
+                DynamicToolCallResult {
+                    success: false,
+                    content: Vec::new(),
+                },
+            )
+            .await?,
+        "a duplicate result stole a call whose terminal receipt was settling"
+    );
+    delivery.abort();
+    assert!(
+        delivery
+            .await
+            .expect_err("delivery API future must be canceled")
+            .is_cancelled()
+    );
+    assert!(
+        !execution.is_finished(),
+        "canceling the delivery future woke the model without a receipt"
+    );
+
+    drop(emit_guard);
+    let model_result = tokio::time::timeout(Duration::from_secs(2), execution)
+        .await
+        .context("model did not receive the result after terminal publication")?
+        .context("dynamic tool task panicked")??;
+    assert_eq!(model_result.content, RESULT_SECRET);
+
+    let detail = manager.get_thread_detail(&thread.id).await?;
+    assert!(detail.pending_dynamic_tool_calls.is_empty());
+    let terminal = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .filter(|event| {
+            matches!(
+                event.event.as_str(),
+                "tool_call.resolved" | "tool_call.timeout" | "tool_call.canceled"
+            ) && event.payload.get("call_id").and_then(Value::as_str) == Some(call.call_id.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(terminal.len(), 1);
+    assert_eq!(terminal[0].event, "tool_call.resolved");
+    assert_eq!(terminal[0].payload["success"], true);
+    assert!(
+        !serde_json::to_string(&terminal)?.contains(RESULT_SECRET),
+        "the terminal receipt exposed result content"
+    );
+    assert!(
+        !manager
+            .deliver_dynamic_tool_result(
+                &thread.id,
+                &turn.id,
+                &call.call_id,
+                DynamicToolCallResult {
+                    success: true,
+                    content: Vec::new(),
+                },
+            )
+            .await?,
+        "a duplicate retry settled an already terminal call"
+    );
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dynamic_tool_result_acceptance_survives_receiver_close_before_append() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let receiver = manager.register_pending_dynamic_tool_for_test(
+        &thread.id,
+        "turn_closed_receiver",
+        "call_closed_receiver",
+    )?;
+    let emit_guard = manager.event_emit.lock().await;
+    let delivery_manager = manager.clone();
+    let delivery_thread_id = thread.id.clone();
+    let delivery = tokio::spawn(async move {
+        delivery_manager
+            .deliver_dynamic_tool_result(
+                &delivery_thread_id,
+                "turn_closed_receiver",
+                "call_closed_receiver",
+                DynamicToolCallResult {
+                    success: true,
+                    content: vec![DynamicToolCallContent::InputText {
+                        text: "closed-receiver-secret".to_string(),
+                    }],
+                },
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if manager
+                .pending_dynamic_tools
+                .lock()
+                .get("call_closed_receiver")
+                .is_some_and(|entry| entry.sender.is_none())
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("result did not claim the call before append")?;
+    drop(receiver);
+    drop(emit_guard);
+
+    assert!(
+        delivery.await.context("delivery task panicked")??,
+        "durably accepted result was reported as missing after receiver close"
+    );
+    assert!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_dynamic_tool_calls
+            .is_empty()
+    );
+    let terminal = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .filter(|event| {
+            event.payload.get("call_id").and_then(Value::as_str) == Some("call_closed_receiver")
+                && matches!(
+                    event.event.as_str(),
+                    "tool_call.resolved" | "tool_call.timeout" | "tool_call.canceled"
+                )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(terminal.len(), 1);
+    assert_eq!(terminal[0].event, "tool_call.resolved");
+    assert_eq!(terminal[0].payload["result_accepted"], true);
+    assert!(
+        !serde_json::to_string(&terminal)?.contains("closed-receiver-secret"),
+        "closed-receiver acceptance exposed result content"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn dynamic_tool_receipt_append_failure_rolls_back_for_retry() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut receiver = manager.register_pending_dynamic_tool_for_test(
+        &thread.id,
+        "turn_retry_after_append_failure",
+        "call_retry_after_append_failure",
+    )?;
+    let claim = match manager.claim_pending_dynamic_tool(
+        &thread.id,
+        "turn_retry_after_append_failure",
+        "call_retry_after_append_failure",
+    ) {
+        PendingDynamicToolClaim::Claimed(claim) => claim,
+        PendingDynamicToolClaim::Settling(_)
+        | PendingDynamicToolClaim::Indeterminate
+        | PendingDynamicToolClaim::Missing => {
+            bail!("failed to claim the append-failure fixture")
+        }
+    };
+
+    // Replace this throwaway thread's event log with a symlink. Runtime store
+    // hardening rejects the append deterministically, exercising settlement
+    // rollback without relying on platform permission behavior.
+    let events_path = manager.store.events_path(&thread.id)?;
+    let backup_path = events_path.with_extension("jsonl.append-failure-backup");
+    std::fs::rename(&events_path, &backup_path)?;
+    std::os::unix::fs::symlink(&backup_path, &events_path)?;
+    let ack = manager.spawn_dynamic_tool_settlement(
+        claim,
+        DynamicToolTerminalOutcome::Resolved(DynamicToolCallResult {
+            success: true,
+            content: vec![DynamicToolCallContent::InputText {
+                text: "discarded-before-retry".to_string(),
+            }],
+        }),
+    );
+    let failed = RuntimeThreadManager::await_dynamic_tool_settlement(ack).await;
+    std::fs::remove_file(&events_path)?;
+    std::fs::rename(&backup_path, &events_path)?;
+    assert!(
+        failed.is_err(),
+        "symlinked event append unexpectedly succeeded"
+    );
+
+    {
+        let pending = manager.pending_dynamic_tools.lock();
+        let entry = pending
+            .get("call_retry_after_append_failure")
+            .context("failed receipt append stranded or removed the pending call")?;
+        assert!(
+            entry
+                .sender
+                .as_ref()
+                .is_some_and(|sender| !sender.is_closed()),
+            "failed receipt append left a Settling entry without its sender"
+        );
+    }
+    assert_eq!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_dynamic_tool_calls
+            .len(),
+        1,
+        "rollback removed the snapshot-authoritative pending request"
+    );
+
+    assert!(
+        manager
+            .deliver_dynamic_tool_result(
+                &thread.id,
+                "turn_retry_after_append_failure",
+                "call_retry_after_append_failure",
+                DynamicToolCallResult {
+                    success: true,
+                    content: vec![DynamicToolCallContent::InputText {
+                        text: "retry-result".to_string(),
+                    }],
+                },
+            )
+            .await?,
+        "retry did not settle the restored call"
+    );
+    let delivered = tokio::time::timeout(Duration::from_secs(2), &mut receiver)
+        .await
+        .context("restored receiver was not woken by retry")??;
+    assert_eq!(
+        delivered.content,
+        vec![DynamicToolCallContent::InputText {
+            text: "retry-result".to_string(),
+        }]
+    );
+    let resolved = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .filter(|event| {
+            event.event == "tool_call.resolved"
+                && event.payload.get("call_id").and_then(Value::as_str)
+                    == Some("call_retry_after_append_failure")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(resolved.len(), 1);
+    assert!(
+        !serde_json::to_string(&resolved)?.contains("retry-result"),
+        "retried terminal receipt exposed result content"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn dynamic_tool_post_write_failures_rollback_without_duplicate_receipts() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+
+    for (index, fault) in [
+        EventAppendTestFault::AfterFlush,
+        EventAppendTestFault::AfterSync,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let turn_id = format!("turn_post_write_{index}");
+        let call_id = format!("call_post_write_{index}");
+        let result_text = format!("post-write-result-{index}");
+        let mut receiver =
+            manager.register_pending_dynamic_tool_for_test(&thread.id, &turn_id, &call_id)?;
+        let fault_guard = EventAppendFaultGuard::arm(&thread.id, fault);
+        let error = manager
+            .deliver_dynamic_tool_result(
+                &thread.id,
+                &turn_id,
+                &call_id,
+                DynamicToolCallResult {
+                    success: true,
+                    content: vec![DynamicToolCallContent::InputText {
+                        text: result_text.clone(),
+                    }],
+                },
+            )
+            .await
+            .expect_err("injected post-write failure unexpectedly settled");
+        drop(fault_guard);
+        assert!(
+            error.to_string().contains("rolled back"),
+            "post-write failure was not classified retry-safe: {error}"
+        );
+
+        let failed_snapshot = manager.get_thread_detail(&thread.id).await?;
+        assert!(
+            failed_snapshot
+                .pending_dynamic_tool_calls
+                .iter()
+                .any(|call| call.call_id == call_id),
+            "rolled-back call disappeared from the canonical snapshot"
+        );
+        assert!(
+            manager
+                .events_since(&thread.id, Some(failed_snapshot.latest_seq))?
+                .is_empty(),
+            "failed append left a replay-visible terminal suffix"
+        );
+        assert!(
+            manager.events_since(&thread.id, None)?.iter().all(|event| {
+                event.payload.get("call_id").and_then(Value::as_str) != Some(call_id.as_str())
+            }),
+            "failed append left a visible terminal record before retry"
+        );
+
+        assert!(
+            manager
+                .deliver_dynamic_tool_result(
+                    &thread.id,
+                    &turn_id,
+                    &call_id,
+                    DynamicToolCallResult {
+                        success: true,
+                        content: vec![DynamicToolCallContent::InputText {
+                            text: result_text.clone(),
+                        }],
+                    },
+                )
+                .await?,
+            "retry did not durably accept the rolled-back result"
+        );
+        let delivered = tokio::time::timeout(Duration::from_secs(2), &mut receiver)
+            .await
+            .context("retried result did not reach its model receiver")??;
+        assert_eq!(
+            delivered.content,
+            vec![DynamicToolCallContent::InputText {
+                text: result_text.clone(),
+            }]
+        );
+
+        let replay = manager.events_since(&thread.id, Some(failed_snapshot.latest_seq))?;
+        let terminal = replay
+            .iter()
+            .filter(|event| {
+                event.event == "tool_call.resolved"
+                    && event.payload.get("call_id").and_then(Value::as_str)
+                        == Some(call_id.as_str())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(terminal.len(), 1);
+        assert!(terminal[0].seq > failed_snapshot.latest_seq);
+        assert_eq!(terminal[0].payload["result_accepted"], true);
+        assert!(
+            !serde_json::to_string(&terminal)?.contains(&result_text),
+            "retried terminal receipt exposed result content"
+        );
+        let settled_snapshot = manager.get_thread_detail(&thread.id).await?;
+        assert!(
+            settled_snapshot
+                .pending_dynamic_tool_calls
+                .iter()
+                .all(|call| call.call_id != call_id)
+        );
+        assert!(settled_snapshot.latest_seq >= terminal[0].seq);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn restart_recovers_terminal_turn_after_dynamic_receipt_append_failure() -> Result<()> {
+    let data_dir = test_runtime_dir();
+    let manager = test_manager(data_dir.clone())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let turn_id = "turn_terminal_recovery";
+    let call_id = "call_terminal_recovery";
+    let mut turn = sample_turn(&thread.id, turn_id, RuntimeTurnStatus::Completed);
+    turn.ended_at = Some(Utc::now());
+    turn.duration_ms = Some(1);
+    manager.store.save_turn(&turn)?;
+    {
+        let _thread_mutation = manager.store.thread_mutation.lock();
+        let mut persisted_thread = manager.store.load_thread(&thread.id)?;
+        persisted_thread.latest_turn_id = Some(turn_id.to_string());
+        manager.store.save_thread(&persisted_thread)?;
+    }
+    let params = DynamicToolCallParams {
+        thread_id: thread.id.clone(),
+        turn_id: turn_id.to_string(),
+        call_id: call_id.to_string(),
+        namespace: Some("recovery".to_string()),
+        tool: "recover_lookup".to_string(),
+        arguments: json!({ "record": "recovery-only" }),
+    };
+    manager
+        .emit_event_for_test(
+            &thread.id,
+            Some(turn_id),
+            "tool_call.requested",
+            json!(&params),
+        )
+        .await?;
+    let receiver = manager.register_pending_dynamic_tool(params)?;
+
+    let fault_guard = EventAppendFaultGuard::arm(&thread.id, EventAppendTestFault::AfterSync);
+    let error = manager
+        .deliver_dynamic_tool_result(
+            &thread.id,
+            turn_id,
+            call_id,
+            DynamicToolCallResult {
+                success: true,
+                content: vec![DynamicToolCallContent::InputText {
+                    text: "never-committed-result".to_string(),
+                }],
+            },
+        )
+        .await
+        .expect_err("injected terminal receipt append unexpectedly succeeded");
+    drop(fault_guard);
+    assert!(error.to_string().contains("rolled back"));
+    assert!(manager.events_since(&thread.id, None)?.iter().all(|event| {
+        event.event != "turn.completed"
+            && !matches!(
+                event.event.as_str(),
+                "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
+            )
+    }));
+    drop(receiver);
+    drop(manager);
+
+    let recovered = test_manager(data_dir.clone())?;
+    // Opening is synchronous; the first async observation flushes queued
+    // recovery receipts in terminal-call-before-turn order.
+    let recovered_turn = recovered.get_thread(&thread.id).await?;
+    assert_eq!(recovered_turn.latest_turn_id.as_deref(), Some(turn_id));
+    let events = recovered.events_since(&thread.id, None)?;
+    let canceled = events
+        .iter()
+        .filter(|event| {
+            event.event == "tool_call.canceled"
+                && event.payload.get("call_id").and_then(Value::as_str) == Some(call_id)
+        })
+        .collect::<Vec<_>>();
+    let completed = events
+        .iter()
+        .filter(|event| {
+            event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(canceled.len(), 1);
+    assert_eq!(canceled[0].payload["reason"], "process_restart");
+    assert_eq!(canceled[0].payload["recovered"], true);
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].payload["recovered"], true);
+    assert!(canceled[0].seq < completed[0].seq);
+    assert_eq!(
+        completed[0]
+            .payload
+            .pointer("/turn/status")
+            .and_then(Value::as_str),
+        Some("completed")
+    );
+
+    // Re-observation and a second manager restart both remain idempotent.
+    recovered.get_thread(&thread.id).await?;
+    assert_eq!(
+        recovered
+            .events_since(&thread.id, None)?
+            .iter()
+            .filter(|event| {
+                event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+            })
+            .count(),
+        1
+    );
+    drop(recovered);
+    let reopened = test_manager(data_dir)?;
+    reopened.get_thread(&thread.id).await?;
+    let reopened_events = reopened.events_since(&thread.id, None)?;
+    assert_eq!(
+        reopened_events
+            .iter()
+            .filter(|event| {
+                event.event == "tool_call.canceled"
+                    && event.payload.get("call_id").and_then(Value::as_str) == Some(call_id)
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        reopened_events
+            .iter()
+            .filter(|event| {
+                event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+            })
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn consecutive_dynamic_receipt_failures_queue_in_process_recovery() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let turn_id = "turn_consecutive_receipt_failures";
+    let call_id = "call_consecutive_receipt_failures";
+    let turn = sample_turn(&thread.id, turn_id, RuntimeTurnStatus::InProgress);
+    manager.store.save_turn(&turn)?;
+    {
+        let _thread_mutation = manager.store.thread_mutation.lock();
+        let mut persisted_thread = manager.store.load_thread(&thread.id)?;
+        persisted_thread.latest_turn_id = Some(turn_id.to_string());
+        manager.store.save_thread(&persisted_thread)?;
+    }
+    let params = DynamicToolCallParams {
+        thread_id: thread.id.clone(),
+        turn_id: turn_id.to_string(),
+        call_id: call_id.to_string(),
+        namespace: Some("recovery".to_string()),
+        tool: "retry_lookup".to_string(),
+        arguments: json!({ "record": "in-process" }),
+    };
+    let requested = manager
+        .emit_event_for_test(
+            &thread.id,
+            Some(turn_id),
+            "tool_call.requested",
+            json!(&params),
+        )
+        .await?;
+    let mut receiver = manager.register_pending_dynamic_tool(params)?;
+
+    // The submitted result and the monitor's terminal cancellation both fail
+    // after fsync, with each JSONL line transactionally removed. The monitor
+    // must retain an in-process recovery path instead of evicting the engine
+    // with an Awaiting call and no future owner.
+    let fault_guard =
+        EventAppendFaultGuard::arm_repeated(&thread.id, EventAppendTestFault::AfterSync, 2);
+    let result_error = manager
+        .deliver_dynamic_tool_result(
+            &thread.id,
+            turn_id,
+            call_id,
+            DynamicToolCallResult {
+                success: true,
+                content: vec![DynamicToolCallContent::InputText {
+                    text: "rolled-back-result".to_string(),
+                }],
+            },
+        )
+        .await
+        .expect_err("first injected receipt failure unexpectedly succeeded");
+    assert!(result_error.to_string().contains("rolled back"));
+    manager
+        .settle_claimed_turn_failure(&thread.id, turn_id, "forced monitor failure")
+        .await;
+    drop(fault_guard);
+
+    assert!(
+        manager
+            .recovery_receipts
+            .lock()
+            .get(&thread.id)
+            .is_some_and(|receipts| receipts.iter().any(|receipt| receipt.turn.id == turn_id)),
+        "second retry-safe failure did not queue in-process recovery"
+    );
+    assert_eq!(manager.pending_dynamic_tools_count(), 1);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), &mut receiver)
+            .await
+            .is_err(),
+        "failed cancellation unexpectedly closed the model receiver"
+    );
+    assert!(manager.events_since(&thread.id, None)?.iter().all(|event| {
+        event.event != "turn.completed"
+            && !matches!(
+                event.event.as_str(),
+                "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
+            )
+    }));
+
+    // The next async observation owns the queued retry. It durably cancels
+    // the call before publishing exactly one recovered turn completion.
+    manager.get_thread(&thread.id).await?;
+    let closed = tokio::time::timeout(Duration::from_secs(2), &mut receiver)
+        .await
+        .context("recovery did not wake the model receiver")?;
+    assert!(closed.is_err(), "terminal recovery delivered a tool result");
+    let events = manager.events_since(&thread.id, None)?;
+    let canceled = events
+        .iter()
+        .filter(|event| {
+            event.event == "tool_call.canceled"
+                && event.payload.get("call_id").and_then(Value::as_str) == Some(call_id)
+        })
+        .collect::<Vec<_>>();
+    let completed = events
+        .iter()
+        .filter(|event| {
+            event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(canceled.len(), 1);
+    assert_eq!(canceled[0].payload["reason"], "turn_terminal");
+    assert_eq!(canceled[0].payload["terminal"], true);
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].payload["recovered"], true);
+    assert!(canceled[0].seq < completed[0].seq);
+    assert!(
+        canceled[0].seq > requested.seq.saturating_add(1),
+        "rolled-back append sequence values were unexpectedly reused"
+    );
+    assert_eq!(manager.pending_dynamic_tools_count(), 0);
+    assert!(!manager.recovery_receipts.lock().contains_key(&thread.id));
+
+    manager.get_thread(&thread.id).await?;
+    let replay = manager.events_since(&thread.id, None)?;
+    assert_eq!(
+        replay
+            .iter()
+            .filter(|event| {
+                event.event == "tool_call.canceled"
+                    && event.payload.get("call_id").and_then(Value::as_str) == Some(call_id)
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        replay
+            .iter()
+            .filter(|event| {
+                event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+            })
+            .count(),
+        1
+    );
     Ok(())
 }
 

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::core::engine::{MockApprovalEvent, mock_engine_handle};
 use crate::core::events::{Event as EngineEvent, TurnOutcomeStatus};
 use std::time::{Duration, Instant};
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 use uuid::Uuid;
 
@@ -3520,6 +3520,113 @@ async fn user_input_snapshot_survives_reload_and_clears_after_submission() -> Re
             base_url: None,
         })
         .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_detail_cursor_precedes_projection_reads_at_terminal_boundary() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "complete while the snapshot is paused".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+
+    let (hook_tx, mut hook_rx) = mpsc::unbounded_channel();
+    manager.set_snapshot_test_hook(hook_tx);
+    let snapshot_manager = manager.clone();
+    let snapshot_thread_id = thread.id.clone();
+    let snapshot_task = tokio::spawn(async move {
+        snapshot_manager
+            .get_thread_detail(&snapshot_thread_id)
+            .await
+    });
+
+    let point = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+        .await
+        .context("snapshot did not capture its replay cursor")?
+        .context("snapshot test hook closed")?;
+    assert_eq!(point.thread_id, thread.id);
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "snapshot_terminal".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::MessageStarted { index: 0 })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::MessageComplete { index: 0 })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+
+    let completed_event = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = manager
+                .events_since(&thread.id, Some(point.latest_seq))?
+                .into_iter()
+                .find(|event| {
+                    event.turn_id.as_deref() == Some(&turn.id) && event.event == "turn.completed"
+                })
+            {
+                break Ok::<_, anyhow::Error>(event);
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("terminal event did not cross the paused snapshot boundary")??;
+    point
+        .resume
+        .send(())
+        .map_err(|_| anyhow!("snapshot dropped its resume barrier"))?;
+
+    let detail = snapshot_task.await.context("snapshot task panicked")??;
+    assert_eq!(detail.latest_seq, point.latest_seq);
+    assert!(completed_event.seq > detail.latest_seq);
+    assert_eq!(
+        detail
+            .turns
+            .iter()
+            .find(|record| record.id == turn.id)
+            .map(|record| record.status),
+        Some(RuntimeTurnStatus::Completed),
+        "the snapshot should contain the concurrently saved terminal projection"
+    );
+    assert!(
+        manager
+            .events_since(&thread.id, Some(detail.latest_seq))?
+            .iter()
+            .any(|event| event.seq == completed_event.seq),
+        "the same terminal transition must remain replayable from the snapshot cursor"
+    );
     Ok(())
 }
 

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -42,6 +42,22 @@ fn test_approval_timeout_ms(ms: u64) -> ApprovalTimeoutGuard {
     }
 }
 
+struct DynamicToolTimeoutGuard {
+    previous_ms: u64,
+}
+
+impl Drop for DynamicToolTimeoutGuard {
+    fn drop(&mut self) {
+        set_test_dynamic_tool_result_timeout_ms(self.previous_ms);
+    }
+}
+
+fn test_dynamic_tool_timeout_ms(ms: u64) -> DynamicToolTimeoutGuard {
+    DynamicToolTimeoutGuard {
+        previous_ms: set_test_dynamic_tool_result_timeout_ms(ms),
+    }
+}
+
 fn sample_thread(thread_id: &str) -> ThreadRecord {
     let now = Utc::now();
     ThreadRecord {
@@ -3631,6 +3647,127 @@ async fn thread_detail_cursor_precedes_projection_reads_at_terminal_boundary() -
 }
 
 #[tokio::test]
+async fn thread_detail_materializes_stream_prefixes_before_their_delta_cursor() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "snapshot both streamed prefixes".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "delta_snapshot".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::MessageStarted { index: 0 })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::MessageDelta {
+            index: 0,
+            content: "durable message prefix".to_string(),
+        })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::ThinkingStarted { index: 1 })
+        .await?;
+    harness
+        .tx_event
+        .send(EngineEvent::ThinkingDelta {
+            index: 1,
+            content: "durable reasoning prefix".to_string(),
+        })
+        .await?;
+
+    let deltas = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let deltas = manager
+                .events_since(&thread.id, None)?
+                .into_iter()
+                .filter(|event| {
+                    event.turn_id.as_deref() == Some(&turn.id) && event.event == "item.delta"
+                })
+                .collect::<Vec<_>>();
+            if deltas.len() == 2 {
+                break Ok::<_, anyhow::Error>(deltas);
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("stream deltas were not durably sequenced")??;
+
+    let detail = manager.get_thread_detail(&thread.id).await?;
+    let latest_delta_seq = deltas.iter().map(|event| event.seq).max().unwrap_or(0);
+    assert!(detail.latest_seq >= latest_delta_seq);
+    let message = detail
+        .items
+        .iter()
+        .find(|item| item.kind == TurnItemKind::AgentMessage)
+        .context("snapshot omitted the streaming message item")?;
+    let reasoning = detail
+        .items
+        .iter()
+        .find(|item| item.kind == TurnItemKind::AgentReasoning)
+        .context("snapshot omitted the streaming reasoning item")?;
+    assert_eq!(message.status, TurnItemLifecycleStatus::InProgress);
+    assert_eq!(message.detail.as_deref(), Some("durable message prefix"));
+    assert_eq!(reasoning.status, TurnItemLifecycleStatus::InProgress);
+    assert_eq!(
+        reasoning.detail.as_deref(),
+        Some("durable reasoning prefix")
+    );
+    assert_eq!(
+        manager.store.load_item(&message.id)?.detail,
+        message.detail,
+        "message prefix must already be on disk before its delta cursor"
+    );
+    assert_eq!(
+        manager.store.load_item(&reasoning.id)?.detail,
+        reasoning.detail,
+        "reasoning prefix must already be on disk before its delta cursor"
+    );
+    assert!(
+        manager
+            .events_since(&thread.id, Some(detail.latest_seq))?
+            .iter()
+            .all(|event| event.event != "item.delta"),
+        "the snapshot itself must carry every delta at or before latest_seq"
+    );
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Interrupted,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn terminal_turn_cancels_pending_user_input_and_clears_snapshot() -> Result<()> {
     let manager = test_manager(test_runtime_dir())?;
     let thread = manager
@@ -3725,6 +3862,379 @@ async fn terminal_turn_cancels_pending_user_input_and_clears_snapshot() -> Resul
         }
         sleep(Duration::from_millis(20)).await;
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn dynamic_tool_result_settles_snapshot_and_emits_one_safe_resolution() -> Result<()> {
+    use crate::tools::spec::DynamicToolExecutor;
+
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "run an external lookup".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "dynamic_result".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+
+    const RESULT_SECRET: &str = "dynamic-result-secret";
+    let executor = manager.clone();
+    let executor_thread_id = thread.id.clone();
+    let execution = tokio::spawn(async move {
+        DynamicToolExecutor::execute_dynamic_tool(
+            &executor,
+            Some(executor_thread_id),
+            Some("bench".to_string()),
+            "lookup".to_string(),
+            json!({ "record_id": "record-7" }),
+        )
+        .await
+    });
+
+    let pending = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let detail = manager.get_thread_detail(&thread.id).await?;
+            if let Some(call) = detail.pending_dynamic_tool_calls.first() {
+                break Ok::<_, anyhow::Error>((detail.latest_seq, call.clone()));
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("dynamic tool call did not reach the canonical snapshot")??;
+    let (snapshot_seq, call) = pending;
+    assert_eq!(call.thread_id, thread.id);
+    assert_eq!(call.turn_id, turn.id);
+    assert_eq!(call.namespace.as_deref(), Some("bench"));
+    assert_eq!(call.tool, "lookup");
+    assert_eq!(call.arguments["record_id"], "record-7");
+    let requested = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .find(|event| {
+            event.event == "tool_call.requested"
+                && event.payload.get("call_id").and_then(Value::as_str)
+                    == Some(call.call_id.as_str())
+        })
+        .context("dynamic tool request was not durable")?;
+    assert!(requested.seq <= snapshot_seq);
+    assert!(
+        manager
+            .events_since(&thread.id, Some(snapshot_seq))?
+            .iter()
+            .all(|event| event.event != "tool_call.requested"),
+        "the pending call must be recoverable from the snapshot once replay starts at latest_seq"
+    );
+
+    assert!(
+        manager
+            .deliver_dynamic_tool_result(
+                &thread.id,
+                &turn.id,
+                &call.call_id,
+                DynamicToolCallResult {
+                    success: true,
+                    content: vec![DynamicToolCallContent::InputText {
+                        text: RESULT_SECRET.to_string(),
+                    }],
+                },
+            )
+            .await?
+    );
+    let result = execution.await.context("dynamic tool task panicked")??;
+    assert_eq!(
+        result.content, RESULT_SECRET,
+        "the model-facing result changed"
+    );
+    assert!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_dynamic_tool_calls
+            .is_empty()
+    );
+    let resolved = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .filter(|event| {
+            event.event == "tool_call.resolved"
+                && event.payload.get("call_id").and_then(Value::as_str)
+                    == Some(call.call_id.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].payload["status"], "resolved");
+    assert_eq!(resolved[0].payload["success"], true);
+    assert!(
+        !serde_json::to_string(&resolved)?.contains(RESULT_SECRET),
+        "terminal dynamic-tool lifecycle must not echo result content"
+    );
+    assert!(
+        !manager
+            .deliver_dynamic_tool_result(
+                &thread.id,
+                &turn.id,
+                &call.call_id,
+                DynamicToolCallResult {
+                    success: true,
+                    content: Vec::new(),
+                },
+            )
+            .await?,
+        "a duplicate result must not settle or emit twice"
+    );
+    assert_eq!(
+        manager
+            .events_since(&thread.id, None)?
+            .iter()
+            .filter(|event| event.event == "tool_call.resolved")
+            .count(),
+        1
+    );
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    Ok(())
+}
+
+#[test]
+fn pending_dynamic_tool_registry_rejects_duplicates_and_is_bounded() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let mut receivers = Vec::with_capacity(MAX_PENDING_DYNAMIC_TOOL_CALLS);
+    receivers.push(manager.register_pending_dynamic_tool_for_test(
+        "thread-bound",
+        "turn-bound",
+        "call-0",
+    )?);
+    assert!(
+        manager
+            .register_pending_dynamic_tool_for_test("thread-bound", "turn-bound", "call-0",)
+            .is_err(),
+        "duplicate call IDs must not replace an existing result channel"
+    );
+
+    for index in 1..MAX_PENDING_DYNAMIC_TOOL_CALLS {
+        receivers.push(manager.register_pending_dynamic_tool_for_test(
+            "thread-bound",
+            "turn-bound",
+            &format!("call-{index}"),
+        )?);
+    }
+    assert_eq!(
+        manager.pending_dynamic_tools_count(),
+        MAX_PENDING_DYNAMIC_TOOL_CALLS
+    );
+    let error = manager
+        .register_pending_dynamic_tool_for_test("thread-bound", "turn-bound", "call-over-limit")
+        .expect_err("pending dynamic tool registry exceeded its hard limit");
+    assert!(
+        error
+            .to_string()
+            .contains("pending dynamic tool call limit")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn dynamic_tool_timeout_clears_snapshot_and_emits_once() -> Result<()> {
+    use crate::tools::spec::{DynamicToolExecutor, ToolError};
+
+    let _timeout_guard = test_dynamic_tool_timeout_ms(25);
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "let an external lookup time out".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "dynamic_timeout".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+
+    let error = DynamicToolExecutor::execute_dynamic_tool(
+        &manager,
+        Some(thread.id.clone()),
+        None,
+        "slow_lookup".to_string(),
+        json!({ "marker": "request-only" }),
+    )
+    .await
+    .expect_err("dynamic tool unexpectedly resolved");
+    assert!(matches!(error, ToolError::Timeout { .. }));
+    assert!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_dynamic_tool_calls
+            .is_empty()
+    );
+    let timeout_events = manager
+        .events_since(&thread.id, None)?
+        .into_iter()
+        .filter(|event| event.event == "tool_call.timeout")
+        .collect::<Vec<_>>();
+    assert_eq!(timeout_events.len(), 1);
+    assert_eq!(timeout_events[0].turn_id.as_deref(), Some(turn.id.as_str()));
+    assert_eq!(timeout_events[0].payload["status"], "timeout");
+    assert_eq!(timeout_events[0].payload["timeout_secs"], 0);
+    assert!(timeout_events[0].payload.get("arguments").is_none());
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Completed,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn terminal_turn_cancels_pending_dynamic_tool_exactly_once() -> Result<()> {
+    use crate::tools::spec::DynamicToolExecutor;
+
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let turn = manager
+        .start_turn(
+            &thread.id,
+            StartTurnRequest {
+                prompt: "cancel an external lookup with the turn".to_string(),
+                ..StartTurnRequest::default()
+            },
+        )
+        .await?;
+    assert!(matches!(
+        harness.rx_op.recv().await,
+        Some(Op::SendMessage { .. })
+    ));
+    harness
+        .tx_event
+        .send(EngineEvent::TurnStarted {
+            turn_id: "dynamic_cancel".to_string(),
+            created_at: Utc::now(),
+            route: None,
+        })
+        .await?;
+
+    let executor = manager.clone();
+    let executor_thread_id = thread.id.clone();
+    let execution = tokio::spawn(async move {
+        DynamicToolExecutor::execute_dynamic_tool(
+            &executor,
+            Some(executor_thread_id),
+            None,
+            "cancel_lookup".to_string(),
+            json!({ "id": "pending" }),
+        )
+        .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if !manager
+                .get_thread_detail(&thread.id)
+                .await?
+                .pending_dynamic_tool_calls
+                .is_empty()
+            {
+                break Ok::<_, anyhow::Error>(());
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("dynamic call did not become pending")??;
+
+    harness
+        .tx_event
+        .send(EngineEvent::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Interrupted,
+            error: None,
+            tool_catalog: None,
+            base_url: None,
+        })
+        .await?;
+    execution
+        .await
+        .context("dynamic tool task panicked")?
+        .expect_err("terminal turn unexpectedly resolved the dynamic tool");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let detail = manager.get_thread_detail(&thread.id).await?;
+            let canceled = manager
+                .events_since(&thread.id, None)?
+                .into_iter()
+                .filter(|event| event.event == "tool_call.canceled")
+                .collect::<Vec<_>>();
+            if detail.pending_dynamic_tool_calls.is_empty() && canceled.len() == 1 {
+                assert_eq!(canceled[0].payload["status"], "canceled");
+                assert_eq!(canceled[0].payload["terminal"], true);
+                break Ok::<_, anyhow::Error>(());
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .context("terminal dynamic call did not disappear exactly once")??;
+    assert_eq!(
+        turn.id,
+        manager
+            .get_thread(&thread.id)
+            .await?
+            .latest_turn_id
+            .unwrap()
+    );
     Ok(())
 }
 

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1979,6 +1979,24 @@ fn store_open_rejects_symlinked_state_file() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+#[cfg(unix)]
+#[test]
+fn event_append_rollback_rejects_a_swapped_symlink_target() -> Result<()> {
+    let dir = test_runtime_dir();
+    std::fs::create_dir_all(&dir)?;
+    let outside = dir.join("outside.jsonl");
+    let events_path = dir.join("events.jsonl");
+    std::fs::write(&outside, b"must-remain-intact\n")?;
+    std::os::unix::fs::symlink(&outside, &events_path)?;
+
+    let error = rollback_failed_event_append(&events_path, 0)
+        .expect_err("rollback followed a swapped symlink target");
+    assert!(format!("{error:#}").contains("must not be a symlink"));
+    assert_eq!(std::fs::read(&outside)?, b"must-remain-intact\n");
+    std::fs::remove_dir_all(&dir)?;
+    Ok(())
+}
+
 #[test]
 fn store_open_rejects_root_traversal() {
     let dir = test_runtime_dir();

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1796,6 +1796,89 @@ async fn store_open_does_not_discard_newline_terminated_malformed_event() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+#[tokio::test]
+async fn event_replay_is_bounded_and_tail_cursor_skips_only_omitted_history() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread_id = "thr_bounded_replay";
+    let path = manager.store.events_path(thread_id)?;
+    let mut encoded = Vec::new();
+    for seq in 1_u64..=600 {
+        let event = RuntimeEventRecord {
+            schema_version: CURRENT_RUNTIME_SCHEMA_VERSION,
+            seq,
+            timestamp: Utc::now(),
+            thread_id: thread_id.to_string(),
+            turn_id: None,
+            item_id: None,
+            event: "test.event".to_string(),
+            payload: json!({ "seq": seq }),
+        };
+        serde_json::to_writer(&mut encoded, &event)?;
+        encoded.push(b'\n');
+    }
+    std::fs::write(path, encoded)?;
+
+    let mut full = manager.replay_events(thread_id, None, None).await?;
+    assert_eq!(full.base_seq, 0);
+    let mut full_sequences = Vec::new();
+    while let Some(batch) = full.batches.recv().await {
+        let batch = batch.map_err(anyhow::Error::msg)?;
+        assert!(
+            batch.len() <= RUNTIME_EVENT_REPLAY_BATCH_SIZE,
+            "replay batch exceeded its memory bound"
+        );
+        full_sequences.extend(batch.into_iter().map(|event| event.seq));
+    }
+    assert_eq!(full_sequences, (1_u64..=600).collect::<Vec<_>>());
+
+    let mut tail = manager.replay_events(thread_id, None, Some(10)).await?;
+    assert_eq!(tail.base_seq, 590);
+    let mut tail_sequences = Vec::new();
+    while let Some(batch) = tail.batches.recv().await {
+        tail_sequences.extend(
+            batch
+                .map_err(anyhow::Error::msg)?
+                .into_iter()
+                .map(|event| event.seq),
+        );
+    }
+    assert_eq!(tail_sequences, (591_u64..=600).collect::<Vec<_>>());
+
+    let mut empty_tail = manager.replay_events(thread_id, None, Some(0)).await?;
+    assert_eq!(empty_tail.base_seq, 600);
+    assert!(empty_tail.batches.recv().await.is_none());
+    assert!(
+        manager
+            .replay_events(
+                thread_id,
+                None,
+                Some(MAX_RUNTIME_EVENT_REPLAY_TAIL.saturating_add(1)),
+            )
+            .await
+            .is_err()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn event_reader_ignores_an_unterminated_live_append_tail() -> Result<()> {
+    let dir = test_runtime_dir();
+    let store = RuntimeThreadStore::open(dir.clone())?;
+    let committed = store
+        .append_event("thr_live_tail", None, None, "committed", json!({}))
+        .await?;
+    let path = store.events_path("thr_live_tail")?;
+    let mut file = std::fs::OpenOptions::new().append(true).open(path)?;
+    std::io::Write::write_all(&mut file, br#"{"schema_version":2,"seq":999"#)?;
+    std::io::Write::flush(&mut file)?;
+
+    let replay = store.events_since("thr_live_tail", None)?;
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0].seq, committed.seq);
+    let _ = std::fs::remove_dir_all(dir);
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn store_open_rejects_symlinked_state_file() {

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1711,6 +1711,91 @@ fn store_load_thread_rejects_newer_schema_version() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+#[tokio::test]
+async fn store_open_truncates_only_torn_final_event_record_and_preserves_sequence_gap() {
+    let dir = test_runtime_dir();
+    let store = RuntimeThreadStore::open(dir.clone()).expect("open store");
+    let first = store
+        .append_event("thr_torn_tail", None, None, "first", json!({ "value": 1 }))
+        .await
+        .expect("append first event");
+    let torn = store
+        .append_event("thr_torn_tail", None, None, "torn", json!({ "value": 2 }))
+        .await
+        .expect("append event to tear");
+    let path = store.events_path("thr_torn_tail").expect("event path");
+    let original_len = std::fs::metadata(&path).expect("event metadata").len();
+    assert!(original_len > 16);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .expect("open event log for simulated crash")
+        .set_len(original_len - 16)
+        .expect("tear final event record");
+    drop(store);
+
+    let reopened = RuntimeThreadStore::open(dir.clone()).expect("repair torn event tail");
+    let replay = reopened
+        .events_since("thr_torn_tail", None)
+        .expect("replay repaired event log");
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0].seq, first.seq);
+
+    let after_repair = reopened
+        .append_event(
+            "thr_torn_tail",
+            None,
+            None,
+            "after_repair",
+            json!({ "value": 3 }),
+        )
+        .await
+        .expect("append after repair");
+    assert_eq!(after_repair.seq, torn.seq.saturating_add(1));
+    assert_eq!(
+        reopened
+            .events_since("thr_torn_tail", None)
+            .expect("replay repaired and appended events")
+            .iter()
+            .map(|event| event.seq)
+            .collect::<Vec<_>>(),
+        vec![first.seq, after_repair.seq]
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn store_open_does_not_discard_newline_terminated_malformed_event() {
+    let dir = test_runtime_dir();
+    let store = RuntimeThreadStore::open(dir.clone()).expect("open store");
+    store
+        .append_event("thr_bad_tail", None, None, "valid", json!({}))
+        .await
+        .expect("append valid event");
+    let path = store.events_path("thr_bad_tail").expect("event path");
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open event log");
+    std::io::Write::write_all(&mut file, b"{malformed-but-terminated}\n")
+        .expect("append malformed event");
+    std::io::Write::flush(&mut file).expect("flush malformed event");
+    drop(file);
+    drop(store);
+
+    let reopened = RuntimeThreadStore::open(dir.clone()).expect("open terminated event log");
+    let error = reopened
+        .events_since("thr_bad_tail", None)
+        .expect_err("terminated malformed event must fail closed");
+    assert!(
+        format!("{error:#}").contains("Failed to parse event line"),
+        "unexpected replay error: {error:#}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
 #[cfg(unix)]
 #[test]
 fn store_open_rejects_symlinked_state_file() {
@@ -4876,6 +4961,76 @@ async fn restart_recovers_terminal_turn_after_dynamic_receipt_append_failure() -
             })
             .count(),
         1
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn restart_reconciles_unresolved_dynamic_call_after_existing_turn_completion() -> Result<()> {
+    let data_dir = test_runtime_dir();
+    let manager = test_manager(data_dir.clone())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let turn_id = "turn_legacy_completed_request";
+    let call_id = "call_legacy_completed_request";
+    let mut turn = sample_turn(&thread.id, turn_id, RuntimeTurnStatus::Completed);
+    turn.ended_at = Some(Utc::now());
+    turn.duration_ms = Some(1);
+    manager.store.save_turn(&turn)?;
+    let params = DynamicToolCallParams {
+        thread_id: thread.id.clone(),
+        turn_id: turn_id.to_string(),
+        call_id: call_id.to_string(),
+        namespace: Some("legacy".to_string()),
+        tool: "legacy_lookup".to_string(),
+        arguments: json!({ "record": "persisted-before-terminal-receipts" }),
+    };
+    manager
+        .emit_event_for_test(
+            &thread.id,
+            Some(turn_id),
+            "tool_call.requested",
+            json!(&params),
+        )
+        .await?;
+    manager
+        .emit_event_for_test(
+            &thread.id,
+            Some(turn_id),
+            "turn.completed",
+            json!({ "turn": &turn }),
+        )
+        .await?;
+    drop(manager);
+
+    let recovered = test_manager(data_dir)?;
+    recovered.get_thread(&thread.id).await?;
+    let events = recovered.events_since(&thread.id, None)?;
+    let terminal_calls = events
+        .iter()
+        .filter(|event| {
+            event.turn_id.as_deref() == Some(turn_id)
+                && event.payload.get("call_id").and_then(Value::as_str) == Some(call_id)
+                && matches!(
+                    event.event.as_str(),
+                    "tool_call.resolved" | "tool_call.canceled" | "tool_call.timeout"
+                )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(terminal_calls.len(), 1);
+    assert_eq!(terminal_calls[0].event, "tool_call.canceled");
+    assert_eq!(terminal_calls[0].payload["reason"], "process_restart");
+    assert_eq!(terminal_calls[0].payload["recovered"], true);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+            })
+            .count(),
+        1,
+        "recovery duplicated an already durable turn completion"
     );
     Ok(())
 }

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -3649,6 +3649,287 @@ async fn user_input_snapshot_survives_reload_and_clears_after_submission() -> Re
 }
 
 #[tokio::test]
+async fn unknown_user_input_id_is_not_delivered_to_engine() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    let delivered = manager
+        .submit_user_input(
+            &thread.id,
+            "input_missing",
+            crate::tools::user_input::UserInputResponse {
+                answers: vec![crate::tools::user_input::UserInputAnswer {
+                    id: "choice".to_string(),
+                    label: "Missing".to_string(),
+                    value: "must-not-enter-engine-mailbox".to_string(),
+                }],
+            },
+        )
+        .await?;
+    assert!(!delivered);
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            harness.recv_user_input_submission()
+        )
+        .await
+        .is_err(),
+        "unknown request entered the engine mailbox"
+    );
+    assert!(manager.events_since(&thread.id, None)?.iter().all(|event| {
+        !matches!(
+            event.event.as_str(),
+            "user_input.answered" | "user_input.canceled"
+        )
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn user_input_receipt_append_failure_restores_request_without_delivery() -> Result<()> {
+    const SECRET: &str = "answer-only-for-engine-after-retry";
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    manager.register_pending_user_input(
+        &thread.id,
+        PendingUserInputRequest {
+            id: "input_retry".to_string(),
+            turn_id: "turn_retry".to_string(),
+            request: crate::tools::user_input::UserInputRequest {
+                questions: Vec::new(),
+            },
+        },
+    );
+    let response = || crate::tools::user_input::UserInputResponse {
+        answers: vec![crate::tools::user_input::UserInputAnswer {
+            id: "choice".to_string(),
+            label: "Retry".to_string(),
+            value: SECRET.to_string(),
+        }],
+    };
+
+    let fault_guard = EventAppendFaultGuard::arm(&thread.id, EventAppendTestFault::AfterSync);
+    let error = manager
+        .submit_user_input(&thread.id, "input_retry", response())
+        .await
+        .expect_err("injected receipt append unexpectedly succeeded");
+    drop(fault_guard);
+    assert!(format!("{error:#}").contains("rolled back"));
+    assert_eq!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_user_inputs
+            .len(),
+        1,
+        "retry-safe append failure removed the authoritative prompt"
+    );
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            harness.recv_user_input_submission()
+        )
+        .await
+        .is_err(),
+        "answer reached the engine before its receipt was durable"
+    );
+
+    assert!(
+        manager
+            .submit_user_input(&thread.id, "input_retry", response())
+            .await?,
+        "restored request was not retryable"
+    );
+    let (_, delivered) =
+        tokio::time::timeout(Duration::from_secs(2), harness.recv_user_input_submission())
+            .await
+            .context("retried answer did not reach the engine")?
+            .context("retried answer was canceled")?;
+    assert_eq!(delivered.answers[0].value, SECRET);
+    let events = manager.events_since(&thread.id, None)?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event == "user_input.answered")
+            .count(),
+        1
+    );
+    assert!(!serde_json::to_string(&events)?.contains(SECRET));
+    Ok(())
+}
+
+#[tokio::test]
+async fn user_input_settlement_outlives_canceled_api_future() -> Result<()> {
+    const SECRET: &str = "answer-survives-request-disconnect";
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    manager.register_pending_user_input(
+        &thread.id,
+        PendingUserInputRequest {
+            id: "input_detached".to_string(),
+            turn_id: "turn_detached".to_string(),
+            request: crate::tools::user_input::UserInputRequest {
+                questions: Vec::new(),
+            },
+        },
+    );
+
+    let emit_guard = manager.event_emit.lock().await;
+    let submit_manager = manager.clone();
+    let thread_id = thread.id.clone();
+    let submission = tokio::spawn(async move {
+        submit_manager
+            .submit_user_input(
+                &thread_id,
+                "input_detached",
+                crate::tools::user_input::UserInputResponse {
+                    answers: vec![crate::tools::user_input::UserInputAnswer {
+                        id: "choice".to_string(),
+                        label: "Continue".to_string(),
+                        value: SECRET.to_string(),
+                    }],
+                },
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if manager
+                .pending_user_inputs
+                .lock()
+                .get(&(thread.id.clone(), "input_detached".to_string()))
+                .is_some_and(|entry| entry.settling)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("submission did not claim the pending request")?;
+    submission.abort();
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            harness.recv_user_input_submission()
+        )
+        .await
+        .is_err(),
+        "answer reached the engine before its receipt append was released"
+    );
+    drop(emit_guard);
+
+    let (_, delivered) =
+        tokio::time::timeout(Duration::from_secs(2), harness.recv_user_input_submission())
+            .await
+            .context("detached settlement did not reach the engine")?
+            .context("detached settlement was canceled")?;
+    assert_eq!(delivered.answers[0].value, SECRET);
+    let detail = manager.get_thread_detail(&thread.id).await?;
+    assert!(detail.pending_user_inputs.is_empty());
+    let events = manager.events_since(&thread.id, None)?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.event == "user_input.answered")
+            .count(),
+        1
+    );
+    assert!(!serde_json::to_string(&events)?.contains(SECRET));
+    Ok(())
+}
+
+#[tokio::test]
+async fn terminal_user_input_cancellation_is_durable_before_engine_delivery() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let mut harness = install_mock_engine(&manager, &thread.id).await;
+    manager.register_pending_user_input(
+        &thread.id,
+        PendingUserInputRequest {
+            id: "input_terminal_order".to_string(),
+            turn_id: "turn_terminal_order".to_string(),
+            request: crate::tools::user_input::UserInputRequest {
+                questions: Vec::new(),
+            },
+        },
+    );
+
+    let emit_guard = manager.event_emit.lock().await;
+    let engine = harness.handle.clone();
+    let settle_manager = manager.clone();
+    let thread_id = thread.id.clone();
+    let settlement = tokio::spawn(async move {
+        settle_manager
+            .settle_user_inputs_for_terminal_turn(&thread_id, "turn_terminal_order", Some(engine))
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if manager
+                .pending_user_inputs
+                .lock()
+                .get(&(thread.id.clone(), "input_terminal_order".to_string()))
+                .is_some_and(|entry| entry.settling)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("terminal cancellation did not claim the request")?;
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(25),
+            harness.recv_user_input_submission()
+        )
+        .await
+        .is_err(),
+        "terminal cancellation reached the engine before durable append"
+    );
+    drop(emit_guard);
+    settlement
+        .await
+        .context("terminal settlement task panicked")??;
+    assert!(
+        tokio::time::timeout(Duration::from_secs(2), harness.recv_user_input_submission())
+            .await
+            .context("engine did not receive terminal cancellation")?
+            .is_none(),
+        "terminal cancellation delivered a submitted response"
+    );
+    let events = manager.events_since(&thread.id, None)?;
+    let canceled = events
+        .iter()
+        .find(|event| {
+            event.event == "user_input.canceled"
+                && event.payload.get("input_id").and_then(Value::as_str)
+                    == Some("input_terminal_order")
+        })
+        .context("missing terminal cancellation receipt")?;
+    assert_eq!(canceled.payload["terminal"], true);
+    assert!(
+        manager
+            .get_thread_detail(&thread.id)
+            .await?
+            .pending_user_inputs
+            .is_empty()
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_detail_cursor_precedes_projection_reads_at_terminal_boundary() -> Result<()> {
     let manager = test_manager(test_runtime_dir())?;
     let thread = manager

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1669,14 +1669,28 @@ async fn wait_for_terminal_turn(
     let deadline = Instant::now() + timeout;
     loop {
         let turn = manager.store.load_turn(turn_id)?;
-        if matches!(
+        let terminal = matches!(
             turn.status,
             RuntimeTurnStatus::Completed
                 | RuntimeTurnStatus::Failed
                 | RuntimeTurnStatus::Interrupted
                 | RuntimeTurnStatus::Canceled
-        ) {
-            return Ok(turn);
+        );
+        if terminal {
+            let receipt_is_durable =
+                manager
+                    .events_since(&turn.thread_id, None)?
+                    .iter()
+                    .any(|event| {
+                        event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+                    });
+            let claim_is_clear = manager
+                .active_turn_flags(&turn.thread_id, turn_id)
+                .await
+                .is_none();
+            if receipt_is_durable && claim_is_clear {
+                return Ok(turn);
+            }
         }
         if Instant::now() >= deadline {
             bail!("Timed out waiting for turn {turn_id}");
@@ -1761,6 +1775,72 @@ async fn store_open_truncates_only_torn_final_event_record_and_preserves_sequenc
             .collect::<Vec<_>>(),
         vec![first.seq, after_repair.seq]
     );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn store_open_treats_valid_json_without_newline_as_uncommitted_append() {
+    let dir = test_runtime_dir();
+    let store = RuntimeThreadStore::open(dir.clone()).expect("open store");
+    let committed = store
+        .append_event(
+            "thr_missing_commit_marker",
+            None,
+            None,
+            "committed",
+            json!({ "value": 1 }),
+        )
+        .await
+        .expect("append committed event");
+    let uncommitted = store
+        .append_event(
+            "thr_missing_commit_marker",
+            None,
+            None,
+            "missing_marker",
+            json!({ "value": 2 }),
+        )
+        .await
+        .expect("append event whose commit marker will be removed");
+    let path = store
+        .events_path("thr_missing_commit_marker")
+        .expect("event path");
+    let encoded = std::fs::read(&path).expect("read event log");
+    assert_eq!(encoded.last(), Some(&b'\n'));
+    let without_marker = &encoded[..encoded.len() - 1];
+    let final_json = without_marker
+        .rsplit(|byte| *byte == b'\n')
+        .next()
+        .expect("final JSON record");
+    serde_json::from_slice::<RuntimeEventRecord>(final_json)
+        .expect("the unterminated tail must otherwise be valid JSON");
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .expect("open event log for simulated crash")
+        .set_len(u64::try_from(without_marker.len()).expect("event log length fits u64"))
+        .expect("remove only the newline commit marker");
+    drop(store);
+
+    let reopened = RuntimeThreadStore::open(dir.clone()).expect("repair uncommitted event tail");
+    let replay = reopened
+        .events_since("thr_missing_commit_marker", None)
+        .expect("replay repaired event log");
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0].seq, committed.seq);
+
+    let after_repair = reopened
+        .append_event(
+            "thr_missing_commit_marker",
+            None,
+            None,
+            "after_repair",
+            json!({ "value": 3 }),
+        )
+        .await
+        .expect("append after repair");
+    assert_eq!(after_repair.seq, uncommitted.seq.saturating_add(1));
 
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -4076,10 +4156,47 @@ async fn thread_detail_cursor_precedes_projection_reads_at_terminal_boundary() -
         })
         .await?;
 
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if manager
+                    .events_since(&thread.id, Some(point.latest_seq))?
+                    .iter()
+                    .any(|event| {
+                        event.turn_id.as_deref() == Some(&turn.id)
+                            && event.event == "turn.completed"
+                    })
+                {
+                    break Ok::<_, anyhow::Error>(());
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .is_err(),
+        "terminal publication crossed a snapshot projection boundary"
+    );
+    point
+        .resume
+        .send(())
+        .map_err(|_| anyhow!("snapshot dropped its resume barrier"))?;
+
+    let detail = snapshot_task.await.context("snapshot task panicked")??;
+    assert_eq!(detail.latest_seq, point.latest_seq);
+    assert_eq!(
+        detail
+            .turns
+            .iter()
+            .find(|record| record.id == turn.id)
+            .map(|record| record.status),
+        Some(RuntimeTurnStatus::InProgress),
+        "the paused snapshot must retain the pre-terminal projection"
+    );
+
     let completed_event = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             if let Some(event) = manager
-                .events_since(&thread.id, Some(point.latest_seq))?
+                .events_since(&thread.id, Some(detail.latest_seq))?
                 .into_iter()
                 .find(|event| {
                     event.turn_id.as_deref() == Some(&turn.id) && event.event == "turn.completed"
@@ -4091,24 +4208,8 @@ async fn thread_detail_cursor_precedes_projection_reads_at_terminal_boundary() -
         }
     })
     .await
-    .context("terminal event did not cross the paused snapshot boundary")??;
-    point
-        .resume
-        .send(())
-        .map_err(|_| anyhow!("snapshot dropped its resume barrier"))?;
-
-    let detail = snapshot_task.await.context("snapshot task panicked")??;
-    assert_eq!(detail.latest_seq, point.latest_seq);
+    .context("terminal event did not follow the released snapshot boundary")??;
     assert!(completed_event.seq > detail.latest_seq);
-    assert_eq!(
-        detail
-            .turns
-            .iter()
-            .find(|record| record.id == turn.id)
-            .map(|record| record.status),
-        Some(RuntimeTurnStatus::Completed),
-        "the snapshot should contain the concurrently saved terminal projection"
-    );
     assert!(
         manager
             .events_since(&thread.id, Some(detail.latest_seq))?
@@ -5395,6 +5496,69 @@ async fn restart_reconciles_unresolved_dynamic_call_after_existing_turn_completi
             .count(),
         1,
         "recovery duplicated an already durable turn completion"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_recovery_dedupe_scans_emit_each_terminal_receipt_once() -> Result<()> {
+    let manager = test_manager(test_runtime_dir())?;
+    let thread = manager
+        .create_thread(CreateThreadRequest::default())
+        .await?;
+    let turn_id = "turn_concurrent_recovery_dedupe";
+    let call_id = "call_concurrent_recovery_dedupe";
+    let mut turn = sample_turn(&thread.id, turn_id, RuntimeTurnStatus::Completed);
+    turn.ended_at = Some(Utc::now());
+    let params = DynamicToolCallParams {
+        thread_id: thread.id.clone(),
+        turn_id: turn_id.to_string(),
+        call_id: call_id.to_string(),
+        namespace: Some("recovery".to_string()),
+        tool: "dedupe_lookup".to_string(),
+        arguments: json!({ "record": "same-terminal-receipt" }),
+    };
+
+    let (first_call, second_call) = tokio::join!(
+        manager.emit_recovered_dynamic_cancellation_if_missing(&params),
+        manager.emit_recovered_dynamic_cancellation_if_missing(&params),
+    );
+    assert_eq!(
+        usize::from(first_call?) + usize::from(second_call?),
+        1,
+        "the event_emit boundary must linearize dynamic-terminal dedupe"
+    );
+
+    let (first_turn, second_turn) = tokio::join!(
+        manager.emit_turn_completed_if_missing(&turn, true),
+        manager.emit_turn_completed_if_missing(&turn, true),
+    );
+    assert_eq!(
+        usize::from(first_turn?) + usize::from(second_turn?),
+        1,
+        "the event_emit boundary must linearize turn-completion dedupe"
+    );
+
+    let events = manager.events_since(&thread.id, None)?;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                event.event == "tool_call.canceled"
+                    && event.turn_id.as_deref() == Some(turn_id)
+                    && event.payload.get("call_id").and_then(Value::as_str) == Some(call_id)
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                event.event == "turn.completed" && event.turn_id.as_deref() == Some(turn_id)
+            })
+            .count(),
+        1
     );
     Ok(())
 }

--- a/crates/tui/src/runtime_web/app.mjs
+++ b/crates/tui/src/runtime_web/app.mjs
@@ -24,6 +24,9 @@ export const STREAM_EVENT_NAMES = [
   "agent.completed",
   "agent.list",
   "tool_call.requested",
+  "tool_call.resolved",
+  "tool_call.canceled",
+  "tool_call.timeout",
 ];
 
 export function createThreadState(threadId = "") {
@@ -37,6 +40,7 @@ export function createThreadState(threadId = "") {
     latestSeq: 0,
     approvals: new Map(),
     userInputs: new Map(),
+    dynamicToolCalls: new Map(),
   };
 }
 
@@ -70,6 +74,10 @@ export function applySnapshot(state, detail, expectedThreadId = state.threadId) 
   for (const input of Array.isArray(detail.pending_user_inputs) ? detail.pending_user_inputs : []) {
     const inputId = input?.input_id || input?.id;
     if (inputId) state.userInputs.set(inputId, input);
+  }
+  state.dynamicToolCalls = new Map();
+  for (const call of Array.isArray(detail.pending_dynamic_tool_calls) ? detail.pending_dynamic_tool_calls : []) {
+    if (call?.call_id) state.dynamicToolCalls.set(call.call_id, call);
   }
   return true;
 }
@@ -128,6 +136,14 @@ export function applyRuntimeEvent(state, envelope) {
   } else if (eventName === "user_input.answered" || eventName === "user_input.canceled") {
     const inputId = payload.input_id || payload.id;
     if (inputId) state.userInputs.delete(inputId);
+  } else if (eventName === "tool_call.requested") {
+    if (payload.call_id) state.dynamicToolCalls.set(payload.call_id, payload);
+  } else if (
+    eventName === "tool_call.resolved"
+    || eventName === "tool_call.canceled"
+    || eventName === "tool_call.timeout"
+  ) {
+    if (payload.call_id) state.dynamicToolCalls.delete(payload.call_id);
   }
   return true;
 }

--- a/crates/tui/src/runtime_web/app.mjs
+++ b/crates/tui/src/runtime_web/app.mjs
@@ -108,6 +108,10 @@ export function applyRuntimeEvent(state, envelope) {
     || eventName === "item.completed"
     || eventName === "item.failed"
     || eventName === "item.interrupted"
+    || eventName === "agent.spawned"
+    || eventName === "agent.progress"
+    || eventName === "agent.completed"
+    || eventName === "agent.list"
   ) {
     if (payload.item) upsertItem(state, payload.item);
   } else if (eventName === "item.delta") {

--- a/crates/tui/src/runtime_web/app.mjs
+++ b/crates/tui/src/runtime_web/app.mjs
@@ -1,6 +1,7 @@
-const STREAM_EVENT_NAMES = [
-  "thread.created",
+export const STREAM_EVENT_NAMES = [
+  "thread.started",
   "thread.updated",
+  "thread.forked",
   "turn.started",
   "turn.lifecycle",
   "turn.steered",
@@ -10,6 +11,7 @@ const STREAM_EVENT_NAMES = [
   "item.delta",
   "item.completed",
   "item.failed",
+  "item.interrupted",
   "approval.required",
   "approval.decided",
   "approval.timeout",
@@ -21,6 +23,7 @@ const STREAM_EVENT_NAMES = [
   "agent.progress",
   "agent.completed",
   "agent.list",
+  "tool_call.requested",
 ];
 
 export function createThreadState(threadId = "") {
@@ -83,7 +86,10 @@ export function applyRuntimeEvent(state, envelope) {
     ? envelope.payload
     : {};
 
-  if (eventName === "thread.updated" && payload.thread) {
+  if (
+    (eventName === "thread.started" || eventName === "thread.updated" || eventName === "thread.forked")
+    && payload.thread
+  ) {
     state.thread = payload.thread;
   } else if (eventName === "turn.started" || eventName === "turn.completed") {
     if (payload.turn) upsertTurn(state, payload.turn);
@@ -97,7 +103,12 @@ export function applyRuntimeEvent(state, envelope) {
     const turnId = envelope.turn_id;
     const turn = turnId ? state.turns.get(turnId) : null;
     if (turn) state.turns.set(turnId, { ...turn, status: "in_progress" });
-  } else if (eventName === "item.started" || eventName === "item.completed" || eventName === "item.failed") {
+  } else if (
+    eventName === "item.started"
+    || eventName === "item.completed"
+    || eventName === "item.failed"
+    || eventName === "item.interrupted"
+  ) {
     if (payload.item) upsertItem(state, payload.item);
   } else if (eventName === "item.delta") {
     appendItemDelta(state, envelope.item_id, payload);

--- a/crates/tui/src/runtime_web/app.mjs
+++ b/crates/tui/src/runtime_web/app.mjs
@@ -72,13 +72,10 @@ export function applySnapshot(state, detail, expectedThreadId = state.threadId) 
 }
 
 export function applyRuntimeEvent(state, envelope) {
-  if (!envelope || envelope.thread_id !== state.threadId) {
+  if (runtimeEventContinuity(state, envelope) !== "next") {
     return false;
   }
   const sequence = normalizedSequence(envelope.seq);
-  if (sequence <= state.latestSeq) {
-    return false;
-  }
   state.latestSeq = sequence;
 
   const eventName = envelope.event || envelope.kind || "";
@@ -118,6 +115,23 @@ export function applyRuntimeEvent(state, envelope) {
     if (inputId) state.userInputs.delete(inputId);
   }
   return true;
+}
+
+export function runtimeEventContinuity(state, envelope) {
+  if (!envelope || envelope.thread_id !== state.threadId) {
+    return "ignore";
+  }
+  const sequence = normalizedSequence(envelope.seq);
+  if (sequence <= state.latestSeq) {
+    return "ignore";
+  }
+  if (Object.hasOwn(envelope, "previous_seq")) {
+    const previousSequence = normalizedSequence(envelope.previous_seq);
+    if (previousSequence !== state.latestSeq) {
+      return "gap";
+    }
+  }
+  return "next";
 }
 
 export async function snapshotThenSubscribe({
@@ -366,9 +380,18 @@ function startBrowserClient() {
     app.stream = stream;
     stream.onopen = () => setConnection("ready", "Local runtime connected");
     const receive = (message) => {
-      if (generation !== app.generation || threadId !== app.selectedThreadId) return;
+      if (
+        app.stream !== stream
+        || generation !== app.generation
+        || threadId !== app.selectedThreadId
+      ) return;
       try {
         const envelope = JSON.parse(message.data);
+        if (runtimeEventContinuity(app.threadState, envelope) === "gap") {
+          showStatus("Runtime event continuity changed; refreshing the thread snapshot…");
+          void recoverProjection(threadId, generation, stream);
+          return;
+        }
         if (!applyRuntimeEvent(app.threadState, envelope)) return;
         renderAll(true);
         if (envelope.event === "turn.completed" || envelope.event === "thread.updated") {
@@ -380,8 +403,12 @@ function startBrowserClient() {
     };
     for (const name of STREAM_EVENT_NAMES) stream.addEventListener(name, receive);
     stream.onerror = () => {
+      if (app.stream !== stream) {
+        stream.close();
+        return;
+      }
       stream.close();
-      if (app.stream === stream) app.stream = null;
+      app.stream = null;
       if (generation !== app.generation || threadId !== app.selectedThreadId) return;
       setConnection("", "Reconnecting to local runtime…");
       app.reconnectTimer = setTimeout(
@@ -389,6 +416,42 @@ function startBrowserClient() {
         900,
       );
     };
+  }
+
+  async function recoverProjection(threadId, generation, sourceStream = null) {
+    if (
+      generation !== app.generation
+      || threadId !== app.selectedThreadId
+      || (sourceStream && app.stream !== sourceStream)
+    ) return;
+
+    if (app.stream) app.stream.close();
+    app.stream = null;
+    if (app.reconnectTimer) clearTimeout(app.reconnectTimer);
+    app.reconnectTimer = null;
+    setConnection("", "Refreshing thread snapshot…");
+
+    try {
+      const subscribed = await snapshotThenSubscribe({
+        state: app.threadState,
+        threadId,
+        loadSnapshot: (id) => api(`/v1/threads/${encodeURIComponent(id)}`),
+        subscribe: (id, sequence) => connectStream(id, sequence, generation),
+        isCurrent: () => generation === app.generation && threadId === app.selectedThreadId,
+      });
+      if (!subscribed) return;
+      renderAll();
+      showStatus("");
+      setConnection("ready", "Local runtime connected");
+    } catch (error) {
+      if (generation !== app.generation || threadId !== app.selectedThreadId) return;
+      showStatus(`Could not refresh the thread snapshot: ${error.message}`);
+      setConnection("error", "Runtime recovery failed");
+      app.reconnectTimer = setTimeout(
+        () => recoverProjection(threadId, generation),
+        900,
+      );
+    }
   }
 
   function renderAll(preserveScroll = false) {

--- a/crates/tui/src/runtime_web/app.mjs
+++ b/crates/tui/src/runtime_web/app.mjs
@@ -101,6 +101,9 @@ export function applyRuntimeEvent(state, envelope) {
     state.thread = payload.thread;
   } else if (eventName === "turn.started" || eventName === "turn.completed") {
     if (payload.turn) upsertTurn(state, payload.turn);
+    if (eventName === "turn.completed") {
+      clearTurnAttention(state, envelope.turn_id || payload.turn?.id || "");
+    }
   } else if (eventName === "turn.lifecycle") {
     const turnId = envelope.turn_id;
     const turn = turnId ? state.turns.get(turnId) : null;
@@ -126,18 +129,33 @@ export function applyRuntimeEvent(state, envelope) {
     appendItemDelta(state, envelope.item_id, payload);
   } else if (eventName === "approval.required") {
     const approvalId = payload.approval_id || payload.id;
-    if (approvalId) state.approvals.set(approvalId, payload);
+    if (approvalId) {
+      state.approvals.set(approvalId, {
+        ...payload,
+        turn_id: payload.turn_id || envelope.turn_id || "",
+      });
+    }
   } else if (eventName === "approval.decided" || eventName === "approval.timeout") {
     const approvalId = payload.approval_id || payload.id;
     if (approvalId) state.approvals.delete(approvalId);
   } else if (eventName === "user_input.required") {
     const inputId = payload.id;
-    if (inputId) state.userInputs.set(inputId, payload);
+    if (inputId) {
+      state.userInputs.set(inputId, {
+        ...payload,
+        turn_id: payload.turn_id || envelope.turn_id || "",
+      });
+    }
   } else if (eventName === "user_input.answered" || eventName === "user_input.canceled") {
     const inputId = payload.input_id || payload.id;
     if (inputId) state.userInputs.delete(inputId);
   } else if (eventName === "tool_call.requested") {
-    if (payload.call_id) state.dynamicToolCalls.set(payload.call_id, payload);
+    if (payload.call_id) {
+      state.dynamicToolCalls.set(payload.call_id, {
+        ...payload,
+        turn_id: payload.turn_id || envelope.turn_id || "",
+      });
+    }
   } else if (
     eventName === "tool_call.resolved"
     || eventName === "tool_call.canceled"
@@ -146,6 +164,18 @@ export function applyRuntimeEvent(state, envelope) {
     if (payload.call_id) state.dynamicToolCalls.delete(payload.call_id);
   }
   return true;
+}
+
+function clearTurnAttention(state, turnId) {
+  for (const [id, approval] of state.approvals) {
+    if (!approval?.turn_id || approval.turn_id === turnId) state.approvals.delete(id);
+  }
+  for (const [id, input] of state.userInputs) {
+    if (!input?.turn_id || input.turn_id === turnId) state.userInputs.delete(id);
+  }
+  for (const [id, call] of state.dynamicToolCalls) {
+    if (!call?.turn_id || call.turn_id === turnId) state.dynamicToolCalls.delete(id);
+  }
 }
 
 export function runtimeEventContinuity(state, envelope) {

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -319,6 +319,55 @@ test("assembles deltas and replaces the live item with its settled receipt", () 
   assert.deepEqual(state.itemOrder, ["item-new", "item-stop"]);
 });
 
+test("projects agent lifecycle receipts live and settles them without a snapshot reload", () => {
+  const state = createThreadState("thread-a");
+  applySnapshot(state, { ...snapshot(), items: [], latest_seq: 1 });
+
+  const agentItem = (status, summary) => ({
+    id: "item-agent",
+    turn_id: "turn-1",
+    kind: "status",
+    status,
+    summary,
+    detail: summary,
+  });
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(2, "agent.spawned", { item: agentItem("in_progress", "Agent spawned") }),
+  );
+  assert.equal(state.items.get("item-agent").status, "in_progress");
+  assert.deepEqual(state.itemOrder, ["item-agent"]);
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(3, "agent.progress", { item: agentItem("in_progress", "Agent checking") }),
+  );
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(4, "agent.completed", { item: agentItem("completed", "Agent completed") }),
+  );
+  assert.equal(state.items.get("item-agent").status, "completed");
+  assert.equal(state.items.get("item-agent").summary, "Agent completed");
+  assert.deepEqual(state.itemOrder, ["item-agent"]);
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(5, "agent.list", {
+      item: {
+        id: "item-agent-list",
+        turn_id: "turn-1",
+        kind: "status",
+        status: "completed",
+        summary: "Agent list refreshed",
+        detail: "Agent list refreshed",
+      },
+    }),
+  );
+  assert.equal(state.items.get("item-agent-list").status, "completed");
+  assert.deepEqual(state.itemOrder, ["item-agent", "item-agent-list"]);
+  assert.equal(state.latestSeq, 5);
+});
+
 test("tracks approval and user-input attention until each is resolved", () => {
   const state = createThreadState("thread-a");
   applySnapshot(state, snapshot());

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -238,6 +238,14 @@ test("gap recovery snapshot restores approval and user-input attention before re
         turn_id: "turn-1",
         request: { questions: [{ id: "choice", question: "Continue?", options: [] }] },
       }],
+      pending_dynamic_tool_calls: [{
+        thread_id: "thread-a",
+        turn_id: "turn-1",
+        call_id: "call-recovered",
+        namespace: "bench",
+        tool: "lookup",
+        arguments: { id: "7" },
+      }],
     }),
     subscribe: (threadId, sequence) => subscriptions.push([threadId, sequence]),
   });
@@ -247,6 +255,8 @@ test("gap recovery snapshot restores approval and user-input attention before re
   assert.equal(state.approvals.has("approval-recovered"), true);
   assert.equal(state.userInputs.size, 1);
   assert.equal(state.userInputs.has("input-recovered"), true);
+  assert.equal(state.dynamicToolCalls.size, 1);
+  assert.equal(state.dynamicToolCalls.get("call-recovered").tool, "lookup");
   assert.deepEqual(subscriptions, [["thread-a", 15]]);
 
   const duplicate = runtimeEvent(
@@ -425,6 +435,65 @@ test("hydrates pending attention from a reload snapshot and clears cancellation 
     runtimeEvent(8, "user_input.canceled", { id: "input-reload", terminal: true }),
   );
   assert.equal(state.userInputs.has("input-reload"), false);
+});
+
+test("dynamic tool calls hydrate and disappear exactly once across terminal variants", () => {
+  const state = createThreadState("thread-a");
+  assert.equal(applySnapshot(state, {
+    ...snapshot(),
+    pending_dynamic_tool_calls: [{
+      thread_id: "thread-a",
+      turn_id: "turn-1",
+      call_id: "call-snapshot",
+      tool: "snapshot_lookup",
+      arguments: { id: "snapshot" },
+    }],
+  }), true);
+  assert.equal(state.dynamicToolCalls.get("call-snapshot").tool, "snapshot_lookup");
+
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(8, "tool_call.requested", {
+      thread_id: "thread-a",
+      turn_id: "turn-1",
+      call_id: "call-live",
+      tool: "live_lookup",
+      arguments: { id: "live" },
+    }),
+  ), true);
+  assert.equal(state.dynamicToolCalls.size, 2);
+
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(9, "tool_call.resolved", { call_id: "call-snapshot", status: "resolved" }),
+  ), true);
+  assert.equal(state.dynamicToolCalls.has("call-snapshot"), false);
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(9, "tool_call.resolved", { call_id: "call-snapshot", status: "resolved" }),
+  ), false);
+  assert.equal(state.dynamicToolCalls.size, 1);
+
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(10, "tool_call.canceled", { call_id: "call-live", status: "canceled" }),
+  ), true);
+  assert.equal(state.dynamicToolCalls.size, 0);
+
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(11, "tool_call.requested", {
+      call_id: "call-timeout",
+      tool: "slow_lookup",
+      arguments: {},
+    }),
+  ), true);
+  assert.equal(state.dynamicToolCalls.has("call-timeout"), true);
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(12, "tool_call.timeout", { call_id: "call-timeout", status: "timeout" }),
+  ), true);
+  assert.equal(state.dynamicToolCalls.size, 0);
 });
 
 test("preserves drafts per thread without browser storage", () => {

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -8,6 +8,7 @@ import {
   createThreadState,
   eventStreamUrl,
   restoreDraft,
+  runtimeEventContinuity,
   saveDraft,
   setSafeText,
   snapshotThenSubscribe,
@@ -161,6 +162,74 @@ test("reconnect cursor advances monotonically and duplicate or stale-thread even
   assert.equal(state.items.get("item-1").detail, "Hello world");
   assert.equal(state.latestSeq, 8);
   assert.equal(eventStreamUrl("thread-a", state.latestSeq), "/v1/threads/thread-a/events?since_seq=8");
+});
+
+test("uses the stream predecessor cursor to detect real gaps without assuming global sequences are contiguous", () => {
+  const state = createThreadState("thread-a");
+  applySnapshot(state, snapshot("thread-a", 7));
+
+  const interleaved = runtimeEvent(
+    12,
+    "item.delta",
+    { delta: " after other threads", kind: "agent_message" },
+    { item_id: "item-1", previous_seq: 7 },
+  );
+  assert.equal(runtimeEventContinuity(state, interleaved), "next");
+  assert.equal(applyRuntimeEvent(state, interleaved), true);
+  assert.equal(state.latestSeq, 12);
+
+  const gap = runtimeEvent(
+    15,
+    "approval.required",
+    { approval_id: "approval-missed", tool_name: "exec_shell" },
+    { previous_seq: 14 },
+  );
+  assert.equal(runtimeEventContinuity(state, gap), "gap");
+  assert.equal(applyRuntimeEvent(state, gap), false);
+  assert.equal(state.latestSeq, 12);
+  assert.equal(state.approvals.has("approval-missed"), false);
+});
+
+test("gap recovery snapshot restores approval and user-input attention before resubscribing", async () => {
+  const state = createThreadState("thread-a");
+  applySnapshot(state, snapshot("thread-a", 7));
+  const subscriptions = [];
+
+  const recovered = await snapshotThenSubscribe({
+    state,
+    threadId: "thread-a",
+    loadSnapshot: async () => ({
+      ...snapshot("thread-a", 15),
+      pending_approvals: [{
+        id: "approval-recovered",
+        turn_id: "turn-1",
+        tool_name: "exec_command",
+        description: "Run a local check",
+      }],
+      pending_user_inputs: [{
+        id: "input-recovered",
+        turn_id: "turn-1",
+        request: { questions: [{ id: "choice", question: "Continue?", options: [] }] },
+      }],
+    }),
+    subscribe: (threadId, sequence) => subscriptions.push([threadId, sequence]),
+  });
+
+  assert.equal(recovered, true);
+  assert.equal(state.approvals.size, 1);
+  assert.equal(state.approvals.has("approval-recovered"), true);
+  assert.equal(state.userInputs.size, 1);
+  assert.equal(state.userInputs.has("input-recovered"), true);
+  assert.deepEqual(subscriptions, [["thread-a", 15]]);
+
+  const duplicate = runtimeEvent(
+    15,
+    "approval.required",
+    { approval_id: "approval-recovered", tool_name: "exec_command" },
+    { previous_seq: 14 },
+  );
+  assert.equal(applyRuntimeEvent(state, duplicate), false);
+  assert.equal(state.approvals.size, 1);
 });
 
 test("assembles deltas and replaces the live item with its settled receipt", () => {

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 import {
+  STREAM_EVENT_NAMES,
   applyRuntimeEvent,
   applySnapshot,
   createThreadState,
@@ -190,6 +191,32 @@ test("uses the stream predecessor cursor to detect real gaps without assuming gl
   assert.equal(state.approvals.has("approval-missed"), false);
 });
 
+test("registers the full emitted Runtime vocabulary and advances continuity for every event", async () => {
+  const runtimeSource = await readFile(
+    new URL("../src/runtime_threads.rs", import.meta.url),
+    "utf8",
+  );
+  const emittedNames = new Set(
+    [...runtimeSource.matchAll(
+      /"((?:thread|turn|item|approval|user_input|sandbox|agent|tool_call)\.[a-z_]+)"/g,
+    )].map((match) => match[1]),
+  );
+  assert.deepEqual(new Set(STREAM_EVENT_NAMES), emittedNames);
+  assert.equal(STREAM_EVENT_NAMES.includes("thread.created"), false);
+
+  const state = createThreadState("thread-a");
+  applySnapshot(state, snapshot("thread-a", 7));
+  let previousSeq = 7;
+  for (const eventName of STREAM_EVENT_NAMES) {
+    const sequence = previousSeq + 2;
+    const envelope = runtimeEvent(sequence, eventName, {}, { previous_seq: previousSeq });
+    assert.equal(runtimeEventContinuity(state, envelope), "next", eventName);
+    assert.equal(applyRuntimeEvent(state, envelope), true, eventName);
+    assert.equal(state.latestSeq, sequence, eventName);
+    previousSeq = sequence;
+  }
+});
+
 test("gap recovery snapshot restores approval and user-input attention before resubscribing", async () => {
   const state = createThreadState("thread-a");
   applySnapshot(state, snapshot("thread-a", 7));
@@ -265,6 +292,31 @@ test("assembles deltas and replaces the live item with its settled receipt", () 
   );
   assert.equal(state.items.get("item-new").status, "completed");
   assert.deepEqual(state.itemOrder, ["item-new"]);
+
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(5, "item.delta", { delta: "partial", kind: "tool_call" }, { item_id: "item-stop" }),
+  );
+  applyRuntimeEvent(
+    state,
+    runtimeEvent(
+      6,
+      "item.interrupted",
+      {
+        item: {
+          id: "item-stop",
+          turn_id: "turn-1",
+          kind: "tool_call",
+          status: "interrupted",
+          summary: "Interrupted",
+          detail: "partial",
+        },
+      },
+      { item_id: "item-stop" },
+    ),
+  );
+  assert.equal(state.items.get("item-stop").status, "interrupted");
+  assert.deepEqual(state.itemOrder, ["item-new", "item-stop"]);
 });
 
 test("tracks approval and user-input attention until each is resolved", () => {

--- a/crates/tui/tests/runtime_web_client.test.mjs
+++ b/crates/tui/tests/runtime_web_client.test.mjs
@@ -437,6 +437,30 @@ test("hydrates pending attention from a reload snapshot and clears cancellation 
   assert.equal(state.userInputs.has("input-reload"), false);
 });
 
+test("turn completion defensively clears attention owned by that turn", () => {
+  const state = createThreadState("thread-a");
+  assert.equal(applySnapshot(state, {
+    ...snapshot(),
+    pending_approvals: [{ id: "approval-terminal", turn_id: "turn-1" }],
+    pending_user_inputs: [{ id: "input-terminal", turn_id: "turn-1", request: { questions: [] } }],
+    pending_dynamic_tool_calls: [{ call_id: "call-terminal", turn_id: "turn-1", tool: "lookup" }],
+  }), true);
+  state.approvals.set("approval-other", { id: "approval-other", turn_id: "turn-other" });
+  state.userInputs.set("input-other", { id: "input-other", turn_id: "turn-other" });
+  state.dynamicToolCalls.set("call-other", { call_id: "call-other", turn_id: "turn-other" });
+
+  assert.equal(applyRuntimeEvent(
+    state,
+    runtimeEvent(8, "turn.completed", { turn: { id: "turn-1", status: "completed" } }),
+  ), true);
+  assert.equal(state.approvals.has("approval-terminal"), false);
+  assert.equal(state.userInputs.has("input-terminal"), false);
+  assert.equal(state.dynamicToolCalls.has("call-terminal"), false);
+  assert.equal(state.approvals.has("approval-other"), true);
+  assert.equal(state.userInputs.has("input-other"), true);
+  assert.equal(state.dynamicToolCalls.has("call-other"), true);
+});
+
 test("dynamic tool calls hydrate and disappear exactly once across terminal variants", () => {
   const state = createThreadState("thread-a");
   assert.equal(applySnapshot(state, {

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -298,11 +298,12 @@ work; resolve approvals; and answer Runtime user-input requests. Selection
 loads `GET /v1/threads/{id}` first, then opens the replayable event stream with
 `since_seq=latest_seq`; reconnection advances from the newest accepted sequence
 and drops duplicates or events from a stale selection. The thread detail
-snapshot includes `pending_approvals` and `pending_user_inputs`; clients must
-hydrate those fields before subscribing so a reload cannot strand a prompt
-whose `*.required` event is at or before `latest_seq`. Resolution is also
-published as `approval.decided`, `user_input.answered`, or
-`user_input.canceled` for already-connected clients.
+snapshot includes `pending_approvals`, `pending_user_inputs`, and
+`pending_dynamic_tool_calls`; clients must hydrate those fields before
+subscribing so a reload cannot strand work whose request event is at or before
+`latest_seq`. Resolution is also published as `approval.decided`,
+`user_input.answered`, `user_input.canceled`, `tool_call.resolved`,
+`tool_call.canceled`, or `tool_call.timeout` for already-connected clients.
 
 Model, mode, permission posture, workspace, and branch are display-only in this
 client. Files/Changes, PTY/terminal, preview, artifacts, provider login/model
@@ -417,6 +418,17 @@ accept an empty string to clear a previously-set value. Added in v0.8.10 (#562):
 **User input**
 - `POST /v1/user-input/{thread_id}/{input_id}` with body
   `{ "answers": [{ "id": "question-id", "label": "Choice", "value": "Choice" }] }`
+
+Submitted values are delivered to the active model turn but are deliberately
+excluded from durable Runtime items and events. The settled tool item contains
+only a neutral receipt and a machine-readable `response_redacted` marker.
+
+**Client-executed dynamic tools**
+- `POST /v1/threads/{thread_id}/turns/{turn_id}/tool-calls/{call_id}/result`
+
+The thread and turn in the result route must match the pending call. A call is
+settled at most once; wrong-route and duplicate results return 404. Terminal
+lifecycle events carry identifiers and status only, never tool result content.
 
 **Events** (SSE replay + live stream)
 - `GET /v1/threads/{id}/events?since_seq=<u64>`

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -429,6 +429,22 @@ only a neutral receipt and a machine-readable `response_redacted` marker.
 The thread and turn in the result route must match the pending call. A call is
 settled at most once; wrong-route and duplicate results return 404. Terminal
 lifecycle events carry identifiers and status only, never tool result content.
+The Runtime commits the terminal lifecycle event before making a submitted
+result available to the model. Result delivery, timeout, and terminal-turn
+cancellation race through one settlement owner, so exactly one of these events
+is durable for a call:
+
+- `tool_call.requested` — the typed client-executed call became pending;
+- `tool_call.resolved` — a result was durably accepted by the Runtime
+  (`result_accepted: true`; `success` is result metadata, but result content is
+  excluded);
+- `tool_call.timeout` — no result won before the bounded wait expired;
+- `tool_call.canceled` — the turn terminated before a submitted result won.
+
+HTTP `202 Accepted` and `tool_call.resolved` share that durable-acceptance
+meaning. Neither claims that the model consumed the result: a concurrent turn
+shutdown may close the model receiver after acceptance. Once the Runtime has
+accepted the result, that call is terminal and a duplicate result returns 404.
 
 **Events** (SSE replay + live stream)
 - `GET /v1/threads/{id}/events?since_seq=<u64>`
@@ -546,6 +562,10 @@ not persisted in `TurnRecord`.
 - If the process restarts while a turn or item is `queued` or `in_progress`,
   the recovered record is marked `interrupted` with an `"Interrupted by
   process restart"` error.
+- If a terminal turn record reached disk but its terminal event sequence did
+  not, the first async read reconciles any unresolved dynamic calls as
+  `tool_call.canceled` and then emits one `turn.completed`. Existing terminal
+  call and turn receipts are detected and never duplicated.
 - Task execution performs its own recovery on top of the same persisted
   thread/turn store.
 
@@ -565,6 +585,7 @@ The SSE event payload shape for `/v1/threads/{id}/events`:
 {
   "schema_version": 1,
   "seq": 42,
+  "previous_seq": 38,
   "event": "item.delta",
   "kind": "item.delta",
   "thread_id": "thr_1234abcd",
@@ -585,6 +606,14 @@ Compatibility notes:
   the runtime store schema used for persisted thread/turn/event records.
 - `event` remains the SSE event name in existing clients; it is preserved as-is.
 - `kind` mirrors `event` in the stable envelope for typed clients.
+- `seq` is allocated globally across all Runtime threads. Consequently, gaps
+  between a thread's events are normal when other threads interleave. On this
+  per-thread SSE stream, `previous_seq` is the sequence of the last event
+  delivered for this thread (or the requested replay cursor for the first
+  event); clients detect loss by comparing it with their accepted per-thread
+  cursor, not by requiring `seq == previous_seq + 1`. Sequence allocation is
+  also not rewound after an append is transactionally rolled back, so a retry
+  can intentionally skip an unused value without implying a missing event.
 - `thread.started`, `turn.started`, and `turn.completed` are emitted as SSE event
   names exactly as before.
 - `timestamp` remains the canonical event time for schema version 1. `created_at`
@@ -596,7 +625,17 @@ Common event names: `thread.started`, `thread.forked`, `turn.started`,
 `turn.completed`, `item.started`, `item.delta`, `item.completed`,
 `item.failed`, `item.interrupted`, `approval.required`, `approval.decided`,
 `approval.timeout`, `user_input.required`, `user_input.answered`,
-`user_input.canceled`, `sandbox.denied`.
+`user_input.canceled`, `tool_call.requested`, `tool_call.resolved`,
+`tool_call.timeout`, `tool_call.canceled`, `sandbox.denied`.
+
+Agent-message and reasoning deltas are materialized into the item projection
+before their corresponding `item.delta` event is sequenced. To avoid an fsync
+for every provider fragment, adjacent deltas are coalesced to configured bounds
+of at most 32 ms or approximately 16 KiB before publication (an indivisible
+upstream chunk can itself exceed the byte target). A process crash inside that
+unpublished window can lose the recent suffix; no durable event claims that
+suffix existed. Once an `item.delta` is durable, snapshots at or beyond its
+cursor include the same materialized prefix.
 
 `approval.required` events may include a `matched_rule` string when an
 execution-policy rule caused the prompt. This field is explanatory metadata for

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -457,6 +457,13 @@ accepted the result, that call is terminal and a duplicate result returns 404.
 **Events** (SSE replay + live stream)
 - `GET /v1/threads/{id}/events?since_seq=<u64>`
 
+Durable history parsing runs off the async server workers and reaches SSE in
+bounded batches of at most 256 events through a backpressured channel. Broadcast
+delivery is only a wake-up optimization: a lagged receiver opens the same
+bounded durable replay from its last accepted cursor. Optional `replay_limit`
+returns the newest requested tail and may not exceed 4096; `previous_seq` on
+the first returned event advances past exactly the omitted history.
+
 **Snapshots** (read-only side-git restore point listing)
 - `GET /v1/snapshots?limit=20`
 

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -421,7 +421,15 @@ accept an empty string to clear a previously-set value. Added in v0.8.10 (#562):
 
 Submitted values are delivered to the active model turn but are deliberately
 excluded from durable Runtime items and events. The settled tool item contains
-only a neutral receipt and a machine-readable `response_redacted` marker.
+only a neutral receipt and a machine-readable `response_redacted` marker. The
+Runtime accepts only an exact pending `(thread_id, input_id)` request; an
+unknown, concurrently settling, or already settled id returns 404 and is never
+placed in the engine mailbox. It commits the secret-free
+`user_input.answered` receipt before removing the snapshot-authoritative prompt
+or delivering the answer to the engine. That settlement runs independently of
+the HTTP connection, so disconnecting after submission cannot leave a prompt
+half accepted. Terminal-turn cancellation follows the same receipt-before-
+removal ordering through `user_input.canceled`.
 
 **Client-executed dynamic tools**
 - `POST /v1/threads/{thread_id}/turns/{turn_id}/tool-calls/{call_id}/result`

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -577,6 +577,11 @@ not persisted in `TurnRecord`.
 - If the process restarts while a turn or item is `queued` or `in_progress`,
   the recovered record is marked `interrupted` with an `"Interrupted by
   process restart"` error.
+- The trailing newline is an event append's commit marker. On startup, a final
+  JSONL fragment without that delimiter is truncated and fsynced even when its
+  bytes form valid JSON; it is an uncommitted append, and its already-reserved
+  sequence number is not reused. Newline-terminated malformed records are not
+  identifiable crash debris and continue to fail closed during replay.
 - If a terminal turn record reached disk but its terminal event sequence did
   not, the first async read reconciles any unresolved dynamic calls as
   `tool_call.canceled` and then emits one `turn.completed`. Existing terminal


### PR DESCRIPTION
## Summary

- subscribe before durable replay and recover broadcast lag without replay/live gaps
- detect browser projection gaps with per-stream predecessor cursors and resnapshot safely
- persist partial message/reasoning prefixes before cursor advancement
- make replay bounded and backpressured, with JSONL scans and projection reads off async workers
- recover interrupted final JSONL appends using the newline commit marker while preserving sequence gaps and failing closed on durable malformed records
- preserve transactional receipt rollback on Windows without weakening atomic success-path append semantics
- redact submitted `request_user_input` answers from Runtime receipts while preserving model delivery, durable settlement, cancellation, and retry semantics
- make client-executed dynamic tool calls snapshot-recoverable, route-scoped, bounded, and exactly-once through resolution, cancellation, and timeout
- make terminal recovery idempotent by `(turn_id, call_id)` while keeping dedupe scans off Tokio workers and terminal projection publication atomic to snapshots
- reject unknown user-input identifiers and oversized replay requests at the HTTP boundary
- document the completed Runtime lifecycle contract

Closes #4514.

## Exact integration state

- base: `d87e05729cda0ae6cba3ebdf386670f90808d925`
- head: `0c1f90c04ca924bf6c917b1cef6391f265693af2`
- rebased without conflicts from remote head `d045e4bd9610d219bcc6a6e44cd4be15baa6ea92`
- #4521 workspace-dotenv authority files are unchanged from the exact base; its targeted authority tests pass

## Verification on exact head

- `cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_threads` — 119 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked runtime_api` — 99 passed
- `node --test crates/tui/tests/runtime_web_client.test.mjs` — 15 passed
- `cargo test -p codewhale-tui --test dotenv_authority --locked` — 2 passed
- `cargo check -p codewhale-tui --bin codewhale-tui --locked`
- `cargo clippy -p codewhale-tui --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check` and `git diff --check origin/main...HEAD`
- every rebased commit retains `Signed-off-by: Hunter B <hmbown@gmail.com>`

The macOS linker emitted its existing `__eh_frame section too large` warning during test links; it did not fail a gate. Fresh native Windows CI is required for the final receipt-rollback commit.

## Review notes

The compatibility endpoint continues to deliver submitted answers to the active model turn, but no answer label/value is projected into the embedded web client or durable Runtime state. Dynamic-tool terminal events likewise contain identifiers and status only, never result content.

Terminal turn persistence, the deduplicated `turn.completed` receipt, and active-claim cleanup share a per-thread projection boundary. Snapshot readers therefore see either the pre-terminal state or the fully ordered terminal lifecycle, including when the dedupe scan yields to a blocking worker.


