### PR TITLE
docs(public): Strunk voice + 0.9.1 version truth for README, site, npm

### DIFF
--- a/README.es-419.md
+++ b/README.es-419.md
@@ -1,17 +1,32 @@
-<!-- source: README.md sha256:ddc9cd7b5aea -->
+<!-- source: README.md sha256:120251f534ca -->
 # Codewhale
 
-Un agente de código para tu terminal. Funciona con cualquier modelo; los
-modelos abiertos primero.
+**Un runtime. Todos los modelos. Tu máquina.**
 
-Le das un proveedor, un modelo y una tarea. Lee código, edita archivos, ejecuta
-comandos, verifica los resultados y sigue avanzando hasta que la tarea queda
-lista o te necesita. TUI para el trabajo interactivo, `codewhale exec` para
-scripts y CI. Rust, MIT, corre completamente en tu máquina.
+Codewhale es un agente de código para tu terminal. Funciona con cualquier
+modelo; los modelos abiertos primero. Le das un proveedor, un modelo y una
+tarea: lee tu código, edita archivos, ejecuta comandos, verifica su trabajo y
+se detiene cuando la tarea queda lista o te necesita. Cambia de modelo a
+mitad de tarea con `/model`. Usa la TUI para el trabajo interactivo y
+`codewhale exec` para scripts y CI. Rust, MIT, corre en tu máquina.
 
-Empezó como `deepseek-tui`. La comunidad que se formó a su alrededor necesitaba
-más proveedores, así que ahora DeepSeek, Claude, GPT, Kimi, GLM y más de 30
-otros corren sobre el mismo runtime y las mismas herramientas.
+**Por qué Codewhale:**
+- **Sin lock-in.** DeepSeek, Claude, GPT, Kimi, GLM, más de 30 proveedores, y
+  tu propio vLLM, SGLang u Ollama — sin key — corren por un solo runtime y un
+  solo conjunto de herramientas. Los presupuestos de contexto y los precios
+  vienen de la ruta real. Un precio desconocido se muestra como desconocido,
+  nunca como $0.
+- **Seguro por construcción.** El modo Plan es de solo lectura. Las
+  aprobaciones controlan cada llamada riesgosa. El sandbox del sistema
+  operativo resiste — Seatbelt, Landlock, seccomp, bwrap. El
+  `constitution.json` de un repo se compila en bloqueos de escritura que ni
+  siquiera Full Access puede saltarse.
+- **Trabajo que sobrevive.** Los fleets registran cada paso en un libro mayor
+  de solo agregado; `fleet resume` retoma donde te detuviste. Cada turno deja
+  un recibo que puedes inspeccionar.
+
+Nació como `deepseek-tui`. Su comunidad necesitaba más proveedores, así que
+construimos un runtime donde el modelo es un componente, no el producto.
 
 [English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -46,43 +61,17 @@ Plan / Act / Operate, `Shift+Tab` cicla la postura de aprobación
 Ask / Auto-Review / Full Access, y `!` ejecuta un comando de shell por la ruta
 normal de aprobación.
 
-## Qué hace
+## Para saber más
 
-- Resuelve tu elección de proveedor + modelo a una ruta concreta: endpoint,
-  wire protocol, límite de contexto, precio. Los presupuestos de contexto y el
-  costo que se muestra vienen de la ruta real; un precio desconocido se muestra
-  como desconocido, no como $0.
-  ([docs/PROVIDERS.md](docs/PROVIDERS.md))
-- Habla con proveedores que alojan modelos abiertos (`deepseek`, `openrouter`,
-  `moonshot`, `zai`, `minimax`, `nvidia-nim`, …), con tu propio `vllm` /
-  `sglang` / `ollama` sin clave, y con Anthropic de forma nativa sobre la
-  Messages API, con thinking y caché de prompts.
-- Ejecuta múltiples workers de forma durable: Fleet registra el trabajo en un
-  ledger append-only, así que las ejecuciones sobreviven reinicios y
-  `fleet resume` retoma donde quedaron las cosas. Workflow planifica trabajos
-  más grandes en carriles reanudables y verificables.
-  ([docs/FLEET.md](docs/FLEET.md))
-- Regula el riesgo con código, no con corazonadas: tres modos (Plan es de solo
-  lectura), una postura de aprobación separada, sandbox a nivel del sistema
-  operativo (Seatbelt, Landlock + seccomp, bwrap), hooks que pueden
-  permitir/denegar/preguntar por cada llamada a herramienta, y snapshots en un
-  git paralelo para que `/restore` nunca toque tu historial real.
-- Permite que un repo declare su propia ley: los invariantes de
-  `.codewhale/constitution.json` se compilan en bloqueos de escritura que ni
-  siquiera Full Access puede saltarse.
-  ([docs/CONFIGURATION.md](docs/CONFIGURATION.md))
-- Habla MCP en ambas direcciones, carga skills reutilizables, expone APIs de
-  runtime HTTP/SSE y ACP, y respalda una
-  [GUI para VS Code](https://github.com/HengQuWorld/CodeWhale-VSCode) de la
-  comunidad.
-- La TUI muestra el trabajo como recibos que puedes inspeccionar, mantiene en
-  movimiento una sola fila en vivo, tiene un inspector de contexto real, 12
-  temas, modos de movimiento reducido y ASCII seguro, y está disponible en
-  English, 简体中文, 日本語, Tiếng Việt, Español, Português, 한국어 y 繁體中文
-  parcial.
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — cada ruta de proveedor: alojada,
+  gateway y local
+- [docs/FLEET.md](docs/FLEET.md) — fleets, el libro mayor y resume
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hooks y la
+  constitution
 
-Todo lo demás — configuración, atajos de teclado, detalles del sandbox,
-arquitectura — está en [docs](docs) y en [codewhale.net](https://codewhale.net/).
+Todo lo demás — modos, atajos de teclado, detalles del sandbox, MCP, la API
+del runtime, arquitectura — está en [docs](docs) y en
+[codewhale.net](https://codewhale.net/).
 
 ## Contribuir
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,11 +1,32 @@
-<!-- source: README.md sha256:ddc9cd7b5aea -->
+<!-- source: README.md sha256:120251f534ca -->
 # Codewhale
 
-ターミナルで動くコーディングエージェント。あらゆるモデルで動作し、オープンモデルを最優先します。
+**ひとつのランタイム。あらゆるモデル。あなたのマシン。**
 
-プロバイダ、モデル、タスクを渡すと、コードを読み、ファイルを編集し、コマンドを実行し、結果を確認して、タスクが完了するかあなたの手が必要になるまで作業を続けます。対話的な作業には TUI を、スクリプトと CI には `codewhale exec` を。Rust 製、MIT ライセンスで、すべて手元のマシン上で動きます。
+Codewhale はターミナルで動くコーディングエージェントです。あらゆるモデルで
+動作し、オープンモデルを最優先します。プロバイダ、モデル、タスクを渡すと、
+コードを読み、ファイルを編集し、コマンドを実行し、自分の作業を確認して、
+タスクが完了するかあなたの手が必要になった時点で止まります。タスクの途中でも
+`/model` でモデルを切り替えられます。対話的な作業には TUI を、スクリプトと
+CI には `codewhale exec` を。Rust 製、MIT ライセンス、あなたのマシン上で
+動きます。
 
-このプロジェクトは `deepseek-tui` として始まりました。その周りに生まれたコミュニティがより多くのプロバイダを必要としたため、いまでは DeepSeek、Claude、GPT、Kimi、GLM ほか 30 以上のモデルが、同じランタイムと同じツール群を通って動いています。
+**Codewhale を選ぶ理由:**
+- **ロックインなし。** DeepSeek、Claude、GPT、Kimi、GLM をはじめ 30 以上の
+  プロバイダ、そしてキー不要のあなた自身の vLLM・SGLang・Ollama が、ひとつの
+  ランタイムとひとつのツール群を通って動きます。コンテキスト予算と価格は
+  実際のルートに由来します。不明な価格は不明と表示され、$0 とは決して
+  表示されません。
+- **構造として安全。** Plan モードは読み取り専用。リスクのある呼び出しは
+  すべて承認でゲートされます。OS サンドボックスが守ります — Seatbelt、
+  Landlock、seccomp、bwrap。リポジトリの `constitution.json` は書き込み
+  ホールドへとコンパイルされ、Full Access でもスキップできません。
+- **消えない作業。** Fleet はすべてのステップを追記専用の台帳に記録し、
+  `fleet resume` で止めたところから再開できます。どのターンも検証できる
+  レシートを残します。
+
+`deepseek-tui` として生まれました。コミュニティがより多くのプロバイダを
+必要としたので、モデルを製品ではなく部品として扱うランタイムを作りました。
 
 [English](README.md) · [简体中文](README.zh-CN.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -33,17 +54,17 @@ codewhale exec "fix the failing test"    # headless
 
 TUI では、`/model` がプロバイダとモデルをまとめて切り替え、`/fleet` がワーカーのチームを走らせ、`/restore` がターンを取り消します。`Tab` は Plan / Act / Operate を順に切り替え、`Shift+Tab` は Ask / Auto-Review / Full Access の承認スタンスを順に切り替え、`!` は Shell コマンドを通常の承認経路で実行します。
 
-## できること
+## さらに詳しく
 
-- プロバイダとモデルの選択を具体的なルートに解決します: エンドポイント、ワイヤプロトコル、コンテキスト上限、価格。コンテキスト予算とコスト表示は実際のルートに基づき、不明な価格は $0 ではなく不明として表示されます。([docs/PROVIDERS.md](docs/PROVIDERS.md))
-- ホスト型のオープンモデルプロバイダ（`deepseek`、`openrouter`、`moonshot`、`zai`、`minimax`、`nvidia-nim` など）、キー不要で使える自前の `vllm` / `sglang` / `ollama`、そして thinking とプロンプトキャッシュに対応した Messages API 経由のネイティブな Anthropic と通信します。
-- 複数のワーカーを耐久的に走らせます: Fleet は作業を追記専用の台帳（ledger）に記録するため、実行は再起動を生き延び、`fleet resume` が止まったところから再開します。Workflow は大きなジョブを、再開可能で検証可能なレーンへ計画します。([docs/FLEET.md](docs/FLEET.md))
-- リスクは雰囲気ではなくコードでゲートします: 3 つのモード（Plan は読み取り専用）、独立した承認スタンス、OS サンドボックス（Seatbelt、Landlock + seccomp、bwrap）、ツール呼び出しごとに allow/deny/ask を判定できるフック、そして `/restore` が実際の履歴に決して触れないようにする side-git スナップショット。
-- リポジトリが自らの法を宣言できます: `.codewhale/constitution.json` の不変条件は、Full Access でもスキップできない書き込みホールドにコンパイルされます。([docs/CONFIGURATION.md](docs/CONFIGURATION.md))
-- MCP はクライアントとサーバーの両方向に対応し、再利用可能なスキルを読み込み、HTTP/SSE と ACP の Runtime API を公開し、コミュニティ製の [VS Code GUI](https://github.com/HengQuWorld/CodeWhale-VSCode) を支えています。
-- TUI は作業を検査可能なレシートとして表示し、ライブに動く行は常に 1 行だけに保ち、本物のコンテキストインスペクタ、12 のテーマ、モーション低減モードと ASCII セーフモードを備えます。UI は英語、简体中文、日本語、Tiếng Việt、Español、Português、한국어で利用でき、繁體中文には部分的に対応しています。
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — ホスト型・ゲートウェイ・ローカル
+  まで、すべてのプロバイダルート
+- [docs/FLEET.md](docs/FLEET.md) — Fleet、台帳、再開
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`、フック、
+  constitution
 
-それ以外のすべて — 設定、キーバインド、サンドボックスの詳細、アーキテクチャ — は [docs](docs) と [codewhale.net](https://codewhale.net/) にあります。
+その他 — モード、キーバインド、サンドボックスの詳細、MCP、ランタイム API、
+アーキテクチャ — は [docs](docs) と [codewhale.net](https://codewhale.net/)
+にあります。
 
 ## コントリビューション
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,19 +1,31 @@
-<!-- source: README.md sha256:ddc9cd7b5aea -->
+<!-- source: README.md sha256:120251f534ca -->
 # Codewhale
 
-터미널에서 쓰는 코딩 에이전트입니다. 어떤 모델과도 동작하며, 오픈 모델을
-우선합니다.
+**하나의 런타임. 모든 모델. 당신의 컴퓨터.**
 
-프로바이더, 모델, 작업을 지정하면 코드를 읽고, 파일을 편집하고, 명령을
-실행하고, 결과를 확인하며, 작업이 끝나거나 사용자의 판단이 필요해질
-때까지 계속 진행합니다. 대화형 작업에는 TUI를, 스크립트와 CI에는
-`codewhale exec`를 사용합니다. Rust로 작성되었고, MIT 라이선스이며,
-전부 사용자의 컴퓨터에서 실행됩니다.
+Codewhale은 터미널에서 쓰는 코딩 에이전트입니다. 어떤 모델과도 동작하며,
+오픈 모델을 우선합니다. 프로바이더, 모델, 작업을 지정하면 코드를 읽고,
+파일을 편집하고, 명령을 실행하고, 스스로 작업을 확인하며, 작업이 끝나거나
+사용자의 판단이 필요해지면 멈춥니다. 작업 도중에도 `/model`로 모델을 바꿀
+수 있습니다. 대화형 작업에는 TUI를, 스크립트와 CI에는 `codewhale exec`를
+사용합니다. Rust로 작성, MIT 라이선스, 당신의 컴퓨터에서 실행됩니다.
 
-이 프로젝트는 `deepseek-tui`로 시작했습니다. 그 주위에 형성된
-커뮤니티에 더 많은 프로바이더가 필요했고, 지금은 DeepSeek, Claude, GPT,
-Kimi, GLM과 그 밖의 30개 이상이 같은 런타임과 같은 도구를 통해
-실행됩니다.
+**Codewhale을 쓰는 이유:**
+- **종속 없음.** DeepSeek, Claude, GPT, Kimi, GLM 등 30개 이상의 프로바이더와
+  키 없이 쓰는 자체 vLLM, SGLang, Ollama가 하나의 런타임과 하나의 도구
+  세트를 통해 동작합니다. 컨텍스트 예산과 가격은 실제 라우트에서 가져오며,
+  알 수 없는 가격은 알 수 없음으로 표시됩니다 — 절대 $0으로 표시되지
+  않습니다.
+- **구조적으로 안전.** Plan 모드는 읽기 전용입니다. 위험한 호출은 모두
+  승인을 거칩니다. OS 샌드박스가 지켜냅니다 — Seatbelt, Landlock, seccomp,
+  bwrap. 저장소의 `constitution.json`은 Full Access조차 건너뛸 수 없는 쓰기
+  홀드로 컴파일됩니다.
+- **사라지지 않는 작업.** Fleet은 모든 단계를 추가 전용 원장에 기록하고,
+  `fleet resume`은 멈춘 지점부터 이어갑니다. 매 턴마다 확인할 수 있는
+  영수증이 남습니다.
+
+`deepseek-tui`로 태어났습니다. 커뮤니티가 더 많은 프로바이더를 필요로 했고,
+그래서 모델이 제품이 아니라 부품인 런타임을 만들었습니다.
 
 [English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -49,40 +61,16 @@ Plan / Act / Operate 모드를 순환하고, `Shift+Tab`은
 Ask / Auto-Review / Full Access 승인 태세를 순환하며, `!`는 일반 승인
 경로를 거쳐 셸 명령을 실행합니다.
 
-## 하는 일
+## 더 알아보기
 
-- 선택한 프로바이더 + 모델을 구체적인 라우트로 해석합니다: 엔드포인트,
-  와이어 프로토콜, 컨텍스트 한도, 가격. 컨텍스트 예산과 비용 표시는
-  실제 라우트에서 나오며, 알 수 없는 가격은 $0가 아니라 알 수 없음으로
-  표시됩니다. ([docs/PROVIDERS.md](docs/PROVIDERS.md))
-- 호스팅형 오픈 모델 프로바이더(`deepseek`, `openrouter`, `moonshot`,
-  `zai`, `minimax`, `nvidia-nim`, …)와 통신하고, 키 없이 자체
-  `vllm` / `sglang` / `ollama`에 연결하며, Anthropic에는 thinking과
-  프롬프트 캐싱을 갖춘 Messages API로 네이티브 연결합니다.
-- 여러 워커를 내구성 있게 실행합니다: Fleet은 작업을 추가 전용 원장에
-  기록하므로 실행은 재시작에도 살아남고, `fleet resume`은 멈춘
-  지점부터 이어서 진행합니다. Workflow는 더 큰 작업을 재개 가능하고
-  검증 가능한 레인으로 계획합니다. ([docs/FLEET.md](docs/FLEET.md))
-- 위험을 감이 아니라 코드로 통제합니다: 세 가지 모드(Plan은 읽기 전용),
-  별도의 승인 태세, OS 샌드박싱(Seatbelt, Landlock + seccomp, bwrap),
-  도구 호출마다 허용/거부/질문할 수 있는 훅, 그리고 `/restore`가 실제
-  히스토리를 결코 건드리지 않게 하는 side-git 스냅샷.
-- 저장소가 자체 법을 선언할 수 있습니다:
-  `.codewhale/constitution.json`의 불변 조건은 Full Access조차 건너뛸
-  수 없는 쓰기 보류로 컴파일됩니다.
-  ([docs/CONFIGURATION.md](docs/CONFIGURATION.md))
-- 양방향으로 MCP를 지원하고, 재사용 가능한 스킬을 불러오며, HTTP/SSE 및
-  ACP 런타임 API를 노출하고, 커뮤니티
-  [VS Code GUI](https://github.com/HengQuWorld/CodeWhale-VSCode)를
-  뒷받침합니다.
-- TUI는 작업을 점검할 수 있는 리시트로 보여 주고, 움직이는 라이브 행은
-  하나로 유지하며, 실제 컨텍스트 인스펙터, 12가지 테마, 모션 축소
-  모드와 ASCII 안전 모드를 갖추고 있습니다. UI 언어는 영어, 중국어
-  간체, 일본어, 베트남어, 스페인어, 포르투갈어, 한국어를 지원하며,
-  중국어 번체는 부분 지원입니다.
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — 호스팅·게이트웨이·로컬까지 모든
+  프로바이더 라우트
+- [docs/FLEET.md](docs/FLEET.md) — Fleet, 원장, 재개
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, 훅,
+  constitution
 
-그 밖의 모든 것 — 설정, 키 바인딩, 샌드박스 세부 사항, 아키텍처 — 은
-[docs](docs)와 [codewhale.net](https://codewhale.net/)에 있습니다.
+나머지 — 모드, 키 바인딩, 샌드박스 세부 사항, MCP, 런타임 API, 아키텍처 —
+는 [docs](docs)와 [codewhale.net](https://codewhale.net/)에 있습니다.
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # Codewhale
 
-A coding agent for your terminal. Works with any model; open models first.
+**One runtime. Every model. Your machine.**
 
-You give it a provider, a model, and a task. It reads code, edits files, runs
-commands, checks the results, and keeps going until the task is done or it
-needs you. TUI for interactive work, `codewhale exec` for scripts and CI.
-Rust, MIT, runs entirely on your machine.
+Codewhale is a coding agent for your terminal. It works with any model;
+open models first. Give it a provider, a model, and a task: it reads your
+code, edits files, runs commands, checks its work, and stops when the job
+is done or it needs you. Switch models mid-task with `/model`. Use the TUI
+for interactive work, `codewhale exec` for scripts and CI. Rust, MIT,
+runs on your machine.
 
-It started as `deepseek-tui`. The community that formed around it needed more
-providers, so now DeepSeek, Claude, GPT, Kimi, GLM, and 30+ others run through
-the same runtime and tools.
+**Why Codewhale:**
+- **No lock-in.** DeepSeek, Claude, GPT, Kimi, GLM, 30+ providers, and your
+  own vLLM, SGLang, or Ollama — no key required — run through one runtime
+  and one toolset. Context budgets and prices come from the real route. An
+  unknown price shows as unknown, never as $0.
+- **Safe by construction.** Plan mode is read-only. Approvals gate every
+  risky call. The OS sandbox holds — Seatbelt, Landlock, seccomp, bwrap.
+  A repo's `constitution.json` compiles into write holds that even Full
+  Access cannot skip.
+- **Work that survives.** Fleets record every step in an append-only
+  ledger; `fleet resume` picks up where you stopped. Every turn leaves a
+  receipt you can inspect.
+
+Born as `deepseek-tui`. Its community needed more providers, so we built
+one where the model is a component, not the product.
 
 [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -43,37 +57,17 @@ team of workers, `/restore` undoes a turn, `Tab` cycles Plan / Act / Operate,
 `Shift+Tab` cycles the Ask / Auto-Review / Full Access approval posture, and
 `!` runs a shell command through the normal approval path.
 
-## What it does
+## Learn more
 
-- Resolves your provider + model choice to a concrete route: endpoint, wire
-  protocol, context limit, price. Context budgets and cost display come from
-  the real route; an unknown price shows as unknown, not $0.
-  ([docs/PROVIDERS.md](docs/PROVIDERS.md))
-- Talks to hosted open-model providers (`deepseek`, `openrouter`, `moonshot`,
-  `zai`, `minimax`, `nvidia-nim`, …), to your own `vllm` / `sglang` / `ollama`
-  with no key, and to Anthropic natively over the Messages API with thinking
-  and prompt caching.
-- Runs multiple workers durably: Fleet records work in an append-only ledger,
-  so runs survive restarts and `fleet resume` picks up where things stopped.
-  Workflow plans bigger jobs into resumable, verifiable lanes.
-  ([docs/FLEET.md](docs/FLEET.md))
-- Gates risk in code, not vibes: three modes (Plan is read-only), a separate
-  approval posture, OS sandboxing (Seatbelt, Landlock + seccomp, bwrap),
-  hooks that can allow/deny/ask per tool call, and side-git snapshots so
-  `/restore` never touches your real history.
-- Lets a repo declare its own law: `.codewhale/constitution.json` invariants
-  compile into write holds that even Full Access can't skip.
-  ([docs/CONFIGURATION.md](docs/CONFIGURATION.md))
-- Speaks MCP in both directions, loads reusable skills, exposes HTTP/SSE and
-  ACP runtime APIs, and backs a community
-  [VS Code GUI](https://github.com/HengQuWorld/CodeWhale-VSCode).
-- The TUI shows work as receipts you can inspect, keeps one live row moving,
-  has a real context inspector, 12 themes, reduced-motion and ASCII-safe
-  modes, and ships in English, 简体中文, 日本語, Tiếng Việt, Español,
-  Português, 한국어, and partial 繁體中文.
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — every provider route: hosted,
+  gateway, and local
+- [docs/FLEET.md](docs/FLEET.md) — fleets, the ledger, and resume
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hooks, and
+  the constitution
 
-Everything else — configuration, keybindings, sandbox details, architecture —
-is in [docs](docs) and on [codewhale.net](https://codewhale.net/).
+Everything else — modes, keybindings, sandbox details, MCP, the runtime API,
+architecture — is in [docs](docs) and on
+[codewhale.net](https://codewhale.net/).
 
 ## Contributing
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,18 +1,31 @@
-<!-- source: README.md sha256:ddc9cd7b5aea -->
+<!-- source: README.md sha256:120251f534ca -->
 # Codewhale
 
-Um agente de código para o seu terminal. Funciona com qualquer modelo; modelos
-abertos em primeiro lugar.
+**Um runtime. Todos os modelos. Sua máquina.**
 
-Você informa um provedor, um modelo e uma tarefa. Ele lê código, edita
-arquivos, executa comandos, verifica os resultados e continua até a tarefa
-terminar ou até precisar de você. TUI para trabalho interativo,
-`codewhale exec` para scripts e CI. Rust, MIT, roda inteiramente na sua
-máquina.
+O Codewhale é um agente de código para o seu terminal. Funciona com qualquer
+modelo; modelos abertos em primeiro lugar. Você informa um provedor, um
+modelo e uma tarefa: ele lê seu código, edita arquivos, executa comandos,
+verifica o próprio trabalho e para quando a tarefa termina ou quando precisa
+de você. Troque de modelo no meio da tarefa com `/model`. Use a TUI para
+trabalho interativo e `codewhale exec` para scripts e CI. Rust, MIT, roda na
+sua máquina.
 
-Começou como `deepseek-tui`. A comunidade que se formou em volta dele
-precisava de mais provedores, então hoje DeepSeek, Claude, GPT, Kimi, GLM e
-mais de 30 outros rodam pelo mesmo runtime e pelas mesmas ferramentas.
+**Por que Codewhale:**
+- **Sem lock-in.** DeepSeek, Claude, GPT, Kimi, GLM, mais de 30 provedores, e
+  seu próprio vLLM, SGLang ou Ollama — sem key — rodam por um único runtime e
+  um único conjunto de ferramentas. Orçamentos de contexto e preços vêm da
+  rota real. Um preço desconhecido aparece como desconhecido, nunca como $0.
+- **Seguro por construção.** O modo Plan é somente leitura. Aprovações
+  controlam cada chamada arriscada. O sandbox do sistema operacional segura —
+  Seatbelt, Landlock, seccomp, bwrap. O `constitution.json` de um repositório
+  é compilado em bloqueios de escrita que nem o Full Access consegue pular.
+- **Trabalho que sobrevive.** Fleets registram cada passo em um livro-razão
+  de apenas inclusão; `fleet resume` retoma de onde você parou. Cada turno
+  deixa um recibo que você pode inspecionar.
+
+Nasceu como `deepseek-tui`. Sua comunidade precisava de mais provedores,
+então construímos um runtime em que o modelo é um componente, não o produto.
 
 [English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -46,43 +59,17 @@ de workers, `/restore` desfaz um turno, `Tab` cicla entre Plan / Act / Operate,
 `Shift+Tab` cicla a postura de permissão Ask / Auto-Review / Full Access, e
 `!` executa um comando de shell pelo caminho normal de aprovação.
 
-## O que ele faz
+## Saiba mais
 
-- Resolve sua escolha de provedor + modelo em uma rota concreta: endpoint,
-  protocolo de comunicação, limite de contexto, preço. Orçamentos de contexto
-  e a exibição de custo vêm da rota real; um preço desconhecido aparece como
-  desconhecido, não como $0.
-  ([docs/PROVIDERS.md](docs/PROVIDERS.md))
-- Conversa com provedores hospedados de modelos abertos (`deepseek`,
-  `openrouter`, `moonshot`, `zai`, `minimax`, `nvidia-nim`, …), com seu
-  próprio `vllm` / `sglang` / `ollama` sem chave, e com a Anthropic
-  nativamente pela Messages API, com thinking e cache de prompt.
-- Executa vários workers de forma durável: o Fleet registra o trabalho em um
-  ledger append-only, então as execuções sobrevivem a reinícios e
-  `fleet resume` retoma de onde as coisas pararam. O Workflow planeja
-  trabalhos maiores em trilhas retomáveis e verificáveis.
-  ([docs/FLEET.md](docs/FLEET.md))
-- Controla risco em código, não em achismo: três modos (Plan é somente
-  leitura), uma postura de permissão separada, sandbox do sistema operacional
-  (Seatbelt, Landlock + seccomp, bwrap), hooks que podem
-  permitir/negar/perguntar a cada chamada de ferramenta, e snapshots em um git
-  paralelo para que `/restore` nunca toque no seu histórico real.
-- Permite que um repositório declare sua própria lei: os invariantes de
-  `.codewhale/constitution.json` compilam em bloqueios de escrita que nem o
-  Full Access consegue pular.
-  ([docs/CONFIGURATION.md](docs/CONFIGURATION.md))
-- Fala MCP nas duas direções, carrega skills reutilizáveis, expõe APIs de
-  runtime HTTP/SSE e ACP, e dá suporte a uma
-  [GUI para VS Code](https://github.com/HengQuWorld/CodeWhale-VSCode) da
-  comunidade.
-- A TUI mostra o trabalho como recibos que você pode inspecionar, mantém uma
-  única linha ao vivo em movimento, tem um inspetor de contexto de verdade,
-  12 temas, modos de movimento reduzido e ASCII seguro, e é distribuída em
-  English, 简体中文, 日本語, Tiếng Việt, Español, Português, 한국어 e 繁體中文
-  parcial.
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — cada rota de provedor: hospedada,
+  gateway e local
+- [docs/FLEET.md](docs/FLEET.md) — fleets, o livro-razão e resume
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hooks e a
+  constitution
 
-Todo o resto — configuração, atalhos de teclado, detalhes do sandbox,
-arquitetura — está em [docs](docs) e em [codewhale.net](https://codewhale.net/).
+Todo o resto — modos, atalhos de teclado, detalhes do sandbox, MCP, a API do
+runtime, arquitetura — está em [docs](docs) e em
+[codewhale.net](https://codewhale.net/).
 
 ## Contribuindo
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,16 +1,30 @@
-<!-- source: README.md sha256:ddc9cd7b5aea -->
+<!-- source: README.md sha256:120251f534ca -->
 # Codewhale
 
-Một coding agent cho terminal của bạn. Hoạt động với mọi model; ưu tiên model mở.
+**Một runtime. Mọi model. Máy của bạn.**
 
-Bạn đưa cho nó một provider, một model và một nhiệm vụ. Nó đọc code, sửa file,
-chạy lệnh, kiểm tra kết quả, và tiếp tục cho đến khi nhiệm vụ hoàn thành hoặc
-cần đến bạn. TUI cho công việc tương tác, `codewhale exec` cho script và CI.
-Viết bằng Rust, giấy phép MIT, chạy hoàn toàn trên máy của bạn.
+Codewhale là một coding agent cho terminal của bạn. Hoạt động với mọi model;
+ưu tiên model mở. Đưa cho nó một provider, một model và một nhiệm vụ: nó đọc
+code của bạn, sửa file, chạy lệnh, kiểm tra công việc của mình, và dừng lại
+khi nhiệm vụ hoàn thành hoặc cần đến bạn. Đổi model giữa chừng bằng `/model`.
+Dùng TUI cho công việc tương tác, `codewhale exec` cho script và CI. Viết
+bằng Rust, giấy phép MIT, chạy trên máy của bạn.
 
-Dự án khởi đầu là `deepseek-tui`. Cộng đồng hình thành quanh nó cần nhiều
-provider hơn, nên giờ đây DeepSeek, Claude, GPT, Kimi, GLM và hơn 30 model
-khác chạy qua cùng một runtime và bộ công cụ.
+**Vì sao chọn Codewhale:**
+- **Không bị khóa chân.** DeepSeek, Claude, GPT, Kimi, GLM, hơn 30 provider,
+  và vLLM, SGLang hay Ollama của riêng bạn — không cần key — đều chạy qua một
+  runtime và một bộ công cụ. Ngân sách ngữ cảnh và giá lấy từ route thật; giá
+  chưa rõ hiển thị là chưa rõ, không bao giờ là $0.
+- **An toàn từ thiết kế.** Chế độ Plan chỉ đọc. Mọi lệnh gọi rủi ro đều qua
+  phê duyệt. Sandbox của hệ điều hành giữ vững — Seatbelt, Landlock, seccomp,
+  bwrap. `constitution.json` của repo được biên dịch thành các chốt chặn ghi
+  mà ngay cả Full Access cũng không thể bỏ qua.
+- **Công việc không mất.** Fleet ghi lại từng bước vào sổ cái chỉ ghi thêm;
+  `fleet resume` tiếp tục từ chỗ bạn dừng. Mỗi lượt đều để lại một biên nhận
+  bạn có thể kiểm tra.
+
+Sinh ra từ `deepseek-tui`. Cộng đồng của nó cần nhiều provider hơn, nên chúng
+tôi xây một runtime nơi model là một linh kiện, không phải sản phẩm.
 
 [English](README.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -44,40 +58,16 @@ worker, `/restore` hoàn tác một lượt, `Tab` chuyển vòng qua Plan / Act
 Operate, `Shift+Tab` chuyển vòng qua mức phê duyệt Ask / Auto-Review / Full
 Access, và `!` chạy một lệnh shell qua đường phê duyệt bình thường.
 
-## Nó làm gì
+## Tìm hiểu thêm
 
-- Phân giải lựa chọn provider + model của bạn thành một route cụ thể:
-  endpoint, giao thức wire, giới hạn context, giá. Ngân sách context và phần
-  hiển thị chi phí lấy từ route thật; giá chưa biết được hiển thị là chưa
-  biết, không phải $0. ([docs/PROVIDERS.md](docs/PROVIDERS.md))
-- Nói chuyện với các provider model mở dạng hosted (`deepseek`, `openrouter`,
-  `moonshot`, `zai`, `minimax`, `nvidia-nim`, …), với `vllm` / `sglang` /
-  `ollama` của riêng bạn mà không cần key, và với Anthropic một cách native
-  qua Messages API với thinking và prompt caching.
-- Chạy nhiều worker một cách bền vững: Fleet ghi công việc vào một ledger chỉ
-  ghi thêm (append-only), nên các lượt chạy sống sót qua restart và
-  `fleet resume` tiếp tục từ chỗ đã dừng. Workflow lập kế hoạch cho những việc
-  lớn hơn thành các lane có thể tiếp tục và kiểm chứng được.
-  ([docs/FLEET.md](docs/FLEET.md))
-- Chặn rủi ro bằng code, không bằng cảm tính: ba chế độ (Plan chỉ đọc), mức
-  phê duyệt tách riêng, sandbox cấp hệ điều hành (Seatbelt, Landlock +
-  seccomp, bwrap), hook có thể allow/deny/ask cho từng lần gọi công cụ, và
-  snapshot side-git để `/restore` không bao giờ chạm vào lịch sử thật của bạn.
-- Cho phép repo tự tuyên bố luật của mình: các bất biến trong
-  `.codewhale/constitution.json` được biên dịch thành các chốt chặn ghi mà
-  ngay cả Full Access cũng không thể bỏ qua.
-  ([docs/CONFIGURATION.md](docs/CONFIGURATION.md))
-- Nói MCP theo cả hai chiều, nạp các skill tái sử dụng, cung cấp runtime API
-  HTTP/SSE và ACP, và làm nền cho một
-  [GUI VS Code](https://github.com/HengQuWorld/CodeWhale-VSCode) của cộng đồng.
-- TUI hiển thị công việc dưới dạng những biên nhận bạn có thể kiểm tra, giữ
-  đúng một dòng live chuyển động, có trình kiểm tra context thực thụ, 12
-  theme, chế độ giảm chuyển động và chế độ ASCII an toàn, và có sẵn tiếng Anh,
-  tiếng Trung giản thể, tiếng Nhật, tiếng Việt, tiếng Tây Ban Nha, tiếng Bồ
-  Đào Nha, tiếng Hàn, và một phần tiếng Trung phồn thể.
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — mọi route provider: dịch vụ,
+  gateway và cục bộ
+- [docs/FLEET.md](docs/FLEET.md) — fleet, sổ cái và resume
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`, hook và
+  constitution
 
-Mọi thứ còn lại — cấu hình, phím tắt, chi tiết sandbox, kiến trúc — nằm trong
-[docs](docs) và trên [codewhale.net](https://codewhale.net/).
+Mọi thứ còn lại — chế độ, phím tắt, chi tiết sandbox, MCP, runtime API, kiến
+trúc — nằm trong [docs](docs) và trên [codewhale.net](https://codewhale.net/).
 
 ## Đóng góp
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,11 +1,16 @@
-<!-- source: README.md sha256:ddc9cd7b5aea -->
+<!-- source: README.md sha256:120251f534ca -->
 # Codewhale
 
-一个运行在终端里的编程智能体。适配任意模型；开放模型优先。
+**一个运行时。所有模型。你的机器。**
 
-你给它一个 provider、一个模型和一个任务。它读代码、改文件、跑命令、检查结果，一直做到任务完成或需要你介入为止。交互式工作用 TUI，脚本和 CI 用 `codewhale exec`。Rust 编写，MIT 许可，完全在你自己的机器上运行。
+Codewhale 是运行在终端里的编程智能体。适配任意模型；开放模型优先。给它一个 provider、一个模型和一个任务：它会读你的代码、改文件、跑命令、检查自己的工作，在任务完成或需要你介入时停下。任务中途用 `/model` 切换模型。交互式工作用 TUI，脚本和 CI 用 `codewhale exec`。Rust 编写，MIT 许可，运行在你自己的机器上。
 
-它最初叫 `deepseek-tui`。围绕它形成的社区需要更多 provider，于是现在 DeepSeek、Claude、GPT、Kimi、GLM 以及其他 30 多个模型都跑在同一套运行时和工具之上。
+**为什么选 Codewhale：**
+- **不被锁定。** DeepSeek、Claude、GPT、Kimi、GLM 等 30 多家 provider，以及你自己的 vLLM、SGLang、Ollama——无需 key——都跑在同一套运行时和同一套工具之上。上下文预算与价格取自真实路由；价格未知时显示未知，绝不显示 $0。
+- **安全靠构造。** Plan 模式只读。审批把关每一次高风险调用。操作系统级沙箱守住底线——Seatbelt、Landlock、seccomp、bwrap。仓库的 `constitution.json` 会编译成写入拦截，连 Full Access 也无法跳过。
+- **工作不丢失。** Fleet 把每一步记录在只追加的账本里；`fleet resume` 从你停下的地方继续。每一轮都留下可查验的回执。
+
+它诞生于 `deepseek-tui`。社区需要更多 provider，于是我们造了一个把模型当组件、而不是当产品的运行时。
 
 [English](README.md) · [日本語](README.ja-JP.md) · [Tiếng Việt](README.vi.md) · [한국어](README.ko-KR.md) · [Español](README.es-419.md) · [Português](README.pt-BR.md) · [codewhale.net](https://codewhale.net/) · [Docs](docs) · [Changelog](CHANGELOG.md)
 
@@ -33,17 +38,13 @@ codewhale exec "fix the failing test"    # headless
 
 在 TUI 中：`/model` 同时切换 provider 和模型，`/fleet` 运行一组 worker，`/restore` 撤销某一轮，`Tab` 在 Plan / Act / Operate 之间循环切换，`Shift+Tab` 在 Ask / Auto-Review / Full Access 审批姿态之间循环切换，`!` 让 shell 命令经由正常的审批路径运行。
 
-## 它做什么
+## 了解更多
 
-- 把你选定的 provider + 模型解析为一条具体路由：端点、传输协议、上下文上限、价格。上下文预算与费用显示都取自真实路由；价格未知时就显示未知，而不是 $0。（[docs/PROVIDERS.md](docs/PROVIDERS.md)）
-- 可连接托管的开放模型 provider（`deepseek`、`openrouter`、`moonshot`、`zai`、`minimax`、`nvidia-nim` 等），可无 key 直连你自己的 `vllm` / `sglang` / `ollama`，也能通过 Messages API 原生对接 Anthropic，支持 thinking 与 prompt 缓存。
-- 以可持久化的方式运行多个 worker：Fleet 把工作记录在只追加的账本里，运行不会因重启而丢失，`fleet resume` 能从中断处继续。Workflow 把更大的任务规划成可恢复、可验证的 lane。（[docs/FLEET.md](docs/FLEET.md)）
-- 风险把关靠代码，不靠感觉：三种模式（Plan 为只读）、独立的审批姿态、操作系统级沙箱（Seatbelt、Landlock + seccomp、bwrap）、可对每次工具调用做 allow/deny/ask 决策的 hooks，以及 side-git 快照——`/restore` 永远不会碰你真正的提交历史。
-- 允许仓库声明自己的法律：`.codewhale/constitution.json` 中的不变量会编译成写入拦截，连 Full Access 也无法跳过。（[docs/CONFIGURATION.md](docs/CONFIGURATION.md)）
-- 双向支持 MCP，可加载可复用的 skills，对外提供 HTTP/SSE 与 ACP 运行时 API，并支撑社区维护的 [VS Code GUI](https://github.com/HengQuWorld/CodeWhale-VSCode)。
-- TUI 把工作显示为可逐条查验的回执，同一时间只让一行保持动态，内置真实的上下文查看器、12 套主题、减弱动效与 ASCII 安全模式，界面语言覆盖英语、简体中文、日语、越南语、西班牙语、葡萄牙语和韩语，繁体中文为部分翻译。
+- [docs/PROVIDERS.md](docs/PROVIDERS.md) — 每一条 provider 路由：托管、网关与本地
+- [docs/FLEET.md](docs/FLEET.md) — Fleet、账本与恢复
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.toml`、hooks 与 constitution
 
-其余内容——配置、键位绑定、沙箱细节、架构——见 [docs](docs) 与 [codewhale.net](https://codewhale.net/)。
+其余内容——模式、键位绑定、沙箱细节、MCP、运行时 API、架构——见 [docs](docs) 与 [codewhale.net](https://codewhale.net/)。
 
 ## 贡献
 

--- a/npm/codewhale/package.json
+++ b/npm/codewhale/package.json
@@ -2,7 +2,7 @@
   "name": "codewhale",
   "version": "0.9.1",
   "codewhaleBinaryVersion": "0.9.1",
-  "description": "Install and run Codewhale, the agentic terminal for open-source and open-weight coding models, from GitHub release artifacts.",
+  "description": "Terminal coding agent for any model, open models first. One runtime on your machine. Rust, MIT.",
   "author": "Hmbown",
   "license": "MIT",
   "funding": [

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -47,11 +47,11 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     path: "/",
     locale,
     title: isZh
-      ? "Codewhale 文档与开源运行时"
-      : "Codewhale documentation and open-source runtime",
+      ? "Codewhale — 一个运行时，所有模型，你的机器"
+      : "Codewhale — One runtime. Every model. Your machine.",
     description: isZh
-      ? "安装 Codewhale，并查找有关模式、权限、工具、提供商、配置、运行时 API 和社区贡献的准确文档。"
-      : "Install Codewhale and find precise documentation for modes, permissions, tools, providers, configuration, the runtime API, and community contributions.",
+      ? "开源终端编程智能体，适配任意模型，开放模型优先。TUI、CLI 与本地工具——运行在你自己的机器上。Rust 编写，MIT 许可。"
+      : "Open-source terminal coding agent for any model, open models first. TUI, CLI, and local tools — runs on your machine. Rust, MIT.",
   });
 }
 

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -70,26 +70,32 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           <div className="portal-hero-copy">
             <div className="portal-mark">
               <Whale size={28} className="text-current" />
-              <span>{isZh ? "Codewhale 文档" : "Codewhale documentation"}</span>
+              <span>{isZh ? "一个运行时 · 所有模型 · 你的机器" : "One runtime · every model · your machine"}</span>
             </div>
-            <h1>{isZh ? "Codewhale 文档" : "Codewhale documentation"}</h1>
+            <h1>Codewhale</h1>
             <p className="portal-lede">
               {isZh
-                ? "安装这个开源终端编程智能体，连接你已有的模型提供商，并在需要时查找有关模式、权限、工具、配置和运行时集成的准确说明。"
-                : "Install the open-source terminal coding agent, connect the provider you already use, and find precise guidance for modes, permissions, tools, configuration, and runtime integrations."}
+                ? "Codewhale 是运行在终端里的编程智能体。适配任意模型；开放模型优先。给它一个提供商、一个模型和一个任务：它会读你的代码、改文件、跑命令、检查自己的工作，在任务完成或需要你介入时停下。交互式工作用 TUI，脚本和 CI 用 codewhale exec。Rust 编写，MIT 许可，运行在你自己的机器上。"
+                : "Codewhale is a coding agent for your terminal. It works with any model; open models first. Give it a provider, a model, and a task: it reads your code, edits files, runs commands, checks its work, and stops when the job is done or it needs you. Use the TUI for interactive work, codewhale exec for scripts and CI. Rust, MIT, runs on your machine."}
             </p>
             <div className="portal-actions">
-              <Link href={`/${locale}/docs`} className="portal-button portal-button-primary">
-                {isZh ? "浏览文档" : "Browse the documentation"}
+              <Link href={`/${locale}/install`} className="portal-button portal-button-primary">
+                {isZh ? "安装" : "Install"}
               </Link>
-              <Link href={`/${locale}/install`} className="portal-button portal-button-secondary">
-                {isZh ? "查看安装指南" : "Read the installation guide"}
+              <Link href={`/${locale}/docs`} className="portal-button portal-button-secondary">
+                {isZh ? "文档" : "Docs"}
               </Link>
+              <a
+                href="https://github.com/Hmbown/CodeWhale"
+                className="portal-button portal-button-secondary"
+              >
+                GitHub
+              </a>
             </div>
             <p className="portal-meta">
               {isZh
-                ? `当前运行时版本为 ${facts.version ?? "0.8.x"}，支持 ${facts.providers.length} 个提供商，并采用 ${facts.license ?? "MIT"} 许可证。`
-                : `The current runtime is version ${facts.version ?? "0.8.x"}, supports ${facts.providers.length} providers, and is licensed under ${facts.license ?? "MIT"}.`}
+                ? `当前运行时版本为 ${facts.version ?? "0.9.x"}，支持 ${facts.providers.length} 个提供商，并采用 ${facts.license ?? "MIT"} 许可证。`
+                : `The current runtime is version ${facts.version ?? "0.9.x"}, supports ${facts.providers.length} providers, and is licensed under ${facts.license ?? "MIT"}.`}
             </p>
           </div>
 

--- a/web/lib/page-meta.ts
+++ b/web/lib/page-meta.ts
@@ -6,8 +6,7 @@ export const SITE_URL = "https://codewhale.net";
 export const SITE_NAME = "Codewhale";
 
 /** The one-line product identity, used as the default OG image alt text. */
-export const IDENTITY_PHRASE =
-  "Documentation and source for the open-source Codewhale terminal coding runtime.";
+export const IDENTITY_PHRASE = "One runtime. Every model. Your machine.";
 
 /** Shared OG card rendered by app/opengraph-image.tsx (1200×630 PNG). */
 const OG_IMAGE = {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "codewhale-web",
   "version": "0.1.0",
   "private": true,
-  "description": "Community site for CodeWhale — codewhale.net",
+  "description": "Community site for Codewhale — codewhale.net",
   "scripts": {
     "dev": "node scripts/derive-facts.mjs && next dev",
     "prebuild": "node scripts/derive-facts.mjs",

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -7,7 +7,7 @@ release_base="${CODEWHALE_RELEASE_BASE_URL:-${DEEPSEEK_TUI_RELEASE_BASE_URL:-}}"
 
 usage() {
   cat <<'USAGE'
-CodeWhale installer for macOS and Linux.
+Codewhale installer for macOS and Linux.
 
 Usage:
   curl -fsSL https://codewhale.net/install.sh | sh
@@ -147,7 +147,7 @@ check_glibc() {
   host="$(glibc_version || true)"
   if [ -z "$host" ] || ! version_at_least "$host" "$required"; then
     cat >&2 <<EOF
-codewhale install: prebuilt CodeWhale $target assets require glibc $required or newer.
+codewhale install: prebuilt Codewhale $target assets require glibc $required or newer.
 This system reports glibc ${host:-unavailable}.
 
 Linux x64 uses a static musl build. Linux arm64 release assets are GNU libc
@@ -195,7 +195,7 @@ manifest_asset="codewhale-artifacts-sha256.txt"
 tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t codewhale-install)"
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 
-say "Installing CodeWhale for $target"
+say "Installing Codewhale for $target"
 say "Release assets: $release_base"
 say "Install dir: $install_dir"
 


### PR DESCRIPTION
## Summary

Recreates #4541 against main (the original stacked PR auto-closed when its base branch was deleted after #4540 merged). Content is identical; see #4541 for the original review context.

- README hero per the 0.9.1 public-surface brief §4.1 (One runtime. Every model. Your machine.), with Why-bullets on lock-in/sandbox/ledger and locale hero ports (es-419/ja/ko/pt-BR/vi/zh-CN).
- Site H1/eyebrow/lede/CTAs and meta/OG identity per §4.3/§4.7; product-first hero, docs below the fold.
- npm `description` per §4.4 (description only; version untouched at 0.9.1).
- Codewhale casing on public prose; stars omitted (live count 39,915 — under the ~40k line's bar).
- Suggested GitHub repo description for Hunter (not changed by automation): `One runtime for every model — a terminal coding agent that runs on your machine. Rust, MIT.`

## Verification

- `npm ci` + `vitest run` — 76 tests passed; `eslint .` clean; `next build` succeeds; `check:docs` PASS (version=0.9.1)
- `python3 scripts/check-readme-translations.py` — 6 translations in sync
- `python3 scripts/check-coauthor-trailers.py` — passed

Residual: locale hero translations would benefit from native-speaker review; PR3 (visual polish) and PR4 (on-site P0 docs) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)