### PR TITLE
fix(goal): keep lifecycle mutation root-owned

### DIFF
--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1980,7 +1980,8 @@ fn refresh_system_prompt_uses_runtime_goal_state() {
     let (mut engine, _handle) = Engine::new(EngineConfig::default(), &Config::default());
     {
         let mut goal = engine.config.goal_state.lock().expect("goal lock");
-        goal.create("Close the runtime goal loop".to_string(), None);
+        goal.create("Close the runtime goal loop".to_string(), None)
+            .expect("create goal");
     }
 
     engine.refresh_system_prompt();
@@ -2003,7 +2004,8 @@ async fn runtime_goal_updates_emit_ui_snapshot() {
     let (engine, handle) = Engine::new(EngineConfig::default(), &Config::default());
     {
         let mut goal = engine.config.goal_state.lock().expect("goal lock");
-        goal.create("Ship the release lane".to_string(), Some(42_000));
+        goal.create("Ship the release lane".to_string(), Some(42_000))
+            .expect("create goal");
         goal.mark_complete(
             "verified with focused tests".to_string(),
             crate::tools::goal::GoalCompletionVerification {
@@ -6581,7 +6583,8 @@ fn turn_metadata_surfaces_context_and_resource_usage() {
     });
     {
         let mut goal = engine.config.goal_state.lock().expect("goal lock");
-        goal.create("Finish telemetry visibility".to_string(), Some(2_000));
+        goal.create("Finish telemetry visibility".to_string(), Some(2_000))
+            .expect("create goal");
         goal.record_usage(1_000, 100);
     }
 

--- a/crates/tui/src/tools/goal.rs
+++ b/crates/tui/src/tools/goal.rs
@@ -136,7 +136,16 @@ impl GoalState {
         }
     }
 
-    pub fn create(&mut self, objective: String, token_budget: Option<u32>) {
+    pub fn create(
+        &mut self,
+        objective: String,
+        token_budget: Option<u32>,
+    ) -> Result<(), &'static str> {
+        if self.objective.is_some() && self.status != Some(GoalStatus::Complete) {
+            return Err(
+                "An unfinished goal already exists. Complete or clear it before creating another.",
+            );
+        }
         self.objective = Some(objective);
         self.token_budget = token_budget;
         self.status = Some(GoalStatus::Active);
@@ -148,6 +157,7 @@ impl GoalState {
         self.evidence = None;
         self.blocker = None;
         self.completion_verification = None;
+        Ok(())
     }
 
     pub fn record_usage(&mut self, token_delta: u64, time_delta_seconds: u64) {
@@ -361,6 +371,15 @@ fn json_result(snapshot: &GoalSnapshot) -> Result<ToolResult, ToolError> {
     ToolResult::json(snapshot).map_err(|err| ToolError::execution_failed(err.to_string()))
 }
 
+fn require_root_goal_mutation(context: &ToolContext) -> Result<(), ToolError> {
+    if context.owner_agent_id.is_some() {
+        return Err(ToolError::invalid_input(
+            "Goal lifecycle mutation is root-agent only; sub-agents may inspect the parent goal with get_goal.",
+        ));
+    }
+    Ok(())
+}
+
 pub struct CreateGoalTool {
     goal_state: SharedGoalState,
 }
@@ -379,7 +398,7 @@ impl ToolSpec for CreateGoalTool {
     }
 
     fn description(&self) -> &'static str {
-        "Create the current runtime goal. Use this only when the user explicitly asks to pursue a persistent objective."
+        "Create the current runtime goal. Use this only when the user explicitly asks to pursue a persistent objective and no unfinished goal exists; complete or clear an unfinished goal before creating another."
     }
 
     fn input_schema(&self) -> Value {
@@ -409,7 +428,8 @@ impl ToolSpec for CreateGoalTool {
         ApprovalRequirement::Auto
     }
 
-    async fn execute(&self, input: Value, _context: &ToolContext) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        require_root_goal_mutation(context)?;
         let objective = required_str(&input, "objective")?.trim().to_string();
         if objective.is_empty() {
             return Err(ToolError::invalid_input("objective cannot be empty"));
@@ -417,7 +437,9 @@ impl ToolSpec for CreateGoalTool {
         let token_budget = parse_token_budget(&input)?;
         let snapshot = {
             let mut state = lock_goal_state(&self.goal_state)?;
-            state.create(objective, token_budget);
+            state
+                .create(objective, token_budget)
+                .map_err(ToolError::invalid_input)?;
             state.snapshot()
         };
         json_result(&snapshot)
@@ -555,7 +577,8 @@ impl ToolSpec for UpdateGoalTool {
         ApprovalRequirement::Auto
     }
 
-    async fn execute(&self, input: Value, _context: &ToolContext) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
+        require_root_goal_mutation(context)?;
         let status = required_str(&input, "status")?.trim().to_ascii_lowercase();
         let snapshot = {
             let mut state = lock_goal_state(&self.goal_state)?;
@@ -667,6 +690,108 @@ mod tests {
         );
         assert!(completed.content.contains("focused tests passed"));
         assert!(!state.lock().expect("goal lock").is_active());
+    }
+
+    #[test]
+    fn unfinished_goal_replacement_fails_closed_without_mutating_state() {
+        for status in [GoalStatus::Active, GoalStatus::Paused, GoalStatus::Blocked] {
+            let mut state = GoalState::default();
+            state.sync_from_host_status(
+                Some("preserve the current objective"),
+                Some(1_200),
+                status,
+            );
+            state.record_usage(300, 12);
+            state.record_continuation();
+            let before = state.snapshot();
+
+            let error = state
+                .create("replace it silently".to_string(), Some(99))
+                .expect_err("unfinished goal replacement must fail");
+
+            assert!(
+                error.contains("unfinished goal"),
+                "status {status:?}: {error}"
+            );
+            assert_eq!(
+                state.snapshot(),
+                before,
+                "status {status:?} must preserve the entire goal snapshot"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_goal_can_be_replaced_with_fresh_accounting() {
+        let mut state = GoalState::default();
+        state
+            .create("finish the first objective".to_string(), Some(1_200))
+            .expect("create first goal");
+        state.record_usage(300, 12);
+        state.record_continuation();
+        state
+            .mark_complete(
+                "focused tests passed".to_string(),
+                GoalCompletionVerification {
+                    status: "passed".to_string(),
+                    check: "cargo test".to_string(),
+                    summary: "goal tests passed".to_string(),
+                },
+            )
+            .expect("complete first goal");
+
+        state
+            .create("start the next objective".to_string(), Some(2_400))
+            .expect("completed goal may be replaced");
+
+        let snapshot = state.snapshot();
+        assert_eq!(
+            snapshot.objective.as_deref(),
+            Some("start the next objective")
+        );
+        assert_eq!(snapshot.status, "active");
+        assert_eq!(snapshot.token_budget, Some(2_400));
+        assert_eq!(snapshot.tokens_used, 0);
+        assert_eq!(snapshot.time_used_seconds, 0);
+        assert_eq!(snapshot.continuation_count, 0);
+        assert_eq!(snapshot.evidence, None);
+        assert_eq!(snapshot.blocker, None);
+        assert_eq!(snapshot.completion_verification, None);
+    }
+
+    #[tokio::test]
+    async fn subagent_context_cannot_mutate_parent_goal() {
+        let state = new_shared_goal_state_from_host_status(
+            Some("keep root lifecycle authority".to_string()),
+            Some(1_200),
+            GoalStatus::Active,
+        );
+        let before = state.lock().expect("goal lock").snapshot();
+        let child_context = ToolContext::new(".").with_owner_agent("agent_child", "child verifier");
+
+        let create_error = CreateGoalTool::new(state.clone())
+            .execute(
+                json!({"objective": "replace the parent goal"}),
+                &child_context,
+            )
+            .await
+            .expect_err("child create_goal must fail");
+        assert!(create_error.to_string().contains("root-agent only"));
+
+        let update_error = UpdateGoalTool::new(state.clone())
+            .execute(
+                json!({"status": "blocked", "blocker": "child decided to stop"}),
+                &child_context,
+            )
+            .await
+            .expect_err("child update_goal must fail");
+        assert!(update_error.to_string().contains("root-agent only"));
+
+        assert_eq!(
+            state.lock().expect("goal lock").snapshot(),
+            before,
+            "rejected child mutations must leave the parent goal unchanged"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -9246,7 +9246,8 @@ impl SubAgentToolRegistry {
         todo_list: SharedTodoList,
         plan_state: SharedPlanState,
     ) -> Self {
-        // Build the full agent surface — same as the parent's Agent mode.
+        // Build the full agent surface — same as the parent's Agent mode except
+        // for root-owned goal lifecycle mutation.
         // Children inherit shell, file, patch, search, web, git, diagnostics,
         // review, and RLM, plus per-child fresh todo/plan state. `agent` is
         // retained only when depth budget remains.
@@ -9268,7 +9269,13 @@ impl SubAgentToolRegistry {
             registry = registry.with_mcp_tools(std::sync::Arc::clone(pool));
         }
 
-        let registry = registry.build(context);
+        let mut registry = registry.build(context);
+        // Children may inspect the parent goal for context, but only the root
+        // agent may create or transition that shared lifecycle. Removing the
+        // mutators after all built-in and MCP registrations also prevents an
+        // accidental name collision from restoring child authority.
+        registry.remove_tool("create_goal");
+        registry.remove_tool("update_goal");
 
         Self {
             allowed_tools: explicit_allowed_tools,

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -3021,19 +3021,24 @@ fn subagent_auto_reasoning_resolves_to_distinct_v4_tiers() {
 #[test]
 fn test_subagent_tool_registry_reports_unavailable_tools() {
     let tmp = tempdir().expect("tempdir");
-    let mut runtime = stub_runtime();
+    let mut runtime =
+        stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
     runtime.context = ToolContext::new(tmp.path().to_path_buf());
     runtime.allow_shell = false;
     let registry = SubAgentToolRegistry::new(
         runtime,
         SubAgentType::Explore,
-        Some(vec!["read_file".to_string(), "missing_tool".to_string()]),
+        Some(vec![
+            "read_file".to_string(),
+            "update_goal".to_string(),
+            "missing_tool".to_string(),
+        ]),
         Arc::new(Mutex::new(TodoList::new())),
         Arc::new(Mutex::new(PlanState::default())),
     );
     assert_eq!(
         registry.unavailable_allowed_tools(),
-        vec!["missing_tool".to_string()]
+        vec!["update_goal".to_string(), "missing_tool".to_string()]
     );
 }
 
@@ -3096,7 +3101,7 @@ fn disabled_feature_agent_surface_options() -> AgentToolSurfaceOptions {
 }
 
 #[test]
-fn subagent_general_catalog_matches_parent_agent_surface_when_features_enabled() {
+fn subagent_general_catalog_keeps_parent_surface_except_root_goal_mutators() {
     let tmp = tempdir().expect("tempdir");
     let mut runtime =
         stub_runtime().with_agent_tool_surface_options(enabled_agent_surface_options());
@@ -3120,9 +3125,20 @@ fn subagent_general_catalog_matches_parent_agent_surface_when_features_enabled()
 
     let parent_names = tool_names(parent_registry.to_api_tools());
     let child_names = tool_names(child_registry.tools_for_model(&SubAgentType::General));
+    let expected_child_names = parent_names
+        .iter()
+        .filter(|name| !matches!(name.as_str(), "create_goal" | "update_goal"))
+        .cloned()
+        .collect::<HashSet<_>>();
+
+    assert!(parent_names.contains("create_goal"));
+    assert!(parent_names.contains("update_goal"));
+    assert!(child_names.contains("get_goal"));
+    assert!(!child_names.contains("create_goal"));
+    assert!(!child_names.contains("update_goal"));
     assert_eq!(
-        child_names, parent_names,
-        "default General sub-agent catalog must stay in parity with the parent Agent surface"
+        child_names, expected_child_names,
+        "default General sub-agent catalog must match the parent Agent surface except for root-owned goal mutators"
     );
 }
 

--- a/crates/tui/src/tui/user_input.rs
+++ b/crates/tui/src/tui/user_input.rs
@@ -127,7 +127,12 @@ impl UserInputView {
 
     /// True when the multi-select "Confirm selection" row is highlighted.
     fn is_confirm_selected(&self) -> bool {
-        self.is_multi_select() && self.selected + 1 == self.option_count()
+        self.confirm_index() == Some(self.selected)
+    }
+
+    fn confirm_index(&self) -> Option<usize> {
+        self.is_multi_select()
+            .then(|| self.option_count().saturating_sub(1))
     }
 
     fn is_multi_select(&self) -> bool {
@@ -382,8 +387,7 @@ impl ModalView for UserInputView {
         // Multi-select gets a dedicated "Confirm selection" row after the
         // options (and after "Other" when present). Selecting and pressing
         // Enter on it flushes the pending set as the question's answers.
-        if self.is_multi_select() {
-            let confirm_index = self.option_count();
+        if let Some(confirm_index) = self.confirm_index() {
             let confirm_number = confirm_index + 1;
             push_option_lines(
                 &mut lines,
@@ -603,5 +607,29 @@ mod tests {
         );
         assert!(rendered.contains("Submit 1 selected"));
         assert!(rendered.contains("toggle"));
+        assert!(
+            rendered.contains(">  3) Confirm selection"),
+            "confirm row should display selected focus at its real quick-pick index"
+        );
+        assert!(
+            !rendered.contains("4) Confirm selection"),
+            "confirm row must not advertise an unreachable quick-pick number"
+        );
+    }
+
+    #[test]
+    fn user_input_modal_numbers_confirm_after_other_row() {
+        let mut view = sample_view();
+        view.request.questions[0].multi_select = true;
+        view.request.questions[0].allow_free_text = true;
+        view.selected = view.option_count() - 1;
+
+        let rendered = render_view(&view, 120, 40);
+        assert!(rendered.contains("3) Other"));
+        assert!(
+            rendered.contains(">  4) Confirm selection"),
+            "confirm should follow the optional Other row with selected focus"
+        );
+        assert!(!rendered.contains("5) Confirm selection"));
     }
 }


### PR DESCRIPTION
## Summary

- keep one unfinished Goal lifecycle authoritative: active, paused, and blocked goals cannot be replaced in place, while completed goals can start fresh
- reserve goal creation/status mutation for the root agent while retaining delegated read access and an execution-layer defense
- make the multi-select confirmation row's visible focus, numbering, and keyboard activation share one true index with or without the free-form row
- preserve the existing Ask, Auto-Review, and Full Access permission semantics

## Verification

- Goal-related tests: 54 passed
- delegated unavailable-tool test: 1 passed
- user-input renderer tests: 5 passed
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- Gitleaks exact two-commit scan: no leaks

Installed-dogfood QA will exercise the provider-driven multi-select interaction before release preparation is complete.

Fixes #4529
