### PR TITLE
feat(work-graph): core model, reducer, validation

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -122,6 +122,7 @@ mod tools;
 mod tui;
 mod utils;
 mod vision;
+mod work_graph;
 mod worker_profile;
 mod working_set;
 mod workspace_discovery;

--- a/crates/tui/src/work_graph/compat.rs
+++ b/crates/tui/src/work_graph/compat.rs
@@ -1,0 +1,35 @@
+//! Compat projections — signatures only in this slice.
+//!
+//! Invariant V10 is enforced at the type level: every projection is a pure
+//! function taking `&WorkGraphSnapshot` and returning owned data. Nothing
+//! hands a projection mutable graph access, so projections cannot write the
+//! graph or each other — one graph writes every projection.
+//!
+//! The session-compat slice implements these bodies (plan/todo snapshot
+//! derivation and legacy tool adapters). Until then they are declared but
+//! unimplemented so the type-level story — and its compile-time test — is
+//! already in force.
+
+use super::model::WorkGraphSnapshot;
+
+/// Placeholder for the derived plan snapshot (shaped in the session-compat
+/// slice to match the existing plan store's wire format).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PlanProjection;
+
+/// Placeholder for the derived todo snapshot (shaped in the session-compat
+/// slice to match the existing todo store's wire format).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TodoProjection;
+
+/// Derive the plan view. Pure function of the snapshot (V10).
+pub fn project_plan(snapshot: &WorkGraphSnapshot) -> PlanProjection {
+    let _ = snapshot;
+    unimplemented!("implemented in the session-compat slice")
+}
+
+/// Derive the todo view. Pure function of the snapshot (V10).
+pub fn project_todos(snapshot: &WorkGraphSnapshot) -> TodoProjection {
+    let _ = snapshot;
+    unimplemented!("implemented in the session-compat slice")
+}

--- a/crates/tui/src/work_graph/events.rs
+++ b/crates/tui/src/work_graph/events.rs
@@ -1,0 +1,222 @@
+//! Changes, observations, and receipts — the reducer's entire input/output
+//! vocabulary.
+//!
+//! The reducer never reads clocks or RNG: [`ChangeCtx`] carries the timestamp,
+//! the session identity used for deterministic ID derivation, and an optional
+//! idempotency key. Same snapshot + same change + same ctx ⇒ same result,
+//! always.
+//!
+//! Spec-silent shapes chosen minimally here (documented on each type):
+//! [`WorkNodePatch`], [`WorkGraphProposal`], [`ApprovalRef`], and the
+//! placeholder observation types that later slices' liveness adapters will
+//! feed ([`OperationObservation`], [`OwnerState`], [`CancelOutcome`]).
+
+use serde::{Deserialize, Serialize};
+
+use super::ids::{ChangeId, ProposalId, WorkEdgeId, WorkNodeId};
+use super::model::{
+    AcceptanceRequirement, EvidenceRef, IdempotencyKey, NodeState, OperationBinding, Provenance,
+    Ts, WorkEdge, WorkNode,
+};
+
+/// A single mutation of the work graph. The reducer is the only write path;
+/// UI, tools, and runtime adapters all speak this vocabulary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+// Variants intentionally carry full payloads (a node, a proposal) rather than
+// boxed indirection: changes are transient values, not stored long-term.
+#[allow(clippy::large_enum_variant)]
+pub enum WorkGraphChange {
+    AddNode {
+        node: WorkNode,
+    },
+    UpdateNode {
+        id: WorkNodeId,
+        patch: WorkNodePatch,
+    },
+    AddEdge {
+        edge: WorkEdge,
+    },
+    RemoveEdge {
+        id: WorkEdgeId,
+    },
+    BindOperation {
+        node: WorkNodeId,
+        binding: OperationBinding,
+    },
+    ReconcileOperation {
+        node: WorkNodeId,
+        obs: OperationObservation,
+    },
+    AttachEvidence {
+        node: WorkNodeId,
+        evidence: EvidenceRef,
+    },
+    ProposePlanDiff {
+        proposal: WorkGraphProposal,
+    },
+    AcceptPlanDiff {
+        proposal_id: ProposalId,
+        approval: ApprovalRef,
+    },
+    Supersede {
+        old: WorkNodeId,
+        replacement: WorkNodeId,
+    },
+}
+
+impl WorkGraphChange {
+    /// Stable discriminant name recorded on receipts. Names only — receipts
+    /// never carry payload text.
+    #[must_use]
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            WorkGraphChange::AddNode { .. } => "add_node",
+            WorkGraphChange::UpdateNode { .. } => "update_node",
+            WorkGraphChange::AddEdge { .. } => "add_edge",
+            WorkGraphChange::RemoveEdge { .. } => "remove_edge",
+            WorkGraphChange::BindOperation { .. } => "bind_operation",
+            WorkGraphChange::ReconcileOperation { .. } => "reconcile_operation",
+            WorkGraphChange::AttachEvidence { .. } => "attach_evidence",
+            WorkGraphChange::ProposePlanDiff { .. } => "propose_plan_diff",
+            WorkGraphChange::AcceptPlanDiff { .. } => "accept_plan_diff",
+            WorkGraphChange::Supersede { .. } => "supersede",
+        }
+    }
+}
+
+/// Partial update of a node. Spec-silent shape: `Option` per patchable field,
+/// `None` meaning "leave unchanged". Identity, kind, binding, and evidence
+/// are deliberately NOT patchable here — they move only through their
+/// dedicated changes (`BindOperation`, `AttachEvidence`, `Supersede`).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct WorkNodePatch {
+    pub title: Option<String>,
+    pub state: Option<NodeState>,
+    pub acceptance: Option<Vec<AcceptanceRequirement>>,
+    pub provenance: Option<Provenance>,
+}
+
+/// A reviewable plan diff. Spec-silent shape: explicit added/updated/removed
+/// sets rather than nested changes, so the whole delta is inspectable before
+/// acceptance and applies atomically (validated as one unit — no silent
+/// mutation of objectives, dependencies, acceptance, or scope).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkGraphProposal {
+    pub id: ProposalId,
+    pub added_nodes: Vec<WorkNode>,
+    pub added_edges: Vec<WorkEdge>,
+    pub updated_nodes: Vec<ProposedNodeUpdate>,
+    pub removed_edges: Vec<WorkEdgeId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposedNodeUpdate {
+    pub id: WorkNodeId,
+    pub patch: WorkNodePatch,
+}
+
+/// Reference to the approval that accepted a plan diff. Spec-silent shape:
+/// a reference-only string (approval receipt / user action handle), recorded
+/// on the Approval node the acceptance creates.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalRef {
+    pub reference: String,
+}
+
+/// Lifecycle state as reported by an operation's owner. Placeholder for the
+/// liveness slice; present now so reducer signatures are final.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnerState {
+    Running,
+    Waiting,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// Typed cancellation outcomes, mirroring real owner semantics (immediate
+/// abort vs teardown-wait vs already-finished vs unknown-after-restart).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CancelOutcome {
+    Requested,
+    Acknowledged,
+    Forced,
+    AlreadyFinished,
+    NotFound,
+    StaleUnknown,
+}
+
+/// An observation about a bound operation, produced by owner adapters (later
+/// slice) and consumed by the reducer. The reducer applies these purely; it
+/// never queries owners itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationObservation {
+    /// Owner is authoritative. Idempotency key = `(binding, seq)`.
+    OwnerReported {
+        state: OwnerState,
+        seq: u64,
+        at: Ts,
+    },
+    /// No live handle for the binding (e.g. after restart). Never maps to
+    /// Active or Completed — only to Stale (fail toward honesty).
+    OwnerMissing {
+        checked_at: Ts,
+    },
+    CancelUpdate {
+        outcome: CancelOutcome,
+        at: Ts,
+    },
+}
+
+/// Compact record of the most recent observation, stored on the binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservationSummary {
+    pub owner_state: OwnerState,
+    pub seq: u64,
+    pub observed_at: Ts,
+}
+
+/// Everything ambient the reducer needs, supplied by the caller so the
+/// reducer itself stays pure: no clock reads, no RNG, no globals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeCtx {
+    /// Session identity used for deterministic ID derivation.
+    pub session_id: String,
+    /// Timestamp to record for this change (milliseconds since Unix epoch).
+    pub now: Ts,
+    /// Present for owner-observation changes; duplicates inside the
+    /// snapshot's dedup window become no-op receipts.
+    pub idempotency_key: Option<IdempotencyKey>,
+}
+
+/// Receipt for an applied (or deduplicated) change. Bounded history of these
+/// lives on the snapshot. Receipts carry discriminant names and identifiers
+/// only — no payload text, no secrets.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChangeReceipt {
+    pub change_id: ChangeId,
+    pub revision: u64,
+    pub summary: String,
+    pub applied_at: Ts,
+    pub idempotency_key: Option<IdempotencyKey>,
+    pub no_op: bool,
+}
+
+impl ChangeReceipt {
+    #[must_use]
+    pub fn of(change: &WorkGraphChange, revision: u64, ctx: &ChangeCtx) -> Self {
+        let kind = change.kind_name();
+        ChangeReceipt {
+            change_id: ChangeId::derive(&ctx.session_id, &format!("change:{revision}:{kind}")),
+            revision,
+            summary: kind.to_string(),
+            applied_at: ctx.now,
+            idempotency_key: ctx.idempotency_key.clone(),
+            no_op: false,
+        }
+    }
+}

--- a/crates/tui/src/work_graph/ids.rs
+++ b/crates/tui/src/work_graph/ids.rs
@@ -1,0 +1,82 @@
+//! Deterministic identifiers for the work graph.
+//!
+//! Every ID derives from `(session_id, discriminator)` via SHA-256 — there is
+//! no RNG anywhere in this module tree — so replaying the same change
+//! sequence (or re-importing the same legacy state) yields byte-identical
+//! graphs, IDs included. That determinism is what makes import idempotent and
+//! snapshots comparable across processes.
+//!
+//! Format: `<prefix>` + first 12 hex chars of
+//! `sha256(prefix U+001F session_id U+001F discriminator)`. The unit
+//! separator keeps `("ab", "c")` and `("a", "bc")` from colliding, and the
+//! prefix participates in the hash so distinct ID types never share digests
+//! for the same discriminator.
+
+use serde::{Deserialize, Serialize};
+
+use crate::hashing::sha256_hex;
+
+fn derive_raw(prefix: &str, session_id: &str, discriminator: &str) -> String {
+    let digest = sha256_hex(format!("{prefix}\u{1f}{session_id}\u{1f}{discriminator}"));
+    format!("{prefix}{}", &digest[..12])
+}
+
+macro_rules! graph_id {
+    ($(#[$meta:meta])* $name:ident, $prefix:literal) => {
+        $(#[$meta])*
+        #[derive(
+            Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub const PREFIX: &'static str = $prefix;
+
+            /// Deterministically derive an ID from the owning session and a
+            /// caller-chosen discriminator (e.g. `"plan:3"`, `"objective"`).
+            #[must_use]
+            pub fn derive(session_id: &str, discriminator: &str) -> Self {
+                Self(derive_raw($prefix, session_id, discriminator))
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+graph_id!(
+    /// Identity of a node in the work graph (`"wn:" + sha256(...)[..12]`).
+    WorkNodeId,
+    "wn:"
+);
+graph_id!(
+    /// Identity of an edge in the work graph.
+    WorkEdgeId,
+    "we:"
+);
+graph_id!(
+    /// Identity of an applied change (recorded on its [`ChangeReceipt`](super::ChangeReceipt)).
+    ChangeId,
+    "ch:"
+);
+graph_id!(
+    /// Identity of a proposed plan diff awaiting review.
+    ProposalId,
+    "pp:"
+);
+graph_id!(
+    /// Identity of an operation binding; used with an owner-reported sequence
+    /// number as the reducer idempotency key.
+    BindingId,
+    "bd:"
+);

--- a/crates/tui/src/work_graph/mod.rs
+++ b/crates/tui/src/work_graph/mod.rs
@@ -1,0 +1,96 @@
+//! Work Graph — the single authoritative work ledger for a session.
+//!
+//! One graph carries objectives, plan steps, operations, evidence, blockers,
+//! and approvals. **Invariant: one graph writes every projection; projections
+//! never write each other.** Plan and todo views, work-surface rows, and the
+//! inspector all derive from [`WorkGraphSnapshot`] through pure functions.
+//!
+//! Why a graph instead of parallel trackers: flat status lists let an agent
+//! mark work "done" by assertion, lose dependency structure, and cannot say
+//! what evidence backed a completion. Here completion and verification are
+//! distinct states, `Verified` is unreachable without a satisfying evidence
+//! path (V4, fail-closed), dependencies are first-class edges (acyclic, V1),
+//! and liveness truth stays with the owning subsystems — the graph records
+//! observations, it never invents them.
+//!
+//! This slice is the core only: model, changes, pure reducer, validation.
+//! Session persistence, legacy import, UI projections, and liveness adapters
+//! land in later slices; nothing in the app or engine calls this yet.
+// Staged cutover: later slices wire persistence, UI, and liveness; until
+// then the public surface (including re-exports) has no external callers.
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+mod compat;
+mod events;
+mod ids;
+mod model;
+mod reducer;
+mod validate;
+
+#[cfg(test)]
+mod tests;
+
+pub use events::{
+    ApprovalRef, CancelOutcome, ChangeCtx, ChangeReceipt, ObservationSummary, OperationObservation,
+    OwnerState, ProposedNodeUpdate, WorkGraphChange, WorkGraphProposal, WorkNodePatch,
+};
+pub use ids::{BindingId, ChangeId, ProposalId, WorkEdgeId, WorkNodeId};
+pub use model::{
+    AcceptanceRequirement, BoundedSet, BoundedVec, EdgeKind, EvidenceKind, EvidenceKindTag,
+    EvidenceRef, EvidenceRefError, HISTORY_CAP, IdempotencyKey, NodeKind, NodeState,
+    OperationBinding, Provenance, SCHEMA_VERSION, SEEN_KEYS_CAP, Ts, WorkEdge, WorkGraphSnapshot,
+    WorkNode, external_identity_is_well_formed,
+};
+pub use reducer::apply;
+pub use validate::{ValidationCode, ValidationReport, Violation, validate};
+
+/// Convenience wrapper owning the current snapshot. [`WorkGraph::apply`]
+/// commits the reducer's result on success and leaves the snapshot untouched
+/// on rejection — the fail-closed contract, packaged.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkGraph {
+    snapshot: WorkGraphSnapshot,
+}
+
+impl WorkGraph {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            snapshot: WorkGraphSnapshot::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn from_snapshot(snapshot: WorkGraphSnapshot) -> Self {
+        Self { snapshot }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> &WorkGraphSnapshot {
+        &self.snapshot
+    }
+
+    #[must_use]
+    pub fn into_snapshot(self) -> WorkGraphSnapshot {
+        self.snapshot
+    }
+
+    /// Apply one change through the reducer. On `Ok` the new snapshot is
+    /// committed; on `Err` the held snapshot is unchanged.
+    pub fn apply(
+        &mut self,
+        change: WorkGraphChange,
+        ctx: ChangeCtx,
+    ) -> Result<ChangeReceipt, ValidationReport> {
+        let (next, receipt) = reducer::apply(&self.snapshot, change, ctx)?;
+        self.snapshot = next;
+        Ok(receipt)
+    }
+}
+
+impl Default for WorkGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tui/src/work_graph/model.rs
+++ b/crates/tui/src/work_graph/model.rs
@@ -1,0 +1,580 @@
+//! Core work-graph data model.
+//!
+//! One graph carries plan, todo, operations, evidence, and approvals; every
+//! user-visible projection derives from it and never writes back. The model is
+//! plain data — no threads, no service objects — mutated only through the
+//! reducer in [`super::reducer`].
+//!
+//! Design notes where the cutover spec is silent:
+//! - Timestamps are a plain `i64` of milliseconds since the Unix epoch
+//!   ([`Ts`]); the reducer never reads clocks, so callers supply them.
+//! - [`WorkEdge`] is `{id, kind, from, to}` — the minimal directed labeled
+//!   edge. `Contains` points parent → child; `Verifies` points evidence →
+//!   verified node; `Supersedes` points replacement → superseded.
+//! - Evidence payloads live on Evidence-kind nodes via [`WorkNode::evidence`];
+//!   verification checks walk `Verifies` edges to those nodes.
+//! - [`BoundedVec`] / [`BoundedSet`] are small deterministic FIFO containers
+//!   (oldest entry evicted first); no hashing, so iteration order is stable.
+
+use serde::{Deserialize, Serialize};
+
+use super::events::{ChangeReceipt, ObservationSummary, WorkGraphProposal};
+use super::ids::{BindingId, WorkEdgeId, WorkNodeId};
+
+/// Milliseconds since the Unix epoch (UTC). Supplied by callers via
+/// [`super::ChangeCtx`]; the reducer never reads clocks itself.
+pub type Ts = i64;
+
+/// Current snapshot schema version.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Bounded change-history window kept on the snapshot.
+pub const HISTORY_CAP: usize = 256;
+
+/// Bounded idempotency-key dedup window kept on the snapshot.
+pub const SEEN_KEYS_CAP: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeKind {
+    Objective,
+    PlanStep,
+    Operation,
+    Evidence,
+    Blocker,
+    Approval,
+    RuntimeRef,
+    LaneRef,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeKind {
+    Contains,
+    DependsOn,
+    Blocks,
+    Produces,
+    Verifies,
+    RunsOn,
+    RequiresApproval,
+    Supersedes,
+}
+
+/// Node lifecycle state. The load-bearing distinction: [`NodeState::Completed`]
+/// means an operation *ended*; only [`NodeState::Verified`] — reachable solely
+/// when an evidence path satisfies every acceptance requirement — means done.
+/// An ended process is never proof its acceptance criteria hold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeState {
+    Ready,
+    Active,
+    Waiting,
+    Blocked,
+    /// Operation ended — NOT done.
+    Completed,
+    /// Evidence path satisfies acceptance — this is "done".
+    Verified,
+    /// The owner can no longer confirm the process (distinct from
+    /// silent-but-live; a confirmed-live silent job stays `Active`).
+    Stale,
+    Superseded,
+    Cancelled,
+    Failed,
+}
+
+impl NodeState {
+    /// Terminal states protected by invariant V9: never overwritten except
+    /// via an explicit `Supersede` change or a reconcile-rule change.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            NodeState::Verified | NodeState::Superseded | NodeState::Cancelled
+        )
+    }
+
+    /// Live states for invariant V2 (no orphaned live work).
+    #[must_use]
+    pub fn is_live(self) -> bool {
+        matches!(self, NodeState::Active | NodeState::Waiting)
+    }
+}
+
+/// Fieldless discriminant of [`EvidenceKind`], used by acceptance
+/// requirements so they can match a kind without naming payload values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKindTag {
+    ToolRun,
+    Artifact,
+    TestSummary,
+    Receipt,
+    Approval,
+    Route,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceKind {
+    ToolRun,
+    Artifact { digest: String },
+    TestSummary,
+    Receipt { owner: String },
+    Approval,
+    Route,
+}
+
+impl EvidenceKind {
+    #[must_use]
+    pub fn tag(&self) -> EvidenceKindTag {
+        match self {
+            EvidenceKind::ToolRun => EvidenceKindTag::ToolRun,
+            EvidenceKind::Artifact { .. } => EvidenceKindTag::Artifact,
+            EvidenceKind::TestSummary => EvidenceKindTag::TestSummary,
+            EvidenceKind::Receipt { .. } => EvidenceKindTag::Receipt,
+            EvidenceKind::Approval => EvidenceKindTag::Approval,
+            EvidenceKind::Route => EvidenceKindTag::Route,
+        }
+    }
+}
+
+/// Reason an [`EvidenceRef`] could not be constructed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidenceRefError {
+    EmptyReference,
+    ReferenceTooLong { len: usize },
+    AbsolutePath,
+    HomeRelativePath,
+    ContainsWhitespaceOrControl,
+    LooksLikeKeyMaterial,
+}
+
+impl std::fmt::Display for EvidenceRefError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvidenceRefError::EmptyReference => write!(f, "evidence reference is empty"),
+            EvidenceRefError::ReferenceTooLong { len } => {
+                write!(f, "evidence reference too long ({len} chars)")
+            }
+            EvidenceRefError::AbsolutePath => {
+                write!(f, "evidence reference must not be an absolute path")
+            }
+            EvidenceRefError::HomeRelativePath => {
+                write!(f, "evidence reference must not be a home-relative path")
+            }
+            EvidenceRefError::ContainsWhitespaceOrControl => {
+                write!(
+                    f,
+                    "evidence reference must not contain whitespace or control chars"
+                )
+            }
+            EvidenceRefError::LooksLikeKeyMaterial => {
+                write!(f, "evidence reference must not embed key material")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EvidenceRefError {}
+
+const EVIDENCE_REFERENCE_MAX_LEN: usize = 512;
+
+/// Summary/reference-only pointer to evidence: a logical artifact ID, run ID,
+/// or receipt handle — never absolute paths, never secrets, never raw logs or
+/// reasoning text.
+///
+/// Enforced by construction where feasible: fields are private, [`Self::new`]
+/// is the only way to build one (serde routes through it via `try_from`), and
+/// it rejects absolute/home paths, whitespace/control characters (which also
+/// blocks pasted log or prose content), and PEM-style key-material markers.
+/// `raw_bytes` records the pre-truncation size of the underlying output so
+/// "still growing" and "stuck" stay distinguishable after truncation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "EvidenceRefRaw", into = "EvidenceRefRaw")]
+pub struct EvidenceRef {
+    kind: EvidenceKind,
+    reference: String,
+    raw_bytes: Option<u64>,
+    truncated: bool,
+}
+
+impl EvidenceRef {
+    pub fn new(
+        kind: EvidenceKind,
+        reference: impl Into<String>,
+        raw_bytes: Option<u64>,
+        truncated: bool,
+    ) -> Result<Self, EvidenceRefError> {
+        let reference = reference.into();
+        if reference.is_empty() {
+            return Err(EvidenceRefError::EmptyReference);
+        }
+        if reference.chars().count() > EVIDENCE_REFERENCE_MAX_LEN {
+            return Err(EvidenceRefError::ReferenceTooLong {
+                len: reference.chars().count(),
+            });
+        }
+        let mut chars = reference.chars();
+        let first = chars.next().unwrap_or('\0');
+        // Unix absolute, UNC/backslash, or `X:/`-style drive paths.
+        let drive_absolute = {
+            let bytes = reference.as_bytes();
+            bytes.len() >= 3
+                && bytes[0].is_ascii_alphabetic()
+                && bytes[1] == b':'
+                && (bytes[2] == b'/' || bytes[2] == b'\\')
+        };
+        if first == '/' || first == '\\' || drive_absolute {
+            return Err(EvidenceRefError::AbsolutePath);
+        }
+        if first == '~' {
+            return Err(EvidenceRefError::HomeRelativePath);
+        }
+        if reference
+            .chars()
+            .any(|c| c.is_whitespace() || c.is_control())
+        {
+            return Err(EvidenceRefError::ContainsWhitespaceOrControl);
+        }
+        if reference.contains("-----BEGIN") {
+            return Err(EvidenceRefError::LooksLikeKeyMaterial);
+        }
+        Ok(Self {
+            kind,
+            reference,
+            raw_bytes,
+            truncated,
+        })
+    }
+
+    #[must_use]
+    pub fn kind(&self) -> &EvidenceKind {
+        &self.kind
+    }
+
+    #[must_use]
+    pub fn reference(&self) -> &str {
+        &self.reference
+    }
+
+    /// Pre-truncation size of the underlying output, persisted on the node.
+    #[must_use]
+    pub fn raw_bytes(&self) -> Option<u64> {
+        self.raw_bytes
+    }
+
+    #[must_use]
+    pub fn truncated(&self) -> bool {
+        self.truncated
+    }
+}
+
+/// Serde shadow for [`EvidenceRef`] so deserialization re-runs constructor
+/// validation instead of bypassing it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceRefRaw {
+    kind: EvidenceKind,
+    reference: String,
+    raw_bytes: Option<u64>,
+    truncated: bool,
+}
+
+impl TryFrom<EvidenceRefRaw> for EvidenceRef {
+    type Error = EvidenceRefError;
+
+    fn try_from(raw: EvidenceRefRaw) -> Result<Self, Self::Error> {
+        EvidenceRef::new(raw.kind, raw.reference, raw.raw_bytes, raw.truncated)
+    }
+}
+
+impl From<EvidenceRef> for EvidenceRefRaw {
+    fn from(value: EvidenceRef) -> Self {
+        EvidenceRefRaw {
+            kind: value.kind,
+            reference: value.reference,
+            raw_bytes: value.raw_bytes,
+            truncated: value.truncated,
+        }
+    }
+}
+
+/// A requirement that must be satisfied by evidence before a node may be
+/// [`NodeState::Verified`] (invariant V4).
+///
+/// Deliberately minimal for this slice: one variant matching an evidence kind.
+/// Richer predicates (thresholds, specific commands) can be added as variants
+/// without touching the verification walk.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcceptanceRequirement {
+    /// Satisfied when at least one attached evidence item has this kind.
+    EvidenceOfKind { kind: EvidenceKindTag },
+}
+
+impl AcceptanceRequirement {
+    #[must_use]
+    pub fn is_satisfied_by(&self, evidence: &EvidenceRef) -> bool {
+        match self {
+            AcceptanceRequirement::EvidenceOfKind { kind } => evidence.kind().tag() == *kind,
+        }
+    }
+}
+
+/// Where a fact in the graph came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+    Import {
+        source_digest: String,
+        ordinal: Option<u32>,
+    },
+    ToolUpdate {
+        tool: String,
+        call_id: String,
+    },
+    RuntimeReconcile {
+        source: String,
+        observed_at: Ts,
+    },
+    UserEdit {
+        proposal_id: super::ids::ProposalId,
+    },
+}
+
+/// Binding from an Operation node to the external process that owns its
+/// lifecycle. `external` uses the existing identity scheme verbatim:
+/// `"task:{id}" | "shell:{id}" | "worker:{id}" | "workflow:{id}" |
+/// "fleet:{run}/{task}" | "lane:{id}"` — the same strings the live work
+/// surface already parses for actions, so bindings stay joinable with
+/// today's owners without translation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OperationBinding {
+    pub external: String,
+    /// Whether the owner persists lifecycle records across restart. Shell
+    /// sessions are in-memory only (`durable == false`): after a restart they
+    /// become [`NodeState::Stale`], never silently "still running".
+    pub durable: bool,
+    pub last_observation: Option<ObservationSummary>,
+}
+
+/// Returns true when `external` is well-formed under exactly one prefix of
+/// the existing identity scheme.
+#[must_use]
+pub fn external_identity_is_well_formed(external: &str) -> bool {
+    fn plain(id: &str) -> bool {
+        !id.is_empty() && !id.chars().any(|c| c.is_whitespace() || c.is_control())
+    }
+    if let Some(rest) = external.strip_prefix("fleet:") {
+        return match rest.split_once('/') {
+            Some((run, task)) => plain(run) && plain(task),
+            None => false,
+        };
+    }
+    ["task:", "shell:", "worker:", "workflow:", "lane:"]
+        .iter()
+        .any(|prefix| external.strip_prefix(prefix).is_some_and(plain))
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkNode {
+    pub id: WorkNodeId,
+    pub kind: NodeKind,
+    pub title: String,
+    pub state: NodeState,
+    /// Empty acceptance means [`NodeState::Completed`] may render as done;
+    /// non-empty acceptance makes `Verified` (evidence-gated) the only done.
+    pub acceptance: Vec<AcceptanceRequirement>,
+    /// Operation nodes only (invariant V3).
+    pub binding: Option<OperationBinding>,
+    /// Evidence-kind nodes only; the payload the `Verifies` walk reads.
+    pub evidence: Option<EvidenceRef>,
+    pub provenance: Provenance,
+    pub created_at: Ts,
+    pub updated_at: Ts,
+}
+
+/// Directed labeled edge. Minimal by design; edge-level metadata can be
+/// modeled as nodes (e.g. Approval) rather than edge payloads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkEdge {
+    pub id: WorkEdgeId,
+    pub kind: EdgeKind,
+    pub from: WorkNodeId,
+    pub to: WorkNodeId,
+}
+
+/// Idempotency key for owner-reported observations: `(binding, seq)`. Applied
+/// changes carrying a key already inside the snapshot's dedup window become
+/// receipts without effect, so replayed runtime events cannot double-apply.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct IdempotencyKey {
+    pub binding: BindingId,
+    pub seq: u64,
+}
+
+/// Deterministic FIFO vector bounded at `N`: pushing beyond capacity evicts
+/// the oldest entry. Kept as a plain `Vec` so ordering (and serialization) is
+/// stable. The bound is re-checked by validation (V8), so an oversized
+/// deserialized snapshot fails closed rather than growing unbounded.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BoundedVec<T, const N: usize> {
+    items: Vec<T>,
+}
+
+impl<T, const N: usize> BoundedVec<T, N> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    pub fn push_bounded(&mut self, item: T) {
+        if self.items.len() >= N {
+            self.items.remove(0);
+        }
+        self.items.push(item);
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    #[must_use]
+    pub fn last(&self) -> Option<&T> {
+        self.items.last()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.items.iter()
+    }
+
+    #[must_use]
+    pub const fn capacity() -> usize {
+        N
+    }
+}
+
+impl<T, const N: usize> Default for BoundedVec<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Deterministic FIFO set bounded at `N`: inserting a duplicate is a no-op;
+/// inserting beyond capacity evicts the oldest member. Linear scans keep it
+/// hash-free and iteration-order stable for reproducible serialization.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BoundedSet<T, const N: usize> {
+    items: Vec<T>,
+}
+
+impl<T: PartialEq, const N: usize> BoundedSet<T, N> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    #[must_use]
+    pub fn contains(&self, item: &T) -> bool {
+        self.items.contains(item)
+    }
+
+    /// Returns true if the item was newly inserted.
+    pub fn insert(&mut self, item: T) -> bool {
+        if self.contains(&item) {
+            return false;
+        }
+        if self.items.len() >= N {
+            self.items.remove(0);
+        }
+        self.items.push(item);
+        true
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl<T: PartialEq, const N: usize> Default for BoundedSet<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The whole graph as a value. Serialized opaquely inside session state by a
+/// later slice; this slice keeps it standalone.
+///
+/// `proposals` is a spec-silent addition: pending plan-diff proposals must
+/// live somewhere the reducer can find them when `AcceptPlanDiff` arrives by
+/// ID, and the snapshot is the only state the reducer sees.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkGraphSnapshot {
+    pub schema: u32,
+    pub revision: u64,
+    pub nodes: Vec<WorkNode>,
+    pub edges: Vec<WorkEdge>,
+    pub history: BoundedVec<ChangeReceipt, HISTORY_CAP>,
+    pub import_digest: Option<String>,
+    /// `(binding, seq)` dedup window for replayed runtime observations.
+    pub seen_keys: BoundedSet<IdempotencyKey, SEEN_KEYS_CAP>,
+    pub proposals: Vec<WorkGraphProposal>,
+}
+
+impl WorkGraphSnapshot {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            schema: SCHEMA_VERSION,
+            revision: 0,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            history: BoundedVec::new(),
+            import_digest: None,
+            seen_keys: BoundedSet::new(),
+            proposals: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn node(&self, id: &WorkNodeId) -> Option<&WorkNode> {
+        self.nodes.iter().find(|n| &n.id == id)
+    }
+
+    pub(super) fn node_mut(&mut self, id: &WorkNodeId) -> Option<&mut WorkNode> {
+        self.nodes.iter_mut().find(|n| &n.id == id)
+    }
+
+    #[must_use]
+    pub fn edge(&self, id: &WorkEdgeId) -> Option<&WorkEdge> {
+        self.edges.iter().find(|e| &e.id == id)
+    }
+
+    /// "Done" for dependency/approval purposes: verified, or completed with
+    /// no acceptance requirements (nothing left to verify).
+    #[must_use]
+    pub fn node_is_done(node: &WorkNode) -> bool {
+        matches!(node.state, NodeState::Verified)
+            || (matches!(node.state, NodeState::Completed) && node.acceptance.is_empty())
+    }
+}
+
+impl Default for WorkGraphSnapshot {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tui/src/work_graph/reducer.rs
+++ b/crates/tui/src/work_graph/reducer.rs
@@ -1,0 +1,366 @@
+//! The only write path for the work graph.
+//!
+//! [`apply`] is pure and deterministic: no clock reads, no RNG, no I/O — the
+//! caller-supplied [`ChangeCtx`] carries timestamps and session identity, and
+//! every derived ID comes from SHA-256 over `(session_id, discriminator)`.
+//! The same snapshot + change + ctx always produce byte-identical results.
+//!
+//! Contract per change:
+//! 1. idempotency-key duplicates are acknowledged as no-op receipts;
+//! 2. the change is applied to a copy;
+//! 3. the candidate is validated fail-closed — on any violation the input
+//!    snapshot is untouched and the caller gets the full report;
+//! 4. the revision increments exactly once;
+//! 5. the receipt is pushed onto the bounded history.
+//!
+//! Callers on `Ok`: derive compat snapshots → validate combined → persist →
+//! publish projections (publish AFTER the persist enqueue, never before).
+//! On `Err`: surface the report; no state changed.
+
+use super::events::{
+    CancelOutcome, ChangeCtx, ChangeReceipt, ObservationSummary, OperationObservation, OwnerState,
+    WorkGraphChange, WorkGraphProposal, WorkNodePatch,
+};
+use super::ids::{ChangeId, WorkEdgeId, WorkNodeId};
+use super::model::{
+    EdgeKind, EvidenceRef, NodeKind, NodeState, OperationBinding, Provenance, WorkEdge,
+    WorkGraphSnapshot, WorkNode,
+};
+use super::validate::{ValidationCode, ValidationReport, validate};
+
+/// Apply one change, producing the next snapshot and a receipt, or a
+/// validation report with the input snapshot untouched.
+pub fn apply(
+    g: &WorkGraphSnapshot,
+    change: WorkGraphChange,
+    ctx: ChangeCtx,
+) -> Result<(WorkGraphSnapshot, ChangeReceipt), ValidationReport> {
+    if let Some(key) = &ctx.idempotency_key {
+        if g.seen_keys.contains(key) {
+            // Duplicate runtime event: acknowledge without effect.
+            let receipt = ChangeReceipt {
+                change_id: ChangeId::derive(
+                    &ctx.session_id,
+                    &format!("noop:{}:{}", key.binding.as_str(), key.seq),
+                ),
+                revision: g.revision,
+                summary: format!("{} (duplicate)", change.kind_name()),
+                applied_at: ctx.now,
+                idempotency_key: Some(key.clone()),
+                no_op: true,
+            };
+            return Ok((g.clone(), receipt));
+        }
+    }
+
+    let mut next = apply_pure(g, &change, &ctx)?;
+    validate(&next)?; // fail closed: `g` unchanged on Err
+    next.revision = g.revision + 1; // exactly once
+    let receipt = ChangeReceipt::of(&change, next.revision, &ctx);
+    next.history.push_bounded(receipt.clone());
+    if let Some(key) = ctx.idempotency_key {
+        next.seen_keys.insert(key);
+    }
+    Ok((next, receipt))
+}
+
+fn structural(message: impl Into<String>) -> ValidationReport {
+    ValidationReport::single(ValidationCode::Structural, message)
+}
+
+fn apply_pure(
+    g: &WorkGraphSnapshot,
+    change: &WorkGraphChange,
+    ctx: &ChangeCtx,
+) -> Result<WorkGraphSnapshot, ValidationReport> {
+    let mut next = g.clone();
+    match change {
+        WorkGraphChange::AddNode { node } => {
+            add_node(&mut next, node.clone())?;
+        }
+        WorkGraphChange::UpdateNode { id, patch } => {
+            patch_node(&mut next, id, patch, ctx.now)?;
+        }
+        WorkGraphChange::AddEdge { edge } => {
+            add_edge(&mut next, edge.clone())?;
+        }
+        WorkGraphChange::RemoveEdge { id } => {
+            let before = next.edges.len();
+            next.edges.retain(|e| &e.id != id);
+            if next.edges.len() == before {
+                return Err(structural(format!("edge {id} not found")));
+            }
+        }
+        WorkGraphChange::BindOperation { node, binding } => {
+            let now = ctx.now;
+            let target = next
+                .node_mut(node)
+                .ok_or_else(|| structural(format!("node {node} not found")))?;
+            target.binding = Some(binding.clone());
+            target.updated_at = now;
+        }
+        WorkGraphChange::ReconcileOperation { node, obs } => {
+            reconcile(&mut next, node, obs, ctx)?;
+        }
+        WorkGraphChange::AttachEvidence { node, evidence } => {
+            attach_evidence(&mut next, node, evidence, ctx)?;
+        }
+        WorkGraphChange::ProposePlanDiff { proposal } => {
+            if next.proposals.iter().any(|p| p.id == proposal.id) {
+                return Err(structural(format!("duplicate proposal {}", proposal.id)));
+            }
+            next.proposals.push(proposal.clone());
+        }
+        WorkGraphChange::AcceptPlanDiff {
+            proposal_id,
+            approval,
+        } => {
+            let index = next
+                .proposals
+                .iter()
+                .position(|p| p.id == *proposal_id)
+                .ok_or_else(|| structural(format!("proposal {proposal_id} not found")))?;
+            let proposal = next.proposals.remove(index);
+            apply_proposal(&mut next, &proposal, ctx)?;
+            // Record the acceptance as an Approval node so the review action
+            // itself is part of the graph's history.
+            let approval_node = WorkNode {
+                id: WorkNodeId::derive(
+                    &ctx.session_id,
+                    &format!("approval:{}", proposal_id.as_str()),
+                ),
+                kind: NodeKind::Approval,
+                title: format!("plan diff approved: {}", approval.reference),
+                state: NodeState::Completed,
+                acceptance: Vec::new(),
+                binding: None,
+                evidence: None,
+                provenance: Provenance::UserEdit {
+                    proposal_id: proposal_id.clone(),
+                },
+                created_at: ctx.now,
+                updated_at: ctx.now,
+            };
+            add_node(&mut next, approval_node)?;
+        }
+        WorkGraphChange::Supersede { old, replacement } => {
+            if old == replacement {
+                return Err(structural("node cannot supersede itself"));
+            }
+            if next.node(replacement).is_none() {
+                return Err(structural(format!(
+                    "replacement node {replacement} not found"
+                )));
+            }
+            let now = ctx.now;
+            {
+                let old_node = next
+                    .node_mut(old)
+                    .ok_or_else(|| structural(format!("node {old} not found")))?;
+                // Explicit supersede is the sanctioned way past V9's
+                // terminal-state protection.
+                old_node.state = NodeState::Superseded;
+                old_node.updated_at = now;
+            }
+            let edge = WorkEdge {
+                id: WorkEdgeId::derive(
+                    &ctx.session_id,
+                    &format!("supersedes:{}:{}", replacement.as_str(), old.as_str()),
+                ),
+                kind: EdgeKind::Supersedes,
+                from: replacement.clone(),
+                to: old.clone(),
+            };
+            add_edge(&mut next, edge)?;
+        }
+    }
+    Ok(next)
+}
+
+fn add_node(next: &mut WorkGraphSnapshot, node: WorkNode) -> Result<(), ValidationReport> {
+    if next.node(&node.id).is_some() {
+        return Err(structural(format!("duplicate node {}", node.id)));
+    }
+    next.nodes.push(node);
+    Ok(())
+}
+
+fn add_edge(next: &mut WorkGraphSnapshot, edge: WorkEdge) -> Result<(), ValidationReport> {
+    if next.edge(&edge.id).is_some() {
+        return Err(structural(format!("duplicate edge {}", edge.id)));
+    }
+    for endpoint in [&edge.from, &edge.to] {
+        if next.node(endpoint).is_none() {
+            return Err(structural(format!(
+                "edge {} references missing node {endpoint}",
+                edge.id
+            )));
+        }
+    }
+    next.edges.push(edge);
+    Ok(())
+}
+
+/// V9 at the write path: terminal states are never overwritten by patches;
+/// only the explicit `Supersede` change (or a reconcile-rule change) may move
+/// a node out of a terminal state.
+fn patch_node(
+    next: &mut WorkGraphSnapshot,
+    id: &WorkNodeId,
+    patch: &WorkNodePatch,
+    now: i64,
+) -> Result<(), ValidationReport> {
+    let node = next
+        .node_mut(id)
+        .ok_or_else(|| structural(format!("node {id} not found")))?;
+    if node.state.is_terminal() && patch.state.is_some() {
+        return Err(ValidationReport::single(
+            ValidationCode::V9,
+            format!(
+                "node {id} is terminal ({:?}); use Supersede to replace it",
+                node.state
+            ),
+        ));
+    }
+    if let Some(title) = &patch.title {
+        node.title = title.clone();
+    }
+    if let Some(state) = patch.state {
+        node.state = state;
+    }
+    if let Some(acceptance) = &patch.acceptance {
+        node.acceptance = acceptance.clone();
+    }
+    if let Some(provenance) = &patch.provenance {
+        node.provenance = provenance.clone();
+    }
+    node.updated_at = now;
+    Ok(())
+}
+
+/// Pure application of an owner observation. The owner is authoritative for
+/// lifecycle; the graph never invents liveness:
+/// - a missing owner maps to `Stale` — NEVER to Active or Completed;
+/// - a terminal owner lifecycle maps to `Completed` — never `Verified`
+///   (verification only ever comes from evidence, V4);
+/// - nodes already in a terminal state keep it (V9); only the observation
+///   summary is updated.
+fn reconcile(
+    next: &mut WorkGraphSnapshot,
+    id: &WorkNodeId,
+    obs: &OperationObservation,
+    ctx: &ChangeCtx,
+) -> Result<(), ValidationReport> {
+    let now = ctx.now;
+    let node = next
+        .node_mut(id)
+        .ok_or_else(|| structural(format!("node {id} not found")))?;
+    let binding = node
+        .binding
+        .as_mut()
+        .ok_or_else(|| structural(format!("node {id} has no operation binding")))?;
+
+    let new_state = match obs {
+        OperationObservation::OwnerReported { state, seq, at } => {
+            binding.last_observation = Some(ObservationSummary {
+                owner_state: *state,
+                seq: *seq,
+                observed_at: *at,
+            });
+            Some(match state {
+                OwnerState::Running => NodeState::Active,
+                OwnerState::Waiting => NodeState::Waiting,
+                OwnerState::Completed => NodeState::Completed,
+                OwnerState::Failed => NodeState::Failed,
+                OwnerState::Cancelled => NodeState::Cancelled,
+            })
+        }
+        OperationObservation::OwnerMissing { .. } => Some(NodeState::Stale),
+        OperationObservation::CancelUpdate { outcome, .. } => match outcome {
+            // In-flight acknowledgements: record only, no state claim yet.
+            CancelOutcome::Requested | CancelOutcome::Acknowledged => None,
+            CancelOutcome::Forced => Some(NodeState::Cancelled),
+            CancelOutcome::AlreadyFinished => Some(NodeState::Completed),
+            CancelOutcome::NotFound | CancelOutcome::StaleUnknown => Some(NodeState::Stale),
+        },
+    };
+    if let Some(state) = new_state {
+        if !node.state.is_terminal() {
+            node.state = state;
+        }
+    }
+    node.updated_at = now;
+    Ok(())
+}
+
+/// Materialize evidence as an Evidence node plus a `Verifies` edge onto the
+/// target, both with deterministically derived IDs (so the same evidence
+/// reference attaches at most once — a repeat is a structural rejection, not
+/// a duplicate node).
+fn attach_evidence(
+    next: &mut WorkGraphSnapshot,
+    target: &WorkNodeId,
+    evidence: &EvidenceRef,
+    ctx: &ChangeCtx,
+) -> Result<(), ValidationReport> {
+    if next.node(target).is_none() {
+        return Err(structural(format!("node {target} not found")));
+    }
+    let evidence_id = WorkNodeId::derive(
+        &ctx.session_id,
+        &format!("evidence:{}:{}", target.as_str(), evidence.reference()),
+    );
+    let node = WorkNode {
+        id: evidence_id.clone(),
+        kind: NodeKind::Evidence,
+        title: format!("evidence: {}", evidence.reference()),
+        state: NodeState::Completed,
+        acceptance: Vec::new(),
+        binding: None,
+        evidence: Some(evidence.clone()),
+        provenance: Provenance::RuntimeReconcile {
+            source: "attach_evidence".to_string(),
+            observed_at: ctx.now,
+        },
+        created_at: ctx.now,
+        updated_at: ctx.now,
+    };
+    add_node(next, node)?;
+    let edge = WorkEdge {
+        id: WorkEdgeId::derive(
+            &ctx.session_id,
+            &format!("verifies:{}:{}", evidence_id.as_str(), target.as_str()),
+        ),
+        kind: EdgeKind::Verifies,
+        from: evidence_id,
+        to: target.clone(),
+    };
+    add_edge(next, edge)
+}
+
+/// Apply an accepted proposal atomically: nodes first (so added edges may
+/// reference them), then edges, then patches, then removals. Any failure
+/// rejects the whole acceptance (the caller's snapshot stays untouched).
+fn apply_proposal(
+    next: &mut WorkGraphSnapshot,
+    proposal: &WorkGraphProposal,
+    ctx: &ChangeCtx,
+) -> Result<(), ValidationReport> {
+    for node in &proposal.added_nodes {
+        add_node(next, node.clone())?;
+    }
+    for edge in &proposal.added_edges {
+        add_edge(next, edge.clone())?;
+    }
+    for update in &proposal.updated_nodes {
+        patch_node(next, &update.id, &update.patch, ctx.now)?;
+    }
+    for edge_id in &proposal.removed_edges {
+        let before = next.edges.len();
+        next.edges.retain(|e| &e.id != edge_id);
+        if next.edges.len() == before {
+            return Err(structural(format!("edge {edge_id} not found")));
+        }
+    }
+    Ok(())
+}

--- a/crates/tui/src/work_graph/tests.rs
+++ b/crates/tui/src/work_graph/tests.rs
@@ -1,0 +1,708 @@
+//! Work-graph unit tests: one test per invariant V1–V10, plus the reducer
+//! contract (determinism, idempotency dedup, fail-closed rejection, bounded
+//! history) and serde round-trip.
+
+use super::compat;
+use super::*;
+
+const SESSION: &str = "sess-test";
+
+fn nid(disc: &str) -> WorkNodeId {
+    WorkNodeId::derive(SESSION, disc)
+}
+
+fn eid(disc: &str) -> WorkEdgeId {
+    WorkEdgeId::derive(SESSION, disc)
+}
+
+fn ctx(now: Ts) -> ChangeCtx {
+    ChangeCtx {
+        session_id: SESSION.to_string(),
+        now,
+        idempotency_key: None,
+    }
+}
+
+fn ctx_keyed(now: Ts, seq: u64) -> ChangeCtx {
+    ChangeCtx {
+        session_id: SESSION.to_string(),
+        now,
+        idempotency_key: Some(IdempotencyKey {
+            binding: BindingId::derive(SESSION, "binding:op"),
+            seq,
+        }),
+    }
+}
+
+fn mk_node(disc: &str, kind: NodeKind, state: NodeState, now: Ts) -> WorkNode {
+    WorkNode {
+        id: nid(disc),
+        kind,
+        title: disc.to_string(),
+        state,
+        acceptance: Vec::new(),
+        binding: None,
+        evidence: None,
+        provenance: Provenance::Import {
+            source_digest: "digest".to_string(),
+            ordinal: None,
+        },
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn mk_edge(disc: &str, kind: EdgeKind, from: &str, to: &str) -> WorkEdge {
+    WorkEdge {
+        id: eid(disc),
+        kind,
+        from: nid(from),
+        to: nid(to),
+    }
+}
+
+fn must(graph: &mut WorkGraph, change: WorkGraphChange, now: Ts) -> ChangeReceipt {
+    graph.apply(change, ctx(now)).expect("change should apply")
+}
+
+/// Objective ─Contains→ PlanStep ─Contains→ Operation (all Ready).
+fn seeded() -> WorkGraph {
+    let mut graph = WorkGraph::new();
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("root", NodeKind::Objective, NodeState::Ready, 1),
+        },
+        1,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("step", NodeKind::PlanStep, NodeState::Ready, 2),
+        },
+        2,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AddEdge {
+            edge: mk_edge("c:root:step", EdgeKind::Contains, "root", "step"),
+        },
+        3,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("op", NodeKind::Operation, NodeState::Ready, 4),
+        },
+        4,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AddEdge {
+            edge: mk_edge("c:step:op", EdgeKind::Contains, "step", "op"),
+        },
+        5,
+    );
+    graph
+}
+
+fn set_state(graph: &mut WorkGraph, disc: &str, state: NodeState, now: Ts) {
+    must(
+        graph,
+        WorkGraphChange::UpdateNode {
+            id: nid(disc),
+            patch: WorkNodePatch {
+                state: Some(state),
+                ..WorkNodePatch::default()
+            },
+        },
+        now,
+    );
+}
+
+fn expect_code(
+    result: Result<ChangeReceipt, ValidationReport>,
+    code: ValidationCode,
+) -> ValidationReport {
+    let report = result.expect_err("change should be rejected");
+    assert!(report.contains_code(code), "expected {code:?} in {report}",);
+    report
+}
+
+#[test]
+fn v1_depends_on_cycles_rejected() {
+    let mut graph = seeded();
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("step2", NodeKind::PlanStep, NodeState::Ready, 6),
+        },
+        6,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AddEdge {
+            edge: mk_edge("d:step:step2", EdgeKind::DependsOn, "step", "step2"),
+        },
+        7,
+    );
+    let result = graph.apply(
+        WorkGraphChange::AddEdge {
+            edge: mk_edge("d:step2:step", EdgeKind::DependsOn, "step2", "step"),
+        },
+        ctx(8),
+    );
+    expect_code(result, ValidationCode::V1);
+}
+
+#[test]
+fn v2_live_operation_requires_plan_ancestry() {
+    let mut graph = seeded();
+    // Attached operation may go live.
+    set_state(&mut graph, "op", NodeState::Active, 6);
+
+    // An orphaned live operation is rejected outright.
+    let result = graph.apply(
+        WorkGraphChange::AddNode {
+            node: mk_node("orphan-op", NodeKind::Operation, NodeState::Active, 7),
+        },
+        ctx(7),
+    );
+    expect_code(result, ValidationCode::V2);
+}
+
+#[test]
+fn v3_binding_only_on_operation_nodes() {
+    let mut graph = seeded();
+    let result = graph.apply(
+        WorkGraphChange::BindOperation {
+            node: nid("step"),
+            binding: OperationBinding {
+                external: "task:task_0123456789abcdef".to_string(),
+                durable: true,
+                last_observation: None,
+            },
+        },
+        ctx(6),
+    );
+    expect_code(result, ValidationCode::V3);
+}
+
+#[test]
+fn v4_verified_requires_satisfying_evidence() {
+    let mut graph = seeded();
+
+    // Verified with empty acceptance: rejected.
+    let result = graph.apply(
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                state: Some(NodeState::Verified),
+                ..WorkNodePatch::default()
+            },
+        },
+        ctx(6),
+    );
+    expect_code(result, ValidationCode::V4);
+
+    // Give the node an acceptance requirement; Verified without evidence is
+    // still rejected — cannot-verify never fails open into done.
+    must(
+        &mut graph,
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                acceptance: Some(vec![AcceptanceRequirement::EvidenceOfKind {
+                    kind: EvidenceKindTag::TestSummary,
+                }]),
+                ..WorkNodePatch::default()
+            },
+        },
+        7,
+    );
+    let result = graph.apply(
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                state: Some(NodeState::Verified),
+                ..WorkNodePatch::default()
+            },
+        },
+        ctx(8),
+    );
+    expect_code(result, ValidationCode::V4);
+    // The failed attempt changed nothing; the caller's recourse is Blocked,
+    // never silently-verified.
+    assert_eq!(
+        graph.snapshot().node(&nid("op")).unwrap().state,
+        NodeState::Ready
+    );
+
+    // Wrong-kind evidence does not satisfy the requirement.
+    must(
+        &mut graph,
+        WorkGraphChange::AttachEvidence {
+            node: nid("op"),
+            evidence: EvidenceRef::new(EvidenceKind::ToolRun, "tool-call:1", None, false).unwrap(),
+        },
+        9,
+    );
+    let result = graph.apply(
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                state: Some(NodeState::Verified),
+                ..WorkNodePatch::default()
+            },
+        },
+        ctx(10),
+    );
+    expect_code(result, ValidationCode::V4);
+
+    // Satisfying evidence unlocks Verified.
+    must(
+        &mut graph,
+        WorkGraphChange::AttachEvidence {
+            node: nid("op"),
+            evidence: EvidenceRef::new(EvidenceKind::TestSummary, "test-run:42", Some(2048), true)
+                .unwrap(),
+        },
+        11,
+    );
+    set_state(&mut graph, "op", NodeState::Verified, 12);
+    assert_eq!(
+        graph.snapshot().node(&nid("op")).unwrap().state,
+        NodeState::Verified
+    );
+}
+
+#[test]
+fn v5_blocked_requires_visible_cause() {
+    let mut graph = seeded();
+    let result = graph.apply(
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                state: Some(NodeState::Blocked),
+                ..WorkNodePatch::default()
+            },
+        },
+        ctx(6),
+    );
+    expect_code(result, ValidationCode::V5);
+
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("blocker", NodeKind::Blocker, NodeState::Ready, 7),
+        },
+        7,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AddEdge {
+            edge: mk_edge("b:blocker:op", EdgeKind::Blocks, "blocker", "op"),
+        },
+        8,
+    );
+    set_state(&mut graph, "op", NodeState::Blocked, 9);
+    assert_eq!(
+        graph.snapshot().node(&nid("op")).unwrap().state,
+        NodeState::Blocked
+    );
+}
+
+#[test]
+fn v6_binding_external_identity() {
+    let mut graph = seeded();
+
+    // Unknown scheme: rejected.
+    let result = graph.apply(
+        WorkGraphChange::BindOperation {
+            node: nid("op"),
+            binding: OperationBinding {
+                external: "mystery:xyz".to_string(),
+                durable: true,
+                last_observation: None,
+            },
+        },
+        ctx(6),
+    );
+    expect_code(result, ValidationCode::V6);
+
+    // Well-formed externals bind; fleet's two-part form parses too.
+    assert!(external_identity_is_well_formed("fleet:run_1/task_2"));
+    assert!(!external_identity_is_well_formed("fleet:run-only"));
+    must(
+        &mut graph,
+        WorkGraphChange::BindOperation {
+            node: nid("op"),
+            binding: OperationBinding {
+                external: "shell:shell_ab12cd34".to_string(),
+                durable: false,
+                last_observation: None,
+            },
+        },
+        7,
+    );
+
+    // A second operation cannot claim the same external identity.
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("op2", NodeKind::Operation, NodeState::Ready, 8),
+        },
+        8,
+    );
+    let result = graph.apply(
+        WorkGraphChange::BindOperation {
+            node: nid("op2"),
+            binding: OperationBinding {
+                external: "shell:shell_ab12cd34".to_string(),
+                durable: false,
+                last_observation: None,
+            },
+        },
+        ctx(9),
+    );
+    expect_code(result, ValidationCode::V6);
+}
+
+#[test]
+fn v7_reference_nodes_stay_inert() {
+    let mut graph = seeded();
+    let result = graph.apply(
+        WorkGraphChange::AddNode {
+            node: mk_node("rt", NodeKind::RuntimeRef, NodeState::Active, 6),
+        },
+        ctx(6),
+    );
+    expect_code(result, ValidationCode::V7);
+
+    // Inert reference nodes are fine.
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("lane", NodeKind::LaneRef, NodeState::Ready, 7),
+        },
+        7,
+    );
+}
+
+#[test]
+fn v8_revision_and_history_monotonic() {
+    // Applied changes increment the revision exactly once each and receipts
+    // land in order.
+    let graph = seeded();
+    assert_eq!(graph.snapshot().revision, 5);
+    let revisions: Vec<u64> = graph
+        .snapshot()
+        .history
+        .iter()
+        .map(|r| r.revision)
+        .collect();
+    assert_eq!(revisions, vec![1, 2, 3, 4, 5]);
+
+    // A snapshot whose history revisions are out of order fails validation.
+    let mut bad = graph.snapshot().clone();
+    let mut receipt = bad.history.last().unwrap().clone();
+    receipt.revision = 2; // duplicate/regressing revision
+    bad.history.push_bounded(receipt);
+    let report = validate(&bad).expect_err("out-of-order history must fail");
+    assert!(report.contains_code(ValidationCode::V8));
+}
+
+#[test]
+fn v9_terminal_states_only_move_via_supersede() {
+    let mut graph = seeded();
+    set_state(&mut graph, "op", NodeState::Cancelled, 6);
+
+    // Patching a terminal node's state is rejected.
+    let result = graph.apply(
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                state: Some(NodeState::Active),
+                ..WorkNodePatch::default()
+            },
+        },
+        ctx(7),
+    );
+    expect_code(result, ValidationCode::V9);
+
+    // Explicit Supersede is the sanctioned path.
+    must(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: mk_node("op-new", NodeKind::Operation, NodeState::Ready, 8),
+        },
+        8,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::Supersede {
+            old: nid("op"),
+            replacement: nid("op-new"),
+        },
+        9,
+    );
+    let snapshot = graph.snapshot();
+    assert_eq!(
+        snapshot.node(&nid("op")).unwrap().state,
+        NodeState::Superseded
+    );
+    assert!(snapshot.edges.iter().any(|e| {
+        matches!(e.kind, EdgeKind::Supersedes) && e.from == nid("op-new") && e.to == nid("op")
+    }));
+}
+
+#[test]
+fn v10_projections_are_pure_functions_of_snapshot() {
+    // Type-level enforcement: projections coerce to plain fns over an
+    // immutable snapshot reference — no mutable access, no ambient state.
+    let _plan: fn(&WorkGraphSnapshot) -> compat::PlanProjection = compat::project_plan;
+    let _todos: fn(&WorkGraphSnapshot) -> compat::TodoProjection = compat::project_todos;
+}
+
+/// A representative change sequence exercising nodes, edges, bindings,
+/// reconciliation, evidence, proposals, and supersede.
+fn scripted_run() -> WorkGraph {
+    let mut graph = seeded();
+    must(
+        &mut graph,
+        WorkGraphChange::BindOperation {
+            node: nid("op"),
+            binding: OperationBinding {
+                external: "task:task_0123456789abcdef".to_string(),
+                durable: true,
+                last_observation: None,
+            },
+        },
+        6,
+    );
+    graph
+        .apply(
+            WorkGraphChange::ReconcileOperation {
+                node: nid("op"),
+                obs: OperationObservation::OwnerReported {
+                    state: OwnerState::Running,
+                    seq: 1,
+                    at: 7,
+                },
+            },
+            ctx_keyed(7, 1),
+        )
+        .expect("reconcile applies");
+    must(
+        &mut graph,
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                acceptance: Some(vec![AcceptanceRequirement::EvidenceOfKind {
+                    kind: EvidenceKindTag::ToolRun,
+                }]),
+                ..WorkNodePatch::default()
+            },
+        },
+        8,
+    );
+    graph
+        .apply(
+            WorkGraphChange::ReconcileOperation {
+                node: nid("op"),
+                obs: OperationObservation::OwnerReported {
+                    state: OwnerState::Completed,
+                    seq: 2,
+                    at: 9,
+                },
+            },
+            ctx_keyed(9, 2),
+        )
+        .expect("reconcile applies");
+    must(
+        &mut graph,
+        WorkGraphChange::AttachEvidence {
+            node: nid("op"),
+            evidence: EvidenceRef::new(EvidenceKind::ToolRun, "tool-call:99", Some(512), false)
+                .unwrap(),
+        },
+        10,
+    );
+    set_state(&mut graph, "op", NodeState::Verified, 11);
+
+    let proposal = WorkGraphProposal {
+        id: ProposalId::derive(SESSION, "proposal:1"),
+        added_nodes: vec![mk_node("step2", NodeKind::PlanStep, NodeState::Ready, 12)],
+        added_edges: vec![mk_edge("c:root:step2", EdgeKind::Contains, "root", "step2")],
+        updated_nodes: vec![ProposedNodeUpdate {
+            id: nid("step"),
+            patch: WorkNodePatch {
+                title: Some("step (revised)".to_string()),
+                ..WorkNodePatch::default()
+            },
+        }],
+        removed_edges: Vec::new(),
+    };
+    must(
+        &mut graph,
+        WorkGraphChange::ProposePlanDiff { proposal },
+        12,
+    );
+    must(
+        &mut graph,
+        WorkGraphChange::AcceptPlanDiff {
+            proposal_id: ProposalId::derive(SESSION, "proposal:1"),
+            approval: ApprovalRef {
+                reference: "user-review:1".to_string(),
+            },
+        },
+        13,
+    );
+    graph
+}
+
+#[test]
+fn reducer_is_deterministic_including_ids() {
+    let first = scripted_run();
+    let second = scripted_run();
+    assert_eq!(first.snapshot(), second.snapshot());
+    // Byte-identical serialization: same IDs, same ordering, same receipts.
+    let a = serde_json::to_string(first.snapshot()).unwrap();
+    let b = serde_json::to_string(second.snapshot()).unwrap();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn idempotency_key_dedup_is_a_no_op() {
+    let mut graph = scripted_run();
+    let before = graph.snapshot().clone();
+
+    // Same (binding, seq) as an already-applied observation: acknowledged,
+    // nothing changes — not revision, not history, not node state.
+    let receipt = graph
+        .apply(
+            WorkGraphChange::ReconcileOperation {
+                node: nid("op"),
+                obs: OperationObservation::OwnerReported {
+                    state: OwnerState::Failed,
+                    seq: 2,
+                    at: 99,
+                },
+            },
+            ctx_keyed(99, 2),
+        )
+        .expect("duplicate is acknowledged, not errored");
+    assert!(receipt.no_op);
+    assert_eq!(receipt.revision, before.revision);
+    assert_eq!(graph.snapshot(), &before);
+}
+
+#[test]
+fn rejected_change_leaves_snapshot_untouched() {
+    let mut graph = seeded();
+    let before = graph.snapshot().clone();
+    let result = graph.apply(
+        WorkGraphChange::UpdateNode {
+            id: nid("op"),
+            patch: WorkNodePatch {
+                state: Some(NodeState::Verified), // V4: no acceptance, no evidence
+                ..WorkNodePatch::default()
+            },
+        },
+        ctx(6),
+    );
+    expect_code(result, ValidationCode::V4);
+    assert_eq!(graph.snapshot(), &before);
+
+    // Same fail-closed contract on the pure entry point.
+    let report = apply(
+        &before,
+        WorkGraphChange::RemoveEdge {
+            id: eid("does-not-exist"),
+        },
+        ctx(7),
+    )
+    .expect_err("missing edge is rejected");
+    assert!(report.contains_code(ValidationCode::Structural));
+}
+
+#[test]
+fn history_stays_bounded_at_cap() {
+    let mut graph = seeded();
+    let seeded_revision = graph.snapshot().revision;
+    let extra = HISTORY_CAP as u64 + 44;
+    for i in 0..extra {
+        must(
+            &mut graph,
+            WorkGraphChange::UpdateNode {
+                id: nid("step"),
+                patch: WorkNodePatch {
+                    title: Some(format!("step v{i}")),
+                    ..WorkNodePatch::default()
+                },
+            },
+            100 + i as Ts,
+        );
+    }
+    let snapshot = graph.snapshot();
+    assert_eq!(snapshot.revision, seeded_revision + extra);
+    assert_eq!(snapshot.history.len(), HISTORY_CAP);
+    // Oldest receipts were evicted FIFO; the window ends at the current
+    // revision and starts exactly HISTORY_CAP entries back.
+    let first = snapshot.history.iter().next().unwrap().revision;
+    let last = snapshot.history.last().unwrap().revision;
+    assert_eq!(last, snapshot.revision);
+    assert_eq!(first, snapshot.revision - (HISTORY_CAP as u64 - 1));
+}
+
+#[test]
+fn snapshot_serde_round_trips() {
+    let graph = scripted_run();
+    let json = serde_json::to_string(graph.snapshot()).unwrap();
+    let restored: WorkGraphSnapshot = serde_json::from_str(&json).unwrap();
+    assert_eq!(&restored, graph.snapshot());
+    validate(&restored).expect("restored snapshot still satisfies invariants");
+}
+
+#[test]
+fn evidence_ref_rejects_paths_and_key_material() {
+    let err = |reference: &str| {
+        EvidenceRef::new(EvidenceKind::ToolRun, reference, None, false)
+            .expect_err("reference should be rejected")
+    };
+    assert_eq!(err(""), EvidenceRefError::EmptyReference);
+    assert_eq!(err("/var/log/system.log"), EvidenceRefError::AbsolutePath);
+    assert_eq!(err("\\\\server\\share"), EvidenceRefError::AbsolutePath);
+    assert_eq!(err("C:\\temp\\out.txt"), EvidenceRefError::AbsolutePath);
+    assert_eq!(err("~/notes.txt"), EvidenceRefError::HomeRelativePath);
+    assert_eq!(
+        err("two words"),
+        EvidenceRefError::ContainsWhitespaceOrControl
+    );
+    assert_eq!(
+        err("line\nbreak"),
+        EvidenceRefError::ContainsWhitespaceOrControl
+    );
+    // Built at runtime so secret scanners never see a contiguous PEM marker
+    // in source; the validator still receives the real prefix.
+    let pem_marker = format!("-----{}-RSA-KEY", "BEGIN");
+    assert_eq!(err(&pem_marker), EvidenceRefError::LooksLikeKeyMaterial);
+
+    // Deserialization re-runs constructor validation — serde is not a bypass.
+    let smuggled =
+        r#"{"kind":"tool_run","reference":"/etc/hosts","raw_bytes":null,"truncated":false}"#;
+    assert!(serde_json::from_str::<EvidenceRef>(smuggled).is_err());
+
+    let ok = EvidenceRef::new(
+        EvidenceKind::Artifact {
+            digest: "sha256:abc123".to_string(),
+        },
+        "artifact:build-77",
+        Some(4096),
+        true,
+    )
+    .unwrap();
+    assert_eq!(ok.reference(), "artifact:build-77");
+    assert_eq!(ok.raw_bytes(), Some(4096));
+    assert!(ok.truncated());
+}

--- a/crates/tui/src/work_graph/validate.rs
+++ b/crates/tui/src/work_graph/validate.rs
@@ -1,0 +1,430 @@
+//! Invariant validation — fail closed.
+//!
+//! [`validate`] checks every whole-snapshot invariant (V1–V8 below, plus
+//! structural well-formedness). The reducer calls it on the candidate
+//! snapshot after every change and rejects the change on any violation,
+//! leaving the input snapshot untouched. There is no fail-open path: if a
+//! node cannot be verified, it does not become Verified — verification
+//! infrastructure trouble must surface as a rejection (callers then mark the
+//! node Blocked), never as silently-assumed success.
+//!
+//! Invariants:
+//! - V1  `DependsOn` edges are acyclic.
+//! - V2  every live (`Active`/`Waiting`) Operation reaches an
+//!   Objective/PlanStep via `Contains` ancestry — no orphaned live work.
+//! - V3  `binding.is_some()` ⇒ `kind == Operation`.
+//! - V4  `Verified` ⇒ acceptance non-empty ⇒ a `Verifies`-edge evidence path
+//!   satisfies every requirement. Completion is never verification.
+//! - V5  `Blocked` ⇒ an incoming `Blocks` edge, an unmet `DependsOn`, or a
+//!   pending `RequiresApproval` path exists.
+//! - V6  each binding's `external` matches exactly one identity scheme and no
+//!   two operations bind the same external identity.
+//! - V7  `RuntimeRef`/`LaneRef` nodes never carry liveness state — the
+//!   owning subsystems are the only liveness source.
+//! - V8  history is bounded and its revisions strictly increase.
+//! - V9  terminal states are never overwritten except via explicit
+//!   `Supersede` (enforced in the reducer, which sees the predecessor
+//!   snapshot; single-snapshot validation cannot observe overwrites).
+//! - V10 compat projections are pure functions of the snapshot — enforced at
+//!   the type level: projection functions take `&WorkGraphSnapshot` (see
+//!   `compat.rs`); nothing hands them mutable graph access.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::ids::WorkNodeId;
+use super::model::{
+    EdgeKind, HISTORY_CAP, NodeKind, NodeState, SCHEMA_VERSION, WorkGraphSnapshot, WorkNode,
+    external_identity_is_well_formed,
+};
+
+/// Which rule a violation belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationCode {
+    /// Basic well-formedness (unique IDs, resolvable endpoints, schema).
+    Structural,
+    V1,
+    V2,
+    V3,
+    V4,
+    V5,
+    V6,
+    V7,
+    V8,
+    V9,
+    /// Never emitted at runtime: enforced by projection function signatures.
+    V10,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Violation {
+    pub code: ValidationCode,
+    pub message: String,
+}
+
+/// Result of a failed validation. A change producing any violation is
+/// rejected wholesale; the pre-change snapshot is returned to the caller
+/// untouched.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationReport {
+    pub violations: Vec<Violation>,
+}
+
+impl ValidationReport {
+    #[must_use]
+    pub fn single(code: ValidationCode, message: impl Into<String>) -> Self {
+        ValidationReport {
+            violations: vec![Violation {
+                code,
+                message: message.into(),
+            }],
+        }
+    }
+
+    #[must_use]
+    pub fn contains_code(&self, code: ValidationCode) -> bool {
+        self.violations.iter().any(|v| v.code == code)
+    }
+}
+
+impl std::fmt::Display for ValidationReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "work graph validation failed:")?;
+        for v in &self.violations {
+            write!(f, " [{:?}] {};", v.code, v.message)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ValidationReport {}
+
+/// Validate a whole snapshot. `Ok(())` or every violation found.
+pub fn validate(snapshot: &WorkGraphSnapshot) -> Result<(), ValidationReport> {
+    let mut violations = Vec::new();
+
+    check_structural(snapshot, &mut violations);
+    check_v1_depends_on_acyclic(snapshot, &mut violations);
+    check_v2_live_operations_rooted(snapshot, &mut violations);
+    check_v3_binding_only_on_operations(snapshot, &mut violations);
+    check_v4_verified_requires_evidence(snapshot, &mut violations);
+    check_v5_blocked_has_cause(snapshot, &mut violations);
+    check_v6_binding_identity(snapshot, &mut violations);
+    check_v7_refs_inert(snapshot, &mut violations);
+    check_v8_history_bounded_monotonic(snapshot, &mut violations);
+
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationReport { violations })
+    }
+}
+
+fn check_structural(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    if snapshot.schema != SCHEMA_VERSION {
+        out.push(Violation {
+            code: ValidationCode::Structural,
+            message: format!("unknown schema {}", snapshot.schema),
+        });
+    }
+    let mut node_ids = HashSet::new();
+    for node in &snapshot.nodes {
+        if !node_ids.insert(&node.id) {
+            out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!("duplicate node id {}", node.id),
+            });
+        }
+        if node.evidence.is_some() && !matches!(node.kind, NodeKind::Evidence) {
+            out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!(
+                    "node {} carries evidence but is not an Evidence node",
+                    node.id
+                ),
+            });
+        }
+    }
+    let mut edge_ids = HashSet::new();
+    for edge in &snapshot.edges {
+        if !edge_ids.insert(&edge.id) {
+            out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!("duplicate edge id {}", edge.id),
+            });
+        }
+        for endpoint in [&edge.from, &edge.to] {
+            if !node_ids.contains(endpoint) {
+                out.push(Violation {
+                    code: ValidationCode::Structural,
+                    message: format!("edge {} references missing node {}", edge.id, endpoint),
+                });
+            }
+        }
+    }
+}
+
+/// V1: DFS three-color cycle detection over `DependsOn` edges.
+fn check_v1_depends_on_acyclic(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    let mut adjacency: HashMap<&WorkNodeId, Vec<&WorkNodeId>> = HashMap::new();
+    for edge in &snapshot.edges {
+        if matches!(edge.kind, EdgeKind::DependsOn) {
+            adjacency.entry(&edge.from).or_default().push(&edge.to);
+        }
+    }
+    let mut done: HashSet<&WorkNodeId> = HashSet::new();
+    let mut in_progress: HashSet<&WorkNodeId> = HashSet::new();
+
+    fn visit<'a>(
+        node: &'a WorkNodeId,
+        adjacency: &HashMap<&'a WorkNodeId, Vec<&'a WorkNodeId>>,
+        done: &mut HashSet<&'a WorkNodeId>,
+        in_progress: &mut HashSet<&'a WorkNodeId>,
+    ) -> bool {
+        if done.contains(node) {
+            return true;
+        }
+        if !in_progress.insert(node) {
+            return false; // back edge → cycle
+        }
+        let acyclic = adjacency
+            .get(node)
+            .map(|next| next.iter().all(|n| visit(n, adjacency, done, in_progress)))
+            .unwrap_or(true);
+        in_progress.remove(node);
+        done.insert(node);
+        acyclic
+    }
+
+    for node in &snapshot.nodes {
+        if !visit(&node.id, &adjacency, &mut done, &mut in_progress) {
+            out.push(Violation {
+                code: ValidationCode::V1,
+                message: format!("depends_on cycle reachable from node {}", node.id),
+            });
+            return; // one report is enough; graph is already invalid
+        }
+    }
+}
+
+/// V2: every live Operation climbs `Contains` ancestry to an
+/// Objective/PlanStep. `Contains` points parent → child, so we walk incoming
+/// edges upward with a visited set (defensive against malformed cycles).
+fn check_v2_live_operations_rooted(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    for node in &snapshot.nodes {
+        if !(matches!(node.kind, NodeKind::Operation) && node.state.is_live()) {
+            continue;
+        }
+        let mut visited: HashSet<&WorkNodeId> = HashSet::new();
+        let mut frontier: Vec<&WorkNodeId> = vec![&node.id];
+        let mut rooted = false;
+        while let Some(current) = frontier.pop() {
+            if !visited.insert(current) {
+                continue;
+            }
+            for edge in &snapshot.edges {
+                if matches!(edge.kind, EdgeKind::Contains) && &edge.to == current {
+                    if let Some(parent) = snapshot.node(&edge.from) {
+                        if matches!(parent.kind, NodeKind::Objective | NodeKind::PlanStep) {
+                            rooted = true;
+                        }
+                        frontier.push(&parent.id);
+                    }
+                }
+            }
+            if rooted {
+                break;
+            }
+        }
+        if !rooted {
+            out.push(Violation {
+                code: ValidationCode::V2,
+                message: format!(
+                    "live operation {} has no Objective/PlanStep ancestry",
+                    node.id
+                ),
+            });
+        }
+    }
+}
+
+fn check_v3_binding_only_on_operations(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    for node in &snapshot.nodes {
+        if node.binding.is_some() && !matches!(node.kind, NodeKind::Operation) {
+            out.push(Violation {
+                code: ValidationCode::V3,
+                message: format!("non-operation node {} carries a binding", node.id),
+            });
+        }
+    }
+}
+
+/// V4: `Verified` demands non-empty acceptance and, for every requirement, at
+/// least one Evidence node linked by a `Verifies` edge whose payload
+/// satisfies it. There is no fail-open branch: absence of satisfying
+/// evidence — for any reason, including verification infrastructure being
+/// unavailable — is a rejection.
+fn check_v4_verified_requires_evidence(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    for node in &snapshot.nodes {
+        if !matches!(node.state, NodeState::Verified) {
+            continue;
+        }
+        if node.acceptance.is_empty() {
+            out.push(Violation {
+                code: ValidationCode::V4,
+                message: format!("verified node {} has no acceptance requirements", node.id),
+            });
+            continue;
+        }
+        let evidence: Vec<&WorkNode> = snapshot
+            .edges
+            .iter()
+            .filter(|e| matches!(e.kind, EdgeKind::Verifies) && e.to == node.id)
+            .filter_map(|e| snapshot.node(&e.from))
+            .filter(|n| matches!(n.kind, NodeKind::Evidence))
+            .collect();
+        for requirement in &node.acceptance {
+            let satisfied = evidence.iter().any(|ev| {
+                ev.evidence
+                    .as_ref()
+                    .is_some_and(|payload| requirement.is_satisfied_by(payload))
+            });
+            if !satisfied {
+                out.push(Violation {
+                    code: ValidationCode::V4,
+                    message: format!(
+                        "verified node {} lacks satisfying evidence for {:?}",
+                        node.id, requirement
+                    ),
+                });
+            }
+        }
+    }
+}
+
+/// V5: `Blocked` must have a visible cause.
+fn check_v5_blocked_has_cause(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    for node in &snapshot.nodes {
+        if !matches!(node.state, NodeState::Blocked) {
+            continue;
+        }
+        let blocked_by_edge = snapshot
+            .edges
+            .iter()
+            .any(|e| matches!(e.kind, EdgeKind::Blocks) && e.to == node.id);
+        let unmet_dependency = snapshot.edges.iter().any(|e| {
+            matches!(e.kind, EdgeKind::DependsOn)
+                && e.from == node.id
+                && snapshot
+                    .node(&e.to)
+                    .is_some_and(|dep| !WorkGraphSnapshot::node_is_done(dep))
+        });
+        let pending_approval = snapshot.edges.iter().any(|e| {
+            matches!(e.kind, EdgeKind::RequiresApproval)
+                && e.from == node.id
+                && snapshot
+                    .node(&e.to)
+                    .is_some_and(|approval| !WorkGraphSnapshot::node_is_done(approval))
+        });
+        if !(blocked_by_edge || unmet_dependency || pending_approval) {
+            out.push(Violation {
+                code: ValidationCode::V5,
+                message: format!("blocked node {} has no blocking cause", node.id),
+            });
+        }
+    }
+}
+
+/// V6: binding externals are well-formed under exactly one scheme prefix and
+/// unique across operations. (Cross-checking against the owners' live
+/// registries is the liveness slice's job; within the snapshot this is the
+/// enforceable core.)
+fn check_v6_binding_identity(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    let mut seen: HashMap<&str, &WorkNodeId> = HashMap::new();
+    for node in &snapshot.nodes {
+        let Some(binding) = &node.binding else {
+            continue;
+        };
+        if !external_identity_is_well_formed(&binding.external) {
+            out.push(Violation {
+                code: ValidationCode::V6,
+                message: format!(
+                    "node {} binding external {:?} matches no identity scheme",
+                    node.id, binding.external
+                ),
+            });
+        }
+        if let Some(previous) = seen.insert(binding.external.as_str(), &node.id) {
+            out.push(Violation {
+                code: ValidationCode::V6,
+                message: format!(
+                    "external {:?} bound by both {} and {}",
+                    binding.external, previous, node.id
+                ),
+            });
+        }
+    }
+}
+
+/// V7: reference nodes are inert — they never carry liveness state, because
+/// the owning subsystems are the only source of liveness truth.
+fn check_v7_refs_inert(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    for node in &snapshot.nodes {
+        if matches!(node.kind, NodeKind::RuntimeRef | NodeKind::LaneRef)
+            && !matches!(node.state, NodeState::Ready)
+        {
+            out.push(Violation {
+                code: ValidationCode::V7,
+                message: format!(
+                    "reference node {} carries liveness state {:?}",
+                    node.id, node.state
+                ),
+            });
+        }
+    }
+}
+
+/// V8: bounded history with strictly increasing revisions. (The exactly-once
+/// revision increment itself is a reducer property, covered by tests.)
+fn check_v8_history_bounded_monotonic(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
+    if snapshot.history.len() > HISTORY_CAP {
+        out.push(Violation {
+            code: ValidationCode::V8,
+            message: format!(
+                "history length {} exceeds bound {HISTORY_CAP}",
+                snapshot.history.len()
+            ),
+        });
+    }
+    let mut previous: Option<u64> = None;
+    for receipt in snapshot.history.iter() {
+        if let Some(prev) = previous {
+            if receipt.revision <= prev {
+                out.push(Violation {
+                    code: ValidationCode::V8,
+                    message: format!(
+                        "history revisions not strictly increasing ({} then {})",
+                        prev, receipt.revision
+                    ),
+                });
+                break;
+            }
+        }
+        previous = Some(receipt.revision);
+    }
+    if let Some(last) = snapshot.history.last() {
+        // During apply, validation runs before the increment, so the newest
+        // receipt may equal the current revision but never exceed it by >1.
+        if last.revision > snapshot.revision.saturating_add(1) {
+            out.push(Violation {
+                code: ValidationCode::V8,
+                message: format!(
+                    "history revision {} ahead of snapshot revision {}",
+                    last.revision, snapshot.revision
+                ),
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Scope

WG1 of the staged work-graph cutover: the core of a single authoritative work ledger per session — model, changes, pure reducer, and invariant validation. **No integration yet**: the module compiles into the TUI bin but nothing in the app/engine calls it. Session persistence + legacy import (WG2), UI cutover (WG3), and liveness bindings (WG4) are later slices.

Governing invariant: **one graph writes every projection; projections never write each other.** Plan/todo views and work-surface rows will all derive from `WorkGraphSnapshot` through pure functions (`compat.rs` carries the type-level enforcement now: projections take `&WorkGraphSnapshot`, stubs until WG2).

## What's in the module (`crates/tui/src/work_graph/`)

- **ids.rs** — deterministic IDs: `"wn:" + sha256(session_id, discriminator)[..12]` (per-type prefixes for edges/changes/proposals/bindings). No RNG anywhere; replays and re-imports are byte-identical, IDs included.
- **model.rs** — `NodeKind`/`EdgeKind`/`NodeState` with the load-bearing `Completed` (operation ended) vs `Verified` (evidence satisfies acceptance) distinction; `WorkNode`, `WorkEdge`, `OperationBinding` reusing the existing `task:`/`shell:`/`worker:`/`workflow:`/`fleet:{run}/{task}`/`lane:` identity strings verbatim; `Provenance`; `EvidenceRef` (reference-only by construction — rejects absolute/home paths, whitespace/control chars, key-material markers; serde deserialization re-runs the constructor); `WorkGraphSnapshot` (schema=1, revision, bounded 256-receipt history, bounded idempotency-key window).
- **events.rs** — `WorkGraphChange` (incl. `ProposePlanDiff`/`AcceptPlanDiff`/`Supersede`), observation placeholder types for the liveness slice, `ChangeReceipt`, `ChangeCtx` carrying timestamps and session identity so the reducer never reads clocks or RNG.
- **reducer.rs** — `apply()`: idempotency-key no-op dedup → pure application → fail-closed validation (input untouched on rejection) → exactly-once revision increment → bounded history push.
- **validate.rs** — invariants V1–V10 with `ValidationReport`. V4: `Verified` requires non-empty acceptance and a satisfying `Verifies`-edge evidence path; cannot-verify is a rejection (callers mark Blocked), never fail-open. V9 (terminal states only move via explicit `Supersede`) is enforced at the write path.
- **tests.rs** — one test per invariant V1–V10, reducer determinism (same sequence twice ⇒ identical snapshots including IDs), idempotency dedup, fail-closed rejection leaves the snapshot untouched, bounded history, serde round-trip, evidence-ref constructor rejection. 16 tests.

Design choices where the spec was silent are documented in code docs (`WorkNodePatch` shape, `WorkEdge {id, kind, from, to}`, minimal `AcceptanceRequirement`, FIFO `BoundedVec`/`BoundedSet`, `proposals` held on the snapshot so `AcceptPlanDiff` can resolve by ID, `Ts` as epoch-millis `i64`).

## Verification

```
cargo fmt --check -p codewhale-tui                       # clean
cargo clippy -p codewhale-tui --all-targets -- -D warnings \
  -A clippy::uninlined_format_args -A clippy::too_many_arguments \
  -A clippy::unnecessary_map_or -A clippy::collapsible_if \
  -A clippy::assertions_on_constants                     # clean
cargo test -p codewhale-tui --bin codewhale-tui -- work_graph
# test result: ok. 16 passed; 0 failed; 0 ignored; 7386 filtered out
```

The only test-build warning (linker `__eh_frame` size on the large test binary) was confirmed pre-existing on the base revision by rebuilding with this change stashed.

Implemented with AI agent assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
