### PR TITLE
feat(tools): make terminal outcomes explicit

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -10,9 +10,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
+mod outcome;
 mod prepared;
 mod resources;
 
+pub use outcome::{ToolExecutionOutcome, ToolTerminalStatus};
 pub use prepared::PreparedToolCall;
 pub use resources::{ResourceClaim, schedule_non_conflicting};
 
@@ -62,6 +64,8 @@ pub enum ToolError {
     ExecutionFailed { message: String },
     #[error("Failed to execute tool: operation timed out after {seconds}s")]
     Timeout { seconds: u64 },
+    #[error("Tool execution cancelled: {message}")]
+    Cancelled { message: String },
     #[error("Failed to locate tool: {message}")]
     NotAvailable { message: String },
     #[error("Failed to authorize tool execution: {message}")]
@@ -86,6 +90,13 @@ impl ToolError {
     #[must_use]
     pub fn execution_failed(msg: impl Into<String>) -> Self {
         Self::ExecutionFailed {
+            message: msg.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn cancelled(msg: impl Into<String>) -> Self {
+        Self::Cancelled {
             message: msg.into(),
         }
     }

--- a/crates/tools/src/outcome.rs
+++ b/crates/tools/src/outcome.rs
@@ -1,0 +1,177 @@
+use crate::{ToolError, ToolResult};
+
+/// Machine-readable terminal state for one tool call.
+///
+/// This is intentionally separate from [`ToolResult::success`]: a cancelled
+/// call still needs a legacy model-visible result so the call/result transcript
+/// stays well formed, while the runtime must not report that call as a generic
+/// failure or infer cancellation from output text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolTerminalStatus {
+    Succeeded,
+    Failed,
+    Denied,
+    InvalidArguments,
+    Cancelled,
+    TimedOut,
+}
+
+impl ToolTerminalStatus {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Denied => "denied",
+            Self::InvalidArguments => "invalid_arguments",
+            Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
+        }
+    }
+}
+
+/// Terminal wrapper around the v0.9.1-compatible tool result/error contract.
+///
+/// Exactly one of `result` and `error` is populated by the constructors. The
+/// existing UI and transcript paths can keep consuming [`Self::legacy_result`]
+/// while audit and orchestration use [`Self::status`] directly.
+#[derive(Debug, Clone)]
+pub struct ToolExecutionOutcome {
+    pub status: ToolTerminalStatus,
+    pub result: Option<ToolResult>,
+    pub error: Option<ToolError>,
+}
+
+impl ToolExecutionOutcome {
+    #[must_use]
+    pub fn from_legacy(result: Result<ToolResult, ToolError>) -> Self {
+        match result {
+            Ok(result) => {
+                let status = if result.success {
+                    ToolTerminalStatus::Succeeded
+                } else {
+                    ToolTerminalStatus::Failed
+                };
+                Self {
+                    status,
+                    result: Some(result),
+                    error: None,
+                }
+            }
+            Err(error) => {
+                let status = match &error {
+                    ToolError::InvalidInput { .. } | ToolError::MissingField { .. } => {
+                        ToolTerminalStatus::InvalidArguments
+                    }
+                    ToolError::PathEscape { .. } | ToolError::PermissionDenied { .. } => {
+                        ToolTerminalStatus::Denied
+                    }
+                    ToolError::Timeout { .. } => ToolTerminalStatus::TimedOut,
+                    ToolError::Cancelled { .. } => ToolTerminalStatus::Cancelled,
+                    ToolError::ExecutionFailed { .. } | ToolError::NotAvailable { .. } => {
+                        ToolTerminalStatus::Failed
+                    }
+                };
+                Self {
+                    status,
+                    result: None,
+                    error: Some(error),
+                }
+            }
+        }
+    }
+
+    /// Construct a cancelled outcome while retaining the legacy benign result
+    /// used to close the provider tool-call pair.
+    #[must_use]
+    pub fn cancelled(result: ToolResult) -> Self {
+        Self {
+            status: ToolTerminalStatus::Cancelled,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn legacy_result(&self) -> Result<ToolResult, ToolError> {
+        match (&self.result, &self.error) {
+            (Some(result), None) => Ok(result.clone()),
+            (None, Some(error)) => Err(error.clone()),
+            _ => unreachable!("ToolExecutionOutcome must contain exactly one result or error"),
+        }
+    }
+
+    pub fn into_legacy_result(self) -> Result<ToolResult, ToolError> {
+        match (self.result, self.error) {
+            (Some(result), None) => Ok(result),
+            (None, Some(error)) => Err(error),
+            _ => unreachable!("ToolExecutionOutcome must contain exactly one result or error"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn legacy_results_map_to_explicit_terminal_statuses() {
+        let cases = [
+            (Ok(ToolResult::success("ok")), ToolTerminalStatus::Succeeded),
+            (Ok(ToolResult::error("failed")), ToolTerminalStatus::Failed),
+            (
+                Err(ToolError::invalid_input("bad arguments")),
+                ToolTerminalStatus::InvalidArguments,
+            ),
+            (
+                Err(ToolError::missing_field("path")),
+                ToolTerminalStatus::InvalidArguments,
+            ),
+            (
+                Err(ToolError::path_escape(PathBuf::from("../secret"))),
+                ToolTerminalStatus::Denied,
+            ),
+            (
+                Err(ToolError::permission_denied("no")),
+                ToolTerminalStatus::Denied,
+            ),
+            (
+                Err(ToolError::Timeout { seconds: 5 }),
+                ToolTerminalStatus::TimedOut,
+            ),
+            (
+                Err(ToolError::cancelled("stop")),
+                ToolTerminalStatus::Cancelled,
+            ),
+            (
+                Err(ToolError::execution_failed("boom")),
+                ToolTerminalStatus::Failed,
+            ),
+            (
+                Err(ToolError::not_available("missing")),
+                ToolTerminalStatus::Failed,
+            ),
+        ];
+
+        for (legacy, expected) in cases {
+            let outcome = ToolExecutionOutcome::from_legacy(legacy);
+            assert_eq!(outcome.status, expected);
+            let populated =
+                usize::from(outcome.result.is_some()) + usize::from(outcome.error.is_some());
+            assert_eq!(populated, 1);
+        }
+    }
+
+    #[test]
+    fn cancelled_result_keeps_legacy_pair_but_not_failure_status() {
+        let legacy = ToolResult::error("not executed");
+        let outcome = ToolExecutionOutcome::cancelled(legacy.clone());
+
+        assert_eq!(outcome.status, ToolTerminalStatus::Cancelled);
+        let restored = outcome.legacy_result().expect("legacy result");
+        assert_eq!(restored.content, legacy.content);
+        assert!(!restored.success);
+    }
+}

--- a/crates/tools/src/outcome.rs
+++ b/crates/tools/src/outcome.rs
@@ -39,8 +39,8 @@ impl ToolTerminalStatus {
 #[derive(Debug, Clone)]
 pub struct ToolExecutionOutcome {
     pub status: ToolTerminalStatus,
-    pub result: Option<ToolResult>,
-    pub error: Option<ToolError>,
+    result: Option<ToolResult>,
+    error: Option<ToolError>,
 }
 
 impl ToolExecutionOutcome {

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1012,6 +1012,15 @@ impl DeepSeekClient {
     /// Anthropic Messages, and OpenAI Responses — streaming and non-streaming
     /// alike — receive the same sanitized payload.
     fn prepare_model_bound_request(&self, mut request: MessageRequest) -> MessageRequest {
+        let repair = crate::tool_history_repair::repair_tool_call_pairs(&mut request.messages);
+        if !repair.is_empty() {
+            tracing::warn!(
+                repaired_call_ids = ?repair.repaired_call_ids,
+                duplicate_result_ids = ?repair.duplicate_result_ids,
+                orphan_result_ids = ?repair.orphan_result_ids,
+                "repaired tool call/result history before provider projection"
+            );
+        }
         for message in &mut request.messages {
             for block in &mut message.content {
                 if let ContentBlock::ToolResult { content, .. } = block {
@@ -2827,6 +2836,40 @@ mod tests {
                 _ => None,
             })
             .expect("tool result content")
+    }
+
+    #[test]
+    fn model_bound_request_repairs_dangling_tool_call_before_adapter_projection() {
+        let client = client_with_config_secret_sentinels();
+        let mut request = request_with_tool_result("unused");
+        request.messages.pop();
+
+        let prepared = client.prepare_model_bound_request(request);
+
+        assert!(prepared.messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error: Some(true),
+                        ..
+                    } if tool_use_id == "call-secret-test"
+                        && content.contains("crashed_and_repaired")
+                )
+            })
+        }));
+        assert!(prepared.messages.iter().any(|message| {
+            message.role == "assistant"
+                && message.content.iter().any(|block| {
+                    matches!(
+                        block,
+                        ContentBlock::Text { text, .. }
+                            if text.contains("[tool_history_repair]")
+                    )
+                })
+        }));
     }
 
     #[test]

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1012,7 +1012,8 @@ impl DeepSeekClient {
     /// Anthropic Messages, and OpenAI Responses — streaming and non-streaming
     /// alike — receive the same sanitized payload.
     fn prepare_model_bound_request(&self, mut request: MessageRequest) -> MessageRequest {
-        let repair = crate::tool_history_repair::repair_tool_call_pairs(&mut request.messages);
+        let repair =
+            crate::tool_history_repair::repair_tool_call_pairs_for_provider(&mut request.messages);
         if !repair.is_empty() {
             tracing::warn!(
                 repaired_call_ids = ?repair.repaired_call_ids,
@@ -2860,15 +2861,18 @@ mod tests {
                 )
             })
         }));
-        assert!(prepared.messages.iter().any(|message| {
-            message.role == "assistant"
-                && message.content.iter().any(|block| {
-                    matches!(
-                        block,
-                        ContentBlock::Text { text, .. }
-                            if text.contains("[tool_history_repair]")
-                    )
-                })
+        assert_eq!(
+            prepared.messages.last().expect("repaired result").role,
+            "user"
+        );
+        assert!(!prepared.messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::Text { text, .. }
+                        if text.contains("[tool_history_repair]")
+                )
+            })
         }));
     }
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -50,7 +50,9 @@ use crate::seam_manager::{SeamConfig, SeamManager};
 use crate::tools::goal::{GoalSnapshot, GoalStatus, SharedGoalState, new_shared_goal_state};
 use crate::tools::plan::{PlanSnapshot, SharedPlanState, new_shared_plan_state};
 use crate::tools::shell::{SharedShellManager, new_shared_shell_manager};
-use crate::tools::spec::{ApprovalRequirement, ResourceClaim, ToolError, ToolResult};
+use crate::tools::spec::{
+    ApprovalRequirement, ResourceClaim, ToolError, ToolExecutionOutcome, ToolResult,
+};
 use crate::tools::spec::{
     RuntimeToolServices, SharedFileReadTracker, new_shared_file_read_tracker,
 };

--- a/crates/tui/src/core/engine/approval.rs
+++ b/crates/tui/src/core/engine/approval.rs
@@ -76,7 +76,7 @@ impl Engine {
             tokio::select! {
                 _ = self.cancel_token.cancelled() => {
                     let suffix = self.cancel_reason_suffix();
-                    return Err(ToolError::execution_failed(
+                    return Err(ToolError::cancelled(
                         format!("Request cancelled while awaiting approval{suffix}"),
                     ));
                 }
@@ -123,7 +123,7 @@ impl Engine {
             tokio::select! {
                 _ = self.cancel_token.cancelled() => {
                     let suffix = self.cancel_reason_suffix();
-                    return Err(ToolError::execution_failed(
+                    return Err(ToolError::cancelled(
                         format!("Request cancelled while awaiting user input{suffix}"),
                     ));
                 }
@@ -135,7 +135,7 @@ impl Engine {
                                     return Ok(response);
                                 }
                                 UserInputDecision::Cancelled { id } if id == tool_id => {
-                                    return Err(ToolError::execution_failed(
+                                    return Err(ToolError::cancelled(
                                         "User input cancelled".to_string(),
                                     ));
                                 }
@@ -157,12 +157,9 @@ impl Engine {
                                     ),
                                 })
                                 .await;
-                            return Err(ToolError::execution_failed(
-                                format!(
-                                    "User input timed out after {}s",
-                                    USER_INPUT_TIMEOUT.as_secs()
-                                ),
-                            ));
+                            return Err(ToolError::Timeout {
+                                seconds: USER_INPUT_TIMEOUT.as_secs(),
+                            });
                         }
                     }
                 }

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -18,7 +18,9 @@
 use serde_json::json;
 
 use crate::models::{Tool, ToolCaller};
-use crate::tools::spec::{ResourceClaim, ToolError, ToolResult, schedule_non_conflicting};
+use crate::tools::spec::{
+    ResourceClaim, ToolError, ToolExecutionOutcome, ToolResult, schedule_non_conflicting,
+};
 use crate::tui::app::AppMode;
 
 use super::ToolUseState;
@@ -32,7 +34,7 @@ pub(super) struct ToolExecOutcome {
     pub(super) name: String,
     pub(super) input: serde_json::Value,
     pub(super) started_at: std::time::Instant,
-    pub(super) result: Result<ToolResult, ToolError>,
+    pub(super) terminal: ToolExecutionOutcome,
 }
 
 #[derive(Debug, Clone)]
@@ -190,6 +192,7 @@ pub(super) fn format_tool_error_with_schema(
         ToolError::Timeout { seconds } => format!(
             "Tool '{tool_name}' timed out after {seconds}s. Try a narrower scope or a longer timeout."
         ),
+        ToolError::Cancelled { message } => message.clone(),
         ToolError::NotAvailable { message } => {
             let lower = message.to_ascii_lowercase();
             // #3020: Pass through self-explanatory messages that already name the

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -2542,10 +2542,14 @@ fn tool_exec_outcome_tracks_duration() {
         name: "grep_files".to_string(),
         input: json!({"pattern": "test"}),
         started_at: Instant::now(),
-        result: Ok(ToolResult::success("ok")),
+        terminal: ToolExecutionOutcome::from_legacy(Ok(ToolResult::success("ok"))),
     };
 
     assert!(outcome.started_at.elapsed().as_nanos() > 0);
+    assert_eq!(
+        outcome.terminal.status,
+        crate::tools::spec::ToolTerminalStatus::Succeeded
+    );
 }
 
 #[test]
@@ -8481,6 +8485,7 @@ fn tool_failure_audit_payload_carries_category_and_severity() {
         "event": "tool.result",
         "tool_id": "tool-1",
         "tool_name": "exec_shell",
+        "status": ToolExecutionOutcome::from_legacy(Err(error.clone())).status.as_str(),
         "success": false,
         "error": error.to_string(),
         "category": envelope.category.to_string(),
@@ -8489,6 +8494,7 @@ fn tool_failure_audit_payload_carries_category_and_severity() {
 
     assert_eq!(payload["category"], "timeout");
     assert_eq!(payload["severity"], "warning");
+    assert_eq!(payload["status"], "timed_out");
     assert_eq!(payload["success"], false);
 }
 

--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -391,6 +391,7 @@ impl Engine {
                     ToolError::PathEscape { .. } => "path_escape",
                     ToolError::ExecutionFailed { .. } => "execution_failed",
                     ToolError::Timeout { .. } => "timeout",
+                    ToolError::Cancelled { .. } => "cancelled",
                     ToolError::NotAvailable { .. } => "not_available",
                     ToolError::PermissionDenied { .. } => "permission_denied",
                 };

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2076,7 +2076,8 @@ impl Engine {
                 // Interrupted. This branch is a no-op on the normal path.
                 if self.cancel_token.is_cancelled() {
                     for plan in plans {
-                        let result = Ok(interrupted_tool_result());
+                        let terminal = ToolExecutionOutcome::cancelled(interrupted_tool_result());
+                        let result = terminal.legacy_result();
                         let _ = self
                             .tx_event
                             .send(Event::ToolCallComplete {
@@ -2091,7 +2092,7 @@ impl Engine {
                             name: plan.name,
                             input: plan.input,
                             started_at: Instant::now(),
-                            result,
+                            terminal,
                         });
                     }
                     continue;
@@ -2129,7 +2130,7 @@ impl Engine {
                                 name: plan.name,
                                 input: plan.input,
                                 started_at: Instant::now(),
-                                result,
+                                terminal: ToolExecutionOutcome::from_legacy(result),
                             });
                             continue;
                         }
@@ -2140,7 +2141,7 @@ impl Engine {
                                 name: plan.name,
                                 input: plan.input,
                                 started_at: Instant::now(),
-                                result: Err(err),
+                                terminal: ToolExecutionOutcome::from_legacy(Err(err)),
                             });
                             continue;
                         }
@@ -2208,7 +2209,7 @@ impl Engine {
                                 name: plan.name,
                                 input: plan.input,
                                 started_at,
-                                result,
+                                terminal: ToolExecutionOutcome::from_legacy(result),
                             }
                         });
                     }
@@ -2237,7 +2238,9 @@ impl Engine {
                             if outcomes[index].is_some() {
                                 continue;
                             }
-                            let result = Ok(interrupted_tool_result());
+                            let terminal =
+                                ToolExecutionOutcome::cancelled(interrupted_tool_result());
+                            let result = terminal.legacy_result();
                             let _ = self
                                 .tx_event
                                 .send(Event::ToolCallComplete {
@@ -2252,7 +2255,7 @@ impl Engine {
                                 name,
                                 input,
                                 started_at: Instant::now(),
-                                result,
+                                terminal,
                             });
                         }
                     }
@@ -2279,7 +2282,7 @@ impl Engine {
                                 name: tool_name,
                                 input: tool_input,
                                 started_at: Instant::now(),
-                                result,
+                                terminal: ToolExecutionOutcome::from_legacy(result),
                             });
                             continue;
                         }
@@ -2300,7 +2303,7 @@ impl Engine {
                                 name: tool_name,
                                 input: tool_input,
                                 started_at: Instant::now(),
-                                result,
+                                terminal: ToolExecutionOutcome::from_legacy(result),
                             });
                             continue;
                         }
@@ -2308,15 +2311,18 @@ impl Engine {
                         if tool_name == MULTI_TOOL_PARALLEL_NAME {
                             let started_at = Instant::now();
                             let cancel_token = self.cancel_token.clone();
-                            let result = tokio::select! {
+                            let terminal = tokio::select! {
                                 biased;
-                                () = cancel_token.cancelled() => Ok(interrupted_tool_result()),
+                                () = cancel_token.cancelled() => {
+                                    ToolExecutionOutcome::cancelled(interrupted_tool_result())
+                                },
                                 result = self.execute_parallel_tool(
                                     tool_input.clone(),
                                     tool_registry,
                                     tool_exec_lock.clone(),
-                                ) => result,
+                                ) => ToolExecutionOutcome::from_legacy(result),
                             };
+                            let result = terminal.legacy_result();
 
                             let _ = self
                                 .tx_event
@@ -2333,7 +2339,7 @@ impl Engine {
                                 name: tool_name,
                                 input: tool_input,
                                 started_at,
-                                result,
+                                terminal,
                             });
                             continue;
                         }
@@ -2362,7 +2368,7 @@ impl Engine {
                                 name: tool_name,
                                 input: tool_input,
                                 started_at,
-                                result,
+                                terminal: ToolExecutionOutcome::from_legacy(result),
                             });
                             continue;
                         }
@@ -2395,7 +2401,7 @@ impl Engine {
                                 name: tool_name,
                                 input: tool_input,
                                 started_at,
-                                result,
+                                terminal: ToolExecutionOutcome::from_legacy(result),
                             });
                             continue;
                         }
@@ -2510,26 +2516,29 @@ impl Engine {
                         }
 
                         let started_at = Instant::now();
-                        let mut result = if let Some(result_override) = result_override {
-                            result_override
-                        } else {
-                            tokio::select! {
-                                biased;
-                                () = self.cancel_token.cancelled() => Ok(interrupted_tool_result()),
-                                result = Self::execute_tool_with_lock(
-                                    tool_exec_lock.clone(),
-                                    plan.supports_parallel,
-                                    plan.interactive,
-                                    self.tx_event.clone(),
-                                    tool_name.clone(),
-                                    tool_input.clone(),
-                                    self.session.workspace.clone(),
-                                    tool_registry,
-                                    mcp_pool.clone(),
-                                    context_override,
-                                ) => result,
-                            }
-                        };
+                        let (mut result, cancelled_before_completion) =
+                            if let Some(result_override) = result_override {
+                                (result_override, false)
+                            } else {
+                                tokio::select! {
+                                    biased;
+                                    () = self.cancel_token.cancelled() => {
+                                        (Ok(interrupted_tool_result()), true)
+                                    },
+                                    result = Self::execute_tool_with_lock(
+                                        tool_exec_lock.clone(),
+                                        plan.supports_parallel,
+                                        plan.interactive,
+                                        self.tx_event.clone(),
+                                        tool_name.clone(),
+                                        tool_input.clone(),
+                                        self.session.workspace.clone(),
+                                        tool_registry,
+                                        mcp_pool.clone(),
+                                        context_override,
+                                    ) => (result, false),
+                                }
+                            };
 
                         if let Some(approval_stamp) = approval_stamp
                             && let Ok(tool_result) = result.as_mut()
@@ -2570,13 +2579,20 @@ impl Engine {
                             })
                             .await;
 
+                        let terminal = if cancelled_before_completion {
+                            ToolExecutionOutcome::cancelled(
+                                result.expect("cancelled tool result is always model-visible"),
+                            )
+                        } else {
+                            ToolExecutionOutcome::from_legacy(result)
+                        };
                         outcomes[plan.index] = Some(ToolExecOutcome {
                             index: plan.index,
                             id: tool_id,
                             name: tool_name,
                             input: tool_input,
                             started_at,
-                            result,
+                            terminal,
                         });
                     }
                 }
@@ -2602,7 +2618,9 @@ impl Engine {
             for outcome in outcomes.into_iter().flatten() {
                 let tool_input = outcome.input.clone();
                 let tool_name_for_ws = outcome.name.clone();
-                let observed_signal = match &outcome.result {
+                let terminal_status = outcome.terminal.status;
+                let result = outcome.terminal.into_legacy_result();
+                let observed_signal = match &result {
                     Ok(output) if output.success => {
                         stuck_guard.observe(StepFingerprint::tool(&outcome.name, &tool_input, None))
                     }
@@ -2628,14 +2646,15 @@ impl Engine {
                     goal_tool_ran = true;
                 }
                 let should_stop_this_turn =
-                    should_stop_after_plan_tool(mode, &outcome.name, &outcome.result);
+                    should_stop_after_plan_tool(mode, &outcome.name, &result);
 
-                match outcome.result {
+                match result {
                     Ok(output) => {
                         emit_tool_audit(json!({
                             "event": "tool.result",
                             "tool_id": outcome.id.clone(),
                             "tool_name": outcome.name.clone(),
+                            "status": terminal_status.as_str(),
                             "success": output.success,
                         }));
                         let output_for_context = compact_tool_result_for_route(
@@ -2693,6 +2712,7 @@ impl Engine {
                             "event": "tool.result",
                             "tool_id": outcome.id.clone(),
                             "tool_name": outcome.name.clone(),
+                            "status": terminal_status.as_str(),
                             "success": false,
                             "error": e.to_string(),
                             "category": envelope.category.to_string(),

--- a/crates/tui/src/error_taxonomy.rs
+++ b/crates/tui/src/error_taxonomy.rs
@@ -416,6 +416,13 @@ impl From<ToolError> for ErrorEnvelope {
                 "tool_timeout",
                 format!("Tool timed out after {seconds}s"),
             ),
+            ToolError::Cancelled { message } => Self::new(
+                ErrorCategory::Tool,
+                ErrorSeverity::Info,
+                false,
+                "tool_cancelled",
+                message,
+            ),
             ToolError::NotAvailable { message } => Self::new(
                 ErrorCategory::State,
                 ErrorSeverity::Error,

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -117,6 +117,7 @@ mod task_manager;
 #[cfg(test)]
 mod test_support;
 mod tls;
+mod tool_history_repair;
 mod tool_output_receipts;
 mod tools;
 mod tui;
@@ -9329,6 +9330,7 @@ fn tool_error_receipt_category(error: &crate::tools::spec::ToolError) -> &'stati
         ToolError::PathEscape { .. } => "path_escape",
         ToolError::ExecutionFailed { .. } => "execution_failed",
         ToolError::Timeout { .. } => "timeout",
+        ToolError::Cancelled { .. } => "cancelled",
         ToolError::NotAvailable { .. } => "not_available",
         ToolError::PermissionDenied { .. } => "permission_denied",
     }

--- a/crates/tui/src/session_manager.rs
+++ b/crates/tui/src/session_manager.rs
@@ -626,6 +626,18 @@ impl SessionManager {
 
         session.system_prompt = strip_legacy_truncation_note(session.system_prompt);
 
+        let repair = crate::tool_history_repair::repair_tool_call_pairs(&mut session.messages);
+        if !repair.is_empty() {
+            session.metadata.message_count = session.messages.len();
+            tracing::warn!(
+                session_id = %session.metadata.id,
+                repaired_call_ids = ?repair.repaired_call_ids,
+                duplicate_result_ids = ?repair.duplicate_result_ids,
+                orphan_result_ids = ?repair.orphan_result_ids,
+                "repaired persisted tool call/result history"
+            );
+        }
+
         Ok(session)
     }
 
@@ -1469,6 +1481,51 @@ mod tests {
         let loaded = manager.load_session(&session_id).expect("load");
         assert_eq!(loaded.metadata.id, session_id);
         assert_eq!(loaded.messages.len(), 2);
+    }
+
+    #[test]
+    fn load_session_repairs_dangling_tool_call_with_visible_receipt() {
+        let tmp = tempdir().expect("tempdir");
+        let manager = SessionManager::new(tmp.path().join("sessions")).expect("new");
+        let messages = vec![Message {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::ToolUse {
+                id: "call-crashed".to_string(),
+                name: "read_file".to_string(),
+                input: serde_json::json!({"path": "README.md"}),
+                caller: None,
+            }],
+        }];
+        let session = create_saved_session(&messages, "test-model", tmp.path(), 0, None);
+        let session_id = session.metadata.id.clone();
+        manager.save_session(&session).expect("save");
+
+        let loaded = manager.load_session(&session_id).expect("load");
+
+        assert_eq!(loaded.metadata.message_count, loaded.messages.len());
+        assert!(loaded.messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error: Some(true),
+                        ..
+                    } if tool_use_id == "call-crashed" && content.contains("crashed_and_repaired")
+                )
+            })
+        }));
+        assert!(loaded.messages.iter().any(|message| {
+            message.role == "assistant"
+                && message.content.iter().any(|block| {
+                    matches!(
+                        block,
+                        ContentBlock::Text { text, .. }
+                            if text.contains("[tool_history_repair]")
+                    )
+                })
+        }));
     }
 
     #[test]

--- a/crates/tui/src/tool_history_repair.rs
+++ b/crates/tui/src/tool_history_repair.rs
@@ -1,0 +1,338 @@
+//! Deterministic integrity repair for persisted model-visible tool history.
+//!
+//! Session JSON predates a durable per-call journal, so process exit can leave
+//! a `tool_use` without its terminal `tool_result`. Provider APIs reject that
+//! shape. This module repairs the existing message format without changing its
+//! schema and returns a bounded diagnostic receipt for every mutation.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::models::{ContentBlock, Message};
+
+const CRASH_REPAIR_CONTENT: &str =
+    "Tool call interrupted by process exit; terminal status: crashed_and_repaired.";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ToolRepairReceipt {
+    pub(crate) repaired_call_ids: Vec<String>,
+    pub(crate) duplicate_result_ids: Vec<String>,
+    pub(crate) orphan_result_ids: Vec<String>,
+}
+
+impl ToolRepairReceipt {
+    #[must_use]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.repaired_call_ids.is_empty()
+            && self.duplicate_result_ids.is_empty()
+            && self.orphan_result_ids.is_empty()
+    }
+
+    fn visible_message(&self) -> String {
+        format!(
+            "[tool_history_repair] Repaired {} crashed tool call(s); quarantined {} duplicate and {} orphan terminal result(s).",
+            self.repaired_call_ids.len(),
+            self.duplicate_result_ids.len(),
+            self.orphan_result_ids.len(),
+        )
+    }
+}
+
+/// Repair tool-use/result integrity in place.
+///
+/// The first terminal result after a known call and before the next assistant
+/// turn is retained. Results that precede their call, arrive after a later
+/// assistant turn, reference no call, or repeat a retained result are
+/// quarantined by removing them from model-visible history. Every dangling
+/// call receives a synthetic error result directly after its assistant call
+/// message. A visible system receipt makes the repair apparent after resume.
+pub(crate) fn repair_tool_call_pairs(messages: &mut Vec<Message>) -> ToolRepairReceipt {
+    let mut call_message_by_id = HashMap::new();
+    let mut call_ids_in_order = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        if message.role != "assistant" {
+            continue;
+        }
+        for block in &message.content {
+            if let ContentBlock::ToolUse { id, .. } = block
+                && !call_message_by_id.contains_key(id)
+            {
+                call_message_by_id.insert(id.clone(), message_index);
+                call_ids_in_order.push(id.clone());
+            }
+        }
+    }
+
+    let mut retained_results = HashSet::new();
+    let mut duplicate_result_ids = Vec::new();
+    let mut orphan_result_ids = Vec::new();
+    let mut keep_results = HashSet::new();
+    let mut result_ordinal = 0usize;
+    let mut latest_assistant_message = None;
+
+    for (message_index, message) in messages.iter().enumerate() {
+        if message.role == "assistant" {
+            latest_assistant_message = Some(message_index);
+        }
+        for block in &message.content {
+            let ContentBlock::ToolResult { tool_use_id, .. } = block else {
+                continue;
+            };
+            let ordinal = result_ordinal;
+            result_ordinal = result_ordinal.saturating_add(1);
+
+            let follows_known_call =
+                call_message_by_id
+                    .get(tool_use_id)
+                    .is_some_and(|call_index| {
+                        *call_index < message_index && latest_assistant_message == Some(*call_index)
+                    });
+            if !follows_known_call {
+                orphan_result_ids.push(tool_use_id.clone());
+            } else if !retained_results.insert(tool_use_id.clone()) {
+                duplicate_result_ids.push(tool_use_id.clone());
+            } else {
+                keep_results.insert(ordinal);
+            }
+        }
+    }
+
+    let repaired_call_ids: Vec<_> = call_ids_in_order
+        .into_iter()
+        .filter(|id| !retained_results.contains(id))
+        .collect();
+    let repaired_set: HashSet<_> = repaired_call_ids.iter().cloned().collect();
+
+    let receipt = ToolRepairReceipt {
+        repaired_call_ids,
+        duplicate_result_ids,
+        orphan_result_ids,
+    };
+    if receipt.is_empty() {
+        return receipt;
+    }
+
+    let original = std::mem::take(messages);
+    let mut rebuilt = Vec::with_capacity(
+        original
+            .len()
+            .saturating_add(receipt.repaired_call_ids.len()),
+    );
+    let mut seen_result_ordinal = 0usize;
+
+    for message in original {
+        let missing_after_message: Vec<_> = if message.role == "assistant" {
+            message
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::ToolUse { id, .. } if repaired_set.contains(id) => {
+                        Some(id.clone())
+                    }
+                    _ => None,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let mut filtered = message;
+        filtered.content.retain(|block| {
+            if matches!(block, ContentBlock::ToolResult { .. }) {
+                let keep = keep_results.contains(&seen_result_ordinal);
+                seen_result_ordinal = seen_result_ordinal.saturating_add(1);
+                keep
+            } else {
+                true
+            }
+        });
+        if !filtered.content.is_empty() {
+            rebuilt.push(filtered);
+        }
+
+        if !missing_after_message.is_empty() {
+            rebuilt.push(Message {
+                role: "user".to_string(),
+                content: missing_after_message
+                    .into_iter()
+                    .map(|tool_use_id| ContentBlock::ToolResult {
+                        tool_use_id,
+                        content: CRASH_REPAIR_CONTENT.to_string(),
+                        is_error: Some(true),
+                        content_blocks: None,
+                    })
+                    .collect(),
+            });
+        }
+    }
+
+    rebuilt.push(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: receipt.visible_message(),
+            cache_control: None,
+        }],
+    });
+    *messages = rebuilt;
+    receipt
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn tool_call(id: &str) -> Message {
+        Message {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: "read_file".to_string(),
+                input: json!({"path": "README.md"}),
+                caller: None,
+            }],
+        }
+    }
+
+    fn tool_result(id: &str, content: &str) -> Message {
+        Message {
+            role: "user".to_string(),
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: content.to_string(),
+                is_error: None,
+                content_blocks: None,
+            }],
+        }
+    }
+
+    fn text(role: &str, content: &str) -> Message {
+        Message {
+            role: role.to_string(),
+            content: vec![ContentBlock::Text {
+                text: content.to_string(),
+                cache_control: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn well_formed_history_is_unchanged() {
+        let mut messages = vec![tool_call("call-1"), tool_result("call-1", "ok")];
+        let before = messages.clone();
+
+        let receipt = repair_tool_call_pairs(&mut messages);
+
+        assert!(receipt.is_empty());
+        assert_eq!(messages, before);
+    }
+
+    #[test]
+    fn repairs_dangling_calls_beside_their_assistant_message() {
+        let mut messages = vec![
+            tool_call("call-1"),
+            text("assistant", "later assistant text"),
+        ];
+
+        let receipt = repair_tool_call_pairs(&mut messages);
+
+        assert_eq!(receipt.repaired_call_ids, vec!["call-1"]);
+        assert_eq!(messages[1].role, "user");
+        assert!(matches!(
+            &messages[1].content[0],
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error: Some(true),
+                ..
+            } if tool_use_id == "call-1" && content.contains("crashed_and_repaired")
+        ));
+        assert_eq!(messages.last().expect("receipt").role, "assistant");
+    }
+
+    #[test]
+    fn quarantines_orphan_and_duplicate_results_without_losing_other_blocks() {
+        let mut mixed_result = tool_result("call-1", "duplicate");
+        mixed_result.content.push(ContentBlock::Text {
+            text: "keep me".to_string(),
+            cache_control: None,
+        });
+        let mut messages = vec![
+            tool_result("orphan", "bad"),
+            tool_call("call-1"),
+            tool_result("call-1", "first"),
+            mixed_result,
+        ];
+
+        let receipt = repair_tool_call_pairs(&mut messages);
+
+        assert_eq!(receipt.orphan_result_ids, vec!["orphan"]);
+        assert_eq!(receipt.duplicate_result_ids, vec!["call-1"]);
+        let result_contents: Vec<_> = messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .filter_map(|block| match block {
+                ContentBlock::ToolResult { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(result_contents, vec!["first"]);
+        assert!(messages.iter().any(|message| {
+            message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Text { text, .. } if text == "keep me"))
+        }));
+    }
+
+    #[test]
+    fn repair_is_idempotent() {
+        let mut messages = vec![tool_call("call-1"), tool_result("orphan", "bad")];
+
+        let first = repair_tool_call_pairs(&mut messages);
+        let after_first = messages.clone();
+        let second = repair_tool_call_pairs(&mut messages);
+
+        assert!(!first.is_empty());
+        assert!(second.is_empty());
+        assert_eq!(messages, after_first);
+    }
+
+    #[test]
+    fn result_preceding_its_call_is_orphaned_and_call_is_repaired() {
+        let mut messages = vec![tool_result("call-1", "too early"), tool_call("call-1")];
+
+        let receipt = repair_tool_call_pairs(&mut messages);
+
+        assert_eq!(receipt.orphan_result_ids, vec!["call-1"]);
+        assert_eq!(receipt.repaired_call_ids, vec!["call-1"]);
+        assert!(messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult { content, .. }
+                        if content.contains("crashed_and_repaired")
+                )
+            })
+        }));
+    }
+
+    #[test]
+    fn result_after_a_later_assistant_turn_is_quarantined_as_too_late() {
+        let mut messages = vec![
+            tool_call("call-1"),
+            text("assistant", "a later model turn"),
+            tool_result("call-1", "too late"),
+        ];
+
+        let receipt = repair_tool_call_pairs(&mut messages);
+
+        assert_eq!(receipt.orphan_result_ids, vec!["call-1"]);
+        assert_eq!(receipt.repaired_call_ids, vec!["call-1"]);
+        assert!(!messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(block, ContentBlock::ToolResult { content, .. } if content == "too late")
+            })
+        }));
+    }
+}

--- a/crates/tui/src/tool_history_repair.rs
+++ b/crates/tui/src/tool_history_repair.rs
@@ -46,6 +46,24 @@ impl ToolRepairReceipt {
 /// call receives a synthetic error result directly after its assistant call
 /// message. A visible system receipt makes the repair apparent after resume.
 pub(crate) fn repair_tool_call_pairs(messages: &mut Vec<Message>) -> ToolRepairReceipt {
+    repair_tool_call_pairs_inner(messages, true)
+}
+
+/// Repair an ephemeral provider request without appending a trailing receipt.
+///
+/// Anthropic-style APIs interpret a final assistant message as a completion
+/// prefill. Pair repair must therefore leave the synthetic user tool result as
+/// the request tail; the durable session-facing path owns the visible receipt.
+pub(crate) fn repair_tool_call_pairs_for_provider(
+    messages: &mut Vec<Message>,
+) -> ToolRepairReceipt {
+    repair_tool_call_pairs_inner(messages, false)
+}
+
+fn repair_tool_call_pairs_inner(
+    messages: &mut Vec<Message>,
+    append_visible_receipt: bool,
+) -> ToolRepairReceipt {
     let mut call_message_by_id = HashMap::new();
     let mut call_ids_in_order = Vec::new();
     for (message_index, message) in messages.iter().enumerate() {
@@ -165,13 +183,15 @@ pub(crate) fn repair_tool_call_pairs(messages: &mut Vec<Message>) -> ToolRepairR
         }
     }
 
-    rebuilt.push(Message {
-        role: "assistant".to_string(),
-        content: vec![ContentBlock::Text {
-            text: receipt.visible_message(),
-            cache_control: None,
-        }],
-    });
+    if append_visible_receipt {
+        rebuilt.push(Message {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::Text {
+                text: receipt.visible_message(),
+                cache_control: None,
+            }],
+        });
+    }
     *messages = rebuilt;
     receipt
 }
@@ -248,6 +268,25 @@ mod tests {
             } if tool_use_id == "call-1" && content.contains("crashed_and_repaired")
         ));
         assert_eq!(messages.last().expect("receipt").role, "assistant");
+    }
+
+    #[test]
+    fn provider_repair_never_appends_an_assistant_prefill_receipt() {
+        let mut messages = vec![tool_call("call-1")];
+
+        let receipt = repair_tool_call_pairs_for_provider(&mut messages);
+
+        assert_eq!(receipt.repaired_call_ids, vec!["call-1"]);
+        assert_eq!(messages.last().expect("synthetic result").role, "user");
+        assert!(!messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::Text { text, .. }
+                        if text.contains("[tool_history_repair]")
+                )
+            })
+        }));
     }
 
     #[test]

--- a/crates/tui/src/tools/dev_server_readiness.rs
+++ b/crates/tui/src/tools/dev_server_readiness.rs
@@ -380,7 +380,7 @@ async fn sleep_until_next_poll(
     let delay = remaining.min(poll_interval);
     if let Some(token) = context.cancel_token.as_ref() {
         tokio::select! {
-            () = token.cancelled() => Err(ToolError::execution_failed("wait_for_dev_server cancelled")),
+            () = token.cancelled() => Err(ToolError::cancelled("wait_for_dev_server cancelled")),
             () = sleep(delay) => Ok(()),
         }
     } else {
@@ -395,7 +395,7 @@ fn check_cancelled(context: &ToolContext) -> Result<(), ToolError> {
         .as_ref()
         .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
     {
-        return Err(ToolError::execution_failed("wait_for_dev_server cancelled"));
+        return Err(ToolError::cancelled("wait_for_dev_server cancelled"));
     }
     Ok(())
 }

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -1213,7 +1213,7 @@ fn check_list_dir_cancelled(cancel_token: Option<&CancellationToken>) -> Result<
 }
 
 fn list_dir_cancelled() -> ToolError {
-    ToolError::execution_failed("list_dir cancelled before completion")
+    ToolError::cancelled("list_dir cancelled before completion")
 }
 
 fn list_dir_timeout(timeout: Duration) -> ToolError {

--- a/crates/tui/src/tools/file_search.rs
+++ b/crates/tui/src/tools/file_search.rs
@@ -168,7 +168,7 @@ where
 }
 
 fn file_search_cancelled() -> ToolError {
-    ToolError::execution_failed("file_search cancelled before completion")
+    ToolError::cancelled("file_search cancelled before completion")
 }
 
 fn file_search_timeout(timeout: Duration) -> ToolError {

--- a/crates/tui/src/tools/search.rs
+++ b/crates/tui/src/tools/search.rs
@@ -290,7 +290,7 @@ where
 }
 
 fn grep_cancelled() -> ToolError {
-    ToolError::execution_failed("grep_files cancelled before completion")
+    ToolError::cancelled("grep_files cancelled before completion")
 }
 
 fn grep_timeout(timeout: Duration) -> ToolError {
@@ -539,9 +539,7 @@ fn visit_files_recursive(
 
 fn check_cancelled(cancel_token: Option<&CancellationToken>) -> Result<(), ToolError> {
     if cancel_token.is_some_and(CancellationToken::is_cancelled) {
-        return Err(ToolError::execution_failed(
-            "search cancelled before completion",
-        ));
+        return Err(ToolError::cancelled("search cancelled before completion"));
     }
     Ok(())
 }

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -27,9 +27,9 @@ use crate::tools::shell::{SharedShellManager, new_shared_shell_manager};
 use crate::worker_profile::ShellPolicy;
 #[allow(unused_imports)]
 pub use codewhale_tools::{
-    ApprovalRequirement, PreparedToolCall, ResourceClaim, ToolCapability, ToolError, ToolResult,
-    optional_bool, optional_str, optional_u64, required_str, required_u64,
-    schedule_non_conflicting,
+    ApprovalRequirement, PreparedToolCall, ResourceClaim, ToolCapability, ToolError,
+    ToolExecutionOutcome, ToolResult, ToolTerminalStatus, optional_bool, optional_str,
+    optional_u64, required_str, required_u64, schedule_non_conflicting,
 };
 
 #[async_trait]

--- a/crates/tui/src/tools/subagent/coord.rs
+++ b/crates/tui/src/tools/subagent/coord.rs
@@ -629,7 +629,7 @@ async fn wait_for_activity(
         tokio::select! {
             biased;
             () = &mut cancelled => {
-                return Err(ToolError::execution_failed(
+                return Err(ToolError::cancelled(
                     "Wait interrupted by user cancellation before child activity.".to_string(),
                 ));
             }

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -458,6 +458,12 @@ pub fn history_cells_from_message(msg: &Message) -> Vec<HistoryCell> {
     for block in &msg.content {
         match block {
             ContentBlock::Text { text, .. } => {
+                if text.starts_with("[tool_history_repair]") {
+                    cells.push(HistoryCell::System {
+                        content: text.clone(),
+                    });
+                    continue;
+                }
                 // Check if this is an `<archived_context>` block.
                 if msg.role == "assistant"
                     && let Some(archived) = parse_archived_context(text)

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -845,6 +845,24 @@ fn archived_context_metadata_preserves_spaces_in_attributes() {
 }
 
 #[test]
+fn tool_history_repair_receipt_renders_as_system_history() {
+    let msg = Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "[tool_history_repair] Repaired 1 crashed tool call(s); quarantined 0 duplicate and 0 orphan terminal result(s).".to_string(),
+            cache_control: None,
+        }],
+    };
+
+    let cells = super::history_cells_from_message(&msg);
+
+    assert!(matches!(
+        cells.as_slice(),
+        [HistoryCell::System { content }] if content.starts_with("[tool_history_repair]")
+    ));
+}
+
+#[test]
 fn history_replays_update_plan_tool_use_as_plan_card() {
     let msg = Message {
         role: "assistant".to_string(),


### PR DESCRIPTION
## Summary

- add a typed terminal outcome contract for succeeded, failed, denied, invalid arguments, cancelled, and timed out calls
- route cancellation and timeout sites through explicit typed errors while preserving legacy ToolResult/event/storage compatibility
- deterministically repair dangling, orphaned, duplicate, early, and too-late tool results at session load and provider request boundaries
- expose a bounded visible repair receipt in persisted history and terminal status in tool audit receipts
- keep the provider-bound repair receipt-free so Anthropic-style APIs never interpret diagnostics as an assistant prefill

## Safety and compatibility

- no journal, storage-schema, public event, or provider credential changes
- repair is deterministic and idempotent
- legacy result consumers remain supported through one conversion seam
- cancellation remains a legacy error-shaped result but is no longer classified as generic failure internally
- result/error state is private and constructor-enforced

## Exact-head verification

Head: `859f3b99c433ae28ea1f37b79e2507340afaaeee`
Base: `d53b8f97b1e6f9f8419e22111247a2a3d5b8d686`

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p codewhale-tools --locked` (23 unit + 3 parity passed)
- `cargo test -p codewhale-tui --locked` (7,512 unit passed, 0 failed, 3 ignored; all integration suites green, including QA PTY 17/17 with 1 documented ignore, release runtime 5/5 with 1 heavy benchmark ignored, tool lifecycle 3/3, workflow stream 3/3)
- direct provider-bound regression proves repair ends on the synthetic user tool result with no receipt prefill
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- gitleaks exact two-commit scan: no leaks
- added-line private-path and credential-value scans: clean

Only the pre-existing macOS compact-unwind linker warning appeared during tests.