### PR TITLE
fix(tui): show status feedback and update compaction budget on Ctrl+T effort cycle

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3623,13 +3623,26 @@ impl App {
         if self.reject_setting_change_while_busy("Thinking") {
             return;
         }
+        self.reasoning_effort_explicit = true;
+        self.apply_reasoning_effort_cycle();
+    }
+
+    /// Advance reasoning effort to the next tier for the active provider and
+    /// surface the change: set a status message and refresh the compaction
+    /// budget. Shared by the Ctrl+T shortcut (`cycle_effort`) and the hotbar
+    /// `reasoning.cycle` action so the two paths cannot drift.
+    pub(crate) fn apply_reasoning_effort_cycle(&mut self) {
         self.reasoning_effort = self
             .reasoning_effort
             .cycle_next_for_provider(self.api_provider);
-        self.reasoning_effort_explicit = true;
         self.last_effective_reasoning_effort = None;
+        self.update_model_compaction_budget();
+        self.status_message = Some(format!(
+            "Reasoning effort: {}",
+            self.reasoning_effort
+                .display_label_for_provider(self.api_provider)
+        ));
         self.needs_redraw = true;
-        // Effort chip in the header is canonical — no duplicate toast.
     }
 
     /// Cycle the durable Agent permission posture: Ask → Auto-Review → Bypass.

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -299,6 +299,34 @@ fn mode_and_thinking_are_locked_while_a_turn_is_running() {
 }
 
 #[test]
+fn cycle_effort_updates_effort_status_and_compaction() {
+    // Ctrl+T parity with the hotbar's `reasoning.cycle` action: cycling the
+    // effort must surface a status message and refresh the compaction budget,
+    // not just silently flip the setting.
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Deepseek;
+    app.auto_model = false;
+    app.reasoning_effort = ReasoningEffort::Off;
+    // Sentinel so the test can observe update_model_compaction_budget().
+    app.compact_threshold = 0;
+
+    app.cycle_effort();
+
+    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    assert!(app.reasoning_effort_explicit);
+    assert_eq!(
+        app.status_message.as_deref(),
+        Some("Reasoning effort: high"),
+        "Ctrl+T must give visible feedback like the hotbar action"
+    );
+    assert_ne!(
+        app.compact_threshold, 0,
+        "cycling effort must refresh the compaction budget"
+    );
+    assert!(app.needs_redraw);
+}
+
+#[test]
 fn reasoning_effort_api_values_are_provider_aware_for_codex() {
     assert_eq!(
         ReasoningEffort::Off.normalize_for_provider(ApiProvider::OpenaiCodex),

--- a/crates/tui/src/tui/hotbar/actions.rs
+++ b/crates/tui/src/tui/hotbar/actions.rs
@@ -1030,16 +1030,7 @@ impl HotbarAction for AppHotbarAction {
                 if app.auto_model {
                     bail!("Reasoning effort is controlled by auto model routing.");
                 }
-                app.reasoning_effort = app
-                    .reasoning_effort
-                    .cycle_next_for_provider(app.api_provider);
-                app.last_effective_reasoning_effort = None;
-                app.update_model_compaction_budget();
-                app.status_message = Some(format!(
-                    "Reasoning effort: {}",
-                    app.reasoning_effort
-                        .display_label_for_provider(app.api_provider)
-                ));
+                app.apply_reasoning_effort_cycle();
                 Ok(HotbarDispatch::AppAction(AppAction::UpdateCompaction(
                     app.compaction_config(),
                 )))


### PR DESCRIPTION
## Summary

Ctrl+T cycles the reasoning effort with no visible feedback in common layouts (reproduced at 140x40; the canonical header effort chip is unreachable in the default Ombre shell), and it also skipped refreshing the model compaction budget. This PR gives the Ctrl+T path parity with the hotbar's `reasoning.cycle` action by extracting one shared helper both paths call.

## Root cause

- `crates/tui/src/tui/app.rs:3622` — `App::cycle_effort` (Ctrl+T, dispatched from `crates/tui/src/tui/ui.rs:5171`) cycled `reasoning_effort` but set no `status_message` and never called `update_model_compaction_budget()`; a comment claimed the header effort chip was canonical, but that chip is not visible in the default Ombre shell.
- `crates/tui/src/tui/hotbar/actions.rs:1029-1046` — the hotbar `AppHotbarKind::ReasoningCycle` path did both (status message via `display_label_for_provider`, plus `update_model_compaction_budget()`), so the two paths had drifted.

## Change

- `crates/tui/src/tui/app.rs`: new shared helper `App::apply_reasoning_effort_cycle()` — cycles the effort for the active provider, resets `last_effective_reasoning_effort`, calls `update_model_compaction_budget()`, sets `status_message = "Reasoning effort: {label}"` using the same `display_label_for_provider` call the hotbar used, and requests a redraw. `cycle_effort` now delegates to it (keeping its busy-lock guard and `reasoning_effort_explicit = true`).
- `crates/tui/src/tui/hotbar/actions.rs`: `ReasoningCycle` now calls the same helper, so the paths cannot drift again; it still returns `AppAction::UpdateCompaction`.
- `crates/tui/src/tui/app/tests.rs`: new `cycle_effort_updates_effort_status_and_compaction` test mirroring the hotbar's `reasoning_cycle_updates_effort_and_compaction`, placed next to the existing busy-lock test.

## Verification

`cargo fmt --check -p codewhale-tui` — exit 0, no output.

`cargo clippy -p codewhale-tui --all-targets -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`:

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 07s
```
(exit 0, zero warnings)

`cargo test -p codewhale-tui --bin codewhale-tui -- effort`:

```
test tui::app::tests::cycle_effort_updates_effort_status_and_compaction ... ok
test tui::hotbar::actions::tests::reasoning_cycle_updates_effort_and_compaction ... ok
test tui::hotbar::actions::tests::reasoning_cycle_uses_codex_effort_tiers ... ok

test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 7328 filtered out; finished in 0.76s
```

Also ran `cargo test -p codewhale-tui --bin codewhale-tui -- mode_and_thinking_are_locked`:

```
test tui::app::tests::mode_and_thinking_are_locked_while_a_turn_is_running ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7378 filtered out; finished in 0.07s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
