### PR TITLE
feat(kimi-code): exact K3 route truth and reasoning-effort canonicalization

### DIFF
--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -88,6 +88,13 @@ pub struct CredentialHelp {
     pub guidance: &'static str,
 }
 
+/// Kimi Code's membership-plan key console.
+///
+/// This is intentionally distinct from Moonshot's direct API console.  The
+/// route-specific helper below owns the choice so a configured Kimi Code route
+/// is never described as a generic Moonshot route.
+pub const KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL: &str = "https://www.kimi.com/code/console";
+
 /// Static metadata for a built-in model provider.
 pub trait Provider: Send + Sync {
     /// Provider enum variant represented by this entry.
@@ -135,6 +142,9 @@ pub trait Provider: Send + Sync {
 /// URLs here are provider-owned links already documented in this repository.
 /// If no stable vendor credential page is known, the URL remains absent and the
 /// guidance explains the supported local, OAuth, or configuration path.
+/// This is provider-level fallback metadata: callers that know a concrete base
+/// URL must use [`credential_help_for_route`] so route-owned credentials do not
+/// inherit a default endpoint's console.
 #[must_use]
 pub const fn credential_help(kind: ProviderKind) -> CredentialHelp {
     use CredentialAcquisition::{ApiKey, ApiKeyOrOAuth, Configuration, LocalOptional, OAuth};
@@ -222,7 +232,7 @@ pub const fn credential_help(kind: ProviderKind) -> CredentialHelp {
             acquisition: ApiKey,
             credential_url: Some("https://platform.kimi.ai/console/api-keys"),
             docs_url: Some("https://platform.kimi.ai/docs/overview"),
-            guidance: "Sign in to Kimi API Platform, create and copy an API key, then paste it into Codewhale; first-class Kimi OAuth is not available.",
+            guidance: "For Moonshot's default direct API route, sign in to Kimi API Platform and create and copy an API key. A configured Kimi Code route uses a separate membership-plan console and never imports Kimi CLI credentials; first-class Kimi OAuth is not available.",
         },
         ProviderKind::Sglang => CredentialHelp {
             acquisition: LocalOptional,
@@ -341,6 +351,54 @@ pub const fn credential_help(kind: ProviderKind) -> CredentialHelp {
             guidance: "Set this custom provider's base_url and api_key_env or api_key in configuration; no canonical vendor credential page exists.",
         },
     }
+}
+
+/// Whether a configured route is exactly the official Kimi Code endpoint.
+///
+/// A trailing slash is insignificant, but neighboring Kimi-hosted paths must
+/// not inherit membership-plan credentials merely because they share a host.
+#[must_use]
+pub fn is_exact_kimi_code_route(kind: ProviderKind, base_url: &str) -> bool {
+    if kind != ProviderKind::Moonshot {
+        return false;
+    }
+
+    // URL schemes and host names are ASCII case-insensitive; paths are not.
+    // Do not lowercase the whole URL here: `/CODING/v1` is a neighboring
+    // route, not the membership-plan endpoint. Keep this intentionally
+    // dependency-free because provider metadata is used by low-level config
+    // callers that should not need URL parsing machinery just for this guard.
+    let trimmed = base_url.trim();
+    let normalized = trimmed.strip_suffix('/').unwrap_or(trimmed);
+    let Some((scheme, authority_and_path)) = normalized.split_once("://") else {
+        return false;
+    };
+    let Some((authority, path)) = authority_and_path.split_once('/') else {
+        return false;
+    };
+
+    scheme.eq_ignore_ascii_case("https")
+        && authority.eq_ignore_ascii_case("api.kimi.com")
+        && path == "coding/v1"
+}
+
+/// Return credential help for one concrete provider route.
+///
+/// This protects non-UI callers such as diagnostics and command surfaces from
+/// presenting Moonshot's direct API console for a Kimi Code membership-plan
+/// endpoint. It performs no discovery, credential lookup, or network I/O.
+#[must_use]
+pub fn credential_help_for_route(kind: ProviderKind, base_url: &str) -> CredentialHelp {
+    if is_exact_kimi_code_route(kind, base_url) {
+        return CredentialHelp {
+            acquisition: CredentialAcquisition::ApiKey,
+            credential_url: Some(KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL),
+            docs_url: None,
+            guidance: "Create a Kimi Code membership-plan API key in the Kimi Code console. This route uses api.kimi.com/coding/v1; Codewhale does not import Kimi CLI credentials.",
+        };
+    }
+
+    credential_help(kind)
 }
 
 macro_rules! provider {
@@ -1210,6 +1268,54 @@ mod tests {
         );
         assert!(help.guidance.contains("create and copy an API key"));
         assert!(help.guidance.contains("OAuth is not available"));
+    }
+
+    #[test]
+    fn kimi_code_route_credential_help_is_distinct_from_direct_moonshot() {
+        let direct = credential_help_for_route(ProviderKind::Moonshot, DEFAULT_MOONSHOT_BASE_URL);
+        let kimi_code =
+            credential_help_for_route(ProviderKind::Moonshot, "https://api.kimi.com/coding/v1/");
+
+        assert_eq!(
+            direct.credential_url,
+            Some("https://platform.kimi.ai/console/api-keys")
+        );
+        assert_eq!(
+            kimi_code.credential_url,
+            Some(KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL)
+        );
+        assert_eq!(kimi_code.docs_url, None);
+        assert!(kimi_code.guidance.contains("membership-plan API key"));
+        assert!(
+            kimi_code
+                .guidance
+                .contains("does not import Kimi CLI credentials")
+        );
+        assert!(!is_exact_kimi_code_route(
+            ProviderKind::Moonshot,
+            "https://api.kimi.com/coding/v1/preview"
+        ));
+
+        // Scheme and hostname casing are insignificant, but the endpoint
+        // path is a route identifier and must remain exact.
+        assert!(is_exact_kimi_code_route(
+            ProviderKind::Moonshot,
+            "HTTPS://API.KIMI.COM/coding/v1/"
+        ));
+        for neighboring_route in [
+            "https://api.kimi.com/CODING/v1",
+            "https://api.kimi.com/coding/V1",
+            "http://api.kimi.com/coding/v1",
+            "https://api.kimi.com:443/coding/v1",
+            "https://api.kimi.com/coding/v1?preview=1",
+            "https://api.kimi.com/coding/v1#fragment",
+            "https://api.kimi.com/coding/v1//",
+        ] {
+            assert!(
+                !is_exact_kimi_code_route(ProviderKind::Moonshot, neighboring_route),
+                "{neighboring_route} must not inherit Kimi Code membership semantics"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/acp_server.rs
+++ b/crates/tui/src/acp_server.rs
@@ -542,7 +542,13 @@ impl AcpServer {
         let client = DeepSeekClient::new(&execution_config)?;
         let reasoning_effort = route
             .reasoning_effort
-            .and_then(|effort| effort.api_value_for_provider(execution_config.api_provider()))
+            .and_then(|effort| {
+                effort.api_value_for_route(
+                    execution_config.api_provider(),
+                    &execution_config.deepseek_base_url(),
+                    &route.model,
+                )
+            })
             .map(str::to_string);
 
         let request = MessageRequest {

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -194,6 +194,25 @@ const DEFAULT_CLIENT_RATE_LIMIT_RPS: f64 = 8.0;
 const DEFAULT_CLIENT_RATE_LIMIT_BURST: f64 = 16.0;
 const ALLOW_INSECURE_HTTP_ENV: &str = "DEEPSEEK_ALLOW_INSECURE_HTTP";
 
+fn client_user_agent(api_provider: ApiProvider) -> &'static str {
+    // The ChatGPT Codex backend is the sole route with a documented
+    // compatibility exception. Kimi Code, including K3, must keep the normal
+    // Codewhale identity rather than impersonating a Kimi CLI.
+    if api_provider == ApiProvider::OpenaiCodex {
+        concat!(
+            "codex_cli_rs/0.137.0 (CodeWhale ",
+            env!("CARGO_PKG_VERSION"),
+            ")"
+        )
+    } else {
+        concat!(
+            "Mozilla/5.0 (compatible; codewhale/",
+            env!("CARGO_PKG_VERSION"),
+            "; +https://github.com/Hmbown/CodeWhale)"
+        )
+    }
+}
+
 /// Upper bound on a single sleep inside the provider-wide rate-limit pause
 /// loop in `send_with_retry`. The pause window lives in process-global state
 /// (`retry_status`), so waiting requests re-poll it on this cadence instead
@@ -1039,25 +1058,9 @@ impl DeepSeekClient {
             base_url,
             auth_disabled,
         )?;
-        // The ChatGPT Codex backend sits behind Cloudflare bot protection that
-        // only admits the Codex CLI's user agent; present a codex_cli_rs UA on
-        // that path so the request is handled like the official client.
-        let user_agent: &str = if api_provider == ApiProvider::OpenaiCodex {
-            concat!(
-                "codex_cli_rs/0.137.0 (CodeWhale ",
-                env!("CARGO_PKG_VERSION"),
-                ")"
-            )
-        } else {
-            concat!(
-                "Mozilla/5.0 (compatible; codewhale/",
-                env!("CARGO_PKG_VERSION"),
-                "; +https://github.com/Hmbown/CodeWhale)"
-            )
-        };
         let mut builder = crate::tls::reqwest_client_builder()
             .default_headers(headers)
-            .user_agent(user_agent)
+            .user_agent(client_user_agent(api_provider))
             .connect_timeout(Duration::from_secs(30))
             .tcp_keepalive(Some(Duration::from_secs(30)))
             .http2_keep_alive_interval(Some(Duration::from_secs(15)))
@@ -4674,6 +4677,15 @@ mod tests {
         let mut body = json!({});
         apply_reasoning_effort(&mut body, Some("off"), ApiProvider::Moonshot);
         assert_eq!(body, json!({ "thinking": { "type": "disabled" } }));
+    }
+
+    #[test]
+    fn moonshot_uses_codewhale_user_agent_not_kimi_cli_identity() {
+        let user_agent = client_user_agent(ApiProvider::Moonshot);
+
+        assert!(user_agent.contains("codewhale/"));
+        assert!(!user_agent.to_ascii_lowercase().contains("kimi_cli"));
+        assert!(!user_agent.to_ascii_lowercase().contains("kimi-code-cli"));
     }
 
     #[test]

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::time::timeout as tokio_timeout;
 
-use crate::config::{TOGETHER_INKLING_MODEL, wire_model_for_provider_route};
+use crate::config::{
+    TOGETHER_INKLING_MODEL, is_exact_kimi_code_k3_route, wire_model_for_provider_route,
+};
 
 /// Default timeout for the initial streaming response headers.
 ///
@@ -134,6 +136,43 @@ fn apply_inkling_reasoning_effort(
     body["reasoning_effort"] = json!(wire_effort);
 }
 
+/// Apply Kimi Code K3's route-specific nested thinking effort after the
+/// generic Moonshot shaping. Other Moonshot and Kimi-compatible routes accept
+/// only the generic enabled/disabled form, so the exact endpoint and bare
+/// model identifier are both part of this guard.
+fn apply_kimi_code_k3_reasoning_effort(
+    body: &mut Value,
+    provider: ApiProvider,
+    base_url: &str,
+    model: &str,
+    effort: Option<&str>,
+) {
+    if !is_exact_kimi_code_k3_route(provider, base_url, model) {
+        return;
+    }
+    let Some(effort) = effort else {
+        return;
+    };
+
+    let thinking = match effort.trim().to_ascii_lowercase().as_str() {
+        "off" | "none" | "disabled" | "false" => json!({ "type": "disabled" }),
+        "low" | "minimum" | "minimal" | "light" => {
+            json!({ "type": "enabled", "effort": "low" })
+        }
+        "medium" | "high" => json!({ "type": "enabled", "effort": "high" }),
+        "xhigh" | "ultra" | "max" => json!({ "type": "enabled", "effort": "max" }),
+        _ => return,
+    };
+
+    // K3 uses the nested `thinking.effort` dialect. Do not leave an
+    // OpenAI-style effort value behind if another shaping layer was added
+    // before this route-specific override.
+    if let Some(object) = body.as_object_mut() {
+        object.remove("reasoning_effort");
+    }
+    body["thinking"] = thinking;
+}
+
 fn openai_compatible_reasoning_effort(
     effort: &str,
     supports_max: bool,
@@ -194,7 +233,11 @@ impl DeepSeekClient {
         request: &MessageRequest,
     ) -> Result<MessageResponse> {
         let cacheable = crate::llm_response_cache::request_is_cacheable(request);
-        let messages = build_chat_messages_for_request_and_provider(request, self.api_provider);
+        let messages = build_chat_messages_for_request_and_provider_and_route(
+            request,
+            self.api_provider,
+            &self.base_url,
+        );
         let model =
             wire_model_for_provider_route(self.api_provider, &self.base_url, &request.model);
         let mut body = json!({
@@ -279,6 +322,13 @@ impl DeepSeekClient {
             &model,
             request.reasoning_effort.as_deref(),
         );
+        apply_kimi_code_k3_reasoning_effort(
+            &mut body,
+            self.api_provider,
+            &self.base_url,
+            &model,
+            request.reasoning_effort.as_deref(),
+        );
         mirror_minimax_reasoning_details_for_body(&mut body, self.api_provider);
 
         let response_cache_key = if cacheable {
@@ -350,7 +400,11 @@ impl DeepSeekClient {
         request: MessageRequest,
     ) -> Result<StreamEventBox> {
         // Try true SSE streaming via chat completions (widely supported)
-        let messages = build_chat_messages_for_request_and_provider(&request, self.api_provider);
+        let messages = build_chat_messages_for_request_and_provider_and_route(
+            &request,
+            self.api_provider,
+            &self.base_url,
+        );
         let model =
             wire_model_for_provider_route(self.api_provider, &self.base_url, &request.model);
         let mut body = json!({
@@ -439,6 +493,13 @@ impl DeepSeekClient {
             &model,
             request.reasoning_effort.as_deref(),
         );
+        apply_kimi_code_k3_reasoning_effort(
+            &mut body,
+            self.api_provider,
+            &self.base_url,
+            &model,
+            request.reasoning_effort.as_deref(),
+        );
 
         // Bulletproof final sanitizer: walk the wire payload and force
         // `reasoning_content` onto any assistant message that has tool_calls
@@ -448,11 +509,12 @@ impl DeepSeekClient {
         // misses a case (e.g. a session restored from disk, a sub-agent
         // adding messages directly, or a cached prefix mismatch), this pass
         // still produces a valid request.
-        let replay_input_tokens = sanitize_thinking_mode_messages(
+        let replay_input_tokens = sanitize_thinking_mode_messages_for_route(
             &mut body,
             &model,
             request.reasoning_effort.as_deref(),
             self.api_provider,
+            &self.base_url,
         );
         mirror_minimax_reasoning_details_for_body(&mut body, self.api_provider);
 
@@ -481,6 +543,7 @@ impl DeepSeekClient {
         }
 
         let api_provider = self.api_provider;
+        let base_url = self.base_url.clone();
 
         // Capture transport-shape headers before we consume `response` into
         // `bytes_stream()`. They are surfaced in the decode-error log path so
@@ -521,8 +584,9 @@ impl DeepSeekClient {
             let mut tool_indices: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
             let mut reasoning_detail_buffers: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
             let mut inline_reasoning_tags = InlineReasoningTagState::default();
-            let reasoning_stream_style = reasoning_stream_style_for_stream(
+            let reasoning_stream_style = reasoning_stream_style_for_route(
                 api_provider,
+                &base_url,
                 &model,
                 configured_reasoning_stream_style.as_deref(),
             );
@@ -752,11 +816,26 @@ pub(super) fn build_chat_messages_for_request(request: &MessageRequest) -> Vec<V
     PromptBuilder::for_request(request).build()
 }
 
+#[cfg(test)]
 pub(super) fn build_chat_messages_for_request_and_provider(
     request: &MessageRequest,
     provider: ApiProvider,
 ) -> Vec<Value> {
-    PromptBuilder::for_request(request).build_for_provider(provider)
+    build_chat_messages_for_request_and_provider_and_route(request, provider, "")
+}
+
+/// Build a wire prompt for one fully resolved provider route.
+///
+/// Most provider behavior is keyed only by the provider kind and model. Kimi
+/// Code K3 is deliberately narrower: the bare `k3` model owns reasoning
+/// replay only on its official membership-plan endpoint, so callers that have
+/// a concrete base URL must retain it through prompt construction.
+pub(super) fn build_chat_messages_for_request_and_provider_and_route(
+    request: &MessageRequest,
+    provider: ApiProvider,
+    base_url: &str,
+) -> Vec<Value> {
+    PromptBuilder::for_request(request).build_for_provider_and_route(provider, base_url)
 }
 
 pub(crate) fn inspect_prompt_for_request(request: &MessageRequest) -> PromptInspection {
@@ -797,13 +876,14 @@ impl<'a> PromptBuilder<'a> {
         )
     }
 
-    fn build_for_provider(self, provider: ApiProvider) -> Vec<Value> {
+    fn build_for_provider_and_route(self, provider: ApiProvider, base_url: &str) -> Vec<Value> {
         let mut messages = build_chat_messages_with_reasoning(
             self.system,
             self.messages,
             self.model,
-            should_replay_reasoning_content_for_provider(
+            should_replay_reasoning_content_for_provider_on_route(
                 provider,
+                base_url,
                 self.model,
                 self.reasoning_effort,
             ),
@@ -2094,13 +2174,30 @@ fn reasoning_effort_enables_thinking(effort: Option<&str>) -> bool {
 /// Also tallies the size of all replayed `reasoning_content` and logs it, so
 /// users on `RUST_LOG=codewhale_tui=debug` can see how much of their input
 /// budget is being spent re-sending prior thinking traces.
+#[cfg(test)]
 pub(super) fn sanitize_thinking_mode_messages(
     body: &mut Value,
     model: &str,
     effort: Option<&str>,
     provider: ApiProvider,
 ) -> Option<u32> {
-    if !should_replay_reasoning_content_for_provider(provider, model, effort) {
+    sanitize_thinking_mode_messages_for_route(body, model, effort, provider, "")
+}
+
+/// Route-aware variant of [`sanitize_thinking_mode_messages`].
+///
+/// The wrapper above remains intentionally route-agnostic for existing test
+/// helpers and generic callers. Production chat requests call this version so
+/// exact Kimi Code K3 assistant tool turns retain the reasoning trace that
+/// K3 expects on the next request.
+pub(super) fn sanitize_thinking_mode_messages_for_route(
+    body: &mut Value,
+    model: &str,
+    effort: Option<&str>,
+    provider: ApiProvider,
+    base_url: &str,
+) -> Option<u32> {
+    if !should_replay_reasoning_content_for_provider_on_route(provider, base_url, model, effort) {
         return None;
     }
     let messages = body.get_mut("messages").and_then(Value::as_array_mut)?;
@@ -2257,8 +2354,24 @@ fn should_replay_reasoning_content(model: &str, effort: Option<&str>) -> bool {
     requires_reasoning_content(model)
 }
 
+#[cfg(test)]
 fn should_replay_reasoning_content_for_provider(
     provider: ApiProvider,
+    model: &str,
+    effort: Option<&str>,
+) -> bool {
+    should_replay_reasoning_content_for_provider_on_route(provider, "", model, effort)
+}
+
+/// Route-aware reasoning replay policy.
+///
+/// Keep the bare K3 identifier out of the global model catalog: direct
+/// Moonshot and arbitrary OpenAI-compatible routes can also expose a `k3`
+/// model name, but only Kimi Code's exact membership-plan endpoint has this
+/// replay contract.
+fn should_replay_reasoning_content_for_provider_on_route(
+    provider: ApiProvider,
+    base_url: &str,
     model: &str,
     effort: Option<&str>,
 ) -> bool {
@@ -2272,6 +2385,10 @@ fn should_replay_reasoning_content_for_provider(
         .unwrap_or(false)
     {
         return false;
+    }
+
+    if is_exact_kimi_code_k3_route(provider, base_url, model) {
+        return true;
     }
 
     if requires_reasoning_content(model) {
@@ -2298,7 +2415,21 @@ fn should_replay_reasoning_content_for_provider(
 /// known reasoning-capable large models are classified only on providers whose
 /// streaming shape exposes reasoning fields, so `reasoning`/`reasoning_content`
 /// deltas become Thinking cells instead of leaking as normal answer text.
+#[cfg(test)]
 fn is_reasoning_model_for_stream(provider: ApiProvider, model: &str) -> bool {
+    is_reasoning_model_for_stream_on_route(provider, "", model)
+}
+
+/// Route-aware stream classification for providers that share model names.
+fn is_reasoning_model_for_stream_on_route(
+    provider: ApiProvider,
+    base_url: &str,
+    model: &str,
+) -> bool {
+    if is_exact_kimi_code_k3_route(provider, base_url, model) {
+        return true;
+    }
+
     if requires_reasoning_content(model) {
         return true;
     }
@@ -2312,8 +2443,19 @@ pub(super) enum ReasoningStreamStyle {
     None,
 }
 
+#[cfg(test)]
 fn reasoning_stream_style_for_stream(
     provider: ApiProvider,
+    model: &str,
+    configured: Option<&str>,
+) -> ReasoningStreamStyle {
+    reasoning_stream_style_for_route(provider, "", model, configured)
+}
+
+/// Choose stream decoding semantics for a fully resolved provider route.
+fn reasoning_stream_style_for_route(
+    provider: ApiProvider,
+    base_url: &str,
     model: &str,
     configured: Option<&str>,
 ) -> ReasoningStreamStyle {
@@ -2325,7 +2467,7 @@ fn reasoning_stream_style_for_stream(
             "Ignoring unrecognized reasoning_stream_style `{configured}`; expected separate_field, inline_tags, or none"
         ));
     }
-    if is_reasoning_model_for_stream(provider, model) {
+    if is_reasoning_model_for_stream_on_route(provider, base_url, model) {
         ReasoningStreamStyle::SeparateField
     } else {
         ReasoningStreamStyle::None
@@ -3244,8 +3386,14 @@ mod arcee_waf_message_encoding_tests {
 
 #[cfg(test)]
 mod minimax_reasoning_replay_tests {
-    use super::build_chat_messages_for_request_and_provider;
-    use crate::config::{ApiProvider, DEFAULT_MINIMAX_MODEL};
+    use super::{
+        build_chat_messages_for_request_and_provider,
+        build_chat_messages_for_request_and_provider_and_route,
+    };
+    use crate::config::{
+        ApiProvider, DEFAULT_KIMI_CODE_BASE_URL, DEFAULT_MINIMAX_MODEL, DEFAULT_MOONSHOT_BASE_URL,
+        KIMI_CODE_K3_MODEL,
+    };
     use crate::models::{ContentBlock, Message, MessageRequest};
 
     fn request_with_assistant_thinking() -> MessageRequest {
@@ -3301,6 +3449,34 @@ mod minimax_reasoning_replay_tests {
                 .pointer("/reasoning_details/0/text")
                 .and_then(|value| value.as_str()),
             Some("Inspect tool state")
+        );
+    }
+
+    #[test]
+    fn kimi_code_k3_replays_thinking_only_on_the_exact_membership_route() {
+        let mut request = request_with_assistant_thinking();
+        request.model = KIMI_CODE_K3_MODEL.to_string();
+
+        let exact = build_chat_messages_for_request_and_provider_and_route(
+            &request,
+            ApiProvider::Moonshot,
+            DEFAULT_KIMI_CODE_BASE_URL,
+        );
+        assert_eq!(
+            exact[0]
+                .get("reasoning_content")
+                .and_then(serde_json::Value::as_str),
+            Some("Inspect tool state")
+        );
+
+        let neighbor = build_chat_messages_for_request_and_provider_and_route(
+            &request,
+            ApiProvider::Moonshot,
+            DEFAULT_MOONSHOT_BASE_URL,
+        );
+        assert!(
+            neighbor[0].get("reasoning_content").is_none(),
+            "a generic Moonshot k3 identifier must not inherit Kimi Code replay"
         );
     }
 }
@@ -3683,6 +3859,32 @@ mod stream_decoder_tests {
 
         assert_eq!(thinking_delta_text(&events), "private plan");
         assert_eq!(text_delta_text(&events), "Public answer.");
+    }
+
+    #[test]
+    fn exact_kimi_code_k3_streams_reasoning_content_as_thinking() {
+        let style = reasoning_stream_style_for_route(
+            ApiProvider::Moonshot,
+            crate::config::DEFAULT_KIMI_CODE_BASE_URL,
+            crate::config::KIMI_CODE_K3_MODEL,
+            None,
+        );
+        assert_eq!(style, ReasoningStreamStyle::SeparateField);
+
+        let events = decode_chunks_with_style(
+            &[r#"{"choices":[{"delta":{"reasoning_content":"private K3 plan"}}]}"#],
+            style,
+        );
+        assert_eq!(thinking_delta_text(&events), "private K3 plan");
+        assert_eq!(text_delta_text(&events), "");
+
+        let generic_style = reasoning_stream_style_for_route(
+            ApiProvider::Moonshot,
+            crate::config::DEFAULT_MOONSHOT_BASE_URL,
+            crate::config::KIMI_CODE_K3_MODEL,
+            None,
+        );
+        assert_eq!(generic_style, ReasoningStreamStyle::None);
     }
 
     #[test]
@@ -4556,10 +4758,12 @@ mod alias_thinking_detection_tests {
     //! turn. See upstream API docs:
     //! https://api-docs.deepseek.com/guides/thinking_mode
     use super::{
-        apply_inkling_reasoning_effort, apply_openai_reasoning_effort, apply_provider_token_limit,
-        is_reasoning_model_for_stream, provider_accepts_reasoning_content,
-        requires_reasoning_content, should_replay_reasoning_content,
-        should_replay_reasoning_content_for_provider,
+        ReasoningStreamStyle, apply_inkling_reasoning_effort, apply_kimi_code_k3_reasoning_effort,
+        apply_openai_reasoning_effort, apply_provider_token_limit, is_reasoning_model_for_stream,
+        is_reasoning_model_for_stream_on_route, provider_accepts_reasoning_content,
+        reasoning_stream_style_for_route, requires_reasoning_content,
+        should_replay_reasoning_content, should_replay_reasoning_content_for_provider,
+        should_replay_reasoning_content_for_provider_on_route,
     };
     use crate::config::ApiProvider;
     use serde_json::json;
@@ -4680,6 +4884,60 @@ mod alias_thinking_detection_tests {
     }
 
     #[test]
+    fn bare_k3_reasoning_semantics_are_scoped_to_exact_kimi_code_route() {
+        let kimi_code = crate::config::DEFAULT_KIMI_CODE_BASE_URL;
+        let direct_moonshot = crate::config::DEFAULT_MOONSHOT_BASE_URL;
+
+        assert!(should_replay_reasoning_content_for_provider_on_route(
+            ApiProvider::Moonshot,
+            kimi_code,
+            crate::config::KIMI_CODE_K3_MODEL,
+            Some("high"),
+        ));
+        assert!(is_reasoning_model_for_stream_on_route(
+            ApiProvider::Moonshot,
+            kimi_code,
+            crate::config::KIMI_CODE_K3_MODEL,
+        ));
+        assert_eq!(
+            reasoning_stream_style_for_route(
+                ApiProvider::Moonshot,
+                kimi_code,
+                crate::config::KIMI_CODE_K3_MODEL,
+                None,
+            ),
+            ReasoningStreamStyle::SeparateField
+        );
+
+        assert!(!should_replay_reasoning_content_for_provider_on_route(
+            ApiProvider::Moonshot,
+            direct_moonshot,
+            crate::config::KIMI_CODE_K3_MODEL,
+            Some("high"),
+        ));
+        assert!(!is_reasoning_model_for_stream_on_route(
+            ApiProvider::Moonshot,
+            direct_moonshot,
+            crate::config::KIMI_CODE_K3_MODEL,
+        ));
+        assert_eq!(
+            reasoning_stream_style_for_route(
+                ApiProvider::Moonshot,
+                direct_moonshot,
+                crate::config::KIMI_CODE_K3_MODEL,
+                None,
+            ),
+            ReasoningStreamStyle::None
+        );
+        assert!(!should_replay_reasoning_content_for_provider_on_route(
+            ApiProvider::Moonshot,
+            kimi_code,
+            crate::config::KIMI_CODE_K3_MODEL,
+            Some("off"),
+        ));
+    }
+
+    #[test]
     fn xiaomi_mimo_uses_max_completion_tokens_payload_key() {
         let mut body = json!({
             "model": "mimo-v2.5-pro",
@@ -4786,6 +5044,62 @@ mod alias_thinking_detection_tests {
         );
         assert_eq!(other_provider["thinking"]["type"], json!("enabled"));
         assert!(other_provider.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn kimi_code_k3_uses_documented_nested_thinking_effort() {
+        for (requested, expected) in [
+            ("low", json!({ "type": "enabled", "effort": "low" })),
+            ("minimum", json!({ "type": "enabled", "effort": "low" })),
+            ("light", json!({ "type": "enabled", "effort": "low" })),
+            ("medium", json!({ "type": "enabled", "effort": "high" })),
+            ("high", json!({ "type": "enabled", "effort": "high" })),
+            ("xhigh", json!({ "type": "enabled", "effort": "max" })),
+            ("ultra", json!({ "type": "enabled", "effort": "max" })),
+            ("max", json!({ "type": "enabled", "effort": "max" })),
+            ("none", json!({ "type": "disabled" })),
+            ("off", json!({ "type": "disabled" })),
+        ] {
+            let mut body = json!({ "reasoning_effort": "stale" });
+            apply_kimi_code_k3_reasoning_effort(
+                &mut body,
+                ApiProvider::Moonshot,
+                crate::config::DEFAULT_KIMI_CODE_BASE_URL,
+                crate::config::KIMI_CODE_K3_MODEL,
+                Some(requested),
+            );
+
+            assert_eq!(body["thinking"], expected, "requested {requested}");
+            assert!(body.get("reasoning_effort").is_none());
+        }
+    }
+
+    #[test]
+    fn kimi_code_k3_effort_override_never_leaks_to_neighbor_routes() {
+        for (base_url, model) in [
+            (crate::config::DEFAULT_KIMI_CODE_BASE_URL, "kimi-k3"),
+            (
+                crate::config::DEFAULT_KIMI_CODE_BASE_URL,
+                crate::config::DEFAULT_KIMI_CODE_MODEL,
+            ),
+            (crate::config::DEFAULT_MOONSHOT_BASE_URL, "k3"),
+        ] {
+            let mut body = json!({ "thinking": { "type": "enabled" } });
+            apply_kimi_code_k3_reasoning_effort(
+                &mut body,
+                ApiProvider::Moonshot,
+                base_url,
+                model,
+                Some("max"),
+            );
+
+            assert_eq!(body["thinking"], json!({ "type": "enabled" }));
+            assert!(
+                body.pointer("/thinking/effort").is_none(),
+                "{base_url} / {model}"
+            );
+            assert!(body.get("reasoning_effort").is_none());
+        }
     }
 
     #[test]

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -4895,8 +4895,13 @@ impl Config {
                 .provider_config_for(provider)
                 .is_some_and(provider_config_uses_kimi_imported_token)
         {
+            let credential_help =
+                credential_help_for_provider_route(provider, &self.deepseek_base_url());
             anyhow::bail!(
-                "Kimi CLI credential import is unsupported. Codewhale does not impersonate or reuse Kimi OAuth clients; configure a Kimi API key from https://platform.kimi.ai/console/api-keys instead."
+                "Kimi CLI credential import is unsupported. Codewhale does not impersonate or reuse Kimi OAuth clients; configure an API key from {} instead.",
+                credential_help
+                    .credential_url
+                    .unwrap_or("the selected provider's API-key console")
             );
         }
 
@@ -5039,17 +5044,31 @@ impl Config {
                 provider.env_vars_label(),
                 provider_config_table_name(provider)?
             ),
-            ApiProvider::Moonshot => anyhow::bail!(
-                "Moonshot/Kimi API key not found. Get a key: {}. Run 'codewhale auth set --provider moonshot', \
-                 set {}, or add [{}] api_key. \
-                 For a Kimi Code plan key, set [providers.moonshot] base_url = \
-                 \"https://api.kimi.com/coding/v1\" and model = \"kimi-for-coding\".",
-                provider
-                    .credential_url()
-                    .unwrap_or("https://platform.kimi.ai/console/api-keys"),
-                provider.env_vars_label(),
-                provider_config_table_name(provider)?
-            ),
+            ApiProvider::Moonshot => {
+                let credential_help =
+                    credential_help_for_provider_route(provider, &self.deepseek_base_url());
+                if moonshot_base_url_is_exact_kimi_code(&self.deepseek_base_url()) {
+                    anyhow::bail!(
+                        "Kimi Code membership-plan API key not found. Get a plan key: {}. This route uses api.kimi.com/coding/v1 and does not import Kimi CLI credentials. Run 'codewhale auth set --provider moonshot', set {}, or add [{}] api_key.",
+                        credential_help
+                            .credential_url
+                            .unwrap_or(KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL),
+                        provider.env_vars_label(),
+                        provider_config_table_name(provider)?
+                    );
+                }
+                anyhow::bail!(
+                    "Moonshot/Kimi API key not found. Get a key: {}. Run 'codewhale auth set --provider moonshot', \
+                     set {}, or add [{}] api_key. \
+                     For a Kimi Code plan key, set [providers.moonshot] base_url = \
+                     \"https://api.kimi.com/coding/v1\" and model = \"kimi-for-coding\".",
+                    credential_help
+                        .credential_url
+                        .unwrap_or("https://platform.kimi.ai/console/api-keys"),
+                    provider.env_vars_label(),
+                    provider_config_table_name(provider)?
+                );
+            }
             ApiProvider::Anthropic | ApiProvider::Openmodel => {
                 anyhow::bail!("{}", missing_provider_api_key_message(provider)?)
             }
@@ -7094,6 +7113,49 @@ fn moonshot_base_url_uses_kimi_code(base_url: &str) -> bool {
     normalized == DEFAULT_KIMI_CODE_BASE_URL
         || normalized == "https://api.kimi.com/coding"
         || normalized.starts_with("https://api.kimi.com/coding/")
+}
+
+/// The Kimi Code API endpoint, normalized only for insignificant trailing
+/// slashes. This must stay stricter than `moonshot_base_url_uses_kimi_code`:
+/// route-specific K3 capability and request shaping are not safe for arbitrary
+/// Kimi-hosted paths.
+pub(crate) fn moonshot_base_url_is_exact_kimi_code(base_url: &str) -> bool {
+    codewhale_config::provider::is_exact_kimi_code_route(
+        codewhale_config::ProviderKind::Moonshot,
+        base_url,
+    )
+}
+
+/// Whether a route is exactly the Kimi Code K3 membership-plan route.
+///
+/// Keep the bare `k3` identifier route-owned. In particular, do not infer a
+/// Kimi Code plan entitlement for direct Moonshot `kimi-k3`, generic `k3`, or
+/// `kimi-for-coding` routes.
+pub(crate) fn is_exact_kimi_code_k3_route(
+    provider: ApiProvider,
+    base_url: &str,
+    model: &str,
+) -> bool {
+    provider == ApiProvider::Moonshot
+        && moonshot_base_url_is_exact_kimi_code(base_url)
+        && model.trim().eq_ignore_ascii_case(KIMI_CODE_K3_MODEL)
+}
+
+/// Credential help for a concrete provider route.
+///
+/// `ProviderKind::Moonshot` intentionally retains its generic direct-API
+/// metadata in `codewhale-config`: that remains correct for Moonshot's own
+/// platform route. The Kimi Code membership endpoint is a distinct route and
+/// must not send its users to the generic API console or imply CLI credential
+/// import support.
+pub(crate) fn credential_help_for_provider_route(
+    provider: ApiProvider,
+    base_url: &str,
+) -> codewhale_config::provider::CredentialHelp {
+    provider.kind().map_or_else(
+        || provider.credential_help(),
+        |kind| codewhale_config::provider::credential_help_for_route(kind, base_url),
+    )
 }
 
 pub(crate) fn provider_config_uses_kimi_imported_token(config: &ProviderConfig) -> bool {

--- a/crates/tui/src/config/models.rs
+++ b/crates/tui/src/config/models.rs
@@ -102,6 +102,14 @@ pub const MOONSHOT_KIMI_K2_6_MODEL: &str = "kimi-k2.6";
 pub const DEFAULT_MOONSHOT_BASE_URL: &str = "https://api.moonshot.ai/v1";
 pub const DEFAULT_KIMI_CODE_MODEL: &str = "kimi-for-coding";
 pub const DEFAULT_KIMI_CODE_BASE_URL: &str = "https://api.kimi.com/coding/v1";
+pub const KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL: &str =
+    codewhale_config::provider::KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL;
+/// Official Kimi Code route model id. It is deliberately distinct from
+/// Moonshot's pay-as-you-go `kimi-k3` catalog id.
+pub const KIMI_CODE_K3_MODEL: &str = "k3";
+/// Conservative Kimi Code K3 context baseline. Higher plan entitlements must
+/// be supplied by an explicit provider configuration or fresh provider facts.
+pub const KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS: u32 = 262_144;
 pub const DEFAULT_SGLANG_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 pub const DEFAULT_SGLANG_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub const DEFAULT_SGLANG_BASE_URL: &str = "http://localhost:30000/v1";

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -7457,6 +7457,11 @@ api_key = "stale-api-key"
     assert!(
         error
             .to_string()
+            .contains(KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL)
+    );
+    assert!(
+        !error
+            .to_string()
             .contains("https://platform.kimi.ai/console/api-keys")
     );
     assert!(!has_api_key_for(&config, ApiProvider::Moonshot));
@@ -7466,6 +7471,34 @@ api_key = "stale-api-key"
         "Codewhale must never read, refresh, or rewrite Kimi CLI credentials"
     );
     Ok(())
+}
+
+#[test]
+fn moonshot_credential_help_keeps_direct_and_kimi_code_routes_distinct() {
+    let direct =
+        credential_help_for_provider_route(ApiProvider::Moonshot, DEFAULT_MOONSHOT_BASE_URL);
+    assert_eq!(
+        direct.credential_url,
+        Some("https://platform.kimi.ai/console/api-keys")
+    );
+    assert_eq!(
+        direct.docs_url,
+        Some("https://platform.kimi.ai/docs/overview")
+    );
+
+    let kimi_code =
+        credential_help_for_provider_route(ApiProvider::Moonshot, DEFAULT_KIMI_CODE_BASE_URL);
+    assert_eq!(
+        kimi_code.credential_url,
+        Some(KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL)
+    );
+    assert_eq!(kimi_code.docs_url, None);
+    assert!(kimi_code.guidance.contains("membership-plan API key"));
+    assert!(
+        kimi_code
+            .guidance
+            .contains("does not import Kimi CLI credentials")
+    );
 }
 
 #[test]
@@ -7673,6 +7706,41 @@ base_url = "https://api.kimi.com/coding/v1"
     assert_eq!(config.default_model(), DEFAULT_KIMI_CODE_MODEL);
     assert_eq!(config.deepseek_api_key()?, "kimi-code-key");
     assert!(has_api_key_for(&config, ApiProvider::Moonshot));
+    Ok(())
+}
+
+#[test]
+fn moonshot_kimi_code_missing_key_reports_membership_plan_console() -> Result<()> {
+    let _lock = lock_test_env();
+    let temp = tempfile::tempdir()?;
+    let _guard = EnvGuard::new(temp.path());
+    let config = Config {
+        provider: Some(ApiProvider::Moonshot.as_str().to_string()),
+        providers: Some(ProvidersConfig {
+            moonshot: ProviderConfig {
+                base_url: Some(DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+                model: Some(KIMI_CODE_K3_MODEL.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let error = config
+        .deepseek_api_key()
+        .expect_err("Kimi Code route needs a membership-plan API key");
+    let message = error.to_string();
+    assert!(
+        message.contains(KIMI_CODE_MEMBERSHIP_PLAN_CONSOLE_URL),
+        "{message}"
+    );
+    assert!(message.contains("api.kimi.com/coding/v1"), "{message}");
+    assert!(
+        message.contains("does not import Kimi CLI credentials"),
+        "{message}"
+    );
+    assert!(!message.contains("https://platform.kimi.ai/console/api-keys"));
     Ok(())
 }
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -499,6 +499,8 @@ impl Engine {
                 self.session.reasoning_effort.as_deref(),
                 &self.session.messages,
                 self.api_provider,
+                &self.api_config.deepseek_base_url(),
+                &self.config.model,
             );
 
             // Check prefix-cache stability before building the request.
@@ -3283,6 +3285,8 @@ fn resolve_auto_effort(
     reasoning_effort: Option<&str>,
     messages: &[Message],
     provider: crate::config::ApiProvider,
+    base_url: &str,
+    wire_model: &str,
 ) -> Option<String> {
     match reasoning_effort {
         Some(effort) if effort == REASONING_EFFORT_AUTO => {
@@ -3315,10 +3319,10 @@ fn resolve_auto_effort(
             // their own turn pass and can pass is_subagent=true when they
             // call this function directly.
             let tier = crate::auto_reasoning::select(false, &last_msg);
-            let resolved =
-                crate::model_routing::normalize_auto_route_effort_for_provider(provider, tier)
-                    .as_setting()
-                    .to_string();
+            let resolved = tier
+                .normalize_for_route(provider, base_url, wire_model)
+                .as_setting()
+                .to_string();
             tracing::debug!(
                 reasoning_effort = %resolved,
                 is_subagent = false,
@@ -3557,7 +3561,9 @@ mod tests {
             resolve_auto_effort(
                 Some("auto"),
                 &messages,
-                crate::config::ApiProvider::Deepseek
+                crate::config::ApiProvider::Deepseek,
+                crate::config::DEFAULT_DEEPSEEK_BASE_URL,
+                "deepseek-v4-pro",
             ),
             Some("high".to_string()),
             "auto thinking should classify the user request, not stored metadata"

--- a/crates/tui/src/fleet/profile.rs
+++ b/crates/tui/src/fleet/profile.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 
+use crate::tui::app::ReasoningEffort;
+
 #[allow(unused_imports)]
 pub use codewhale_config::{
     FleetDelegationHints, FleetLoadout, FleetProfile, FleetProfilePermissions, FleetRole, FleetSlot,
@@ -470,20 +472,20 @@ fn normalize_agent_profile_reasoning_effort(
     let Some(value) = non_empty_trimmed(value) else {
         return Ok(None);
     };
-    let normalized = match value.to_ascii_lowercase().as_str() {
-        "inherit" | "parent" | "same" | "current" | "default" | "unset" => return Ok(None),
-        "off" | "disabled" | "none" | "false" => "off",
-        "low" | "minimal" => "low",
-        "medium" | "mid" => "medium",
-        "high" => "high",
-        "auto" | "automatic" => "auto",
-        "max" | "maximum" | "xhigh" | "ultracode" => "max",
-        _ => bail!(
-            "agent profile {} reasoning_effort {value:?} must be one of: inherit, auto, off, low, medium, high, max",
-            path.display()
-        ),
-    };
-    Ok(Some(normalized.to_string()))
+    if matches!(
+        value.to_ascii_lowercase().as_str(),
+        "inherit" | "parent" | "same" | "current" | "default" | "unset"
+    ) {
+        return Ok(None);
+    }
+    ReasoningEffort::parse_strict(value)
+        .map(|effort| Some(effort.as_setting().to_string()))
+        .map_err(|_| {
+            anyhow!(
+                "agent profile {} reasoning_effort {value:?} must be one of: inherit, auto, off, low, medium, high, max",
+                path.display()
+            )
+        })
 }
 
 fn is_agent_profile_token_char(ch: char) -> bool {

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6856,7 +6856,7 @@ async fn run_review(config: &Config, args: ReviewArgs) -> Result<()> {
     let model = route.model.clone();
     let reasoning_effort = route
         .reasoning_effort
-        .and_then(|effort| cli_reasoning_effort_value(&execution_config, effort));
+        .and_then(|effort| cli_reasoning_effort_value(&execution_config, &model, effort));
 
     let system = SystemPrompt::Text(
         "You are a senior code reviewer. Focus on bugs, risks, behavioral regressions, and missing tests. \
@@ -8677,10 +8677,11 @@ struct CliAutoRoute {
 
 fn cli_reasoning_effort_value(
     config: &Config,
+    model: &str,
     effort: crate::tui::app::ReasoningEffort,
 ) -> Option<String> {
     effort
-        .api_value_for_provider(config.api_provider())
+        .api_value_for_route(config.api_provider(), &config.deepseek_base_url(), model)
         .map(str::to_string)
 }
 
@@ -8689,19 +8690,15 @@ fn normalize_cli_reasoning_effort(value: &str) -> Result<Option<String>> {
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let normalized = match trimmed.to_ascii_lowercase().as_str() {
-        "inherit" | "parent" | "same" | "current" | "default" | "unset" => return Ok(None),
-        "off" | "disabled" | "none" | "false" => "off",
-        "low" | "minimal" => "low",
-        "medium" | "mid" => "medium",
-        "high" => "high",
-        "auto" | "automatic" => "auto",
-        "max" | "maximum" | "xhigh" | "ultracode" => "max",
-        _ => bail!(
-            "Unrecognized --reasoning-effort {trimmed:?}. Expected: auto, off, low, medium, high, max, or default."
-        ),
-    };
-    Ok(Some(normalized.to_string()))
+    if matches!(
+        trimmed.to_ascii_lowercase().as_str(),
+        "inherit" | "parent" | "same" | "current" | "default" | "unset"
+    ) {
+        return Ok(None);
+    }
+    crate::tui::app::ReasoningEffort::parse_strict(trimmed)
+        .map(|effort| Some(effort.as_setting().to_string()))
+        .map_err(anyhow::Error::msg)
 }
 
 fn config_for_cli_route(config: &Config, route: &CliAutoRoute) -> Config {
@@ -8820,7 +8817,7 @@ async fn run_one_shot(
     let client = DeepSeekClient::new(&execution_config)?;
     let reasoning_effort = route
         .reasoning_effort
-        .and_then(|effort| cli_reasoning_effort_value(&execution_config, effort));
+        .and_then(|effort| cli_reasoning_effort_value(&execution_config, &route.model, effort));
 
     let request = MessageRequest {
         model: route.model,
@@ -8870,7 +8867,7 @@ async fn run_one_shot_json(
     let model = route.model.clone();
     let reasoning_effort = route
         .reasoning_effort
-        .and_then(|effort| cli_reasoning_effort_value(&execution_config, effort));
+        .and_then(|effort| cli_reasoning_effort_value(&execution_config, &model, effort));
     let request = MessageRequest {
         model: model.clone(),
         messages: vec![Message {
@@ -9477,7 +9474,7 @@ async fn build_direct_workflow_tool(
     let client = DeepSeekClient::new(config)?;
     let reasoning_effort = route
         .reasoning_effort
-        .and_then(|effort| cli_reasoning_effort_value(config, effort));
+        .and_then(|effort| cli_reasoning_effort_value(config, &route.model, effort));
     let mcp_pool = if let Some((pool, failures)) =
         initialize_direct_workflow_mcp_pool(config, workspace, network_policy, plugin_registry)
             .await
@@ -9894,7 +9891,7 @@ async fn run_exec_agent(
     };
     let effective_reasoning_effort = route
         .reasoning_effort
-        .and_then(|effort| cli_reasoning_effort_value(&execution_config, effort));
+        .and_then(|effort| cli_reasoning_effort_value(&execution_config, &effective_model, effort));
 
     let settings = crate::settings::Settings::load().unwrap_or_default();
     let auto_compact_enabled = if crate::settings::Settings::auto_compact_explicitly_configured() {

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -422,18 +422,7 @@ fn extract_first_json_object(raw: &str) -> Option<&str> {
 }
 
 fn parse_auto_route_reasoning_effort(effort: &str) -> Option<ReasoningEffort> {
-    match effort.trim().to_ascii_lowercase().as_str() {
-        "off" | "disabled" | "none" | "false" => Some(ReasoningEffort::Off),
-        "low" | "minimal" | "medium" | "mid" => Some(ReasoningEffort::High),
-        "high" => Some(ReasoningEffort::High),
-        "max" | "maximum" | "xhigh" | "ultracode" => Some(ReasoningEffort::Max),
-        _ => None,
-    }
-}
-
-#[must_use]
-pub(crate) fn normalize_auto_route_effort(effort: ReasoningEffort) -> ReasoningEffort {
-    normalize_auto_route_effort_for_provider(ApiProvider::Deepseek, effort)
+    ReasoningEffort::parse_strict(effort).ok()
 }
 
 #[must_use]
@@ -448,6 +437,39 @@ pub(crate) fn normalize_auto_route_effort_for_provider(
         ReasoningEffort::Low | ReasoningEffort::Medium => ReasoningEffort::High,
         other => other,
     }
+}
+
+/// Route-aware equivalent of [`normalize_auto_route_effort_for_provider`].
+/// The inventory knows the selected provider/model, and the route resolver
+/// supplies the endpoint needed to distinguish Kimi Code's official bare-K3
+/// contract from generic Moonshot.
+#[must_use]
+pub(crate) fn normalize_auto_route_effort_for_configured_route(
+    config: &Config,
+    provider: ApiProvider,
+    model: &str,
+    effort: ReasoningEffort,
+) -> ReasoningEffort {
+    crate::route_runtime::resolve_runtime_route(config, provider, Some(model))
+        .map(|route| {
+            effort.normalize_for_route(provider, &route.candidate.endpoint.base_url, &route.model)
+        })
+        .unwrap_or_else(|_| normalize_auto_route_effort_for_provider(provider, effort))
+}
+
+fn normalize_auto_route_selection_for_config(
+    config: &Config,
+    mut selection: AutoRouteSelection,
+) -> AutoRouteSelection {
+    selection.reasoning_effort = selection.reasoning_effort.map(|effort| {
+        normalize_auto_route_effort_for_configured_route(
+            config,
+            selection.provider,
+            &selection.model,
+            effort,
+        )
+    });
+    selection
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -487,19 +509,18 @@ pub(crate) async fn resolve_auto_route_with_inventory_for_session(
     if !inventory.router_available {
         // Fall back to heuristic-only auto routing when the flash router
         // is unavailable (e.g. non-DeepSeek providers like wanjie-ark).
-        return Ok(auto_route_from_inventory_heuristic(
+        return Ok(normalize_auto_route_selection_for_config(
             config,
-            latest_request,
-            &inventory,
+            auto_route_from_inventory_heuristic(config, latest_request, &inventory),
         ));
     }
 
     let heuristic = auto_route_from_inventory_heuristic(config, latest_request, &inventory);
     if cfg!(test) {
-        return Ok(heuristic);
+        return Ok(normalize_auto_route_selection_for_config(config, heuristic));
     }
 
-    match auto_route_inventory_recommendation(
+    let selection = match auto_route_inventory_recommendation(
         config,
         &inventory,
         latest_request,
@@ -510,9 +531,10 @@ pub(crate) async fn resolve_auto_route_with_inventory_for_session(
     )
     .await
     {
-        Ok(Some(recommendation)) => Ok(auto_route_from_classifier(&inventory, recommendation)),
-        Ok(None) | Err(_) => Ok(auto_route_classifier_fallback(heuristic, &inventory)),
-    }
+        Ok(Some(recommendation)) => auto_route_from_classifier(&inventory, recommendation),
+        Ok(None) | Err(_) => auto_route_classifier_fallback(heuristic, &inventory),
+    };
+    Ok(normalize_auto_route_selection_for_config(config, selection))
 }
 
 pub(crate) fn resolve_explicit_route_with_inventory(
@@ -535,8 +557,10 @@ pub(crate) fn resolve_explicit_route_with_inventory(
             provider: candidate.provider,
             model: candidate.model.clone(),
             reasoning_effort: config.reasoning_effort().map(|setting| {
-                normalize_auto_route_effort_for_provider(
+                normalize_auto_route_effort_for_configured_route(
+                    config,
                     candidate.provider,
+                    &candidate.model,
                     ReasoningEffort::from_setting(setting),
                 )
             }),
@@ -558,8 +582,10 @@ pub(crate) fn resolve_explicit_route_with_inventory(
         provider: candidate.provider,
         model: candidate.model.clone(),
         reasoning_effort: config.reasoning_effort().map(|setting| {
-            normalize_auto_route_effort_for_provider(
+            normalize_auto_route_effort_for_configured_route(
+                config,
                 candidate.provider,
+                &candidate.model,
                 ReasoningEffort::from_setting(setting),
             )
         }),
@@ -904,8 +930,7 @@ fn parse_inventory_auto_route_recommendation(
         .or_else(|| value.get("reasoning_effort"))
         .or_else(|| value.get("effort"))
         .and_then(serde_json::Value::as_str)
-        .and_then(parse_auto_route_reasoning_effort)
-        .map(|effort| normalize_auto_route_effort_for_provider(provider, effort));
+        .and_then(parse_auto_route_reasoning_effort);
 
     Some(InventoryAutoRouteRecommendation {
         provider,
@@ -1151,6 +1176,56 @@ mod tests {
     }
 
     #[test]
+    fn configured_route_effort_normalizer_keeps_kimi_code_low_medium_local() {
+        let mut config = Config {
+            provider: Some("moonshot".to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                moonshot: crate::config::ProviderConfig {
+                    base_url: Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+                    model: Some("k3".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            normalize_auto_route_effort_for_configured_route(
+                &config,
+                ApiProvider::Moonshot,
+                "k3",
+                ReasoningEffort::Low,
+            ),
+            ReasoningEffort::Low
+        );
+        assert_eq!(
+            normalize_auto_route_effort_for_configured_route(
+                &config,
+                ApiProvider::Moonshot,
+                "k3",
+                ReasoningEffort::Medium,
+            ),
+            ReasoningEffort::Medium
+        );
+
+        config
+            .providers
+            .as_mut()
+            .expect("providers")
+            .moonshot
+            .base_url = Some(crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string());
+        assert_eq!(
+            normalize_auto_route_effort_for_configured_route(
+                &config,
+                ApiProvider::Moonshot,
+                "k3",
+                ReasoningEffort::Low,
+            ),
+            ReasoningEffort::High
+        );
+    }
+
+    #[test]
     fn inventory_auto_route_recommendation_requires_runnable_pair() {
         let _env_lock = crate::test_support::lock_test_env();
         let _deepseek = crate::test_support::EnvVarGuard::set("DEEPSEEK_API_KEY", "ds-key");
@@ -1187,7 +1262,10 @@ mod tests {
         .expect("wrapped inventory route should parse");
         assert_eq!(wrapped.provider, ApiProvider::Zai);
         assert_eq!(wrapped.model, crate::config::ZAI_GLM_5_TURBO_MODEL);
-        assert_eq!(wrapped.reasoning_effort, Some(ReasoningEffort::High));
+        // Parsing is strict and literal; the historic Medium->High coercion
+        // is applied downstream by normalize_auto_route_selection_for_config
+        // so route-specific contracts (Kimi Code K3) can keep Medium.
+        assert_eq!(wrapped.reasoning_effort, Some(ReasoningEffort::Medium));
     }
 
     #[test]

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -1,10 +1,55 @@
+use chrono::{DateTime, Duration, Utc};
 use codewhale_config::route::{
     LogicalModelRef, ReadyRouteCandidate, RouteLimits, RouteRequest, RouteResolver, WireModelId,
 };
+use serde::Serialize;
 
 use crate::client::DeepSeekClient;
 use crate::codex_model_cache::{CodexModelCacheFreshness, model_roster};
-use crate::config::{ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL, ProviderIdentity};
+use crate::config::{
+    ApiProvider, Config, DEFAULT_NVIDIA_NIM_BASE_URL, KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS,
+    ProviderIdentity, is_exact_kimi_code_k3_route,
+};
+
+/// Why a route is using its effective context-window value.  Keep this
+/// receipt separate from the numeric route limits so every consumer can state
+/// whether the number is operator-configured, freshly provider-reported, a
+/// Kimi Code safety floor, catalog data, or a conservative fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ContextWindowSource {
+    Configured,
+    ProviderReported,
+    StaticKimiCodeSafeFloor,
+    Catalog,
+    Fallback,
+}
+
+/// Context window carried alongside an exact runtime route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) struct ContextWindowResolution {
+    pub(crate) tokens: u32,
+    pub(crate) source: ContextWindowSource,
+}
+
+/// Authenticated Kimi Code `/models` metadata that a caller has already
+/// validated.  This is intentionally route-scoped: generic Moonshot metadata
+/// can never promote a bare `k3` route.  The current runtime has no implicit
+/// network probe; an authenticated model-listing consumer may pass this value
+/// to [`resolve_route_candidate_with_context_metadata`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderReportedKimiCodeContext {
+    pub(crate) context_tokens: u32,
+    pub(crate) observed_at: DateTime<Utc>,
+}
+
+const KIMI_CODE_REPORTED_CONTEXT_MAX_AGE_HOURS: i64 = 24;
+
+#[derive(Debug)]
+pub(crate) struct RouteCandidateResolution {
+    pub(crate) candidate: ReadyRouteCandidate,
+    pub(crate) context_window: ContextWindowResolution,
+}
 
 #[derive(Clone)]
 pub(crate) struct ResolvedRuntimeRoute {
@@ -12,6 +57,7 @@ pub(crate) struct ResolvedRuntimeRoute {
     pub(crate) candidate: ReadyRouteCandidate,
     pub(crate) config: Box<Config>,
     pub(crate) model: String,
+    pub(crate) context_window: ContextWindowResolution,
     preflighted_client: Option<DeepSeekClient>,
 }
 
@@ -35,6 +81,7 @@ pub(crate) struct ValidatedRuntimeRoute {
     pub(crate) candidate: ReadyRouteCandidate,
     pub(crate) config: Box<Config>,
     pub(crate) model: String,
+    pub(crate) context_window: ContextWindowResolution,
     pub(crate) client: DeepSeekClient,
 }
 
@@ -80,6 +127,7 @@ impl ResolvedRuntimeRoute {
             candidate: self.candidate,
             config: self.config,
             model: self.model,
+            context_window: self.context_window,
             client,
         })
     }
@@ -98,6 +146,7 @@ impl ValidatedRuntimeRoute {
             candidate: self.candidate,
             config: self.config,
             model: self.model,
+            context_window: self.context_window,
             preflighted_client: Some(self.client),
         }
     }
@@ -110,6 +159,30 @@ pub(crate) fn resolve_route_candidate(
     base_url_override: Option<String>,
     context_window_override: Option<u32>,
 ) -> Result<ReadyRouteCandidate, String> {
+    resolve_route_candidate_with_context_metadata(
+        provider,
+        model_selector,
+        saved_provider_model,
+        base_url_override,
+        context_window_override,
+        None,
+    )
+    .map(|resolution| resolution.candidate)
+}
+
+/// Resolve a candidate together with a non-secret context-window provenance
+/// receipt.  `provider_reported_context` is accepted only for the exact Kimi
+/// Code bare-K3 endpoint, only at the documented 1M entitlement, and only
+/// while fresh; this prevents generic Moonshot or stale metadata from being
+/// inherited by a membership-plan route.
+pub(crate) fn resolve_route_candidate_with_context_metadata(
+    provider: ApiProvider,
+    model_selector: Option<&str>,
+    saved_provider_model: Option<&str>,
+    base_url_override: Option<String>,
+    context_window_override: Option<u32>,
+    provider_reported_context: Option<ProviderReportedKimiCodeContext>,
+) -> Result<RouteCandidateResolution, String> {
     let route_request = RouteRequest {
         explicit_provider: provider.kind(),
         model_selector: model_selector.map(|model| LogicalModelRef::from(model.to_string())),
@@ -120,14 +193,16 @@ pub(crate) fn resolve_route_candidate(
     let mut candidate = RouteResolver::new()
         .resolve(&route_request)
         .map_err(|err| err.to_string())?;
-    apply_context_window_override(&mut candidate.limits, context_window_override);
     if provider == ApiProvider::OpenaiCodex {
         // Models.dev describes the public API offering, not the account-scoped
         // ChatGPT OAuth route. Strip API-only limits, then carry the fresh
         // Codex roster's per-model context into every runtime consumer.
         candidate.limits.input_tokens = None;
         candidate.limits.output_tokens = None;
-        if context_window_override.is_none() {
+        if context_window_override
+            .filter(|window| *window > 0)
+            .is_none()
+        {
             let roster = model_roster();
             candidate.limits.context_tokens = if roster.freshness == CodexModelCacheFreshness::Fresh
             {
@@ -140,7 +215,83 @@ pub(crate) fn resolve_route_candidate(
             };
         }
     }
-    Ok(candidate)
+
+    let configured = context_window_override.filter(|window| *window > 0);
+    if let Some(context_window) = configured {
+        apply_context_window_override(&mut candidate.limits, Some(context_window));
+        return Ok(RouteCandidateResolution {
+            candidate,
+            context_window: ContextWindowResolution {
+                tokens: context_window,
+                source: ContextWindowSource::Configured,
+            },
+        });
+    }
+
+    let is_exact_kimi_code_k3 = is_exact_kimi_code_k3_route(
+        provider,
+        &candidate.endpoint.base_url,
+        candidate.wire_model_id.as_str(),
+    );
+    let now = Utc::now();
+    if is_exact_kimi_code_k3
+        && provider_reported_context.is_some_and(|reported| {
+            reported.context_tokens == 1_048_576
+                && reported.observed_at <= now
+                && now.signed_duration_since(reported.observed_at)
+                    <= Duration::hours(KIMI_CODE_REPORTED_CONTEXT_MAX_AGE_HOURS)
+        })
+    {
+        let reported = provider_reported_context.expect("checked above");
+        candidate.limits.context_tokens = Some(u64::from(reported.context_tokens));
+        return Ok(RouteCandidateResolution {
+            candidate,
+            context_window: ContextWindowResolution {
+                tokens: reported.context_tokens,
+                source: ContextWindowSource::ProviderReported,
+            },
+        });
+    }
+
+    // Kimi Code's bare `k3` is a membership-plan route, not an alias for
+    // Moonshot's public `kimi-k3` catalog entry.  The safe all-plan floor is
+    // the route's next precedence after an explicit config or fresh, scoped
+    // provider report.
+    if is_exact_kimi_code_k3 {
+        candidate.limits.context_tokens = Some(u64::from(KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS));
+        return Ok(RouteCandidateResolution {
+            candidate,
+            context_window: ContextWindowResolution {
+                tokens: KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS,
+                source: ContextWindowSource::StaticKimiCodeSafeFloor,
+            },
+        });
+    }
+
+    if let Some(tokens) = candidate
+        .limits
+        .context_tokens
+        .and_then(|tokens| u32::try_from(tokens).ok())
+    {
+        return Ok(RouteCandidateResolution {
+            candidate,
+            context_window: ContextWindowResolution {
+                tokens,
+                source: ContextWindowSource::Catalog,
+            },
+        });
+    }
+
+    let fallback_tokens =
+        crate::config::provider_capability(provider, candidate.wire_model_id.as_str())
+            .context_window;
+    Ok(RouteCandidateResolution {
+        candidate,
+        context_window: ContextWindowResolution {
+            tokens: fallback_tokens,
+            source: ContextWindowSource::Fallback,
+        },
+    })
 }
 
 fn apply_context_window_override(limits: &mut RouteLimits, context_window: Option<u32>) {
@@ -178,13 +329,15 @@ pub(crate) fn resolve_runtime_route_for_identity(
     let provider = identity.provider;
     let mut route_config = prepared_route_config(config, &identity, model_selector);
     let saved_provider_model = configured_model_for_route(&route_config, provider);
-    let candidate = resolve_route_candidate(
+    let resolution = resolve_route_candidate_with_context_metadata(
         provider,
         model_selector,
         saved_provider_model,
         Some(route_config.deepseek_base_url()),
         route_config.context_window_for_provider_config(provider),
+        None,
     )?;
+    let candidate = resolution.candidate;
     let model = candidate.wire_model_id.as_str().to_string();
     set_model_for_route(&mut route_config, provider, &model);
 
@@ -193,6 +346,7 @@ pub(crate) fn resolve_runtime_route_for_identity(
         candidate,
         config: Box::new(route_config),
         model,
+        context_window: resolution.context_window,
         preflighted_client: None,
     })
 }
@@ -339,6 +493,159 @@ mod tests {
             ),
             1_048_576
         );
+    }
+
+    #[test]
+    fn kimi_code_bare_k3_uses_conservative_route_baseline() {
+        let candidate = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+            None,
+        )
+        .expect("Kimi Code K3 route");
+
+        assert_eq!(candidate.wire_model_id.as_str(), "k3");
+        assert_eq!(candidate.limits.context_tokens, Some(262_144));
+    }
+
+    #[test]
+    fn kimi_code_context_resolution_records_precedence_and_rejects_bad_metadata() {
+        let base = Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string());
+        let static_floor = resolve_route_candidate_with_context_metadata(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            base.clone(),
+            None,
+            None,
+        )
+        .expect("Kimi Code route");
+        assert_eq!(static_floor.context_window.tokens, 262_144);
+        assert_eq!(
+            static_floor.context_window.source,
+            ContextWindowSource::StaticKimiCodeSafeFloor
+        );
+
+        let configured = resolve_route_candidate_with_context_metadata(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            base.clone(),
+            Some(1_048_576),
+            Some(ProviderReportedKimiCodeContext {
+                context_tokens: 1_048_576,
+                observed_at: Utc::now(),
+            }),
+        )
+        .expect("configured route");
+        assert_eq!(configured.context_window.tokens, 1_048_576);
+        assert_eq!(
+            configured.context_window.source,
+            ContextWindowSource::Configured
+        );
+
+        let reported = resolve_route_candidate_with_context_metadata(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            base.clone(),
+            None,
+            Some(ProviderReportedKimiCodeContext {
+                context_tokens: 1_048_576,
+                observed_at: Utc::now(),
+            }),
+        )
+        .expect("fresh documented provider metadata");
+        assert_eq!(reported.context_window.tokens, 1_048_576);
+        assert_eq!(
+            reported.context_window.source,
+            ContextWindowSource::ProviderReported
+        );
+
+        let stale = resolve_route_candidate_with_context_metadata(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            base,
+            None,
+            Some(ProviderReportedKimiCodeContext {
+                context_tokens: 1_048_576,
+                observed_at: Utc::now() - Duration::hours(25),
+            }),
+        )
+        .expect("stale metadata falls back safely");
+        assert_eq!(
+            stale.context_window.source,
+            ContextWindowSource::StaticKimiCodeSafeFloor
+        );
+
+        let generic = resolve_route_candidate_with_context_metadata(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            Some(crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string()),
+            None,
+            Some(ProviderReportedKimiCodeContext {
+                context_tokens: 1_048_576,
+                observed_at: Utc::now(),
+            }),
+        )
+        .expect("generic Moonshot route");
+        assert_ne!(
+            generic.context_window.source,
+            ContextWindowSource::ProviderReported,
+            "Moonshot metadata may not promote bare K3 outside the exact Kimi Code route"
+        );
+    }
+
+    #[test]
+    fn kimi_code_k3_context_override_wins_over_conservative_baseline() {
+        let candidate = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+            Some(1_048_576),
+        )
+        .expect("Kimi Code K3 route");
+
+        assert_eq!(candidate.limits.context_tokens, Some(1_048_576));
+    }
+
+    #[test]
+    fn kimi_code_k3_baseline_does_not_leak_to_other_moonshot_routes() {
+        let exact_endpoint = Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string());
+        let direct_moonshot = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("kimi-k3"),
+            None,
+            exact_endpoint.clone(),
+            None,
+        )
+        .expect("direct Moonshot K3 route");
+        assert_eq!(direct_moonshot.limits.context_tokens, Some(1_048_576));
+
+        let generic_moonshot = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            Some(crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string()),
+            None,
+        )
+        .expect("generic Moonshot route");
+        assert_ne!(generic_moonshot.limits.context_tokens, Some(262_144));
+
+        let kimi_code_default = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some(crate::config::DEFAULT_KIMI_CODE_MODEL),
+            None,
+            exact_endpoint,
+            None,
+        )
+        .expect("Kimi Code default route");
+        assert_ne!(kimi_code_default.limits.context_tokens, Some(262_144));
     }
 
     #[test]

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -4372,12 +4372,17 @@ impl RuntimeThreadManager {
                 selection.provider,
                 Some(&selection.model),
             )?;
-            (
-                route,
-                selection
-                    .reasoning_effort
-                    .map(|effort| effort.as_setting().to_string()),
-            )
+            let reasoning_effort = selection.reasoning_effort.map(|effort| {
+                effort
+                    .normalize_for_route(
+                        route.identity.provider,
+                        &route.candidate.endpoint.base_url,
+                        &route.model,
+                    )
+                    .as_setting()
+                    .to_string()
+            });
+            (route, reasoning_effort)
         } else {
             (
                 resolve_runtime_thread_route_for_identity(

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::{ApiProvider, expand_path, normalize_model_name};
 use crate::localization::normalize_configured_locale;
 use crate::palette::{normalize_hex_rgb_color, normalize_theme_name};
+use crate::tui::app::ReasoningEffort;
 
 const SETTINGS_FILE_NAME: &str = "settings.toml";
 const TUI_PREFS_FILE_NAME: &str = "tui.toml";
@@ -1469,20 +1470,9 @@ fn normalize_reasoning_effort_setting(value: &str) -> Result<Option<String>> {
         return Ok(None);
     }
 
-    let normalized = match trimmed.to_ascii_lowercase().as_str() {
-        "off" | "disabled" | "none" | "false" => "off",
-        "low" | "minimal" => "low",
-        "medium" | "mid" => "medium",
-        "high" => "high",
-        "auto" | "automatic" => "auto",
-        "max" | "maximum" | "xhigh" | "ultracode" => "max",
-        _ => {
-            anyhow::bail!(
-                "Failed to update setting: invalid reasoning_effort '{value}'. Expected: auto, off, low, medium, high, max, xhigh, ultracode, or default."
-            );
-        }
-    };
-    Ok(Some(normalized.to_string()))
+    ReasoningEffort::parse_strict(trimmed)
+        .map(|effort| Some(effort.as_setting().to_string()))
+        .map_err(|err| anyhow::anyhow!("Failed to update setting: {err}"))
 }
 
 /// Parse a boolean value from various formats

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1440,15 +1440,17 @@ impl SubAgentThinking {
         let normalized = value.trim().to_ascii_lowercase();
         match normalized.as_str() {
             "inherit" | "parent" | "same" | "current" => Ok(Self::Inherit),
-            "auto" | "automatic" => Ok(Self::Auto),
-            "off" | "disabled" | "none" | "false" => Ok(Self::Effort(ReasoningEffort::Off)),
-            "low" | "minimal" => Ok(Self::Effort(ReasoningEffort::Low)),
-            "medium" | "mid" => Ok(Self::Effort(ReasoningEffort::Medium)),
-            "high" => Ok(Self::Effort(ReasoningEffort::High)),
-            "max" | "maximum" | "xhigh" | "ultracode" => Ok(Self::Effort(ReasoningEffort::Max)),
-            _ => Err(ToolError::invalid_input(
-                "thinking must be one of: inherit, auto, off, low, medium, high, max".to_string(),
-            )),
+            _ => ReasoningEffort::parse_strict(value)
+                .map(|effort| match effort {
+                    ReasoningEffort::Auto => Self::Auto,
+                    effort => Self::Effort(effort),
+                })
+                .map_err(|_| {
+                    ToolError::invalid_input(
+                        "thinking must be one of: inherit, auto, off, low, medium, high, max"
+                            .to_string(),
+                    )
+                }),
         }
     }
 }
@@ -8608,6 +8610,7 @@ fn worker_profile_subagent_assignment_route(
 
     let reasoning_effort = subagent_reasoning_effort_for_request(
         runtime,
+        &model,
         prompt,
         requested_fast_lane,
         requested_thinking,
@@ -8618,14 +8621,22 @@ fn worker_profile_subagent_assignment_route(
 
 fn subagent_reasoning_effort_for_request(
     runtime: &SubAgentRuntime,
+    model: &str,
     prompt: &str,
     requested_fast_lane: bool,
     requested_thinking: SubAgentThinking,
 ) -> Option<String> {
+    let normalize = |effort: ReasoningEffort| {
+        effort.normalize_for_route(
+            runtime.client.api_provider(),
+            runtime.client.base_url(),
+            model,
+        )
+    };
     match requested_thinking {
-        SubAgentThinking::Effort(effort) => Some(effort.as_setting().to_string()),
+        SubAgentThinking::Effort(effort) => Some(normalize(effort).as_setting().to_string()),
         SubAgentThinking::Auto => Some(
-            auto_subagent_reasoning_effort(prompt)
+            normalize(auto_subagent_reasoning_effort(prompt))
                 .as_setting()
                 .to_string(),
         ),
@@ -8641,29 +8652,42 @@ fn subagent_reasoning_effort_for_request(
             } else {
                 ReasoningEffort::Off
             };
-            Some(effort.as_setting().to_string())
+            Some(normalize(effort).as_setting().to_string())
         }
-        SubAgentThinking::Inherit => fallback_subagent_reasoning_effort(runtime, prompt),
+        SubAgentThinking::Inherit => fallback_subagent_reasoning_effort(runtime, model, prompt),
     }
 }
 
-fn fallback_subagent_reasoning_effort(runtime: &SubAgentRuntime, prompt: &str) -> Option<String> {
+fn fallback_subagent_reasoning_effort(
+    runtime: &SubAgentRuntime,
+    model: &str,
+    prompt: &str,
+) -> Option<String> {
+    let normalize = |effort: ReasoningEffort| {
+        effort.normalize_for_route(
+            runtime.client.api_provider(),
+            runtime.client.base_url(),
+            model,
+        )
+    };
     if runtime.reasoning_effort_auto {
         Some(
-            auto_subagent_reasoning_effort(prompt)
+            normalize(auto_subagent_reasoning_effort(prompt))
                 .as_setting()
                 .to_string(),
         )
     } else {
-        runtime.reasoning_effort.clone()
+        runtime
+            .reasoning_effort
+            .as_deref()
+            .map(ReasoningEffort::from_setting)
+            .map(normalize)
+            .map(|effort| effort.as_setting().to_string())
     }
 }
 
 fn auto_subagent_reasoning_effort(prompt: &str) -> ReasoningEffort {
-    match crate::auto_reasoning::select(false, prompt) {
-        ReasoningEffort::Low | ReasoningEffort::Medium => ReasoningEffort::High,
-        other => other,
-    }
+    crate::auto_reasoning::select(false, prompt)
 }
 
 fn parse_optional_subagent_model(input: &Value, key: &str) -> Result<Option<String>, ToolError> {

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -246,19 +246,35 @@ pub enum ReasoningEffort {
 }
 
 impl ReasoningEffort {
-    /// Parse a config-file string into an effort tier. Unknown values fall
-    /// back to the default (`Max`) rather than erroring out.
+    /// Parse an operator-supplied effort value.
+    ///
+    /// This is deliberately the one canonical spelling table for every
+    /// human-facing route.  Callers that read an old persisted config may use
+    /// [`Self::from_setting`] for its compatibility fallback, but a new CLI,
+    /// settings, or tool input must reject an unknown value instead of quietly
+    /// turning it into `max`.
+    pub fn parse_strict(value: &str) -> Result<Self, String> {
+        let trimmed = value.trim();
+        match trimmed.to_ascii_lowercase().as_str() {
+            "off" | "disabled" | "none" | "false" => Ok(Self::Off),
+            "low" | "minimum" | "minimal" | "light" => Ok(Self::Low),
+            "medium" | "mid" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "auto" | "automatic" => Ok(Self::Auto),
+            "max" | "maximum" | "xhigh" | "ultra" | "ultracode" => Ok(Self::Max),
+            _ => Err(format!(
+                "Unrecognized reasoning effort {trimmed:?}. Expected: auto, off, low, medium, high, or max."
+            )),
+        }
+    }
+
+    /// Parse a persisted config-file string into an effort tier. Unknown
+    /// legacy values fall back to the default (`Max`) so an old malformed
+    /// settings file never prevents startup.  New user input should use
+    /// [`Self::parse_strict`] instead.
     #[must_use]
     pub fn from_setting(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "off" | "disabled" | "none" | "false" => Self::Off,
-            "low" | "minimal" => Self::Low,
-            "medium" | "mid" => Self::Medium,
-            "high" => Self::High,
-            "auto" | "automatic" => Self::Auto,
-            "max" | "maximum" | "xhigh" | "ultracode" => Self::Max,
-            _ => Self::default(),
-        }
+        Self::parse_strict(value).unwrap_or_default()
     }
 
     #[must_use]
@@ -324,6 +340,32 @@ impl ReasoningEffort {
         }
     }
 
+    /// Resolve an effort against the exact provider route that will receive
+    /// the request.  Low/medium remain distinct only for the official Kimi
+    /// Code K3 endpoint; generic Moonshot and every other non-Codex route
+    /// retain the historic high coercion.  This intentionally does not change
+    /// [`Self::normalize_for_provider`], whose generic wire semantics are used
+    /// by older callers that do not yet have a route receipt.
+    #[must_use]
+    pub fn normalize_for_route(
+        self,
+        provider: ApiProvider,
+        base_url: &str,
+        wire_model: &str,
+    ) -> Self {
+        let normalized = self.normalize_for_provider(provider);
+        if crate::config::is_exact_kimi_code_k3_route(provider, base_url, wire_model) {
+            return normalized;
+        }
+        if provider == ApiProvider::OpenaiCodex {
+            return normalized;
+        }
+        match normalized {
+            Self::Low | Self::Medium => Self::High,
+            other => other,
+        }
+    }
+
     #[must_use]
     pub fn api_value_for_provider(self, provider: ApiProvider) -> Option<&'static str> {
         if provider != ApiProvider::OpenaiCodex {
@@ -339,10 +381,34 @@ impl ReasoningEffort {
         })
     }
 
+    /// Provider-facing value after exact-route normalization.
+    #[must_use]
+    pub fn api_value_for_route(
+        self,
+        provider: ApiProvider,
+        base_url: &str,
+        wire_model: &str,
+    ) -> Option<&'static str> {
+        self.normalize_for_route(provider, base_url, wire_model)
+            .api_value_for_provider(provider)
+    }
+
     #[must_use]
     pub fn as_setting_for_provider(self, provider: ApiProvider) -> &'static str {
         self.api_value_for_provider(provider)
             .unwrap_or_else(|| self.as_setting())
+    }
+
+    /// Persist the canonical setting after exact-route normalization.
+    #[must_use]
+    pub fn as_setting_for_route(
+        self,
+        provider: ApiProvider,
+        base_url: &str,
+        wire_model: &str,
+    ) -> &'static str {
+        self.normalize_for_route(provider, base_url, wire_model)
+            .as_setting_for_provider(provider)
     }
 
     /// Cycle through the three behaviorally distinct tiers.
@@ -1689,6 +1755,8 @@ pub(crate) struct PendingProviderSwitch {
     pub previous_model: String,
     pub previous_model_ids_passthrough: bool,
     pub previous_route_limits: Option<RouteLimits>,
+    pub previous_route_base_url: String,
+    pub previous_context_window_source: crate::route_runtime::ContextWindowSource,
     pub previous_context_window_override: Option<u32>,
     pub previous_config: Config,
     pub previous_onboarding: OnboardingState,
@@ -1820,6 +1888,14 @@ pub struct App {
     pub model_ids_passthrough: bool,
     /// Resolved provider/model route limits for the active runtime route.
     pub active_route_limits: Option<RouteLimits>,
+    /// Exact resolved endpoint for the active runtime route. This stays
+    /// separate from persisted config so endpoint-sensitive compatibility
+    /// (notably Kimi Code's bare `k3`) is never inferred from a provider name
+    /// alone.
+    pub active_route_base_url: String,
+    /// Provenance for `active_route_limits`' effective context window. This
+    /// is an operator-facing receipt, not a claim about provider billing.
+    pub active_context_window_source: crate::route_runtime::ContextWindowSource,
     /// User-configured provider context-window override for the active route.
     pub active_context_window_override: Option<u32>,
     /// Pending provider transition for transactional rollback when the next
@@ -2846,25 +2922,46 @@ impl App {
             .unwrap_or(model);
         let auto_model = model.trim().eq_ignore_ascii_case("auto");
         let active_context_window_override = config.context_window_for_provider_config(provider);
-        let active_route_limits = if auto_model {
-            active_context_window_override.map(|window| RouteLimits {
-                context_tokens: Some(u64::from(window)),
-                ..RouteLimits::default()
-            })
-        } else {
-            let saved_provider_model = config
-                .provider_config_for(provider)
-                .and_then(|provider| provider.model.as_deref());
-            crate::route_runtime::resolve_route_candidate(
-                provider,
-                Some(&model),
-                saved_provider_model,
-                Some(effective_auth_config.deepseek_base_url()),
-                active_context_window_override,
-            )
-            .ok()
-            .and_then(|candidate| crate::route_budget::known_route_limits(candidate.limits))
-        };
+        let configured_route_base_url = effective_auth_config.deepseek_base_url();
+        let (active_route_limits, active_route_base_url, active_context_window_source) =
+            if auto_model {
+                (
+                    active_context_window_override.map(|window| RouteLimits {
+                        context_tokens: Some(u64::from(window)),
+                        ..RouteLimits::default()
+                    }),
+                    configured_route_base_url,
+                    if active_context_window_override.is_some() {
+                        crate::route_runtime::ContextWindowSource::Configured
+                    } else {
+                        crate::route_runtime::ContextWindowSource::Fallback
+                    },
+                )
+            } else {
+                let saved_provider_model = config
+                    .provider_config_for(provider)
+                    .and_then(|provider| provider.model.as_deref());
+                crate::route_runtime::resolve_route_candidate_with_context_metadata(
+                    provider,
+                    Some(&model),
+                    saved_provider_model,
+                    Some(configured_route_base_url.clone()),
+                    active_context_window_override,
+                    None,
+                )
+                .map(|resolution| {
+                    (
+                        crate::route_budget::known_route_limits(resolution.candidate.limits),
+                        resolution.candidate.endpoint.base_url,
+                        resolution.context_window.source,
+                    )
+                })
+                .unwrap_or((
+                    None,
+                    configured_route_base_url,
+                    crate::route_runtime::ContextWindowSource::Fallback,
+                ))
+            };
         let reasoning_effort_explicit =
             settings.reasoning_effort.is_some() || config.reasoning_effort_is_explicit();
         let configured_reasoning_effort = settings
@@ -3117,6 +3214,8 @@ impl App {
             last_fallback_reason: None,
             model_ids_passthrough,
             active_route_limits,
+            active_route_base_url,
+            active_context_window_source,
             active_context_window_override,
             pending_provider_switch: None,
             reasoning_effort,
@@ -6649,8 +6748,25 @@ impl App {
         self.active_route_limits = crate::route_budget::known_route_limits(limits);
     }
 
+    /// Install an already-resolved runtime route receipt in one operation so
+    /// endpoint-sensitive reasoning and context reporting cannot drift apart.
+    pub fn set_active_route_resolution(
+        &mut self,
+        base_url: impl Into<String>,
+        limits: RouteLimits,
+        context_window_source: crate::route_runtime::ContextWindowSource,
+    ) {
+        self.active_route_base_url = base_url.into();
+        self.set_active_route_limits(limits);
+        self.active_context_window_source = context_window_source;
+    }
+
     pub fn set_active_context_window_override(&mut self, context_window: Option<u32>) {
         self.active_context_window_override = context_window;
+        if context_window.is_some() {
+            self.active_context_window_source =
+                crate::route_runtime::ContextWindowSource::Configured;
+        }
         if self.active_route_limits.is_none() {
             self.active_route_limits = self.context_window_override_limits();
         }
@@ -6778,15 +6894,19 @@ impl App {
         base_url: &str,
         model_override: Option<&str>,
     ) {
+        let wire_model = model_override.unwrap_or(&self.model);
         let inferred = model_override.and_then(|model| {
             crate::config::legacy_deepseek_alias_effort_for_route(provider, base_url, model)
         });
         self.reasoning_effort = if self.reasoning_effort_explicit {
-            self.reasoning_effort.normalize_for_provider(provider)
+            self.reasoning_effort
+                .normalize_for_route(provider, base_url, wire_model)
         } else if let Some(effort) = inferred {
-            ReasoningEffort::from_setting_for_provider(effort, provider)
+            ReasoningEffort::from_setting(effort)
+                .normalize_for_route(provider, base_url, wire_model)
         } else {
-            self.reasoning_effort.normalize_for_provider(provider)
+            self.reasoning_effort
+                .normalize_for_route(provider, base_url, wire_model)
         };
         self.last_effective_reasoning_effort = None;
     }

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -327,6 +327,56 @@ fn reasoning_effort_api_values_are_provider_aware_for_codex() {
 }
 
 #[test]
+fn reasoning_effort_uses_one_strict_alias_table_and_legacy_fallback() {
+    for raw in ["off", "none", "disabled", "false"] {
+        assert_eq!(ReasoningEffort::parse_strict(raw), Ok(ReasoningEffort::Off));
+    }
+    for raw in ["low", "minimum", "minimal", "light"] {
+        assert_eq!(ReasoningEffort::parse_strict(raw), Ok(ReasoningEffort::Low));
+    }
+    for raw in ["medium", "mid"] {
+        assert_eq!(
+            ReasoningEffort::parse_strict(raw),
+            Ok(ReasoningEffort::Medium)
+        );
+    }
+    for raw in ["xhigh", "ultra", "max", "maximum", "ultracode"] {
+        assert_eq!(ReasoningEffort::parse_strict(raw), Ok(ReasoningEffort::Max));
+    }
+    assert!(ReasoningEffort::parse_strict("surprise").is_err());
+    assert_eq!(
+        ReasoningEffort::from_setting("surprise"),
+        ReasoningEffort::Max
+    );
+}
+
+#[test]
+fn reasoning_effort_preserves_kimi_code_low_and_medium_only_on_exact_route() {
+    let kimi_base = crate::config::DEFAULT_KIMI_CODE_BASE_URL;
+    let moonshot_base = crate::config::DEFAULT_MOONSHOT_BASE_URL;
+    assert_eq!(
+        ReasoningEffort::Low.normalize_for_route(ApiProvider::Moonshot, kimi_base, "k3"),
+        ReasoningEffort::Low
+    );
+    assert_eq!(
+        ReasoningEffort::Medium.normalize_for_route(ApiProvider::Moonshot, kimi_base, "k3"),
+        ReasoningEffort::Medium
+    );
+    assert_eq!(
+        ReasoningEffort::Low.normalize_for_route(ApiProvider::Moonshot, moonshot_base, "k3"),
+        ReasoningEffort::High
+    );
+    assert_eq!(
+        ReasoningEffort::Medium.normalize_for_route(
+            ApiProvider::Moonshot,
+            kimi_base,
+            "kimi-for-coding",
+        ),
+        ReasoningEffort::High
+    );
+}
+
+#[test]
 fn set_model_selection_normalizes_codex_fixed_model_effort() {
     let mut app = App::new(test_options(false), &Config::default());
     app.api_provider = ApiProvider::OpenaiCodex;

--- a/crates/tui/src/tui/auto_router.rs
+++ b/crates/tui/src/tui/auto_router.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use crate::config::Config;
 use crate::model_routing;
 use crate::models::{ContentBlock, Message};
-use crate::tui::app::{App, QueuedMessage, ReasoningEffort};
+use crate::tui::app::{App, QueuedMessage};
 
 /// Whether the next turn should consult the auto-route flash model.
 pub(super) fn should_resolve_auto_model_selection(app: &App) -> bool {
@@ -43,11 +43,6 @@ pub(super) async fn resolve_auto_model_selection(
             .as_setting_for_provider(app.api_provider),
     )
     .await
-}
-
-/// Normalize the heuristic effort to the canonical auto-route effort.
-pub(super) fn normalize_auto_routed_effort(effort: ReasoningEffort) -> ReasoningEffort {
-    model_routing::normalize_auto_route_effort(effort)
 }
 
 /// Build a compact recent-context summary for the auto-route prompt.

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -51,6 +51,18 @@ const DEFAULT_PICKER_EFFORTS: &[ReasoningEffort] = &[
     ReasoningEffort::High,
     ReasoningEffort::Max,
 ];
+/// Kimi Code K3 accepts route-specific low and medium controls at the
+/// official membership endpoint. Medium becomes K3's nested high wire effort,
+/// but keeping the selected intent visible is important for recovery and
+/// route receipts.
+const KIMI_CODE_K3_PICKER_EFFORTS: &[ReasoningEffort] = &[
+    ReasoningEffort::Auto,
+    ReasoningEffort::Off,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::Max,
+];
 const CODEX_PICKER_EFFORTS: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
@@ -259,12 +271,30 @@ impl ModelPickerView {
         let selected_model_idx = selected_model_idx.unwrap_or(0);
 
         let initial_effort = app.reasoning_effort;
-        let effort_rows = picker_efforts_for_provider(app.api_provider, app.auto_model);
-        let normalized = normalize_picker_effort(initial_effort, app.api_provider, app.auto_model);
+        let effort_rows = picker_efforts_for_route(
+            app.api_provider,
+            &config.deepseek_base_url(),
+            &initial_model,
+            app.auto_model,
+        );
+        let normalized = normalize_picker_effort(
+            initial_effort,
+            app.api_provider,
+            &config.deepseek_base_url(),
+            &initial_model,
+            app.auto_model,
+        );
         let selected_effort_idx = effort_rows
             .iter()
             .position(|e| *e == normalized)
-            .unwrap_or_else(|| default_picker_effort_idx(app.api_provider, app.auto_model));
+            .unwrap_or_else(|| {
+                default_picker_effort_idx(
+                    app.api_provider,
+                    &config.deepseek_base_url(),
+                    &initial_model,
+                    app.auto_model,
+                )
+            });
 
         let mut view = Self {
             initial_model,
@@ -408,10 +438,21 @@ impl ModelPickerView {
     }
 
     fn current_efforts(&self) -> &'static [ReasoningEffort] {
-        picker_efforts_for_provider(
-            self.resolved_provider().unwrap_or(self.initial_provider),
-            self.resolved_model().trim().eq_ignore_ascii_case("auto"),
+        let provider = self.resolved_provider().unwrap_or(self.initial_provider);
+        let model = self.resolved_model();
+        let base_url = self.resolved_base_url_for_provider(provider, &model);
+        picker_efforts_for_route(
+            provider,
+            &base_url,
+            &model,
+            model.trim().eq_ignore_ascii_case("auto"),
         )
+    }
+
+    fn resolved_base_url_for_provider(&self, provider: ApiProvider, model: &str) -> String {
+        crate::route_runtime::resolve_runtime_route(&self.route_config, provider, Some(model))
+            .map(|route| route.candidate.endpoint.base_url)
+            .unwrap_or_else(|_| provider.default_base_url().to_string())
     }
 
     fn custom_model_row(&self) -> Option<(String, ApiProvider)> {
@@ -495,12 +536,18 @@ impl ModelPickerView {
 
     fn select_effort_for_current_model(&mut self, effort: ReasoningEffort) {
         let provider = self.resolved_provider().unwrap_or(self.initial_provider);
-        let model_is_auto = self.resolved_model().trim().eq_ignore_ascii_case("auto");
-        let normalized = normalize_picker_effort(effort, provider, model_is_auto);
-        self.selected_effort_idx = picker_efforts_for_provider(provider, model_is_auto)
-            .iter()
-            .position(|candidate| *candidate == normalized)
-            .unwrap_or_else(|| default_picker_effort_idx(provider, model_is_auto));
+        let model = self.resolved_model();
+        let model_is_auto = model.trim().eq_ignore_ascii_case("auto");
+        let base_url = self.resolved_base_url_for_provider(provider, &model);
+        let normalized =
+            normalize_picker_effort(effort, provider, &base_url, &model, model_is_auto);
+        self.selected_effort_idx =
+            picker_efforts_for_route(provider, &base_url, &model, model_is_auto)
+                .iter()
+                .position(|candidate| *candidate == normalized)
+                .unwrap_or_else(|| {
+                    default_picker_effort_idx(provider, &base_url, &model, model_is_auto)
+                });
     }
 
     fn move_up(&mut self) -> bool {
@@ -1806,12 +1853,17 @@ impl ModelPickerView {
     }
 }
 
-fn picker_efforts_for_provider(
+fn picker_efforts_for_route(
     provider: ApiProvider,
+    base_url: &str,
+    wire_model: &str,
     model_is_auto: bool,
 ) -> &'static [ReasoningEffort] {
     if model_is_auto {
         return AUTO_MODEL_PICKER_EFFORTS;
+    }
+    if crate::config::is_exact_kimi_code_k3_route(provider, base_url, wire_model) {
+        return KIMI_CODE_K3_PICKER_EFFORTS;
     }
     match provider {
         ApiProvider::OpenaiCodex => CODEX_PICKER_EFFORTS,
@@ -1822,21 +1874,22 @@ fn picker_efforts_for_provider(
 fn normalize_picker_effort(
     effort: ReasoningEffort,
     provider: ApiProvider,
+    base_url: &str,
+    wire_model: &str,
     model_is_auto: bool,
 ) -> ReasoningEffort {
     if model_is_auto {
         return ReasoningEffort::Auto;
     }
-    if provider == ApiProvider::OpenaiCodex {
-        return effort.normalize_for_provider(provider);
-    }
-    match effort {
-        ReasoningEffort::Low | ReasoningEffort::Medium => ReasoningEffort::High,
-        other => other,
-    }
+    effort.normalize_for_route(provider, base_url, wire_model)
 }
 
-fn default_picker_effort_idx(provider: ApiProvider, model_is_auto: bool) -> usize {
+fn default_picker_effort_idx(
+    provider: ApiProvider,
+    base_url: &str,
+    wire_model: &str,
+    model_is_auto: bool,
+) -> usize {
     let default_effort = if model_is_auto {
         ReasoningEffort::Auto
     } else if provider == ApiProvider::OpenaiCodex {
@@ -1844,7 +1897,7 @@ fn default_picker_effort_idx(provider: ApiProvider, model_is_auto: bool) -> usiz
     } else {
         ReasoningEffort::High
     };
-    picker_efforts_for_provider(provider, model_is_auto)
+    picker_efforts_for_route(provider, base_url, wire_model, model_is_auto)
         .iter()
         .position(|effort| *effort == default_effort)
         .unwrap_or(0)
@@ -2744,6 +2797,42 @@ mod tests {
     }
 
     #[test]
+    fn picker_preserves_kimi_code_k3_low_medium_but_not_generic_moonshot() {
+        let (mut app, mut config, _lock) = create_test_app();
+        config.provider = Some("moonshot".to_string());
+        config.providers = Some(crate::config::ProvidersConfig {
+            moonshot: crate::config::ProviderConfig {
+                base_url: Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+                model: Some("k3".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        app.api_provider = crate::config::ApiProvider::Moonshot;
+        app.model = "k3".to_string();
+        app.auto_model = false;
+        app.reasoning_effort = ReasoningEffort::Medium;
+
+        let view = ModelPickerView::new(&app, &config);
+        assert_eq!(view.resolved_effort(), ReasoningEffort::Medium);
+        assert_eq!(
+            view.current_efforts(),
+            KIMI_CODE_K3_PICKER_EFFORTS,
+            "the official K3 route must expose low/medium before sending a secret"
+        );
+
+        config
+            .providers
+            .as_mut()
+            .expect("providers")
+            .moonshot
+            .base_url = Some(crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string());
+        let generic = ModelPickerView::new(&app, &config);
+        assert_eq!(generic.resolved_effort(), ReasoningEffort::High);
+        assert_eq!(generic.current_efforts(), DEFAULT_PICKER_EFFORTS);
+    }
+
+    #[test]
     fn picker_exposes_auto_and_distinct_thinking_tiers() {
         let model_labels = picker_model_ids_for_provider(crate::config::ApiProvider::Deepseek);
         assert_eq!(
@@ -2751,11 +2840,15 @@ mod tests {
             vec!["auto", "deepseek-v4-pro", "deepseek-v4-flash"]
         );
 
-        let effort_labels: Vec<_> =
-            picker_efforts_for_provider(crate::config::ApiProvider::Deepseek, false)
-                .iter()
-                .map(|effort| effort.as_setting())
-                .collect();
+        let effort_labels: Vec<_> = picker_efforts_for_route(
+            crate::config::ApiProvider::Deepseek,
+            crate::config::DEFAULT_DEEPSEEK_BASE_URL,
+            "deepseek-v4-pro",
+            false,
+        )
+        .iter()
+        .map(|effort| effort.as_setting())
+        .collect();
         assert_eq!(effort_labels, vec!["auto", "off", "high", "max"]);
     }
 
@@ -2770,13 +2863,15 @@ mod tests {
         let view = ModelPickerView::new(&app, &config);
 
         assert_eq!(view.resolved_effort(), ReasoningEffort::Low);
-        let labels: Vec<_> =
-            picker_efforts_for_provider(crate::config::ApiProvider::OpenaiCodex, false)
-                .iter()
-                .map(|effort| {
-                    effort.display_label_for_provider(crate::config::ApiProvider::OpenaiCodex)
-                })
-                .collect();
+        let labels: Vec<_> = picker_efforts_for_route(
+            crate::config::ApiProvider::OpenaiCodex,
+            crate::config::DEFAULT_OPENAI_CODEX_BASE_URL,
+            "gpt-5.5-codex",
+            false,
+        )
+        .iter()
+        .map(|effort| effort.display_label_for_provider(crate::config::ApiProvider::OpenaiCodex))
+        .collect();
         assert_eq!(labels, vec!["low", "medium", "high", "xhigh"]);
     }
 
@@ -4022,11 +4117,15 @@ mod tests {
 
     #[test]
     fn deepseek_picker_exposes_auto_off_high_max() {
-        let labels: Vec<&str> =
-            picker_efforts_for_provider(crate::config::ApiProvider::Deepseek, false)
-                .iter()
-                .map(|effort| effort.short_label())
-                .collect();
+        let labels: Vec<&str> = picker_efforts_for_route(
+            crate::config::ApiProvider::Deepseek,
+            crate::config::DEFAULT_DEEPSEEK_BASE_URL,
+            "deepseek-v4-pro",
+            false,
+        )
+        .iter()
+        .map(|effort| effort.short_label())
+        .collect();
         assert_eq!(labels, vec!["auto", "off", "high", "max"]);
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -6344,11 +6344,11 @@ async fn run_cache_warmup(app: &App, config: &Config) -> Result<(Usage, String, 
     let base_url = client.base_url().to_string();
     let reasoning_effort = if app.reasoning_effort == ReasoningEffort::Auto {
         app.last_effective_reasoning_effort
-            .and_then(|effort| effort.api_value_for_provider(app.api_provider))
+            .and_then(|effort| effort.api_value_for_route(app.api_provider, &base_url, &app.model))
             .map(str::to_string)
     } else {
         app.reasoning_effort
-            .api_value_for_provider(app.api_provider)
+            .api_value_for_route(app.api_provider, &base_url, &app.model)
             .map(str::to_string)
     };
     let request = MessageRequest {
@@ -7191,6 +7191,8 @@ fn rollback_provider_after_auth_failure(app: &mut App, config: &mut Config) -> O
         previous_model,
         previous_model_ids_passthrough,
         previous_route_limits,
+        previous_route_base_url,
+        previous_context_window_source,
         previous_context_window_override,
         previous_config,
         previous_onboarding,
@@ -7216,6 +7218,8 @@ fn rollback_provider_after_auth_failure(app: &mut App, config: &mut Config) -> O
     app.model_ids_passthrough = previous_model_ids_passthrough;
     app.active_context_window_override = previous_context_window_override;
     app.active_route_limits = previous_route_limits;
+    app.active_route_base_url = previous_route_base_url;
+    app.active_context_window_source = previous_context_window_source;
     app.update_model_compaction_budget();
     app.clear_model_scoped_telemetry();
     app.offline_mode = false;
@@ -8076,23 +8080,26 @@ async fn dispatch_user_message(
         let effort = auto_selection
             .as_ref()
             .and_then(|selection| selection.reasoning_effort)
-            .unwrap_or_else(|| {
-                auto_router::normalize_auto_routed_effort(crate::auto_reasoning::select(
-                    false,
-                    &message.display,
-                ))
-            });
+            .unwrap_or_else(|| crate::auto_reasoning::select(false, &message.display));
         Some(effort)
     } else {
         None
     };
     let effective_reasoning_effort = if let Some(effort) = selected_reasoning_effort {
         effort
-            .api_value_for_provider(effective_provider)
+            .api_value_for_route(
+                effective_provider,
+                &turn_route.candidate.endpoint.base_url,
+                &turn_route.model,
+            )
             .map(str::to_string)
     } else {
         app.reasoning_effort
-            .api_value_for_provider(effective_provider)
+            .api_value_for_route(
+                effective_provider,
+                &turn_route.candidate.endpoint.base_url,
+                &turn_route.model,
+            )
             .map(str::to_string)
     };
 
@@ -8440,8 +8447,6 @@ async fn apply_model_picker_choice(
     let model_is_auto = model.trim().eq_ignore_ascii_case("auto");
     if model_is_auto {
         effort = ReasoningEffort::Auto;
-    } else {
-        effort = effort.normalize_for_provider(target_provider);
     }
     if target_provider != app.api_provider
         || target_identity != app.provider_identity_for_persistence()
@@ -8461,12 +8466,66 @@ async fn apply_model_picker_choice(
             return;
         }
         if !model_is_auto {
+            effort = effort.normalize_for_route(
+                app.api_provider,
+                &app.active_route_base_url,
+                &app.model,
+            );
             apply_picker_effort_choice(app, engine_handle, effort, previous_effort).await;
             return;
         }
     }
 
     let model_changed = model != previous_model || app.auto_model != model_is_auto;
+    let mut resolved_model = model.clone();
+    let mut route_base_url = config.deepseek_base_url();
+    if !model_is_auto {
+        let saved_provider_model = config
+            .provider_config_for(app.api_provider)
+            .and_then(|provider| provider.model.as_deref());
+        match crate::route_runtime::resolve_route_candidate_with_context_metadata(
+            app.api_provider,
+            Some(&model),
+            saved_provider_model,
+            Some(config.deepseek_base_url()),
+            config.context_window_for_provider_config(app.api_provider),
+            None,
+        ) {
+            Ok(resolution) => {
+                resolved_model = resolution.candidate.wire_model_id.as_str().to_string();
+                route_base_url = resolution.candidate.endpoint.base_url.clone();
+                if model_changed {
+                    app.set_active_context_window_override(
+                        config.context_window_for_provider_config(app.api_provider),
+                    );
+                    app.set_active_route_resolution(
+                        route_base_url.clone(),
+                        resolution.candidate.limits,
+                        resolution.context_window.source,
+                    );
+                }
+            }
+            Err(reason) => {
+                app.status_message = Some(reason);
+                return;
+            }
+        }
+    } else if model_changed {
+        app.set_active_context_window_override(
+            config.context_window_for_provider_config(app.api_provider),
+        );
+        app.active_route_limits = app.context_window_override_limits();
+        app.active_route_base_url = route_base_url.clone();
+        app.active_context_window_source = if app.active_context_window_override.is_some() {
+            crate::route_runtime::ContextWindowSource::Configured
+        } else {
+            crate::route_runtime::ContextWindowSource::Fallback
+        };
+    }
+
+    if !model_is_auto {
+        effort = effort.normalize_for_route(app.api_provider, &route_base_url, &resolved_model);
+    }
     let effort_changed = effort != previous_effort;
     if !model_changed && !effort_changed {
         app.status_message = Some(format!(
@@ -8474,37 +8533,6 @@ async fn apply_model_picker_choice(
             effort.display_label_for_provider(app.api_provider)
         ));
         return;
-    }
-
-    let mut resolved_model = model.clone();
-    if model_changed && !model_is_auto {
-        let saved_provider_model = config
-            .provider_config_for(app.api_provider)
-            .and_then(|provider| provider.model.as_deref());
-        match resolve_route_candidate(
-            app.api_provider,
-            Some(&model),
-            saved_provider_model,
-            Some(config.deepseek_base_url()),
-            config.context_window_for_provider_config(app.api_provider),
-        ) {
-            Ok(candidate) => {
-                resolved_model = candidate.wire_model_id.as_str().to_string();
-                app.set_active_context_window_override(
-                    config.context_window_for_provider_config(app.api_provider),
-                );
-                app.set_active_route_limits(candidate.limits);
-            }
-            Err(reason) => {
-                app.status_message = Some(reason);
-                return;
-            }
-        }
-    } else if model_changed && model_is_auto {
-        app.set_active_context_window_override(
-            config.context_window_for_provider_config(app.api_provider),
-        );
-        app.active_route_limits = app.context_window_override_limits();
     }
 
     if model_changed {
@@ -8542,7 +8570,7 @@ async fn apply_model_picker_choice(
         if effort_changed {
             settings.set(
                 "reasoning_effort",
-                effort.as_setting_for_provider(app.api_provider),
+                effort.as_setting_for_route(app.api_provider, &route_base_url, &resolved_model),
             )?;
         }
         settings.save()
@@ -8604,7 +8632,7 @@ async fn apply_picker_effort_choice(
     mut effort: ReasoningEffort,
     previous_effort: ReasoningEffort,
 ) {
-    effort = effort.normalize_for_provider(app.api_provider);
+    effort = effort.normalize_for_route(app.api_provider, &app.active_route_base_url, &app.model);
     if effort == previous_effort {
         return;
     }
@@ -8618,7 +8646,7 @@ async fn apply_picker_effort_choice(
         let mut settings = crate::settings::Settings::load_persisted()?;
         settings.set(
             "reasoning_effort",
-            effort.as_setting_for_provider(app.api_provider),
+            effort.as_setting_for_route(app.api_provider, &app.active_route_base_url, &app.model),
         )?;
         settings.save()
     })()
@@ -8668,6 +8696,8 @@ async fn switch_provider(
         previous_model: previous_model.clone(),
         previous_model_ids_passthrough,
         previous_route_limits: app.active_route_limits,
+        previous_route_base_url: app.active_route_base_url.clone(),
+        previous_context_window_source: app.active_context_window_source,
         previous_context_window_override: app.active_context_window_override,
         previous_config: previous_config.clone(),
         previous_onboarding: app.onboarding,
@@ -9497,7 +9527,7 @@ async fn apply_command_result(
                     model,
                     Some(provider),
                     None,
-                    previous_effort.normalize_for_provider(provider),
+                    previous_effort,
                     previous_model,
                     previous_effort,
                 )


### PR DESCRIPTION
# Scope

Stage 1 of a 3-PR stacked train splitting the validated Kimi Code K3 remediation lane (snapshot `cd9935ee8`). This PR establishes exact route truth for Kimi Code's membership-plan K3 endpoint and canonicalizes reasoning-effort handling:

- **One strict reasoning-effort alias table** — `ReasoningEffort::parse_strict` is now the single spelling table for CLI (`--reasoning-effort`), settings, and tool inputs; unknown values are rejected instead of silently becoming `max`. `from_setting` keeps its permissive legacy fallback for persisted configs only.
- **Exact Kimi Code route guards** — `is_exact_kimi_code_k3_route` / `moonshot_base_url_is_exact_kimi_code`: the bare `k3` contract belongs only to the exact `api.kimi.com/coding/v1` endpoint; generic Moonshot never inherits it.
- **Route-exact effort normalization** — `normalize_for_route` / `api_value_for_route` / `as_setting_for_route` keep `low`/`medium` distinct only on the exact K3 route (and Codex); all other routes retain the historic coercion.
- **K3-only thinking mapping, reasoning replay/stream style, UA, and credential-help routing** in the client and config layers.
- **`route_runtime` context resolution** — 262K-floor context window with `ContextWindowSource` provenance, plus App-side route receipts (`active_route_base_url`, `active_context_window_source`) installed atomically via `set_active_route_resolution`, with transactional rollback in the provider-switch path.

# Disclosures

- **Effort-normalization refactor**: the historic Low/Medium→High coercion, previously scattered across per-provider call sites, is centralized into `normalize_for_route` and `normalize_auto_route_selection_for_config`. As part of adopting one canonical alias table, the parser now accepts the **`"ultra"` alias for every provider** (mapping to `max`), not just where it was previously special-cased.
- **Provider-reported 1M context metadata arm is staged plumbing with no production caller** — `resolve_route_candidate_with_context_metadata`'s `provider_reported_context` parameter is only exercised by tests. Only an explicit user override reaches 1M; the catalog default for the K3 route is the 262K safe floor.

# Verification

- `cargo fmt --check -p codewhale-tui -p codewhale-cli -p codewhale-config` — clean
- `cargo check --tests -p codewhale-tui -p codewhale-cli -p codewhale-config` — zero warnings
- `cargo test -p codewhale-config` — `409 passed; 0 failed`
- `cargo test -p codewhale-cli --lib` — `165 passed; 0 failed`
- `cargo test -p codewhale-tui --bin codewhale-tui -- kimi effort route_runtime client config model_routing` — `1081 passed; 0 failed`

Stacked train — merge in order: this PR (#4555) → #4556 → #4557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
