### PR TITLE
feat(web): add bounded backend failover and query cache

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -675,6 +675,8 @@ max_subagents = 10 # optional (1-20)
 # with Bing fallback — no API key needed. Bing remains selectable for users who
 # explicitly prefer it. Switch to Tavily, Bocha, Metaso, Baidu, Volcengine,
 # Sofya, or a trusted SearXNG instance for API-backed search.
+# API runtime failures and empty responses visibly degrade through DuckDuckGo
+# then Bing. Missing configuration and network-policy denials fail closed.
 #
 # [search]
 # provider = "duckduckgo"  # duckduckgo | bing | tavily | bocha | metaso | searxng | baidu | volcengine | sofya
@@ -682,8 +684,8 @@ max_subagents = 10 # optional (1-20)
 #                            # bing:       HTML scrape, no API key
 #                            # tavily:     https://tavily.com — AI search, needs api_key
 #                            # bocha:      https://bochaai.com — 博查AI搜索，国内友好，需api_key
-#                            # metaso:     https://metaso.cn — 秘塔AI搜索，每天 100 次免费
-#                            #             设置 METASO_API_KEY 或 [search] api_key 可提升额度
+#                            # metaso:     https://metaso.cn — 秘塔AI搜索，需 api_key
+#                            #             设置 METASO_API_KEY 或 [search] api_key
 #                            # searxng:    https://docs.searxng.org — trusted/self-hosted JSON API,
 #                            #             set base_url; no public instance is used by default
 #                            # baidu:      百度 AI Search via qianfan.baidubce.com，需 api_key
@@ -694,7 +696,7 @@ max_subagents = 10 # optional (1-20)
 #                            #             also falls back to the SOFYA_API_KEY env var
 # base_url = "https://search.example/" # optional DuckDuckGo-compatible HTML endpoint;
 #                                      # required SearXNG root or /search endpoint
-# api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, baidu, volcengine, and sofya; optional for metaso; unused by searxng
+# api_key = "YOUR_SEARCH_KEY" # required for tavily, bocha, metaso, baidu, volcengine, and sofya; unused by searxng
 #                             # WARNING: treat config.toml like a secret file when
 #                             # storing API keys. Prefer env vars for local smoke tests.
 #
@@ -705,6 +707,7 @@ max_subagents = 10 # optional (1-20)
 #   DEEPSEEK_SEARCH_BASE_URL  → search.base_url (legacy alias)
 #   METASO_API_KEY           → metaso key fallback
 #   BAIDU_SEARCH_API_KEY     → baidu key fallback
+#   VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY → volcengine key fallback
 #   SOFYA_API_KEY            → sofya key fallback
 
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/tui/src/config/search.rs
+++ b/crates/tui/src/config/search.rs
@@ -24,8 +24,8 @@ pub enum SearchProvider {
     Tavily,
     /// Bocha AI Search API (<https://bochaai.com>). Requires api_key.
     Bocha,
-    /// Metaso AI Search API (<https://metaso.cn>). Uses built-in default key
-    /// or `METASO_API_KEY` env var; configurable via `[search] api_key`.
+    /// Metaso AI Search API (<https://metaso.cn>). Requires `[search] api_key`
+    /// or the `METASO_API_KEY` env var.
     #[serde(alias = "metaso")]
     Metaso,
     /// SearXNG JSON search API. Requires a trusted/self-hosted `base_url`.
@@ -130,7 +130,7 @@ pub struct SearchConfig {
     #[serde(default)]
     pub base_url: Option<String>,
     /// API key for Tavily, Bocha, Metaso, Baidu, or Volcengine. Not required for Bing, DuckDuckGo, or SearXNG.
-    /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in default.
+    /// Metaso also falls back to the `METASO_API_KEY` env var.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY` env var.
     /// Volcengine also falls back to `VOLCENGINE_API_KEY` / `VOLCENGINE_ARK_API_KEY` / `ARK_API_KEY` env vars.
     #[serde(default)]

--- a/crates/tui/src/config/search.rs
+++ b/crates/tui/src/config/search.rs
@@ -7,7 +7,10 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Search provider enumeration — selects which backend `web_search` uses.
+/// Search provider enumeration — selects the first backend `web_search` uses.
+/// API-backed providers may visibly degrade through the default DuckDuckGo →
+/// Bing chain after runtime failure or an empty result. Configuration and
+/// network-policy errors fail closed without crossing providers.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchProvider {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -413,8 +413,9 @@ pub struct EngineConfig {
     pub workshop: Option<crate::tools::large_output_router::WorkshopConfig>,
     /// Which search backend `web_search` should use. Default: DuckDuckGo.
     pub search_provider: crate::config::SearchProvider,
-    /// API key for Tavily, Bocha, Metaso, or Baidu. `None` for Bing or DuckDuckGo.
-    /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in key.
+    /// API key for Tavily, Bocha, Metaso, Baidu, Volcengine, or Sofya.
+    /// `None` for Bing, DuckDuckGo, or SearXNG.
+    /// Metaso also falls back to the `METASO_API_KEY` env var.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY`.
     pub search_api_key: Option<String>,
     /// Optional DuckDuckGo-compatible HTML endpoint override.

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -247,8 +247,9 @@ pub struct ToolContext {
     /// Which search backend `web_search` should use. Default: DuckDuckGo. Set via
     /// `[search] provider` in config.toml.
     pub search_provider: crate::config::SearchProvider,
-    /// API key for Tavily, Bocha, Metaso, or Baidu. `None` for Bing or DuckDuckGo.
-    /// Metaso also falls back to `METASO_API_KEY` env var, then a built-in key.
+    /// API key for Tavily, Bocha, Metaso, Baidu, Volcengine, or Sofya.
+    /// `None` for Bing, DuckDuckGo, or SearXNG.
+    /// Metaso also falls back to the `METASO_API_KEY` env var.
     /// Baidu also falls back to `BAIDU_SEARCH_API_KEY`.
     pub search_api_key: Option<String>,
     /// Optional DuckDuckGo-compatible HTML endpoint override for `web_search`.

--- a/crates/tui/src/tools/web/backend.rs
+++ b/crates/tui/src/tools/web/backend.rs
@@ -269,7 +269,7 @@ impl SearchBackend for ConfiguredSearchBackend<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
 
@@ -378,6 +378,70 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn first_attempt_budget_overrides_the_default_fair_share() {
+        struct DeadlineBackend {
+            observed_budget: Arc<Mutex<Option<Duration>>>,
+        }
+
+        #[async_trait]
+        impl SearchBackend for DeadlineBackend {
+            fn id(&self) -> BackendId {
+                BackendId::Volcengine
+            }
+
+            fn capabilities(&self) -> QueryCapabilities {
+                QueryCapabilities::count_only()
+            }
+
+            async fn search(
+                &self,
+                _query: &SearchQuery,
+                deadline: Instant,
+            ) -> Result<BackendSearch, ToolError> {
+                *self.observed_budget.lock().expect("budget lock") =
+                    Some(deadline.saturating_duration_since(Instant::now()));
+                Ok(BackendSearch {
+                    backend: BackendId::Volcengine,
+                    source: "volcengine".to_string(),
+                    backend_detail: None,
+                    results: vec![result()],
+                    degraded: Vec::new(),
+                    note: None,
+                })
+            }
+        }
+
+        let observed_budget = Arc::new(Mutex::new(None));
+        let volcengine = DeadlineBackend {
+            observed_budget: Arc::clone(&observed_budget),
+        };
+        let fallback = FakeBackend {
+            id: BackendId::DuckDuckGo,
+            result: Ok(vec![result()]),
+        };
+        let first_attempt_budget = Duration::from_millis(1_500);
+        let response = run_backend_chain(
+            &[&volcengine, &fallback],
+            &query(),
+            Instant::now() + Duration::from_secs(2),
+            Some(first_attempt_budget),
+        )
+        .await
+        .expect("the first backend should complete inside its dedicated budget");
+
+        assert_eq!(response.raw.backend, BackendId::Volcengine);
+        let observed = observed_budget
+            .lock()
+            .expect("budget lock")
+            .expect("first backend must observe a deadline");
+        assert!(
+            observed > Duration::from_millis(1_250),
+            "dedicated first-attempt budget should exceed the default one-second fair share: {observed:?}"
+        );
+        assert!(observed <= first_attempt_budget);
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/web/backend.rs
+++ b/crates/tui/src/tools/web/backend.rs
@@ -1,15 +1,15 @@
 //! Search backend selection and the shared async adapter contract.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 
-use super::contract::{BackendId, BackendSearch, QueryCapabilities, SearchQuery};
+use super::contract::{BackendId, BackendSearch, DegradedReason, QueryCapabilities, SearchQuery};
 use crate::config::SearchProvider;
 use crate::tools::spec::{ToolContext, ToolError};
 
 #[async_trait]
-pub(crate) trait SearchBackend {
+pub(crate) trait SearchBackend: Send + Sync {
     fn id(&self) -> BackendId;
     fn capabilities(&self) -> QueryCapabilities;
     async fn search(
@@ -38,11 +38,11 @@ pub(crate) enum ConfiguredSearchBackend<'a> {
 
 impl<'a> ConfiguredSearchBackend<'a> {
     #[must_use]
-    pub(crate) fn from_context(context: &'a ToolContext) -> Self {
+    pub(crate) fn from_provider(context: &'a ToolContext, provider: SearchProvider) -> Self {
         let backend = BackendContext {
             tool_context: context,
         };
-        match context.search_provider {
+        match provider {
             SearchProvider::Bing => Self::Bing(backend),
             SearchProvider::DuckDuckGo => Self::DuckDuckGo(backend),
             SearchProvider::Tavily => Self::Tavily(backend),
@@ -84,6 +84,152 @@ impl<'a> ConfiguredSearchBackend<'a> {
     }
 }
 
+pub(crate) struct SearchBackendChain<'a> {
+    backends: Vec<ConfiguredSearchBackend<'a>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ChainedSearch {
+    pub(crate) raw: BackendSearch,
+    pub(crate) capabilities: QueryCapabilities,
+}
+
+impl<'a> SearchBackendChain<'a> {
+    #[must_use]
+    pub(crate) fn from_context(context: &'a ToolContext) -> Self {
+        let selected = context.search_provider;
+        let mut backends = vec![ConfiguredSearchBackend::from_provider(context, selected)];
+        if !matches!(selected, SearchProvider::Bing | SearchProvider::DuckDuckGo) {
+            backends.push(ConfiguredSearchBackend::from_provider(
+                context,
+                SearchProvider::DuckDuckGo,
+            ));
+        }
+        Self { backends }
+    }
+
+    #[must_use]
+    pub(crate) fn initial_backend(&self) -> BackendId {
+        self.backends
+            .first()
+            .expect("a search chain always has a configured backend")
+            .id()
+    }
+
+    pub(crate) async fn search(
+        &self,
+        query: &SearchQuery,
+        deadline: Instant,
+        first_attempt_budget: Option<Duration>,
+    ) -> Result<ChainedSearch, ToolError> {
+        let backends = self
+            .backends
+            .iter()
+            .map(|backend| backend as &dyn SearchBackend)
+            .collect::<Vec<_>>();
+        run_backend_chain(&backends, query, deadline, first_attempt_budget).await
+    }
+}
+
+async fn run_backend_chain(
+    backends: &[&dyn SearchBackend],
+    query: &SearchQuery,
+    deadline: Instant,
+    first_attempt_budget: Option<Duration>,
+) -> Result<ChainedSearch, ToolError> {
+    let mut degraded = Vec::new();
+    let mut last_empty = None;
+    let mut attempted = Vec::new();
+
+    for (index, backend) in backends.iter().enumerate() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let backend_id = backend.id();
+        if let Some(previous) = attempted.last() {
+            degraded.push(DegradedReason::BackendFallback {
+                from: *previous,
+                to: backend_id,
+            });
+        }
+        attempted.push(backend_id);
+
+        let attempts_left = u32::try_from(backends.len() - index).unwrap_or(u32::MAX);
+        let fair_share = remaining / attempts_left;
+        let attempt_budget = if index == 0 {
+            first_attempt_budget
+                .map(|budget| budget.min(remaining))
+                .unwrap_or(fair_share)
+        } else {
+            fair_share
+        }
+        .max(Duration::from_millis(1));
+        let attempt_deadline = Instant::now() + attempt_budget;
+
+        let result = tokio::time::timeout(attempt_budget, backend.search(query, attempt_deadline))
+            .await
+            .map_err(|_| ToolError::Timeout {
+                seconds: u64::try_from(attempt_budget.as_millis())
+                    .unwrap_or(u64::MAX)
+                    .div_ceil(1_000),
+            })
+            .and_then(std::convert::identity);
+
+        match result {
+            Ok(mut raw) if !raw.results.is_empty() => {
+                degraded.append(&mut raw.degraded);
+                raw.degraded = degraded;
+                return Ok(ChainedSearch {
+                    raw,
+                    capabilities: backend.capabilities(),
+                });
+            }
+            Ok(mut raw) => {
+                degraded.push(DegradedReason::NoUsableResults {
+                    backend: backend_id,
+                });
+                degraded.append(&mut raw.degraded);
+                last_empty = Some((raw, backend.capabilities()));
+            }
+            Err(error) if is_fail_closed(&error) => return Err(error),
+            Err(error) if backends.len() == 1 => return Err(error),
+            Err(_) => degraded.push(DegradedReason::BackendUnavailable {
+                backend: backend_id,
+            }),
+        }
+    }
+
+    if let Some((mut raw, capabilities)) = last_empty {
+        raw.degraded = degraded;
+        return Ok(ChainedSearch { raw, capabilities });
+    }
+
+    if attempted.is_empty() {
+        return Err(ToolError::Timeout { seconds: 1 });
+    }
+
+    let backend_ids = attempted
+        .into_iter()
+        .map(BackendId::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(ToolError::not_available(format!(
+        "web search backends unavailable: {backend_ids}"
+    )))
+}
+
+const fn is_fail_closed(error: &ToolError) -> bool {
+    matches!(
+        error,
+        ToolError::InvalidInput { .. }
+            | ToolError::MissingField { .. }
+            | ToolError::PathEscape { .. }
+            | ToolError::Cancelled { .. }
+            | ToolError::PermissionDenied { .. }
+    )
+}
+
 #[async_trait]
 impl SearchBackend for ConfiguredSearchBackend<'_> {
     fn id(&self) -> BackendId {
@@ -123,7 +269,54 @@ impl SearchBackend for ConfiguredSearchBackend<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+
+    struct FakeBackend {
+        id: BackendId,
+        result: Result<Vec<super::super::contract::SearchResult>, ToolError>,
+    }
+
+    #[async_trait]
+    impl SearchBackend for FakeBackend {
+        fn id(&self) -> BackendId {
+            self.id
+        }
+
+        fn capabilities(&self) -> QueryCapabilities {
+            QueryCapabilities::count_only()
+        }
+
+        async fn search(
+            &self,
+            _query: &SearchQuery,
+            _deadline: Instant,
+        ) -> Result<BackendSearch, ToolError> {
+            Ok(BackendSearch {
+                backend: self.id,
+                source: self.id.as_str().to_string(),
+                backend_detail: None,
+                results: self.result.clone()?,
+                degraded: Vec::new(),
+                note: None,
+            })
+        }
+    }
+
+    fn query() -> SearchQuery {
+        SearchQuery::new("bounded chain".to_string(), 5, None, Vec::new(), None)
+    }
+
+    fn result() -> super::super::contract::SearchResult {
+        super::super::contract::SearchResult::new(
+            1,
+            "Fallback result".to_string(),
+            "https://example.com/result".to_string(),
+            None,
+            None,
+        )
+    }
 
     #[test]
     fn every_configured_provider_maps_to_one_explicit_backend_adapter() {
@@ -142,12 +335,154 @@ mod tests {
         for (provider, expected) in cases {
             let mut context = ToolContext::new(std::path::PathBuf::from("."));
             context.search_provider = provider;
-            let backend = ConfiguredSearchBackend::from_context(&context);
+            let backend = ConfiguredSearchBackend::from_provider(&context, provider);
             assert_eq!(backend.id(), expected);
             assert_eq!(
                 backend.capabilities().max_results,
                 super::super::contract::CapabilityState::Supported
             );
         }
+    }
+
+    #[tokio::test]
+    async fn unavailable_api_falls_back_with_explicit_receipts() {
+        let api = FakeBackend {
+            id: BackendId::Tavily,
+            result: Err(ToolError::execution_failed(
+                "provider detail must stay private",
+            )),
+        };
+        let scrape = FakeBackend {
+            id: BackendId::DuckDuckGo,
+            result: Ok(vec![result()]),
+        };
+        let response = run_backend_chain(
+            &[&api, &scrape],
+            &query(),
+            Instant::now() + Duration::from_secs(1),
+            None,
+        )
+        .await
+        .expect("fallback should succeed");
+
+        assert_eq!(response.raw.backend, BackendId::DuckDuckGo);
+        assert_eq!(
+            response.raw.degraded,
+            vec![
+                DegradedReason::BackendUnavailable {
+                    backend: BackendId::Tavily,
+                },
+                DegradedReason::BackendFallback {
+                    from: BackendId::Tavily,
+                    to: BackendId::DuckDuckGo,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn all_unavailable_returns_typed_error_with_backend_ids_only() {
+        let private_error = "secret provider response";
+        let api = FakeBackend {
+            id: BackendId::Bocha,
+            result: Err(ToolError::execution_failed(private_error)),
+        };
+        let scrape = FakeBackend {
+            id: BackendId::DuckDuckGo,
+            result: Err(ToolError::execution_failed("different private response")),
+        };
+        let error = run_backend_chain(
+            &[&api, &scrape],
+            &query(),
+            Instant::now() + Duration::from_secs(1),
+            None,
+        )
+        .await
+        .expect_err("all-down chain must fail");
+        let message = error.to_string();
+
+        assert!(matches!(error, ToolError::NotAvailable { .. }));
+        assert!(message.contains("bocha, duckduckgo"));
+        assert!(!message.contains(private_error));
+        assert!(!message.contains("different private response"));
+    }
+
+    #[tokio::test]
+    async fn policy_failure_does_not_leak_query_to_fallback() {
+        struct CountingBackend {
+            calls: Arc<std::sync::atomic::AtomicUsize>,
+        }
+        #[async_trait]
+        impl SearchBackend for CountingBackend {
+            fn id(&self) -> BackendId {
+                BackendId::DuckDuckGo
+            }
+
+            fn capabilities(&self) -> QueryCapabilities {
+                QueryCapabilities::count_only()
+            }
+
+            async fn search(
+                &self,
+                _query: &SearchQuery,
+                _deadline: Instant,
+            ) -> Result<BackendSearch, ToolError> {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(ToolError::execution_failed("unexpected fallback"))
+            }
+        }
+
+        let api = FakeBackend {
+            id: BackendId::Searxng,
+            result: Err(ToolError::permission_denied("policy blocked")),
+        };
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let scrape = CountingBackend {
+            calls: Arc::clone(&calls),
+        };
+        let error = run_backend_chain(
+            &[&api, &scrape],
+            &query(),
+            Instant::now() + Duration::from_secs(1),
+            None,
+        )
+        .await
+        .expect_err("policy error must fail closed");
+
+        assert!(matches!(error, ToolError::PermissionDenied { .. }));
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_api_falls_back_and_records_no_usable_results() {
+        let api = FakeBackend {
+            id: BackendId::Metaso,
+            result: Ok(Vec::new()),
+        };
+        let scrape = FakeBackend {
+            id: BackendId::DuckDuckGo,
+            result: Ok(vec![result()]),
+        };
+        let response = run_backend_chain(
+            &[&api, &scrape],
+            &query(),
+            Instant::now() + Duration::from_secs(1),
+            None,
+        )
+        .await
+        .expect("empty API response should fall back");
+
+        assert_eq!(
+            response.raw.degraded,
+            vec![
+                DegradedReason::NoUsableResults {
+                    backend: BackendId::Metaso,
+                },
+                DegradedReason::BackendFallback {
+                    from: BackendId::Metaso,
+                    to: BackendId::DuckDuckGo,
+                },
+            ]
+        );
     }
 }

--- a/crates/tui/src/tools/web/cache.rs
+++ b/crates/tui/src/tools/web/cache.rs
@@ -1,4 +1,4 @@
-//! Small session-scoped TTL cache for fetched response bodies.
+//! Small session-scoped TTL caches for web searches and fetched bodies.
 
 use std::num::NonZeroUsize;
 use std::sync::{Arc, OnceLock};
@@ -7,10 +7,15 @@ use std::time::{Duration, Instant};
 use lru::LruCache;
 use parking_lot::Mutex;
 
+use super::contract::{BackendId, SearchQuery, SearchResponse};
+
 const FETCH_CACHE_ENTRIES: usize = 256;
+const SEARCH_CACHE_ENTRIES: usize = 128;
 const FETCH_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+const SEARCH_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 
 static FETCH_CACHE: OnceLock<Mutex<LruCache<FetchCacheKey, FetchCacheEntry>>> = OnceLock::new();
+static SEARCH_CACHE: OnceLock<Mutex<LruCache<SearchCacheKey, SearchCacheEntry>>> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct FetchCacheKey {
@@ -36,12 +41,48 @@ struct FetchCacheEntry {
     payload: CachedFetch,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SearchCacheKey {
+    namespace: String,
+    initial_backend: BackendId,
+    base_url: Option<String>,
+    query: SearchQuery,
+}
+
+#[derive(Debug, Clone)]
+struct SearchCacheEntry {
+    searched_at: Instant,
+    response: SearchResponse,
+}
+
 fn cache() -> &'static Mutex<LruCache<FetchCacheKey, FetchCacheEntry>> {
     FETCH_CACHE.get_or_init(|| {
         Mutex::new(LruCache::new(
             NonZeroUsize::new(FETCH_CACHE_ENTRIES).expect("non-zero cache capacity"),
         ))
     })
+}
+
+fn search_cache() -> &'static Mutex<LruCache<SearchCacheKey, SearchCacheEntry>> {
+    SEARCH_CACHE.get_or_init(|| {
+        Mutex::new(LruCache::new(
+            NonZeroUsize::new(SEARCH_CACHE_ENTRIES).expect("non-zero search cache capacity"),
+        ))
+    })
+}
+
+fn search_key(
+    namespace: &str,
+    initial_backend: BackendId,
+    base_url: Option<&str>,
+    query: &SearchQuery,
+) -> SearchCacheKey {
+    SearchCacheKey {
+        namespace: namespace.to_string(),
+        initial_backend,
+        base_url: base_url.map(str::to_string),
+        query: query.clone(),
+    }
 }
 
 fn key(namespace: &str, url: &reqwest::Url, accept: &str) -> FetchCacheKey {
@@ -93,9 +134,47 @@ pub(crate) fn insert(namespace: &str, url: &reqwest::Url, accept: &str, payload:
     );
 }
 
+pub(crate) fn get_search(
+    namespace: &str,
+    initial_backend: BackendId,
+    base_url: Option<&str>,
+    query: &SearchQuery,
+) -> Option<SearchResponse> {
+    let key = search_key(namespace, initial_backend, base_url, query);
+    let mut cache = search_cache().lock();
+    let entry = cache.get(&key)?.clone();
+    if entry.searched_at.elapsed() > SEARCH_CACHE_TTL {
+        cache.pop(&key);
+        return None;
+    }
+
+    Some(entry.response)
+}
+
+pub(crate) fn insert_search(
+    namespace: &str,
+    initial_backend: BackendId,
+    base_url: Option<&str>,
+    query: &SearchQuery,
+    response: SearchResponse,
+) {
+    search_cache().lock().put(
+        search_key(namespace, initial_backend, base_url, query),
+        SearchCacheEntry {
+            searched_at: Instant::now(),
+            response,
+        },
+    );
+}
+
 #[cfg(test)]
 pub(crate) fn reset() {
     cache().lock().clear();
+}
+
+#[cfg(test)]
+pub(crate) fn reset_search() {
+    search_cache().lock().clear();
 }
 
 #[cfg(test)]
@@ -111,6 +190,39 @@ mod tests {
             bytes: Arc::new(bytes.to_vec()),
             truncated,
             redirects: 0,
+        }
+    }
+
+    fn search_response(query: SearchQuery) -> SearchResponse {
+        use super::super::contract::{
+            HonoredQueryCapabilities, QueryCapabilities, SearchReceipt, SearchResult,
+        };
+
+        SearchResponse {
+            query: query.query.clone(),
+            source: "duckduckgo".to_string(),
+            count: 1,
+            message: "Found 1 result(s)".to_string(),
+            results: vec![SearchResult::new(
+                1,
+                "Cached result".to_string(),
+                "https://example.com/result".to_string(),
+                None,
+                None,
+            )],
+            receipt: SearchReceipt {
+                backend: BackendId::DuckDuckGo,
+                backend_detail: None,
+                requested: query,
+                capabilities: QueryCapabilities::count_only(),
+                honored: HonoredQueryCapabilities {
+                    max_results: true,
+                    ..HonoredQueryCapabilities::default()
+                },
+                degraded: Vec::new(),
+                latency_ms: 4,
+                cache_hit: false,
+            },
         }
     }
 
@@ -137,5 +249,34 @@ mod tests {
         assert!(get("session-a", &url, "text/html", 10).is_some());
         assert!(get("session-b", &url, "text/html", 10).is_none());
         assert!(get("session-a", &url, "application/json", 10).is_none());
+    }
+
+    #[test]
+    fn search_cache_is_scoped_by_session_backend_endpoint_and_query() {
+        reset_search();
+        let query = SearchQuery::new("cached query".to_string(), 5, None, Vec::new(), None);
+        insert_search(
+            "session-a",
+            BackendId::Tavily,
+            None,
+            &query,
+            search_response(query.clone()),
+        );
+
+        assert!(get_search("session-a", BackendId::Tavily, None, &query).is_some());
+        assert!(get_search("session-b", BackendId::Tavily, None, &query).is_none());
+        assert!(get_search("session-a", BackendId::DuckDuckGo, None, &query).is_none());
+        assert!(
+            get_search(
+                "session-a",
+                BackendId::Tavily,
+                Some("https://search.example/"),
+                &query,
+            )
+            .is_none()
+        );
+        let other_query =
+            SearchQuery::new("different query".to_string(), 5, None, Vec::new(), None);
+        assert!(get_search("session-a", BackendId::Tavily, None, &other_query).is_none());
     }
 }

--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -41,7 +41,7 @@ impl BackendId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Recency {
     Day,
@@ -65,7 +65,7 @@ impl Recency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct SearchQuery {
     pub(crate) query: String,
     pub(crate) max_results: u8,
@@ -168,6 +168,9 @@ impl QueryKnob {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum DegradedReason {
+    BackendUnavailable { backend: BackendId },
+    NoUsableResults { backend: BackendId },
+    BackendFallback { from: BackendId, to: BackendId },
     ChallengeDetected { backend: BackendId },
     ScrapeFallback { from: BackendId, to: BackendId },
     KnobIgnored { knob: QueryKnob },
@@ -179,6 +182,17 @@ impl DegradedReason {
     #[must_use]
     pub(crate) fn message(&self) -> String {
         match self {
+            Self::BackendUnavailable { backend } => {
+                format!("{} was unavailable", backend.as_str())
+            }
+            Self::NoUsableResults { backend } => {
+                format!("{} returned no usable results", backend.as_str())
+            }
+            Self::BackendFallback { from, to } => format!(
+                "{} did not answer; tried {} next",
+                from.as_str(),
+                to.as_str()
+            ),
             Self::ChallengeDetected { backend } => {
                 format!("{} returned a bot challenge", backend.as_str())
             }

--- a/crates/tui/src/tools/web/fetch.rs
+++ b/crates/tui/src/tools/web/fetch.rs
@@ -395,7 +395,6 @@ mod tests {
 
     #[tokio::test]
     async fn transient_server_error_retries_once_then_caches() {
-        cache::reset();
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
         Mock::given(method("GET"))
@@ -426,7 +425,6 @@ mod tests {
 
     #[tokio::test]
     async fn truncated_cache_refetches_when_larger_body_is_requested() {
-        cache::reset();
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/large"))
@@ -487,7 +485,6 @@ mod tests {
     async fn tightened_network_policy_blocks_an_existing_cache_entry() {
         use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
 
-        cache::reset();
         let url = reqwest::Url::parse("https://example.com/cached").unwrap();
         cache::insert(
             "policy-cache",
@@ -529,7 +526,6 @@ mod tests {
     async fn tightened_network_policy_checks_cached_redirect_destination() {
         use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
 
-        cache::reset();
         let initial_url = reqwest::Url::parse("https://8.8.8.8/cached").unwrap();
         cache::insert(
             "redirect-policy-cache",

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -45,9 +45,6 @@ const METASO_ENDPOINT: &str = "https://metaso.cn/api/v1";
 const BAIDU_ENDPOINT: &str = "https://qianfan.baidubce.com/v2/ai_search/web_search";
 const VOLCENGINE_RESPONSES_ENDPOINT: &str = "https://ark.cn-beijing.volces.com/api/v3/responses";
 const SOFYA_ENDPOINT: &str = "https://sofya.co/v1/search";
-/// Intentionally public default key provided by Metaso for open-source/community use.
-/// Last-resort fallback after config and env var. Rate-limited to ~100 searches/day.
-const METASO_DEFAULT_API_KEY: &str = "mk-E384C1DD5E8501BB7EFE27C949AFDE5B";
 const ERROR_BODY_PREVIEW_BYTES: usize = 512;
 const VOLCENGINE_MIN_TIMEOUT_MS: u64 = 90_000;
 
@@ -436,8 +433,7 @@ impl WebSearchTool {
     }
 
     /// Search via Metaso AI Search API (<https://metaso.cn>). Falls back to
-    /// `METASO_API_KEY` env var then a built-in default key if no config key
-    /// is set.
+    /// `METASO_API_KEY` when no config key is set.
     async fn run_metaso_search(
         &self,
         query: &str,
@@ -450,7 +446,11 @@ impl WebSearchTool {
             .search_api_key
             .as_deref()
             .or(env_key.as_deref())
-            .unwrap_or(METASO_DEFAULT_API_KEY);
+            .ok_or_else(|| {
+                ToolError::execution_failed(
+                    "Metaso search requires an API key. Set `METASO_API_KEY` or `[search] api_key` in config.toml.",
+                )
+            })?;
 
         let client = crate::tls::reqwest_client_builder()
             .timeout(Duration::from_millis(timeout_ms))
@@ -780,6 +780,11 @@ fn preflight_search_provider(context: &ToolContext) -> Result<(), ToolError> {
         SearchProvider::Bocha if !configured_key => Err(ToolError::execution_failed(
             "Bocha search requires an API key. Set `[search] api_key = \"sk-...\"` in config.toml.",
         )),
+        SearchProvider::Metaso if !configured_key && !env_key("METASO_API_KEY") => {
+            Err(ToolError::execution_failed(
+                "Metaso search requires an API key. Set `METASO_API_KEY` or `[search] api_key` in config.toml.",
+            ))
+        }
         SearchProvider::Baidu if !configured_key && !env_key("BAIDU_SEARCH_API_KEY") => {
             Err(ToolError::execution_failed(
                 "Baidu search requires an API key. Set `BAIDU_SEARCH_API_KEY` or `[search] api_key` in config.toml.",
@@ -2423,28 +2428,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn metaso_provider_uses_built_in_key_when_no_config_key_set() {
-        // Unlike Tavily/Bocha, Metaso falls back to a built-in default, so
-        // the call should NOT return an API-key-related error — it should
-        // either succeed or fail with a network-level error, but never a
-        // missing-key error.
+    #[allow(clippy::await_holding_lock)]
+    async fn metaso_provider_without_api_key_fails_closed_before_fallback() {
         use crate::config::SearchProvider;
         use crate::tools::spec::{ToolContext, ToolSpec};
+
+        let _guard = crate::test_support::lock_test_env();
+        let previous = std::env::var_os("METASO_API_KEY");
+        unsafe { std::env::remove_var("METASO_API_KEY") };
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut ctx = ToolContext::new(tmp.path().to_path_buf());
         ctx.search_provider = SearchProvider::Metaso;
         ctx.search_api_key = None;
-        let result = WebSearchTool
+        let error = WebSearchTool
             .execute(json!({"query": "anything"}), &ctx)
-            .await;
-        let msg = match &result {
-            Ok(res) => format!("{res:?}"),
-            Err(e) => e.to_string(),
-        };
+            .await
+            .expect_err("missing Metaso key must fail before the fallback chain");
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var("METASO_API_KEY", value) },
+            None => unsafe { std::env::remove_var("METASO_API_KEY") },
+        }
+
+        let message = error.to_string();
         assert!(
-            !msg.contains("API key"),
-            "should not complain about missing API key (built-in default); got `{msg}`"
+            message.contains("Metaso")
+                && message.contains("API key")
+                && message.contains("METASO_API_KEY"),
+            "got `{message}`"
+        );
+        assert!(
+            !message.contains("duckduckgo"),
+            "missing configuration must not cross providers: `{message}`"
         );
     }
 

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1,5 +1,7 @@
-//! Web search tool backed by multiple providers: Bing HTML scrape, DuckDuckGo
-//! (HTML scrape with Bing fallback), Tavily API, Bocha (博查) API,
+//! Web search tool backed by a bounded backend chain: configured API search,
+//! then DuckDuckGo HTML scrape with a one-way Bing fallback. Explicit Bing and
+//! private DuckDuckGo-compatible routes remain single-provider. API adapters
+//! include Tavily, Bocha (博查),
 //! Metaso API (<https://metaso.cn>), SearXNG JSON API, Baidu AI Search,
 //! Volcengine Ark, and Sofya (<https://sofya.co>).
 //!
@@ -23,7 +25,8 @@ use serde_json::{Value, json};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-use super::web::backend::{ConfiguredSearchBackend, SearchBackend};
+use super::web::backend::SearchBackendChain;
+use super::web::cache;
 use super::web::contract::{
     BackendId, BackendSearch, DegradedReason, HonoredQueryCapabilities, MAX_SEARCH_RESULTS,
     QueryKnob, Recency, SearchQuery, SearchReceipt, SearchResponse, SearchResult,
@@ -46,6 +49,7 @@ const SOFYA_ENDPOINT: &str = "https://sofya.co/v1/search";
 /// Last-resort fallback after config and env var. Rate-limited to ~100 searches/day.
 const METASO_DEFAULT_API_KEY: &str = "mk-E384C1DD5E8501BB7EFE27C949AFDE5B";
 const ERROR_BODY_PREVIEW_BYTES: usize = 512;
+const VOLCENGINE_MIN_TIMEOUT_MS: u64 = 90_000;
 
 /// Returns `Ok(())` if the policy allows the call, or a `ToolError` otherwise.
 /// Falls through silently when no policy is attached (back-compat).
@@ -95,7 +99,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web and return ranked results with URLs and snippets. Default backend is DuckDuckGo with Bing fallback; set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml to switch backends, or `[search] base_url` for a DuckDuckGo-compatible endpoint or trusted SearXNG instance. Use this instead of scraping search engines with `curl` in `exec_shell`. For a known canonical URL, prefer `fetch_url` directly."
+        "Search the web and return ranked results with URLs, snippets, and an execution receipt. Default backend is DuckDuckGo with Bing fallback. Configured API backends are tried first and visibly degrade through DuckDuckGo then Bing when unavailable; configuration and network-policy errors fail closed. Explicit Bing and private DuckDuckGo-compatible routes do not cross providers. Set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml, or `[search] base_url` for a private DuckDuckGo-compatible endpoint or trusted SearXNG instance. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {
@@ -719,24 +723,123 @@ pub(crate) async fn execute_search(
         )));
     }
 
-    let backend = ConfiguredSearchBackend::from_context(context);
-    debug_assert_eq!(backend.id().as_str(), context.search_provider.as_str());
-    let capabilities = backend.capabilities();
-    let started = Instant::now();
-    let effective_timeout_ms = if backend.id() == BackendId::Volcengine {
-        timeout_ms.max(90_000)
-    } else {
-        timeout_ms.max(1)
-    };
-    let timeout = Duration::from_millis(effective_timeout_ms);
-    let deadline = started + timeout;
-    let raw = tokio::time::timeout(timeout, backend.search(&query, deadline))
-        .await
-        .map_err(|_| ToolError::Timeout {
-            seconds: effective_timeout_ms.div_ceil(1_000),
-        })??;
+    preflight_search_provider(context)?;
+    let chain = SearchBackendChain::from_context(context);
+    debug_assert_eq!(
+        chain.initial_backend().as_str(),
+        context.search_provider.as_str()
+    );
+    let initial_backend = chain.initial_backend();
+    let normalized_base_url = normalized_search_base_url(context.search_base_url.as_deref());
 
-    Ok(finalize_search_response(query, capabilities, raw, started))
+    if let Some(mut cached) = cache::get_search(
+        &context.state_namespace,
+        initial_backend,
+        normalized_base_url.as_deref(),
+        &query,
+    ) {
+        validate_cached_search_policy(&cached, context)?;
+        cached.receipt.cache_hit = true;
+        cached.receipt.latency_ms = 0;
+        return Ok(cached);
+    }
+
+    let started = Instant::now();
+    let requested_timeout = Duration::from_millis(timeout_ms.max(1));
+    let (total_timeout, first_attempt_budget) = if initial_backend == BackendId::Volcengine {
+        let provider_budget = Duration::from_millis(VOLCENGINE_MIN_TIMEOUT_MS);
+        (provider_budget + requested_timeout, Some(provider_budget))
+    } else {
+        (requested_timeout, None)
+    };
+    let deadline = started + total_timeout;
+    let chained = chain.search(&query, deadline, first_attempt_budget).await?;
+    let response =
+        finalize_search_response(query.clone(), chained.capabilities, chained.raw, started);
+    cache::insert_search(
+        &context.state_namespace,
+        initial_backend,
+        normalized_base_url.as_deref(),
+        &query,
+        response.clone(),
+    );
+    Ok(response)
+}
+
+fn preflight_search_provider(context: &ToolContext) -> Result<(), ToolError> {
+    let configured_key = context
+        .search_api_key
+        .as_deref()
+        .is_some_and(|key| !key.trim().is_empty());
+    let env_key = |name: &str| std::env::var_os(name).is_some_and(|value| !value.is_empty());
+
+    match context.search_provider {
+        SearchProvider::Tavily if !configured_key => Err(ToolError::execution_failed(
+            "Tavily search requires an API key. Set `[search] api_key = \"tvly-...\"` in config.toml.",
+        )),
+        SearchProvider::Bocha if !configured_key => Err(ToolError::execution_failed(
+            "Bocha search requires an API key. Set `[search] api_key = \"sk-...\"` in config.toml.",
+        )),
+        SearchProvider::Baidu if !configured_key && !env_key("BAIDU_SEARCH_API_KEY") => {
+            Err(ToolError::execution_failed(
+                "Baidu search requires an API key. Set `BAIDU_SEARCH_API_KEY` or `[search] api_key` in config.toml.",
+            ))
+        }
+        SearchProvider::Volcengine
+            if !configured_key
+                && !env_key("VOLCENGINE_API_KEY")
+                && !env_key("VOLCENGINE_ARK_API_KEY")
+                && !env_key("ARK_API_KEY") =>
+        {
+            Err(ToolError::execution_failed(
+                "Volcengine search requires an API key. Set `[search] api_key`, or VOLCENGINE_API_KEY / VOLCENGINE_ARK_API_KEY / ARK_API_KEY env var.",
+            ))
+        }
+        SearchProvider::Sofya if !configured_key && !env_key("SOFYA_API_KEY") => {
+            Err(ToolError::execution_failed(
+                "Sofya search requires an API key. Set `[search] api_key = \"ay_live_...\"` in config.toml or the SOFYA_API_KEY env var.",
+            ))
+        }
+        _ => Ok(()),
+    }
+}
+
+fn normalized_search_base_url(base_url: Option<&str>) -> Option<String> {
+    let raw = configured_search_base_url(base_url)?;
+    let Ok(mut url) = reqwest::Url::parse(raw) else {
+        return Some(raw.to_string());
+    };
+    url.set_fragment(None);
+    Some(url.to_string())
+}
+
+fn validate_cached_search_policy(
+    response: &SearchResponse,
+    context: &ToolContext,
+) -> Result<(), ToolError> {
+    let host = response
+        .receipt
+        .backend_detail
+        .as_deref()
+        .or_else(|| default_backend_host(response.receipt.backend))
+        .ok_or_else(|| {
+            ToolError::execution_failed("cached search receipt did not identify its backend host")
+        })?;
+    check_policy(context.network_policy.as_ref(), host)
+}
+
+const fn default_backend_host(backend: BackendId) -> Option<&'static str> {
+    match backend {
+        BackendId::Bing => Some(BING_HOST),
+        BackendId::DuckDuckGo => Some("html.duckduckgo.com"),
+        BackendId::Tavily => Some("api.tavily.com"),
+        BackendId::Bocha => Some("api.bochaai.com"),
+        BackendId::Metaso => Some("metaso.cn"),
+        BackendId::Searxng => None,
+        BackendId::Baidu => Some("qianfan.baidubce.com"),
+        BackendId::Volcengine => Some("ark.cn-beijing.volces.com"),
+        BackendId::Sofya => Some("sofya.co"),
+    }
 }
 
 fn finalize_search_response(
@@ -917,6 +1020,17 @@ async fn run_scrape_search(
     timeout_ms: u64,
     context: &ToolContext,
 ) -> Result<BackendSearch, ToolError> {
+    // A configured API backend may carry a provider-specific base URL (most
+    // notably SearXNG). The public scrape fallback must never reinterpret
+    // that endpoint as DuckDuckGo-compatible HTML.
+    let fallback_context = (provider == SearchProvider::DuckDuckGo
+        && context.search_provider != SearchProvider::DuckDuckGo)
+        .then(|| {
+            let mut cloned = context.clone();
+            cloned.search_base_url = None;
+            cloned
+        });
+    let context = fallback_context.as_ref().unwrap_or(context);
     run_scrape_search_with_endpoints(
         provider,
         query,
@@ -948,19 +1062,13 @@ async fn run_scrape_search_with_endpoints(
     if provider == SearchProvider::Bing {
         check_policy(decider, BING_HOST)?;
         let results = run_bing_search(&client, &query.query, max_results, endpoints.bing).await?;
-        if !results.is_empty() {
-            return Ok(BackendSearch {
-                backend: BackendId::Bing,
-                source: "bing".to_string(),
-                backend_detail: None,
-                results: normalize_entries(results),
-                degraded,
-                note: None,
-            });
-        }
-        degraded.push(DegradedReason::ScrapeFallback {
-            from: BackendId::Bing,
-            to: BackendId::DuckDuckGo,
+        return Ok(BackendSearch {
+            backend: BackendId::Bing,
+            source: "bing".to_string(),
+            backend_detail: None,
+            results: normalize_entries(results),
+            degraded,
+            note: None,
         });
     }
 
@@ -996,8 +1104,6 @@ async fn run_scrape_search_with_endpoints(
     let results = parse_duckduckgo_results(&body, max_results);
     let blocked = is_duckduckgo_challenge(&body);
     if !results.is_empty() {
-        let note = (provider == SearchProvider::Bing)
-            .then(|| "Bing returned no results; used DuckDuckGo fallback".to_string());
         return Ok(BackendSearch {
             backend: BackendId::DuckDuckGo,
             source: if allow_bing_fallback {
@@ -1008,7 +1114,7 @@ async fn run_scrape_search_with_endpoints(
             backend_detail: (!allow_bing_fallback).then_some(duckduckgo_host),
             results: normalize_entries(results),
             degraded,
-            note,
+            note: None,
         });
     }
     if blocked {
@@ -1712,7 +1818,7 @@ mod tests {
         parse_volcengine_results, run_scrape_search_with_endpoints, sanitize_error_body,
         searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
-    use crate::tools::web::contract::{QueryCapabilities, SearchQuery};
+    use crate::tools::web::contract::{BackendId, QueryCapabilities, SearchQuery};
     use crate::tools::web::scrape::{decode_html_entities, normalize_bing_url};
     use serde_json::json;
 
@@ -2593,7 +2699,7 @@ mod tests {
     #[tokio::test]
     async fn searxng_empty_results_report_backend() {
         use crate::config::SearchProvider;
-        use crate::tools::spec::{ToolContext, ToolSpec};
+        use crate::tools::spec::ToolContext;
         use wiremock::matchers::{method, path, query_param};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2611,26 +2717,24 @@ mod tests {
         ctx.search_provider = SearchProvider::Searxng;
         ctx.search_base_url = Some(server.uri());
 
-        let result = WebSearchTool
-            .execute(json!({"query": "empty"}), &ctx)
+        let (results, host) = WebSearchTool
+            .run_searxng_search("empty", 5, 5_000, &ctx)
             .await
-            .expect("empty searxng response should still be structured");
-        let value: serde_json::Value =
-            serde_json::from_str(&result.content).expect("web search json response");
+            .expect("empty SearXNG adapter response should be successful");
+        let expected_host = reqwest::Url::parse(&server.uri())
+            .expect("mock URL")
+            .host_str()
+            .expect("mock host")
+            .to_string();
 
-        assert_eq!(value["count"].as_u64(), Some(0));
-        assert!(
-            value["message"]
-                .as_str()
-                .expect("message")
-                .contains("Backend: searxng at")
-        );
+        assert!(results.is_empty());
+        assert_eq!(host, expected_host);
     }
 
     #[tokio::test]
     async fn searxng_http_errors_are_actionable() {
         use crate::config::SearchProvider;
-        use crate::tools::spec::{ToolContext, ToolSpec};
+        use crate::tools::spec::ToolContext;
         use wiremock::matchers::{method, path, query_param};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2649,7 +2753,7 @@ mod tests {
         ctx.search_base_url = Some(server.uri());
 
         let err = WebSearchTool
-            .execute(json!({"query": "blocked"}), &ctx)
+            .run_searxng_search("blocked", 5, 5_000, &ctx)
             .await
             .expect_err("403 should be actionable");
         let msg = err.to_string();
@@ -2664,7 +2768,7 @@ mod tests {
     #[tokio::test]
     async fn searxng_rate_limit_error_mentions_configured_instance() {
         use crate::config::SearchProvider;
-        use crate::tools::spec::{ToolContext, ToolSpec};
+        use crate::tools::spec::ToolContext;
         use wiremock::matchers::{method, path, query_param};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2683,7 +2787,7 @@ mod tests {
         ctx.search_base_url = Some(server.uri());
 
         let err = WebSearchTool
-            .execute(json!({"query": "later"}), &ctx)
+            .run_searxng_search("later", 5, 5_000, &ctx)
             .await
             .expect_err("429 should be actionable");
         let msg = err.to_string();
@@ -2698,7 +2802,7 @@ mod tests {
     #[tokio::test]
     async fn searxng_invalid_json_is_actionable() {
         use crate::config::SearchProvider;
-        use crate::tools::spec::{ToolContext, ToolSpec};
+        use crate::tools::spec::ToolContext;
         use wiremock::matchers::{method, path, query_param};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2717,7 +2821,7 @@ mod tests {
         ctx.search_base_url = Some(server.uri());
 
         let err = WebSearchTool
-            .execute(json!({"query": "html"}), &ctx)
+            .run_searxng_search("html", 5, 5_000, &ctx)
             .await
             .expect_err("invalid JSON should be actionable");
         let msg = err.to_string();
@@ -2771,6 +2875,129 @@ mod tests {
 
         assert_eq!(value["source"].as_str(), Some(expected_host.as_str()));
         assert_eq!(value["count"].as_u64(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn repeated_search_uses_session_cache_and_marks_receipt() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::{ToolContext, ToolSpec};
+        use crate::tools::web::cache;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        cache::reset_search();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "session cache receipt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"
+                <html><body>
+                  <a class="result__a" href="https://example.com/cached">Cached result</a>
+                  <div class="result__snippet">Fetched once.</div>
+                </body></html>
+                "#,
+            ))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut context = ToolContext::new(tmp.path().to_path_buf())
+            .with_state_namespace("web-search-query-cache");
+        context.search_provider = SearchProvider::DuckDuckGo;
+        context.search_base_url = Some(format!("{}/html/", server.uri()));
+
+        let first = WebSearchTool
+            .execute(json!({"query": "session cache receipt"}), &context)
+            .await
+            .expect("first search should succeed");
+        let second = WebSearchTool
+            .execute(json!({"query": "session cache receipt"}), &context)
+            .await
+            .expect("second search should hit cache");
+        let first: serde_json::Value =
+            serde_json::from_str(&first.content).expect("first response json");
+        let second: serde_json::Value =
+            serde_json::from_str(&second.content).expect("second response json");
+        let requests = server.received_requests().await.expect("recorded requests");
+
+        assert_eq!(requests.len(), 1);
+        assert_eq!(first["receipt"]["cache_hit"], false);
+        assert_eq!(second["receipt"]["cache_hit"], true);
+        assert_eq!(second["receipt"]["latency_ms"], 0);
+        assert_eq!(second["results"], first["results"]);
+
+        use crate::network_policy::{Decision, NetworkPolicy, NetworkPolicyDecider};
+        let denied_host = reqwest::Url::parse(&server.uri())
+            .expect("mock server URL")
+            .host_str()
+            .expect("mock server host")
+            .to_string();
+        let policy = NetworkPolicy {
+            default: Decision::Allow.into(),
+            allow: Vec::new(),
+            deny: vec![denied_host],
+            proxy: Vec::new(),
+            proxy_fake_ip_cidrs: Vec::new(),
+            audit: false,
+        };
+        let blocked = context
+            .clone()
+            .with_network_policy(NetworkPolicyDecider::new(policy, None));
+        let error = WebSearchTool
+            .execute(json!({"query": "session cache receipt"}), &blocked)
+            .await
+            .expect_err("tightened policy must win over the query cache");
+        assert!(error.to_string().contains("blocked by network policy"));
+        assert_eq!(
+            server
+                .received_requests()
+                .await
+                .expect("recorded requests")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_bing_does_not_fall_back_to_duckduckgo() {
+        use crate::config::SearchProvider;
+        use crate::tools::spec::ToolContext;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/bing"))
+            .and(query_param("q", "one way fallback"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut context = ToolContext::new(tmp.path().to_path_buf());
+        context.search_provider = SearchProvider::Bing;
+        context.search_base_url = Some(format!("{}/must-not-be-used", server.uri()));
+        let query = SearchQuery::new("one way fallback".to_string(), 5, None, Vec::new(), None);
+        let raw = run_scrape_search_with_endpoints(
+            SearchProvider::Bing,
+            &query,
+            5_000,
+            &context,
+            ScrapeEndpoints {
+                bing: &format!("{}/bing", server.uri()),
+                allow_bing_fallback: Some(true),
+            },
+        )
+        .await
+        .expect("empty Bing response is a successful empty search");
+        let requests = server.received_requests().await.expect("recorded requests");
+
+        assert_eq!(raw.backend, BackendId::Bing);
+        assert!(raw.results.is_empty());
+        assert!(raw.degraded.is_empty());
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/bing");
     }
 
     #[tokio::test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1663,6 +1663,11 @@ parseable results. Bing remains selectable for users who explicitly want it,
 and Tavily, Bocha, Metaso, SearXNG, Baidu, Volcengine, or Sofya can be selected
 when an API-backed provider is preferred.
 
+Configured API providers are attempted first. Runtime failure or an empty
+result visibly degrades through DuckDuckGo and then Bing; the structured search
+receipt records every hop. Missing configuration and network-policy denials
+fail closed without sending the query to another provider.
+
 For a private/internal search service that serves DuckDuckGo-compatible HTML,
 keep `provider = "duckduckgo"` and set `base_url`; Codewhale appends the `q`
 query parameter to that endpoint and applies network policy to its host.
@@ -1677,8 +1682,8 @@ configured instance's JSON API. Set `provider = "searxng"` and
 by default because public instances often disable JSON output or rate-limit API
 traffic.
 
-**Metaso** ([metaso.cn](https://metaso.cn)) has a 100 searches/day free quota;
-set `METASO_API_KEY` or `[search] api_key` for a higher quota.
+**Metaso** ([metaso.cn](https://metaso.cn)) requires a user-supplied key. Set
+`METASO_API_KEY` or `[search] api_key`; Codewhale does not ship a shared key.
 
 **Baidu** uses Baidu AI Search at
 `https://qianfan.baidubce.com/v2/ai_search/web_search`. Set
@@ -1694,7 +1699,7 @@ Sofya model provider.
 [search]
 provider = "searxng" # duckduckgo | bing | tavily | bocha | metaso | searxng | baidu | volcengine | sofya
 # base_url = "https://search.example/" # optional with provider = "duckduckgo"; required with "searxng"
-# api_key = "YOUR_KEY" # required for tavily, bocha, baidu, volcengine, and sofya; optional for metaso; unused by searxng
+# api_key = "YOUR_KEY" # required for tavily, bocha, metaso, baidu, volcengine, and sofya; unused by searxng
 ```
 
 ## Local Media Attachments


### PR DESCRIPTION
## Summary

- add a bounded configured search chain: selected API backend to DuckDuckGo, with Bing only when explicitly selected
- emit typed, visible degradation receipts while keeping policy, cancellation, and invalid configuration fail-closed
- add a session-scoped 15-minute query cache with backend, endpoint, namespace, and normalized-query isolation plus policy revalidation on hits
- remove the compiled Metaso shared key; Metaso now requires user configuration or METASO_API_KEY

## Testing

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features --no-fail-fast
- [x] cargo test -p codewhale-tui --all-targets --no-fail-fast (7,547 passed; 3 intentional ignores; all integration targets passed)
- [x] cargo test -p codewhale-tui tools::web --no-fail-fast (145 passed; 1 intentional ignore)
- [x] python3 scripts/check-provider-registry.py
- [x] python3 scripts/check-readme-translations.py
- [x] staged added-line gitleaks scan with redaction

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes (not applicable; no UI surface changed)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable)

No tag, release, package publication, deploy, or other publication action is part of this PR.