### PR TITLE
feat(tools): batch by prepared resource claims

### DIFF
--- a/crates/tools/src/resources.rs
+++ b/crates/tools/src/resources.rs
@@ -4,9 +4,8 @@ use serde::{Deserialize, Serialize};
 
 /// A conservative resource claim calculated before a tool may execute.
 ///
-/// The prepared-call seam only records these claims. The product scheduler
-/// continues to use its established Boolean policy until resource-aware
-/// batching lands.
+/// The prepared-call seam records these claims before authority checks and the
+/// product scheduler uses them to keep parallel batches non-conflicting.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceClaim {
@@ -59,22 +58,34 @@ fn trees_overlap(left: &Path, right: &Path) -> bool {
 /// claims share a batch; conflicting items retain their original order.
 #[must_use]
 pub fn schedule_non_conflicting<T>(items: Vec<(T, Vec<ResourceClaim>)>) -> Vec<Vec<T>> {
-    let mut batches: Vec<(Vec<T>, Vec<ResourceClaim>)> = Vec::new();
+    let mut batches = Vec::new();
+    let mut batch = Vec::new();
+    let mut batch_claims = Vec::new();
+
     for (item, claims) in items {
-        if let Some((batch, batch_claims)) = batches.iter_mut().find(|(_, batch_claims)| {
-            !claims.iter().any(|claim| {
+        let global_barrier = !batch.is_empty()
+            && (claims.contains(&ResourceClaim::GlobalExclusive)
+                || batch_claims.contains(&ResourceClaim::GlobalExclusive));
+        let conflicts = global_barrier
+            || claims.iter().any(|claim| {
                 batch_claims
                     .iter()
                     .any(|existing| claim.conflicts_with(existing))
-            })
-        }) {
-            batch.push(item);
-            batch_claims.extend(claims);
-        } else {
-            batches.push((vec![item], claims));
+            });
+        if conflicts && !batch.is_empty() {
+            batches.push(std::mem::take(&mut batch));
+            batch_claims.clear();
         }
+
+        batch.push(item);
+        batch_claims.extend(claims);
     }
-    batches.into_iter().map(|(items, _)| items).collect()
+
+    if !batch.is_empty() {
+        batches.push(batch);
+    }
+
+    batches
 }
 
 #[cfg(test)]
@@ -99,6 +110,56 @@ mod tests {
             ("b", vec![ResourceClaim::WritePath(PathBuf::from("b.rs"))]),
         ]);
         assert_eq!(batches, vec![vec!["a", "b"]]);
+    }
+
+    #[test]
+    fn intervening_conflict_preserves_contiguous_order() {
+        let path = PathBuf::from("src/lib.rs");
+        let batches = schedule_non_conflicting(vec![
+            ("read-before", vec![ResourceClaim::ReadPath(path.clone())]),
+            ("write", vec![ResourceClaim::WritePath(path.clone())]),
+            ("read-after", vec![ResourceClaim::ReadPath(path)]),
+        ]);
+        assert_eq!(
+            batches,
+            vec![vec!["read-before"], vec!["write"], vec!["read-after"]]
+        );
+    }
+
+    #[test]
+    fn tree_claims_conflict_only_when_a_write_scope_overlaps() {
+        let src = PathBuf::from("workspace/src");
+        let nested = PathBuf::from("workspace/src/nested");
+        let source_file = PathBuf::from("workspace/src/lib.rs");
+        let test_file = PathBuf::from("workspace/tests/test.rs");
+
+        assert!(
+            !ResourceClaim::ReadTree(src.clone())
+                .conflicts_with(&ResourceClaim::ReadPath(source_file.clone()))
+        );
+        assert!(
+            ResourceClaim::ReadTree(src.clone())
+                .conflicts_with(&ResourceClaim::WritePath(source_file.clone()))
+        );
+        assert!(
+            !ResourceClaim::ReadTree(src.clone())
+                .conflicts_with(&ResourceClaim::WritePath(test_file))
+        );
+        assert!(
+            ResourceClaim::WriteTree(src.clone())
+                .conflicts_with(&ResourceClaim::ReadPath(source_file))
+        );
+        assert!(ResourceClaim::WriteTree(src).conflicts_with(&ResourceClaim::ReadTree(nested)));
+    }
+
+    #[test]
+    fn global_exclusive_stays_a_singleton_barrier() {
+        let batches = schedule_non_conflicting(vec![
+            ("before", Vec::new()),
+            ("global", vec![ResourceClaim::GlobalExclusive]),
+            ("after", Vec::new()),
+        ]);
+        assert_eq!(batches, vec![vec!["before"], vec!["global"], vec!["after"]]);
     }
 
     #[test]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -50,7 +50,7 @@ use crate::seam_manager::{SeamConfig, SeamManager};
 use crate::tools::goal::{GoalSnapshot, GoalStatus, SharedGoalState, new_shared_goal_state};
 use crate::tools::plan::{PlanSnapshot, SharedPlanState, new_shared_plan_state};
 use crate::tools::shell::{SharedShellManager, new_shared_shell_manager};
-use crate::tools::spec::{ApprovalRequirement, ToolError, ToolResult};
+use crate::tools::spec::{ApprovalRequirement, ResourceClaim, ToolError, ToolResult};
 use crate::tools::spec::{
     RuntimeToolServices, SharedFileReadTracker, new_shared_file_read_tracker,
 };

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -18,7 +18,7 @@
 use serde_json::json;
 
 use crate::models::{Tool, ToolCaller};
-use crate::tools::spec::{ToolError, ToolResult};
+use crate::tools::spec::{ResourceClaim, ToolError, ToolResult};
 use crate::tui::app::AppMode;
 
 use super::ToolUseState;
@@ -49,6 +49,7 @@ pub(super) struct ToolExecutionPlan {
     pub(super) supports_parallel: bool,
     pub(super) read_only: bool,
     pub(super) detached_start: bool,
+    pub(super) resources: Vec<ResourceClaim>,
     pub(super) blocked_error: Option<ToolError>,
     pub(super) guard_result: Option<ToolResult>,
 }
@@ -495,7 +496,13 @@ pub(super) fn parse_parallel_tool_calls(
 
 #[cfg(test)]
 pub(super) fn should_parallelize_tool_batch(plans: &[ToolExecutionPlan]) -> bool {
-    !plans.is_empty() && plans.iter().all(tool_plan_can_join_parallel_batch)
+    !plans.is_empty()
+        && plans.iter().all(tool_plan_can_join_parallel_batch)
+        && plans.iter().enumerate().all(|(index, plan)| {
+            plans[index + 1..]
+                .iter()
+                .all(|other| !tool_plans_conflict(plan, other))
+        })
 }
 
 pub(super) fn tool_plan_is_parallel_safe(plan: &ToolExecutionPlan) -> bool {
@@ -508,6 +515,17 @@ pub(super) fn tool_plan_can_join_parallel_batch(plan: &ToolExecutionPlan) -> boo
             || (plan.detached_start && !plan.approval_required && !plan.interactive))
 }
 
+pub(super) fn tool_plans_conflict(left: &ToolExecutionPlan, right: &ToolExecutionPlan) -> bool {
+    left.resources.contains(&ResourceClaim::GlobalExclusive)
+        || right.resources.contains(&ResourceClaim::GlobalExclusive)
+        || left.resources.iter().any(|left_claim| {
+            right
+                .resources
+                .iter()
+                .any(|right_claim| left_claim.conflicts_with(right_claim))
+        })
+}
+
 pub(super) fn plan_tool_execution_batches(
     plans: Vec<ToolExecutionPlan>,
 ) -> Vec<ToolExecutionBatch> {
@@ -516,6 +534,14 @@ pub(super) fn plan_tool_execution_batches(
 
     for plan in plans {
         if tool_plan_can_join_parallel_batch(&plan) {
+            if parallel_chunk
+                .iter()
+                .any(|existing| tool_plans_conflict(existing, &plan))
+            {
+                batches.push(ToolExecutionBatch::Parallel(std::mem::take(
+                    &mut parallel_chunk,
+                )));
+            }
             parallel_chunk.push(plan);
             continue;
         }

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -18,7 +18,7 @@
 use serde_json::json;
 
 use crate::models::{Tool, ToolCaller};
-use crate::tools::spec::{ResourceClaim, ToolError, ToolResult};
+use crate::tools::spec::{ResourceClaim, ToolError, ToolResult, schedule_non_conflicting};
 use crate::tui::app::AppMode;
 
 use super::ToolUseState;
@@ -496,13 +496,17 @@ pub(super) fn parse_parallel_tool_calls(
 
 #[cfg(test)]
 pub(super) fn should_parallelize_tool_batch(plans: &[ToolExecutionPlan]) -> bool {
-    !plans.is_empty()
-        && plans.iter().all(tool_plan_can_join_parallel_batch)
-        && plans.iter().enumerate().all(|(index, plan)| {
-            plans[index + 1..]
-                .iter()
-                .all(|other| !tool_plans_conflict(plan, other))
-        })
+    if plans.is_empty() || !plans.iter().all(tool_plan_can_join_parallel_batch) {
+        return false;
+    }
+    schedule_non_conflicting(
+        plans
+            .iter()
+            .map(|plan| ((), plan.resources.clone()))
+            .collect(),
+    )
+    .len()
+        == 1
 }
 
 pub(super) fn tool_plan_is_parallel_safe(plan: &ToolExecutionPlan) -> bool {
@@ -515,48 +519,31 @@ pub(super) fn tool_plan_can_join_parallel_batch(plan: &ToolExecutionPlan) -> boo
             || (plan.detached_start && !plan.approval_required && !plan.interactive))
 }
 
-pub(super) fn tool_plans_conflict(left: &ToolExecutionPlan, right: &ToolExecutionPlan) -> bool {
-    left.resources.contains(&ResourceClaim::GlobalExclusive)
-        || right.resources.contains(&ResourceClaim::GlobalExclusive)
-        || left.resources.iter().any(|left_claim| {
-            right
-                .resources
-                .iter()
-                .any(|right_claim| left_claim.conflicts_with(right_claim))
-        })
-}
-
 pub(super) fn plan_tool_execution_batches(
     plans: Vec<ToolExecutionPlan>,
 ) -> Vec<ToolExecutionBatch> {
     let mut batches = Vec::new();
-    let mut parallel_chunk = Vec::new();
+    let mut parallel_candidates = Vec::new();
+
+    let flush_parallel = |parallel_candidates: &mut Vec<_>,
+                          batches: &mut Vec<ToolExecutionBatch>| {
+        for chunk in schedule_non_conflicting(std::mem::take(parallel_candidates)) {
+            batches.push(ToolExecutionBatch::Parallel(chunk));
+        }
+    };
 
     for plan in plans {
         if tool_plan_can_join_parallel_batch(&plan) {
-            if parallel_chunk
-                .iter()
-                .any(|existing| tool_plans_conflict(existing, &plan))
-            {
-                batches.push(ToolExecutionBatch::Parallel(std::mem::take(
-                    &mut parallel_chunk,
-                )));
-            }
-            parallel_chunk.push(plan);
+            let resources = plan.resources.clone();
+            parallel_candidates.push((plan, resources));
             continue;
         }
 
-        if !parallel_chunk.is_empty() {
-            batches.push(ToolExecutionBatch::Parallel(std::mem::take(
-                &mut parallel_chunk,
-            )));
-        }
+        flush_parallel(&mut parallel_candidates, &mut batches);
         batches.push(ToolExecutionBatch::Serial(Box::new(plan)));
     }
 
-    if !parallel_chunk.is_empty() {
-        batches.push(ToolExecutionBatch::Parallel(parallel_chunk));
-    }
+    flush_parallel(&mut parallel_candidates, &mut batches);
 
     batches
 }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1087,8 +1087,18 @@ fn make_plan_at(
         supports_parallel,
         read_only,
         detached_start: false,
+        resources: vec![ResourceClaim::ReadPath(PathBuf::from(format!(
+            "src-{index}.rs"
+        )))],
         blocked_error: None,
         guard_result: None,
+    }
+}
+
+fn parallel_batch_indices(batch: &ToolExecutionBatch) -> Vec<usize> {
+    match batch {
+        ToolExecutionBatch::Parallel(plans) => plans.iter().map(|plan| plan.index).collect(),
+        ToolExecutionBatch::Serial(_) => panic!("expected parallel batch"),
     }
 }
 
@@ -2071,6 +2081,44 @@ fn parallel_batch_requires_read_only_parallel_tools() {
 }
 
 #[test]
+fn parallel_batch_rejects_conflicting_prepared_resources() {
+    let mut first = make_plan_at(0, true, true, false, false);
+    first.resources = vec![ResourceClaim::ReadPath(PathBuf::from("src/lib.rs"))];
+    let mut second = make_plan_at(1, true, true, false, false);
+    second.resources = vec![ResourceClaim::WritePath(PathBuf::from("src/lib.rs"))];
+    assert!(!should_parallelize_tool_batch(&[first, second]));
+
+    let mut first = make_plan_at(0, true, true, false, false);
+    first.resources = vec![ResourceClaim::ReadPath(PathBuf::from("src/a.rs"))];
+    let mut second = make_plan_at(1, true, true, false, false);
+    second.resources = vec![ResourceClaim::WritePath(PathBuf::from("src/b.rs"))];
+    assert!(should_parallelize_tool_batch(&[first, second]));
+
+    let mut global = make_plan_at(0, true, true, false, false);
+    global.resources = vec![ResourceClaim::GlobalExclusive];
+    let mut claimless = make_plan_at(1, true, true, false, false);
+    claimless.resources.clear();
+    assert!(!should_parallelize_tool_batch(&[global, claimless]));
+}
+
+#[test]
+fn conflicting_resource_barriers_preserve_tool_order() {
+    let path = PathBuf::from("src/lib.rs");
+    let mut read_before = make_plan_at(0, true, true, false, false);
+    read_before.resources = vec![ResourceClaim::ReadPath(path.clone())];
+    let mut write = make_plan_at(1, true, true, false, false);
+    write.resources = vec![ResourceClaim::WritePath(path.clone())];
+    let mut read_after = make_plan_at(2, true, true, false, false);
+    read_after.resources = vec![ResourceClaim::ReadPath(path)];
+
+    let batches = plan_tool_execution_batches(vec![read_before, write, read_after]);
+    assert_eq!(batches.len(), 3);
+    assert_eq!(parallel_batch_indices(&batches[0]), vec![0]);
+    assert_eq!(parallel_batch_indices(&batches[1]), vec![1]);
+    assert_eq!(parallel_batch_indices(&batches[2]), vec![2]);
+}
+
+#[test]
 fn tool_execution_batches_use_serial_barriers() {
     let batches = plan_tool_execution_batches(vec![
         make_plan_at(0, true, true, false, false),
@@ -2122,80 +2170,72 @@ fn tool_execution_batches_use_serial_barriers() {
 }
 
 #[test]
-fn shell_readonly_plans_batch_around_serial_barrier() {
+fn globally_exclusive_shell_plans_never_share_a_batch() {
     let mut shell_a = make_plan_at(0, true, true, false, false);
     shell_a.name = "exec_shell".to_string();
     shell_a.input = json!({"command": "git status -s"});
+    shell_a.resources = vec![ResourceClaim::GlobalExclusive];
     let mut shell_b = make_plan_at(1, true, true, false, false);
     shell_b.name = "exec_shell".to_string();
     shell_b.input = json!({"command": "git log --oneline -5"});
+    shell_b.resources = vec![ResourceClaim::GlobalExclusive];
     let mut write_shell = make_plan_at(2, false, false, true, false);
     write_shell.name = "exec_shell".to_string();
     write_shell.input = json!({"command": "cargo build"});
+    write_shell.resources = vec![ResourceClaim::GlobalExclusive];
     let mut shell_c = make_plan_at(3, true, true, false, false);
     shell_c.name = "exec_shell".to_string();
     shell_c.input = json!({"command": "bash -lc 'rg TODO crates/tui/src/core'"});
+    shell_c.resources = vec![ResourceClaim::GlobalExclusive];
 
     let batches = plan_tool_execution_batches(vec![shell_a, shell_b, write_shell, shell_c]);
-    assert_eq!(batches.len(), 3);
+    assert_eq!(batches.len(), 4);
 
     match &batches[0] {
-        ToolExecutionBatch::Parallel(plans) => {
-            assert_eq!(
-                plans.iter().map(|plan| plan.index).collect::<Vec<_>>(),
-                vec![0, 1]
-            );
-        }
+        ToolExecutionBatch::Parallel(plans) => assert_eq!(plans[0].index, 0),
         ToolExecutionBatch::Serial(_) => panic!("first batch should be parallel"),
     }
     match &batches[1] {
+        ToolExecutionBatch::Parallel(plans) => assert_eq!(plans[0].index, 1),
+        ToolExecutionBatch::Serial(_) => panic!("second batch should be parallel"),
+    }
+    match &batches[2] {
         ToolExecutionBatch::Serial(plan) => assert_eq!(plan.index, 2),
         ToolExecutionBatch::Parallel(_) => panic!("write shell should be a serial barrier"),
     }
-    match &batches[2] {
-        ToolExecutionBatch::Parallel(plans) => {
-            assert_eq!(
-                plans.iter().map(|plan| plan.index).collect::<Vec<_>>(),
-                vec![3]
-            );
-        }
-        ToolExecutionBatch::Serial(_) => panic!("third batch should be parallel"),
+    match &batches[3] {
+        ToolExecutionBatch::Parallel(plans) => assert_eq!(plans[0].index, 3),
+        ToolExecutionBatch::Serial(_) => panic!("fourth batch should be parallel"),
     }
 }
 
 #[test]
-fn background_shell_starts_batch_with_readonly_tools_when_auto_approved() {
+fn globally_exclusive_background_shell_does_not_overlap_readonly_shells() {
     let mut shell_a = make_plan_at(0, true, true, false, false);
     shell_a.name = "exec_shell".to_string();
     shell_a.input = json!({"command": "git status -s"});
+    shell_a.resources = vec![ResourceClaim::GlobalExclusive];
 
     let mut background_cargo = make_plan_at(1, false, false, false, false);
     background_cargo.name = "exec_shell".to_string();
     background_cargo.input = json!({"command": "cargo check --workspace", "background": true});
     background_cargo.detached_start = true;
+    background_cargo.resources = vec![ResourceClaim::GlobalExclusive];
 
     let mut shell_b = make_plan_at(2, true, true, false, false);
     shell_b.name = "exec_shell".to_string();
     shell_b.input = json!({"command": "rg TODO crates/tui/src/core"});
+    shell_b.resources = vec![ResourceClaim::GlobalExclusive];
 
     let batches = plan_tool_execution_batches(vec![shell_a, background_cargo, shell_b]);
-    assert_eq!(batches.len(), 1);
-
-    match &batches[0] {
-        ToolExecutionBatch::Parallel(plans) => {
-            assert_eq!(
-                plans.iter().map(|plan| plan.index).collect::<Vec<_>>(),
-                vec![0, 1, 2]
-            );
-        }
-        ToolExecutionBatch::Serial(_) => {
-            panic!("background shell start should join parallel batch")
-        }
-    }
+    assert_eq!(batches.len(), 3);
+    assert_eq!(parallel_batch_indices(&batches[0]), vec![0]);
+    assert_eq!(parallel_batch_indices(&batches[1]), vec![1]);
+    assert_eq!(parallel_batch_indices(&batches[2]), vec![2]);
 }
 
 #[test]
-fn background_verifier_starts_batch_with_readonly_tools_when_auto_approved() {
+fn globally_exclusive_background_verifier_does_not_overlap_readonly_tools() {
     let mut shell_a = make_plan_at(0, true, true, false, false);
     shell_a.name = "exec_shell".to_string();
     shell_a.input = json!({"command": "git status -s"});
@@ -2204,87 +2244,59 @@ fn background_verifier_starts_batch_with_readonly_tools_when_auto_approved() {
     verifier.name = "run_verifiers".to_string();
     verifier.input = json!({"profile": "rust", "level": "full", "background": true});
     verifier.detached_start = true;
+    verifier.resources = vec![ResourceClaim::GlobalExclusive];
 
     let mut shell_b = make_plan_at(2, true, true, false, false);
     shell_b.name = "exec_shell".to_string();
     shell_b.input = json!({"command": "rg TODO crates/tui/src/core"});
 
     let batches = plan_tool_execution_batches(vec![shell_a, verifier, shell_b]);
-    assert_eq!(batches.len(), 1);
-
-    match &batches[0] {
-        ToolExecutionBatch::Parallel(plans) => {
-            assert_eq!(
-                plans.iter().map(|plan| plan.index).collect::<Vec<_>>(),
-                vec![0, 1, 2]
-            );
-        }
-        ToolExecutionBatch::Serial(_) => {
-            panic!("background verifier start should join parallel batch")
-        }
-    }
+    assert_eq!(batches.len(), 3);
+    assert_eq!(parallel_batch_indices(&batches[0]), vec![0]);
+    assert_eq!(parallel_batch_indices(&batches[1]), vec![1]);
+    assert_eq!(parallel_batch_indices(&batches[2]), vec![2]);
 }
 
-// #3801: agent `action=start` plans with `detached_start=true` and no approval
-// (YOLO / auto-approve mode) should all join one parallel batch instead of
-// being serialized N ways under the global tool-execution write lock.
+// Detached starts remain eligible for a parallel chunk, but their conservative
+// global claim prevents overlap until the agent scheduler exposes narrower
+// budget/session claims.
 #[test]
-fn agent_start_detached_plans_join_single_parallel_batch() {
-    // Simulate 4 independent `agent start` calls — each is a detached_start,
-    // not read-only, not parallel-safe in the read-only sense, but qualifies
-    // for the detached-start parallel-batch path.
+fn globally_exclusive_agent_starts_are_singleton_batches() {
     let plans: Vec<ToolExecutionPlan> = (0..4)
         .map(|i| {
             let mut plan = make_plan_at(i, false, false, false, false);
             plan.name = "agent".to_string();
             plan.detached_start = true;
+            plan.resources = vec![ResourceClaim::GlobalExclusive];
             plan
         })
         .collect();
 
     let batches = plan_tool_execution_batches(plans);
-    assert_eq!(
-        batches.len(),
-        1,
-        "all 4 agent starts should form 1 parallel batch"
-    );
-    match &batches[0] {
-        ToolExecutionBatch::Parallel(plans) => {
-            assert_eq!(plans.len(), 4);
-            assert!(
-                plans.iter().all(|p| p.detached_start),
-                "every plan in the parallel batch should be a detached_start"
-            );
-        }
-        ToolExecutionBatch::Serial(_) => {
-            panic!("agent starts should be parallel, not serial");
-        }
+    assert_eq!(batches.len(), 4);
+    for (index, batch) in batches.iter().enumerate() {
+        assert_eq!(parallel_batch_indices(batch), vec![index]);
     }
 }
 
-// #3801: mixed agent starts and read-only tools should coexist in a parallel batch.
 #[test]
-fn agent_start_detached_plans_batch_with_readonly_tools() {
+fn globally_exclusive_agent_start_splits_neighboring_readonly_tools() {
     let mut grep_a = make_plan_at(0, true, true, false, false);
     grep_a.name = "grep_files".to_string();
 
     let mut agent_start = make_plan_at(1, false, false, false, false);
     agent_start.name = "agent".to_string();
     agent_start.detached_start = true;
+    agent_start.resources = vec![ResourceClaim::GlobalExclusive];
 
     let mut grep_b = make_plan_at(2, true, true, false, false);
     grep_b.name = "grep_files".to_string();
 
     let batches = plan_tool_execution_batches(vec![grep_a, agent_start, grep_b]);
-    assert_eq!(batches.len(), 1);
-    match &batches[0] {
-        ToolExecutionBatch::Parallel(plans) => {
-            assert_eq!(plans.len(), 3);
-        }
-        ToolExecutionBatch::Serial(_) => {
-            panic!("read-only tools + detached agent start should form 1 parallel batch");
-        }
-    }
+    assert_eq!(batches.len(), 3);
+    assert_eq!(parallel_batch_indices(&batches[0]), vec![0]);
+    assert_eq!(parallel_batch_indices(&batches[1]), vec![1]);
+    assert_eq!(parallel_batch_indices(&batches[2]), vec![2]);
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tool_preparation.rs
+++ b/crates/tui/src/core/engine/tool_preparation.rs
@@ -4,6 +4,9 @@
 //! the input-specific policy decision inspectable and reusable, including a
 //! mandatory second preparation after a hook rewrites input.
 
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
 use serde_json::Value;
 
 use crate::mcp::McpPool;
@@ -52,8 +55,10 @@ pub(super) fn prepare_tool_call(
     if let Some(registry) = registry
         && let Some(spec) = registry.get(name)
     {
+        let mut call = spec.prepare(input, registry.context())?;
+        call.resources = registered_resource_claims(name, &call.input, registry.context())?;
         return Ok(PreparedToolPolicy {
-            call: spec.prepare(input, registry.context())?,
+            call,
             auto_approve: registry.context().auto_approve,
         });
     }
@@ -127,6 +132,91 @@ fn conservative_execution_policy(
         },
         auto_approve,
     }
+}
+
+fn registered_resource_claims(
+    name: &str,
+    input: &Value,
+    context: &crate::tools::ToolContext,
+) -> Result<Vec<ResourceClaim>, ToolError> {
+    match name {
+        "read_file" => path_claim(input, "path", None, context, ResourceClaim::ReadPath),
+        "write_file" | "edit_file" => {
+            path_claim(input, "path", None, context, ResourceClaim::WritePath)
+        }
+        "list_dir" | "grep_files" | "file_search" => {
+            path_claim(input, "path", Some("."), context, ResourceClaim::ReadTree)
+        }
+        "apply_patch" => apply_patch_resource_claims(input, context),
+        "terminal/run" => Ok(terminal_claim(input, "session", Some("term-1"))),
+        "terminal/send" | "terminal/wait" | "terminal/cancel" | "terminal/reset" => {
+            Ok(terminal_claim(input, "session", None))
+        }
+        "exec_shell_wait"
+        | "exec_wait"
+        | "exec_shell_interact"
+        | "exec_interact"
+        | "exec_shell_cancel" => Ok(terminal_claim(input, "task_id", None)),
+        _ => Ok(global_exclusive_claim()),
+    }
+}
+
+fn path_claim(
+    input: &Value,
+    key: &str,
+    default: Option<&str>,
+    context: &crate::tools::ToolContext,
+    build: fn(PathBuf) -> ResourceClaim,
+) -> Result<Vec<ResourceClaim>, ToolError> {
+    let raw = input
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .or(default);
+    let Some(raw) = raw else {
+        return Ok(global_exclusive_claim());
+    };
+    Ok(context
+        .resolve_path(raw)
+        .map_or_else(|_| global_exclusive_claim(), |path| vec![build(path)]))
+}
+
+fn apply_patch_resource_claims(
+    input: &Value,
+    context: &crate::tools::ToolContext,
+) -> Result<Vec<ResourceClaim>, ToolError> {
+    let Ok(preflight) = crate::tools::apply_patch::preflight_apply_patch(input) else {
+        return Ok(global_exclusive_claim());
+    };
+    if preflight.touched_files.is_empty() {
+        return Ok(global_exclusive_claim());
+    }
+
+    let mut claims = BTreeSet::new();
+    for path in preflight.touched_files {
+        let Ok(path) = context.resolve_path(&path) else {
+            return Ok(global_exclusive_claim());
+        };
+        claims.insert(ResourceClaim::WritePath(path));
+    }
+    Ok(claims.into_iter().collect())
+}
+
+fn terminal_claim(input: &Value, key: &str, default: Option<&str>) -> Vec<ResourceClaim> {
+    input
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .or(default)
+        .map_or_else(global_exclusive_claim, |id| {
+            vec![ResourceClaim::Terminal(id.to_string())]
+        })
+}
+
+fn global_exclusive_claim() -> Vec<ResourceClaim> {
+    vec![ResourceClaim::GlobalExclusive]
 }
 
 #[cfg(test)]
@@ -355,5 +445,163 @@ mod tests {
             prepared.call.approval,
             prepared.auto_approve,
         ));
+    }
+
+    #[test]
+    fn hook_rewrite_reprepares_resource_claims_from_final_input() {
+        let root = tempdir().expect("tempdir");
+        let context = ToolContext::new(root.path().to_path_buf());
+        let original_path = context.resolve_path("before.rs").expect("original path");
+        let rewritten_path = context.resolve_path("after.rs").expect("rewritten path");
+        let mut registry = ToolRegistry::new(context);
+        registry.register(Arc::new(crate::tools::file::ReadFileTool));
+
+        let original = prepare_tool_call(
+            "read_file",
+            json!({"path": "before.rs"}),
+            Some(&registry),
+            false,
+        )
+        .expect("prepare original read");
+        let rewritten = reprepare_tool_call_after_hook(
+            "read_file",
+            json!({"path": "after.rs"}),
+            Some(&registry),
+            false,
+        )
+        .expect("reprepare rewritten read");
+
+        assert_eq!(
+            original.call.resources,
+            vec![ResourceClaim::ReadPath(original_path)]
+        );
+        assert_eq!(
+            rewritten.call.resources,
+            vec![ResourceClaim::ReadPath(rewritten_path)]
+        );
+    }
+
+    #[test]
+    fn registered_file_claims_are_canonical_and_input_specific() {
+        let root = tempdir().expect("tempdir");
+        let context = ToolContext::new(root.path().to_path_buf());
+        let exact = context.resolve_path("src/lib.rs").expect("exact path");
+        let tree = context.resolve_path("src").expect("tree path");
+
+        assert_eq!(
+            registered_resource_claims("read_file", &json!({"path": "src/lib.rs"}), &context,)
+                .expect("read claim"),
+            vec![ResourceClaim::ReadPath(exact.clone())]
+        );
+        assert_eq!(
+            registered_resource_claims("edit_file", &json!({"path": "src/lib.rs"}), &context,)
+                .expect("write claim"),
+            vec![ResourceClaim::WritePath(exact)]
+        );
+        assert_eq!(
+            registered_resource_claims("grep_files", &json!({"path": "src"}), &context)
+                .expect("tree claim"),
+            vec![ResourceClaim::ReadTree(tree)]
+        );
+        assert_eq!(
+            registered_resource_claims("read_file", &json!({"path": "../../outside"}), &context,)
+                .expect("path escape must fall back conservatively"),
+            vec![ResourceClaim::GlobalExclusive]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_aliases_resolve_to_the_same_file_claim() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().expect("tempdir");
+        let real_dir = root.path().join("real");
+        std::fs::create_dir(&real_dir).expect("create real directory");
+        std::fs::write(real_dir.join("lib.rs"), "fn main() {}\n").expect("write real file");
+        symlink("real", root.path().join("alias")).expect("create directory symlink");
+        let context = ToolContext::new(root.path().to_path_buf());
+        let canonical_real = real_dir
+            .join("lib.rs")
+            .canonicalize()
+            .expect("canonical file");
+
+        let read_alias =
+            registered_resource_claims("read_file", &json!({"path": "alias/lib.rs"}), &context)
+                .expect("alias claim");
+        let write_real =
+            registered_resource_claims("write_file", &json!({"path": "real/lib.rs"}), &context)
+                .expect("real claim");
+
+        assert_eq!(read_alias, vec![ResourceClaim::ReadPath(canonical_real)]);
+        assert!(read_alias[0].conflicts_with(&write_real[0]));
+    }
+
+    #[test]
+    fn apply_patch_claims_every_resolved_target_or_falls_back_global() {
+        let root = tempdir().expect("tempdir");
+        let context = ToolContext::new(root.path().to_path_buf());
+        let a = context.resolve_path("a.rs").expect("a path");
+        let b = context.resolve_path("b.rs").expect("b path");
+
+        let claims = registered_resource_claims(
+            "apply_patch",
+            &json!({
+                "replace": [
+                    {"path": "b.rs", "content": "b"},
+                    {"path": "a.rs", "content": "a"}
+                ]
+            }),
+            &context,
+        )
+        .expect("patch claims");
+        assert_eq!(
+            claims,
+            vec![ResourceClaim::WritePath(a), ResourceClaim::WritePath(b)]
+        );
+
+        assert_eq!(
+            registered_resource_claims(
+                "apply_patch",
+                &json!({"patch": "not a unified diff"}),
+                &context,
+            )
+            .expect("fallback claim"),
+            vec![ResourceClaim::GlobalExclusive]
+        );
+        assert_eq!(
+            registered_resource_claims(
+                "apply_patch",
+                &json!({"replace": [{"path": "../../outside", "content": "nope"}]}),
+                &context,
+            )
+            .expect("escaped target fallback"),
+            vec![ResourceClaim::GlobalExclusive]
+        );
+    }
+
+    #[test]
+    fn terminal_and_unknown_tools_keep_conservative_claims() {
+        let root = tempdir().expect("tempdir");
+        let context = ToolContext::new(root.path().to_path_buf());
+
+        assert_eq!(
+            registered_resource_claims("terminal/run", &json!({}), &context)
+                .expect("default terminal"),
+            vec![ResourceClaim::Terminal("term-1".to_string())]
+        );
+        assert_eq!(
+            registered_resource_claims(
+                "exec_shell_interact",
+                &json!({"task_id": "task-7"}),
+                &context,
+            )
+            .expect("task terminal"),
+            vec![ResourceClaim::Terminal("task-7".to_string())]
+        );
+        assert_eq!(
+            registered_resource_claims("plugin_tool", &json!({}), &context).expect("unknown tool"),
+            vec![ResourceClaim::GlobalExclusive]
+        );
     }
 }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1624,6 +1624,7 @@ impl Engine {
                 let mut supports_parallel = false;
                 let mut read_only = false;
                 let mut detached_start = false;
+                let mut resources = vec![ResourceClaim::GlobalExclusive];
                 let mut blocked_error: Option<ToolError> = None;
                 let guard_result: Option<ToolResult> = None;
                 // #3026: set by a hook `ask` decision; applied AFTER the
@@ -1794,6 +1795,7 @@ impl Engine {
                     read_only = prepared.call.read_only;
                     detached_start = prepared.call.starts_detached;
                     tool_input = prepared.call.input;
+                    resources = prepared.call.resources;
 
                     let approval = match prepared.call.approval {
                         ApprovalRequirement::Auto => "auto",
@@ -1808,7 +1810,7 @@ impl Engine {
                         "supports_parallel": supports_parallel,
                         "starts_detached": detached_start,
                         "approval": approval,
-                        "resources": prepared.call.resources,
+                        "resources": &resources,
                         "reprepared_after_hook": reprepared_after_hook,
                     }));
                 }
@@ -1987,6 +1989,7 @@ impl Engine {
                     supports_parallel,
                     read_only,
                     detached_start,
+                    resources,
                     blocked_error,
                     guard_result,
                 });

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -29,6 +29,7 @@ use crate::worker_profile::ShellPolicy;
 pub use codewhale_tools::{
     ApprovalRequirement, PreparedToolCall, ResourceClaim, ToolCapability, ToolError, ToolResult,
     optional_bool, optional_str, optional_u64, required_str, required_u64,
+    schedule_non_conflicting,
 };
 
 #[async_trait]


### PR DESCRIPTION
## Summary

- Resolve canonical resource claims from the final prepared input for first-party file/tree/patch tools and terminal session/task follow-ups.
- Keep shell starts, plugins, dynamic tools, agents, MCP/code/JS paths, and unknown tools globally exclusive until they expose narrower safe claims.
- Require the existing Boolean parallel eligibility **and** pairwise non-conflicting claims, preserving contiguous model-call order across every conflict barrier.
- Treat unresolved, malformed, or escaped resource paths as `GlobalExclusive`; execution retains its existing validation/error behavior while scheduling fails conservative.

## Compatibility boundary

This keeps the current executor, `FuturesUnordered` batch driver, approval flow, persistence format, UI, and authority gates. It does not add long-lived leases, a fair scheduler service, write parallelism, or a journal. Detached agent/shell starts remain Boolean-eligible but form singleton batches under the conservative global fallback until narrower budget/session claims exist.

## Verification

Exact head `da3e92ba985028722900eff267fc602c129aa3f8` atop merged prepared-call seam `1ad4620cabd6c5e9169ddc2b383a312b603d5855`:

- `cargo test -q -p codewhale-tools --locked`: 21 passed; parity suite 3 passed
- `cargo test -q -p codewhale-tui --locked`: 7,502 passed / 0 failed / 3 ignored; QA PTY 17 passed / 1 ignored; release runtime 5 passed / 1 ignored; all integration suites green
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`; `git diff --check`
- exact-commit gitleaks and added-line private-path/credential scan clean

Coverage includes independent resources, same-path read/write barriers, read/write/read order, ancestor/tree overlap, canonical symlink aliases, multi-file patches, hook-rewritten paths, terminal identity, global-vs-claimless barriers, and conservative fallbacks.

## Review focus

- Canonical path resolution uses the exact `ToolContext::resolve_path` workspace/symlink/trusted-root boundary used by execution.
- `GlobalExclusive` must conflict even with a claimless plan.
- The former #3801 tests that expected detached agent starts to overlap are deliberately re-keyed to the conservative fallback contract; narrower agent budget/session claims belong in a later scheduler slice.

No tag, release, registry publication, deploy, or branch deletion is part of this PR.