### PR TITLE
feat(work-graph): session compat + legacy adapters

### DIFF
--- a/crates/tui/src/commands/groups/session/rename.rs
+++ b/crates/tui/src/commands/groups/session/rename.rs
@@ -103,6 +103,11 @@ pub(crate) fn rename_with_manager(
         Ok(_) => {
             app.current_session_metadata = Some(session.metadata.clone());
             app.session_title = Some(new_title.to_string());
+            if let Err(err) = app.publish_pending_work_state() {
+                return CommandResult::error(format!(
+                    "Session renamed, but Work views were not published: {err}"
+                ));
+            }
             CommandResult::message(format!("Session renamed to \"{new_title}\""))
         }
         Err(e) => CommandResult::error(format!("Could not save session: {e}")),

--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -59,11 +59,16 @@ pub fn save(app: &mut App, path: Option<&str>) -> CommandResult {
                 Ok(j) => j,
                 Err(e) => return CommandResult::error(format!("Failed to serialize session: {e}")),
             };
-            match std::fs::write(&save_path, json) {
+            match crate::utils::write_atomic(&save_path, json.as_bytes()) {
                 Ok(()) => {
                     app.current_session_id = Some(session.metadata.id.clone());
                     app.current_session_metadata = Some(session.metadata.clone());
                     app.session_title = Some(session.metadata.title.clone());
+                    if let Err(err) = app.publish_pending_work_state() {
+                        return CommandResult::error(format!(
+                            "Session saved, but Work views were not published: {err}"
+                        ));
+                    }
                     CommandResult::message(format!(
                         "Session saved to {} (ID: {})",
                         save_path.display(),
@@ -158,6 +163,11 @@ pub fn fork(app: &mut App) -> CommandResult {
 
     if let Err(err) = manager.save_session(&forked) {
         return CommandResult::error(format!("Failed to save forked session: {err}"));
+    }
+    if let Err(err) = app.publish_pending_work_state() {
+        return CommandResult::error(format!(
+            "Sessions saved, but Work views were not published: {err}"
+        ));
     }
 
     app.current_session_id = Some(forked.metadata.id.clone());

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -4990,6 +4990,7 @@ impl RuntimeThreadManager {
                     active_task_id: thread.task_id.clone(),
                     active_thread_id: Some(thread.id.clone()),
                     dynamic_tool_executor: Some(Arc::new(self.clone())),
+                    work: None,
                     shell_manager: None,
                     hook_executor: None,
                     handle_store: crate::tools::handle::new_shared_handle_store(),

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 
 /// Maximum number of sessions to retain
 const MAX_SESSIONS: usize = 50;
+const WORK_GRAPH_IMPORT_ARCHIVE_DIR: &str = ".work-graph-import-archive";
 const CURRENT_SESSION_SCHEMA_VERSION: u32 = 1;
 const CURRENT_QUEUE_SCHEMA_VERSION: u32 = 1;
 
@@ -212,8 +213,12 @@ impl SessionMetadata {
 
 /// Durable Work-panel state. Optional on [`SavedSession`] so every session
 /// written before v0.8.68 remains loadable without migration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct SessionWorkState {
+    /// Authoritative Work Graph. Optional so pre-Work-Graph sessions and old
+    /// binaries continue to exchange fully populated Plan/To-do views.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<crate::work_graph::WorkGraphSnapshot>,
     #[serde(default, skip_serializing_if = "TodoListSnapshot::is_empty")]
     pub todos: TodoListSnapshot,
     #[serde(default, skip_serializing_if = "PlanSnapshot::is_empty")]
@@ -223,7 +228,11 @@ pub struct SessionWorkState {
 impl SessionWorkState {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.todos.is_empty() && self.plan.is_empty()
+        self.graph
+            .as_ref()
+            .is_none_or(crate::work_graph::WorkGraphSnapshot::is_empty)
+            && self.todos.is_empty()
+            && self.plan.is_empty()
     }
 }
 
@@ -364,6 +373,8 @@ impl SessionManager {
     pub fn save_session(&self, session: &SavedSession) -> std::io::Result<PathBuf> {
         let path = self.validated_session_path(&session.metadata.id)?;
 
+        self.archive_before_first_graph_write(session, &path)?;
+
         let content = serde_json::to_string_pretty(&session)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
@@ -382,11 +393,49 @@ impl SessionManager {
     /// concurrent sessions never overwrite each other's crash-recovery state.
     pub fn save_checkpoint(&self, session: &SavedSession) -> std::io::Result<PathBuf> {
         let path = self.validated_checkpoint_path(&session.metadata.id)?;
+        let session_path = self.validated_session_path(&session.metadata.id)?;
+        self.archive_before_first_graph_write(session, &session_path)?;
         fs::create_dir_all(self.checkpoints_dir())?;
         let content = serde_json::to_string_pretty(&session)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         write_atomic(&path, content.as_bytes())?;
         Ok(path)
+    }
+
+    /// Preserve the exact pre-import session once, before the first graph-
+    /// bearing session or checkpoint write can replace it.
+    fn archive_before_first_graph_write(
+        &self,
+        session: &SavedSession,
+        source: &Path,
+    ) -> std::io::Result<()> {
+        let writes_graph = session
+            .work_state
+            .as_ref()
+            .and_then(|state| state.graph.as_ref())
+            .is_some_and(|graph| !graph.is_empty());
+        if !writes_graph || !source.exists() {
+            return Ok(());
+        }
+        let bytes = fs::read(source)?;
+        let already_graph_backed = serde_json::from_slice::<SavedSession>(&bytes)
+            .ok()
+            .and_then(|saved| saved.work_state)
+            .and_then(|state| state.graph)
+            .is_some_and(|graph| !graph.is_empty());
+        if already_graph_backed {
+            return Ok(());
+        }
+        let archive_dir = self.sessions_dir.join(WORK_GRAPH_IMPORT_ARCHIVE_DIR);
+        fs::create_dir_all(&archive_dir)?;
+        let archive =
+            archive_dir.join(source.file_name().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "invalid session path")
+            })?);
+        if !archive.exists() {
+            write_atomic(&archive, &bytes)?;
+        }
+        Ok(())
     }
 
     fn read_checkpoint_file(&self, path: &Path) -> std::io::Result<Option<SavedSession>> {
@@ -2065,6 +2114,83 @@ mod tests {
                 .load_session_checkpoint(&session.metadata.id)
                 .expect("load checkpoint")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn graph_backed_work_state_remains_readable_by_legacy_shape() {
+        #[derive(serde::Deserialize)]
+        struct LegacyWorkState {
+            #[serde(default)]
+            todos: crate::tools::todo::TodoListSnapshot,
+            #[serde(default)]
+            plan: crate::tools::plan::PlanSnapshot,
+        }
+
+        let fixture = include_bytes!("../tests/fixtures/work_graph_session_v1_reader.json");
+        let current: SavedSession = serde_json::from_slice(fixture).expect("current reader");
+        let state = current.work_state.expect("fixture Work state");
+        let legacy: LegacyWorkState = serde_json::from_value(
+            serde_json::from_slice::<serde_json::Value>(fixture)
+                .expect("fixture JSON")["work_state"]
+                .clone(),
+        )
+        .expect("v1 reader ignores graph");
+        assert_eq!(legacy.todos, state.todos);
+        assert_eq!(legacy.plan, state.plan);
+        let graph = state.graph.expect("fixture graph");
+        crate::work_graph::validate(&graph).expect("valid fixture graph");
+        assert_eq!(crate::work_graph::project_todos(&graph), state.todos);
+        assert_eq!(crate::work_graph::project_plan(&graph), state.plan);
+    }
+
+    #[test]
+    fn first_graph_write_archives_exact_legacy_session_once() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let mut session = create_saved_session(
+            &[make_test_message("user", "archive before import")],
+            "test-model",
+            tmp.path(),
+            0,
+            None,
+        );
+        let plan = crate::tools::plan::PlanSnapshot {
+            items: vec![crate::tools::plan::PlanItemArg {
+                step: "Import".to_string(),
+                status: crate::tools::plan::StepStatus::Pending,
+            }],
+            ..crate::tools::plan::PlanSnapshot::default()
+        };
+        let todos = crate::tools::todo::TodoListSnapshot::default();
+        session.work_state = Some(SessionWorkState {
+            graph: None,
+            todos: todos.clone(),
+            plan: plan.clone(),
+        });
+        let path = manager.save_session(&session).expect("save legacy session");
+        let legacy_bytes = fs::read(&path).expect("read legacy bytes");
+
+        let graph = crate::work_graph::import_legacy(&session.metadata.id, &plan, &todos)
+            .expect("import graph");
+        session.work_state = Some(SessionWorkState {
+            graph: Some(graph),
+            todos,
+            plan,
+        });
+        manager.save_session(&session).expect("first graph write");
+        let archive = manager
+            .sessions_dir
+            .join(WORK_GRAPH_IMPORT_ARCHIVE_DIR)
+            .join(path.file_name().expect("session filename"));
+        assert_eq!(fs::read(&archive).expect("archive exists"), legacy_bytes);
+
+        session.metadata.title = "later graph write".to_string();
+        manager.save_session(&session).expect("second graph write");
+        assert_eq!(
+            fs::read(&archive).expect("archive still exists"),
+            legacy_bytes,
+            "later graph writes must not replace the pre-import receipt"
         );
     }
 

--- a/crates/tui/src/tools/plan.rs
+++ b/crates/tui/src/tools/plan.rs
@@ -580,7 +580,7 @@ impl ToolSpec for UpdatePlanTool {
     async fn execute(
         &self,
         input: serde_json::Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let empty_plan = Vec::new();
         let plan_items = match input.get("plan") {
@@ -625,11 +625,34 @@ impl ToolSpec for UpdatePlanTool {
             plan: plan_args,
         };
 
-        let mut state = self.plan_state.lock().await;
-
-        state.update(args);
-
-        let snapshot = state.snapshot();
+        let mut next_state = PlanState::default();
+        next_state.update(args);
+        let desired = next_state.snapshot();
+        let snapshot = if let Some(work) = context.runtime.work.as_ref()
+            && work.matches_plan(&self.plan_state)
+        {
+            work.apply_plan_update(&context.state_namespace, self.name(), &desired)
+                .await
+                .map_err(ToolError::execution_failed)?
+        } else {
+            let mut state = self.plan_state.lock().await;
+            state.update(UpdatePlanArgs {
+                title: desired.title.clone(),
+                objective: desired.objective.clone(),
+                context_summary: desired.context_summary.clone(),
+                explanation: desired.explanation.clone(),
+                sources_used: desired.sources_used.clone(),
+                critical_files: desired.critical_files.clone(),
+                constraints: desired.constraints.clone(),
+                recommended_approach: desired.recommended_approach.clone(),
+                verification_plan: desired.verification_plan.clone(),
+                risks_and_unknowns: desired.risks_and_unknowns.clone(),
+                handoff_packet: desired.handoff_packet.clone(),
+                plan: desired.items.clone(),
+            });
+            state.snapshot()
+        };
+        let state = PlanState::from_snapshot(&snapshot);
         let (pending, in_progress, completed) = state.counts();
         let progress = state.progress_percent();
 
@@ -681,6 +704,36 @@ mod tests {
             !description.contains("phase-level"),
             "Strategy must not reuse Workflow Phase vocabulary: {description}"
         );
+    }
+
+    #[tokio::test]
+    async fn update_plan_routes_through_attached_work_graph() {
+        let plan = new_shared_plan_state();
+        let todos = crate::tools::todo::new_shared_todo_list();
+        let work = crate::work_graph::new_shared_work_runtime(todos, plan.clone());
+        let tool = UpdatePlanTool::new(plan);
+        let mut context = ToolContext::new(std::env::temp_dir());
+        context.runtime.work = Some(work.clone());
+
+        tool.execute(
+            json!({
+                "objective": "Prove the real tool path",
+                "plan": [{"step": "Update graph", "status": "in_progress"}]
+            }),
+            &context,
+        )
+        .await
+        .expect("update_plan succeeds");
+
+        let state = work
+            .capture(Some(&context.state_namespace))
+            .expect("capture")
+            .expect("graph state");
+        assert_eq!(
+            state.plan.objective.as_deref(),
+            Some("Prove the real tool path")
+        );
+        assert_eq!(state.graph.compat.plan_order.len(), 1);
     }
 
     #[test]

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -57,6 +57,8 @@ pub struct RuntimeToolServices {
     pub active_task_id: Option<String>,
     pub active_thread_id: Option<String>,
     pub dynamic_tool_executor: Option<Arc<dyn DynamicToolExecutor>>,
+    /// Active-session Work Graph authority plus its legacy Plan/To-do views.
+    pub work: Option<crate::work_graph::SharedWorkRuntime>,
     /// Hook executor for `shell_env` injection (#456) and any future
     /// tool-side hook events. `None` outside the live engine — test
     /// contexts that don't care about hooks get a no-op.
@@ -78,6 +80,7 @@ impl Default for RuntimeToolServices {
             active_task_id: None,
             active_thread_id: None,
             dynamic_tool_executor: None,
+            work: None,
             hook_executor: None,
             handle_store: new_shared_handle_store(),
             rlm_sessions: new_shared_rlm_session_store(),
@@ -98,6 +101,7 @@ impl std::fmt::Debug for RuntimeToolServices {
                 "dynamic_tool_executor",
                 &self.dynamic_tool_executor.is_some(),
             )
+            .field("work", &self.work.is_some())
             .field("hook_executor", &self.hook_executor.is_some())
             .field("handle_store", &true)
             .field("rlm_sessions", &true)

--- a/crates/tui/src/tools/todo.rs
+++ b/crates/tui/src/tools/todo.rs
@@ -332,7 +332,7 @@ impl ToolSpec for TodoAddTool {
     async fn execute(
         &self,
         input: serde_json::Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let content = input
             .get("content")
@@ -344,9 +344,12 @@ impl ToolSpec for TodoAddTool {
             .and_then(TodoStatus::from_str)
             .unwrap_or(TodoStatus::Pending);
 
-        let mut list = self.todo_list.lock().await;
-        let item = list.add(content.to_string(), status);
-        let snapshot = list.snapshot();
+        let current = current_todo_snapshot(context, &self.todo_list).await?;
+        let mut desired = TodoList::from_snapshot(&current).map_err(ToolError::execution_failed)?;
+        let item = desired.add(content.to_string(), status);
+        let snapshot =
+            publish_todo_snapshot(context, &self.todo_list, self.tool_name, desired.snapshot())
+                .await?;
 
         let result = serde_json::to_string_pretty(&snapshot).unwrap_or_else(|_| "{}".to_string());
         Ok(ToolResult::success(format!(
@@ -428,7 +431,7 @@ impl ToolSpec for TodoUpdateTool {
     async fn execute(
         &self,
         input: serde_json::Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let id = input
             .get("id")
@@ -441,9 +444,15 @@ impl ToolSpec for TodoUpdateTool {
             .and_then(TodoStatus::from_str)
             .ok_or_else(|| ToolError::invalid_input("Missing or invalid 'status'"))?;
 
-        let mut list = self.todo_list.lock().await;
-        let updated = list.update_status(id, status);
-        let snapshot = list.snapshot();
+        let current = current_todo_snapshot(context, &self.todo_list).await?;
+        let mut desired = TodoList::from_snapshot(&current).map_err(ToolError::execution_failed)?;
+        let updated = desired.update_status(id, status);
+        let snapshot = if updated.is_some() {
+            publish_todo_snapshot(context, &self.todo_list, self.tool_name, desired.snapshot())
+                .await?
+        } else {
+            current
+        };
         let result = serde_json::to_string_pretty(&snapshot).unwrap_or_else(|_| "{}".to_string());
 
         match updated {
@@ -517,10 +526,9 @@ impl ToolSpec for TodoListTool {
     async fn execute(
         &self,
         _input: serde_json::Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
-        let list = self.todo_list.lock().await;
-        let snapshot = list.snapshot();
+        let snapshot = current_todo_snapshot(context, &self.todo_list).await?;
         let result = serde_json::to_string_pretty(&snapshot).unwrap_or_else(|_| "{}".to_string());
         Ok(ToolResult::success(format!(
             "Todo list ({} items, {}% complete)\n{}",
@@ -596,17 +604,14 @@ impl ToolSpec for TodoWriteTool {
     async fn execute(
         &self,
         input: serde_json::Value,
-        _context: &ToolContext,
+        context: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let todos = input
             .get("todos")
             .and_then(|v| v.as_array())
             .ok_or_else(|| ToolError::invalid_input("Missing or invalid 'todos' array"))?;
 
-        let mut list = self.todo_list.lock().await;
-
-        // Clear and rebuild the list
-        list.clear();
+        let mut list = TodoList::new();
 
         for item in todos {
             let content = item
@@ -624,7 +629,9 @@ impl ToolSpec for TodoWriteTool {
             list.add(content.to_string(), status);
         }
 
-        let snapshot = list.snapshot();
+        let snapshot =
+            publish_todo_snapshot(context, &self.todo_list, self.tool_name, list.snapshot())
+                .await?;
         let result = serde_json::to_string_pretty(&snapshot).unwrap_or_else(|_| "{}".to_string());
 
         Ok(ToolResult::success(format!(
@@ -639,6 +646,40 @@ impl ToolSpec for TodoWriteTool {
 
 fn is_compat_alias(tool_name: &str) -> bool {
     tool_name != CANONICAL_PROGRESS_TOOL
+}
+
+async fn current_todo_snapshot(
+    context: &ToolContext,
+    todo_list: &SharedTodoList,
+) -> Result<TodoListSnapshot, ToolError> {
+    if let Some(work) = context.runtime.work.as_ref()
+        && work.matches_todos(todo_list)
+    {
+        return work
+            .current_todos()
+            .await
+            .map_err(ToolError::execution_failed);
+    }
+    Ok(todo_list.lock().await.snapshot())
+}
+
+async fn publish_todo_snapshot(
+    context: &ToolContext,
+    todo_list: &SharedTodoList,
+    tool_name: &str,
+    desired: TodoListSnapshot,
+) -> Result<TodoListSnapshot, ToolError> {
+    if let Some(work) = context.runtime.work.as_ref()
+        && work.matches_todos(todo_list)
+    {
+        return work
+            .apply_todo_update(&context.state_namespace, tool_name, &desired)
+            .await
+            .map_err(ToolError::execution_failed);
+    }
+    *todo_list.lock().await =
+        TodoList::from_snapshot(&desired).map_err(ToolError::execution_failed)?;
+    Ok(desired)
 }
 
 fn work_progress_metadata(snapshot: &TodoListSnapshot, tool_name: &str) -> serde_json::Value {
@@ -792,6 +833,45 @@ mod tests {
         assert_eq!(
             metadata["task_updates"]["checklist"]["items"][0]["content"],
             "wire durable task tools"
+        );
+    }
+
+    #[tokio::test]
+    async fn work_update_and_hidden_alias_route_through_attached_graph() {
+        let todos = new_shared_todo_list();
+        let plan = crate::tools::plan::new_shared_plan_state();
+        let work = crate::work_graph::new_shared_work_runtime(todos.clone(), plan);
+        let mut context = ToolContext::new(std::env::temp_dir());
+        context.runtime.work = Some(work.clone());
+
+        TodoWriteTool::work_update(todos.clone())
+            .execute(
+                json!({"todos": [{"content": "Graph-owned", "status": "in_progress"}]}),
+                &context,
+            )
+            .await
+            .expect("work_update");
+        assert!(todos.lock().await.snapshot().is_empty());
+        TodoUpdateTool::checklist(todos.clone())
+            .execute(json!({"id": 1, "status": "completed"}), &context)
+            .await
+            .expect("hidden alias update");
+
+        let state = work
+            .capture(Some(&context.state_namespace))
+            .expect("capture")
+            .expect("graph state");
+        assert_eq!(state.todos.items[0].status, TodoStatus::Completed);
+        let node = state
+            .graph
+            .node(&state.graph.compat.todos[0].node)
+            .expect("projected node");
+        assert_eq!(node.state, crate::work_graph::NodeState::Completed);
+        assert!(todos.lock().await.snapshot().is_empty());
+        assert_eq!(work.publish_pending().await, Ok(true));
+        assert_eq!(
+            todos.lock().await.snapshot().items[0].status,
+            TodoStatus::Completed
         );
     }
 

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -3102,6 +3102,9 @@ impl App {
 
         // Initialize plan state
         let plan_state = new_shared_plan_state();
+        let todos = new_shared_todo_list();
+        let work_runtime =
+            crate::work_graph::new_shared_work_runtime(todos.clone(), plan_state.clone());
 
         let skills_scan_codewhale_only = config.skills_config().scan_codewhale_only();
         let skills_dir = resolve_skills_dir(&workspace, &global_skills_dir, config);
@@ -3366,9 +3369,10 @@ impl App {
             plan_state,
             plan_prompt_pending: false,
             plan_tool_used_in_turn: false,
-            todos: new_shared_todo_list(),
+            todos,
             runtime_services: RuntimeToolServices {
                 shell_manager: Some(shell_manager),
+                work: Some(work_runtime),
                 ..RuntimeToolServices::default()
             },
             mcp_snapshot: None,
@@ -6669,11 +6673,23 @@ impl App {
     /// Capture the durable Work state without ever converting lock contention
     /// into an empty snapshot.
     pub fn work_state_snapshot(&self) -> Result<Option<SessionWorkState>, String> {
+        if let Some(work) = self.runtime_services.work.as_ref() {
+            return work
+                .capture(self.current_session_id.as_deref())
+                .map(|state| {
+                    state.map(|state| SessionWorkState {
+                        graph: Some(state.graph),
+                        todos: state.todos,
+                        plan: state.plan,
+                    })
+                });
+        }
         let todos = Self::retry_lock(&self.todos, 100)
             .ok_or_else(|| "To-do state is busy; try saving again".to_string())?;
         let plan = Self::retry_lock(&self.plan_state, 100)
             .ok_or_else(|| "Plan state is busy; try saving again".to_string())?;
         let state = SessionWorkState {
+            graph: None,
             todos: todos.snapshot(),
             plan: plan.snapshot(),
         };
@@ -6684,6 +6700,19 @@ impl App {
     /// must skip a contended first save instead of pausing the UI or writing a
     /// false empty state.
     pub fn try_work_state_snapshot(&mut self) -> Result<Option<SessionWorkState>, String> {
+        if let Some(work) = self.runtime_services.work.as_ref() {
+            let state = work
+                .try_capture(self.current_session_id.as_deref())
+                .map(|state| {
+                    state.map(|state| SessionWorkState {
+                        graph: Some(state.graph),
+                        todos: state.todos,
+                        plan: state.plan,
+                    })
+                })?;
+            self.last_known_work_state = Some(state.clone());
+            return Ok(state);
+        }
         let todos = self
             .todos
             .try_lock()
@@ -6693,6 +6722,7 @@ impl App {
             .try_lock()
             .map_err(|_| "Plan state is busy".to_string())?;
         let state = SessionWorkState {
+            graph: None,
             todos: todos.snapshot(),
             plan: plan.snapshot(),
         };
@@ -6704,7 +6734,25 @@ impl App {
     }
 
     /// Atomically replace the live Work state from a saved session.
-    pub fn restore_work_state(&mut self, state: Option<&SessionWorkState>) -> Result<(), String> {
+    pub fn restore_work_state(
+        &mut self,
+        session_id: &str,
+        state: Option<&SessionWorkState>,
+    ) -> Result<(), String> {
+        if let Some(work) = self.runtime_services.work.as_ref() {
+            let empty = SessionWorkState::default();
+            let state = state.unwrap_or(&empty);
+            let restored =
+                work.restore(session_id, state.graph.as_ref(), &state.todos, &state.plan)?;
+            let normalized_state = restored.map(|state| SessionWorkState {
+                graph: Some(state.graph),
+                todos: state.todos,
+                plan: state.plan,
+            });
+            self.cached_work_summary = None;
+            self.last_known_work_state = Some(normalized_state);
+            return Ok(());
+        }
         let (restored_todos, restored_plan) = match state {
             Some(state) => (
                 TodoList::from_snapshot(&state.todos)?,
@@ -6713,6 +6761,7 @@ impl App {
             None => (TodoList::new(), PlanState::default()),
         };
         let normalized_state = SessionWorkState {
+            graph: None,
             todos: restored_todos.snapshot(),
             plan: restored_plan.snapshot(),
         };
@@ -6732,6 +6781,14 @@ impl App {
     }
 
     pub fn clear_todos(&mut self) -> bool {
+        if let Some(work) = self.runtime_services.work.as_ref() {
+            if !work.clear(self.current_session_id.as_deref()) {
+                return false;
+            }
+            self.cached_work_summary = None;
+            self.last_known_work_state = Some(None);
+            return true;
+        }
         // Acquire both stores before mutating either one. `/clear` must never
         // report success after clearing only half of the Work surface.
         let Some(mut todos) = Self::retry_lock(&self.todos, 100) else {
@@ -6747,6 +6804,20 @@ impl App {
         self.cached_work_summary = None;
         self.last_known_work_state = Some(None);
         true
+    }
+
+    /// Publish a validated Work Graph transaction after a synchronous caller
+    /// has completed its atomic session write.
+    pub fn publish_pending_work_state(&mut self) -> Result<bool, String> {
+        let published = self
+            .runtime_services
+            .work
+            .as_ref()
+            .map_or(Ok(false), |work| work.publish_pending_sync())?;
+        if published {
+            self.cached_work_summary = None;
+        }
+        Ok(published)
     }
 
     pub fn update_model_compaction_budget(&mut self) {

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -1644,7 +1644,7 @@ fn work_state_snapshot_round_trips_todos_and_plan() {
 
     let mut restored = App::new(test_options(false), &Config::default());
     restored
-        .restore_work_state(Some(&state))
+        .restore_work_state("restored-session", Some(&state))
         .expect("restore Work state");
     assert_eq!(
         restored.work_state_snapshot().expect("snapshot"),

--- a/crates/tui/src/tui/persistence_actor.rs
+++ b/crates/tui/src/tui/persistence_actor.rs
@@ -114,9 +114,9 @@ pub struct PersistActorHandle {
 
 impl PersistActorHandle {
     /// Queue a persistence request without blocking. If the actor's channel is
-    /// closed (shutdown has already happened) the request is silently dropped.
-    pub fn try_send(&self, request: PersistRequest) {
-        let _ = self.tx.send(request);
+    /// closed (shutdown has already happened), return `false`.
+    pub fn try_send(&self, request: PersistRequest) -> bool {
+        self.tx.send(request).is_ok()
     }
 }
 
@@ -136,9 +136,15 @@ pub fn init_actor(handle: PersistActorHandle) {
 /// ignored) when the actor hasn't been initialised yet — this can happen in
 /// tests or early startup before the actor is ready.
 pub fn persist(request: PersistRequest) {
-    if let Some(handle) = ACTOR_TX.get() {
-        handle.try_send(request);
-    }
+    let _ = try_persist(request);
+}
+
+/// Queue persistence and report whether the actor accepted ownership. Work
+/// Graph projections use this acknowledgement as their publish boundary.
+pub fn try_persist(request: PersistRequest) -> bool {
+    ACTOR_TX
+        .get()
+        .is_some_and(|handle| handle.try_send(request))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tui/src/tui/plan_todo_bridge.rs
+++ b/crates/tui/src/tui/plan_todo_bridge.rs
@@ -1,10 +1,4 @@
-//! Projection of an accepted Plan into the independent Work/To-do store.
-
-use crate::tools::plan::{PlanSnapshot, SharedPlanState, StepStatus};
-use crate::tools::todo::{SharedTodoList, TodoList, TodoListSnapshot, TodoStatus};
-
-const PROVENANCE_PREFIX: &str = "\u{2063}cw-plan-step:";
-const PROVENANCE_SUFFIX: &str = "\u{2063}";
+//! Accepted-Plan transition into the Work Graph.
 
 /// The outcomes that can follow the Plan confirmation prompt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16,275 +10,52 @@ pub enum PlanAcceptance {
 }
 
 impl PlanAcceptance {
-    fn is_accept(self) -> bool {
-        matches!(self, Self::AcceptAct | Self::AcceptFullAccess)
-    }
-}
-
-/// Project an accepted plan into the existing To-do list.
-///
-/// Plan and To-do remain separate stores. The plan is read once, then only
-/// rows carrying this bridge's provenance marker are created or updated.
-pub async fn project_accepted_plan(
-    plan_state: &SharedPlanState,
-    todo_list: &SharedTodoList,
-    acceptance: PlanAcceptance,
-) -> Result<usize, String> {
-    if !acceptance.is_accept() {
-        return Ok(0);
-    }
-
-    let plan = plan_state.lock().await.snapshot();
-    let mut todos = todo_list.lock().await;
-    let mut snapshot = todos.snapshot();
-    let changed = project_plan_snapshot(&plan, &mut snapshot)?;
-    *todos = TodoList::from_snapshot(&snapshot)?;
-    Ok(changed)
-}
-
-/// Project a plan snapshot into a To-do snapshot.
-///
-/// The ordinal is the stable identity available from the current Plan
-/// contract: Plan steps do not carry IDs. It is deliberately stored as an
-/// invisible marker so ordinary To-do rows remain unchanged to users.
-pub fn project_plan_snapshot(
-    plan: &PlanSnapshot,
-    todos: &mut TodoListSnapshot,
-) -> Result<usize, String> {
-    let mut list = TodoList::from_snapshot(todos)?;
-    let mut changed = 0;
-
-    for (index, step) in plan.items.iter().enumerate() {
-        let marker = provenance_marker(index);
-        let content = format!("{}{}", step.step.trim(), marker);
-        let status = todo_status(step.status.clone());
-
-        if let Some(item) = list
-            .snapshot()
-            .items
-            .iter()
-            .find(|item| provenance_index(&item.content) == Some(index))
-            .cloned()
-        {
-            let mut updated = false;
-            let content_changed = item.content != content;
-            if content_changed {
-                replace_content(&mut list, item.id, content);
-                updated = true;
-            }
-            // Preserve a user's completed projection only while it still
-            // represents the same plan step. Ordinals are the only stable IDs
-            // in the current Plan contract, so an inserted/replaced step at the
-            // same ordinal must take the new plan status instead of inheriting
-            // a stale completion.
-            if item.status != status && (item.status != TodoStatus::Completed || content_changed) {
-                list.update_status(item.id, status);
-                updated = true;
-            }
-            if updated {
-                changed += 1;
-            }
-        } else {
-            list.add(content, status);
-            changed += 1;
+    fn approval_reference(self) -> Option<&'static str> {
+        match self {
+            Self::AcceptAct => Some("accept_act"),
+            Self::AcceptFullAccess => Some("accept_full_access"),
+            Self::Revise | Self::Exit => None,
         }
     }
-
-    let mut projected = list.snapshot();
-    let before_retain = projected.items.len();
-    projected.items.retain(|item| {
-        provenance_index(&item.content).is_none_or(|index| index < plan.items.len())
-    });
-    changed += before_retain.saturating_sub(projected.items.len());
-    // Rebuild once more so derived fields and the single-in-progress invariant
-    // are computed from the pruned projection.
-    *todos = TodoList::from_snapshot(&projected)?.snapshot();
-    Ok(changed)
 }
 
-fn todo_status(status: StepStatus) -> TodoStatus {
-    match status {
-        StepStatus::Pending => TodoStatus::Pending,
-        StepStatus::InProgress => TodoStatus::InProgress,
-        StepStatus::Completed => TodoStatus::Completed,
-    }
-}
-
-fn provenance_marker(index: usize) -> String {
-    format!("{PROVENANCE_PREFIX}{index}{PROVENANCE_SUFFIX}")
-}
-
-fn provenance_index(content: &str) -> Option<usize> {
-    let start = content.find(PROVENANCE_PREFIX)? + PROVENANCE_PREFIX.len();
-    let end = content[start..].find(PROVENANCE_SUFFIX)? + start;
-    content[start..end].parse().ok()
-}
-
-fn replace_content(list: &mut TodoList, id: u32, content: String) {
-    let mut snapshot = list.snapshot();
-    if let Some(item) = snapshot.items.iter_mut().find(|item| item.id == id) {
-        item.content = content;
-    }
-    if let Ok(rebuilt) = TodoList::from_snapshot(&snapshot) {
-        *list = rebuilt;
-    }
+/// Record accepted Plan projection through `AcceptPlanDiff`; the retired
+/// Plan→To-do writer has no fallback path.
+pub async fn project_accepted_plan(
+    work: Option<&crate::work_graph::SharedWorkRuntime>,
+    session_id: Option<&str>,
+    acceptance: PlanAcceptance,
+) -> Result<usize, String> {
+    let Some(approval_reference) = acceptance.approval_reference() else {
+        return Ok(0);
+    };
+    let work = work.ok_or_else(|| "Work Graph runtime is not attached".to_string())?;
+    work.accept_plan(session_id, approval_reference).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tools::plan::{PlanItemArg, StepStatus};
-    use crate::tools::todo::{TodoItem, TodoStatus};
 
-    fn plan(items: &[(&str, StepStatus)]) -> PlanSnapshot {
-        PlanSnapshot {
-            items: items
-                .iter()
-                .map(|(step, status)| PlanItemArg {
-                    step: (*step).to_string(),
-                    status: status.clone(),
-                })
-                .collect(),
-            ..PlanSnapshot::default()
-        }
-    }
-
-    fn todos(items: &[(&str, TodoStatus)]) -> TodoListSnapshot {
-        TodoListSnapshot {
-            items: items
-                .iter()
-                .enumerate()
-                .map(|(id, (content, status))| TodoItem {
-                    id: u32::try_from(id + 1).expect("test id"),
-                    content: (*content).to_string(),
-                    status: *status,
-                })
-                .collect(),
-            ..TodoListSnapshot::default()
-        }
-    }
-
-    #[test]
-    fn projection_creates_first_class_rows() {
-        let mut actual = TodoListSnapshot::default();
-        let changed = project_plan_snapshot(
-            &plan(&[
-                ("Inspect", StepStatus::Pending),
-                ("Ship", StepStatus::Completed),
-            ]),
-            &mut actual,
-        )
-        .expect("projection");
-        assert_eq!(changed, 2);
-        assert_eq!(actual.items.len(), 2);
-        assert_eq!(actual.items[0].status, TodoStatus::Pending);
-        assert_eq!(actual.items[1].status, TodoStatus::Completed);
-        assert_eq!(provenance_index(&actual.items[0].content), Some(0));
-    }
-
-    #[test]
-    fn repeated_acceptance_is_idempotent_and_updates_changed_steps() {
-        let mut actual = TodoListSnapshot::default();
-        let first = plan(&[("Old", StepStatus::Pending)]);
-        project_plan_snapshot(&first, &mut actual).expect("first projection");
+    #[tokio::test]
+    async fn revise_and_exit_need_no_graph_and_never_write() {
         assert_eq!(
-            project_plan_snapshot(&first, &mut actual).expect("repeat projection"),
-            0
+            project_accepted_plan(None, None, PlanAcceptance::Revise).await,
+            Ok(0)
         );
-        let second = plan(&[("New", StepStatus::InProgress)]);
-        let changed = project_plan_snapshot(&second, &mut actual).expect("reprojection");
-        assert_eq!(changed, 1);
-        assert_eq!(actual.items.len(), 1);
-        assert!(actual.items[0].content.starts_with("New"));
-        assert_eq!(actual.items[0].status, TodoStatus::InProgress);
-        assert_eq!(provenance_index(&actual.items[0].content), Some(0));
-    }
-
-    #[test]
-    fn projection_preserves_user_rows_and_order() {
-        let mut actual = todos(&[("User row", TodoStatus::Pending)]);
-        project_plan_snapshot(&plan(&[("Plan row", StepStatus::Pending)]), &mut actual)
-            .expect("projection");
-        assert_eq!(actual.items[0].content, "User row");
-        assert!(actual.items[1].content.starts_with("Plan row"));
-    }
-
-    #[test]
-    fn completed_projected_rows_are_not_resurrected() {
-        let mut actual = TodoListSnapshot::default();
-        project_plan_snapshot(&plan(&[("Done", StepStatus::Completed)]), &mut actual)
-            .expect("first projection");
-        project_plan_snapshot(&plan(&[("Done", StepStatus::Pending)]), &mut actual)
-            .expect("reprojection");
-        assert_eq!(actual.items[0].status, TodoStatus::Completed);
-    }
-
-    #[test]
-    fn replaced_step_does_not_inherit_completion_from_the_same_ordinal() {
-        let mut actual = TodoListSnapshot::default();
-        project_plan_snapshot(&plan(&[("Old", StepStatus::Completed)]), &mut actual)
-            .expect("first projection");
-        project_plan_snapshot(&plan(&[("New", StepStatus::Pending)]), &mut actual)
-            .expect("replacement projection");
-        assert!(actual.items[0].content.starts_with("New"));
-        assert_eq!(actual.items[0].status, TodoStatus::Pending);
-    }
-
-    #[test]
-    fn shorter_plan_retires_only_stale_projected_rows() {
-        let mut actual = todos(&[("User row", TodoStatus::Pending)]);
-        project_plan_snapshot(
-            &plan(&[
-                ("Keep", StepStatus::Pending),
-                ("Remove", StepStatus::Pending),
-            ]),
-            &mut actual,
-        )
-        .expect("first projection");
-        let changed = project_plan_snapshot(&plan(&[("Keep", StepStatus::Pending)]), &mut actual)
-            .expect("shorter projection");
-        assert_eq!(changed, 1);
-        assert_eq!(actual.items.len(), 2);
-        assert_eq!(actual.items[0].content, "User row");
-        assert!(actual.items[1].content.starts_with("Keep"));
-    }
-
-    #[test]
-    fn revise_and_exit_are_no_ops() {
-        let actual = todos(&[("User row", TodoStatus::Completed)]);
-        let before = actual.clone();
-        assert!(!PlanAcceptance::Revise.is_accept());
-        assert!(!PlanAcceptance::Exit.is_accept());
-        assert_eq!(actual, before);
+        assert_eq!(
+            project_accepted_plan(None, None, PlanAcceptance::Exit).await,
+            Ok(0)
+        );
     }
 
     #[tokio::test]
-    async fn revise_and_exit_do_not_mutate_shared_todos() {
-        let plan_state = crate::tools::plan::new_shared_plan_state();
-        plan_state
-            .lock()
-            .await
-            .update(crate::tools::plan::UpdatePlanArgs {
-                plan: vec![PlanItemArg {
-                    step: "Do not project".to_string(),
-                    status: StepStatus::Pending,
-                }],
-                ..crate::tools::plan::UpdatePlanArgs::default()
-            });
-        let todo_list = crate::tools::todo::new_shared_todo_list();
-        todo_list
-            .lock()
-            .await
-            .add("User row".to_string(), TodoStatus::Pending);
-        let before = todo_list.lock().await.snapshot();
-
-        project_accepted_plan(&plan_state, &todo_list, PlanAcceptance::Revise)
-            .await
-            .expect("revise no-op");
-        project_accepted_plan(&plan_state, &todo_list, PlanAcceptance::Exit)
-            .await
-            .expect("exit no-op");
-
-        assert_eq!(todo_list.lock().await.snapshot(), before);
+    async fn acceptance_fails_closed_without_graph_authority() {
+        assert_eq!(
+            project_accepted_plan(None, None, PlanAcceptance::AcceptAct)
+                .await
+                .unwrap_err(),
+            "Work Graph runtime is not attached"
+        );
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1130,6 +1130,7 @@ pub async fn run_tui(
         active_task_id: None,
         active_thread_id: None,
         dynamic_tool_executor: None,
+        work: app.runtime_services.work.clone(),
         // #456: plumb the App's HookExecutor so `exec_shell` can surface
         // the configured `shell_env` hooks. Clone the shared Arc.
         hook_executor: app.runtime_services.hook_executor.clone(),
@@ -2648,6 +2649,20 @@ async fn run_event_loop(
                         }
                         handle_tool_call_complete(app, &id, &name, &result);
 
+                        if result.is_ok()
+                            && is_work_graph_mutation_tool(&name)
+                            && let Err(err) = persist_pending_work_checkpoint(app).await
+                        {
+                            tracing::warn!(
+                                tool = %name,
+                                error = %err,
+                                "Work Graph checkpoint was not enqueued; projections remain unpublished"
+                            );
+                            app.status_message = Some(format!(
+                                "Work update is pending: checkpoint could not be queued ({err})"
+                            ));
+                        }
+
                         // Immediately refresh the task panel sidebar when a
                         // tool that changes task state completes, so the
                         // Tasks panel stays in sync with tool execution
@@ -3072,7 +3087,30 @@ async fn run_event_loop(
                         {
                             app.current_session_id = Some(session.metadata.id.clone());
                             completed_snapshot_id = Some(session.metadata.id.clone());
-                            persistence_actor::persist(PersistRequest::SessionSnapshot(session));
+                            let queued = persistence_actor::try_persist(
+                                PersistRequest::SessionSnapshot(session),
+                            );
+                            if queued {
+                                if let Err(err) = publish_pending_work_projection(app).await {
+                                    tracing::warn!(
+                                        error = %err,
+                                        "completed-turn Work projections remain unpublished"
+                                    );
+                                    app.status_message = Some(format!(
+                                        "Session queued, but Work views could not publish ({err})"
+                                    ));
+                                }
+                            } else if app
+                                .runtime_services
+                                .work
+                                .as_ref()
+                                .is_some_and(|work| work.has_pending_publish())
+                            {
+                                app.status_message = Some(
+                                    "Work update is pending: session snapshot could not be queued"
+                                        .to_string(),
+                                );
+                            }
                         }
                         if let Some(session_id) = completed_snapshot_id {
                             persistence_actor::persist(PersistRequest::ClearCheckpoint {
@@ -3236,9 +3274,14 @@ async fn run_event_loop(
                                 if app.current_session_id.is_none() {
                                     app.current_session_id = Some(session.metadata.id.clone());
                                 }
-                                persistence_actor::persist(PersistRequest::SaveCheckpoint {
-                                    session,
-                                });
+                                if let Err(err) = persist_with_pending_work_boundary(
+                                    app,
+                                    PersistRequest::SaveCheckpoint { session },
+                                ) {
+                                    app.status_message = Some(format!(
+                                        "Work update is pending: checkpoint could not be queued ({err})"
+                                    ));
+                                }
                             }
                         } else if app.session_title.is_none() {
                             // Never synchronously reload the growing session
@@ -6773,6 +6816,69 @@ fn build_session_snapshot(
     Ok(session)
 }
 
+fn is_work_graph_mutation_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "update_plan"
+            | "work_update"
+            | "checklist_write"
+            | "todo_write"
+            | "checklist_add"
+            | "todo_add"
+            | "checklist_update"
+            | "todo_update"
+    )
+}
+
+async fn publish_pending_work_projection(app: &mut App) -> Result<bool, String> {
+    let Some(work) = app.runtime_services.work.clone() else {
+        return Ok(false);
+    };
+    let published = work.publish_pending().await?;
+    if published {
+        app.cached_work_summary = None;
+    }
+    Ok(published)
+}
+
+async fn persist_pending_work_checkpoint(app: &mut App) -> Result<bool, String> {
+    let Some(work) = app.runtime_services.work.clone() else {
+        return Ok(false);
+    };
+    if !work.has_pending_publish() {
+        return Ok(false);
+    }
+    let manager = SessionManager::default_location()
+        .map_err(|err| format!("could not open sessions directory: {err}"))?;
+    let session = build_session_snapshot(app, &manager)?;
+    if app.current_session_id.is_none() {
+        app.current_session_id = Some(session.metadata.id.clone());
+    }
+    if !persistence_actor::try_persist(PersistRequest::SaveCheckpoint { session }) {
+        return Err("persistence actor is unavailable".to_string());
+    }
+    publish_pending_work_projection(app).await
+}
+
+fn persist_with_pending_work_boundary(
+    app: &mut App,
+    request: PersistRequest,
+) -> Result<(), String> {
+    let has_pending = app
+        .runtime_services
+        .work
+        .as_ref()
+        .is_some_and(|work| work.has_pending_publish());
+    if !has_pending {
+        persistence_actor::persist(request);
+        return Ok(());
+    }
+    if !persistence_actor::try_persist(request) {
+        return Err("persistence actor is unavailable".to_string());
+    }
+    app.publish_pending_work_state().map(|_| ())
+}
+
 fn apply_picker_session_rename_to_active_app(
     app: &mut App,
     metadata: crate::session_manager::SessionMetadata,
@@ -6921,7 +7027,13 @@ fn persist_recovery_snapshot(app: &mut App) {
         if app.current_session_id.is_none() {
             app.current_session_id = Some(session.metadata.id.clone());
         }
-        persistence_actor::persist(PersistRequest::SessionSnapshot(session));
+        if let Err(err) =
+            persist_with_pending_work_boundary(app, PersistRequest::SessionSnapshot(session))
+        {
+            app.status_message = Some(format!(
+                "Work update is pending: recovery snapshot could not be queued ({err})"
+            ));
+        }
     }
 }
 
@@ -6930,7 +7042,13 @@ fn persist_full_reset_snapshot(app: &mut App) {
         && let Ok(session) = build_session_snapshot(app, &manager)
     {
         app.current_session_id = Some(session.metadata.id.clone());
-        persistence_actor::persist(PersistRequest::SessionSnapshot(session));
+        if let Err(err) =
+            persist_with_pending_work_boundary(app, PersistRequest::SessionSnapshot(session))
+        {
+            app.status_message = Some(format!(
+                "Work update is pending: reset snapshot could not be queued ({err})"
+            ));
+        }
     }
     // `/clear` and `/new` are explicit boundaries. Never let an older
     // in-flight checkpoint resurrect the session the user just discarded,
@@ -8281,7 +8399,13 @@ async fn dispatch_user_message(
         if app.current_session_id.is_none() {
             app.current_session_id = Some(session.metadata.id.clone());
         }
-        persistence_actor::persist(PersistRequest::SaveCheckpoint { session });
+        if let Err(err) =
+            persist_with_pending_work_boundary(app, PersistRequest::SaveCheckpoint { session })
+        {
+            app.status_message = Some(format!(
+                "Work update is pending: turn checkpoint could not be queued ({err})"
+            ));
+        }
     }
 
     Ok(())
@@ -10818,9 +10942,16 @@ async fn apply_plan_choice(
         PlanChoice::RevisePlan => PlanAcceptance::Revise,
         PlanChoice::ExitPlan => PlanAcceptance::Exit,
     };
-    project_accepted_plan(&app.plan_state, &app.todos, acceptance)
+    project_accepted_plan(
+        app.runtime_services.work.as_ref(),
+        app.current_session_id.as_deref(),
+        acceptance,
+    )
+    .await
+    .map_err(|err| anyhow::anyhow!("failed to project accepted plan: {err}"))?;
+    persist_pending_work_checkpoint(app)
         .await
-        .map_err(|err| anyhow::anyhow!("failed to project accepted plan: {err}"))?;
+        .map_err(|err| anyhow::anyhow!("accepted plan was not checkpointed: {err}"))?;
 
     match choice {
         PlanChoice::AcceptAgent => {
@@ -12006,12 +12137,25 @@ async fn handle_view_events(
             ViewEvent::SessionRenamed { metadata } => {
                 let session_id = metadata.id.clone();
                 let title = metadata.title.clone();
+                let mut work_snapshot_warning = None;
                 if apply_picker_session_rename_to_active_app(app, metadata)
                     && let Ok(manager) = SessionManager::default_location()
                 {
                     match build_session_snapshot(app, &manager) {
                         Ok(session) => {
-                            persistence_actor::persist(PersistRequest::SessionSnapshot(session))
+                            if let Err(err) = persist_with_pending_work_boundary(
+                                app,
+                                PersistRequest::SessionSnapshot(session),
+                            ) {
+                                tracing::warn!(
+                                    session_id = %session_id,
+                                    error = %err,
+                                    "Could not queue active session rename Work snapshot"
+                                );
+                                work_snapshot_warning = Some(format!(
+                                    "Session renamed, but Work snapshot is pending ({err})"
+                                ));
+                            }
                         }
                         Err(err) => {
                             tracing::warn!(
@@ -12022,11 +12166,13 @@ async fn handle_view_events(
                         }
                     }
                 }
-                app.status_message = Some(format!(
-                    "Renamed session {} to \"{}\"",
-                    crate::session_manager::truncate_id(&session_id),
-                    title
-                ));
+                app.status_message = Some(work_snapshot_warning.unwrap_or_else(|| {
+                    format!(
+                        "Renamed session {} to \"{}\"",
+                        crate::session_manager::truncate_id(&session_id),
+                        title
+                    )
+                }));
             }
             ViewEvent::SessionDeleted { session_id, title } => {
                 app.status_message = Some(format!(
@@ -13629,7 +13775,7 @@ fn apply_loaded_session(
     // Restore/validate the contended state before mutating conversation or
     // workspace fields. A failed session switch must leave the current session
     // wholly intact.
-    app.restore_work_state(session.work_state.as_ref())?;
+    app.restore_work_state(&session.metadata.id, session.work_state.as_ref())?;
     *config = *restored_route.config;
     let projected_messages =
         crate::runtime_handoff::project_messages_for_restore(&session.messages);

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -11554,8 +11554,8 @@ fn session_snapshot_preserves_last_work_state_when_lock_is_busy() {
     assert_eq!(contended.work_state, expected);
 }
 
-#[test]
-fn session_snapshot_prefers_newer_memory_over_stale_disk_when_lock_is_busy() {
+#[tokio::test]
+async fn session_snapshot_prefers_newer_memory_over_stale_disk_when_lock_is_busy() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let manager =
         crate::session_manager::SessionManager::new(tmp.path().join("sessions")).expect("manager");
@@ -11569,11 +11569,28 @@ fn session_snapshot_prefers_newer_memory_over_stale_disk_when_lock_is_busy() {
     manager
         .save_session(&disk_snapshot)
         .expect("save disk snapshot");
+    app.publish_pending_work_state()
+        .expect("publish saved disk state");
 
-    app.todos.try_lock().expect("todos lock").add(
+    let mut desired = crate::tools::todo::TodoList::from_snapshot(
+        &app.todos.try_lock().expect("todos lock").snapshot(),
+    )
+    .expect("current To-do state");
+    desired.add(
         "newer memory state".to_string(),
         crate::tools::todo::TodoStatus::InProgress,
     );
+    app.runtime_services
+        .work
+        .as_ref()
+        .expect("Work Graph runtime")
+        .apply_todo_update(
+            "work-cache-newer-than-disk",
+            "work_update",
+            &desired.snapshot(),
+        )
+        .await
+        .expect("graph-backed memory update");
     let memory_snapshot = build_session_snapshot(&mut app, &manager).expect("memory snapshot");
     assert_ne!(memory_snapshot.work_state, disk_snapshot.work_state);
 
@@ -11699,6 +11716,7 @@ fn contended_work_restore_leaves_current_session_wholly_unchanged() {
     app.current_session_id = Some("current-session".to_string());
     let mut session = saved_session_with_messages(vec![text_message("user", "replacement")]);
     session.work_state = Some(crate::session_manager::SessionWorkState {
+        graph: None,
         todos: crate::tools::todo::TodoListSnapshot {
             items: vec![crate::tools::todo::TodoItem {
                 id: 1,

--- a/crates/tui/src/work_graph/compat.rs
+++ b/crates/tui/src/work_graph/compat.rs
@@ -1,35 +1,121 @@
-//! Compat projections — signatures only in this slice.
+//! Pure compatibility projections for the pre-Work-Graph Plan and To-do wire
+//! formats.
 //!
-//! Invariant V10 is enforced at the type level: every projection is a pure
-//! function taking `&WorkGraphSnapshot` and returning owned data. Nothing
-//! hands a projection mutable graph access, so projections cannot write the
-//! graph or each other — one graph writes every projection.
-//!
-//! The session-compat slice implements these bodies (plan/todo snapshot
-//! derivation and legacy tool adapters). Until then they are declared but
-//! unimplemented so the type-level story — and its compile-time test — is
-//! already in force.
+//! The graph owns the ordering, metadata, titles, and states. These functions
+//! only derive owned snapshots; they never receive mutable graph access (V10).
 
-use super::model::WorkGraphSnapshot;
+use crate::tools::plan::{PlanItemArg, PlanSnapshot, StepStatus};
+use crate::tools::todo::{TodoItem, TodoListSnapshot, TodoStatus};
 
-/// Placeholder for the derived plan snapshot (shaped in the session-compat
-/// slice to match the existing plan store's wire format).
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct PlanProjection;
+use super::model::{CompatPlanMetadata, NodeState, WorkGraphSnapshot, WorkNode};
 
-/// Placeholder for the derived todo snapshot (shaped in the session-compat
-/// slice to match the existing todo store's wire format).
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct TodoProjection;
+pub type PlanProjection = PlanSnapshot;
+pub type TodoProjection = TodoListSnapshot;
 
-/// Derive the plan view. Pure function of the snapshot (V10).
-pub fn project_plan(snapshot: &WorkGraphSnapshot) -> PlanProjection {
-    let _ = snapshot;
-    unimplemented!("implemented in the session-compat slice")
+impl CompatPlanMetadata {
+    #[must_use]
+    pub fn from_plan_snapshot(snapshot: &PlanSnapshot) -> Self {
+        Self {
+            title: snapshot.title.clone(),
+            objective: snapshot.objective.clone(),
+            context_summary: snapshot.context_summary.clone(),
+            explanation: snapshot.explanation.clone(),
+            sources_used: snapshot.sources_used.clone(),
+            critical_files: snapshot.critical_files.clone(),
+            constraints: snapshot.constraints.clone(),
+            recommended_approach: snapshot.recommended_approach.clone(),
+            verification_plan: snapshot.verification_plan.clone(),
+            risks_and_unknowns: snapshot.risks_and_unknowns.clone(),
+            handoff_packet: snapshot.handoff_packet.clone(),
+        }
+    }
+
+    #[must_use]
+    fn to_plan_snapshot(&self) -> PlanSnapshot {
+        PlanSnapshot {
+            title: self.title.clone(),
+            objective: self.objective.clone(),
+            context_summary: self.context_summary.clone(),
+            explanation: self.explanation.clone(),
+            sources_used: self.sources_used.clone(),
+            critical_files: self.critical_files.clone(),
+            constraints: self.constraints.clone(),
+            recommended_approach: self.recommended_approach.clone(),
+            verification_plan: self.verification_plan.clone(),
+            risks_and_unknowns: self.risks_and_unknowns.clone(),
+            handoff_packet: self.handoff_packet.clone(),
+            items: Vec::new(),
+        }
+    }
 }
 
-/// Derive the todo view. Pure function of the snapshot (V10).
+/// Derive the complete legacy Strategy/Plan snapshot.
+#[must_use]
+pub fn project_plan(snapshot: &WorkGraphSnapshot) -> PlanProjection {
+    let mut plan = snapshot.compat.plan.to_plan_snapshot();
+    plan.items = snapshot
+        .compat
+        .plan_order
+        .iter()
+        .filter_map(|id| snapshot.node(id))
+        .map(|node| PlanItemArg {
+            step: node.title.clone(),
+            status: plan_status(node),
+        })
+        .collect();
+    plan
+}
+
+/// Derive the complete legacy To-do snapshot. Migration provenance stays in
+/// the graph; old readers receive clean, user-visible content.
+#[must_use]
 pub fn project_todos(snapshot: &WorkGraphSnapshot) -> TodoProjection {
-    let _ = snapshot;
-    unimplemented!("implemented in the session-compat slice")
+    let items = snapshot
+        .compat
+        .todos
+        .iter()
+        .filter_map(|binding| {
+            let node = snapshot.node(&binding.node)?;
+            Some(TodoItem {
+                id: binding.legacy_id,
+                content: node.title.clone(),
+                status: todo_status(node),
+            })
+        })
+        .collect::<Vec<_>>();
+    let completed = items
+        .iter()
+        .filter(|item| item.status == TodoStatus::Completed)
+        .count();
+    let completion_pct = if items.is_empty() {
+        0
+    } else {
+        let rounded = (completed.saturating_mul(100) + items.len() / 2) / items.len();
+        u8::try_from(rounded).unwrap_or(u8::MAX)
+    };
+    let in_progress_id = items
+        .iter()
+        .find(|item| item.status == TodoStatus::InProgress)
+        .map(|item| item.id);
+    TodoListSnapshot {
+        items,
+        completion_pct,
+        in_progress_id,
+    }
+}
+
+fn plan_status(node: &WorkNode) -> StepStatus {
+    match node.state {
+        NodeState::Active => StepStatus::InProgress,
+        NodeState::Completed | NodeState::Verified => StepStatus::Completed,
+        _ => StepStatus::Pending,
+    }
+}
+
+fn todo_status(node: &WorkNode) -> TodoStatus {
+    match node.state {
+        NodeState::Active => TodoStatus::InProgress,
+        NodeState::Completed | NodeState::Verified => TodoStatus::Completed,
+        _ => TodoStatus::Pending,
+    }
 }

--- a/crates/tui/src/work_graph/events.rs
+++ b/crates/tui/src/work_graph/events.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use super::ids::{ChangeId, ProposalId, WorkEdgeId, WorkNodeId};
 use super::model::{
-    AcceptanceRequirement, EvidenceRef, IdempotencyKey, NodeState, OperationBinding, Provenance,
-    Ts, WorkEdge, WorkNode,
+    AcceptanceRequirement, CompatProjectionState, EvidenceRef, IdempotencyKey, NodeState,
+    OperationBinding, Provenance, Ts, WorkEdge, WorkNode,
 };
 
 /// A single mutation of the work graph. The reducer is the only write path;
@@ -63,6 +63,14 @@ pub enum WorkGraphChange {
         old: WorkNodeId,
         replacement: WorkNodeId,
     },
+    /// Atomically replace the inputs for the legacy Plan/To-do projections.
+    ReplaceCompatProjection {
+        compat: CompatProjectionState,
+    },
+    /// Record the canonical digest of a completed legacy import.
+    SetImportDigest {
+        digest: String,
+    },
 }
 
 impl WorkGraphChange {
@@ -81,6 +89,8 @@ impl WorkGraphChange {
             WorkGraphChange::ProposePlanDiff { .. } => "propose_plan_diff",
             WorkGraphChange::AcceptPlanDiff { .. } => "accept_plan_diff",
             WorkGraphChange::Supersede { .. } => "supersede",
+            WorkGraphChange::ReplaceCompatProjection { .. } => "replace_compat_projection",
+            WorkGraphChange::SetImportDigest { .. } => "set_import_digest",
         }
     }
 }

--- a/crates/tui/src/work_graph/migration.rs
+++ b/crates/tui/src/work_graph/migration.rs
@@ -1,0 +1,365 @@
+//! Deterministic import of the pre-Work-Graph Plan and To-do session state.
+
+use crate::hashing::sha256_hex;
+use crate::tools::plan::{PlanSnapshot, PlanState, StepStatus};
+use crate::tools::todo::{TodoList, TodoListSnapshot, TodoStatus};
+
+use super::{
+    ChangeCtx, CompatPlanMetadata, CompatProjectionState, CompatTodoBinding, EdgeKind, NodeKind,
+    NodeState, Provenance, ValidationReport, WorkEdge, WorkEdgeId, WorkGraph, WorkGraphChange,
+    WorkGraphSnapshot, WorkNode, WorkNodeId, WorkNodePatch,
+};
+
+const PLAN_PROVENANCE_PREFIX: &str = "\u{2063}cw-plan-step:";
+const PLAN_PROVENANCE_SUFFIX: &str = "\u{2063}";
+
+/// Import legacy state into a deterministic graph. Repeating the same import
+/// produces the same IDs, digest, and serialized snapshot.
+pub fn import_legacy(
+    session_id: &str,
+    plan: &PlanSnapshot,
+    todos: &TodoListSnapshot,
+) -> Result<WorkGraphSnapshot, String> {
+    let plan = PlanState::from_snapshot(plan).snapshot();
+    let todos = TodoList::from_snapshot(todos)?.snapshot();
+    let canonical = serde_json::to_vec(&(&plan, &todos))
+        .map_err(|err| format!("could not canonicalize legacy Work state: {err}"))?;
+    let digest = sha256_hex(canonical);
+
+    let mut graph = WorkGraph::new();
+    let ctx = ChangeCtx {
+        session_id: session_id.to_string(),
+        now: 0,
+        idempotency_key: None,
+    };
+    let objective_id = WorkNodeId::derive(session_id, "objective");
+    let objective_title = plan
+        .objective
+        .as_deref()
+        .or(plan.title.as_deref())
+        .unwrap_or("Imported session work")
+        .to_string();
+    apply(
+        &mut graph,
+        WorkGraphChange::AddNode {
+            node: WorkNode {
+                id: objective_id.clone(),
+                kind: NodeKind::Objective,
+                title: objective_title,
+                state: NodeState::Ready,
+                acceptance: Vec::new(),
+                binding: None,
+                evidence: None,
+                provenance: Provenance::Import {
+                    source_digest: digest.clone(),
+                    ordinal: None,
+                },
+                created_at: 0,
+                updated_at: 0,
+            },
+        },
+        &ctx,
+    )?;
+
+    let mut compat = CompatProjectionState {
+        plan: CompatPlanMetadata::from_plan_snapshot(&plan),
+        ..CompatProjectionState::default()
+    };
+    for (index, item) in plan.items.iter().enumerate() {
+        let ordinal = u32::try_from(index).map_err(|_| "too many legacy plan steps")?;
+        let id = WorkNodeId::derive(session_id, &format!("plan:{index}"));
+        apply(
+            &mut graph,
+            WorkGraphChange::AddNode {
+                node: WorkNode {
+                    id: id.clone(),
+                    kind: NodeKind::PlanStep,
+                    title: item.step.trim().to_string(),
+                    state: node_state_from_plan(&item.status),
+                    acceptance: Vec::new(),
+                    binding: None,
+                    evidence: None,
+                    provenance: Provenance::Import {
+                        source_digest: digest.clone(),
+                        ordinal: Some(ordinal),
+                    },
+                    created_at: 0,
+                    updated_at: 0,
+                },
+            },
+            &ctx,
+        )?;
+        add_contains_edge(&mut graph, session_id, &objective_id, &id, &ctx)?;
+        compat.plan_order.push(id);
+    }
+
+    for item in &todos.items {
+        let (clean_title, marker_index) = strip_plan_provenance(&item.content);
+        let aliased = marker_index
+            .and_then(|index| {
+                usize::try_from(index)
+                    .ok()
+                    .map(|usize_index| (index, usize_index))
+            })
+            .and_then(|(index, usize_index)| {
+                compat
+                    .plan_order
+                    .get(usize_index)
+                    .cloned()
+                    .map(|node| (index, node))
+            });
+        let (node, plan_index) = if let Some((index, node)) = aliased {
+            let current = graph
+                .snapshot()
+                .node(&node)
+                .map(|node| node.state)
+                .ok_or_else(|| "legacy plan alias references a missing node".to_string())?;
+            let desired = more_advanced_state(current, node_state_from_todo(item.status));
+            if desired != current {
+                apply(
+                    &mut graph,
+                    WorkGraphChange::UpdateNode {
+                        id: node.clone(),
+                        patch: WorkNodePatch {
+                            state: Some(desired),
+                            ..WorkNodePatch::default()
+                        },
+                    },
+                    &ctx,
+                )?;
+            }
+            (node, Some(index))
+        } else {
+            let node = WorkNodeId::derive(session_id, &format!("todo:{}", item.id));
+            apply(
+                &mut graph,
+                WorkGraphChange::AddNode {
+                    node: WorkNode {
+                        id: node.clone(),
+                        kind: NodeKind::PlanStep,
+                        title: clean_title,
+                        // Add live operations as Ready, root them, then apply
+                        // their live state so V2 is true after every change.
+                        state: NodeState::Ready,
+                        acceptance: Vec::new(),
+                        binding: None,
+                        evidence: None,
+                        provenance: Provenance::Import {
+                            source_digest: digest.clone(),
+                            ordinal: Some(item.id),
+                        },
+                        created_at: 0,
+                        updated_at: 0,
+                    },
+                },
+                &ctx,
+            )?;
+            add_contains_edge(&mut graph, session_id, &objective_id, &node, &ctx)?;
+            let desired = node_state_from_todo(item.status);
+            if desired != NodeState::Ready {
+                apply(
+                    &mut graph,
+                    WorkGraphChange::UpdateNode {
+                        id: node.clone(),
+                        patch: WorkNodePatch {
+                            state: Some(desired),
+                            ..WorkNodePatch::default()
+                        },
+                    },
+                    &ctx,
+                )?;
+            }
+            (node, None)
+        };
+        compat.todos.push(CompatTodoBinding {
+            legacy_id: item.id,
+            node,
+            plan_index,
+        });
+    }
+
+    apply(
+        &mut graph,
+        WorkGraphChange::ReplaceCompatProjection { compat },
+        &ctx,
+    )?;
+    apply(
+        &mut graph,
+        WorkGraphChange::SetImportDigest { digest },
+        &ctx,
+    )?;
+    Ok(graph.into_snapshot())
+}
+
+fn apply(graph: &mut WorkGraph, change: WorkGraphChange, ctx: &ChangeCtx) -> Result<(), String> {
+    graph
+        .apply(change, ctx.clone())
+        .map(|_| ())
+        .map_err(|err: ValidationReport| err.to_string())
+}
+
+fn add_contains_edge(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    objective: &WorkNodeId,
+    child: &WorkNodeId,
+    ctx: &ChangeCtx,
+) -> Result<(), String> {
+    apply(
+        graph,
+        WorkGraphChange::AddEdge {
+            edge: WorkEdge {
+                id: WorkEdgeId::derive(
+                    session_id,
+                    &format!("contains:{}:{}", objective.as_str(), child.as_str()),
+                ),
+                kind: EdgeKind::Contains,
+                from: objective.clone(),
+                to: child.clone(),
+            },
+        },
+        ctx,
+    )
+}
+
+fn node_state_from_plan(status: &StepStatus) -> NodeState {
+    match status {
+        StepStatus::Pending => NodeState::Ready,
+        StepStatus::InProgress => NodeState::Active,
+        StepStatus::Completed => NodeState::Completed,
+    }
+}
+
+fn node_state_from_todo(status: TodoStatus) -> NodeState {
+    match status {
+        TodoStatus::Pending => NodeState::Ready,
+        TodoStatus::InProgress => NodeState::Active,
+        TodoStatus::Completed => NodeState::Completed,
+    }
+}
+
+fn more_advanced_state(left: NodeState, right: NodeState) -> NodeState {
+    fn rank(state: NodeState) -> u8 {
+        match state {
+            NodeState::Completed | NodeState::Verified => 2,
+            NodeState::Active => 1,
+            _ => 0,
+        }
+    }
+    if rank(right) > rank(left) {
+        right
+    } else {
+        left
+    }
+}
+
+/// The only remaining parser for the retired Plan→To-do marker writer.
+fn strip_plan_provenance(content: &str) -> (String, Option<u32>) {
+    let Some(start) = content.find(PLAN_PROVENANCE_PREFIX) else {
+        return (
+            content
+                .replace(PLAN_PROVENANCE_SUFFIX, "")
+                .trim()
+                .to_string(),
+            None,
+        );
+    };
+    let value_start = start + PLAN_PROVENANCE_PREFIX.len();
+    let (marker_end, index) =
+        if let Some(relative_end) = content[value_start..].find(PLAN_PROVENANCE_SUFFIX) {
+            let end = value_start + relative_end;
+            (
+                end + PLAN_PROVENANCE_SUFFIX.len(),
+                content[value_start..end].parse::<u32>().ok(),
+            )
+        } else {
+            // A truncated retired marker was never user content. Drop the
+            // unterminated suffix so hidden migration metadata cannot leak into
+            // either compatibility projection.
+            (content.len(), None)
+        };
+    let mut clean = String::with_capacity(content.len());
+    clean.push_str(&content[..start]);
+    clean.push_str(&content[marker_end..]);
+    (
+        clean.replace(PLAN_PROVENANCE_SUFFIX, "").trim().to_string(),
+        index,
+    )
+}
+
+#[cfg(test)]
+fn plan_provenance_marker(index: u32) -> String {
+    format!("{PLAN_PROVENANCE_PREFIX}{index}{PLAN_PROVENANCE_SUFFIX}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::plan::PlanItemArg;
+    use crate::tools::todo::TodoItem;
+    use crate::work_graph::{project_plan, project_todos, validate};
+
+    #[test]
+    fn legacy_import_is_deterministic_and_projects_complete_old_views() {
+        let plan = PlanSnapshot {
+            objective: Some("Ship it".to_string()),
+            items: vec![PlanItemArg {
+                step: "Verify".to_string(),
+                status: StepStatus::InProgress,
+            }],
+            ..PlanSnapshot::default()
+        };
+        let todos = TodoListSnapshot {
+            items: vec![TodoItem {
+                id: 4,
+                content: format!("Verify{}", plan_provenance_marker(0)),
+                status: TodoStatus::InProgress,
+            }],
+            completion_pct: 0,
+            in_progress_id: Some(4),
+        };
+        let first = import_legacy("session-1", &plan, &todos).expect("import");
+        let second = import_legacy("session-1", &plan, &todos).expect("repeat import");
+        assert_eq!(first, second);
+        validate(&first).expect("valid graph");
+        assert_eq!(project_plan(&first), plan);
+        let projected_todos = project_todos(&first);
+        assert_eq!(projected_todos.items[0].content, "Verify");
+        assert_eq!(projected_todos.items[0].status, TodoStatus::InProgress);
+        assert_eq!(first.compat.todos[0].node, first.compat.plan_order[0]);
+        assert!(!first.nodes[1].title.contains('\u{2063}'));
+    }
+
+    #[test]
+    fn malformed_retired_markers_never_leak_into_old_views() {
+        let plan = PlanSnapshot::default();
+        let todos = TodoListSnapshot {
+            items: vec![
+                TodoItem {
+                    id: 1,
+                    content: format!(
+                        "Visible{PLAN_PROVENANCE_PREFIX}not-a-number{PLAN_PROVENANCE_SUFFIX}"
+                    ),
+                    status: TodoStatus::Pending,
+                },
+                TodoItem {
+                    id: 2,
+                    content: format!("Also visible{PLAN_PROVENANCE_PREFIX}truncated"),
+                    status: TodoStatus::Pending,
+                },
+            ],
+            completion_pct: 0,
+            in_progress_id: None,
+        };
+        let graph = import_legacy("malformed-markers", &plan, &todos).expect("import");
+        let projected = project_todos(&graph);
+        assert_eq!(projected.items[0].content, "Visible");
+        assert_eq!(projected.items[1].content, "Also visible");
+        assert!(
+            projected
+                .items
+                .iter()
+                .all(|item| !item.content.contains('\u{2063}'))
+        );
+    }
+}

--- a/crates/tui/src/work_graph/mod.rs
+++ b/crates/tui/src/work_graph/mod.rs
@@ -24,25 +24,30 @@
 mod compat;
 mod events;
 mod ids;
+mod migration;
 mod model;
 mod reducer;
+mod runtime;
 mod validate;
 
 #[cfg(test)]
 mod tests;
 
+pub use compat::{PlanProjection, TodoProjection, project_plan, project_todos};
 pub use events::{
     ApprovalRef, CancelOutcome, ChangeCtx, ChangeReceipt, ObservationSummary, OperationObservation,
     OwnerState, ProposedNodeUpdate, WorkGraphChange, WorkGraphProposal, WorkNodePatch,
 };
 pub use ids::{BindingId, ChangeId, ProposalId, WorkEdgeId, WorkNodeId};
+pub use migration::import_legacy;
 pub use model::{
-    AcceptanceRequirement, BoundedSet, BoundedVec, EdgeKind, EvidenceKind, EvidenceKindTag,
-    EvidenceRef, EvidenceRefError, HISTORY_CAP, IdempotencyKey, NodeKind, NodeState,
-    OperationBinding, Provenance, SCHEMA_VERSION, SEEN_KEYS_CAP, Ts, WorkEdge, WorkGraphSnapshot,
-    WorkNode, external_identity_is_well_formed,
+    AcceptanceRequirement, BoundedSet, BoundedVec, CompatPlanMetadata, CompatProjectionState,
+    CompatTodoBinding, EdgeKind, EvidenceKind, EvidenceKindTag, EvidenceRef, EvidenceRefError,
+    HISTORY_CAP, IdempotencyKey, NodeKind, NodeState, OperationBinding, Provenance, SCHEMA_VERSION,
+    SEEN_KEYS_CAP, Ts, WorkEdge, WorkGraphSnapshot, WorkNode, external_identity_is_well_formed,
 };
 pub use reducer::apply;
+pub use runtime::{SharedWorkRuntime, WorkRuntime, WorkRuntimeSnapshot, new_shared_work_runtime};
 pub use validate::{ValidationCode, ValidationReport, Violation, validate};
 
 /// Convenience wrapper owning the current snapshot. [`WorkGraph::apply`]

--- a/crates/tui/src/work_graph/model.rs
+++ b/crates/tui/src/work_graph/model.rs
@@ -404,6 +404,84 @@ pub struct WorkEdge {
     pub to: WorkNodeId,
 }
 
+/// Graph-owned presentation metadata for the legacy Strategy/Plan surface.
+///
+/// Plan steps themselves live as `PlanStep` nodes. These fields have no
+/// first-class node equivalent yet, so they remain attached to the graph as
+/// presentation metadata rather than living in a separately writable store.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompatPlanMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub objective: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explanation: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources_used: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub critical_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recommended_approach: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risks_and_unknowns: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff_packet: Option<String>,
+}
+
+impl CompatPlanMetadata {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.objective.is_none()
+            && self.context_summary.is_none()
+            && self.explanation.is_none()
+            && self.sources_used.is_empty()
+            && self.critical_files.is_empty()
+            && self.constraints.is_empty()
+            && self.recommended_approach.is_none()
+            && self.verification_plan.is_none()
+            && self.risks_and_unknowns.is_none()
+            && self.handoff_packet.is_none()
+    }
+}
+
+/// One row in the legacy To-do projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompatTodoBinding {
+    pub legacy_id: u32,
+    pub node: WorkNodeId,
+    /// When present, the legacy row aliases this ordinal in `plan_order`.
+    /// The retired invisible marker is never reconstructed; the graph keeps
+    /// the provenance explicitly while old readers receive clean content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_index: Option<u32>,
+}
+
+/// Ordering and presentation state needed to derive old Plan/To-do snapshots.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompatProjectionState {
+    #[serde(default, skip_serializing_if = "CompatPlanMetadata::is_empty")]
+    pub plan: CompatPlanMetadata,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plan_order: Vec<WorkNodeId>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub todos: Vec<CompatTodoBinding>,
+}
+
+impl CompatProjectionState {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.plan.is_empty() && self.plan_order.is_empty() && self.todos.is_empty()
+    }
+}
+
 /// Idempotency key for owner-reported observations: `(binding, seq)`. Applied
 /// changes carrying a key already inside the snapshot's dedup window become
 /// receipts without effect, so replayed runtime events cannot double-apply.
@@ -533,6 +611,9 @@ pub struct WorkGraphSnapshot {
     /// `(binding, seq)` dedup window for replayed runtime observations.
     pub seen_keys: BoundedSet<IdempotencyKey, SEEN_KEYS_CAP>,
     pub proposals: Vec<WorkGraphProposal>,
+    /// Graph-owned inputs for the fully populated legacy Plan/To-do views.
+    #[serde(default, skip_serializing_if = "CompatProjectionState::is_empty")]
+    pub compat: CompatProjectionState,
 }
 
 impl WorkGraphSnapshot {
@@ -547,6 +628,7 @@ impl WorkGraphSnapshot {
             import_digest: None,
             seen_keys: BoundedSet::new(),
             proposals: Vec::new(),
+            compat: CompatProjectionState::default(),
         }
     }
 
@@ -570,6 +652,16 @@ impl WorkGraphSnapshot {
     pub fn node_is_done(node: &WorkNode) -> bool {
         matches!(node.state, NodeState::Verified)
             || (matches!(node.state, NodeState::Completed) && node.acceptance.is_empty())
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+            && self.edges.is_empty()
+            && self.history.is_empty()
+            && self.import_digest.is_none()
+            && self.proposals.is_empty()
+            && self.compat.is_empty()
     }
 }
 

--- a/crates/tui/src/work_graph/reducer.rs
+++ b/crates/tui/src/work_graph/reducer.rs
@@ -173,6 +173,15 @@ fn apply_pure(
             };
             add_edge(&mut next, edge)?;
         }
+        WorkGraphChange::ReplaceCompatProjection { compat } => {
+            next.compat = compat.clone();
+        }
+        WorkGraphChange::SetImportDigest { digest } => {
+            if digest.is_empty() {
+                return Err(structural("legacy import digest cannot be empty"));
+            }
+            next.import_digest = Some(digest.clone());
+        }
     }
     Ok(next)
 }

--- a/crates/tui/src/work_graph/runtime.rs
+++ b/crates/tui/src/work_graph/runtime.rs
@@ -1,0 +1,1082 @@
+//! Active-session Work Graph authority and legacy tool adapters.
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::tools::plan::{PlanSnapshot, PlanState, SharedPlanState, StepStatus};
+use crate::tools::todo::{SharedTodoList, TodoList, TodoListSnapshot, TodoStatus};
+
+use super::{
+    ApprovalRef, ChangeCtx, CompatPlanMetadata, CompatProjectionState, CompatTodoBinding, EdgeKind,
+    NodeKind, NodeState, ProposalId, Provenance, WorkEdge, WorkEdgeId, WorkGraph, WorkGraphChange,
+    WorkGraphProposal, WorkGraphSnapshot, WorkNode, WorkNodeId, WorkNodePatch, import_legacy,
+    project_plan, project_todos, validate,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkRuntimeSnapshot {
+    pub graph: WorkGraphSnapshot,
+    pub todos: TodoListSnapshot,
+    pub plan: PlanSnapshot,
+}
+
+#[derive(Debug, Default)]
+struct ActiveGraph {
+    session_id: Option<String>,
+    snapshot: Option<WorkGraphSnapshot>,
+    pending_publish: bool,
+}
+
+/// One active session graph plus the read-only legacy views it publishes.
+pub struct WorkRuntime {
+    todos: SharedTodoList,
+    plan: SharedPlanState,
+    graph: Mutex<ActiveGraph>,
+}
+
+pub type SharedWorkRuntime = Arc<WorkRuntime>;
+
+impl std::fmt::Debug for WorkRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let graph = lock_unpoisoned(&self.graph);
+        f.debug_struct("WorkRuntime")
+            .field("session_id", &graph.session_id)
+            .field("has_graph", &graph.snapshot.is_some())
+            .field("pending_publish", &graph.pending_publish)
+            .finish()
+    }
+}
+
+#[must_use]
+pub fn new_shared_work_runtime(todos: SharedTodoList, plan: SharedPlanState) -> SharedWorkRuntime {
+    Arc::new(WorkRuntime {
+        todos,
+        plan,
+        graph: Mutex::new(ActiveGraph::default()),
+    })
+}
+
+impl WorkRuntime {
+    #[must_use]
+    pub fn matches_todos(&self, todos: &SharedTodoList) -> bool {
+        Arc::ptr_eq(&self.todos, todos)
+    }
+
+    #[must_use]
+    pub fn matches_plan(&self, plan: &SharedPlanState) -> bool {
+        Arc::ptr_eq(&self.plan, plan)
+    }
+
+    /// Apply an `update_plan` payload through the graph and publish both
+    /// legacy projections only after the candidate graph validates.
+    pub async fn apply_plan_update(
+        &self,
+        session_id: &str,
+        tool: &str,
+        plan: &PlanSnapshot,
+    ) -> Result<PlanSnapshot, String> {
+        let todos_guard = self.todos.lock().await;
+        let plan_guard = self.plan.lock().await;
+        let mut active = lock_unpoisoned(&self.graph);
+        let base = graph_for_update(
+            &mut active,
+            session_id,
+            &plan_guard.snapshot(),
+            &todos_guard.snapshot(),
+        )?;
+        let next = update_plan_graph(base, session_id, tool, plan)?;
+        let derived_plan = project_plan(&next);
+        let derived_todos = project_todos(&next);
+        let next_plan = PlanState::from_snapshot(&derived_plan);
+        let next_todos = TodoList::from_snapshot(&derived_todos)?;
+        validate_combined(&next, &next_plan.snapshot(), &next_todos.snapshot())?;
+        active.snapshot = Some(next);
+        active.pending_publish = true;
+        Ok(derived_plan)
+    }
+
+    /// Apply a legacy To-do/checklist payload through the graph and publish
+    /// both projections from the committed candidate.
+    pub async fn apply_todo_update(
+        &self,
+        session_id: &str,
+        tool: &str,
+        todos: &TodoListSnapshot,
+    ) -> Result<TodoListSnapshot, String> {
+        let todos_guard = self.todos.lock().await;
+        let plan_guard = self.plan.lock().await;
+        let mut active = lock_unpoisoned(&self.graph);
+        let base = graph_for_update(
+            &mut active,
+            session_id,
+            &plan_guard.snapshot(),
+            &todos_guard.snapshot(),
+        )?;
+        let next = update_todo_graph(base, session_id, tool, todos)?;
+        let derived_plan = project_plan(&next);
+        let derived_todos = project_todos(&next);
+        let next_plan = PlanState::from_snapshot(&derived_plan);
+        let next_todos = TodoList::from_snapshot(&derived_todos)?;
+        validate_combined(&next, &next_plan.snapshot(), &next_todos.snapshot())?;
+        active.snapshot = Some(next);
+        active.pending_publish = true;
+        Ok(derived_todos)
+    }
+
+    /// Alias every current plan step into the legacy To-do view. This
+    /// replaces the old Plan→To-do bridge writer with a graph change.
+    pub async fn accept_plan(
+        &self,
+        session_id: Option<&str>,
+        approval_reference: &str,
+    ) -> Result<usize, String> {
+        let todos_guard = self.todos.lock().await;
+        let plan_guard = self.plan.lock().await;
+        let mut active = lock_unpoisoned(&self.graph);
+        let session_id = resolved_session_id(&active, session_id);
+        let base = graph_for_update(
+            &mut active,
+            &session_id,
+            &plan_guard.snapshot(),
+            &todos_guard.snapshot(),
+        )?;
+        if base.compat.plan_order.is_empty() {
+            // There is no Plan diff to accept. A legacy-only To-do import may
+            // still have happened while resolving the base and must receive
+            // its first graph-bearing persistence boundary.
+            if !base.is_empty() {
+                active.snapshot = Some(base);
+                active.pending_publish = true;
+            }
+            return Ok(0);
+        }
+        let mut graph = WorkGraph::from_snapshot(base);
+        let active_plan_node = graph
+            .snapshot()
+            .compat
+            .plan_order
+            .iter()
+            .find(|id| {
+                graph
+                    .snapshot()
+                    .node(id)
+                    .is_some_and(|node| node.state == NodeState::Active)
+            })
+            .cloned();
+        if let Some(active_plan_node) = active_plan_node.as_ref() {
+            let competing = graph
+                .snapshot()
+                .compat
+                .todos
+                .iter()
+                .filter(|binding| &binding.node != active_plan_node)
+                .filter_map(|binding| {
+                    graph
+                        .snapshot()
+                        .node(&binding.node)
+                        .filter(|node| node.state == NodeState::Active)
+                        .map(|node| (node.id.clone(), node.title.clone()))
+                })
+                .collect::<Vec<_>>();
+            for (id, title) in competing {
+                patch_existing_node(
+                    &mut graph,
+                    &session_id,
+                    "plan_acceptance",
+                    &id,
+                    title,
+                    NodeState::Ready,
+                )?;
+            }
+        }
+        let mut compat = graph.snapshot().compat.clone();
+        let mut next_id = compat
+            .todos
+            .iter()
+            .map(|binding| binding.legacy_id)
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| "To-do item IDs are exhausted".to_string())?;
+        let before = compat.todos.len();
+        for (index, node) in compat.plan_order.iter().enumerate() {
+            if compat.todos.iter().any(|binding| &binding.node == node) {
+                continue;
+            }
+            compat.todos.push(CompatTodoBinding {
+                legacy_id: next_id,
+                node: node.clone(),
+                plan_index: Some(u32::try_from(index).map_err(|_| "too many plan steps")?),
+            });
+            next_id = next_id
+                .checked_add(1)
+                .ok_or_else(|| "To-do item IDs are exhausted".to_string())?;
+        }
+        let changed = compat.todos.len().saturating_sub(before);
+        let proposal_id = ProposalId::derive(
+            &session_id,
+            &format!("plan-acceptance:{}", graph.snapshot().revision),
+        );
+        apply_change(
+            &mut graph,
+            &session_id,
+            "plan_acceptance",
+            WorkGraphChange::ProposePlanDiff {
+                proposal: WorkGraphProposal {
+                    id: proposal_id.clone(),
+                    added_nodes: Vec::new(),
+                    added_edges: Vec::new(),
+                    updated_nodes: Vec::new(),
+                    removed_edges: Vec::new(),
+                },
+            },
+        )?;
+        apply_change(
+            &mut graph,
+            &session_id,
+            "plan_acceptance",
+            WorkGraphChange::AcceptPlanDiff {
+                proposal_id,
+                approval: ApprovalRef {
+                    reference: approval_reference.to_string(),
+                },
+            },
+        )?;
+        apply_change(
+            &mut graph,
+            &session_id,
+            "plan_acceptance",
+            WorkGraphChange::ReplaceCompatProjection { compat },
+        )?;
+        let next = graph.into_snapshot();
+        let derived_plan = project_plan(&next);
+        let derived_todos = project_todos(&next);
+        let next_plan = PlanState::from_snapshot(&derived_plan);
+        let next_todos = TodoList::from_snapshot(&derived_todos)?;
+        validate_combined(&next, &next_plan.snapshot(), &next_todos.snapshot())?;
+        active.snapshot = Some(next);
+        active.pending_publish = true;
+        Ok(changed)
+    }
+
+    /// Publish the latest validated legacy views after the caller has queued
+    /// their graph-backed session/checkpoint write.
+    pub async fn publish_pending(&self) -> Result<bool, String> {
+        let mut todos = self.todos.lock().await;
+        let mut plan = self.plan.lock().await;
+        let mut active = lock_unpoisoned(&self.graph);
+        if !active.pending_publish {
+            return Ok(false);
+        }
+        let graph = active
+            .snapshot
+            .as_ref()
+            .ok_or_else(|| "pending Work projection has no graph".to_string())?;
+        let derived_plan = project_plan(graph);
+        let derived_todos = project_todos(graph);
+        let next_plan = PlanState::from_snapshot(&derived_plan);
+        let next_todos = TodoList::from_snapshot(&derived_todos)?;
+        validate_combined(graph, &next_plan.snapshot(), &next_todos.snapshot())?;
+        *plan = next_plan;
+        *todos = next_todos;
+        active.pending_publish = false;
+        Ok(true)
+    }
+
+    /// Synchronous counterpart for explicit save/rename/fork commands that
+    /// have already completed their atomic disk write.
+    pub fn publish_pending_sync(&self) -> Result<bool, String> {
+        let mut todos = retry_lock(&self.todos, 100).ok_or_else(|| {
+            "To-do state is busy; saved Work views were not published".to_string()
+        })?;
+        let mut plan = retry_lock(&self.plan, 100)
+            .ok_or_else(|| "Plan state is busy; saved Work views were not published".to_string())?;
+        let mut active = lock_unpoisoned(&self.graph);
+        if !active.pending_publish {
+            return Ok(false);
+        }
+        let graph = active
+            .snapshot
+            .as_ref()
+            .ok_or_else(|| "pending Work projection has no graph".to_string())?;
+        let derived_plan = project_plan(graph);
+        let derived_todos = project_todos(graph);
+        let next_plan = PlanState::from_snapshot(&derived_plan);
+        let next_todos = TodoList::from_snapshot(&derived_todos)?;
+        validate_combined(graph, &next_plan.snapshot(), &next_todos.snapshot())?;
+        *plan = next_plan;
+        *todos = next_todos;
+        active.pending_publish = false;
+        Ok(true)
+    }
+
+    #[must_use]
+    pub fn has_pending_publish(&self) -> bool {
+        lock_unpoisoned(&self.graph).pending_publish
+    }
+
+    /// Latest graph-derived To-do view, including an unpublished transaction.
+    pub async fn current_todos(&self) -> Result<TodoListSnapshot, String> {
+        let projected = {
+            let active = lock_unpoisoned(&self.graph);
+            active.snapshot.as_ref().map(project_todos)
+        };
+        if let Some(projected) = projected {
+            return Ok(projected);
+        }
+        Ok(self.todos.lock().await.snapshot())
+    }
+
+    /// Capture a persistence-ready graph plus fully populated old views.
+    /// Legacy-only in-memory state is imported once and normalized in place.
+    pub fn capture(&self, session_id: Option<&str>) -> Result<Option<WorkRuntimeSnapshot>, String> {
+        self.capture_with_retries(session_id, 100)
+    }
+
+    /// Non-blocking capture for the render/event loop.
+    pub fn try_capture(
+        &self,
+        session_id: Option<&str>,
+    ) -> Result<Option<WorkRuntimeSnapshot>, String> {
+        self.capture_with_retries(session_id, 1)
+    }
+
+    fn capture_with_retries(
+        &self,
+        session_id: Option<&str>,
+        retries: u32,
+    ) -> Result<Option<WorkRuntimeSnapshot>, String> {
+        let todos = retry_lock(&self.todos, retries)
+            .ok_or_else(|| "To-do state is busy; try saving again".to_string())?;
+        let plan = retry_lock(&self.plan, retries)
+            .ok_or_else(|| "Plan state is busy; try saving again".to_string())?;
+        let mut active = lock_unpoisoned(&self.graph);
+        let todos_snapshot = todos.snapshot();
+        let plan_snapshot = plan.snapshot();
+        if todos_snapshot.is_empty()
+            && plan_snapshot.is_empty()
+            && active
+                .snapshot
+                .as_ref()
+                .is_none_or(WorkGraphSnapshot::is_empty)
+        {
+            return Ok(None);
+        }
+        let had_graph = active.snapshot.is_some();
+        let had_pending_publish = active.pending_publish;
+        let session_id = resolved_session_id(&active, session_id);
+        let graph = graph_for_update(&mut active, &session_id, &plan_snapshot, &todos_snapshot)?;
+        let derived_plan = project_plan(&graph);
+        let derived_todos = project_todos(&graph);
+        validate_combined(&graph, &derived_plan, &derived_todos)?;
+        if had_graph
+            && !had_pending_publish
+            && (derived_plan != plan_snapshot || derived_todos != todos_snapshot)
+        {
+            return Err("live Work Graph and legacy views disagree".to_string());
+        }
+        active.snapshot = Some(graph.clone());
+        if !had_graph {
+            active.pending_publish = true;
+        }
+        Ok(Some(WorkRuntimeSnapshot {
+            graph,
+            todos: derived_todos,
+            plan: derived_plan,
+        }))
+    }
+
+    /// Validate and atomically activate persisted state. Sessions without a
+    /// graph are deterministically imported from their complete old views.
+    pub fn restore(
+        &self,
+        session_id: &str,
+        graph: Option<&WorkGraphSnapshot>,
+        todos: &TodoListSnapshot,
+        plan: &PlanSnapshot,
+    ) -> Result<Option<WorkRuntimeSnapshot>, String> {
+        let had_graph = graph.is_some();
+        let graph = match graph {
+            Some(graph) => {
+                validate(graph).map_err(|err| err.to_string())?;
+                graph.clone()
+            }
+            None if todos.is_empty() && plan.is_empty() => WorkGraphSnapshot::new(),
+            None => import_legacy(session_id, plan, todos)?,
+        };
+        let derived_plan = project_plan(&graph);
+        let derived_todos = project_todos(&graph);
+        if graph.is_empty() {
+            if !todos.is_empty() || !plan.is_empty() {
+                return Err("empty Work Graph cannot carry non-empty legacy views".to_string());
+            }
+        } else if graph.import_digest.is_some() && graph.compat.is_empty() {
+            return Err("imported Work Graph is missing compatibility projections".to_string());
+        }
+        validate_combined(&graph, &derived_plan, &derived_todos)?;
+        if had_graph && (&derived_plan != plan || &derived_todos != todos) {
+            return Err("persisted Work Graph and legacy views disagree".to_string());
+        }
+        let next_plan = PlanState::from_snapshot(&derived_plan);
+        let next_todos = TodoList::from_snapshot(&derived_todos)?;
+        let mut todos_guard = retry_lock(&self.todos, 100)
+            .ok_or_else(|| "To-do state is busy; session was not restored".to_string())?;
+        let mut plan_guard = retry_lock(&self.plan, 100)
+            .ok_or_else(|| "Plan state is busy; session was not restored".to_string())?;
+        let mut active = lock_unpoisoned(&self.graph);
+        *todos_guard = next_todos;
+        *plan_guard = next_plan;
+        active.session_id = Some(session_id.to_string());
+        active.snapshot = Some(graph.clone());
+        // A legacy load has already restored its complete old views, but its
+        // newly imported graph still needs one acknowledged graph-bearing
+        // write (and pre-import archive) before the migration is settled.
+        active.pending_publish = !had_graph && !graph.is_empty();
+        if graph.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(WorkRuntimeSnapshot {
+                graph,
+                todos: derived_todos,
+                plan: derived_plan,
+            }))
+        }
+    }
+
+    pub fn clear(&self, session_id: Option<&str>) -> bool {
+        let Some(mut todos) = retry_lock(&self.todos, 100) else {
+            return false;
+        };
+        let Some(mut plan) = retry_lock(&self.plan, 100) else {
+            return false;
+        };
+        let mut active = lock_unpoisoned(&self.graph);
+        todos.clear();
+        *plan = PlanState::default();
+        active.session_id = Some(resolved_session_id(&active, session_id));
+        active.snapshot = Some(WorkGraphSnapshot::new());
+        active.pending_publish = false;
+        true
+    }
+}
+
+fn graph_for_update(
+    active: &mut ActiveGraph,
+    session_id: &str,
+    plan: &PlanSnapshot,
+    todos: &TodoListSnapshot,
+) -> Result<WorkGraphSnapshot, String> {
+    match active.session_id.as_deref() {
+        // App session transitions are already blocked while runtime work is
+        // active. Rebind the authority namespace without re-keying graph IDs
+        // so save-as/fork/new-session flows keep one coherent snapshot.
+        Some(active_id) if active_id != session_id => {
+            active.session_id = Some(session_id.to_string());
+        }
+        None => active.session_id = Some(session_id.to_string()),
+        Some(_) => {}
+    }
+    if let Some(snapshot) = active.snapshot.as_ref() {
+        validate(snapshot).map_err(|err| err.to_string())?;
+        return Ok(snapshot.clone());
+    }
+    let graph = if plan.is_empty() && todos.is_empty() {
+        WorkGraphSnapshot::new()
+    } else {
+        import_legacy(session_id, plan, todos)?
+    };
+    active.snapshot = Some(graph.clone());
+    Ok(graph)
+}
+
+fn update_plan_graph(
+    base: WorkGraphSnapshot,
+    session_id: &str,
+    tool: &str,
+    plan: &PlanSnapshot,
+) -> Result<WorkGraphSnapshot, String> {
+    let mut graph = WorkGraph::from_snapshot(base);
+    let objective = ensure_objective(&mut graph, session_id, tool, plan)?;
+    let desired_active_alias = plan.items.iter().enumerate().find_map(|(index, item)| {
+        (item.status == StepStatus::InProgress)
+            .then(|| graph.snapshot().compat.plan_order.get(index).cloned())
+            .flatten()
+            .filter(|node| {
+                graph
+                    .snapshot()
+                    .compat
+                    .todos
+                    .iter()
+                    .any(|binding| &binding.node == node)
+            })
+    });
+    if desired_active_alias.is_some() {
+        deactivate_projected_todos(&mut graph, session_id, tool)?;
+    }
+
+    let mut order = Vec::with_capacity(plan.items.len());
+    for (index, item) in plan.items.iter().enumerate() {
+        let id = graph
+            .snapshot()
+            .compat
+            .plan_order
+            .get(index)
+            .cloned()
+            .unwrap_or_else(|| WorkNodeId::derive(session_id, &format!("plan:{index}")));
+        let provenance = tool_provenance(graph.snapshot(), tool);
+        upsert_node(
+            &mut graph,
+            session_id,
+            tool,
+            WorkNode {
+                id: id.clone(),
+                kind: NodeKind::PlanStep,
+                title: item.step.trim().to_string(),
+                state: plan_node_state(&item.status),
+                acceptance: Vec::new(),
+                binding: None,
+                evidence: None,
+                provenance,
+                created_at: now_ms(),
+                updated_at: now_ms(),
+            },
+        )?;
+        ensure_contains(&mut graph, session_id, tool, &objective, &id)?;
+        order.push(id);
+    }
+    let mut compat = graph.snapshot().compat.clone();
+    compat.plan = CompatPlanMetadata::from_plan_snapshot(plan);
+    compat.plan_order = order;
+    compat.todos.retain(|binding| {
+        binding.plan_index.is_none_or(|index| {
+            usize::try_from(index)
+                .ok()
+                .is_some_and(|i| i < plan.items.len())
+        })
+    });
+    for binding in &mut compat.todos {
+        if let Some(index) = binding.plan_index
+            && let Some(node) = compat
+                .plan_order
+                .get(usize::try_from(index).unwrap_or(usize::MAX))
+        {
+            binding.node.clone_from(node);
+        }
+    }
+    apply_change(
+        &mut graph,
+        session_id,
+        tool,
+        WorkGraphChange::ReplaceCompatProjection { compat },
+    )?;
+    Ok(graph.into_snapshot())
+}
+
+fn update_todo_graph(
+    base: WorkGraphSnapshot,
+    session_id: &str,
+    tool: &str,
+    todos: &TodoListSnapshot,
+) -> Result<WorkGraphSnapshot, String> {
+    let mut graph = WorkGraph::from_snapshot(base);
+    deactivate_projected_todos(&mut graph, session_id, tool)?;
+    let current_plan = project_plan(graph.snapshot());
+    let objective = ensure_objective(&mut graph, session_id, tool, &current_plan)?;
+    let plan_order = graph.snapshot().compat.plan_order.clone();
+    let mut bindings = Vec::with_capacity(todos.items.len());
+    for item in &todos.items {
+        let title = item.content.trim().to_string();
+        let alias = graph
+            .snapshot()
+            .compat
+            .todos
+            .iter()
+            .find(|binding| binding.legacy_id == item.id)
+            .and_then(|binding| {
+                binding
+                    .plan_index
+                    .map(|index| (index, binding.node.clone()))
+            })
+            .filter(|(index, node)| {
+                plan_order.get(usize::try_from(*index).unwrap_or(usize::MAX)) == Some(node)
+            });
+        let (node, plan_index) = if let Some((index, node)) = alias {
+            patch_existing_node(
+                &mut graph,
+                session_id,
+                tool,
+                &node,
+                title,
+                todo_node_state(item.status),
+            )?;
+            (node, Some(index))
+        } else {
+            let node = graph
+                .snapshot()
+                .compat
+                .todos
+                .iter()
+                .find(|binding| binding.legacy_id == item.id && binding.plan_index.is_none())
+                .map(|binding| binding.node.clone())
+                .unwrap_or_else(|| WorkNodeId::derive(session_id, &format!("todo:{}", item.id)));
+            let desired = todo_node_state(item.status);
+            let provenance = tool_provenance(graph.snapshot(), tool);
+            upsert_node(
+                &mut graph,
+                session_id,
+                tool,
+                WorkNode {
+                    id: node.clone(),
+                    kind: NodeKind::PlanStep,
+                    title,
+                    state: if desired == NodeState::Active {
+                        NodeState::Ready
+                    } else {
+                        desired
+                    },
+                    acceptance: Vec::new(),
+                    binding: None,
+                    evidence: None,
+                    provenance,
+                    created_at: now_ms(),
+                    updated_at: now_ms(),
+                },
+            )?;
+            ensure_contains(&mut graph, session_id, tool, &objective, &node)?;
+            if desired == NodeState::Active {
+                let clean_title = graph
+                    .snapshot()
+                    .node(&node)
+                    .map(|node| node.title.clone())
+                    .ok_or_else(|| format!("node {node} not found after insert"))?;
+                patch_existing_node(&mut graph, session_id, tool, &node, clean_title, desired)?;
+            }
+            (node, None)
+        };
+        bindings.push(CompatTodoBinding {
+            legacy_id: item.id,
+            node,
+            plan_index,
+        });
+    }
+    let mut compat = graph.snapshot().compat.clone();
+    compat.todos = bindings;
+    apply_change(
+        &mut graph,
+        session_id,
+        tool,
+        WorkGraphChange::ReplaceCompatProjection { compat },
+    )?;
+    Ok(graph.into_snapshot())
+}
+
+fn ensure_objective(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    tool: &str,
+    plan: &PlanSnapshot,
+) -> Result<WorkNodeId, String> {
+    let id = graph
+        .snapshot()
+        .nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::Objective)
+        .map(|node| node.id.clone())
+        .unwrap_or_else(|| WorkNodeId::derive(session_id, "objective"));
+    let title = plan
+        .objective
+        .as_deref()
+        .or(plan.title.as_deref())
+        .unwrap_or("Session work")
+        .to_string();
+    upsert_node(
+        graph,
+        session_id,
+        tool,
+        WorkNode {
+            id: id.clone(),
+            kind: NodeKind::Objective,
+            title,
+            state: NodeState::Ready,
+            acceptance: Vec::new(),
+            binding: None,
+            evidence: None,
+            provenance: tool_provenance(graph.snapshot(), tool),
+            created_at: now_ms(),
+            updated_at: now_ms(),
+        },
+    )?;
+    Ok(id)
+}
+
+fn upsert_node(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    tool: &str,
+    node: WorkNode,
+) -> Result<(), String> {
+    if let Some(existing) = graph.snapshot().node(&node.id) {
+        if existing.kind != node.kind {
+            return Err(format!("node {} changed kind", node.id));
+        }
+        patch_existing_node(graph, session_id, tool, &node.id, node.title, node.state)
+    } else {
+        apply_change(graph, session_id, tool, WorkGraphChange::AddNode { node })
+    }
+}
+
+fn patch_existing_node(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    tool: &str,
+    id: &WorkNodeId,
+    title: String,
+    state: NodeState,
+) -> Result<(), String> {
+    let current = graph
+        .snapshot()
+        .node(id)
+        .ok_or_else(|| format!("node {id} not found"))?;
+    let provenance = tool_provenance(graph.snapshot(), tool);
+    if current.title == title && current.state == state && current.provenance == provenance {
+        return Ok(());
+    }
+    apply_change(
+        graph,
+        session_id,
+        tool,
+        WorkGraphChange::UpdateNode {
+            id: id.clone(),
+            patch: WorkNodePatch {
+                title: Some(title),
+                state: Some(state),
+                provenance: Some(provenance),
+                ..WorkNodePatch::default()
+            },
+        },
+    )
+}
+
+fn ensure_contains(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    tool: &str,
+    parent: &WorkNodeId,
+    child: &WorkNodeId,
+) -> Result<(), String> {
+    let id = WorkEdgeId::derive(
+        session_id,
+        &format!("contains:{}:{}", parent.as_str(), child.as_str()),
+    );
+    if graph.snapshot().edge(&id).is_some() {
+        return Ok(());
+    }
+    apply_change(
+        graph,
+        session_id,
+        tool,
+        WorkGraphChange::AddEdge {
+            edge: WorkEdge {
+                id,
+                kind: EdgeKind::Contains,
+                from: parent.clone(),
+                to: child.clone(),
+            },
+        },
+    )
+}
+
+fn deactivate_projected_todos(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    tool: &str,
+) -> Result<(), String> {
+    let active = graph
+        .snapshot()
+        .compat
+        .todos
+        .iter()
+        .filter_map(|binding| {
+            graph
+                .snapshot()
+                .node(&binding.node)
+                .filter(|node| node.state == NodeState::Active)
+                .map(|node| (node.id.clone(), node.title.clone()))
+        })
+        .collect::<Vec<_>>();
+    for (id, title) in active {
+        patch_existing_node(graph, session_id, tool, &id, title, NodeState::Ready)?;
+    }
+    Ok(())
+}
+
+fn apply_change(
+    graph: &mut WorkGraph,
+    session_id: &str,
+    tool: &str,
+    change: WorkGraphChange,
+) -> Result<(), String> {
+    graph
+        .apply(
+            change,
+            ChangeCtx {
+                session_id: session_id.to_string(),
+                now: now_ms(),
+                idempotency_key: None,
+            },
+        )
+        .map(|_| ())
+        .map_err(|err| format!("{tool}: {err}"))
+}
+
+fn validate_combined(
+    graph: &WorkGraphSnapshot,
+    plan: &PlanSnapshot,
+    todos: &TodoListSnapshot,
+) -> Result<(), String> {
+    validate(graph).map_err(|err| err.to_string())?;
+    if &project_plan(graph) != plan {
+        return Err("Work Graph Plan projection is inconsistent".to_string());
+    }
+    if &project_todos(graph) != todos {
+        return Err("Work Graph To-do projection is inconsistent".to_string());
+    }
+    TodoList::from_snapshot(todos)?;
+    Ok(())
+}
+
+fn tool_provenance(snapshot: &WorkGraphSnapshot, tool: &str) -> Provenance {
+    Provenance::ToolUpdate {
+        tool: tool.to_string(),
+        call_id: format!("{tool}:{}", snapshot.revision.saturating_add(1)),
+    }
+}
+
+fn plan_node_state(status: &StepStatus) -> NodeState {
+    match status {
+        StepStatus::Pending => NodeState::Ready,
+        StepStatus::InProgress => NodeState::Active,
+        StepStatus::Completed => NodeState::Completed,
+    }
+}
+
+fn todo_node_state(status: TodoStatus) -> NodeState {
+    match status {
+        TodoStatus::Pending => NodeState::Ready,
+        TodoStatus::InProgress => NodeState::Active,
+        TodoStatus::Completed => NodeState::Completed,
+    }
+}
+
+fn resolved_session_id(active: &ActiveGraph, requested: Option<&str>) -> String {
+    requested
+        .map(str::to_string)
+        .or_else(|| active.session_id.clone())
+        .unwrap_or_else(|| "unsaved-work".to_string())
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn retry_lock<T>(
+    mutex: &tokio::sync::Mutex<T>,
+    retries: u32,
+) -> Option<tokio::sync::MutexGuard<'_, T>> {
+    for _ in 0..retries {
+        if let Ok(guard) = mutex.try_lock() {
+            return Some(guard);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::plan::PlanItemArg;
+    use crate::tools::todo::TodoItem;
+
+    #[tokio::test]
+    async fn adapters_keep_graph_and_both_legacy_views_in_lockstep() {
+        let todos = crate::tools::todo::new_shared_todo_list();
+        let plan = crate::tools::plan::new_shared_plan_state();
+        let runtime = new_shared_work_runtime(todos.clone(), plan.clone());
+        let plan_snapshot = PlanSnapshot {
+            objective: Some("Release".to_string()),
+            items: vec![PlanItemArg {
+                step: "Test".to_string(),
+                status: StepStatus::InProgress,
+            }],
+            ..PlanSnapshot::default()
+        };
+        runtime
+            .apply_plan_update("session", "update_plan", &plan_snapshot)
+            .await
+            .expect("plan update");
+        assert_eq!(
+            runtime.accept_plan(Some("session"), "accept_act").await,
+            Ok(1)
+        );
+        assert_eq!(runtime.publish_pending().await, Ok(true));
+        assert_eq!(
+            runtime.accept_plan(Some("session"), "accept_act").await,
+            Ok(0),
+            "already-aliased acceptance adds no duplicate To-do rows"
+        );
+        let repeated_acceptance = runtime
+            .capture(Some("session"))
+            .expect("capture repeated acceptance")
+            .expect("state");
+        assert_eq!(
+            repeated_acceptance
+                .graph
+                .nodes
+                .iter()
+                .filter(|node| node.kind == NodeKind::Approval)
+                .count(),
+            2,
+            "every explicit acceptance retains its own Approval node"
+        );
+        assert_eq!(runtime.publish_pending().await, Ok(true));
+        let todo_snapshot = todos.lock().await.snapshot();
+        assert_eq!(todo_snapshot.items.len(), 1);
+        let desired = TodoListSnapshot {
+            items: vec![TodoItem {
+                id: todo_snapshot.items[0].id,
+                content: todo_snapshot.items[0].content.clone(),
+                status: TodoStatus::Completed,
+            }],
+            completion_pct: 100,
+            in_progress_id: None,
+        };
+        runtime
+            .apply_todo_update("session", "work_update", &desired)
+            .await
+            .expect("todo update");
+        assert_eq!(runtime.publish_pending().await, Ok(true));
+        assert_eq!(
+            plan.lock().await.snapshot().items[0].status,
+            StepStatus::Completed
+        );
+        let captured = runtime
+            .capture(Some("session"))
+            .expect("capture")
+            .expect("state");
+        assert_eq!(project_plan(&captured.graph), captured.plan);
+        assert_eq!(project_todos(&captured.graph), captured.todos);
+    }
+
+    #[tokio::test]
+    async fn accepting_active_plan_step_preserves_single_active_todo() {
+        let todos = crate::tools::todo::new_shared_todo_list();
+        let plan = crate::tools::plan::new_shared_plan_state();
+        let runtime = new_shared_work_runtime(todos, plan);
+        runtime
+            .apply_todo_update(
+                "session",
+                "work_update",
+                &TodoListSnapshot {
+                    items: vec![TodoItem {
+                        id: 1,
+                        content: "Existing work".to_string(),
+                        status: TodoStatus::InProgress,
+                    }],
+                    completion_pct: 0,
+                    in_progress_id: Some(1),
+                },
+            )
+            .await
+            .expect("todo update");
+        runtime
+            .apply_plan_update(
+                "session",
+                "update_plan",
+                &PlanSnapshot {
+                    items: vec![PlanItemArg {
+                        step: "Accepted work".to_string(),
+                        status: StepStatus::InProgress,
+                    }],
+                    ..PlanSnapshot::default()
+                },
+            )
+            .await
+            .expect("plan update");
+        assert_eq!(
+            runtime
+                .capture(Some("session"))
+                .expect("capture")
+                .expect("state")
+                .todos
+                .in_progress_id,
+            Some(1),
+            "an unaccepted plan must not disturb active To-do work"
+        );
+
+        runtime
+            .accept_plan(Some("session"), "accept_act")
+            .await
+            .expect("accept plan");
+        let captured = runtime
+            .capture(Some("session"))
+            .expect("capture")
+            .expect("state");
+        assert_eq!(
+            captured
+                .todos
+                .items
+                .iter()
+                .filter(|item| item.status == TodoStatus::InProgress)
+                .count(),
+            1
+        );
+        assert_eq!(captured.todos.in_progress_id, Some(2));
+        assert!(
+            captured
+                .graph
+                .nodes
+                .iter()
+                .any(|node| node.kind == NodeKind::Approval),
+            "accepted plans must retain an Approval node"
+        );
+    }
+
+    #[test]
+    fn legacy_restore_stays_pending_until_first_graph_bearing_write() {
+        let todos = crate::tools::todo::new_shared_todo_list();
+        let plan = crate::tools::plan::new_shared_plan_state();
+        let runtime = new_shared_work_runtime(todos.clone(), plan.clone());
+        let legacy_plan = PlanSnapshot {
+            items: vec![PlanItemArg {
+                step: "Migrate once".to_string(),
+                status: StepStatus::InProgress,
+            }],
+            ..PlanSnapshot::default()
+        };
+
+        runtime
+            .restore(
+                "legacy-session",
+                None,
+                &TodoListSnapshot::default(),
+                &legacy_plan,
+            )
+            .expect("restore legacy state");
+        assert!(runtime.has_pending_publish());
+        let captured = runtime
+            .capture(Some("legacy-session"))
+            .expect("capture imported graph")
+            .expect("state");
+        assert!(captured.graph.import_digest.is_some());
+        assert_eq!(plan.blocking_lock().snapshot(), legacy_plan);
+        assert_eq!(runtime.publish_pending_sync(), Ok(true));
+        assert!(!runtime.has_pending_publish());
+        assert!(todos.blocking_lock().snapshot().is_empty());
+    }
+}

--- a/crates/tui/src/work_graph/tests.rs
+++ b/crates/tui/src/work_graph/tests.rs
@@ -464,6 +464,19 @@ fn v10_projections_are_pure_functions_of_snapshot() {
     let _todos: fn(&WorkGraphSnapshot) -> compat::TodoProjection = compat::project_todos;
 }
 
+#[test]
+fn compat_todo_binding_rejects_non_plan_step_node() {
+    let mut bad = seeded().snapshot().clone();
+    bad.compat.todos.push(CompatTodoBinding {
+        legacy_id: 1,
+        node: nid("root"),
+        plan_index: None,
+    });
+
+    let report = validate(&bad).expect_err("compat To-do rows must bind to PlanStep nodes");
+    assert!(report.contains_code(ValidationCode::Structural));
+}
+
 /// A representative change sequence exercising nodes, edges, bindings,
 /// reconciliation, evidence, proposals, and supersede.
 fn scripted_run() -> WorkGraph {

--- a/crates/tui/src/work_graph/validate.rs
+++ b/crates/tui/src/work_graph/validate.rs
@@ -164,6 +164,81 @@ fn check_structural(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
             }
         }
     }
+
+    let mut plan_ids = HashSet::new();
+    for id in &snapshot.compat.plan_order {
+        if !plan_ids.insert(id) {
+            out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!("duplicate plan projection node {id}"),
+            });
+        }
+        match snapshot.node(id) {
+            Some(node) if matches!(node.kind, NodeKind::PlanStep) => {}
+            Some(_) => out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!("plan projection node {id} is not a PlanStep"),
+            }),
+            None => out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!("plan projection references missing node {id}"),
+            }),
+        }
+    }
+
+    let mut todo_ids = HashSet::new();
+    let mut active_todos = 0usize;
+    for binding in &snapshot.compat.todos {
+        if binding.legacy_id == 0 || !todo_ids.insert(binding.legacy_id) {
+            out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!("invalid or duplicate legacy To-do id {}", binding.legacy_id),
+            });
+        }
+        match snapshot.node(&binding.node) {
+            Some(node) => {
+                if node.kind != NodeKind::PlanStep {
+                    out.push(Violation {
+                        code: ValidationCode::Structural,
+                        message: format!(
+                            "To-do projection {} node {} is not a PlanStep",
+                            binding.legacy_id, binding.node
+                        ),
+                    });
+                }
+                if matches!(node.state, NodeState::Active) {
+                    active_todos += 1;
+                }
+            }
+            None => out.push(Violation {
+                code: ValidationCode::Structural,
+                message: format!(
+                    "To-do projection {} references missing node {}",
+                    binding.legacy_id, binding.node
+                ),
+            }),
+        }
+        if let Some(index) = binding.plan_index {
+            let aliased = usize::try_from(index)
+                .ok()
+                .and_then(|index| snapshot.compat.plan_order.get(index));
+            if aliased != Some(&binding.node) {
+                out.push(Violation {
+                    code: ValidationCode::Structural,
+                    message: format!(
+                        "To-do projection {} has an invalid plan alias",
+                        binding.legacy_id
+                    ),
+                });
+            }
+        }
+    }
+    if active_todos > 1 {
+        out.push(Violation {
+            code: ValidationCode::Structural,
+            message: "legacy To-do projection has more than one active row".to_string(),
+        });
+    }
 }
 
 /// V1: DFS three-color cycle detection over `DependsOn` edges.

--- a/crates/tui/tests/fixtures/work_graph_session_v1_reader.json
+++ b/crates/tui/tests/fixtures/work_graph_session_v1_reader.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "id": "11111111-2222-4333-8444-555555555555",
+    "title": "Work Graph old-reader fixture",
+    "created_at": "2026-07-18T00:00:00Z",
+    "updated_at": "2026-07-18T00:00:00Z",
+    "message_count": 0,
+    "total_tokens": 0,
+    "model": "fixture-model",
+    "model_provider": "deepseek",
+    "workspace": "/tmp/codewhale-wg2-old-reader",
+    "mode": "plan"
+  },
+  "messages": [],
+  "system_prompt": null,
+  "work_state": {
+    "graph": {
+      "schema": 1,
+      "revision": 0,
+      "nodes": [
+        {
+          "id": "wn:111111111111",
+          "kind": "objective",
+          "title": "Fixture objective",
+          "state": "ready",
+          "acceptance": [],
+          "binding": null,
+          "evidence": null,
+          "provenance": {
+            "import": {
+              "source_digest": "fixture-digest",
+              "ordinal": null
+            }
+          },
+          "created_at": 0,
+          "updated_at": 0
+        },
+        {
+          "id": "wn:222222222222",
+          "kind": "plan_step",
+          "title": "Visible fixture step",
+          "state": "active",
+          "acceptance": [],
+          "binding": null,
+          "evidence": null,
+          "provenance": {
+            "import": {
+              "source_digest": "fixture-digest",
+              "ordinal": 0
+            }
+          },
+          "created_at": 0,
+          "updated_at": 0
+        }
+      ],
+      "edges": [
+        {
+          "id": "we:111111111111",
+          "kind": "contains",
+          "from": "wn:111111111111",
+          "to": "wn:222222222222"
+        }
+      ],
+      "history": [],
+      "import_digest": "fixture-digest",
+      "seen_keys": [],
+      "proposals": [],
+      "compat": {
+        "plan": {
+          "objective": "Fixture objective"
+        },
+        "plan_order": ["wn:222222222222"],
+        "todos": [
+          {
+            "legacy_id": 7,
+            "node": "wn:222222222222",
+            "plan_index": 0
+          }
+        ]
+      }
+    },
+    "todos": {
+      "items": [
+        {
+          "id": 7,
+          "content": "Visible fixture step",
+          "status": "in_progress"
+        }
+      ],
+      "completion_pct": 0,
+      "in_progress_id": 7
+    },
+    "plan": {
+      "objective": "Fixture objective",
+      "items": [
+        {
+          "step": "Visible fixture step",
+          "status": "in_progress"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- make the active-session Work Graph authoritative for Plan and To-do tools
- preserve complete legacy Plan/To-do projections for v1 readers without invisible markers
- import legacy state deterministically and archive the exact pre-import session once
- publish compatibility views only after an accepted graph-bearing persistence boundary
- keep same-turn tool updates coherent against unpublished transaction state

## Compatibility and safety

- no session schema bump; `work_state.graph` remains optional
- old readers ignore the graph field and retain projected Plan/To-do state
- standalone legacy To-do rows import as `PlanStep` nodes and the validator rejects other node kinds
- session save/checkpoint/rename/fork paths persist before publishing compatibility views
- no credentials or live user sessions were inspected or copied

An installed old binary (`0.9.1 (641ec4d5af8b)`) successfully deserialized and forked the checked-in v1-reader fixture from an isolated temporary home. The subsequent no-TTY launch failed at raw-mode setup, after the fork file had been written; this is the expected non-interactive terminal limitation rather than a reader failure.

## Exact-head verification

Head: `715bc54be2a57074e87aa389a94cd5410ef548b9`

- `cargo test -p codewhale-tui --bin codewhale-tui --locked` — 7469 passed, 0 failed, 3 ignored
- focused Work Graph, runtime, Plan, To-do, bridge, session-manager, lifecycle, rename, and fixture tests passed
- `cargo clippy -p codewhale-tui --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- added-line scan found no likely embedded credentials, private keys, or local workspace paths

Publication is not part of this PR.
