### PR TITLE
fix(tui): insert boundary between Responses reasoning summary parts

### DIFF
--- a/crates/tui/src/client/responses.rs
+++ b/crates/tui/src/client/responses.rs
@@ -138,6 +138,11 @@ impl DeepSeekClient {
             });
 
             let mut current_block_index: Option<u32> = None;
+            // Whether reasoning text has already been emitted for the current
+            // reasoning block. Used to insert a paragraph break between
+            // consecutive summary parts, which the wire protocol delivers
+            // back-to-back with no separator.
+            let mut reasoning_text_emitted = false;
             let mut saw_tool_call = false;
             let mut usage_data: Option<Usage> = None;
             // Raw byte buffer: decode only COMPLETE lines so a multi-byte
@@ -249,6 +254,7 @@ impl DeepSeekClient {
                                                 Some(content_block_counter - 1);
                                         }
                                         "reasoning" => {
+                                            reasoning_text_emitted = false;
                                             content_block_counter += 1;
                                             yield Ok(StreamEvent::ContentBlockStart {
                                                 index: content_block_counter - 1,
@@ -296,10 +302,30 @@ impl DeepSeekClient {
                                     event.get("delta").and_then(|d| d.as_str())
                                     && let Some(idx) = current_block_index
                                 {
+                                    if !delta_text.is_empty() {
+                                        reasoning_text_emitted = true;
+                                    }
                                     yield Ok(StreamEvent::ContentBlockDelta {
                                         index: idx,
                                         delta: Delta::ThinkingDelta {
                                             thinking: delta_text.to_string(),
+                                        },
+                                    });
+                                }
+                            }
+                            "response.reasoning_summary_part.added" => {
+                                // Consecutive summary parts arrive with no
+                                // separator in the text deltas, so without a
+                                // boundary they concatenate as
+                                // "…done.**Next Phase**…". Insert a paragraph
+                                // break before every part after the first.
+                                if reasoning_text_emitted
+                                    && let Some(idx) = current_block_index
+                                {
+                                    yield Ok(StreamEvent::ContentBlockDelta {
+                                        index: idx,
+                                        delta: Delta::ThinkingDelta {
+                                            thinking: "\n\n".to_string(),
                                         },
                                     });
                                 }
@@ -935,6 +961,61 @@ mod tests {
             err.downcast_ref::<crate::llm_client::LlmError>().is_some(),
             "LlmError should survive the anyhow chain"
         );
+    }
+
+    #[tokio::test]
+    async fn responses_stream_inserts_boundary_between_reasoning_summary_parts() {
+        let server = MockServer::start().await;
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_1\",\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"partA\"}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_1\",\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"partB\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\"}\n\n",
+            "data: [DONE]\n\n",
+        );
+        Mock::given(method("POST"))
+            .and(path(CODEX_RESPONSES_PATH))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let client = {
+            let _env_lock = crate::test_support::lock_test_env();
+            let _codex_token =
+                crate::test_support::EnvVarGuard::set("OPENAI_CODEX_ACCESS_TOKEN", "test-token");
+            let _legacy_codex_token =
+                crate::test_support::EnvVarGuard::remove("CODEX_ACCESS_TOKEN");
+            DeepSeekClient::new(&test_codex_config(&server)).unwrap()
+        };
+        let mut stream = client
+            .handle_responses_stream(minimal_responses_request())
+            .await
+            .unwrap();
+
+        let mut thinking = String::new();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = stream.next().await {
+                if let StreamEvent::ContentBlockDelta {
+                    delta: Delta::ThinkingDelta { thinking: chunk },
+                    ..
+                } = event.unwrap()
+                {
+                    thinking.push_str(&chunk);
+                }
+            }
+        })
+        .await
+        .expect("Responses reasoning stream should finish after [DONE]");
+
+        // The second summary part must be separated from the first by a
+        // paragraph break, and no separator may precede the first part.
+        assert_eq!(thinking, "partA\n\npartB");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Responses SSE reasoning summary parts were concatenated with no separator, rendering run-together thinking text like `…done.**Next Phase**…`. The decoder now emits a `\n\n` ThinkingDelta boundary before each summary part after the first, so parts render as separate paragraphs.

## Root cause

In `crates/tui/src/client/responses.rs`:

- `response.reasoning_summary_text.delta` / `response.reasoning_text.delta` are mapped to `Delta::ThinkingDelta` (previously lines 293-306).
- `response.reasoning_summary_part.added` had **no arm** and fell into the ignore-unknown catch-all (previously lines 345-347), so consecutive summary parts streamed back-to-back with no separator between them.

## Change

- Added a `reasoning_text_emitted` flag, reset at the reasoning `ContentBlockStart` (`response.output_item.added` with `item.type == "reasoning"`) and set once any non-empty reasoning text delta is emitted.
- Added an arm for `response.reasoning_summary_part.added`: when reasoning text was already emitted for the current block, emit `Delta::ThinkingDelta { thinking: "\n\n" }`. No separator is emitted before the first part.
- Non-streaming fold path (`handle_responses_message`): it consumes the same `StreamEvent`s produced by the streaming decoder, so the boundary is inherited automatically. Summary parts are not distinguishable as separate entities in the fold (it only sees folded `ThinkingDelta`s), so no fold-side change is needed or possible.
- Added fixture test `responses_stream_inserts_boundary_between_reasoning_summary_parts` (wiremock SSE fixture): two summary parts yield accumulated thinking text exactly `partA\n\npartB`.

## Replay-safety check (honest result)

The premise that Codex replay uses encrypted reasoning items did **not** hold up against this codebase, but the change is still safe:

- The request builder asks for `reasoning.encrypted_content` via `include` (`responses.rs:74`), but the SSE decoder never captures encrypted content, and replay does not use it.
- Accumulated thinking text **does** feed back into requests: the turn loop persists streamed thinking into `ContentBlock::Thinking` (`crates/tui/src/core/engine/turn_loop.rs:1233-1238`), and `convert_messages_to_responses_input` replays it as a plain `reasoning` item with `summary: [{type: "summary_text", text: <thinking>}]` (`responses.rs` assistant arm, `ContentBlock::Thinking` case).
- So the injected `\n\n` **will** appear in replayed summary text. This cannot corrupt replay because the replayed payload is unsigned freeform text: no signature exists on this bridge (`Delta::SignatureDelta` never occurs on the Responses path, per the comment at the fold site referencing #3014/#3884-era behavior, and `ContentBlockStart::Thinking` is folded with `signature: None`), and no encrypted payload is round-tripped. The whitespace-only separator arguably makes the replayed summary more faithful to the upstream multi-part structure.

## Verification

`cargo fmt --check -p codewhale-tui` — exit 0, no output.

`cargo clippy -p codewhale-tui --all-targets -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`:

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 03s
```

(exit 0, zero warnings/errors in output)

`cargo test -p codewhale-tui --bin codewhale-tui -- responses_stream`:

```
running 4 tests
test client::responses::tests::responses_stream_fails_fast_on_non_retryable_provider_error ... ok
test client::responses::tests::responses_stream_inserts_boundary_between_reasoning_summary_parts ... ok
test client::responses::tests::responses_stream_retries_transient_server_error ... ok
test client::responses::tests::responses_stream_retries_rate_limited_request ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 7375 filtered out; finished in 0.02s
```

(The one compile-time warning in the test build is the pre-existing macOS linker message `__eh_frame section too large`, not a code warning.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
