### PR TITLE
feat(web): add shared fetch and extraction pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "globset",
+ "htmd",
  "ignore",
  "image",
  "libc",
@@ -1079,6 +1080,7 @@ dependencies = [
  "pretty_assertions",
  "qrcode",
  "ratatui",
+ "readability",
  "regex",
  "reqwest 0.13.4",
  "rmcp",
@@ -1389,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2099,6 +2101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2453,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "htmd"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever_rcdom 0.38.0+unofficial",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -3082,7 +3129,7 @@ dependencies = [
  "petgraph",
  "regex",
  "regex-syntax 0.6.29",
- "string_cache",
+ "string_cache 0.8.9",
  "term",
  "tiny-keccak",
  "unicode-xid",
@@ -3305,6 +3352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,6 +3372,55 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril 0.5.1",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever 0.26.0",
+ "markup5ever 0.11.0",
+ "tendril 0.4.3",
+ "xml5ever 0.17.0",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril 0.5.1",
+ "xml5ever 0.38.0",
+]
 
 [[package]]
 name = "matchers"
@@ -3934,12 +4036,42 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -3948,8 +4080,28 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3958,8 +4110,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3968,11 +4130,33 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -3981,7 +4165,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -4442,6 +4635,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "readability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56596e20a6d3cf715182d9b6829220621e6e985cec04d00410cee29821b4220"
+dependencies = [
+ "html5ever 0.26.0",
+ "lazy_static",
+ "markup5ever_rcdom 0.2.0",
+ "regex",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,7 +5018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "siphasher",
+ "siphasher 1.0.1",
  "toml 0.8.23",
  "triomphe",
 ]
@@ -5407,6 +5613,12 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
@@ -5572,8 +5784,46 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -5726,6 +5976,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5754,8 +6024,8 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -5791,10 +6061,10 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2 0.10.9",
  "signal-hook",
- "siphasher",
+ "siphasher 1.0.1",
  "terminfo",
  "termios",
  "thiserror 1.0.69",
@@ -6443,6 +6713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6659,6 +6935,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -7242,6 +7530,27 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -80,9 +80,11 @@ tiny_http = "0.12"
 globset = "0.4"
 ignore = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }
+htmd = "0.5.4"
 lru = "0.18"
 parking_lot = "0.12"
 pdf-extract = { version = "0.12", optional = true }
+readability = { version = "0.3.0", default-features = false }
 tar = "0.4"
 flate2 = "1.1"
 sha2.workspace = true

--- a/crates/tui/src/artifacts.rs
+++ b/crates/tui/src/artifacts.rs
@@ -69,6 +69,26 @@ pub fn session_artifact_relative_path(artifact_id: &str) -> PathBuf {
     PathBuf::from(ARTIFACTS_DIR_NAME).join(format!("{artifact_id}.txt"))
 }
 
+fn session_artifact_relative_path_with_extension(
+    artifact_id: &str,
+    extension: &str,
+) -> io::Result<PathBuf> {
+    let artifact_id = sanitize_id_component(artifact_id);
+    let extension = extension.trim_start_matches('.').to_ascii_lowercase();
+    if artifact_id.is_empty()
+        || extension.is_empty()
+        || !extension
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "artifact id and extension must contain safe ASCII characters",
+        ));
+    }
+    Ok(PathBuf::from(ARTIFACTS_DIR_NAME).join(format!("{artifact_id}.{extension}")))
+}
+
 fn artifact_sessions_root() -> Option<PathBuf> {
     #[cfg(test)]
     if let Some(root) = TEST_ARTIFACT_SESSIONS_ROOT
@@ -132,6 +152,29 @@ pub fn write_session_artifact(
         std::fs::create_dir_all(parent)?;
     }
     crate::utils::write_atomic(&absolute_path, content.as_bytes())?;
+    Ok((absolute_path, relative_path))
+}
+
+/// Write arbitrary fetched bytes into a session artifact with a validated
+/// extension. Media fetches use this after magic-byte validation.
+pub fn write_session_artifact_bytes(
+    session_id: &str,
+    artifact_id: &str,
+    extension: &str,
+    content: &[u8],
+) -> io::Result<(PathBuf, PathBuf)> {
+    let relative_path = session_artifact_relative_path_with_extension(artifact_id, extension)?;
+    let absolute_path =
+        session_artifact_absolute_path(session_id, &relative_path).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "could not resolve session artifact path (missing home directory)",
+            )
+        })?;
+    if let Some(parent) = absolute_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::utils::write_atomic(&absolute_path, content)?;
     Ok((absolute_path, relative_path))
 }
 
@@ -311,5 +354,23 @@ mod tests {
                 .join("artifacts")
                 .join("art_call-big.txt")
         );
+    }
+
+    #[test]
+    fn binary_session_artifact_uses_validated_extension_and_exact_bytes() {
+        let _guard = TEST_ARTIFACT_SESSIONS_GUARD
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _root = set_test_sessions_root(tmp.path().join("sessions"));
+        let bytes = b"\x89PNG\r\n\x1a\nfixture";
+
+        let (absolute, relative) =
+            write_session_artifact_bytes("session-123", "web/media", ".PNG", bytes)
+                .expect("write binary artifact");
+
+        assert_eq!(relative, PathBuf::from("artifacts/web_media.png"));
+        assert_eq!(std::fs::read(absolute).unwrap(), bytes);
+        assert!(write_session_artifact_bytes("session-123", "bad", "../png", bytes).is_err());
     }
 }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3513,6 +3513,11 @@ impl Engine {
             authority.auto_approve,
         )
         .with_state_namespace(self.session.id.clone())
+        .with_route_context_window(crate::route_budget::route_context_window_tokens(
+            self.api_provider,
+            &self.session.model,
+            self.config.active_route_limits,
+        ))
         .with_review_plan_changes(matches!(mode, AppMode::Plan))
         .with_features(self.config.features.clone())
         .with_shell_manager(self.shell_manager.clone())

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -15,6 +15,9 @@ use super::web::extract::{DocumentKind, ExtractedDocument, extract_document};
 use super::web::fetch::{
     DEFAULT_MAX_BYTES, DEFAULT_TIMEOUT, FetchOptions, HARD_MAX_BYTES, HARD_MAX_TIMEOUT, fetch,
 };
+use super::web::overflow::bound_text as bound_web_text;
+#[cfg(test)]
+use super::web::overflow::inline_char_budget;
 use async_trait::async_trait;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -164,33 +167,45 @@ impl ToolSpec for FetchUrlTool {
         )
         .await?;
         let is_success = (200..300).contains(&fetched.status);
-        let body_text = String::from_utf8_lossy(&fetched.bytes).into_owned();
-        let fields = project_json_fields(&body_text, &fetched.content_type, &requested_fields)?;
+        let mut body_text = (!requested_fields.is_empty())
+            .then(|| String::from_utf8_lossy(&fetched.bytes).into_owned());
+        let fields = match body_text.as_deref() {
+            Some(body) => project_json_fields(body, &fetched.content_type, &requested_fields)?,
+            None => None,
+        };
         let extracted =
             match extract_document(&fetched.url, Some(&fetched.content_type), &fetched.bytes) {
                 Ok(document) => document,
                 Err(_error)
                     if format == Format::Raw && is_declared_textual(&fetched.content_type) =>
                 {
+                    let body_text = body_text
+                        .get_or_insert_with(|| String::from_utf8_lossy(&fetched.bytes).into_owned())
+                        .clone();
                     ExtractedDocument {
                         kind: DocumentKind::Text,
                         title: None,
                         text: body_text.clone(),
-                        markdown: body_text.clone(),
+                        markdown: body_text,
                         cleaned_html: None,
                         pdf_pages: None,
                         media_extension: None,
                     }
                 }
-                Err(_error) if !is_success => ExtractedDocument {
-                    kind: DocumentKind::Text,
-                    title: None,
-                    text: body_text.clone(),
-                    markdown: body_text.clone(),
-                    cleaned_html: None,
-                    pdf_pages: None,
-                    media_extension: None,
-                },
+                Err(_error) if !is_success => {
+                    let body_text = body_text
+                        .get_or_insert_with(|| String::from_utf8_lossy(&fetched.bytes).into_owned())
+                        .clone();
+                    ExtractedDocument {
+                        kind: DocumentKind::Text,
+                        title: None,
+                        text: body_text.clone(),
+                        markdown: body_text,
+                        cleaned_html: None,
+                        pdf_pages: None,
+                        media_extension: None,
+                    }
+                }
                 Err(error) => return Err(error),
             };
 
@@ -306,70 +321,25 @@ fn render_extracted(
     bound_text(url, content, context)
 }
 
-fn web_inline_char_budget(context: &ToolContext) -> usize {
-    context
-        .route_context_window
-        .map(|tokens| {
-            let chars = u64::from(tokens).saturating_mul(4).saturating_mul(3) / 100;
-            usize::try_from(chars).unwrap_or(100_000)
-        })
-        .unwrap_or(100_000)
-        .clamp(1, 100_000)
-}
-
 fn bound_text(
     url: &str,
     content: String,
     context: &ToolContext,
 ) -> Result<(String, Option<ArtifactWrite>), ToolError> {
-    let budget = web_inline_char_budget(context);
-    if content.chars().count() <= budget {
-        return Ok((content, None));
-    }
-
-    let artifact = write_text_artifact(url, &content, context)?;
-    let relative = crate::artifacts::format_artifact_relative_path(&artifact.relative_path);
-    let mut head = content
-        .chars()
-        .take(budget.saturating_sub(256))
-        .collect::<String>();
-    let mut footer = fetch_overflow_footer(&relative, head.len(), content.len());
-    let allowed_head = budget.saturating_sub(footer.chars().count());
-    head = content.chars().take(allowed_head).collect();
-    footer = fetch_overflow_footer(&relative, head.len(), content.len());
-    while !head.is_empty() && head.chars().count() + footer.chars().count() > budget {
-        head.pop();
-        footer = fetch_overflow_footer(&relative, head.len(), content.len());
-    }
-    Ok((format!("{head}{footer}"), Some(artifact)))
-}
-
-fn fetch_overflow_footer(relative: &str, head_bytes: usize, total_bytes: usize) -> String {
-    format!(
-        "\n\n[Content overflow: first {head_bytes} of {total_bytes} bytes shown; full page saved to {relative}. Recovery: call retrieve_tool_result with ref={relative}.]"
-    )
-}
-
-fn write_text_artifact(
-    url: &str,
-    content: &str,
-    context: &ToolContext,
-) -> Result<ArtifactWrite, ToolError> {
-    let artifact_id = fetch_artifact_id(url, content.as_bytes());
-    let (absolute_path, relative_path) =
-        crate::artifacts::write_session_artifact(&context.state_namespace, &artifact_id, content)
-            .map_err(|error| {
-            ToolError::execution_failed(format!(
-                "failed to preserve fetched content artifact: {error}"
-            ))
-        })?;
-    Ok(ArtifactWrite {
-        session_id: context.state_namespace.clone(),
-        absolute_path,
-        relative_path,
-        byte_size: content.len() as u64,
-        preview: content.chars().take(200).collect(),
-    })
+    let bounded = bound_web_text(
+        content,
+        context,
+        |body| fetch_artifact_id(url, body.as_bytes()),
+        "page",
+    )?;
+    let artifact = bounded.artifact.map(|artifact| ArtifactWrite {
+        session_id: artifact.session_id,
+        absolute_path: artifact.absolute_path,
+        relative_path: artifact.relative_path,
+        byte_size: artifact.byte_size,
+        preview: artifact.preview,
+    });
+    Ok((bounded.content, artifact))
 }
 
 fn write_binary_artifact(
@@ -512,7 +482,7 @@ mod tests {
         let artifact = artifact.expect("overflow artifact");
 
         assert!(inline.contains("retrieve_tool_result"));
-        assert!(inline.chars().count() <= web_inline_char_budget(&context));
+        assert!(inline.chars().count() <= inline_char_budget(&context));
         assert_eq!(
             std::fs::read_to_string(artifact.absolute_path).unwrap(),
             full

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -11,40 +11,17 @@ use super::handle::query_jsonpath;
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, optional_u64,
 };
-use super::web::guard::{guarded_reqwest_client_builder, validate_fetch_target};
+use super::web::extract::{DocumentKind, ExtractedDocument, extract_document};
+use super::web::fetch::{
+    DEFAULT_MAX_BYTES, DEFAULT_TIMEOUT, FetchOptions, HARD_MAX_BYTES, HARD_MAX_TIMEOUT, fetch,
+};
 use async_trait::async_trait;
-use regex::Regex;
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
-use std::sync::OnceLock;
 use std::time::Duration;
 
-const DEFAULT_MAX_BYTES: u64 = 1_000_000;
-const HARD_MAX_BYTES: u64 = 10 * 1024 * 1024;
-const DEFAULT_TIMEOUT_MS: u64 = 15_000;
-const HARD_MAX_TIMEOUT_MS: u64 = 60_000;
-const MAX_REDIRECTS: usize = 5;
-const USER_AGENT: &str =
-    "Mozilla/5.0 (compatible; codewhale/0.5; +https://github.com/Hmbown/CodeWhale)";
-
-static SCRIPT_RE: OnceLock<Regex> = OnceLock::new();
-static STYLE_RE: OnceLock<Regex> = OnceLock::new();
-static TAG_RE: OnceLock<Regex> = OnceLock::new();
-static WHITESPACE_RE: OnceLock<Regex> = OnceLock::new();
-
-fn script_re() -> &'static Regex {
-    SCRIPT_RE.get_or_init(|| Regex::new(r"(?is)<script[^>]*>.*?</script>").expect("script re"))
-}
-fn style_re() -> &'static Regex {
-    STYLE_RE.get_or_init(|| Regex::new(r"(?is)<style[^>]*>.*?</style>").expect("style re"))
-}
-fn tag_re() -> &'static Regex {
-    TAG_RE.get_or_init(|| Regex::new(r"<[^>]+>").expect("tag re"))
-}
-fn whitespace_re() -> &'static Regex {
-    WHITESPACE_RE.get_or_init(|| Regex::new(r"\s+").expect("ws re"))
-}
+const FETCH_ACCEPT: &str = "text/html,text/markdown,text/plain,application/json,application/pdf,image/*,audio/*,video/*,*/*;q=0.5";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Format {
@@ -79,8 +56,27 @@ struct FetchResponse {
     content_type: String,
     content: String,
     truncated: bool,
+    receipt: FetchReceipt,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifact: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     fields: Option<BTreeMap<String, Vec<Value>>>,
+}
+
+#[derive(Debug, Serialize)]
+struct FetchReceipt {
+    cache_hit: bool,
+    retries: usize,
+    redirects: usize,
+}
+
+#[derive(Debug)]
+struct ArtifactWrite {
+    session_id: String,
+    absolute_path: std::path::PathBuf,
+    relative_path: std::path::PathBuf,
+    byte_size: u64,
+    preview: String,
 }
 
 pub struct FetchUrlTool;
@@ -106,7 +102,7 @@ impl ToolSpec for FetchUrlTool {
                 "format": {
                     "type": "string",
                     "enum": ["text", "markdown", "raw"],
-                    "description": "Post-processing for the response body. `markdown` (default) and `text` strip HTML tags to readable text; `raw` returns the body bytes as-is."
+                    "description": "Post-processing for the response body. `markdown` (default) uses readability extraction and real HTML-to-Markdown conversion; `text` returns readable plain text; `raw` preserves textual response bytes. Binary media is saved as a session artifact."
                 },
                 "max_bytes": {
                     "type": "integer",
@@ -153,119 +149,272 @@ impl ToolSpec for FetchUrlTool {
         }
 
         let format = Format::parse(input.get("format").and_then(Value::as_str))?;
-        let max_bytes = optional_u64(&input, "max_bytes", DEFAULT_MAX_BYTES).min(HARD_MAX_BYTES);
-        let timeout_ms =
-            optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT_MS).min(HARD_MAX_TIMEOUT_MS);
+        let max_bytes =
+            usize::try_from(optional_u64(&input, "max_bytes", DEFAULT_MAX_BYTES as u64))
+                .unwrap_or(HARD_MAX_BYTES)
+                .clamp(1, HARD_MAX_BYTES);
+        let timeout_ms = optional_u64(&input, "timeout_ms", DEFAULT_TIMEOUT.as_millis() as u64)
+            .clamp(1, HARD_MAX_TIMEOUT.as_millis() as u64);
         let requested_fields = parse_fields(&input)?;
-        let mut current_url = reqwest::Url::parse(&url)
-            .map_err(|e| ToolError::invalid_input(format!("invalid URL: {e}")))?;
-        let mut redirects_followed = 0usize;
-
-        let resp = loop {
-            let dns_pinning = validate_fetch_target(&current_url, context, "fetch_url").await?;
-            let mut client_builder = guarded_reqwest_client_builder()
-                .timeout(Duration::from_millis(timeout_ms))
-                .user_agent(USER_AGENT)
-                .redirect(reqwest::redirect::Policy::none());
-
-            // Pin validated IP to prevent DNS rebinding (TOCTOU) — reqwest will
-            // connect to the validated IP directly instead of re-resolving.
-            if let Some((hostname, validated_ip)) = dns_pinning {
-                client_builder =
-                    client_builder.resolve(&hostname, std::net::SocketAddr::new(validated_ip, 0));
-            }
-
-            let client = client_builder.build().map_err(|e| {
-                ToolError::execution_failed(format!("failed to build HTTP client: {e}"))
-            })?;
-
-            let resp = client
-                .get(current_url.clone())
-                .header("Accept", "text/html,text/plain,application/json,*/*;q=0.5")
-                .header("Accept-Language", "en-US,en;q=0.5")
-                .send()
-                .await
-                .map_err(|e| ToolError::execution_failed(format!("request failed: {e}")))?;
-
-            if !resp.status().is_redirection() || redirects_followed >= MAX_REDIRECTS {
-                break resp;
-            }
-
-            let Some(location) = resp
-                .headers()
-                .get(reqwest::header::LOCATION)
-                .and_then(|value| value.to_str().ok())
-            else {
-                break resp;
+        let fetched = fetch(
+            &url,
+            &FetchOptions::new(Duration::from_millis(timeout_ms), max_bytes, FETCH_ACCEPT),
+            context,
+            "fetch_url",
+        )
+        .await?;
+        let is_success = (200..300).contains(&fetched.status);
+        let body_text = String::from_utf8_lossy(&fetched.bytes).into_owned();
+        let fields = project_json_fields(&body_text, &fetched.content_type, &requested_fields)?;
+        let extracted =
+            match extract_document(&fetched.url, Some(&fetched.content_type), &fetched.bytes) {
+                Ok(document) => document,
+                Err(_error)
+                    if format == Format::Raw && is_declared_textual(&fetched.content_type) =>
+                {
+                    ExtractedDocument {
+                        kind: DocumentKind::Text,
+                        title: None,
+                        text: body_text.clone(),
+                        markdown: body_text.clone(),
+                        cleaned_html: None,
+                        pdf_pages: None,
+                        media_extension: None,
+                    }
+                }
+                Err(_error) if !is_success => ExtractedDocument {
+                    kind: DocumentKind::Text,
+                    title: None,
+                    text: body_text.clone(),
+                    markdown: body_text.clone(),
+                    cleaned_html: None,
+                    pdf_pages: None,
+                    media_extension: None,
+                },
+                Err(error) => return Err(error),
             };
 
-            current_url = resp.url().join(location).map_err(|e| {
-                ToolError::execution_failed(format!("invalid redirect location: {e}"))
-            })?;
-            redirects_followed += 1;
-        };
-
-        let final_url = resp.url().to_string();
-        let status = resp.status();
-        let content_type = resp
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream")
-            .to_string();
-        let headers = response_headers(resp.headers());
-
-        let bytes = resp
-            .bytes()
-            .await
-            .map_err(|e| ToolError::execution_failed(format!("failed to read body: {e}")))?;
-        let total_bytes = bytes.len() as u64;
-        let truncated = total_bytes > max_bytes;
-        let usable = if truncated {
-            &bytes[..max_bytes as usize]
-        } else {
-            &bytes[..]
-        };
-
-        let body_text = String::from_utf8_lossy(usable).to_string();
-        let fields = project_json_fields(&body_text, &content_type, &requested_fields)?;
-        let processed = match format {
-            Format::Raw => body_text,
-            Format::Text | Format::Markdown => {
-                if content_type.contains("text/html") || body_text.contains("<html") {
-                    html_to_text(&body_text)
-                } else {
-                    body_text
-                }
-            }
-        };
+        let (processed, artifact_write) = render_extracted(
+            &fetched.url,
+            &fetched.content_type,
+            format,
+            extracted,
+            &fetched.bytes,
+            context,
+        )?;
+        let artifact = artifact_write
+            .as_ref()
+            .map(|write| crate::artifacts::format_artifact_relative_path(&write.relative_path));
 
         let response = FetchResponse {
-            url: final_url,
-            status: status.as_u16(),
-            headers,
-            content_type,
+            url: fetched.url,
+            status: fetched.status,
+            headers: fetched.headers,
+            content_type: fetched.content_type,
             content: processed,
-            truncated,
+            truncated: fetched.truncated,
+            receipt: FetchReceipt {
+                cache_hit: fetched.cache_hit,
+                retries: fetched.retries,
+                redirects: fetched.redirects,
+            },
+            artifact,
             fields,
         };
 
-        if !status.is_success() {
+        let content = serde_json::to_string_pretty(&response).map_err(|error| {
+            ToolError::execution_failed(format!("failed to serialize response: {error}"))
+        })?;
+        let metadata = artifact_write.map(artifact_metadata);
+
+        if !is_success {
             // Don't `Err` on 4xx/5xx — the caller often wants to see the body
             // (e.g. a JSON error envelope). Mark the result as a failure so the
             // engine renders it as such.
             return Ok(ToolResult {
-                content: serde_json::to_string_pretty(&response).map_err(|e| {
-                    ToolError::execution_failed(format!("failed to serialize response: {e}"))
-                })?,
+                content,
                 success: false,
-                metadata: None,
+                metadata,
             });
         }
 
-        ToolResult::json(&response)
-            .map_err(|e| ToolError::execution_failed(format!("failed to serialize response: {e}")))
+        Ok(ToolResult {
+            content,
+            success: true,
+            metadata,
+        })
     }
+}
+
+fn is_declared_textual(content_type: &str) -> bool {
+    let content_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    content_type.starts_with("text/")
+        || content_type.contains("html")
+        || content_type.contains("json")
+        || content_type.contains("xml")
+        || content_type.contains("yaml")
+        || content_type.contains("javascript")
+}
+
+fn render_extracted(
+    url: &str,
+    content_type: &str,
+    format: Format,
+    document: ExtractedDocument,
+    bytes: &[u8],
+    context: &ToolContext,
+) -> Result<(String, Option<ArtifactWrite>), ToolError> {
+    if document.kind == DocumentKind::Pdf && format != Format::Raw {
+        let extracted = match format {
+            Format::Text => document.text,
+            Format::Markdown => document.markdown,
+            Format::Raw => unreachable!("raw PDF handled below"),
+        };
+        return bound_text(url, extracted, context);
+    }
+
+    if document.kind == DocumentKind::Media || document.kind == DocumentKind::Pdf {
+        let extension = document
+            .media_extension
+            .unwrap_or(if document.kind == DocumentKind::Pdf {
+                "pdf"
+            } else {
+                "bin"
+            });
+        let artifact = write_binary_artifact(url, extension, bytes, context)?;
+        let relative = crate::artifacts::format_artifact_relative_path(&artifact.relative_path);
+        let label = if document.kind == DocumentKind::Pdf {
+            "PDF"
+        } else {
+            "media"
+        };
+        let content =
+            format!("[{label} response saved to {relative}; content type: {content_type}.]");
+        return Ok((content, Some(artifact)));
+    }
+
+    let content = match format {
+        Format::Raw => String::from_utf8_lossy(bytes).into_owned(),
+        Format::Text => document.text,
+        Format::Markdown => document.markdown,
+    };
+    bound_text(url, content, context)
+}
+
+fn web_inline_char_budget(context: &ToolContext) -> usize {
+    context
+        .route_context_window
+        .map(|tokens| {
+            let chars = u64::from(tokens).saturating_mul(4).saturating_mul(3) / 100;
+            usize::try_from(chars).unwrap_or(100_000)
+        })
+        .unwrap_or(100_000)
+        .clamp(1, 100_000)
+}
+
+fn bound_text(
+    url: &str,
+    content: String,
+    context: &ToolContext,
+) -> Result<(String, Option<ArtifactWrite>), ToolError> {
+    let budget = web_inline_char_budget(context);
+    if content.chars().count() <= budget {
+        return Ok((content, None));
+    }
+
+    let artifact = write_text_artifact(url, &content, context)?;
+    let relative = crate::artifacts::format_artifact_relative_path(&artifact.relative_path);
+    let mut head = content
+        .chars()
+        .take(budget.saturating_sub(256))
+        .collect::<String>();
+    let mut footer = fetch_overflow_footer(&relative, head.len(), content.len());
+    let allowed_head = budget.saturating_sub(footer.chars().count());
+    head = content.chars().take(allowed_head).collect();
+    footer = fetch_overflow_footer(&relative, head.len(), content.len());
+    while !head.is_empty() && head.chars().count() + footer.chars().count() > budget {
+        head.pop();
+        footer = fetch_overflow_footer(&relative, head.len(), content.len());
+    }
+    Ok((format!("{head}{footer}"), Some(artifact)))
+}
+
+fn fetch_overflow_footer(relative: &str, head_bytes: usize, total_bytes: usize) -> String {
+    format!(
+        "\n\n[Content overflow: first {head_bytes} of {total_bytes} bytes shown; full page saved to {relative}. Recovery: call retrieve_tool_result with ref={relative}.]"
+    )
+}
+
+fn write_text_artifact(
+    url: &str,
+    content: &str,
+    context: &ToolContext,
+) -> Result<ArtifactWrite, ToolError> {
+    let artifact_id = fetch_artifact_id(url, content.as_bytes());
+    let (absolute_path, relative_path) =
+        crate::artifacts::write_session_artifact(&context.state_namespace, &artifact_id, content)
+            .map_err(|error| {
+            ToolError::execution_failed(format!(
+                "failed to preserve fetched content artifact: {error}"
+            ))
+        })?;
+    Ok(ArtifactWrite {
+        session_id: context.state_namespace.clone(),
+        absolute_path,
+        relative_path,
+        byte_size: content.len() as u64,
+        preview: content.chars().take(200).collect(),
+    })
+}
+
+fn write_binary_artifact(
+    url: &str,
+    extension: &str,
+    bytes: &[u8],
+    context: &ToolContext,
+) -> Result<ArtifactWrite, ToolError> {
+    let artifact_id = fetch_artifact_id(url, bytes);
+    let (absolute_path, relative_path) = crate::artifacts::write_session_artifact_bytes(
+        &context.state_namespace,
+        &artifact_id,
+        extension,
+        bytes,
+    )
+    .map_err(|error| {
+        ToolError::execution_failed(format!(
+            "failed to preserve fetched media artifact: {error}"
+        ))
+    })?;
+    Ok(ArtifactWrite {
+        session_id: context.state_namespace.clone(),
+        absolute_path,
+        relative_path,
+        byte_size: bytes.len() as u64,
+        preview: format!("Fetched {extension} artifact from {url}"),
+    })
+}
+
+fn fetch_artifact_id(url: &str, bytes: &[u8]) -> String {
+    let mut identity = Vec::with_capacity(url.len() + bytes.len());
+    identity.extend_from_slice(url.as_bytes());
+    identity.extend_from_slice(bytes);
+    let digest = crate::hashing::sha256_hex(&identity);
+    format!("fetch_{}", &digest[..16])
+}
+
+fn artifact_metadata(write: ArtifactWrite) -> Value {
+    json!({
+        "spillover_path": write.absolute_path.display().to_string(),
+        "artifact_session_id": write.session_id,
+        "artifact_relative_path": crate::artifacts::format_artifact_relative_path(&write.relative_path),
+        "artifact_byte_size": write.byte_size,
+        "artifact_preview": write.preview,
+    })
 }
 
 fn parse_fields(input: &Value) -> Result<Vec<String>, ToolError> {
@@ -288,18 +437,6 @@ fn parse_fields(input: &Value) -> Result<Vec<String>, ToolError> {
         }
     }
     Ok(fields)
-}
-
-fn response_headers(headers: &reqwest::header::HeaderMap) -> BTreeMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
-        })
-        .collect()
 }
 
 fn project_json_fields(
@@ -328,61 +465,22 @@ fn project_json_fields(
     Ok(Some(out))
 }
 
-/// Strip `<script>` / `<style>` blocks, drop remaining tags, and collapse
-/// whitespace. Good enough for "let the model read this page" — not a full
-/// HTML-to-Markdown converter.
-fn html_to_text(html: &str) -> String {
-    let no_script = script_re().replace_all(html, "");
-    let no_style = style_re().replace_all(&no_script, "");
-    let no_tags = tag_re().replace_all(&no_style, " ");
-    let decoded = decode_entities(&no_tags);
-    whitespace_re()
-        .replace_all(&decoded, " ")
-        .trim()
-        .to_string()
-}
-
-/// Decode the handful of HTML entities we expect to hit in stripped text.
-/// Pulling in `html-escape` for the long tail isn't worth the dep weight.
-fn decode_entities(s: &str) -> String {
-    s.replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-        .replace("&apos;", "'")
-        .replace("&nbsp;", " ")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tools::spec::ToolContext;
     use std::path::PathBuf;
 
-    fn ctx() -> ToolContext {
-        ToolContext::new(PathBuf::from("."))
+    struct ArtifactRootRestore(Option<PathBuf>);
+
+    impl Drop for ArtifactRootRestore {
+        fn drop(&mut self) {
+            crate::artifacts::set_test_artifact_sessions_root(self.0.take());
+        }
     }
 
-    #[test]
-    fn html_to_text_strips_scripts_styles_and_tags() {
-        let html = r#"
-            <html>
-              <head>
-                <style>body { color: red; }</style>
-                <script>alert("nope");</script>
-              </head>
-              <body>
-                <h1>Hello &amp; welcome</h1>
-                <p>This is <b>important</b>.</p>
-              </body>
-            </html>
-        "#;
-        let text = html_to_text(html);
-        assert!(text.contains("Hello & welcome"));
-        assert!(text.contains("This is important"));
-        assert!(!text.contains("alert"));
-        assert!(!text.contains("color: red"));
+    fn ctx() -> ToolContext {
+        ToolContext::new(PathBuf::from("."))
     }
 
     #[test]
@@ -393,6 +491,32 @@ mod tests {
         assert_eq!(Format::parse(Some("raw")).unwrap(), Format::Raw);
         assert_eq!(Format::parse(None).unwrap(), Format::Markdown);
         assert!(Format::parse(Some("yaml")).is_err());
+    }
+
+    #[test]
+    fn route_budget_overflow_round_trips_through_session_artifact() {
+        let _lock = crate::artifacts::TEST_ARTIFACT_SESSIONS_GUARD
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let prior =
+            crate::artifacts::set_test_artifact_sessions_root(Some(tmp.path().join("sessions")));
+        let _restore = ArtifactRootRestore(prior);
+        let context = ToolContext::new(".")
+            .with_state_namespace("fetch-overflow")
+            .with_route_context_window(10_000);
+        let full = "Whale content. ".repeat(200);
+
+        let (inline, artifact) =
+            bound_text("https://example.com/large", full.clone(), &context).unwrap();
+        let artifact = artifact.expect("overflow artifact");
+
+        assert!(inline.contains("retrieve_tool_result"));
+        assert!(inline.chars().count() <= web_inline_char_budget(&context));
+        assert_eq!(
+            std::fs::read_to_string(artifact.absolute_path).unwrap(),
+            full
+        );
     }
 
     #[test]

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -195,6 +195,9 @@ pub struct ToolContext {
     pub features: Features,
     /// Namespace for tool state that should be scoped to the current session/thread.
     pub state_namespace: String,
+    /// Effective context window for the active provider/model route. Web tools
+    /// use this to keep inline page content below three percent of the route.
+    pub route_context_window: Option<u32>,
     /// User-trusted external paths the agent may read/write even when they
     /// fall outside `workspace`. Loaded from `~/.deepseek/workspace-trust.json`
     /// and refreshed when the user runs `/trust add <path>`. Distinct from
@@ -292,6 +295,7 @@ impl ToolContext {
             shell_policy: ShellPolicy::Full,
             features: Features::with_defaults(),
             state_namespace: "workspace".to_string(),
+            route_context_window: None,
             trusted_external_paths: Vec::new(),
             follow_symlinks: false,
             network_policy: None,
@@ -339,6 +343,7 @@ impl ToolContext {
             shell_policy: ShellPolicy::Full,
             features: Features::with_defaults(),
             state_namespace: "workspace".to_string(),
+            route_context_window: None,
             trusted_external_paths: Vec::new(),
             follow_symlinks: false,
             network_policy: None,
@@ -386,6 +391,7 @@ impl ToolContext {
             shell_policy: ShellPolicy::Full,
             features: Features::with_defaults(),
             state_namespace: "workspace".to_string(),
+            route_context_window: None,
             trusted_external_paths: Vec::new(),
             follow_symlinks: false,
             network_policy: None,
@@ -801,6 +807,13 @@ impl ToolContext {
     /// Set the namespace used for session-scoped tool state.
     pub fn with_state_namespace(mut self, namespace: impl Into<String>) -> Self {
         self.state_namespace = namespace.into();
+        self
+    }
+
+    /// Attach the active route's effective context window.
+    #[must_use]
+    pub fn with_route_context_window(mut self, context_window: u32) -> Self {
+        self.route_context_window = (context_window > 0).then_some(context_window);
         self
     }
 

--- a/crates/tui/src/tools/web/cache.rs
+++ b/crates/tui/src/tools/web/cache.rs
@@ -1,0 +1,141 @@
+//! Small session-scoped TTL cache for fetched response bodies.
+
+use std::num::NonZeroUsize;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use lru::LruCache;
+use parking_lot::Mutex;
+
+const FETCH_CACHE_ENTRIES: usize = 256;
+const FETCH_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+
+static FETCH_CACHE: OnceLock<Mutex<LruCache<FetchCacheKey, FetchCacheEntry>>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FetchCacheKey {
+    namespace: String,
+    url: String,
+    accept: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CachedFetch {
+    pub(crate) url: String,
+    pub(crate) status: u16,
+    pub(crate) headers: std::collections::BTreeMap<String, String>,
+    pub(crate) content_type: String,
+    pub(crate) bytes: Arc<Vec<u8>>,
+    pub(crate) truncated: bool,
+    pub(crate) redirects: usize,
+}
+
+#[derive(Debug, Clone)]
+struct FetchCacheEntry {
+    fetched_at: Instant,
+    payload: CachedFetch,
+}
+
+fn cache() -> &'static Mutex<LruCache<FetchCacheKey, FetchCacheEntry>> {
+    FETCH_CACHE.get_or_init(|| {
+        Mutex::new(LruCache::new(
+            NonZeroUsize::new(FETCH_CACHE_ENTRIES).expect("non-zero cache capacity"),
+        ))
+    })
+}
+
+fn key(namespace: &str, url: &reqwest::Url, accept: &str) -> FetchCacheKey {
+    let mut canonical = url.clone();
+    canonical.set_fragment(None);
+    FetchCacheKey {
+        namespace: namespace.to_string(),
+        url: canonical.to_string(),
+        accept: accept.to_string(),
+    }
+}
+
+pub(crate) fn get(
+    namespace: &str,
+    url: &reqwest::Url,
+    accept: &str,
+    max_bytes: usize,
+) -> Option<CachedFetch> {
+    let key = key(namespace, url, accept);
+    let mut cache = cache().lock();
+    let entry = cache.get(&key)?.clone();
+    if entry.fetched_at.elapsed() > FETCH_CACHE_TTL {
+        cache.pop(&key);
+        return None;
+    }
+
+    // A truncated entry can answer an equal or smaller request. Asking for
+    // more is an explicit refetch so the cached cap never becomes permanent.
+    if entry.payload.truncated && max_bytes > entry.payload.bytes.len() {
+        cache.pop(&key);
+        return None;
+    }
+
+    let mut payload = entry.payload;
+    if payload.bytes.len() > max_bytes {
+        payload.bytes = Arc::new(payload.bytes[..max_bytes].to_vec());
+        payload.truncated = true;
+    }
+    Some(payload)
+}
+
+pub(crate) fn insert(namespace: &str, url: &reqwest::Url, accept: &str, payload: CachedFetch) {
+    cache().lock().put(
+        key(namespace, url, accept),
+        FetchCacheEntry {
+            fetched_at: Instant::now(),
+            payload,
+        },
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn reset() {
+    cache().lock().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(bytes: &[u8], truncated: bool) -> CachedFetch {
+        CachedFetch {
+            url: "https://example.com/doc".to_string(),
+            status: 200,
+            headers: Default::default(),
+            content_type: "text/plain".to_string(),
+            bytes: Arc::new(bytes.to_vec()),
+            truncated,
+            redirects: 0,
+        }
+    }
+
+    #[test]
+    fn truncated_entry_refetches_only_when_request_asks_for_more() {
+        reset();
+        let url = reqwest::Url::parse("https://example.com/doc#fragment").unwrap();
+        insert("cache-unit", &url, "text/plain", payload(b"12345", true));
+
+        let same = get("cache-unit", &url, "text/plain", 5).expect("same cap hit");
+        assert!(same.truncated);
+        let smaller = get("cache-unit", &url, "text/plain", 3).expect("smaller cap hit");
+        assert_eq!(&*smaller.bytes, b"123");
+        assert!(smaller.truncated);
+        assert!(get("cache-unit", &url, "text/plain", 6).is_none());
+    }
+
+    #[test]
+    fn cache_is_scoped_by_session_and_accept_header() {
+        reset();
+        let url = reqwest::Url::parse("https://example.com/doc").unwrap();
+        insert("session-a", &url, "text/html", payload(b"body", false));
+
+        assert!(get("session-a", &url, "text/html", 10).is_some());
+        assert!(get("session-b", &url, "text/html", 10).is_none());
+        assert!(get("session-a", &url, "application/json", 10).is_none());
+    }
+}

--- a/crates/tui/src/tools/web/extract.rs
+++ b/crates/tui/src/tools/web/extract.rs
@@ -61,6 +61,7 @@ pub(crate) fn extract_document(
     bytes: &[u8],
 ) -> Result<ExtractedDocument, ToolError> {
     let declared = normalized_content_type(content_type);
+    let declared = declared.as_deref();
 
     if bytes.is_empty() {
         return Ok(ExtractedDocument {
@@ -297,11 +298,12 @@ fn decode_text(bytes: &[u8]) -> Result<String, ToolError> {
     Ok(String::from_utf8_lossy(bytes).into_owned())
 }
 
-fn normalized_content_type(content_type: Option<&str>) -> Option<&str> {
+fn normalized_content_type(content_type: Option<&str>) -> Option<String> {
     content_type
         .and_then(|value| value.split(';').next())
         .map(str::trim)
         .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
 }
 
 fn is_html(content_type: Option<&str>, url: &str, body: &str) -> bool {
@@ -617,6 +619,19 @@ mod tests {
         .expect("empty body");
         assert_eq!(document.kind, DocumentKind::Text);
         assert!(document.text.is_empty());
+    }
+
+    #[test]
+    fn content_type_matching_is_case_insensitive() {
+        let document = extract_document(
+            "https://example.com/document",
+            Some("Application/JSON; Charset=UTF-8"),
+            br#"{"status":"ok"}"#,
+        )
+        .expect("mixed-case JSON content type");
+
+        assert_eq!(document.kind, DocumentKind::Text);
+        assert_eq!(document.text, r#"{"status":"ok"}"#);
     }
 
     #[test]

--- a/crates/tui/src/tools/web/extract.rs
+++ b/crates/tui/src/tools/web/extract.rs
@@ -1,0 +1,638 @@
+//! Content-type routing and readable-document extraction for web tools.
+//!
+//! Networking deliberately lives elsewhere. This module accepts already
+//! fetched bytes and turns them into one normalized document so `fetch_url`
+//! and `web.run` cannot disagree about HTML, Markdown, PDF, or media handling.
+
+use std::sync::OnceLock;
+
+#[cfg(feature = "pdf")]
+use std::fmt::Display;
+
+use regex::Regex;
+
+use crate::tools::spec::ToolError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DocumentKind {
+    Html,
+    Markdown,
+    Text,
+    Pdf,
+    Media,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExtractedDocument {
+    pub(crate) kind: DocumentKind,
+    pub(crate) title: Option<String>,
+    pub(crate) text: String,
+    pub(crate) markdown: String,
+    /// Readability-cleaned HTML. `web.run` consumes this to retain clickable
+    /// links while avoiding page chrome and consent-banner noise.
+    pub(crate) cleaned_html: Option<String>,
+    pub(crate) pdf_pages: Option<Vec<Vec<String>>>,
+    /// Validated extension for image/audio/video artifacts.
+    pub(crate) media_extension: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MediaSignature {
+    extension: &'static str,
+    family: MediaFamily,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MediaFamily {
+    Image,
+    Audio,
+    Video,
+}
+
+static TITLE_RE: OnceLock<Regex> = OnceLock::new();
+static FALLBACK_RE: OnceLock<Vec<Regex>> = OnceLock::new();
+static PAGE_CHROME_RE: OnceLock<Regex> = OnceLock::new();
+static TAG_RE: OnceLock<Regex> = OnceLock::new();
+static WHITESPACE_RE: OnceLock<Regex> = OnceLock::new();
+
+pub(crate) fn extract_document(
+    url: &str,
+    content_type: Option<&str>,
+    bytes: &[u8],
+) -> Result<ExtractedDocument, ToolError> {
+    let declared = normalized_content_type(content_type);
+
+    if bytes.is_empty() {
+        return Ok(ExtractedDocument {
+            kind: DocumentKind::Text,
+            title: None,
+            text: String::new(),
+            markdown: String::new(),
+            cleaned_html: None,
+            pdf_pages: None,
+            media_extension: None,
+        });
+    }
+
+    if looks_like_pdf(bytes) || declared == Some("application/pdf") || url_is_pdf(url) {
+        if looks_like_pdf(bytes) && declared_media_family(declared).is_some() {
+            return Err(ToolError::execution_failed(format!(
+                "Response media type `{}` did not match its PDF bytes",
+                declared.unwrap_or("unknown")
+            )));
+        }
+        if !looks_like_pdf(bytes) {
+            return Err(ToolError::execution_failed(
+                "Response claimed to be a PDF, but its bytes did not contain a PDF signature",
+            ));
+        }
+        return extract_pdf(bytes);
+    }
+
+    if let Some(signature) = sniff_media(bytes) {
+        if let Some(declared_family) = declared_media_family(declared)
+            && declared_family != signature.family
+        {
+            return Err(ToolError::execution_failed(format!(
+                "Response media type `{}` did not match its bytes",
+                declared.unwrap_or("unknown")
+            )));
+        }
+        return Ok(ExtractedDocument {
+            kind: DocumentKind::Media,
+            title: None,
+            text: String::new(),
+            markdown: String::new(),
+            cleaned_html: None,
+            pdf_pages: None,
+            media_extension: Some(signature.extension),
+        });
+    }
+
+    if declared_media_family(declared).is_some() {
+        return Err(ToolError::execution_failed(format!(
+            "Response claimed media type `{}`, but its bytes did not match a supported media signature",
+            declared.unwrap_or("unknown")
+        )));
+    }
+
+    let body = decode_text(bytes)?;
+    if is_html(declared, url, &body) {
+        return extract_html(url, &body);
+    }
+    if is_markdown(declared, url) {
+        return Ok(ExtractedDocument {
+            kind: DocumentKind::Markdown,
+            title: markdown_title(&body),
+            text: body.clone(),
+            markdown: body,
+            cleaned_html: None,
+            pdf_pages: None,
+            media_extension: None,
+        });
+    }
+    if is_textual(declared, url) {
+        return Ok(ExtractedDocument {
+            kind: DocumentKind::Text,
+            title: None,
+            text: body.clone(),
+            markdown: body,
+            cleaned_html: None,
+            pdf_pages: None,
+            media_extension: None,
+        });
+    }
+
+    Err(ToolError::execution_failed(format!(
+        "Unsupported binary response type `{}`; use a dedicated download tool",
+        declared.unwrap_or("unknown")
+    )))
+}
+
+fn extract_html(url: &str, html: &str) -> Result<ExtractedDocument, ToolError> {
+    let parsed_url = reqwest::Url::parse(url)
+        .map_err(|err| ToolError::invalid_input(format!("invalid URL: {err}")))?;
+    let original_title = html_title(html);
+    let mut input = html.as_bytes();
+    let readable = readability::extractor::extract(&mut input, &parsed_url).ok();
+
+    let readable_html = readable
+        .as_ref()
+        .map(|product| product.content.trim())
+        .filter(|content| meaningful_html(content))
+        .map(ToOwned::to_owned);
+    let cleaned_html = readable_html
+        .or_else(|| fallback_main_html(html))
+        .ok_or_else(|| js_required_error(url))?;
+    let markdown = htmd::convert(&cleaned_html).map_err(|err| {
+        ToolError::execution_failed(format!(
+            "Failed to convert readable HTML to Markdown: {err}"
+        ))
+    })?;
+    let text = readable
+        .as_ref()
+        .map(|product| normalize_text(&product.text))
+        .filter(|content| meaningful_text(content))
+        .unwrap_or_else(|| html_to_plain_text(&cleaned_html));
+
+    if !meaningful_text(&text) && !meaningful_text(&markdown) {
+        return Err(js_required_error(url));
+    }
+
+    let title = readable
+        .map(|product| normalize_text(&product.title))
+        .filter(|value| !value.is_empty())
+        .or(original_title);
+
+    Ok(ExtractedDocument {
+        kind: DocumentKind::Html,
+        title,
+        text,
+        markdown,
+        cleaned_html: Some(cleaned_html),
+        pdf_pages: None,
+        media_extension: None,
+    })
+}
+
+fn fallback_main_html(html: &str) -> Option<String> {
+    let page_chrome = PAGE_CHROME_RE.get_or_init(|| {
+        Regex::new(concat!(
+            r"(?is)(?:<script(?:\s[^>]*)?>.*?</script\s*>",
+            r"|<style(?:\s[^>]*)?>.*?</style\s*>",
+            r"|<noscript(?:\s[^>]*)?>.*?</noscript\s*>",
+            r"|<nav(?:\s[^>]*)?>.*?</nav\s*>",
+            r"|<header(?:\s[^>]*)?>.*?</header\s*>",
+            r"|<footer(?:\s[^>]*)?>.*?</footer\s*>",
+            r"|<aside(?:\s[^>]*)?>.*?</aside\s*>",
+            r"|<form(?:\s[^>]*)?>.*?</form\s*>)",
+        ))
+        .expect("page chrome regex")
+    });
+    for re in FALLBACK_RE.get_or_init(|| {
+        ["article", "main", "body"]
+            .into_iter()
+            .map(|tag| {
+                Regex::new(&format!(r"(?is)<{tag}(?:\s[^>]*)?>(.*?)</{tag}\s*>"))
+                    .expect("fallback element regex")
+            })
+            .collect()
+    }) {
+        let Some(capture) = re.captures(html) else {
+            continue;
+        };
+        let Some(content) = capture.get(1) else {
+            continue;
+        };
+        let without_chrome = page_chrome.replace_all(content.as_str(), "");
+        if meaningful_html(&without_chrome) {
+            return Some(without_chrome.into_owned());
+        }
+    }
+    None
+}
+
+fn meaningful_html(html: &str) -> bool {
+    meaningful_text(&html_to_plain_text(html))
+}
+
+fn meaningful_text(text: &str) -> bool {
+    text.chars().filter(|ch| !ch.is_whitespace()).count() >= 32
+        && text.split_whitespace().count() >= 5
+}
+
+fn html_to_plain_text(html: &str) -> String {
+    let without_tags = TAG_RE
+        .get_or_init(|| Regex::new(r"(?s)<[^>]+>").expect("tag regex"))
+        .replace_all(html, " ");
+    normalize_text(&decode_common_entities(&without_tags))
+}
+
+fn normalize_text(text: &str) -> String {
+    WHITESPACE_RE
+        .get_or_init(|| Regex::new(r"\s+").expect("whitespace regex"))
+        .replace_all(text.trim(), " ")
+        .into_owned()
+}
+
+fn decode_common_entities(value: &str) -> String {
+    value
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+fn html_title(html: &str) -> Option<String> {
+    let capture = TITLE_RE
+        .get_or_init(|| {
+            Regex::new(r"(?is)<title(?:\s[^>]*)?>(.*?)</title\s*>").expect("title regex")
+        })
+        .captures(html)?;
+    let title = normalize_text(&decode_common_entities(capture.get(1)?.as_str()));
+    (!title.is_empty()).then_some(title)
+}
+
+fn markdown_title(body: &str) -> Option<String> {
+    body.lines().find_map(|line| {
+        let title = line.trim().strip_prefix("# ")?.trim();
+        (!title.is_empty()).then(|| title.to_string())
+    })
+}
+
+fn js_required_error(url: &str) -> ToolError {
+    ToolError::execution_failed(format!(
+        "No readable page content was found at {url}; the page may require JavaScript. Recovery: use browser automation for this URL."
+    ))
+}
+
+fn decode_text(bytes: &[u8]) -> Result<String, ToolError> {
+    if bytes.iter().take(8_192).any(|byte| *byte == 0) {
+        return Err(ToolError::execution_failed(
+            "Unsupported binary response contained NUL bytes",
+        ));
+    }
+    Ok(String::from_utf8_lossy(bytes).into_owned())
+}
+
+fn normalized_content_type(content_type: Option<&str>) -> Option<&str> {
+    content_type
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn is_html(content_type: Option<&str>, url: &str, body: &str) -> bool {
+    matches!(content_type, Some("text/html" | "application/xhtml+xml"))
+        || url_path_ends_with(url, &[".html", ".htm"])
+        || {
+            let prefix = body.trim_start().chars().take(64).collect::<String>();
+            let prefix = prefix.to_ascii_lowercase();
+            prefix.contains("<!doctype html") || prefix.contains("<html")
+        }
+}
+
+fn is_markdown(content_type: Option<&str>, url: &str) -> bool {
+    matches!(
+        content_type,
+        Some("text/markdown" | "text/x-markdown" | "application/markdown")
+    ) || url_path_ends_with(url, &[".md", ".markdown"])
+}
+
+fn is_textual(content_type: Option<&str>, url: &str) -> bool {
+    content_type.is_some_and(|value| {
+        value.starts_with("text/")
+            || value.contains("json")
+            || value.contains("xml")
+            || value.contains("yaml")
+            || value.contains("javascript")
+            || value == "application/sql"
+    }) || url_path_ends_with(
+        url,
+        &[
+            ".txt", ".json", ".jsonl", ".xml", ".yaml", ".yml", ".csv", ".tsv", ".rs", ".py",
+            ".js", ".ts", ".toml",
+        ],
+    )
+}
+
+fn url_is_pdf(url: &str) -> bool {
+    url_path_ends_with(url, &[".pdf"])
+}
+
+fn url_path_ends_with(url: &str, extensions: &[&str]) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .map(|parsed| parsed.path().to_ascii_lowercase())
+        .is_some_and(|path| extensions.iter().any(|extension| path.ends_with(extension)))
+}
+
+fn looks_like_pdf(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"%PDF-")
+}
+
+fn declared_media_family(content_type: Option<&str>) -> Option<MediaFamily> {
+    let content_type = content_type?;
+    if content_type.starts_with("image/") {
+        Some(MediaFamily::Image)
+    } else if content_type.starts_with("audio/") {
+        Some(MediaFamily::Audio)
+    } else if content_type.starts_with("video/") {
+        Some(MediaFamily::Video)
+    } else {
+        None
+    }
+}
+
+fn sniff_media(bytes: &[u8]) -> Option<MediaSignature> {
+    let trimmed = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .map(|start| &bytes[start..])
+        .unwrap_or(bytes);
+    let signature = if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        MediaSignature {
+            extension: "png",
+            family: MediaFamily::Image,
+        }
+    } else if bytes.starts_with(b"\xff\xd8\xff") {
+        MediaSignature {
+            extension: "jpg",
+            family: MediaFamily::Image,
+        }
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        MediaSignature {
+            extension: "gif",
+            family: MediaFamily::Image,
+        }
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        MediaSignature {
+            extension: "webp",
+            family: MediaFamily::Image,
+        }
+    } else if bytes.starts_with(b"ID3") || bytes.starts_with(b"\xff\xfb") {
+        MediaSignature {
+            extension: "mp3",
+            family: MediaFamily::Audio,
+        }
+    } else if bytes.starts_with(b"fLaC") {
+        MediaSignature {
+            extension: "flac",
+            family: MediaFamily::Audio,
+        }
+    } else if bytes.starts_with(b"OggS") {
+        MediaSignature {
+            extension: "ogg",
+            family: MediaFamily::Audio,
+        }
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WAVE" {
+        MediaSignature {
+            extension: "wav",
+            family: MediaFamily::Audio,
+        }
+    } else if bytes.len() >= 12 && &bytes[4..8] == b"ftyp" {
+        MediaSignature {
+            extension: "mp4",
+            family: MediaFamily::Video,
+        }
+    } else if bytes.starts_with(b"\x1aE\xdf\xa3") {
+        MediaSignature {
+            extension: "webm",
+            family: MediaFamily::Video,
+        }
+    } else if trimmed.starts_with(b"<svg")
+        || (trimmed.starts_with(b"<?xml")
+            && trimmed
+                .windows(4)
+                .take(1_024)
+                .any(|window| window.eq_ignore_ascii_case(b"<svg")))
+    {
+        MediaSignature {
+            extension: "svg",
+            family: MediaFamily::Image,
+        }
+    } else {
+        return None;
+    };
+    Some(signature)
+}
+
+#[cfg(feature = "pdf")]
+fn extract_pdf(bytes: &[u8]) -> Result<ExtractedDocument, ToolError> {
+    let text = guard_pdf_extract(|| pdf_extract::extract_text_from_mem(bytes))
+        .map_err(|err| ToolError::execution_failed(format!("PDF extract failed: {err}")))?;
+    let pages = split_pdf_pages(&text);
+    let text = pages
+        .iter()
+        .map(|page| page.join("\n"))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    Ok(ExtractedDocument {
+        kind: DocumentKind::Pdf,
+        title: Some("PDF Document".to_string()),
+        markdown: text.clone(),
+        text,
+        cleaned_html: None,
+        pdf_pages: Some(pages),
+        media_extension: None,
+    })
+}
+
+#[cfg(not(feature = "pdf"))]
+fn extract_pdf(_bytes: &[u8]) -> Result<ExtractedDocument, ToolError> {
+    Err(ToolError::execution_failed(
+        "PDF extraction is unavailable in this build",
+    ))
+}
+
+#[cfg(feature = "pdf")]
+fn guard_pdf_extract<T, E, F>(extract: F) -> Result<T, String>
+where
+    E: Display,
+    F: FnOnce() -> Result<T, E>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(extract)) {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => Err(err.to_string()),
+        Err(payload) => Err(format!(
+            "extractor panicked: {}",
+            panic_payload_message(payload.as_ref())
+        )),
+    }
+}
+
+#[cfg(feature = "pdf")]
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+#[cfg(feature = "pdf")]
+fn split_pdf_pages(text: &str) -> Vec<Vec<String>> {
+    text.split('\x0C')
+        .map(|page| {
+            page.lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_becomes_readable_markdown_without_page_chrome() {
+        let html = br#"<!doctype html><html><head><title>Whale &amp; Signal</title></head><body>
+            <nav>Products Pricing Log in Cookies</nav>
+            <article><h1>Fetch once</h1><p>This is the important article body with enough words to be useful.</p>
+            <a href="/proof">Read the proof</a></article>
+            <footer>Privacy Cookies Terms</footer></body></html>"#;
+        let document = extract_document("https://example.com/post", Some("text/html"), html)
+            .expect("extract html");
+
+        assert_eq!(document.kind, DocumentKind::Html);
+        assert_eq!(document.title.as_deref(), Some("Whale & Signal"));
+        assert!(document.markdown.contains("Fetch once") || document.title.is_some());
+        assert!(
+            document
+                .markdown
+                .contains("[Read the proof](https://example.com/proof)")
+        );
+        assert!(!document.markdown.contains("Products Pricing"));
+        assert!(!document.markdown.contains("Privacy Cookies"));
+    }
+
+    #[test]
+    fn sparse_document_uses_article_fallback() {
+        let html = br#"<html><head><title>Fallback</title></head><body><nav>cookie banner</nav>
+            <article><h2>Small source</h2><p>Five useful words survive this compact article fallback path.</p></article>
+            </body></html>"#;
+        let document = extract_document("https://example.com/short", Some("text/html"), html)
+            .expect("extract fallback");
+
+        assert!(document.markdown.contains("## Small source"));
+        assert!(!document.markdown.contains("cookie banner"));
+    }
+
+    #[test]
+    fn javascript_shell_returns_actionable_error() {
+        let error = extract_document(
+            "https://example.com/app",
+            Some("text/html"),
+            b"<html><body><div id='root'></div><script>boot()</script></body></html>",
+        )
+        .expect_err("empty app shell must fail");
+
+        let message = error.to_string();
+        assert!(message.contains("may require JavaScript"));
+        assert!(message.contains("browser automation"));
+    }
+
+    #[test]
+    fn markdown_passes_through_unchanged() {
+        let body = b"# Release note\n\nA complete markdown response remains intact.\n";
+        let document = extract_document(
+            "https://example.com/release.md",
+            Some("text/markdown; charset=utf-8"),
+            body,
+        )
+        .expect("extract markdown");
+
+        assert_eq!(document.kind, DocumentKind::Markdown);
+        assert_eq!(document.markdown.as_bytes(), body);
+        assert_eq!(document.title.as_deref(), Some("Release note"));
+    }
+
+    #[test]
+    fn media_requires_matching_magic_bytes() {
+        let error = extract_document(
+            "https://example.com/not-image.png",
+            Some("image/png"),
+            b"<html>not really an image</html>",
+        )
+        .expect_err("spoofed media must fail");
+        assert!(error.to_string().contains("did not match"));
+
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        png.extend_from_slice(b"fake test payload");
+        let document = extract_document(
+            "https://example.com/image",
+            Some("application/octet-stream"),
+            &png,
+        )
+        .expect("sniff png");
+        assert_eq!(document.kind, DocumentKind::Media);
+        assert_eq!(document.media_extension, Some("png"));
+    }
+
+    #[test]
+    fn arbitrary_binary_is_rejected() {
+        let error = extract_document(
+            "https://example.com/archive.bin",
+            Some("application/octet-stream"),
+            b"PK\x03\x04archive bytes",
+        )
+        .expect_err("archive must be rejected");
+        assert!(error.to_string().contains("Unsupported binary response"));
+    }
+
+    #[test]
+    fn empty_success_body_is_valid_text() {
+        let document = extract_document(
+            "https://example.com/no-content",
+            Some("application/octet-stream"),
+            b"",
+        )
+        .expect("empty body");
+        assert_eq!(document.kind, DocumentKind::Text);
+        assert!(document.text.is_empty());
+    }
+
+    #[test]
+    fn svg_requires_and_accepts_svg_markup_signature() {
+        let svg = br#"<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>"#;
+        let document = extract_document("https://example.com/diagram", Some("image/svg+xml"), svg)
+            .expect("sniff svg");
+        assert_eq!(document.kind, DocumentKind::Media);
+        assert_eq!(document.media_extension, Some("svg"));
+    }
+
+    #[cfg(feature = "pdf")]
+    #[test]
+    fn pdf_panic_is_contained() {
+        let error = guard_pdf_extract::<(), &str, _>(|| panic!("malformed pdf"))
+            .expect_err("panic must be captured");
+        assert!(error.contains("extractor panicked: malformed pdf"));
+    }
+}

--- a/crates/tui/src/tools/web/fetch.rs
+++ b/crates/tui/src/tools/web/fetch.rs
@@ -9,7 +9,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use futures_util::StreamExt;
 
 use super::cache::{self, CachedFetch};
-use super::guard::{DnsPin, guarded_reqwest_client_builder, validate_fetch_target};
+use super::guard::{
+    DnsPin, guarded_reqwest_client_builder, validate_fetch_target, validate_network_policy,
+};
 use crate::tools::spec::{ToolContext, ToolError};
 
 pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -98,6 +100,16 @@ async fn fetch_inner(
         options.accept,
         options.max_bytes,
     ) {
+        let cached_url = reqwest::Url::parse(&cached.url).map_err(|err| {
+            ToolError::execution_failed(format!("cached response URL was invalid: {err}"))
+        })?;
+        let cached_host = cached_url.host_str().ok_or_else(|| {
+            ToolError::execution_failed("cached response URL did not include a host")
+        })?;
+        // No network request occurs on a cache hit, so DNS/SSRF validation is
+        // unnecessary. The final redirect destination still needs a policy
+        // check in case the session policy was tightened after insertion.
+        validate_network_policy(cached_host, context, tool_label)?;
         return Ok(from_cached(cached, true, 0));
     }
 
@@ -510,6 +522,49 @@ mod tests {
         )
         .await
         .expect_err("policy must win over cache");
+        assert!(error.to_string().contains("blocked by network policy"));
+    }
+
+    #[tokio::test]
+    async fn tightened_network_policy_checks_cached_redirect_destination() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        cache::reset();
+        let initial_url = reqwest::Url::parse("https://8.8.8.8/cached").unwrap();
+        cache::insert(
+            "redirect-policy-cache",
+            &initial_url,
+            "text/plain",
+            CachedFetch {
+                url: "https://1.1.1.1/redirected".to_string(),
+                status: 200,
+                headers: BTreeMap::new(),
+                content_type: "text/plain".to_string(),
+                bytes: Arc::new(b"cached".to_vec()),
+                truncated: false,
+                redirects: 1,
+            },
+        );
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: vec!["1.1.1.1".to_string()],
+            proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
+            audit: false,
+        };
+        let context = context("redirect-policy-cache")
+            .with_network_policy(NetworkPolicyDecider::new(policy, None));
+
+        let error = fetch(
+            initial_url.as_str(),
+            &FetchOptions::new(Duration::from_secs(1), 100, "text/plain"),
+            &context,
+            "fetch_url",
+        )
+        .await
+        .expect_err("final redirect policy must win over cache");
+        assert!(error.to_string().contains("1.1.1.1"));
         assert!(error.to_string().contains("blocked by network policy"));
     }
 }

--- a/crates/tui/src/tools/web/fetch.rs
+++ b/crates/tui/src/tools/web/fetch.rs
@@ -1,0 +1,515 @@
+//! Unified guarded fetch pipeline for `fetch_url` and `web.run`.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+#[cfg(not(test))]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use futures_util::StreamExt;
+
+use super::cache::{self, CachedFetch};
+use super::guard::{DnsPin, guarded_reqwest_client_builder, validate_fetch_target};
+use crate::tools::spec::{ToolContext, ToolError};
+
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const HARD_MAX_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const DEFAULT_MAX_BYTES: usize = 1_000_000;
+pub(crate) const HARD_MAX_BYTES: usize = 10 * 1024 * 1024;
+const MAX_REDIRECTS: usize = 5;
+const USER_AGENT: &str =
+    "Mozilla/5.0 (compatible; codewhale/0.9.1; +https://github.com/Hmbown/CodeWhale)";
+
+#[derive(Debug, Clone)]
+pub(crate) struct FetchOptions {
+    pub(crate) timeout: Duration,
+    pub(crate) max_bytes: usize,
+    pub(crate) accept: &'static str,
+}
+
+impl FetchOptions {
+    pub(crate) fn new(timeout: Duration, max_bytes: usize, accept: &'static str) -> Self {
+        Self {
+            timeout: timeout.min(HARD_MAX_TIMEOUT),
+            max_bytes: max_bytes.clamp(1, HARD_MAX_BYTES),
+            accept,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FetchedPayload {
+    pub(crate) url: String,
+    pub(crate) status: u16,
+    pub(crate) headers: BTreeMap<String, String>,
+    pub(crate) content_type: String,
+    pub(crate) bytes: Arc<Vec<u8>>,
+    pub(crate) truncated: bool,
+    pub(crate) cache_hit: bool,
+    pub(crate) retries: usize,
+    pub(crate) redirects: usize,
+}
+
+pub(crate) async fn fetch(
+    url: &str,
+    options: &FetchOptions,
+    context: &ToolContext,
+    tool_label: &str,
+) -> Result<FetchedPayload, ToolError> {
+    fetch_inner(url, options, context, tool_label, None).await
+}
+
+#[cfg(test)]
+pub(crate) async fn fetch_with_initial_pin(
+    url: &str,
+    options: &FetchOptions,
+    context: &ToolContext,
+    tool_label: &str,
+    initial_pin: DnsPin,
+) -> Result<FetchedPayload, ToolError> {
+    fetch_inner(url, options, context, tool_label, Some(initial_pin)).await
+}
+
+async fn fetch_inner(
+    url: &str,
+    options: &FetchOptions,
+    context: &ToolContext,
+    tool_label: &str,
+    test_initial_pin: Option<DnsPin>,
+) -> Result<FetchedPayload, ToolError> {
+    let initial_url = reqwest::Url::parse(url)
+        .map_err(|err| ToolError::invalid_input(format!("invalid URL: {err}")))?;
+    if !matches!(initial_url.scheme(), "http" | "https") {
+        return Err(ToolError::invalid_input(
+            "only http:// and https:// URLs are supported",
+        ));
+    }
+
+    // Validation precedes cache lookup so a policy tightened during the
+    // session cannot be bypassed by a previously cached response.
+    let validated_initial_pin = match test_initial_pin {
+        Some(pin) => pin,
+        None => validate_fetch_target(&initial_url, context, tool_label).await?,
+    };
+
+    if let Some(cached) = cache::get(
+        &context.state_namespace,
+        &initial_url,
+        options.accept,
+        options.max_bytes,
+    ) {
+        return Ok(from_cached(cached, true, 0));
+    }
+
+    let deadline = Instant::now() + options.timeout;
+    let mut last_transient = None;
+    for attempt in 0..=1 {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match fetch_attempt(
+            initial_url.clone(),
+            options,
+            context,
+            tool_label,
+            remaining,
+            validated_initial_pin.clone(),
+        )
+        .await
+        {
+            Ok(payload) if is_transient_status(payload.status) && attempt == 0 => {
+                last_transient = Some(format!("HTTP {}", payload.status));
+            }
+            Ok(payload) => {
+                let fetched = from_cached(payload.clone(), false, attempt);
+                if (200..300).contains(&payload.status) {
+                    cache::insert(
+                        &context.state_namespace,
+                        &initial_url,
+                        options.accept,
+                        payload,
+                    );
+                }
+                return Ok(fetched);
+            }
+            Err(AttemptError::Fatal(error)) => return Err(error),
+            Err(AttemptError::Transient(message)) if attempt == 0 => {
+                last_transient = Some(message);
+            }
+            Err(AttemptError::Transient(message)) => {
+                return Err(ToolError::execution_failed(format!(
+                    "request failed after one retry: {message}"
+                )));
+            }
+        }
+
+        let delay = retry_delay();
+        if deadline.saturating_duration_since(Instant::now()) <= delay {
+            break;
+        }
+        tokio::time::sleep(delay).await;
+    }
+
+    Err(ToolError::execution_failed(format!(
+        "request timed out before retry completed{}",
+        last_transient
+            .map(|message| format!(" (last failure: {message})"))
+            .unwrap_or_default()
+    )))
+}
+
+#[derive(Debug)]
+enum AttemptError {
+    Fatal(ToolError),
+    Transient(String),
+}
+
+async fn fetch_attempt(
+    initial_url: reqwest::Url,
+    options: &FetchOptions,
+    context: &ToolContext,
+    tool_label: &str,
+    timeout: Duration,
+    initial_pin: DnsPin,
+) -> Result<CachedFetch, AttemptError> {
+    let mut current_url = initial_url;
+    let mut redirects = 0usize;
+    let mut initial_pin = initial_pin;
+    let deadline = Instant::now() + timeout;
+
+    let response = loop {
+        let dns_pin = if redirects == 0 {
+            match initial_pin.take() {
+                Some(pin) => Some(pin),
+                None => validate_fetch_target(&current_url, context, tool_label)
+                    .await
+                    .map_err(AttemptError::Fatal)?,
+            }
+        } else {
+            validate_fetch_target(&current_url, context, tool_label)
+                .await
+                .map_err(AttemptError::Fatal)?
+        };
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(AttemptError::Transient(
+                "request timed out while following redirects".to_string(),
+            ));
+        }
+        let mut builder = guarded_reqwest_client_builder()
+            .timeout(remaining)
+            .user_agent(USER_AGENT)
+            .redirect(reqwest::redirect::Policy::none());
+        if let Some((hostname, validated_ip)) = dns_pin {
+            builder = builder.resolve(&hostname, std::net::SocketAddr::new(validated_ip, 0));
+        }
+        let client = builder.build().map_err(|err| {
+            AttemptError::Fatal(ToolError::execution_failed(format!(
+                "failed to build HTTP client: {err}"
+            )))
+        })?;
+        let response = client
+            .get(current_url.clone())
+            .header("Accept", options.accept)
+            .header("Accept-Language", "en-US,en;q=0.5")
+            .send()
+            .await
+            .map_err(|err| AttemptError::Transient(err.to_string()))?;
+
+        if !response.status().is_redirection() {
+            break response;
+        }
+        if redirects >= MAX_REDIRECTS {
+            return Err(AttemptError::Fatal(ToolError::execution_failed(
+                "request exceeded the five-redirect limit",
+            )));
+        }
+        let Some(location) = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            break response;
+        };
+        current_url = response.url().join(location).map_err(|err| {
+            AttemptError::Fatal(ToolError::execution_failed(format!(
+                "invalid redirect location: {err}"
+            )))
+        })?;
+        redirects += 1;
+    };
+
+    let final_url = response.url().to_string();
+    let status = response.status().as_u16();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let headers = response_headers(response.headers());
+    let mut stream = response.bytes_stream();
+    let mut bytes = Vec::with_capacity(options.max_bytes.min(64 * 1024));
+    let mut truncated = false;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|err| AttemptError::Transient(err.to_string()))?;
+        let remaining = options.max_bytes.saturating_sub(bytes.len());
+        if chunk.len() > remaining {
+            bytes.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        bytes.extend_from_slice(&chunk);
+        if bytes.len() == options.max_bytes {
+            // A response exactly at the cap may be complete. Ask for one more
+            // chunk to distinguish exact length from actual truncation.
+            if let Some(next) = stream.next().await {
+                let next = next.map_err(|err| AttemptError::Transient(err.to_string()))?;
+                truncated = !next.is_empty();
+            }
+            break;
+        }
+    }
+
+    Ok(CachedFetch {
+        url: final_url,
+        status,
+        headers,
+        content_type,
+        bytes: Arc::new(bytes),
+        truncated,
+        redirects,
+    })
+}
+
+fn from_cached(payload: CachedFetch, cache_hit: bool, retries: usize) -> FetchedPayload {
+    FetchedPayload {
+        url: payload.url,
+        status: payload.status,
+        headers: payload.headers,
+        content_type: payload.content_type,
+        bytes: payload.bytes,
+        truncated: payload.truncated,
+        cache_hit,
+        retries,
+        redirects: payload.redirects,
+    }
+}
+
+fn response_headers(headers: &reqwest::header::HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .filter(|(name, _)| {
+            !matches!(
+                name.as_str(),
+                "authorization"
+                    | "proxy-authorization"
+                    | "cookie"
+                    | "set-cookie"
+                    | "set-cookie2"
+                    | "x-api-key"
+                    | "api-key"
+            )
+        })
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect()
+}
+
+fn is_transient_status(status: u16) -> bool {
+    (500..600).contains(&status)
+}
+
+fn retry_delay() -> Duration {
+    #[cfg(test)]
+    return Duration::ZERO;
+
+    #[cfg(not(test))]
+    {
+        let jitter_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| u64::from(duration.subsec_nanos()) % 41)
+            .unwrap_or(0);
+        Duration::from_millis(30 + jitter_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    use super::*;
+
+    fn context(namespace: &str) -> ToolContext {
+        ToolContext::new(".").with_state_namespace(namespace)
+    }
+
+    fn pin() -> DnsPin {
+        Some((
+            "public.example".to_string(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        ))
+    }
+
+    #[derive(Clone)]
+    struct FailOnce {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Respond for FailOnce {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                ResponseTemplate::new(503).set_body_json(json!({"error": "retry"}))
+            } else {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/plain")
+                    .set_body_string("recovered response")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn transient_server_error_retries_once_then_caches() {
+        cache::reset();
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("GET"))
+            .and(path("/retry"))
+            .respond_with(FailOnce {
+                calls: Arc::clone(&calls),
+            })
+            .mount(&server)
+            .await;
+        let url = format!("http://public.example:{}/retry", server.address().port());
+        let options = FetchOptions::new(Duration::from_secs(5), 1_024, "text/plain");
+        let context = context("fetch-retry-cache");
+
+        let first = fetch_with_initial_pin(&url, &options, &context, "test", pin())
+            .await
+            .expect("retry succeeds");
+        assert_eq!(first.status, 200);
+        assert_eq!(first.retries, 1);
+        assert!(!first.cache_hit);
+        assert_eq!(&*first.bytes, b"recovered response");
+
+        let second = fetch_with_initial_pin(&url, &options, &context, "test", pin())
+            .await
+            .expect("cache hit");
+        assert!(second.cache_hit);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn truncated_cache_refetches_when_larger_body_is_requested() {
+        cache::reset();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/large"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/plain")
+                    .set_body_string("0123456789"),
+            )
+            .mount(&server)
+            .await;
+        let url = format!("http://public.example:{}/large", server.address().port());
+        let context = context("fetch-truncated-refetch");
+
+        let small = fetch_with_initial_pin(
+            &url,
+            &FetchOptions::new(Duration::from_secs(5), 4, "text/plain"),
+            &context,
+            "test",
+            pin(),
+        )
+        .await
+        .expect("small fetch");
+        assert_eq!(&*small.bytes, b"0123");
+        assert!(small.truncated);
+
+        let large = fetch_with_initial_pin(
+            &url,
+            &FetchOptions::new(Duration::from_secs(5), 16, "text/plain"),
+            &context,
+            "test",
+            pin(),
+        )
+        .await
+        .expect("larger refetch");
+        assert_eq!(&*large.bytes, b"0123456789");
+        assert!(!large.truncated);
+        assert!(!large.cache_hit);
+    }
+
+    #[test]
+    fn response_headers_drop_set_cookie_values() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("content-type", "text/plain".parse().unwrap());
+        headers.insert("set-cookie", "session=secret".parse().unwrap());
+        headers.insert("x-api-key", "secret".parse().unwrap());
+
+        let filtered = response_headers(&headers);
+
+        assert_eq!(
+            filtered.get("content-type").map(String::as_str),
+            Some("text/plain")
+        );
+        assert!(!filtered.contains_key("set-cookie"));
+        assert!(!filtered.contains_key("x-api-key"));
+    }
+
+    #[tokio::test]
+    async fn tightened_network_policy_blocks_an_existing_cache_entry() {
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+
+        cache::reset();
+        let url = reqwest::Url::parse("https://example.com/cached").unwrap();
+        cache::insert(
+            "policy-cache",
+            &url,
+            "text/plain",
+            CachedFetch {
+                url: url.to_string(),
+                status: 200,
+                headers: BTreeMap::new(),
+                content_type: "text/plain".to_string(),
+                bytes: Arc::new(b"cached".to_vec()),
+                truncated: false,
+                redirects: 0,
+            },
+        );
+        let policy = NetworkPolicy {
+            default: Decision::Deny.into(),
+            allow: Vec::new(),
+            deny: Vec::new(),
+            proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
+            audit: false,
+        };
+        let context =
+            context("policy-cache").with_network_policy(NetworkPolicyDecider::new(policy, None));
+
+        let error = fetch(
+            url.as_str(),
+            &FetchOptions::new(Duration::from_secs(1), 100, "text/plain"),
+            &context,
+            "fetch_url",
+        )
+        .await
+        .expect_err("policy must win over cache");
+        assert!(error.to_string().contains("blocked by network policy"));
+    }
+}

--- a/crates/tui/src/tools/web/mod.rs
+++ b/crates/tui/src/tools/web/mod.rs
@@ -9,4 +9,5 @@ pub(crate) mod contract;
 pub(crate) mod extract;
 pub(crate) mod fetch;
 pub(crate) mod guard;
+pub(crate) mod overflow;
 pub mod scrape;

--- a/crates/tui/src/tools/web/mod.rs
+++ b/crates/tui/src/tools/web/mod.rs
@@ -4,6 +4,9 @@
 //! module so security and parsing behavior cannot drift between tools.
 
 pub(crate) mod backend;
+pub(crate) mod cache;
 pub(crate) mod contract;
+pub(crate) mod extract;
+pub(crate) mod fetch;
 pub(crate) mod guard;
 pub mod scrape;

--- a/crates/tui/src/tools/web/overflow.rs
+++ b/crates/tui/src/tools/web/overflow.rs
@@ -1,0 +1,89 @@
+//! Shared route-sized inline output with recoverable session spillover.
+
+use std::path::PathBuf;
+
+use crate::tools::spec::{ToolContext, ToolError};
+
+#[derive(Debug)]
+pub(crate) struct OverflowArtifact {
+    pub(crate) session_id: String,
+    pub(crate) absolute_path: PathBuf,
+    pub(crate) relative_path: PathBuf,
+    pub(crate) byte_size: u64,
+    pub(crate) preview: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct BoundedText {
+    pub(crate) content: String,
+    pub(crate) artifact: Option<OverflowArtifact>,
+}
+
+pub(crate) fn inline_char_budget(context: &ToolContext) -> usize {
+    context
+        .route_context_window
+        .map(|tokens| {
+            let chars = u64::from(tokens).saturating_mul(4).saturating_mul(3) / 100;
+            usize::try_from(chars).unwrap_or(100_000)
+        })
+        .unwrap_or(100_000)
+        .clamp(1, 100_000)
+}
+
+pub(crate) fn bound_text<F>(
+    content: String,
+    context: &ToolContext,
+    artifact_id: F,
+    subject: &str,
+) -> Result<BoundedText, ToolError>
+where
+    F: FnOnce(&str) -> String,
+{
+    let budget = inline_char_budget(context);
+    if content.chars().count() <= budget {
+        return Ok(BoundedText {
+            content,
+            artifact: None,
+        });
+    }
+
+    let artifact_id = artifact_id(&content);
+    let (absolute_path, relative_path) =
+        crate::artifacts::write_session_artifact(&context.state_namespace, &artifact_id, &content)
+            .map_err(|error| {
+                ToolError::execution_failed(format!(
+                    "failed to preserve {subject} content artifact: {error}"
+                ))
+            })?;
+    let relative = crate::artifacts::format_artifact_relative_path(&relative_path);
+    let mut head = content
+        .chars()
+        .take(budget.saturating_sub(256))
+        .collect::<String>();
+    let mut footer = overflow_footer(subject, &relative, head.len(), content.len());
+    let allowed_head = budget.saturating_sub(footer.chars().count());
+    head = content.chars().take(allowed_head).collect();
+    footer = overflow_footer(subject, &relative, head.len(), content.len());
+    while !head.is_empty() && head.chars().count() + footer.chars().count() > budget {
+        head.pop();
+        footer = overflow_footer(subject, &relative, head.len(), content.len());
+    }
+    let preview = content.chars().take(200).collect();
+
+    Ok(BoundedText {
+        content: format!("{head}{footer}"),
+        artifact: Some(OverflowArtifact {
+            session_id: context.state_namespace.clone(),
+            absolute_path,
+            relative_path,
+            byte_size: content.len() as u64,
+            preview,
+        }),
+    })
+}
+
+fn overflow_footer(subject: &str, relative: &str, head_bytes: usize, total_bytes: usize) -> String {
+    format!(
+        "\n\n[Content overflow: first {head_bytes} of {total_bytes} bytes shown; full {subject} saved to {relative}. Recovery: call retrieve_tool_result with ref={relative}.]"
+    )
+}

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -13,6 +13,9 @@ use super::web::fetch::fetch_with_initial_pin;
 use super::web::fetch::{FetchOptions, HARD_MAX_BYTES, fetch};
 #[cfg(test)]
 use super::web::guard::DnsPin;
+use super::web::overflow::bound_text as bound_web_text;
+#[cfg(test)]
+use super::web::overflow::inline_char_budget;
 use async_trait::async_trait;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -1114,73 +1117,36 @@ fn page_from_fetched(
     }
 }
 
-fn web_inline_char_budget(context: &ToolContext) -> usize {
-    context
-        .route_context_window
-        .map(|tokens| {
-            let chars = u64::from(tokens).saturating_mul(4).saturating_mul(3) / 100;
-            usize::try_from(chars).unwrap_or(100_000)
-        })
-        .unwrap_or(100_000)
-        .clamp(1, 100_000)
-}
-
 fn bounded_web_run_result(
     output: &WebRunOutput,
     context: &ToolContext,
 ) -> Result<ToolResult, ToolError> {
     let full = serde_json::to_string_pretty(output)
         .map_err(|error| ToolError::execution_failed(error.to_string()))?;
-    let budget = web_inline_char_budget(context);
-    if full.chars().count() <= budget {
-        return Ok(ToolResult {
-            content: full,
-            success: true,
-            metadata: None,
-        });
-    }
-
-    let digest = crate::hashing::sha256_hex(full.as_bytes());
-    let artifact_id = format!("web_run_{}", &digest[..16]);
-    let (absolute_path, relative_path) =
-        crate::artifacts::write_session_artifact(&context.state_namespace, &artifact_id, &full)
-            .map_err(|error| {
-                ToolError::execution_failed(format!(
-                    "failed to preserve web.run result artifact: {error}"
-                ))
-            })?;
-    let relative = crate::artifacts::format_artifact_relative_path(&relative_path);
-    let mut head = full
-        .chars()
-        .take(budget.saturating_sub(256))
-        .collect::<String>();
-    let mut footer = web_run_overflow_footer(&relative, head.len(), full.len());
-    let allowed_head = budget.saturating_sub(footer.chars().count());
-    head = full.chars().take(allowed_head).collect();
-    footer = web_run_overflow_footer(&relative, head.len(), full.len());
-    while !head.is_empty() && head.chars().count() + footer.chars().count() > budget {
-        head.pop();
-        footer = web_run_overflow_footer(&relative, head.len(), full.len());
-    }
-    let preview = full.chars().take(200).collect::<String>();
+    let bounded = bound_web_text(
+        full,
+        context,
+        |body| {
+            let digest = crate::hashing::sha256_hex(body.as_bytes());
+            format!("web_run_{}", &digest[..16])
+        },
+        "web.run result",
+    )?;
+    let metadata = bounded.artifact.map(|artifact| {
+        json!({
+            "spillover_path": artifact.absolute_path.display().to_string(),
+            "artifact_session_id": artifact.session_id,
+            "artifact_relative_path": crate::artifacts::format_artifact_relative_path(&artifact.relative_path),
+            "artifact_byte_size": artifact.byte_size,
+            "artifact_preview": artifact.preview,
+        })
+    });
 
     Ok(ToolResult {
-        content: format!("{head}{footer}"),
+        content: bounded.content,
         success: true,
-        metadata: Some(json!({
-            "spillover_path": absolute_path.display().to_string(),
-            "artifact_session_id": context.state_namespace,
-            "artifact_relative_path": relative,
-            "artifact_byte_size": full.len() as u64,
-            "artifact_preview": preview,
-        })),
+        metadata,
     })
-}
-
-fn web_run_overflow_footer(relative: &str, head_bytes: usize, total_bytes: usize) -> String {
-    format!(
-        "\n\n[Content overflow: first {head_bytes} of {total_bytes} bytes shown; full web.run result saved to {relative}. Recovery: call retrieve_tool_result with ref={relative}.]"
-    )
 }
 
 fn render_view(
@@ -1597,7 +1563,7 @@ mod tests {
         let full = std::fs::read_to_string(path).unwrap();
 
         assert!(result.content.contains("retrieve_tool_result"));
-        assert!(result.content.chars().count() <= web_inline_char_budget(&context));
+        assert!(result.content.chars().count() <= inline_char_budget(&context));
         assert_eq!(
             serde_json::from_str::<Value>(&full).unwrap()["warnings"][0],
             output.warnings[0]

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -7,14 +7,17 @@ use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec,
     optional_u64, required_str,
 };
-use super::web::guard::{DnsPin, guarded_reqwest_client_builder, validate_fetch_target};
+use super::web::extract::{DocumentKind, extract_document};
+#[cfg(test)]
+use super::web::fetch::fetch_with_initial_pin;
+use super::web::fetch::{FetchOptions, HARD_MAX_BYTES, fetch};
+#[cfg(test)]
+use super::web::guard::DnsPin;
 use async_trait::async_trait;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, VecDeque};
-#[cfg(feature = "pdf")]
-use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
@@ -27,10 +30,9 @@ use super::web::contract::{
 use super::web_search::{domain_matches, execute_search};
 
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
-const DEFAULT_OPEN_TIMEOUT_MS: u64 = 20_000;
+const DEFAULT_OPEN_TIMEOUT_MS: u64 = 15_000;
 const MAX_WEB_RUN_SESSIONS: usize = 64;
 const MAX_PAGES_PER_SESSION: usize = 256;
-const MAX_REDIRECTS: usize = 5;
 const WEB_RUN_SESSION_TTL: Duration = Duration::from_secs(30 * 60);
 const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
 
@@ -186,6 +188,7 @@ struct WebPage {
     lines: Vec<String>,
     links: Vec<WebLink>,
     pdf_pages: Option<Vec<Vec<String>>>,
+    truncated: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -261,6 +264,8 @@ struct PageViewResult {
     line_start: usize,
     line_end: usize,
     total_lines: usize,
+    #[serde(default, skip_serializing_if = "is_false")]
+    truncated: bool,
     content: String,
     links: Vec<WebLink>,
 }
@@ -269,6 +274,10 @@ struct PageViewResult {
 struct FindMatch {
     line: usize,
     text: String,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -653,7 +662,7 @@ impl ToolSpec for WebRunTool {
             }
         }
 
-        ToolResult::json(&output).map_err(|e| ToolError::execution_failed(e.to_string()))
+        bounded_web_run_result(&output, context)
     }
 }
 
@@ -970,6 +979,7 @@ fn page_from_search(query: &str, results: &[NormalizedSearchResult]) -> WebPage 
         lines,
         links,
         pdf_pages: None,
+        truncated: false,
     }
 }
 
@@ -978,187 +988,199 @@ async fn fetch_page(
     timeout_ms: u64,
     context: &ToolContext,
 ) -> Result<WebPage, ToolError> {
-    fetch_page_with_initial_pin(url, timeout_ms, context, None).await
+    let payload = fetch(
+        url,
+        &FetchOptions::new(
+            Duration::from_millis(timeout_ms),
+            HARD_MAX_BYTES,
+            "text/html,text/markdown,text/plain,application/xhtml+xml,application/pdf,image/*,audio/*,video/*,*/*;q=0.5",
+        ),
+        context,
+        "web_run",
+    )
+    .await?;
+    page_from_fetched(payload, context)
 }
 
+#[cfg(test)]
 async fn fetch_page_with_initial_pin(
     url: &str,
     timeout_ms: u64,
     context: &ToolContext,
-    mut initial_pin: Option<DnsPin>,
+    initial_pin: Option<DnsPin>,
 ) -> Result<WebPage, ToolError> {
-    let mut current_url = reqwest::Url::parse(url)
-        .map_err(|e| ToolError::invalid_input(format!("invalid URL: {e}")))?;
-    let mut redirects_followed = 0usize;
+    let payload = fetch_with_initial_pin(
+        url,
+        &FetchOptions::new(
+            Duration::from_millis(timeout_ms),
+            HARD_MAX_BYTES,
+            "text/html,text/markdown,text/plain,application/xhtml+xml,application/pdf,image/*,audio/*,video/*,*/*;q=0.5",
+        ),
+        context,
+        "web_run",
+        initial_pin.flatten(),
+    )
+    .await?;
+    page_from_fetched(payload, context)
+}
 
-    let resp = loop {
-        let dns_pinning = if redirects_followed == 0 {
-            match initial_pin.take() {
-                Some(pin) => pin,
-                None => validate_fetch_target(&current_url, context, "web_run").await?,
-            }
-        } else {
-            validate_fetch_target(&current_url, context, "web_run").await?
-        };
-        let mut client_builder = guarded_reqwest_client_builder()
-            .timeout(Duration::from_millis(timeout_ms))
-            .user_agent(USER_AGENT)
-            .redirect(reqwest::redirect::Policy::none());
-
-        // Pin validated IP to prevent DNS rebinding (TOCTOU) — reqwest will
-        // connect to the validated IP directly instead of re-resolving.
-        if let Some((hostname, validated_ip)) = dns_pinning {
-            client_builder =
-                client_builder.resolve(&hostname, std::net::SocketAddr::new(validated_ip, 0));
-        }
-
-        let client = client_builder.build().map_err(|e| {
-            ToolError::execution_failed(format!("Failed to build HTTP client: {e}"))
-        })?;
-
-        let resp = client
-            .get(current_url.clone())
-            .header(
-                "Accept",
-                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            )
-            .header("Accept-Language", "en-US,en;q=0.5")
-            .send()
-            .await
-            .map_err(|e| ToolError::execution_failed(format!("Web request failed: {e}")))?;
-
-        if !resp.status().is_redirection() || redirects_followed >= MAX_REDIRECTS {
-            break resp;
-        }
-
-        let Some(location) = resp
-            .headers()
-            .get(reqwest::header::LOCATION)
-            .and_then(|value| value.to_str().ok())
-        else {
-            break resp;
-        };
-
-        current_url = resp
-            .url()
-            .join(location)
-            .map_err(|e| ToolError::execution_failed(format!("invalid redirect location: {e}")))?;
-        redirects_followed += 1;
-    };
-
-    let final_url = resp.url().to_string();
-    let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-    let bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| ToolError::execution_failed(format!("Failed to read response: {e}")))?;
-
-    if !status.is_success() {
+fn page_from_fetched(
+    payload: super::web::fetch::FetchedPayload,
+    context: &ToolContext,
+) -> Result<WebPage, ToolError> {
+    if !(200..300).contains(&payload.status) {
         return Err(ToolError::execution_failed(format!(
             "Web request failed: HTTP {}",
-            status.as_u16()
+            payload.status
         )));
     }
-
-    #[cfg(feature = "pdf")]
-    if is_pdf(&content_type, &final_url) {
-        return parse_pdf_page(&final_url, content_type, &bytes);
-    }
-
-    let body = String::from_utf8_lossy(&bytes).to_string();
-    let (lines, links, title) = parse_html(&body, &final_url);
-
-    Ok(WebPage {
-        url: final_url,
-        title,
-        content_type,
-        lines,
-        links,
-        pdf_pages: None,
-    })
-}
-
-#[cfg(feature = "pdf")]
-fn is_pdf(content_type: &Option<String>, url: &str) -> bool {
-    if let Some(ct) = content_type
-        && ct.to_lowercase().contains("application/pdf")
-    {
-        return true;
-    }
-    url.to_lowercase().ends_with(".pdf")
-}
-
-#[cfg(feature = "pdf")]
-fn parse_pdf_page(
-    url: &str,
-    content_type: Option<String>,
-    bytes: &[u8],
-) -> Result<WebPage, ToolError> {
-    let text = pdf_extract_text(bytes)?;
-    let pages = split_pdf_pages(&text);
-    let lines = pages.first().cloned().unwrap_or_default();
-
-    Ok(WebPage {
-        url: url.to_string(),
-        title: Some("PDF Document".to_string()),
-        content_type,
-        lines,
-        links: Vec::new(),
-        pdf_pages: Some(pages),
-    })
-}
-
-#[cfg(feature = "pdf")]
-fn pdf_extract_text(bytes: &[u8]) -> Result<String, ToolError> {
-    guard_pdf_extract(|| pdf_extract::extract_text_from_mem(bytes))
-        .map_err(|e| ToolError::execution_failed(format!("PDF extract failed: {e}")))
-}
-
-#[cfg(feature = "pdf")]
-fn guard_pdf_extract<T, E, F>(extract: F) -> Result<T, String>
-where
-    E: Display,
-    F: FnOnce() -> Result<T, E>,
-{
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(extract)) {
-        Ok(Ok(value)) => Ok(value),
-        Ok(Err(err)) => Err(err.to_string()),
-        Err(payload) => Err(format!(
-            "extractor panicked: {}",
-            panic_payload_message(payload.as_ref())
-        )),
-    }
-}
-
-#[cfg(feature = "pdf")]
-fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
-    if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "unknown panic".to_string()
+    let document = extract_document(&payload.url, Some(&payload.content_type), &payload.bytes)?;
+    let content_type = Some(payload.content_type);
+    match document.kind {
+        DocumentKind::Html => {
+            let html = document.cleaned_html.ok_or_else(|| {
+                ToolError::execution_failed("Readable HTML extraction returned no document")
+            })?;
+            let (lines, links, parsed_title) = parse_html(&html, &payload.url);
+            Ok(WebPage {
+                url: payload.url,
+                title: document.title.or(parsed_title),
+                content_type,
+                lines,
+                links,
+                pdf_pages: None,
+                truncated: payload.truncated,
+            })
+        }
+        DocumentKind::Markdown => {
+            let (lines, links) = parse_markdown(&document.markdown, &payload.url);
+            Ok(WebPage {
+                url: payload.url,
+                title: document.title,
+                content_type,
+                lines,
+                links,
+                pdf_pages: None,
+                truncated: payload.truncated,
+            })
+        }
+        DocumentKind::Text => Ok(WebPage {
+            url: payload.url,
+            title: document.title,
+            content_type,
+            lines: readable_lines(&document.text),
+            links: Vec::new(),
+            pdf_pages: None,
+            truncated: payload.truncated,
+        }),
+        DocumentKind::Pdf => {
+            let pages = document.pdf_pages.unwrap_or_default();
+            Ok(WebPage {
+                url: payload.url,
+                title: document.title,
+                content_type,
+                lines: pages.first().cloned().unwrap_or_default(),
+                links: Vec::new(),
+                pdf_pages: Some(pages),
+                truncated: payload.truncated,
+            })
+        }
+        DocumentKind::Media => {
+            let extension = document.media_extension.unwrap_or("bin");
+            let digest = crate::hashing::sha256_hex(&*payload.bytes);
+            let artifact_id = format!("web_media_{}", &digest[..16]);
+            let (_absolute, relative) = crate::artifacts::write_session_artifact_bytes(
+                &context.state_namespace,
+                &artifact_id,
+                extension,
+                &payload.bytes,
+            )
+            .map_err(|error| {
+                ToolError::execution_failed(format!(
+                    "failed to preserve fetched media artifact: {error}"
+                ))
+            })?;
+            let path = crate::artifacts::format_artifact_relative_path(&relative);
+            Ok(WebPage {
+                url: payload.url,
+                title: Some("Media artifact".to_string()),
+                content_type,
+                lines: vec![format!("Fetched media saved to {path}")],
+                links: Vec::new(),
+                pdf_pages: None,
+                truncated: payload.truncated,
+            })
+        }
     }
 }
 
-#[cfg(feature = "pdf")]
-fn split_pdf_pages(text: &str) -> Vec<Vec<String>> {
-    let raw_pages: Vec<&str> = text.split('\x0C').collect();
-    raw_pages
-        .iter()
-        .map(|page| {
-            page.lines()
-                .map(|line| line.trim())
-                .filter(|line| !line.is_empty())
-                .map(|line| line.to_string())
-                .collect::<Vec<_>>()
+fn web_inline_char_budget(context: &ToolContext) -> usize {
+    context
+        .route_context_window
+        .map(|tokens| {
+            let chars = u64::from(tokens).saturating_mul(4).saturating_mul(3) / 100;
+            usize::try_from(chars).unwrap_or(100_000)
         })
-        .collect()
+        .unwrap_or(100_000)
+        .clamp(1, 100_000)
+}
+
+fn bounded_web_run_result(
+    output: &WebRunOutput,
+    context: &ToolContext,
+) -> Result<ToolResult, ToolError> {
+    let full = serde_json::to_string_pretty(output)
+        .map_err(|error| ToolError::execution_failed(error.to_string()))?;
+    let budget = web_inline_char_budget(context);
+    if full.chars().count() <= budget {
+        return Ok(ToolResult {
+            content: full,
+            success: true,
+            metadata: None,
+        });
+    }
+
+    let digest = crate::hashing::sha256_hex(full.as_bytes());
+    let artifact_id = format!("web_run_{}", &digest[..16]);
+    let (absolute_path, relative_path) =
+        crate::artifacts::write_session_artifact(&context.state_namespace, &artifact_id, &full)
+            .map_err(|error| {
+                ToolError::execution_failed(format!(
+                    "failed to preserve web.run result artifact: {error}"
+                ))
+            })?;
+    let relative = crate::artifacts::format_artifact_relative_path(&relative_path);
+    let mut head = full
+        .chars()
+        .take(budget.saturating_sub(256))
+        .collect::<String>();
+    let mut footer = web_run_overflow_footer(&relative, head.len(), full.len());
+    let allowed_head = budget.saturating_sub(footer.chars().count());
+    head = full.chars().take(allowed_head).collect();
+    footer = web_run_overflow_footer(&relative, head.len(), full.len());
+    while !head.is_empty() && head.chars().count() + footer.chars().count() > budget {
+        head.pop();
+        footer = web_run_overflow_footer(&relative, head.len(), full.len());
+    }
+    let preview = full.chars().take(200).collect::<String>();
+
+    Ok(ToolResult {
+        content: format!("{head}{footer}"),
+        success: true,
+        metadata: Some(json!({
+            "spillover_path": absolute_path.display().to_string(),
+            "artifact_session_id": context.state_namespace,
+            "artifact_relative_path": relative,
+            "artifact_byte_size": full.len() as u64,
+            "artifact_preview": preview,
+        })),
+    })
+}
+
+fn web_run_overflow_footer(relative: &str, head_bytes: usize, total_bytes: usize) -> String {
+    format!(
+        "\n\n[Content overflow: first {head_bytes} of {total_bytes} bytes shown; full web.run result saved to {relative}. Recovery: call retrieve_tool_result with ref={relative}.]"
+    )
 }
 
 fn render_view(
@@ -1196,6 +1218,7 @@ fn render_view(
         line_start: start,
         line_end: end,
         total_lines: total,
+        truncated: page.truncated,
         content,
         links: page.links.clone(),
     }
@@ -1279,6 +1302,7 @@ static BLOCK_RE: OnceLock<Regex> = OnceLock::new();
 static SCRIPT_RE: OnceLock<Regex> = OnceLock::new();
 static STYLE_RE: OnceLock<Regex> = OnceLock::new();
 static TITLE_RE: OnceLock<Regex> = OnceLock::new();
+static MARKDOWN_LINK_RE: OnceLock<Regex> = OnceLock::new();
 
 fn get_anchor_re() -> &'static Regex {
     ANCHOR_RE.get_or_init(|| {
@@ -1332,6 +1356,45 @@ fn parse_html(html: &str, base_url: &str) -> (Vec<String>, Vec<WebLink>, Option<
     }
 
     (lines, links, title)
+}
+
+fn parse_markdown(markdown: &str, base_url: &str) -> (Vec<String>, Vec<WebLink>) {
+    let re = MARKDOWN_LINK_RE.get_or_init(|| {
+        Regex::new(r#"\[([^\]]+)\]\(([^\s)]+)(?:\s+"[^"]*")?\)"#).expect("markdown link regex")
+    });
+    let mut links = Vec::new();
+    let mut replaced = String::with_capacity(markdown.len());
+    let mut last = 0;
+    for capture in re.captures_iter(markdown) {
+        let Some(full) = capture.get(0) else { continue };
+        let Some(text) = capture.get(1) else { continue };
+        let Some(target) = capture.get(2) else {
+            continue;
+        };
+        replaced.push_str(&markdown[last..full.start()]);
+        let id = links.len() + 1;
+        let text = normalize_whitespace(text.as_str());
+        let url = resolve_url(base_url, target.as_str());
+        links.push(WebLink {
+            id,
+            url,
+            text: text.clone(),
+        });
+        replaced.push_str(&format!("[{id}] {text}"));
+        last = full.end();
+    }
+    replaced.push_str(&markdown[last..]);
+    (readable_lines(&replaced), links)
+}
+
+fn readable_lines(text: &str) -> Vec<String> {
+    text.lines()
+        .flat_map(|line| {
+            let line = normalize_whitespace(line);
+            wrap_line(&line, ResponseLength::Medium.wrap_width())
+        })
+        .filter(|line| !line.is_empty())
+        .collect()
 }
 
 fn extract_title(html: &str) -> Option<String> {
@@ -1451,6 +1514,14 @@ mod tests {
 
     static WEB_RUN_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
+    struct ArtifactRootRestore(Option<PathBuf>);
+
+    impl Drop for ArtifactRootRestore {
+        fn drop(&mut self) {
+            crate::artifacts::set_test_artifact_sessions_root(self.0.take());
+        }
+    }
+
     fn lock_web_run_test_state() -> MutexGuard<'static, ()> {
         WEB_RUN_TEST_LOCK.blocking_lock()
     }
@@ -1463,6 +1534,7 @@ mod tests {
             lines: vec!["example line".to_string()],
             links: Vec::new(),
             pdf_pages: None,
+            truncated: false,
         }
     }
 
@@ -1488,6 +1560,48 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].url, "https://example.com");
         assert!(lines.iter().any(|line| line.contains("Example")));
+    }
+
+    #[test]
+    fn markdown_link_parsing_preserves_click_targets() {
+        let (lines, links) = parse_markdown(
+            "## Guide\n\nRead [the proof](/proof) before shipping.",
+            "https://example.com/docs/start",
+        );
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].url, "https://example.com/proof");
+        assert!(lines.iter().any(|line| line.contains("[1] the proof")));
+    }
+
+    #[test]
+    fn oversized_web_run_output_round_trips_through_session_artifact() {
+        let _lock = crate::artifacts::TEST_ARTIFACT_SESSIONS_GUARD
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let prior =
+            crate::artifacts::set_test_artifact_sessions_root(Some(tmp.path().join("sessions")));
+        let _restore = ArtifactRootRestore(prior);
+        let context = ToolContext::new(".")
+            .with_state_namespace("web-run-overflow")
+            .with_route_context_window(10_000);
+        let output = WebRunOutput {
+            warnings: vec!["large receipt ".repeat(200)],
+            ..WebRunOutput::default()
+        };
+
+        let result = bounded_web_run_result(&output, &context).unwrap();
+        let metadata = result.metadata.expect("artifact metadata");
+        let path = metadata["spillover_path"].as_str().unwrap();
+        let full = std::fs::read_to_string(path).unwrap();
+
+        assert!(result.content.contains("retrieve_tool_result"));
+        assert!(result.content.chars().count() <= web_inline_char_budget(&context));
+        assert_eq!(
+            serde_json::from_str::<Value>(&full).unwrap()["warnings"][0],
+            output.warnings[0]
+        );
     }
 
     #[test]
@@ -1640,18 +1754,6 @@ mod tests {
                 .iter()
                 .all(|entry| entry.url.contains("docs.example.co.uk"))
         );
-    }
-
-    #[cfg(feature = "pdf")]
-    #[test]
-    fn pdf_extract_panic_is_returned_as_tool_error_text() {
-        let err = guard_pdf_extract(|| -> Result<String, &'static str> {
-            panic!("assertion failed: name == \"Identity-H\"");
-        })
-        .expect_err("panic should become an error");
-
-        assert!(err.contains("extractor panicked"));
-        assert!(err.contains("Identity-H"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the shared guarded fetch pipeline with redirect revalidation, retry/deadline controls, session TTL cache, and receipt metadata
- add content classification plus real HTML-to-Markdown/readability extraction for HTML, Markdown, text, PDF, media, and binary responses
- route fetch_url and web.run open/click through the seam with context-sized inline output, shared session-artifact spillover, and actionable JavaScript-shell handling
- recheck cached redirect destinations against active network policy and normalize response media types case-insensitively

## Verification at exact head 977e45b87ca4d7c52cee1efd931fba8efe5addca
- cargo fmt --all -- --check
- cargo test -p codewhale-tui --bin codewhale-tui: 7540 passed, 3 ignored, 0 failed
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- focused tools::web suite: 64 passed, 1 ignored helper, 0 failed
- fetch_url tests: 10 passed
- web.run overflow artifact round-trip: passed
- git diff --check
- gitleaks git --log-opts origin/main..HEAD --redact: 4 commits scanned, no leaks

## Review response
Claude found duplicated budget/spillover behavior across the two tool surfaces. Commit 977e45b moves it into one shared web helper and also makes large-body UTF-8 conversion and artifact hashing lazy. The follow-up review reports no findings outstanding.

## Audit note
Local cargo audit --deny warnings reports only the pre-existing RUSTSEC-2026-0192 ttf-parser 0.25.1 advisory, already documented in deny.toml through the existing pdf-extract dependency. No new advisory was introduced by the readability or htmd dependencies.