### PR TITLE
chore(work-graph): satisfy current clippy

### DIFF
--- a/crates/tui/src/work_graph/reducer.rs
+++ b/crates/tui/src/work_graph/reducer.rs
@@ -35,22 +35,22 @@ pub fn apply(
     change: WorkGraphChange,
     ctx: ChangeCtx,
 ) -> Result<(WorkGraphSnapshot, ChangeReceipt), ValidationReport> {
-    if let Some(key) = &ctx.idempotency_key {
-        if g.seen_keys.contains(key) {
-            // Duplicate runtime event: acknowledge without effect.
-            let receipt = ChangeReceipt {
-                change_id: ChangeId::derive(
-                    &ctx.session_id,
-                    &format!("noop:{}:{}", key.binding.as_str(), key.seq),
-                ),
-                revision: g.revision,
-                summary: format!("{} (duplicate)", change.kind_name()),
-                applied_at: ctx.now,
-                idempotency_key: Some(key.clone()),
-                no_op: true,
-            };
-            return Ok((g.clone(), receipt));
-        }
+    if let Some(key) = &ctx.idempotency_key
+        && g.seen_keys.contains(key)
+    {
+        // Duplicate runtime event: acknowledge without effect.
+        let receipt = ChangeReceipt {
+            change_id: ChangeId::derive(
+                &ctx.session_id,
+                &format!("noop:{}:{}", key.binding.as_str(), key.seq),
+            ),
+            revision: g.revision,
+            summary: format!("{} (duplicate)", change.kind_name()),
+            applied_at: ctx.now,
+            idempotency_key: Some(key.clone()),
+            no_op: true,
+        };
+        return Ok((g.clone(), receipt));
     }
 
     let mut next = apply_pure(g, &change, &ctx)?;
@@ -284,10 +284,10 @@ fn reconcile(
             CancelOutcome::NotFound | CancelOutcome::StaleUnknown => Some(NodeState::Stale),
         },
     };
-    if let Some(state) = new_state {
-        if !node.state.is_terminal() {
-            node.state = state;
-        }
+    if let Some(state) = new_state
+        && !node.state.is_terminal()
+    {
+        node.state = state;
     }
     node.updated_at = now;
     Ok(())

--- a/crates/tui/src/work_graph/validate.rs
+++ b/crates/tui/src/work_graph/validate.rs
@@ -225,13 +225,14 @@ fn check_v2_live_operations_rooted(snapshot: &WorkGraphSnapshot, out: &mut Vec<V
                 continue;
             }
             for edge in &snapshot.edges {
-                if matches!(edge.kind, EdgeKind::Contains) && &edge.to == current {
-                    if let Some(parent) = snapshot.node(&edge.from) {
-                        if matches!(parent.kind, NodeKind::Objective | NodeKind::PlanStep) {
-                            rooted = true;
-                        }
-                        frontier.push(&parent.id);
+                if matches!(edge.kind, EdgeKind::Contains)
+                    && &edge.to == current
+                    && let Some(parent) = snapshot.node(&edge.from)
+                {
+                    if matches!(parent.kind, NodeKind::Objective | NodeKind::PlanStep) {
+                        rooted = true;
                     }
+                    frontier.push(&parent.id);
                 }
             }
             if rooted {
@@ -400,17 +401,17 @@ fn check_v8_history_bounded_monotonic(snapshot: &WorkGraphSnapshot, out: &mut Ve
     }
     let mut previous: Option<u64> = None;
     for receipt in snapshot.history.iter() {
-        if let Some(prev) = previous {
-            if receipt.revision <= prev {
-                out.push(Violation {
-                    code: ValidationCode::V8,
-                    message: format!(
-                        "history revisions not strictly increasing ({} then {})",
-                        prev, receipt.revision
-                    ),
-                });
-                break;
-            }
+        if let Some(prev) = previous
+            && receipt.revision <= prev
+        {
+            out.push(Violation {
+                code: ValidationCode::V8,
+                message: format!(
+                    "history revisions not strictly increasing ({} then {})",
+                    prev, receipt.revision
+                ),
+            });
+            break;
         }
         previous = Some(receipt.revision);
     }


### PR DESCRIPTION
## Summary

- collapse four nested conditionals flagged by the current Rust toolchain
- preserve Work Graph reducer and validation behavior
- unblock clean TUI clippy verification for subsequent v0.9.1 lanes

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked work_graph` (16 passed)
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked -- -D warnings`
- `git diff --check`
