### PR TITLE
ci(release): add exact-head candidate artifacts

### DIFF
--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -42,6 +42,23 @@ assert.match(candidate, /^  workflow_dispatch:\n    inputs:\n      expected_sha:
 assert.doesNotMatch(candidate, /^  (push|pull_request|schedule):/m);
 assert.match(candidate, /uses: \.\/\.github\/workflows\/release-artifacts\.yml/);
 assert.match(candidate, /source_sha: \$\{\{ needs\.resolve\.outputs\.sha \}\}/);
+assert.match(candidate, /^  web:\n/m);
+assert.match(candidate, /ref: \$\{\{ needs\.resolve\.outputs\.sha \}\}/);
+assert.match(candidate, /working-directory: web/);
+for (const command of [
+  "npm ci",
+  "npm run check:facts",
+  "npm run prebuild",
+  "npm run check:docs",
+  "npm test",
+  "npm run lint",
+  "npx tsc --noEmit",
+  "npm run build",
+]) {
+  assert.match(candidate, new RegExp(`run: ${command.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}`));
+}
+assert.match(candidate, /^    needs: \[resolve, web\]$/m);
+assert.match(candidate, /needs\.web\.result == 'success'/);
 
 for (const [label, workflow] of [
   ["release candidate", candidate],

--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -105,6 +105,13 @@ assert.match(release, /uses: \.\/\.github\/workflows\/release-artifacts\.yml/);
 assert.doesNotMatch(release, /^  (build|bundle|windows-installer):/m);
 assert.match(release, /name: codewhale-release-assets\n\s+path: artifacts/);
 assert.match(release, /files: artifacts\/\*/);
+assert.equal(
+  (release.match(/ensure-release-assets-absent\.js/g) || []).length,
+  2,
+  "public release must refuse existing assets before work and immediately before upload",
+);
+assert.match(release, /overwrite_files:\s*false/);
+assert.match(release, /fail_on_unmatched_files:\s*true/);
 
 assert.match(runbook, /release[- ]candidate/i);
 assert.match(runbook, /expected_sha/);

--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -79,6 +79,24 @@ for (const [label, workflow] of [
   }
 }
 
+for (const [label, workflow] of [
+  ["release candidate", candidate],
+  ["shared artifact", artifacts],
+  ["public release", release],
+]) {
+  const remoteActions = [...workflow.matchAll(/^\s+(?:-\s+)?uses:\s+([^@\s]+)@([^#\s]+)/gm)]
+    .map((match) => ({ action: match[1], ref: match[2] }))
+    .filter(({ action }) => !action.startsWith("./"));
+  assert.ok(remoteActions.length > 0, `${label} workflow must exercise pinned actions`);
+  for (const { action, ref } of remoteActions) {
+    assert.match(
+      ref,
+      /^[0-9a-f]{40}$/,
+      `${label} action ${action} must use an audited full commit SHA`,
+    );
+  }
+}
+
 assert.match(artifacts, /^  workflow_call:/m);
 assert.match(artifacts, /^permissions:\n  contents: read$/m);
 const expectedTargets = [

--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -55,7 +55,7 @@ for (const command of [
   "npx tsc --noEmit",
   "npm run build",
 ]) {
-  assert.match(candidate, new RegExp(`run: ${command.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}`));
+  assert.match(candidate, new RegExp(`run: ${command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 }
 assert.match(candidate, /^    needs: \[resolve, web\]$/m);
 assert.match(candidate, /needs\.web\.result == 'success'/);

--- a/.github/scripts/release-workflows.test.js
+++ b/.github/scripts/release-workflows.test.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const {
+  allAssetNames,
+  allReleaseAssetNames,
+  BUNDLE_ASSET_NAMES,
+} = require(path.join(repoRoot, "npm", "codewhale", "scripts", "artifacts"));
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function valuesForKey(source, key) {
+  const expression = new RegExp(`^\\s+${key}:\\s+([^#\\s]+)\\s*$`, "gm");
+  return [...source.matchAll(expression)].map((match) => match[1]);
+}
+
+const ci = read(".github/workflows/ci.yml");
+const candidate = read(".github/workflows/release-candidate.yml");
+const artifacts = read(".github/workflows/release-artifacts.yml");
+const release = read(".github/workflows/release.yml");
+const bundles = read("scripts/release/create-release-bundles.sh");
+const runbook = read("docs/RELEASE_RUNBOOK.md");
+
+assert.match(ci, /^  workflow_dispatch:\n    inputs:\n      expected_sha:/m);
+const manualForceBlock = ci.match(
+  /if \[\[ "\$\{EVENT_NAME\}" == "workflow_dispatch" \]\]; then([\s\S]*?)\n\s+if \[\[ "\$\{EVENT_NAME\}" == "schedule" \]\]; then/,
+);
+assert.ok(manualForceBlock, "CI must have a dedicated manual-dispatch force-full branch");
+for (const output of ["heavy", "workflow", "mobile", "actions"]) {
+  assert.match(manualForceBlock[1], new RegExp(`echo "${output}=true"`));
+}
+assert.match(manualForceBlock[1], /#EXPECTED_SHA.*-ne 40/s);
+assert.match(manualForceBlock[1], /actual.*EXPECTED_SHA/s);
+
+assert.match(candidate, /^  workflow_dispatch:\n    inputs:\n      expected_sha:/m);
+assert.doesNotMatch(candidate, /^  (push|pull_request|schedule):/m);
+assert.match(candidate, /uses: \.\/\.github\/workflows\/release-artifacts\.yml/);
+assert.match(candidate, /source_sha: \$\{\{ needs\.resolve\.outputs\.sha \}\}/);
+
+for (const [label, workflow] of [
+  ["release candidate", candidate],
+  ["shared artifact", artifacts],
+]) {
+  for (const forbidden of [
+    /contents:\s*write/,
+    /packages:\s*write/,
+    /softprops\/action-gh-release/,
+    /docker\/login-action/,
+    /docker\/build-push-action/,
+    /\bgh release\b/,
+    /\bnpm publish\b/,
+    /\bcargo publish\b/,
+    /\bgit push\b/,
+  ]) {
+    assert.doesNotMatch(workflow, forbidden, `${label} workflow contains publication capability`);
+  }
+}
+
+assert.match(artifacts, /^  workflow_call:/m);
+assert.match(artifacts, /^permissions:\n  contents: read$/m);
+const expectedTargets = [
+  "x86_64-unknown-linux-musl",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-linux-android",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "aarch64-pc-windows-msvc",
+].sort();
+assert.deepEqual([...new Set(valuesForKey(artifacts, "target"))].sort(), expectedTargets);
+
+const builtAssetNames = [
+  ...valuesForKey(artifacts, "cli_artifact"),
+  ...valuesForKey(artifacts, "shim_artifact"),
+  ...valuesForKey(artifacts, "tui_artifact"),
+];
+assert.equal(builtAssetNames.length, 21);
+assert.deepEqual(
+  [...new Set(builtAssetNames)].sort(),
+  allAssetNames().filter((name) => name !== "codewhale.bat").sort(),
+);
+const bundleInvocations = [...bundles.matchAll(
+  /^bundle (\S+) \\\n\s+\S+ \S+ \S+ (tar\.gz|zip) (""|portable)$/gm,
+)].map((match) => {
+  const variant = match[3] === "portable" ? "-portable" : "";
+  return `codewhale-${match[1]}${variant}.${match[2]}`;
+});
+assert.deepEqual(bundleInvocations.sort(), [...BUNDLE_ASSET_NAMES].sort());
+assert.match(artifacts, /aarch64-pc-windows-msvc/);
+assert.match(artifacts, /aarch64-linux-android/);
+assert.match(artifacts, /codew-windows-arm64\.exe/);
+assert.match(artifacts, /CodeWhaleSetup\.exe/);
+assert.match(artifacts, /assemble-release-assets\.js --verify release-assets/);
+assert.match(artifacts, /CODEWHALE_SMOKE_ASSETS_DIR/);
+
+assert.equal(allReleaseAssetNames().length, 34);
+assert.match(release, /^  artifacts:\n/m);
+assert.match(release, /uses: \.\/\.github\/workflows\/release-artifacts\.yml/);
+assert.doesNotMatch(release, /^  (build|bundle|windows-installer):/m);
+assert.match(release, /name: codewhale-release-assets\n\s+path: artifacts/);
+assert.match(release, /files: artifacts\/\*/);
+
+assert.match(runbook, /release[- ]candidate/i);
+assert.match(runbook, /expected_sha/);
+assert.match(runbook, /34/);
+assert.match(runbook, /does not create a tag/i);
+assert.match(runbook, /explicit.*approval/i);
+
+console.log("Release workflow contracts OK: exact-head full CI and 7-target/34-asset non-publishing candidate.");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
           bash .github/scripts/update-homebrew-tap.test.sh
           node .github/scripts/release-workflows.test.js
           node --test scripts/release/assemble-release-assets.test.js
+          node --test scripts/release/ensure-release-assets-absent.test.js
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [master, main]
   schedule:
     - cron: '31 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Exact 40-character commit selected by --ref (manual runs always force full CI)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -40,10 +46,30 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: |
           set -euo pipefail
 
-          if [[ "${EVENT_NAME}" == "schedule" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${#EXPECTED_SHA}" -ne 40 || "${EXPECTED_SHA}" =~ [^0-9a-fA-F] ]]; then
+              echo "::error::expected_sha must be a full 40-character commit SHA." >&2
+              exit 1
+            fi
+            actual="$(git rev-parse HEAD)"
+            expected_normalized="$(printf '%s' "${EXPECTED_SHA}" | tr '[:upper:]' '[:lower:]')"
+            if [[ "${actual}" != "${expected_normalized}" ]]; then
+              echo "::error::Dispatch resolved to ${actual}, not requested ${EXPECTED_SHA}." >&2
+              exit 1
+            fi
+            echo "Manual exact-head dispatch: forcing heavy, workflow, mobile, and action gates."
+            echo "heavy=true" >> "${GITHUB_OUTPUT}"
+            echo "workflow=true" >> "${GITHUB_OUTPUT}"
+            echo "mobile=true" >> "${GITHUB_OUTPUT}"
+            echo "actions=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${EVENT_NAME}" == "schedule" ]]; then
             echo "heavy=true" >> "${GITHUB_OUTPUT}"
             echo "workflow=true" >> "${GITHUB_OUTPUT}"
             echo "mobile=true" >> "${GITHUB_OUTPUT}"
@@ -147,6 +173,8 @@ jobs:
           bash scripts/release/require-release-tag-checkout.test.sh
           bash scripts/release/verify-remote-tag.test.sh
           bash .github/scripts/update-homebrew-tap.test.sh
+          node .github/scripts/release-workflows.test.js
+          node --test scripts/release/assemble-release-assets.test.js
 
   lint:
     name: Lint
@@ -286,30 +314,30 @@ jobs:
         if: needs.changes.outputs.heavy != 'true'
         run: echo "No executable Rust changes detected; preserving required Test context."
       - uses: actions/checkout@v7
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
       - uses: mozilla-actions/sccache-action@v0.0.10
         id: sccache
         continue-on-error: true
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
       - name: Enable sccache
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest' && steps.sccache.outcome == 'success'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch') && steps.sccache.outcome == 'success'
         shell: bash
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
           echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
           echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         with:
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run tests
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         run: cargo test --workspace --all-features --locked
       - name: Lockfile drift guard
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         run: git diff --exit-code -- Cargo.lock
       - name: Run Offline Eval Harness
         # The eval harness is OS-independent prompt/composition checking;
@@ -319,12 +347,12 @@ jobs:
         if: needs.changes.outputs.heavy == 'true' && matrix.os == 'macos-latest'
         run: cargo run -p codewhale-tui --all-features -- eval
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest' && steps.sccache.outcome == 'success'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch') && steps.sccache.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: sccache --show-stats
       - name: Linux test location
-        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest' && github.event_name != 'workflow_dispatch'
         run: echo "Linux workspace tests run on CNB for mirrored first-party branches."
 
   npm-wrapper-smoke:
@@ -344,31 +372,31 @@ jobs:
         if: needs.changes.outputs.heavy != 'true'
         run: echo "No executable Rust changes detected; preserving required npm wrapper smoke context."
       - uses: actions/checkout@v7
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
       - uses: mozilla-actions/sccache-action@v0.0.10
         id: sccache
         continue-on-error: true
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
       - name: Enable sccache
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest' && steps.sccache.outcome == 'success'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch') && steps.sccache.outcome == 'success'
         shell: bash
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
           echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
           echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
       - uses: actions/setup-node@v6
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         with:
           node-version: 20
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         with:
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build wrapper binaries
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         # The smoke validates wrapper install/delegation plumbing, not
         # codegen quality, so skip fat LTO + codegen-units=1 for a much
         # cheaper release build. Shipped binaries keep the real profile via
@@ -378,15 +406,15 @@ jobs:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '16'
         run: cargo build --release --locked -p codewhale-cli -p codewhale-tui
       - name: Smoke wrapper install and delegated entrypoints
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch')
         run: node scripts/release/npm-wrapper-smoke.js
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true' && matrix.os != 'ubuntu-latest' && steps.sccache.outcome == 'success'
+        if: needs.changes.outputs.heavy == 'true' && (matrix.os != 'ubuntu-latest' || github.event_name == 'workflow_dispatch') && steps.sccache.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: sccache --show-stats
       - name: Linux smoke location
-        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest'
+        if: needs.changes.outputs.heavy == 'true' && matrix.os == 'ubuntu-latest' && github.event_name != 'workflow_dispatch'
         run: echo "Linux npm wrapper smoke runs on CNB for mirrored first-party branches."
 
   mobile-smoke:
@@ -458,7 +486,7 @@ jobs:
   # Check documentation builds without warnings
   docs:
     name: Documentation
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -98,24 +98,26 @@ jobs:
             tui_artifact: codewhale-tui-windows-arm64.exe
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.source_sha }}
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master 2026-07-18
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         id: sccache
         continue-on-error: true
       - name: Enable sccache
         if: steps.sccache.outcome == 'success'
         shell: bash
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
-          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
-          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
-      - uses: Swatinem/rust-cache@v2
+          {
+            echo "SCCACHE_GHA_ENABLED=true"
+            echo "RUSTC_WRAPPER=sccache"
+            echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1"
+          } >> "${GITHUB_ENV}"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
       - name: Install Linux ARM64 system dependencies
@@ -173,12 +175,14 @@ jobs:
             echo "Android archiver not found: ${ar}" >&2
             exit 1
           fi
-          echo "ANDROID_NDK_ROOT=${ndk}" >> "${GITHUB_ENV}"
-          echo "ANDROID_NDK_HOME=${ndk}" >> "${GITHUB_ENV}"
-          echo "CC_aarch64_linux_android=${linker}" >> "${GITHUB_ENV}"
-          echo "AR_aarch64_linux_android=${ar}" >> "${GITHUB_ENV}"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${linker}" >> "${GITHUB_ENV}"
-          echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android=--target=aarch64-linux-android24 --sysroot=${ndk}/toolchains/llvm/prebuilt/linux-x86_64/sysroot" >> "${GITHUB_ENV}"
+          {
+            echo "ANDROID_NDK_ROOT=${ndk}"
+            echo "ANDROID_NDK_HOME=${ndk}"
+            echo "CC_aarch64_linux_android=${linker}"
+            echo "AR_aarch64_linux_android=${ar}"
+            echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${linker}"
+            echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android=--target=aarch64-linux-android24 --sysroot=${ndk}/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          } >> "${GITHUB_ENV}"
       - name: Build
         if: matrix.target != 'x86_64-unknown-linux-musl'
         shell: bash
@@ -212,21 +216,21 @@ jobs:
           stage_binary "${{ matrix.cli_binary }}" "${{ matrix.cli_artifact }}"
           stage_binary "${{ matrix.shim_binary }}" "${{ matrix.shim_artifact }}"
           stage_binary "${{ matrix.tui_binary }}" "${{ matrix.tui_artifact }}"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.cli_artifact }}
           path: ${{ matrix.cli_artifact }}
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
           overwrite: true
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.shim_artifact }}
           path: ${{ matrix.shim_artifact }}
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
           overwrite: true
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.tui_artifact }}
           path: ${{ matrix.tui_artifact }}
@@ -239,17 +243,17 @@ jobs:
     if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.source_sha }}
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: '*'
       - name: Create and checksum platform archives
         shell: bash
         run: bash scripts/release/create-release-bundles.sh artifacts bundles
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: codewhale-bundles
           path: |
@@ -265,10 +269,10 @@ jobs:
     if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.source_sha }}
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: '*windows-x64.exe'
@@ -295,7 +299,7 @@ jobs:
           if (!(Test-Path "scripts\installer\CodeWhaleSetup.exe")) {
             throw "CodeWhaleSetup.exe was not produced"
           }
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: CodeWhaleSetup.exe
           path: scripts/installer/CodeWhaleSetup.exe
@@ -308,19 +312,19 @@ jobs:
     if: ${{ !cancelled() && needs.bundle.result == 'success' && needs.windows-installer.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.source_sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: intermediate-artifacts
           pattern: '*'
       - name: Assemble exact authoritative release inventory
         run: node scripts/release/assemble-release-assets.js intermediate-artifacts release-assets
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: codewhale-release-assets
           path: release-assets/*
@@ -334,13 +338,13 @@ jobs:
     if: ${{ !cancelled() && needs.assemble.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.source_sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: codewhale-release-assets
           path: release-assets

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,367 @@
+name: Release artifacts
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Exact 40-character source commit to build
+        required: true
+        type: string
+      version:
+        description: Workspace version without a v prefix
+        required: true
+        type: string
+      retention_days:
+        description: Retention for Actions-only intermediate and assembled artifacts
+        required: false
+        default: 7
+        type: number
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -Dwarnings
+  DEEPSEEK_BUILD_SHA: ${{ inputs.source_sha }}
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            platform: linux-x64
+            cli_binary: codewhale
+            shim_binary: codew
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-x64
+            shim_artifact: codew-linux-x64
+            tui_artifact: codewhale-tui-linux-x64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            platform: linux-arm64
+            cli_binary: codewhale
+            shim_binary: codew
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-linux-arm64
+            shim_artifact: codew-linux-arm64
+            tui_artifact: codewhale-tui-linux-arm64
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            platform: android-arm64
+            cli_binary: codewhale
+            shim_binary: codew
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-android-arm64
+            shim_artifact: codew-android-arm64
+            tui_artifact: codewhale-tui-android-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            platform: macos-x64
+            cli_binary: codewhale
+            shim_binary: codew
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-macos-x64
+            shim_artifact: codew-macos-x64
+            tui_artifact: codewhale-tui-macos-x64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            platform: macos-arm64
+            cli_binary: codewhale
+            shim_binary: codew
+            tui_binary: codewhale-tui
+            cli_artifact: codewhale-macos-arm64
+            shim_artifact: codew-macos-arm64
+            tui_artifact: codewhale-tui-macos-arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: windows-x64
+            cli_binary: codewhale.exe
+            shim_binary: codew.exe
+            tui_binary: codewhale-tui.exe
+            cli_artifact: codewhale-windows-x64.exe
+            shim_artifact: codew-windows-x64.exe
+            tui_artifact: codewhale-tui-windows-x64.exe
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            platform: windows-arm64
+            cli_binary: codewhale.exe
+            shim_binary: codew.exe
+            tui_binary: codewhale-tui.exe
+            cli_artifact: codewhale-windows-arm64.exe
+            shim_artifact: codew-windows-arm64.exe
+            tui_artifact: codewhale-tui-windows-arm64.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
+        id: sccache
+        continue-on-error: true
+      - name: Enable sccache
+        if: steps.sccache.outcome == 'success'
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
+          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
+          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - name: Install Linux ARM64 system dependencies
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          for i in 1 2 3 4 5; do
+            sudo apt-get update && break
+            echo "apt-get update failed (attempt $i); retrying in 15s"
+            sleep 15
+          done
+          sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Build static Linux x64 binaries (musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add --toolchain stable x86_64-unknown-linux-musl
+          cargo build --release --locked --target x86_64-unknown-linux-musl -p codewhale-cli -p codewhale-tui
+      - name: Configure Android NDK linker
+        if: matrix.target == 'aarch64-linux-android' && runner.os == 'Linux'
+        shell: bash
+        env:
+          ANDROID_NDK_VERSION: 27.2.12479018
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev
+          ndk="${ANDROID_NDK_ROOT:-${ANDROID_NDK_HOME:-}}"
+          linker=""
+          if [[ -n "${ndk}" ]]; then
+            linker="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+          fi
+          if [[ -z "${linker}" || ! -x "${linker}" ]]; then
+            if ! command -v sdkmanager >/dev/null 2>&1; then
+              echo "sdkmanager is required to install Android NDK ${ANDROID_NDK_VERSION}" >&2
+              exit 1
+            fi
+            android_home="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+            if [[ -z "${android_home}" ]]; then
+              echo "ANDROID_HOME or ANDROID_SDK_ROOT is required to install Android NDK ${ANDROID_NDK_VERSION}" >&2
+              exit 1
+            fi
+            yes | sdkmanager --licenses >/dev/null || true
+            sdkmanager --install "ndk;${ANDROID_NDK_VERSION}"
+            ndk="${android_home}/ndk/${ANDROID_NDK_VERSION}"
+            linker="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+          fi
+          ar="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+          if [[ ! -x "${linker}" ]]; then
+            echo "Android linker not found: ${linker}" >&2
+            exit 1
+          fi
+          if [[ ! -x "${ar}" ]]; then
+            echo "Android archiver not found: ${ar}" >&2
+            exit 1
+          fi
+          echo "ANDROID_NDK_ROOT=${ndk}" >> "${GITHUB_ENV}"
+          echo "ANDROID_NDK_HOME=${ndk}" >> "${GITHUB_ENV}"
+          echo "CC_aarch64_linux_android=${linker}" >> "${GITHUB_ENV}"
+          echo "AR_aarch64_linux_android=${ar}" >> "${GITHUB_ENV}"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${linker}" >> "${GITHUB_ENV}"
+          echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android=--target=aarch64-linux-android24 --sysroot=${ndk}/toolchains/llvm/prebuilt/linux-x86_64/sysroot" >> "${GITHUB_ENV}"
+      - name: Build
+        if: matrix.target != 'x86_64-unknown-linux-musl'
+        shell: bash
+        run: cargo build --release --locked --target ${{ matrix.target }} -p codewhale-cli -p codewhale-tui
+      - name: Smoke binaries on matching native runners
+        if: >-
+          matrix.target != 'aarch64-linux-android' &&
+          ((startsWith(matrix.target, 'x86_64-') && runner.arch == 'X64') ||
+          (startsWith(matrix.target, 'aarch64-') && runner.arch == 'ARM64'))
+        shell: bash
+        run: |
+          bin_dir="target/${{ matrix.target }}/release"
+          "${bin_dir}/${{ matrix.cli_binary }}" --version
+          "${bin_dir}/${{ matrix.shim_binary }}" --version
+          "${bin_dir}/${{ matrix.tui_binary }}" --version
+      - name: Stage binaries
+        shell: bash
+        run: |
+          stage_binary() {
+            local binary="$1"
+            local artifact="$2"
+            local bin_path="target/${{ matrix.target }}/release/${binary}"
+            if [[ ! -f "${bin_path}" ]]; then
+              echo "Binary not at ${bin_path}; searching target/ for ${binary}:" >&2
+              find target -name "${binary}" -type f
+              exit 1
+            fi
+            cp "${bin_path}" "${artifact}"
+          }
+
+          stage_binary "${{ matrix.cli_binary }}" "${{ matrix.cli_artifact }}"
+          stage_binary "${{ matrix.shim_binary }}" "${{ matrix.shim_artifact }}"
+          stage_binary "${{ matrix.tui_binary }}" "${{ matrix.tui_artifact }}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.cli_artifact }}
+          path: ${{ matrix.cli_artifact }}
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+          overwrite: true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.shim_artifact }}
+          path: ${{ matrix.shim_artifact }}
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+          overwrite: true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.tui_artifact }}
+          path: ${{ matrix.tui_artifact }}
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+          overwrite: true
+
+  bundle:
+    needs: build
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: '*'
+      - name: Create and checksum platform archives
+        shell: bash
+        run: bash scripts/release/create-release-bundles.sh artifacts bundles
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codewhale-bundles
+          path: |
+            bundles/*.tar.gz
+            bundles/*.zip
+            bundles/codewhale-bundles-sha256.txt
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+          overwrite: true
+
+  windows-installer:
+    needs: build
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: '*windows-x64.exe'
+      - name: Install NSIS
+        shell: pwsh
+        run: choco install nsis -y --no-progress
+      - name: Build NSIS installer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Copy-Item "artifacts\codewhale-windows-x64.exe\codewhale-windows-x64.exe" "scripts\installer\codewhale.exe"
+          Copy-Item "artifacts\codew-windows-x64.exe\codew-windows-x64.exe" "scripts\installer\codew.exe"
+          Copy-Item "artifacts\codewhale-tui-windows-x64.exe\codewhale-tui-windows-x64.exe" "scripts\installer\codewhale-tui.exe"
+          $makensis = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
+          if (!(Test-Path $makensis)) {
+            $makensis = "${env:ProgramFiles}\NSIS\makensis.exe"
+          }
+          if (!(Test-Path $makensis)) {
+            throw "makensis.exe not found after NSIS install"
+          }
+          Push-Location scripts\installer
+          & $makensis "/DVERSION=${{ inputs.version }}" "codewhale.nsi"
+          Pop-Location
+          if (!(Test-Path "scripts\installer\CodeWhaleSetup.exe")) {
+            throw "CodeWhaleSetup.exe was not produced"
+          }
+      - uses: actions/upload-artifact@v7
+        with:
+          name: CodeWhaleSetup.exe
+          path: scripts/installer/CodeWhaleSetup.exe
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+          overwrite: true
+
+  assemble:
+    needs: [bundle, windows-installer]
+    if: ${{ !cancelled() && needs.bundle.result == 'success' && needs.windows-installer.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - uses: actions/download-artifact@v8
+        with:
+          path: intermediate-artifacts
+          pattern: '*'
+      - name: Assemble exact authoritative release inventory
+        run: node scripts/release/assemble-release-assets.js intermediate-artifacts release-assets
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codewhale-release-assets
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+          compression-level: 0
+          overwrite: true
+
+  smoke:
+    needs: assemble
+    if: ${{ !cancelled() && needs.assemble.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - uses: actions/download-artifact@v8
+        with:
+          name: codewhale-release-assets
+          path: release-assets
+      - name: Verify 34-asset inventory and checksum manifests
+        run: node scripts/release/assemble-release-assets.js --verify release-assets
+      - name: Test release inventory contracts
+        run: |
+          node --test scripts/release/assemble-release-assets.test.js
+          node --test npm/codewhale/test/artifacts.test.js npm/codewhale/test/release-assets.test.js
+      - name: Smoke packed npm wrapper against candidate assets
+        env:
+          CODEWHALE_SMOKE_ASSETS_DIR: ${{ github.workspace }}/release-assets
+        run: node scripts/release/npm-wrapper-smoke.js
+      - name: Record non-public candidate identity
+        shell: bash
+        run: |
+          {
+            echo "### Release artifact candidate"
+            echo ""
+            echo "- Source: \`${{ inputs.source_sha }}\`"
+            echo "- Version metadata: \`${{ inputs.version }}\`"
+            echo "- Inventory: 7 targets / 34 files"
+            echo "- Publication: none (Actions artifact \`codewhale-release-assets\` only)"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -71,9 +71,43 @@ jobs:
       - name: Reconfirm clean source snapshot
         run: git diff --exit-code
 
-  artifacts:
+  web:
+    name: Verify exact candidate web surface
     needs: resolve
     if: ${{ !cancelled() && needs.resolve.result == 'success' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install web dependencies
+        run: npm ci
+      - name: Check public facts drift
+        run: npm run check:facts
+      - name: Generate derived facts
+        run: npm run prebuild
+      - name: Check public docs parity
+        run: npm run check:docs
+      - name: Run web tests
+        run: npm test
+      - name: Run web lint
+        run: npm run lint
+      - name: Run web type check
+        run: npx tsc --noEmit
+      - name: Build production web surface
+        run: npm run build
+
+  artifacts:
+    needs: [resolve, web]
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.web.result == 'success' }}
     uses: ./.github/workflows/release-artifacts.yml
     with:
       source_sha: ${{ needs.resolve.outputs.sha }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -25,13 +25,13 @@ jobs:
       sha: ${{ steps.source.outputs.sha }}
       version: ${{ steps.source.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-18
       - name: Match dispatch to the requested commit
         id: source
         shell: bash
@@ -80,10 +80,10 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,81 @@
+name: Release candidate
+
+# Safe pre-publication artifact proof. This workflow never creates a tag or
+# release and never writes to a registry, container repository, tap, or deploy.
+on:
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Exact 40-character commit selected by --ref (must match the dispatch SHA)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-candidate-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve exact candidate source
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+      version: ${{ steps.source.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Match dispatch to the requested commit
+        id: source
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${#EXPECTED_SHA}" -ne 40 || "${EXPECTED_SHA}" =~ [^0-9a-fA-F] ]]; then
+            echo "::error::expected_sha must be a full 40-character commit SHA." >&2
+            exit 1
+          fi
+          actual="$(git rev-parse HEAD)"
+          expected_normalized="$(printf '%s' "${EXPECTED_SHA}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "${actual}" != "${expected_normalized}" ]]; then
+            echo "::error::Dispatch resolved to ${actual}, not requested ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+
+          workspace_version="$(grep -E '^version = "' Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)".*/\1/')"
+          npm_version="$(node -p "require('./npm/codewhale/package.json').version")"
+          binary_version="$(node -p "require('./npm/codewhale/package.json').codewhaleBinaryVersion")"
+          if [[ "${workspace_version}" != "${npm_version}" ]]; then
+            echo "::error::Candidate version drift: workspace=${workspace_version}, npm=${npm_version}, binary=${binary_version}." >&2
+            exit 1
+          fi
+          if [[ "${workspace_version}" != "${binary_version}" ]]; then
+            echo "::error::Candidate version drift: workspace=${workspace_version}, npm=${npm_version}, binary=${binary_version}." >&2
+            exit 1
+          fi
+
+          echo "sha=${actual}" >> "${GITHUB_OUTPUT}"
+          echo "version=${workspace_version}" >> "${GITHUB_OUTPUT}"
+      - name: Check version and OHOS release contracts
+        run: |
+          ./scripts/release/check-versions.sh
+          ./scripts/release/check-ohos-deps.sh
+      - name: Reconfirm clean source snapshot
+        run: git diff --exit-code
+
+  artifacts:
+    needs: resolve
+    if: ${{ !cancelled() && needs.resolve.result == 'success' }}
+    uses: ./.github/workflows/release-artifacts.yml
+    with:
+      source_sha: ${{ needs.resolve.outputs.sha }}
+      version: ${{ needs.resolve.outputs.version }}
+      retention_days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,11 @@ jobs:
           ./scripts/release/check-versions.sh
       - name: Require release source on main
         run: ./scripts/release/ensure-release-on-main.sh "${{ steps.release.outputs.sha }}"
+      - name: Refuse an existing public asset set
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: node scripts/release/ensure-release-assets-absent.js "${GITHUB_REPOSITORY}" "${TAG}"
 
   parity:
     needs: resolve
@@ -285,12 +290,19 @@ jobs:
             "https://github.com/${GITHUB_REPOSITORY}.git" \
             "${TAG}" \
             "${EXPECTED_SHA}"
+      - name: Reconfirm public asset set is still empty
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: node repo/scripts/release/ensure-release-assets-absent.js "${GITHUB_REPOSITORY}" "${TAG}"
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: artifacts/*
           prerelease: false
           body_path: release-body.md
+          overwrite_files: false
+          fail_on_unmatched_files: true
 
   homebrew:
     needs: [release, resolve]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       sha: ${{ steps.release.outputs.sha }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
       - name: Resolve release source
@@ -71,9 +71,11 @@ jobs:
             exit 1
           fi
 
-          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
-          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
-          echo "version=${tag#v}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "tag=${tag}"
+            echo "sha=${sha}"
+            echo "version=${tag#v}"
+          } >> "${GITHUB_OUTPUT}"
       - name: Validate tagged release metadata
         shell: bash
         env:
@@ -110,23 +112,25 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master 2026-07-18
         with:
           toolchain: stable
           components: clippy, rustfmt
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         id: sccache
         continue-on-error: true
       - name: Enable sccache
         if: steps.sccache.outcome == 'success'
         shell: bash
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
-          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
-          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
+          {
+            echo "SCCACHE_GHA_ENABLED=true"
+            echo "RUSTC_WRAPPER=sccache"
+            echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1"
+          } >> "${GITHUB_ENV}"
       - name: Install Linux system dependencies
         run: |
           for i in 1 2 3 4 5; do
@@ -135,7 +139,7 @@ jobs:
             sleep 15
           done
           sudo apt-get install -y libdbus-1-dev pkg-config
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
       - name: Format check
@@ -180,21 +184,21 @@ jobs:
       packages: write
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
           path: source
       - name: Checkout release infrastructure
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
           path: infra
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -205,7 +209,7 @@ jobs:
         run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ${{ steps.image.outputs.name }}
@@ -230,7 +234,7 @@ jobs:
             "${TAG}" \
             "${EXPECTED_SHA}"
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
@@ -263,14 +267,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
           path: repo
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: codewhale-release-assets
           path: artifacts
@@ -295,7 +299,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.resolve.outputs.tag }}
         run: node repo/scripts/release/ensure-release-assets-absent.js "${GITHUB_REPOSITORY}" "${TAG}"
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: artifacts/*
@@ -322,7 +326,7 @@ jobs:
           else
             echo "available=true" >> "${GITHUB_OUTPUT}"
           fi
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         if: steps.homebrew-token.outputs.available == 'true'
         with:
           ref: ${{ needs.resolve.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,84 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      sha: ${{ steps.release.outputs.sha }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Resolve release source
+        id: release
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if ! [[ "${INPUT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Release version '${INPUT_VERSION}' must use X.Y.Z." >&2
+              exit 1
+            fi
+            tag="v${INPUT_VERSION}"
+            if [[ "${GITHUB_REF}" != "refs/tags/${tag}" ]]; then
+              echo "::error::Dispatch release.yml from --ref ${tag}, not ${GITHUB_REF}." >&2
+              exit 1
+            fi
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '${tag}' must use vX.Y.Z." >&2
+            exit 1
+          fi
+          if ! git rev-parse --verify "refs/tags/${tag}^{commit}" >/dev/null 2>&1; then
+            echo "::error::Release tag ${tag} does not exist. Create it from the frozen main commit before dispatching." >&2
+            exit 1
+          fi
+
+          sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          event_sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+          if [[ "${event_sha}" != "${sha}" ]]; then
+            echo "::error::Trigger SHA ${event_sha} does not match ${tag} at ${sha}; the tag moved after this run was created." >&2
+            exit 1
+          fi
+
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+          echo "version=${tag#v}" >> "${GITHUB_OUTPUT}"
+      - name: Validate tagged release metadata
+        shell: bash
+        env:
+          SHA: ${{ steps.release.outputs.sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git checkout --detach "${SHA}"
+          expected="${TAG#v}"
+          workspace_version="$(grep -E '^version = "' Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)".*/\1/')"
+          npm_version="$(node -p "require('./npm/codewhale/package.json').version")"
+          binary_version="$(node -p "require('./npm/codewhale/package.json').codewhaleBinaryVersion")"
+          for pair in \
+            "workspace:${workspace_version}" \
+            "npm:${npm_version}" \
+            "npm binary:${binary_version}"; do
+            label="${pair%%:*}"
+            actual="${pair#*:}"
+            if [[ "${actual}" != "${expected}" ]]; then
+              echo "::error::${label} version ${actual} does not match tag ${TAG}." >&2
+              exit 1
+            fi
+          done
+          ./scripts/release/check-versions.sh
+      - name: Require release source on main
+        run: ./scripts/release/ensure-release-on-main.sh "${{ steps.release.outputs.sha }}"
+
   parity:
     needs: resolve
     runs-on: ubuntu-latest
@@ -36,8 +114,6 @@ jobs:
           components: clippy, rustfmt
       - uses: mozilla-actions/sccache-action@v0.0.10
         id: sccache
-        # A cache bootstrap failure must degrade to an uncached build, never
-        # fail a release gate.
         continue-on-error: true
       - name: Enable sccache
         if: steps.sccache.outcome == 'success'
@@ -47,7 +123,6 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
           echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
       - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
         run: |
           for i in 1 2 3 4 5; do
             sudo apt-get update && break
@@ -82,449 +157,18 @@ jobs:
       - name: Lockfile drift guard
         run: git diff --exit-code -- Cargo.lock
 
-  resolve:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.release.outputs.tag }}
-      sha: ${{ steps.release.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Resolve release source
-        id: release
-        shell: bash
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            if ! [[ "${INPUT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::error::Release version '${INPUT_VERSION}' must use X.Y.Z." >&2
-              exit 1
-            fi
-            tag="v${INPUT_VERSION}"
-            if [ "${GITHUB_REF}" != "refs/tags/${tag}" ]; then
-              echo "::error::Dispatch release.yml from --ref ${tag}, not ${GITHUB_REF}." >&2
-              exit 1
-            fi
-          else
-            tag="${GITHUB_REF_NAME}"
-          fi
-
-          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag '${tag}' must use vX.Y.Z." >&2
-            exit 1
-          fi
-          if ! git rev-parse --verify "refs/tags/${tag}^{commit}" >/dev/null 2>&1; then
-            echo "::error::Release tag ${tag} does not exist. Create it from the frozen main commit before dispatching." >&2
-            exit 1
-          fi
-
-          sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
-          event_sha="$(git rev-parse "${GITHUB_SHA}^{commit}")"
-          if [ "${event_sha}" != "${sha}" ]; then
-            echo "::error::Trigger SHA ${event_sha} does not match ${tag} at ${sha}; the tag moved after this run was created." >&2
-            exit 1
-          fi
-
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
-      - name: Validate tagged release metadata
-        shell: bash
-        env:
-          SHA: ${{ steps.release.outputs.sha }}
-          TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git checkout --detach "${SHA}"
-          expected="${TAG#v}"
-          workspace_version="$(grep -E '^version = "' Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)".*/\1/')"
-          npm_version="$(node -p "require('./npm/codewhale/package.json').version")"
-          binary_version="$(node -p "require('./npm/codewhale/package.json').codewhaleBinaryVersion")"
-          for pair in \
-            "workspace:${workspace_version}" \
-            "npm:${npm_version}" \
-            "npm binary:${binary_version}"; do
-            label="${pair%%:*}"
-            actual="${pair#*:}"
-            if [ "${actual}" != "${expected}" ]; then
-              echo "::error::${label} version ${actual} does not match tag ${TAG}." >&2
-              exit 1
-            fi
-          done
-          ./scripts/release/check-versions.sh
-      - name: Require release source on main
-        run: ./scripts/release/ensure-release-on-main.sh "${{ steps.release.outputs.sha }}"
-
-  build:
+  artifacts:
     needs: [parity, resolve]
-    # Tag pushes and exact-tag recovery dispatches both prove the same source
-    # through the full parity gate before any release binary is built.
     if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.parity.result == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            platform: linux-x64
-            cli_binary: codewhale
-            shim_binary: codew
-            tui_binary: codewhale-tui
-            cli_artifact: codewhale-linux-x64
-            shim_artifact: codew-linux-x64
-            tui_artifact: codewhale-tui-linux-x64
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            platform: linux-arm64
-            cli_binary: codewhale
-            shim_binary: codew
-            tui_binary: codewhale-tui
-            cli_artifact: codewhale-linux-arm64
-            shim_artifact: codew-linux-arm64
-            tui_artifact: codewhale-tui-linux-arm64
-          - os: ubuntu-latest
-            target: aarch64-linux-android
-            platform: android-arm64
-            cli_binary: codewhale
-            shim_binary: codew
-            tui_binary: codewhale-tui
-            cli_artifact: codewhale-android-arm64
-            shim_artifact: codew-android-arm64
-            tui_artifact: codewhale-tui-android-arm64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            platform: macos-x64
-            cli_binary: codewhale
-            shim_binary: codew
-            tui_binary: codewhale-tui
-            cli_artifact: codewhale-macos-x64
-            shim_artifact: codew-macos-x64
-            tui_artifact: codewhale-tui-macos-x64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            platform: macos-arm64
-            cli_binary: codewhale
-            shim_binary: codew
-            tui_binary: codewhale-tui
-            cli_artifact: codewhale-macos-arm64
-            shim_artifact: codew-macos-arm64
-            tui_artifact: codewhale-tui-macos-arm64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: windows-x64
-            cli_binary: codewhale.exe
-            shim_binary: codew.exe
-            tui_binary: codewhale-tui.exe
-            cli_artifact: codewhale-windows-x64.exe
-            shim_artifact: codew-windows-x64.exe
-            tui_artifact: codewhale-tui-windows-x64.exe
-          - os: windows-11-arm
-            target: aarch64-pc-windows-msvc
-            platform: windows-arm64
-            cli_binary: codewhale.exe
-            shim_binary: codew.exe
-            tui_binary: codewhale-tui.exe
-            cli_artifact: codewhale-windows-arm64.exe
-            shim_artifact: codew-windows-arm64.exe
-            tui_artifact: codewhale-tui-windows-arm64.exe
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-      - uses: mozilla-actions/sccache-action@v0.0.10
-        id: sccache
-        # A cache bootstrap failure must degrade to an uncached build, never
-        # fail a release gate.
-        continue-on-error: true
-      - name: Enable sccache
-        if: steps.sccache.outcome == 'success'
-        shell: bash
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "${GITHUB_ENV}"
-          echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
-          echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> "${GITHUB_ENV}"
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-      - name: Install Linux ARM64 system dependencies
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          for i in 1 2 3 4 5; do
-            sudo apt-get update && break
-            echo "apt-get update failed (attempt $i); retrying in 15s"
-            sleep 15
-          done
-          sudo apt-get install -y libdbus-1-dev pkg-config
-      - name: Build static Linux x64 binary (musl)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
-          rustup target add --toolchain stable x86_64-unknown-linux-musl
-          cargo build --release --locked --target x86_64-unknown-linux-musl -p codewhale-cli -p codewhale-tui
-      - name: Configure Android NDK linker
-        if: matrix.target == 'aarch64-linux-android' && runner.os == 'Linux'
-        shell: bash
-        env:
-          ANDROID_NDK_VERSION: 27.2.12479018
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y libclang-dev
-          ndk="${ANDROID_NDK_ROOT:-${ANDROID_NDK_HOME:-}}"
-          linker=""
-          if [[ -n "${ndk}" ]]; then
-            linker="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
-          fi
-          if [[ -z "${linker}" || ! -x "${linker}" ]]; then
-            if ! command -v sdkmanager >/dev/null 2>&1; then
-              echo "sdkmanager is required to install Android NDK ${ANDROID_NDK_VERSION}" >&2
-              exit 1
-            fi
-            android_home="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
-            if [[ -z "${android_home}" ]]; then
-              echo "ANDROID_HOME or ANDROID_SDK_ROOT is required to install Android NDK ${ANDROID_NDK_VERSION}" >&2
-              exit 1
-            fi
-            yes | sdkmanager --licenses >/dev/null || true
-            sdkmanager --install "ndk;${ANDROID_NDK_VERSION}"
-            ndk="${android_home}/ndk/${ANDROID_NDK_VERSION}"
-            linker="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
-          fi
-          ar="${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
-          if [[ ! -x "${linker}" ]]; then
-            echo "Android linker not found: ${linker}" >&2
-            exit 1
-          fi
-          if [[ ! -x "${ar}" ]]; then
-            echo "Android archiver not found: ${ar}" >&2
-            exit 1
-          fi
-          echo "ANDROID_NDK_ROOT=${ndk}" >> "${GITHUB_ENV}"
-          echo "ANDROID_NDK_HOME=${ndk}" >> "${GITHUB_ENV}"
-          echo "CC_aarch64_linux_android=${linker}" >> "${GITHUB_ENV}"
-          echo "AR_aarch64_linux_android=${ar}" >> "${GITHUB_ENV}"
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${linker}" >> "${GITHUB_ENV}"
-          echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android=--target=aarch64-linux-android24 --sysroot=${ndk}/toolchains/llvm/prebuilt/linux-x86_64/sysroot" >> "${GITHUB_ENV}"
-      - name: Build
-        if: matrix.target != 'x86_64-unknown-linux-musl'
-        shell: bash
-        env:
-          DEEPSEEK_BUILD_SHA: ${{ needs.resolve.outputs.sha }}
-        run: cargo build --release --locked --target ${{ matrix.target }} -p codewhale-cli -p codewhale-tui
-      - name: Smoke native ARM binaries
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-pc-windows-msvc'
-        shell: bash
-        run: |
-          bin_dir="target/${{ matrix.target }}/release"
-          "${bin_dir}/${{ matrix.cli_binary }}" --version
-          "${bin_dir}/${{ matrix.shim_binary }}" --version
-          "${bin_dir}/${{ matrix.tui_binary }}" --version
-      - name: Stage binaries
-        shell: bash
-        run: |
-          stage_binary() {
-            local binary="$1"
-            local artifact="$2"
-            local bin_path="target/${{ matrix.target }}/release/${binary}"
-            if [ ! -f "${bin_path}" ]; then
-              echo "Binary not at ${bin_path}; searching target/ for ${binary}:"
-              find target -name "${binary}" -type f
-              exit 1
-            fi
-            cp "${bin_path}" "${artifact}"
-          }
-
-          stage_binary "${{ matrix.cli_binary }}" "${{ matrix.cli_artifact }}"
-          stage_binary "${{ matrix.shim_binary }}" "${{ matrix.shim_artifact }}"
-          stage_binary "${{ matrix.tui_binary }}" "${{ matrix.tui_artifact }}"
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.cli_artifact }}
-          path: ${{ matrix.cli_artifact }}
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.shim_artifact }}
-          path: ${{ matrix.shim_artifact }}
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.tui_artifact }}
-          path: ${{ matrix.tui_artifact }}
-
-  bundle:
-    needs: [build, resolve]
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          pattern: '*'
-      - name: Create platform archives
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p bundles
-          # Keep the manifest at the same depth as the archives. The release
-          # upload glob only publishes artifacts/*/*, so nesting this under a
-          # checksums directory silently omits it from the GitHub Release.
-          MANIFEST="bundles/codewhale-bundles-sha256.txt"
-          : > "$MANIFEST"
-
-          bundle() {
-            local platform="$1"   # linux-x64, linux-arm64, android-arm64, macos-x64, macos-arm64, windows-x64, windows-arm64
-            local cli_src="$2"    # artifact name for codewhale binary
-            local shim_src="$3"   # artifact name for codew shim
-            local tui_src="$4"    # artifact name for codewhale-tui binary
-            local ext="$5"        # tar.gz or zip
-            local variant="$6"    # '' (standard) or 'portable' (Windows only, no install script)
-            shift 6
-
-            local dir="bundles/codewhale-${platform}${variant:+-}${variant}"
-            mkdir -p "$dir"
-
-            # Copy binaries, stripping platform suffixes
-            local cli_dst="codewhale"
-            local shim_dst="codew"
-            local tui_dst="codewhale-tui"
-            if [[ "$platform" == windows-* ]]; then
-              cli_dst="codewhale.exe"
-              shim_dst="codew.exe"
-              tui_dst="codewhale-tui.exe"
-            fi
-            cp "artifacts/${cli_src}/${cli_src}" "$dir/${cli_dst}"
-            cp "artifacts/${shim_src}/${shim_src}" "$dir/${shim_dst}"
-            cp "artifacts/${tui_src}/${tui_src}" "$dir/${tui_dst}"
-
-            # Add install script (standard variant only)
-            if [[ "$variant" != "portable" ]]; then
-              if [[ "$platform" == windows-* ]]; then
-                cp scripts/release/install.bat "$dir/"
-                # Convert line endings to CRLF for Windows
-                sed -i 's/$/\r/' "$dir/install.bat" 2>/dev/null || true
-              else
-                cp scripts/release/install.sh "$dir/"
-                chmod +x "$dir/install.sh"
-              fi
-            fi
-
-            if [[ "$ext" == "zip" ]]; then
-              (cd bundles && zip -r "codewhale-${platform}${variant:+-}${variant}.zip" "codewhale-${platform}${variant:+-}${variant}/")
-            else
-              tar -czf "bundles/codewhale-${platform}${variant:+-}${variant}.tar.gz" -C bundles "codewhale-${platform}${variant:+-}${variant}/"
-            fi
-
-            local archive="codewhale-${platform}${variant:+-}${variant}.${ext}"
-            local checksum
-            checksum="$(sha256sum "bundles/${archive}" | awk '{print $1}')"
-            # Release users download the archive and manifest into one
-            # directory, so manifest rows must contain the public basename,
-            # not the workflow-internal bundles/ path.
-            printf '%s  %s\n' "$checksum" "$archive" >> "$MANIFEST"
-            echo "  Created bundles/${archive}"
-          }
-
-          # Platform: linux-x64
-          bundle linux-x64 \
-            codewhale-linux-x64 codew-linux-x64 codewhale-tui-linux-x64 tar.gz ""
-
-          # Platform: linux-arm64
-          bundle linux-arm64 \
-            codewhale-linux-arm64 codew-linux-arm64 codewhale-tui-linux-arm64 tar.gz ""
-
-          # Platform: android-arm64 (Termux)
-          bundle android-arm64 \
-            codewhale-android-arm64 codew-android-arm64 codewhale-tui-android-arm64 tar.gz ""
-
-          # Platform: macos-x64
-          bundle macos-x64 \
-            codewhale-macos-x64 codew-macos-x64 codewhale-tui-macos-x64 tar.gz ""
-
-          # Platform: macos-arm64
-          bundle macos-arm64 \
-            codewhale-macos-arm64 codew-macos-arm64 codewhale-tui-macos-arm64 tar.gz ""
-
-          # Platform: windows-x64 (standard + portable)
-          bundle windows-x64 \
-            codewhale-windows-x64.exe codew-windows-x64.exe codewhale-tui-windows-x64.exe zip ""
-          bundle windows-x64 \
-            codewhale-windows-x64.exe codew-windows-x64.exe codewhale-tui-windows-x64.exe zip "portable"
-
-          # Platform: windows-arm64 (standard + portable)
-          bundle windows-arm64 \
-            codewhale-windows-arm64.exe codew-windows-arm64.exe codewhale-tui-windows-arm64.exe zip ""
-          bundle windows-arm64 \
-            codewhale-windows-arm64.exe codew-windows-arm64.exe codewhale-tui-windows-arm64.exe zip "portable"
-
-          echo ""
-          echo "=== Archive checksums ==="
-          cat "$MANIFEST"
-
-      - name: Upload bundle artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: codewhale-bundles
-          path: bundles/*
-          if-no-files-found: error
-
-  windows-installer:
-    needs: [build, resolve]
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          pattern: '*windows-x64.exe'
-      - name: Install NSIS
-        shell: pwsh
-        run: choco install nsis -y --no-progress
-      - name: Build NSIS installer
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $version = "${{ needs.resolve.outputs.tag }}".TrimStart("v")
-          Copy-Item "artifacts\codewhale-windows-x64.exe\codewhale-windows-x64.exe" "scripts\installer\codewhale.exe"
-          Copy-Item "artifacts\codew-windows-x64.exe\codew-windows-x64.exe" "scripts\installer\codew.exe"
-          Copy-Item "artifacts\codewhale-tui-windows-x64.exe\codewhale-tui-windows-x64.exe" "scripts\installer\codewhale-tui.exe"
-          $makensis = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
-          if (!(Test-Path $makensis)) {
-            $makensis = "${env:ProgramFiles}\NSIS\makensis.exe"
-          }
-          if (!(Test-Path $makensis)) {
-            throw "makensis.exe not found after NSIS install"
-          }
-          Push-Location scripts\installer
-          & $makensis "/DVERSION=$version" "codewhale.nsi"
-          Pop-Location
-          if (!(Test-Path "scripts\installer\CodeWhaleSetup.exe")) {
-            throw "CodeWhaleSetup.exe was not produced"
-          }
-      - name: Upload installer artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: CodeWhaleSetup.exe
-          path: scripts/installer/CodeWhaleSetup.exe
-          if-no-files-found: error
+    uses: ./.github/workflows/release-artifacts.yml
+    with:
+      source_sha: ${{ needs.resolve.outputs.sha }}
+      version: ${{ needs.resolve.outputs.version }}
+      retention_days: 14
 
   docker:
-    needs: [build, resolve]
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    needs: [artifacts, resolve]
+    if: ${{ !cancelled() && needs.artifacts.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -583,9 +227,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v7
         env:
-          # The build record is useful in CI, but it is uploaded as a
-          # `.dockerbuild` artifact. The release job intentionally downloads
-          # all binary artifacts, so suppress the extra record artifact there.
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -611,59 +252,25 @@ jobs:
           docker run --rm --entrypoint codewhale-tui "${IMAGE}" --version
 
   release:
-    needs: [build, bundle, windows-installer, docker, resolve]
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.bundle.result == 'success' && needs.windows-installer.result == 'success' && needs.docker.result == 'success' }}
+    needs: [artifacts, docker, resolve]
+    if: ${{ !cancelled() && needs.artifacts.result == 'success' && needs.docker.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      # Checked out into a subdirectory so it cannot clobber the downloaded
-      # artifacts; used for the release-body generator and the CHANGELOG.
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
           path: repo
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
       - uses: actions/download-artifact@v8
         with:
+          name: codewhale-release-assets
           path: artifacts
-          pattern: '*'
-      - name: Generate Windows npm launcher asset
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts/codewhale-windows-launcher
-          {
-            printf '@echo off\r\n'
-            printf 'where wt >nul 2>nul\r\n'
-            printf 'set NO_ANIMATIONS=1\r\n'
-            printf 'if "%%ERRORLEVEL%%"=="0" (\r\n'
-            printf '    wt --title Codewhale cmd /k "%%~dp0codewhale-windows-x64.exe"\r\n'
-            printf ') else (\r\n'
-            printf '    "%%~dp0codewhale-windows-x64.exe"\r\n'
-            printf ')\r\n'
-            printf '\r\n'
-          } > artifacts/codewhale-windows-launcher/codewhale.bat
-      - name: List artifacts
-        run: find artifacts -type f
-      - name: Generate checksum manifest
-        shell: bash
-        run: |
-          mkdir -p artifacts/checksums
-          # Canonical manifest used by codewhale's `codewhale update` flow.
-          manifest="artifacts/checksums/codewhale-artifacts-sha256.txt"
-          : > "${manifest}"
-          # softprops/action-gh-release uploads artifacts/*/*. Hash that exact
-          # public file set rather than unpacked bundle internals that never
-          # become release assets.
-          while IFS= read -r -d '' file; do
-            hash="$(sha256sum "${file}" | awk '{print $1}')"
-            base="$(basename "${file}")"
-            printf '%s  %s\n' "${hash}" "${base}" >> "${manifest}"
-          done < <(
-            find artifacts -mindepth 2 -maxdepth 2 -type f \
-              ! -path 'artifacts/checksums/*' -print0 | sort -z
-          )
-          cat "${manifest}"
+      - name: Revalidate exact authoritative asset set
+        run: node repo/scripts/release/assemble-release-assets.js --verify artifacts
       - name: Generate release body from CHANGELOG
         shell: bash
         run: |
@@ -681,7 +288,7 @@ jobs:
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
-          files: artifacts/*/*
+          files: artifacts/*
           prerelease: false
           body_path: release-body.md
 
@@ -697,13 +304,12 @@ jobs:
         env:
           TOKEN: ${{ secrets.HOMEBREW_TAP_PAT || secrets.RELEASE_TAG_PAT }}
         run: |
-          if [ -z "${TOKEN:-}" ]; then
+          if [[ -z "${TOKEN:-}" ]]; then
             echo "No Homebrew tap token configured; skipping tap update."
             echo "available=false" >> "${GITHUB_OUTPUT}"
           else
             echo "available=true" >> "${GITHUB_OUTPUT}"
           fi
-      # Use the same immutable source as every other release job.
       - uses: actions/checkout@v7
         if: steps.homebrew-token.outputs.available == 'true'
         with:
@@ -713,8 +319,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download ${{ needs.resolve.outputs.tag }} \
-            --repo ${{ github.repository }} \
+          gh release download "${{ needs.resolve.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
             --pattern 'codewhale-artifacts-sha256.txt' \
             --dir /tmp
       - name: Revalidate release tag before Homebrew tap write
@@ -737,7 +343,5 @@ jobs:
         run: bash .github/scripts/update-homebrew-tap.sh
 
 # npm publish is intentionally not automated. The npm account requires 2FA OTP
-# on every publish, and a granular automation token that bypasses 2FA has not
-# been provisioned. Release the npm wrapper manually from a developer machine
-# after the GitHub Release has been created — see the "npm Wrapper Release"
-# section of docs/RELEASE_RUNBOOK.md for the exact commands.
+# on every publish. Publish the wrapper manually only after the immutable public
+# GitHub asset gate in docs/RELEASE_RUNBOOK.md succeeds.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -161,6 +161,17 @@ release anxiety: contributors cannot tell whether their work merged.
 
 - [ ] All required CI jobs are green. The `versions` job should mirror the
       preflight `check-versions.sh` and is your last line of defense.
+- [ ] After the final source reaches `main`, dispatch exact-head full CI and the
+      non-publishing release-candidate build with the same 40-character SHA:
+      ```bash
+      candidate_sha="$(git rev-parse origin/main)"
+      gh workflow run ci.yml --ref main -f expected_sha="${candidate_sha}"
+      gh workflow run release-candidate.yml --ref main -f expected_sha="${candidate_sha}"
+      ```
+      Both runs must resolve to that SHA. The candidate must report all seven
+      targets and the complete 34-file asset inventory, including Android
+      arm64, Windows arm64, `codew`, the NSIS installer, archives, and checksum
+      manifests. These are Actions artifacts only and are not a release.
 - [ ] PR has been reviewed.
 
 ## 7. Tag and release (after review)

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -243,7 +243,10 @@ and fails branch-only release sources before assets are published.
      `gh workflow run release.yml --ref vX.Y.Z -f version=X.Y.Z`.
    - Never dispatch from `main`, and do not start a duplicate while the
      tag-triggered run is merely delayed. The workflow serializes runs for the
-     same tag, but a duplicate still rebuilds public artifacts unnecessarily.
+     same tag. It also refuses to start release work when that tag already owns
+     any GitHub Release asset, rechecks immediately before upload, and disables
+     the release action's overwrite behavior. A normal rerun must never replace
+     public bytes.
 4. Wait for the GitHub Release workflow and all public assets to finish, then
    fetch the release tag and run the public asset gate. Do not publish any
    Cargo or npm package until it passes:
@@ -410,8 +413,13 @@ If the workflow failed for the release tag, use the exact-tag rerun or
   - rerun `./scripts/release/publish-crates.sh publish`
   - already-published crate versions will be skipped
 - GitHub assets missing or checksum manifest incomplete:
-  - fix `.github/workflows/release.yml`
-  - retag or upload corrected assets before `npm publish`
+  - fix `.github/workflows/release.yml`, but do not rerun it over an existing
+    asset set and do not delete assets merely to make the guard pass
+  - if any asset may have been public or consumed, cut a new patch version
+  - only after explicit maintainer approval and proof that no downstream
+    publication or consumer treated the failed asset set as public may a
+    deliberately scoped recovery remove the failed release before an exact-tag
+    rerun; record that exception in the release packet
 - npm packaging-only problem:
   - bump only the npm package version
   - keep `codewhaleBinaryVersion` on the last known-good Rust release

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -114,6 +114,51 @@ node scripts/release/npm-wrapper-smoke.js
 Set `DEEPSEEK_TUI_KEEP_SMOKE_DIR=1` to keep the temporary pack/install
 directory for inspection.
 
+## Exact-head GitHub proof before publication
+
+Two manual workflows provide exact-head evidence without crossing the public
+release boundary. Run them only after the intended source is on a named ref
+(normally the frozen `main`), and pass the full commit SHA as an independent
+guard against that ref moving between inspection and dispatch:
+
+```bash
+git fetch origin main
+candidate_sha="$(git rev-parse origin/main)"
+
+gh workflow run ci.yml --ref main \
+  -f expected_sha="${candidate_sha}"
+gh workflow run release-candidate.yml --ref main \
+  -f expected_sha="${candidate_sha}"
+```
+
+The manual `ci.yml` path verifies that the dispatch resolved to
+`expected_sha`, disables light-change shortcuts, and forces the heavy Rust,
+workflow, mobile, Actions, Linux, macOS, Windows, npm-wrapper, and documentation
+gates. A mismatch fails before those gates start; it never silently tests a
+different head.
+
+`release-candidate.yml` also fails unless the selected ref resolves to the
+exact requested SHA. It invokes the same reusable artifact workflow as the
+public release, building all seven targets (including Android arm64 and native
+Windows arm64), staging `codewhale`, `codew`, and `codewhale-tui`, building the
+NSIS installer and nine platform archives, and validating the authoritative
+34-file inventory from `npm/codewhale/scripts/artifacts.js`. It then installs
+the packed npm wrapper against those assembled local assets and exercises its
+delegated entrypoints. The resulting `codewhale-release-assets` bundle is a
+short-lived GitHub Actions artifact only.
+
+This candidate workflow does not create a tag or GitHub Release, publish a
+crate or npm package, push a container, update Homebrew, deploy anything, or
+write repository contents. Its green result is evidence, not publication
+authorization. The stop line remains explicit Hunter approval: do not create
+the `vX.Y.Z` tag, dispatch `release.yml`, or run any registry publication step
+until that approval is given.
+
+The Android target is cross-built and included in the checksum/bundle gates,
+but GitHub's Linux runner cannot execute the Android binary as a real Termux
+user. Keep the real-device limitation in the release packet unless separate
+device evidence exists.
+
 To exercise `npm run release:check` locally as well, regenerate the local asset
 directory with a full asset matrix fixture before starting the server:
 

--- a/scripts/release/assemble-release-assets.js
+++ b/scripts/release/assemble-release-assets.js
@@ -109,9 +109,6 @@ function windowsLauncherContents() {
 }
 
 function intermediateArtifactPath(inputDirectory, name) {
-  if (name === "CodeWhaleSetup.exe") {
-    return path.join(inputDirectory, "CodeWhaleSetup.exe", name);
-  }
   if (name === BUNDLE_CHECKSUM_MANIFEST || BUNDLE_ASSET_NAMES.includes(name)) {
     return path.join(inputDirectory, "codewhale-bundles", name);
   }

--- a/scripts/release/assemble-release-assets.js
+++ b/scripts/release/assemble-release-assets.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs/promises");
+const path = require("path");
+
+const {
+  allReleaseAssetNames,
+  BUNDLE_ASSET_NAMES,
+  BUNDLE_CHECKSUM_MANIFEST,
+  CHECKSUM_MANIFEST,
+  checksummedReleaseAssetNames,
+} = require("../../npm/codewhale/scripts/artifacts");
+
+const WINDOWS_LAUNCHER = "codewhale.bat";
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/release/assemble-release-assets.js INPUT_DIR OUTPUT_DIR",
+    "  node scripts/release/assemble-release-assets.js --verify ASSET_DIR",
+  ].join("\n");
+}
+
+async function sha256(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(await fs.readFile(filePath));
+  return hash.digest("hex");
+}
+
+function parseChecksumManifest(content, label) {
+  const checksums = new Map();
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const match = trimmed.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    if (!match) {
+      throw new Error(`${label} contains an invalid checksum row: ${trimmed}`);
+    }
+    const name = match[2];
+    if (checksums.has(name)) {
+      throw new Error(`${label} contains duplicate checksum rows for ${name}`);
+    }
+    checksums.set(name, match[1].toLowerCase());
+  }
+  return checksums;
+}
+
+function assertExactNames(actualNames, expectedNames, label) {
+  const actual = new Set(actualNames);
+  const expected = new Set(expectedNames);
+  const missing = expectedNames.filter((name) => !actual.has(name));
+  const unexpected = actualNames.filter((name) => !expected.has(name));
+  if (missing.length > 0 || unexpected.length > 0 || actual.size !== actualNames.length) {
+    throw new Error(
+      `${label} does not match the authoritative inventory` +
+        `${missing.length > 0 ? `; missing: ${missing.join(", ")}` : ""}` +
+        `${unexpected.length > 0 ? `; unexpected: ${unexpected.join(", ")}` : ""}` +
+        `${actual.size !== actualNames.length ? "; duplicate basenames are present" : ""}`,
+    );
+  }
+}
+
+async function assertManifest(directory, manifestName, expectedNames) {
+  const manifestPath = path.join(directory, manifestName);
+  const checksums = parseChecksumManifest(
+    await fs.readFile(manifestPath, "utf8"),
+    manifestName,
+  );
+  assertExactNames([...checksums.keys()], expectedNames, manifestName);
+  for (const name of expectedNames) {
+    const actual = await sha256(path.join(directory, name));
+    if (checksums.get(name) !== actual) {
+      throw new Error(`${manifestName} checksum mismatch for ${name}`);
+    }
+  }
+}
+
+async function verifyAssetDirectory(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const nonFiles = entries.filter((entry) => !entry.isFile());
+  if (nonFiles.length > 0) {
+    throw new Error(
+      `Release asset directory must be flat; found: ${nonFiles.map((entry) => entry.name).join(", ")}`,
+    );
+  }
+
+  const expected = allReleaseAssetNames();
+  assertExactNames(entries.map((entry) => entry.name), expected, "Release asset directory");
+  await assertManifest(directory, CHECKSUM_MANIFEST, checksummedReleaseAssetNames());
+  await assertManifest(directory, BUNDLE_CHECKSUM_MANIFEST, BUNDLE_ASSET_NAMES);
+  console.log(`Verified ${expected.length} release assets in ${directory}`);
+}
+
+function windowsLauncherContents() {
+  return [
+    "@echo off",
+    "where wt >nul 2>nul",
+    "set NO_ANIMATIONS=1",
+    'if "%ERRORLEVEL%"=="0" (',
+    '    wt --title Codewhale cmd /k "%~dp0codewhale-windows-x64.exe"',
+    ") else (",
+    '    "%~dp0codewhale-windows-x64.exe"',
+    ")",
+    "",
+  ].join("\r\n");
+}
+
+function intermediateArtifactPath(inputDirectory, name) {
+  if (name === "CodeWhaleSetup.exe") {
+    return path.join(inputDirectory, "CodeWhaleSetup.exe", name);
+  }
+  if (name === BUNDLE_CHECKSUM_MANIFEST || BUNDLE_ASSET_NAMES.includes(name)) {
+    return path.join(inputDirectory, "codewhale-bundles", name);
+  }
+  return path.join(inputDirectory, name, name);
+}
+
+async function assemble(inputDirectory, outputDirectory) {
+  const expected = allReleaseAssetNames();
+  const generated = new Set([WINDOWS_LAUNCHER, CHECKSUM_MANIFEST]);
+  const copiedNames = expected.filter((name) => !generated.has(name));
+  const sources = new Map();
+  for (const name of copiedNames) {
+    const source = intermediateArtifactPath(inputDirectory, name);
+    let sourceStat;
+    try {
+      sourceStat = await fs.lstat(source);
+    } catch (error) {
+      if (error && error.code === "ENOENT") {
+        throw new Error(`Downloaded release artifacts are missing ${name} at ${source}`);
+      }
+      throw error;
+    }
+    if (!sourceStat.isFile()) {
+      throw new Error(`Downloaded release artifact must be a regular file: ${source}`);
+    }
+    sources.set(name, source);
+  }
+
+  await fs.mkdir(outputDirectory, { recursive: true });
+  const existing = await fs.readdir(outputDirectory);
+  if (existing.length > 0) {
+    throw new Error(`Output directory must be empty: ${outputDirectory}`);
+  }
+
+  for (const name of copiedNames) {
+    await fs.copyFile(sources.get(name), path.join(outputDirectory, name));
+  }
+  await fs.writeFile(
+    path.join(outputDirectory, WINDOWS_LAUNCHER),
+    windowsLauncherContents(),
+    "utf8",
+  );
+
+  const checksumRows = [];
+  for (const name of [...checksummedReleaseAssetNames()].sort()) {
+    checksumRows.push(`${await sha256(path.join(outputDirectory, name))}  ${name}`);
+  }
+  await fs.writeFile(
+    path.join(outputDirectory, CHECKSUM_MANIFEST),
+    `${checksumRows.join("\n")}\n`,
+    "utf8",
+  );
+
+  await verifyAssetDirectory(outputDirectory);
+}
+
+async function main() {
+  if (process.argv[2] === "--verify") {
+    if (process.argv.length !== 4) {
+      throw new Error(usage());
+    }
+    await verifyAssetDirectory(path.resolve(process.argv[3]));
+    return;
+  }
+  if (process.argv.length !== 4) {
+    throw new Error(usage());
+  }
+  await assemble(path.resolve(process.argv[2]), path.resolve(process.argv[3]));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Release asset assembly failed: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  assemble,
+  parseChecksumManifest,
+  verifyAssetDirectory,
+  windowsLauncherContents,
+};

--- a/scripts/release/assemble-release-assets.test.js
+++ b/scripts/release/assemble-release-assets.test.js
@@ -107,6 +107,7 @@ test("bundle helper creates the exact nine archives and checksum manifest", () =
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-bundle-assembly-"));
   const input = path.join(tempRoot, "input");
   const output = path.join(tempRoot, "output");
+  const repeatedOutput = path.join(tempRoot, "output-repeated");
   try {
     fs.mkdirSync(input, { recursive: true });
     for (const name of allReleaseAssetNames().filter((asset) =>
@@ -116,12 +117,19 @@ test("bundle helper creates the exact nine archives and checksum manifest", () =
     )) {
       const artifactDirectory = path.join(input, name);
       fs.mkdirSync(artifactDirectory, { recursive: true });
-      fs.writeFileSync(path.join(artifactDirectory, name), `fixture:${name}\n`, { mode: 0o755 });
+      // GitHub's artifact transport normalizes regular files to 0644. The
+      // bundler must restore executable modes for non-Windows archives.
+      fs.writeFileSync(path.join(artifactDirectory, name), `fixture:${name}\n`, { mode: 0o644 });
     }
 
     execFileSync(
       "bash",
       [path.join(repoRoot, "scripts/release/create-release-bundles.sh"), input, output],
+      { cwd: repoRoot, stdio: "pipe" },
+    );
+    execFileSync(
+      "bash",
+      [path.join(repoRoot, "scripts/release/create-release-bundles.sh"), input, repeatedOutput],
       { cwd: repoRoot, stdio: "pipe" },
     );
     assert.deepEqual(
@@ -134,7 +142,17 @@ test("bundle helper creates the exact nine archives and checksum manifest", () =
     );
     for (const name of BUNDLE_ASSET_NAMES) {
       assert.equal(checksums.get(name), sha256(path.join(output, name)));
+      assert.deepEqual(
+        fs.readFileSync(path.join(output, name)),
+        fs.readFileSync(path.join(repeatedOutput, name)),
+        `${name} should be byte-reproducible for identical inputs`,
+      );
     }
+    assert.deepEqual(
+      fs.readFileSync(path.join(output, BUNDLE_CHECKSUM_MANIFEST)),
+      fs.readFileSync(path.join(repeatedOutput, BUNDLE_CHECKSUM_MANIFEST)),
+      "bundle checksum manifest should be reproducible",
+    );
 
     const linuxEntries = execFileSync(
       "tar",
@@ -143,6 +161,17 @@ test("bundle helper creates the exact nine archives and checksum manifest", () =
     );
     for (const entry of ["codewhale", "codew", "codewhale-tui", "install.sh"]) {
       assert.match(linuxEntries, new RegExp(`codewhale-linux-x64/${entry}\\n`));
+    }
+    const extracted = path.join(tempRoot, "extracted");
+    fs.mkdirSync(extracted);
+    execFileSync(
+      "tar",
+      ["-xzf", path.join(output, "codewhale-linux-x64.tar.gz"), "-C", extracted],
+      { stdio: "pipe" },
+    );
+    for (const entry of ["codewhale", "codew", "codewhale-tui", "install.sh"]) {
+      const mode = fs.statSync(path.join(extracted, "codewhale-linux-x64", entry)).mode & 0o777;
+      assert.equal(mode, 0o755, `${entry} should remain executable after artifact transport`);
     }
     const portableEntries = execFileSync(
       "unzip",

--- a/scripts/release/assemble-release-assets.test.js
+++ b/scripts/release/assemble-release-assets.test.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  allReleaseAssetNames,
+  BUNDLE_ASSET_NAMES,
+  BUNDLE_CHECKSUM_MANIFEST,
+  CHECKSUM_MANIFEST,
+  checksummedReleaseAssetNames,
+} = require("../../npm/codewhale/scripts/artifacts");
+const {
+  assemble,
+  parseChecksumManifest,
+  verifyAssetDirectory,
+  windowsLauncherContents,
+} = require("./assemble-release-assets");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function sha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function makeIntermediateArtifacts(root) {
+  const generated = new Set(["codewhale.bat", CHECKSUM_MANIFEST]);
+  const copied = allReleaseAssetNames().filter((name) => !generated.has(name));
+  for (const name of copied) {
+    if (name === BUNDLE_CHECKSUM_MANIFEST) {
+      continue;
+    }
+    const artifactDirectory = BUNDLE_ASSET_NAMES.includes(name)
+      ? path.join(root, "codewhale-bundles")
+      : path.join(root, name);
+    fs.mkdirSync(artifactDirectory, { recursive: true });
+    fs.writeFileSync(path.join(artifactDirectory, name), `fixture:${name}\n`);
+  }
+
+  const bundleManifestDirectory = path.join(root, "codewhale-bundles");
+  fs.mkdirSync(bundleManifestDirectory, { recursive: true });
+  const rows = BUNDLE_ASSET_NAMES.map((name) => {
+    const matches = fs
+      .readdirSync(root, { recursive: true })
+      .map((entry) => path.join(root, entry))
+      .filter((entry) => path.basename(entry) === name && fs.statSync(entry).isFile());
+    assert.equal(matches.length, 1, `fixture should contain one ${name}`);
+    return `${sha256(matches[0])}  ${name}`;
+  }).sort();
+  fs.writeFileSync(
+    path.join(bundleManifestDirectory, BUNDLE_CHECKSUM_MANIFEST),
+    `${rows.join("\n")}\n`,
+  );
+}
+
+test("authoritative release inventory contains seven targets and 34 assets", () => {
+  const assets = allReleaseAssetNames();
+  assert.equal(assets.length, 34);
+  assert.equal(checksummedReleaseAssetNames().length, 33);
+  for (const required of [
+    "codewhale-android-arm64",
+    "codew-android-arm64",
+    "codewhale-windows-arm64.exe",
+    "codew-windows-arm64.exe",
+    "codewhale-windows-arm64.zip",
+    "CodeWhaleSetup.exe",
+  ]) {
+    assert.ok(assets.includes(required), `missing ${required}`);
+  }
+});
+
+test("assembly creates and verifies the exact release asset directory", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-asset-assembly-"));
+  const input = path.join(tempRoot, "input");
+  const output = path.join(tempRoot, "output");
+  try {
+    fs.mkdirSync(input, { recursive: true });
+    makeIntermediateArtifacts(input);
+    await assemble(input, output);
+    await assert.doesNotReject(() => verifyAssetDirectory(output));
+
+    assert.deepEqual(
+      fs.readdirSync(output).sort(),
+      [...allReleaseAssetNames()].sort(),
+    );
+    assert.equal(
+      fs.readFileSync(path.join(output, "codewhale.bat"), "utf8"),
+      windowsLauncherContents(),
+    );
+
+    const checksums = parseChecksumManifest(
+      fs.readFileSync(path.join(output, CHECKSUM_MANIFEST), "utf8"),
+      CHECKSUM_MANIFEST,
+    );
+    assert.deepEqual([...checksums.keys()].sort(), [...checksummedReleaseAssetNames()].sort());
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("bundle helper creates the exact nine archives and checksum manifest", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-bundle-assembly-"));
+  const input = path.join(tempRoot, "input");
+  const output = path.join(tempRoot, "output");
+  try {
+    fs.mkdirSync(input, { recursive: true });
+    for (const name of allReleaseAssetNames().filter((asset) =>
+      /^(codewhale|codew|codewhale-tui)-(linux|android|macos|windows)-/.test(asset) &&
+      !asset.endsWith(".tar.gz") &&
+      !asset.endsWith(".zip"),
+    )) {
+      const artifactDirectory = path.join(input, name);
+      fs.mkdirSync(artifactDirectory, { recursive: true });
+      fs.writeFileSync(path.join(artifactDirectory, name), `fixture:${name}\n`, { mode: 0o755 });
+    }
+
+    execFileSync(
+      "bash",
+      [path.join(repoRoot, "scripts/release/create-release-bundles.sh"), input, output],
+      { cwd: repoRoot, stdio: "pipe" },
+    );
+    assert.deepEqual(
+      fs.readdirSync(output).sort(),
+      [...BUNDLE_ASSET_NAMES, BUNDLE_CHECKSUM_MANIFEST].sort(),
+    );
+    const checksums = parseChecksumManifest(
+      fs.readFileSync(path.join(output, BUNDLE_CHECKSUM_MANIFEST), "utf8"),
+      BUNDLE_CHECKSUM_MANIFEST,
+    );
+    for (const name of BUNDLE_ASSET_NAMES) {
+      assert.equal(checksums.get(name), sha256(path.join(output, name)));
+    }
+
+    const linuxEntries = execFileSync(
+      "tar",
+      ["-tzf", path.join(output, "codewhale-linux-x64.tar.gz")],
+      { encoding: "utf8" },
+    );
+    for (const entry of ["codewhale", "codew", "codewhale-tui", "install.sh"]) {
+      assert.match(linuxEntries, new RegExp(`codewhale-linux-x64/${entry}\\n`));
+    }
+    const portableEntries = execFileSync(
+      "unzip",
+      ["-Z1", path.join(output, "codewhale-windows-arm64-portable.zip")],
+      { encoding: "utf8" },
+    );
+    assert.match(portableEntries, /codewhale-windows-arm64-portable\/codew\.exe\n/);
+    assert.doesNotMatch(portableEntries, /install\.bat/);
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("verification rejects modified and unexpected assets", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codewhale-asset-tamper-"));
+  const input = path.join(tempRoot, "input");
+  const output = path.join(tempRoot, "output");
+  try {
+    fs.mkdirSync(input, { recursive: true });
+    makeIntermediateArtifacts(input);
+    await assemble(input, output);
+    fs.appendFileSync(path.join(output, "codewhale-linux-x64"), "tampered\n");
+    await assert.rejects(
+      () => verifyAssetDirectory(output),
+      /checksum mismatch for codewhale-linux-x64/,
+    );
+
+    fs.writeFileSync(path.join(output, "unexpected.txt"), "unexpected\n");
+    await assert.rejects(
+      () => verifyAssetDirectory(output),
+      /unexpected: unexpected\.txt/,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});

--- a/scripts/release/create-release-bundles.sh
+++ b/scripts/release/create-release-bundles.sh
@@ -9,6 +9,12 @@ fi
 artifact_dir="$1"
 bundle_dir="$2"
 
+# Archive metadata must be stable across recovery builds. The public workflow
+# still refuses to replace existing release assets; reproducible packaging is a
+# diagnostic and provenance aid, not permission to overwrite published bytes.
+export TZ=UTC
+archive_timestamp="200001010000"
+
 if [[ ! -d "${artifact_dir}" ]]; then
   echo "input artifact directory does not exist: ${artifact_dir}" >&2
   exit 1
@@ -52,6 +58,15 @@ bundle() {
   cp "${artifact_dir}/${shim_src}/${shim_src}" "${stage_dir}/${shim_dst}"
   cp "${artifact_dir}/${tui_src}/${tui_src}" "${stage_dir}/${tui_dst}"
 
+  # actions/upload-artifact intentionally normalizes downloaded files to 0644.
+  # Restore the executable contract before constructing Unix archives.
+  if [[ "${platform}" != windows-* ]]; then
+    chmod 0755 \
+      "${stage_dir}/${cli_dst}" \
+      "${stage_dir}/${shim_dst}" \
+      "${stage_dir}/${tui_dst}"
+  fi
+
   if [[ "${variant}" != "portable" ]]; then
     if [[ "${platform}" == windows-* ]]; then
       cp scripts/release/install.bat "${stage_dir}/"
@@ -62,11 +77,26 @@ bundle() {
     fi
   fi
 
+  # zip and tar both record mtimes; normalize every staged entry so identical
+  # inputs do not produce packaging-only checksum drift on a rerun.
+  find "${stage_dir}" -exec touch -t "${archive_timestamp}" {} +
+
   local archive="${bundle_dir}/${stem}.${ext}"
   if [[ "${ext}" == "zip" ]]; then
-    (cd "${stage_root}" && zip -qr "${archive}" "${stem}/")
+    (cd "${stage_root}" && zip -Xqr "${archive}" "${stem}/")
+  elif tar --version 2>/dev/null | grep -q 'GNU tar'; then
+    tar \
+      --sort=name \
+      --mtime='2000-01-01 00:00:00 UTC' \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --format=ustar \
+      -cf - \
+      -C "${stage_root}" \
+      "${stem}/" | gzip -n > "${archive}"
   else
-    tar -czf "${archive}" -C "${stage_root}" "${stem}/"
+    COPYFILE_DISABLE=1 tar -cf - -C "${stage_root}" "${stem}/" | gzip -n > "${archive}"
   fi
 
   local checksum

--- a/scripts/release/create-release-bundles.sh
+++ b/scripts/release/create-release-bundles.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 INPUT_ARTIFACT_DIR OUTPUT_BUNDLE_DIR" >&2
+  exit 2
+fi
+
+artifact_dir="$1"
+bundle_dir="$2"
+
+if [[ ! -d "${artifact_dir}" ]]; then
+  echo "input artifact directory does not exist: ${artifact_dir}" >&2
+  exit 1
+fi
+artifact_dir="$(cd "${artifact_dir}" && pwd)"
+
+if [[ -e "${bundle_dir}" && -n "$(find "${bundle_dir}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  echo "output bundle directory must be empty: ${bundle_dir}" >&2
+  exit 1
+fi
+mkdir -p "${bundle_dir}"
+bundle_dir="$(cd "${bundle_dir}" && pwd)"
+
+manifest="${bundle_dir}/codewhale-bundles-sha256.txt"
+: > "${manifest}"
+
+bundle() {
+  local platform="$1"
+  local cli_src="$2"
+  local shim_src="$3"
+  local tui_src="$4"
+  local ext="$5"
+  local variant="$6"
+
+  local stem="codewhale-${platform}${variant:+-}${variant}"
+  local stage_root
+  stage_root="$(mktemp -d)"
+  local stage_dir="${stage_root}/${stem}"
+  mkdir -p "${stage_dir}"
+
+  local cli_dst="codewhale"
+  local shim_dst="codew"
+  local tui_dst="codewhale-tui"
+  if [[ "${platform}" == windows-* ]]; then
+    cli_dst="codewhale.exe"
+    shim_dst="codew.exe"
+    tui_dst="codewhale-tui.exe"
+  fi
+
+  cp "${artifact_dir}/${cli_src}/${cli_src}" "${stage_dir}/${cli_dst}"
+  cp "${artifact_dir}/${shim_src}/${shim_src}" "${stage_dir}/${shim_dst}"
+  cp "${artifact_dir}/${tui_src}/${tui_src}" "${stage_dir}/${tui_dst}"
+
+  if [[ "${variant}" != "portable" ]]; then
+    if [[ "${platform}" == windows-* ]]; then
+      cp scripts/release/install.bat "${stage_dir}/"
+      sed -i 's/$/\r/' "${stage_dir}/install.bat" 2>/dev/null || true
+    else
+      cp scripts/release/install.sh "${stage_dir}/"
+      chmod +x "${stage_dir}/install.sh"
+    fi
+  fi
+
+  local archive="${bundle_dir}/${stem}.${ext}"
+  if [[ "${ext}" == "zip" ]]; then
+    (cd "${stage_root}" && zip -qr "${archive}" "${stem}/")
+  else
+    tar -czf "${archive}" -C "${stage_root}" "${stem}/"
+  fi
+
+  local checksum
+  checksum="$(sha256sum "${archive}" | awk '{print $1}')"
+  printf '%s  %s\n' "${checksum}" "$(basename "${archive}")" >> "${manifest}"
+  rm -rf "${stage_root}"
+  echo "Created ${archive}"
+}
+
+bundle linux-x64 \
+  codewhale-linux-x64 codew-linux-x64 codewhale-tui-linux-x64 tar.gz ""
+bundle linux-arm64 \
+  codewhale-linux-arm64 codew-linux-arm64 codewhale-tui-linux-arm64 tar.gz ""
+bundle android-arm64 \
+  codewhale-android-arm64 codew-android-arm64 codewhale-tui-android-arm64 tar.gz ""
+bundle macos-x64 \
+  codewhale-macos-x64 codew-macos-x64 codewhale-tui-macos-x64 tar.gz ""
+bundle macos-arm64 \
+  codewhale-macos-arm64 codew-macos-arm64 codewhale-tui-macos-arm64 tar.gz ""
+bundle windows-x64 \
+  codewhale-windows-x64.exe codew-windows-x64.exe codewhale-tui-windows-x64.exe zip ""
+bundle windows-x64 \
+  codewhale-windows-x64.exe codew-windows-x64.exe codewhale-tui-windows-x64.exe zip portable
+bundle windows-arm64 \
+  codewhale-windows-arm64.exe codew-windows-arm64.exe codewhale-tui-windows-arm64.exe zip ""
+bundle windows-arm64 \
+  codewhale-windows-arm64.exe codew-windows-arm64.exe codewhale-tui-windows-arm64.exe zip portable
+
+sort -o "${manifest}" "${manifest}"
+echo "Bundle checksum manifest:"
+cat "${manifest}"

--- a/scripts/release/ensure-release-assets-absent.js
+++ b/scripts/release/ensure-release-assets-absent.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require("node:child_process");
+
+function usage() {
+  return "Usage: node scripts/release/ensure-release-assets-absent.js OWNER/REPO vX.Y.Z";
+}
+
+function validateTarget(repo, tag) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error(`Invalid GitHub repository: ${repo}`);
+  }
+  if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+    throw new Error(`Invalid release tag: ${tag}`);
+  }
+}
+
+function isNotFoundError(error) {
+  return (
+    error &&
+    error.status !== 0 &&
+    /\bHTTP 404\b/.test(String(error.stderr || ""))
+  );
+}
+
+function fetchRelease(repo, tag, ghBin = process.env.GH_BIN || "gh", exec = execFileSync) {
+  validateTarget(repo, tag);
+  const endpoint = `repos/${repo}/releases/tags/${encodeURIComponent(tag)}`;
+  let output;
+  try {
+    output = exec(ghBin, ["api", endpoint], {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+    const detail = String(error && error.stderr ? error.stderr : "").trim();
+    throw new Error(
+      `Could not inspect GitHub Release ${tag}${detail ? `: ${detail}` : ""}`,
+    );
+  }
+
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    throw new Error(`GitHub Release ${tag} returned invalid JSON: ${error.message}`);
+  }
+}
+
+function assertReleaseAssetsAbsent(release, tag) {
+  if (release === null) {
+    return;
+  }
+  if (!release || !Array.isArray(release.assets)) {
+    throw new Error(`GitHub Release ${tag} did not provide an asset inventory`);
+  }
+  if (release.assets.length === 0) {
+    return;
+  }
+
+  const names = release.assets.map((asset) => asset && asset.name).filter(Boolean);
+  const inventory = names.length > 0 ? names.join(", ") : `${release.assets.length} unnamed asset(s)`;
+  throw new Error(
+    `Refusing to replace existing assets for ${tag}: ${inventory}. ` +
+      "A normal Release workflow rerun must never delete or overwrite public bytes.",
+  );
+}
+
+function main() {
+  if (process.argv.length !== 4) {
+    throw new Error(usage());
+  }
+  const repo = process.argv[2];
+  const tag = process.argv[3];
+  const release = fetchRelease(repo, tag);
+  assertReleaseAssetsAbsent(release, tag);
+  console.log(
+    release === null
+      ? `No existing GitHub Release assets found for ${tag}.`
+      : `Existing GitHub Release ${tag} has no assets; first upload may proceed.`,
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Release immutability check failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  assertReleaseAssetsAbsent,
+  fetchRelease,
+  isNotFoundError,
+  validateTarget,
+};

--- a/scripts/release/ensure-release-assets-absent.test.js
+++ b/scripts/release/ensure-release-assets-absent.test.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  assertReleaseAssetsAbsent,
+  fetchRelease,
+  isNotFoundError,
+  validateTarget,
+} = require("./ensure-release-assets-absent");
+
+test("release immutability guard accepts a missing release or empty inventory", () => {
+  assert.doesNotThrow(() => assertReleaseAssetsAbsent(null, "v0.9.1"));
+  assert.doesNotThrow(() => assertReleaseAssetsAbsent({ assets: [] }, "v0.9.1"));
+});
+
+test("release immutability guard refuses any existing public asset", () => {
+  assert.throws(
+    () =>
+      assertReleaseAssetsAbsent(
+        {
+          assets: [
+            { name: "codewhale-linux-x64" },
+            { name: "codewhale-artifacts-sha256.txt" },
+          ],
+        },
+        "v0.9.1",
+      ),
+    /Refusing to replace existing assets for v0\.9\.1: codewhale-linux-x64, codewhale-artifacts-sha256\.txt/,
+  );
+});
+
+test("release immutability guard fails closed on malformed inventories", () => {
+  assert.throws(
+    () => assertReleaseAssetsAbsent({}, "v0.9.1"),
+    /did not provide an asset inventory/,
+  );
+});
+
+test("release lookup treats only an explicit GitHub 404 as absent", () => {
+  const notFound = Object.assign(new Error("not found"), {
+    status: 1,
+    stderr: "gh: Not Found (HTTP 404)\n",
+  });
+  assert.equal(isNotFoundError(notFound), true);
+  assert.equal(
+    fetchRelease("Hmbown/CodeWhale", "v0.9.1", "gh", () => {
+      throw notFound;
+    }),
+    null,
+  );
+
+  const forbidden = Object.assign(new Error("forbidden"), {
+    status: 1,
+    stderr: "gh: Resource not accessible (HTTP 403)\n",
+  });
+  assert.throws(
+    () =>
+      fetchRelease("Hmbown/CodeWhale", "v0.9.1", "gh", () => {
+        throw forbidden;
+      }),
+    /Could not inspect GitHub Release v0\.9\.1.*HTTP 403/,
+  );
+});
+
+test("release lookup parses the exact tag endpoint and validates targets", () => {
+  let invocation;
+  const release = fetchRelease("Hmbown/CodeWhale", "v0.9.1", "/fake/gh", (...args) => {
+    invocation = args;
+    return JSON.stringify({ assets: [] });
+  });
+  assert.deepEqual(release, { assets: [] });
+  assert.equal(invocation[0], "/fake/gh");
+  assert.deepEqual(invocation[1], ["api", "repos/Hmbown/CodeWhale/releases/tags/v0.9.1"]);
+  assert.doesNotThrow(() => validateTarget("Hmbown/CodeWhale", "v0.9.1"));
+  assert.throws(() => validateTarget("bad repo", "v0.9.1"), /Invalid GitHub repository/);
+  assert.throws(() => validateTarget("Hmbown/CodeWhale", "main"), /Invalid release tag/);
+});
+
+test("release lookup rejects malformed successful API output", () => {
+  assert.throws(
+    () => fetchRelease("Hmbown/CodeWhale", "v0.9.1", "gh", () => "not-json"),
+    /returned invalid JSON/,
+  );
+});

--- a/scripts/release/npm-wrapper-smoke.js
+++ b/scripts/release/npm-wrapper-smoke.js
@@ -134,7 +134,12 @@ function parsePackJson(stdout) {
 
 async function main() {
   const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "codewhale-npm-smoke-"));
-  const releaseAssetsDir = path.join(tempRoot, "release-assets");
+  const suppliedAssetsDir = String(
+    process.env.CODEWHALE_SMOKE_ASSETS_DIR || "",
+  ).trim();
+  const releaseAssetsDir = suppliedAssetsDir
+    ? path.resolve(suppliedAssetsDir)
+    : path.join(tempRoot, "release-assets");
   const packDir = path.join(tempRoot, "pack");
   const installDir = path.join(tempRoot, "install");
   let keepTemp = process.env.DEEPSEEK_TUI_KEEP_SMOKE_DIR === "1";
@@ -144,7 +149,15 @@ async function main() {
     await fsp.mkdir(packDir, { recursive: true });
     await fsp.mkdir(installDir, { recursive: true });
 
-    await runCommand(process.execPath, [prepareAssetsScript, releaseAssetsDir]);
+    if (suppliedAssetsDir) {
+      const assetDirectoryStat = await fsp.stat(releaseAssetsDir);
+      if (!assetDirectoryStat.isDirectory()) {
+        throw new Error(`CODEWHALE_SMOKE_ASSETS_DIR is not a directory: ${releaseAssetsDir}`);
+      }
+      console.log(`Using preassembled release assets from ${releaseAssetsDir}`);
+    } else {
+      await runCommand(process.execPath, [prepareAssetsScript, releaseAssetsDir]);
+    }
     const served = await serveDirectory(releaseAssetsDir);
     server = served.server;
 


### PR DESCRIPTION
## What changed

- add an exact-SHA `workflow_dispatch` path that forces the complete CI profile
- add a non-publishing release-candidate workflow over the authoritative seven-target matrix
- share build, bundle, installer, inventory, checksum, and npm dogfood logic with the public release workflow
- preserve executable bits after Actions artifact transport and make archive construction deterministic for identical inputs
- refuse public release reruns that would replace any existing asset bytes

## Safety boundary

The candidate workflow has read-only repository permissions and uploads short-lived Actions artifacts only. It cannot create a tag or GitHub Release, publish crates or npm, push containers or Homebrew changes, or deploy the website. Public `v0.9.1` tagging and publication remain explicitly approval-gated.

## Validation

- 53 Node workflow/assembly/immutability/npm tests
- `actionlint`
- `shellcheck`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/release/check-versions.sh`
- `./scripts/release/check-ohos-deps.sh`
- exact-range and worktree `gitleaks`

The workflow has not been dispatched. Its first exact-head run belongs after this implementation and every other v0.9.1 source change reach final `main`.

Fixes #4531
