### PR TITLE
fix(xai): flatten root oneOf tool schemas rejected with 400

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -228,6 +228,32 @@ impl DeepSeekClient {
                     }
                 }
             }
+            // xAI rejects a parameters root that is not a plain object schema
+            // (e.g. apply_patch's root `oneOf` required-groups) with a 400.
+            if matches!(self.api_provider, crate::config::ApiProvider::Xai) {
+                for t in &mut chat_tools {
+                    let Some(function) = t
+                        .as_object_mut()
+                        .and_then(|t| t.get_mut("function"))
+                        .and_then(|f| f.as_object_mut())
+                    else {
+                        continue;
+                    };
+                    let note = function.get_mut("parameters").and_then(|parameters| {
+                        crate::tools::schema_sanitize::sanitize_for_xai_parameters(parameters)
+                    });
+                    if let Some(note) = note
+                        && let Some(description) = function
+                            .get_mut("description")
+                            .and_then(|d| d.as_str().map(str::to_string))
+                    {
+                        function.insert(
+                            "description".to_string(),
+                            json!(format!("{description} {note}")),
+                        );
+                    }
+                }
+            }
             body["tools"] = json!(chat_tools);
         }
         if should_send_tool_choice_for_chat(self.api_provider, request.reasoning_effort.as_deref())
@@ -359,6 +385,32 @@ impl DeepSeekClient {
                         .and_then(|f| f.get_mut("parameters"))
                     {
                         crate::tools::schema_sanitize::sanitize_for_kimi_parameters(fn_obj);
+                    }
+                }
+            }
+            // xAI rejects a parameters root that is not a plain object schema
+            // (e.g. apply_patch's root `oneOf` required-groups) with a 400.
+            if matches!(self.api_provider, crate::config::ApiProvider::Xai) {
+                for t in &mut chat_tools {
+                    let Some(function) = t
+                        .as_object_mut()
+                        .and_then(|t| t.get_mut("function"))
+                        .and_then(|f| f.as_object_mut())
+                    else {
+                        continue;
+                    };
+                    let note = function.get_mut("parameters").and_then(|parameters| {
+                        crate::tools::schema_sanitize::sanitize_for_xai_parameters(parameters)
+                    });
+                    if let Some(note) = note
+                        && let Some(description) = function
+                            .get_mut("description")
+                            .and_then(|d| d.as_str().map(str::to_string))
+                    {
+                        function.insert(
+                            "description".to_string(),
+                            json!(format!("{description} {note}")),
+                        );
                     }
                 }
             }

--- a/crates/tui/src/tools/schema_sanitize.rs
+++ b/crates/tui/src/tools/schema_sanitize.rs
@@ -69,6 +69,20 @@ pub fn sanitize_for_strict(schema: &mut Value) {
     enforce_strict_subset(schema);
 }
 
+/// Sanitize a tool `parameters` schema for xAI chat completions.
+///
+/// xAI validates that the parameters root is an object schema and rejects a
+/// root-level `anyOf`/`oneOf` union with any non-object branch
+/// ("tool parameter root must be an object type"). The built-in `apply_patch`
+/// schema's `oneOf: [{required:["patch"]}, {required:["changes"]}]` trips this
+/// with a 400 on the first tool-bearing request. The Responses-API pass
+/// performs exactly the required normalization — merge root composition
+/// properties, force `type: object`, drop root-only composition keywords —
+/// so reuse it and surface the dropped constraint as a description note.
+pub fn sanitize_for_xai_parameters(parameters: &mut Value) -> Option<String> {
+    sanitize_for_responses(parameters)
+}
+
 /// Sanitize a schema for OpenAI Responses function tools.
 ///
 /// The Responses API requires the top-level `parameters` schema to be an object
@@ -928,6 +942,30 @@ mod tests {
         assert!(schema.get("anyOf").is_none());
         assert!(schema["properties"]["value"].get("anyOf").is_some());
         assert_eq!(note, None);
+    }
+
+    #[test]
+    fn xai_sanitize_flattens_apply_patch_root_one_of() {
+        // The exact shape that produced the live 400:
+        // "apply_patch: tool parameter root must be an object type (root
+        // schema is an anyOf/oneOf union with a non-object branch)".
+        use crate::tools::spec::ToolSpec as _;
+        let mut schema = crate::tools::apply_patch::ApplyPatchTool.input_schema();
+        assert!(schema.get("oneOf").is_some(), "fixture must match the tool");
+
+        let note = sanitize_for_xai_parameters(&mut schema);
+
+        assert_eq!(schema["type"], "object");
+        assert!(schema.get("oneOf").is_none());
+        assert!(schema.get("anyOf").is_none());
+        assert!(schema["properties"].get("patch").is_some());
+        assert!(schema["properties"].get("changes").is_some());
+        assert_eq!(
+            note.as_deref(),
+            Some(
+                "Exactly one of these parameter groups must be provided: `changes` | `patch` | `replace`."
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Live-hit release blocker: a real grok-4.5 session (device login + endpoint auth working) failed its first tool-bearing request with `Invalid request (400): apply_patch: tool parameter root must be an object type (root schema is an anyOf/oneOf union with a non-object branch)`.

xAI validates that a tool's `parameters` root is a plain object schema. The built-in `apply_patch` schema uses root `oneOf` required-groups (`patch` | `changes` | `replace`), which xAI rejects — and any MCP tool with a root union would hit the same wall.

**Fix**: new `sanitize_for_xai_parameters` (a documented reuse of the existing OpenAI Responses root-composition pass — this exact problem was already solved for the Responses API): merge root alternative properties into `properties`, force `type: object`, drop root-only composition keywords, and append the dropped "exactly one of …" constraint to the tool description so the model keeps the contract. Wired into both the non-streaming and streaming chat paths for `provider == Xai`, mirroring the Moonshot/Kimi parameter pass (#2438 precedent).

## Verification

- New test `xai_sanitize_flattens_apply_patch_root_one_of` runs the pass on the real `ApplyPatchTool` schema: object root, no `oneOf`/`anyOf`, `patch`/`changes` preserved as properties, constraint note exact.
- `cargo test -p codewhale-tui --bin codewhale-tui -- schema_sanitize` — 36 passed; `-- client` — 284 passed.
- `cargo clippy --all-targets` with CI lint flags — clean; `cargo fmt --check` — clean.

## Related

#4410 — this was found during the live xAI acceptance test; device-code login and endpoint auth succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)