### PR TITLE
feat(work-graph): harden reasoning effort receipts

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -248,6 +248,19 @@ pub enum ReasoningEffort {
     Max,
 }
 
+impl From<ReasoningEffort> for crate::work_graph::ReasoningEffortTier {
+    fn from(value: ReasoningEffort) -> Self {
+        match value {
+            ReasoningEffort::Off => Self::Off,
+            ReasoningEffort::Low => Self::Low,
+            ReasoningEffort::Medium => Self::Medium,
+            ReasoningEffort::High => Self::High,
+            ReasoningEffort::Auto => Self::Auto,
+            ReasoningEffort::Max => Self::Max,
+        }
+    }
+}
+
 impl ReasoningEffort {
     /// Parse an operator-supplied effort value.
     ///
@@ -3741,7 +3754,6 @@ impl App {
         if self.reject_setting_change_while_busy("Thinking") {
             return;
         }
-        self.reasoning_effort_explicit = true;
         self.apply_reasoning_effort_cycle();
     }
 
@@ -3750,15 +3762,32 @@ impl App {
     /// budget. Shared by the Ctrl+T shortcut (`cycle_effort`) and the hotbar
     /// `reasoning.cycle` action so the two paths cannot drift.
     pub(crate) fn apply_reasoning_effort_cycle(&mut self) {
-        self.reasoning_effort = self
+        let requested = self
             .reasoning_effort
             .cycle_next_for_provider(self.api_provider);
+        let effective = self.effective_reasoning_effort_for_active_route(requested);
+        let provider = self.provider_identity_for_persistence().to_string();
+        if let Some(work) = self.runtime_services.work.clone()
+            && let Err(err) = work.record_reasoning_effort_change(
+                self.current_session_id.as_deref(),
+                requested.into(),
+                effective.into(),
+                &provider,
+            )
+        {
+            self.status_message = Some(format!(
+                "Reasoning effort unchanged: Work receipt failed ({err})"
+            ));
+            self.needs_redraw = true;
+            return;
+        }
+        self.reasoning_effort = requested;
+        self.reasoning_effort_explicit = true;
         self.last_effective_reasoning_effort = None;
         self.update_model_compaction_budget();
         self.status_message = Some(format!(
             "Reasoning effort: {}",
-            self.reasoning_effort
-                .display_label_for_provider(self.api_provider)
+            Self::reasoning_effort_resolution_label(requested, effective, self.api_provider)
         ));
         self.needs_redraw = true;
     }
@@ -7088,19 +7117,42 @@ impl App {
         (identity.to_string(), model)
     }
 
-    pub fn reasoning_effort_display_label(&self) -> String {
-        if self.auto_model || self.reasoning_effort == ReasoningEffort::Auto {
-            if let Some(effective) = self.last_effective_reasoning_effort {
-                return format!(
-                    "auto: {}",
-                    effective.display_label_for_provider(self.api_provider)
-                );
-            }
-            return "auto".to_string();
+    fn effective_reasoning_effort_for_active_route(
+        &self,
+        requested: ReasoningEffort,
+    ) -> ReasoningEffort {
+        if self.auto_model || requested == ReasoningEffort::Auto {
+            return self
+                .last_effective_reasoning_effort
+                .unwrap_or(ReasoningEffort::Auto);
         }
-        self.reasoning_effort
-            .display_label_for_provider(self.api_provider)
-            .to_string()
+        requested.normalize_for_route(self.api_provider, &self.active_route_base_url, &self.model)
+    }
+
+    fn reasoning_effort_resolution_label(
+        requested: ReasoningEffort,
+        effective: ReasoningEffort,
+        provider: ApiProvider,
+    ) -> String {
+        if requested == effective {
+            return effective.display_label_for_provider(provider).to_string();
+        }
+        let effective = effective.display_label_for_provider(provider);
+        if requested == ReasoningEffort::Auto {
+            format!("auto: {effective}")
+        } else {
+            format!("{}→{effective}", requested.short_label())
+        }
+    }
+
+    pub fn reasoning_effort_display_label(&self) -> String {
+        let requested = if self.auto_model {
+            ReasoningEffort::Auto
+        } else {
+            self.reasoning_effort
+        };
+        let effective = self.effective_reasoning_effort_for_active_route(requested);
+        Self::reasoning_effort_resolution_label(requested, effective, self.api_provider)
     }
 
     pub fn compaction_config(&self) -> CompactionConfig {

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -324,6 +324,49 @@ fn cycle_effort_updates_effort_status_and_compaction() {
         "cycling effort must refresh the compaction budget"
     );
     assert!(app.needs_redraw);
+
+    let work = app
+        .work_state_snapshot()
+        .expect("Work snapshot")
+        .expect("effort activity creates graph state");
+    let graph = work.graph.expect("Work Graph");
+    let activity = graph.activities.last().expect("effort activity");
+    match activity {
+        crate::work_graph::WorkActivityEvent::ReasoningEffortChanged {
+            requested,
+            effective,
+            provider,
+            operation,
+            ..
+        } => {
+            assert_eq!(*requested, crate::work_graph::ReasoningEffortTier::High);
+            assert_eq!(*effective, crate::work_graph::ReasoningEffortTier::High);
+            assert_eq!(provider, "deepseek");
+            assert!(operation.is_none());
+        }
+    }
+    let wire = serde_json::to_value(activity).expect("serialize activity");
+    assert_eq!(wire["kind"], "reasoning_effort_changed");
+    assert!(
+        wire.get("text").is_none(),
+        "activity must not carry reasoning text"
+    );
+}
+
+#[test]
+fn reasoning_effort_display_receipts_route_normalization() {
+    let mut app = App::new(test_options(false), &Config::default());
+    app.api_provider = ApiProvider::Moonshot;
+    app.auto_model = false;
+    app.reasoning_effort = ReasoningEffort::Low;
+    app.active_route_base_url = crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string();
+    app.model = "kimi-k2.5".to_string();
+
+    assert_eq!(app.reasoning_effort_display_label(), "low→high");
+
+    app.active_route_base_url = crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string();
+    app.model = "k3".to_string();
+    assert_eq!(app.reasoning_effort_display_label(), "low");
 }
 
 #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -4519,6 +4519,11 @@ async fn run_event_loop(
                             {
                                 return Ok(());
                             }
+                            if let Err(err) = persist_pending_work_checkpoint(app).await {
+                                app.status_message = Some(format!(
+                                    "Hotbar change applied, but its Work receipt is pending ({err})"
+                                ));
+                            }
                             app.needs_redraw = true;
                         }
                     }
@@ -5212,6 +5217,11 @@ async fn run_event_loop(
                             {
                                 return Ok(());
                             }
+                            if let Err(err) = persist_pending_work_checkpoint(app).await {
+                                app.status_message = Some(format!(
+                                    "Hotbar change applied, but its Work receipt is pending ({err})"
+                                ));
+                            }
                             app.needs_redraw = true;
                         }
                     }
@@ -5295,6 +5305,14 @@ async fn run_event_loop(
             }
 
             // Global keybindings
+            if handle_reasoning_effort_key(app, &key) {
+                if let Err(err) = persist_pending_work_checkpoint(app).await {
+                    app.status_message = Some(format!(
+                        "Reasoning effort changed, but its Work receipt is pending ({err})"
+                    ));
+                }
+                continue;
+            }
             match key.code {
                 KeyCode::Enter
                     if app.input.is_empty()
@@ -5356,12 +5374,6 @@ async fn run_event_loop(
                         app.mark_history_updated();
                         app.needs_redraw = true;
                     }
-                    continue;
-                }
-                KeyCode::Char('t') | KeyCode::Char('T')
-                    if key.modifiers == KeyModifiers::CONTROL =>
-                {
-                    app.cycle_effort();
                     continue;
                 }
                 KeyCode::Char('t') | KeyCode::Char('T')
@@ -6299,6 +6311,19 @@ fn clear_work_inspector_after_pager_close(app: &mut App, was_work_inspector: boo
     if was_work_inspector && app.view_stack.top_kind() != Some(ModalKind::Pager) {
         app.work_surface.opened = None;
     }
+}
+
+/// The event-loop seam for Ctrl+T. Keeping the `KeyEvent` predicate and App
+/// mutation together makes the real terminal route directly testable rather
+/// than testing `cycle_effort` in isolation.
+fn handle_reasoning_effort_key(app: &mut App, key: &event::KeyEvent) -> bool {
+    if !matches!(key.code, KeyCode::Char('t') | KeyCode::Char('T'))
+        || key.modifiers != KeyModifiers::CONTROL
+    {
+        return false;
+    }
+    app.cycle_effort();
+    true
 }
 
 fn hotbar_slot_from_key(app: &App, key: &event::KeyEvent) -> Option<u8> {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -62,6 +62,30 @@ fn permission_cycle_shortcut_accepts_both_shift_tab_encodings() {
 }
 
 #[test]
+fn ctrl_t_key_event_reaches_reasoning_effort_cycle() {
+    let mut app = create_test_app();
+    app.api_provider = crate::config::ApiProvider::Deepseek;
+    app.auto_model = false;
+    app.reasoning_effort = ReasoningEffort::Off;
+
+    assert!(handle_reasoning_effort_key(
+        &mut app,
+        &KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+    ));
+    assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+    assert!(
+        !handle_reasoning_effort_key(
+            &mut app,
+            &KeyEvent::new(
+                KeyCode::Char('T'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
+        ),
+        "Ctrl+Shift+T remains owned by the live transcript overlay",
+    );
+}
+
+#[test]
 fn underwater_motion_keeps_its_smoother_cadence_during_live_status() {
     let mut app = create_test_app();
     // App::new reads real terminal overlays. This test owns the authored

--- a/crates/tui/src/tui/widgets/header.rs
+++ b/crates/tui/src/tui/widgets/header.rs
@@ -502,7 +502,7 @@ impl<'a> HeaderWidget<'a> {
         let mode_width = 3 + mode_label.width();
         let full_effort_width = 3 + effort.width();
         let compact_effort = Self::compact_effort_label(effort);
-        let compact_effort_width = 4;
+        let compact_effort_width = 3 + compact_effort.width();
         let effort = if effort.is_empty() {
             String::new()
         } else if used + mode_width + full_effort_width <= max_width {

--- a/crates/tui/src/tui/widgets/header.rs
+++ b/crates/tui/src/tui/widgets/header.rs
@@ -499,9 +499,25 @@ impl<'a> HeaderWidget<'a> {
             format!("{provider}:{model}")
         };
         let effort = self.data.reasoning_effort_label.unwrap_or("").trim();
-        let fixed_width =
-            3 + mode_label.width() + usize::from(!effort.is_empty()) * (3 + effort.width());
-        let route_budget = max_width.saturating_sub(used + fixed_width + 1);
+        let mode_width = 3 + mode_label.width();
+        let full_effort_width = 3 + effort.width();
+        let compact_effort = Self::compact_effort_label(effort);
+        let compact_effort_width = 4;
+        let effort = if effort.is_empty() {
+            String::new()
+        } else if used + mode_width + full_effort_width <= max_width {
+            effort.to_string()
+        } else if used + mode_width + compact_effort_width <= max_width {
+            compact_effort.to_string()
+        } else {
+            String::new()
+        };
+        // Reserve mode + effort before granting any width to the route. A
+        // long provider/model identity may truncate, but it cannot silently
+        // evict the requested/effective effort receipt.
+        let fixed_width = mode_width + usize::from(!effort.is_empty()) * (3 + effort.width());
+        let status_route_gap = usize::from(used > 0);
+        let route_budget = max_width.saturating_sub(used + fixed_width + status_route_gap);
         let route = if route_budget >= 4 {
             Self::truncate_to_width(&route, route_budget)
         } else {
@@ -526,6 +542,26 @@ impl<'a> HeaderWidget<'a> {
             ));
         }
         spans
+    }
+
+    fn compact_effort_label(label: &str) -> &'static str {
+        let effective = label
+            .rsplit_once('→')
+            .map_or(label, |(_, effective)| effective);
+        let effective = effective
+            .rsplit_once(':')
+            .map_or(effective, |(_, effective)| effective)
+            .trim()
+            .to_ascii_lowercase();
+        match effective.as_str() {
+            "off" => "o",
+            "low" => "l",
+            "med" | "medium" => "m",
+            "high" => "h",
+            "max" | "maximum" | "xhigh" => "x",
+            "auto" => "a",
+            _ => "·",
+        }
     }
 }
 
@@ -567,6 +603,7 @@ mod tests {
     use crate::palette;
     use crate::tui::app::AppMode;
     use ratatui::{buffer::Buffer, layout::Rect};
+    use unicode_width::UnicodeWidthStr;
 
     fn render_header(data: HeaderData<'_>, width: u16) -> String {
         let widget = HeaderWidget::new(data);
@@ -575,6 +612,14 @@ mod tests {
         widget.render(area, &mut buf);
 
         (0..width).map(|x| buf[(x, 0)].symbol()).collect::<String>()
+    }
+
+    fn render_left(data: HeaderData<'_>, width: usize) -> String {
+        HeaderWidget::new(data)
+            .left_spans(width)
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
     }
 
     #[test]
@@ -858,6 +903,47 @@ mod tests {
             whale_idx < max_idx,
             "expected whale to render before effort label, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn route_truncation_reserves_requested_effective_effort() {
+        let rendered = render_left(
+            HeaderData::new(
+                AppMode::Agent,
+                "a-very-long-model-route-that-must-truncate",
+                "codewhale-tui",
+                false,
+                palette::WHALE_BG,
+            )
+            .with_provider(Some("xiaomi-mimo"))
+            .with_reasoning_effort(Some("low→high"))
+            .with_status_indicator(Some("cw")),
+            28,
+        );
+
+        assert!(rendered.contains("low→high"), "{rendered:?}");
+        assert!(rendered.contains("act"), "{rendered:?}");
+        assert!(rendered.width() <= 28, "{rendered:?}");
+    }
+
+    #[test]
+    fn narrow_header_uses_one_glyph_effective_effort() {
+        let rendered = render_left(
+            HeaderData::new(
+                AppMode::Agent,
+                "a-very-long-model-route",
+                "codewhale-tui",
+                false,
+                palette::WHALE_BG,
+            )
+            .with_reasoning_effort(Some("low→high"))
+            .with_status_indicator(Some("cw")),
+            14,
+        );
+
+        assert!(!rendered.contains("low→high"), "{rendered:?}");
+        assert!(rendered.ends_with(" · h"), "{rendered:?}");
+        assert!(rendered.width() <= 14, "{rendered:?}");
     }
 
     #[test]

--- a/crates/tui/src/work_graph/events.rs
+++ b/crates/tui/src/work_graph/events.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use super::ids::{ChangeId, ProposalId, WorkEdgeId, WorkNodeId};
 use super::model::{
     AcceptanceRequirement, CompatProjectionState, EvidenceRef, IdempotencyKey, NodeState,
-    OperationBinding, Provenance, Ts, WorkEdge, WorkNode,
+    OperationBinding, Provenance, Ts, WorkActivityEvent, WorkEdge, WorkNode,
 };
 
 /// A single mutation of the work graph. The reducer is the only write path;
@@ -77,6 +77,10 @@ pub enum WorkGraphChange {
     SetImportDigest {
         digest: String,
     },
+    /// Append one bounded, configuration-only activity receipt.
+    RecordActivity {
+        event: WorkActivityEvent,
+    },
 }
 
 impl WorkGraphChange {
@@ -98,6 +102,7 @@ impl WorkGraphChange {
             WorkGraphChange::Supersede { .. } => "supersede",
             WorkGraphChange::ReplaceCompatProjection { .. } => "replace_compat_projection",
             WorkGraphChange::SetImportDigest { .. } => "set_import_digest",
+            WorkGraphChange::RecordActivity { .. } => "record_activity",
         }
     }
 }

--- a/crates/tui/src/work_graph/mod.rs
+++ b/crates/tui/src/work_graph/mod.rs
@@ -46,10 +46,11 @@ pub use liveness::{
 };
 pub use migration::import_legacy;
 pub use model::{
-    AcceptanceRequirement, BoundedSet, BoundedVec, CompatPlanMetadata, CompatProjectionState,
-    CompatTodoBinding, EdgeKind, EvidenceKind, EvidenceKindTag, EvidenceRef, EvidenceRefError,
-    HISTORY_CAP, IdempotencyKey, NodeKind, NodeState, OperationBinding, Provenance, SCHEMA_VERSION,
-    SEEN_KEYS_CAP, Ts, WorkEdge, WorkGraphSnapshot, WorkNode, external_identity_is_well_formed,
+    ACTIVITY_CAP, AcceptanceRequirement, BoundedSet, BoundedVec, CompatPlanMetadata,
+    CompatProjectionState, CompatTodoBinding, EdgeKind, EvidenceKind, EvidenceKindTag, EvidenceRef,
+    EvidenceRefError, HISTORY_CAP, IdempotencyKey, NodeKind, NodeState, OperationBinding,
+    Provenance, ReasoningEffortTier, SCHEMA_VERSION, SEEN_KEYS_CAP, Ts, WorkActivityEvent,
+    WorkEdge, WorkGraphSnapshot, WorkNode, external_identity_is_well_formed,
 };
 pub use reducer::apply;
 pub(crate) use runtime::{ACTIVE_OPERATION_SUMMARY_END, ACTIVE_OPERATION_SUMMARY_START};

--- a/crates/tui/src/work_graph/model.rs
+++ b/crates/tui/src/work_graph/model.rs
@@ -31,8 +31,39 @@ pub const SCHEMA_VERSION: u32 = 1;
 /// Bounded change-history window kept on the snapshot.
 pub const HISTORY_CAP: usize = 256;
 
+/// Bounded user-visible configuration activity kept on the snapshot.
+pub const ACTIVITY_CAP: usize = 256;
+
 /// Bounded idempotency-key dedup window kept on the snapshot.
 pub const SEEN_KEYS_CAP: usize = 1024;
+
+/// Canonical reasoning-effort tiers recorded as configuration facts. This is
+/// deliberately an enum rather than free-form text so Work Graph activity can
+/// never become a side channel for model reasoning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffortTier {
+    Off,
+    Low,
+    Medium,
+    High,
+    Auto,
+    Max,
+}
+
+/// Bounded, receipt-only activity attached to the session graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkActivityEvent {
+    ReasoningEffortChanged {
+        requested: ReasoningEffortTier,
+        effective: ReasoningEffortTier,
+        provider: String,
+        ts: Ts,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operation: Option<WorkNodeId>,
+    },
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -615,6 +646,9 @@ pub struct WorkGraphSnapshot {
     pub nodes: Vec<WorkNode>,
     pub edges: Vec<WorkEdge>,
     pub history: BoundedVec<ChangeReceipt, HISTORY_CAP>,
+    /// Configuration facts only; never prompts, output, or reasoning text.
+    #[serde(default, skip_serializing_if = "BoundedVec::is_empty")]
+    pub activities: BoundedVec<WorkActivityEvent, ACTIVITY_CAP>,
     pub import_digest: Option<String>,
     /// `(binding, seq)` dedup window for replayed runtime observations.
     pub seen_keys: BoundedSet<IdempotencyKey, SEEN_KEYS_CAP>,
@@ -633,6 +667,7 @@ impl WorkGraphSnapshot {
             nodes: Vec::new(),
             edges: Vec::new(),
             history: BoundedVec::new(),
+            activities: BoundedVec::new(),
             import_digest: None,
             seen_keys: BoundedSet::new(),
             proposals: Vec::new(),
@@ -667,6 +702,7 @@ impl WorkGraphSnapshot {
         self.nodes.is_empty()
             && self.edges.is_empty()
             && self.history.is_empty()
+            && self.activities.is_empty()
             && self.import_digest.is_none()
             && self.proposals.is_empty()
             && self.compat.is_empty()

--- a/crates/tui/src/work_graph/reducer.rs
+++ b/crates/tui/src/work_graph/reducer.rs
@@ -23,8 +23,8 @@ use super::events::{
 };
 use super::ids::{ChangeId, WorkEdgeId, WorkNodeId};
 use super::model::{
-    EdgeKind, EvidenceRef, NodeKind, NodeState, OperationBinding, Provenance, WorkEdge,
-    WorkGraphSnapshot, WorkNode,
+    EdgeKind, EvidenceRef, NodeKind, NodeState, OperationBinding, Provenance, WorkActivityEvent,
+    WorkEdge, WorkGraphSnapshot, WorkNode,
 };
 use super::validate::{ValidationCode, ValidationReport, validate};
 
@@ -190,6 +190,22 @@ fn apply_pure(
                 return Err(structural("legacy import digest cannot be empty"));
             }
             next.import_digest = Some(digest.clone());
+        }
+        WorkGraphChange::RecordActivity { event } => {
+            let operation = match event {
+                WorkActivityEvent::ReasoningEffortChanged { operation, .. } => operation,
+            };
+            if let Some(operation) = operation {
+                let node = next.node(operation).ok_or_else(|| {
+                    structural(format!("activity references missing operation {operation}"))
+                })?;
+                if node.kind != NodeKind::Operation || !node.state.is_live() {
+                    return Err(structural(format!(
+                        "activity operation {operation} is not live"
+                    )));
+                }
+            }
+            next.activities.push_bounded(event.clone());
         }
     }
     Ok(next)

--- a/crates/tui/src/work_graph/runtime.rs
+++ b/crates/tui/src/work_graph/runtime.rs
@@ -12,10 +12,10 @@ use super::{
     ApprovalRef, BindingId, ChangeCtx, CompatPlanMetadata, CompatProjectionState,
     CompatTodoBinding, EdgeKind, IdempotencyKey, NodeKind, NodeState, OperationBinding,
     OperationIntent, OperationObservation, OperationOwnerSnapshot, ProposalId, ProposedNodeUpdate,
-    Provenance, WorkEdge, WorkEdgeId, WorkGraph, WorkGraphChange, WorkGraphProposal,
-    WorkGraphSnapshot, WorkNode, WorkNodeId, WorkNodePatch, external_identity_is_well_formed,
-    fleet_task_owner_snapshot, import_legacy, lane_owner_snapshot, project_plan, project_todos,
-    validate,
+    Provenance, ReasoningEffortTier, WorkActivityEvent, WorkEdge, WorkEdgeId, WorkGraph,
+    WorkGraphChange, WorkGraphProposal, WorkGraphSnapshot, WorkNode, WorkNodeId, WorkNodePatch,
+    external_identity_is_well_formed, fleet_task_owner_snapshot, import_legacy,
+    lane_owner_snapshot, project_plan, project_todos, validate,
 };
 
 pub(crate) const ACTIVE_OPERATION_SUMMARY_START: &str =
@@ -376,6 +376,67 @@ impl WorkRuntime {
         }
         out.push_str(ACTIVE_OPERATION_SUMMARY_END);
         Some(out)
+    }
+
+    /// Record one reasoning-effort configuration change as bounded graph
+    /// activity. The event contains typed tiers and a non-secret route
+    /// identity only; there is no field capable of carrying reasoning text.
+    /// When live operations exist, the most recently updated one receives the
+    /// historical link. Later terminalization does not invalidate that link.
+    pub fn record_reasoning_effort_change(
+        &self,
+        session_id: Option<&str>,
+        requested: ReasoningEffortTier,
+        effective: ReasoningEffortTier,
+        provider: &str,
+    ) -> Result<Option<WorkNodeId>, String> {
+        let todos = retry_lock(&self.todos, 100)
+            .ok_or_else(|| "To-do state is busy; effort change was not recorded".to_string())?;
+        let plan = retry_lock(&self.plan, 100)
+            .ok_or_else(|| "Plan state is busy; effort change was not recorded".to_string())?;
+        let mut active = lock_unpoisoned(&self.graph);
+        let session_id = resolved_session_id(&active, session_id);
+        let base = graph_for_update(
+            &mut active,
+            &session_id,
+            &plan.snapshot(),
+            &todos.snapshot(),
+        )?;
+        let operation = base
+            .nodes
+            .iter()
+            .filter(|node| node.kind == NodeKind::Operation && node.state.is_live())
+            .max_by(|left, right| {
+                left.updated_at
+                    .cmp(&right.updated_at)
+                    .then_with(|| left.id.as_str().cmp(right.id.as_str()))
+            })
+            .map(|node| node.id.clone());
+        let now = now_ms();
+        let mut graph = WorkGraph::from_snapshot(base);
+        graph
+            .apply(
+                WorkGraphChange::RecordActivity {
+                    event: WorkActivityEvent::ReasoningEffortChanged {
+                        requested,
+                        effective,
+                        provider: provider.to_string(),
+                        ts: now,
+                        operation: operation.clone(),
+                    },
+                },
+                ChangeCtx {
+                    session_id,
+                    now,
+                    idempotency_key: None,
+                },
+            )
+            .map_err(|err| format!("reasoning effort: {err}"))?;
+        let next = graph.into_snapshot();
+        validate_combined(&next, &project_plan(&next), &project_todos(&next))?;
+        active.snapshot = Some(next);
+        active.pending_publish = true;
+        Ok(operation)
     }
 
     /// Apply an `update_plan` payload through the graph and publish both
@@ -2422,6 +2483,38 @@ mod tests {
         assert!(summary.contains("shell:shell_test"), "{summary}");
         assert!(summary.contains("silent 'owner' command"), "{summary}");
         assert!(!summary.contains("4,096"), "{summary}");
+
+        assert_eq!(
+            runtime.record_reasoning_effort_change(
+                Some("session"),
+                ReasoningEffortTier::Low,
+                ReasoningEffortTier::High,
+                "moonshot",
+            ),
+            Ok(Some(node_id.clone()))
+        );
+        let activity = runtime
+            .capture(Some("session"))
+            .expect("capture effort activity")
+            .expect("graph")
+            .graph
+            .activities
+            .last()
+            .cloned()
+            .expect("effort activity");
+        let ts = match &activity {
+            WorkActivityEvent::ReasoningEffortChanged { ts, .. } => *ts,
+        };
+        assert_eq!(
+            activity,
+            WorkActivityEvent::ReasoningEffortChanged {
+                requested: ReasoningEffortTier::Low,
+                effective: ReasoningEffortTier::High,
+                provider: "moonshot".to_string(),
+                ts,
+                operation: Some(node_id.clone()),
+            }
+        );
 
         runtime
             .record_operation_approval(

--- a/crates/tui/src/work_graph/tests.rs
+++ b/crates/tui/src/work_graph/tests.rs
@@ -61,6 +61,20 @@ fn mk_edge(disc: &str, kind: EdgeKind, from: &str, to: &str) -> WorkEdge {
     }
 }
 
+fn effort_activity(
+    provider: impl Into<String>,
+    ts: Ts,
+    operation: Option<WorkNodeId>,
+) -> WorkActivityEvent {
+    WorkActivityEvent::ReasoningEffortChanged {
+        requested: ReasoningEffortTier::Low,
+        effective: ReasoningEffortTier::High,
+        provider: provider.into(),
+        ts,
+        operation,
+    }
+}
+
 fn must(graph: &mut WorkGraph, change: WorkGraphChange, now: Ts) -> ChangeReceipt {
     graph.apply(change, ctx(now)).expect("change should apply")
 }
@@ -671,6 +685,99 @@ fn history_stays_bounded_at_cap() {
     let last = snapshot.history.last().unwrap().revision;
     assert_eq!(last, snapshot.revision);
     assert_eq!(first, snapshot.revision - (HISTORY_CAP as u64 - 1));
+}
+
+#[test]
+fn activity_receipts_reject_bad_provider_identity_and_oversized_snapshots() {
+    let mut graph = seeded();
+    for provider in [
+        String::new(),
+        "bad route".to_string(),
+        "bad\nroute".to_string(),
+        "x".repeat(129),
+    ] {
+        let before = graph.snapshot().clone();
+        let result = graph.apply(
+            WorkGraphChange::RecordActivity {
+                event: effort_activity(provider, 10, None),
+            },
+            ctx(10),
+        );
+        expect_code(result, ValidationCode::Structural);
+        assert_eq!(graph.snapshot(), &before, "rejection must be atomic");
+    }
+
+    for offset in 0..(ACTIVITY_CAP + 8) {
+        let ts = 100 + offset as Ts;
+        must(
+            &mut graph,
+            WorkGraphChange::RecordActivity {
+                event: effort_activity("xiaomi-mimo", ts, None),
+            },
+            ts,
+        );
+    }
+    assert_eq!(graph.snapshot().activities.len(), ACTIVITY_CAP);
+    assert_eq!(
+        graph.snapshot().activities.iter().next(),
+        Some(&effort_activity("xiaomi-mimo", 108, None)),
+        "bounded writes evict the oldest receipt"
+    );
+
+    let mut wire = serde_json::to_value(graph.snapshot()).expect("serialize graph");
+    let activities = wire["activities"].as_array_mut().expect("activity array");
+    activities.push(activities.last().expect("bounded receipt").clone());
+    let oversized: WorkGraphSnapshot =
+        serde_json::from_value(wire).expect("deserialize untrusted oversized snapshot");
+    let report = validate(&oversized).expect_err("oversized activity must fail closed");
+    assert!(report.contains_code(ValidationCode::Structural));
+}
+
+#[test]
+fn activity_operation_links_require_live_operations_at_write_time() {
+    let mut graph = seeded();
+    for operation in [nid("missing"), nid("root")] {
+        let before = graph.snapshot().clone();
+        let result = graph.apply(
+            WorkGraphChange::RecordActivity {
+                event: effort_activity("xiaomi-mimo", 10, Some(operation)),
+            },
+            ctx(10),
+        );
+        expect_code(result, ValidationCode::Structural);
+        assert_eq!(graph.snapshot(), &before, "rejection must be atomic");
+    }
+
+    set_state(&mut graph, "op", NodeState::Active, 10);
+    set_state(&mut graph, "op", NodeState::Completed, 11);
+    let result = graph.apply(
+        WorkGraphChange::RecordActivity {
+            event: effort_activity("xiaomi-mimo", 12, Some(nid("op"))),
+        },
+        ctx(12),
+    );
+    expect_code(result, ValidationCode::Structural);
+
+    for operation in [nid("missing"), nid("root")] {
+        let mut malformed = graph.snapshot().clone();
+        malformed
+            .activities
+            .push_bounded(effort_activity("xiaomi-mimo", 13, Some(operation)));
+        let report = validate(&malformed).expect_err("invalid historical link must fail closed");
+        assert!(report.contains_code(ValidationCode::Structural));
+    }
+
+    let mut historical = seeded();
+    set_state(&mut historical, "op", NodeState::Active, 20);
+    must(
+        &mut historical,
+        WorkGraphChange::RecordActivity {
+            event: effort_activity("xiaomi-mimo", 21, Some(nid("op"))),
+        },
+        21,
+    );
+    set_state(&mut historical, "op", NodeState::Completed, 22);
+    validate(historical.snapshot()).expect("a formerly-live historical link remains valid");
 }
 
 #[test]

--- a/crates/tui/src/work_graph/validate.rs
+++ b/crates/tui/src/work_graph/validate.rs
@@ -35,8 +35,8 @@ use serde::{Deserialize, Serialize};
 
 use super::ids::WorkNodeId;
 use super::model::{
-    EdgeKind, HISTORY_CAP, NodeKind, NodeState, SCHEMA_VERSION, WorkGraphSnapshot, WorkNode,
-    external_identity_is_well_formed,
+    ACTIVITY_CAP, EdgeKind, HISTORY_CAP, NodeKind, NodeState, SCHEMA_VERSION, WorkActivityEvent,
+    WorkGraphSnapshot, WorkNode, external_identity_is_well_formed,
 };
 
 /// Which rule a violation belongs to.
@@ -238,6 +238,49 @@ fn check_structural(snapshot: &WorkGraphSnapshot, out: &mut Vec<Violation>) {
             code: ValidationCode::Structural,
             message: "legacy To-do projection has more than one active row".to_string(),
         });
+    }
+
+    if snapshot.activities.len() > ACTIVITY_CAP {
+        out.push(Violation {
+            code: ValidationCode::Structural,
+            message: format!(
+                "activity length {} exceeds bound {ACTIVITY_CAP}",
+                snapshot.activities.len()
+            ),
+        });
+    }
+    for activity in snapshot.activities.iter() {
+        let (provider, operation) = match activity {
+            WorkActivityEvent::ReasoningEffortChanged {
+                provider,
+                operation,
+                ..
+            } => (provider, operation),
+        };
+        if provider.is_empty()
+            || provider.chars().count() > 128
+            || provider
+                .chars()
+                .any(|ch| ch.is_whitespace() || ch.is_control())
+        {
+            out.push(Violation {
+                code: ValidationCode::Structural,
+                message: "activity provider is not a bounded route identity".to_string(),
+            });
+        }
+        if let Some(operation) = operation {
+            match snapshot.node(operation) {
+                Some(node) if node.kind == NodeKind::Operation => {}
+                Some(_) => out.push(Violation {
+                    code: ValidationCode::Structural,
+                    message: format!("activity operation {operation} is not an Operation node"),
+                }),
+                None => out.push(Violation {
+                    code: ValidationCode::Structural,
+                    message: format!("activity references missing operation {operation}"),
+                }),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- route Ctrl+T through a directly tested key-event seam shared with the reasoning-cycle action
- reserve requested/effective effort ahead of provider/model route truncation, with a one-glyph effective tier at the narrowest widths
- record bounded, typed Work Graph activity containing only requested tier, effective tier, provider identity, timestamp, and an optional live Operation link
- keep model reasoning text structurally unrepresentable in the activity schema

## Local verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked` — 7,488 passed; 0 failed; 3 ignored
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `gitleaks git --no-banner --redact --log-opts='origin/main..HEAD' .` — no leaks
- added-line private-path and credential-marker scan — clean

## Scope

This is WG5 from the v0.9.1 Work Graph cutover. It is directly based on the merged WG4 main commit `6ce2a5829744f396b07155fd143570e06643a7f8`.

No tag, release, registry publication, deploy, or branch deletion is part of this PR.
