### PR TITLE
test(work-graph): prove acceptance and migration continuity

### DIFF
--- a/crates/tui/src/commands/groups/session/session.rs
+++ b/crates/tui/src/commands/groups/session/session.rs
@@ -664,6 +664,29 @@ mod tests {
                 cache_control: None,
             }],
         });
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add(
+                "preserve fork Work".to_string(),
+                crate::tools::todo::TodoStatus::InProgress,
+            );
+        }
+        {
+            let mut plan = app.plan_state.try_lock().expect("plan lock");
+            plan.update(crate::tools::plan::UpdatePlanArgs {
+                objective: Some("Fork without Work drift".to_string()),
+                ..crate::tools::plan::UpdatePlanArgs::default()
+            });
+        }
+        app.cycle_effort();
+        let expected_work = app
+            .work_state_snapshot()
+            .expect("Work snapshot")
+            .expect("graph-backed Work state");
+        assert!(
+            expected_work.graph.is_some(),
+            "fork fixture must use a graph"
+        );
 
         let result = fork(&mut app);
 
@@ -696,6 +719,8 @@ mod tests {
             child.metadata.model_provider_id.as_deref(),
             Some("lm-studio")
         );
+        assert_eq!(parent.work_state.as_ref(), Some(&expected_work));
+        assert_eq!(child.work_state.as_ref(), Some(&expected_work));
         let cached_child = app
             .current_session_metadata
             .as_ref()
@@ -1238,6 +1263,22 @@ mod tests {
             content: "Hi there".to_string(),
             streaming: false,
         });
+        {
+            let mut todos = app.todos.try_lock().expect("todos lock");
+            todos.add(
+                "export must not mutate this".to_string(),
+                crate::tools::todo::TodoStatus::InProgress,
+            );
+        }
+        app.cycle_effort();
+        let work_before = app.work_state_snapshot().expect("Work snapshot");
+        assert!(
+            work_before
+                .as_ref()
+                .and_then(|work| work.graph.as_ref())
+                .is_some(),
+            "export fixture must use graph-backed Work"
+        );
 
         let export_path = tmpdir.path().join("export.md");
         let result = export(&mut app, Some(export_path.to_str().unwrap()));
@@ -1251,6 +1292,12 @@ mod tests {
         assert!(content.contains("**Model:**"));
         assert!(content.contains("**You:**"));
         assert!(content.contains("**Assistant:**"));
+        assert_eq!(
+            app.work_state_snapshot()
+                .expect("Work snapshot after export"),
+            work_before,
+            "export is a projection and must never write Work state"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -620,8 +620,28 @@ fn compact_tokens(tokens: i64) -> String {
     }
 }
 
-/// Render the one-line shell header. Route, mode, permission, active-agent
-/// count, and context each have exactly one owner here.
+fn compact_effort_label(label: &str) -> &'static str {
+    let effective = label
+        .rsplit_once('→')
+        .map_or(label, |(_, effective)| effective);
+    let effective = effective
+        .rsplit_once(':')
+        .map_or(effective, |(_, effective)| effective)
+        .trim()
+        .to_ascii_lowercase();
+    match effective.as_str() {
+        "off" => "o",
+        "low" => "l",
+        "med" | "medium" => "m",
+        "high" => "h",
+        "max" | "maximum" | "xhigh" => "x",
+        "auto" => "a",
+        _ => "·",
+    }
+}
+
+/// Render the one-line shell header. Route, mode, requested/effective effort,
+/// permission, active-agent count, and context each have exactly one owner.
 pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -633,6 +653,7 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
 
     let (effective_provider, effective_model) = app.effective_route_identity_display();
     let route_label = format!("{effective_provider} · {effective_model}");
+    let effort_label = app.reasoning_effort_display_label();
     let status_indicator = crate::tui::widgets::header_status_indicator_frame(
         (!app.low_motion && app.fancy_animations)
             .then_some(app.turn_started_at)
@@ -658,6 +679,8 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
                 _ => app.ui_theme.mode_agent,
             }),
         ),
+        Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
+        Span::styled(effort_label.clone(), Style::default().fg(app.ui_theme.info)),
     ];
     // The selected brand/status mark is part of the user's chosen header,
     // not expendable wide-screen decoration. Keep it in compact layouts too;
@@ -672,7 +695,8 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
         ));
     }
     // Permission is safety state, not optional chrome. Compact terminals shed
-    // the status mark and context meter, but keep the effective posture.
+    // route detail and the context meter, but keep mode, effective effort, and
+    // the effective posture.
     left.push(Span::styled(
         " · ",
         Style::default().fg(app.ui_theme.text_dim),
@@ -715,9 +739,16 @@ pub fn render_header(area: Rect, buf: &mut Buffer, app: &App) {
     if span_width(&left) > left_budget {
         let mode = mode_label(app.ui_locale, app.mode);
         let permission = permission_label(app);
+        let effort = if tier == ShellTier::Compact {
+            compact_effort_label(&effort_label).to_string()
+        } else {
+            effort_label.clone()
+        };
         let suffix = vec![
             Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
             Span::styled(mode, Style::default().fg(app.ui_theme.accent_primary)),
+            Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
+            Span::styled(effort, Style::default().fg(app.ui_theme.info)),
             Span::styled(" · ", Style::default().fg(app.ui_theme.text_dim)),
             Span::styled(permission, Style::default().fg(app.ui_theme.text_muted)),
         ];
@@ -1043,11 +1074,37 @@ mod tests {
         let mut app = test_app();
         app.mode = AppMode::Operate;
         app.approval_mode = ApprovalMode::Bypass;
+        app.reasoning_effort = crate::tui::app::ReasoningEffort::Low;
         app.model = "provider/model-with-a-deliberately-long-route-name".to_string();
 
         let header = header_text(&app, 40);
 
         assert!(header.starts_with("cw"), "brand missing: {header:?}");
+        assert!(
+            header.to_ascii_lowercase().contains("operate"),
+            "mode missing: {header:?}"
+        );
+        assert!(
+            header.contains("Full Access"),
+            "permission posture missing: {header:?}"
+        );
+        assert!(
+            header.contains(" · h · Full Access"),
+            "effective effort missing: {header:?}"
+        );
+    }
+
+    #[test]
+    fn normal_header_keeps_requested_effective_effort_before_route_detail() {
+        let mut app = test_app();
+        app.mode = AppMode::Operate;
+        app.approval_mode = ApprovalMode::Bypass;
+        app.reasoning_effort = crate::tui::app::ReasoningEffort::Low;
+        app.model = "provider/model-with-a-deliberately-long-route-name".to_string();
+
+        let header = header_text(&app, 80);
+
+        assert!(header.contains("low→high"), "effort missing: {header:?}");
         assert!(
             header.to_ascii_lowercase().contains("operate"),
             "mode missing: {header:?}"

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -719,7 +719,10 @@ fn work_and_permission_are_visible_at_release_terminal_sizes() -> anyhow::Result
         let codewhale_home = ws.home().join(".codewhale");
         let codex_home = ws.home().join(".codex");
         std::fs::create_dir_all(&codex_home)?;
-        std::fs::write(codewhale_home.join("config.toml"), "allow_shell = true\n")?;
+        std::fs::write(
+            codewhale_home.join("config.toml"),
+            "allow_shell = true\nreasoning_effort = \"low\"\n",
+        )?;
         std::fs::write(
             codewhale_home.join("settings.toml"),
             "permission_posture = \"full-access\"\n",
@@ -825,6 +828,16 @@ fn work_and_permission_are_visible_at_release_terminal_sizes() -> anyhow::Result
             frame.contains("Operate") || frame.contains("operate"),
             "restored mode missing at {cols}x{rows}:\n{dump}"
         );
+        let header = frame.row(0);
+        let effort_receipt = if cols >= 60 {
+            " · high · Full Access"
+        } else {
+            " · h · Full Access"
+        };
+        assert!(
+            header.contains(effort_receipt),
+            "effective effort missing at {cols}x{rows}: {header:?}\n{dump}"
+        );
 
         if let Some(dir) = std::env::var_os("CODEWHALE_QA_EVIDENCE_DIR") {
             let dir = std::path::PathBuf::from(dir);
@@ -834,6 +847,223 @@ fn work_and_permission_are_visible_at_release_terminal_sizes() -> anyhow::Result
 
         let _ = h.shutdown();
     }
+    Ok(())
+}
+
+/// WG6 integrated proof: a real TUI migrates legacy Plan/To-do state, records
+/// Ctrl+T as a typed receipt, preserves it across explicit save/export/save,
+/// and restores the same graph-backed Work state after process restart.
+#[test]
+fn legacy_work_ctrl_t_save_export_and_restart_are_consistent() -> anyhow::Result<()> {
+    let _guard = qa_pty_test_lock();
+    let ws = make_sealed_workspace()?;
+    let codewhale_home = ws.home().join(".codewhale");
+    let codex_home = ws.home().join(".codex");
+    std::fs::create_dir_all(&codex_home)?;
+    std::fs::write(
+        codewhale_home.join("config.toml"),
+        "allow_shell = true\nreasoning_effort = \"low\"\n",
+    )?;
+    std::fs::write(
+        codewhale_home.join("settings.toml"),
+        "permission_posture = \"full-access\"\n",
+    )?;
+    std::fs::write(
+        codex_home.join("models_cache.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "fetched_at": chrono::Utc::now(),
+            "models": [{"slug": "gpt-pty-fixture", "priority": 1}]
+        }))?,
+    )?;
+
+    let legacy_path = ws.workspace().join("legacy-work-session.json");
+    std::fs::write(
+        &legacy_path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "schema_version": 1,
+            "metadata": {
+                "id": "pty-wg6-legacy",
+                "title": "WG6 legacy continuity",
+                "created_at": "2026-07-10T00:00:00Z",
+                "updated_at": "2026-07-10T00:00:00Z",
+                "message_count": 0,
+                "total_tokens": 0,
+                "model": "deepseek-v4-pro",
+                "model_provider": "deepseek",
+                "workspace": ws.workspace(),
+                "mode": "operate",
+                "cost": {},
+                "cumulative_turn_secs": 0
+            },
+            "messages": [],
+            "system_prompt": null,
+            "work_state": {
+                "todos": {
+                    "items": [
+                        {"id": 1, "content": "persisted inspect", "status": "completed"},
+                        {"id": 2, "content": "persisted patch", "status": "in_progress"}
+                    ],
+                    "completion_pct": 50,
+                    "in_progress_id": 2
+                },
+                "plan": {
+                    "objective": "Keep WG6 Work durable",
+                    "items": [{"step": "verify integrated PTY", "status": "in_progress"}]
+                }
+            }
+        }))?,
+    )?;
+
+    let spawn = || {
+        Harness::builder(Harness::cargo_bin("codewhale-tui"))
+            .cwd(ws.workspace())
+            .clear_env()
+            .seal_home(ws.home())
+            .env("CODEWHALE_HOME", codewhale_home.to_string_lossy())
+            .env(
+                "DEEPSEEK_CONFIG_PATH",
+                codewhale_home.join("config.toml").to_string_lossy(),
+            )
+            .env("CODEX_HOME", codex_home.to_string_lossy())
+            .env("DEEPSEEK_API_KEY", "ci-test-key-not-real")
+            .env("DEEPSEEK_BASE_URL", "http://127.0.0.1:1")
+            .env("NO_ANIMATIONS", "1")
+            .env("RUST_LOG", "warn")
+            .args([
+                "--workspace",
+                ws.workspace().to_str().expect("utf-8 workspace path"),
+                "--no-project-config",
+                "--skip-onboarding",
+            ])
+            .size(16, 60)
+            .spawn()
+    };
+
+    let mut h = spawn()?;
+    enter_launch_session(&mut h)?;
+    h.send(keys::key::text(&format!(
+        "/load {}",
+        legacy_path.to_string_lossy()
+    )))?;
+    h.wait_for_text("/load", KEY_TIMEOUT)?;
+    h.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    h.send(keys::key::enter())?;
+    h.wait_for_text("Work", KEY_TIMEOUT)?;
+    h.wait_for_idle(Duration::from_millis(250), Duration::from_secs(3))?;
+    assert!(
+        h.frame().contains("persisted"),
+        "{}",
+        h.frame().debug_dump()
+    );
+
+    h.send(b"\x14")?;
+    h.wait_for_text("Reasoning effort: max", KEY_TIMEOUT)?;
+    h.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    let cycled = h.frame();
+    assert!(
+        cycled.row(0).contains(" · max · Full Access"),
+        "Ctrl+T effort missing from narrow header:\n{}",
+        cycled.debug_dump()
+    );
+    assert!(cycled.contains("Work"), "{}", cycled.debug_dump());
+
+    let before_path = ws.workspace().join("wg6-before-export.json");
+    h.send(keys::key::text(&format!(
+        "/save {}",
+        before_path.to_string_lossy()
+    )))?;
+    h.wait_for_text("/save", KEY_TIMEOUT)?;
+    h.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    h.send(keys::key::enter())?;
+    h.wait_for_text("Session saved to", KEY_TIMEOUT)?;
+
+    let export_path = ws.workspace().join("wg6-export.md");
+    h.send(keys::key::text(&format!(
+        "/export {}",
+        export_path.to_string_lossy()
+    )))?;
+    h.wait_for_text("/export", KEY_TIMEOUT)?;
+    h.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    h.send(keys::key::enter())?;
+    h.wait_for_text("Exported to", KEY_TIMEOUT)?;
+
+    let after_path = ws.workspace().join("wg6-after-export.json");
+    h.send(keys::key::text(&format!(
+        "/save {}",
+        after_path.to_string_lossy()
+    )))?;
+    h.wait_for_text("/save", KEY_TIMEOUT)?;
+    h.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    h.send(keys::key::enter())?;
+    h.wait_for_text("Session saved to", KEY_TIMEOUT)?;
+
+    let deadline = Instant::now() + KEY_TIMEOUT;
+    while (!before_path.exists() || !after_path.exists() || !export_path.exists())
+        && Instant::now() < deadline
+    {
+        h.pump();
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(before_path.exists(), "first save was not written");
+    assert!(after_path.exists(), "post-export save was not written");
+    assert!(export_path.exists(), "export was not written");
+
+    let before: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&before_path)?)?;
+    let after: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&after_path)?)?;
+    let work = &before["work_state"];
+    assert!(work["graph"].is_object(), "migrated graph missing: {work}");
+    assert_eq!(
+        work["todos"]["items"][1]["content"], "persisted patch",
+        "visible legacy To-do state drifted"
+    );
+    assert_eq!(
+        work["plan"]["objective"], "Keep WG6 Work durable",
+        "visible legacy Plan state drifted"
+    );
+    let activity = work["graph"]["activities"]
+        .as_array()
+        .and_then(|activities| activities.last())
+        .expect("Ctrl+T Work activity");
+    assert_eq!(activity["kind"], "reasoning_effort_changed");
+    assert_eq!(activity["requested"], "max");
+    assert_eq!(activity["effective"], "max");
+    assert_eq!(activity["provider"], "deepseek");
+    let receipt = activity.as_object().expect("typed activity object");
+    for forbidden in ["text", "content", "reasoning", "reasoning_text"] {
+        assert!(
+            !receipt.contains_key(forbidden),
+            "activity leaked forbidden field {forbidden}: {activity}"
+        );
+    }
+    assert_eq!(
+        before["work_state"], after["work_state"],
+        "export mutated graph-backed Work state"
+    );
+    assert!(
+        std::fs::read_to_string(&export_path)?.contains("# Chat Export"),
+        "full export artifact missing"
+    );
+    let _ = h.shutdown();
+
+    let mut restored = spawn()?;
+    enter_launch_session(&mut restored)?;
+    restored.send(keys::key::text(&format!(
+        "/load {}",
+        after_path.to_string_lossy()
+    )))?;
+    restored.wait_for_text("/load", KEY_TIMEOUT)?;
+    restored.wait_for_idle(Duration::from_millis(150), Duration::from_secs(2))?;
+    restored.send(keys::key::enter())?;
+    restored.wait_for_text("Work", KEY_TIMEOUT)?;
+    restored.wait_for_idle(Duration::from_millis(250), Duration::from_secs(3))?;
+    let frame = restored.frame();
+    assert!(frame.contains("persisted"), "{}", frame.debug_dump());
+    assert!(
+        frame.row(0).contains(" · high · Full Access"),
+        "restart lost narrow effort/permission truth:\n{}",
+        frame.debug_dump()
+    );
+    let _ = restored.shutdown();
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- render requested/effective reasoning effort in the default Blue Stage header, reserving it with mode and permission truth before route detail
- add real-PTY WG6 proof for legacy Plan/To-do migration, Ctrl+T typed activity, save/export/save consistency, and fresh-process restore
- prove fork preserves the exact graph-backed Work state in parent and child, and full export is a non-mutating projection

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [ ] `cargo test --workspace --all-features` (not run; complete locked `codewhale-tui` package suite run instead)
- [x] `cargo test -p codewhale-tui --locked` (7,491 passed, 3 ignored; all integration suites green)
- [x] PTY 17 passed, 1 ignored; release-runtime 5 passed, 1 ignored
- [x] one-commit gitleaks and added-line private-path scans

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior through real PTY acceptance at 120x32, 100x30, 80x24, 60x16, and 40x12
- [x] No contributor harvesting/co-authoring in this change

No tag, release, registry publication, deploy, or branch deletion is part of this PR.