### PR TITLE
update tui Cargo.toml for HarmonyOS build

### DIFF
--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -102,6 +102,7 @@ vt100 = "0.16"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+portable-pty = "0.9"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
@@ -110,7 +111,6 @@ windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Secur
 arboard = "3.4"
 
 [target.'cfg(not(target_env = "ohos"))'.dependencies]
-portable-pty = "0.9"
 starlark = "0.13.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/scripts/release/check-ohos-deps.sh
+++ b/scripts/release/check-ohos-deps.sh
@@ -118,7 +118,7 @@ cargo_tree_with_retry() {
 tree="$(cargo_tree_with_retry "${package}" --all-features --no-dedupe)"
 
 disallowed="$(
-  grep -E '^(nix v0\.(28|29)\.|portable-pty v|starlark v|arboard v|keyring v)' <<<"${tree}" || true
+  grep -E '^(starlark v|arboard v|keyring v)' <<<"${tree}" || true
 )"
 
 if [[ -n "${disallowed}" ]]; then
@@ -126,9 +126,10 @@ if [[ -n "${disallowed}" ]]; then
     echo "::error::OHOS target graph for ${package} includes unsupported dependencies:"
     echo "${disallowed}"
     echo
-    echo "The OpenHarmony port avoids the rustyline/starlark/portable-pty/nix chain"
-    echo "by target-gating those crates away from target_env=ohos. Keep this graph"
-    echo "clean unless a real OHOS-compatible dependency update lands."
+    echo "The OpenHarmony port avoids the rustyline/starlark/arboard/keyring chain"
+    echo "by target-gating those crates away from target_env=ohos. portable-pty (and"
+    echo "its transitive nix dep) are now included via cfg(unix) for OHOS PTY support."
+    echo "Keep this graph clean unless a real OHOS-compatible dependency update lands."
   } >&2
   exit 1
 fi


### PR DESCRIPTION
1. move portable-pty crate from target_evn ohos to cfg("unix") in tui Cargo.toml.
2. the newest portable-pty 0.9 and nix transitived have fulfilled requirements of musl, so both of them lifed from the gate.

## Summary
Compiled codewhale on HarmonyOS PC and got the TUI running successfully again.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
