### PR TITLE
feat(route): make ReadyRouteCandidate immutable with sourced limit overrides

### DIFF
--- a/crates/app-server/src/chat_completions.rs
+++ b/crates/app-server/src/chat_completions.rs
@@ -98,8 +98,9 @@ fn resolve_endpoint(
         model_selector: Some(LogicalModelRef::from(selected_model.as_str())),
         saved_provider_model: None,
         base_url_override: Some(base_url.clone()),
+        limit_overrides: Vec::new(),
     })?;
-    let model = route.wire_model_id.as_str().to_string();
+    let model = route.wire_model_id().as_str().to_string();
 
     let auth_mode = provider_cfg.auth_mode.as_deref().or_else(|| {
         (provider_kind == config.provider)

--- a/crates/config/src/route/candidate.rs
+++ b/crates/config/src/route/candidate.rs
@@ -5,13 +5,14 @@
 //! > Execution requires a `ReadyRouteCandidate`.
 //! > A `ReadyRouteCandidate` can only be produced by `RouteResolver`.
 //!
-//! Fields are pub-*read*, but the type cannot be *constructed* outside this
-//! crate: the struct is `#[non_exhaustive]` (no other crate can build it via a
-//! struct literal) and deliberately does not derive `Deserialize` (so it cannot
-//! be fabricated from JSON either). The only constructor is
-//! [`ReadyRouteCandidate::new`]
+//! Fields are private and exposed only through read-only getters, so the type
+//! can neither be *constructed* nor *mutated* outside this crate, and it
+//! deliberately does not derive `Deserialize` (so it cannot be fabricated from
+//! JSON either). The only constructor is [`ReadyRouteCandidate::new`]
 //! (`pub(super)`), and [`super::resolver::RouteResolver::resolve`] is its sole
-//! caller. A candidate's existence is therefore proof it passed the resolver.
+//! caller. A candidate's existence is therefore proof it passed the resolver,
+//! and a candidate's limits are therefore exactly what the resolver produced
+//! (including any [`SourcedLimitOverride`]s recorded on it).
 //!
 //! DEFERRED: #3384's full sketch also carried `capabilities: CapabilityProfile`
 //! and `config_snapshot: Config`. Both are intentionally omitted here: pulling
@@ -58,6 +59,57 @@ pub enum ResolvedAuthSource {
     Secret,
     /// No credential resolved.
     Missing,
+    /// Auth resolution has not been performed for this candidate.
+    ///
+    /// The route resolver never inspects credentials, so a freshly resolved
+    /// candidate honestly reports `Unresolved` rather than claiming `Missing`
+    /// (which would assert a lookup that never happened).
+    Unresolved,
+}
+
+/// Which token limit a [`SourcedLimitOverride`] targets.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LimitField {
+    /// [`RouteLimits::context_tokens`](super::offering::RouteLimits).
+    ContextTokens,
+    /// [`RouteLimits::input_tokens`](super::offering::RouteLimits).
+    InputTokens,
+    /// [`RouteLimits::output_tokens`](super::offering::RouteLimits).
+    OutputTokens,
+}
+
+/// Why a limit override was requested.
+///
+/// This is provenance, not policy: the resolver applies whatever the caller
+/// requested and records the source on the candidate so every consumer can see
+/// where an effective limit came from.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OverrideSource {
+    /// Operator-configured context window.
+    UserContextWindow,
+    /// Catalog limits describe the public API offering, not the account-scoped
+    /// Codex route; the API-only limits are stripped.
+    CodexPublicApiLimitStrip,
+    /// Per-model context from the fresh Codex account roster.
+    CodexRosterCorrection,
+    /// Fresh, route-scoped provider-reported context metadata.
+    ProviderReportedContextWindow,
+    /// Conservative all-plan safe floor for a membership-plan route.
+    MembershipPlanSafeFloor,
+}
+
+/// One sourced limit override, applied by the resolver BEFORE the candidate is
+/// constructed and recorded on the candidate as provenance.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourcedLimitOverride {
+    /// The limit field to override.
+    pub field: LimitField,
+    /// The value to set (`None` clears the limit to "unknown").
+    pub value: Option<u64>,
+    /// Why the override was requested.
+    pub source: OverrideSource,
 }
 
 /// Pricing/quota class for the resolved route.
@@ -106,34 +158,53 @@ pub struct ValidationReport {
 
 /// A runtime-resolved, executable route.
 ///
-/// Fields are read-only to callers; the type cannot be constructed outside this
-/// crate (`#[non_exhaustive]` + no `Deserialize`). The only constructor is
-/// [`Self::new`], which is `pub(super)`; see module docs.
+/// The candidate is IMMUTABLE once minted: every field is private and exposed
+/// only through read-only getters, the type cannot be constructed outside this
+/// crate (private fields + no `Deserialize`), and there are no setters. The
+/// only constructor is [`Self::new`], which is `pub(super)`; see module docs.
+/// Post-resolution limit adjustments must instead be requested up front via
+/// [`super::resolver::RouteRequest::limit_overrides`], which the resolver
+/// applies BEFORE construction and records in [`Self::applied_limit_overrides`].
+///
+/// Immutability is compile-time enforced — this does not build:
+///
+/// ```compile_fail
+/// use codewhale_config::route::{RouteRequest, RouteResolver};
+///
+/// let mut candidate = RouteResolver::new()
+///     .resolve(&RouteRequest::default())
+///     .unwrap();
+/// // ERROR: field `limits` of `ReadyRouteCandidate` is private
+/// candidate.limits.context_tokens = Some(1);
+/// ```
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct ReadyRouteCandidate {
     /// Resolved provider id.
-    pub provider_id: ProviderId,
+    provider_id: ProviderId,
     /// Resolved provider kind.
-    pub provider_kind: ProviderKind,
+    provider_kind: ProviderKind,
     /// The selector the user/route requested.
-    pub logical_model: LogicalModelRef,
+    logical_model: LogicalModelRef,
     /// Canonical model identity, if one was resolved.
-    pub canonical_model: Option<ModelId>,
+    canonical_model: Option<ModelId>,
     /// Provider-owned wire id put on the request.
-    pub wire_model_id: WireModelId,
+    wire_model_id: WireModelId,
     /// Resolved endpoint transport facts.
-    pub endpoint: ResolvedEndpoint,
+    endpoint: ResolvedEndpoint,
     /// Resolved auth source CLASS (never a secret value).
-    pub auth: ResolvedAuthSource,
+    auth: ResolvedAuthSource,
     /// Selected wire protocol.
-    pub protocol: RequestProtocol,
-    /// Route/offering-scoped token limits, when known.
-    pub limits: RouteLimits,
+    protocol: RequestProtocol,
+    /// Route/offering-scoped token limits, when known (overrides applied).
+    limits: RouteLimits,
     /// Pricing/quota class, if known.
-    pub pricing: Option<PricingSku>,
+    pricing: Option<PricingSku>,
     /// Validation outcome.
-    pub validation: ValidationReport,
+    validation: ValidationReport,
+    /// Provenance of every limit override applied at resolution time.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    applied_limit_overrides: Vec<SourcedLimitOverride>,
 }
 
 impl ReadyRouteCandidate {
@@ -152,6 +223,7 @@ impl ReadyRouteCandidate {
         limits: RouteLimits,
         pricing: Option<PricingSku>,
         validation: ValidationReport,
+        applied_limit_overrides: Vec<SourcedLimitOverride>,
     ) -> Self {
         Self {
             provider_id,
@@ -165,6 +237,79 @@ impl ReadyRouteCandidate {
             limits,
             pricing,
             validation,
+            applied_limit_overrides,
         }
+    }
+
+    /// Resolved provider id.
+    #[must_use]
+    pub fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    /// Resolved provider kind.
+    #[must_use]
+    pub fn provider_kind(&self) -> ProviderKind {
+        self.provider_kind
+    }
+
+    /// The selector the user/route requested.
+    #[must_use]
+    pub fn logical_model(&self) -> &LogicalModelRef {
+        &self.logical_model
+    }
+
+    /// Canonical model identity, if one was resolved.
+    #[must_use]
+    pub fn canonical_model(&self) -> Option<&ModelId> {
+        self.canonical_model.as_ref()
+    }
+
+    /// Provider-owned wire id put on the request.
+    #[must_use]
+    pub fn wire_model_id(&self) -> &WireModelId {
+        &self.wire_model_id
+    }
+
+    /// Resolved endpoint transport facts.
+    #[must_use]
+    pub fn endpoint(&self) -> &ResolvedEndpoint {
+        &self.endpoint
+    }
+
+    /// Resolved auth source CLASS (never a secret value).
+    #[must_use]
+    pub fn auth(&self) -> &ResolvedAuthSource {
+        &self.auth
+    }
+
+    /// Selected wire protocol.
+    #[must_use]
+    pub fn protocol(&self) -> RequestProtocol {
+        self.protocol
+    }
+
+    /// Route/offering-scoped token limits, when known (overrides applied).
+    #[must_use]
+    pub fn limits(&self) -> RouteLimits {
+        self.limits
+    }
+
+    /// Pricing/quota class, if known.
+    #[must_use]
+    pub fn pricing(&self) -> Option<&PricingSku> {
+        self.pricing.as_ref()
+    }
+
+    /// Validation outcome.
+    #[must_use]
+    pub fn validation(&self) -> &ValidationReport {
+        &self.validation
+    }
+
+    /// Provenance of every limit override applied at resolution time.
+    #[must_use]
+    pub fn applied_limit_overrides(&self) -> &[SourcedLimitOverride] {
+        &self.applied_limit_overrides
     }
 }

--- a/crates/config/src/route/conformance_tests.rs
+++ b/crates/config/src/route/conformance_tests.rs
@@ -18,6 +18,7 @@ fn none_request(kind: ProviderKind) -> RouteRequest {
         model_selector: None,
         saved_provider_model: None,
         base_url_override: None,
+        limit_overrides: Vec::new(),
     }
 }
 
@@ -72,12 +73,13 @@ fn every_provider_kind_resolves_its_default_route() {
         });
 
         assert_eq!(
-            candidate.provider_kind, kind,
+            candidate.provider_kind(),
+            kind,
             "{kind:?}: resolved to a different provider"
         );
         assert_eq!(
-            candidate.provider_id,
-            ProviderId::from_kind(kind),
+            candidate.provider_id(),
+            &ProviderId::from_kind(kind),
             "{kind:?}: resolved provider id mismatch"
         );
 
@@ -96,7 +98,7 @@ fn every_provider_kind_resolves_its_default_route() {
                 |offering| offering.wire_model_id.as_str().to_string(),
             );
         assert_eq!(
-            candidate.wire_model_id.as_str(),
+            candidate.wire_model_id().as_str(),
             expected_wire,
             "{kind:?}: None selector must resolve to the bundled default offering (or descriptor default)"
         );
@@ -112,23 +114,25 @@ fn every_provider_kind_resolves_the_auto_selector() {
             model_selector: Some(LogicalModelRef::from("auto")),
             saved_provider_model: None,
             base_url_override: None,
+            limit_overrides: Vec::new(),
         };
         let candidate = resolver
             .resolve(&request)
             .unwrap_or_else(|err| panic!("{kind:?}: `auto` must resolve, got {err:?}"));
 
         assert_eq!(
-            candidate.provider_kind, kind,
+            candidate.provider_kind(),
+            kind,
             "{kind:?}: auto resolved to a different provider"
         );
         assert!(
-            candidate.logical_model.is_auto(),
+            candidate.logical_model().is_auto(),
             "{kind:?}: `auto` must stay the auto sentinel, never a literal model"
         );
         // `auto` with no catalog default falls back to the descriptor default,
         // which conformance #2 already pins; here we only assert it resolves.
         assert!(
-            !candidate.wire_model_id.as_str().trim().is_empty(),
+            !candidate.wire_model_id().as_str().trim().is_empty(),
             "{kind:?}: auto resolved to an empty wire model"
         );
     }

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -34,7 +34,8 @@ pub mod offering;
 pub mod resolver;
 
 pub use candidate::{
-    PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint, ValidationReport,
+    LimitField, OverrideSource, PricingSku, ReadyRouteCandidate, ResolvedAuthSource,
+    ResolvedEndpoint, SourcedLimitOverride, ValidationReport,
 };
 pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
 pub use errors::RouteError;

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -28,7 +28,8 @@
 //! which structurally bars prompt-content routing.
 
 use super::candidate::{
-    PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint, ValidationReport,
+    LimitField, PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint,
+    SourcedLimitOverride, ValidationReport,
 };
 use super::descriptor::ProviderDescriptor;
 use super::errors::RouteError;
@@ -51,6 +52,11 @@ pub struct RouteRequest {
     pub saved_provider_model: Option<WireModelId>,
     /// An explicit base URL override for the endpoint.
     pub base_url_override: Option<String>,
+    /// Sourced limit overrides, applied in order BEFORE the candidate is
+    /// constructed and recorded on it as provenance. This is the ONLY channel
+    /// for adjusting a route's effective limits: the candidate itself is
+    /// immutable once minted.
+    pub limit_overrides: Vec<SourcedLimitOverride>,
 }
 
 /// Resolves [`RouteRequest`]s into [`ReadyRouteCandidate`]s.
@@ -192,6 +198,18 @@ impl RouteResolver {
         }
         let validation = ValidationReport { ok: true, messages };
 
+        // Apply caller-requested limit overrides in order, BEFORE the candidate
+        // is minted. The candidate is immutable afterwards; the applied
+        // overrides are recorded on it as provenance.
+        let mut limits = limits;
+        for limit_override in &req.limit_overrides {
+            match limit_override.field {
+                LimitField::ContextTokens => limits.context_tokens = limit_override.value,
+                LimitField::InputTokens => limits.input_tokens = limit_override.value,
+                LimitField::OutputTokens => limits.output_tokens = limit_override.value,
+            }
+        }
+
         Ok(ReadyRouteCandidate::new(
             provider_id,
             provider_kind,
@@ -199,7 +217,9 @@ impl RouteResolver {
             canonical_model,
             wire_model_id,
             endpoint,
-            ResolvedAuthSource::Missing,
+            // The resolver never inspects credentials: auth is honestly
+            // `Unresolved` at resolution time, not a claimed `Missing`.
+            ResolvedAuthSource::Unresolved,
             descriptor.protocol(),
             limits,
             // #3085: honest pricing projected from the matched offering (the
@@ -207,6 +227,7 @@ impl RouteResolver {
             // no offering was matched or the offering carried no price.
             Some(pricing),
             validation,
+            req.limit_overrides.clone(),
         ))
     }
 

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -1,10 +1,12 @@
 //! Behavior tests for the route foundation (#2608 / #3084 / #3384).
 
-use super::RequestProtocol;
 use super::descriptor::ProviderDescriptor;
 use super::errors::RouteError;
 use super::ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};
 use super::resolver::{RouteRequest, RouteResolver};
+use super::{
+    LimitField, OverrideSource, RequestProtocol, ResolvedAuthSource, SourcedLimitOverride,
+};
 use crate::ProviderKind;
 use crate::models_dev::ModelsDevCatalog;
 
@@ -15,6 +17,7 @@ fn req(provider: Option<ProviderKind>, model: Option<&str>) -> RouteRequest {
         model_selector: model.map(LogicalModelRef::from),
         saved_provider_model: None,
         base_url_override: None,
+        limit_overrides: Vec::new(),
     }
 }
 
@@ -133,6 +136,122 @@ fn newtypes_serialize_transparently() {
 }
 
 #[test]
+fn resolver_reports_auth_as_unresolved_until_preflight() {
+    let candidate = RouteResolver::new()
+        .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
+        .expect("route resolves");
+
+    assert_eq!(candidate.auth(), &ResolvedAuthSource::Unresolved);
+    assert_eq!(
+        serde_json::to_value(&candidate).expect("candidate serializes")["auth"],
+        "unresolved"
+    );
+}
+
+#[test]
+fn resolver_applies_every_limit_override_field_before_construction() {
+    let mut request = req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro"));
+    request.limit_overrides = vec![
+        SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(111),
+            source: OverrideSource::UserContextWindow,
+        },
+        SourcedLimitOverride {
+            field: LimitField::InputTokens,
+            value: Some(222),
+            source: OverrideSource::CodexPublicApiLimitStrip,
+        },
+        SourcedLimitOverride {
+            field: LimitField::OutputTokens,
+            value: Some(333),
+            source: OverrideSource::CodexRosterCorrection,
+        },
+    ];
+
+    let candidate = RouteResolver::new()
+        .resolve(&request)
+        .expect("route with overrides resolves");
+
+    assert_eq!(candidate.limits().context_tokens, Some(111));
+    assert_eq!(candidate.limits().input_tokens, Some(222));
+    assert_eq!(candidate.limits().output_tokens, Some(333));
+}
+
+#[test]
+fn resolver_applies_repeated_limit_overrides_in_request_order() {
+    let mut request = req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro"));
+    request.limit_overrides = vec![
+        SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(111),
+            source: OverrideSource::CodexRosterCorrection,
+        },
+        SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: None,
+            source: OverrideSource::CodexPublicApiLimitStrip,
+        },
+        SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(333),
+            source: OverrideSource::UserContextWindow,
+        },
+    ];
+
+    let candidate = RouteResolver::new()
+        .resolve(&request)
+        .expect("route with ordered overrides resolves");
+
+    assert_eq!(candidate.limits().context_tokens, Some(333));
+}
+
+#[test]
+fn resolver_records_exact_limit_override_provenance() {
+    let overrides = vec![
+        SourcedLimitOverride {
+            field: LimitField::InputTokens,
+            value: None,
+            source: OverrideSource::CodexPublicApiLimitStrip,
+        },
+        SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(128_000),
+            source: OverrideSource::CodexRosterCorrection,
+        },
+    ];
+    let mut request = req(Some(ProviderKind::OpenaiCodex), None);
+    request.limit_overrides = overrides.clone();
+
+    let candidate = RouteResolver::new()
+        .resolve(&request)
+        .expect("Codex route with sourced overrides resolves");
+
+    assert_eq!(candidate.applied_limit_overrides(), overrides.as_slice());
+}
+
+#[test]
+fn resolved_auth_source_existing_variants_keep_wire_compatibility() {
+    let cases = [
+        (ResolvedAuthSource::Cli, "cli"),
+        (ResolvedAuthSource::ConfigFile, "config_file"),
+        (ResolvedAuthSource::Keyring, "keyring"),
+        (ResolvedAuthSource::Env, "env"),
+        (ResolvedAuthSource::Command, "command"),
+        (ResolvedAuthSource::Secret, "secret"),
+        (ResolvedAuthSource::Missing, "missing"),
+    ];
+
+    for (source, wire) in cases {
+        let encoded = serde_json::to_string(&source).expect("auth source serializes");
+        assert_eq!(encoded, format!("\"{wire}\""));
+        let decoded: ResolvedAuthSource =
+            serde_json::from_str(&encoded).expect("auth source deserializes");
+        assert_eq!(decoded, source);
+    }
+}
+
+#[test]
 fn descriptor_for_every_kind_has_nonempty_transport_facts() {
     for kind in ProviderKind::ALL {
         let d = ProviderDescriptor::for_kind(kind);
@@ -177,10 +296,10 @@ fn resolver_explicit_provider_scoped_model_maps_to_wire_id() {
     let out = r
         .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
         .expect("should resolve");
-    assert_eq!(out.provider_kind, ProviderKind::Deepseek);
-    assert_eq!(out.wire_model_id.as_str(), "deepseek-v4-pro");
+    assert_eq!(out.provider_kind(), ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id().as_str(), "deepseek-v4-pro");
     assert_eq!(
-        out.canonical_model.as_ref().map(ModelId::as_str),
+        out.canonical_model().map(ModelId::as_str),
         Some("deepseek-v4-pro")
     );
 }
@@ -195,10 +314,10 @@ fn resolver_aggregator_preserves_prefixed_wire_id_without_inferring_deepseek() {
         ))
         .expect("aggregator should resolve");
     // Provider stays Together, NOT Deepseek, despite the deepseek-ai/ prefix.
-    assert_eq!(out.provider_kind, ProviderKind::Together);
-    assert_ne!(out.provider_kind, ProviderKind::Deepseek);
+    assert_eq!(out.provider_kind(), ProviderKind::Together);
+    assert_ne!(out.provider_kind(), ProviderKind::Deepseek);
     // Wire id preserved verbatim.
-    assert_eq!(out.wire_model_id.as_str(), "deepseek-ai/DeepSeek-V4-Pro");
+    assert_eq!(out.wire_model_id().as_str(), "deepseek-ai/DeepSeek-V4-Pro");
 }
 
 #[test]
@@ -223,11 +342,11 @@ fn resolver_openrouter_keeps_provider_for_every_namespace_prefix() {
             .unwrap_or_else(|e| panic!("{raw} should resolve on openrouter: {e}"));
         // ...but the provider stays Openrouter regardless.
         assert_eq!(
-            out.provider_kind,
+            out.provider_kind(),
             ProviderKind::Openrouter,
             "{raw} must not change provider"
         );
-        assert_eq!(out.wire_model_id.as_str(), raw, "{raw} wire id verbatim");
+        assert_eq!(out.wire_model_id().as_str(), raw, "{raw} wire id verbatim");
     }
 }
 
@@ -254,10 +373,10 @@ fn resolver_auto_is_sentinel_not_literal_model() {
         .resolve(&req(Some(ProviderKind::Deepseek), Some("auto")))
         .expect("auto should resolve");
     // The logical selector is the auto sentinel...
-    assert!(out.logical_model.is_auto());
+    assert!(out.logical_model().is_auto());
     // ...and "auto" is NOT put on the wire as a literal model.
-    assert_ne!(out.wire_model_id.as_str(), "auto");
-    assert_eq!(out.wire_model_id.as_str(), "deepseek-v4-pro");
+    assert_ne!(out.wire_model_id().as_str(), "auto");
+    assert_eq!(out.wire_model_id().as_str(), "deepseek-v4-pro");
 }
 
 #[test]
@@ -267,11 +386,11 @@ fn resolver_can_use_models_dev_offering_for_provider_scoped_route() {
         .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.2")))
         .expect("Models.dev-backed Z.ai route should resolve");
 
-    assert_eq!(out.provider_kind, ProviderKind::Zai);
-    assert_eq!(out.provider_id.as_str(), "zai");
-    assert_eq!(out.wire_model_id.as_str(), "glm-5.2");
+    assert_eq!(out.provider_kind(), ProviderKind::Zai);
+    assert_eq!(out.provider_id().as_str(), "zai");
+    assert_eq!(out.wire_model_id().as_str(), "glm-5.2");
     assert_eq!(
-        out.canonical_model.as_ref().map(ModelId::as_str),
+        out.canonical_model().map(ModelId::as_str),
         Some("zhipuai/glm-5.2")
     );
 }
@@ -283,14 +402,14 @@ fn resolver_auto_uses_models_dev_default_offering_when_available() {
         .resolve(&req(Some(ProviderKind::Zai), Some("auto")))
         .expect("auto should resolve through catalog default");
 
-    assert!(out.logical_model.is_auto());
+    assert!(out.logical_model().is_auto());
     assert_eq!(
-        out.wire_model_id.as_str(),
+        out.wire_model_id().as_str(),
         "glm-5.2",
         "catalog default should win over the built-in Z.ai spelling"
     );
     assert_eq!(
-        out.canonical_model.as_ref().map(ModelId::as_str),
+        out.canonical_model().map(ModelId::as_str),
         Some("zhipuai/glm-5.2")
     );
 }
@@ -322,14 +441,15 @@ fn resolver_auto_falls_back_to_descriptor_default_without_catalog_default() {
         .resolve(&req(Some(ProviderKind::Zai), Some("auto")))
         .expect("auto should resolve to the descriptor default");
 
-    assert!(out.logical_model.is_auto());
+    assert!(out.logical_model().is_auto());
     assert_eq!(
-        out.wire_model_id.as_str(),
+        out.wire_model_id().as_str(),
         "GLM-5.2",
         "no catalog default → descriptor built-in default wins"
     );
     assert_eq!(
-        out.canonical_model, None,
+        out.canonical_model(),
+        None,
         "descriptor fallback carries no catalog canonical link"
     );
 }
@@ -341,11 +461,11 @@ fn resolver_models_dev_prefixed_wire_id_stays_inside_provider_scope() {
         .resolve(&req(Some(ProviderKind::Openrouter), Some("z-ai/glm-5.2")))
         .expect("OpenRouter Models.dev row should resolve");
 
-    assert_eq!(out.provider_kind, ProviderKind::Openrouter);
-    assert_ne!(out.provider_kind, ProviderKind::Zai);
-    assert_eq!(out.wire_model_id.as_str(), "z-ai/glm-5.2");
+    assert_eq!(out.provider_kind(), ProviderKind::Openrouter);
+    assert_ne!(out.provider_kind(), ProviderKind::Zai);
+    assert_eq!(out.wire_model_id().as_str(), "z-ai/glm-5.2");
     assert_eq!(
-        out.canonical_model.as_ref().map(ModelId::as_str),
+        out.canonical_model().map(ModelId::as_str),
         Some("zhipuai/glm-5.2")
     );
 }
@@ -357,10 +477,10 @@ fn resolver_carries_models_dev_limits_into_ready_candidate() {
         .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.2")))
         .expect("Z.AI Models.dev row should resolve");
 
-    assert_eq!(out.limits.context_tokens, Some(1_000_000));
-    assert_eq!(out.limits.input_tokens, Some(900_000));
-    assert_eq!(out.limits.output_tokens, Some(131_072));
-    assert!(out.limits.has_known_limit());
+    assert_eq!(out.limits().context_tokens, Some(1_000_000));
+    assert_eq!(out.limits().input_tokens, Some(900_000));
+    assert_eq!(out.limits().output_tokens, Some(131_072));
+    assert!(out.limits().has_known_limit());
 }
 
 #[test]
@@ -372,12 +492,18 @@ fn minimax_anthropic_routes_use_catalog_limits_and_messages_protocol() {
             .resolve(&req(Some(ProviderKind::MinimaxAnthropic), Some(model)))
             .expect("MiniMax Messages route should resolve");
 
-        assert_eq!(route.provider_kind, ProviderKind::MinimaxAnthropic);
-        assert_eq!(route.wire_model_id.as_str(), model);
-        assert_eq!(route.protocol, RequestProtocol::AnthropicMessages);
-        assert_eq!(route.endpoint.protocol, RequestProtocol::AnthropicMessages);
-        assert_eq!(route.endpoint.base_url, "https://api.minimax.io/anthropic");
-        assert_eq!(route.limits.context_tokens, Some(context));
+        assert_eq!(route.provider_kind(), ProviderKind::MinimaxAnthropic);
+        assert_eq!(route.wire_model_id().as_str(), model);
+        assert_eq!(route.protocol(), RequestProtocol::AnthropicMessages);
+        assert_eq!(
+            route.endpoint().protocol,
+            RequestProtocol::AnthropicMessages
+        );
+        assert_eq!(
+            route.endpoint().base_url,
+            "https://api.minimax.io/anthropic"
+        );
+        assert_eq!(route.limits().context_tokens, Some(context));
     }
 }
 
@@ -392,12 +518,12 @@ fn resolver_keeps_limits_provider_scoped_for_same_canonical_model() {
         .expect("hosted OpenRouter route should resolve");
 
     assert_eq!(
-        direct.canonical_model.as_ref().map(ModelId::as_str),
-        hosted.canonical_model.as_ref().map(ModelId::as_str)
+        direct.canonical_model().map(ModelId::as_str),
+        hosted.canonical_model().map(ModelId::as_str)
     );
-    assert_eq!(direct.limits.context_tokens, Some(1_000_000));
-    assert_eq!(hosted.limits.context_tokens, Some(128_000));
-    assert_eq!(hosted.limits.output_tokens, Some(32_768));
+    assert_eq!(direct.limits().context_tokens, Some(1_000_000));
+    assert_eq!(hosted.limits().context_tokens, Some(128_000));
+    assert_eq!(hosted.limits().output_tokens, Some(32_768));
 }
 
 #[test]
@@ -434,13 +560,14 @@ fn resolver_custom_endpoint_allows_namespaced_selector_for_strict_provider() {
         model_selector: Some(LogicalModelRef::from("vendor/custom-coder")),
         saved_provider_model: None,
         base_url_override: Some("https://example.local/v1".to_string()),
+        limit_overrides: Vec::new(),
     };
     let out = r
         .resolve(&request)
         .expect("custom endpoint should defer model validation upstream");
-    assert_eq!(out.provider_kind, ProviderKind::Deepseek);
-    assert_eq!(out.wire_model_id.as_str(), "vendor/custom-coder");
-    assert_eq!(out.endpoint.base_url, "https://example.local/v1");
+    assert_eq!(out.provider_kind(), ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id().as_str(), "vendor/custom-coder");
+    assert_eq!(out.endpoint().base_url, "https://example.local/v1");
 }
 
 #[test]
@@ -456,6 +583,7 @@ fn resolver_treats_every_official_deepseek_endpoint_as_strict_direct() {
             model_selector: Some(LogicalModelRef::from("anthropic/claude-foo")),
             saved_provider_model: None,
             base_url_override: Some(base_url.to_string()),
+            limit_overrides: Vec::new(),
         };
         assert!(
             matches!(
@@ -475,11 +603,12 @@ fn resolver_does_not_trust_deepseek_hostname_substrings() {
         model_selector: Some(LogicalModelRef::from("vendor/custom-coder")),
         saved_provider_model: None,
         base_url_override: Some("https://api.deepseek.com.evil.example/v1".to_string()),
+        limit_overrides: Vec::new(),
     };
     let route = resolver
         .resolve(&request)
         .expect("lookalike host must be treated as a custom endpoint");
-    assert_eq!(route.wire_model_id.as_str(), "vendor/custom-coder");
+    assert_eq!(route.wire_model_id().as_str(), "vendor/custom-coder");
 }
 
 #[test]
@@ -493,17 +622,21 @@ fn resolver_explicit_custom_with_base_url_override_passes_model_through_verbatim
         model_selector: Some(LogicalModelRef::from("vendor/custom-model-v1")),
         saved_provider_model: None,
         base_url_override: Some("https://api.example.com/v1".to_string()),
+        limit_overrides: Vec::new(),
     };
     let out = r
         .resolve(&request)
         .expect("custom provider should resolve via pass-through");
-    assert_eq!(out.provider_kind, ProviderKind::Custom);
-    assert_eq!(out.provider_id.as_str(), "custom");
-    assert_eq!(out.wire_model_id.as_str(), "vendor/custom-model-v1");
-    assert_eq!(out.endpoint.base_url, "https://api.example.com/v1");
-    assert_eq!(out.protocol, crate::route::RequestProtocol::ChatCompletions);
-    assert!(out.validation.ok);
-    assert!(out.validation.messages.is_empty());
+    assert_eq!(out.provider_kind(), ProviderKind::Custom);
+    assert_eq!(out.provider_id().as_str(), "custom");
+    assert_eq!(out.wire_model_id().as_str(), "vendor/custom-model-v1");
+    assert_eq!(out.endpoint().base_url, "https://api.example.com/v1");
+    assert_eq!(
+        out.protocol(),
+        crate::route::RequestProtocol::ChatCompletions
+    );
+    assert!(out.validation().ok);
+    assert!(out.validation().messages.is_empty());
 }
 
 #[test]
@@ -535,29 +668,29 @@ fn default_resolver_yields_real_facts_from_bundled_catalog() {
     let glm = r
         .resolve(&req(Some(ProviderKind::Zai), Some("GLM-5.2")))
         .expect("Z.ai GLM-5.2 should resolve from the bundled catalog");
-    assert_eq!(glm.provider_kind, ProviderKind::Zai);
-    assert_eq!(glm.wire_model_id.as_str(), "GLM-5.2");
+    assert_eq!(glm.provider_kind(), ProviderKind::Zai);
+    assert_eq!(glm.wire_model_id().as_str(), "GLM-5.2");
     assert_eq!(
-        glm.limits.context_tokens,
+        glm.limits().context_tokens,
         Some(1_000_000),
         "GLM-5.2 must carry its real context window, not the unknown default"
     );
-    assert_eq!(glm.limits.output_tokens, Some(131_072));
-    assert!(glm.limits.has_known_limit());
+    assert_eq!(glm.limits().output_tokens, Some(131_072));
+    assert!(glm.limits().has_known_limit());
 
     // A Kimi row (Moonshot) likewise resolves with its real window — a model
     // the 4-row seam never knew about at all.
     let kimi_k27 = r
         .resolve(&req(Some(ProviderKind::Moonshot), Some("kimi-k2.7-code")))
         .expect("Moonshot kimi-k2.7-code should resolve from the bundled catalog");
-    assert_eq!(kimi_k27.limits.context_tokens, Some(262_144));
-    assert_eq!(kimi_k27.limits.output_tokens, Some(262_144));
+    assert_eq!(kimi_k27.limits().context_tokens, Some(262_144));
+    assert_eq!(kimi_k27.limits().output_tokens, Some(262_144));
 
     let kimi_k3 = r
         .resolve(&req(Some(ProviderKind::Moonshot), Some("kimi-k3")))
         .expect("Moonshot kimi-k3 should resolve from the bundled catalog");
-    assert_eq!(kimi_k3.limits.context_tokens, Some(1_048_576));
-    assert_eq!(kimi_k3.limits.output_tokens, Some(131_072));
+    assert_eq!(kimi_k3.limits().context_tokens, Some(1_048_576));
+    assert_eq!(kimi_k3.limits().output_tokens, Some(131_072));
 
     // With the #3085 pricing keystone present on the release branch, the asset's
     // provider-scoped `cost` now projects onto the candidate via
@@ -567,9 +700,9 @@ fn default_resolver_yields_real_facts_from_bundled_catalog() {
     let glm51 = r
         .resolve(&req(Some(ProviderKind::Zai), Some("glm-5.1")))
         .expect("Z.ai glm-5.1 should resolve from the bundled catalog");
-    assert_eq!(glm51.limits.context_tokens, Some(202_752));
+    assert_eq!(glm51.limits().context_tokens, Some(202_752));
     assert!(matches!(
-        glm51.pricing,
+        glm51.pricing(),
         Some(super::candidate::PricingSku::Token { .. })
     ));
 }
@@ -587,7 +720,7 @@ fn default_resolver_preserves_seam_canonical_joins() {
         .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
         .expect("deepseek-v4-pro resolves");
     assert_eq!(
-        direct.canonical_model.as_ref().map(ModelId::as_str),
+        direct.canonical_model().map(ModelId::as_str),
         Some("deepseek-v4-pro")
     );
 
@@ -598,11 +731,14 @@ fn default_resolver_preserves_seam_canonical_joins() {
         ))
         .expect("together hosted deepseek resolves");
     assert_eq!(
-        hosted.canonical_model.as_ref().map(ModelId::as_str),
+        hosted.canonical_model().map(ModelId::as_str),
         Some("deepseek-v4-pro"),
         "seam canonical join must survive the asset merge"
     );
-    assert_eq!(hosted.wire_model_id.as_str(), "deepseek-ai/DeepSeek-V4-Pro");
+    assert_eq!(
+        hosted.wire_model_id().as_str(),
+        "deepseek-ai/DeepSeek-V4-Pro"
+    );
 }
 
 #[test]
@@ -613,16 +749,16 @@ fn together_inkling_aliases_use_the_exact_wire_identity_without_invented_metadat
         let route = resolver
             .resolve(&req(Some(ProviderKind::Together), Some(requested)))
             .expect("Together Inkling route should resolve");
-        assert_eq!(route.provider_kind, ProviderKind::Together, "{requested}");
+        assert_eq!(route.provider_kind(), ProviderKind::Together, "{requested}");
         assert_eq!(
-            route.wire_model_id.as_str(),
+            route.wire_model_id().as_str(),
             "thinkingmachines/inkling",
             "{requested}"
         );
-        assert!(route.canonical_model.is_none(), "{requested}");
-        assert!(!route.limits.has_known_limit(), "{requested}");
+        assert!(route.canonical_model().is_none(), "{requested}");
+        assert!(!route.limits().has_known_limit(), "{requested}");
         assert!(matches!(
-            route.pricing,
+            route.pricing(),
             Some(super::candidate::PricingSku::UnknownOrStale)
         ));
     }
@@ -637,10 +773,11 @@ fn together_custom_endpoint_preserves_its_explicit_model_id() {
             model_selector: Some(LogicalModelRef::from("inkling")),
             saved_provider_model: None,
             base_url_override: Some("http://127.0.0.1:8000/v1".to_string()),
+            limit_overrides: Vec::new(),
         })
         .expect("custom Together-compatible endpoint should resolve");
 
-    assert_eq!(route.wire_model_id.as_str(), "inkling");
+    assert_eq!(route.wire_model_id().as_str(), "inkling");
 }
 
 #[test]
@@ -651,10 +788,10 @@ fn openrouter_qwen37_plus_aliases_use_exact_catalog_wire_identity() {
         let route = resolver
             .resolve(&req(Some(ProviderKind::Openrouter), Some(requested)))
             .expect("OpenRouter Qwen 3.7 Plus route should resolve");
-        assert_eq!(route.wire_model_id.as_str(), "qwen/qwen3.7-plus");
-        assert!(!route.limits.has_known_limit());
+        assert_eq!(route.wire_model_id().as_str(), "qwen/qwen3.7-plus");
+        assert!(!route.limits().has_known_limit());
         assert!(matches!(
-            route.pricing,
+            route.pricing(),
             Some(super::candidate::PricingSku::Token {
                 input_per_mtok: Some(_),
                 output_per_mtok: Some(_)
@@ -671,10 +808,11 @@ fn openrouter_custom_endpoint_preserves_qwen37_alias() {
             model_selector: Some(LogicalModelRef::from("qwen3.7-plus")),
             saved_provider_model: None,
             base_url_override: Some("https://gateway.example.test/v1".to_string()),
+            limit_overrides: Vec::new(),
         })
         .expect("custom OpenRouter-compatible endpoint should resolve");
 
-    assert_eq!(route.wire_model_id.as_str(), "qwen3.7-plus");
+    assert_eq!(route.wire_model_id().as_str(), "qwen3.7-plus");
 }
 
 #[test]
@@ -689,15 +827,19 @@ fn opencode_go_resolver_accepts_only_chat_completions_models() {
             let route = resolver
                 .resolve(&req(Some(ProviderKind::OpencodeGo), Some(&requested)))
                 .unwrap_or_else(|error| panic!("{requested} should resolve: {error}"));
-            assert_eq!(route.provider_kind, ProviderKind::OpencodeGo, "{requested}");
-            assert_eq!(route.wire_model_id.as_str(), model, "{requested}");
+            assert_eq!(
+                route.provider_kind(),
+                ProviderKind::OpencodeGo,
+                "{requested}"
+            );
+            assert_eq!(route.wire_model_id().as_str(), model, "{requested}");
         }
     }
 
     let automatic = resolver
         .resolve(&req(Some(ProviderKind::OpencodeGo), Some("auto")))
         .expect("OpenCode Go auto should resolve to its Chat default");
-    assert_eq!(automatic.wire_model_id.as_str(), "deepseek-v4-pro");
+    assert_eq!(automatic.wire_model_id().as_str(), "deepseek-v4-pro");
 }
 
 #[test]
@@ -721,6 +863,7 @@ fn opencode_go_resolver_rejects_messages_models_even_on_custom_base_urls() {
                     model_selector: Some(LogicalModelRef::from(requested.as_str())),
                     saved_provider_model: None,
                     base_url_override,
+                    limit_overrides: Vec::new(),
                 };
                 assert!(
                     matches!(
@@ -740,8 +883,8 @@ fn resolver_deepseek_none_selector_uses_default_wire_id() {
     let out = r
         .resolve(&req(Some(ProviderKind::Deepseek), None))
         .expect("none selector should use provider default");
-    assert_eq!(out.provider_kind, ProviderKind::Deepseek);
-    assert_eq!(out.wire_model_id.as_str(), "deepseek-v4-pro");
+    assert_eq!(out.provider_kind(), ProviderKind::Deepseek);
+    assert_eq!(out.wire_model_id().as_str(), "deepseek-v4-pro");
 }
 
 #[test]
@@ -761,6 +904,7 @@ fn resolver_empty_saved_provider_model_is_empty_model_error() {
         model_selector: None,
         saved_provider_model: Some(WireModelId::from("")),
         base_url_override: None,
+        limit_overrides: Vec::new(),
     };
     assert!(matches!(r.resolve(&request), Err(RouteError::EmptyModel)));
 }
@@ -771,10 +915,10 @@ fn resolver_passthrough_provider_preserves_custom_id_verbatim() {
     let out = r
         .resolve(&req(Some(ProviderKind::Ollama), Some("my-local:7b")))
         .expect("local passthrough should resolve");
-    assert_eq!(out.provider_kind, ProviderKind::Ollama);
-    assert_eq!(out.wire_model_id.as_str(), "my-local:7b");
-    assert_eq!(out.limits, Default::default());
-    assert!(out.validation.ok);
+    assert_eq!(out.provider_kind(), ProviderKind::Ollama);
+    assert_eq!(out.wire_model_id().as_str(), "my-local:7b");
+    assert_eq!(out.limits(), Default::default());
+    assert!(out.validation().ok);
 }
 
 #[test]
@@ -827,12 +971,13 @@ fn resolver_protocol_matches_descriptor_for_every_provider() {
             .resolve(&request)
             .unwrap_or_else(|e| panic!("{kind:?} should resolve its own default: {e}"));
         assert_eq!(
-            out.protocol,
+            out.protocol(),
             ProviderDescriptor::for_kind(kind).protocol(),
             "{kind:?} candidate protocol must match descriptor"
         );
         assert_eq!(
-            out.endpoint.protocol, out.protocol,
+            out.endpoint().protocol,
+            out.protocol(),
             "{kind:?} endpoint protocol"
         );
     }
@@ -875,13 +1020,13 @@ fn priced_offering_yields_token_pricing_sku() {
         .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
         .expect("priced DeepSeek route should resolve");
 
-    match out.pricing {
+    match out.pricing() {
         Some(PricingSku::Token {
             input_per_mtok,
             output_per_mtok,
         }) => {
-            assert_eq!(input_per_mtok, Some(0.28));
-            assert_eq!(output_per_mtok, Some(0.42));
+            assert_eq!(*input_per_mtok, Some(0.28));
+            assert_eq!(*output_per_mtok, Some(0.42));
         }
         other => panic!("expected Some(Token), got {other:?}"),
     }
@@ -899,9 +1044,9 @@ fn unpriced_offering_stays_unknown() {
         .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
         .expect("bundled DeepSeek route should resolve");
     assert!(
-        matches!(out.pricing, Some(PricingSku::UnknownOrStale)),
+        matches!(out.pricing(), Some(PricingSku::UnknownOrStale)),
         "bundled offering carries no price → UnknownOrStale, got {:?}",
-        out.pricing
+        out.pricing()
     );
 
     // A pass-through route with no matched offering is likewise unknown.
@@ -909,7 +1054,7 @@ fn unpriced_offering_stays_unknown() {
         .resolve(&req(Some(ProviderKind::Ollama), Some("my-local:7b")))
         .expect("local passthrough should resolve");
     assert!(matches!(
-        passthrough.pricing,
+        passthrough.pricing(),
         Some(PricingSku::UnknownOrStale)
     ));
 }
@@ -925,6 +1070,7 @@ fn req_with_base(provider: ProviderKind, model: &str, base_url: &str) -> RouteRe
         model_selector: Some(LogicalModelRef::from(model)),
         saved_provider_model: None,
         base_url_override: Some(base_url.to_string()),
+        limit_overrides: Vec::new(),
     }
 }
 
@@ -941,16 +1087,16 @@ fn http_custom_endpoint_emits_insecure_warning() {
 
     // Advisory only: the route stays usable.
     assert!(
-        out.validation.ok,
+        out.validation().ok,
         "insecure http is advisory, not a hard fail"
     );
     assert!(
-        out.validation
+        out.validation()
             .messages
             .iter()
             .any(|m| m.contains("insecure http")),
         "expected an insecure-http advisory, got {:?}",
-        out.validation.messages
+        out.validation().messages
     );
 }
 
@@ -966,11 +1112,11 @@ fn loopback_http_endpoint_does_not_warn() {
         let out = r
             .resolve(&req_with_base(ProviderKind::Ollama, "my-local:7b", base))
             .unwrap_or_else(|e| panic!("loopback route {base} should resolve: {e}"));
-        assert!(out.validation.ok);
+        assert!(out.validation().ok);
         assert!(
-            out.validation.messages.is_empty(),
+            out.validation().messages.is_empty(),
             "loopback {base} must not warn, got {:?}",
-            out.validation.messages
+            out.validation().messages
         );
     }
 }
@@ -985,10 +1131,10 @@ fn https_endpoint_has_no_warning() {
             "https://example.com/v1",
         ))
         .expect("https endpoint should resolve");
-    assert!(out.validation.ok);
+    assert!(out.validation().ok);
     assert!(
-        out.validation.messages.is_empty(),
+        out.validation().messages.is_empty(),
         "https must not warn, got {:?}",
-        out.validation.messages
+        out.validation().messages
     );
 }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -902,8 +902,8 @@ impl DeepSeekClient {
     /// `config`.
     pub fn from_candidate(config: &Config, candidate: &ReadyRouteCandidate) -> Result<Self> {
         Self::from_parts(
-            candidate.endpoint.base_url.clone(),
-            candidate.wire_model_id.as_str().to_string(),
+            candidate.endpoint().base_url.clone(),
+            candidate.wire_model_id().as_str().to_string(),
             config,
         )
     }
@@ -6469,8 +6469,11 @@ mod tests {
             .expect("client should construct from candidate");
 
         // The transport is bound to the candidate, not re-derived from Config.
-        assert_eq!(client.base_url, route.candidate.endpoint.base_url);
-        assert_eq!(client.default_model, route.candidate.wire_model_id.as_str());
+        assert_eq!(client.base_url, route.candidate.endpoint().base_url);
+        assert_eq!(
+            client.default_model,
+            route.candidate.wire_model_id().as_str()
+        );
     }
 
     #[test]
@@ -6538,9 +6541,9 @@ mod tests {
         assert_eq!(client.api_provider, ApiProvider::Custom);
         // The candidate carried the custom endpoint + verbatim wire model.
         assert_eq!(
-            route.candidate.endpoint.base_url,
+            route.candidate.endpoint().base_url,
             "https://api.example.com/v1"
         );
-        assert_eq!(route.candidate.wire_model_id.as_str(), "custom-model-v1");
+        assert_eq!(route.candidate.wire_model_id().as_str(), "custom-model-v1");
     }
 }

--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -227,8 +227,8 @@ pub fn model(app: &mut App, model_name: Option<&str>) -> CommandResult {
         app.set_model_selection(model_id.clone());
         if let Some(resolution) = route_resolution {
             app.set_active_route_resolution(
-                resolution.candidate.endpoint.base_url,
-                resolution.candidate.limits,
+                resolution.candidate.endpoint().base_url.clone(),
+                resolution.candidate.limits(),
                 resolution.context_window.source,
             );
         } else {

--- a/crates/tui/src/context_report.rs
+++ b/crates/tui/src/context_report.rs
@@ -242,7 +242,7 @@ pub fn build_headless_context_report(config: &Config, workspace: &Path) -> Promp
     let provider = config.api_provider();
     let provider_identity = config.provider_identity_for(provider);
     let route = crate::route_runtime::resolve_runtime_route(config, provider, Some(&model)).ok();
-    let route_limits = route.as_ref().map(|route| route.candidate.limits);
+    let route_limits = route.as_ref().map(|route| route.candidate.limits());
     let context_window_source = route
         .as_ref()
         .map(|route| route.context_window.source)

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -898,7 +898,7 @@ impl Engine {
         let identity = route.identity.key;
         let provider_id = route.identity.exact_id;
         let model = route.model;
-        let limits = crate::route_budget::known_route_limits(route.candidate.limits);
+        let limits = crate::route_budget::known_route_limits(route.candidate.limits());
         let api_config = *route.config;
         let client = route.client;
 
@@ -941,7 +941,7 @@ impl Engine {
         let identity = route.identity.key;
         let provider_id = route.identity.exact_id;
         let model = route.model;
-        let limits = crate::route_budget::known_route_limits(route.candidate.limits);
+        let limits = crate::route_budget::known_route_limits(route.candidate.limits());
         let api_config = *route.config;
         let concrete_client = preflighted_client
             .map(Ok)
@@ -2644,7 +2644,7 @@ impl Engine {
         let effective_provider = route.identity.provider;
         let provider_identity = route.identity.key.clone();
         let model = route.model.clone();
-        let route_limits = crate::route_budget::known_route_limits(route.candidate.limits);
+        let route_limits = crate::route_budget::known_route_limits(route.candidate.limits());
         if let Err(err) = self.install_resolved_runtime_route(route) {
             let _ = self
                 .tx_event

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -202,20 +202,20 @@ pub(crate) fn resolve_fleet_route_with_config(
             None => ApiProvider::Deepseek,
         };
         let candidate = resolve_route_candidate(provider, model_selector, None, None, None).ok()?;
-        let provider_id = candidate.provider_id.as_str().to_string();
+        let provider_id = candidate.provider_id().as_str().to_string();
         (candidate, provider_id, None, "resolver")
     };
 
     Some(FleetResolvedRoute {
         provider_id,
         provider_exact_id,
-        provider_kind: candidate.provider_kind.as_str().to_string(),
+        provider_kind: candidate.provider_kind().as_str().to_string(),
         canonical_model: candidate
-            .canonical_model
+            .canonical_model()
             .as_ref()
             .map(|model| model.as_str().to_string()),
-        wire_model_id: candidate.wire_model_id.as_str().to_string(),
-        protocol: route_protocol_label(candidate.protocol).to_string(),
+        wire_model_id: candidate.wire_model_id().as_str().to_string(),
+        protocol: route_protocol_label(candidate.protocol()).to_string(),
         role,
         loadout: loadout_intent_label(&loadout),
         model_class,
@@ -1475,12 +1475,15 @@ mod tests {
         .expect("openrouter should resolve the pinned model directly");
         assert_eq!(
             route.wire_model_id,
-            openrouter_candidate.wire_model_id.as_str()
+            openrouter_candidate.wire_model_id().as_str()
         );
-        assert_eq!(route.provider_id, openrouter_candidate.provider_id.as_str());
+        assert_eq!(
+            route.provider_id,
+            openrouter_candidate.provider_id().as_str()
+        );
         assert_eq!(
             route.provider_kind,
-            openrouter_candidate.provider_kind.as_str()
+            openrouter_candidate.provider_kind().as_str()
         );
         assert_eq!(route.reasoning_effort.as_deref(), Some("max"));
         // Differs from DeepSeek — the pre-#4093 hardcoded default AND the
@@ -1546,9 +1549,12 @@ mod tests {
         .expect("openrouter should resolve the saved model directly");
         assert_eq!(
             route.wire_model_id,
-            openrouter_candidate.wire_model_id.as_str()
+            openrouter_candidate.wire_model_id().as_str()
         );
-        assert_eq!(route.provider_id, openrouter_candidate.provider_id.as_str());
+        assert_eq!(
+            route.provider_id,
+            openrouter_candidate.provider_id().as_str()
+        );
         assert_eq!(route.reasoning_effort.as_deref(), Some("max"));
         assert_ne!(route.provider_id, "deepseek");
     }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -10119,7 +10119,7 @@ async fn run_exec_agent(
     let approval_posture = if auto_approve { "auto_tools" } else { "ask" }.to_string();
     let sandbox_posture = explicit_sandbox.unwrap_or("configured_default").to_string();
     let active_route_limits =
-        crate::route_budget::known_route_limits(validated_route.candidate.limits);
+        crate::route_budget::known_route_limits(validated_route.candidate.limits());
     let max_subagents = if max_subagents == config.max_subagents_for_provider(config.api_provider())
     {
         execution_config

--- a/crates/tui/src/model_inventory.rs
+++ b/crates/tui/src/model_inventory.rs
@@ -91,7 +91,7 @@ impl ModelInventory {
                 if let Ok(route) =
                     crate::route_runtime::resolve_runtime_route(config, provider, Some(&model))
                 {
-                    if let Some(context_window) = route.candidate.limits.context_tokens {
+                    if let Some(context_window) = route.candidate.limits().context_tokens {
                         capability.context_window = context_window.min(u64::from(u32::MAX)) as u32;
                     }
                     // Do not promote bare `k3` into the global capability
@@ -99,8 +99,8 @@ impl ModelInventory {
                     // Kimi Code's exact membership-plan route.
                     if crate::config::is_exact_kimi_code_k3_route(
                         provider,
-                        &route.candidate.endpoint.base_url,
-                        route.candidate.wire_model_id.as_str(),
+                        &route.candidate.endpoint().base_url,
+                        route.candidate.wire_model_id().as_str(),
                     ) {
                         capability.thinking_supported = true;
                     }

--- a/crates/tui/src/model_routing.rs
+++ b/crates/tui/src/model_routing.rs
@@ -452,7 +452,7 @@ pub(crate) fn normalize_auto_route_effort_for_configured_route(
 ) -> ReasoningEffort {
     crate::route_runtime::resolve_runtime_route(config, provider, Some(model))
         .map(|route| {
-            effort.normalize_for_route(provider, &route.candidate.endpoint.base_url, &route.model)
+            effort.normalize_for_route(provider, &route.candidate.endpoint().base_url, &route.model)
         })
         .unwrap_or_else(|_| normalize_auto_route_effort_for_provider(provider, effort))
 }

--- a/crates/tui/src/provider_readiness.rs
+++ b/crates/tui/src/provider_readiness.rs
@@ -375,10 +375,11 @@ pub(crate) fn route_is_valid_for_model(
                 .filter(|value| !value.is_empty())
                 .map(str::to_string)
         },
+        limit_overrides: Vec::new(),
     };
     RouteResolver::new()
         .resolve(&request)
-        .is_ok_and(|candidate| candidate.validation.ok)
+        .is_ok_and(|candidate| candidate.validation().ok)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Duration, Utc};
 use codewhale_config::route::{
-    LogicalModelRef, ReadyRouteCandidate, RouteLimits, RouteRequest, RouteResolver, WireModelId,
+    LimitField, LogicalModelRef, OverrideSource, ReadyRouteCandidate, RouteRequest, RouteResolver,
+    SourcedLimitOverride, WireModelId,
 };
 use serde::Serialize;
 
@@ -196,55 +197,121 @@ pub(crate) fn resolve_route_candidate_with_context_metadata(
     context_window_override: Option<u32>,
     provider_reported_context: Option<ProviderReportedKimiCodeContext>,
 ) -> Result<RouteCandidateResolution, String> {
-    let route_request = RouteRequest {
+    let resolver = RouteResolver::new();
+    let base_request = RouteRequest {
         explicit_provider: provider.kind(),
         model_selector: model_selector.map(|model| LogicalModelRef::from(model.to_string())),
         saved_provider_model: saved_provider_model
             .map(|model| WireModelId::from(model.to_string())),
         base_url_override,
+        limit_overrides: Vec::new(),
     };
-    let mut candidate = RouteResolver::new()
-        .resolve(&route_request)
+    // First pass: resolve the route without overrides to learn the effective
+    // endpoint, wire model id, and catalog limits. Candidates are immutable, so
+    // limit adjustments are planned from this read-only resolution and then
+    // requested through `RouteRequest::limit_overrides` on a second pass; the
+    // resolver applies them BEFORE minting the final candidate and records
+    // their provenance on it.
+    let resolved = resolver
+        .resolve(&base_request)
         .map_err(|err| err.to_string())?;
+    let plan = plan_limit_overrides(
+        provider,
+        &resolved,
+        context_window_override,
+        provider_reported_context,
+    );
+    let candidate = if plan.overrides.is_empty() {
+        resolved
+    } else {
+        resolver
+            .resolve(&RouteRequest {
+                limit_overrides: plan.overrides,
+                ..base_request
+            })
+            .map_err(|err| err.to_string())?
+    };
+    Ok(RouteCandidateResolution {
+        candidate,
+        context_window: plan.context_window,
+    })
+}
+
+/// The sourced limit overrides a route needs, plus the context-window receipt
+/// describing the effective context value they produce.
+struct LimitOverridePlan {
+    overrides: Vec<SourcedLimitOverride>,
+    context_window: ContextWindowResolution,
+}
+
+/// Plan the limit overrides for a resolved route.
+///
+/// Precedence (unchanged from the previous post-hoc mutation order):
+/// provider-scoped roster/API corrections first, then operator-configured
+/// context, then fresh route-scoped provider-reported context, then the
+/// membership-plan safe floor, then catalog data, then the conservative
+/// fallback.
+fn plan_limit_overrides(
+    provider: ApiProvider,
+    resolved: &ReadyRouteCandidate,
+    context_window_override: Option<u32>,
+    provider_reported_context: Option<ProviderReportedKimiCodeContext>,
+) -> LimitOverridePlan {
+    let mut overrides = Vec::new();
+    let configured = context_window_override.filter(|window| *window > 0);
+    let mut effective_context = resolved.limits().context_tokens;
     if provider == ApiProvider::OpenaiCodex {
         // Models.dev describes the public API offering, not the account-scoped
         // ChatGPT OAuth route. Strip API-only limits, then carry the fresh
         // Codex roster's per-model context into every runtime consumer.
-        candidate.limits.input_tokens = None;
-        candidate.limits.output_tokens = None;
-        if context_window_override
-            .filter(|window| *window > 0)
-            .is_none()
-        {
+        overrides.push(SourcedLimitOverride {
+            field: LimitField::InputTokens,
+            value: None,
+            source: OverrideSource::CodexPublicApiLimitStrip,
+        });
+        overrides.push(SourcedLimitOverride {
+            field: LimitField::OutputTokens,
+            value: None,
+            source: OverrideSource::CodexPublicApiLimitStrip,
+        });
+        if configured.is_none() {
             let roster = model_roster();
-            candidate.limits.context_tokens = if roster.freshness == CodexModelCacheFreshness::Fresh
-            {
+            let roster_context = if roster.freshness == CodexModelCacheFreshness::Fresh {
                 roster
-                    .metadata_for(candidate.wire_model_id.as_str())
+                    .metadata_for(resolved.wire_model_id().as_str())
                     .and_then(|metadata| metadata.context_window)
                     .map(u64::from)
             } else {
                 None
             };
+            effective_context = roster_context;
+            overrides.push(SourcedLimitOverride {
+                field: LimitField::ContextTokens,
+                value: roster_context,
+                source: OverrideSource::CodexRosterCorrection,
+            });
         }
     }
 
-    let configured = context_window_override.filter(|window| *window > 0);
     if let Some(context_window) = configured {
-        apply_context_window_override(&mut candidate.limits, Some(context_window));
-        return Ok(RouteCandidateResolution {
-            candidate,
+        overrides.push(SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(u64::from(context_window)),
+            source: OverrideSource::UserContextWindow,
+        });
+        return LimitOverridePlan {
+            overrides,
             context_window: ContextWindowResolution {
                 tokens: context_window,
                 source: ContextWindowSource::Configured,
             },
-        });
+        };
     }
 
     let is_exact_kimi_code_k3 = is_exact_kimi_code_k3_route(
         provider,
-        &candidate.endpoint.base_url,
-        candidate.wire_model_id.as_str(),
+        &resolved.endpoint().base_url,
+        resolved.wire_model_id().as_str(),
     );
     let now = Utc::now();
     if is_exact_kimi_code_k3
@@ -256,14 +323,18 @@ pub(crate) fn resolve_route_candidate_with_context_metadata(
         })
     {
         let reported = provider_reported_context.expect("checked above");
-        candidate.limits.context_tokens = Some(u64::from(reported.context_tokens));
-        return Ok(RouteCandidateResolution {
-            candidate,
+        overrides.push(SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(u64::from(reported.context_tokens)),
+            source: OverrideSource::ProviderReportedContextWindow,
+        });
+        return LimitOverridePlan {
+            overrides,
             context_window: ContextWindowResolution {
                 tokens: reported.context_tokens,
                 source: ContextWindowSource::ProviderReported,
             },
-        });
+        };
     }
 
     // Kimi Code's bare `k3` is a membership-plan route, not an alias for
@@ -271,45 +342,39 @@ pub(crate) fn resolve_route_candidate_with_context_metadata(
     // the route's next precedence after an explicit config or fresh, scoped
     // provider report.
     if is_exact_kimi_code_k3 {
-        candidate.limits.context_tokens = Some(u64::from(KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS));
-        return Ok(RouteCandidateResolution {
-            candidate,
+        overrides.push(SourcedLimitOverride {
+            field: LimitField::ContextTokens,
+            value: Some(u64::from(KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS)),
+            source: OverrideSource::MembershipPlanSafeFloor,
+        });
+        return LimitOverridePlan {
+            overrides,
             context_window: ContextWindowResolution {
                 tokens: KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS,
                 source: ContextWindowSource::StaticKimiCodeSafeFloor,
             },
-        });
+        };
     }
 
-    if let Some(tokens) = candidate
-        .limits
-        .context_tokens
-        .and_then(|tokens| u32::try_from(tokens).ok())
-    {
-        return Ok(RouteCandidateResolution {
-            candidate,
+    if let Some(tokens) = effective_context.and_then(|tokens| u32::try_from(tokens).ok()) {
+        return LimitOverridePlan {
+            overrides,
             context_window: ContextWindowResolution {
                 tokens,
                 source: ContextWindowSource::Catalog,
             },
-        });
+        };
     }
 
     let fallback_tokens =
-        crate::config::provider_capability(provider, candidate.wire_model_id.as_str())
+        crate::config::provider_capability(provider, resolved.wire_model_id().as_str())
             .context_window;
-    Ok(RouteCandidateResolution {
-        candidate,
+    LimitOverridePlan {
+        overrides,
         context_window: ContextWindowResolution {
             tokens: fallback_tokens,
             source: ContextWindowSource::Fallback,
         },
-    })
-}
-
-fn apply_context_window_override(limits: &mut RouteLimits, context_window: Option<u32>) {
-    if let Some(context_window) = context_window.filter(|window| *window > 0) {
-        limits.context_tokens = Some(u64::from(context_window));
     }
 }
 
@@ -351,7 +416,7 @@ pub(crate) fn resolve_runtime_route_for_identity(
         None,
     )?;
     let candidate = resolution.candidate;
-    let model = candidate.wire_model_id.as_str().to_string();
+    let model = candidate.wire_model_id().as_str().to_string();
     set_model_for_route(&mut route_config, provider, &model);
 
     Ok(ResolvedRuntimeRoute {
@@ -476,14 +541,14 @@ mod tests {
         )
         .expect("Codex route");
 
-        assert_eq!(candidate.limits.context_tokens, Some(128_000));
-        assert_eq!(candidate.limits.input_tokens, None);
-        assert_eq!(candidate.limits.output_tokens, None);
+        assert_eq!(candidate.limits().context_tokens, Some(128_000));
+        assert_eq!(candidate.limits().input_tokens, None);
+        assert_eq!(candidate.limits().output_tokens, None);
         assert_eq!(
             crate::route_budget::route_context_window_tokens(
                 ApiProvider::OpenaiCodex,
                 crate::config::DEFAULT_OPENAI_CODEX_MODEL,
-                Some(candidate.limits),
+                Some(candidate.limits()),
             ),
             128_000
         );
@@ -495,14 +560,14 @@ mod tests {
             resolve_route_candidate(ApiProvider::Moonshot, Some("kimi-k3"), None, None, None)
                 .expect("Moonshot Kimi K3 route");
 
-        assert_eq!(candidate.wire_model_id.as_str(), "kimi-k3");
-        assert_eq!(candidate.limits.context_tokens, Some(1_048_576));
-        assert_eq!(candidate.limits.output_tokens, Some(131_072));
+        assert_eq!(candidate.wire_model_id().as_str(), "kimi-k3");
+        assert_eq!(candidate.limits().context_tokens, Some(1_048_576));
+        assert_eq!(candidate.limits().output_tokens, Some(131_072));
         assert_eq!(
             crate::route_budget::route_context_window_tokens(
                 ApiProvider::Moonshot,
                 "kimi-k3",
-                Some(candidate.limits),
+                Some(candidate.limits()),
             ),
             1_048_576
         );
@@ -519,8 +584,8 @@ mod tests {
         )
         .expect("Kimi Code K3 route");
 
-        assert_eq!(candidate.wire_model_id.as_str(), "k3");
-        assert_eq!(candidate.limits.context_tokens, Some(262_144));
+        assert_eq!(candidate.wire_model_id().as_str(), "k3");
+        assert_eq!(candidate.limits().context_tokens, Some(262_144));
     }
 
     #[test]
@@ -624,7 +689,7 @@ mod tests {
         )
         .expect("Kimi Code K3 route");
 
-        assert_eq!(candidate.limits.context_tokens, Some(1_048_576));
+        assert_eq!(candidate.limits().context_tokens, Some(1_048_576));
     }
 
     #[test]
@@ -638,7 +703,7 @@ mod tests {
             None,
         )
         .expect("direct Moonshot K3 route");
-        assert_eq!(direct_moonshot.limits.context_tokens, Some(1_048_576));
+        assert_eq!(direct_moonshot.limits().context_tokens, Some(1_048_576));
 
         let generic_moonshot = resolve_route_candidate(
             ApiProvider::Moonshot,
@@ -648,7 +713,7 @@ mod tests {
             None,
         )
         .expect("generic Moonshot route");
-        assert_ne!(generic_moonshot.limits.context_tokens, Some(262_144));
+        assert_ne!(generic_moonshot.limits().context_tokens, Some(262_144));
 
         let kimi_code_default = resolve_route_candidate(
             ApiProvider::Moonshot,
@@ -658,7 +723,7 @@ mod tests {
             None,
         )
         .expect("Kimi Code default route");
-        assert_ne!(kimi_code_default.limits.context_tokens, Some(262_144));
+        assert_ne!(kimi_code_default.limits().context_tokens, Some(262_144));
     }
 
     #[test]
@@ -759,18 +824,18 @@ mod tests {
         // Endpoint + model come from the named table; the prefixed model id is
         // preserved verbatim as the wire id (no provider-prefix sniffing).
         assert_eq!(
-            route.candidate.endpoint.base_url,
+            route.candidate.endpoint().base_url,
             "https://api.example.com/v1"
         );
         assert_eq!(
-            route.candidate.wire_model_id.as_str(),
+            route.candidate.wire_model_id().as_str(),
             "vendor/custom-model-v1"
         );
         assert_eq!(route.model, "vendor/custom-model-v1");
-        assert_eq!(route.candidate.protocol, RequestProtocol::ChatCompletions);
+        assert_eq!(route.candidate.protocol(), RequestProtocol::ChatCompletions);
         // HTTPS endpoint: route is valid with no insecure-http advisory.
-        assert!(route.candidate.validation.ok);
-        assert!(route.candidate.validation.messages.is_empty());
+        assert!(route.candidate.validation().ok);
+        assert!(route.candidate.validation().messages.is_empty());
         // The selected provider name is preserved (not overwritten with "custom").
         assert_eq!(route.config.provider.as_deref(), Some("my_thing"));
     }
@@ -802,7 +867,7 @@ mod tests {
             .expect("custom route should resolve");
 
         assert_eq!(route.model, "qwen3.7");
-        assert_eq!(route.candidate.limits.context_tokens, Some(1_000_000));
+        assert_eq!(route.candidate.limits().context_tokens, Some(1_000_000));
     }
 
     #[test]
@@ -813,19 +878,19 @@ mod tests {
 
         // Advisory only: the route still validates (ok == true) but warns that
         // credentials would be sent in plaintext over a non-loopback http URL.
-        assert!(route.candidate.validation.ok);
+        assert!(route.candidate.validation().ok);
         assert!(
             route
                 .candidate
-                .validation
+                .validation()
                 .messages
                 .iter()
                 .any(|message| message.contains("insecure http")),
             "expected insecure-http advisory, got {:?}",
-            route.candidate.validation.messages
+            route.candidate.validation().messages
         );
         assert_eq!(
-            route.candidate.endpoint.base_url,
+            route.candidate.endpoint().base_url,
             "http://gpu.internal.example:8000/v1"
         );
     }

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1738,7 +1738,7 @@ impl RuntimeThreadManager {
         let stream_chunk_timeout_secs = self.read_config().stream_chunk_timeout_secs();
         for (thread_id, engine, route) in validated {
             let provider = route.identity.provider;
-            let route_limits = known_route_limits(route.candidate.limits);
+            let route_limits = known_route_limits(route.candidate.limits());
             let engine_compaction = runtime_compaction_config(
                 provider,
                 &route.model,
@@ -4376,7 +4376,7 @@ impl RuntimeThreadManager {
                 effort
                     .normalize_for_route(
                         route.identity.provider,
-                        &route.candidate.endpoint.base_url,
+                        &route.candidate.endpoint().base_url,
                         &route.model,
                     )
                     .as_setting()
@@ -4403,7 +4403,7 @@ impl RuntimeThreadManager {
         let provider = route.identity.provider;
         let provider_identity = route.identity.clone();
         let model = route.model.clone();
-        let route_limits = known_route_limits(route.candidate.limits);
+        let route_limits = known_route_limits(route.candidate.limits());
         let settings = crate::settings::Settings::load().unwrap_or_default();
         let compaction = runtime_compaction_config(
             provider,
@@ -4726,7 +4726,7 @@ impl RuntimeThreadManager {
         let route_provider = route.identity.provider;
         let route_identity = route.identity.clone();
         let route_model = route.model.clone();
-        let route_limits = known_route_limits(route.candidate.limits);
+        let route_limits = known_route_limits(route.candidate.limits());
         let settings = crate::settings::Settings::load().unwrap_or_default();
         let compaction = runtime_compaction_config(
             route_provider,
@@ -4913,7 +4913,7 @@ impl RuntimeThreadManager {
             let provider = route.identity.provider;
             let route_identity = route.identity;
             let route_model = route.model;
-            let route_limits = known_route_limits(route.candidate.limits);
+            let route_limits = known_route_limits(route.candidate.limits());
             let cfg = route.config;
 
             // Resolve the provider-route-aware auto-compaction default unless the

--- a/crates/tui/src/runtime_threads/tests.rs
+++ b/crates/tui/src/runtime_threads/tests.rs
@@ -1260,7 +1260,7 @@ async fn config_reload_updates_next_turn_route_without_mutating_engine_route() -
                 Some(crate::route_budget::route_context_window_tokens(
                     ApiProvider::Custom,
                     "local-model",
-                    crate::route_budget::known_route_limits(route.candidate.limits),
+                    crate::route_budget::known_route_limits(route.candidate.limits()),
                 ))
             );
         }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -2958,8 +2958,8 @@ impl App {
                 )
                 .map(|resolution| {
                     (
-                        crate::route_budget::known_route_limits(resolution.candidate.limits),
-                        resolution.candidate.endpoint.base_url,
+                        crate::route_budget::known_route_limits(resolution.candidate.limits()),
+                        resolution.candidate.endpoint().base_url.clone(),
                         resolution.context_window.source,
                     )
                 })

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -451,7 +451,7 @@ impl ModelPickerView {
 
     fn resolved_base_url_for_provider(&self, provider: ApiProvider, model: &str) -> String {
         crate::route_runtime::resolve_runtime_route(&self.route_config, provider, Some(model))
-            .map(|route| route.candidate.endpoint.base_url)
+            .map(|route| route.candidate.endpoint().base_url.clone())
             .unwrap_or_else(|_| provider.default_base_url().to_string())
     }
 

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -561,8 +561,8 @@ impl ProviderDashboardRow {
         ) = match route {
             Ok(resolution) => {
                 let candidate = resolution.candidate;
-                if !candidate.validation.messages.is_empty() {
-                    messages.extend(candidate.validation.messages.clone());
+                if !candidate.validation().messages.is_empty() {
+                    messages.extend(candidate.validation().messages.clone());
                 }
                 (
                     if provider == ApiProvider::DeepseekCN {
@@ -570,15 +570,15 @@ impl ProviderDashboardRow {
                             .clone()
                             .unwrap_or_else(|| provider.default_base_url().to_string())
                     } else {
-                        candidate.endpoint.base_url
+                        candidate.endpoint().base_url.clone()
                     },
-                    vec![protocol_label(candidate.protocol).to_string()],
+                    vec![protocol_label(candidate.protocol()).to_string()],
                     ProviderDefaultRoute {
-                        logical_model: candidate.logical_model.raw().to_string(),
-                        wire_model: candidate.wire_model_id.as_str().to_string(),
+                        logical_model: candidate.logical_model().raw().to_string(),
+                        wire_model: candidate.wire_model_id().as_str().to_string(),
                     },
-                    pricing_label(provider, candidate.pricing.as_ref()),
-                    candidate.validation.ok,
+                    pricing_label(provider, candidate.pricing()),
+                    candidate.validation().ok,
                     Some(resolution.context_window.tokens),
                     Some(resolution.context_window.source.label().to_string()),
                 )

--- a/crates/tui/src/tui/setup/mod.rs
+++ b/crates/tui/src/tui/setup/mod.rs
@@ -4438,8 +4438,8 @@ mod tests {
         )
         .expect("bare k3 on the Kimi Code route must resolve");
         app.set_active_route_resolution(
-            resolution.candidate.endpoint.base_url,
-            resolution.candidate.limits,
+            resolution.candidate.endpoint().base_url.clone(),
+            resolution.candidate.limits(),
             resolution.context_window.source,
         );
         let facts = SetupRuntimeFacts::from_app_config(&app, &config);

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8016,7 +8016,7 @@ fn compaction_for_validated_route(
     app.compaction_config_for_route(
         route.identity.provider,
         &route.model,
-        crate::route_budget::known_route_limits(route.candidate.limits),
+        crate::route_budget::known_route_limits(route.candidate.limits()),
     )
 }
 
@@ -8132,7 +8132,7 @@ async fn dispatch_user_message(
     } else {
         turn_route
     };
-    let turn_route_limits = crate::route_budget::known_route_limits(turn_route.candidate.limits);
+    let turn_route_limits = crate::route_budget::known_route_limits(turn_route.candidate.limits());
     let effective_provider_identity = turn_route.identity.key.clone();
     let effective_provider_label = if effective_provider == ApiProvider::Custom {
         effective_provider_identity.clone()
@@ -8168,7 +8168,7 @@ async fn dispatch_user_message(
         effort
             .api_value_for_route(
                 effective_provider,
-                &turn_route.candidate.endpoint.base_url,
+                &turn_route.candidate.endpoint().base_url,
                 &turn_route.model,
             )
             .map(str::to_string)
@@ -8176,7 +8176,7 @@ async fn dispatch_user_message(
         app.reasoning_effort
             .api_value_for_route(
                 effective_provider,
-                &turn_route.candidate.endpoint.base_url,
+                &turn_route.candidate.endpoint().base_url,
                 &turn_route.model,
             )
             .map(str::to_string)
@@ -8576,15 +8576,15 @@ async fn apply_model_picker_choice(
             None,
         ) {
             Ok(resolution) => {
-                resolved_model = resolution.candidate.wire_model_id.as_str().to_string();
-                route_base_url = resolution.candidate.endpoint.base_url.clone();
+                resolved_model = resolution.candidate.wire_model_id().as_str().to_string();
+                route_base_url = resolution.candidate.endpoint().base_url.clone();
                 if model_changed {
                     app.set_active_context_window_override(
                         config.context_window_for_provider_config(app.api_provider),
                     );
                     app.set_active_route_resolution(
                         route_base_url.clone(),
-                        resolution.candidate.limits,
+                        resolution.candidate.limits(),
                         resolution.context_window.source,
                     );
                 }
@@ -8854,8 +8854,8 @@ async fn switch_provider(
     };
     let target_identity_record = validated_route.identity.clone();
     let target_identity = target_identity_record.key.clone();
-    let resolved_endpoint = validated_route.candidate.endpoint.base_url.clone();
-    let route_limits = validated_route.candidate.limits;
+    let resolved_endpoint = validated_route.candidate.endpoint().base_url.clone();
+    let route_limits = validated_route.candidate.limits();
     let context_window_source = validated_route.context_window.source;
     let new_model = validated_route.model.clone();
     *config = *validated_route.config;
@@ -9003,7 +9003,7 @@ async fn apply_provider_fallback_switch(
         }
     };
     let target_identity = resolved_route.identity.clone();
-    let resolved_endpoint = resolved_route.candidate.endpoint.base_url.clone();
+    let resolved_endpoint = resolved_route.candidate.endpoint().base_url.clone();
     let next_config = resolved_route.config;
     let new_model = resolved_route.model;
     let context_window_source = resolved_route.context_window.source;
@@ -9037,7 +9037,7 @@ async fn apply_provider_fallback_switch(
     app.set_active_context_window_override(config.context_window_for_provider_config(target));
     app.set_active_route_resolution(
         new_base_url.clone(),
-        resolved_route.candidate.limits,
+        resolved_route.candidate.limits(),
         context_window_source,
     );
     app.update_model_compaction_budget();
@@ -10006,7 +10006,7 @@ async fn apply_command_result(
                         let new_model = validated_route.model.clone();
                         let provider_identity = validated_route.identity.clone();
                         let route_limits = crate::route_budget::known_route_limits(
-                            validated_route.candidate.limits,
+                            validated_route.candidate.limits(),
                         );
                         app.config_profile = Some(profile.clone());
                         *config = new_config.clone();
@@ -13855,8 +13855,8 @@ fn resolve_loaded_session_route(app: &mut App, config: &Config) {
         None,
     ) {
         Ok(resolution) => app.set_active_route_resolution(
-            resolution.candidate.endpoint.base_url,
-            resolution.candidate.limits,
+            resolution.candidate.endpoint().base_url.clone(),
+            resolution.candidate.limits(),
             resolution.context_window.source,
         ),
         Err(_) => {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -5392,7 +5392,7 @@ fn auto_routed_turn_compaction_uses_selected_route_not_stale_app_route() {
         .expect("resolve auto-selected route")
         .validate()
         .expect("preflight auto-selected route");
-    let route_limits = crate::route_budget::known_route_limits(route.candidate.limits);
+    let route_limits = crate::route_budget::known_route_limits(route.candidate.limits());
 
     let compaction =
         app.compaction_config_for_route(route.identity.provider, &route.model, route_limits);
@@ -11846,7 +11846,7 @@ fn named_custom_provider_resume_uses_exact_live_endpoint_model_and_workspace() {
     let route = resolve_runtime_route(&config, app.api_provider, Some(&app.model))
         .expect("runtime route remains exact");
     assert_eq!(
-        route.candidate.endpoint.base_url,
+        route.candidate.endpoint().base_url,
         "http://127.0.0.1:1234/v1"
     );
     assert_eq!(route.model, "local-code-model");
@@ -14402,11 +14402,11 @@ async fn failed_fallback_restores_exact_literal_custom_identity_without_root_cro
     .expect("restored identity must still resolve the exact literal table");
     assert_eq!(route.identity.exact_id.as_deref(), Some("custom"));
     assert_eq!(
-        route.candidate.endpoint.base_url,
+        route.candidate.endpoint().base_url,
         "http://127.0.0.1:18181/v1"
     );
     assert_ne!(
-        route.candidate.endpoint.base_url,
+        route.candidate.endpoint().base_url,
         "http://127.0.0.1:18180/v1"
     );
 }


### PR DESCRIPTION
## Summary

- seal `ReadyRouteCandidate` behind private fields and read-only getters so a resolved route cannot be mutated after construction
- represent context/output/tool-limit changes as ordered, sourced `RouteLimitOverride` requests applied by the resolver before the ready candidate is minted
- preserve exact applied-override provenance and last-write precedence
- report auth as `ResolvedAuthSource::Unresolved` during pure resolution; credential preflight remains outside the resolver
- update TUI, Fleet, app-server, picker, diagnostics, and runtime call sites to consume the immutable contract

This is the bounded P1 route-authority slice from the v0.9.1 cutover plan. It changes construction/ownership, not provider selection policy.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-config route --locked` (76 passed)
- `cargo test -p codewhale-config --doc --locked` (1 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked route_runtime::tests` (12 passed)
- `cargo check -p codewhale-app-server --locked`
- `cargo clippy -p codewhale-config -p codewhale-tui -p codewhale-app-server --all-targets --all-features --locked -- -D warnings`
- `git diff --check origin/main...HEAD`

Focused coverage includes unresolved auth JSON compatibility, all three limit fields, ordered repeated overrides, exact applied provenance, and existing auth variant wire spellings.

Current exact head: `4698f8b78c451a0e5cbabe73e0d46e13698cdefd`.
