### PR TITLE
fix(config): stop root DeepSeek default leaking onto vendor-locked routes

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4447,15 +4447,32 @@ impl Config {
         if provider == ApiProvider::XiaomiMimo {
             return DEFAULT_XIAOMI_MIMO_MODEL.to_string();
         }
+        // A root DeepSeek-family default must not leak onto a vendor-locked
+        // official endpoint that can never serve it (the provider then
+        // rejects every request, e.g. `deepseek-v4-pro` on api.x.ai). Custom
+        // base URLs keep full pass-through: a compatible proxy may
+        // legitimately serve any model id.
+        let foreign_root_default = |model: &str| {
+            !self.active_provider_preserves_custom_base_url_model()
+                && matches!(
+                    provider,
+                    ApiProvider::Xai | ApiProvider::Openai | ApiProvider::Moonshot
+                )
+                && normalize_model_name(model).is_some()
+        };
         if let Some(model) = self.default_text_model.as_deref()
             && (provider_passes_model_through(provider)
                 || self.active_provider_preserves_custom_base_url_model())
+            && !foreign_root_default(model)
         {
             return model.trim().to_string();
         }
         if let Some(model) = self.default_text_model.as_deref()
             && !root_deepseek_model_is_foreign_to_direct_provider(provider, model)
             && let Some(normalized) = normalize_model_name_for_provider(provider, model)
+            // A wire-slug translation (e.g. the Moonshot map) resolves the
+            // foreign default to a native model; an identity result does not.
+            && (!foreign_root_default(model) || !normalized.eq_ignore_ascii_case(model.trim()))
         {
             return normalized;
         }

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -5606,6 +5606,59 @@ fn nvidia_nim_provider_normalizes_deepseek_v4_flash_alias() -> Result<()> {
 }
 
 #[test]
+fn vendor_locked_providers_reject_foreign_root_default_model() {
+    let _lock = lock_test_env();
+    for (provider, expected) in [
+        ("xai", DEFAULT_XAI_MODEL),
+        ("openai", DEFAULT_OPENAI_MODEL),
+        ("moonshot", DEFAULT_MOONSHOT_MODEL),
+    ] {
+        let config = Config {
+            provider: Some(provider.to_string()),
+            default_text_model: Some("deepseek-v4-pro".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.default_model(),
+            expected,
+            "a root DeepSeek default must not leak onto the official {provider} endpoint"
+        );
+    }
+}
+
+#[test]
+fn xai_custom_endpoint_keeps_root_default_model_pass_through() {
+    let _lock = lock_test_env();
+    let mut providers = ProvidersConfig::default();
+    providers.xai.base_url = Some("https://proxy.example.test/v1".to_string());
+    let config = Config {
+        provider: Some("xai".to_string()),
+        default_text_model: Some("deepseek-v4-pro".to_string()),
+        providers: Some(providers),
+        ..Default::default()
+    };
+    assert_eq!(
+        config.default_model(),
+        "deepseek-v4-pro",
+        "custom compatible endpoints may serve any model id"
+    );
+}
+
+#[test]
+fn xai_explicit_provider_model_is_honored_over_vendor_default() {
+    let _lock = lock_test_env();
+    let mut providers = ProvidersConfig::default();
+    providers.xai.model = Some("grok-4.5-mini".to_string());
+    let config = Config {
+        provider: Some("xai".to_string()),
+        default_text_model: Some("deepseek-v4-pro".to_string()),
+        providers: Some(providers),
+        ..Default::default()
+    };
+    assert_eq!(config.default_model(), "grok-4.5-mini");
+}
+
+#[test]
 fn nvidia_nim_env_overrides_provider_and_credentials() -> Result<()> {
     let _lock = lock_test_env();
     let nanos = SystemTime::now()


### PR DESCRIPTION
## Summary

Live-hit on the current dogfood build: a session with provider xai booted as `deepseek-v4-pro` (header note `xai → xai / deepseek-v4-pro → deepseek-v4-pro`) and every request failed with xAI's model-not-found error.

**Root cause**: `Config::default_model()` returns a root `default_text_model` verbatim for any provider in `provider_passes_model_through` — a list that includes xAI, OpenAI, and Moonshot, whose official endpoints are vendor-locked and can never serve a DeepSeek-family model. A second branch (`normalize_model_name_for_provider`) re-leaks the same id as an identity mapping. The provider-switch path resolves through the same function, which is why a same-provider switch could not self-heal.

**Fix**: a recognized DeepSeek-family root default (`normalize_model_name` match) no longer passes through to xAI/OpenAI/Moonshot on their official endpoints; resolution falls to the provider's native default (`grok-4.5` for xAI). Wire-slug translations that resolve to a native model still apply; custom base URLs keep full pass-through; explicit `[providers.<p>] model` entries are unchanged.

## Verification

- 3 new tests: vendor-locked trio falls back to native defaults; custom endpoint keeps pass-through; explicit provider model honored.
- `cargo test -p codewhale-tui --bin codewhale-tui -- config::tests` — 388 passed, 0 failed.
- `-- model_routing provider_readiness` — 46 passed. Clippy (CI flags) clean; fmt clean.

## Related

#4410 live acceptance testing surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)