### PR TITLE
fix(web): share SSRF guard and isolate web.run sessions

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -729,6 +729,8 @@ max_subagents = 10 # optional (1-20)
 # default = "prompt"     # allow | deny | prompt
 # allow = ["api.deepseek.com", "github.com", ".githubusercontent.com"]
 # deny = []
+# proxy = ["github.com", ".githubusercontent.com"]
+# proxy_fake_ip_cidrs = ["198.18.0.0/15"] # requires both matching host and address
 # audit = true            # one line per call to ~/.codewhale/audit.log
 
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1881,6 +1881,10 @@ pub struct NetworkPolicyToml {
     /// explicitly trusted proxy setup. Literal IP URLs remain blocked.
     #[serde(default)]
     pub proxy: Vec<String>,
+    /// Explicit fake-IP placeholder CIDRs for those proxy hosts. The runtime
+    /// accepts only subnets contained by `198.18.0.0/15`.
+    #[serde(default)]
+    pub proxy_fake_ip_cidrs: Vec<String>,
     /// Whether to record one audit-log line per outbound network call.
     #[serde(default = "default_network_audit")]
     pub audit: bool,
@@ -1901,6 +1905,7 @@ impl Default for NetworkPolicyToml {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: default_network_audit(),
         }
     }

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -17,12 +17,14 @@ fn network_policy_toml_deserializes_proxy_hosts() {
         r#"
         default = "allow"
         proxy = ["github.com", ".githubusercontent.com"]
+        proxy_fake_ip_cidrs = ["198.18.0.0/15"]
         "#,
     )
     .expect("network policy toml");
 
     assert_eq!(policy.default, "allow");
     assert_eq!(policy.proxy, ["github.com", ".githubusercontent.com"]);
+    assert_eq!(policy.proxy_fake_ip_cidrs, ["198.18.0.0/15"]);
     assert!(policy.audit);
 }
 

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2530,6 +2530,10 @@ pub struct NetworkPolicyToml {
     /// explicitly trusted proxy setup. Literal IP URLs remain blocked.
     #[serde(default)]
     pub proxy: Vec<String>,
+    /// Explicit fake-IP placeholder CIDRs for those proxy hosts. Only subnets
+    /// within `198.18.0.0/15` are accepted by the runtime SSRF guard.
+    #[serde(default)]
+    pub proxy_fake_ip_cidrs: Vec<String>,
     /// Whether to record one audit-log line per outbound network call.
     #[serde(default = "default_network_audit")]
     pub audit: bool,
@@ -2550,6 +2554,7 @@ impl Default for NetworkPolicyToml {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: default_network_audit(),
         }
     }
@@ -2565,6 +2570,7 @@ impl NetworkPolicyToml {
             allow: self.allow,
             deny: self.deny,
             proxy: self.proxy,
+            proxy_fake_ip_cidrs: self.proxy_fake_ip_cidrs,
             audit: self.audit,
         }
     }

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -685,6 +685,7 @@ fn network_policy_toml_maps_proxy_hosts_to_runtime_policy() {
         r#"
         default = "allow"
         proxy = ["github.com", ".githubusercontent.com"]
+        proxy_fake_ip_cidrs = ["198.18.0.0/15"]
         "#,
     )
     .expect("network policy toml");
@@ -692,6 +693,7 @@ fn network_policy_toml_maps_proxy_hosts_to_runtime_policy() {
     let runtime = policy.into_runtime();
 
     assert_eq!(runtime.proxy, ["github.com", ".githubusercontent.com"]);
+    assert_eq!(runtime.proxy_fake_ip_cidrs, ["198.18.0.0/15"]);
     assert!(runtime.trusts_proxy_fakeip_host("github.com"));
     assert!(runtime.trusts_proxy_fakeip_host("raw.githubusercontent.com"));
 }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -12561,6 +12561,7 @@ mod terminal_mode_tests {
                 allow: Vec::new(),
                 deny: Vec::new(),
                 proxy: Vec::new(),
+                proxy_fake_ip_cidrs: Vec::new(),
                 audit: false,
             },
             None,

--- a/crates/tui/src/network_policy.rs
+++ b/crates/tui/src/network_policy.rs
@@ -107,6 +107,12 @@ pub struct NetworkPolicy {
     /// explicitly trusted proxy setup. This does not affect literal IP URLs.
     #[serde(default)]
     pub proxy: Vec<String>,
+    /// Explicit fake-IP placeholder CIDRs used by the trusted proxy setup.
+    /// Only subnets contained by the IETF benchmark range `198.18.0.0/15`
+    /// are eligible; loopback, RFC1918, link-local, metadata, and ULA ranges
+    /// can never be trusted through this setting.
+    #[serde(default)]
+    pub proxy_fake_ip_cidrs: Vec<String>,
     /// Whether to record one audit-log line per network call. Defaults to true.
     #[serde(default = "default_audit")]
     pub audit: bool,
@@ -127,6 +133,7 @@ impl Default for NetworkPolicy {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: true,
         }
     }
@@ -276,6 +283,15 @@ fn parse_ipv4_cidr(cidr: &str) -> Option<(Ipv4Addr, u8)> {
         return None;
     }
     Some((base, prefix))
+}
+
+/// Parse only fake-IP networks that are fully contained by the IETF benchmark
+/// block. This keeps an overly broad or mistaken config entry from weakening
+/// the unconditional loopback/private/link-local/metadata protections.
+fn parse_trusted_fakeip_cidr(cidr: &str) -> Option<(Ipv4Addr, u8)> {
+    let (base, prefix) = parse_ipv4_cidr(cidr)?;
+    let octets = base.octets();
+    (prefix >= 15 && octets[0] == 198 && matches!(octets[1], 18..=19)).then_some((base, prefix))
 }
 
 /// Whether `ip` is contained in the `base/prefix` IPv4 CIDR block.
@@ -452,11 +468,16 @@ impl NetworkPolicyDecider {
     /// Build a decider from a policy. The session cache starts empty.
     #[must_use]
     pub fn new(policy: NetworkPolicy, auditor: Option<NetworkAuditor>) -> Self {
+        let trusted_fakeip_cidrs = policy
+            .proxy_fake_ip_cidrs
+            .iter()
+            .filter_map(|cidr| parse_trusted_fakeip_cidr(cidr))
+            .collect();
         Self {
             policy,
             cache: NetworkSessionCache::new(),
             auditor,
-            trusted_fakeip_cidrs: Vec::new(),
+            trusted_fakeip_cidrs,
         }
     }
 
@@ -465,7 +486,7 @@ impl NetworkPolicyDecider {
     #[must_use]
     pub fn with_trusted_fakeip_cidrs(mut self, cidrs: &[&str]) -> Self {
         for cidr in cidrs {
-            if let Some(parsed) = parse_ipv4_cidr(cidr) {
+            if let Some(parsed) = parse_trusted_fakeip_cidr(cidr) {
                 self.trusted_fakeip_cidrs.push(parsed);
             }
         }
@@ -606,6 +627,7 @@ mod tests {
             allow: allow.iter().map(|s| (*s).to_string()).collect(),
             deny: deny.iter().map(|s| (*s).to_string()).collect(),
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: false,
         }
     }
@@ -709,7 +731,12 @@ mod tests {
     #[test]
     fn trusted_fakeip_cidr_allows_placeholder_but_not_real_private() {
         let decider = NetworkPolicyDecider::new(NetworkPolicy::default(), None)
-            .with_trusted_fakeip_cidrs(&["198.18.0.0/15"]);
+            .with_trusted_fakeip_cidrs(&[
+                "198.18.0.0/15",
+                "127.0.0.0/8",
+                "10.0.0.0/8",
+                "169.254.0.0/16",
+            ]);
 
         // fake-ip placeholder range (clash default / IETF benchmark) is trusted
         assert!(decider.is_trusted_fakeip_addr(&"198.18.0.5".parse::<std::net::IpAddr>().unwrap()));
@@ -728,6 +755,21 @@ mod tests {
         // no ranges configured → nothing trusted
         let bare = NetworkPolicyDecider::new(NetworkPolicy::default(), None);
         assert!(!bare.is_trusted_fakeip_addr(&"198.18.0.5".parse::<std::net::IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn configured_fakeip_cidrs_are_loaded_but_unsafe_ranges_are_ignored() {
+        let mut policy = NetworkPolicy::default();
+        policy.proxy_fake_ip_cidrs = vec![
+            "198.18.0.0/15".to_string(),
+            "127.0.0.0/8".to_string(),
+            "10.0.0.0/8".to_string(),
+        ];
+        let decider = NetworkPolicyDecider::new(policy, None);
+
+        assert!(decider.is_trusted_fakeip_addr(&"198.19.0.5".parse().unwrap()));
+        assert!(!decider.is_trusted_fakeip_addr(&"127.0.0.1".parse().unwrap()));
+        assert!(!decider.is_trusted_fakeip_addr(&"10.0.0.1".parse().unwrap()));
     }
 
     #[test]

--- a/crates/tui/src/network_policy.rs
+++ b/crates/tui/src/network_policy.rs
@@ -759,12 +759,14 @@ mod tests {
 
     #[test]
     fn configured_fakeip_cidrs_are_loaded_but_unsafe_ranges_are_ignored() {
-        let mut policy = NetworkPolicy::default();
-        policy.proxy_fake_ip_cidrs = vec![
-            "198.18.0.0/15".to_string(),
-            "127.0.0.0/8".to_string(),
-            "10.0.0.0/8".to_string(),
-        ];
+        let policy = NetworkPolicy {
+            proxy_fake_ip_cidrs: vec![
+                "198.18.0.0/15".to_string(),
+                "127.0.0.0/8".to_string(),
+                "10.0.0.0/8".to_string(),
+            ],
+            ..NetworkPolicy::default()
+        };
         let decider = NetworkPolicyDecider::new(policy, None);
 
         assert!(decider.is_trusted_fakeip_addr(&"198.19.0.5".parse().unwrap()));

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -11,7 +11,7 @@ use super::handle::query_jsonpath;
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, optional_u64,
 };
-use super::web::guard::validate_fetch_target;
+use super::web::guard::{guarded_reqwest_client_builder, validate_fetch_target};
 use async_trait::async_trait;
 use regex::Regex;
 use serde::Serialize;
@@ -163,7 +163,7 @@ impl ToolSpec for FetchUrlTool {
 
         let resp = loop {
             let dns_pinning = validate_fetch_target(&current_url, context, "fetch_url").await?;
-            let mut client_builder = crate::tls::reqwest_client_builder()
+            let mut client_builder = guarded_reqwest_client_builder()
                 .timeout(Duration::from_millis(timeout_ms))
                 .user_agent(USER_AGENT)
                 .redirect(reqwest::redirect::Policy::none());
@@ -462,6 +462,7 @@ mod tests {
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
@@ -483,6 +484,7 @@ mod tests {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: vec!["198.18.0.1".to_string()],
+            proxy_fake_ip_cidrs: vec!["198.18.0.0/15".to_string()],
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -11,7 +11,7 @@ use super::handle::query_jsonpath;
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, optional_u64,
 };
-use crate::network_policy::{Decision, NetworkPolicyDecider};
+use super::web::guard::validate_fetch_target;
 use async_trait::async_trait;
 use regex::Regex;
 use serde::Serialize;
@@ -162,7 +162,7 @@ impl ToolSpec for FetchUrlTool {
         let mut redirects_followed = 0usize;
 
         let resp = loop {
-            let dns_pinning = validate_fetch_target(&current_url, context).await?;
+            let dns_pinning = validate_fetch_target(&current_url, context, "fetch_url").await?;
             let mut client_builder = crate::tls::reqwest_client_builder()
                 .timeout(Duration::from_millis(timeout_ms))
                 .user_agent(USER_AGENT)
@@ -266,154 +266,6 @@ impl ToolSpec for FetchUrlTool {
         ToolResult::json(&response)
             .map_err(|e| ToolError::execution_failed(format!("failed to serialize response: {e}")))
     }
-}
-
-/// Check if an IP address is loopback, private, link-local, cloud-metadata,
-/// multicast, or reserved — all addresses that should not be reachable via
-/// an LLM-initiated fetch_url request (SSRF prevention).
-fn is_restricted_ip(ip: &std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_multicast()
-                || v4.is_broadcast()
-                || v4.is_unspecified()
-                // 100.64.0.0/10 — Carrier-grade NAT (CGNAT / shared address space)
-                || matches!(v4.octets(), [100, 64..=127, ..])
-                // 169.254.169.254 — cloud metadata (AWS/GCP/Azure)
-                || *ip == std::net::IpAddr::V4(std::net::Ipv4Addr::new(169, 254, 169, 254))
-                // 198.18.0.0/15 — IETF benchmark testing
-                || matches!(v4.octets(), [198, 18..=19, ..])
-                // 240.0.0.0/4 — reserved (former Class E)
-                || v4.octets()[0] >= 240
-        }
-        std::net::IpAddr::V6(v6) => {
-            // IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) — unwrap and check as IPv4
-            // to prevent bypass via ::ffff:127.0.0.1 etc.
-            if v6.is_unspecified()
-                || matches!(v6.octets(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, ..])
-            {
-                return true;
-            }
-            if let Some(v4) = v6.to_ipv4_mapped() {
-                return is_restricted_ip(&std::net::IpAddr::V4(v4));
-            }
-            v6.is_loopback()
-                || v6.is_multicast()
-                || matches!(v6.segments(), [0xfc00..=0xfdff, ..]) // ULA fc00::/7
-                || matches!(v6.segments(), [0xfe80..=0xfebf, ..]) // Link-local fe80::/10
-        }
-    }
-}
-
-async fn validate_fetch_target(
-    url: &reqwest::Url,
-    context: &ToolContext,
-) -> Result<Option<(String, std::net::IpAddr)>, ToolError> {
-    if url.scheme() != "http" && url.scheme() != "https" {
-        return Err(ToolError::invalid_input(
-            "only http:// and https:// URLs are supported",
-        ));
-    }
-
-    let host = url
-        .host_str()
-        .map(str::to_ascii_lowercase)
-        .ok_or_else(|| ToolError::invalid_input("URL must include a host"))?;
-
-    validate_network_policy(&host, context)?;
-
-    // SSRF protection: resolve hostname and reject private/link-local/loopback IPs.
-    // Prevents LLM-prompted requests to cloud metadata (169.254.169.254),
-    // localhost services, and internal networks.
-    if host == "localhost" || host == "localhost.localdomain" {
-        return Err(ToolError::permission_denied(
-            "requests to localhost are not allowed",
-        ));
-    }
-    // Normalize bracketed IPv6 literals before the literal-IP check so they
-    // route through the same restricted-IP policy as unbracketed forms
-    // (GHSA-88gh-2526-gfrr).
-    let ip_candidate = host
-        .strip_prefix('[')
-        .and_then(|s| s.strip_suffix(']'))
-        .unwrap_or(host.as_str());
-    if let Ok(ip) = ip_candidate.parse::<std::net::IpAddr>() {
-        if is_restricted_ip(&ip) {
-            return Err(ToolError::permission_denied(format!(
-                "IP {ip} is a restricted address (private/loopback/link-local)"
-            )));
-        }
-        return Ok(None);
-    }
-
-    let addrs = tokio::net::lookup_host((host.as_str(), 0u16))
-        .await
-        .map_err(|e| {
-            ToolError::permission_denied(format!(
-                "could not resolve host before fetch_url request: {e}"
-            ))
-        })?;
-    let mut first_valid: Option<std::net::IpAddr> = None;
-    for addr in addrs {
-        validate_dns_resolved_ip(&host, &addr.ip(), context.network_policy.as_ref())?;
-        if first_valid.is_none() {
-            first_valid = Some(addr.ip());
-        }
-    }
-
-    let Some(validated_ip) = first_valid else {
-        return Err(ToolError::permission_denied(
-            "host resolved to no addresses before fetch_url request",
-        ));
-    };
-    Ok(Some((host, validated_ip)))
-}
-
-fn validate_network_policy(host: &str, context: &ToolContext) -> Result<(), ToolError> {
-    let Some(decider) = context.network_policy.as_ref() else {
-        return Ok(());
-    };
-
-    match decider.evaluate(host, "fetch_url") {
-        Decision::Allow => Ok(()),
-        Decision::Deny => Err(ToolError::permission_denied(format!(
-            "network call to '{host}' blocked by network policy"
-        ))),
-        Decision::Prompt => Err(ToolError::permission_denied(format!(
-            "network call to '{host}' requires approval; \
-             re-run after `/network allow {host}` or set network.default = \"allow\" in config"
-        ))),
-    }
-}
-
-fn validate_dns_resolved_ip(
-    host: &str,
-    ip: &std::net::IpAddr,
-    decider: Option<&NetworkPolicyDecider>,
-) -> Result<(), ToolError> {
-    if !is_restricted_ip(ip) {
-        return Ok(());
-    }
-
-    // Allow the resolved IP past the restricted-IP block if either:
-    //   * it falls inside a configured fake-IP placeholder range (a TUN /
-    //     transparent-proxy setup in `fake-ip` mode resolves every host into a
-    //     reserved range such as `198.18.0.0/15`), or
-    //   * the host is on the explicitly-trusted proxy list.
-    // Real private/loopback/link-local/metadata IPs match neither and stay blocked.
-    if let Some(decider) = decider
-        && (decider.is_trusted_fakeip_addr(ip) || decider.trusts_proxy_fakeip_host(host))
-    {
-        decider.record_trusted_proxy_fakeip_allow(host, "fetch_url");
-        return Ok(());
-    }
-
-    Err(ToolError::permission_denied(format!(
-        "resolved IP {ip} is a restricted address (private/loopback/link-local)"
-    )))
 }
 
 fn parse_fields(input: &Value) -> Result<Vec<String>, ToolError> {
@@ -592,61 +444,6 @@ mod tests {
         assert!(res.is_err());
     }
 
-    #[test]
-    fn rejects_private_localhost_literal() {
-        assert!(is_restricted_ip(&"127.0.0.1".parse().unwrap()));
-        assert!(is_restricted_ip(&"::1".parse().unwrap()));
-    }
-
-    #[test]
-    fn rejects_private_rfc1918() {
-        assert!(is_restricted_ip(&"10.0.0.1".parse().unwrap()));
-        assert!(is_restricted_ip(&"172.16.0.1".parse().unwrap()));
-        assert!(is_restricted_ip(&"192.168.1.1".parse().unwrap()));
-    }
-
-    #[test]
-    fn rejects_cloud_metadata() {
-        assert!(is_restricted_ip(&"169.254.169.254".parse().unwrap()));
-    }
-
-    #[test]
-    fn rejects_link_local() {
-        assert!(is_restricted_ip(&"169.254.1.1".parse().unwrap()));
-    }
-
-    #[test]
-    fn rejects_cgnat() {
-        assert!(is_restricted_ip(&"100.64.0.1".parse().unwrap()));
-        assert!(!is_restricted_ip(&"100.63.0.1".parse().unwrap()));
-        assert!(!is_restricted_ip(&"100.128.0.1".parse().unwrap()));
-    }
-
-    #[test]
-    fn rejects_ipv6_ula() {
-        assert!(is_restricted_ip(&"fc00::1".parse().unwrap()));
-        assert!(is_restricted_ip(&"fd12:3456::1".parse().unwrap()));
-    }
-
-    #[test]
-    fn rejects_ipv4_mapped_ipv6() {
-        // ::ffff:127.0.0.1 — IPv4-mapped IPv6 loopback bypass
-        assert!(is_restricted_ip(&"::ffff:127.0.0.1".parse().unwrap()));
-        assert!(is_restricted_ip(&"::ffff:10.0.0.1".parse().unwrap()));
-        assert!(is_restricted_ip(&"::ffff:169.254.169.254".parse().unwrap()));
-        assert!(is_restricted_ip(&"::ffff:192.168.1.1".parse().unwrap()));
-        // :: (unspecified)
-        assert!(is_restricted_ip(&"::".parse().unwrap()));
-    }
-
-    #[test]
-    fn allows_public_ips() {
-        assert!(!is_restricted_ip(&"8.8.8.8".parse().unwrap()));
-        assert!(!is_restricted_ip(&"1.1.1.1".parse().unwrap()));
-        assert!(!is_restricted_ip(&"93.184.216.34".parse().unwrap()));
-        assert!(!is_restricted_ip(&"2606:4700::1".parse().unwrap()));
-    }
-
     #[tokio::test]
     async fn rejects_localhost_hostname() {
         let tool = FetchUrlTool;
@@ -678,146 +475,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn redirected_localhost_hostname_is_rejected() {
-        let url = reqwest::Url::parse("http://localhost:8080/admin").unwrap();
-        let err = validate_fetch_target(&url, &ctx()).await.unwrap_err();
-        assert!(format!("{err}").contains("localhost"));
-    }
-
-    #[tokio::test]
-    async fn redirected_private_ip_literal_is_rejected() {
-        let url = reqwest::Url::parse("http://169.254.169.254/latest/meta-data").unwrap();
-        let err = validate_fetch_target(&url, &ctx()).await.unwrap_err();
-        assert!(format!("{err}").contains("restricted address"));
-    }
-
-    // GHSA-88gh-2526-gfrr — regression coverage for bracketed IPv6 literals.
-    #[tokio::test]
-    async fn rejects_ipv6_literal_loopback() {
-        let url = reqwest::Url::parse("http://[::1]/").unwrap();
-        let err = validate_fetch_target(&url, &ctx())
-            .await
-            .expect_err("[::1] must be rejected as restricted");
-        assert!(format!("{err}").contains("restricted"));
-    }
-
-    #[tokio::test]
-    async fn rejects_ipv6_literal_ula() {
-        let url = reqwest::Url::parse("http://[fc00::1]/").unwrap();
-        let err = validate_fetch_target(&url, &ctx())
-            .await
-            .expect_err("[fc00::1] must be rejected as restricted");
-        assert!(format!("{err}").contains("restricted"));
-    }
-
-    #[tokio::test]
-    async fn rejects_ipv6_literal_link_local() {
-        let url = reqwest::Url::parse("http://[fe80::1]/").unwrap();
-        let err = validate_fetch_target(&url, &ctx())
-            .await
-            .expect_err("[fe80::1] must be rejected as restricted");
-        assert!(format!("{err}").contains("restricted"));
-    }
-
-    #[tokio::test]
-    async fn rejects_ipv6_literal_ipv4_mapped_loopback() {
-        let url = reqwest::Url::parse("http://[::ffff:127.0.0.1]/").unwrap();
-        let err = validate_fetch_target(&url, &ctx())
-            .await
-            .expect_err("[::ffff:127.0.0.1] must be rejected as restricted");
-        assert!(format!("{err}").contains("restricted"));
-    }
-
-    #[tokio::test]
-    async fn rejects_ipv6_literal_unspecified() {
-        let url = reqwest::Url::parse("http://[::]/").unwrap();
-        let err = validate_fetch_target(&url, &ctx())
-            .await
-            .expect_err("[::] must be rejected as restricted");
-        assert!(format!("{err}").contains("restricted"));
-    }
-
-    #[tokio::test]
-    async fn redirected_host_respects_network_policy() {
-        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
-        let policy = NetworkPolicy {
-            default: Decision::Deny.into(),
-            allow: vec!["api.deepseek.com".to_string()],
-            deny: vec![],
-            proxy: Vec::new(),
-            audit: false,
-        };
-        let decider = NetworkPolicyDecider::new(policy, None);
-        let ctx = ToolContext::new(PathBuf::from(".")).with_network_policy(decider);
-        let url = reqwest::Url::parse("https://example.com/redirect-target").unwrap();
-        let err = validate_fetch_target(&url, &ctx).await.unwrap_err();
-        assert!(format!("{err}").contains("blocked"));
-    }
-
-    #[tokio::test]
-    async fn unresolved_hostname_is_rejected_before_request() {
-        let url =
-            reqwest::Url::parse("https://codewhale-unresolvable-fetch-target.invalid/resource")
-                .unwrap();
-        let err = validate_fetch_target(&url, &ctx())
-            .await
-            .expect_err("unresolved host must fail preflight");
-        let message = format!("{err}");
-        assert!(
-            message.contains("could not resolve host") || message.contains("restricted address"),
-            "error must identify preflight DNS or restricted-IP failure; got {err}"
-        );
-    }
-
-    #[test]
-    fn restricted_dns_result_is_denied_without_proxy_opt_in() {
-        let ip = "198.18.0.1".parse().unwrap();
-
-        let err = validate_dns_resolved_ip("github.com", &ip, None)
-            .expect_err("fake-IP DNS result must be denied by default");
-
-        assert!(format!("{err}").contains("resolved IP 198.18.0.1 is a restricted address"));
-    }
-
-    #[test]
-    fn proxy_opt_in_allows_restricted_dns_for_matching_host() {
-        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
-
-        let policy = NetworkPolicy {
-            default: Decision::Allow.into(),
-            allow: Vec::new(),
-            deny: Vec::new(),
-            proxy: vec!["github.com".to_string()],
-            audit: false,
-        };
-        let decider = NetworkPolicyDecider::new(policy, None);
-        let ip = "198.18.0.1".parse().unwrap();
-
-        validate_dns_resolved_ip("github.com", &ip, Some(&decider))
-            .expect("proxy opt-in should allow fake-IP DNS for matching host");
-    }
-
-    #[test]
-    fn proxy_opt_in_does_not_allow_unlisted_host() {
-        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
-
-        let policy = NetworkPolicy {
-            default: Decision::Allow.into(),
-            allow: Vec::new(),
-            deny: Vec::new(),
-            proxy: vec!["github.com".to_string()],
-            audit: false,
-        };
-        let decider = NetworkPolicyDecider::new(policy, None);
-        let ip = "198.18.0.1".parse().unwrap();
-
-        let err = validate_dns_resolved_ip("example.com", &ip, Some(&decider))
-            .expect_err("proxy opt-in must be scoped to configured hosts");
-
-        assert!(format!("{err}").contains("resolved IP 198.18.0.1 is a restricted address"));
-    }
-
-    #[tokio::test]
     async fn proxy_opt_in_does_not_allow_restricted_ip_literal() {
         use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
 
@@ -838,31 +495,5 @@ mod tests {
             .expect_err("literal restricted IP URLs must stay blocked");
 
         assert!(format!("{err}").contains("IP 198.18.0.1 is a restricted address"));
-    }
-
-    #[test]
-    fn proxy_dns_allow_is_audited() {
-        use crate::network_policy::{
-            Decision, NetworkAuditor, NetworkPolicy, NetworkPolicyDecider,
-        };
-        use tempfile::tempdir;
-
-        let dir = tempdir().expect("tempdir");
-        let auditor = NetworkAuditor::new(dir.path().join("audit.log"), true);
-        let policy = NetworkPolicy {
-            default: Decision::Allow.into(),
-            allow: Vec::new(),
-            deny: Vec::new(),
-            proxy: vec!["github.com".to_string()],
-            audit: true,
-        };
-        let decider = NetworkPolicyDecider::new(policy, Some(auditor));
-        let ip = "198.18.0.1".parse().unwrap();
-
-        validate_dns_resolved_ip("github.com", &ip, Some(&decider)).expect("proxy DNS allow");
-
-        let body = std::fs::read_to_string(dir.path().join("audit.log")).expect("audit log");
-        assert!(body.contains("github.com"));
-        assert!(body.contains("TrustedProxyFakeIp-Allow"));
     }
 }

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -62,6 +62,7 @@ pub mod truncate;
 pub mod user_input;
 pub mod validate_data;
 pub mod verifier;
+pub mod web;
 pub mod web_run;
 pub mod web_search;
 pub mod workflow;

--- a/crates/tui/src/tools/web/guard.rs
+++ b/crates/tui/src/tools/web/guard.rs
@@ -15,6 +15,14 @@ use std::net::IpAddr;
 /// connection uses the pre-validated address instead of re-resolving.
 pub(crate) type DnsPin = Option<(String, IpAddr)>;
 
+/// Build the transport used after a destination has passed SSRF validation.
+/// Ambient HTTP(S)/SOCKS proxies are deliberately disabled: a proxy would
+/// receive the original hostname, resolve it again outside this process, and
+/// bypass the validated DNS pin.
+pub(crate) fn guarded_reqwest_client_builder() -> reqwest::ClientBuilder {
+    crate::tls::reqwest_client_builder().no_proxy()
+}
+
 /// Check if an IP address is loopback, private, link-local, cloud-metadata,
 /// multicast, or reserved — all addresses that should not be reachable via
 /// an LLM-initiated fetch request (SSRF prevention).
@@ -157,14 +165,13 @@ pub(crate) fn validate_dns_resolved_ip(
         return Ok(());
     }
 
-    // Allow the resolved IP past the restricted-IP block if either:
-    //   * it falls inside a configured fake-IP placeholder range (a TUN /
-    //     transparent-proxy setup in `fake-ip` mode resolves every host into a
-    //     reserved range such as `198.18.0.0/15`), or
-    //   * the host is on the explicitly-trusted proxy list.
-    // Real private/loopback/link-local/metadata IPs match neither and stay blocked.
+    // A fake-IP exception requires both an explicitly trusted hostname and an
+    // explicitly trusted placeholder CIDR. The CIDR parser admits only subnets
+    // inside 198.18.0.0/15, so real private/loopback/link-local/metadata/ULA
+    // addresses remain blocked even when the hostname is trusted.
     if let Some(decider) = decider
-        && (decider.is_trusted_fakeip_addr(ip) || decider.trusts_proxy_fakeip_host(host))
+        && decider.is_trusted_fakeip_addr(ip)
+        && decider.trusts_proxy_fakeip_host(host)
     {
         decider.record_trusted_proxy_fakeip_allow(host, tool);
         return Ok(());
@@ -179,10 +186,220 @@ pub(crate) fn validate_dns_resolved_ip(
 mod tests {
     use super::*;
     use crate::tools::spec::ToolContext;
+    #[cfg(not(windows))]
+    use std::io::{Read, Write};
+    #[cfg(not(windows))]
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::PathBuf;
+    #[cfg(not(windows))]
+    use std::process::Command;
+    #[cfg(not(windows))]
+    use std::sync::Arc;
+    #[cfg(not(windows))]
+    use std::sync::atomic::{AtomicBool, Ordering};
+    #[cfg(not(windows))]
+    use std::time::{Duration, Instant};
 
     fn ctx() -> ToolContext {
         ToolContext::new(PathBuf::from("."))
+    }
+
+    #[cfg(not(windows))]
+    #[derive(Clone, Copy, Debug)]
+    enum AmbientProxyKind {
+        Http,
+        HttpsConnect,
+        SocksRemoteDns,
+    }
+
+    #[cfg(not(windows))]
+    fn spawn_accept_probe(
+        stop: Arc<AtomicBool>,
+        respond_http: bool,
+        drain_http_headers: bool,
+    ) -> (u16, std::thread::JoinHandle<bool>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind probe listener");
+        let port = listener.local_addr().expect("probe address").port();
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking probe listener");
+        let handle = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        if drain_http_headers {
+                            stream
+                                .set_read_timeout(Some(Duration::from_secs(2)))
+                                .expect("probe read timeout");
+                            let mut request = Vec::new();
+                            let mut chunk = [0_u8; 1024];
+                            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                let read = stream.read(&mut chunk).expect("read probe request");
+                                if read == 0 {
+                                    break;
+                                }
+                                request.extend_from_slice(&chunk[..read]);
+                            }
+                        }
+                        if respond_http {
+                            let _ = stream.write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                            );
+                        }
+                        return true;
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(err) => panic!("probe accept failed: {err}"),
+                }
+                if stop.load(Ordering::SeqCst) || Instant::now() >= deadline {
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        });
+        (port, handle)
+    }
+
+    #[cfg(not(windows))]
+    fn run_ambient_proxy_probe(kind: AmbientProxyKind, guarded: bool) -> (bool, bool) {
+        let stop = Arc::new(AtomicBool::new(false));
+        let (target_port, target_handle) = spawn_accept_probe(
+            Arc::clone(&stop),
+            matches!(
+                kind,
+                AmbientProxyKind::Http | AmbientProxyKind::SocksRemoteDns
+            ),
+            matches!(
+                kind,
+                AmbientProxyKind::Http | AmbientProxyKind::SocksRemoteDns
+            ),
+        );
+        let (proxy_port, proxy_handle) = spawn_accept_probe(Arc::clone(&stop), true, false);
+
+        let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+        command.args([
+            "--exact",
+            "tools::web::guard::tests::guarded_transport_proxy_probe_child",
+            "--ignored",
+            "--nocapture",
+        ]);
+        for key in [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+            "REQUEST_METHOD",
+        ] {
+            command.env_remove(key);
+        }
+        command
+            .env("CODEWHALE_PROXY_PROBE_CHILD", "1")
+            .env(
+                "CODEWHALE_PROXY_PROBE_GUARDED",
+                if guarded { "1" } else { "0" },
+            )
+            .env("CODEWHALE_PROXY_PROBE_TARGET_PORT", target_port.to_string());
+        match kind {
+            AmbientProxyKind::Http => {
+                let proxy = format!("http://127.0.0.1:{proxy_port}");
+                command
+                    .env("CODEWHALE_PROXY_PROBE_SCHEME", "http")
+                    .env("HTTP_PROXY", &proxy)
+                    .env("http_proxy", proxy);
+            }
+            AmbientProxyKind::HttpsConnect => {
+                let proxy = format!("http://127.0.0.1:{proxy_port}");
+                command
+                    .env("CODEWHALE_PROXY_PROBE_SCHEME", "https")
+                    .env("HTTPS_PROXY", &proxy)
+                    .env("https_proxy", proxy);
+            }
+            AmbientProxyKind::SocksRemoteDns => {
+                let proxy = format!("socks5h://127.0.0.1:{proxy_port}");
+                command
+                    .env("CODEWHALE_PROXY_PROBE_SCHEME", "http")
+                    .env("ALL_PROXY", &proxy)
+                    .env("all_proxy", proxy);
+            }
+        }
+
+        let output = command.output().expect("run proxy probe child");
+        stop.store(true, Ordering::SeqCst);
+        let target_hit = target_handle.join().expect("join target probe");
+        let proxy_hit = proxy_handle.join().expect("join proxy probe");
+        assert!(
+            output.status.success(),
+            "proxy probe child failed for {kind:?} guarded={guarded}:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        (target_hit, proxy_hit)
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    #[ignore = "subprocess helper for ambient proxy regression test"]
+    async fn guarded_transport_proxy_probe_child() {
+        if std::env::var_os("CODEWHALE_PROXY_PROBE_CHILD").is_none() {
+            return;
+        }
+        let guarded = std::env::var("CODEWHALE_PROXY_PROBE_GUARDED").as_deref() == Ok("1");
+        let scheme = std::env::var("CODEWHALE_PROXY_PROBE_SCHEME").expect("probe scheme");
+        let target_port = std::env::var("CODEWHALE_PROXY_PROBE_TARGET_PORT")
+            .expect("probe target port")
+            .parse::<u16>()
+            .expect("numeric target port");
+        let host = "guarded-proxy-probe.example.invalid";
+        let builder = if guarded {
+            guarded_reqwest_client_builder()
+        } else {
+            crate::tls::reqwest_client_builder()
+        };
+        let client = builder
+            .timeout(Duration::from_secs(2))
+            .resolve(
+                host,
+                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), target_port),
+            )
+            .build()
+            .expect("build proxy probe client");
+        let result = client
+            .get(format!("{scheme}://{host}:{target_port}/"))
+            .send()
+            .await;
+        if guarded && scheme == "http" {
+            assert!(
+                result.is_ok(),
+                "guarded HTTP target should answer: {result:?}"
+            );
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn guarded_transport_bypasses_ambient_http_https_and_remote_dns_socks_proxies() {
+        for kind in [
+            AmbientProxyKind::Http,
+            AmbientProxyKind::HttpsConnect,
+            AmbientProxyKind::SocksRemoteDns,
+        ] {
+            let (unguarded_target, unguarded_proxy) = run_ambient_proxy_probe(kind, false);
+            assert!(
+                unguarded_proxy && !unguarded_target,
+                "control client must demonstrate ambient {kind:?} proxy interception"
+            );
+
+            let (guarded_target, guarded_proxy) = run_ambient_proxy_probe(kind, true);
+            assert!(
+                guarded_target && !guarded_proxy,
+                "guarded client must preserve its DNS pin and bypass ambient {kind:?} proxy"
+            );
+        }
     }
 
     #[test]
@@ -312,6 +529,7 @@ mod tests {
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
@@ -349,7 +567,7 @@ mod tests {
     }
 
     #[test]
-    fn proxy_opt_in_allows_restricted_dns_for_matching_host() {
+    fn proxy_host_and_fakeip_cidr_allow_matching_placeholder() {
         use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
 
         let policy = NetworkPolicy {
@@ -357,13 +575,86 @@ mod tests {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: vec!["github.com".to_string()],
+            proxy_fake_ip_cidrs: vec!["198.18.0.0/15".to_string()],
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
         let ip = "198.18.0.1".parse().unwrap();
 
         validate_dns_resolved_ip("github.com", &ip, Some(&decider), "fetch_url")
-            .expect("proxy opt-in should allow fake-IP DNS for matching host");
+            .expect("matching host and fake-IP CIDR should allow the placeholder");
+    }
+
+    #[test]
+    fn proxy_host_without_fakeip_cidr_does_not_allow_restricted_dns() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            proxy_fake_ip_cidrs: Vec::new(),
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ip = "198.18.0.1".parse().unwrap();
+
+        validate_dns_resolved_ip("github.com", &ip, Some(&decider), "fetch_url")
+            .expect_err("hostname trust alone must not allow a restricted address");
+    }
+
+    #[test]
+    fn fakeip_cidr_without_proxy_host_does_not_allow_restricted_dns() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: Vec::new(),
+            proxy_fake_ip_cidrs: vec!["198.18.0.0/15".to_string()],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ip = "198.18.0.1".parse().unwrap();
+
+        validate_dns_resolved_ip("github.com", &ip, Some(&decider), "fetch_url")
+            .expect_err("fake-IP CIDR alone must not allow an untrusted hostname");
+    }
+
+    #[test]
+    fn proxy_host_never_exempts_real_private_or_local_addresses() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            proxy_fake_ip_cidrs: vec![
+                "198.18.0.0/15".to_string(),
+                "127.0.0.0/8".to_string(),
+                "10.0.0.0/8".to_string(),
+                "169.254.0.0/16".to_string(),
+            ],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+
+        for ip in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "fc00::1",
+        ] {
+            let ip = ip.parse().unwrap();
+            assert!(
+                validate_dns_resolved_ip("github.com", &ip, Some(&decider), "fetch_url").is_err(),
+                "{ip} must remain restricted"
+            );
+        }
     }
 
     #[test]
@@ -375,6 +666,7 @@ mod tests {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: vec!["github.com".to_string()],
+            proxy_fake_ip_cidrs: vec!["198.18.0.0/15".to_string()],
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
@@ -400,6 +692,7 @@ mod tests {
             allow: Vec::new(),
             deny: Vec::new(),
             proxy: vec!["github.com".to_string()],
+            proxy_fake_ip_cidrs: vec!["198.18.0.0/15".to_string()],
             audit: true,
         };
         let decider = NetworkPolicyDecider::new(policy, Some(auditor));

--- a/crates/tui/src/tools/web/guard.rs
+++ b/crates/tui/src/tools/web/guard.rs
@@ -1,0 +1,431 @@
+//! Shared SSRF guard for LLM-initiated HTTP fetches (`fetch_url`, `web.run`).
+//!
+//! Validates scheme/host, enforces network policy, resolves DNS and rejects
+//! private/loopback/link-local/metadata addresses, and returns an optional
+//! DNS pin so callers can bind the HTTP client to the validated address
+//! (preventing TOCTOU rebinding). Callers that follow redirects must
+//! re-invoke [`validate_fetch_target`] on every new Location.
+
+use crate::network_policy::{Decision, NetworkPolicyDecider};
+use crate::tools::spec::{ToolContext, ToolError};
+use std::net::IpAddr;
+
+/// DNS pin returned when a hostname was resolved to a validated public IP.
+/// Callers should pass this to `reqwest::ClientBuilder::resolve` so the
+/// connection uses the pre-validated address instead of re-resolving.
+pub(crate) type DnsPin = Option<(String, IpAddr)>;
+
+/// Check if an IP address is loopback, private, link-local, cloud-metadata,
+/// multicast, or reserved — all addresses that should not be reachable via
+/// an LLM-initiated fetch request (SSRF prevention).
+pub(crate) fn is_restricted_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_multicast()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                // 100.64.0.0/10 — Carrier-grade NAT (CGNAT / shared address space)
+                || matches!(v4.octets(), [100, 64..=127, ..])
+                // 169.254.169.254 — cloud metadata (AWS/GCP/Azure)
+                || *ip == IpAddr::V4(std::net::Ipv4Addr::new(169, 254, 169, 254))
+                // 198.18.0.0/15 — IETF benchmark testing
+                || matches!(v4.octets(), [198, 18..=19, ..])
+                // 240.0.0.0/4 — reserved (former Class E)
+                || v4.octets()[0] >= 240
+        }
+        IpAddr::V6(v6) => {
+            // IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) — unwrap and check as IPv4
+            // to prevent bypass via ::ffff:127.0.0.1 etc.
+            if v6.is_unspecified()
+                || matches!(v6.octets(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, ..])
+            {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_restricted_ip(&IpAddr::V4(v4));
+            }
+            v6.is_loopback()
+                || v6.is_multicast()
+                || matches!(v6.segments(), [0xfc00..=0xfdff, ..]) // ULA fc00::/7
+                || matches!(v6.segments(), [0xfe80..=0xfebf, ..]) // Link-local fe80::/10
+        }
+    }
+}
+
+/// Validate that `url` is a safe fetch target under SSRF and network policy.
+///
+/// On success returns an optional DNS pin `(hostname, ip)` for hostnames that
+/// were resolved; literal public IPs return `None` (no pin needed).
+///
+/// `tool` is the policy/audit label (e.g. `"fetch_url"`, `"web_run"`).
+pub(crate) async fn validate_fetch_target(
+    url: &reqwest::Url,
+    context: &ToolContext,
+    tool: &str,
+) -> Result<DnsPin, ToolError> {
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return Err(ToolError::invalid_input(
+            "only http:// and https:// URLs are supported",
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| ToolError::invalid_input("URL must include a host"))?;
+
+    validate_network_policy(&host, context, tool)?;
+
+    // SSRF protection: resolve hostname and reject private/link-local/loopback IPs.
+    // Prevents LLM-prompted requests to cloud metadata (169.254.169.254),
+    // localhost services, and internal networks.
+    if host == "localhost" || host == "localhost.localdomain" {
+        return Err(ToolError::permission_denied(
+            "requests to localhost are not allowed",
+        ));
+    }
+    // Normalize bracketed IPv6 literals before the literal-IP check so they
+    // route through the same restricted-IP policy as unbracketed forms
+    // (GHSA-88gh-2526-gfrr).
+    let ip_candidate = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host.as_str());
+    if let Ok(ip) = ip_candidate.parse::<IpAddr>() {
+        if is_restricted_ip(&ip) {
+            return Err(ToolError::permission_denied(format!(
+                "IP {ip} is a restricted address (private/loopback/link-local)"
+            )));
+        }
+        return Ok(None);
+    }
+
+    let addrs = tokio::net::lookup_host((host.as_str(), 0u16))
+        .await
+        .map_err(|e| {
+            ToolError::permission_denied(format!(
+                "could not resolve host before {tool} request: {e}"
+            ))
+        })?;
+    let mut first_valid: Option<IpAddr> = None;
+    for addr in addrs {
+        validate_dns_resolved_ip(&host, &addr.ip(), context.network_policy.as_ref(), tool)?;
+        if first_valid.is_none() {
+            first_valid = Some(addr.ip());
+        }
+    }
+
+    let Some(validated_ip) = first_valid else {
+        return Err(ToolError::permission_denied(format!(
+            "host resolved to no addresses before {tool} request"
+        )));
+    };
+    Ok(Some((host, validated_ip)))
+}
+
+pub(crate) fn validate_network_policy(
+    host: &str,
+    context: &ToolContext,
+    tool: &str,
+) -> Result<(), ToolError> {
+    let Some(decider) = context.network_policy.as_ref() else {
+        return Ok(());
+    };
+
+    match decider.evaluate(host, tool) {
+        Decision::Allow => Ok(()),
+        Decision::Deny => Err(ToolError::permission_denied(format!(
+            "network call to '{host}' blocked by network policy"
+        ))),
+        Decision::Prompt => Err(ToolError::permission_denied(format!(
+            "network call to '{host}' requires approval; \
+             re-run after `/network allow {host}` or set network.default = \"allow\" in config"
+        ))),
+    }
+}
+
+pub(crate) fn validate_dns_resolved_ip(
+    host: &str,
+    ip: &IpAddr,
+    decider: Option<&NetworkPolicyDecider>,
+    tool: &str,
+) -> Result<(), ToolError> {
+    if !is_restricted_ip(ip) {
+        return Ok(());
+    }
+
+    // Allow the resolved IP past the restricted-IP block if either:
+    //   * it falls inside a configured fake-IP placeholder range (a TUN /
+    //     transparent-proxy setup in `fake-ip` mode resolves every host into a
+    //     reserved range such as `198.18.0.0/15`), or
+    //   * the host is on the explicitly-trusted proxy list.
+    // Real private/loopback/link-local/metadata IPs match neither and stay blocked.
+    if let Some(decider) = decider
+        && (decider.is_trusted_fakeip_addr(ip) || decider.trusts_proxy_fakeip_host(host))
+    {
+        decider.record_trusted_proxy_fakeip_allow(host, tool);
+        return Ok(());
+    }
+
+    Err(ToolError::permission_denied(format!(
+        "resolved IP {ip} is a restricted address (private/loopback/link-local)"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::spec::ToolContext;
+    use std::path::PathBuf;
+
+    fn ctx() -> ToolContext {
+        ToolContext::new(PathBuf::from("."))
+    }
+
+    #[test]
+    fn rejects_private_localhost_literal() {
+        assert!(is_restricted_ip(&"127.0.0.1".parse().unwrap()));
+        assert!(is_restricted_ip(&"::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_private_rfc1918() {
+        assert!(is_restricted_ip(&"10.0.0.1".parse().unwrap()));
+        assert!(is_restricted_ip(&"172.16.0.1".parse().unwrap()));
+        assert!(is_restricted_ip(&"192.168.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_cloud_metadata() {
+        assert!(is_restricted_ip(&"169.254.169.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_link_local() {
+        assert!(is_restricted_ip(&"169.254.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_cgnat() {
+        assert!(is_restricted_ip(&"100.64.0.1".parse().unwrap()));
+        assert!(!is_restricted_ip(&"100.63.0.1".parse().unwrap()));
+        assert!(!is_restricted_ip(&"100.128.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_ipv6_ula() {
+        assert!(is_restricted_ip(&"fc00::1".parse().unwrap()));
+        assert!(is_restricted_ip(&"fd12:3456::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_ipv6() {
+        // ::ffff:127.0.0.1 — IPv4-mapped IPv6 loopback bypass
+        assert!(is_restricted_ip(&"::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_restricted_ip(&"::ffff:10.0.0.1".parse().unwrap()));
+        assert!(is_restricted_ip(&"::ffff:169.254.169.254".parse().unwrap()));
+        assert!(is_restricted_ip(&"::ffff:192.168.1.1".parse().unwrap()));
+        // :: (unspecified)
+        assert!(is_restricted_ip(&"::".parse().unwrap()));
+    }
+
+    #[test]
+    fn allows_public_ips() {
+        assert!(!is_restricted_ip(&"8.8.8.8".parse().unwrap()));
+        assert!(!is_restricted_ip(&"1.1.1.1".parse().unwrap()));
+        assert!(!is_restricted_ip(&"93.184.216.34".parse().unwrap()));
+        assert!(!is_restricted_ip(&"2606:4700::1".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn redirected_localhost_hostname_is_rejected() {
+        let url = reqwest::Url::parse("http://localhost:8080/admin").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("localhost"));
+    }
+
+    #[tokio::test]
+    async fn redirected_private_ip_literal_is_rejected() {
+        let url = reqwest::Url::parse("http://169.254.169.254/latest/meta-data").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("restricted address"));
+    }
+
+    // GHSA-88gh-2526-gfrr — regression coverage for bracketed IPv6 literals.
+    #[tokio::test]
+    async fn rejects_ipv6_literal_loopback() {
+        let url = reqwest::Url::parse("http://[::1]/").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .expect_err("[::1] must be rejected as restricted");
+        assert!(format!("{err}").contains("restricted"));
+    }
+
+    #[tokio::test]
+    async fn rejects_ipv6_literal_ula() {
+        let url = reqwest::Url::parse("http://[fc00::1]/").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .expect_err("[fc00::1] must be rejected as restricted");
+        assert!(format!("{err}").contains("restricted"));
+    }
+
+    #[tokio::test]
+    async fn rejects_ipv6_literal_link_local() {
+        let url = reqwest::Url::parse("http://[fe80::1]/").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .expect_err("[fe80::1] must be rejected as restricted");
+        assert!(format!("{err}").contains("restricted"));
+    }
+
+    #[tokio::test]
+    async fn rejects_ipv6_literal_ipv4_mapped_loopback() {
+        let url = reqwest::Url::parse("http://[::ffff:127.0.0.1]/").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .expect_err("[::ffff:127.0.0.1] must be rejected as restricted");
+        assert!(format!("{err}").contains("restricted"));
+    }
+
+    #[tokio::test]
+    async fn rejects_ipv6_literal_unspecified() {
+        let url = reqwest::Url::parse("http://[::]/").unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .expect_err("[::] must be rejected as restricted");
+        assert!(format!("{err}").contains("restricted"));
+    }
+
+    #[tokio::test]
+    async fn redirected_host_respects_network_policy() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+        let policy = NetworkPolicy {
+            default: Decision::Deny.into(),
+            allow: vec!["api.deepseek.com".to_string()],
+            deny: vec![],
+            proxy: Vec::new(),
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ctx = ToolContext::new(PathBuf::from(".")).with_network_policy(decider);
+        let url = reqwest::Url::parse("https://example.com/redirect-target").unwrap();
+        let err = validate_fetch_target(&url, &ctx, "fetch_url")
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("blocked"));
+    }
+
+    #[tokio::test]
+    async fn unresolved_hostname_is_rejected_before_request() {
+        let url =
+            reqwest::Url::parse("https://codewhale-unresolvable-fetch-target.invalid/resource")
+                .unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "fetch_url")
+            .await
+            .expect_err("unresolved host must fail preflight");
+        let message = format!("{err}");
+        assert!(
+            message.contains("could not resolve host") || message.contains("restricted address"),
+            "error must identify preflight DNS or restricted-IP failure; got {err}"
+        );
+    }
+
+    #[test]
+    fn restricted_dns_result_is_denied_without_proxy_opt_in() {
+        let ip = "198.18.0.1".parse().unwrap();
+
+        let err = validate_dns_resolved_ip("github.com", &ip, None, "fetch_url")
+            .expect_err("fake-IP DNS result must be denied by default");
+
+        assert!(format!("{err}").contains("resolved IP 198.18.0.1 is a restricted address"));
+    }
+
+    #[test]
+    fn proxy_opt_in_allows_restricted_dns_for_matching_host() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ip = "198.18.0.1".parse().unwrap();
+
+        validate_dns_resolved_ip("github.com", &ip, Some(&decider), "fetch_url")
+            .expect("proxy opt-in should allow fake-IP DNS for matching host");
+    }
+
+    #[test]
+    fn proxy_opt_in_does_not_allow_unlisted_host() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            audit: false,
+        };
+        let decider = NetworkPolicyDecider::new(policy, None);
+        let ip = "198.18.0.1".parse().unwrap();
+
+        let err = validate_dns_resolved_ip("example.com", &ip, Some(&decider), "fetch_url")
+            .expect_err("proxy opt-in must be scoped to configured hosts");
+
+        assert!(format!("{err}").contains("resolved IP 198.18.0.1 is a restricted address"));
+    }
+
+    #[test]
+    fn proxy_dns_allow_is_audited() {
+        use crate::network_policy::{
+            Decision, NetworkAuditor, NetworkPolicy, NetworkPolicyDecider,
+        };
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("tempdir");
+        let auditor = NetworkAuditor::new(dir.path().join("audit.log"), true);
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: vec!["github.com".to_string()],
+            audit: true,
+        };
+        let decider = NetworkPolicyDecider::new(policy, Some(auditor));
+        let ip = "198.18.0.1".parse().unwrap();
+
+        validate_dns_resolved_ip("github.com", &ip, Some(&decider), "fetch_url")
+            .expect("proxy DNS allow");
+
+        let body = std::fs::read_to_string(dir.path().join("audit.log")).expect("audit log");
+        assert!(body.contains("github.com"));
+        assert!(body.contains("TrustedProxyFakeIp-Allow"));
+    }
+
+    #[tokio::test]
+    async fn web_run_tool_label_is_used_in_dns_error() {
+        let url =
+            reqwest::Url::parse("https://codewhale-unresolvable-web-run-target.invalid/resource")
+                .unwrap();
+        let err = validate_fetch_target(&url, &ctx(), "web_run")
+            .await
+            .expect_err("unresolved host must fail preflight");
+        let message = format!("{err}");
+        // Either DNS failure (mentions web_run) or a restricted resolution.
+        assert!(
+            message.contains("web_run") || message.contains("restricted address"),
+            "error should be labeled for web_run or report restricted IP; got {err}"
+        );
+    }
+}

--- a/crates/tui/src/tools/web/mod.rs
+++ b/crates/tui/src/tools/web/mod.rs
@@ -1,3 +1,7 @@
-//! Shared web-tool helpers (SSRF guard, etc.).
+//! Shared web-tool helpers: the SSRF guard and the search scrapers.
+//!
+//! `fetch_url`, `web_search`, and `web.run` are thin surfaces over this
+//! module so security and parsing behavior cannot drift between tools.
 
 pub(crate) mod guard;
+pub mod scrape;

--- a/crates/tui/src/tools/web/mod.rs
+++ b/crates/tui/src/tools/web/mod.rs
@@ -1,0 +1,3 @@
+//! Shared web-tool helpers (SSRF guard, etc.).
+
+pub(crate) mod guard;

--- a/crates/tui/src/tools/web/scrape.rs
+++ b/crates/tui/src/tools/web/scrape.rs
@@ -1,0 +1,609 @@
+//! Shared DuckDuckGo / Bing HTML SERP scrapers and spam filter.
+//!
+//! Used by both `web_search` and `web_run` so parser behavior (including the
+//! #964 single-domain spam heuristic) cannot drift between the two paths.
+
+use base64::{Engine as _, engine::general_purpose};
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// One parsed search hit: title, absolute URL, optional snippet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScrapedSearchResult {
+    pub title: String,
+    pub url: String,
+    pub snippet: Option<String>,
+}
+
+// Cached regex patterns for HTML parsing
+static TITLE_RE: OnceLock<Regex> = OnceLock::new();
+static SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
+static TAG_RE: OnceLock<Regex> = OnceLock::new();
+static BING_RESULT_RE: OnceLock<Regex> = OnceLock::new();
+static BING_TITLE_RE: OnceLock<Regex> = OnceLock::new();
+static BING_SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
+
+fn get_title_re() -> &'static Regex {
+    TITLE_RE.get_or_init(|| {
+        Regex::new(r#"<a[^>]*class=\"result__a\"[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>"#)
+            .expect("title regex pattern is valid")
+    })
+}
+
+fn get_snippet_re() -> &'static Regex {
+    SNIPPET_RE.get_or_init(|| {
+        Regex::new(
+            r#"<a[^>]*class=\"result__snippet\"[^>]*>(.*?)</a>|<div[^>]*class=\"result__snippet\"[^>]*>(.*?)</div>"#,
+        )
+        .expect("snippet regex pattern is valid")
+    })
+}
+
+fn get_tag_re() -> &'static Regex {
+    TAG_RE.get_or_init(|| Regex::new(r"<[^>]+>").expect("tag regex pattern is valid"))
+}
+
+fn get_bing_result_re() -> &'static Regex {
+    BING_RESULT_RE.get_or_init(|| {
+        Regex::new(r#"(?is)<li[^>]*class=\"[^\"]*\bb_algo\b[^\"]*\"[^>]*>(.*?)</li>"#)
+            .expect("bing result regex pattern is valid")
+    })
+}
+
+fn get_bing_title_re() -> &'static Regex {
+    BING_TITLE_RE.get_or_init(|| {
+        Regex::new(r#"(?is)<h2[^>]*>.*?<a[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>"#)
+            .expect("bing title regex pattern is valid")
+    })
+}
+
+fn get_bing_snippet_re() -> &'static Regex {
+    BING_SNIPPET_RE.get_or_init(|| {
+        Regex::new(r#"(?is)<div[^>]*class=\"[^\"]*\bb_caption\b[^\"]*\"[^>]*>.*?<p[^>]*>(.*?)</p>"#)
+            .expect("bing snippet regex pattern is valid")
+    })
+}
+
+/// Parse DuckDuckGo HTML SERP results. Applies the spam filter unconditionally:
+/// a single-domain-dominated result set is returned as empty.
+pub fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<ScrapedSearchResult> {
+    let title_re = get_title_re();
+    let snippet_re = get_snippet_re();
+    let snippets: Vec<String> = snippet_re
+        .captures_iter(html)
+        .filter_map(|cap| cap.get(1).or_else(|| cap.get(2)))
+        .map(|m| normalize_text(m.as_str()))
+        .collect();
+
+    let mut results = Vec::new();
+    for (idx, cap) in title_re.captures_iter(html).enumerate() {
+        if results.len() >= max_results {
+            break;
+        }
+        let href = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let title_raw = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+        let title = normalize_text(title_raw);
+        if title.is_empty() {
+            continue;
+        }
+        let url = normalize_duckduckgo_url(href);
+        let snippet = snippets
+            .get(idx)
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
+
+        results.push(ScrapedSearchResult {
+            title,
+            url,
+            snippet,
+        });
+    }
+
+    if is_likely_spam_results(&results) {
+        // Same defence as the Bing path (#964): a DDG fallback page can
+        // also serve a single-domain stuffed result set when the upstream
+        // is degraded. Drop rather than mislead the model.
+        return Vec::new();
+    }
+    results
+}
+
+/// Parse Bing HTML SERP results. Applies the spam filter unconditionally.
+pub fn parse_bing_results(html: &str, max_results: usize) -> Vec<ScrapedSearchResult> {
+    let mut results = Vec::new();
+    for cap in get_bing_result_re().captures_iter(html) {
+        if results.len() >= max_results {
+            break;
+        }
+        let Some(block) = cap.get(1).map(|m| m.as_str()) else {
+            continue;
+        };
+        let Some(title_cap) = get_bing_title_re().captures(block) else {
+            continue;
+        };
+        let href = title_cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let title_raw = title_cap.get(2).map(|m| m.as_str()).unwrap_or("");
+        let title = normalize_text(title_raw);
+        if title.is_empty() {
+            continue;
+        }
+        let snippet = get_bing_snippet_re()
+            .captures(block)
+            .and_then(|snippet_cap| snippet_cap.get(1))
+            .map(|m| normalize_text(m.as_str()))
+            .filter(|s| !s.is_empty());
+
+        results.push(ScrapedSearchResult {
+            title,
+            url: normalize_bing_url(href),
+            snippet,
+        });
+    }
+
+    if is_likely_spam_results(&results) {
+        // Bing's scraping endpoint occasionally serves a stuffed page
+        // where the same low-quality domain owns most of the b_algo
+        // entries — #964 reported eight in a row from
+        // `astralia.forumgratuit.org` for unrelated queries. Treat the
+        // batch as "no results" so the caller surfaces a clean failure
+        // message instead of routing the model toward junk.
+        return Vec::new();
+    }
+    results
+}
+
+/// Detect DuckDuckGo bot-challenge interstitial HTML.
+pub fn is_duckduckgo_challenge(html: &str) -> bool {
+    html.contains("anomaly-modal") || html.contains("Unfortunately, bots use DuckDuckGo too")
+}
+
+/// Heuristic spam detector for scraped SERP HTML (#964).
+///
+/// Returns `true` when one root domain owns at least 60% of the result
+/// set and there are at least three results. A real-world top-five page
+/// from Google/Bing/DDG mixes domains; a result page dominated by one
+/// host is almost always SEO spam or a bot-detection-stuffed substitute.
+pub fn is_likely_spam_results(results: &[ScrapedSearchResult]) -> bool {
+    if results.len() < 3 {
+        return false;
+    }
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for r in results {
+        if let Some(host) = root_domain(&r.url) {
+            *counts.entry(host).or_insert(0) += 1;
+        }
+    }
+    let Some(&max) = counts.values().max() else {
+        return false;
+    };
+    // 60% threshold: 3-of-5, 4-of-6, 5-of-8 all trip; 2-of-5 doesn't.
+    max * 5 >= results.len() * 3
+}
+
+/// Extract the registrable root domain (eTLD+1 approximation) from a URL
+/// so spam detection groups `astralia.forumgratuit.org` with
+/// `russia.forumgratuit.org`. Returns lowercase host minus the leftmost
+/// label, or the bare host when there are only two labels.
+pub fn root_domain(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let host = after_scheme.split(['/', '?', '#']).next()?;
+    let host = host.split('@').next_back()?;
+    let host = host.split(':').next()?.to_ascii_lowercase();
+    if host.is_empty() {
+        return None;
+    }
+    let labels: Vec<&str> = host.split('.').filter(|s| !s.is_empty()).collect();
+    if labels.len() <= 2 {
+        return Some(host);
+    }
+    Some(labels[labels.len().saturating_sub(2)..].join("."))
+}
+
+fn normalize_duckduckgo_url(href: &str) -> String {
+    if let Some(uddg) = extract_query_param(href, "uddg") {
+        let decoded = percent_decode(&uddg);
+        if !decoded.is_empty() {
+            return decoded;
+        }
+    }
+    if href.starts_with("//") {
+        return format!("https:{href}");
+    }
+    if href.starts_with('/') {
+        return format!("https://duckduckgo.com{href}");
+    }
+    href.to_string()
+}
+
+/// Normalize a Bing SERP result href, unwrapping `/ck/a?...&u=<base64>` redirects.
+pub fn normalize_bing_url(href: &str) -> String {
+    // Bing wraps every SERP result URL in a `/ck/a?...&u=<base64>` click-tracking
+    // redirect, and in the raw HTML the separators are `&amp;` entities. Without
+    // decoding entities first, `extract_query_param` looks for `u` but the actual
+    // key is `amp;u`, so the real URL is never recovered: every result collapses to
+    // a `bing.com` root domain, which the spam heuristic then rejects — yielding
+    // zero results for the default Bing backend. Decode entities before parsing.
+    let href = decode_html_entities(href);
+    let href = href.as_str();
+    if let Some(encoded) = extract_query_param(href, "u") {
+        let decoded = percent_decode(&encoded);
+        let token = decoded.strip_prefix("a1").unwrap_or(&decoded);
+        let mut padded = token.replace('-', "+").replace('_', "/");
+        while !padded.len().is_multiple_of(4) {
+            padded.push('=');
+        }
+        if let Ok(bytes) = general_purpose::STANDARD.decode(padded)
+            && let Ok(url) = String::from_utf8(bytes)
+            && (url.starts_with("http://") || url.starts_with("https://"))
+        {
+            return url;
+        }
+    }
+    if href.starts_with("//") {
+        return format!("https:{href}");
+    }
+    if href.starts_with('/') {
+        return format!("https://www.bing.com{href}");
+    }
+    href.to_string()
+}
+
+fn normalize_text(text: &str) -> String {
+    let stripped = strip_html_tags(text);
+    let decoded = decode_html_entities(&stripped);
+    decoded.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_html_tags(text: &str) -> String {
+    get_tag_re().replace_all(text, "").to_string()
+}
+
+/// Decode common HTML named and numeric character references.
+pub fn decode_html_entities(text: &str) -> String {
+    static ENTITY_RE: OnceLock<Regex> = OnceLock::new();
+    let re = ENTITY_RE.get_or_init(|| {
+        Regex::new(r"&(?:#(\d+)|#x([0-9A-Fa-f]+)|([a-zA-Z]+));").expect("HTML entity regex")
+    });
+
+    re.replace_all(text, |caps: &regex::Captures| {
+        if let Some(dec) = caps.get(1) {
+            return dec
+                .as_str()
+                .parse::<u32>()
+                .ok()
+                .and_then(std::char::from_u32)
+                .unwrap_or('\u{FFFD}')
+                .to_string();
+        }
+        if let Some(hex) = caps.get(2) {
+            return u32::from_str_radix(hex.as_str(), 16)
+                .ok()
+                .and_then(std::char::from_u32)
+                .unwrap_or('\u{FFFD}')
+                .to_string();
+        }
+        let named = caps.get(3).map(|m| m.as_str());
+        match named {
+            Some("amp") => "&",
+            Some("lt") => "<",
+            Some("gt") => ">",
+            Some("quot") => "\"",
+            Some("apos") => "'",
+            Some("nbsp") => " ",
+            Some("copy") => "\u{00A9}",
+            Some("reg") => "\u{00AE}",
+            Some("mdash") => "\u{2014}",
+            Some("ndash") => "\u{2013}",
+            Some("lsquo") => "\u{2018}",
+            Some("rsquo") => "\u{2019}",
+            Some("ldquo") => "\u{201C}",
+            Some("rdquo") => "\u{201D}",
+            Some("hellip") => "\u{2026}",
+            _ => return caps.get(0).map(|m| m.as_str()).unwrap_or("").to_string(),
+        }
+        .to_string()
+    })
+    .to_string()
+}
+
+/// Percent-decode a URL component. `+` becomes space (query-string convention).
+pub fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                let hex = &input[i + 1..i + 3];
+                if let Ok(val) = u8::from_str_radix(hex, 16) {
+                    out.push(val);
+                    i += 3;
+                    continue;
+                }
+                out.push(bytes[i]);
+            }
+            b'+' => out.push(b' '),
+            _ => out.push(bytes[i]),
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).to_string()
+}
+
+fn extract_query_param(url: &str, key: &str) -> Option<String> {
+    let query = url.split_once('?')?.1;
+    for part in query.split('&') {
+        let mut iter = part.splitn(2, '=');
+        let name = iter.next().unwrap_or("");
+        if name == key {
+            return iter.next().map(str::to_string);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(url: &str) -> ScrapedSearchResult {
+        ScrapedSearchResult {
+            title: "x".into(),
+            url: url.into(),
+            snippet: None,
+        }
+    }
+
+    // Regression guard: Bing /ck/a redirect hrefs are HTML-entity-encoded
+    // (`&amp;`). normalize_bing_url must decode entities before extracting the
+    // `u=` base64 payload, otherwise the real URL is never recovered and the
+    // result's root domain collapses to bing.com (then dropped as spam → 0
+    // results for the default Bing backend).
+    #[test]
+    fn bing_ckurl_with_html_entities_decodes_real_url() {
+        let href = "https://www.bing.com/ck/a?!&amp;&amp;p=abc&amp;u=a1aHR0cHM6Ly9ydXN0LWxhbmcub3JnLw&amp;ntb=1";
+        assert_eq!(normalize_bing_url(href), "https://rust-lang.org/");
+    }
+
+    #[test]
+    fn parses_bing_results_and_decodes_redirect_url() {
+        let html = r#"
+            <ol>
+              <li class="b_algo">
+                <h2><a href="https://www.bing.com/ck/a?u=a1aHR0cHM6Ly9leGFtcGxlLmNvbS9wYXRoP3E9MQ">Example &amp; Result</a></h2>
+                <div class="b_caption"><p>A <strong>useful</strong> snippet.</p></div>
+              </li>
+            </ol>
+        "#;
+
+        let results = parse_bing_results(html, 5);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Example & Result");
+        assert_eq!(results[0].url, "https://example.com/path?q=1");
+        assert_eq!(results[0].snippet.as_deref(), Some("A useful snippet."));
+    }
+
+    #[test]
+    fn parses_duckduckgo_results() {
+        let html = r#"
+            <a class="result__a" href="https://example.com/rust">Rust &amp; async</a>
+            <a class="result__snippet">A <b>useful</b> snippet.</a>
+            <a class="result__a" href="//docs.rs/tokio">Tokio</a>
+            <div class="result__snippet">Runtime docs</div>
+        "#;
+        let results = parse_duckduckgo_results(html, 5);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Rust & async");
+        assert_eq!(results[0].url, "https://example.com/rust");
+        assert_eq!(results[0].snippet.as_deref(), Some("A useful snippet."));
+        assert_eq!(results[1].url, "https://docs.rs/tokio");
+    }
+
+    #[test]
+    fn root_domain_strips_subdomain_keeps_two_labels() {
+        assert_eq!(
+            root_domain("https://astralia.forumgratuit.org/path/page").as_deref(),
+            Some("forumgratuit.org"),
+        );
+        assert_eq!(
+            root_domain("http://www.example.com/").as_deref(),
+            Some("example.com"),
+        );
+        assert_eq!(
+            root_domain("https://example.com").as_deref(),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn root_domain_handles_port_and_userinfo() {
+        assert_eq!(
+            root_domain("http://user:pass@blog.example.com:8080/x").as_deref(),
+            Some("example.com"),
+        );
+    }
+
+    #[test]
+    fn root_domain_returns_none_for_garbage() {
+        assert!(
+            root_domain("not-a-url").as_deref().is_some(),
+            "bare token is treated as host"
+        );
+        assert!(root_domain("https:///path").is_none());
+    }
+
+    #[test]
+    fn spam_detector_flags_single_domain_dominance() {
+        // #964 reproduction: 5/5 results from the same low-quality host.
+        let r = vec![
+            entry("https://astralia.forumgratuit.org/page1"),
+            entry("https://russia.forumgratuit.org/page2"),
+            entry("https://other.forumgratuit.org/page3"),
+            entry("https://hello.forumgratuit.org/page4"),
+            entry("https://world.forumgratuit.org/page5"),
+        ];
+        assert!(is_likely_spam_results(&r));
+    }
+
+    #[test]
+    fn spam_detector_passes_diverse_serp() {
+        // A normal SERP mixes domains; nothing flagged.
+        let r = vec![
+            entry("https://example.com/a"),
+            entry("https://wikipedia.org/b"),
+            entry("https://stackoverflow.com/c"),
+            entry("https://reddit.com/d"),
+            entry("https://example.com/e"),
+        ];
+        assert!(!is_likely_spam_results(&r));
+    }
+
+    #[test]
+    fn spam_detector_passes_short_result_set() {
+        // Two results from the same domain isn't enough signal — false
+        // positives on legitimate two-link answers (docs + homepage)
+        // would hurt more than letting them through.
+        let r = vec![
+            entry("https://example.com/a"),
+            entry("https://example.com/b"),
+        ];
+        assert!(!is_likely_spam_results(&r));
+    }
+
+    #[test]
+    fn spam_detector_threshold_is_sixty_percent() {
+        // 3-of-5 same domain trips the 60% threshold.
+        let r3of5 = vec![
+            entry("https://spam.example.com/a"),
+            entry("https://spam.example.com/b"),
+            entry("https://spam.example.com/c"),
+            entry("https://other.com/d"),
+            entry("https://third.com/e"),
+        ];
+        assert!(is_likely_spam_results(&r3of5));
+        // 2-of-5 does NOT trip the threshold.
+        let r2of5 = vec![
+            entry("https://spam.example.com/a"),
+            entry("https://spam.example.com/b"),
+            entry("https://other.com/c"),
+            entry("https://third.com/d"),
+            entry("https://fourth.com/e"),
+        ];
+        assert!(!is_likely_spam_results(&r2of5));
+    }
+
+    #[test]
+    fn parse_duckduckgo_filters_spam_domain_dominance() {
+        // Shared path used by web_run and web_search: spam SERP → empty.
+        let html = r#"
+            <a class="result__a" href="https://astralia.forumgratuit.org/a">A</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://russia.forumgratuit.org/b">B</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://other.forumgratuit.org/c">C</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://hello.forumgratuit.org/d">D</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://world.forumgratuit.org/e">E</a>
+            <a class="result__snippet">s</a>
+        "#;
+        assert!(parse_duckduckgo_results(html, 10).is_empty());
+    }
+
+    #[test]
+    fn parse_bing_filters_spam_domain_dominance() {
+        let html = r#"
+            <ol>
+              <li class="b_algo">
+                <h2><a href="https://astralia.forumgratuit.org/a">A</a></h2>
+                <div class="b_caption"><p>s</p></div>
+              </li>
+              <li class="b_algo">
+                <h2><a href="https://russia.forumgratuit.org/b">B</a></h2>
+                <div class="b_caption"><p>s</p></div>
+              </li>
+              <li class="b_algo">
+                <h2><a href="https://other.forumgratuit.org/c">C</a></h2>
+                <div class="b_caption"><p>s</p></div>
+              </li>
+              <li class="b_algo">
+                <h2><a href="https://hello.forumgratuit.org/d">D</a></h2>
+                <div class="b_caption"><p>s</p></div>
+              </li>
+              <li class="b_algo">
+                <h2><a href="https://world.forumgratuit.org/e">E</a></h2>
+                <div class="b_caption"><p>s</p></div>
+              </li>
+            </ol>
+        "#;
+        assert!(parse_bing_results(html, 10).is_empty());
+    }
+
+    #[test]
+    fn decode_html_entities_handles_named_entities() {
+        assert_eq!(decode_html_entities("&amp;"), "&");
+        assert_eq!(decode_html_entities("&lt;"), "<");
+        assert_eq!(decode_html_entities("&gt;"), ">");
+        assert_eq!(decode_html_entities("&quot;"), "\"");
+        assert_eq!(decode_html_entities("&apos;"), "'");
+        assert_eq!(decode_html_entities("&nbsp;"), " ");
+        assert_eq!(decode_html_entities("&copy;"), "\u{00A9}");
+        assert_eq!(decode_html_entities("&mdash;"), "\u{2014}");
+    }
+
+    #[test]
+    fn decode_html_entities_handles_decimal_numeric_references() {
+        assert_eq!(decode_html_entities("&#65;"), "A");
+        assert_eq!(decode_html_entities("&#60;"), "<");
+        assert_eq!(decode_html_entities("&#8211;"), "\u{2013}");
+    }
+
+    #[test]
+    fn decode_html_entities_handles_hex_numeric_references() {
+        assert_eq!(decode_html_entities("&#x41;"), "A");
+        assert_eq!(decode_html_entities("&#x3C;"), "<");
+        assert_eq!(decode_html_entities("&#x2014;"), "\u{2014}");
+    }
+
+    #[test]
+    fn decode_html_entities_passthrough_unknown() {
+        assert_eq!(decode_html_entities("&unknown;"), "&unknown;");
+    }
+
+    #[test]
+    fn decode_html_entities_mixed_content() {
+        let input = "Hello &amp; welcome to &quot;Rust&apos;s world&quot; &mdash; enjoy!";
+        let expected = "Hello & welcome to \"Rust's world\" \u{2014} enjoy!";
+        assert_eq!(decode_html_entities(input), expected);
+    }
+
+    #[test]
+    fn percent_decode_handles_utf8_multibyte_sequences() {
+        // Percent-encoded CJK: %E4%B8%AA%E4%BA%BA = 个人 (each glyph is 3 UTF-8 bytes).
+        assert_eq!(percent_decode("Hello %E4%B8%AA%E4%BA%BA"), "Hello 个人");
+        assert_eq!(percent_decode("%E7%B4%A0%E6%9D%90"), "素材");
+        // Percent-encoded UTF-8 inside a URL path (DuckDuckGo `uddg=` redirect shape).
+        assert_eq!(
+            percent_decode("https://example.com/%E9%A1%B5%E9%9D%A2"),
+            "https://example.com/页面"
+        );
+        // Raw UTF-8 in the input passes through unchanged.
+        assert_eq!(percent_decode("查询 keyword"), "查询 keyword");
+        // Query-string convention: `+` becomes space; `%20` becomes space.
+        assert_eq!(percent_decode("foo+bar%20baz"), "foo bar baz");
+    }
+
+    #[test]
+    fn is_duckduckgo_challenge_detects_interstitial() {
+        assert!(is_duckduckgo_challenge(
+            "Unfortunately, bots use DuckDuckGo too."
+        ));
+        assert!(is_duckduckgo_challenge(
+            r#"<div class="anomaly-modal">challenge</div>"#
+        ));
+        assert!(!is_duckduckgo_challenge(
+            r#"<a class="result__a" href="https://example.com">ok</a>"#
+        ));
+    }
+}

--- a/crates/tui/src/tools/web/scrape.rs
+++ b/crates/tui/src/tools/web/scrape.rs
@@ -1,7 +1,7 @@
 //! Shared DuckDuckGo / Bing HTML SERP scrapers and spam filter.
 //!
 //! Used by both `web_search` and `web_run` so parser behavior (including the
-//! #964 single-domain spam heuristic) cannot drift between the two paths.
+//! #964 evidence-based spam filter) cannot drift between the two paths.
 
 use base64::{Engine as _, engine::general_purpose};
 use regex::Regex;
@@ -64,8 +64,7 @@ fn get_bing_snippet_re() -> &'static Regex {
     })
 }
 
-/// Parse DuckDuckGo HTML SERP results. Applies the spam filter unconditionally:
-/// a single-domain-dominated result set is returned as empty.
+/// Parse DuckDuckGo HTML SERP results. Known spam-domain hits are omitted.
 pub fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<ScrapedSearchResult> {
     let title_re = get_title_re();
     let snippet_re = get_snippet_re();
@@ -87,6 +86,9 @@ pub fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<ScrapedSe
             continue;
         }
         let url = normalize_duckduckgo_url(href);
+        if is_known_spam_url(&url) {
+            continue;
+        }
         let snippet = snippets
             .get(idx)
             .map(|s| s.to_string())
@@ -99,16 +101,10 @@ pub fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<ScrapedSe
         });
     }
 
-    if is_likely_spam_results(&results) {
-        // Same defence as the Bing path (#964): a DDG fallback page can
-        // also serve a single-domain stuffed result set when the upstream
-        // is degraded. Drop rather than mislead the model.
-        return Vec::new();
-    }
     results
 }
 
-/// Parse Bing HTML SERP results. Applies the spam filter unconditionally.
+/// Parse Bing HTML SERP results. Known spam-domain hits are omitted.
 pub fn parse_bing_results(html: &str, max_results: usize) -> Vec<ScrapedSearchResult> {
     let mut results = Vec::new();
     for cap in get_bing_result_re().captures_iter(html) {
@@ -133,21 +129,15 @@ pub fn parse_bing_results(html: &str, max_results: usize) -> Vec<ScrapedSearchRe
             .map(|m| normalize_text(m.as_str()))
             .filter(|s| !s.is_empty());
 
+        let url = normalize_bing_url(href);
+        if is_known_spam_url(&url) {
+            continue;
+        }
         results.push(ScrapedSearchResult {
             title,
-            url: normalize_bing_url(href),
+            url,
             snippet,
         });
-    }
-
-    if is_likely_spam_results(&results) {
-        // Bing's scraping endpoint occasionally serves a stuffed page
-        // where the same low-quality domain owns most of the b_algo
-        // entries — #964 reported eight in a row from
-        // `astralia.forumgratuit.org` for unrelated queries. Treat the
-        // batch as "no results" so the caller surfaces a clean failure
-        // message instead of routing the model toward junk.
-        return Vec::new();
     }
     results
 }
@@ -157,46 +147,21 @@ pub fn is_duckduckgo_challenge(html: &str) -> bool {
     html.contains("anomaly-modal") || html.contains("Unfortunately, bots use DuckDuckGo too")
 }
 
-/// Heuristic spam detector for scraped SERP HTML (#964).
-///
-/// Returns `true` when one root domain owns at least 60% of the result
-/// set and there are at least three results. A real-world top-five page
-/// from Google/Bing/DDG mixes domains; a result page dominated by one
-/// host is almost always SEO spam or a bot-detection-stuffed substitute.
-pub fn is_likely_spam_results(results: &[ScrapedSearchResult]) -> bool {
-    if results.len() < 3 {
-        return false;
-    }
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for r in results {
-        if let Some(host) = root_domain(&r.url) {
-            *counts.entry(host).or_insert(0) += 1;
-        }
-    }
-    let Some(&max) = counts.values().max() else {
+/// Evidence-based filter for the domain family in #964. A broad same-domain
+/// ratio is not a spam signal: site-scoped searches and documentation hosts
+/// legitimately return many results from one registrable domain.
+fn is_known_spam_url(url: &str) -> bool {
+    const KNOWN_SPAM_DOMAINS: &[&str] = &["forumgratuit.org"];
+
+    let Ok(parsed) = reqwest::Url::parse(url) else {
         return false;
     };
-    // 60% threshold: 3-of-5, 4-of-6, 5-of-8 all trip; 2-of-5 doesn't.
-    max * 5 >= results.len() * 3
-}
-
-/// Extract the registrable root domain (eTLD+1 approximation) from a URL
-/// so spam detection groups `astralia.forumgratuit.org` with
-/// `russia.forumgratuit.org`. Returns lowercase host minus the leftmost
-/// label, or the bare host when there are only two labels.
-pub fn root_domain(url: &str) -> Option<String> {
-    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
-    let host = after_scheme.split(['/', '?', '#']).next()?;
-    let host = host.split('@').next_back()?;
-    let host = host.split(':').next()?.to_ascii_lowercase();
-    if host.is_empty() {
-        return None;
-    }
-    let labels: Vec<&str> = host.split('.').filter(|s| !s.is_empty()).collect();
-    if labels.len() <= 2 {
-        return Some(host);
-    }
-    Some(labels[labels.len().saturating_sub(2)..].join("."))
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    KNOWN_SPAM_DOMAINS
+        .iter()
+        .any(|domain| host == *domain || host.ends_with(&format!(".{domain}")))
 }
 
 fn normalize_duckduckgo_url(href: &str) -> String {
@@ -220,9 +185,8 @@ pub fn normalize_bing_url(href: &str) -> String {
     // Bing wraps every SERP result URL in a `/ck/a?...&u=<base64>` click-tracking
     // redirect, and in the raw HTML the separators are `&amp;` entities. Without
     // decoding entities first, `extract_query_param` looks for `u` but the actual
-    // key is `amp;u`, so the real URL is never recovered: every result collapses to
-    // a `bing.com` root domain, which the spam heuristic then rejects — yielding
-    // zero results for the default Bing backend. Decode entities before parsing.
+    // key is `amp;u`, so the real URL is never recovered and callers receive Bing's
+    // tracking URL instead of the cited source. Decode entities before parsing.
     let href = decode_html_entities(href);
     let href = href.as_str();
     if let Some(encoded) = extract_query_param(href, "u") {
@@ -346,19 +310,10 @@ fn extract_query_param(url: &str, key: &str) -> Option<String> {
 mod tests {
     use super::*;
 
-    fn entry(url: &str) -> ScrapedSearchResult {
-        ScrapedSearchResult {
-            title: "x".into(),
-            url: url.into(),
-            snippet: None,
-        }
-    }
-
     // Regression guard: Bing /ck/a redirect hrefs are HTML-entity-encoded
     // (`&amp;`). normalize_bing_url must decode entities before extracting the
     // `u=` base64 payload, otherwise the real URL is never recovered and the
-    // result's root domain collapses to bing.com (then dropped as spam → 0
-    // results for the default Bing backend).
+    // result remains a Bing tracking URL instead of the cited source.
     #[test]
     fn bing_ckurl_with_html_entities_decodes_real_url() {
         let href = "https://www.bing.com/ck/a?!&amp;&amp;p=abc&amp;u=a1aHR0cHM6Ly9ydXN0LWxhbmcub3JnLw&amp;ntb=1";
@@ -401,101 +356,60 @@ mod tests {
     }
 
     #[test]
-    fn root_domain_strips_subdomain_keeps_two_labels() {
-        assert_eq!(
-            root_domain("https://astralia.forumgratuit.org/path/page").as_deref(),
-            Some("forumgratuit.org"),
-        );
-        assert_eq!(
-            root_domain("http://www.example.com/").as_deref(),
-            Some("example.com"),
-        );
-        assert_eq!(
-            root_domain("https://example.com").as_deref(),
-            Some("example.com")
-        );
+    fn known_spam_filter_is_domain_specific() {
+        assert!(is_known_spam_url("https://astralia.forumgratuit.org/page1"));
+        assert!(!is_known_spam_url("https://forumgratuit.org.example/a"));
+        assert!(!is_known_spam_url("https://docs.example.com/a"));
     }
 
     #[test]
-    fn root_domain_handles_port_and_userinfo() {
-        assert_eq!(
-            root_domain("http://user:pass@blog.example.com:8080/x").as_deref(),
-            Some("example.com"),
-        );
+    fn legitimate_same_domain_results_are_preserved() {
+        let html = r#"
+            <a class="result__a" href="https://docs.example.com/a">A</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.com/b">B</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.com/c">C</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.com/d">D</a>
+            <a class="result__snippet">s</a>
+        "#;
+        assert_eq!(parse_duckduckgo_results(html, 10).len(), 4);
     }
 
     #[test]
-    fn root_domain_returns_none_for_garbage() {
-        assert!(
-            root_domain("not-a-url").as_deref().is_some(),
-            "bare token is treated as host"
-        );
-        assert!(root_domain("https:///path").is_none());
+    fn public_suffix_and_private_suffix_hosts_are_not_misgrouped() {
+        let html = r#"
+            <a class="result__a" href="https://alpha.example.co.uk/a">A</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://beta.example.co.uk/b">B</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://alice.github.io/c">C</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://bob.github.io/d">D</a>
+            <a class="result__snippet">s</a>
+        "#;
+        assert_eq!(parse_duckduckgo_results(html, 10).len(), 4);
     }
 
     #[test]
-    fn spam_detector_flags_single_domain_dominance() {
-        // #964 reproduction: 5/5 results from the same low-quality host.
-        let r = vec![
-            entry("https://astralia.forumgratuit.org/page1"),
-            entry("https://russia.forumgratuit.org/page2"),
-            entry("https://other.forumgratuit.org/page3"),
-            entry("https://hello.forumgratuit.org/page4"),
-            entry("https://world.forumgratuit.org/page5"),
-        ];
-        assert!(is_likely_spam_results(&r));
+    fn max_results_three_keeps_legitimate_same_domain_results() {
+        let html = r#"
+            <a class="result__a" href="https://docs.example.com/a">A</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.com/b">B</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.com/c">C</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.com/d">D</a>
+            <a class="result__snippet">s</a>
+        "#;
+        assert_eq!(parse_duckduckgo_results(html, 3).len(), 3);
     }
 
     #[test]
-    fn spam_detector_passes_diverse_serp() {
-        // A normal SERP mixes domains; nothing flagged.
-        let r = vec![
-            entry("https://example.com/a"),
-            entry("https://wikipedia.org/b"),
-            entry("https://stackoverflow.com/c"),
-            entry("https://reddit.com/d"),
-            entry("https://example.com/e"),
-        ];
-        assert!(!is_likely_spam_results(&r));
-    }
-
-    #[test]
-    fn spam_detector_passes_short_result_set() {
-        // Two results from the same domain isn't enough signal — false
-        // positives on legitimate two-link answers (docs + homepage)
-        // would hurt more than letting them through.
-        let r = vec![
-            entry("https://example.com/a"),
-            entry("https://example.com/b"),
-        ];
-        assert!(!is_likely_spam_results(&r));
-    }
-
-    #[test]
-    fn spam_detector_threshold_is_sixty_percent() {
-        // 3-of-5 same domain trips the 60% threshold.
-        let r3of5 = vec![
-            entry("https://spam.example.com/a"),
-            entry("https://spam.example.com/b"),
-            entry("https://spam.example.com/c"),
-            entry("https://other.com/d"),
-            entry("https://third.com/e"),
-        ];
-        assert!(is_likely_spam_results(&r3of5));
-        // 2-of-5 does NOT trip the threshold.
-        let r2of5 = vec![
-            entry("https://spam.example.com/a"),
-            entry("https://spam.example.com/b"),
-            entry("https://other.com/c"),
-            entry("https://third.com/d"),
-            entry("https://fourth.com/e"),
-        ];
-        assert!(!is_likely_spam_results(&r2of5));
-    }
-
-    #[test]
-    fn parse_duckduckgo_filters_spam_domain_dominance() {
-        // Shared path used by web_run and web_search: spam SERP → empty.
+    fn parse_duckduckgo_filters_known_spam_domain() {
+        // Shared path used by web_run and web_search: known spam → empty.
         let html = r#"
             <a class="result__a" href="https://astralia.forumgratuit.org/a">A</a>
             <a class="result__snippet">s</a>
@@ -512,7 +426,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_bing_filters_spam_domain_dominance() {
+    fn parse_bing_filters_known_spam_domain() {
         let html = r#"
             <ol>
               <li class="b_algo">

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -7,7 +7,7 @@ use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_u64, required_str,
 };
-use super::web::guard::validate_fetch_target;
+use super::web::guard::{DnsPin, guarded_reqwest_client_builder, validate_fetch_target};
 use async_trait::async_trait;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -600,7 +600,7 @@ impl ToolSpec for WebRunTool {
                 if link_id == 0 {
                     return Err(ToolError::invalid_input("click.id must be >= 1"));
                 }
-                let page = get_page(&ref_id).ok_or_else(|| {
+                let page = get_page(&context.state_namespace, &ref_id).ok_or_else(|| {
                     ToolError::invalid_input(format!("Unknown ref_id '{ref_id}'"))
                 })?;
                 let link = page.links.iter().find(|l| l.id == link_id).ok_or_else(|| {
@@ -627,7 +627,7 @@ impl ToolSpec for WebRunTool {
             for find_req in find_requests {
                 let ref_id = required_str(find_req, "ref_id")?.to_string();
                 let pattern = required_str(find_req, "pattern")?.to_string();
-                let page = get_page(&ref_id).ok_or_else(|| {
+                let page = get_page(&context.state_namespace, &ref_id).ok_or_else(|| {
                     ToolError::invalid_input(format!("Unknown ref_id '{ref_id}'"))
                 })?;
                 let find_result = find_in_page(&ref_id, &pattern, &page, response_length);
@@ -643,7 +643,7 @@ impl ToolSpec for WebRunTool {
             for shot in shots {
                 let ref_id = required_str(shot, "ref_id")?.to_string();
                 let pageno = optional_u64(shot, "pageno", 0) as usize;
-                let page = get_page(&ref_id).ok_or_else(|| {
+                let page = get_page(&context.state_namespace, &ref_id).ok_or_else(|| {
                     ToolError::invalid_input(format!("Unknown ref_id '{ref_id}'"))
                 })?;
                 let screenshot = screenshot_page(&ref_id, pageno, &page)?;
@@ -727,15 +727,18 @@ fn store_page(namespace: &str, ref_id: &str, page: WebPage) {
     });
 }
 
-fn get_page(ref_id: &str) -> Option<Arc<WebPage>> {
+fn get_page(namespace: &str, ref_id: &str) -> Option<Arc<WebPage>> {
     let cache = WEB_RUN_STATE.get_or_init(WebRunCache::default);
     let stored = {
         let pages = cache.pages.read();
         pages.get(ref_id).cloned()
     }?;
+    if stored.namespace != namespace {
+        return None;
+    }
     {
         let mut sessions = cache.sessions.write();
-        if let Some(session) = sessions.get_mut(&stored.namespace) {
+        if let Some(session) = sessions.get_mut(namespace) {
             session.last_access = Instant::now();
         }
     }
@@ -759,7 +762,7 @@ async fn resolve_or_fetch_page(
     timeout_ms: u64,
     context: &ToolContext,
 ) -> Result<Arc<WebPage>, ToolError> {
-    if let Some(page) = get_page(ref_id) {
+    if let Some(page) = get_page(&context.state_namespace, ref_id) {
         return Ok(page);
     }
     if looks_like_url(ref_id) {
@@ -1112,13 +1115,29 @@ async fn fetch_page(
     timeout_ms: u64,
     context: &ToolContext,
 ) -> Result<WebPage, ToolError> {
+    fetch_page_with_initial_pin(url, timeout_ms, context, None).await
+}
+
+async fn fetch_page_with_initial_pin(
+    url: &str,
+    timeout_ms: u64,
+    context: &ToolContext,
+    mut initial_pin: Option<DnsPin>,
+) -> Result<WebPage, ToolError> {
     let mut current_url = reqwest::Url::parse(url)
         .map_err(|e| ToolError::invalid_input(format!("invalid URL: {e}")))?;
     let mut redirects_followed = 0usize;
 
     let resp = loop {
-        let dns_pinning = validate_fetch_target(&current_url, context, "web_run").await?;
-        let mut client_builder = crate::tls::reqwest_client_builder()
+        let dns_pinning = if redirects_followed == 0 {
+            match initial_pin.take() {
+                Some(pin) => pin,
+                None => validate_fetch_target(&current_url, context, "web_run").await?,
+            }
+        } else {
+            validate_fetch_target(&current_url, context, "web_run").await?
+        };
+        let mut client_builder = guarded_reqwest_client_builder()
             .timeout(Duration::from_millis(timeout_ms))
             .user_agent(USER_AGENT)
             .redirect(reqwest::redirect::Policy::none());
@@ -1607,6 +1626,16 @@ mod tests {
         }
     }
 
+    fn sample_page_with_link(url: &str, target: &str) -> WebPage {
+        let mut page = sample_page(url);
+        page.links.push(WebLink {
+            id: 1,
+            url: target.to_string(),
+            text: "target".to_string(),
+        });
+        page
+    }
+
     #[test]
     fn html_link_parsing_extracts_links() {
         let html = r#"
@@ -1671,8 +1700,7 @@ mod tests {
 
     #[test]
     fn web_run_search_path_filters_known_spam_domain() {
-        // Intended behavior change vs pre-unify web_run: spam filter applies
-        // unconditionally on the shared scraper used by web_run (#964).
+        // The shared scraper used by web_run filters the known #964 spam family.
         let html = r#"
             <a class="result__a" href="https://astralia.forumgratuit.org/a">A</a>
             <a class="result__snippet">spam</a>
@@ -1688,7 +1716,31 @@ mod tests {
         let results = parse_duckduckgo_results(html, 10);
         assert!(
             results.is_empty(),
-            "web_run path must drop single-domain spam SERPs via shared scraper"
+            "web_run path must drop the known spam family via the shared scraper"
+        );
+    }
+
+    #[test]
+    fn domain_scoped_fixture_preserves_legitimate_same_site_results() {
+        let html = r#"
+            <a class="result__a" href="https://docs.example.co.uk/a">A</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.co.uk/b">B</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://docs.example.co.uk/c">C</a>
+            <a class="result__snippet">s</a>
+            <a class="result__a" href="https://other.example/d">D</a>
+            <a class="result__snippet">s</a>
+        "#;
+        let domains = vec!["docs.example.co.uk".to_string()];
+        let mut results = parse_duckduckgo_results(html, 10);
+        results.retain(|entry| domain_matches(&entry.url, &domains));
+
+        assert_eq!(results.len(), 3);
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry.url.contains("docs.example.co.uk"))
         );
     }
 
@@ -1731,8 +1783,75 @@ mod tests {
             sample_page("https://example.com/alpha"),
         );
 
-        assert!(get_page(&ref_alpha).is_some());
-        assert!(get_page(&ref_beta).is_none());
+        assert!(get_page("session-alpha", &ref_alpha).is_some());
+        assert!(get_page("session-beta", &ref_alpha).is_none());
+        assert!(get_page("session-beta", &ref_beta).is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_open_rejects_exact_foreign_session_ref() {
+        let _lock = lock_web_run_test_state();
+        reset_web_run_state();
+        let ref_id = format!("{}turn0search1", scoped_ref_prefix("foreign-open-owner"));
+        store_page(
+            "foreign-open-owner",
+            &ref_id,
+            sample_page("https://example.com/private-session-page"),
+        );
+        let context =
+            ToolContext::new(PathBuf::from(".")).with_state_namespace("foreign-open-caller");
+
+        let err = WebRunTool
+            .execute(json!({"open": [{"ref_id": ref_id}]}), &context)
+            .await
+            .expect_err("foreign exact ref must not open");
+
+        assert!(format!("{err}").contains("Unknown ref_id"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_click_rejects_exact_foreign_session_ref() {
+        let _lock = lock_web_run_test_state();
+        reset_web_run_state();
+        let ref_id = format!("{}turn0search1", scoped_ref_prefix("foreign-click-owner"));
+        store_page(
+            "foreign-click-owner",
+            &ref_id,
+            sample_page_with_link(
+                "https://example.com/private-session-page",
+                "https://example.com/target",
+            ),
+        );
+        let context =
+            ToolContext::new(PathBuf::from(".")).with_state_namespace("foreign-click-caller");
+
+        let err = WebRunTool
+            .execute(json!({"click": [{"ref_id": ref_id, "id": 1}]}), &context)
+            .await
+            .expect_err("foreign exact ref must not be clickable");
+
+        assert!(format!("{err}").contains("Unknown ref_id"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_click_routes_target_through_shared_ssrf_guard() {
+        let _lock = lock_web_run_test_state();
+        reset_web_run_state();
+        let namespace = "guarded-click-session";
+        let ref_id = format!("{}turn0search1", scoped_ref_prefix(namespace));
+        store_page(
+            namespace,
+            &ref_id,
+            sample_page_with_link("https://example.com/source", "http://127.0.0.1/admin"),
+        );
+        let context = ToolContext::new(PathBuf::from(".")).with_state_namespace(namespace);
+
+        let err = WebRunTool
+            .execute(json!({"click": [{"ref_id": ref_id, "id": 1}]}), &context)
+            .await
+            .expect_err("click target must be SSRF-guarded");
+
+        assert!(format!("{err}").contains("restricted address"));
     }
 
     #[test]
@@ -1743,8 +1862,8 @@ mod tests {
         let ref_id = format!("{}turn0search1", scoped_ref_prefix(namespace));
         store_page(namespace, &ref_id, sample_page("https://example.com/alpha"));
 
-        let first = get_page(&ref_id).expect("first page read");
-        let second = get_page(&ref_id).expect("second page read");
+        let first = get_page(namespace, &ref_id).expect("first page read");
+        let second = get_page(namespace, &ref_id).expect("second page read");
 
         assert!(Arc::ptr_eq(&first, &second));
     }
@@ -1779,7 +1898,7 @@ mod tests {
         });
 
         assert!(panic_result.is_err());
-        assert!(get_page(&ref_id).is_some());
+        assert!(get_page(namespace, &ref_id).is_some());
         assert_eq!(next_turn_for_namespace(namespace), 42);
     }
 
@@ -1815,7 +1934,7 @@ mod tests {
 
         let _ = next_turn_for_namespace("session-beta");
 
-        assert!(get_page(&ref_id).is_none());
+        assert!(get_page(namespace, &ref_id).is_none());
     }
 
     #[test]
@@ -1834,6 +1953,7 @@ mod tests {
             allow: vec!["api.deepseek.com".to_string()],
             deny: vec![],
             proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
             audit: false,
         };
         let decider = NetworkPolicyDecider::new(policy, None);
@@ -1891,52 +2011,25 @@ mod tests {
         use wiremock::matchers::method;
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        // Serve a 302 from loopback; Location points at a private IP.
-        // fetch_page disables auto-redirects and re-validates every Location
-        // with the shared SSRF guard (same path as an open/click hop).
+        // Use a public-looking hostname pinned to the local fixture for the
+        // already-validated first hop. The redirect itself still goes through
+        // the real shared guard inside fetch_page's redirect loop.
         let server = MockServer::start().await;
         let private_location = "http://10.0.0.5/internal";
         Mock::given(method("GET"))
             .respond_with(ResponseTemplate::new(302).insert_header("Location", private_location))
             .mount(&server)
             .await;
+        let host = "public-redirect.example.test";
+        let initial_url = format!("http://{host}:{}/", server.address().port());
+        let pin = Some((host.to_string(), "127.0.0.1".parse().unwrap()));
 
-        // Unguarded client confirms the mock shape (public-host stand-in → private).
-        let client = crate::tls::reqwest_client_builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("client");
-        let resp = client
-            .get(server.uri())
-            .send()
+        let err = fetch_page_with_initial_pin(&initial_url, 5_000, &ssrf_ctx(), Some(pin))
             .await
-            .expect("unguarded mock fetch");
-        assert!(resp.status().is_redirection());
-        let location = resp
-            .headers()
-            .get(reqwest::header::LOCATION)
-            .and_then(|v| v.to_str().ok())
-            .expect("Location header");
-        let next = resp.url().join(location).expect("join redirect Location");
-        assert_eq!(next.as_str(), private_location);
-
-        // Exact re-validation hop fetch_page performs before following:
-        let err = validate_fetch_target(&next, &ssrf_ctx(), "web_run")
-            .await
-            .expect_err("redirect to private IP must be refused");
+            .expect_err("guarded redirect to private IP must be refused");
         assert!(
             format!("{err}").contains("restricted address"),
-            "expected restricted-address error consistent with fetch_url; got {err}"
-        );
-
-        // And the open path refuses when the target itself is the private URL
-        // (same guard entry point as a followed redirect).
-        let err = fetch_page(private_location, 5_000, &ssrf_ctx())
-            .await
-            .expect_err("private redirect target must be refused on open");
-        assert!(
-            format!("{err}").contains("restricted address"),
-            "expected restricted-address error; got {err}"
+            "redirect loop must surface the shared guard rejection; got {err}"
         );
     }
 }

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -9,7 +9,6 @@ use super::spec::{
 };
 use super::web::guard::validate_fetch_target;
 use async_trait::async_trait;
-use base64::{Engine as _, engine::general_purpose};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -21,6 +20,11 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use parking_lot::{RwLock, RwLockWriteGuard};
+
+use super::web::scrape::{
+    ScrapedSearchResult, is_duckduckgo_challenge, parse_bing_results as scrape_bing_results,
+    parse_duckduckgo_results as scrape_duckduckgo_results,
+};
 
 const MAX_RESULTS: usize = 10;
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
@@ -1393,11 +1397,6 @@ static BLOCK_RE: OnceLock<Regex> = OnceLock::new();
 static SCRIPT_RE: OnceLock<Regex> = OnceLock::new();
 static STYLE_RE: OnceLock<Regex> = OnceLock::new();
 static TITLE_RE: OnceLock<Regex> = OnceLock::new();
-static SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
-static SEARCH_TITLE_RE: OnceLock<Regex> = OnceLock::new();
-static BING_RESULT_RE: OnceLock<Regex> = OnceLock::new();
-static BING_TITLE_RE: OnceLock<Regex> = OnceLock::new();
-static BING_SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
 
 fn get_anchor_re() -> &'static Regex {
     ANCHOR_RE.get_or_init(|| {
@@ -1427,43 +1426,6 @@ fn get_style_re() -> &'static Regex {
 
 fn get_title_re() -> &'static Regex {
     TITLE_RE.get_or_init(|| Regex::new(r"(?is)<title[^>]*>(.*?)</title>").unwrap())
-}
-
-fn get_search_title_re() -> &'static Regex {
-    SEARCH_TITLE_RE.get_or_init(|| {
-        Regex::new(r#"<a[^>]*class=\"result__a\"[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>"#)
-            .expect("title regex pattern is valid")
-    })
-}
-
-fn get_search_snippet_re() -> &'static Regex {
-    SNIPPET_RE.get_or_init(|| {
-        Regex::new(
-            r#"<a[^>]*class=\"result__snippet\"[^>]*>(.*?)</a>|<div[^>]*class=\"result__snippet\"[^>]*>(.*?)</div>"#,
-        )
-        .expect("snippet regex pattern is valid")
-    })
-}
-
-fn get_bing_result_re() -> &'static Regex {
-    BING_RESULT_RE.get_or_init(|| {
-        Regex::new(r#"(?is)<li[^>]*class=\"[^\"]*\bb_algo\b[^\"]*\"[^>]*>(.*?)</li>"#)
-            .expect("bing result regex pattern is valid")
-    })
-}
-
-fn get_bing_title_re() -> &'static Regex {
-    BING_TITLE_RE.get_or_init(|| {
-        Regex::new(r#"(?is)<h2[^>]*>.*?<a[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>"#)
-            .expect("bing title regex pattern is valid")
-    })
-}
-
-fn get_bing_snippet_re() -> &'static Regex {
-    BING_SNIPPET_RE.get_or_init(|| {
-        Regex::new(r#"(?is)<div[^>]*class=\"[^\"]*\bb_caption\b[^\"]*\"[^>]*>.*?<p[^>]*>(.*?)</p>"#)
-            .expect("bing snippet regex pattern is valid")
-    })
 }
 
 fn parse_html(html: &str, base_url: &str) -> (Vec<String>, Vec<WebLink>, Option<String>) {
@@ -1593,149 +1555,25 @@ fn decode_html_entities(text: &str) -> String {
 }
 
 fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<SearchEntry> {
-    let title_re = get_search_title_re();
-    let snippet_re = get_search_snippet_re();
-    let snippets: Vec<String> = snippet_re
-        .captures_iter(html)
-        .filter_map(|cap| cap.get(1).or_else(|| cap.get(2)))
-        .map(|m| normalize_whitespace(&decode_html_entities(&strip_tags(m.as_str()))))
-        .collect();
-
-    let mut results = Vec::new();
-    for (idx, cap) in title_re.captures_iter(html).enumerate() {
-        if results.len() >= max_results {
-            break;
-        }
-        let href = cap.get(1).map(|m| m.as_str()).unwrap_or("");
-        let title_raw = cap.get(2).map(|m| m.as_str()).unwrap_or("");
-        let title = normalize_whitespace(&decode_html_entities(&strip_tags(title_raw)));
-        if title.is_empty() {
-            continue;
-        }
-        let url = normalize_search_url(href);
-        let snippet = snippets
-            .get(idx)
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty());
-
-        results.push(SearchEntry {
-            title,
-            url,
-            snippet,
-        });
-    }
-
-    results
-}
-
-fn is_duckduckgo_challenge(html: &str) -> bool {
-    html.contains("anomaly-modal") || html.contains("Unfortunately, bots use DuckDuckGo too")
+    scrape_duckduckgo_results(html, max_results)
+        .into_iter()
+        .map(search_entry_from_scraped)
+        .collect()
 }
 
 fn parse_bing_results(html: &str, max_results: usize) -> Vec<SearchEntry> {
-    let mut results = Vec::new();
-    for cap in get_bing_result_re().captures_iter(html) {
-        if results.len() >= max_results {
-            break;
-        }
-        let Some(block) = cap.get(1).map(|m| m.as_str()) else {
-            continue;
-        };
-        let Some(title_cap) = get_bing_title_re().captures(block) else {
-            continue;
-        };
-        let href = title_cap.get(1).map(|m| m.as_str()).unwrap_or("");
-        let title_raw = title_cap.get(2).map(|m| m.as_str()).unwrap_or("");
-        let title = normalize_whitespace(&decode_html_entities(&strip_tags(title_raw)));
-        if title.is_empty() {
-            continue;
-        }
-        let snippet = get_bing_snippet_re()
-            .captures(block)
-            .and_then(|snippet_cap| snippet_cap.get(1))
-            .map(|m| normalize_whitespace(&decode_html_entities(&strip_tags(m.as_str()))))
-            .filter(|s| !s.is_empty());
-
-        results.push(SearchEntry {
-            title,
-            url: normalize_bing_url(href),
-            snippet,
-        });
-    }
-
-    results
+    scrape_bing_results(html, max_results)
+        .into_iter()
+        .map(search_entry_from_scraped)
+        .collect()
 }
 
-fn normalize_search_url(href: &str) -> String {
-    if let Some(uddg) = extract_query_param(href, "uddg") {
-        let decoded = percent_decode(&uddg);
-        if !decoded.is_empty() {
-            return decoded;
-        }
+fn search_entry_from_scraped(entry: ScrapedSearchResult) -> SearchEntry {
+    SearchEntry {
+        title: entry.title,
+        url: entry.url,
+        snippet: entry.snippet,
     }
-    if href.starts_with("//") {
-        return format!("https:{href}");
-    }
-    if href.starts_with('/') {
-        return format!("https://duckduckgo.com{href}");
-    }
-    href.to_string()
-}
-
-fn normalize_bing_url(href: &str) -> String {
-    if let Some(encoded) = extract_query_param(href, "u") {
-        let decoded = percent_decode(&encoded);
-        let token = decoded.strip_prefix("a1").unwrap_or(&decoded);
-        let mut padded = token.replace('-', "+").replace('_', "/");
-        while !padded.len().is_multiple_of(4) {
-            padded.push('=');
-        }
-        if let Ok(bytes) = general_purpose::STANDARD.decode(padded)
-            && let Ok(url) = String::from_utf8(bytes)
-            && looks_like_url(&url)
-        {
-            return url;
-        }
-    }
-    if href.starts_with("//") {
-        return format!("https:{href}");
-    }
-    if href.starts_with('/') {
-        return format!("https://www.bing.com{href}");
-    }
-    href.to_string()
-}
-
-fn extract_query_param(url: &str, key: &str) -> Option<String> {
-    let query_start = url.find('?')?;
-    let query = &url[query_start + 1..];
-    for part in query.split('&') {
-        let (k, v) = part.split_once('=')?;
-        if k == key {
-            return Some(v.to_string());
-        }
-    }
-    None
-}
-
-fn percent_decode(input: &str) -> String {
-    let mut out = Vec::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut idx = 0;
-    while idx < bytes.len() {
-        if bytes[idx] == b'%'
-            && idx + 2 < bytes.len()
-            && let Ok(hex) = std::str::from_utf8(&bytes[idx + 1..idx + 3])
-            && let Ok(val) = u8::from_str_radix(hex, 16)
-        {
-            out.push(val);
-            idx += 3;
-            continue;
-        }
-        out.push(bytes[idx]);
-        idx += 1;
-    }
-    String::from_utf8_lossy(&out).into_owned()
 }
 
 fn url_encode(input: &str) -> String {
@@ -1832,19 +1670,26 @@ mod tests {
     }
 
     #[test]
-    fn percent_decode_handles_utf8_multibyte_sequences() {
-        // Percent-encoded CJK: %E4%B8%AA%E4%BA%BA = 个人 (each glyph is 3 UTF-8 bytes).
-        assert_eq!(percent_decode("Hello %E4%B8%AA%E4%BA%BA"), "Hello 个人");
-        assert_eq!(percent_decode("%E7%B4%A0%E6%9D%90"), "素材");
-        // Percent-encoded UTF-8 inside a URL path (DuckDuckGo `uddg=` redirect shape).
-        assert_eq!(
-            percent_decode("https://example.com/%E9%A1%B5%E9%9D%A2"),
-            "https://example.com/页面"
+    fn web_run_search_path_filters_known_spam_domain() {
+        // Intended behavior change vs pre-unify web_run: spam filter applies
+        // unconditionally on the shared scraper used by web_run (#964).
+        let html = r#"
+            <a class="result__a" href="https://astralia.forumgratuit.org/a">A</a>
+            <a class="result__snippet">spam</a>
+            <a class="result__a" href="https://russia.forumgratuit.org/b">B</a>
+            <a class="result__snippet">spam</a>
+            <a class="result__a" href="https://other.forumgratuit.org/c">C</a>
+            <a class="result__snippet">spam</a>
+            <a class="result__a" href="https://hello.forumgratuit.org/d">D</a>
+            <a class="result__snippet">spam</a>
+            <a class="result__a" href="https://world.forumgratuit.org/e">E</a>
+            <a class="result__snippet">spam</a>
+        "#;
+        let results = parse_duckduckgo_results(html, 10);
+        assert!(
+            results.is_empty(),
+            "web_run path must drop single-domain spam SERPs via shared scraper"
         );
-        // Raw UTF-8 in the input passes through unchanged.
-        assert_eq!(percent_decode("查询 keyword"), "查询 keyword");
-        // ASCII-only inputs preserve existing behavior; `+` stays literal.
-        assert_eq!(percent_decode("foo+bar%20baz"), "foo+bar baz");
     }
 
     #[cfg(feature = "pdf")]

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -1605,14 +1605,12 @@ fn url_encode(input: &str) -> String {
 mod tests {
     use super::*;
     use std::path::PathBuf;
-    use std::sync::{Mutex, MutexGuard};
+    use tokio::sync::{Mutex, MutexGuard};
 
-    static WEB_RUN_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static WEB_RUN_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
     fn lock_web_run_test_state() -> MutexGuard<'static, ()> {
-        WEB_RUN_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+        WEB_RUN_TEST_LOCK.blocking_lock()
     }
 
     fn sample_page(url: &str) -> WebPage {
@@ -1790,7 +1788,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn execute_open_rejects_exact_foreign_session_ref() {
-        let _lock = lock_web_run_test_state();
+        let _lock = WEB_RUN_TEST_LOCK.lock().await;
         reset_web_run_state();
         let ref_id = format!("{}turn0search1", scoped_ref_prefix("foreign-open-owner"));
         store_page(
@@ -1811,7 +1809,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn execute_click_rejects_exact_foreign_session_ref() {
-        let _lock = lock_web_run_test_state();
+        let _lock = WEB_RUN_TEST_LOCK.lock().await;
         reset_web_run_state();
         let ref_id = format!("{}turn0search1", scoped_ref_prefix("foreign-click-owner"));
         store_page(
@@ -1835,7 +1833,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn execute_click_routes_target_through_shared_ssrf_guard() {
-        let _lock = lock_web_run_test_state();
+        let _lock = WEB_RUN_TEST_LOCK.lock().await;
         reset_web_run_state();
         let namespace = "guarded-click-session";
         let ref_id = format!("{}turn0search1", scoped_ref_prefix(namespace));

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -7,7 +7,7 @@ use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_u64, required_str,
 };
-use crate::network_policy::{Decision, host_from_url};
+use super::web::guard::validate_fetch_target;
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use regex::Regex;
@@ -27,6 +27,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 15_000;
 const DEFAULT_OPEN_TIMEOUT_MS: u64 = 20_000;
 const MAX_WEB_RUN_SESSIONS: usize = 64;
 const MAX_PAGES_PER_SESSION: usize = 256;
+const MAX_REDIRECTS: usize = 5;
 const WEB_RUN_SESSION_TTL: Duration = Duration::from_secs(30 * 60);
 const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
 
@@ -758,8 +759,7 @@ async fn resolve_or_fetch_page(
         return Ok(page);
     }
     if looks_like_url(ref_id) {
-        check_network_policy(ref_id, context)?;
-        return fetch_page(ref_id, timeout_ms).await.map(Arc::new);
+        return fetch_page(ref_id, timeout_ms, context).await.map(Arc::new);
     }
     Err(ToolError::invalid_input(format!(
         "Unknown ref_id '{ref_id}'"
@@ -1103,45 +1103,64 @@ fn page_from_search(query: &str, results: &[SearchEntry]) -> WebPage {
     }
 }
 
-/// Check network policy for a URL before fetching.
-/// Returns an error if the policy denies access.
-fn check_network_policy(url: &str, context: &ToolContext) -> Result<(), ToolError> {
-    let Some(decider) = context.network_policy.as_ref() else {
-        return Ok(());
+async fn fetch_page(
+    url: &str,
+    timeout_ms: u64,
+    context: &ToolContext,
+) -> Result<WebPage, ToolError> {
+    let mut current_url = reqwest::Url::parse(url)
+        .map_err(|e| ToolError::invalid_input(format!("invalid URL: {e}")))?;
+    let mut redirects_followed = 0usize;
+
+    let resp = loop {
+        let dns_pinning = validate_fetch_target(&current_url, context, "web_run").await?;
+        let mut client_builder = crate::tls::reqwest_client_builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .user_agent(USER_AGENT)
+            .redirect(reqwest::redirect::Policy::none());
+
+        // Pin validated IP to prevent DNS rebinding (TOCTOU) — reqwest will
+        // connect to the validated IP directly instead of re-resolving.
+        if let Some((hostname, validated_ip)) = dns_pinning {
+            client_builder =
+                client_builder.resolve(&hostname, std::net::SocketAddr::new(validated_ip, 0));
+        }
+
+        let client = client_builder.build().map_err(|e| {
+            ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
+        })?;
+
+        let resp = client
+            .get(current_url.clone())
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .header("Accept-Language", "en-US,en;q=0.5")
+            .send()
+            .await
+            .map_err(|e| ToolError::execution_failed(format!("Web request failed: {e}")))?;
+
+        if !resp.status().is_redirection() || redirects_followed >= MAX_REDIRECTS {
+            break resp;
+        }
+
+        let Some(location) = resp
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            break resp;
+        };
+
+        current_url = resp
+            .url()
+            .join(location)
+            .map_err(|e| ToolError::execution_failed(format!("invalid redirect location: {e}")))?;
+        redirects_followed += 1;
     };
-    let Some(host) = host_from_url(url) else {
-        return Ok(());
-    };
-    match decider.evaluate(&host, "web_run") {
-        Decision::Allow => Ok(()),
-        Decision::Deny => Err(ToolError::permission_denied(format!(
-            "network call to '{host}' blocked by network policy"
-        ))),
-        Decision::Prompt => Err(ToolError::permission_denied(format!(
-            "network call to '{host}' requires approval; \
-             re-run after `/network allow {host}` or set network.default = \"allow\" in config"
-        ))),
-    }
-}
 
-async fn fetch_page(url: &str, timeout_ms: u64) -> Result<WebPage, ToolError> {
-    let client = crate::tls::reqwest_client_builder()
-        .timeout(Duration::from_millis(timeout_ms))
-        .user_agent(USER_AGENT)
-        .build()
-        .map_err(|e| ToolError::execution_failed(format!("Failed to build HTTP client: {e}")))?;
-
-    let resp = client
-        .get(url)
-        .header(
-            "Accept",
-            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        )
-        .header("Accept-Language", "en-US,en;q=0.5")
-        .send()
-        .await
-        .map_err(|e| ToolError::execution_failed(format!("Web request failed: {e}")))?;
-
+    let final_url = resp.url().to_string();
     let status = resp.status();
     let content_type = resp
         .headers()
@@ -1161,15 +1180,15 @@ async fn fetch_page(url: &str, timeout_ms: u64) -> Result<WebPage, ToolError> {
     }
 
     #[cfg(feature = "pdf")]
-    if is_pdf(&content_type, url) {
-        return parse_pdf_page(url, content_type, &bytes);
+    if is_pdf(&content_type, &final_url) {
+        return parse_pdf_page(&final_url, content_type, &bytes);
     }
 
     let body = String::from_utf8_lossy(&bytes).to_string();
-    let (lines, links, title) = parse_html(&body, url);
+    let (lines, links, title) = parse_html(&body, &final_url);
 
     Ok(WebPage {
-        url: url.to_string(),
+        url: final_url,
         title,
         content_type,
         lines,
@@ -1961,8 +1980,8 @@ mod tests {
         assert!(!looks_like_url("turn0search0"));
     }
 
-    #[test]
-    fn network_policy_denies_direct_open_url() {
+    #[tokio::test]
+    async fn network_policy_denies_direct_open_url() {
         use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
 
         let policy = NetworkPolicy {
@@ -1975,8 +1994,104 @@ mod tests {
         let decider = NetworkPolicyDecider::new(policy, None);
         let ctx = ToolContext::new(PathBuf::from(".")).with_network_policy(decider);
 
-        let err = check_network_policy("https://example.com/private", &ctx)
+        let err = fetch_page("https://example.com/private", 5_000, &ctx)
+            .await
             .expect_err("blocked host should fail");
         assert!(format!("{err}").contains("blocked by network policy"));
+    }
+
+    fn ssrf_ctx() -> ToolContext {
+        ToolContext::new(PathBuf::from("."))
+    }
+
+    #[tokio::test]
+    async fn open_refuses_loopback_ip_url() {
+        let err = resolve_or_fetch_page("http://127.0.0.1/", 5_000, &ssrf_ctx())
+            .await
+            .expect_err("loopback open must be refused");
+        assert!(
+            format!("{err}").contains("restricted address"),
+            "expected restricted-address error; got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_refuses_private_range_ip_url() {
+        let err = resolve_or_fetch_page("http://192.168.1.50/admin", 5_000, &ssrf_ctx())
+            .await
+            .expect_err("private-range open must be refused");
+        assert!(
+            format!("{err}").contains("restricted address"),
+            "expected restricted-address error; got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_refuses_metadata_endpoint_ip_url() {
+        let err = resolve_or_fetch_page(
+            "http://169.254.169.254/latest/meta-data",
+            5_000,
+            &ssrf_ctx(),
+        )
+        .await
+        .expect_err("cloud metadata open must be refused");
+        assert!(
+            format!("{err}").contains("restricted address"),
+            "expected restricted-address error; got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_refuses_redirect_from_public_host_to_private_ip() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Serve a 302 from loopback; Location points at a private IP.
+        // fetch_page disables auto-redirects and re-validates every Location
+        // with the shared SSRF guard (same path as an open/click hop).
+        let server = MockServer::start().await;
+        let private_location = "http://10.0.0.5/internal";
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(302).insert_header("Location", private_location))
+            .mount(&server)
+            .await;
+
+        // Unguarded client confirms the mock shape (public-host stand-in → private).
+        let client = crate::tls::reqwest_client_builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("client");
+        let resp = client
+            .get(server.uri())
+            .send()
+            .await
+            .expect("unguarded mock fetch");
+        assert!(resp.status().is_redirection());
+        let location = resp
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .expect("Location header");
+        let next = resp.url().join(location).expect("join redirect Location");
+        assert_eq!(next.as_str(), private_location);
+
+        // Exact re-validation hop fetch_page performs before following:
+        let err = validate_fetch_target(&next, &ssrf_ctx(), "web_run")
+            .await
+            .expect_err("redirect to private IP must be refused");
+        assert!(
+            format!("{err}").contains("restricted address"),
+            "expected restricted-address error consistent with fetch_url; got {err}"
+        );
+
+        // And the open path refuses when the target itself is the private URL
+        // (same guard entry point as a followed redirect).
+        let err = fetch_page(private_location, 5_000, &ssrf_ctx())
+            .await
+            .expect_err("private redirect target must be refused on open");
+        assert!(
+            format!("{err}").contains("restricted address"),
+            "expected restricted-address error; got {err}"
+        );
     }
 }

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1480,122 +1480,17 @@ mod tests {
         parse_baidu_results, parse_bocha_results, parse_searxng_results, parse_sofya_results,
         sanitize_error_body, searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
-    use crate::tools::web::scrape::{
-        ScrapedSearchResult, decode_html_entities, is_likely_spam_results, normalize_bing_url,
-        root_domain,
-    };
+    use crate::tools::web::scrape::{decode_html_entities, normalize_bing_url};
     use serde_json::json;
 
     // Regression guard: Bing /ck/a redirect hrefs are HTML-entity-encoded
     // (`&amp;`). normalize_bing_url must decode entities before extracting the
     // `u=` base64 payload, otherwise the real URL is never recovered and the
-    // result's root domain collapses to bing.com (then dropped as spam → 0
-    // results for the default Bing backend).
+    // result remains a Bing tracking URL instead of the cited source.
     #[test]
     fn bing_ckurl_with_html_entities_decodes_real_url() {
         let href = "https://www.bing.com/ck/a?!&amp;&amp;p=abc&amp;u=a1aHR0cHM6Ly9ydXN0LWxhbmcub3JnLw&amp;ntb=1";
         assert_eq!(normalize_bing_url(href), "https://rust-lang.org/");
-    }
-
-    fn entry(url: &str) -> ScrapedSearchResult {
-        ScrapedSearchResult {
-            title: "x".into(),
-            url: url.into(),
-            snippet: None,
-        }
-    }
-
-    #[test]
-    fn root_domain_strips_subdomain_keeps_two_labels() {
-        assert_eq!(
-            root_domain("https://astralia.forumgratuit.org/path/page").as_deref(),
-            Some("forumgratuit.org"),
-        );
-        assert_eq!(
-            root_domain("http://www.example.com/").as_deref(),
-            Some("example.com"),
-        );
-        assert_eq!(
-            root_domain("https://example.com").as_deref(),
-            Some("example.com")
-        );
-    }
-
-    #[test]
-    fn root_domain_handles_port_and_userinfo() {
-        assert_eq!(
-            root_domain("http://user:pass@blog.example.com:8080/x").as_deref(),
-            Some("example.com"),
-        );
-    }
-
-    #[test]
-    fn root_domain_returns_none_for_garbage() {
-        assert!(
-            root_domain("not-a-url").as_deref().is_some(),
-            "bare token is treated as host"
-        );
-        assert!(root_domain("https:///path").is_none());
-    }
-
-    #[test]
-    fn spam_detector_flags_single_domain_dominance() {
-        // #964 reproduction: 5/5 results from the same low-quality host.
-        let r = vec![
-            entry("https://astralia.forumgratuit.org/page1"),
-            entry("https://russia.forumgratuit.org/page2"),
-            entry("https://other.forumgratuit.org/page3"),
-            entry("https://hello.forumgratuit.org/page4"),
-            entry("https://world.forumgratuit.org/page5"),
-        ];
-        assert!(is_likely_spam_results(&r));
-    }
-
-    #[test]
-    fn spam_detector_passes_diverse_serp() {
-        // A normal SERP mixes domains; nothing flagged.
-        let r = vec![
-            entry("https://example.com/a"),
-            entry("https://wikipedia.org/b"),
-            entry("https://stackoverflow.com/c"),
-            entry("https://reddit.com/d"),
-            entry("https://example.com/e"),
-        ];
-        assert!(!is_likely_spam_results(&r));
-    }
-
-    #[test]
-    fn spam_detector_passes_short_result_set() {
-        // Two results from the same domain isn't enough signal — false
-        // positives on legitimate two-link answers (docs + homepage)
-        // would hurt more than letting them through.
-        let r = vec![
-            entry("https://example.com/a"),
-            entry("https://example.com/b"),
-        ];
-        assert!(!is_likely_spam_results(&r));
-    }
-
-    #[test]
-    fn spam_detector_threshold_is_sixty_percent() {
-        // 3-of-5 same domain trips the 60% threshold.
-        let r3of5 = vec![
-            entry("https://spam.example.com/a"),
-            entry("https://spam.example.com/b"),
-            entry("https://spam.example.com/c"),
-            entry("https://other.com/d"),
-            entry("https://third.com/e"),
-        ];
-        assert!(is_likely_spam_results(&r3of5));
-        // 2-of-5 does NOT trip the threshold.
-        let r2of5 = vec![
-            entry("https://spam.example.com/a"),
-            entry("https://spam.example.com/b"),
-            entry("https://other.com/c"),
-            entry("https://third.com/d"),
-            entry("https://fourth.com/e"),
-        ];
-        assert!(!is_likely_spam_results(&r2of5));
     }
 
     #[test]

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -17,12 +17,16 @@ use super::spec::{
 use crate::config::SearchProvider;
 use crate::network_policy::{Decision, NetworkPolicyDecider};
 use async_trait::async_trait;
-use base64::{Engine as _, engine::general_purpose};
 use regex::Regex;
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::sync::OnceLock;
 use std::time::Duration;
+
+use super::web::scrape::{
+    ScrapedSearchResult, is_duckduckgo_challenge, parse_bing_results as scrape_bing_results,
+    parse_duckduckgo_results as scrape_duckduckgo_results,
+};
 
 const DUCKDUCKGO_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
 const BING_HOST: &str = "www.bing.com";
@@ -55,55 +59,8 @@ fn check_policy(decider: Option<&NetworkPolicyDecider>, host: &str) -> Result<()
     }
 }
 
-// Cached regex patterns for HTML parsing
-static TITLE_RE: OnceLock<Regex> = OnceLock::new();
-static SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
-static TAG_RE: OnceLock<Regex> = OnceLock::new();
-static BING_RESULT_RE: OnceLock<Regex> = OnceLock::new();
-static BING_TITLE_RE: OnceLock<Regex> = OnceLock::new();
-static BING_SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
+// Cached regex for secret redaction in error bodies
 static BEARER_TOKEN_RE: OnceLock<Regex> = OnceLock::new();
-
-fn get_title_re() -> &'static Regex {
-    TITLE_RE.get_or_init(|| {
-        Regex::new(r#"<a[^>]*class=\"result__a\"[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>"#)
-            .expect("title regex pattern is valid")
-    })
-}
-
-fn get_snippet_re() -> &'static Regex {
-    SNIPPET_RE.get_or_init(|| {
-        Regex::new(
-            r#"<a[^>]*class=\"result__snippet\"[^>]*>(.*?)</a>|<div[^>]*class=\"result__snippet\"[^>]*>(.*?)</div>"#,
-        )
-        .expect("snippet regex pattern is valid")
-    })
-}
-
-fn get_tag_re() -> &'static Regex {
-    TAG_RE.get_or_init(|| Regex::new(r"<[^>]+>").expect("tag regex pattern is valid"))
-}
-
-fn get_bing_result_re() -> &'static Regex {
-    BING_RESULT_RE.get_or_init(|| {
-        Regex::new(r#"(?is)<li[^>]*class=\"[^\"]*\bb_algo\b[^\"]*\"[^>]*>(.*?)</li>"#)
-            .expect("bing result regex pattern is valid")
-    })
-}
-
-fn get_bing_title_re() -> &'static Regex {
-    BING_TITLE_RE.get_or_init(|| {
-        Regex::new(r#"(?is)<h2[^>]*>.*?<a[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>"#)
-            .expect("bing title regex pattern is valid")
-    })
-}
-
-fn get_bing_snippet_re() -> &'static Regex {
-    BING_SNIPPET_RE.get_or_init(|| {
-        Regex::new(r#"(?is)<div[^>]*class=\"[^\"]*\bb_caption\b[^\"]*\"[^>]*>.*?<p[^>]*>(.*?)</p>"#)
-            .expect("bing snippet regex pattern is valid")
-    })
-}
 
 fn get_bearer_token_re() -> &'static Regex {
     BEARER_TOKEN_RE.get_or_init(|| {
@@ -1039,6 +996,16 @@ fn truncate_error_body(body: &str) -> String {
     }
 }
 
+static TAG_RE: OnceLock<Regex> = OnceLock::new();
+
+fn get_tag_re() -> &'static Regex {
+    TAG_RE.get_or_init(|| Regex::new(r"<[^>]+>").expect("tag regex pattern is valid"))
+}
+
+fn strip_html_tags(text: &str) -> String {
+    get_tag_re().replace_all(text, "").to_string()
+}
+
 fn sanitize_error_body(body: &str) -> String {
     let stripped = strip_html_tags(body);
     let visible: String = stripped
@@ -1428,182 +1395,25 @@ async fn run_bing_search(
 }
 
 fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<WebSearchEntry> {
-    let title_re = get_title_re();
-    let snippet_re = get_snippet_re();
-    let snippets: Vec<String> = snippet_re
-        .captures_iter(html)
-        .filter_map(|cap| cap.get(1).or_else(|| cap.get(2)))
-        .map(|m| normalize_text(m.as_str()))
-        .collect();
-
-    let mut results = Vec::new();
-    for (idx, cap) in title_re.captures_iter(html).enumerate() {
-        if results.len() >= max_results {
-            break;
-        }
-        let href = cap.get(1).map(|m| m.as_str()).unwrap_or("");
-        let title_raw = cap.get(2).map(|m| m.as_str()).unwrap_or("");
-        let title = normalize_text(title_raw);
-        if title.is_empty() {
-            continue;
-        }
-        let url = normalize_url(href);
-        let snippet = snippets
-            .get(idx)
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty());
-
-        results.push(WebSearchEntry {
-            title,
-            url,
-            snippet,
-        });
-    }
-
-    if is_likely_spam_results(&results) {
-        // Same defence as the Bing path (#964): a DDG fallback page can
-        // also serve a single-domain stuffed result set when the upstream
-        // is degraded. Drop rather than mislead the model.
-        return Vec::new();
-    }
-    results
-}
-
-fn is_duckduckgo_challenge(html: &str) -> bool {
-    html.contains("anomaly-modal") || html.contains("Unfortunately, bots use DuckDuckGo too")
+    scrape_duckduckgo_results(html, max_results)
+        .into_iter()
+        .map(web_search_entry_from_scraped)
+        .collect()
 }
 
 fn parse_bing_results(html: &str, max_results: usize) -> Vec<WebSearchEntry> {
-    let mut results = Vec::new();
-    for cap in get_bing_result_re().captures_iter(html) {
-        if results.len() >= max_results {
-            break;
-        }
-        let Some(block) = cap.get(1).map(|m| m.as_str()) else {
-            continue;
-        };
-        let Some(title_cap) = get_bing_title_re().captures(block) else {
-            continue;
-        };
-        let href = title_cap.get(1).map(|m| m.as_str()).unwrap_or("");
-        let title_raw = title_cap.get(2).map(|m| m.as_str()).unwrap_or("");
-        let title = normalize_text(title_raw);
-        if title.is_empty() {
-            continue;
-        }
-        let snippet = get_bing_snippet_re()
-            .captures(block)
-            .and_then(|snippet_cap| snippet_cap.get(1))
-            .map(|m| normalize_text(m.as_str()))
-            .filter(|s| !s.is_empty());
-
-        results.push(WebSearchEntry {
-            title,
-            url: normalize_bing_url(href),
-            snippet,
-        });
-    }
-
-    if is_likely_spam_results(&results) {
-        // Bing's scraping endpoint occasionally serves a stuffed page
-        // where the same low-quality domain owns most of the b_algo
-        // entries — #964 reported eight in a row from
-        // `astralia.forumgratuit.org` for unrelated queries. Treat the
-        // batch as "no results" so the caller surfaces a clean failure
-        // message instead of routing the model toward junk.
-        return Vec::new();
-    }
-    results
+    scrape_bing_results(html, max_results)
+        .into_iter()
+        .map(web_search_entry_from_scraped)
+        .collect()
 }
 
-/// Heuristic spam detector for scraped SERP HTML (#964).
-///
-/// Returns `true` when one root domain owns at least 60% of the result
-/// set and there are at least three results. A real-world top-five page
-/// from Google/Bing/DDG mixes domains; a result page dominated by one
-/// host is almost always SEO spam or a bot-detection-stuffed substitute.
-fn is_likely_spam_results(results: &[WebSearchEntry]) -> bool {
-    if results.len() < 3 {
-        return false;
+fn web_search_entry_from_scraped(entry: ScrapedSearchResult) -> WebSearchEntry {
+    WebSearchEntry {
+        title: entry.title,
+        url: entry.url,
+        snippet: entry.snippet,
     }
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for r in results {
-        if let Some(host) = root_domain(&r.url) {
-            *counts.entry(host).or_insert(0) += 1;
-        }
-    }
-    let Some(&max) = counts.values().max() else {
-        return false;
-    };
-    // 60% threshold: 3-of-5, 4-of-6, 5-of-8 all trip; 2-of-5 doesn't.
-    max * 5 >= results.len() * 3
-}
-
-/// Extract the registrable root domain (eTLD+1 approximation) from a URL
-/// so spam detection groups `astralia.forumgratuit.org` with
-/// `russia.forumgratuit.org`. Returns lowercase host minus the leftmost
-/// label, or the bare host when there are only two labels.
-fn root_domain(url: &str) -> Option<String> {
-    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
-    let host = after_scheme.split(['/', '?', '#']).next()?;
-    let host = host.split('@').next_back()?;
-    let host = host.split(':').next()?.to_ascii_lowercase();
-    if host.is_empty() {
-        return None;
-    }
-    let labels: Vec<&str> = host.split('.').filter(|s| !s.is_empty()).collect();
-    if labels.len() <= 2 {
-        return Some(host);
-    }
-    Some(labels[labels.len().saturating_sub(2)..].join("."))
-}
-
-fn normalize_url(href: &str) -> String {
-    if let Some(uddg) = extract_query_param(href, "uddg") {
-        let decoded = percent_decode(&uddg);
-        if !decoded.is_empty() {
-            return decoded;
-        }
-    }
-    if href.starts_with("//") {
-        return format!("https:{href}");
-    }
-    if href.starts_with('/') {
-        return format!("https://duckduckgo.com{href}");
-    }
-    href.to_string()
-}
-
-fn normalize_bing_url(href: &str) -> String {
-    // Bing wraps every SERP result URL in a `/ck/a?...&u=<base64>` click-tracking
-    // redirect, and in the raw HTML the separators are `&amp;` entities. Without
-    // decoding entities first, `extract_query_param` looks for `u` but the actual
-    // key is `amp;u`, so the real URL is never recovered: every result collapses to
-    // a `bing.com` root domain, which the spam heuristic then rejects — yielding
-    // zero results for the default Bing backend. Decode entities before parsing.
-    let href = decode_html_entities(href);
-    let href = href.as_str();
-    if let Some(encoded) = extract_query_param(href, "u") {
-        let decoded = percent_decode(&encoded);
-        let token = decoded.strip_prefix("a1").unwrap_or(&decoded);
-        let mut padded = token.replace('-', "+").replace('_', "/");
-        while !padded.len().is_multiple_of(4) {
-            padded.push('=');
-        }
-        if let Ok(bytes) = general_purpose::STANDARD.decode(padded)
-            && let Ok(url) = String::from_utf8(bytes)
-            && (url.starts_with("http://") || url.starts_with("https://"))
-        {
-            return url;
-        }
-    }
-    if href.starts_with("//") {
-        return format!("https:{href}");
-    }
-    if href.starts_with('/') {
-        return format!("https://www.bing.com{href}");
-    }
-    href.to_string()
 }
 
 fn duckduckgo_search_url(
@@ -1658,114 +1468,21 @@ fn duckduckgo_allows_bing_fallback(base_url: Option<&str>) -> bool {
     configured_search_base_url(base_url).is_none()
 }
 
-fn normalize_text(text: &str) -> String {
-    let stripped = strip_html_tags(text);
-    let decoded = decode_html_entities(&stripped);
-    decoded.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn strip_html_tags(text: &str) -> String {
-    get_tag_re().replace_all(text, "").to_string()
-}
-
-fn decode_html_entities(text: &str) -> String {
-    use regex::Regex;
-    use std::sync::OnceLock;
-
-    static ENTITY_RE: OnceLock<Regex> = OnceLock::new();
-    let re = ENTITY_RE.get_or_init(|| {
-        Regex::new(r"&(?:#(\d+)|#x([0-9A-Fa-f]+)|([a-zA-Z]+));").expect("HTML entity regex")
-    });
-
-    re.replace_all(text, |caps: &regex::Captures| {
-        if let Some(dec) = caps.get(1) {
-            return dec
-                .as_str()
-                .parse::<u32>()
-                .ok()
-                .and_then(std::char::from_u32)
-                .unwrap_or('\u{FFFD}')
-                .to_string();
-        }
-        if let Some(hex) = caps.get(2) {
-            return u32::from_str_radix(hex.as_str(), 16)
-                .ok()
-                .and_then(std::char::from_u32)
-                .unwrap_or('\u{FFFD}')
-                .to_string();
-        }
-        let named = caps.get(3).map(|m| m.as_str());
-        match named {
-            Some("amp") => "&",
-            Some("lt") => "<",
-            Some("gt") => ">",
-            Some("quot") => "\"",
-            Some("apos") => "'",
-            Some("nbsp") => " ",
-            Some("copy") => "\u{00A9}",
-            Some("reg") => "\u{00AE}",
-            Some("mdash") => "\u{2014}",
-            Some("ndash") => "\u{2013}",
-            Some("lsquo") => "\u{2018}",
-            Some("rsquo") => "\u{2019}",
-            Some("ldquo") => "\u{201C}",
-            Some("rdquo") => "\u{201D}",
-            Some("hellip") => "\u{2026}",
-            _ => return caps.get(0).map(|m| m.as_str()).unwrap_or("").to_string(),
-        }
-        .to_string()
-    })
-    .to_string()
-}
-
 fn url_encode(input: &str) -> String {
     crate::utils::url_encode(input)
-}
-
-fn percent_decode(input: &str) -> String {
-    let bytes = input.as_bytes();
-    let mut out = Vec::new();
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'%' if i + 2 < bytes.len() => {
-                let hex = &input[i + 1..i + 3];
-                if let Ok(val) = u8::from_str_radix(hex, 16) {
-                    out.push(val);
-                    i += 3;
-                    continue;
-                }
-                out.push(bytes[i]);
-            }
-            b'+' => out.push(b' '),
-            _ => out.push(bytes[i]),
-        }
-        i += 1;
-    }
-    String::from_utf8_lossy(&out).to_string()
-}
-
-fn extract_query_param(url: &str, key: &str) -> Option<String> {
-    let query = url.split_once('?')?.1;
-    for part in query.split('&') {
-        let mut iter = part.splitn(2, '=');
-        let name = iter.next().unwrap_or("");
-        if name == key {
-            return iter.next().map(str::to_string);
-        }
-    }
-    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ERROR_BODY_PREVIEW_BYTES, WebSearchEntry, WebSearchTool, baidu_search_payload,
-        bocha_error_message, decode_html_entities, duckduckgo_search_url, extract_search_query,
-        is_likely_spam_results, normalize_bing_url, optional_search_max_results,
+        ERROR_BODY_PREVIEW_BYTES, WebSearchTool, baidu_search_payload, bocha_error_message,
+        duckduckgo_search_url, extract_search_query, optional_search_max_results,
         parse_baidu_results, parse_bocha_results, parse_searxng_results, parse_sofya_results,
-        root_domain, sanitize_error_body, searxng_search_url, truncate_error_body,
-        volcengine_extract_text,
+        sanitize_error_body, searxng_search_url, truncate_error_body, volcengine_extract_text,
+    };
+    use crate::tools::web::scrape::{
+        ScrapedSearchResult, decode_html_entities, is_likely_spam_results, normalize_bing_url,
+        root_domain,
     };
     use serde_json::json;
 
@@ -1780,8 +1497,8 @@ mod tests {
         assert_eq!(normalize_bing_url(href), "https://rust-lang.org/");
     }
 
-    fn entry(url: &str) -> WebSearchEntry {
-        WebSearchEntry {
+    fn entry(url: &str) -> ScrapedSearchResult {
+        ScrapedSearchResult {
             title: "x".into(),
             url: url.into(),
             snippet: None,

--- a/crates/tui/tests/skill_cli.rs
+++ b/crates/tui/tests/skill_cli.rs
@@ -65,6 +65,7 @@ fn allow_all_policy() -> NetworkPolicy {
         allow: Vec::new(),
         deny: Vec::new(),
         proxy: Vec::new(),
+        proxy_fake_ip_cidrs: Vec::new(),
         audit: false,
     }
 }
@@ -75,6 +76,7 @@ fn deny_all_policy() -> NetworkPolicy {
         allow: Vec::new(),
         deny: Vec::new(),
         proxy: Vec::new(),
+        proxy_fake_ip_cidrs: Vec::new(),
         audit: false,
     }
 }
@@ -85,6 +87,7 @@ fn prompt_all_policy() -> NetworkPolicy {
         allow: Vec::new(),
         deny: Vec::new(),
         proxy: Vec::new(),
+        proxy_fake_ip_cidrs: Vec::new(),
         audit: false,
     }
 }


### PR DESCRIPTION
## Summary

- route `fetch_url` and `web.run` page fetches through one DNS-pinned SSRF guard
- disable ambient HTTP/HTTPS/SOCKS proxies on guarded transports so a proxy cannot re-resolve a validated hostname
- keep loopback, private, link-local, metadata, CGNAT, and IPv6 ULA fail-closed; trusted proxy hosts are useful only when the resolved address is also inside the explicit `198.18.0.0/15` fake-IP placeholder range
- isolate cached `web.run` pages by state namespace and reject exact foreign-session refs for both open and click
- guard real click targets and every redirect hop, including public-to-private redirects
- share DuckDuckGo/Bing scraping between `web_search` and `web.run`, filtering the known spam family without dropping legitimate same-domain, `.co.uk`, `github.io`, or small result sets

This is the repaired W1 slice. It closes the proxy-rebinding, trusted-host private-address, cache namespace, redirect/click, and broad same-root heuristic findings from security review.

## Security verification after merging current main

- shared guard: 26 passed, 1 subprocess helper ignored
- `web.run`: 22 passed
- shared scraper: 16 passed
- `fetch_url`: 10 passed
- network policy: 23 passed
- config: 414 passed, 1 doc test passed
- `cargo fmt --all -- --check`
- `cargo clippy -p codewhale-config -p codewhale-tui --all-targets --all-features --locked -- -D warnings`
- `git diff --check origin/main...HEAD`

The complete locked workspace/all-features suite also passed before the initial push (TUI 7480 passed / 3 ignored; PTY 16 passed / 1 ignored; integration and doc tests green). Exact-head CI is required before merge.

Current exact head: `ab87b0eb645973f161356f37dcd41d12bc9a36d4`.
