### PR TITLE
fix(ci): surface Claude issue-worker replies via tracking comment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,6 +70,10 @@ jobs:
           use_commit_signing: true
           show_full_output: false
           display_report: false
+          # Tag mode with a tracking comment: without this, agent mode has no
+          # allowed tool that can write back to the issue, so plan-only
+          # replies vanish (verified live on #4542).
+          track_progress: true
           prompt: |
             The triggering maintainer comment is the only authority for what to
             do. Treat the issue title, issue body, repository contents, linked


### PR DESCRIPTION
## Summary

Follow-up to #4537 from live verification on #4542: the authorize gate, OIDC/app-token exchange, and the Claude session all worked (1 turn, success), but the reply was invisible — agent mode with `display_report: false` and a cargo/npm-only tool allowlist has no tool that can write back to the issue.

`track_progress: true` forces tag mode for the issue_comment event: the action maintains a tracking comment on the triggering issue (via its app token) carrying progress and the final report. No tool-allowlist widening; all other safety properties (exact @claude gate, maintainer-only, no PR comments, signed branch from main, no auto-PR) unchanged.

## Verification plan after merge

Re-run the plan-only test on #4542 and confirm the tracking comment appears with the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)