### PR TITLE
fix(release): exercise every shipped entrypoint

### DIFF
--- a/.cnb.yml
+++ b/.cnb.yml
@@ -64,6 +64,7 @@
         export PATH="$PWD/target/release:$PATH"
         node scripts/release/npm-wrapper-smoke.js
         ./target/release/codewhale --version
+        ./target/release/codew --version
         ./target/release/codewhale-tui --version
 
 .linux_release_preflight: &linux_release_preflight
@@ -103,6 +104,7 @@
         export PATH="$PWD/target/release:$PATH"
         node scripts/release/npm-wrapper-smoke.js
         ./target/release/codewhale --version
+        ./target/release/codew --version
         ./target/release/codewhale-tui --version
 
 main:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
               scripts/release/npm-wrapper-smoke.js|scripts/mobile-smoke.sh|scripts/check-provider-registry.py)
                 heavy=true
                 ;;
-              docs/*|*.md|.github/PULL_REQUEST_TEMPLATE.md|.github/ISSUE_TEMPLATE/*|.github/scripts/agent-task-metadata.test.sh|.github/workflows/agent-task-labels.yml|.github/workflows/auto-tag.yml|.github/workflows/stale.yml|.github/workflows/triage.yml|scripts/v0867-setup-qa.sh|scripts/release/check-versions.sh|scripts/release/check-ohos-deps.sh|scripts/release/prepare-release.sh|scripts/release/prepare-release.test.sh|scripts/check-coauthor-trailers.py)
+              docs/*|*.md|.github/PULL_REQUEST_TEMPLATE.md|.github/ISSUE_TEMPLATE/*|.github/scripts/agent-task-metadata.test.sh|.github/workflows/agent-task-labels.yml|.github/workflows/auto-tag.yml|.github/workflows/stale.yml|.github/workflows/triage.yml|scripts/v0867-setup-qa.sh|scripts/release/check-versions.sh|scripts/release/check-ohos-deps.sh|scripts/release/install-dogfood.sh|scripts/release/install-dogfood.test.sh|scripts/release/prepare-release.sh|scripts/release/prepare-release.test.sh|scripts/check-coauthor-trailers.py)
                 ;;
               *)
                 heavy=true
@@ -169,6 +169,7 @@ jobs:
         run: |
           bash .github/scripts/agent-task-metadata.test.sh
           bash scripts/release/generate-release-body.test.sh
+          bash scripts/release/install-dogfood.test.sh
           bash scripts/release/prepare-release.test.sh
           bash scripts/release/require-release-tag-checkout.test.sh
           bash scripts/release/verify-remote-tag.test.sh

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -3,14 +3,8 @@ name: Web Frontend
 on:
   push:
     branches: [master, main]
-    paths:
-      - 'web/**'
-      - '.github/workflows/web.yml'
   pull_request:
     branches: [master, main]
-    paths:
-      - 'web/**'
-      - '.github/workflows/web.yml'
   workflow_dispatch:
 
 permissions:
@@ -49,10 +43,14 @@ jobs:
         # Fails CI when docs-map.ts references non-existent repo files or
         # when website version / command snippets are stale.
         run: npm run check:docs
+      - name: Run tests
+        run: npm test
       - name: Run ESLint
         run: npm run lint
       - name: TypeScript type check
         run: npx tsc --noEmit
+      - name: Build production site
+        run: npm run build
 
   deploy:
     name: Deploy to Cloudflare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,9 @@ Thank you to the contributors whose code, reports, and reviews shaped v0.9.1:
   report that exposed lossy high-bit process-status handling (#4100).
 - [@w1w218](https://github.com/w1w218) — the Windows ARM64 release request and
   real-device motivation (#4267).
+- [@SparkofSpike](https://github.com/SparkofSpike) — the Windows Ctrl+O
+  reproduction that exposed pre-pager result truncation and conflicting composer
+  shortcut routing (#4482).
 
 ## [0.9.0] - 2026-07-16
 

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -149,6 +149,9 @@ Thank you to the contributors whose code, reports, and reviews shaped v0.9.1:
   report that exposed lossy high-bit process-status handling (#4100).
 - [@w1w218](https://github.com/w1w218) — the Windows ARM64 release request and
   real-device motivation (#4267).
+- [@SparkofSpike](https://github.com/SparkofSpike) — the Windows Ctrl+O
+  reproduction that exposed pre-pager result truncation and conflicting composer
+  shortcut routing (#4482).
 
 ## [0.9.0] - 2026-07-16
 

--- a/docs/CNB_MIRROR.md
+++ b/docs/CNB_MIRROR.md
@@ -21,7 +21,7 @@ against it:
 
 ```bash
 # Verify a downloaded CNB binary against the CNB manifest
-sha256sum -c codewhale-artifacts-sha256.txt
+sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing
 ```
 
 ## How it works

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -205,7 +205,8 @@ curl -L -O https://github.com/Hmbown/CodeWhale/releases/latest/download/codewhal
 sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing
 ```
 
-On macOS, use `shasum -a 256 -c codewhale-artifacts-sha256.txt` instead of
+On macOS, use
+`shasum -a 256 -c codewhale-artifacts-sha256.txt --ignore-missing` instead of
 `sha256sum`.
 
 If antivirus software flags an official release binary, treat it as unresolved
@@ -458,7 +459,8 @@ curl -L -o /tmp/codewhale-artifacts-sha256.txt \
 ( cd ~/.local/bin && sha256sum -c /tmp/codewhale-artifacts-sha256.txt --ignore-missing )
 ```
 
-(Use `shasum -a 256 -c` instead of `sha256sum` on macOS.)
+(Use `shasum -a 256 -c /tmp/codewhale-artifacts-sha256.txt --ignore-missing`
+instead of `sha256sum -c` on macOS.)
 
 ### Roll back to a previous release
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -65,8 +65,10 @@ generic checklist does not enumerate.
       `npm/codewhale/package.json` (`version` + `codewhaleBinaryVersion`),
       the README install-tag examples, refreshes `Cargo.lock`, regenerates
       `crates/tui/CHANGELOG.md` and `web/lib/facts.generated.ts`, and ends
-      by running `check-versions.sh`. Write the CHANGELOG entry **before**
-      running it.
+      by running the version and OHOS gates. Write the CHANGELOG entry
+      **before** running it. The helper is safe to rerun at the requested
+      workspace version; it skips replacements but refreshes both generated
+      files and reruns the gates.
 - [ ] `npm/deepseek-tui/package.json` remains private/compatibility-only and
       is **not** bumped or published.
 - [ ] `./scripts/release/check-versions.sh` reports

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -81,7 +81,6 @@ cargo fmt --all -- --check
 cargo check --workspace --all-targets --locked
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 cargo test --workspace --all-features --locked
-cargo publish --dry-run --locked --allow-dirty -p codewhale-tui
 ./scripts/release/publish-crates.sh dry-run
 ```
 
@@ -100,11 +99,11 @@ without unpublished workspace dependencies and a packaging preflight for depende
 workspace crates. That avoids false negatives from crates.io not yet containing the
 new workspace version while still validating package contents before publish.
 
-For npm wrapper verification, build the two shipped binaries and run the
+For npm wrapper verification, build the three shipped entrypoints and run the
 cross-platform smoke harness. This packs the npm wrapper, installs it into a
-clean temporary project, serves local release assets over HTTP, and checks both
-the dispatcher-to-TUI path (`codewhale doctor --help`) and the direct TUI
-entrypoint (`codewhale-tui --help`).
+clean temporary project, serves local release assets over HTTP, and checks the
+dispatcher-to-TUI path (`codewhale doctor --help`), the installed native shortcut
+(`codew --version`), and the direct TUI entrypoint (`codewhale-tui --help`).
 
 ```bash
 cargo build --release --locked -p codewhale-cli -p codewhale-tui
@@ -231,7 +230,9 @@ and fails branch-only release sources before assets are published.
    `./scripts/release/prepare-release.sh X.Y.Z` — it bumps every
    version-bearing file (workspace + crate pins + npm wrapper + README
    install tags), refreshes the lockfile and generated files, and runs
-   `check-versions.sh`.
+   the version and OHOS gates. It is safe to rerun after the workspace already
+   equals `X.Y.Z`: the second run skips replacements, refreshes the packaged
+   changelog and web facts, and reruns both gates.
 2. Run `./scripts/release/publish-crates.sh dry-run` locally; it must be clean.
 3. Merge the release PR into `main` before tagging. After the same-version
    queue is frozen and `main` is at the intended source SHA, create `vX.Y.Z`

--- a/npm/codewhale/bin/codew.js
+++ b/npm/codewhale/bin/codew.js
@@ -2,7 +2,7 @@
 
 const { run } = require("../scripts/run");
 
-run("codewhale").catch((error) => {
-  console.error("Failed to start codewhale:", error.message);
+run("codew").catch((error) => {
+  console.error("Failed to start codew:", error.message);
   process.exit(1);
 });

--- a/npm/codewhale/scripts/install.js
+++ b/npm/codewhale/scripts/install.js
@@ -142,12 +142,16 @@ function maxAttempts(context = "runtime", env = process.env) {
 }
 
 function binaryPaths() {
-  const { codewhale, tui } = detectBinaryNames();
+  const { codewhale, codew, tui } = detectBinaryNames();
   const releaseDir = releaseBinaryDirectory();
   return {
     codewhale: {
       asset: codewhale,
       target: path.join(releaseDir, process.platform === "win32" ? "codewhale.exe" : "codewhale"),
+    },
+    codew: {
+      asset: codew,
+      target: path.join(releaseDir, process.platform === "win32" ? "codew.exe" : "codew"),
     },
     tui: {
       asset: tui,
@@ -203,7 +207,7 @@ function installFailureHint(error) {
       "codewhale install hint:",
       `  DEEPSEEK_TUI_RELEASE_BASE_URL is set to ${releaseBase}`,
       "  Verify that this directory contains codewhale-artifacts-sha256.txt",
-      "  plus the codewhale/codewhale-tui binary assets for your platform.",
+      "  plus the codewhale/codew/codewhale-tui binary assets for your platform.",
     ].join("\n");
   }
 
@@ -1133,6 +1137,7 @@ async function run(options = {}) {
 
   await Promise.all([
     ensureBinary(paths.codewhale.target, paths.codewhale.asset, version, repo, getChecksums, { context }),
+    ensureBinary(paths.codew.target, paths.codew.asset, version, repo, getChecksums, { context }),
     ensureBinary(paths.tui.target, paths.tui.asset, version, repo, getChecksums, { context }),
   ]);
 }
@@ -1142,6 +1147,9 @@ async function getBinaryPath(name) {
   const paths = binaryPaths();
   if (name === "codewhale") {
     return paths.codewhale.target;
+  }
+  if (name === "codew") {
+    return paths.codew.target;
   }
   if (name === "codewhale-tui") {
     return paths.tui.target;
@@ -1162,6 +1170,7 @@ module.exports = {
     httpRequest,
     defaultTimeoutMs,
     defaultStallMs,
+    binaryPaths,
     ensureBinary,
     maxAttempts,
     withRetry,

--- a/npm/codewhale/test/install.test.js
+++ b/npm/codewhale/test/install.test.js
@@ -64,6 +64,13 @@ test("install script remains parseable before the Node support guard runs", () =
   assert.equal(installScript.includes("?."), false);
 });
 
+test("native shortcut has its own platform asset and installed path", () => {
+  const paths = _internal.binaryPaths();
+  assert.match(paths.codew.asset, /^codew-/);
+  assert.equal(path.basename(paths.codew.target), process.platform === "win32" ? "codew.exe" : "codew");
+  assert.notEqual(paths.codew.target, paths.codewhale.target);
+});
+
 test("install failure hint explains release base override for blocked GitHub downloads", () => {
   const previous = process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;
   delete process.env.DEEPSEEK_TUI_RELEASE_BASE_URL;

--- a/npm/codewhale/test/run.test.js
+++ b/npm/codewhale/test/run.test.js
@@ -33,6 +33,29 @@ test("version flags prefer the installed binary over package metadata", async ()
   assert.deepEqual(exits, [0]);
 });
 
+test("codew wrapper dispatches the native shortcut binary", async () => {
+  const resolvedNames = [];
+  const spawned = [];
+
+  await run("codew", {
+    args: ["--version"],
+    getBinaryPath: async (name) => {
+      resolvedNames.push(name);
+      return "/tmp/codew-test-binary";
+    },
+    spawnSync: (binary, args) => {
+      spawned.push({ binary, args });
+      return { status: 0 };
+    },
+    exit: () => {},
+  });
+
+  assert.deepEqual(resolvedNames, ["codew"]);
+  assert.deepEqual(spawned, [
+    { binary: "/tmp/codew-test-binary", args: ["--version"] },
+  ]);
+});
+
 test("version flags fall back to package metadata when the binary is unavailable", async () => {
   const originalLog = console.log;
   const lines = [];

--- a/scripts/release/generate-release-body.sh
+++ b/scripts/release/generate-release-body.sh
@@ -39,13 +39,14 @@ cat <<EOF
 
 ## Install
 
-### Recommended — npm (one command, both binaries)
+### Recommended — npm (one command, all three entrypoints)
 
 \`\`\`bash
 npm install -g codewhale
 \`\`\`
 
-The wrapper downloads the matched runtime binaries from this Release and places them in the same directory.
+The wrapper downloads the matched \`codewhale\`, \`codew\`, and \`codewhale-tui\`
+binaries from this Release and places them in the same directory.
 
 ### Docker / GHCR
 
@@ -107,14 +108,14 @@ Download the checksum manifests from this Release and verify:
 
 \`\`\`bash
 # Linux — archive bundles
-sha256sum -c codewhale-bundles-sha256.txt
+sha256sum -c codewhale-bundles-sha256.txt --ignore-missing
 
 # Linux — individual binaries
-sha256sum -c codewhale-artifacts-sha256.txt
+sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing
 
 # macOS
-shasum -a 256 -c codewhale-bundles-sha256.txt
-shasum -a 256 -c codewhale-artifacts-sha256.txt
+shasum -a 256 -c codewhale-bundles-sha256.txt --ignore-missing
+shasum -a 256 -c codewhale-artifacts-sha256.txt --ignore-missing
 \`\`\`
 
 ## What's in ${tag}

--- a/scripts/release/generate-release-body.test.sh
+++ b/scripts/release/generate-release-body.test.sh
@@ -30,6 +30,24 @@ grep -Fq -- 'codewhale-home:/home/codewhale/.codewhale' <<<"${body}"
 grep -Fq -- 'codewhale-android-arm64.tar.gz' <<<"${body}"
 grep -Fq -- 'codewhale-windows-arm64.zip' <<<"${body}"
 grep -Fq -- 'The image ships the `codewhale` dispatcher, `codew` shim, and `codewhale-tui` runtime.' <<<"${body}"
+grep -Fq -- '### Recommended — npm (one command, all three entrypoints)' <<<"${body}"
+grep -Fq -- 'sha256sum -c codewhale-bundles-sha256.txt --ignore-missing' <<<"${body}"
+grep -Fq -- 'sha256sum -c codewhale-artifacts-sha256.txt --ignore-missing' <<<"${body}"
+grep -Fq -- 'shasum -a 256 -c codewhale-bundles-sha256.txt --ignore-missing' <<<"${body}"
+grep -Fq -- 'shasum -a 256 -c codewhale-artifacts-sha256.txt --ignore-missing' <<<"${body}"
+
+checksum_dir="${tmp_dir}/checksums"
+mkdir -p "${checksum_dir}"
+printf 'downloaded platform\n' >"${checksum_dir}/codewhale-linux-x64.tar.gz"
+present_hash="$(sha256sum "${checksum_dir}/codewhale-linux-x64.tar.gz" | awk '{print $1}')"
+{
+  printf '%s  %s\n' "${present_hash}" "codewhale-linux-x64.tar.gz"
+  printf '%064d  %s\n' 0 "codewhale-windows-x64.zip"
+} >"${checksum_dir}/codewhale-bundles-sha256.txt"
+(
+  cd "${checksum_dir}"
+  sha256sum -c codewhale-bundles-sha256.txt --ignore-missing >/dev/null
+)
 if grep -Fq -- "### Contributors" <<<"${body}"; then
   echo "nested contributor heading leaked into generated release body" >&2
   exit 1

--- a/scripts/release/install-dogfood.sh
+++ b/scripts/release/install-dogfood.sh
@@ -10,8 +10,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
 src_dir="${1:-${repo_root}/target/release}"
 
-if [[ ! -x "${src_dir}/codewhale" || ! -x "${src_dir}/codewhale-tui" ]]; then
-  echo "ERROR: expected executable codewhale and codewhale-tui in ${src_dir}" >&2
+if [[ ! -x "${src_dir}/codewhale" || ! -x "${src_dir}/codew" || ! -x "${src_dir}/codewhale-tui" ]]; then
+  echo "ERROR: expected executable codewhale, codew, and codewhale-tui in ${src_dir}" >&2
   echo "Build first: cargo build --release -p codewhale-cli -p codewhale-tui --locked" >&2
   exit 1
 fi
@@ -30,16 +30,19 @@ else
 fi
 
 cli_version="$("${src_dir}/codewhale" --version)"
+shim_version="$("${src_dir}/codew" --version)"
 tui_version="$("${src_dir}/codewhale-tui" --version)"
 short_sha="${source_sha:0:12}"
-if [[ "${cli_version}" != *"${short_sha}"* || "${tui_version}" != *"${short_sha}"* ]]; then
+if [[ "${cli_version}" != *"${short_sha}"* || "${shim_version}" != *"${short_sha}"* || "${tui_version}" != *"${short_sha}"* ]]; then
   echo "ERROR: release binaries do not embed current HEAD ${short_sha}" >&2
   echo "  codewhale: ${cli_version}" >&2
+  echo "  codew: ${shim_version}" >&2
   echo "  codewhale-tui: ${tui_version}" >&2
   echo "Rebuild this checkout before installing." >&2
   exit 1
 fi
 cli_sha="$(shasum -a 256 "${src_dir}/codewhale" | awk '{print $1}')"
+shim_sha="$(shasum -a 256 "${src_dir}/codew" | awk '{print $1}')"
 tui_sha="$(shasum -a 256 "${src_dir}/codewhale-tui" | awk '{print $1}')"
 
 default_install_dirs="${HOME}/.cargo/bin:${HOME}/.local/bin"
@@ -73,21 +76,39 @@ installed=()
 for dest in "${dest_dirs[@]}"; do
   mkdir -p "${dest}"
   install_binary "${src_dir}/codewhale" "${dest}/codewhale"
+  install_binary "${src_dir}/codew" "${dest}/codew"
   install_binary "${src_dir}/codewhale-tui" "${dest}/codewhale-tui"
-  ln -sfn "${dest}/codewhale" "${dest}/codew"
   installed+=("${dest}/codewhale" "${dest}/codewhale-tui" "${dest}/codew")
 done
 
-path_tui="$(zsh -lc 'command -v codewhale-tui' 2>/dev/null || true)"
-if [[ -z "${path_tui}" || ! -x "${path_tui}" ]]; then
-  echo "ERROR: fresh login shell cannot resolve codewhale-tui" >&2
-  exit 1
-fi
-path_tui_sha="$(shasum -a 256 "${path_tui}" | awk '{print $1}')"
-if [[ "${path_tui_sha}" != "${tui_sha}" ]]; then
-  echo "ERROR: fresh-shell codewhale-tui is not the installed build: ${path_tui}" >&2
-  exit 1
-fi
+verify_fresh_shell_binary() {
+  local command_name="$1"
+  local expected_sha="$2"
+  local command_path
+  local command_sha
+  local command_version
+
+  command_path="$(zsh -lc "command -v ${command_name}" 2>/dev/null || true)"
+  if [[ -z "${command_path}" || ! -x "${command_path}" ]]; then
+    echo "ERROR: fresh login shell cannot resolve ${command_name}" >&2
+    return 1
+  fi
+  command_sha="$(shasum -a 256 "${command_path}" | awk '{print $1}')"
+  if [[ "${command_sha}" != "${expected_sha}" ]]; then
+    echo "ERROR: fresh-shell ${command_name} is not the installed build: ${command_path}" >&2
+    return 1
+  fi
+  command_version="$(zsh -lc "${command_name} --version" 2>/dev/null || true)"
+  if [[ "${command_version}" != *"${short_sha}"* ]]; then
+    echo "ERROR: fresh-shell ${command_name} does not report current HEAD ${short_sha}" >&2
+    return 1
+  fi
+  printf '%s\n' "${command_path}"
+}
+
+path_cli="$(verify_fresh_shell_binary codewhale "${cli_sha}")"
+path_shim="$(verify_fresh_shell_binary codew "${shim_sha}")"
+path_tui="$(verify_fresh_shell_binary codewhale-tui "${tui_sha}")"
 
 default_receipt_root="${HOME}/.codewhale/dogfood-receipts"
 if [[ -d "/Volumes/VIXinSSD/CW/backups" ]]; then
@@ -104,8 +125,12 @@ receipt="${receipt_root}/${timestamp}-${source_sha:0:12}.txt"
   echo "source_dir=${src_dir}"
   echo "codewhale_version=${cli_version}"
   echo "codewhale_sha256=${cli_sha}"
+  echo "codew_version=${shim_version}"
+  echo "codew_sha256=${shim_sha}"
   echo "codewhale_tui_version=${tui_version}"
   echo "codewhale_tui_sha256=${tui_sha}"
+  echo "fresh_shell_codewhale=${path_cli}"
+  echo "fresh_shell_codew=${path_shim}"
   echo "fresh_shell_codewhale_tui=${path_tui}"
   printf 'installed_path=%s\n' "${installed[@]}"
 } >"${receipt}"

--- a/scripts/release/install-dogfood.test.sh
+++ b/scripts/release/install-dogfood.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fixture="${tmp_dir}/repo"
+src_dir="${fixture}/target/release"
+dest_dir="${tmp_dir}/installed"
+receipt_dir="${tmp_dir}/receipts"
+fake_bin="${tmp_dir}/bin"
+marker="${tmp_dir}/invocations.log"
+
+mkdir -p "${fixture}/scripts/release" "${src_dir}" "${dest_dir}" "${fake_bin}"
+cp "${repo_root}/scripts/release/install-dogfood.sh" \
+  "${fixture}/scripts/release/install-dogfood.sh"
+printf 'target/\n' >"${fixture}/.gitignore"
+
+git -C "${fixture}" init --quiet
+git -C "${fixture}" config user.name "Dogfood Test"
+git -C "${fixture}" config user.email "dogfood-test@example.invalid"
+git -C "${fixture}" add .gitignore scripts/release/install-dogfood.sh
+git -C "${fixture}" -c commit.gpgsign=false commit --quiet -m "fixture"
+source_sha="$(git -C "${fixture}" rev-parse HEAD)"
+
+make_binary() {
+  local name="$1"
+  cat >"${src_dir}/${name}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "--version" ]]; then
+  printf '%s\n' '${name} 0.9.1 (${source_sha})'
+  printf '%s\n' '${name}' >>"\${DOGFOOD_TEST_MARKER}"
+  exit 0
+fi
+exit 2
+EOF
+  chmod +x "${src_dir}/${name}"
+}
+
+make_binary codewhale
+make_binary codew
+make_binary codewhale-tui
+
+# Reproduce the old dogfood state: codew was a symlink to the dispatcher.
+printf 'old dispatcher\n' >"${dest_dir}/codewhale"
+ln -s "${dest_dir}/codewhale" "${dest_dir}/codew"
+
+cat >"${fake_bin}/zsh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "-lc" ]]
+case "${2:-}" in
+  "command -v codewhale") printf '%s\n' "${DOGFOOD_TEST_DEST}/codewhale" ;;
+  "command -v codew") printf '%s\n' "${DOGFOOD_TEST_DEST}/codew" ;;
+  "command -v codewhale-tui") printf '%s\n' "${DOGFOOD_TEST_DEST}/codewhale-tui" ;;
+  "codewhale --version") exec "${DOGFOOD_TEST_DEST}/codewhale" --version ;;
+  "codew --version") exec "${DOGFOOD_TEST_DEST}/codew" --version ;;
+  "codewhale-tui --version") exec "${DOGFOOD_TEST_DEST}/codewhale-tui" --version ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "${fake_bin}/zsh"
+
+HOME="${tmp_dir}/home" \
+PATH="${fake_bin}:${PATH}" \
+DOGFOOD_TEST_DEST="${dest_dir}" \
+DOGFOOD_TEST_MARKER="${marker}" \
+CODEWHALE_INSTALL_DIRS="${dest_dir}" \
+CODEWHALE_DOGFOOD_RECEIPT_DIR="${receipt_dir}" \
+  "${fixture}/scripts/release/install-dogfood.sh" "${src_dir}" >/dev/null
+
+for name in codewhale codew codewhale-tui; do
+  cmp -s "${src_dir}/${name}" "${dest_dir}/${name}" || {
+    echo "installed ${name} differs from the built fixture" >&2
+    exit 1
+  }
+done
+
+if [[ -L "${dest_dir}/codew" ]]; then
+  echo "dogfood install left codew as a symlink" >&2
+  exit 1
+fi
+
+[[ "$(grep -c '^codew$' "${marker}")" -ge 2 ]] || {
+  echo "native codew was not exercised before and after installation" >&2
+  exit 1
+}
+
+receipt="$(find "${receipt_dir}" -type f -name '*.txt' -print -quit)"
+[[ -n "${receipt}" ]]
+grep -Fq "codew_sha256=" "${receipt}"
+grep -Fq "fresh_shell_codew=${dest_dir}/codew" "${receipt}"
+grep -Fq "installed_path=${dest_dir}/codew" "${receipt}"
+
+echo "install-dogfood tests passed"

--- a/scripts/release/npm-wrapper-smoke.js
+++ b/scripts/release/npm-wrapper-smoke.js
@@ -182,6 +182,10 @@ async function main() {
       cwd: installDir,
       env,
     });
+    await runCommand("npx", ["--no-install", "codew", "--version"], {
+      cwd: installDir,
+      env,
+    });
     await runCommand("npx", ["--no-install", "codewhale-tui", "--help"], {
       cwd: installDir,
       env,

--- a/scripts/release/prepare-release.sh
+++ b/scripts/release/prepare-release.sh
@@ -24,17 +24,14 @@ repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo}"
 
 old="$(grep -E '^version = "' Cargo.toml | head -n1 | sed -E 's/^version = "([^"]+)".*/\1/')"
-if [[ "${old}" == "${new}" ]]; then
-  echo "workspace is already at ${new}; nothing to bump"
-  exit 0
-fi
-echo "Bumping ${old} -> ${new}"
-
 if ! grep -q "^## \[${new}\]" CHANGELOG.md; then
   echo "warning: CHANGELOG.md has no '## [${new}]' entry yet — add it before tagging" >&2
 fi
 
-OLD_VERSION="${old}" NEW_VERSION="${new}" python3 - <<'PY'
+if [[ "${old}" != "${new}" ]]; then
+  echo "Bumping ${old} -> ${new}"
+
+  OLD_VERSION="${old}" NEW_VERSION="${new}" python3 - <<'PY'
 import os, pathlib, re, sys
 
 old, new = os.environ["OLD_VERSION"], os.environ["NEW_VERSION"]
@@ -142,8 +139,11 @@ bump(
 )
 PY
 
-echo "Refreshing Cargo.lock..."
-cargo update --workspace --offline >/dev/null
+  echo "Refreshing Cargo.lock..."
+  cargo update --workspace --offline >/dev/null
+else
+  echo "Workspace is already at ${new}; refreshing generated release state and rerunning gates."
+fi
 
 echo "Regenerating crates/tui/CHANGELOG.md slice..."
 ./scripts/sync-changelog.sh
@@ -153,4 +153,5 @@ node web/scripts/derive-facts.mjs
 
 echo "Validating..."
 ./scripts/release/check-versions.sh
+./scripts/release/check-ohos-deps.sh
 echo "Done. Review 'git diff', commit, and follow docs/RELEASE_CHECKLIST.md."

--- a/scripts/release/prepare-release.test.sh
+++ b/scripts/release/prepare-release.test.sh
@@ -81,6 +81,12 @@ set -euo pipefail
 : >"${PREPARE_RELEASE_TEST_MARKERS}/check-versions"
 EOF
 
+  cat >"${root}/scripts/release/check-ohos-deps.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: >"${PREPARE_RELEASE_TEST_MARKERS}/check-ohos-deps"
+EOF
+
   cat >"${root}/web/scripts/derive-facts.mjs" <<'EOF'
 import { writeFileSync } from "node:fs";
 
@@ -90,6 +96,7 @@ EOF
   chmod +x \
     "${root}/bin/cargo" \
     "${root}/scripts/release/prepare-release.sh" \
+    "${root}/scripts/release/check-ohos-deps.sh" \
     "${root}/scripts/release/check-versions.sh" \
     "${root}/scripts/sync-changelog.sh"
 }
@@ -118,12 +125,49 @@ if grep -R -E -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' \
   echo "tag-free localized README unexpectedly gained a release tag" >&2
   exit 1
 fi
-for marker in cargo sync-changelog derive-facts check-versions; do
+for marker in cargo sync-changelog derive-facts check-versions check-ohos-deps; do
   [[ -f "${success_markers}/${marker}" ]] || {
     echo "prepare-release did not reach ${marker}" >&2
     exit 1
   }
 done
+
+same_root="${tmp_dir}/same"
+same_markers="${tmp_dir}/same-markers"
+same_log="${tmp_dir}/same.log"
+make_fixture "${same_root}"
+mkdir -p "${same_markers}"
+cat >"${same_root}/CHANGELOG.md" <<'EOF'
+## [Unreleased]
+
+## [0.8.68] - 2026-07-18
+
+### Changed
+
+- Test already-prepared release.
+EOF
+
+PREPARE_RELEASE_TEST_MARKERS="${same_markers}" \
+  PATH="${same_root}/bin:${PATH}" \
+  "${same_root}/scripts/release/prepare-release.sh" 0.8.68 \
+  >"${same_log}"
+
+grep -Fq \
+  'Workspace is already at 0.8.68; refreshing generated release state and rerunning gates.' \
+  "${same_log}"
+for marker in sync-changelog derive-facts check-versions check-ohos-deps; do
+  [[ -f "${same_markers}/${marker}" ]] || {
+    echo "same-version prepare-release did not reach ${marker}" >&2
+    exit 1
+  }
+done
+if [[ -f "${same_markers}/cargo" ]]; then
+  echo "same-version prepare-release unexpectedly mutated Cargo.lock" >&2
+  exit 1
+fi
+grep -Fq 'version = "0.8.68"' "${same_root}/Cargo.toml"
+grep -Fq 'version = "0.8.68"' "${same_root}/crates/example/Cargo.toml"
+grep -Fq '"version": "0.8.68"' "${same_root}/npm/codewhale/package.json"
 
 stale_root="${tmp_dir}/stale"
 stale_markers="${tmp_dir}/stale-markers"

--- a/web/lib/release-credits.ts
+++ b/web/lib/release-credits.ts
@@ -35,4 +35,5 @@ export const RELEASE_CONTRIBUTORS: string[] = [
 export const RELEASE_HELPERS: string[] = [
   "@AiurArtanis",
   "@seanthefuturegorilla",
+  "@SparkofSpike",
 ];


### PR DESCRIPTION
## Summary

- make same-version `prepare-release.sh` reruns refresh the generated changelog and web facts, then rerun both version and OHOS gates instead of exiting early
- install and exercise the separately shipped native `codew` entrypoint in local dogfood, npm packaging, CNB smoke, and durable install receipts
- keep the website verification workflow always on for every `main` push/PR and add its existing tests plus a production build to the required web job
- make release-body and install documentation checksum commands truthful for single-platform downloads by using `--ignore-missing`
- align the runbook with the canonical multi-crate publish dry-run instead of the misleading standalone TUI dry-run

This was rebased after #4532 landed. It does not modify the candidate/public release workflows, their exact-SHA checks, overwrite refusal, or pinned publication-path Actions. Cloudflare deployment remains manual-dispatch-only.

## Testing

- [x] `./scripts/release/check-versions.sh`
- [x] `./scripts/release/check-ohos-deps.sh`
- [x] `bash scripts/release/generate-release-body.test.sh`
- [x] `bash scripts/release/install-dogfood.test.sh`
- [x] `bash scripts/release/prepare-release.test.sh`
- [x] `npm test --prefix npm/codewhale` (45/45)
- [x] `/opt/homebrew/bin/actionlint -ignore SC2129 -ignore SC2221 -ignore SC2222 .github/workflows/ci.yml .github/workflows/web.yml .github/workflows/release.yml .github/workflows/release-candidate.yml`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check origin/main...HEAD`
- [x] `cd web && npm ci && npm run check:facts && npm run prebuild && npm run check:docs`
- [x] `cd web && npm run lint && npx tsc --noEmit && npm run build`
- [ ] `cd web && npm test` — 75/76 pass; the always-on gate intentionally exposes existing release-credit drift: `@SparkofSpike` is in the current `docs/CONTRIBUTORS.md` band but not yet in the root v0.9.1 changelog/website arrays. The final consolidated v0.9.1 credit reconciliation will make all three public surfaces exact.
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

An exact-head release build and packed npm install smoke are running locally; their receipt will be added before review handoff.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — no TUI UI changes
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — no harvested code or new co-authors in this PR

## Release boundary

This PR only prepares and validates release source. It does not create a tag, GitHub Release, public asset upload, registry publication, or deployment.
