### PR TITLE
feat(persistence): per-session crash checkpoints with flush reporting

### DIFF
--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -2972,12 +2972,20 @@ struct CleanPlan {
 }
 
 fn collect_clean_targets(checkpoints_dir: &Path) -> CleanPlan {
-    let candidates = ["latest.json", "offline_queue.json"];
-    let targets = candidates
-        .iter()
-        .map(|name| checkpoints_dir.join(name))
-        .filter(|p| p.exists())
-        .collect();
+    // Every `*.json` file in the checkpoints directory is checkpoint state:
+    // per-session crash checkpoints (`<session_id>.json`), the legacy
+    // single-slot checkpoint (`latest.json`), and the offline input queue
+    // (`offline_queue.json`). Non-JSON files and subdirectories are left
+    // alone.
+    let mut targets: Vec<PathBuf> = std::fs::read_dir(checkpoints_dir)
+        .map(|entries| {
+            entries
+                .filter_map(|entry| entry.ok().map(|e| e.path()))
+                .filter(|p| p.is_file() && p.extension().is_some_and(|ext| ext == "json"))
+                .collect()
+        })
+        .unwrap_or_default();
+    targets.sort();
     CleanPlan { targets }
 }
 
@@ -8232,25 +8240,56 @@ fn default_mouse_capture_enabled(
     true
 }
 
-/// Load a recent crash-recovery checkpoint, pruning stale checkpoints first.
-fn load_recent_checkpoint(
-    manager: &session_manager::SessionManager,
-) -> Option<(session_manager::SavedSession, std::time::Duration)> {
-    let session = manager.load_checkpoint().ok().flatten()?;
+/// A loadable crash-recovery checkpoint candidate: session content, file
+/// age, and which slot it came from (per-session file or the legacy single
+/// slot).
+struct RecentCheckpoint {
+    session: session_manager::SavedSession,
+    age: std::time::Duration,
+    source: session_manager::CheckpointSource,
+}
 
-    let checkpoint_path = manager
-        .sessions_dir()
-        .join("checkpoints")
-        .join("latest.json");
-    let metadata = std::fs::metadata(&checkpoint_path).ok()?;
-    let mtime = metadata.modified().ok()?;
-    let age = std::time::SystemTime::now().duration_since(mtime).ok()?;
-    if age > std::time::Duration::from_secs(24 * 3600) {
-        let _ = manager.clear_checkpoint();
-        return None;
+const CHECKPOINT_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
+
+/// Load all recent crash-recovery checkpoints, pruning stale ones first.
+///
+/// Candidates are the per-session checkpoint files plus the legacy
+/// single-slot `checkpoints/latest.json` (compatibility read). Files older
+/// than 24 hours are removed; unreadable files are skipped. The result is
+/// sorted most recent first.
+fn load_recent_checkpoints(manager: &session_manager::SessionManager) -> Vec<RecentCheckpoint> {
+    let refs = manager.list_checkpoints().unwrap_or_default();
+    let mut recent = Vec::new();
+    for checkpoint_ref in refs {
+        let Ok(age) = std::time::SystemTime::now().duration_since(checkpoint_ref.modified) else {
+            continue;
+        };
+        if age > CHECKPOINT_MAX_AGE {
+            let _ = match &checkpoint_ref.source {
+                session_manager::CheckpointSource::Session(id) => {
+                    manager.clear_session_checkpoint(id)
+                }
+                session_manager::CheckpointSource::Legacy => manager.clear_legacy_checkpoint(),
+            };
+            continue;
+        }
+        let loaded = match &checkpoint_ref.source {
+            session_manager::CheckpointSource::Session(id) => manager.load_session_checkpoint(id),
+            session_manager::CheckpointSource::Legacy => manager.load_legacy_checkpoint(),
+        };
+        let Ok(Some(session)) = loaded else {
+            continue;
+        };
+        recent.push(RecentCheckpoint {
+            session,
+            age,
+            source: checkpoint_ref.source,
+        });
     }
-
-    Some((session, age))
+    // `list_checkpoints` sorts newest-first already; keep it explicit here so
+    // selection does not silently depend on the manager's ordering.
+    recent.sort_by_key(|c| c.age);
+    recent
 }
 
 fn checkpoint_age_label(age: std::time::Duration) -> String {
@@ -8267,73 +8306,116 @@ fn checkpoint_age_label(age: std::time::Duration) -> String {
 /// recovery was requested *and* the checkpoint belongs to the current
 /// workspace.
 ///
-/// The checkpoint must exist and its file mtime must be within 24 hours.
-/// **The checkpoint's workspace must also match the resolved launch workspace
-/// after canonicalisation.** If the workspace doesn't match, the checkpoint is
-/// persisted as a regular session (so the user can find it via
-/// `codewhale sessions` / `codewhale resume <id>`) and cleared, but not loaded.
+/// Candidates are all per-session checkpoint files plus the legacy
+/// single-slot `checkpoints/latest.json`; each must be younger than 24 hours
+/// **and its workspace must match the resolved launch workspace after
+/// canonicalisation** — the newest matching candidate wins. If no candidate
+/// matches, a one-line notice points at `codewhale sessions`, and nothing is
+/// auto-loaded: another workspace's checkpoint file is never touched (it may
+/// belong to a live session there).
 fn recover_interrupted_checkpoint_for_resume(launch_workspace: &Path) -> Option<String> {
     let manager = session_manager::SessionManager::default_location().ok()?;
-    let (session, age) = load_recent_checkpoint(&manager)?;
+    let candidates = load_recent_checkpoints(&manager);
+    if candidates.is_empty() {
+        return None;
+    }
 
     // Refuse to silently restore a session from another workspace. Compare
     // against the resolved launch workspace, not the shell cwd, so callers
     // using `--workspace` cannot accidentally recover a checkpoint from the
     // directory their shell happened to be in.
-    let session_workspace = session.metadata.workspace.clone();
-    let workspace_matches =
-        session_manager::workspace_scope_matches(&session_workspace, launch_workspace);
+    let (matching, mismatched): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|candidate| {
+        session_manager::workspace_scope_matches(
+            &candidate.session.metadata.workspace,
+            launch_workspace,
+        )
+    });
 
-    if !workspace_matches {
-        // Persist the checkpoint so the user can find it via `codewhale
-        // sessions`, then clear it so the next launch in this folder doesn't
-        // re-trip the nag. Print a one-line notice pointing at the explicit
-        // resume command — but DO NOT auto-load the session here.
-        let _ = manager.save_session(&session);
-        let _ = manager.clear_checkpoint();
-        eprintln!(
-            "Note: an interrupted session from another workspace ({}) is \
-             available. Run `codewhale sessions` to list saved sessions. Starting \
-             fresh in {}.",
-            session_workspace.display(),
-            launch_workspace.display(),
-        );
+    let Some(best) = matching.into_iter().next() else {
+        if let Some(newest) = mismatched.first() {
+            eprintln!(
+                "Note: an interrupted session from another workspace ({}) is \
+                 available. Run `codewhale sessions` to list saved sessions. Starting \
+                 fresh in {}.",
+                newest.session.metadata.workspace.display(),
+                launch_workspace.display(),
+            );
+        }
+        return None;
+    };
+
+    let session_id = best.session.metadata.id.clone();
+
+    // Persist the checkpoint as a regular session so the TUI can load it by
+    // id — unless a newer regular session file for the same id already
+    // exists (e.g. `--continue` ran before and the session advanced since).
+    // A stale checkpoint must never overwrite newer durable session state.
+    if !saved_session_is_newer(&manager, &best.session)
+        && manager.save_session(&best.session).is_err()
+    {
         return None;
     }
 
-    let session_id = session.metadata.id.clone();
-
-    // Persist the checkpoint as a regular session so the TUI can load it by id.
-    if manager.save_session(&session).is_err() {
-        return None;
+    match &best.source {
+        session_manager::CheckpointSource::Session(id) => {
+            // Consume the per-session checkpoint now that it is recovered.
+            let _ = manager.clear_session_checkpoint(id);
+        }
+        session_manager::CheckpointSource::Legacy => {
+            // Migrate the legacy slot to a per-session file (never
+            // overwriting an existing one) and leave `latest.json` in place
+            // so an older binary can still find it; its writer is already
+            // gone and the file ages out within 24 hours.
+            let _ = manager.write_session_checkpoint_if_absent(&best.session);
+        }
     }
 
-    // Clear the checkpoint now that it has been recovered.
-    let _ = manager.clear_checkpoint();
-
-    let age_str = checkpoint_age_label(age);
+    let age_str = checkpoint_age_label(best.age);
     eprintln!("Recovered interrupted session ({age_str}). Use --fresh to start fresh.",);
 
     Some(session_id)
+}
+
+/// Whether a regular session file for the checkpoint's id already exists and
+/// is at least as recent as the checkpoint. When it is, persisting the
+/// checkpoint over it would replace newer durable state with older in-flight
+/// state.
+fn saved_session_is_newer(
+    manager: &session_manager::SessionManager,
+    checkpoint: &session_manager::SavedSession,
+) -> bool {
+    manager
+        .load_session(&checkpoint.metadata.id)
+        .is_ok_and(|existing| existing.metadata.updated_at >= checkpoint.metadata.updated_at)
 }
 
 /// Preserve an interrupted checkpoint on a normal fresh launch without
 /// attaching it to the new TUI instance. This keeps "open another codewhale in
 /// the same folder" from re-entering the previous in-flight session while still
 /// leaving an explicit resume path.
+///
+/// Only the newest recent checkpoint drives the notice. The legacy
+/// single-slot file is persisted as a regular session and consumed (today's
+/// behavior for that slot); per-session checkpoint files are persisted but
+/// left in place — they may belong to a live session in another terminal,
+/// and `--continue` reads them directly.
 fn preserve_interrupted_checkpoint_for_explicit_resume(launch_workspace: &Path) {
     let Some(manager) = session_manager::SessionManager::default_location().ok() else {
         return;
     };
-    let Some((session, age)) = load_recent_checkpoint(&manager) else {
+    let Some(newest) = load_recent_checkpoints(&manager).into_iter().next() else {
         return;
     };
 
-    let session_workspace = session.metadata.workspace.clone();
-    let _ = manager.save_session(&session);
-    let _ = manager.clear_checkpoint();
+    let session_workspace = newest.session.metadata.workspace.clone();
+    if !saved_session_is_newer(&manager, &newest.session) {
+        let _ = manager.save_session(&newest.session);
+    }
+    if newest.source == session_manager::CheckpointSource::Legacy {
+        let _ = manager.clear_legacy_checkpoint();
+    }
 
-    let age_str = checkpoint_age_label(age);
+    let age_str = checkpoint_age_label(newest.age);
     if session_manager::workspace_scope_matches(&session_workspace, launch_workspace) {
         eprintln!(
             "Found an in-flight session snapshot ({age_str}). Starting a new \
@@ -15233,22 +15315,31 @@ mod setup_helper_tests {
     }
 
     #[test]
-    fn collect_clean_targets_finds_only_known_files() {
+    fn collect_clean_targets_finds_all_checkpoint_json_files() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         std::fs::write(dir.join("latest.json"), "{}").unwrap();
         std::fs::write(dir.join("offline_queue.json"), "[]").unwrap();
-        std::fs::write(dir.join("unrelated.json"), "{}").unwrap();
+        // Per-session crash checkpoint files are clean targets too.
+        std::fs::write(dir.join("some-session-id.json"), "{}").unwrap();
+        // Non-JSON files and subdirectories are left alone.
+        std::fs::write(dir.join("notes.txt"), "keep").unwrap();
+        std::fs::create_dir_all(dir.join("subdir")).unwrap();
 
         let plan = collect_clean_targets(dir);
-        assert_eq!(plan.targets.len(), 2);
+        assert_eq!(plan.targets.len(), 3);
         assert!(plan.targets.iter().any(|p| p.ends_with("latest.json")));
         assert!(
             plan.targets
                 .iter()
                 .any(|p| p.ends_with("offline_queue.json"))
         );
-        assert!(!plan.targets.iter().any(|p| p.ends_with("unrelated.json")));
+        assert!(
+            plan.targets
+                .iter()
+                .any(|p| p.ends_with("some-session-id.json"))
+        );
+        assert!(!plan.targets.iter().any(|p| p.ends_with("notes.txt")));
     }
 
     #[test]
@@ -15342,10 +15433,52 @@ mod setup_helper_tests {
 
             assert!(
                 manager
-                    .load_checkpoint()
+                    .load_session_checkpoint(&session_id)
                     .expect("load checkpoint")
+                    .is_some(),
+                "normal launch must leave the per-session checkpoint in place \
+                 (it may belong to a live session; `--continue` consumes it)"
+            );
+            assert!(
+                manager.load_session(&session_id).is_ok(),
+                "normal launch should keep an explicit resume target"
+            );
+        });
+    }
+
+    #[test]
+    fn plain_launch_consumes_legacy_checkpoint_after_preserving_it() {
+        let _guard = crate::test_support::lock_test_env();
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        with_home(tmp.path(), || {
+            let manager = SessionManager::default_location().expect("manager");
+            let session = create_saved_session(
+                &[Message {
+                    role: "user".to_string(),
+                    content: vec![ContentBlock::Text {
+                        text: "legacy in flight".to_string(),
+                        cache_control: None,
+                    }],
+                }],
+                "test-model",
+                &workspace,
+                0,
+                None,
+            );
+            let session_id = session.metadata.id.clone();
+            write_legacy_checkpoint(&manager, &session);
+
+            preserve_interrupted_checkpoint_for_explicit_resume(&workspace);
+
+            assert!(
+                manager
+                    .load_legacy_checkpoint()
+                    .expect("load legacy checkpoint")
                     .is_none(),
-                "normal launch should clear latest checkpoint after preserving it"
+                "normal launch should consume the legacy single-slot checkpoint"
             );
             assert!(
                 manager.load_session(&session_id).is_ok(),
@@ -15379,12 +15512,151 @@ mod setup_helper_tests {
             assert_eq!(recovered.as_deref(), Some(session_id.as_str()));
             assert!(
                 manager
-                    .load_checkpoint()
+                    .load_session_checkpoint(&session_id)
                     .expect("load checkpoint")
                     .is_none(),
-                "--continue should consume the checkpoint"
+                "--continue should consume the per-session checkpoint"
             );
             assert!(manager.load_session(&session_id).is_ok());
+        });
+    }
+
+    /// Write a legacy single-slot checkpoint file the way pre-cutover
+    /// binaries did. The current binary only reads this slot.
+    fn write_legacy_checkpoint(manager: &SessionManager, session: &session_manager::SavedSession) {
+        let checkpoints = manager.sessions_dir().join("checkpoints");
+        std::fs::create_dir_all(&checkpoints).expect("create checkpoints dir");
+        let content = serde_json::to_string_pretty(session).expect("serialize checkpoint");
+        std::fs::write(checkpoints.join("latest.json"), content).expect("write legacy checkpoint");
+    }
+
+    #[test]
+    fn continue_recovers_legacy_checkpoint_and_migrates_it() {
+        let _guard = crate::test_support::lock_test_env();
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        with_home(tmp.path(), || {
+            let manager = SessionManager::default_location().expect("manager");
+            let messages = vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "legacy continue".to_string(),
+                    cache_control: None,
+                }],
+            }];
+            let session = create_saved_session(&messages, "test-model", &workspace, 0, None);
+            let session_id = session.metadata.id.clone();
+            write_legacy_checkpoint(&manager, &session);
+
+            let recovered = recover_interrupted_checkpoint_for_resume(&workspace);
+
+            assert_eq!(recovered.as_deref(), Some(session_id.as_str()));
+            assert!(
+                manager.load_session(&session_id).is_ok(),
+                "recovered legacy checkpoint must be loadable as a session"
+            );
+            assert!(
+                manager
+                    .load_session_checkpoint(&session_id)
+                    .expect("load per-session checkpoint")
+                    .is_some(),
+                "legacy recovery must migrate to a per-session checkpoint file"
+            );
+            assert!(
+                manager
+                    .load_legacy_checkpoint()
+                    .expect("load legacy checkpoint")
+                    .is_some(),
+                "legacy latest.json stays in place for one more release"
+            );
+        });
+    }
+
+    #[test]
+    fn continue_refuses_checkpoint_from_other_workspace() {
+        let _guard = crate::test_support::lock_test_env();
+        let tmp = TempDir::new().unwrap();
+        let launch_workspace = tmp.path().join("launch-workspace");
+        let other_workspace = tmp.path().join("other-workspace");
+        std::fs::create_dir_all(&launch_workspace).unwrap();
+        std::fs::create_dir_all(&other_workspace).unwrap();
+
+        with_home(tmp.path(), || {
+            let manager = SessionManager::default_location().expect("manager");
+            let messages = vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "belongs elsewhere".to_string(),
+                    cache_control: None,
+                }],
+            }];
+            let session = create_saved_session(&messages, "test-model", &other_workspace, 0, None);
+            let session_id = session.metadata.id.clone();
+            manager.save_checkpoint(&session).expect("save checkpoint");
+
+            let recovered = recover_interrupted_checkpoint_for_resume(&launch_workspace);
+
+            assert_eq!(recovered, None, "workspace mismatch must refuse recovery");
+            assert!(
+                manager
+                    .load_session_checkpoint(&session_id)
+                    .expect("load checkpoint")
+                    .is_some(),
+                "another workspace's checkpoint file must be left untouched"
+            );
+        });
+    }
+
+    #[test]
+    fn continue_twice_does_not_clobber_newer_session_with_stale_legacy_checkpoint() {
+        let _guard = crate::test_support::lock_test_env();
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        with_home(tmp.path(), || {
+            let manager = SessionManager::default_location().expect("manager");
+            let stale = create_saved_session(
+                &[Message {
+                    role: "user".to_string(),
+                    content: vec![ContentBlock::Text {
+                        text: "crash-time state".to_string(),
+                        cache_control: None,
+                    }],
+                }],
+                "test-model",
+                &workspace,
+                0,
+                None,
+            );
+            let session_id = stale.metadata.id.clone();
+            write_legacy_checkpoint(&manager, &stale);
+
+            // The session advanced after the checkpoint was taken: a newer
+            // regular session file exists for the same id.
+            let mut advanced = stale.clone();
+            advanced.messages.push(Message {
+                role: "assistant".to_string(),
+                content: vec![ContentBlock::Text {
+                    text: "post-recovery progress".to_string(),
+                    cache_control: None,
+                }],
+            });
+            advanced.metadata.message_count = advanced.messages.len();
+            advanced.metadata.updated_at = stale.metadata.updated_at + chrono::Duration::hours(1);
+            manager.save_session(&advanced).expect("save newer session");
+
+            let recovered = recover_interrupted_checkpoint_for_resume(&workspace);
+
+            assert_eq!(recovered.as_deref(), Some(session_id.as_str()));
+            let persisted = manager.load_session(&session_id).expect("load session");
+            assert_eq!(
+                persisted.messages.len(),
+                advanced.messages.len(),
+                "stale checkpoint content must not overwrite the newer session"
+            );
         });
     }
 

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -275,8 +275,30 @@ pub struct SessionManager {
     sessions_dir: PathBuf,
 }
 
+/// Origin of a crash-recovery checkpoint file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckpointSource {
+    /// Per-session checkpoint file `checkpoints/<session_id>.json`.
+    Session(String),
+    /// Legacy single-slot checkpoint file `checkpoints/latest.json`.
+    Legacy,
+}
+
+/// A crash-recovery checkpoint file discovered on disk (metadata only —
+/// callers load the session content separately).
+#[derive(Debug, Clone)]
+pub struct CheckpointRef {
+    pub source: CheckpointSource,
+    pub path: PathBuf,
+    pub modified: std::time::SystemTime,
+}
+
+/// File names in `checkpoints/` that are never per-session checkpoints.
+const LEGACY_CHECKPOINT_FILE: &str = "latest.json";
+const OFFLINE_QUEUE_FILE: &str = "offline_queue.json";
+
 impl SessionManager {
-    fn validated_session_path(&self, id: &str) -> std::io::Result<PathBuf> {
+    fn validated_session_id<'a>(&self, id: &'a str) -> std::io::Result<&'a str> {
         let trimmed = id.trim();
         if trimmed.is_empty() {
             return Err(std::io::Error::new(
@@ -293,7 +315,31 @@ impl SessionManager {
                 format!("Invalid session id '{id}'"),
             ));
         }
+        Ok(trimmed)
+    }
+
+    fn validated_session_path(&self, id: &str) -> std::io::Result<PathBuf> {
+        let trimmed = self.validated_session_id(id)?;
         Ok(self.sessions_dir.join(format!("{trimmed}.json")))
+    }
+
+    fn checkpoints_dir(&self) -> PathBuf {
+        self.sessions_dir.join("checkpoints")
+    }
+
+    fn validated_checkpoint_path(&self, session_id: &str) -> std::io::Result<PathBuf> {
+        let trimmed = self.validated_session_id(session_id)?;
+        // Reserved file names inside `checkpoints/` must never collide with a
+        // per-session checkpoint file.
+        if format!("{trimmed}.json") == LEGACY_CHECKPOINT_FILE
+            || format!("{trimmed}.json") == OFFLINE_QUEUE_FILE
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Session id '{trimmed}' collides with a reserved checkpoint file"),
+            ));
+        }
+        Ok(self.checkpoints_dir().join(format!("{trimmed}.json")))
     }
 
     /// Create a new `SessionManager` with the specified sessions directory
@@ -331,23 +377,23 @@ impl SessionManager {
     }
 
     /// Save a crash-recovery checkpoint for in-flight turns.
+    ///
+    /// Checkpoints are keyed per session (`checkpoints/<session_id>.json`) so
+    /// concurrent sessions never overwrite each other's crash-recovery state.
     pub fn save_checkpoint(&self, session: &SavedSession) -> std::io::Result<PathBuf> {
-        let checkpoints = self.sessions_dir.join("checkpoints");
-        fs::create_dir_all(&checkpoints)?;
-        let path = checkpoints.join("latest.json");
+        let path = self.validated_checkpoint_path(&session.metadata.id)?;
+        fs::create_dir_all(self.checkpoints_dir())?;
         let content = serde_json::to_string_pretty(&session)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         write_atomic(&path, content.as_bytes())?;
         Ok(path)
     }
 
-    /// Load the most recent crash-recovery checkpoint if present.
-    pub fn load_checkpoint(&self) -> std::io::Result<Option<SavedSession>> {
-        let path = self.sessions_dir.join("checkpoints").join("latest.json");
+    fn read_checkpoint_file(&self, path: &Path) -> std::io::Result<Option<SavedSession>> {
         if !path.exists() {
             return Ok(None);
         }
-        let content = fs::read_to_string(&path)?;
+        let content = fs::read_to_string(path)?;
         let mut session: SavedSession = serde_json::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         if session.schema_version > CURRENT_SESSION_SCHEMA_VERSION {
@@ -363,13 +409,100 @@ impl SessionManager {
         Ok(Some(session))
     }
 
-    /// Clear any crash-recovery checkpoint.
-    pub fn clear_checkpoint(&self) -> std::io::Result<()> {
-        let path = self.sessions_dir.join("checkpoints").join("latest.json");
+    /// Load a specific session's crash-recovery checkpoint if present.
+    pub fn load_session_checkpoint(
+        &self,
+        session_id: &str,
+    ) -> std::io::Result<Option<SavedSession>> {
+        let path = self.validated_checkpoint_path(session_id)?;
+        self.read_checkpoint_file(&path)
+    }
+
+    /// Load the legacy single-slot checkpoint (`checkpoints/latest.json`) if
+    /// present. Compatibility read only — this release no longer writes it.
+    pub fn load_legacy_checkpoint(&self) -> std::io::Result<Option<SavedSession>> {
+        let path = self.checkpoints_dir().join(LEGACY_CHECKPOINT_FILE);
+        self.read_checkpoint_file(&path)
+    }
+
+    /// Clear one session's crash-recovery checkpoint. Scoped: this can never
+    /// remove another session's checkpoint file or the legacy slot.
+    pub fn clear_session_checkpoint(&self, session_id: &str) -> std::io::Result<()> {
+        let path = self.validated_checkpoint_path(session_id)?;
         if path.exists() {
             fs::remove_file(path)?;
         }
         Ok(())
+    }
+
+    /// Remove the legacy single-slot checkpoint file.
+    pub fn clear_legacy_checkpoint(&self) -> std::io::Result<()> {
+        let path = self.checkpoints_dir().join(LEGACY_CHECKPOINT_FILE);
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    /// Enumerate all crash-recovery checkpoint files (per-session files plus
+    /// the legacy single slot), sorted most recently modified first. Only
+    /// file metadata is read here; callers load content per candidate.
+    pub fn list_checkpoints(&self) -> std::io::Result<Vec<CheckpointRef>> {
+        let dir = self.checkpoints_dir();
+        let mut refs = Vec::new();
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(refs),
+            Err(err) => return Err(err),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() || path.extension().is_none_or(|ext| ext != "json") {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let source = if name == LEGACY_CHECKPOINT_FILE {
+                CheckpointSource::Legacy
+            } else if name == OFFLINE_QUEUE_FILE {
+                continue;
+            } else {
+                let session_id = name.trim_end_matches(".json").to_string();
+                if self.validated_checkpoint_path(&session_id).is_err() {
+                    continue;
+                }
+                CheckpointSource::Session(session_id)
+            };
+            let Ok(modified) = entry.metadata().and_then(|m| m.modified()) else {
+                continue;
+            };
+            refs.push(CheckpointRef {
+                source,
+                path,
+                modified,
+            });
+        }
+        refs.sort_by_key(|r| std::cmp::Reverse(r.modified));
+        Ok(refs)
+    }
+
+    /// Migrate a session recovered from the legacy single-slot checkpoint to
+    /// a per-session checkpoint file. Never overwrites an existing
+    /// per-session file and leaves the legacy file in place (older binaries
+    /// still read it; the legacy writer is already gone). Returns whether a
+    /// file was written.
+    pub fn write_session_checkpoint_if_absent(
+        &self,
+        session: &SavedSession,
+    ) -> std::io::Result<bool> {
+        let path = self.validated_checkpoint_path(&session.metadata.id)?;
+        if path.exists() {
+            return Ok(false);
+        }
+        self.save_checkpoint(session)?;
+        Ok(true)
     }
 
     /// Save offline queue state (queued + draft messages).
@@ -578,8 +711,9 @@ impl SessionManager {
     /// on boot; today the user-facing entry point is the
     /// `/sessions prune <days>` slash command.
     ///
-    /// Crash-recovery safety: skips the running checkpoint
-    /// (`checkpoints/latest.json`) and any file under `checkpoints/`
+    /// Crash-recovery safety: skips the per-session checkpoint files
+    /// (`checkpoints/<session_id>.json`), the legacy single-slot
+    /// checkpoint (`checkpoints/latest.json`), and any file under `checkpoints/`
     /// — those are owned by the checkpoint subsystem and live with
     /// stricter durability rules. Only top-level `<session_id>.json`
     /// files are candidates.
@@ -1892,21 +2026,138 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
         let messages = vec![make_test_message("user", "checkpoint me")];
-        let session = create_saved_session(&messages, "test-model", tmp.path(), 12, None);
+        let mut session = create_saved_session(&messages, "test-model", tmp.path(), 12, None);
+        session.work_state = Some(SessionWorkState {
+            todos: crate::tools::todo::TodoListSnapshot {
+                items: vec![crate::tools::todo::TodoItem {
+                    id: 1,
+                    content: "verify checkpoint durability".to_string(),
+                    status: crate::tools::todo::TodoStatus::InProgress,
+                }],
+                completion_pct: 0,
+                in_progress_id: Some(1),
+            },
+            ..SessionWorkState::default()
+        });
 
-        manager.save_checkpoint(&session).expect("save checkpoint");
+        let path = manager.save_checkpoint(&session).expect("save checkpoint");
+        assert_eq!(
+            path.file_name().and_then(|n| n.to_str()),
+            Some(format!("{}.json", session.metadata.id).as_str()),
+            "checkpoint file must be keyed by session id"
+        );
         let loaded = manager
-            .load_checkpoint()
+            .load_session_checkpoint(&session.metadata.id)
             .expect("load checkpoint")
             .expect("checkpoint exists");
         assert_eq!(loaded.metadata.id, session.metadata.id);
+        assert_eq!(loaded.messages, session.messages);
+        assert_eq!(
+            loaded.work_state, session.work_state,
+            "work state must survive the checkpoint round trip"
+        );
 
-        manager.clear_checkpoint().expect("clear checkpoint");
+        manager
+            .clear_session_checkpoint(&session.metadata.id)
+            .expect("clear checkpoint");
         assert!(
             manager
-                .load_checkpoint()
+                .load_session_checkpoint(&session.metadata.id)
                 .expect("load checkpoint")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn checkpoints_are_independent_per_session() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let first = create_saved_session(
+            &[make_test_message("user", "session one")],
+            "test-model",
+            tmp.path(),
+            0,
+            None,
+        );
+        let second = create_saved_session(
+            &[make_test_message("user", "session two")],
+            "test-model",
+            tmp.path(),
+            0,
+            None,
+        );
+
+        manager.save_checkpoint(&first).expect("save first");
+        manager.save_checkpoint(&second).expect("save second");
+        manager
+            .clear_session_checkpoint(&first.metadata.id)
+            .expect("clear first");
+
+        assert!(
+            manager
+                .load_session_checkpoint(&first.metadata.id)
+                .expect("load first")
+                .is_none(),
+            "clearing one session must remove only that session's file"
+        );
+        let survivor = manager
+            .load_session_checkpoint(&second.metadata.id)
+            .expect("load second")
+            .expect("second checkpoint survives");
+        assert_eq!(survivor.metadata.id, second.metadata.id);
+    }
+
+    #[test]
+    fn list_checkpoints_includes_legacy_slot_and_skips_offline_queue() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let session = create_saved_session(
+            &[make_test_message("user", "list me")],
+            "test-model",
+            tmp.path(),
+            0,
+            None,
+        );
+        manager.save_checkpoint(&session).expect("save checkpoint");
+        let checkpoints = tmp.path().join("sessions").join("checkpoints");
+        fs::write(checkpoints.join("latest.json"), "{}").expect("write legacy slot");
+        fs::write(checkpoints.join("offline_queue.json"), "{}").expect("write offline queue");
+
+        let refs = manager.list_checkpoints().expect("list checkpoints");
+        assert_eq!(refs.len(), 2, "offline queue must not be a candidate");
+        assert!(
+            refs.iter()
+                .any(|r| r.source == CheckpointSource::Session(session.metadata.id.clone()))
+        );
+        assert!(refs.iter().any(|r| r.source == CheckpointSource::Legacy));
+    }
+
+    #[test]
+    fn legacy_migration_never_overwrites_existing_per_session_checkpoint() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let mut session = create_saved_session(
+            &[make_test_message("user", "original")],
+            "test-model",
+            tmp.path(),
+            0,
+            None,
+        );
+        manager.save_checkpoint(&session).expect("save checkpoint");
+
+        session.messages = vec![make_test_message("user", "stale legacy copy")];
+        let written = manager
+            .write_session_checkpoint_if_absent(&session)
+            .expect("migration attempt");
+        assert!(!written, "migration must not overwrite an existing file");
+        let loaded = manager
+            .load_session_checkpoint(&session.metadata.id)
+            .expect("load")
+            .expect("checkpoint exists");
+        assert_eq!(
+            loaded.messages,
+            vec![make_test_message("user", "original")],
+            "existing per-session checkpoint content must be preserved"
         );
     }
 
@@ -2090,7 +2341,16 @@ mod tests {
         )
         .expect("write checkpoint");
 
-        let err = manager.load_checkpoint().expect_err("should reject schema");
+        let err = manager
+            .load_legacy_checkpoint()
+            .expect_err("should reject schema");
+        assert!(err.to_string().contains("newer than supported"));
+
+        // The same guard applies to per-session checkpoint files.
+        fs::rename(&path, checkpoints.join("sid.json")).expect("rename to per-session file");
+        let err = manager
+            .load_session_checkpoint("sid")
+            .expect_err("should reject schema");
         assert!(err.to_string().contains("newer than supported"));
     }
 

--- a/crates/tui/src/tui/persistence_actor.rs
+++ b/crates/tui/src/tui/persistence_actor.rs
@@ -16,18 +16,23 @@
 //!   to this task. The UI merely `try_send`s a request (non-blocking,
 //!   bounded-channel drop) and returns immediately — keystrokes are never
 //!   gated on write completion.
-//! - **Latest-wins coalescing**: when multiple `Checkpoint`,
+//! - **Latest-wins coalescing per session**: when multiple `SaveCheckpoint`,
 //!   `SessionSnapshot`, or offline-queue requests pile up before the actor's
-//!   next write cycle, only the most recent one is written. `ClearCheckpoint`
-//!   requests accumulate normally (they're cheap and commutative).
+//!   next write cycle, only the most recent one per session is written.
+//!   Checkpoints and clears are keyed by session id, so concurrent sessions
+//!   never coalesce into (or clear) each other's slot.
+//! - **Durability reporting**: every write/removal result is collected; a
+//!   `FlushAndReport` request drains pending work and replies with the
+//!   aggregated results since the last report. Cycles with no listener log
+//!   their failures instead of discarding them.
 //! - **Unbounded channel** for `try_send` to always succeed; the actor
 //!   naturally backpressures via the spawn pool. A few outstanding
 //!   `SavedSession` values in the channel (< 1 MB) is negligible pressure.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::session_manager::{OfflineQueueState, SavedSession, SessionManager};
 use crate::utils::spawn_supervised;
@@ -39,8 +44,9 @@ use crate::utils::spawn_supervised;
 /// Persistence work item sent to the actor.
 #[derive(Debug)]
 pub enum PersistRequest {
-    /// Write a crash-recovery checkpoint (in-flight turn state).
-    Checkpoint(SavedSession),
+    /// Write a crash-recovery checkpoint (in-flight turn state) to the
+    /// session's own file (`checkpoints/<session_id>.json`).
+    SaveCheckpoint { session: SavedSession },
     /// Write a full session snapshot (completed turn, durable save).
     SessionSnapshot(SavedSession),
     /// Write queued/draft offline input for crash recovery.
@@ -50,10 +56,41 @@ pub enum PersistRequest {
     },
     /// Remove the queued/draft offline input file.
     ClearOfflineQueue,
-    /// Remove the crash-recovery checkpoint file.
-    ClearCheckpoint,
+    /// Remove one session's crash-recovery checkpoint file. Scoped: cannot
+    /// remove another session's checkpoint.
+    ClearCheckpoint { session_id: String },
+    /// Flush all pending work now and report durability results through
+    /// `reply`. The report aggregates every write/removal result since the
+    /// previous report (including background write cycles) — errors are
+    /// collected and surfaced, never discarded.
+    FlushAndReport { reply: oneshot::Sender<FlushReport> },
     /// Graceful shutdown — flush pending writes, then exit the actor loop.
     Shutdown,
+}
+
+/// Aggregated durability results: how many writes/removals completed and
+/// which failed (labelled by what was being persisted, with the I/O error
+/// kind).
+#[derive(Debug, Default)]
+pub struct FlushReport {
+    pub completed: usize,
+    pub failures: Vec<(String, std::io::ErrorKind)>,
+}
+
+impl FlushReport {
+    /// Upper bound on retained failure entries when accumulating across
+    /// write cycles. Every failure is logged at the cycle it happened, so
+    /// dropping older-than-bound entries from the reply loses no evidence.
+    const MAX_ACCUMULATED_FAILURES: usize = 256;
+
+    fn merge(&mut self, other: FlushReport) {
+        self.completed += other.completed;
+        self.failures.extend(other.failures);
+        if self.failures.len() > Self::MAX_ACCUMULATED_FAILURES {
+            let excess = self.failures.len() - Self::MAX_ACCUMULATED_FAILURES;
+            self.failures.drain(..excess);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -123,112 +160,58 @@ pub fn spawn_persistence_actor(
         "persistence-actor",
         std::panic::Location::caller(),
         async move {
-            let mut latest_checkpoint: Option<SavedSession> = None;
-            // Latest-wins per session id. Coalescing into one global slot can
-            // drop session A when an immediate `/new` queues session B before
-            // the actor drains.
-            let mut latest_sessions: BTreeMap<String, SavedSession> = BTreeMap::new();
-            let mut latest_offline_queue: Option<PendingOfflineQueue> = None;
-            let mut should_clear: bool = false;
+            let mut pending = PendingState::default();
+            // Durability results from write cycles that no caller has asked
+            // about yet; drained into the next `FlushAndReport` reply.
+            let mut unreported = FlushReport::default();
+
+            // Flush pending work, log new failures, and fold the cycle's
+            // results into the unreported accumulator.
+            fn flush_cycle(
+                manager: &SessionManager,
+                pending: &mut PendingState,
+                unreported: &mut FlushReport,
+            ) {
+                let cycle = flush_inner(manager, pending);
+                log_flush_failures(&cycle);
+                unreported.merge(cycle);
+            }
 
             loop {
                 // Drain everything waiting, keeping only the latest of each kind.
                 while let Ok(req) = rx.try_recv() {
-                    match req {
-                        PersistRequest::Checkpoint(session) => {
-                            // Last-writer-wins: a fresh checkpoint supersedes a
-                            // pending clear so the two never both apply in one
-                            // drain (which previously cleared then re-wrote the
-                            // stale checkpoint, undoing the clear).
-                            latest_checkpoint = Some(session);
-                            should_clear = false;
+                    match pending.absorb(req) {
+                        Control::Continue => {}
+                        Control::Flush(reply) => {
+                            flush_cycle(&manager, &mut pending, &mut unreported);
+                            let _ = reply.send(std::mem::take(&mut unreported));
                         }
-                        PersistRequest::SessionSnapshot(session) => {
-                            latest_sessions.insert(session.metadata.id.clone(), session);
-                        }
-                        PersistRequest::OfflineQueue { state, session_id } => {
-                            latest_offline_queue = Some(PendingOfflineQueue::Save {
-                                state: Box::new(state),
-                                session_id,
-                            });
-                        }
-                        PersistRequest::ClearOfflineQueue => {
-                            latest_offline_queue = Some(PendingOfflineQueue::Clear);
-                        }
-                        PersistRequest::ClearCheckpoint => {
-                            // A clear supersedes a pending checkpoint write.
-                            should_clear = true;
-                            latest_checkpoint = None;
-                        }
-                        PersistRequest::Shutdown => {
-                            flush_inner(
-                                &manager,
-                                latest_checkpoint.as_ref(),
-                                &latest_sessions,
-                                latest_offline_queue.as_ref(),
-                                should_clear,
-                            );
+                        Control::Shutdown => {
+                            flush_cycle(&manager, &mut pending, &mut unreported);
                             return;
                         }
                     }
                 }
 
                 // Write coalesced work.
-                if should_clear {
-                    let _ = manager.clear_checkpoint();
-                    should_clear = false;
-                }
-                if let Some(ref session) = latest_checkpoint.take() {
-                    let _ = manager.save_checkpoint(session);
-                }
-                for (_, session) in std::mem::take(&mut latest_sessions) {
-                    let _ = manager.save_session(&session);
-                }
-                if let Some(ref request) = latest_offline_queue.take() {
-                    apply_offline_queue_request(&manager, request);
-                }
+                flush_cycle(&manager, &mut pending, &mut unreported);
 
                 // Block until the next request arrives.
                 match rx.recv().await {
-                    Some(PersistRequest::Checkpoint(session)) => {
-                        latest_checkpoint = Some(session);
-                        should_clear = false;
-                    }
-                    Some(PersistRequest::SessionSnapshot(session)) => {
-                        latest_sessions.insert(session.metadata.id.clone(), session);
-                    }
-                    Some(PersistRequest::OfflineQueue { state, session_id }) => {
-                        latest_offline_queue = Some(PendingOfflineQueue::Save {
-                            state: Box::new(state),
-                            session_id,
-                        });
-                    }
-                    Some(PersistRequest::ClearOfflineQueue) => {
-                        latest_offline_queue = Some(PendingOfflineQueue::Clear);
-                    }
-                    Some(PersistRequest::ClearCheckpoint) => {
-                        should_clear = true;
-                        latest_checkpoint = None;
-                    }
-                    Some(PersistRequest::Shutdown) => {
-                        flush_inner(
-                            &manager,
-                            latest_checkpoint.as_ref(),
-                            &latest_sessions,
-                            latest_offline_queue.as_ref(),
-                            should_clear,
-                        );
-                        return;
-                    }
+                    Some(req) => match pending.absorb(req) {
+                        Control::Continue => {}
+                        Control::Flush(reply) => {
+                            flush_cycle(&manager, &mut pending, &mut unreported);
+                            let _ = reply.send(std::mem::take(&mut unreported));
+                        }
+                        Control::Shutdown => {
+                            flush_cycle(&manager, &mut pending, &mut unreported);
+                            return;
+                        }
+                    },
                     None => {
                         // Channel closed — final flush and exit.
-                        flush_inner(
-                            &manager,
-                            latest_checkpoint.as_ref(),
-                            &latest_sessions,
-                            latest_offline_queue.as_ref(),
-                            should_clear,
-                        );
+                        flush_cycle(&manager, &mut pending, &mut unreported);
                         return;
                     }
                 }
@@ -239,36 +222,121 @@ pub fn spawn_persistence_actor(
     (handle, task)
 }
 
-/// Write any pending work to disk (used on shutdown).
-fn flush_inner(
-    manager: &SessionManager,
-    checkpoint: Option<&SavedSession>,
-    sessions: &BTreeMap<String, SavedSession>,
-    offline_queue: Option<&PendingOfflineQueue>,
-    should_clear: bool,
-) {
-    if should_clear {
-        let _ = manager.clear_checkpoint();
-    }
-    if let Some(s) = checkpoint {
-        let _ = manager.save_checkpoint(s);
-    }
-    for s in sessions.values() {
-        let _ = manager.save_session(s);
-    }
-    if let Some(request) = offline_queue {
-        apply_offline_queue_request(manager, request);
+/// Coalesced work waiting for the next write cycle.
+#[derive(Debug, Default)]
+struct PendingState {
+    /// Latest-wins per session id. Crash checkpoints are keyed per session
+    /// (mirroring `sessions` below) so concurrent sessions can interleave
+    /// saves and clears without clobbering each other.
+    checkpoints: BTreeMap<String, SavedSession>,
+    /// Session ids whose checkpoint file should be removed.
+    checkpoint_clears: BTreeSet<String>,
+    /// Latest-wins per session id. Coalescing into one global slot can
+    /// drop session A when an immediate `/new` queues session B before
+    /// the actor drains.
+    sessions: BTreeMap<String, SavedSession>,
+    offline_queue: Option<PendingOfflineQueue>,
+}
+
+/// What the actor loop should do after absorbing a request.
+enum Control {
+    Continue,
+    Flush(oneshot::Sender<FlushReport>),
+    Shutdown,
+}
+
+impl PendingState {
+    fn absorb(&mut self, req: PersistRequest) -> Control {
+        match req {
+            PersistRequest::SaveCheckpoint { session } => {
+                // Last-writer-wins per session: a fresh checkpoint supersedes
+                // a pending clear for the same session so the two never both
+                // apply in one drain (which previously cleared then re-wrote
+                // the stale checkpoint, undoing the clear).
+                let id = session.metadata.id.clone();
+                self.checkpoint_clears.remove(&id);
+                self.checkpoints.insert(id, session);
+            }
+            PersistRequest::SessionSnapshot(session) => {
+                self.sessions.insert(session.metadata.id.clone(), session);
+            }
+            PersistRequest::OfflineQueue { state, session_id } => {
+                self.offline_queue = Some(PendingOfflineQueue::Save {
+                    state: Box::new(state),
+                    session_id,
+                });
+            }
+            PersistRequest::ClearOfflineQueue => {
+                self.offline_queue = Some(PendingOfflineQueue::Clear);
+            }
+            PersistRequest::ClearCheckpoint { session_id } => {
+                // A clear supersedes a pending checkpoint write for the same
+                // session only — other sessions' pending work is untouched.
+                self.checkpoints.remove(&session_id);
+                self.checkpoint_clears.insert(session_id);
+            }
+            PersistRequest::FlushAndReport { reply } => return Control::Flush(reply),
+            PersistRequest::Shutdown => return Control::Shutdown,
+        }
+        Control::Continue
     }
 }
 
-fn apply_offline_queue_request(manager: &SessionManager, request: &PendingOfflineQueue) {
-    match request {
-        PendingOfflineQueue::Save { state, session_id } => {
-            let _ = manager.save_offline_queue_state(state, session_id.as_deref());
+/// Write all pending work to disk, draining `pending`. Every write and
+/// removal result is collected into the returned [`FlushReport`] — failures
+/// are reported, never silently discarded.
+fn flush_inner(manager: &SessionManager, pending: &mut PendingState) -> FlushReport {
+    let mut report = FlushReport::default();
+    let mut record = |what: String, result: std::io::Result<()>| match result {
+        Ok(()) => report.completed += 1,
+        Err(err) => report.failures.push((what, err.kind())),
+    };
+
+    for session_id in std::mem::take(&mut pending.checkpoint_clears) {
+        record(
+            format!("clear-checkpoint:{session_id}"),
+            manager.clear_session_checkpoint(&session_id),
+        );
+    }
+    for (session_id, session) in std::mem::take(&mut pending.checkpoints) {
+        record(
+            format!("checkpoint:{session_id}"),
+            manager.save_checkpoint(&session).map(|_| ()),
+        );
+    }
+    for (session_id, session) in std::mem::take(&mut pending.sessions) {
+        record(
+            format!("session:{session_id}"),
+            manager.save_session(&session).map(|_| ()),
+        );
+    }
+    if let Some(request) = pending.offline_queue.take() {
+        match request {
+            PendingOfflineQueue::Save { state, session_id } => record(
+                "offline-queue".to_string(),
+                manager
+                    .save_offline_queue_state(&state, session_id.as_deref())
+                    .map(|_| ()),
+            ),
+            PendingOfflineQueue::Clear => record(
+                "clear-offline-queue".to_string(),
+                manager.clear_offline_queue_state(),
+            ),
         }
-        PendingOfflineQueue::Clear => {
-            let _ = manager.clear_offline_queue_state();
-        }
+    }
+    report
+}
+
+/// Surface flush failures in the log for write cycles that have no caller
+/// waiting on a [`FlushReport`].
+fn log_flush_failures(report: &FlushReport) {
+    for (what, kind) in &report.failures {
+        tracing::warn!(
+            target: "persistence",
+            what = %what,
+            error_kind = ?kind,
+            "persistence write failed",
+        );
     }
 }
 
@@ -402,5 +470,119 @@ mod tests {
                 .title,
             "Session B"
         );
+    }
+
+    #[tokio::test]
+    async fn interleaved_checkpoint_saves_and_clears_stay_per_session() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        let verification_manager = SessionManager::new(sessions_dir).expect("verification manager");
+        let first = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let second = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let first_id = first.metadata.id.clone();
+        let second_id = second.metadata.id.clone();
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        // Interleave: save A, save B, clear A — all coalesced into one drain.
+        handle.try_send(PersistRequest::SaveCheckpoint { session: first });
+        handle.try_send(PersistRequest::SaveCheckpoint { session: second });
+        handle.try_send(PersistRequest::ClearCheckpoint {
+            session_id: first_id.clone(),
+        });
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+
+        assert!(
+            verification_manager
+                .load_session_checkpoint(&first_id)
+                .expect("load first checkpoint")
+                .is_none(),
+            "cleared session must have no checkpoint file"
+        );
+        let survivor = verification_manager
+            .load_session_checkpoint(&second_id)
+            .expect("load second checkpoint")
+            .expect("second session's checkpoint must survive an unrelated clear");
+        assert_eq!(survivor.metadata.id, second_id);
+    }
+
+    #[tokio::test]
+    async fn flush_and_report_returns_completed_counts() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir).expect("manager");
+        let session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::SaveCheckpoint { session });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: reply_tx });
+        let report = reply_rx.await.expect("flush report reply");
+        // Whether the checkpoint was written by an earlier background cycle
+        // or by this flush, the accumulated report must count it and show no
+        // failures — and the actor keeps running afterwards.
+        assert!(report.completed >= 1, "checkpoint write must be counted");
+        assert!(report.failures.is_empty(), "no failures expected");
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
+    }
+
+    #[tokio::test]
+    async fn flush_and_report_propagates_write_failures() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = tmp.path().join("sessions");
+        let manager = SessionManager::new(sessions_dir.clone()).expect("manager");
+        // Occupy the checkpoints directory path with a regular file so every
+        // checkpoint write deterministically fails on all platforms.
+        std::fs::write(sessions_dir.join("checkpoints"), b"not a directory")
+            .expect("block checkpoints dir");
+        let session = crate::session_manager::create_saved_session_with_mode(
+            &[],
+            "deepseek-v4-pro",
+            tmp.path(),
+            0,
+            None,
+            Some("agent"),
+        );
+        let session_id = session.metadata.id.clone();
+        let (handle, task) = spawn_persistence_actor(manager);
+
+        handle.try_send(PersistRequest::SaveCheckpoint { session });
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: reply_tx });
+        let report = reply_rx.await.expect("flush report reply");
+
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|(what, _)| what == &format!("checkpoint:{session_id}")),
+            "failed checkpoint write must be reported, got: {:?}",
+            report.failures
+        );
+        handle.try_send(PersistRequest::Shutdown);
+        task.await.expect("persistence actor join");
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1205,9 +1205,24 @@ pub async fn run_tui(
         let _ = app.execute_hooks(HookEvent::SessionEnd, &context);
     }
 
-    // Flush the persistence actor: clear checkpoint + graceful shutdown.
+    // Flush the persistence actor: clear this session's checkpoint, collect
+    // the durability report (write failures are surfaced, not discarded),
+    // then shut down gracefully.
     if let Some((handle, task)) = persistence_runtime {
-        handle.try_send(PersistRequest::ClearCheckpoint);
+        if let Some(session_id) = app.current_session_id.clone() {
+            handle.try_send(PersistRequest::ClearCheckpoint { session_id });
+        }
+        let (report_tx, report_rx) = tokio::sync::oneshot::channel();
+        handle.try_send(PersistRequest::FlushAndReport { reply: report_tx });
+        if let Ok(report) = report_rx.await
+            && !report.failures.is_empty()
+        {
+            tracing::warn!(
+                target: "persistence",
+                failures = ?report.failures,
+                "session persistence reported write failures during shutdown",
+            );
+        }
         handle.try_send(PersistRequest::Shutdown);
         let _ = task.await;
     }
@@ -3030,16 +3045,18 @@ async fn run_event_loop(
                         // Auto-save completed turn and clear crash checkpoint.
                         // Offloaded to the persistence actor so the UI
                         // stays responsive.
-                        let mut completed_snapshot_queued = false;
+                        let mut completed_snapshot_id: Option<String> = None;
                         if let Ok(manager) = SessionManager::default_location()
                             && let Ok(session) = build_session_snapshot(app, &manager)
                         {
                             app.current_session_id = Some(session.metadata.id.clone());
+                            completed_snapshot_id = Some(session.metadata.id.clone());
                             persistence_actor::persist(PersistRequest::SessionSnapshot(session));
-                            completed_snapshot_queued = true;
                         }
-                        if completed_snapshot_queued {
-                            persistence_actor::persist(PersistRequest::ClearCheckpoint);
+                        if let Some(session_id) = completed_snapshot_id {
+                            persistence_actor::persist(PersistRequest::ClearCheckpoint {
+                                session_id,
+                            });
                         }
 
                         // Refresh DeepSeek account balance after each completed
@@ -3192,7 +3209,15 @@ async fn run_event_loop(
                         {
                             if let Ok(session) = build_session_snapshot(app, &manager) {
                                 app.session_title = Some(session.metadata.title.clone());
-                                persistence_actor::persist(PersistRequest::Checkpoint(session));
+                                // Pin the id so every checkpoint of this
+                                // session lands in the same per-session file
+                                // and the eventual clear targets it.
+                                if app.current_session_id.is_none() {
+                                    app.current_session_id = Some(session.metadata.id.clone());
+                                }
+                                persistence_actor::persist(PersistRequest::SaveCheckpoint {
+                                    session,
+                                });
                             }
                         } else if app.session_title.is_none() {
                             // Never synchronously reload the growing session
@@ -6860,7 +6885,11 @@ fn persist_full_reset_snapshot(app: &mut App) {
     // `/clear` and `/new` are explicit boundaries. Never let an older
     // in-flight checkpoint resurrect the session the user just discarded,
     // even if the replacement snapshot could not be constructed.
-    persistence_actor::persist(PersistRequest::ClearCheckpoint);
+    // `build_session_snapshot` reuses `current_session_id`, so this id is the
+    // discarded session's id whether or not the snapshot above succeeded.
+    if let Some(session_id) = app.current_session_id.clone() {
+        persistence_actor::persist(PersistRequest::ClearCheckpoint { session_id });
+    }
 }
 
 fn maybe_throttled_recovery_snapshot(
@@ -8190,7 +8219,12 @@ async fn dispatch_user_message(
     if let Ok(manager) = SessionManager::default_location()
         && let Ok(session) = build_session_snapshot(app, &manager)
     {
-        persistence_actor::persist(PersistRequest::Checkpoint(session));
+        // Pin the id so every checkpoint of this session lands in the same
+        // per-session file and the eventual clear targets it.
+        if app.current_session_id.is_none() {
+            app.current_session_id = Some(session.metadata.id.clone());
+        }
+        persistence_actor::persist(PersistRequest::SaveCheckpoint { session });
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Cuts the crash-checkpoint subsystem over from a single shared slot to per-session files, and makes the persistence actor report write results instead of discarding them. Spec slice S1 of the v0.9.1 cutover plan.

### Defect evidence (at current `main`, 641ec4d5a)

- **Single-slot checkpoint**: `crates/tui/src/session_manager.rs:335-373` — `save_checkpoint`/`load_checkpoint`/`clear_checkpoint` all hardcode `checkpoints/latest.json`. Two concurrent sessions overwrite each other's crash-recovery state, and any launch in any workspace could consume another session's checkpoint (`crates/tui/src/main.rs:8249/8293/8312/8334` cleared the shared slot unconditionally).
- **Discarded write results**: `crates/tui/src/tui/persistence_actor.rs:178-185` (write cycle) and `:251-257` (`flush_inner`) — every save/clear result went through `let _ = ...`; a full disk or permissions failure was invisible while the actor coalesced only one global checkpoint slot (`latest_checkpoint`, `:126`), even though session snapshots were already keyed per session (`:130`).

### What changed

- **SessionManager**: checkpoints live in `checkpoints/<session_id>.json` (validated ids; reserved names `latest`/`offline_queue` rejected). `latest.json` becomes a compatibility read only. New: per-session load/clear, `list_checkpoints()` candidate enumeration (per-session files ∪ legacy slot, newest first), `write_session_checkpoint_if_absent()` for migration.
- **Persistence actor**: `SaveCheckpoint`/`ClearCheckpoint` keyed per session, mirroring the existing per-session snapshot map — a clear supersedes only the same session's pending write. New `FlushAndReport { reply }` returns `FlushReport { completed, failures: Vec<(String, io::ErrorKind)> }` aggregating every write/removal result since the last report (bounded accumulator; unlistened cycles log failures). `Shutdown` drain semantics unchanged.
- **`--continue` / recovery selection**: candidates = per-session files ∪ legacy `latest.json`; keep age < 24h AND workspace-scope match (reuses `session_manager::workspace_scope_matches` against the resolved launch workspace); newest wins. Stale files are pruned; unreadable files skipped.
- **UI call sites**: `ClearCheckpoint` carries the session id at turn completion, `/clear`//`new` reset, and `run_tui` shutdown; checkpoint saves pin the fresh session's id so all checkpoints of a session land in one file. Shutdown now requests a flush report and logs failures before graceful actor shutdown.
- **`codewhale clean`** targets per-session checkpoint files too.

### Compat / migration notes

- Recovery from the legacy slot writes the per-session file (never overwriting an existing one) and **leaves `latest.json` in place** for one more release — older binaries can still read it; nothing writes it anymore and it ages out in 24h.
- Guard added: a stale checkpoint never overwrites a newer saved session file for the same id, so a second `--continue` within 24h of a legacy recovery cannot clobber post-recovery progress.
- Workspace-mismatched per-session checkpoint files are refused **and left untouched** — they may belong to a live session in another workspace. (The old shared slot persisted-then-cleared on mismatch; that behavior is kept for the legacy slot only.)
- Plain launches no longer consume per-session checkpoint files of possibly-live sessions; they persist a resume target and leave the file for `--continue`. Deviation from the old nag-once behavior: after a crash the in-flight notice can repeat until the session is recovered or the file ages out — chosen so opening another codewhale can never destroy a live session's crash protection.
- Checkpoint schema guard (`newer than supported`) applies to both per-session and legacy reads.

## Testing

- [x] `cargo fmt --check -p codewhale-tui` — clean
- [x] `cargo clippy -p codewhale-tui --all-targets -- -D warnings` (repo's standard allow set) — clean, zero new warnings
- [x] `cargo test -p codewhale-tui --bin codewhale-tui -- persistence checkpoint session_manager` — 115 passed / 0 failed
- [x] Full `cargo test -p codewhale-tui --bin codewhale-tui` — 7394 passed / 0 failed / 2 ignored (one unrelated pre-existing parallelism flake observed across runs: `config::tests::deepseek_provider_defaults_to_beta_endpoint` races the env-var write at `config/tests.rs:6731`; passes isolated; file untouched here)

New tests: interleaved save/clear keeps independent files (actor + manager level); legacy `latest.json` recovery migrates and leaves the slot; migration never overwrites an existing per-session file; workspace-mismatch refusal leaves the file untouched; write failures propagate through `FlushAndReport` (checkpoints dir blocked by a regular file); stale-legacy double-`--continue` cannot clobber a newer session; checkpoint round-trip preserves messages and work state; clean-target coverage.

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes (call-site-only UI changes; covered by the suite — happy to do a manual dogfood pass if wanted)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (n/a — no harvested work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
