### PR TITLE
fix(tui): drop redundant [open] suffix on todo rows

### DIFF
--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -508,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn todo_open_records_hitbox_and_opens_pager() {
+    fn todo_row_body_click_opens_pager_without_open_control() {
         let mut app = app();
         app.todos
             .try_lock()
@@ -519,21 +519,30 @@ mod tests {
         terminal
             .draw(|frame| super::render(frame, frame.area(), &mut app))
             .expect("draw");
+        // Inspect-only rows render no [open] suffix and record no open hitbox;
+        // the row body itself is the pager affordance.
+        let text = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!text.contains("[open]"), "{text}");
         let hit = app
             .work_surface
             .hitboxes
             .iter()
             .find(|hit| hit.id.0.starts_with("todo:"))
             .expect("todo hitbox");
-        assert!(hit.open_zone_start_col.is_some());
-        assert!(hit.open_zone_end_col.is_some());
-        let open_col = hit.open_zone_start_col.expect("open");
+        assert!(hit.open_zone_start_col.is_none());
+        assert!(hit.open_zone_end_col.is_none());
         let row_y = hit.row_y;
         let outcome = super::handle_mouse(
             &mut app,
             MouseEvent {
                 kind: MouseEventKind::Down(crossterm::event::MouseButton::Left),
-                column: open_col,
+                column: 2,
                 row: row_y,
                 modifiers: KeyModifiers::NONE,
             },

--- a/crates/tui/src/tui/work_surface/render.rs
+++ b/crates/tui/src/tui/work_surface/render.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::localization::MessageId;
-use crate::tui::app::{App, SidebarHoverRow, SidebarHoverSection};
+use crate::tui::app::{App, SidebarHoverRow, SidebarHoverSection, SidebarRowAction};
 use crate::tui::ui_text::truncate_line_to_width;
 
 use super::model::{WorkHitbox, WorkRow, WorkSurfacePlacement, WorkTone, project};
@@ -294,6 +294,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     });
 }
 
+/// Whether a row earns an `[open]` control. Rows whose only action is text
+/// inspection (todos) skip it: the row body click already opens the pager,
+/// hover shows the full text, and right-click copies it, so the suffix would
+/// only waste label width.
+fn shows_open_control(row: &WorkRow) -> bool {
+    match &row.primary_action {
+        Some(SidebarRowAction::InspectText { .. }) => row.stop_action.is_some(),
+        Some(_) => true,
+        None => false,
+    }
+}
+
 fn controls_text(
     app: &App,
     row: &WorkRow,
@@ -321,7 +333,7 @@ fn controls_text(
     let open = app.tr(MessageId::SidebarOpenControl);
     let stop = app.tr(MessageId::SidebarStopControl);
     match (
-        row.primary_action.is_some(),
+        shows_open_control(row),
         row.stop_action.is_some(),
         width < 60,
     ) {
@@ -367,7 +379,10 @@ fn control_zones(
     let mut cursor = controls_start;
     let mut open_zone = (None, None);
     let mut stop_zone = (None, None);
-    if row.primary_action.is_some() {
+    // Derive zones from the same predicate as controls_text so hitboxes always
+    // match the rendered glyphs; inspect-only rows have no [open] hitbox and
+    // rely on the row-body click to reach the pager.
+    if shows_open_control(row) {
         let open_width = UnicodeWidthStr::width(open_text.as_str()) as u16;
         open_zone = (Some(cursor), Some(cursor.saturating_add(open_width)));
         cursor = cursor.saturating_add(open_width);


### PR DESCRIPTION
## Summary

Every todo row in the work surface wasted width on a redundant ` [open]` suffix. Todo rows' only action is `InspectText`, and full text access already exists via the row-body click (pager), hover tooltip, and right-click copy — so the suffix bought nothing while shrinking the label budget on every row.

## Root cause

- `crates/tui/src/tui/work_surface/render.rs:321-333` (pre-change): `controls_text` appended `[open]` for any row with a `primary_action`, including todo rows whose only action is `InspectText` (built in `crates/tui/src/tui/work_surface/model.rs:304-323`).
- `crates/tui/src/tui/work_surface/render.rs:337-379` (pre-change): `control_zones` re-derived the open hitbox from the same `primary_action.is_some()` test, so the redundant control also got a hitbox.

## Change

- `render.rs`: new `shows_open_control(row)` predicate — rows whose only action is `InspectText` earn no `[open]` control. Both `controls_text` and `control_zones` now use it, so hitboxes always match the rendered glyphs. Row-body click remains the pager access path (`input.rs` already treats the row body as primary-activate). No new affordances added.
- `mod.rs`: pinned test renamed `todo_open_records_hitbox_and_opens_pager` → `todo_row_body_click_opens_pager_without_open_control`; it now asserts no `[open]` text or open hitbox on todo rows and clicks the row body to open the pager.

## Run rows untouched

Run/worker rows keep their `[open] [stop]` controls — their primary action is not `InspectText`. Verified by running `release_runtime_qa`, including the ignored 32-worker bench that asserts `[open] [stop]` (output below).

## Verification (all from worktree root)

`cargo fmt --check -p codewhale-tui` → exit 0, no output.

`cargo clippy -p codewhale-tui --all-targets -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants`:
```
   Compiling codewhale-tui v0.9.1 (.../crates/tui)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 25.81s
```
Exit 0, zero warnings.

`cargo test -p codewhale-tui --bin codewhale-tui -- work_surface`:
```
test tui::work_surface::tests::todo_row_body_click_opens_pager_without_open_control ... ok
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 7347 filtered out; finished in 0.22s
```

`cargo test -p codewhale-tui --test release_runtime_qa`:
```
test result: ok. 5 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 17.66s
```

`cargo test -p codewhale-tui --test release_runtime_qa --locked -- --ignored bench_thirty_two --test-threads=1` (the test asserting run-row `[open] [stop]`):
```
test release_bench_thirty_two_worker_fanout_stays_live ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 1.93s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)