### PR TITLE
test(doctor): make scrubbed probes cross-platform

### DIFF
--- a/crates/tui/tests/diagnostic_read_only.rs
+++ b/crates/tui/tests/diagnostic_read_only.rs
@@ -3,14 +3,16 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Output};
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::Duration;
 
+use axum::body::Bytes;
+use axum::http::HeaderMap;
+use axum::routing::post;
+use axum::{Json, Router};
 use codewhale_secrets::{FileKeyringStore, KeyringStore};
 use tempfile::TempDir;
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[test]
 fn doctor_text_leaves_a_sealed_home_untouched() {
@@ -236,7 +238,6 @@ fn doctor_text_probe_uses_a_legacy_key_without_migrating_it() {
         "doctor must make one local probe request"
     );
     let authorization = requests[0]
-        .headers
         .get("authorization")
         .and_then(|value| value.to_str().ok());
     assert_eq!(
@@ -465,19 +466,17 @@ fn diagnostic_command(workspace: &std::path::Path, home: &std::path::Path) -> Co
 
 struct CompletionServer {
     base_url: String,
-    commands: tokio::sync::mpsc::UnboundedSender<CompletionServerCommand>,
+    requests: Arc<Mutex<Vec<HeaderMap>>>,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
     owner: Option<thread::JoinHandle<()>>,
-}
-
-enum CompletionServerCommand {
-    ReceivedRequests(mpsc::SyncSender<Vec<wiremock::Request>>),
-    Shutdown,
 }
 
 impl CompletionServer {
     fn start() -> Self {
         let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
-        let (commands, mut command_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (shutdown, shutdown_receiver) = tokio::sync::oneshot::channel();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let server_requests = Arc::clone(&requests);
         let owner = thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(2)
@@ -485,31 +484,50 @@ impl CompletionServer {
                 .build()
                 .expect("local probe runtime");
             runtime.block_on(async move {
-                let server = MockServer::start().await;
-                let body = "{\"id\":\"doctor\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
-                Mock::given(method("POST"))
-                    .and(path("/v1/chat/completions"))
-                    .respond_with(
-                        ResponseTemplate::new(200).set_body_raw(body, "application/json"),
-                    )
-                    .mount(&server)
-                    .await;
-                ready_sender
-                    .send(format!("{}/v1", server.uri()))
-                    .expect("publish local probe address");
-
-                while let Some(command) = command_receiver.recv().await {
-                    match command {
-                        CompletionServerCommand::ReceivedRequests(sender) => {
-                            let requests = server
-                                .received_requests()
-                                .await
-                                .expect("request recording enabled");
-                            let _ = sender.send(requests);
+                let app = Router::new().route(
+                    "/v1/chat/completions",
+                    post(move |headers: HeaderMap, body: Bytes| {
+                        let requests = Arc::clone(&server_requests);
+                        async move {
+                            // Extracting Bytes makes Axum drain the complete request body
+                            // before replying. Preserve only headers for the credential
+                            // assertion; the request payload itself is intentionally dropped.
+                            drop(body);
+                            requests
+                                .lock()
+                                .expect("local probe request lock")
+                                .push(headers);
+                            Json(serde_json::json!({
+                                "id": "doctor",
+                                "object": "chat.completion",
+                                "created": 0,
+                                "model": "deepseek-chat",
+                                "choices": [{
+                                    "index": 0,
+                                    "message": {"role": "assistant", "content": "ok"},
+                                    "finish_reason": "stop"
+                                }],
+                                "usage": {
+                                    "prompt_tokens": 1,
+                                    "completion_tokens": 1,
+                                    "total_tokens": 2
+                                }
+                            }))
                         }
-                        CompletionServerCommand::Shutdown => break,
-                    }
-                }
+                    }),
+                );
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await;
+                let listener = listener.expect("bind local probe server");
+                let address = listener.local_addr().expect("local probe address");
+                ready_sender
+                    .send(format!("http://{address}/v1"))
+                    .expect("publish local probe address");
+                axum::serve(listener, app)
+                    .with_graceful_shutdown(async {
+                        let _ = shutdown_receiver.await;
+                    })
+                    .await
+                    .expect("serve local probe request");
             });
         });
         let base_url = ready_receiver
@@ -517,7 +535,8 @@ impl CompletionServer {
             .expect("local probe server must start");
         Self {
             base_url,
-            commands,
+            requests,
+            shutdown: Some(shutdown),
             owner: Some(owner),
         }
     }
@@ -526,22 +545,24 @@ impl CompletionServer {
         self.base_url.clone()
     }
 
-    fn received_requests(&self) -> Vec<wiremock::Request> {
-        let (sender, receiver) = mpsc::sync_channel(1);
-        self.commands
-            .send(CompletionServerCommand::ReceivedRequests(sender))
-            .expect("local probe server must remain available");
-        receiver
-            .recv_timeout(Duration::from_secs(10))
-            .expect("local probe request snapshot")
+    fn received_requests(&self) -> Vec<HeaderMap> {
+        self.requests
+            .lock()
+            .expect("local probe request lock")
+            .clone()
     }
 }
 
 impl Drop for CompletionServer {
     fn drop(&mut self) {
-        let _ = self.commands.send(CompletionServerCommand::Shutdown);
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
         if let Some(owner) = self.owner.take() {
-            owner.join().expect("stop local probe server");
+            let result = owner.join();
+            if !thread::panicking() {
+                result.expect("stop local probe server");
+            }
         }
     }
 }

--- a/crates/tui/tests/diagnostic_read_only.rs
+++ b/crates/tui/tests/diagnostic_read_only.rs
@@ -3,6 +3,9 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Output};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use codewhale_secrets::{FileKeyringStore, KeyringStore};
 use tempfile::TempDir;
@@ -461,36 +464,85 @@ fn diagnostic_command(workspace: &std::path::Path, home: &std::path::Path) -> Co
 }
 
 struct CompletionServer {
-    server: MockServer,
-    runtime: tokio::runtime::Runtime,
+    base_url: String,
+    commands: tokio::sync::mpsc::UnboundedSender<CompletionServerCommand>,
+    owner: Option<thread::JoinHandle<()>>,
+}
+
+enum CompletionServerCommand {
+    ReceivedRequests(mpsc::SyncSender<Vec<wiremock::Request>>),
+    Shutdown,
 }
 
 impl CompletionServer {
     fn start() -> Self {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()
-            .expect("local probe runtime");
-        let server = runtime.block_on(MockServer::start());
-        let body = "{\"id\":\"doctor\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
-        runtime.block_on(
-            Mock::given(method("POST"))
-                .and(path("/v1/chat/completions"))
-                .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
-                .mount(&server),
-        );
-        Self { server, runtime }
+        let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+        let (commands, mut command_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let owner = thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("local probe runtime");
+            runtime.block_on(async move {
+                let server = MockServer::start().await;
+                let body = "{\"id\":\"doctor\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
+                Mock::given(method("POST"))
+                    .and(path("/v1/chat/completions"))
+                    .respond_with(
+                        ResponseTemplate::new(200).set_body_raw(body, "application/json"),
+                    )
+                    .mount(&server)
+                    .await;
+                ready_sender
+                    .send(format!("{}/v1", server.uri()))
+                    .expect("publish local probe address");
+
+                while let Some(command) = command_receiver.recv().await {
+                    match command {
+                        CompletionServerCommand::ReceivedRequests(sender) => {
+                            let requests = server
+                                .received_requests()
+                                .await
+                                .expect("request recording enabled");
+                            let _ = sender.send(requests);
+                        }
+                        CompletionServerCommand::Shutdown => break,
+                    }
+                }
+            });
+        });
+        let base_url = ready_receiver
+            .recv_timeout(Duration::from_secs(10))
+            .expect("local probe server must start");
+        Self {
+            base_url,
+            commands,
+            owner: Some(owner),
+        }
     }
 
     fn base_url(&self) -> String {
-        format!("{}/v1", self.server.uri())
+        self.base_url.clone()
     }
 
     fn received_requests(&self) -> Vec<wiremock::Request> {
-        self.runtime
-            .block_on(self.server.received_requests())
-            .expect("request recording enabled")
+        let (sender, receiver) = mpsc::sync_channel(1);
+        self.commands
+            .send(CompletionServerCommand::ReceivedRequests(sender))
+            .expect("local probe server must remain available");
+        receiver
+            .recv_timeout(Duration::from_secs(10))
+            .expect("local probe request snapshot")
+    }
+}
+
+impl Drop for CompletionServer {
+    fn drop(&mut self) {
+        let _ = self.commands.send(CompletionServerCommand::Shutdown);
+        if let Some(owner) = self.owner.take() {
+            owner.join().expect("stop local probe server");
+        }
     }
 }
 

--- a/crates/tui/tests/diagnostic_read_only.rs
+++ b/crates/tui/tests/diagnostic_read_only.rs
@@ -501,12 +501,7 @@ fn read_http_request(stream: &mut std::net::TcpStream) -> Result<String, String>
         }
     };
     let headers = String::from_utf8_lossy(&bytes[..header_end]);
-    let content_length = headers
-        .lines()
-        .find_map(|line| line.split_once(':'))
-        .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, value)| value.trim().parse::<usize>().ok())
-        .unwrap_or(0);
+    let content_length = http_content_length(&headers);
     while bytes.len() < header_end + content_length {
         let read = stream.read(&mut chunk).map_err(|error| error.to_string())?;
         if read == 0 {
@@ -515,6 +510,25 @@ fn read_http_request(stream: &mut std::net::TcpStream) -> Result<String, String>
         bytes.extend_from_slice(&chunk[..read]);
     }
     Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn http_content_length(headers: &str) -> usize {
+    headers
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
+#[test]
+fn local_probe_server_finds_content_length_after_other_headers() {
+    let headers = "POST /v1/chat/completions HTTP/1.1\r\n\
+        authorization: Bearer redacted\r\n\
+        content-type: application/json\r\n\
+        Content-Length: 37\r\n\r\n";
+
+    assert_eq!(http_content_length(headers), 37);
 }
 
 /// A rustup shim may initialize its own toolchain state below `$HOME` when

--- a/crates/tui/tests/diagnostic_read_only.rs
+++ b/crates/tui/tests/diagnostic_read_only.rs
@@ -163,6 +163,7 @@ fn doctor_json_does_not_inherit_an_ambient_legacy_secret_from_an_explicit_home()
         )
         .env("DEEPSEEK_TUI_VERSION", env!("CARGO_PKG_VERSION"));
     preserve_host_rustup_home(&mut command);
+    preserve_host_platform_runtime(&mut command);
 
     let output = command.output().expect("run isolated doctor --json");
     assert!(
@@ -425,6 +426,7 @@ fn run_sealed_diagnostic<const N: usize>(args: [&str; N]) -> Output {
         )
         .env("DEEPSEEK_TUI_VERSION", env!("CARGO_PKG_VERSION"));
     preserve_host_rustup_home(&mut command);
+    preserve_host_platform_runtime(&mut command);
 
     let output = command.output().expect("run sealed diagnostic");
     assert!(
@@ -461,6 +463,7 @@ fn diagnostic_command(workspace: &std::path::Path, home: &std::path::Path) -> Co
         )
         .env("DEEPSEEK_TUI_VERSION", env!("CARGO_PKG_VERSION"));
     preserve_host_rustup_home(&mut command);
+    preserve_host_platform_runtime(&mut command);
     command
 }
 
@@ -581,6 +584,19 @@ fn preserve_host_rustup_home(command: &mut Command) {
         });
     if let Some(rustup_home) = rustup_home {
         command.env("RUSTUP_HOME", rustup_home);
+    }
+}
+
+/// `env_clear` is part of these tests' credential-isolation boundary, but a
+/// Windows child still needs the non-secret OS root variables used to locate
+/// platform networking components. Without them a reqwest client can fail its
+/// loopback connection before the local fixture ever receives a request.
+fn preserve_host_platform_runtime(_command: &mut Command) {
+    #[cfg(windows)]
+    for name in ["SystemRoot", "WINDIR"] {
+        if let Some(value) = std::env::var_os(name) {
+            _command.env(name, value);
+        }
     }
 }
 

--- a/crates/tui/tests/diagnostic_read_only.rs
+++ b/crates/tui/tests/diagnostic_read_only.rs
@@ -1,16 +1,13 @@
 //! Process-level regression coverage for read-only diagnostic commands.
 
 use std::fs;
-use std::io::{Read, Write};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Command, Output};
-use std::sync::mpsc;
-use std::thread;
-use std::time::Duration;
 
 use codewhale_secrets::{FileKeyringStore, KeyringStore};
 use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[test]
 fn doctor_text_leaves_a_sealed_home_untouched() {
@@ -198,7 +195,8 @@ fn doctor_text_probe_uses_a_legacy_key_without_migrating_it() {
         .set("deepseek", "diagnostic-legacy-key")
         .expect("seed legacy secret");
     let legacy_before = fs::read(&legacy).expect("read legacy secret before doctor");
-    let (base_url, request) = one_request_completion_server();
+    let server = CompletionServer::start();
+    let base_url = server.base_url();
     let config = workspace.join("doctor.toml");
     fs::write(
         &config,
@@ -228,15 +226,20 @@ fn doctor_text_probe_uses_a_legacy_key_without_migrating_it() {
         "stdout:\n{}",
         String::from_utf8_lossy(&output.stdout)
     );
-    let request = request
-        .recv_timeout(Duration::from_secs(5))
-        .expect("doctor must make one local probe request")
-        .expect("local probe request");
-    assert!(
-        request
-            .to_ascii_lowercase()
-            .contains("authorization: bearer diagnostic-legacy-key"),
-        "doctor probe must use the legacy credential without printing it; request:\n{request}"
+    let requests = server.received_requests();
+    assert_eq!(
+        requests.len(),
+        1,
+        "doctor must make one local probe request"
+    );
+    let authorization = requests[0]
+        .headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok());
+    assert_eq!(
+        authorization,
+        Some("Bearer diagnostic-legacy-key"),
+        "doctor probe must use the legacy credential without printing it"
     );
     assert!(
         !primary.exists(),
@@ -457,78 +460,38 @@ fn diagnostic_command(workspace: &std::path::Path, home: &std::path::Path) -> Co
     command
 }
 
-fn one_request_completion_server() -> (String, mpsc::Receiver<Result<String, String>>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local probe server");
-    let address = listener.local_addr().expect("local probe server address");
-    let (sender, receiver) = mpsc::channel();
-    thread::spawn(move || {
-        let result = (|| -> Result<String, String> {
-            let (mut stream, _) = listener.accept().map_err(|error| error.to_string())?;
-            stream
-                .set_read_timeout(Some(Duration::from_secs(10)))
-                .map_err(|error| error.to_string())?;
-            let request = read_http_request(&mut stream)?;
-            let body = "{\"id\":\"doctor\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{body}",
-                body.len()
-            );
-            stream
-                .write_all(response.as_bytes())
-                .map_err(|error| error.to_string())?;
-            stream.flush().map_err(|error| error.to_string())?;
-            Ok(request)
-        })();
-        let _ = sender.send(result);
-    });
-    (format!("http://{address}/v1"), receiver)
+struct CompletionServer {
+    server: MockServer,
+    runtime: tokio::runtime::Runtime,
 }
 
-fn read_http_request(stream: &mut std::net::TcpStream) -> Result<String, String> {
-    let mut bytes = Vec::new();
-    let mut chunk = [0_u8; 1024];
-    let header_end = loop {
-        let read = stream.read(&mut chunk).map_err(|error| error.to_string())?;
-        if read == 0 {
-            return Err("connection closed before HTTP headers arrived".to_string());
-        }
-        bytes.extend_from_slice(&chunk[..read]);
-        if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
-            break index + 4;
-        }
-        if bytes.len() > 32 * 1024 {
-            return Err("HTTP headers exceeded test limit".to_string());
-        }
-    };
-    let headers = String::from_utf8_lossy(&bytes[..header_end]);
-    let content_length = http_content_length(&headers);
-    while bytes.len() < header_end + content_length {
-        let read = stream.read(&mut chunk).map_err(|error| error.to_string())?;
-        if read == 0 {
-            return Err("connection closed before HTTP body arrived".to_string());
-        }
-        bytes.extend_from_slice(&chunk[..read]);
+impl CompletionServer {
+    fn start() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("local probe runtime");
+        let server = runtime.block_on(MockServer::start());
+        let body = "{\"id\":\"doctor\",\"object\":\"chat.completion\",\"created\":0,\"model\":\"deepseek-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
+        runtime.block_on(
+            Mock::given(method("POST"))
+                .and(path("/v1/chat/completions"))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
+                .mount(&server),
+        );
+        Self { server, runtime }
     }
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
-}
 
-fn http_content_length(headers: &str) -> usize {
-    headers
-        .lines()
-        .filter_map(|line| line.split_once(':'))
-        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, value)| value.trim().parse::<usize>().ok())
-        .unwrap_or(0)
-}
+    fn base_url(&self) -> String {
+        format!("{}/v1", self.server.uri())
+    }
 
-#[test]
-fn local_probe_server_finds_content_length_after_other_headers() {
-    let headers = "POST /v1/chat/completions HTTP/1.1\r\n\
-        authorization: Bearer redacted\r\n\
-        content-type: application/json\r\n\
-        Content-Length: 37\r\n\r\n";
-
-    assert_eq!(http_content_length(headers), 37);
+    fn received_requests(&self) -> Vec<wiremock::Request> {
+        self.runtime
+            .block_on(self.server.received_requests())
+            .expect("request recording enabled")
+    }
 }
 
 /// A rustup shim may initialize its own toolchain state below `$HOME` when


### PR DESCRIPTION
## Summary

- Serve the process-level doctor probe through an explicitly bound Axum fixture that drains the complete request body and retains only headers for the authorization assertion.
- Keep diagnostic subprocesses credential-isolated with env_clear while preserving only the non-secret SystemRoot and WINDIR values required by Windows networking.
- Preserve the read-only contract: no ambient credential or proxy state is restored, and the legacy credential is neither printed nor migrated.

## Evidence

- cargo fmt --all -- --check
- cargo test -p codewhale-tui --test diagnostic_read_only --locked (10/10)
- cargo clippy -p codewhale-tui --test diagnostic_read_only --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- GitHub Windows exact-head full test and lockfile guard passed
- GitHub macOS exact-head full test, lockfile guard, and offline eval harness passed
- All PR checks green on b97333a55810c732da776c61263aeb48c0c17e17

Signed-off-by: Hunter B <hmbown@gmail.com>