### PR TITLE
feat(web): unify search backend receipts

### DIFF
--- a/crates/tui/src/tools/web/backend.rs
+++ b/crates/tui/src/tools/web/backend.rs
@@ -1,0 +1,153 @@
+//! Search backend selection and the shared async adapter contract.
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+
+use super::contract::{BackendId, BackendSearch, QueryCapabilities, SearchQuery};
+use crate::config::SearchProvider;
+use crate::tools::spec::{ToolContext, ToolError};
+
+#[async_trait]
+pub(crate) trait SearchBackend {
+    fn id(&self) -> BackendId;
+    fn capabilities(&self) -> QueryCapabilities;
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        deadline: Instant,
+    ) -> Result<BackendSearch, ToolError>;
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct BackendContext<'a> {
+    tool_context: &'a ToolContext,
+}
+
+pub(crate) enum ConfiguredSearchBackend<'a> {
+    Bing(BackendContext<'a>),
+    DuckDuckGo(BackendContext<'a>),
+    Tavily(BackendContext<'a>),
+    Bocha(BackendContext<'a>),
+    Metaso(BackendContext<'a>),
+    Searxng(BackendContext<'a>),
+    Baidu(BackendContext<'a>),
+    Volcengine(BackendContext<'a>),
+    Sofya(BackendContext<'a>),
+}
+
+impl<'a> ConfiguredSearchBackend<'a> {
+    #[must_use]
+    pub(crate) fn from_context(context: &'a ToolContext) -> Self {
+        let backend = BackendContext {
+            tool_context: context,
+        };
+        match context.search_provider {
+            SearchProvider::Bing => Self::Bing(backend),
+            SearchProvider::DuckDuckGo => Self::DuckDuckGo(backend),
+            SearchProvider::Tavily => Self::Tavily(backend),
+            SearchProvider::Bocha => Self::Bocha(backend),
+            SearchProvider::Metaso => Self::Metaso(backend),
+            SearchProvider::Searxng => Self::Searxng(backend),
+            SearchProvider::Baidu => Self::Baidu(backend),
+            SearchProvider::Volcengine => Self::Volcengine(backend),
+            SearchProvider::Sofya => Self::Sofya(backend),
+        }
+    }
+
+    const fn provider(&self) -> SearchProvider {
+        match self {
+            Self::Bing(_) => SearchProvider::Bing,
+            Self::DuckDuckGo(_) => SearchProvider::DuckDuckGo,
+            Self::Tavily(_) => SearchProvider::Tavily,
+            Self::Bocha(_) => SearchProvider::Bocha,
+            Self::Metaso(_) => SearchProvider::Metaso,
+            Self::Searxng(_) => SearchProvider::Searxng,
+            Self::Baidu(_) => SearchProvider::Baidu,
+            Self::Volcengine(_) => SearchProvider::Volcengine,
+            Self::Sofya(_) => SearchProvider::Sofya,
+        }
+    }
+
+    const fn context(&self) -> &BackendContext<'a> {
+        match self {
+            Self::Bing(context)
+            | Self::DuckDuckGo(context)
+            | Self::Tavily(context)
+            | Self::Bocha(context)
+            | Self::Metaso(context)
+            | Self::Searxng(context)
+            | Self::Baidu(context)
+            | Self::Volcengine(context)
+            | Self::Sofya(context) => context,
+        }
+    }
+}
+
+#[async_trait]
+impl SearchBackend for ConfiguredSearchBackend<'_> {
+    fn id(&self) -> BackendId {
+        match self.provider() {
+            SearchProvider::Bing => BackendId::Bing,
+            SearchProvider::DuckDuckGo => BackendId::DuckDuckGo,
+            SearchProvider::Tavily => BackendId::Tavily,
+            SearchProvider::Bocha => BackendId::Bocha,
+            SearchProvider::Metaso => BackendId::Metaso,
+            SearchProvider::Searxng => BackendId::Searxng,
+            SearchProvider::Baidu => BackendId::Baidu,
+            SearchProvider::Volcengine => BackendId::Volcengine,
+            SearchProvider::Sofya => BackendId::Sofya,
+        }
+    }
+
+    fn capabilities(&self) -> QueryCapabilities {
+        // All current adapters enforce result count. Other knobs are either
+        // post-filtered by the shared harness or reported as not honored.
+        QueryCapabilities::count_only()
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        deadline: Instant,
+    ) -> Result<BackendSearch, ToolError> {
+        crate::tools::web_search::run_backend_search(
+            self.provider(),
+            query,
+            deadline,
+            self.context().tool_context,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_configured_provider_maps_to_one_explicit_backend_adapter() {
+        let cases = [
+            (SearchProvider::Bing, BackendId::Bing),
+            (SearchProvider::DuckDuckGo, BackendId::DuckDuckGo),
+            (SearchProvider::Tavily, BackendId::Tavily),
+            (SearchProvider::Bocha, BackendId::Bocha),
+            (SearchProvider::Metaso, BackendId::Metaso),
+            (SearchProvider::Searxng, BackendId::Searxng),
+            (SearchProvider::Baidu, BackendId::Baidu),
+            (SearchProvider::Volcengine, BackendId::Volcengine),
+            (SearchProvider::Sofya, BackendId::Sofya),
+        ];
+
+        for (provider, expected) in cases {
+            let mut context = ToolContext::new(std::path::PathBuf::from("."));
+            context.search_provider = provider;
+            let backend = ConfiguredSearchBackend::from_context(&context);
+            assert_eq!(backend.id(), expected);
+            assert_eq!(
+                backend.capabilities().max_results,
+                super::super::contract::CapabilityState::Supported
+            );
+        }
+    }
+}

--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -7,7 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub(crate) const MAX_SEARCH_RESULTS: usize = 10;
+pub(crate) const MAX_SEARCH_RESULTS: u8 = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -98,7 +98,8 @@ impl SearchQuery {
         domains.dedup();
         Self {
             query,
-            max_results: u8::try_from(max_results.clamp(1, MAX_SEARCH_RESULTS)).unwrap_or(u8::MAX),
+            max_results: u8::try_from(max_results.clamp(1, usize::from(MAX_SEARCH_RESULTS)))
+                .unwrap_or(MAX_SEARCH_RESULTS),
             recency,
             domains,
             locale: locale

--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -7,6 +7,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub(crate) const MAX_SEARCH_RESULTS: usize = 10;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum BackendId {
@@ -96,7 +98,7 @@ impl SearchQuery {
         domains.dedup();
         Self {
             query,
-            max_results: u8::try_from(max_results.clamp(1, 10)).unwrap_or(10),
+            max_results: u8::try_from(max_results.clamp(1, MAX_SEARCH_RESULTS)).unwrap_or(u8::MAX),
             recency,
             domains,
             locale: locale
@@ -346,5 +348,41 @@ mod tests {
         assert_eq!(value["backend"], "duckduckgo");
         assert_eq!(value["degraded"][0]["kind"], "knob_ignored");
         assert!(receipt.warning().expect("warning").contains("recency"));
+    }
+
+    #[test]
+    fn scrape_fallback_receipt_preserves_backend_transitions() {
+        let receipt = SearchReceipt {
+            backend: BackendId::Bing,
+            backend_detail: None,
+            requested: SearchQuery::new("fallback query".to_string(), 5, None, Vec::new(), None),
+            capabilities: QueryCapabilities::count_only(),
+            honored: HonoredQueryCapabilities {
+                max_results: true,
+                ..HonoredQueryCapabilities::default()
+            },
+            degraded: vec![
+                DegradedReason::ChallengeDetected {
+                    backend: BackendId::DuckDuckGo,
+                },
+                DegradedReason::ScrapeFallback {
+                    from: BackendId::DuckDuckGo,
+                    to: BackendId::Bing,
+                },
+            ],
+            latency_ms: 12,
+            cache_hit: false,
+        };
+
+        let value = serde_json::to_value(&receipt).expect("receipt serializes");
+        assert_eq!(value["backend"], "bing");
+        assert_eq!(value["degraded"][0]["kind"], "challenge_detected");
+        assert_eq!(value["degraded"][0]["backend"], "duckduckgo");
+        assert_eq!(value["degraded"][1]["kind"], "scrape_fallback");
+        assert_eq!(value["degraded"][1]["from"], "duckduckgo");
+        assert_eq!(value["degraded"][1]["to"], "bing");
+        let warning = receipt.warning().expect("warning");
+        assert!(warning.contains("bot challenge"));
+        assert!(warning.contains("used bing fallback"));
     }
 }

--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -1,0 +1,350 @@
+//! Provider-neutral web-search request, result, and receipt types.
+//!
+//! Search backends vary widely in what they accept and return. These types are
+//! the model-visible honesty boundary shared by `web_search` and `web.run`:
+//! callers can distinguish requested knobs, actually honored behavior, and
+//! degraded/post-filtered execution without depending on provider payloads.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BackendId {
+    Bing,
+    #[serde(rename = "duckduckgo")]
+    DuckDuckGo,
+    Tavily,
+    Bocha,
+    Metaso,
+    Searxng,
+    Baidu,
+    Volcengine,
+    Sofya,
+}
+
+impl BackendId {
+    #[must_use]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bing => "bing",
+            Self::DuckDuckGo => "duckduckgo",
+            Self::Tavily => "tavily",
+            Self::Bocha => "bocha",
+            Self::Metaso => "metaso",
+            Self::Searxng => "searxng",
+            Self::Baidu => "baidu",
+            Self::Volcengine => "volcengine",
+            Self::Sofya => "sofya",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Recency {
+    Day,
+    Week,
+    Month,
+    Year,
+    Days(u16),
+}
+
+impl Recency {
+    #[must_use]
+    #[cfg(test)]
+    pub(crate) const fn days(self) -> u16 {
+        match self {
+            Self::Day => 1,
+            Self::Week => 7,
+            Self::Month => 30,
+            Self::Year => 365,
+            Self::Days(days) => days,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchQuery {
+    pub(crate) query: String,
+    pub(crate) max_results: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) recency: Option<Recency>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) domains: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) locale: Option<String>,
+}
+
+impl SearchQuery {
+    #[must_use]
+    pub(crate) fn new(
+        query: String,
+        max_results: usize,
+        recency: Option<Recency>,
+        domains: Vec<String>,
+        locale: Option<String>,
+    ) -> Self {
+        let mut domains = domains
+            .into_iter()
+            .map(|domain| {
+                let domain = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+                domain.trim_start_matches("www.").to_string()
+            })
+            .filter(|domain| !domain.is_empty())
+            .collect::<Vec<_>>();
+        domains.sort_unstable();
+        domains.dedup();
+        Self {
+            query,
+            max_results: u8::try_from(max_results.clamp(1, 10)).unwrap_or(10),
+            recency,
+            domains,
+            locale: locale
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CapabilityState {
+    Supported,
+    Unsupported,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct QueryCapabilities {
+    pub(crate) max_results: CapabilityState,
+    pub(crate) recency: CapabilityState,
+    pub(crate) domains: CapabilityState,
+    pub(crate) locale: CapabilityState,
+    pub(crate) published_date: CapabilityState,
+}
+
+impl QueryCapabilities {
+    #[must_use]
+    pub(crate) const fn count_only() -> Self {
+        Self {
+            max_results: CapabilityState::Supported,
+            recency: CapabilityState::Unsupported,
+            domains: CapabilityState::Unsupported,
+            locale: CapabilityState::Unsupported,
+            published_date: CapabilityState::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct HonoredQueryCapabilities {
+    pub(crate) max_results: bool,
+    pub(crate) recency: bool,
+    pub(crate) domains: bool,
+    pub(crate) locale: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum QueryKnob {
+    Recency,
+    Domains,
+    Locale,
+}
+
+impl QueryKnob {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Recency => "recency",
+            Self::Domains => "domains",
+            Self::Locale => "locale",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum DegradedReason {
+    ChallengeDetected { backend: BackendId },
+    ScrapeFallback { from: BackendId, to: BackendId },
+    KnobIgnored { knob: QueryKnob },
+    PostFiltered { knob: QueryKnob },
+    SynthesizedResults,
+}
+
+impl DegradedReason {
+    #[must_use]
+    pub(crate) fn message(&self) -> String {
+        match self {
+            Self::ChallengeDetected { backend } => {
+                format!("{} returned a bot challenge", backend.as_str())
+            }
+            Self::ScrapeFallback { from, to } => format!(
+                "{} returned no usable results; used {} fallback",
+                from.as_str(),
+                to.as_str()
+            ),
+            Self::KnobIgnored { knob } => {
+                format!("{} filter was not enforced by this backend", knob.as_str())
+            }
+            Self::PostFiltered { knob } => {
+                format!("results were post-filtered by {}", knob.as_str())
+            }
+            Self::SynthesizedResults => {
+                "results were synthesized by a model-backed search response".to_string()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchResult {
+    pub(crate) rank: u8,
+    pub(crate) title: String,
+    pub(crate) url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) snippet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) published: Option<String>,
+    pub(crate) domain: String,
+}
+
+impl SearchResult {
+    #[must_use]
+    pub(crate) fn new(
+        rank: usize,
+        title: String,
+        url: String,
+        snippet: Option<String>,
+        published: Option<String>,
+    ) -> Self {
+        let domain = reqwest::Url::parse(&url)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_ascii_lowercase))
+            .unwrap_or_default();
+        Self {
+            rank: u8::try_from(rank.clamp(1, 255)).unwrap_or(u8::MAX),
+            title,
+            url,
+            snippet,
+            published,
+            domain,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BackendSearch {
+    pub(crate) backend: BackendId,
+    pub(crate) source: String,
+    pub(crate) backend_detail: Option<String>,
+    pub(crate) results: Vec<SearchResult>,
+    pub(crate) degraded: Vec<DegradedReason>,
+    pub(crate) note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchReceipt {
+    pub(crate) backend: BackendId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) backend_detail: Option<String>,
+    pub(crate) requested: SearchQuery,
+    pub(crate) capabilities: QueryCapabilities,
+    pub(crate) honored: HonoredQueryCapabilities,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) degraded: Vec<DegradedReason>,
+    pub(crate) latency_ms: u32,
+    pub(crate) cache_hit: bool,
+}
+
+impl SearchReceipt {
+    #[must_use]
+    pub(crate) fn warning(&self) -> Option<String> {
+        if self.degraded.is_empty() {
+            None
+        } else {
+            Some(
+                self.degraded
+                    .iter()
+                    .map(DegradedReason::message)
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            )
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchResponse {
+    pub(crate) query: String,
+    pub(crate) source: String,
+    pub(crate) count: usize,
+    pub(crate) message: String,
+    pub(crate) results: Vec<SearchResult>,
+    pub(crate) receipt: SearchReceipt,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_query_normalizes_domains_and_bounds_count() {
+        let query = SearchQuery::new(
+            "rust async".to_string(),
+            99,
+            Some(Recency::Week),
+            vec![" WWW.Example.COM. ".to_string(), "example.com".to_string()],
+            Some(" en-US ".to_string()),
+        );
+
+        assert_eq!(query.max_results, 10);
+        assert_eq!(query.domains, vec!["example.com"]);
+        assert_eq!(query.locale.as_deref(), Some("en-US"));
+        assert_eq!(query.recency.map(Recency::days), Some(7));
+    }
+
+    #[test]
+    fn normalized_result_derives_domain_and_rank() {
+        let result = SearchResult::new(
+            2,
+            "Example".to_string(),
+            "https://Docs.Example.com/path".to_string(),
+            Some("summary".to_string()),
+            None,
+        );
+
+        assert_eq!(result.rank, 2);
+        assert_eq!(result.domain, "docs.example.com");
+    }
+
+    #[test]
+    fn degraded_receipt_is_machine_readable_and_human_visible() {
+        let receipt = SearchReceipt {
+            backend: BackendId::DuckDuckGo,
+            backend_detail: None,
+            requested: SearchQuery::new(
+                "fresh result".to_string(),
+                5,
+                Some(Recency::Day),
+                Vec::new(),
+                None,
+            ),
+            capabilities: QueryCapabilities::count_only(),
+            honored: HonoredQueryCapabilities {
+                max_results: true,
+                ..HonoredQueryCapabilities::default()
+            },
+            degraded: vec![DegradedReason::KnobIgnored {
+                knob: QueryKnob::Recency,
+            }],
+            latency_ms: 4,
+            cache_hit: false,
+        };
+
+        let value = serde_json::to_value(&receipt).expect("receipt serializes");
+        assert_eq!(value["backend"], "duckduckgo");
+        assert_eq!(value["degraded"][0]["kind"], "knob_ignored");
+        assert!(receipt.warning().expect("warning").contains("recency"));
+    }
+}

--- a/crates/tui/src/tools/web/mod.rs
+++ b/crates/tui/src/tools/web/mod.rs
@@ -3,5 +3,7 @@
 //! `fetch_url`, `web_search`, and `web.run` are thin surfaces over this
 //! module so security and parsing behavior cannot drift between tools.
 
+pub(crate) mod backend;
+pub(crate) mod contract;
 pub(crate) mod guard;
 pub mod scrape;

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -461,7 +461,7 @@ impl ToolSpec for WebRunTool {
                     response_length.max_results() as u64,
                 ))
                 .unwrap_or(response_length.max_results())
-                .clamp(1, MAX_SEARCH_RESULTS);
+                .clamp(1, usize::from(MAX_SEARCH_RESULTS));
                 let timeout_ms = optional_u64(search, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
 
                 let domains = search
@@ -529,7 +529,7 @@ impl ToolSpec for WebRunTool {
                     response_length.max_results() as u64,
                 ))
                 .unwrap_or(response_length.max_results())
-                .clamp(1, MAX_SEARCH_RESULTS);
+                .clamp(1, usize::from(MAX_SEARCH_RESULTS));
                 let timeout_ms = optional_u64(image, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
 
                 let domains = image

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -21,10 +21,10 @@ use std::time::{Duration, Instant};
 
 use parking_lot::{RwLock, RwLockWriteGuard};
 
-use super::web::scrape::{
-    ScrapedSearchResult, is_duckduckgo_challenge, parse_bing_results as scrape_bing_results,
-    parse_duckduckgo_results as scrape_duckduckgo_results,
+use super::web::contract::{
+    Recency, SearchQuery, SearchReceipt, SearchResult as NormalizedSearchResult,
 };
+use super::web_search::{domain_matches, execute_search};
 
 const MAX_RESULTS: usize = 10;
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
@@ -240,21 +240,15 @@ impl ResponseLength {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct SearchEntry {
-    title: String,
-    url: String,
-    snippet: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct SearchResult {
+struct WebRunSearchResult {
     ref_id: String,
     query: String,
     source: String,
     count: usize,
-    results: Vec<SearchEntry>,
+    results: Vec<NormalizedSearchResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     warning: Option<String>,
+    receipt: SearchReceipt,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -324,7 +318,7 @@ struct ImageQueryResult {
 #[derive(Debug, Clone, Serialize, Default)]
 struct WebRunOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
-    search_query: Option<Vec<SearchResult>>,
+    search_query: Option<Vec<WebRunSearchResult>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     image_query: Option<Vec<ImageQueryResult>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -361,7 +355,7 @@ impl ToolSpec for WebRunTool {
                         "type": "object",
                         "properties": {
                             "q": { "type": "string" },
-                            "recency": { "type": "integer" },
+                            "recency": { "type": "integer", "minimum": 1, "maximum": 3650 },
                             "max_results": { "type": "integer" },
                             "timeout_ms": { "type": "integer" },
                             "domains": { "type": "array", "items": { "type": "string" } }
@@ -481,34 +475,40 @@ impl ToolSpec for WebRunTool {
                     })
                     .unwrap_or_default();
 
-                let (entries, source, warning) =
-                    run_search(&query, max_results, timeout_ms, &domains).await?;
-                let mut warnings = Vec::new();
-                if recency > 0 {
-                    warnings.push(format!(
-                        "Recency filter not enforced (requested last {recency} days)"
-                    ));
-                }
-                if let Some(w) = warning {
-                    warnings.push(w);
-                }
+                let requested_recency = if recency == 0 {
+                    None
+                } else {
+                    let days = u16::try_from(recency)
+                        .ok()
+                        .filter(|days| *days <= 3650)
+                        .ok_or_else(|| {
+                            ToolError::invalid_input(
+                                "Field 'search_query[].recency' must be between 1 and 3650 days",
+                            )
+                        })?;
+                    Some(Recency::Days(days))
+                };
+                let response = execute_search(
+                    SearchQuery::new(query, max_results, requested_recency, domains, None),
+                    timeout_ms,
+                    context,
+                )
+                .await?;
+                let warning = response.receipt.warning();
                 search_counter += 1;
                 let ref_id = format!("{scope}turn{turn}search{search_counter}");
 
-                let page = page_from_search(&query, &entries);
+                let page = page_from_search(&response.query, &response.results);
                 store_page(&context.state_namespace, &ref_id, page);
 
-                results.push(SearchResult {
+                results.push(WebRunSearchResult {
                     ref_id,
-                    query,
-                    source,
-                    count: entries.len(),
-                    results: entries,
-                    warning: if warnings.is_empty() {
-                        None
-                    } else {
-                        Some(warnings.join("; "))
-                    },
+                    query: response.query,
+                    source: response.source,
+                    count: response.count,
+                    results: response.results,
+                    warning,
+                    receipt: response.receipt,
                 });
             }
             if !results.is_empty() {
@@ -777,142 +777,6 @@ fn looks_like_url(value: &str) -> bool {
     value.starts_with("http://") || value.starts_with("https://")
 }
 
-async fn run_search(
-    query: &str,
-    max_results: usize,
-    timeout_ms: u64,
-    domains: &[String],
-) -> Result<(Vec<SearchEntry>, String, Option<String>), ToolError> {
-    let client = crate::tls::reqwest_client_builder()
-        .timeout(Duration::from_millis(timeout_ms))
-        .user_agent(USER_AGENT)
-        .build()
-        .map_err(|e| ToolError::execution_failed(format!("Failed to build HTTP client: {e}")))?;
-
-    let encoded = url_encode(query);
-    let url = format!("https://html.duckduckgo.com/html/?q={encoded}");
-    let resp = client
-        .get(&url)
-        .header(
-            "Accept",
-            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        )
-        .header("Accept-Language", "en-US,en;q=0.5")
-        .send()
-        .await
-        .map_err(|e| ToolError::execution_failed(format!("Web search request failed: {e}")))?;
-
-    let status = resp.status();
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| ToolError::execution_failed(format!("Failed to read response: {e}")))?;
-
-    if !status.is_success() {
-        return Err(ToolError::execution_failed(format!(
-            "Web search failed: HTTP {}",
-            status.as_u16()
-        )));
-    }
-
-    let mut results = parse_duckduckgo_results(&body, max_results);
-    let mut source = "duckduckgo".to_string();
-    let mut warnings = Vec::new();
-
-    if results.is_empty() {
-        let duckduckgo_blocked = is_duckduckgo_challenge(&body);
-        match run_bing_search(&client, query, max_results).await {
-            Ok(fallback_results) if !fallback_results.is_empty() => {
-                results = fallback_results;
-                source = "bing".to_string();
-                warnings.push(if duckduckgo_blocked {
-                    "DuckDuckGo returned a bot challenge; used Bing fallback".to_string()
-                } else {
-                    "DuckDuckGo returned no parseable results; used Bing fallback".to_string()
-                });
-            }
-            Ok(_) if duckduckgo_blocked => {
-                return Err(ToolError::execution_failed(
-                    "DuckDuckGo returned a bot challenge and Bing fallback returned no results",
-                ));
-            }
-            Err(err) if duckduckgo_blocked => {
-                return Err(ToolError::execution_failed(format!(
-                    "DuckDuckGo returned a bot challenge and Bing fallback failed: {err}"
-                )));
-            }
-            Ok(_) | Err(_) => {}
-        }
-    }
-
-    if !domains.is_empty() {
-        let before = results.len();
-        results.retain(|entry| domain_matches(&entry.url, domains));
-        if before != results.len() {
-            warnings.push("Filtered search results by domain list".to_string());
-        }
-    }
-
-    Ok((
-        results,
-        source,
-        if warnings.is_empty() {
-            None
-        } else {
-            Some(warnings.join("; "))
-        },
-    ))
-}
-
-async fn run_bing_search(
-    client: &reqwest::Client,
-    query: &str,
-    max_results: usize,
-) -> Result<Vec<SearchEntry>, ToolError> {
-    let encoded = url_encode(query);
-    let url = format!("https://www.bing.com/search?q={encoded}");
-    let resp = client
-        .get(&url)
-        .header(
-            "Accept",
-            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        )
-        .header("Accept-Language", "en-US,en;q=0.9")
-        .send()
-        .await
-        .map_err(|e| ToolError::execution_failed(format!("Bing fallback request failed: {e}")))?;
-
-    let status = resp.status();
-    let body = resp.text().await.map_err(|e| {
-        ToolError::execution_failed(format!("Failed to read Bing fallback response: {e}"))
-    })?;
-
-    if !status.is_success() {
-        return Err(ToolError::execution_failed(format!(
-            "Bing fallback failed: HTTP {}",
-            status.as_u16()
-        )));
-    }
-
-    Ok(parse_bing_results(&body, max_results))
-}
-
-fn domain_matches(url: &str, domains: &[String]) -> bool {
-    if domains.is_empty() {
-        return true;
-    }
-    let Ok(parsed) = reqwest::Url::parse(url) else {
-        return false;
-    };
-    let Some(host) = parsed.host_str() else {
-        return false;
-    };
-    domains.iter().any(|domain| {
-        let domain = domain.trim_start_matches("www.");
-        host == domain || host.ends_with(&format!(".{domain}"))
-    })
-}
-
 #[derive(Debug, Clone, Deserialize)]
 struct DuckDuckGoImageResponse {
     #[serde(default)]
@@ -1079,7 +943,7 @@ async fn run_image_search(
     Ok((results, warning))
 }
 
-fn page_from_search(query: &str, results: &[SearchEntry]) -> WebPage {
+fn page_from_search(query: &str, results: &[NormalizedSearchResult]) -> WebPage {
     let mut lines = Vec::new();
     let mut links = Vec::new();
 
@@ -1573,28 +1437,6 @@ fn decode_html_entities(text: &str) -> String {
         .replace("&nbsp;", " ")
 }
 
-fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<SearchEntry> {
-    scrape_duckduckgo_results(html, max_results)
-        .into_iter()
-        .map(search_entry_from_scraped)
-        .collect()
-}
-
-fn parse_bing_results(html: &str, max_results: usize) -> Vec<SearchEntry> {
-    scrape_bing_results(html, max_results)
-        .into_iter()
-        .map(search_entry_from_scraped)
-        .collect()
-}
-
-fn search_entry_from_scraped(entry: ScrapedSearchResult) -> SearchEntry {
-    SearchEntry {
-        title: entry.title,
-        url: entry.url,
-        snippet: entry.snippet,
-    }
-}
-
 fn url_encode(input: &str) -> String {
     crate::utils::url_encode(input)
 }
@@ -1604,6 +1446,7 @@ fn url_encode(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::web::scrape::{parse_bing_results, parse_duckduckgo_results};
     use std::path::PathBuf;
     use tokio::sync::{Mutex, MutexGuard};
 
@@ -1674,6 +1517,64 @@ mod tests {
         assert_eq!(
             extract_duckduckgo_vqd(html_plain),
             Some("3-xyz_123".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn text_search_uses_configured_shared_backend_and_exposes_receipt() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::ToolSpec;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "shared seam"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [{
+                    "title": "Shared result",
+                    "url": "https://docs.example.com/shared",
+                    "content": "one adapter path"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut context = ToolContext::new(tmp.path().to_path_buf());
+        context.search_provider = SearchProvider::Searxng;
+        context.search_base_url = Some(server.uri());
+        context.state_namespace = "shared-backend-test".to_string();
+
+        let result = WebRunTool
+            .execute(
+                json!({
+                    "search_query": [{
+                        "q": "shared seam",
+                        "recency": 7,
+                        "domains": ["example.com"]
+                    }]
+                }),
+                &context,
+            )
+            .await
+            .expect("web.run should use configured SearXNG backend");
+        let value: Value = serde_json::from_str(&result.content).expect("web.run json");
+        let search = &value["search_query"][0];
+
+        assert_eq!(search["source"], "searxng");
+        assert_eq!(search["count"], 1);
+        assert_eq!(search["results"][0]["rank"], 1);
+        assert_eq!(search["results"][0]["domain"], "docs.example.com");
+        assert_eq!(search["receipt"]["backend"], "searxng");
+        assert_eq!(search["receipt"]["honored"]["domains"], true);
+        assert!(
+            search["warning"]
+                .as_str()
+                .expect("visible degraded warning")
+                .contains("recency")
         );
     }
 

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -22,11 +22,10 @@ use std::time::{Duration, Instant};
 use parking_lot::{RwLock, RwLockWriteGuard};
 
 use super::web::contract::{
-    Recency, SearchQuery, SearchReceipt, SearchResult as NormalizedSearchResult,
+    MAX_SEARCH_RESULTS, Recency, SearchQuery, SearchReceipt, SearchResult as NormalizedSearchResult,
 };
 use super::web_search::{domain_matches, execute_search};
 
-const MAX_RESULTS: usize = 10;
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
 const DEFAULT_OPEN_TIMEOUT_MS: u64 = 20_000;
 const MAX_WEB_RUN_SESSIONS: usize = 64;
@@ -462,7 +461,7 @@ impl ToolSpec for WebRunTool {
                     response_length.max_results() as u64,
                 ))
                 .unwrap_or(response_length.max_results())
-                .clamp(1, MAX_RESULTS);
+                .clamp(1, MAX_SEARCH_RESULTS);
                 let timeout_ms = optional_u64(search, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
 
                 let domains = search
@@ -530,7 +529,7 @@ impl ToolSpec for WebRunTool {
                     response_length.max_results() as u64,
                 ))
                 .unwrap_or(response_length.max_results())
-                .clamp(1, MAX_RESULTS);
+                .clamp(1, MAX_SEARCH_RESULTS);
                 let timeout_ms = optional_u64(image, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
 
                 let domains = image

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -35,6 +35,7 @@ use super::web::scrape::{
 
 const DUCKDUCKGO_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
 const BING_HOST: &str = "www.bing.com";
+const BING_ENDPOINT: &str = "https://www.bing.com/search";
 const TAVILY_ENDPOINT: &str = "https://api.tavily.com/search";
 const BOCHA_ENDPOINT: &str = "https://api.bochaai.com/v1/web-search";
 const METASO_ENDPOINT: &str = "https://metaso.cn/api/v1";
@@ -729,11 +730,21 @@ pub(crate) async fn execute_search(
     };
     let timeout = Duration::from_millis(effective_timeout_ms);
     let deadline = started + timeout;
-    let mut raw = tokio::time::timeout(timeout, backend.search(&query, deadline))
+    let raw = tokio::time::timeout(timeout, backend.search(&query, deadline))
         .await
         .map_err(|_| ToolError::Timeout {
             seconds: effective_timeout_ms.div_ceil(1_000),
         })??;
+
+    Ok(finalize_search_response(query, capabilities, raw, started))
+}
+
+fn finalize_search_response(
+    query: SearchQuery,
+    capabilities: super::web::contract::QueryCapabilities,
+    mut raw: BackendSearch,
+    started: Instant,
+) -> SearchResponse {
     let mut honored = HonoredQueryCapabilities {
         max_results: true,
         ..HonoredQueryCapabilities::default()
@@ -780,14 +791,14 @@ pub(crate) async fn execute_search(
         (_, None) => format!("Found {count} result(s)"),
     };
 
-    Ok(SearchResponse {
+    SearchResponse {
         query: query.query,
         source: raw.source,
         count,
         message,
         results: raw.results,
         receipt,
-    })
+    }
 }
 
 pub(crate) async fn run_backend_search(
@@ -885,11 +896,43 @@ pub(crate) async fn run_backend_search(
     }
 }
 
+#[derive(Clone, Copy)]
+struct ScrapeEndpoints<'a> {
+    bing: &'a str,
+    allow_bing_fallback: Option<bool>,
+}
+
+impl Default for ScrapeEndpoints<'static> {
+    fn default() -> Self {
+        Self {
+            bing: BING_ENDPOINT,
+            allow_bing_fallback: None,
+        }
+    }
+}
+
 async fn run_scrape_search(
     provider: SearchProvider,
     query: &SearchQuery,
     timeout_ms: u64,
     context: &ToolContext,
+) -> Result<BackendSearch, ToolError> {
+    run_scrape_search_with_endpoints(
+        provider,
+        query,
+        timeout_ms,
+        context,
+        ScrapeEndpoints::default(),
+    )
+    .await
+}
+
+async fn run_scrape_search_with_endpoints(
+    provider: SearchProvider,
+    query: &SearchQuery,
+    timeout_ms: u64,
+    context: &ToolContext,
+    endpoints: ScrapeEndpoints<'_>,
 ) -> Result<BackendSearch, ToolError> {
     let decider = context.network_policy.as_ref();
     let client = crate::tls::reqwest_client_builder()
@@ -904,7 +947,7 @@ async fn run_scrape_search(
 
     if provider == SearchProvider::Bing {
         check_policy(decider, BING_HOST)?;
-        let results = run_bing_search(&client, &query.query, max_results).await?;
+        let results = run_bing_search(&client, &query.query, max_results, endpoints.bing).await?;
         if !results.is_empty() {
             return Ok(BackendSearch {
                 backend: BackendId::Bing,
@@ -923,7 +966,9 @@ async fn run_scrape_search(
 
     let (url, duckduckgo_host) =
         duckduckgo_search_url(context.search_base_url.as_deref(), &query.query)?;
-    let allow_bing_fallback = duckduckgo_allows_bing_fallback(context.search_base_url.as_deref());
+    let allow_bing_fallback = endpoints
+        .allow_bing_fallback
+        .unwrap_or_else(|| duckduckgo_allows_bing_fallback(context.search_base_url.as_deref()));
     check_policy(decider, &duckduckgo_host)?;
     let resp = client
         .get(&url)
@@ -988,7 +1033,7 @@ async fn run_scrape_search(
     }
 
     check_policy(decider, BING_HOST)?;
-    match run_bing_search(&client, &query.query, max_results).await {
+    match run_bing_search(&client, &query.query, max_results, endpoints.bing).await {
         Ok(results) if !results.is_empty() => {
             degraded.push(DegradedReason::ScrapeFallback {
                 from: BackendId::DuckDuckGo,
@@ -1478,7 +1523,7 @@ fn search_query_from_input(input: &Value) -> Result<SearchQuery, ToolError> {
     }
     let max_results = usize::try_from(optional_search_max_results(input))
         .unwrap_or(DEFAULT_MAX_RESULTS)
-        .clamp(1, MAX_SEARCH_RESULTS);
+        .clamp(1, usize::from(MAX_SEARCH_RESULTS));
     let recency = search_option(input, "recency")
         .map(parse_recency)
         .transpose()?;
@@ -1552,11 +1597,13 @@ async fn run_bing_search(
     client: &reqwest::Client,
     query: &str,
     max_results: usize,
+    endpoint: &str,
 ) -> Result<Vec<WebSearchEntry>, ToolError> {
-    let encoded = url_encode(query);
-    let url = format!("https://www.bing.com/search?q={encoded}");
+    let mut url = reqwest::Url::parse(endpoint)
+        .map_err(|error| ToolError::invalid_input(format!("Invalid Bing endpoint: {error}")))?;
+    url.query_pairs_mut().append_pair("q", query);
     let resp = client
-        .get(&url)
+        .get(url)
         .header(
             "Accept",
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -1655,19 +1702,17 @@ fn duckduckgo_allows_bing_fallback(base_url: Option<&str>) -> bool {
     configured_search_base_url(base_url).is_none()
 }
 
-fn url_encode(input: &str) -> String {
-    crate::utils::url_encode(input)
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        ERROR_BODY_PREVIEW_BYTES, WebSearchTool, baidu_search_payload, bocha_error_message,
-        duckduckgo_search_url, extract_search_query, optional_search_max_results,
-        parse_baidu_results, parse_bocha_results, parse_metaso_results, parse_searxng_results,
-        parse_sofya_results, parse_tavily_results, parse_volcengine_results, sanitize_error_body,
+        ERROR_BODY_PREVIEW_BYTES, ScrapeEndpoints, WebSearchTool, baidu_search_payload,
+        bocha_error_message, duckduckgo_search_url, extract_search_query, finalize_search_response,
+        optional_search_max_results, parse_baidu_results, parse_bocha_results,
+        parse_metaso_results, parse_searxng_results, parse_sofya_results, parse_tavily_results,
+        parse_volcengine_results, run_scrape_search_with_endpoints, sanitize_error_body,
         searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
+    use crate::tools::web::contract::{QueryCapabilities, SearchQuery};
     use crate::tools::web::scrape::{decode_html_entities, normalize_bing_url};
     use serde_json::json;
 
@@ -2760,6 +2805,79 @@ mod tests {
                 && msg.contains("bot challenge")
                 && msg.contains("private search service"),
             "got `{msg}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn duckduckgo_challenge_to_bing_success_populates_fallback_receipt() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::ToolContext;
+        use std::time::Instant;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "fallback receipt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<html><body><div class="anomaly-modal">Unfortunately, bots use DuckDuckGo too</div></body></html>"#,
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/bing"))
+            .and(query_param("q", "fallback receipt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"
+                <ol><li class="b_algo">
+                  <h2><a href="https://example.com/fallback">Fallback result</a></h2>
+                  <div class="b_caption"><p>Bing result after challenge.</p></div>
+                </li></ol>
+                "#,
+            ))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut context = ToolContext::new(tmp.path().to_path_buf());
+        context.search_provider = SearchProvider::DuckDuckGo;
+        context.search_base_url = Some(format!("{}/html/", server.uri()));
+        let query = SearchQuery::new("fallback receipt".to_string(), 5, None, Vec::new(), None);
+        let started = Instant::now();
+        let raw = run_scrape_search_with_endpoints(
+            SearchProvider::DuckDuckGo,
+            &query,
+            5_000,
+            &context,
+            ScrapeEndpoints {
+                bing: &format!("{}/bing", server.uri()),
+                allow_bing_fallback: Some(true),
+            },
+        )
+        .await
+        .expect("Bing fallback should succeed");
+        let response =
+            finalize_search_response(query, QueryCapabilities::count_only(), raw, started);
+        let value = serde_json::to_value(&response).expect("response serializes");
+
+        assert_eq!(value["source"], "bing");
+        assert_eq!(value["count"], 1);
+        assert_eq!(value["receipt"]["backend"], "bing");
+        assert_eq!(
+            value["receipt"]["degraded"][0],
+            json!({"kind": "challenge_detected", "backend": "duckduckgo"})
+        );
+        assert_eq!(
+            value["receipt"]["degraded"][1],
+            json!({"kind": "scrape_fallback", "from": "duckduckgo", "to": "bing"})
+        );
+        assert!(
+            response
+                .receipt
+                .warning()
+                .expect("warning")
+                .contains("used bing fallback")
         );
     }
 

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -25,8 +25,8 @@ use std::time::{Duration, Instant};
 
 use super::web::backend::{ConfiguredSearchBackend, SearchBackend};
 use super::web::contract::{
-    BackendId, BackendSearch, DegradedReason, HonoredQueryCapabilities, QueryKnob, Recency,
-    SearchQuery, SearchReceipt, SearchResponse, SearchResult,
+    BackendId, BackendSearch, DegradedReason, HonoredQueryCapabilities, MAX_SEARCH_RESULTS,
+    QueryKnob, Recency, SearchQuery, SearchReceipt, SearchResponse, SearchResult,
 };
 use super::web::scrape::{
     ScrapedSearchResult, is_duckduckgo_challenge, parse_bing_results as scrape_bing_results,
@@ -75,7 +75,6 @@ fn get_bearer_token_re() -> &'static Regex {
 }
 
 const DEFAULT_MAX_RESULTS: usize = 5;
-const MAX_RESULTS: usize = 10;
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
 const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
 
@@ -1479,7 +1478,7 @@ fn search_query_from_input(input: &Value) -> Result<SearchQuery, ToolError> {
     }
     let max_results = usize::try_from(optional_search_max_results(input))
         .unwrap_or(DEFAULT_MAX_RESULTS)
-        .clamp(1, MAX_RESULTS);
+        .clamp(1, MAX_SEARCH_RESULTS);
     let recency = search_option(input, "recency")
         .map(parse_recency)
         .transpose()?;
@@ -1776,7 +1775,7 @@ mod tests {
     #[test]
     fn optional_max_results_uses_default_when_neither_set() {
         // No explicit bound anywhere → the DEFAULT (currently 5)
-        // applies, so the model can't accidentally pull MAX_RESULTS
+        // applies, so the model can't accidentally pull the maximum
         // worth of bandwidth just by omitting the field.
         assert_eq!(optional_search_max_results(&json!({"query": "x"})), 5);
         assert_eq!(

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -21,8 +21,13 @@ use regex::Regex;
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use super::web::backend::{ConfiguredSearchBackend, SearchBackend};
+use super::web::contract::{
+    BackendId, BackendSearch, DegradedReason, HonoredQueryCapabilities, QueryKnob, Recency,
+    SearchQuery, SearchReceipt, SearchResponse, SearchResult,
+};
 use super::web::scrape::{
     ScrapedSearchResult, is_duckduckgo_challenge, parse_bing_results as scrape_bing_results,
     parse_duckduckgo_results as scrape_duckduckgo_results,
@@ -81,15 +86,6 @@ struct WebSearchEntry {
     snippet: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-struct WebSearchResponse {
-    query: String,
-    source: String,
-    count: usize,
-    message: String,
-    results: Vec<WebSearchEntry>,
-}
-
 pub struct WebSearchTool;
 
 #[async_trait]
@@ -122,7 +118,15 @@ impl ToolSpec for WebSearchTool {
                         "properties": {
                             "q": { "type": "string" },
                             "query": { "type": "string" },
-                            "max_results": { "type": "integer" }
+                            "max_results": { "type": "integer" },
+                            "recency": {
+                                "oneOf": [
+                                    { "type": "string", "enum": ["day", "week", "month", "year"] },
+                                    { "type": "integer", "minimum": 1, "maximum": 3650 }
+                                ]
+                            },
+                            "domains": { "type": "array", "items": { "type": "string" } },
+                            "locale": { "type": "string" }
                         }
                     }
                 },
@@ -133,6 +137,22 @@ impl ToolSpec for WebSearchTool {
                 "timeout_ms": {
                     "type": "integer",
                     "description": "Timeout in milliseconds (default: 15000, max: 60000)"
+                },
+                "recency": {
+                    "oneOf": [
+                        { "type": "string", "enum": ["day", "week", "month", "year"] },
+                        { "type": "integer", "minimum": 1, "maximum": 3650 }
+                    ],
+                    "description": "Requested freshness window. Unsupported backends report it as degraded instead of silently ignoring it."
+                },
+                "domains": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Restrict returned results to these domains. Backends without native support report post-filtering."
+                },
+                "locale": {
+                    "type": "string",
+                    "description": "Requested result locale. Unsupported backends report it as degraded."
                 }
             }
         })
@@ -151,218 +171,11 @@ impl ToolSpec for WebSearchTool {
     }
 
     async fn execute(&self, input: Value, context: &ToolContext) -> Result<ToolResult, ToolError> {
-        let query = extract_search_query(&input)?;
-        if query.is_empty() {
-            return Err(ToolError::invalid_input("Query cannot be empty"));
-        }
-        let max_results =
-            usize::try_from(optional_search_max_results(&input)).unwrap_or(DEFAULT_MAX_RESULTS);
-        let max_results = max_results.clamp(1, MAX_RESULTS);
+        let query = search_query_from_input(&input)?;
         let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT_MS).min(60_000);
-
-        if configured_search_base_url(context.search_base_url.as_deref()).is_some()
-            && !matches!(
-                context.search_provider,
-                SearchProvider::DuckDuckGo | SearchProvider::Searxng
-            )
-        {
-            return Err(ToolError::invalid_input(format!(
-                "[search].base_url is only supported with provider = \"duckduckgo\" or \"searxng\"; current provider is \"{}\"",
-                context.search_provider.as_str()
-            )));
-        }
-
-        // Dispatch to the configured API-backed search providers before
-        // building the HTML-scraping client used by Bing/DuckDuckGo.
-        match context.search_provider {
-            SearchProvider::Tavily => {
-                let decider = context.network_policy.as_ref();
-                check_policy(decider, "api.tavily.com")?;
-                return self
-                    .run_tavily_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Bocha => {
-                let decider = context.network_policy.as_ref();
-                check_policy(decider, "api.bochaai.com")?;
-                return self
-                    .run_bocha_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Metaso => {
-                let decider = context.network_policy.as_ref();
-                check_policy(decider, "metaso.cn")?;
-                return self
-                    .run_metaso_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Searxng => {
-                return self
-                    .run_searxng_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Baidu => {
-                let decider = context.network_policy.as_ref();
-                check_policy(decider, "qianfan.baidubce.com")?;
-                return self
-                    .run_baidu_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Volcengine => {
-                let decider = context.network_policy.as_ref();
-                check_policy(decider, "ark.cn-beijing.volces.com")?;
-                return self
-                    .run_volcengine_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Sofya => {
-                let decider = context.network_policy.as_ref();
-                check_policy(decider, "sofya.co")?;
-                return self
-                    .run_sofya_search(&query, max_results, timeout_ms, context)
-                    .await;
-            }
-            SearchProvider::Bing | SearchProvider::DuckDuckGo => {}
-        }
-
-        let decider = context.network_policy.as_ref();
-        let client = crate::tls::reqwest_client_builder()
-            .timeout(Duration::from_millis(timeout_ms))
-            .user_agent(USER_AGENT)
-            .build()
-            .map_err(|e| {
-                ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
-            })?;
-
-        // Track whether Bing was tried and returned zero, so we can surface
-        // the fallback in the result message (#2130).
-        let mut bing_was_empty = false;
-
-        if matches!(context.search_provider, SearchProvider::Bing) {
-            check_policy(decider, BING_HOST)?;
-            let results = run_bing_search(&client, &query, max_results).await?;
-            if !results.is_empty() {
-                return search_tool_result(query, "bing", results, None);
-            }
-            // Bing returned zero results — fall through to DuckDuckGo.
-            bing_was_empty = true;
-        }
-
-        // Per-domain network policy gate (#135). The "host" for web search is
-        // the upstream search engine domain — DuckDuckGo-compatible first,
-        // Bing on fallback. We gate the configured endpoint here; Bing is
-        // gated separately inside the fallback path so a deny on one engine
-        // doesn't silently allow the other.
-        let (url, duckduckgo_host) =
-            duckduckgo_search_url(context.search_base_url.as_deref(), &query)?;
-        let allow_bing_fallback =
-            duckduckgo_allows_bing_fallback(context.search_base_url.as_deref());
-        check_policy(decider, &duckduckgo_host)?;
-
-        let resp = client
-            .get(&url)
-            .header(
-                "Accept",
-                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            )
-            .header("Accept-Language", "en-US,en;q=0.5")
-            .send()
-            .await
-            .map_err(|e| ToolError::execution_failed(format!("Web search request failed: {e}")))?;
-
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| ToolError::execution_failed(format!("Failed to read response: {e}")))?;
-
-        if !status.is_success() {
-            return Err(ToolError::execution_failed(format!(
-                "Web search failed: HTTP {}",
-                status.as_u16()
-            )));
-        }
-
-        let mut results = parse_duckduckgo_results(&body, max_results);
-        let mut source = if allow_bing_fallback {
-            "duckduckgo".to_string()
-        } else {
-            duckduckgo_host.clone()
-        };
-        let mut message_suffix: Option<&str> = None;
-
-        // When Bing returned zero and we fell through to DuckDuckGo, surface
-        // the fallback in the result message (#2130).
-        if bing_was_empty && !results.is_empty() {
-            message_suffix = Some("Bing returned no results; used DuckDuckGo fallback");
-        }
-
-        let duckduckgo_blocked = is_duckduckgo_challenge(&body);
-        if results.is_empty() && duckduckgo_blocked && !allow_bing_fallback {
-            return Err(ToolError::execution_failed(format!(
-                "DuckDuckGo-compatible search endpoint at {duckduckgo_host} returned a bot challenge; check the private search service, credentials, or network policy"
-            )));
-        }
-
-        if results.is_empty() && allow_bing_fallback {
-            // Bing is a separate host — gate it independently so a deny on
-            // DuckDuckGo doesn't silently let Bing through (and vice versa).
-            check_policy(decider, BING_HOST)?;
-            match run_bing_search(&client, &query, max_results).await {
-                Ok(fallback_results) if !fallback_results.is_empty() => {
-                    results = fallback_results;
-                    source = "bing".to_string();
-                    message_suffix = Some(if duckduckgo_blocked {
-                        "DuckDuckGo returned a bot challenge; used Bing fallback"
-                    } else {
-                        "DuckDuckGo returned no parseable results; used Bing fallback"
-                    });
-                }
-                Ok(_) if duckduckgo_blocked => {
-                    return Err(ToolError::execution_failed(
-                        "DuckDuckGo returned a bot challenge and Bing fallback returned no results",
-                    ));
-                }
-                Err(err) if duckduckgo_blocked => {
-                    return Err(ToolError::execution_failed(format!(
-                        "DuckDuckGo returned a bot challenge and Bing fallback failed: {err}"
-                    )));
-                }
-                Ok(_) | Err(_) => {}
-            }
-        }
-
-        search_tool_result(query, source, results, message_suffix)
+        let response = execute_search(query, timeout_ms, context).await?;
+        ToolResult::json(&response).map_err(|error| ToolError::execution_failed(error.to_string()))
     }
-}
-
-fn search_tool_result(
-    query: String,
-    source: impl Into<String>,
-    results: Vec<WebSearchEntry>,
-    message_suffix: Option<&str>,
-) -> Result<ToolResult, ToolError> {
-    let message = if results.is_empty() {
-        if let Some(suffix) = message_suffix {
-            format!("No results found. {suffix}")
-        } else {
-            "No results found".to_string()
-        }
-    } else if let Some(suffix) = message_suffix {
-        format!("Found {} result(s). {suffix}", results.len())
-    } else {
-        format!("Found {} result(s)", results.len())
-    };
-
-    let response = WebSearchResponse {
-        query,
-        source: source.into(),
-        count: results.len(),
-        message,
-        results,
-    };
-
-    ToolResult::json(&response).map_err(|e| ToolError::execution_failed(e.to_string()))
 }
 
 impl WebSearchTool {
@@ -377,7 +190,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<(Vec<WebSearchEntry>, String), ToolError> {
         let (url, host) = searxng_search_url(context.search_base_url.as_deref(), query)?;
         check_policy(context.network_policy.as_ref(), &host)?;
 
@@ -423,9 +236,7 @@ impl WebSearchTool {
             ))
         })?;
 
-        let results = parse_searxng_results(&parsed, max_results);
-        let suffix = format!("Backend: searxng at {host}");
-        search_tool_result(query.to_string(), "searxng", results, Some(&suffix))
+        Ok((parse_searxng_results(&parsed, max_results), host))
     }
 
     /// Search via Tavily AI Search API (<https://tavily.com>).
@@ -435,7 +246,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<Vec<WebSearchEntry>, ToolError> {
         let api_key = context
             .search_api_key
             .as_deref()
@@ -486,43 +297,7 @@ impl WebSearchTool {
             ToolError::execution_failed(format!("Failed to parse Tavily response: {e}"))
         })?;
 
-        let results: Vec<WebSearchEntry> = parsed
-            .get("results")
-            .and_then(|v| v.as_array())
-            .into_iter()
-            .flat_map(|arr| arr.iter())
-            .filter_map(|item| {
-                let title = item.get("title")?.as_str()?.to_string();
-                let url = item.get("url")?.as_str()?.to_string();
-                let snippet = item
-                    .get("content")
-                    .or_else(|| item.get("snippet"))
-                    .and_then(|s| s.as_str())
-                    .map(|s| s.to_string());
-                Some(WebSearchEntry {
-                    title,
-                    url,
-                    snippet,
-                })
-            })
-            .take(max_results)
-            .collect();
-
-        let message = if results.is_empty() {
-            "No results found".to_string()
-        } else {
-            format!("Found {} result(s)", results.len())
-        };
-
-        let response = WebSearchResponse {
-            query: query.to_string(),
-            source: "tavily".to_string(),
-            count: results.len(),
-            message,
-            results,
-        };
-
-        ToolResult::json(&response).map_err(|e| ToolError::execution_failed(e.to_string()))
+        Ok(parse_tavily_results(&parsed, max_results))
     }
 
     /// Search via Sofya web search API (<https://sofya.co>).
@@ -536,7 +311,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<Vec<WebSearchEntry>, ToolError> {
         let env_key = std::env::var("SOFYA_API_KEY").ok();
         let api_key = context
             .search_api_key
@@ -588,23 +363,7 @@ impl WebSearchTool {
             ToolError::execution_failed(format!("Failed to parse Sofya response: {e}"))
         })?;
 
-        let results = parse_sofya_results(&parsed, max_results);
-
-        let message = if results.is_empty() {
-            "No results found".to_string()
-        } else {
-            format!("Found {} result(s)", results.len())
-        };
-
-        let response = WebSearchResponse {
-            query: query.to_string(),
-            source: "sofya".to_string(),
-            count: results.len(),
-            message,
-            results,
-        };
-
-        ToolResult::json(&response).map_err(|e| ToolError::execution_failed(e.to_string()))
+        Ok(parse_sofya_results(&parsed, max_results))
     }
 
     /// Search via Bocha AI Search API (<https://bochaai.com>).
@@ -614,7 +373,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<Vec<WebSearchEntry>, ToolError> {
         let api_key = context
             .search_api_key
             .as_deref()
@@ -669,23 +428,7 @@ impl WebSearchTool {
             return Err(ToolError::execution_failed(error));
         }
 
-        let results = parse_bocha_results(&parsed, max_results);
-
-        let message = if results.is_empty() {
-            "No results found".to_string()
-        } else {
-            format!("Found {} result(s)", results.len())
-        };
-
-        let response = WebSearchResponse {
-            query: query.to_string(),
-            source: "bocha".to_string(),
-            count: results.len(),
-            message,
-            results,
-        };
-
-        ToolResult::json(&response).map_err(|e| ToolError::execution_failed(e.to_string()))
+        Ok(parse_bocha_results(&parsed, max_results))
     }
 
     /// Search via Metaso AI Search API (<https://metaso.cn>). Falls back to
@@ -697,7 +440,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<Vec<WebSearchEntry>, ToolError> {
         let env_key = std::env::var("METASO_API_KEY").ok();
         let api_key = context
             .search_api_key
@@ -766,29 +509,7 @@ impl WebSearchTool {
             }));
         }
 
-        let results: Vec<WebSearchEntry> = parsed
-            .get("webpages")
-            .and_then(|v| v.as_array())
-            .into_iter()
-            .flat_map(|arr| arr.iter())
-            .filter_map(|item| {
-                let title = item.get("title")?.as_str()?.to_string();
-                let url = item.get("link")?.as_str()?.to_string();
-                let snippet = item
-                    .get("snippet")
-                    .or_else(|| item.get("summary"))
-                    .and_then(|s| s.as_str())
-                    .map(|s| s.to_string());
-                Some(WebSearchEntry {
-                    title,
-                    url,
-                    snippet,
-                })
-            })
-            .take(size)
-            .collect();
-
-        search_tool_result(query.to_string(), "metaso", results, None)
+        Ok(parse_metaso_results(&parsed, size))
     }
 
     /// Search via Baidu AI Search API (<https://qianfan.baidubce.com>).
@@ -798,7 +519,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<Vec<WebSearchEntry>, ToolError> {
         let env_key = std::env::var("BAIDU_SEARCH_API_KEY").ok();
         let api_key = context
             .search_api_key
@@ -854,8 +575,7 @@ impl WebSearchTool {
             return Err(ToolError::execution_failed(error));
         }
 
-        let results = parse_baidu_results(&parsed, max_results);
-        search_tool_result(query.to_string(), "baidu", results, None)
+        Ok(parse_baidu_results(&parsed, max_results))
     }
 
     /// Search via Volcengine Ark Responses API web_search tool.
@@ -873,7 +593,7 @@ impl WebSearchTool {
         max_results: usize,
         timeout_ms: u64,
         context: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+    ) -> Result<Vec<WebSearchEntry>, ToolError> {
         let volc_key = std::env::var("VOLCENGINE_API_KEY").ok();
         let volc_ark_key = std::env::var("VOLCENGINE_ARK_API_KEY").ok();
         let ark_key = std::env::var("ARK_API_KEY").ok();
@@ -958,8 +678,7 @@ impl WebSearchTool {
                         ToolError::execution_failed("Volcengine response contains no output text")
                     })?;
 
-                    let results = parse_volcengine_results(&response_text, max_results);
-                    return search_tool_result(query.to_string(), "volcengine", results, None);
+                    return Ok(parse_volcengine_results(&response_text, max_results));
                 }
                 Err(e) => {
                     let is_transient = e.is_timeout() || e.is_connect();
@@ -981,6 +700,362 @@ impl WebSearchTool {
             ToolError::execution_failed("Volcengine search: unexpected retry exit")
         }))
     }
+}
+
+pub(crate) async fn execute_search(
+    query: SearchQuery,
+    timeout_ms: u64,
+    context: &ToolContext,
+) -> Result<SearchResponse, ToolError> {
+    if configured_search_base_url(context.search_base_url.as_deref()).is_some()
+        && !matches!(
+            context.search_provider,
+            SearchProvider::DuckDuckGo | SearchProvider::Searxng
+        )
+    {
+        return Err(ToolError::invalid_input(format!(
+            "[search].base_url is only supported with provider = \"duckduckgo\" or \"searxng\"; current provider is \"{}\"",
+            context.search_provider.as_str()
+        )));
+    }
+
+    let backend = ConfiguredSearchBackend::from_context(context);
+    debug_assert_eq!(backend.id().as_str(), context.search_provider.as_str());
+    let capabilities = backend.capabilities();
+    let started = Instant::now();
+    let effective_timeout_ms = if backend.id() == BackendId::Volcengine {
+        timeout_ms.max(90_000)
+    } else {
+        timeout_ms.max(1)
+    };
+    let timeout = Duration::from_millis(effective_timeout_ms);
+    let deadline = started + timeout;
+    let mut raw = tokio::time::timeout(timeout, backend.search(&query, deadline))
+        .await
+        .map_err(|_| ToolError::Timeout {
+            seconds: effective_timeout_ms.div_ceil(1_000),
+        })??;
+    let mut honored = HonoredQueryCapabilities {
+        max_results: true,
+        ..HonoredQueryCapabilities::default()
+    };
+
+    if query.recency.is_some() {
+        raw.degraded.push(DegradedReason::KnobIgnored {
+            knob: QueryKnob::Recency,
+        });
+    }
+    if !query.domains.is_empty() {
+        raw.results
+            .retain(|result| domain_matches(&result.url, &query.domains));
+        rerank(&mut raw.results);
+        honored.domains = true;
+        raw.degraded.push(DegradedReason::PostFiltered {
+            knob: QueryKnob::Domains,
+        });
+    }
+    if query.locale.is_some() {
+        raw.degraded.push(DegradedReason::KnobIgnored {
+            knob: QueryKnob::Locale,
+        });
+    }
+
+    raw.results.truncate(usize::from(query.max_results));
+    rerank(&mut raw.results);
+    let latency_ms = u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
+    let receipt = SearchReceipt {
+        backend: raw.backend,
+        backend_detail: raw.backend_detail,
+        requested: query.clone(),
+        capabilities,
+        honored,
+        degraded: raw.degraded,
+        latency_ms,
+        cache_hit: false,
+    };
+    let count = raw.results.len();
+    let message = match (count, raw.note.as_deref()) {
+        (0, Some(note)) => format!("No results found. {note}"),
+        (0, None) => "No results found".to_string(),
+        (_, Some(note)) => format!("Found {count} result(s). {note}"),
+        (_, None) => format!("Found {count} result(s)"),
+    };
+
+    Ok(SearchResponse {
+        query: query.query,
+        source: raw.source,
+        count,
+        message,
+        results: raw.results,
+        receipt,
+    })
+}
+
+pub(crate) async fn run_backend_search(
+    provider: SearchProvider,
+    query: &SearchQuery,
+    deadline: Instant,
+    context: &ToolContext,
+) -> Result<BackendSearch, ToolError> {
+    let timeout_ms = u64::try_from(
+        deadline
+            .saturating_duration_since(Instant::now())
+            .as_millis()
+            .max(1),
+    )
+    .unwrap_or(u64::MAX);
+    let max_results = usize::from(query.max_results);
+    let tool = WebSearchTool;
+    let simple = |backend, entries: Vec<WebSearchEntry>| BackendSearch {
+        backend,
+        source: backend.as_str().to_string(),
+        backend_detail: None,
+        results: normalize_entries(entries),
+        degraded: Vec::new(),
+        note: None,
+    };
+
+    match provider {
+        SearchProvider::Tavily => {
+            check_policy(context.network_policy.as_ref(), "api.tavily.com")?;
+            Ok(simple(
+                BackendId::Tavily,
+                tool.run_tavily_search(&query.query, max_results, timeout_ms, context)
+                    .await?,
+            ))
+        }
+        SearchProvider::Bocha => {
+            check_policy(context.network_policy.as_ref(), "api.bochaai.com")?;
+            Ok(simple(
+                BackendId::Bocha,
+                tool.run_bocha_search(&query.query, max_results, timeout_ms, context)
+                    .await?,
+            ))
+        }
+        SearchProvider::Metaso => {
+            check_policy(context.network_policy.as_ref(), "metaso.cn")?;
+            Ok(simple(
+                BackendId::Metaso,
+                tool.run_metaso_search(&query.query, max_results, timeout_ms, context)
+                    .await?,
+            ))
+        }
+        SearchProvider::Searxng => {
+            let (entries, host) = tool
+                .run_searxng_search(&query.query, max_results, timeout_ms, context)
+                .await?;
+            let note = format!("Backend: searxng at {host}");
+            Ok(BackendSearch {
+                backend: BackendId::Searxng,
+                source: "searxng".to_string(),
+                backend_detail: Some(host),
+                results: normalize_entries(entries),
+                degraded: Vec::new(),
+                note: Some(note),
+            })
+        }
+        SearchProvider::Baidu => {
+            check_policy(context.network_policy.as_ref(), "qianfan.baidubce.com")?;
+            Ok(simple(
+                BackendId::Baidu,
+                tool.run_baidu_search(&query.query, max_results, timeout_ms, context)
+                    .await?,
+            ))
+        }
+        SearchProvider::Volcengine => {
+            check_policy(context.network_policy.as_ref(), "ark.cn-beijing.volces.com")?;
+            let mut response = simple(
+                BackendId::Volcengine,
+                tool.run_volcengine_search(&query.query, max_results, timeout_ms, context)
+                    .await?,
+            );
+            response.degraded.push(DegradedReason::SynthesizedResults);
+            Ok(response)
+        }
+        SearchProvider::Sofya => {
+            check_policy(context.network_policy.as_ref(), "sofya.co")?;
+            Ok(simple(
+                BackendId::Sofya,
+                tool.run_sofya_search(&query.query, max_results, timeout_ms, context)
+                    .await?,
+            ))
+        }
+        SearchProvider::Bing | SearchProvider::DuckDuckGo => {
+            run_scrape_search(provider, query, timeout_ms, context).await
+        }
+    }
+}
+
+async fn run_scrape_search(
+    provider: SearchProvider,
+    query: &SearchQuery,
+    timeout_ms: u64,
+    context: &ToolContext,
+) -> Result<BackendSearch, ToolError> {
+    let decider = context.network_policy.as_ref();
+    let client = crate::tls::reqwest_client_builder()
+        .timeout(Duration::from_millis(timeout_ms))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|error| {
+            ToolError::execution_failed(format!("Failed to build HTTP client: {error}"))
+        })?;
+    let max_results = usize::from(query.max_results);
+    let mut degraded = Vec::new();
+
+    if provider == SearchProvider::Bing {
+        check_policy(decider, BING_HOST)?;
+        let results = run_bing_search(&client, &query.query, max_results).await?;
+        if !results.is_empty() {
+            return Ok(BackendSearch {
+                backend: BackendId::Bing,
+                source: "bing".to_string(),
+                backend_detail: None,
+                results: normalize_entries(results),
+                degraded,
+                note: None,
+            });
+        }
+        degraded.push(DegradedReason::ScrapeFallback {
+            from: BackendId::Bing,
+            to: BackendId::DuckDuckGo,
+        });
+    }
+
+    let (url, duckduckgo_host) =
+        duckduckgo_search_url(context.search_base_url.as_deref(), &query.query)?;
+    let allow_bing_fallback = duckduckgo_allows_bing_fallback(context.search_base_url.as_deref());
+    check_policy(decider, &duckduckgo_host)?;
+    let resp = client
+        .get(&url)
+        .header(
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        )
+        .header("Accept-Language", "en-US,en;q=0.5")
+        .send()
+        .await
+        .map_err(|error| {
+            ToolError::execution_failed(format!("Web search request failed: {error}"))
+        })?;
+    let status = resp.status();
+    let body = resp.text().await.map_err(|error| {
+        ToolError::execution_failed(format!("Failed to read response: {error}"))
+    })?;
+    if !status.is_success() {
+        return Err(ToolError::execution_failed(format!(
+            "Web search failed: HTTP {}",
+            status.as_u16()
+        )));
+    }
+
+    let results = parse_duckduckgo_results(&body, max_results);
+    let blocked = is_duckduckgo_challenge(&body);
+    if !results.is_empty() {
+        let note = (provider == SearchProvider::Bing)
+            .then(|| "Bing returned no results; used DuckDuckGo fallback".to_string());
+        return Ok(BackendSearch {
+            backend: BackendId::DuckDuckGo,
+            source: if allow_bing_fallback {
+                "duckduckgo".to_string()
+            } else {
+                duckduckgo_host.clone()
+            },
+            backend_detail: (!allow_bing_fallback).then_some(duckduckgo_host),
+            results: normalize_entries(results),
+            degraded,
+            note,
+        });
+    }
+    if blocked {
+        degraded.push(DegradedReason::ChallengeDetected {
+            backend: BackendId::DuckDuckGo,
+        });
+    }
+    if !allow_bing_fallback {
+        if blocked {
+            return Err(ToolError::execution_failed(format!(
+                "DuckDuckGo-compatible search endpoint at {duckduckgo_host} returned a bot challenge; check the private search service, credentials, or network policy"
+            )));
+        }
+        return Ok(BackendSearch {
+            backend: BackendId::DuckDuckGo,
+            source: duckduckgo_host.clone(),
+            backend_detail: Some(duckduckgo_host),
+            results: Vec::new(),
+            degraded,
+            note: None,
+        });
+    }
+
+    check_policy(decider, BING_HOST)?;
+    match run_bing_search(&client, &query.query, max_results).await {
+        Ok(results) if !results.is_empty() => {
+            degraded.push(DegradedReason::ScrapeFallback {
+                from: BackendId::DuckDuckGo,
+                to: BackendId::Bing,
+            });
+            Ok(BackendSearch {
+                backend: BackendId::Bing,
+                source: "bing".to_string(),
+                backend_detail: None,
+                results: normalize_entries(results),
+                degraded,
+                note: Some(if blocked {
+                    "DuckDuckGo returned a bot challenge; used Bing fallback".to_string()
+                } else {
+                    "DuckDuckGo returned no parseable results; used Bing fallback".to_string()
+                }),
+            })
+        }
+        Ok(_) if blocked => Err(ToolError::execution_failed(
+            "DuckDuckGo returned a bot challenge and Bing fallback returned no results",
+        )),
+        Err(error) if blocked => Err(ToolError::execution_failed(format!(
+            "DuckDuckGo returned a bot challenge and Bing fallback failed: {error}"
+        ))),
+        Ok(_) | Err(_) => Ok(BackendSearch {
+            backend: BackendId::DuckDuckGo,
+            source: "duckduckgo".to_string(),
+            backend_detail: None,
+            results: Vec::new(),
+            degraded,
+            note: None,
+        }),
+    }
+}
+
+fn normalize_entries(entries: Vec<WebSearchEntry>) -> Vec<SearchResult> {
+    entries
+        .into_iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            SearchResult::new(index + 1, entry.title, entry.url, entry.snippet, None)
+        })
+        .collect()
+}
+
+fn rerank(results: &mut [SearchResult]) {
+    for (index, result) in results.iter_mut().enumerate() {
+        result.rank = u8::try_from(index + 1).unwrap_or(u8::MAX);
+    }
+}
+
+pub(crate) fn domain_matches(url: &str, domains: &[String]) -> bool {
+    if domains.is_empty() {
+        return true;
+    }
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let host = host.trim_start_matches("www.").to_ascii_lowercase();
+    domains.iter().any(|domain| {
+        let domain = domain.trim_start_matches("www.").to_ascii_lowercase();
+        host == domain || host.ends_with(&format!(".{domain}"))
+    })
 }
 
 fn truncate_error_body(body: &str) -> String {
@@ -1015,6 +1090,50 @@ fn sanitize_error_body(body: &str) -> String {
     get_bearer_token_re()
         .replace_all(&visible, "Bearer [REDACTED]")
         .to_string()
+}
+
+fn parse_tavily_results(parsed: &Value, max_results: usize) -> Vec<WebSearchEntry> {
+    parsed
+        .get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            let title = item.get("title")?.as_str()?.trim();
+            let url = item.get("url")?.as_str()?.trim();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            Some(WebSearchEntry {
+                title: title.to_string(),
+                url: url.to_string(),
+                snippet: first_non_empty_string(item, &["content", "snippet"]),
+            })
+        })
+        .take(max_results)
+        .collect()
+}
+
+fn parse_metaso_results(parsed: &Value, max_results: usize) -> Vec<WebSearchEntry> {
+    parsed
+        .get("webpages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            let title = item.get("title")?.as_str()?.trim();
+            let url = item.get("link")?.as_str()?.trim();
+            if title.is_empty() || url.is_empty() {
+                return None;
+            }
+            Some(WebSearchEntry {
+                title: title.to_string(),
+                url: url.to_string(),
+                snippet: first_non_empty_string(item, &["snippet", "summary"]),
+            })
+        })
+        .take(max_results)
+        .collect()
 }
 
 fn parse_bocha_results(parsed: &Value, max_results: usize) -> Vec<WebSearchEntry> {
@@ -1353,6 +1472,75 @@ fn optional_search_max_results(input: &Value) -> u64 {
         .unwrap_or(DEFAULT_MAX_RESULTS as u64)
 }
 
+fn search_query_from_input(input: &Value) -> Result<SearchQuery, ToolError> {
+    let query = extract_search_query(input)?;
+    if query.is_empty() {
+        return Err(ToolError::invalid_input("Query cannot be empty"));
+    }
+    let max_results = usize::try_from(optional_search_max_results(input))
+        .unwrap_or(DEFAULT_MAX_RESULTS)
+        .clamp(1, MAX_RESULTS);
+    let recency = search_option(input, "recency")
+        .map(parse_recency)
+        .transpose()?;
+    let domains = match search_option(input, "domains") {
+        Some(value) => value
+            .as_array()
+            .ok_or_else(|| ToolError::invalid_input("Field 'domains' must be an array"))?
+            .iter()
+            .map(|value| {
+                value.as_str().map(str::to_string).ok_or_else(|| {
+                    ToolError::invalid_input("Every 'domains' entry must be a string")
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        None => Vec::new(),
+    };
+    let locale = search_option(input, "locale")
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| ToolError::invalid_input("Field 'locale' must be a string"))
+        })
+        .transpose()?;
+
+    Ok(SearchQuery::new(
+        query,
+        max_results,
+        recency,
+        domains,
+        locale,
+    ))
+}
+
+fn search_option<'a>(input: &'a Value, key: &str) -> Option<&'a Value> {
+    input
+        .get(key)
+        .or_else(|| search_query_items(input).find_map(|item| item.get(key)))
+}
+
+fn parse_recency(value: &Value) -> Result<Recency, ToolError> {
+    if let Some(days) = value.as_u64() {
+        let days = u16::try_from(days)
+            .ok()
+            .filter(|days| (1..=3650).contains(days))
+            .ok_or_else(|| {
+                ToolError::invalid_input("Field 'recency' must be between 1 and 3650 days")
+            })?;
+        return Ok(Recency::Days(days));
+    }
+    match value.as_str() {
+        Some("day") => Ok(Recency::Day),
+        Some("week") => Ok(Recency::Week),
+        Some("month") => Ok(Recency::Month),
+        Some("year") => Ok(Recency::Year),
+        _ => Err(ToolError::invalid_input(
+            "Field 'recency' must be day, week, month, year, or an integer day count",
+        )),
+    }
+}
+
 fn search_query_items(input: &Value) -> impl Iterator<Item = &Value> {
     input
         .get("search_query")
@@ -1477,8 +1665,9 @@ mod tests {
     use super::{
         ERROR_BODY_PREVIEW_BYTES, WebSearchTool, baidu_search_payload, bocha_error_message,
         duckduckgo_search_url, extract_search_query, optional_search_max_results,
-        parse_baidu_results, parse_bocha_results, parse_searxng_results, parse_sofya_results,
-        sanitize_error_body, searxng_search_url, truncate_error_body, volcengine_extract_text,
+        parse_baidu_results, parse_bocha_results, parse_metaso_results, parse_searxng_results,
+        parse_sofya_results, parse_tavily_results, parse_volcengine_results, sanitize_error_body,
+        searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
     use crate::tools::web::scrape::{decode_html_entities, normalize_bing_url};
     use serde_json::json;
@@ -1869,6 +2058,40 @@ mod tests {
     }
 
     #[test]
+    fn tavily_metaso_and_volcengine_payloads_use_normalized_entry_shape() {
+        let tavily = parse_tavily_results(
+            &json!({"results": [{
+                "title": " Tavily result ",
+                "url": "https://tavily.example/result",
+                "content": " content "
+            }]}),
+            5,
+        );
+        let metaso = parse_metaso_results(
+            &json!({"webpages": [{
+                "title": " Metaso result ",
+                "link": "https://metaso.example/result",
+                "summary": " summary "
+            }]}),
+            5,
+        );
+        let volcengine = parse_volcengine_results(
+            r#"{"results":[{"title":"Volcengine result","url":"https://volc.example/result","snippet":"summary"}]}"#,
+            5,
+        );
+
+        for (entries, title, snippet) in [
+            (tavily, "Tavily result", "content"),
+            (metaso, "Metaso result", "summary"),
+            (volcengine, "Volcengine result", "summary"),
+        ] {
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].title, title);
+            assert_eq!(entries[0].snippet.as_deref(), Some(snippet));
+        }
+    }
+
+    #[test]
     fn volcengine_extract_text_skips_non_text_content_blocks() {
         let body = json!({
             "output": [
@@ -2242,11 +2465,84 @@ mod tests {
 
         assert_eq!(value["source"].as_str(), Some("searxng"));
         assert_eq!(value["count"].as_u64(), Some(1));
+        assert_eq!(value["results"][0]["rank"].as_u64(), Some(1));
+        assert_eq!(value["results"][0]["domain"], "example.com");
+        assert_eq!(value["receipt"]["backend"], "searxng");
+        assert_eq!(
+            value["receipt"]["backend_detail"].as_str(),
+            Some("127.0.0.1")
+        );
         assert!(
             value["message"]
                 .as_str()
                 .expect("message")
                 .contains("Backend: searxng at")
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_knobs_are_visible_and_domains_are_post_filtered() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .and(query_param("q", "fresh rust"))
+            .and(query_param("format", "json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {"title": "Keep", "url": "https://docs.example.com/rust", "content": "kept"},
+                    {"title": "Drop", "url": "https://other.test/rust", "content": "dropped"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut ctx = ToolContext::new(tmp.path().to_path_buf());
+        ctx.search_provider = SearchProvider::Searxng;
+        ctx.search_base_url = Some(server.uri());
+
+        let result = WebSearchTool
+            .execute(
+                json!({
+                    "query": "fresh rust",
+                    "recency": "week",
+                    "domains": ["example.com"],
+                    "locale": "en-US"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("structured query should execute");
+        let value: serde_json::Value =
+            serde_json::from_str(&result.content).expect("web search json response");
+
+        assert_eq!(value["count"], 1);
+        assert_eq!(value["results"][0]["domain"], "docs.example.com");
+        assert_eq!(value["receipt"]["honored"]["domains"], true);
+        assert_eq!(value["receipt"]["honored"]["recency"], false);
+        assert_eq!(value["receipt"]["honored"]["locale"], false);
+        let degraded = value["receipt"]["degraded"]
+            .as_array()
+            .expect("degraded receipt array");
+        assert!(
+            degraded
+                .iter()
+                .any(|item| { item["kind"] == "post_filtered" && item["knob"] == "domains" })
+        );
+        assert!(
+            degraded
+                .iter()
+                .any(|item| { item["kind"] == "knob_ignored" && item["knob"] == "recency" })
+        );
+        assert!(
+            degraded
+                .iter()
+                .any(|item| { item["kind"] == "knob_ignored" && item["knob"] == "locale" })
         );
     }
 


### PR DESCRIPTION
## Summary

- add a provider-neutral SearchBackend contract covering all nine configured search providers
- route both web_search and web.run text search through the same adapter and normalization seam
- add ranked/domain-aware results plus receipts for capabilities, honored knobs, degradation, latency, and cache state
- preserve legacy query/source/count/message/results fields and existing SearXNG/custom DuckDuckGo behavior

## Verification

- cargo fmt --all -- --check
- cargo test -p codewhale-tui --all-features (7,534 passed; 3 ignored)
- cargo test -p codewhale-tui web_search -- --nocapture (49 passed)
- cargo test -p codewhale-tui tools::web:: -- --nocapture (46 passed; 1 ignored)
- cargo test -p codewhale-tui text_search_uses_configured_shared_backend_and_exposes_receipt -- --nocapture
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- gitleaks protect --staged --redact --no-banner

## Release boundary

This is W2 only. It does not tag, publish, create release assets, or deploy.