### PR TITLE
feat(routes): carry sourced capability facts

### DIFF
--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -94,12 +94,18 @@ pub struct CatalogOffering {
     /// unknown, not "text-only").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub modalities: Option<ModelsDevModalities>,
+    /// Whether this provider offering accepts attachments, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachment: Option<bool>,
     /// Whether this offering supports reasoning, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
     /// Whether tool calling is supported, when known (#4115).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call: Option<bool>,
+    /// Whether structured output is supported, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured_output: Option<bool>,
     /// Provider-scoped reasoning controls / accepted effort metadata. Kept as
     /// raw JSON so the same model family served through different gateways can
     /// expose different effort vocabularies without lossy collapsing.
@@ -143,6 +149,17 @@ impl CatalogOffering {
                 .as_ref()
                 .map(RouteLimits::from)
                 .unwrap_or_default(),
+            capabilities: crate::route::RouteCapabilities {
+                attachments: crate::route::CapabilityState::from_optional_bool(self.attachment),
+                reasoning: crate::route::CapabilityState::from_optional_bool(self.reasoning),
+                native_tool_calls: crate::route::CapabilityState::from_optional_bool(
+                    self.tool_call,
+                ),
+                structured_output: crate::route::CapabilityState::from_optional_bool(
+                    self.structured_output,
+                ),
+                ..crate::route::RouteCapabilities::default()
+            },
             pricing: crate::pricing::route_pricing_sku(self),
         }
     }
@@ -264,8 +281,10 @@ fn offerings_from_models_dev(
                 limit: model.limit.clone(),
                 cost: model.cost.clone(),
                 modalities: model.modalities.clone(),
+                attachment: model.attachment,
                 reasoning: model.reasoning,
                 tool_call: model.tool_call,
+                structured_output: model.structured_output,
                 reasoning_options: model.reasoning_options.clone(),
                 source: source.clone(),
             });

--- a/crates/config/src/catalog/tests.rs
+++ b/crates/config/src/catalog/tests.rs
@@ -27,8 +27,11 @@ const FIXTURE: &str = r#"{
           "id": "glm-5.2",
           "family": "glm",
           "default": true,
+          "attachment": false,
           "reasoning": true,
           "reasoning_options": [{ "type": "effort", "values": ["high", "max"] }],
+          "tool_call": true,
+          "structured_output": true,
           "modalities": { "input": ["text"], "output": ["text"] },
           "limit": { "context": 1000000, "output": 131072 },
           "cost": { "input": 1.4, "output": 4.4, "cache_read": 0.26 }
@@ -76,6 +79,9 @@ fn hydrates_models_dev_offerings_preserving_offering_facts() {
     assert!(glm.default_for_provider);
     assert_eq!(glm.family.as_deref(), Some("glm"));
     assert_eq!(glm.reasoning, Some(true));
+    assert_eq!(glm.attachment, Some(false));
+    assert_eq!(glm.tool_call, Some(true));
+    assert_eq!(glm.structured_output, Some(true));
     // Provider-scoped reasoning options are preserved, not collapsed.
     assert_eq!(glm.reasoning_options.len(), 1);
     assert_eq!(glm.limit.as_ref().and_then(|l| l.context), Some(1_000_000));
@@ -109,6 +115,26 @@ fn to_offering_projects_routing_identity_and_limits() {
     assert_eq!(glm.endpoint_key, "chat");
     assert_eq!(glm.limits.context_tokens, Some(1_000_000));
     assert_eq!(glm.limits.output_tokens, Some(131_072));
+    assert_eq!(
+        glm.capabilities.attachments,
+        crate::route::CapabilityState::Unsupported
+    );
+    assert_eq!(
+        glm.capabilities.reasoning,
+        crate::route::CapabilityState::Supported
+    );
+    assert_eq!(
+        glm.capabilities.native_tool_calls,
+        crate::route::CapabilityState::Supported
+    );
+    assert_eq!(
+        glm.capabilities.structured_output,
+        crate::route::CapabilityState::Supported
+    );
+    assert_eq!(
+        glm.capabilities.streaming,
+        crate::route::CapabilityState::Unknown
+    );
 }
 
 #[test]

--- a/crates/config/src/models_dev.rs
+++ b/crates/config/src/models_dev.rs
@@ -17,7 +17,10 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::route::{ModelId, ProviderId, ProviderModelOffering, RouteLimits, WireModelId};
+use crate::route::{
+    CapabilityState, ModelId, ProviderId, ProviderModelOffering, RouteCapabilities, RouteLimits,
+    WireModelId,
+};
 
 /// Provider catalog endpoint used by Models.dev.
 pub const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
@@ -94,6 +97,7 @@ impl ModelsDevCatalog {
                 .as_ref()
                 .map(RouteLimits::from)
                 .unwrap_or_default(),
+            capabilities: route_capabilities(model),
             pricing: crate::pricing::route_pricing_sku_from_cost(model.cost.as_ref()),
         })
     }
@@ -124,10 +128,21 @@ impl ModelsDevCatalog {
                         .as_ref()
                         .map(RouteLimits::from)
                         .unwrap_or_default(),
+                    capabilities: route_capabilities(model),
                     pricing: crate::pricing::route_pricing_sku_from_cost(model.cost.as_ref()),
                 })
                 .collect(),
         )
+    }
+}
+
+fn route_capabilities(model: &ModelsDevProviderModel) -> RouteCapabilities {
+    RouteCapabilities {
+        attachments: CapabilityState::from_optional_bool(model.attachment),
+        reasoning: CapabilityState::from_optional_bool(model.reasoning),
+        native_tool_calls: CapabilityState::from_optional_bool(model.tool_call),
+        structured_output: CapabilityState::from_optional_bool(model.structured_output),
+        ..RouteCapabilities::default()
     }
 }
 
@@ -504,6 +519,22 @@ mod tests {
             .expect("route offering");
         assert_eq!(route_offering.limits.context_tokens, Some(1_000_000));
         assert_eq!(route_offering.limits.output_tokens, Some(131_072));
+        assert_eq!(
+            route_offering.capabilities.reasoning,
+            CapabilityState::Supported
+        );
+        assert_eq!(
+            route_offering.capabilities.native_tool_calls,
+            CapabilityState::Supported
+        );
+        assert_eq!(
+            route_offering.capabilities.structured_output,
+            CapabilityState::Supported
+        );
+        assert_eq!(
+            route_offering.capabilities.streaming,
+            CapabilityState::Unknown
+        );
     }
 
     #[test]

--- a/crates/config/src/route/candidate.rs
+++ b/crates/config/src/route/candidate.rs
@@ -14,15 +14,14 @@
 //! and a candidate's limits are therefore exactly what the resolver produced
 //! (including any [`SourcedLimitOverride`]s recorded on it).
 //!
-//! DEFERRED: #3384's full sketch also carried `capabilities: CapabilityProfile`
-//! and `config_snapshot: Config`. Both are intentionally omitted here: pulling
-//! `CapabilityProfile` into `crates/config` would force a `tui -> config` type
-//! move, and embedding `Config` would couple the candidate to the full config
-//! model. They will be added when those types have a home in this crate.
+//! The route-owned, three-state capability profile lives in this crate and is
+//! carried on the candidate. A full `config_snapshot: Config` remains deferred
+//! because embedding it would couple the candidate to the full config model.
 
 use serde::{Deserialize, Serialize};
 
 use super::RequestProtocol;
+use super::capabilities::RouteCapabilities;
 use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
 use super::offering::RouteLimits;
 use crate::ProviderKind;
@@ -198,6 +197,8 @@ pub struct ReadyRouteCandidate {
     protocol: RequestProtocol,
     /// Route/offering-scoped token limits, when known (overrides applied).
     limits: RouteLimits,
+    /// Capability facts for the exact provider/model offering.
+    capabilities: RouteCapabilities,
     /// Pricing/quota class, if known.
     pricing: Option<PricingSku>,
     /// Validation outcome.
@@ -221,6 +222,7 @@ impl ReadyRouteCandidate {
         auth: ResolvedAuthSource,
         protocol: RequestProtocol,
         limits: RouteLimits,
+        capabilities: RouteCapabilities,
         pricing: Option<PricingSku>,
         validation: ValidationReport,
         applied_limit_overrides: Vec<SourcedLimitOverride>,
@@ -235,6 +237,7 @@ impl ReadyRouteCandidate {
             auth,
             protocol,
             limits,
+            capabilities,
             pricing,
             validation,
             applied_limit_overrides,
@@ -293,6 +296,12 @@ impl ReadyRouteCandidate {
     #[must_use]
     pub fn limits(&self) -> RouteLimits {
         self.limits
+    }
+
+    /// Capability facts for the exact provider/model offering.
+    #[must_use]
+    pub fn capabilities(&self) -> RouteCapabilities {
+        self.capabilities
     }
 
     /// Pricing/quota class, if known.

--- a/crates/config/src/route/capabilities.rs
+++ b/crates/config/src/route/capabilities.rs
@@ -1,0 +1,95 @@
+//! Route-scoped capability facts.
+//!
+//! Capability state is deliberately three-valued: an absent catalog fact is
+//! unknown, not unsupported, and must never be promoted to supported by a
+//! transport/protocol heuristic. These values travel with the exact provider
+//! offering selected by [`super::resolver::RouteResolver`].
+
+use serde::{Deserialize, Serialize};
+
+/// Whether a resolved provider/model offering supports one capability.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityState {
+    /// The selected offering explicitly reports support.
+    Supported,
+    /// The selected offering explicitly reports no support.
+    Unsupported,
+    /// The selected offering did not state the fact.
+    #[default]
+    Unknown,
+}
+
+impl CapabilityState {
+    /// Preserve a sourced optional boolean as a three-state fact.
+    #[must_use]
+    pub const fn from_optional_bool(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => Self::Supported,
+            Some(false) => Self::Unsupported,
+            None => Self::Unknown,
+        }
+    }
+
+    /// Whether the source explicitly reports support.
+    #[must_use]
+    pub const fn is_supported(self) -> bool {
+        matches!(self, Self::Supported)
+    }
+}
+
+/// Capability facts owned by one provider/model route offering.
+///
+/// Fields without a current authoritative catalog source remain `Unknown`.
+/// They are present now so live/provider-native facts can be added without
+/// changing the candidate contract or guessing from request protocol.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteCapabilities {
+    #[serde(default)]
+    pub attachments: CapabilityState,
+    #[serde(default)]
+    pub reasoning: CapabilityState,
+    #[serde(default)]
+    pub native_tool_calls: CapabilityState,
+    #[serde(default)]
+    pub structured_output: CapabilityState,
+    #[serde(default)]
+    pub parallel_tool_calls: CapabilityState,
+    #[serde(default)]
+    pub streaming: CapabilityState,
+    #[serde(default)]
+    pub prompt_caching: CapabilityState,
+    #[serde(default)]
+    pub server_side_web_search: CapabilityState,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn optional_boolean_preserves_unknown_and_false() {
+        assert_eq!(
+            CapabilityState::from_optional_bool(None),
+            CapabilityState::Unknown
+        );
+        assert_eq!(
+            CapabilityState::from_optional_bool(Some(false)),
+            CapabilityState::Unsupported
+        );
+        assert_eq!(
+            CapabilityState::from_optional_bool(Some(true)),
+            CapabilityState::Supported
+        );
+    }
+
+    #[test]
+    fn unsourced_route_capabilities_default_to_unknown() {
+        let capabilities = RouteCapabilities::default();
+        assert_eq!(capabilities.streaming, CapabilityState::Unknown);
+        assert_eq!(
+            capabilities.server_side_web_search,
+            CapabilityState::Unknown
+        );
+    }
+}

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -10,6 +10,7 @@
 //! - [`ids`] — provider/model/wire string newtypes + namespace hints.
 //! - [`descriptor`] — route-facing view over the static provider registry.
 //! - [`offering`] — provider/model offering seam (wire-id binding).
+//! - [`capabilities`] — three-state provider/model capability facts.
 //! - [`candidate`] — the runtime-resolved executable route + its parts.
 //! - [`errors`] — route resolution errors.
 //! - [`resolver`] — the sole producer of [`candidate::ReadyRouteCandidate`].
@@ -27,6 +28,7 @@
 pub use crate::provider::WireFormat as RequestProtocol;
 
 pub mod candidate;
+pub mod capabilities;
 pub mod descriptor;
 pub mod errors;
 pub mod ids;
@@ -37,6 +39,7 @@ pub use candidate::{
     LimitField, OverrideSource, PricingSku, ReadyRouteCandidate, ResolvedAuthSource,
     ResolvedEndpoint, SourcedLimitOverride, ValidationReport,
 };
+pub use capabilities::{CapabilityState, RouteCapabilities};
 pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
 pub use errors::RouteError;
 pub use ids::{LogicalModelRef, ModelId, NamespaceHint, ProviderId, WireModelId};

--- a/crates/config/src/route/offering.rs
+++ b/crates/config/src/route/offering.rs
@@ -15,6 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::candidate::PricingSku;
+use super::capabilities::RouteCapabilities;
 use super::ids::{ModelId, ProviderId, WireModelId};
 
 /// Token limits for one resolved route/offering.
@@ -61,6 +62,9 @@ pub struct ProviderModelOffering {
     pub default_for_provider: bool,
     /// Provider/offering-scoped token limits, when known.
     pub limits: RouteLimits,
+    /// Provider/model-scoped capability facts. Unknown is preserved rather
+    /// than inferred from the wire protocol.
+    pub capabilities: RouteCapabilities,
     /// Coarse route-facing pricing meter for this offering (#3085).
     ///
     /// Projected from the offering's sourced cost at the layer that owns it

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -31,6 +31,7 @@ use super::candidate::{
     LimitField, PricingSku, ReadyRouteCandidate, ResolvedAuthSource, ResolvedEndpoint,
     SourcedLimitOverride, ValidationReport,
 };
+use super::capabilities::RouteCapabilities;
 use super::descriptor::ProviderDescriptor;
 use super::errors::RouteError;
 use super::ids::{LogicalModelRef, ModelId, ProviderId, WireModelId};
@@ -63,6 +64,41 @@ pub struct RouteRequest {
 #[derive(Debug, Clone)]
 pub struct RouteResolver {
     offerings: Vec<ProviderModelOffering>,
+}
+
+/// Offering-owned facts selected within one provider scope before the final
+/// executable route candidate is minted.
+struct ResolvedOffering {
+    wire_model_id: WireModelId,
+    canonical_model: Option<ModelId>,
+    endpoint_key: String,
+    limits: RouteLimits,
+    capabilities: RouteCapabilities,
+    pricing: PricingSku,
+}
+
+impl ResolvedOffering {
+    fn unknown(wire_model_id: WireModelId) -> Self {
+        Self {
+            wire_model_id,
+            canonical_model: None,
+            endpoint_key: "chat".to_string(),
+            limits: RouteLimits::default(),
+            capabilities: RouteCapabilities::default(),
+            pricing: PricingSku::UnknownOrStale,
+        }
+    }
+
+    fn from_offering(offering: &ProviderModelOffering) -> Self {
+        Self {
+            wire_model_id: offering.wire_model_id.clone(),
+            canonical_model: offering.canonical_model.clone(),
+            endpoint_key: offering.endpoint_key.clone(),
+            limits: offering.limits,
+            capabilities: offering.capabilities,
+            pricing: offering.pricing.clone(),
+        }
+    }
 }
 
 impl Default for RouteResolver {
@@ -150,29 +186,14 @@ impl RouteResolver {
         } else {
             classify(provider_kind)
         };
-        let (wire_model_id, canonical_model, endpoint_key, limits, pricing) = if is_auto {
+        let selected = if is_auto {
             default_offering.map_or_else(
                 || {
-                    (
-                        descriptor.default_wire_model(),
-                        None,
-                        "chat".to_string(),
-                        RouteLimits::default(),
-                        // No offering in hand on the default branch: pricing is
-                        // honestly unknown (#3085), never a fabricated zero.
-                        PricingSku::UnknownOrStale,
-                    )
+                    // No offering in hand on the default branch: capability
+                    // and pricing facts are honestly unknown.
+                    ResolvedOffering::unknown(descriptor.default_wire_model())
                 },
-                |offering| {
-                    (
-                        offering.wire_model_id.clone(),
-                        offering.canonical_model.clone(),
-                        offering.endpoint_key.clone(),
-                        offering.limits,
-                        // Matched offering: carry its sourced pricing meter.
-                        offering.pricing.clone(),
-                    )
-                },
+                ResolvedOffering::from_offering,
             )
         } else {
             self.scope_selector(provider_kind, &provider_id, &logical_model, class)?
@@ -183,7 +204,7 @@ impl RouteResolver {
                 .base_url_override
                 .clone()
                 .unwrap_or_else(|| descriptor.default_base_url().to_string()),
-            endpoint_key,
+            endpoint_key: selected.endpoint_key,
             protocol: descriptor.protocol(),
         };
 
@@ -201,7 +222,7 @@ impl RouteResolver {
         // Apply caller-requested limit overrides in order, BEFORE the candidate
         // is minted. The candidate is immutable afterwards; the applied
         // overrides are recorded on it as provenance.
-        let mut limits = limits;
+        let mut limits = selected.limits;
         for limit_override in &req.limit_overrides {
             match limit_override.field {
                 LimitField::ContextTokens => limits.context_tokens = limit_override.value,
@@ -214,18 +235,19 @@ impl RouteResolver {
             provider_id,
             provider_kind,
             logical_model,
-            canonical_model,
-            wire_model_id,
+            selected.canonical_model,
+            selected.wire_model_id,
             endpoint,
             // The resolver never inspects credentials: auth is honestly
             // `Unresolved` at resolution time, not a claimed `Missing`.
             ResolvedAuthSource::Unresolved,
             descriptor.protocol(),
             limits,
+            selected.capabilities,
             // #3085: honest pricing projected from the matched offering (the
             // catalog layer maps sourced cost → SKU); `UnknownOrStale` whenever
             // no offering was matched or the offering carried no price.
-            Some(pricing),
+            Some(selected.pricing),
             validation,
             req.limit_overrides.clone(),
         ))
@@ -238,16 +260,7 @@ impl RouteResolver {
         provider_id: &ProviderId,
         logical_model: &LogicalModelRef,
         class: ProviderClass,
-    ) -> Result<
-        (
-            WireModelId,
-            Option<ModelId>,
-            String,
-            RouteLimits,
-            PricingSku,
-        ),
-        RouteError,
-    > {
+    ) -> Result<ResolvedOffering, RouteError> {
         // OpenCode Go publishes one combined model roster across two wire
         // protocols. Codewhale's provider is deliberately Chat Completions
         // only, so this allowlist must sit at the sole route-candidate seam.
@@ -277,14 +290,7 @@ impl RouteResolver {
                 .is_some_and(|m| m.as_str() == raw);
             let matches_wire = offering.wire_model_id.as_str() == raw;
             if matches_canonical || matches_wire {
-                return Ok((
-                    offering.wire_model_id.clone(),
-                    offering.canonical_model.clone(),
-                    offering.endpoint_key.clone(),
-                    offering.limits,
-                    // Matched offering: carry its sourced pricing meter (#3085).
-                    offering.pricing.clone(),
-                ));
+                return Ok(ResolvedOffering::from_offering(offering));
             }
         }
 
@@ -309,26 +315,14 @@ impl RouteResolver {
                 // A bare, unknown model on a strict direct provider is passed
                 // through verbatim (the provider validates it server-side). No
                 // offering matched, so pricing is honestly unknown (#3085).
-                Ok((
-                    WireModelId::from(raw),
-                    None,
-                    "chat".to_string(),
-                    RouteLimits::default(),
-                    PricingSku::UnknownOrStale,
-                ))
+                Ok(ResolvedOffering::unknown(WireModelId::from(raw)))
             }
             // Aggregators, local runtimes, and custom OpenAI-compatible
             // endpoints legitimately accept arbitrary / prefixed ids verbatim.
             ProviderClass::Aggregator | ProviderClass::LocalOrCustom => {
                 let _ = provider_kind;
                 // No offering matched: pricing is honestly unknown (#3085).
-                Ok((
-                    WireModelId::from(raw),
-                    None,
-                    "chat".to_string(),
-                    RouteLimits::default(),
-                    PricingSku::UnknownOrStale,
-                ))
+                Ok(ResolvedOffering::unknown(WireModelId::from(raw)))
             }
         }
     }

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -1012,6 +1012,42 @@ fn priced_deepseek_resolver() -> RouteResolver {
 }
 
 #[test]
+fn resolver_carries_exact_offering_capabilities_without_protocol_inference() {
+    use crate::catalog::{CatalogOffering, CatalogSource};
+    use crate::route::CapabilityState;
+
+    let offering = CatalogOffering {
+        provider: "deepseek".into(),
+        wire_model_id: "deepseek-v4-pro".into(),
+        canonical_model: Some("deepseek-v4-pro".into()),
+        endpoint_key: "chat".into(),
+        default_for_provider: true,
+        attachment: Some(false),
+        reasoning: Some(true),
+        tool_call: Some(false),
+        structured_output: Some(true),
+        source: CatalogSource::Bundled,
+        ..Default::default()
+    };
+    let resolver = RouteResolver::from_offerings(vec![offering.to_offering()]);
+
+    let candidate = resolver
+        .resolve(&req(Some(ProviderKind::Deepseek), Some("deepseek-v4-pro")))
+        .expect("matching offering resolves");
+    let capabilities = candidate.capabilities();
+
+    assert_eq!(capabilities.attachments, CapabilityState::Unsupported);
+    assert_eq!(capabilities.reasoning, CapabilityState::Supported);
+    assert_eq!(capabilities.native_tool_calls, CapabilityState::Unsupported);
+    assert_eq!(capabilities.structured_output, CapabilityState::Supported);
+    assert_eq!(capabilities.streaming, CapabilityState::Unknown);
+    assert_eq!(
+        capabilities.server_side_web_search,
+        CapabilityState::Unknown
+    );
+}
+
+#[test]
 fn priced_offering_yields_token_pricing_sku() {
     use super::candidate::PricingSku;
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -1566,8 +1566,10 @@ impl DeepSeekClient {
                     limit: None,
                     cost: None,
                     modalities: None,
+                    attachment: None,
                     reasoning: None,
                     tool_call: None,
+                    structured_output: None,
                     reasoning_options: Vec::new(),
                     source: CatalogSource::Live {
                         base_url_fingerprint: fingerprint.clone(),
@@ -2200,8 +2202,10 @@ fn openrouter_to_catalog_offering(
         limit,
         cost,
         modalities,
+        attachment: None,
         reasoning,
         tool_call,
+        structured_output: None,
         reasoning_options: Vec::new(),
         source: CatalogSource::Live {
             base_url_fingerprint: base_url_fingerprint.to_string(),

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -640,6 +640,7 @@ pub struct Engine {
     /// custom route across snapshots and config reloads.
     api_provider_id: Option<String>,
     active_route_limits: Option<codewhale_config::route::RouteLimits>,
+    active_route_capabilities: codewhale_config::route::RouteCapabilities,
     rx_op: mpsc::Receiver<Op>,
     /// Clone of the op-channel sender, so the engine can self-dispatch ops
     /// (e.g. a goal-continuation `SendMessage` after a turn completes).
@@ -902,6 +903,7 @@ impl Engine {
         let provider_id = route.identity.exact_id;
         let model = route.model;
         let limits = crate::route_budget::known_route_limits(route.candidate.limits());
+        let capabilities = route.candidate.capabilities();
         let api_config = *route.config;
         let client = route.client;
 
@@ -910,6 +912,7 @@ impl Engine {
         self.api_provider_id = provider_id;
         self.api_config = api_config;
         self.active_route_limits = limits;
+        self.active_route_capabilities = capabilities;
         self.api_key_env_only_recovery = Self::env_only_api_key_recovery_hint(&self.api_config);
         self.deepseek_client = Some(client.clone());
         if !self.model_client_injected {
@@ -945,6 +948,7 @@ impl Engine {
         let provider_id = route.identity.exact_id;
         let model = route.model;
         let limits = crate::route_budget::known_route_limits(route.candidate.limits());
+        let capabilities = route.candidate.capabilities();
         let api_config = *route.config;
         let concrete_client = preflighted_client
             .map(Ok)
@@ -955,6 +959,7 @@ impl Engine {
         self.api_provider_id = provider_id;
         self.api_config = api_config;
         self.active_route_limits = limits;
+        self.active_route_capabilities = capabilities;
         self.api_key_env_only_recovery = Self::env_only_api_key_recovery_hint(&self.api_config);
         match concrete_client {
             Ok(client) => {
@@ -1196,6 +1201,7 @@ impl Engine {
             api_provider_identity,
             api_provider_id,
             active_route_limits,
+            active_route_capabilities: codewhale_config::route::RouteCapabilities::default(),
             rx_op,
             tx_op: tx_op.clone(),
             rx_approval,
@@ -1863,6 +1869,11 @@ impl Engine {
                         self.session.model = model;
                         self.config.model.clone_from(&self.session.model);
                         self.active_route_limits = route_limits;
+                        // This lightweight operation carries no executable
+                        // route candidate, so old provider/model capability
+                        // facts must not bleed into the new model.
+                        self.active_route_capabilities =
+                            codewhale_config::route::RouteCapabilities::default();
                         self.refresh_system_prompt();
                         self.emit_session_updated().await;
                         let _ = self
@@ -2984,9 +2995,11 @@ impl Engine {
             Vec::new()
         };
         let tools = tool_registry.as_ref().map(|registry| {
-            let capability = crate::model_profile::resolved_capability_profile(
+            let capability = crate::model_profile::resolved_capability_profile_for_route(
                 self.api_config.api_provider(),
                 &self.config.model,
+                self.active_route_capabilities,
+                self.active_route_limits.unwrap_or_default(),
             );
             let mut always_load = self.config.tools_always_load.clone();
             if self.config.features.enabled(Feature::Mcp) {

--- a/crates/tui/src/model_profile.rs
+++ b/crates/tui/src/model_profile.rs
@@ -10,30 +10,10 @@
 
 use crate::config::{ApiProvider, RequestPayloadMode, provider_capability};
 use crate::model_registry::{self, ModelProvider};
+use codewhale_config::route::{RouteCapabilities, RouteLimits};
 
-/// Three-state support facts. Unknown is distinct from unsupported.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SupportState {
-    Supported,
-    Unsupported,
-    Unknown,
-}
-
-impl SupportState {
-    #[must_use]
-    pub const fn from_bool(value: bool) -> Self {
-        if value {
-            Self::Supported
-        } else {
-            Self::Unsupported
-        }
-    }
-
-    #[must_use]
-    pub const fn is_supported(self) -> bool {
-        matches!(self, Self::Supported)
-    }
-}
+/// Compatibility name for the canonical config-layer three-state fact.
+pub use codewhale_config::route::CapabilityState as SupportState;
 
 /// Coarse tool-catalog budget for the selected route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,10 +29,11 @@ pub enum ToolSurfaceBudget {
 /// Fact provenance for diagnostics and route explanations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FactProvenance {
+    ResolvedRouteCandidate,
     SeededModelRegistry,
     LegacyModelHeuristics,
     ConservativeUnknownFallback,
-    ProviderCapabilityMatrix,
+    LegacyProviderFallback,
     UserOverride,
 }
 
@@ -166,7 +147,7 @@ pub fn model_profile(model: &str) -> ModelProfile {
                 capabilities: IntrinsicCapabilityProfile {
                     context_window: meta.context_window,
                     max_output: meta.max_output,
-                    reasoning: SupportState::from_bool(meta.supports_reasoning),
+                    reasoning: bool_state(meta.supports_reasoning),
                     native_tool_calls: SupportState::Unknown,
                     parallel_tool_calls: SupportState::Unknown,
                     structured_output: SupportState::Unknown,
@@ -198,7 +179,11 @@ pub fn model_profile(model: &str) -> ModelProfile {
     }
 }
 
-/// Resolve route capabilities from intrinsic model facts plus provider facts.
+/// Resolve a profile from legacy model/provider heuristics.
+///
+/// This remains a picker/startup fallback for call sites that do not yet hold
+/// an executable route candidate. Runtime execution should use
+/// [`resolved_capability_profile_for_route`], where exact offering facts win.
 #[must_use]
 pub fn resolved_capability_profile(
     provider: ApiProvider,
@@ -211,7 +196,7 @@ pub fn resolved_capability_profile(
     )
 }
 
-/// Resolve route capabilities and apply explicit user/config overrides last.
+/// Resolve legacy fallback capabilities and apply explicit overrides last.
 #[must_use]
 pub fn resolved_capability_profile_with_overrides(
     provider: ApiProvider,
@@ -229,10 +214,10 @@ pub fn resolved_capability_profile_with_overrides(
     let max_output = Some(overrides.max_output.unwrap_or(provider_cap.max_output));
     let reasoning = overrides
         .reasoning
-        .unwrap_or_else(|| SupportState::from_bool(provider_cap.thinking_supported));
+        .unwrap_or_else(|| bool_state(provider_cap.thinking_supported));
     let prompt_caching = overrides
         .prompt_caching
-        .unwrap_or_else(|| SupportState::from_bool(provider_cap.cache_telemetry_supported));
+        .unwrap_or_else(|| bool_state(provider_cap.cache_telemetry_supported));
     let native_tool_calls = overrides
         .native_tool_calls
         .unwrap_or_else(|| native_tool_support_for_payload(request_payload_mode));
@@ -247,7 +232,7 @@ pub fn resolved_capability_profile_with_overrides(
         .tool_surface_budget
         .unwrap_or_else(|| tool_surface_for_window(context_window));
 
-    let mut provenance = vec![model.provenance, FactProvenance::ProviderCapabilityMatrix];
+    let mut provenance = vec![model.provenance, FactProvenance::LegacyProviderFallback];
     if overrides != CapabilityOverride::default() {
         provenance.push(FactProvenance::UserOverride);
     }
@@ -267,6 +252,113 @@ pub fn resolved_capability_profile_with_overrides(
         prompt_caching,
         tool_surface_budget,
         provenance,
+    }
+}
+
+/// Resolve capabilities for an exact route candidate.
+///
+/// Sourced route facts and limits win. Legacy provider/model behavior is used
+/// only for fields the selected offering leaves `Unknown`, and that fallback
+/// remains visible in provenance.
+#[must_use]
+pub fn resolved_capability_profile_for_route(
+    provider: ApiProvider,
+    wire_model_id: &str,
+    route_capabilities: RouteCapabilities,
+    route_limits: RouteLimits,
+) -> CapabilityProfile {
+    let mut profile = resolved_capability_profile(provider, wire_model_id);
+    profile.context_window = route_limits
+        .context_tokens
+        .and_then(|tokens| u32::try_from(tokens).ok())
+        .or(profile.context_window);
+    profile.max_output = route_limits
+        .output_tokens
+        .and_then(|tokens| u32::try_from(tokens).ok())
+        .or(profile.max_output);
+    profile.reasoning = route_fact_or_fallback(route_capabilities.reasoning, profile.reasoning);
+    profile.native_tool_calls = route_fact_or_fallback(
+        route_capabilities.native_tool_calls,
+        profile.native_tool_calls,
+    );
+    profile.parallel_tool_calls = route_fact_or_fallback(
+        route_capabilities.parallel_tool_calls,
+        profile.parallel_tool_calls,
+    );
+    profile.structured_output = route_fact_or_fallback(
+        route_capabilities.structured_output,
+        profile.structured_output,
+    );
+    profile.streaming = route_fact_or_fallback(route_capabilities.streaming, profile.streaming);
+    profile.prompt_caching =
+        route_fact_or_fallback(route_capabilities.prompt_caching, profile.prompt_caching);
+    profile.tool_surface_budget = tool_surface_for_window(profile.context_window);
+    profile
+        .provenance
+        .insert(0, FactProvenance::ResolvedRouteCandidate);
+    profile
+}
+
+/// Resolve an exact route profile, then apply explicit user/config overrides.
+#[must_use]
+pub fn resolved_capability_profile_for_route_with_overrides(
+    provider: ApiProvider,
+    wire_model_id: &str,
+    route_capabilities: RouteCapabilities,
+    route_limits: RouteLimits,
+    overrides: CapabilityOverride,
+) -> CapabilityProfile {
+    let mut profile = resolved_capability_profile_for_route(
+        provider,
+        wire_model_id,
+        route_capabilities,
+        route_limits,
+    );
+    if let Some(context_window) = overrides.context_window {
+        profile.context_window = Some(context_window);
+    }
+    if let Some(max_output) = overrides.max_output {
+        profile.max_output = Some(max_output);
+    }
+    if let Some(reasoning) = overrides.reasoning {
+        profile.reasoning = reasoning;
+    }
+    if let Some(native_tool_calls) = overrides.native_tool_calls {
+        profile.native_tool_calls = native_tool_calls;
+    }
+    if let Some(parallel_tool_calls) = overrides.parallel_tool_calls {
+        profile.parallel_tool_calls = parallel_tool_calls;
+    }
+    if let Some(structured_output) = overrides.structured_output {
+        profile.structured_output = structured_output;
+    }
+    if let Some(streaming) = overrides.streaming {
+        profile.streaming = streaming;
+    }
+    if let Some(prompt_caching) = overrides.prompt_caching {
+        profile.prompt_caching = prompt_caching;
+    }
+    profile.tool_surface_budget = overrides
+        .tool_surface_budget
+        .unwrap_or_else(|| tool_surface_for_window(profile.context_window));
+    if overrides != CapabilityOverride::default() {
+        profile.provenance.push(FactProvenance::UserOverride);
+    }
+    profile
+}
+
+const fn bool_state(value: bool) -> SupportState {
+    if value {
+        SupportState::Supported
+    } else {
+        SupportState::Unsupported
+    }
+}
+
+const fn route_fact_or_fallback(route_fact: SupportState, fallback: SupportState) -> SupportState {
+    match route_fact {
+        SupportState::Unknown => fallback,
+        sourced => sourced,
     }
 }
 
@@ -380,5 +472,63 @@ mod tests {
         assert!(!compact.has_large_context());
         assert!(!compact.prefers_full_tool_surface());
         assert!(!compact.suitable_for_broad_fleet_worker());
+    }
+
+    #[test]
+    fn exact_route_facts_override_legacy_provider_heuristics() {
+        let profile = resolved_capability_profile_for_route(
+            ApiProvider::Openai,
+            "gpt-5.4",
+            RouteCapabilities {
+                reasoning: SupportState::Unsupported,
+                native_tool_calls: SupportState::Unsupported,
+                structured_output: SupportState::Supported,
+                ..RouteCapabilities::default()
+            },
+            RouteLimits {
+                context_tokens: Some(42_000),
+                input_tokens: None,
+                output_tokens: Some(7_000),
+            },
+        );
+
+        assert_eq!(profile.context_window, Some(42_000));
+        assert_eq!(profile.max_output, Some(7_000));
+        assert_eq!(profile.reasoning, SupportState::Unsupported);
+        assert_eq!(profile.native_tool_calls, SupportState::Unsupported);
+        assert_eq!(profile.structured_output, SupportState::Supported);
+        assert!(
+            profile
+                .provenance
+                .starts_with(&[FactProvenance::ResolvedRouteCandidate])
+        );
+        assert!(
+            profile
+                .provenance
+                .contains(&FactProvenance::LegacyProviderFallback)
+        );
+    }
+
+    #[test]
+    fn explicit_override_wins_after_exact_route_fact() {
+        let profile = resolved_capability_profile_for_route_with_overrides(
+            ApiProvider::Openai,
+            "gpt-5.4",
+            RouteCapabilities {
+                reasoning: SupportState::Unsupported,
+                ..RouteCapabilities::default()
+            },
+            RouteLimits::default(),
+            CapabilityOverride {
+                reasoning: Some(SupportState::Supported),
+                ..CapabilityOverride::default()
+            },
+        );
+
+        assert_eq!(profile.reasoning, SupportState::Supported);
+        assert_eq!(
+            profile.provenance.last(),
+            Some(&FactProvenance::UserOverride)
+        );
     }
 }

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -29,7 +29,8 @@ use crate::codex_model_cache::{
 use crate::config::{ApiProvider, Config, DEEPSEEK_ALIAS_REPLACEMENT};
 use crate::localization::{Locale, MessageId, tr};
 use crate::model_profile::{
-    CapabilityOverride, SupportState, resolved_capability_profile_with_overrides,
+    CapabilityOverride, SupportState, resolved_capability_profile_for_route_with_overrides,
+    resolved_capability_profile_with_overrides,
 };
 use crate::model_registry;
 use crate::models_dev_live::{self, ModelsDevFreshness};
@@ -1353,12 +1354,21 @@ fn effective_picker_metadata_with_codex(
     };
 
     let context_override = config.context_window_for_provider_config(provider);
-    let profile = resolved_capability_profile_with_overrides(
-        provider,
-        id,
-        CapabilityOverride {
-            context_window: context_override,
-            ..CapabilityOverride::default()
+    let overrides = CapabilityOverride {
+        context_window: context_override,
+        ..CapabilityOverride::default()
+    };
+    let profile = offering.as_ref().map_or_else(
+        || resolved_capability_profile_with_overrides(provider, id, overrides.clone()),
+        |offering| {
+            let route_offering = offering.to_offering();
+            resolved_capability_profile_for_route_with_overrides(
+                provider,
+                id,
+                route_offering.capabilities,
+                route_offering.limits,
+                overrides.clone(),
+            )
         },
     );
     let card_context = card

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -40,10 +40,12 @@ use crate::config::{
 };
 use crate::core::ops::ProviderRuntimeStatus;
 use crate::localization::{Locale, MessageId, tr};
-use crate::model_profile::{SupportState, resolved_capability_profile};
+use crate::model_profile::{
+    SupportState, resolved_capability_profile, resolved_capability_profile_for_route,
+};
 use crate::models_dev_live::{self, ModelsDevFreshness};
 use crate::palette;
-use crate::provider_lake::catalog_model_count_for_provider;
+use crate::provider_lake::{catalog_model_count_for_provider, catalog_offering_for_model};
 use crate::provider_readiness::{
     CredentialState, ProviderReadinessSnapshot, ProviderRouteIdentity, ResolvedProviderReadiness,
     credential_state_for_provider, route_identity_for_model,
@@ -275,7 +277,18 @@ pub struct ProviderCapabilityBadges {
 
 impl ProviderCapabilityBadges {
     fn for_route(provider: ApiProvider, wire_model: &str) -> Self {
-        let cap = resolved_capability_profile(provider, wire_model);
+        let cap = catalog_offering_for_model(provider, wire_model).map_or_else(
+            || resolved_capability_profile(provider, wire_model),
+            |offering| {
+                let route_offering = offering.to_offering();
+                resolved_capability_profile_for_route(
+                    provider,
+                    wire_model,
+                    route_offering.capabilities,
+                    route_offering.limits,
+                )
+            },
+        );
         Self {
             context_window: cap.context_window,
             context_window_source: None,


### PR DESCRIPTION
## Summary

- add canonical three-state route capability facts (`supported`, `unsupported`, `unknown`)
- project sourced Models.dev offering facts through `CatalogOffering` and `ProviderModelOffering` into immutable `ReadyRouteCandidate`
- make exact candidate facts authoritative in runtime and picker profiles; retain legacy provider/model heuristics only as marked fallback
- clear candidate facts on lightweight model switches that cannot prove a new executable route

## Honesty boundary

Unknown facts remain unknown. This slice does not infer streaming, parallel tools, prompt caching, or server-side web search from the request protocol, and it does not add provider-native search claims; those belong to W5 with provider/model evidence.

## Verification

- `cargo test -p codewhale-config --locked` (417 passed + doc test)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked` (7,550 passed, 3 ignored)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- gitleaks staged-diff and exact-commit scans: no leaks

Base: `05aa46f09ea68a72f3776476f1f0ba9269bec6dd`
Head: `f59f627413fab57b0c2bad2083ac2f9d60cb41ee`

No tag, release, registry action, deploy, force push, or branch deletion is part of this PR.