### PR TITLE
fix(tui): initialize plugins for every launch path

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1384,8 +1384,17 @@ async fn run_async_main() -> Result<()> {
     // suspend path, and SIGTERM / SIGHUP from the OS.
     spawn_signal_cleanup_task();
 
-    dotenv().ok();
-    let cli = Cli::parse();
+    // Parse first so help/version/errors still exit without touching plugin
+    // state. Plugin discovery must precede workspace-local dotenv loading:
+    // otherwise an untrusted repository could redirect CODEWHALE_HOME to a
+    // repository-owned plugin manifest containing an stdio MCP server.
+    let (cli, command) = prepare_cli_startup(
+        Cli::parse(),
+        || crate::plugins::init_registry(&[]),
+        || {
+            dotenv().ok();
+        },
+    );
     logging::set_verbose(cli.verbose || logging::env_requests_verbose_logging());
 
     // Install any user prompt overrides from the config directory before an
@@ -1395,7 +1404,7 @@ async fn run_async_main() -> Result<()> {
     crate::prompts::load_prompt_overrides_from_config_home();
 
     // Handle subcommands first
-    if let Some(command) = cli.command.clone() {
+    if let Some(command) = command {
         return match command {
             Commands::Doctor(args) => {
                 let config = load_config_from_cli(&cli)?;
@@ -1671,7 +1680,6 @@ async fn run_async_main() -> Result<()> {
     // for follow-up messages. Use `codewhale exec` for explicit non-interactive
     // one-shot behavior (#2370).
     let config = load_config_from_cli(&cli)?;
-    crate::plugins::init_registry(&[]);
     if let Some(initial_input) = top_level_prompt_initial_input(&cli.prompt) {
         return run_interactive(&cli, &config, None, Some(initial_input)).await;
     }
@@ -1695,6 +1703,17 @@ async fn run_async_main() -> Result<()> {
     // Default: Interactive TUI
     // --yolo starts in YOLO mode (auto-approve; shell enabled)
     run_interactive(&cli, &config, resume_session_id, None).await
+}
+
+fn prepare_cli_startup(
+    cli: Cli,
+    initialize_plugins: impl FnOnce(),
+    load_dotenv: impl FnOnce(),
+) -> (Cli, Option<Commands>) {
+    initialize_plugins();
+    load_dotenv();
+    let command = cli.command.clone();
+    (cli, command)
 }
 
 /// Generate shell completions for the given shell
@@ -11697,6 +11716,54 @@ mod terminal_mode_tests {
         assert!(!last);
         assert_eq!(sessions_resume_command(), "codewhale resume");
         assert!(!sessions_resume_command().contains("--resume"));
+    }
+
+    #[test]
+    fn plugin_registry_initialization_precedes_dotenv_for_all_launch_paths() {
+        use std::cell::Cell;
+
+        #[derive(Clone, Copy)]
+        enum Expected {
+            Plain,
+            Resume,
+            Fork,
+            Exec,
+            Serve,
+        }
+
+        let cases: &[(&[&str], Expected)] = &[
+            (&["codewhale"], Expected::Plain),
+            (&["codewhale", "resume", "--last"], Expected::Resume),
+            (&["codewhale", "fork", "--last"], Expected::Fork),
+            (&["codewhale", "exec", "probe"], Expected::Exec),
+            (&["codewhale", "serve", "--mcp"], Expected::Serve),
+        ];
+
+        for (args, expected) in cases {
+            let phase = Cell::new(0);
+            let (_cli, command) = prepare_cli_startup(
+                parse_cli(args),
+                || {
+                    assert_eq!(phase.get(), 0, "plugin init order for {args:?}");
+                    phase.set(1);
+                },
+                || {
+                    assert_eq!(phase.get(), 1, "dotenv load order for {args:?}");
+                    phase.set(2);
+                },
+            );
+
+            assert_eq!(phase.get(), 2, "startup phases for {args:?}");
+            let correct_variant = matches!(
+                (expected, command.as_ref()),
+                (Expected::Plain, None)
+                    | (Expected::Resume, Some(Commands::Resume { .. }))
+                    | (Expected::Fork, Some(Commands::Fork { .. }))
+                    | (Expected::Exec, Some(Commands::Exec(_)))
+                    | (Expected::Serve, Some(Commands::Serve(_)))
+            );
+            assert!(correct_variant, "unexpected command for {args:?}");
+        }
     }
 
     #[test]

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -2629,44 +2629,45 @@ pub fn workspace_mcp_config_path(workspace: &Path) -> PathBuf {
 }
 
 pub fn load_config_with_workspace(global_path: &Path, workspace: &Path) -> Result<McpConfig> {
-    let mut merged = load_config(global_path)?;
-    let workspace = checked_workspace_path(workspace)?;
-    let project_path = checked_workspace_mcp_config_path(&workspace)?;
-    if !project_path.exists() || paths_refer_to_same_config(global_path, &project_path) {
-        return Ok(merged);
-    }
-    // Workspace-local MCP can spawn stdio servers, so it is only honored after
-    // the user has trusted this workspace in user-owned config. Do not accept
-    // project-local legacy trust markers here: a repository could carry those
-    // files itself and silently reintroduce the project-scope `mcp_config_path`
-    // risk denied in #417.
-    if !workspace_allows_project_mcp_config(&workspace) {
-        return Ok(merged);
-    }
-
-    let mut project = load_config(&project_path)?;
-    for server in project.servers.values_mut() {
-        if server.command.is_some() && server.url.is_none() {
-            server.cwd = Some(resolve_project_mcp_cwd(&workspace, server.cwd.as_deref())?);
-        }
-    }
-    merged.servers.extend(project.servers);
-
-    merged = merge_plugin_mcp_servers(merged)?;
-
-    Ok(merged)
-}
-
-fn merge_plugin_mcp_servers(config: McpConfig) -> Result<McpConfig> {
-    let plugins = crate::plugins::try_with_registry(|r| {
-        r.list_enabled()
+    let plugins = crate::plugins::try_with_registry(|registry| {
+        registry
+            .list_enabled()
             .into_iter()
             .map(|(name, plugin)| (name.clone(), plugin.clone()))
             .collect::<Vec<_>>()
     })
     .unwrap_or_default();
 
-    merge_plugin_mcp_servers_from_plugins(config, plugins)
+    load_config_with_workspace_from_plugins(global_path, workspace, plugins)
+}
+
+fn load_config_with_workspace_from_plugins(
+    global_path: &Path,
+    workspace: &Path,
+    plugins: impl IntoIterator<Item = (String, crate::plugins::manifest::LoadedPlugin)>,
+) -> Result<McpConfig> {
+    let mut merged = load_config(global_path)?;
+    let workspace = checked_workspace_path(workspace)?;
+    let project_path = checked_workspace_mcp_config_path(&workspace)?;
+    let has_distinct_project_config =
+        project_path.exists() && !paths_refer_to_same_config(global_path, &project_path);
+    // Workspace-local MCP can spawn stdio servers, so it is only honored after
+    // the user has trusted this workspace in user-owned config. Do not accept
+    // project-local legacy trust markers here: a repository could carry those
+    // files itself and silently reintroduce the project-scope `mcp_config_path`
+    // risk denied in #417. User-owned plugin MCP remains independent of this
+    // project trust gate and is merged below on every path.
+    if has_distinct_project_config && workspace_allows_project_mcp_config(&workspace) {
+        let mut project = load_config(&project_path)?;
+        for server in project.servers.values_mut() {
+            if server.command.is_some() && server.url.is_none() {
+                server.cwd = Some(resolve_project_mcp_cwd(&workspace, server.cwd.as_deref())?);
+            }
+        }
+        merged.servers.extend(project.servers);
+    }
+
+    merge_plugin_mcp_servers_from_plugins(merged, plugins)
 }
 
 fn merge_plugin_mcp_servers_from_plugins(

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -809,13 +809,70 @@ url = "https://example.invalid/mcp"
     assert!(remote.cwd.is_none());
 }
 
+fn plugin_with_local_mcp(name: &str, base_path: PathBuf) -> crate::plugins::manifest::LoadedPlugin {
+    let manifest = toml::from_str::<crate::plugins::manifest::PluginManifest>(&format!(
+        r#"
+[plugin]
+name = "{name}"
+
+[mcp_servers.local]
+command = "node"
+args = ["server.js"]
+"#,
+    ))
+    .unwrap();
+    crate::plugins::manifest::LoadedPlugin {
+        manifest,
+        base_path,
+        enabled: true,
+    }
+}
+
+#[test]
+fn plugin_mcp_servers_merge_without_project_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let global_path = dir.path().join("global-mcp.json");
+    let workspace = dir.path().join("workspace");
+    let plugin_base = dir.path().join("plugins").join("fixture");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&plugin_base).unwrap();
+    fs::write(
+        &global_path,
+        r#"{"servers": {"global": {"command": "node", "args": ["global.js"]}}}"#,
+    )
+    .unwrap();
+
+    let cfg = load_config_with_workspace_from_plugins(
+        &global_path,
+        &workspace,
+        vec![(
+            "fixture".to_string(),
+            plugin_with_local_mcp("fixture", plugin_base.clone()),
+        )],
+    )
+    .unwrap();
+
+    assert!(cfg.servers.contains_key("global"));
+    let local = cfg
+        .servers
+        .get("fixture-local")
+        .expect("plugin MCP should merge without a project MCP config");
+    assert_eq!(local.command.as_deref(), Some("node"));
+    assert_eq!(
+        local.cwd.as_deref(),
+        Some(plugin_base.canonicalize().unwrap().as_path())
+    );
+}
+
 #[test]
 fn workspace_mcp_config_ignores_project_file_until_workspace_trusted() {
     let dir = tempfile::tempdir().unwrap();
     let global_path = dir.path().join("global-mcp.json");
     let workspace = dir.path().join("workspace");
     let project_dir = workspace.join(".codewhale");
+    let plugin_base = dir.path().join("plugins").join("fixture");
     fs::create_dir_all(&project_dir).unwrap();
+    fs::create_dir_all(&plugin_base).unwrap();
     fs::write(
         &global_path,
         r#"{"servers": {"global": {"command": "node", "args": ["global.js"]}}}"#,
@@ -827,10 +884,22 @@ fn workspace_mcp_config_ignores_project_file_until_workspace_trusted() {
     )
     .unwrap();
 
-    let cfg = load_config_with_workspace(&global_path, &workspace).unwrap();
+    let cfg = load_config_with_workspace_from_plugins(
+        &global_path,
+        &workspace,
+        vec![(
+            "fixture".to_string(),
+            plugin_with_local_mcp("fixture", plugin_base),
+        )],
+    )
+    .unwrap();
 
     assert!(cfg.servers.contains_key("global"));
     assert!(!cfg.servers.contains_key("project"));
+    assert!(
+        cfg.servers.contains_key("fixture-local"),
+        "user plugin MCP should not be gated by project workspace trust"
+    );
 }
 
 #[test]

--- a/crates/tui/src/plugins/discovery.rs
+++ b/crates/tui/src/plugins/discovery.rs
@@ -7,16 +7,19 @@ use super::registry::PluginRegistry;
 const PLUGIN_MANIFEST: &str = "plugin.toml";
 const OVERRIDES_FILE: &str = "overrides.json";
 
-pub fn default_user_plugins_dir() -> PathBuf {
+pub fn default_user_plugins_dir() -> Option<PathBuf> {
+    // User plugins can start stdio MCP servers. If the trusted home directory
+    // cannot be resolved, fail closed instead of scanning a shared temporary
+    // directory that another local user could populate.
     codewhale_config::codewhale_home()
+        .ok()
         .map(|p| p.join("plugins"))
-        .unwrap_or_else(|_| PathBuf::from("/tmp/codewhale/plugins"))
 }
 
 /// Path of the JSON file that records `/plugin enable|disable` choices so they
 /// survive restarts.
-pub fn default_overrides_path() -> PathBuf {
-    default_user_plugins_dir().join(OVERRIDES_FILE)
+pub fn default_overrides_path() -> Option<PathBuf> {
+    default_user_plugins_dir().map(|path| path.join(OVERRIDES_FILE))
 }
 
 /// Read the persisted enable/disable overrides. Missing or malformed files
@@ -42,9 +45,12 @@ pub fn save_overrides(path: &Path, overrides: &HashMap<String, bool>) -> std::io
 pub fn discover_all(builtin_dirs: &[&str]) -> PluginRegistry {
     let mut registry = PluginRegistry::new();
 
-    let overrides_path = default_overrides_path();
-    let overrides = load_overrides(&overrides_path);
-    registry.set_overrides_store(overrides_path, overrides);
+    let user_dir = default_user_plugins_dir();
+    if let Some(user_dir) = user_dir.as_ref() {
+        let overrides_path = user_dir.join(OVERRIDES_FILE);
+        let overrides = load_overrides(&overrides_path);
+        registry.set_overrides_store(overrides_path, overrides);
+    }
 
     for dir in builtin_dirs {
         let path = PathBuf::from(dir);
@@ -53,8 +59,9 @@ pub fn discover_all(builtin_dirs: &[&str]) -> PluginRegistry {
         }
     }
 
-    let user_dir = default_user_plugins_dir();
-    if user_dir.exists() {
+    if let Some(user_dir) = user_dir
+        && user_dir.exists()
+    {
         discover_from_dir(&user_dir, &mut registry, false);
     }
 
@@ -115,10 +122,10 @@ mod tests {
         let home = tmp.path().join("codewhale-home");
         let _home = crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", home.as_os_str());
 
-        assert_eq!(default_user_plugins_dir(), home.join("plugins"));
+        assert_eq!(default_user_plugins_dir(), Some(home.join("plugins")));
         assert_eq!(
             default_overrides_path(),
-            home.join("plugins").join(OVERRIDES_FILE)
+            Some(home.join("plugins").join(OVERRIDES_FILE))
         );
     }
 }


### PR DESCRIPTION
## Summary

- initialize the plugin registry before dispatching plain, `resume`, `fork`, `exec`, and `serve` launches
- load workspace `.env` files only after plugin discovery so an untrusted repository cannot redirect the plugin root
- merge enabled plugin MCP servers whether the workspace has no project MCP file, an untrusted project file, or a trusted project file
- fail closed when the user plugin home cannot be resolved instead of scanning a shared temporary directory

## Regression coverage

- pin startup ordering and command coverage for plain, resume, fork, exec, and serve
- verify plugin MCP servers merge without a project MCP config
- verify an untrusted project MCP file remains ignored while user-owned plugin MCP still merges
- retain the global -> trusted project -> plugin merge precedence

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked terminal_mode_tests::` (71 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked plugins::` (14 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked mcp::tests` (145 passed, 1 ignored)
- `cargo test -p codewhale-tui --test plugin_e2e_acceptance --locked` (4 passed)
- `cargo test --workspace --exclude codewhale-tui --exclude codewhale-lane --locked`
- `cargo build --release -p codewhale-cli -p codewhale-tui --locked`
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings -A clippy::needless_return -A clippy::collapsible_match`

The full local TUI binary suite completed with 7,116 passing, 2 ignored, and 4 independently reproduced Windows/host-state baseline failures: one PowerShell 5.1 UTF-16 fixture read and three tests that observe the host Codex auth file. None intersects this diff; the three auth-sensitive tests pass when `OPENAI_CODEX_AUTH_FILE` points to an isolated missing path.

Fixes #3916
