### PR TITLE
fix(doctor): keep diagnostic commands read-only end to end

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1638,7 +1638,8 @@ fn run() -> Result<()> {
             delegate_to_tui(&cli, &resolved_runtime, args.args)
         }
         Some(Commands::Doctor(args)) => {
-            let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
+            let resolved_runtime =
+                resolve_runtime_for_diagnostic_dispatch(&store, &runtime_overrides);
             delegate_to_tui(&cli, &resolved_runtime, tui_args("doctor", args))
         }
         Some(Commands::Models(args)) => {
@@ -1666,7 +1667,11 @@ fn run() -> Result<()> {
             delegate_to_tui(&cli, &resolved_runtime, tui_args("init", args))
         }
         Some(Commands::Setup(args)) => {
-            let resolved_runtime = resolve_runtime_for_dispatch(&mut store, &runtime_overrides);
+            let resolved_runtime = if setup_is_status_report(&args) {
+                resolve_runtime_for_diagnostic_dispatch(&store, &runtime_overrides)
+            } else {
+                resolve_runtime_for_dispatch(&mut store, &runtime_overrides)
+            };
             delegate_to_tui(&cli, &resolved_runtime, tui_args("setup", args))
         }
         Some(Commands::RemoteSetup(args)) => {
@@ -1822,6 +1827,20 @@ fn resolve_runtime_for_dispatch(
     resolve_runtime_for_dispatch_with_secrets(store, runtime_overrides, &runtime_secrets)
 }
 
+/// Resolve enough routing state to delegate a static diagnostic without
+/// reading or migrating the durable secret store.
+///
+/// The TUI's doctor/setup-status path performs its own read-only source check,
+/// so this dispatcher must not recover and export a credential merely to start
+/// that report. Regular runtime and authentication commands keep using
+/// [`resolve_runtime_for_dispatch`].
+fn resolve_runtime_for_diagnostic_dispatch(
+    store: &ConfigStore,
+    runtime_overrides: &CliRuntimeOverrides,
+) -> ResolvedRuntimeOptions {
+    store.config.resolve_runtime_options(runtime_overrides)
+}
+
 fn resolve_runtime_for_dispatch_with_secrets(
     store: &mut ConfigStore,
     runtime_overrides: &CliRuntimeOverrides,
@@ -1837,6 +1856,10 @@ fn tui_args(command: &str, args: TuiPassthroughArgs) -> Vec<String> {
     forwarded.push(command.to_string());
     forwarded.extend(args.args);
     forwarded
+}
+
+fn setup_is_status_report(args: &TuiPassthroughArgs) -> bool {
+    args.args.iter().any(|arg| arg == "--status")
 }
 
 fn reject_exec_global_flags(args: &[String]) -> Result<()> {

--- a/crates/cli/tests/diagnostic_dispatch_read_only.rs
+++ b/crates/cli/tests/diagnostic_dispatch_read_only.rs
@@ -1,0 +1,164 @@
+//! The facade must not migrate secrets before it delegates static diagnostics.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use codewhale_secrets::{FileKeyringStore, KeyringStore};
+use tempfile::TempDir;
+
+#[test]
+fn dispatcher_diagnostics_leave_legacy_secret_state_unchanged() {
+    for (args, expected_tui_args, expects_json) in [
+        (&["doctor"][..], &["doctor"][..], false),
+        (&["doctor", "--json"][..], &["doctor", "--json"][..], false),
+        (
+            &["doctor", "--context-json"][..],
+            &["doctor", "--context-json"][..],
+            true,
+        ),
+        (
+            &["setup", "--status"][..],
+            &["setup", "--status"][..],
+            false,
+        ),
+    ] {
+        let fixture = TempDir::new().expect("fixture root");
+        let sealed_home = fixture.path().join("sealed-home");
+        let codewhale_home = fixture.path().join("sealed-codewhale-home");
+        let primary_home = sealed_home.join(".codewhale");
+        let legacy = sealed_home
+            .join(".deepseek")
+            .join("secrets")
+            .join("secrets.json");
+        let legacy_settings = sealed_home.join(".deepseek").join("settings.toml");
+        let legacy_settings_bytes = b"default_mode = \"plan\"\n";
+        FileKeyringStore::new(&legacy)
+            .set("deepseek", "synthetic-legacy-fixture")
+            .expect("seed synthetic legacy store");
+        fs::write(&legacy_settings, legacy_settings_bytes).expect("seed legacy settings");
+        let before_paths = relative_paths(&sealed_home);
+        let before_legacy = fs::read(&legacy).expect("read synthetic legacy store");
+
+        let receipt = fixture.path().join("delegated-args.txt");
+        let fake_tui = fixture.path().join("fake-codewhale-tui");
+        fs::write(
+            &fake_tui,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$DIAGNOSTIC_DISPATCH_RECEIPT\"\nif [ \"$1\" = doctor ] && [ \"$2\" = --context-json ]; then\n  printf '%s\\n' '{\"entries\":[]}'\nfi\n",
+        )
+        .expect("write fake TUI");
+        let mut permissions = fs::metadata(&fake_tui)
+            .expect("fake TUI metadata")
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&fake_tui, permissions).expect("make fake TUI executable");
+
+        let output = Command::new(codewhale_binary())
+            .args(args)
+            .env_clear()
+            .env("HOME", &sealed_home)
+            .env("USERPROFILE", &sealed_home)
+            .env("CODEWHALE_HOME", &codewhale_home)
+            .env("CODEWHALE_SECRET_BACKEND", "file")
+            .env("DEEPSEEK_TUI_BIN", &fake_tui)
+            .env("DIAGNOSTIC_DISPATCH_RECEIPT", &receipt)
+            .output()
+            .expect("run dispatcher diagnostic");
+
+        assert!(
+            output.status.success(),
+            "dispatcher {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            fs::read_to_string(&receipt)
+                .expect("fake TUI receipt")
+                .lines()
+                .collect::<Vec<_>>(),
+            expected_tui_args,
+            "dispatcher must preserve the diagnostic command shape"
+        );
+        if expects_json {
+            let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "facade {args:?} must preserve machine-readable output: {error}\nstdout:\n{}\nstderr:\n{}",
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    )
+                });
+            assert!(
+                report["entries"].is_array(),
+                "facade {args:?} must preserve the context source map\nstdout:\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+        }
+        assert_eq!(
+            relative_paths(&sealed_home),
+            before_paths,
+            "dispatcher {args:?} must not create or migrate state below HOME"
+        );
+        assert_eq!(
+            fs::read(&legacy).expect("read synthetic legacy store after diagnostic"),
+            before_legacy,
+            "dispatcher {args:?} must not rewrite the legacy store"
+        );
+        assert_eq!(
+            fs::read(&legacy_settings).expect("read legacy settings after diagnostic"),
+            legacy_settings_bytes,
+            "dispatcher {args:?} must not rewrite legacy settings"
+        );
+        assert!(
+            !primary_home.exists(),
+            "dispatcher {args:?} must not create a primary Codewhale home or migrated state"
+        );
+        assert!(
+            !codewhale_home.exists(),
+            "dispatcher {args:?} must not create an explicit CODEWHALE_HOME"
+        );
+    }
+}
+
+fn relative_paths(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    collect_relative_paths(root, root, &mut paths);
+    paths.sort();
+    paths
+}
+
+fn collect_relative_paths(root: &Path, current: &Path, paths: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(current).expect("read synthetic state directory");
+    for entry in entries {
+        let entry = entry.expect("synthetic state directory entry");
+        let path = entry.path();
+        paths.push(
+            path.strip_prefix(root)
+                .expect("synthetic path below root")
+                .to_path_buf(),
+        );
+        if entry.file_type().expect("synthetic entry type").is_dir() {
+            collect_relative_paths(root, &path, paths);
+        }
+    }
+}
+
+fn codewhale_binary() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_codewhale") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_codewhale") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("current test executable path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("codewhale{}", std::env::consts::EXE_SUFFIX));
+    path
+}

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -50,6 +50,9 @@ pub enum SecretsError {
         /// Observed unix permission mode.
         mode: u32,
     },
+    /// A caller attempted to modify a diagnostic-only secret store.
+    #[error("secret store is read-only")]
+    ReadOnly,
 }
 
 /// Abstract secret store trait.
@@ -358,6 +361,22 @@ pub struct FileKeyringStore {
     path: PathBuf,
 }
 
+/// File-backed secret lookup that never migrates or changes either store.
+///
+/// Normal runtime credential resolution keeps its additive legacy migration:
+/// older entries under `~/.deepseek/secrets/` are copied into the Codewhale
+/// location before use. Diagnostic commands need the same read precedence
+/// without creating that destination, so this store reads the primary file
+/// first and falls back to the legacy file only when the primary has no entry
+/// and the Codewhale home is not explicitly isolated.
+#[derive(Debug, Clone)]
+struct ReadOnlyFileKeyringStore {
+    primary: FileKeyringStore,
+    /// The ambient legacy store is unavailable when `CODEWHALE_HOME` is an
+    /// explicit isolation boundary.
+    legacy: Option<FileKeyringStore>,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct FileSecretsBlob {
     #[serde(default)]
@@ -387,6 +406,20 @@ impl FileKeyringStore {
             );
         }
         Ok(primary)
+    }
+
+    /// Resolve the primary and legacy secret paths without performing legacy
+    /// migration.
+    ///
+    /// This is intended for diagnostic-only lookup. Runtime and authentication
+    /// flows must keep using [`Self::default_path`] so their existing additive
+    /// migration behavior remains unchanged.
+    pub fn default_paths_read_only() -> Result<(PathBuf, Option<PathBuf>), SecretsError> {
+        let primary = default_codewhale_secrets_path()?;
+        let legacy = (!codewhale_home_is_explicit())
+            .then(legacy_deepseek_secrets_path)
+            .transpose()?;
+        Ok((primary, legacy))
     }
 
     fn migrate_legacy_file_if_needed(primary: &Path, legacy: &Path) -> Result<(), SecretsError> {
@@ -500,6 +533,73 @@ impl FileKeyringStore {
     }
 }
 
+impl ReadOnlyFileKeyringStore {
+    fn default_for_diagnostics() -> Result<Self, SecretsError> {
+        let (primary, legacy) = FileKeyringStore::default_paths_read_only()?;
+        Ok(Self::new(primary, legacy))
+    }
+
+    fn new(primary: impl Into<PathBuf>, legacy: Option<PathBuf>) -> Self {
+        Self {
+            primary: FileKeyringStore::new(primary),
+            legacy: legacy.map(FileKeyringStore::new),
+        }
+    }
+}
+
+impl KeyringStore for ReadOnlyFileKeyringStore {
+    fn get(&self, key: &str) -> Result<Option<String>, SecretsError> {
+        match self.primary.get(key)? {
+            Some(value) => Ok(Some(value)),
+            None => self
+                .legacy
+                .as_ref()
+                .map_or(Ok(None), |legacy| legacy.get(key)),
+        }
+    }
+
+    fn set(&self, _key: &str, _value: &str) -> Result<(), SecretsError> {
+        Err(SecretsError::ReadOnly)
+    }
+
+    fn delete(&self, _key: &str) -> Result<(), SecretsError> {
+        Err(SecretsError::ReadOnly)
+    }
+
+    fn backend_name(&self) -> &'static str {
+        FILE_BACKEND_LABEL
+    }
+}
+
+#[derive(Clone)]
+struct ReadOnlyKeyringStore {
+    inner: Arc<dyn KeyringStore>,
+}
+
+impl ReadOnlyKeyringStore {
+    fn new(inner: Arc<dyn KeyringStore>) -> Self {
+        Self { inner }
+    }
+}
+
+impl KeyringStore for ReadOnlyKeyringStore {
+    fn get(&self, key: &str) -> Result<Option<String>, SecretsError> {
+        self.inner.get(key)
+    }
+
+    fn set(&self, _key: &str, _value: &str) -> Result<(), SecretsError> {
+        Err(SecretsError::ReadOnly)
+    }
+
+    fn delete(&self, _key: &str) -> Result<(), SecretsError> {
+        Err(SecretsError::ReadOnly)
+    }
+
+    fn backend_name(&self) -> &'static str {
+        self.inner.backend_name()
+    }
+}
+
 fn write_private_file(path: &Path, body: &[u8]) -> Result<(), SecretsError> {
     atomic_write_private_file(path, body)
 }
@@ -577,6 +677,12 @@ fn legacy_deepseek_secrets_path() -> Result<PathBuf, SecretsError> {
         .join(".deepseek")
         .join("secrets")
         .join("secrets.json"))
+}
+
+/// Match the state/config isolation boundary: an explicit Codewhale home must
+/// not fall back to ambient legacy data under `$HOME/.deepseek`.
+fn codewhale_home_is_explicit() -> bool {
+    std::env::var("CODEWHALE_HOME").is_ok_and(|value| !value.trim().is_empty())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -698,10 +804,61 @@ impl Secrets {
         }
     }
 
+    /// Auto-detect a secret backend for diagnostics without permitting writes
+    /// or legacy migration.
+    ///
+    /// The selected backend and lookup precedence match [`Self::auto_detect`],
+    /// but file-backed lookup reads the Codewhale location first and the legacy
+    /// location second instead of copying legacy entries into a new file. This
+    /// lets status and doctor reports label a saved credential without changing
+    /// user state.
+    #[must_use]
+    pub fn auto_detect_read_only() -> Self {
+        match secret_backend_selection(configured_secret_backend().as_deref()) {
+            SecretBackendSelection::File => Self::file_backed_read_only(),
+            SecretBackendSelection::Unknown => {
+                tracing::warn!(
+                    "{SECRET_BACKEND_ENV}/{LEGACY_SECRET_BACKEND_ENV} has an unsupported value; using file-backed secret store"
+                );
+                Self::file_backed_read_only()
+            }
+            SecretBackendSelection::System => {
+                let default_store = DefaultKeyringStore::default();
+                match default_store.probe() {
+                    Ok(()) => {
+                        Self::new(Arc::new(ReadOnlyKeyringStore::new(Arc::new(default_store))))
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            "OS keyring unavailable ({err}); falling back to file-backed secret store"
+                        );
+                        Self::file_backed_read_only()
+                    }
+                }
+            }
+        }
+    }
+
     fn file_backed_default() -> Self {
         let path = FileKeyringStore::default_path()
             .unwrap_or_else(|_| PathBuf::from(".codewhale-secrets.json"));
         Self::new(Arc::new(FileKeyringStore::new(path)))
+    }
+
+    /// Construct a file-backed diagnostic store without migration or write
+    /// capability.
+    ///
+    /// This reads the Codewhale file first and the legacy file second (unless
+    /// `CODEWHALE_HOME` is explicit), but never copies legacy entries into a
+    /// primary store. It intentionally bypasses an opted-in OS keyring so
+    /// callers that only need non-secret diagnostics do not cause a platform
+    /// credential prompt.
+    #[must_use]
+    pub fn file_backed_read_only() -> Self {
+        let store = ReadOnlyFileKeyringStore::default_for_diagnostics().unwrap_or_else(|_| {
+            ReadOnlyFileKeyringStore::new(PathBuf::from(".codewhale-secrets.json"), None)
+        });
+        Self::new(Arc::new(store))
     }
 
     /// Construct the file-backed default backend directly.
@@ -1029,6 +1186,118 @@ mod tests {
         assert_eq!(secrets.backend_name(), FILE_BACKEND_LABEL);
         // Safety: env mutation guarded by env_lock().
         unsafe { std::env::remove_var(SECRET_BACKEND_ENV) };
+    }
+
+    #[test]
+    fn read_only_auto_detect_reads_legacy_without_migrating_or_allowing_writes() {
+        let _lock = env_lock();
+        clear_known_envs();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", tmp.path());
+        let _userprofile = EnvVarGuard::set("USERPROFILE", tmp.path());
+        let _backend = EnvVarGuard::set(SECRET_BACKEND_ENV, "file");
+        let legacy = tmp
+            .path()
+            .join(".deepseek")
+            .join("secrets")
+            .join("secrets.json");
+        let primary = tmp
+            .path()
+            .join(".codewhale")
+            .join("secrets")
+            .join("secrets.json");
+        FileKeyringStore::new(&legacy)
+            .set("moonshot", "fixture-legacy-value")
+            .unwrap();
+
+        let secrets = Secrets::auto_detect_read_only();
+
+        assert_eq!(
+            secrets.get("moonshot").unwrap().as_deref(),
+            Some("fixture-legacy-value")
+        );
+        assert!(
+            !primary.exists(),
+            "diagnostic lookup must not migrate the legacy store"
+        );
+        assert!(
+            matches!(
+                secrets.set("moonshot", "replacement"),
+                Err(SecretsError::ReadOnly)
+            ),
+            "the diagnostic secret facade must refuse writes"
+        );
+        assert!(
+            !primary.exists(),
+            "a refused diagnostic write must not create the primary store"
+        );
+    }
+
+    #[test]
+    fn read_only_auto_detect_respects_explicit_codewhale_home_isolation() {
+        let _lock = env_lock();
+        clear_known_envs();
+        let tmp = tempfile::tempdir().unwrap();
+        let codewhale_home = tmp.path().join("isolated-codewhale-home");
+        let _home = EnvVarGuard::set("HOME", tmp.path());
+        let _userprofile = EnvVarGuard::set("USERPROFILE", tmp.path());
+        let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+        let _backend = EnvVarGuard::set(SECRET_BACKEND_ENV, "file");
+        let legacy = tmp
+            .path()
+            .join(".deepseek")
+            .join("secrets")
+            .join("secrets.json");
+        let primary = codewhale_home.join("secrets").join("secrets.json");
+        FileKeyringStore::new(&legacy)
+            .set("deepseek", "synthetic-ambient-legacy-value")
+            .unwrap();
+
+        let secrets = Secrets::auto_detect_read_only();
+
+        assert_eq!(
+            secrets.get("deepseek").unwrap(),
+            None,
+            "an explicit CODEWHALE_HOME must not read ambient legacy secrets"
+        );
+        assert!(
+            !primary.exists(),
+            "diagnostic lookup must not create an isolated primary store"
+        );
+        assert!(
+            matches!(
+                secrets.set("deepseek", "replacement"),
+                Err(SecretsError::ReadOnly)
+            ),
+            "the isolated diagnostic facade must refuse writes"
+        );
+        assert!(
+            !primary.exists(),
+            "a refused isolated diagnostic write must not create the primary store"
+        );
+    }
+
+    #[test]
+    fn read_only_auto_detect_reads_the_explicit_primary_store() {
+        let _lock = env_lock();
+        clear_known_envs();
+        let tmp = tempfile::tempdir().unwrap();
+        let codewhale_home = tmp.path().join("isolated-codewhale-home");
+        let _home = EnvVarGuard::set("HOME", tmp.path());
+        let _userprofile = EnvVarGuard::set("USERPROFILE", tmp.path());
+        let _codewhale_home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+        let _backend = EnvVarGuard::set(SECRET_BACKEND_ENV, "file");
+        let primary = codewhale_home.join("secrets").join("secrets.json");
+        FileKeyringStore::new(&primary)
+            .set("deepseek", "synthetic-isolated-primary-value")
+            .unwrap();
+
+        let secrets = Secrets::auto_detect_read_only();
+
+        assert_eq!(
+            secrets.get("deepseek").unwrap().as_deref(),
+            Some("synthetic-isolated-primary-value")
+        );
     }
 
     #[test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -447,11 +447,13 @@ fn push_file_backed_model_bound_secrets(values: &mut Vec<String>) {
         return;
     }
 
-    // Read the file backend directly. `Secrets::auto_detect()` could select
-    // the opt-in OS keychain, where probing every inactive provider would
-    // cause a burst of user-visible credential prompts. The active credential
-    // is already covered by `deepseek_api_key()` regardless of backend.
-    let secrets = codewhale_secrets::Secrets::file_backed();
+    // Redaction needs only a best-effort view of inactive file-backed
+    // credentials. It must not cause a legacy-store migration merely because a
+    // client is being constructed (notably for `doctor`'s live probe). Keep
+    // this file-only to avoid a burst of OS-keychain prompts for inactive
+    // providers; the active credential is already supplied by the route
+    // resolver.
+    let secrets = codewhale_secrets::Secrets::file_backed_read_only();
     let mut slots = Vec::new();
     for provider in ApiProvider::all()
         .iter()

--- a/crates/tui/src/composer_stash.rs
+++ b/crates/tui/src/composer_stash.rs
@@ -34,6 +34,24 @@ use serde::{Deserialize, Serialize};
 
 const STASH_FILE_NAME: &str = "composer_stash.jsonl";
 
+/// Read-only stash facts for diagnostic output.
+///
+/// Unlike the ordinary composer helpers, this report never creates a state
+/// directory or falls back outside an explicit `CODEWHALE_HOME` boundary. It
+/// rejects a stash-file symlink observed during inspection; Unix opens also
+/// use `O_NOFOLLOW` for the final leaf open.
+#[derive(Debug, Clone)]
+pub(crate) struct DiagnosticStashReport {
+    /// Candidate stash path, when the Codewhale home could be resolved.
+    pub(crate) path: Option<PathBuf>,
+    /// Whether a regular stash file was present at that path.
+    pub(crate) present: bool,
+    /// Number of valid, non-empty draft records observed without mutation.
+    pub(crate) count: usize,
+    /// A safe path-shape or read error, if inspection could not complete.
+    pub(crate) error: Option<String>,
+}
+
 /// Hard cap so a runaway script can't fill the user's home with
 /// parked drafts. Older entries are pruned at push time when the
 /// stash exceeds this count.
@@ -60,6 +78,175 @@ fn default_stash_path() -> Option<PathBuf> {
         }
         legacy
     })
+}
+
+/// Inspect the composer stash for `doctor` without changing product state.
+///
+/// Ordinary composer reads retain their historical legacy fallback behavior.
+/// Diagnostics follow the same behavior only when no explicit
+/// `CODEWHALE_HOME` is configured; an explicit home is an isolation boundary
+/// and must not cause doctor to inspect an ambient `$HOME/.codewhale` or
+/// `$HOME/.deepseek` stash.
+pub(crate) fn diagnostic_stash_report() -> DiagnosticStashReport {
+    let primary = match codewhale_config::codewhale_home() {
+        Ok(home) => home.join(STASH_FILE_NAME),
+        Err(error) => {
+            return DiagnosticStashReport {
+                path: None,
+                present: false,
+                count: 0,
+                error: Some(format!(
+                    "could not resolve the Codewhale stash path: {error}"
+                )),
+            };
+        }
+    };
+
+    let explicit_home = codewhale_config::codewhale_home_is_explicit();
+    let legacy = if explicit_home {
+        None
+    } else {
+        match codewhale_config::legacy_deepseek_home() {
+            Ok(home) => Some(home.join(STASH_FILE_NAME)),
+            Err(error) => {
+                return DiagnosticStashReport {
+                    path: Some(primary),
+                    present: false,
+                    count: 0,
+                    error: Some(format!(
+                        "could not resolve the legacy composer stash path: {error}"
+                    )),
+                };
+            }
+        }
+    };
+
+    diagnostic_stash_report_from_paths(primary, legacy, explicit_home)
+}
+
+fn diagnostic_stash_report_from_paths(
+    primary: PathBuf,
+    legacy: Option<PathBuf>,
+    explicit_home: bool,
+) -> DiagnosticStashReport {
+    let path = match std::fs::symlink_metadata(&primary) {
+        Ok(_) => primary,
+        Err(error) if error.kind() == io::ErrorKind::NotFound && !explicit_home => {
+            let Some(legacy) = legacy else {
+                return diagnostic_stash_report_at(primary);
+            };
+            match std::fs::symlink_metadata(&legacy) {
+                Ok(_) => legacy,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => primary,
+                Err(error) => {
+                    return DiagnosticStashReport {
+                        path: Some(legacy),
+                        present: false,
+                        count: 0,
+                        error: Some(format!(
+                            "could not inspect legacy composer stash metadata: {error}"
+                        )),
+                    };
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => primary,
+        Err(error) => {
+            return DiagnosticStashReport {
+                path: Some(primary),
+                present: false,
+                count: 0,
+                error: Some(format!(
+                    "could not inspect composer stash metadata: {error}"
+                )),
+            };
+        }
+    };
+    diagnostic_stash_report_at(path)
+}
+
+fn diagnostic_stash_report_at(path: PathBuf) -> DiagnosticStashReport {
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return DiagnosticStashReport {
+                path: Some(path),
+                present: false,
+                count: 0,
+                error: None,
+            };
+        }
+        Err(error) => {
+            return DiagnosticStashReport {
+                path: Some(path),
+                present: false,
+                count: 0,
+                error: Some(format!(
+                    "could not inspect composer stash metadata: {error}"
+                )),
+            };
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return DiagnosticStashReport {
+            path: Some(path),
+            present: false,
+            count: 0,
+            error: Some("composer stash path is a symlink; doctor did not follow it".to_string()),
+        };
+    }
+    if !metadata.file_type().is_file() {
+        return DiagnosticStashReport {
+            path: Some(path),
+            present: false,
+            count: 0,
+            error: Some("composer stash path is not a regular file".to_string()),
+        };
+    }
+
+    match load_stash_for_diagnostic(&path) {
+        Ok(entries) => DiagnosticStashReport {
+            path: Some(path),
+            present: true,
+            count: entries.len(),
+            error: None,
+        },
+        Err(error) => DiagnosticStashReport {
+            path: Some(path),
+            present: false,
+            count: 0,
+            error: Some(error),
+        },
+    }
+}
+
+fn load_stash_for_diagnostic(path: &Path) -> Result<Vec<StashedDraft>, String> {
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+    };
+    #[cfg(not(unix))]
+    let file = fs::File::open(path);
+    let file = file.map_err(|error| format!("could not open composer stash read-only: {error}"))?;
+
+    let mut entries = Vec::new();
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| format!("could not read composer stash: {error}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(draft) = serde_json::from_str::<StashedDraft>(&line)
+            && !draft.text.is_empty()
+        {
+            entries.push(draft);
+        }
+    }
+    Ok(entries)
 }
 
 /// Load every stashed draft from disk in the order they were
@@ -306,6 +493,50 @@ this is not json
         assert_eq!(
             entries[entries.len() - 1].text,
             format!("draft {}", MAX_STASH_ENTRIES + 5 - 1)
+        );
+    }
+
+    #[test]
+    fn diagnostic_stash_honors_an_explicit_home_without_legacy_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let primary = tmp.path().join("isolated-codewhale").join(STASH_FILE_NAME);
+        let legacy = tmp.path().join("ambient-deepseek").join(STASH_FILE_NAME);
+        std::fs::create_dir_all(legacy.parent().expect("legacy parent")).expect("legacy parent");
+        std::fs::write(&legacy, r#"{"text":"ambient draft"}"#).expect("legacy stash");
+
+        let report = diagnostic_stash_report_from_paths(primary.clone(), Some(legacy), true);
+
+        assert_eq!(report.path.as_deref(), Some(primary.as_path()));
+        assert!(!report.present);
+        assert_eq!(report.count, 0);
+        assert!(report.error.is_none());
+        assert!(
+            !primary.parent().expect("primary parent").exists(),
+            "diagnostic lookup must not create an explicit state home"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn diagnostic_stash_rejects_a_symlink_leaf_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let external = tmp.path().join("external-stash.jsonl");
+        let primary = tmp.path().join("composer_stash.jsonl");
+        std::fs::write(&external, r#"{"text":"external draft"}"#).expect("external stash");
+        symlink(&external, &primary).expect("symlink stash");
+
+        let report = diagnostic_stash_report_from_paths(primary.clone(), None, true);
+
+        assert_eq!(report.path.as_deref(), Some(primary.as_path()));
+        assert!(!report.present);
+        assert_eq!(report.count, 0);
+        assert!(
+            report
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("symlink"))
         );
     }
 }

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4851,6 +4851,38 @@ impl Config {
     /// explicitly set the field (not the legacy `API_KEYRING_SENTINEL`
     /// placeholder, not empty whitespace).
     pub fn deepseek_api_key(&self) -> Result<String> {
+        self.deepseek_api_key_with_secret_store_mode(false)
+    }
+
+    /// Resolve an API key for a diagnostic without migrating a legacy secret
+    /// store or opening a write-capable secret backend.
+    ///
+    /// This retains ordinary credential precedence, including a legacy
+    /// file-backed secret as a fallback, but it must only be used by static
+    /// diagnostic/reporting paths. Normal runtime and authentication paths use
+    /// [`Self::deepseek_api_key`] and preserve their existing migration
+    /// behavior.
+    pub(crate) fn deepseek_api_key_read_only(&self) -> Result<String> {
+        self.deepseek_api_key_with_secret_store_mode(true)
+    }
+
+    /// Clone this route with a diagnostic-only credential in its in-memory
+    /// provider slot.
+    ///
+    /// A live `doctor` probe still needs to construct the ordinary client. By
+    /// materializing the credential on an isolated clone first, that client
+    /// never reaches the normal migrating secret-store resolver while it is
+    /// only checking connectivity. The clone is process-local and is never
+    /// persisted.
+    pub(crate) fn with_read_only_api_key_for_diagnostic(&self) -> Result<Self> {
+        let provider = self.api_provider();
+        let api_key = self.deepseek_api_key_read_only()?;
+        let mut diagnostic = self.clone();
+        diagnostic.set_provider_api_key_override(provider, Some(api_key));
+        Ok(diagnostic)
+    }
+
+    fn deepseek_api_key_with_secret_store_mode(&self, read_only: bool) -> Result<String> {
         let provider = self.api_provider();
         let auth_mode = self.auth_mode_for_provider(provider);
         if auth_mode_disables_api_key(auth_mode.as_deref()) {
@@ -4972,7 +5004,7 @@ impl Config {
         // default; the OS keyring is queried only when the user explicitly
         // selects the system backend.
         if !self.should_skip_secret_store_for_provider(provider)
-            && let Some(value) = provider_secret_store_api_key(self, provider)
+            && let Some(value) = provider_secret_store_api_key_with_mode(self, provider, read_only)
         {
             return Ok(value);
         }
@@ -8824,6 +8856,28 @@ pub(crate) fn provider_secret_store_api_key(
     config: &Config,
     provider: ApiProvider,
 ) -> Option<String> {
+    provider_secret_store_api_key_with_mode(config, provider, false)
+}
+
+/// Read the durable secret-store layer for a diagnostic without migration or
+/// any write-capable store handle.
+///
+/// Doctor and setup-status output need to report whether a saved credential is
+/// present, but must not turn that inspection into a legacy-store migration.
+/// Normal runtime and authentication paths use [`provider_secret_store_api_key`]
+/// and retain their existing migration behavior.
+pub(crate) fn provider_secret_store_api_key_read_only(
+    config: &Config,
+    provider: ApiProvider,
+) -> Option<String> {
+    provider_secret_store_api_key_with_mode(config, provider, true)
+}
+
+fn provider_secret_store_api_key_with_mode(
+    config: &Config,
+    provider: ApiProvider,
+    read_only: bool,
+) -> Option<String> {
     // Keep the named-custom exclusion at the credential boundary itself.
     // Callers also use this policy to avoid unnecessary keyring probes, but a
     // future caller must not be able to read the legacy `custom` slot for an
@@ -8842,7 +8896,12 @@ pub(crate) fn provider_secret_store_api_key(
         return None;
     }
 
-    codewhale_secrets::Secrets::auto_detect()
+    let secrets = if read_only {
+        codewhale_secrets::Secrets::auto_detect_read_only()
+    } else {
+        codewhale_secrets::Secrets::auto_detect()
+    };
+    secrets
         .get(provider_secret_store_slot(provider))
         .ok()
         .flatten()

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -3124,7 +3124,10 @@ fn report_write_status(label: &str, path: &Path, status: WriteStatus) {
     }
 }
 
-/// Source of the resolved DeepSeek API key, used in status reports.
+/// Source of the resolved API key, used only by static doctor/setup reports.
+///
+/// These reports must not migrate a legacy secret store or acquire a
+/// write-capable credential handle just to label a source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ApiKeySource {
     Env,
@@ -3194,7 +3197,7 @@ fn resolve_api_key_source(config: &Config) -> ApiKeySource {
     } else if configured_provider_env_key_source(config).is_some() {
         ApiKeySource::Env
     } else if !config.should_skip_secret_store_for_provider(provider)
-        && crate::config::provider_secret_store_api_key(config, provider).is_some()
+        && crate::config::provider_secret_store_api_key_read_only(config, provider).is_some()
     {
         ApiKeySource::Keyring
     } else if provider_env_key_source_for_config(config).is_some() {
@@ -3352,6 +3355,8 @@ fn run_setup_status(
         .clone()
         .unwrap_or_else(|| DEFAULT_TEXT_MODEL.to_string());
     println!("  · default_text_model: {model}");
+    let (default_mode, default_mode_source) = doctor_runtime_default_mode();
+    println!("  · default_mode: {default_mode} ({default_mode_source})");
 
     let mcp_path = config.mcp_config_path();
     let project_mcp_path = crate::mcp::workspace_mcp_config_path(workspace);
@@ -3825,7 +3830,15 @@ async fn run_doctor(
         use std::io::Write;
         std::io::stdout().flush().ok();
 
-        match test_api_connectivity(config).await {
+        // Resolve a credential through the diagnostic-only store first, then
+        // probe with an in-memory clone. Constructing the normal client from
+        // the original config could otherwise trigger its legacy secret-store
+        // migration while a user merely asks doctor to test connectivity.
+        let connectivity_result = match config.with_read_only_api_key_for_diagnostic() {
+            Ok(diagnostic_config) => test_api_connectivity(&diagnostic_config).await,
+            Err(error) => Err(error),
+        };
+        match connectivity_result {
             Ok(()) => {
                 println!(
                     "\r  {} API connection successful",
@@ -4194,18 +4207,21 @@ async fn run_doctor(
             );
         }
     }
-    let stash_path = codewhale_config::codewhale_home()
-        .ok()
-        .map(|h| h.join("composer_stash.jsonl"));
-    if let Some(stash_path) = stash_path {
-        let stash_count = crate::composer_stash::load_stash().len();
-        if stash_path.exists() {
+    let stash = crate::composer_stash::diagnostic_stash_report();
+    if let Some(stash_path) = stash.path.as_ref() {
+        if let Some(error) = stash.error.as_deref() {
+            println!(
+                "  {} composer stash was not inspected at {}: {error}",
+                "!".truecolor(sky_r, sky_g, sky_b),
+                crate::utils::display_path(stash_path),
+            );
+        } else if stash.present {
             println!(
                 "  {} composer stash at {} ({} parked draft{})",
                 "✓".truecolor(aqua_r, aqua_g, aqua_b),
-                crate::utils::display_path(&stash_path),
-                stash_count,
-                if stash_count == 1 { "" } else { "s" }
+                crate::utils::display_path(stash_path),
+                stash.count,
+                if stash.count == 1 { "" } else { "s" }
             );
         } else {
             println!(
@@ -4213,6 +4229,11 @@ async fn run_doctor(
                 "·".dimmed()
             );
         }
+    } else if let Some(error) = stash.error.as_deref() {
+        println!(
+            "  {} composer stash was not inspected: {error}",
+            "!".truecolor(sky_r, sky_g, sky_b),
+        );
     }
 
     // Tool dependencies — probe external binaries that individual
@@ -4347,7 +4368,7 @@ async fn run_doctor(
     // know they can opt in via `prefer_external_pdftotext = true`, and
     // (b) so users who *did* opt in get a clean signal when the binary
     // is missing rather than discovering it on the next PDF read.
-    let prefer_external = crate::settings::Settings::load()
+    let prefer_external = crate::settings::Settings::load_read_only()
         .map(|s| s.prefer_external_pdftotext)
         .unwrap_or(false);
     match crate::dependencies::resolve_pdftotext() {
@@ -4628,8 +4649,12 @@ fn doctor_legacy_state_report(
 /// This is deliberately separate from `SessionManager::default_location()`:
 /// constructing the manager can trigger the additive legacy migration, while
 /// doctor must remain a read-only diagnostic. Session history is stored as
-/// top-level JSON files; directories (including `checkpoints`) and symlinks are
-/// ignored, so doctor neither traverses checkpoint internals nor follows links.
+/// top-level JSON files. Directories (including `checkpoints`) and symlinks
+/// observed during the scan are ignored, so the diagnostic does not
+/// intentionally traverse checkpoint internals or link targets. These checks
+/// are best-effort observations, not a race-free no-follow guarantee.
+/// A matching filename is only a regular-file counterpart check: doctor does
+/// not parse or compare session descriptors.
 fn doctor_session_recovery_report(
     primary_root: &Path,
     legacy_root: &Path,
@@ -4654,9 +4679,52 @@ fn doctor_session_recovery_report(
         return report;
     }
 
+    let legacy_root_is_present =
+        match doctor_session_directory_is_safe(legacy_root, "legacy state root") {
+            Ok(present) => present,
+            Err(error) => {
+                report.status = DoctorSessionRecoveryStatus::ScanFailed;
+                report.error = Some(error);
+                return report;
+            }
+        };
+    if !legacy_root_is_present {
+        return report;
+    }
+    if let Err(error) = doctor_session_directory_is_safe(primary_root, "primary state root") {
+        report.status = DoctorSessionRecoveryStatus::ScanFailed;
+        report.error = Some(error);
+        return report;
+    }
+
+    let legacy_sessions_are_present = match doctor_session_directory_is_safe(
+        &report.legacy_sessions_path,
+        "legacy sessions root",
+    ) {
+        Ok(present) => present,
+        Err(error) => {
+            report.status = DoctorSessionRecoveryStatus::ScanFailed;
+            report.error = Some(error);
+            return report;
+        }
+    };
+    if !legacy_sessions_are_present {
+        return report;
+    }
+    let primary_sessions_are_present = match doctor_session_directory_is_safe(
+        &report.primary_sessions_path,
+        "primary sessions root",
+    ) {
+        Ok(present) => present,
+        Err(error) => {
+            report.status = DoctorSessionRecoveryStatus::ScanFailed;
+            report.error = Some(error);
+            return report;
+        }
+    };
+
     let entries = match std::fs::read_dir(&report.legacy_sessions_path) {
         Ok(entries) => entries,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return report,
         Err(err) => {
             report.status = DoctorSessionRecoveryStatus::ScanFailed;
             report.error = Some(format!(
@@ -4698,16 +4766,32 @@ fn doctor_session_recovery_report(
         let name = PathBuf::from(entry.file_name());
         let destination_path = report.primary_sessions_path.join(&name);
         match std::fs::symlink_metadata(&destination_path) {
-            Ok(_) => report.already_present_file_count += 1,
+            Ok(metadata) if metadata.file_type().is_file() => {
+                report.already_present_file_count += 1;
+            }
+            Ok(metadata) => {
+                report.status = DoctorSessionRecoveryStatus::ScanFailed;
+                let shape = if metadata.file_type().is_symlink() {
+                    "destination session entry is a symlink"
+                } else {
+                    "destination session entry is not a regular file"
+                };
+                report.error = Some(format!(
+                    "could not inspect destination session metadata at {}: {shape}",
+                    crate::utils::display_path(&destination_path)
+                ));
+                return report;
+            }
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 report.recoverable_file_count += 1;
-                if report.recoverable.len() < DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT {
-                    report.recoverable.push(DoctorRecoverableSessionEntry {
+                record_doctor_recoverable_session(
+                    &mut report.recoverable,
+                    DoctorRecoverableSessionEntry {
                         source_path: entry.path(),
                         destination_path,
                         name,
-                    });
-                }
+                    },
+                );
             }
             Err(err) => {
                 report.status = DoctorSessionRecoveryStatus::ScanFailed;
@@ -4720,19 +4804,70 @@ fn doctor_session_recovery_report(
         }
     }
 
-    report
-        .recoverable
-        .sort_by(|left, right| left.name.cmp(&right.name));
     report.status = if report.legacy_session_file_count == 0 {
         DoctorSessionRecoveryStatus::NoLegacySessions
     } else if report.recoverable_file_count == 0 {
         DoctorSessionRecoveryStatus::MigrationComplete
-    } else if report.primary_sessions_path.is_dir() {
+    } else if primary_sessions_are_present {
         DoctorSessionRecoveryStatus::MigrationIncomplete
     } else {
         DoctorSessionRecoveryStatus::MigrationPending
     };
     report
+}
+
+/// Validate a session-state directory from observed metadata.
+///
+/// `doctor` only compares top-level filenames. It rejects a state-root or
+/// sessions-root symlink observed during inspection rather than using it for a
+/// recovery suggestion. This is a best-effort observation, not a race-free
+/// no-follow guarantee. Missing paths are normal on a fresh install and are
+/// reported as `false`.
+fn doctor_session_directory_is_safe(path: &Path, label: &str) -> std::result::Result<bool, String> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "could not inspect {label} at {}: {error}",
+                crate::utils::display_path(path)
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "could not inspect {label} at {}: path is a symlink",
+            crate::utils::display_path(path)
+        ));
+    }
+    if !metadata.file_type().is_dir() {
+        return Err(format!(
+            "could not inspect {label} at {}: path is not a directory",
+            crate::utils::display_path(path)
+        ));
+    }
+    Ok(true)
+}
+
+/// Keep the report bounded while preserving a deterministic, lexical sample.
+/// `read_dir` order is platform- and filesystem-dependent, so retaining the
+/// first entries encountered would make the JSON and human receipts drift.
+fn record_doctor_recoverable_session(
+    recoverable: &mut Vec<DoctorRecoverableSessionEntry>,
+    entry: DoctorRecoverableSessionEntry,
+) {
+    let insert_at = recoverable
+        .binary_search_by(|existing| existing.name.cmp(&entry.name))
+        .unwrap_or_else(|index| index);
+    if recoverable.len() == DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT
+        && insert_at == recoverable.len()
+    {
+        return;
+    }
+    recoverable.insert(insert_at, entry);
+    if recoverable.len() > DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT {
+        recoverable.pop();
+    }
 }
 
 fn legacy_state_needs_attention(entry: &DoctorLegacyStateEntry) -> bool {
@@ -4822,7 +4957,7 @@ fn print_doctor_session_recovery_report(
         }
         DoctorSessionRecoveryStatus::MigrationComplete => {
             println!(
-                "  {} legacy sessions: all {} filename(s) already exist under {}; legacy originals remain preserved",
+                "  {} legacy sessions: all {} filename(s) have regular-file counterparts under {}; descriptor contents were not compared and legacy originals remain preserved",
                 "✓".truecolor(ok_rgb.0, ok_rgb.1, ok_rgb.2),
                 report.legacy_session_file_count,
                 crate::utils::display_path(&report.primary_sessions_path),
@@ -4914,6 +5049,8 @@ fn doctor_session_recovery_json(report: &DoctorSessionRecoveryReport) -> serde_j
         "read_only": true,
         "chat_contents_read": false,
         "checkpoint_internals_scanned": false,
+        "session_descriptors_compared": false,
+        "counterpart_check": "top_level_filename_and_regular_file_only",
         "codewhale_home_is_explicit": report.codewhale_home_is_explicit,
         "legacy_sessions_path": report.legacy_sessions_path.display().to_string(),
         "primary_sessions_path": report.primary_sessions_path.display().to_string(),
@@ -5209,7 +5346,7 @@ fn autonomy_preference_id(preference: codewhale_config::AutonomyPreference) -> &
 }
 
 fn doctor_runtime_default_mode() -> (String, &'static str) {
-    match crate::settings::Settings::load() {
+    match crate::settings::Settings::load_read_only() {
         Ok(settings) => (settings.default_mode, "settings"),
         Err(_) => (crate::settings::Settings::default().default_mode, "default"),
     }
@@ -5772,6 +5909,7 @@ fn run_doctor_json(
         codewhale_config::codewhale_home_is_explicit(),
     );
 
+    let stash = crate::composer_stash::diagnostic_stash_report();
     let report = json!({
         "version": env!("CARGO_PKG_VERSION"),
         "config_path": config_path.display().to_string(),
@@ -5859,15 +5997,14 @@ fn run_doctor_json(
                     .unwrap_or(0),
             },
             "stash": {
-                "path": codewhale_config::codewhale_home()
-                    .ok()
-                    .map(|h| h.join("composer_stash.jsonl").display().to_string())
+                "path": stash
+                    .path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
                     .unwrap_or_default(),
-                "present": codewhale_config::codewhale_home()
-                    .ok()
-                    .map(|h| h.join("composer_stash.jsonl"))
-                    .is_some_and(|p| p.exists()),
-                "count": crate::composer_stash::load_stash().len(),
+                "present": stash.present,
+                "count": stash.count,
+                "error": stash.error,
             },
         },
         "sandbox": match crate::sandbox::get_platform_sandbox() {
@@ -6011,7 +6148,7 @@ fn doctor_auth_scheme(config: &Config) -> &'static str {
     } else if provider == crate::config::ApiProvider::XiaomiMimo
         && (doctor_xiaomi_mimo_base_url_uses_token_plan(&config.deepseek_base_url())
             || config
-                .deepseek_api_key()
+                .deepseek_api_key_read_only()
                 .ok()
                 .is_some_and(|key| key.trim_start().starts_with("tp-")))
     {
@@ -6021,7 +6158,7 @@ fn doctor_auth_scheme(config: &Config) -> &'static str {
         crate::config::ApiProvider::Sglang
             | crate::config::ApiProvider::Vllm
             | crate::config::ApiProvider::Ollama
-    ) && config.deepseek_api_key().is_err()
+    ) && config.deepseek_api_key_read_only().is_err()
     {
         "none"
     } else {
@@ -10799,6 +10936,15 @@ mod doctor_legacy_state_tests {
         assert_eq!(json["recoverable_file_count"], 1);
         assert_eq!(json["recovery_command"], "codewhale sessions");
         assert_eq!(json["recoverable_files"][0]["name"], "recover-me.json");
+        let serialized = json.to_string();
+        assert!(
+            !serialized.contains("not parsed by doctor"),
+            "the report must not expose session contents"
+        );
+        assert!(
+            !serialized.contains("checkpoint not inspected"),
+            "the report must not expose checkpoint contents"
+        );
     }
 
     #[test]
@@ -10822,6 +10968,12 @@ mod doctor_legacy_state_tests {
         assert_eq!(report.recoverable_file_count, 0);
         assert!(report.recoverable.is_empty());
         assert_eq!(report.already_present_file_count, 1);
+        let json = doctor_session_recovery_json(&report);
+        assert_eq!(json["session_descriptors_compared"], false);
+        assert_eq!(
+            json["counterpart_check"],
+            "top_level_filename_and_regular_file_only"
+        );
     }
 
     #[test]
@@ -10830,14 +10982,18 @@ mod doctor_legacy_state_tests {
         let (primary_root, legacy_root) = roots(&tmp);
         let legacy_sessions = legacy_root.join("sessions");
         fs::create_dir_all(&legacy_sessions).expect("legacy sessions");
-        let total = DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT + 2;
-        for index in 0..total {
+        for index in 0..DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT {
             fs::write(
-                legacy_sessions.join(format!("session-{index:03}.json")),
+                legacy_sessions.join(format!("late-{index:03}.json")),
                 b"fixture",
             )
             .expect("legacy session fixture");
         }
+        fs::write(legacy_sessions.join("early-000.json"), b"fixture")
+            .expect("earliest legacy session fixture");
+        fs::write(legacy_sessions.join("early-001.json"), b"fixture")
+            .expect("second earliest legacy session fixture");
+        let total = DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT + 2;
 
         let report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
         let json = doctor_session_recovery_json(&report);
@@ -10850,6 +11006,16 @@ mod doctor_legacy_state_tests {
         assert_eq!(
             json["recoverable_files"].as_array().map(Vec::len),
             Some(DOCTOR_SESSION_RECOVERY_JSON_SAMPLE_LIMIT)
+        );
+        assert_eq!(
+            report.recoverable.first().map(|entry| entry.name.as_path()),
+            Some(Path::new("early-000.json")),
+            "the bounded sample must not depend on read_dir order"
+        );
+        assert_eq!(
+            report.recoverable.last().map(|entry| entry.name.as_path()),
+            Some(Path::new("late-097.json")),
+            "the bounded sample must retain the lexical prefix"
         );
         assert_eq!(json["recoverable_files_truncated"], true);
     }
@@ -10866,12 +11032,121 @@ mod doctor_legacy_state_tests {
 
         assert_eq!(report.status, DoctorSessionRecoveryStatus::ScanFailed);
         assert!(report.needs_attention());
+        assert!(report.error.as_deref().is_some_and(|error| {
+            error.contains("legacy sessions root") && error.contains("not a directory")
+        }));
+    }
+
+    #[test]
+    fn doctor_session_recovery_rejects_a_non_directory_legacy_state_root() {
+        let tmp = TempDir::new().expect("tempdir");
+        let (primary_root, legacy_root) = roots(&tmp);
+        fs::write(&legacy_root, b"not a state directory").expect("invalid legacy root");
+
+        let report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
+
+        assert_eq!(report.status, DoctorSessionRecoveryStatus::ScanFailed);
+        assert!(report.error.as_deref().is_some_and(|error| {
+            error.contains("legacy state root") && error.contains("not a directory")
+        }));
+    }
+
+    #[test]
+    fn doctor_session_recovery_rejects_a_non_directory_primary_state_root() {
+        let tmp = TempDir::new().expect("tempdir");
+        let (primary_root, legacy_root) = roots(&tmp);
+        fs::create_dir_all(legacy_root.join("sessions")).expect("legacy sessions");
+        fs::write(&primary_root, b"not a state directory").expect("invalid primary root");
+
+        let report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
+
+        assert_eq!(report.status, DoctorSessionRecoveryStatus::ScanFailed);
+        assert!(report.error.as_deref().is_some_and(|error| {
+            error.contains("primary state root") && error.contains("not a directory")
+        }));
+    }
+
+    #[test]
+    fn doctor_session_recovery_rejects_a_non_directory_primary_sessions_root() {
+        let tmp = TempDir::new().expect("tempdir");
+        let (primary_root, legacy_root) = roots(&tmp);
+        fs::create_dir_all(legacy_root.join("sessions")).expect("legacy sessions");
+        fs::create_dir_all(&primary_root).expect("primary root");
+        fs::write(primary_root.join("sessions"), b"not a sessions directory")
+            .expect("invalid primary sessions path");
+
+        let report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
+
+        assert_eq!(report.status, DoctorSessionRecoveryStatus::ScanFailed);
+        assert!(report.error.as_deref().is_some_and(|error| {
+            error.contains("primary sessions root") && error.contains("not a directory")
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn doctor_session_recovery_rejects_a_symlinked_legacy_sessions_root() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let (primary_root, legacy_root) = roots(&tmp);
+        let external_sessions = tmp.path().join("external-sessions");
+        fs::create_dir_all(&external_sessions).expect("external sessions");
+        fs::write(
+            external_sessions.join("must-not-be-enumerated.json"),
+            b"session contents must stay unread",
+        )
+        .expect("external session fixture");
+        fs::create_dir_all(&legacy_root).expect("legacy root");
+        symlink(&external_sessions, legacy_root.join("sessions"))
+            .expect("symlinked legacy sessions root");
+
+        let report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
+
+        assert_eq!(report.status, DoctorSessionRecoveryStatus::ScanFailed);
+        assert!(report.needs_attention());
+        assert_eq!(report.legacy_session_file_count, 0);
+        assert!(report.recoverable.is_empty());
         assert!(
             report
                 .error
                 .as_deref()
-                .is_some_and(|error| error.contains("could not inspect legacy session filenames"))
+                .is_some_and(|error| error.contains("legacy sessions root")
+                    && error.contains("path is a symlink"))
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn doctor_session_recovery_rejects_symlinked_primary_root_and_sessions_root() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let (primary_root, legacy_root) = roots(&tmp);
+        let external_primary = tmp.path().join("external-primary");
+        fs::create_dir_all(external_primary.join("sessions")).expect("external primary");
+        fs::create_dir_all(legacy_root.join("sessions")).expect("legacy sessions");
+        symlink(&external_primary, &primary_root).expect("symlinked primary root");
+
+        let root_report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
+        assert_eq!(root_report.status, DoctorSessionRecoveryStatus::ScanFailed);
+        assert!(root_report.error.as_deref().is_some_and(|error| {
+            error.contains("primary state root") && error.contains("path is a symlink")
+        }));
+
+        fs::remove_file(&primary_root).expect("remove primary root symlink");
+        fs::create_dir_all(&primary_root).expect("primary root");
+        symlink(&external_primary, primary_root.join("sessions"))
+            .expect("symlinked primary sessions root");
+
+        let sessions_report = doctor_session_recovery_report(&primary_root, &legacy_root, false);
+        assert_eq!(
+            sessions_report.status,
+            DoctorSessionRecoveryStatus::ScanFailed
+        );
+        assert!(sessions_report.error.as_deref().is_some_and(|error| {
+            error.contains("primary sessions root") && error.contains("path is a symlink")
+        }));
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -498,6 +498,18 @@ impl Settings {
         Ok(settings)
     }
 
+    /// Load settings for a diagnostic without migrating a legacy file.
+    ///
+    /// This preserves the same candidate precedence, parser normalization, and
+    /// environment overlays as [`Settings::load`]. Unlike an interactive
+    /// startup, diagnostics must not create `~/.codewhale/settings.toml` just
+    /// because they inspected a legacy `~/.deepseek/settings.toml` file.
+    pub(crate) fn load_read_only() -> Result<Self> {
+        let mut settings = Self::load_persisted_read_only()?;
+        settings.apply_env_overrides();
+        Ok(settings)
+    }
+
     /// Load the normalized values stored on disk without terminal/runtime
     /// overlays. Configuration editors use this path so a value labelled
     /// "saved" never silently reports a tmux, SSH, or accessibility override.
@@ -506,10 +518,36 @@ impl Settings {
         Self::load_persisted_from_candidates(primary, legacy_home, legacy_config_dir)
     }
 
+    /// Load normalized disk values for a diagnostic without creating a
+    /// primary settings file from a legacy fallback.
+    fn load_persisted_read_only() -> Result<Self> {
+        let (primary, legacy_home, legacy_config_dir) = settings_path_candidates();
+        Self::load_persisted_from_candidates_with_migration(
+            primary,
+            legacy_home,
+            legacy_config_dir,
+            false,
+        )
+    }
+
     fn load_persisted_from_candidates(
         primary: Option<PathBuf>,
         legacy_home: Option<PathBuf>,
         legacy_config_dir: Option<PathBuf>,
+    ) -> Result<Self> {
+        Self::load_persisted_from_candidates_with_migration(
+            primary,
+            legacy_home,
+            legacy_config_dir,
+            true,
+        )
+    }
+
+    fn load_persisted_from_candidates_with_migration(
+        primary: Option<PathBuf>,
+        legacy_home: Option<PathBuf>,
+        legacy_config_dir: Option<PathBuf>,
+        migrate_legacy_file: bool,
     ) -> Result<Self> {
         let write_path = primary
             .as_ref()
@@ -585,7 +623,9 @@ impl Settings {
             }
             s
         };
-        migrate_settings_file_to_primary_if_needed(&write_path, &read_path);
+        if migrate_legacy_file {
+            migrate_settings_file_to_primary_if_needed(&write_path, &read_path);
+        }
         Ok(settings)
     }
 
@@ -3140,6 +3180,40 @@ mod tests {
         assert!(
             display.contains(&format!("Config file: {}", primary.display())),
             "settings display should surface the canonical codewhale path:\n{display}"
+        );
+    }
+
+    #[test]
+    fn settings_load_read_only_reads_legacy_home_without_creating_primary() {
+        let _g = config_path_test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let primary = tmp.path().join(".codewhale").join("settings.toml");
+        let legacy = tmp.path().join(".deepseek").join("settings.toml");
+        let legacy_bytes =
+            b"default_mode = \"plan\"\nlow_motion = false\nfancy_animations = true\n";
+        std::fs::create_dir_all(legacy.parent().expect("legacy parent")).expect("legacy directory");
+        std::fs::write(&legacy, legacy_bytes).expect("legacy settings");
+        let _config_override = EnvVarRestore::remove("DEEPSEEK_CONFIG_PATH");
+        let _codewhale_home = EnvVarRestore::remove("CODEWHALE_HOME");
+        let _home = EnvVarRestore::set("HOME", tmp.path());
+        let _no_animations = EnvVarRestore::set("NO_ANIMATIONS", "1");
+
+        let loaded = Settings::load_read_only().expect("read-only settings load");
+
+        assert_eq!(loaded.default_mode, "plan");
+        assert!(loaded.low_motion, "environment overlays still apply");
+        assert!(
+            !loaded.fancy_animations,
+            "environment overlays still apply to parsed legacy settings"
+        );
+        assert!(
+            !primary.exists(),
+            "a diagnostic settings read must not create the primary settings path"
+        );
+        assert_eq!(
+            std::fs::read(&legacy).expect("legacy settings after read"),
+            legacy_bytes,
+            "a diagnostic settings read must not rewrite the legacy settings file"
         );
     }
 

--- a/crates/tui/tests/diagnostic_read_only.rs
+++ b/crates/tui/tests/diagnostic_read_only.rs
@@ -1,0 +1,552 @@
+//! Process-level regression coverage for read-only diagnostic commands.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use codewhale_secrets::{FileKeyringStore, KeyringStore};
+use tempfile::TempDir;
+
+#[test]
+fn doctor_text_leaves_a_sealed_home_untouched() {
+    let output = run_sealed_diagnostic(["doctor"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("codewhale Doctor"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn doctor_json_leaves_a_sealed_home_untouched() {
+    let output = run_sealed_diagnostic(["doctor", "--json"]);
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "doctor --json must remain machine-readable: {error}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+    assert_eq!(report["api_connectivity"]["checked"], false);
+}
+
+#[test]
+fn doctor_context_json_leaves_a_sealed_home_untouched() {
+    let output = run_sealed_diagnostic(["doctor", "--context-json"]);
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "doctor --context-json must remain machine-readable: {error}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+    assert!(
+        report["entries"].is_array(),
+        "doctor --context-json must emit a source map\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn setup_status_leaves_a_sealed_home_untouched() {
+    let output = run_sealed_diagnostic(["setup", "--status"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Codewhale Status"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn diagnostics_read_home_legacy_settings_without_migrating_them() {
+    for args in [
+        &["doctor"][..],
+        &["doctor", "--json"][..],
+        &["setup", "--status"][..],
+    ] {
+        let fixture = TempDir::new().expect("fixture root");
+        let workspace = fixture.path().join("workspace");
+        let home = fixture.path().join("home");
+        let legacy = home.join(".deepseek").join("settings.toml");
+        let primary_home = home.join(".codewhale");
+        let legacy_bytes = b"default_mode = \"plan\"\nprefer_external_pdftotext = true\n";
+        fs::create_dir_all(&workspace).expect("workspace");
+        fs::create_dir_all(legacy.parent().expect("legacy parent")).expect("legacy directory");
+        fs::write(&legacy, legacy_bytes).expect("legacy settings");
+
+        let output = diagnostic_command(&workspace, &home)
+            .args(args)
+            .output()
+            .expect("run diagnostic against legacy settings");
+        assert!(
+            output.status.success(),
+            "diagnostic {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        match args {
+            ["doctor"] => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                assert!(
+                    stdout.contains("default_mode=plan (settings)"),
+                    "doctor must report the legacy default mode\nstdout:\n{stdout}"
+                );
+                assert!(
+                    stdout.contains("prefer_external_pdftotext = true"),
+                    "doctor must report the legacy PDF preference\nstdout:\n{stdout}"
+                );
+            }
+            ["doctor", "--json"] => {
+                let report: serde_json::Value =
+                    serde_json::from_slice(&output.stdout).expect("machine-readable doctor report");
+                assert_eq!(
+                    report["setup"]["runtime_posture"]["default_mode"]["value"],
+                    "plan"
+                );
+                assert_eq!(
+                    report["setup"]["runtime_posture"]["default_mode"]["source"],
+                    "settings"
+                );
+            }
+            ["setup", "--status"] => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                assert!(
+                    stdout.contains("default_mode: plan (settings)"),
+                    "setup status must report the legacy default mode\nstdout:\n{stdout}"
+                );
+            }
+            _ => unreachable!("fixed diagnostic command list"),
+        }
+
+        assert_eq!(
+            fs::read(&legacy).expect("legacy settings after diagnostic"),
+            legacy_bytes,
+            "diagnostic {args:?} must not rewrite legacy settings"
+        );
+        assert!(
+            !primary_home.exists(),
+            "diagnostic {args:?} must not create a primary Codewhale home"
+        );
+    }
+}
+
+#[test]
+fn doctor_json_does_not_inherit_an_ambient_legacy_secret_from_an_explicit_home() {
+    let fixture = TempDir::new().expect("fixture root");
+    let workspace = fixture.path().join("workspace");
+    let home = fixture.path().join("home");
+    let codewhale_home = fixture.path().join("isolated-codewhale-home");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let legacy = home.join(".deepseek").join("secrets").join("secrets.json");
+    FileKeyringStore::new(&legacy)
+        .set("deepseek", "synthetic-ambient-legacy-value")
+        .expect("seed ambient legacy secret");
+    let legacy_before = fs::read(&legacy).expect("read legacy secret before doctor");
+
+    let mut command = Command::new(codewhale_tui_binary());
+    command
+        .current_dir(&workspace)
+        .args(["doctor", "--json"])
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").expect("PATH"))
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("CODEWHALE_HOME", &codewhale_home)
+        .env("CODEWHALE_SECRET_BACKEND", "file")
+        .env(
+            "CODEWHALE_RELEASE_BASE_URL",
+            "https://example.invalid/releases",
+        )
+        .env("DEEPSEEK_TUI_VERSION", env!("CARGO_PKG_VERSION"));
+    preserve_host_rustup_home(&mut command);
+
+    let output = command.output().expect("run isolated doctor --json");
+    assert!(
+        output.status.success(),
+        "isolated doctor --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("machine-readable doctor report");
+    assert_eq!(
+        report["api_key"]["source"], "missing",
+        "doctor must not report an ambient legacy secret from outside an explicit home"
+    );
+    assert_eq!(
+        fs::read(&legacy).expect("read legacy secret after doctor"),
+        legacy_before,
+        "doctor must not rewrite the ambient legacy secret"
+    );
+    assert!(
+        !codewhale_home.exists(),
+        "doctor must not create an isolated Codewhale home or secret store"
+    );
+}
+
+#[test]
+fn doctor_text_probe_uses_a_legacy_key_without_migrating_it() {
+    let fixture = TempDir::new().expect("fixture root");
+    let workspace = fixture.path().join("workspace");
+    let home = fixture.path().join("home");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let legacy = home.join(".deepseek").join("secrets").join("secrets.json");
+    let primary = home.join(".codewhale").join("secrets").join("secrets.json");
+    FileKeyringStore::new(&legacy)
+        .set("deepseek", "diagnostic-legacy-key")
+        .expect("seed legacy secret");
+    let legacy_before = fs::read(&legacy).expect("read legacy secret before doctor");
+    let (base_url, request) = one_request_completion_server();
+    let config = workspace.join("doctor.toml");
+    fs::write(
+        &config,
+        format!(
+            "provider = \"deepseek\"\n[providers.deepseek]\nbase_url = \"{base_url}\"\nmodel = \"deepseek-chat\"\nauth_mode = \"api_key\"\n"
+        ),
+    )
+    .expect("write doctor config");
+
+    let output = diagnostic_command(&workspace, &home)
+        .args([
+            "--config",
+            config.to_str().expect("config path"),
+            "doctor",
+            "--probe-local",
+        ])
+        .output()
+        .expect("run doctor probe");
+    assert!(
+        output.status.success(),
+        "doctor probe failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("API connection successful"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let request = request
+        .recv_timeout(Duration::from_secs(5))
+        .expect("doctor must make one local probe request")
+        .expect("local probe request");
+    assert!(
+        request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer diagnostic-legacy-key"),
+        "doctor probe must use the legacy credential without printing it; request:\n{request}"
+    );
+    assert!(
+        !primary.exists(),
+        "doctor's text connectivity probe must not create a migrated primary secret store"
+    );
+    assert_eq!(
+        fs::read(&legacy).expect("read legacy secret after doctor"),
+        legacy_before,
+        "doctor must not rewrite the legacy secret store"
+    );
+}
+
+#[test]
+fn doctor_json_auth_scheme_reads_a_legacy_key_without_migrating_it() {
+    let fixture = TempDir::new().expect("fixture root");
+    let workspace = fixture.path().join("workspace");
+    let home = fixture.path().join("home");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let legacy = home.join(".deepseek").join("secrets").join("secrets.json");
+    let primary = home.join(".codewhale").join("secrets").join("secrets.json");
+    FileKeyringStore::new(&legacy)
+        .set("xiaomi-mimo", "tp-diagnostic-legacy-key")
+        .expect("seed legacy Xiaomi secret");
+    let legacy_before = fs::read(&legacy).expect("read legacy secret before doctor");
+    let config = workspace.join("doctor.toml");
+    fs::write(
+        &config,
+        "provider = \"xiaomi-mimo\"\n[providers.xiaomi_mimo]\nmode = \"standard\"\n",
+    )
+    .expect("write doctor config");
+
+    let output = diagnostic_command(&workspace, &home)
+        .args([
+            "--config",
+            config.to_str().expect("config path"),
+            "doctor",
+            "--json",
+        ])
+        .output()
+        .expect("run doctor json");
+    assert!(
+        output.status.success(),
+        "doctor --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("machine-readable doctor report");
+    assert_eq!(report["api_key"]["source"], "keyring");
+    assert_eq!(report["route"]["auth"]["scheme"], "api-key");
+    assert_eq!(report["route"]["auth"]["source"], "keyring");
+    assert!(
+        !primary.exists(),
+        "doctor --json must not migrate a legacy secret while classifying auth"
+    );
+    assert_eq!(
+        fs::read(&legacy).expect("read legacy secret after doctor"),
+        legacy_before,
+        "doctor --json must not rewrite the legacy secret store"
+    );
+}
+
+#[test]
+fn setup_status_reads_a_legacy_key_without_migrating_it() {
+    let fixture = TempDir::new().expect("fixture root");
+    let workspace = fixture.path().join("workspace");
+    let home = fixture.path().join("home");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let legacy = home.join(".deepseek").join("secrets").join("secrets.json");
+    let primary = home.join(".codewhale").join("secrets").join("secrets.json");
+    FileKeyringStore::new(&legacy)
+        .set("deepseek", "setup-status-legacy-key")
+        .expect("seed legacy secret");
+    let legacy_before = fs::read(&legacy).expect("read legacy secret before setup");
+
+    let output = diagnostic_command(&workspace, &home)
+        .args(["setup", "--status"])
+        .output()
+        .expect("run setup status");
+    assert!(
+        output.status.success(),
+        "setup --status failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("api_key: set via OS keyring"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !primary.exists(),
+        "setup --status must not create a migrated primary secret store"
+    );
+    assert_eq!(
+        fs::read(&legacy).expect("read legacy secret after setup"),
+        legacy_before,
+        "setup --status must not rewrite the legacy secret store"
+    );
+}
+
+#[test]
+fn doctor_json_stash_honors_an_explicit_codewhale_home() {
+    let fixture = TempDir::new().expect("fixture root");
+    let workspace = fixture.path().join("workspace");
+    let home = fixture.path().join("home");
+    let codewhale_home = fixture.path().join("isolated-codewhale-home");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let ambient_stash = home.join(".codewhale").join("composer_stash.jsonl");
+    fs::create_dir_all(ambient_stash.parent().expect("ambient stash parent"))
+        .expect("ambient stash parent");
+    fs::write(
+        &ambient_stash,
+        r#"{"text":"ambient draft must not be inspected"}"#,
+    )
+    .expect("ambient stash");
+    let ambient_before = fs::read(&ambient_stash).expect("read ambient stash before doctor");
+
+    let mut command = diagnostic_command(&workspace, &home);
+    command
+        .args(["doctor", "--json"])
+        .env("CODEWHALE_HOME", &codewhale_home);
+    let output = command.output().expect("run isolated doctor json");
+    assert!(
+        output.status.success(),
+        "isolated doctor --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("machine-readable doctor report");
+    assert_eq!(
+        report["storage"]["stash"]["path"],
+        codewhale_home
+            .join("composer_stash.jsonl")
+            .display()
+            .to_string()
+    );
+    assert_eq!(report["storage"]["stash"]["present"], false);
+    assert_eq!(report["storage"]["stash"]["count"], 0);
+    assert!(report["storage"]["stash"]["error"].is_null());
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("ambient draft must not be inspected"),
+        "doctor must not inspect an ambient stash outside explicit CODEWHALE_HOME"
+    );
+    assert_eq!(
+        fs::read(&ambient_stash).expect("read ambient stash after doctor"),
+        ambient_before,
+        "doctor must not rewrite the ambient stash"
+    );
+    assert!(
+        !codewhale_home.exists(),
+        "a diagnostic must not create an explicit stash home"
+    );
+}
+
+fn run_sealed_diagnostic<const N: usize>(args: [&str; N]) -> Output {
+    let fixture = TempDir::new().expect("fixture root");
+    let workspace = fixture.path().join("workspace");
+    let sealed_home = fixture.path().join("sealed-home");
+    let codewhale_home = fixture.path().join("sealed-codewhale-home");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+
+    let mut command = Command::new(codewhale_tui_binary());
+    command
+        .current_dir(&workspace)
+        .args(args)
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").expect("PATH"))
+        .env("HOME", &sealed_home)
+        .env("USERPROFILE", &sealed_home)
+        .env("CODEWHALE_HOME", &codewhale_home)
+        .env("CODEWHALE_SECRET_BACKEND", "file")
+        // Keep the text doctor command offline: the release crate treats this
+        // as a pinned mirror version and does not issue a metadata request.
+        .env(
+            "CODEWHALE_RELEASE_BASE_URL",
+            "https://example.invalid/releases",
+        )
+        .env("DEEPSEEK_TUI_VERSION", env!("CARGO_PKG_VERSION"));
+    preserve_host_rustup_home(&mut command);
+
+    let output = command.output().expect("run sealed diagnostic");
+    assert!(
+        output.status.success(),
+        "diagnostic {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !sealed_home.exists(),
+        "diagnostic {args:?} must not create a HOME tree at {}",
+        sealed_home.display()
+    );
+    assert!(
+        !codewhale_home.exists(),
+        "diagnostic {args:?} must not create CODEWHALE_HOME or a secrets store at {}",
+        codewhale_home.display()
+    );
+    output
+}
+
+fn diagnostic_command(workspace: &std::path::Path, home: &std::path::Path) -> Command {
+    let mut command = Command::new(codewhale_tui_binary());
+    command
+        .current_dir(workspace)
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").expect("PATH"))
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("CODEWHALE_SECRET_BACKEND", "file")
+        .env(
+            "CODEWHALE_RELEASE_BASE_URL",
+            "https://example.invalid/releases",
+        )
+        .env("DEEPSEEK_TUI_VERSION", env!("CARGO_PKG_VERSION"));
+    preserve_host_rustup_home(&mut command);
+    command
+}
+
+fn one_request_completion_server() -> (String, mpsc::Receiver<Result<String, String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local probe server");
+    let address = listener.local_addr().expect("local probe server address");
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let result = (|| -> Result<String, String> {
+            let (mut stream, _) = listener.accept().map_err(|error| error.to_string())?;
+            stream
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .map_err(|error| error.to_string())?;
+            let request = read_http_request(&mut stream)?;
+            let body = "{\"id\":\"doctor\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .map_err(|error| error.to_string())?;
+            stream.flush().map_err(|error| error.to_string())?;
+            Ok(request)
+        })();
+        let _ = sender.send(result);
+    });
+    (format!("http://{address}/v1"), receiver)
+}
+
+fn read_http_request(stream: &mut std::net::TcpStream) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let header_end = loop {
+        let read = stream.read(&mut chunk).map_err(|error| error.to_string())?;
+        if read == 0 {
+            return Err("connection closed before HTTP headers arrived".to_string());
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+        if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index + 4;
+        }
+        if bytes.len() > 32 * 1024 {
+            return Err("HTTP headers exceeded test limit".to_string());
+        }
+    };
+    let headers = String::from_utf8_lossy(&bytes[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| line.split_once(':'))
+        .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    while bytes.len() < header_end + content_length {
+        let read = stream.read(&mut chunk).map_err(|error| error.to_string())?;
+        if read == 0 {
+            return Err("connection closed before HTTP body arrived".to_string());
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// A rustup shim may initialize its own toolchain state below `$HOME` when
+/// `doctor` asks `rustc --version`. Preserve an already-configured toolchain
+/// root so this test isolates Codewhale's own state contract.
+fn preserve_host_rustup_home(command: &mut Command) {
+    let rustup_home = std::env::var_os("RUSTUP_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".rustup"))
+                .filter(|path| path.is_dir())
+        });
+    if let Some(rustup_home) = rustup_home {
+        command.env("RUSTUP_HOME", rustup_home);
+    }
+}
+
+fn codewhale_tui_binary() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_codewhale-tui") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_codewhale-tui") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("current test executable path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("codewhale-tui{}", std::env::consts::EXE_SUFFIX));
+    path
+}


### PR DESCRIPTION
## Summary

Hardens `codewhale doctor` (text/`--json`/`--context-json`), `setup --status`, and dispatcher diagnostics so read-only inspection can never create or mutate product state. Builds on #4539.

- **Read-only secret lookup**: `ReadOnlyFileKeyringStore` keeps the runtime's read precedence (primary store first, ambient legacy only when `CODEWHALE_HOME` is not explicit) without performing legacy migration or creating a secrets store; `set`/`delete` return a `ReadOnly` error. Runtime/auth flows keep their existing additive migration untouched.
- **Composer stash diagnostics**: `DiagnosticStashReport` reports stash facts without creating state directories, rejects symlinked stash files, and uses `O_NOFOLLOW` on Unix for the leaf open.
- **Doctor session scan hardening**: session-directory shape/symlink safety checks extracted; recoverable-session recording stays filename/metadata-only.
- **Sealed-home proof**: new process-level tests run each diagnostic with `HOME`/`CODEWHALE_HOME` pointing at nonexistent paths and assert neither tree exists afterward; legacy state is read without being migrated; dispatcher diagnostics leave legacy secret state unchanged.

## Verification (rebased onto current main d9cc9233f)

- `cargo fmt --check -p codewhale-tui -p codewhale-cli -p codewhale-secrets` — clean
- `cargo test -p codewhale-secrets` — 42 + doctests passed
- `cargo test -p codewhale-tui --test diagnostic_read_only` — 10 passed (sealed-home)
- `cargo test -p codewhale-cli --test diagnostic_dispatch_read_only` — 1 passed
- `cargo test -p codewhale-tui --bin codewhale-tui doctor` — 62 passed

## Related

#4032, #4539. Quiet-subagent/lifecycle scope (#4022) deliberately not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)