### PR TITLE
feat(protocol): add dependency-neutral run read model

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -183,6 +183,51 @@ pub struct JobRecord {
     pub updated_at: i64,
 }
 
+/// Map a durable [`JobRecord`] to the dependency-neutral run read model.
+///
+/// Pure projection of the record as persisted: unknown budgets stay unset and
+/// nothing is fabricated. `updated_at` (epoch seconds) provides the terminal
+/// timestamp because the job manager records no separate end time.
+#[must_use]
+pub fn job_record_to_agent_run(
+    record: &JobRecord,
+) -> codewhale_protocol::agent_run::AgentRunSnapshot {
+    use codewhale_protocol::agent_run::{
+        AgentRunSnapshot, BudgetSummary, RunSource, RunState, TerminalOutcome, TerminalSummary,
+    };
+
+    let (state, terminal) = match record.status {
+        JobStatus::Queued => (RunState::Queued, None),
+        JobStatus::Running => (RunState::Running, None),
+        JobStatus::Paused => (RunState::Paused, None),
+        JobStatus::Completed | JobStatus::Failed | JobStatus::Cancelled => {
+            let outcome = match record.status {
+                JobStatus::Completed => TerminalOutcome::Completed,
+                JobStatus::Failed => TerminalOutcome::Failed,
+                _ => TerminalOutcome::Cancelled,
+            };
+            (
+                RunState::Terminal,
+                Some(TerminalSummary {
+                    outcome,
+                    ended_at_ms: record.updated_at.checked_mul(1000),
+                    detail: record.detail.clone(),
+                }),
+            )
+        }
+    };
+
+    AgentRunSnapshot {
+        run_id: record.id.clone(),
+        parent: None,
+        source: RunSource::CoreJob,
+        state,
+        budget: BudgetSummary::default(),
+        terminal,
+        refs: Vec::new(),
+    }
+}
+
 /// Manages background jobs with retry logic and persistence.
 #[derive(Debug, Default)]
 pub struct JobManager {
@@ -2899,6 +2944,96 @@ mod tests {
         let jobs = reloaded.list();
         let reloaded_job = jobs.iter().find(|job| job.id == id).unwrap();
         assert_eq!(reloaded_job.status, JobStatus::Paused);
+    }
+
+    // ── O1: JobRecord → AgentRunSnapshot adapter ────────────────────────
+
+    fn sample_job_record(status: JobStatus, detail: Option<&str>) -> JobRecord {
+        JobRecord {
+            id: "job-o1-1".to_string(),
+            name: "sample".to_string(),
+            status,
+            progress: None,
+            detail: detail.map(str::to_string),
+            retry: JobRetryMetadata {
+                attempt: 0,
+                max_attempts: DEFAULT_JOB_MAX_ATTEMPTS,
+                backoff_base_ms: DEFAULT_JOB_BACKOFF_BASE_MS,
+                next_backoff_ms: 0,
+                next_retry_at: None,
+            },
+            history: Vec::new(),
+            created_at: 1_700_000_000,
+            updated_at: 1_700_000_042,
+        }
+    }
+
+    #[test]
+    fn job_record_to_agent_run_maps_non_terminal_states() {
+        use codewhale_protocol::agent_run::RunState;
+
+        for (status, expected) in [
+            (JobStatus::Queued, RunState::Queued),
+            (JobStatus::Running, RunState::Running),
+            (JobStatus::Paused, RunState::Paused),
+        ] {
+            let snapshot = job_record_to_agent_run(&sample_job_record(status, None));
+            assert!(snapshot.is_coherent());
+            assert_eq!(snapshot.run_id, "job-o1-1");
+            assert_eq!(snapshot.parent, None);
+            assert_eq!(
+                snapshot.source,
+                codewhale_protocol::agent_run::RunSource::CoreJob
+            );
+            assert_eq!(snapshot.state, expected);
+            assert!(snapshot.terminal.is_none());
+            assert!(snapshot.refs.is_empty());
+            assert_eq!(
+                snapshot.budget,
+                codewhale_protocol::agent_run::BudgetSummary::default()
+            );
+        }
+    }
+
+    #[test]
+    fn job_record_to_agent_run_maps_terminal_states_without_fabricating_budget() {
+        use codewhale_protocol::agent_run::{RunState, TerminalOutcome};
+
+        let cases = [
+            (
+                JobStatus::Completed,
+                TerminalOutcome::Completed,
+                Some("done"),
+            ),
+            (JobStatus::Failed, TerminalOutcome::Failed, Some("boom")),
+            (JobStatus::Cancelled, TerminalOutcome::Cancelled, None),
+        ];
+
+        for (status, outcome, detail) in cases {
+            let snapshot = job_record_to_agent_run(&sample_job_record(status, detail));
+            assert!(snapshot.is_coherent());
+            assert_eq!(snapshot.state, RunState::Terminal);
+            let terminal = snapshot.terminal.expect("terminal summary");
+            assert_eq!(terminal.outcome, outcome);
+            assert_eq!(terminal.ended_at_ms, Some(1_700_000_042_000));
+            assert_eq!(terminal.detail.as_deref(), detail);
+            assert_eq!(
+                snapshot.budget,
+                codewhale_protocol::agent_run::BudgetSummary::default()
+            );
+            assert!(snapshot.refs.is_empty());
+            assert_eq!(snapshot.parent, None);
+        }
+    }
+
+    #[test]
+    fn job_record_to_agent_run_omits_ended_at_on_updated_at_overflow() {
+        let mut record = sample_job_record(JobStatus::Completed, Some("ok"));
+        record.updated_at = i64::MAX;
+        let snapshot = job_record_to_agent_run(&record);
+        assert!(snapshot.is_coherent());
+        let terminal = snapshot.terminal.expect("terminal summary");
+        assert_eq!(terminal.ended_at_ms, None);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -187,7 +187,9 @@ pub struct JobRecord {
 ///
 /// Pure projection of the record as persisted: unknown budgets stay unset and
 /// nothing is fabricated. `updated_at` (epoch seconds) provides the terminal
-/// timestamp because the job manager records no separate end time.
+/// timestamp because the job manager records no separate end time. The
+/// free-form job detail is intentionally omitted because this owner does not
+/// classify it as safe for a cross-surface read model.
 #[must_use]
 pub fn job_record_to_agent_run(
     record: &JobRecord,
@@ -211,7 +213,7 @@ pub fn job_record_to_agent_run(
                 Some(TerminalSummary {
                     outcome,
                     ended_at_ms: record.updated_at.checked_mul(1000),
-                    detail: record.detail.clone(),
+                    detail: None,
                 }),
             )
         }
@@ -2996,7 +2998,7 @@ mod tests {
     }
 
     #[test]
-    fn job_record_to_agent_run_maps_terminal_states_without_fabricating_budget() {
+    fn job_record_to_agent_run_maps_terminal_states_without_fabricating_fields() {
         use codewhale_protocol::agent_run::{RunState, TerminalOutcome};
 
         let cases = [
@@ -3016,7 +3018,7 @@ mod tests {
             let terminal = snapshot.terminal.expect("terminal summary");
             assert_eq!(terminal.outcome, outcome);
             assert_eq!(terminal.ended_at_ms, Some(1_700_000_042_000));
-            assert_eq!(terminal.detail.as_deref(), detail);
+            assert_eq!(terminal.detail, None);
             assert_eq!(
                 snapshot.budget,
                 codewhale_protocol::agent_run::BudgetSummary::default()
@@ -3024,6 +3026,16 @@ mod tests {
             assert!(snapshot.refs.is_empty());
             assert_eq!(snapshot.parent, None);
         }
+    }
+
+    #[test]
+    fn job_record_to_agent_run_does_not_export_unclassified_detail() {
+        let record = sample_job_record(JobStatus::Failed, Some("owner-private diagnostic"));
+        let snapshot = job_record_to_agent_run(&record);
+        let terminal = snapshot.terminal.as_ref().expect("terminal summary");
+        assert_eq!(terminal.detail, None);
+        let serialized = serde_json::to_string(&snapshot).expect("serialize snapshot");
+        assert!(!serialized.contains("owner-private diagnostic"));
     }
 
     #[test]

--- a/crates/protocol/src/agent_run.rs
+++ b/crates/protocol/src/agent_run.rs
@@ -1,0 +1,342 @@
+//! Dependency-neutral agent-run read model.
+//!
+//! [`AgentRunSnapshot`] is a uniform, serializable projection of "one unit of
+//! agent work" regardless of which subsystem owns it: a direct sub-agent
+//! worker, a workflow run, a fleet run, a core background job, or a managed
+//! task. It carries serialized IDs, neutral enums, and scalar summaries only —
+//! never handles, callbacks, or owner-internal types — so any surface can
+//! consume it without depending on the owning subsystem.
+//!
+//! Ownership contract:
+//! - Each owner keeps its own richer record type and maps it here through a
+//!   pure adapter function living in the owner's crate/module. This crate
+//!   depends on nothing new; owners depend on it, never the reverse.
+//! - Adapters must apply the durable-outranks-live rule: when both a durable
+//!   record and a live in-memory handle exist, a terminal durable state always
+//!   wins over lagging live enrichment. Live state may only refine a run that
+//!   the durable record still considers in-flight.
+//! - Adapters never fabricate values: unknown budgets and timestamps stay
+//!   `None`, and references are logical identifiers within the owner's
+//!   namespace — never filesystem paths and never secrets.
+//!
+//! This is a staging slice: the model compiles and is tested, but nothing
+//! consumes it yet. Consumers arrive with later slices.
+
+use serde::{Deserialize, Serialize};
+
+use super::Status;
+
+/// Which subsystem owns the run behind a snapshot.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunSource {
+    /// A directly spawned sub-agent worker.
+    Direct,
+    /// A workflow VM run.
+    Workflow,
+    /// A fleet run reconstructed from the durable ledger.
+    Fleet,
+    /// A core background job.
+    CoreJob,
+    /// A managed background task.
+    Task,
+}
+
+/// Neutral lifecycle state of a run.
+///
+/// The two wait variants beyond model/tool waits exist because real owner
+/// state machines report them: workers can wait on user input, and jobs and
+/// fleet runs can be explicitly paused. Collapsing those into `Running` or
+/// `Queued` would misreport liveness, so the read model keeps them distinct.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunState {
+    /// Accepted but not started.
+    Queued,
+    /// Spawn intent recorded; startup in progress.
+    Initializing,
+    /// Actively executing.
+    Running,
+    /// Blocked on a model response.
+    WaitingModel,
+    /// Blocked on a tool execution.
+    WaitingTool,
+    /// Blocked on user input.
+    WaitingInput,
+    /// Explicitly paused by the user or system.
+    Paused,
+    /// Cancellation or shutdown requested, not yet terminal.
+    Stopping,
+    /// Finished; see [`AgentRunSnapshot::terminal`] for the outcome.
+    Terminal,
+}
+
+impl Status for RunState {
+    fn is_terminal(&self) -> bool {
+        matches!(self, Self::Terminal)
+    }
+    fn is_active(&self) -> bool {
+        matches!(
+            self,
+            Self::Queued
+                | Self::Initializing
+                | Self::Running
+                | Self::WaitingModel
+                | Self::WaitingTool
+                | Self::WaitingInput
+                | Self::Stopping
+        )
+    }
+    fn is_paused(&self) -> bool {
+        matches!(self, Self::Paused)
+    }
+}
+
+/// Scalar budget/spend facts for a run.
+///
+/// Every field is optional: owners report only what they actually track, and
+/// adapters must not invent values for the rest.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BudgetSummary {
+    /// Token ceiling configured for the run, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<u64>,
+    /// Tokens consumed so far, when the owner tracks spend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_used: Option<u64>,
+    /// Steps taken so far, when the owner counts steps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steps_taken: Option<u32>,
+    /// Step ceiling configured for the run, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_steps: Option<u32>,
+    /// Wall-clock duration in milliseconds, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+/// How a terminal run ended.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalOutcome {
+    /// Ended successfully.
+    Completed,
+    /// Ended with an error.
+    Failed,
+    /// Cancelled by the user or a parent.
+    Cancelled,
+    /// Interrupted (e.g. process restart) before completion.
+    Interrupted,
+    /// Stopped because it exhausted its own budget.
+    BudgetExhausted,
+}
+
+/// Scalar summary of a terminal run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TerminalSummary {
+    pub outcome: TerminalOutcome,
+    /// Epoch milliseconds when the run ended, when the owner recorded it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at_ms: Option<i64>,
+    /// Short human-readable detail (result summary or error text).
+    /// Never raw logs, reasoning text, or secrets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Category of a durable reference attached to a run.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptKind {
+    /// A produced artifact.
+    Artifact,
+    /// A gate/verification result.
+    Gate,
+    /// A durable completion receipt.
+    Receipt,
+    /// An approval record.
+    Approval,
+}
+
+/// Reference to a durable artifact, gate, receipt, or approval.
+///
+/// `reference` is a logical identifier within the owner's namespace — never
+/// an absolute filesystem path, never secret-bearing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReceiptRef {
+    pub kind: ReceiptKind,
+    pub reference: String,
+    /// Optional short human-readable label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Dependency-neutral snapshot of a single agent run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRunSnapshot {
+    /// Serialized run identifier in the owner's existing scheme.
+    pub run_id: String,
+    /// Serialized identifier of the parent run/thread, when the owner
+    /// records one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    /// Which subsystem owns this run.
+    pub source: RunSource,
+    /// Neutral lifecycle state.
+    pub state: RunState,
+    /// Scalar budget facts; defaults to all-unknown.
+    #[serde(default)]
+    pub budget: BudgetSummary,
+    /// Terminal outcome; present exactly when `state == Terminal`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<TerminalSummary>,
+    /// Durable references produced by the run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refs: Vec<ReceiptRef>,
+}
+
+impl AgentRunSnapshot {
+    /// `true` when the terminal summary and lifecycle state agree:
+    /// `state == Terminal` iff a terminal summary is present.
+    ///
+    /// Adapters uphold this by construction; tests assert it.
+    #[must_use]
+    pub fn is_coherent(&self) -> bool {
+        matches!(self.state, RunState::Terminal) == self.terminal.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full_snapshot() -> AgentRunSnapshot {
+        AgentRunSnapshot {
+            run_id: "agent_1234abcd".to_string(),
+            parent: Some("agent_00ff00ff".to_string()),
+            source: RunSource::Direct,
+            state: RunState::Terminal,
+            budget: BudgetSummary {
+                token_budget: Some(50_000),
+                tokens_used: Some(12_345),
+                steps_taken: Some(7),
+                max_steps: Some(40),
+                duration_ms: Some(93_000),
+            },
+            terminal: Some(TerminalSummary {
+                outcome: TerminalOutcome::Completed,
+                ended_at_ms: Some(1_800_000_000_000),
+                detail: Some("verified build".to_string()),
+            }),
+            refs: vec![ReceiptRef {
+                kind: ReceiptKind::Artifact,
+                reference: "runs/agent_1234abcd/result.md".to_string(),
+                label: Some("result".to_string()),
+            }],
+        }
+    }
+
+    fn minimal_snapshot() -> AgentRunSnapshot {
+        AgentRunSnapshot {
+            run_id: "job-42".to_string(),
+            parent: None,
+            source: RunSource::CoreJob,
+            state: RunState::Queued,
+            budget: BudgetSummary::default(),
+            terminal: None,
+            refs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn full_snapshot_round_trips() {
+        let snapshot = full_snapshot();
+        let json = serde_json::to_string(&snapshot).expect("serialize");
+        let back: AgentRunSnapshot = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, snapshot);
+        assert!(back.is_coherent());
+    }
+
+    #[test]
+    fn minimal_snapshot_round_trips_and_skips_empty_fields() {
+        let snapshot = minimal_snapshot();
+        let json = serde_json::to_string(&snapshot).expect("serialize");
+        // Optional/empty fields stay off the wire entirely.
+        assert!(!json.contains("parent"));
+        assert!(!json.contains("terminal"));
+        assert!(!json.contains("refs"));
+        assert!(!json.contains("token_budget"));
+        let back: AgentRunSnapshot = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, snapshot);
+        assert!(back.is_coherent());
+    }
+
+    #[test]
+    fn enum_wire_names_are_snake_case_and_stable() {
+        assert_eq!(
+            serde_json::to_string(&RunSource::CoreJob).unwrap(),
+            "\"core_job\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RunState::WaitingModel).unwrap(),
+            "\"waiting_model\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TerminalOutcome::BudgetExhausted).unwrap(),
+            "\"budget_exhausted\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReceiptKind::Gate).unwrap(),
+            "\"gate\""
+        );
+        // Every state deserializes back to itself.
+        for state in [
+            RunState::Queued,
+            RunState::Initializing,
+            RunState::Running,
+            RunState::WaitingModel,
+            RunState::WaitingTool,
+            RunState::WaitingInput,
+            RunState::Paused,
+            RunState::Stopping,
+            RunState::Terminal,
+        ] {
+            let json = serde_json::to_string(&state).unwrap();
+            let back: RunState = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, state);
+        }
+    }
+
+    #[test]
+    fn run_state_status_trait_partitions_all_states() {
+        for state in [
+            RunState::Queued,
+            RunState::Initializing,
+            RunState::Running,
+            RunState::WaitingModel,
+            RunState::WaitingTool,
+            RunState::WaitingInput,
+            RunState::Paused,
+            RunState::Stopping,
+            RunState::Terminal,
+        ] {
+            let classifications = [state.is_terminal(), state.is_active(), state.is_paused()];
+            assert_eq!(
+                classifications.iter().filter(|flag| **flag).count(),
+                1,
+                "state {state:?} must be exactly one of terminal/active/paused"
+            );
+        }
+    }
+
+    #[test]
+    fn incoherent_snapshot_is_detectable() {
+        let mut snapshot = minimal_snapshot();
+        snapshot.terminal = Some(TerminalSummary {
+            outcome: TerminalOutcome::Completed,
+            ended_at_ms: None,
+            detail: None,
+        });
+        assert!(!snapshot.is_coherent());
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub mod agent_run;
 pub mod fleet;
 pub mod runtime;
 pub mod workroom;


### PR DESCRIPTION
## Summary

- add a dependency-neutral, serializable `AgentRunSnapshot` protocol model
- keep IDs, lifecycle, budgets, terminal summaries, and receipt references owner-neutral
- seed the contract with a pure CoreJob adapter that does not fabricate unavailable facts
- omit CoreJob's unclassified free-form detail from the cross-surface snapshot, with a serialization regression proving it cannot leak

This is the bounded O1 staging slice from the v0.9.1 cutover spec. Other owner adapters remain incremental follow-ups behind the same protocol boundary.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-protocol --locked agent_run` (5 passed)
- `cargo test -p codewhale-core --locked job_record_to_agent_run` (4 passed)
- `cargo clippy -p codewhale-protocol -p codewhale-core --all-targets --all-features --locked -- -D warnings`
- `git diff --check origin/main...HEAD`

Current exact head: `edc8c1d4781afec99c691d958e2284628702da3b`.
