### PR TITLE
feat(web): add provider-native search backend

### DIFF
--- a/crates/config/assets/models_dev.bundled.json
+++ b/crates/config/assets/models_dev.bundled.json
@@ -625,6 +625,24 @@
         }
       }
     },
+    "xai": {
+      "id": "xai",
+      "name": "xAI",
+      "api": "https://api.x.ai/v1",
+      "npm": "@ai-sdk/xai",
+      "env": ["XAI_API_KEY"],
+      "models": {
+        "grok-4.5": {
+          "id": "grok-4.5",
+          "name": "Grok 4.5",
+          "family": "grok",
+          "default": true,
+          "reasoning": true,
+          "tool_call": true,
+          "modalities": { "input": ["text"], "output": ["text"] }
+        }
+      }
+    },
     "xiaomi-mimo": {
       "id": "xiaomi-mimo",
       "name": "Xiaomi MiMo",

--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -158,6 +158,10 @@ impl CatalogOffering {
                 structured_output: crate::route::CapabilityState::from_optional_bool(
                     self.structured_output,
                 ),
+                server_side_web_search: crate::route::documented_server_side_web_search(
+                    &self.provider,
+                    &self.wire_model_id,
+                ),
                 ..crate::route::RouteCapabilities::default()
             },
             pricing: crate::pricing::route_pricing_sku(self),

--- a/crates/config/src/models_dev.rs
+++ b/crates/config/src/models_dev.rs
@@ -87,7 +87,7 @@ impl ModelsDevCatalog {
         let model = provider.models.get(wire_model_id.trim())?;
         let provider_id = provider.effective_id(provider_key);
         Some(ProviderModelOffering {
-            provider: ProviderId::from(provider_id),
+            provider: ProviderId::from(provider_id.clone()),
             canonical_model: model.base_model.clone().map(ModelId::from),
             wire_model_id: WireModelId::from(model.id.clone()),
             endpoint_key: "chat".to_string(),
@@ -97,7 +97,7 @@ impl ModelsDevCatalog {
                 .as_ref()
                 .map(RouteLimits::from)
                 .unwrap_or_default(),
-            capabilities: route_capabilities(model),
+            capabilities: route_capabilities(&provider_id, model),
             pricing: crate::pricing::route_pricing_sku_from_cost(model.cost.as_ref()),
         })
     }
@@ -128,7 +128,7 @@ impl ModelsDevCatalog {
                         .as_ref()
                         .map(RouteLimits::from)
                         .unwrap_or_default(),
-                    capabilities: route_capabilities(model),
+                    capabilities: route_capabilities(&provider_id, model),
                     pricing: crate::pricing::route_pricing_sku_from_cost(model.cost.as_ref()),
                 })
                 .collect(),
@@ -136,12 +136,16 @@ impl ModelsDevCatalog {
     }
 }
 
-fn route_capabilities(model: &ModelsDevProviderModel) -> RouteCapabilities {
+fn route_capabilities(provider_id: &str, model: &ModelsDevProviderModel) -> RouteCapabilities {
     RouteCapabilities {
         attachments: CapabilityState::from_optional_bool(model.attachment),
         reasoning: CapabilityState::from_optional_bool(model.reasoning),
         native_tool_calls: CapabilityState::from_optional_bool(model.tool_call),
         structured_output: CapabilityState::from_optional_bool(model.structured_output),
+        server_side_web_search: crate::route::documented_server_side_web_search(
+            provider_id,
+            &model.id,
+        ),
         ..RouteCapabilities::default()
     }
 }

--- a/crates/config/src/route/capabilities.rs
+++ b/crates/config/src/route/capabilities.rs
@@ -38,6 +38,51 @@ impl CapabilityState {
     }
 }
 
+/// Return the documented server-side web-search fact for one exact direct
+/// provider/model offering.
+///
+/// This is intentionally a small sourced table, not a protocol or model-family
+/// heuristic. Aggregators, custom endpoints, aliases, snapshots, and nearby
+/// model names remain [`CapabilityState::Unknown`] until a provider-owned fact
+/// exists for that exact offering.
+///
+/// Sources:
+/// - OpenAI Responses web search: <https://developers.openai.com/api/docs/guides/tools-web-search>
+/// - Anthropic web search tool: <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+/// - xAI web search tool: <https://docs.x.ai/developers/tools/web-search>
+#[must_use]
+pub(crate) fn documented_server_side_web_search(
+    provider_id: &str,
+    wire_model_id: &str,
+) -> CapabilityState {
+    let provider_id = provider_id.trim().to_ascii_lowercase();
+    let wire_model_id = wire_model_id.trim().to_ascii_lowercase();
+    let supported = match provider_id.as_str() {
+        "openai" => matches!(
+            wire_model_id.as_str(),
+            "gpt-5.6" | "gpt-5.5" | "gpt-5.4" | "gpt-4.1" | "gpt-4.1-mini" | "o4-mini"
+        ),
+        "anthropic" => matches!(
+            wire_model_id.as_str(),
+            "claude-fable-5"
+                | "claude-opus-4-8"
+                | "claude-mythos-5"
+                | "claude-mythos-preview"
+                | "claude-opus-4-7"
+                | "claude-opus-4-6"
+                | "claude-sonnet-5"
+                | "claude-sonnet-4-6"
+        ),
+        "xai" => wire_model_id == "grok-4.5",
+        _ => false,
+    };
+    if supported {
+        CapabilityState::Supported
+    } else {
+        CapabilityState::Unknown
+    }
+}
+
 /// Capability facts owned by one provider/model route offering.
 ///
 /// Fields without a current authoritative catalog source remain `Unknown`.
@@ -91,5 +136,35 @@ mod tests {
             capabilities.server_side_web_search,
             CapabilityState::Unknown
         );
+    }
+
+    #[test]
+    fn documented_web_search_is_exact_and_provider_owned() {
+        assert_eq!(
+            documented_server_side_web_search("xai", "grok-4.5"),
+            CapabilityState::Supported
+        );
+        assert_eq!(
+            documented_server_side_web_search("openai", "gpt-5.6"),
+            CapabilityState::Supported
+        );
+        assert_eq!(
+            documented_server_side_web_search("anthropic", "claude-sonnet-4-6"),
+            CapabilityState::Supported
+        );
+
+        for (provider, model) in [
+            ("openrouter", "openai/gpt-5.6"),
+            ("custom", "gpt-5.6"),
+            ("openai", "gpt-5.6-sol"),
+            ("xai", "grok-4.5-fast"),
+            ("anthropic", "claude-haiku-4-5"),
+        ] {
+            assert_eq!(
+                documented_server_side_web_search(provider, model),
+                CapabilityState::Unknown,
+                "{provider}/{model} must not inherit a capability by similarity"
+            );
+        }
     }
 }

--- a/crates/config/src/route/mod.rs
+++ b/crates/config/src/route/mod.rs
@@ -39,6 +39,7 @@ pub use candidate::{
     LimitField, OverrideSource, PricingSku, ReadyRouteCandidate, ResolvedAuthSource,
     ResolvedEndpoint, SourcedLimitOverride, ValidationReport,
 };
+pub(crate) use capabilities::documented_server_side_web_search;
 pub use capabilities::{CapabilityState, RouteCapabilities};
 pub use descriptor::{EndpointDescriptor, ProviderDescriptor};
 pub use errors::RouteError;

--- a/crates/config/src/route/resolver.rs
+++ b/crates/config/src/route/resolver.rs
@@ -181,12 +181,14 @@ impl RouteResolver {
 
         // 4. Map the selector to a wire id within provider scope.
         //    Prefixed selectors are preserved VERBATIM as the wire id.
-        let class = if request_uses_custom_endpoint(&descriptor, req.base_url_override.as_deref()) {
+        let custom_endpoint =
+            request_uses_custom_endpoint(&descriptor, req.base_url_override.as_deref());
+        let class = if custom_endpoint {
             ProviderClass::LocalOrCustom
         } else {
             classify(provider_kind)
         };
-        let selected = if is_auto {
+        let mut selected = if is_auto {
             default_offering.map_or_else(
                 || {
                     // No offering in hand on the default branch: capability
@@ -198,6 +200,13 @@ impl RouteResolver {
         } else {
             self.scope_selector(provider_kind, &provider_id, &logical_model, class)?
         };
+        if custom_endpoint {
+            // A documented first-party server tool is an endpoint-owned fact.
+            // Reusing a provider enum/model id against a custom compatible
+            // endpoint cannot carry that fact across the authority boundary.
+            selected.capabilities.server_side_web_search =
+                super::capabilities::CapabilityState::Unknown;
+        }
 
         let endpoint = ResolvedEndpoint {
             base_url: req

--- a/crates/config/src/route/tests.rs
+++ b/crates/config/src/route/tests.rs
@@ -1048,6 +1048,42 @@ fn resolver_carries_exact_offering_capabilities_without_protocol_inference() {
 }
 
 #[test]
+fn provider_native_web_search_requires_exact_direct_endpoint_offering() {
+    use crate::route::CapabilityState;
+
+    let resolver = RouteResolver::new();
+    let direct = resolver
+        .resolve(&req(Some(ProviderKind::Xai), Some("grok-4.5")))
+        .expect("bundled direct xAI offering resolves");
+    assert_eq!(
+        direct.capabilities().server_side_web_search,
+        CapabilityState::Supported
+    );
+
+    let aggregator = resolver
+        .resolve(&req(Some(ProviderKind::OpencodeGo), Some("grok-4.5")))
+        .expect("aggregator offering resolves independently");
+    assert_eq!(
+        aggregator.capabilities().server_side_web_search,
+        CapabilityState::Unknown
+    );
+
+    let custom_endpoint = resolver
+        .resolve(&RouteRequest {
+            explicit_provider: Some(ProviderKind::Xai),
+            model_selector: Some(LogicalModelRef::from("grok-4.5")),
+            saved_provider_model: None,
+            base_url_override: Some("https://gateway.example.test/v1".to_string()),
+            limit_overrides: Vec::new(),
+        })
+        .expect("custom compatible endpoint resolves");
+    assert_eq!(
+        custom_endpoint.capabilities().server_side_web_search,
+        CapabilityState::Unknown
+    );
+}
+
+#[test]
 fn priced_offering_yields_token_pricing_sku() {
     use super::candidate::PricingSku;
 

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -2615,6 +2615,7 @@ impl DeepSeekClient {
 
 mod anthropic;
 mod chat;
+mod provider_native_search;
 mod responses;
 
 fn extract_sse_data_value(line: &str) -> Option<&str> {
@@ -2638,6 +2639,7 @@ fn take_sse_line(buffer: &mut Vec<u8>) -> Option<String> {
 }
 
 pub(crate) use chat::{CacheWarmupKey, PromptInspection};
+pub(crate) use provider_native_search::{ProviderNativeSearchClient, ProviderNativeSearchRequest};
 
 pub(crate) fn inspect_prompt_for_request(request: &MessageRequest) -> PromptInspection {
     chat::inspect_prompt_for_request(request)

--- a/crates/tui/src/client/provider_native_search.rs
+++ b/crates/tui/src/client/provider_native_search.rs
@@ -1,0 +1,552 @@
+//! Narrow provider-native web-search client.
+//!
+//! This adapter reuses the active route's authenticated HTTP client without
+//! exposing credentials to tool code. Route capability facts decide whether
+//! the adapter is attached; this module only speaks the three documented
+//! first-party wire contracts.
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+use crate::config::ApiProvider;
+
+use super::{DeepSeekClient, api_url};
+
+const MAX_NATIVE_ANSWER_CHARS: usize = 4_000;
+
+#[derive(Clone)]
+pub(crate) struct ProviderNativeSearchClient {
+    inner: DeepSeekClient,
+}
+
+#[derive(Clone)]
+pub(crate) struct ProviderNativeSearchRequest {
+    pub(crate) query: String,
+    pub(crate) max_results: u8,
+    pub(crate) domains: Vec<String>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ProviderNativeCitation {
+    pub(crate) url: String,
+    pub(crate) title: String,
+    pub(crate) snippet: Option<String>,
+    pub(crate) published: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ProviderNativeSearchResponse {
+    pub(crate) answer: Option<String>,
+    pub(crate) citations: Vec<ProviderNativeCitation>,
+}
+
+impl ProviderNativeSearchClient {
+    #[must_use]
+    pub(crate) fn new(inner: DeepSeekClient) -> Option<Self> {
+        matches!(
+            inner.api_provider,
+            ApiProvider::Openai | ApiProvider::Anthropic | ApiProvider::Xai
+        )
+        .then_some(Self { inner })
+    }
+
+    #[must_use]
+    pub(crate) fn provider(&self) -> ApiProvider {
+        self.inner.api_provider
+    }
+
+    #[must_use]
+    pub(crate) fn model(&self) -> &str {
+        &self.inner.default_model
+    }
+
+    #[must_use]
+    pub(crate) fn host(&self) -> Option<String> {
+        reqwest::Url::parse(&self.inner.base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+    }
+
+    #[must_use]
+    pub(crate) fn cache_identity(&self) -> String {
+        format!(
+            "provider-native://{}/{}/{}",
+            self.inner.api_provider.as_str(),
+            self.host().as_deref().unwrap_or("unknown-host"),
+            self.inner.default_model
+        )
+    }
+
+    #[must_use]
+    pub(crate) const fn maximum_domain_count(&self) -> Option<usize> {
+        match self.inner.api_provider {
+            ApiProvider::Xai => Some(5),
+            ApiProvider::Openai => Some(100),
+            ApiProvider::Anthropic => None,
+            _ => Some(0),
+        }
+    }
+
+    pub(crate) async fn search(
+        &self,
+        request: &ProviderNativeSearchRequest,
+    ) -> Result<ProviderNativeSearchResponse> {
+        let body = match self.inner.api_provider {
+            ApiProvider::Openai => build_responses_search_body(
+                &self.inner.default_model,
+                request,
+                ResponsesSearchDialect::Openai,
+            ),
+            ApiProvider::Xai => build_responses_search_body(
+                &self.inner.default_model,
+                request,
+                ResponsesSearchDialect::Xai,
+            ),
+            ApiProvider::Anthropic => {
+                build_anthropic_search_body(&self.inner.default_model, request)
+            }
+            _ => bail!("active provider has no native web-search adapter"),
+        };
+        let url = match self.inner.api_provider {
+            ApiProvider::Openai | ApiProvider::Xai => api_url(&self.inner.base_url, "responses"),
+            ApiProvider::Anthropic => anthropic_messages_url(&self.inner.base_url),
+            _ => unreachable!("provider checked above"),
+        };
+        let body_bytes = serde_json::to_vec(&body)
+            .context("failed to serialize provider-native web-search request")?;
+        let response = self
+            .inner
+            .send_with_retry(|| {
+                self.inner
+                    .http_client
+                    .post(&url)
+                    .header("Accept", "application/json")
+                    .body(body_bytes.clone())
+            })
+            .await
+            .context("provider-native web search request failed")?;
+        let payload = response
+            .json::<Value>()
+            .await
+            .context("provider-native web search returned invalid JSON")?;
+        let mut parsed = match self.inner.api_provider {
+            ApiProvider::Openai | ApiProvider::Xai => parse_responses_search(&payload),
+            ApiProvider::Anthropic => parse_anthropic_search(&payload),
+            _ => unreachable!("provider checked above"),
+        };
+        parsed.citations.truncate(usize::from(request.max_results));
+        Ok(parsed)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ResponsesSearchDialect {
+    Openai,
+    Xai,
+}
+
+fn search_prompt(request: &ProviderNativeSearchRequest) -> String {
+    format!(
+        "Search the web for the following query and answer only from web sources. \
+         Use concise prose with citations and prefer at most {} distinct sources.\n\n{}",
+        request.max_results, request.query
+    )
+}
+
+fn build_responses_search_body(
+    model: &str,
+    request: &ProviderNativeSearchRequest,
+    dialect: ResponsesSearchDialect,
+) -> Value {
+    let mut tool = json!({ "type": "web_search" });
+    if !request.domains.is_empty() {
+        tool["filters"] = json!({ "allowed_domains": request.domains });
+    }
+    let mut body = json!({
+        "model": model,
+        "input": search_prompt(request),
+        "tools": [tool],
+        "tool_choice": "required",
+        "store": false,
+    });
+    if matches!(dialect, ResponsesSearchDialect::Openai) {
+        body["include"] = json!(["web_search_call.action.sources"]);
+    } else {
+        // xAI documents the same Responses tool shape but not OpenAI's
+        // source-inclusion extension. Citations are recovered from xAI's
+        // response annotations / citations field instead.
+        body.as_object_mut()
+            .expect("search body is an object")
+            .remove("store");
+    }
+    body
+}
+
+fn build_anthropic_search_body(model: &str, request: &ProviderNativeSearchRequest) -> Value {
+    let mut tool = json!({
+        "type": "web_search_20250305",
+        "name": "web_search",
+        "max_uses": 1,
+    });
+    if !request.domains.is_empty() {
+        tool["allowed_domains"] = json!(request.domains);
+    }
+    json!({
+        "model": model,
+        "max_tokens": 2048,
+        "messages": [{ "role": "user", "content": search_prompt(request) }],
+        "tools": [tool],
+    })
+}
+
+fn anthropic_messages_url(base_url: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    if base.ends_with("/v1") {
+        format!("{base}/messages")
+    } else {
+        format!("{base}/v1/messages")
+    }
+}
+
+fn parse_responses_search(payload: &Value) -> ProviderNativeSearchResponse {
+    let mut answer_parts = Vec::new();
+    let mut citations = Vec::new();
+    if let Some(output) = payload.get("output").and_then(Value::as_array) {
+        for item in output {
+            if let Some(sources) = item.pointer("/action/sources").and_then(Value::as_array) {
+                for source in sources {
+                    push_citation(&mut citations, citation_from_value(source, None, None));
+                }
+            }
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                for block in content {
+                    if let Some(text) = block.get("text").and_then(Value::as_str)
+                        && !text.trim().is_empty()
+                    {
+                        answer_parts.push(text.trim().to_string());
+                    }
+                    if let Some(annotations) = block.get("annotations").and_then(Value::as_array) {
+                        for annotation in annotations {
+                            push_citation(
+                                &mut citations,
+                                citation_from_value(annotation, None, None),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if answer_parts.is_empty()
+        && let Some(output_text) = payload.get("output_text").and_then(Value::as_str)
+        && !output_text.trim().is_empty()
+    {
+        answer_parts.push(output_text.trim().to_string());
+    }
+    if let Some(top_level) = payload.get("citations").and_then(Value::as_array) {
+        for citation in top_level {
+            let parsed = citation
+                .as_str()
+                .and_then(|url| citation_from_url(url, None, None, None))
+                .or_else(|| citation_from_value(citation, None, None));
+            push_citation(&mut citations, parsed);
+        }
+    }
+    ProviderNativeSearchResponse {
+        answer: bounded_answer(answer_parts),
+        citations,
+    }
+}
+
+fn parse_anthropic_search(payload: &Value) -> ProviderNativeSearchResponse {
+    let mut answer_parts = Vec::new();
+    let mut citations = Vec::new();
+    if let Some(content) = payload.get("content").and_then(Value::as_array) {
+        for block in content {
+            match block.get("type").and_then(Value::as_str) {
+                Some("web_search_tool_result") => {
+                    if let Some(results) = block.get("content").and_then(Value::as_array) {
+                        for result in results {
+                            let published = result
+                                .get("page_age")
+                                .and_then(Value::as_str)
+                                .map(str::to_string);
+                            push_citation(
+                                &mut citations,
+                                citation_from_value(result, None, published),
+                            );
+                        }
+                    }
+                }
+                Some("text") => {
+                    if let Some(text) = block.get("text").and_then(Value::as_str)
+                        && !text.trim().is_empty()
+                    {
+                        answer_parts.push(text.trim().to_string());
+                    }
+                    if let Some(block_citations) = block.get("citations").and_then(Value::as_array)
+                    {
+                        for citation in block_citations {
+                            let snippet = citation
+                                .get("cited_text")
+                                .and_then(Value::as_str)
+                                .map(str::to_string);
+                            push_citation(
+                                &mut citations,
+                                citation_from_value(citation, snippet, None),
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    ProviderNativeSearchResponse {
+        answer: bounded_answer(answer_parts),
+        citations,
+    }
+}
+
+fn citation_from_value(
+    value: &Value,
+    snippet: Option<String>,
+    published: Option<String>,
+) -> Option<ProviderNativeCitation> {
+    let url = value.get("url").and_then(Value::as_str)?.trim();
+    let title = value
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(str::to_string);
+    citation_from_url(url, title, snippet, published)
+}
+
+fn citation_from_url(
+    url: &str,
+    title: Option<String>,
+    snippet: Option<String>,
+    published: Option<String>,
+) -> Option<ProviderNativeCitation> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return None;
+    }
+    Some(ProviderNativeCitation {
+        url: url.to_string(),
+        title: title.unwrap_or_else(|| fallback_title(url)),
+        snippet,
+        published,
+    })
+}
+
+fn push_citation(
+    citations: &mut Vec<ProviderNativeCitation>,
+    candidate: Option<ProviderNativeCitation>,
+) {
+    let Some(candidate) = candidate else {
+        return;
+    };
+    if let Some(existing) = citations
+        .iter_mut()
+        .find(|existing| existing.url == candidate.url)
+    {
+        if existing.title == fallback_title(&existing.url)
+            && candidate.title != fallback_title(&candidate.url)
+        {
+            existing.title = candidate.title;
+        }
+        if existing.snippet.is_none() {
+            existing.snippet = candidate.snippet;
+        }
+        if existing.published.is_none() {
+            existing.published = candidate.published;
+        }
+        return;
+    }
+    citations.push(candidate);
+}
+
+fn fallback_title(url: &str) -> String {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_string))
+        .unwrap_or_else(|| "Web source".to_string())
+}
+
+fn bounded_answer(parts: Vec<String>) -> Option<String> {
+    let joined = parts.join("\n\n");
+    let trimmed = joined.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.chars().count() <= MAX_NATIVE_ANSWER_CHARS {
+        return Some(trimmed.to_string());
+    }
+    let mut bounded = trimmed
+        .chars()
+        .take(MAX_NATIVE_ANSWER_CHARS.saturating_sub(1))
+        .collect::<String>();
+    bounded.push('…');
+    Some(bounded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ProviderConfig, ProvidersConfig};
+    use wiremock::matchers::{body_partial_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn request() -> ProviderNativeSearchRequest {
+        ProviderNativeSearchRequest {
+            query: "current release".to_string(),
+            max_results: 3,
+            domains: vec!["example.com".to_string()],
+        }
+    }
+
+    #[test]
+    fn responses_payload_requires_search_and_keeps_domains_provider_side() {
+        let body =
+            build_responses_search_body("gpt-5.6", &request(), ResponsesSearchDialect::Openai);
+        assert_eq!(body["tools"][0]["type"], "web_search");
+        assert_eq!(
+            body["tools"][0]["filters"]["allowed_domains"][0],
+            "example.com"
+        );
+        assert_eq!(body["tool_choice"], "required");
+        assert_eq!(body["include"][0], "web_search_call.action.sources");
+    }
+
+    #[test]
+    fn anthropic_payload_uses_basic_direct_search_contract() {
+        let body = build_anthropic_search_body("claude-opus-4-8", &request());
+        assert_eq!(body["tools"][0]["type"], "web_search_20250305");
+        assert_eq!(body["tools"][0]["max_uses"], 1);
+        assert_eq!(body["tools"][0]["allowed_domains"][0], "example.com");
+    }
+
+    #[test]
+    fn responses_parser_separates_answer_and_deduplicated_citations() {
+        let payload = json!({
+            "output": [
+                {
+                    "type": "web_search_call",
+                    "action": { "sources": [
+                        { "url": "https://example.com/a", "title": "Source A" }
+                    ] }
+                },
+                {
+                    "type": "message",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "Grounded answer.",
+                        "annotations": [
+                            { "type": "url_citation", "url": "https://example.com/a", "title": "Source A" },
+                            { "type": "url_citation", "url": "https://example.org/b", "title": "Source B" }
+                        ]
+                    }]
+                }
+            ]
+        });
+        let parsed = parse_responses_search(&payload);
+        assert_eq!(parsed.answer.as_deref(), Some("Grounded answer."));
+        assert_eq!(parsed.citations.len(), 2);
+        assert_eq!(parsed.citations[0].title, "Source A");
+        assert_eq!(parsed.citations[1].url, "https://example.org/b");
+    }
+
+    #[test]
+    fn anthropic_parser_keeps_result_metadata_and_cited_text_separate() {
+        let payload = json!({
+            "content": [
+                {
+                    "type": "web_search_tool_result",
+                    "content": [{
+                        "type": "web_search_result",
+                        "url": "https://example.com/a",
+                        "title": "Source A",
+                        "page_age": "July 18, 2026"
+                    }]
+                },
+                {
+                    "type": "text",
+                    "text": "Grounded answer.",
+                    "citations": [{
+                        "type": "web_search_result_location",
+                        "url": "https://example.com/a",
+                        "title": "Source A",
+                        "cited_text": "Supporting passage"
+                    }]
+                }
+            ]
+        });
+        let parsed = parse_anthropic_search(&payload);
+        assert_eq!(parsed.answer.as_deref(), Some("Grounded answer."));
+        assert_eq!(parsed.citations.len(), 1);
+        assert_eq!(
+            parsed.citations[0].published.as_deref(),
+            Some("July 18, 2026")
+        );
+        assert_eq!(
+            parsed.citations[0].snippet.as_deref(),
+            Some("Supporting passage")
+        );
+    }
+
+    #[test]
+    fn non_http_citations_are_rejected() {
+        let payload = json!({ "citations": ["javascript:alert(1)"] });
+        assert!(parse_responses_search(&payload).citations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn xai_adapter_reuses_active_authenticated_transport() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .and(header("authorization", "Bearer xai-test-key"))
+            .and(body_partial_json(json!({
+                "model": "grok-4.5",
+                "tools": [{
+                    "type": "web_search",
+                    "filters": { "allowed_domains": ["example.com"] }
+                }],
+                "tool_choice": "required"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output_text": "Grounded answer.",
+                "citations": ["https://example.com/source"]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let config = Config {
+            provider: Some("xai".to_string()),
+            providers: Some(ProvidersConfig {
+                xai: ProviderConfig {
+                    api_key: Some("xai-test-key".to_string()),
+                    base_url: Some(format!("{}/v1", server.uri())),
+                    model: Some("grok-4.5".to_string()),
+                    ..ProviderConfig::default()
+                },
+                ..ProvidersConfig::default()
+            }),
+            ..Config::default()
+        };
+        let inner = DeepSeekClient::new(&config).expect("test xAI client");
+        let client = ProviderNativeSearchClient::new(inner).expect("xAI native adapter");
+        let cache_identity = client.cache_identity();
+        assert!(cache_identity.contains("provider-native://xai/"));
+        assert!(cache_identity.ends_with("/grok-4.5"));
+        assert!(!cache_identity.contains("xai-test-key"));
+
+        let response = client.search(&request()).await.expect("native search");
+
+        assert_eq!(response.answer.as_deref(), Some("Grounded answer."));
+        assert_eq!(response.citations.len(), 1);
+        assert_eq!(response.citations[0].url, "https://example.com/source");
+    }
+}

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3588,6 +3588,18 @@ impl Engine {
         ctx.search_provider = self.config.search_provider;
         ctx.search_api_key = self.config.search_api_key.clone();
         ctx.search_base_url = self.config.search_base_url.clone();
+        ctx.route_capabilities = self.active_route_capabilities;
+        if self
+            .active_route_capabilities
+            .server_side_web_search
+            .is_supported()
+        {
+            ctx.provider_native_search = self
+                .deepseek_client
+                .as_ref()
+                .cloned()
+                .and_then(crate::client::ProviderNativeSearchClient::new);
+        }
 
         let policy = authority.sandbox_policy(&self.session.workspace);
         let mut ctx = ctx.with_elevated_sandbox_policy(policy);

--- a/crates/tui/src/tools/spec.rs
+++ b/crates/tui/src/tools/spec.rs
@@ -254,6 +254,12 @@ pub struct ToolContext {
     pub search_api_key: Option<String>,
     /// Optional DuckDuckGo-compatible HTML endpoint override for `web_search`.
     pub search_base_url: Option<String>,
+    /// Opaque client for the active route's documented first-party search
+    /// tool. It owns provider authentication internally and is attached only
+    /// when the exact route capability says server-side search is supported.
+    pub(crate) provider_native_search: Option<crate::client::ProviderNativeSearchClient>,
+    /// Exact active route capability facts. Unknown stays fail-closed.
+    pub(crate) route_capabilities: codewhale_config::route::RouteCapabilities,
 
     /// Per-session workshop variable store (#548). Holds the raw content of
     /// the most recent large-tool routing event so the parent can call
@@ -310,6 +316,8 @@ impl ToolContext {
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
             search_base_url: None,
+            provider_native_search: None,
+            route_capabilities: codewhale_config::route::RouteCapabilities::default(),
             workshop_vars: None,
         }
     }
@@ -358,6 +366,8 @@ impl ToolContext {
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
             search_base_url: None,
+            provider_native_search: None,
+            route_capabilities: codewhale_config::route::RouteCapabilities::default(),
             workshop_vars: None,
         }
     }
@@ -406,6 +416,8 @@ impl ToolContext {
             search_provider: crate::config::SearchProvider::default(),
             search_api_key: None,
             search_base_url: None,
+            provider_native_search: None,
+            route_capabilities: codewhale_config::route::RouteCapabilities::default(),
             workshop_vars: None,
         }
     }

--- a/crates/tui/src/tools/web/backend.rs
+++ b/crates/tui/src/tools/web/backend.rs
@@ -5,6 +5,8 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 
 use super::contract::{BackendId, BackendSearch, DegradedReason, QueryCapabilities, SearchQuery};
+use super::contract::{CapabilityState as QueryCapabilityState, SearchResult};
+use crate::client::ProviderNativeSearchRequest;
 use crate::config::SearchProvider;
 use crate::tools::spec::{ToolContext, ToolError};
 
@@ -34,6 +36,11 @@ pub(crate) enum ConfiguredSearchBackend<'a> {
     Baidu(BackendContext<'a>),
     Volcengine(BackendContext<'a>),
     Sofya(BackendContext<'a>),
+}
+
+#[derive(Clone, Copy)]
+struct ProviderNativeSearchBackend<'a> {
+    context: &'a ToolContext,
 }
 
 impl<'a> ConfiguredSearchBackend<'a> {
@@ -85,7 +92,7 @@ impl<'a> ConfiguredSearchBackend<'a> {
 }
 
 pub(crate) struct SearchBackendChain<'a> {
-    backends: Vec<ConfiguredSearchBackend<'a>>,
+    backends: Vec<Box<dyn SearchBackend + 'a>>,
 }
 
 #[derive(Debug)]
@@ -98,12 +105,18 @@ impl<'a> SearchBackendChain<'a> {
     #[must_use]
     pub(crate) fn from_context(context: &'a ToolContext) -> Self {
         let selected = context.search_provider;
-        let mut backends = vec![ConfiguredSearchBackend::from_provider(context, selected)];
+        let mut backends: Vec<Box<dyn SearchBackend + 'a>> = Vec::new();
+        if should_prepend_provider_native(context) {
+            backends.push(Box::new(ProviderNativeSearchBackend { context }));
+        }
+        backends.push(Box::new(ConfiguredSearchBackend::from_provider(
+            context, selected,
+        )));
         if !matches!(selected, SearchProvider::Bing | SearchProvider::DuckDuckGo) {
-            backends.push(ConfiguredSearchBackend::from_provider(
+            backends.push(Box::new(ConfiguredSearchBackend::from_provider(
                 context,
                 SearchProvider::DuckDuckGo,
-            ));
+            )));
         }
         Self { backends }
     }
@@ -125,10 +138,24 @@ impl<'a> SearchBackendChain<'a> {
         let backends = self
             .backends
             .iter()
-            .map(|backend| backend as &dyn SearchBackend)
+            .map(|backend| backend.as_ref())
             .collect::<Vec<_>>();
         run_backend_chain(&backends, query, deadline, first_attempt_budget).await
     }
+}
+
+fn should_prepend_provider_native(context: &ToolContext) -> bool {
+    provider_native_is_available(
+        context
+            .route_capabilities
+            .server_side_web_search
+            .is_supported(),
+        context.provider_native_search.is_some(),
+    )
+}
+
+const fn provider_native_is_available(capability_supported: bool, client_present: bool) -> bool {
+    capability_supported && client_present
 }
 
 async fn run_backend_chain(
@@ -267,6 +294,99 @@ impl SearchBackend for ConfiguredSearchBackend<'_> {
     }
 }
 
+#[async_trait]
+impl SearchBackend for ProviderNativeSearchBackend<'_> {
+    fn id(&self) -> BackendId {
+        BackendId::ProviderNative
+    }
+
+    fn capabilities(&self) -> QueryCapabilities {
+        QueryCapabilities {
+            max_results: QueryCapabilityState::Supported,
+            recency: QueryCapabilityState::Unsupported,
+            domains: QueryCapabilityState::Supported,
+            locale: QueryCapabilityState::Unsupported,
+            published_date: QueryCapabilityState::Unknown,
+        }
+    }
+
+    async fn search(
+        &self,
+        query: &SearchQuery,
+        _deadline: Instant,
+    ) -> Result<BackendSearch, ToolError> {
+        if !self
+            .context
+            .route_capabilities
+            .server_side_web_search
+            .is_supported()
+        {
+            return Err(ToolError::not_available(
+                "active route does not report provider-native web search",
+            ));
+        }
+        let client = self
+            .context
+            .provider_native_search
+            .as_ref()
+            .ok_or_else(|| ToolError::not_available("provider-native search client unavailable"))?;
+        if let Some(maximum) = client.maximum_domain_count()
+            && query.domains.len() > maximum
+        {
+            return Err(ToolError::invalid_input(format!(
+                "{} native web search accepts at most {maximum} domains",
+                client.provider().as_str()
+            )));
+        }
+        let host = client.host().ok_or_else(|| {
+            ToolError::execution_failed("provider-native search endpoint has no valid host")
+        })?;
+        crate::tools::web_search::check_policy(
+            self.context.network_policy.as_ref(),
+            host.as_str(),
+        )?;
+        let response = client
+            .search(&ProviderNativeSearchRequest {
+                query: query.query.clone(),
+                max_results: query.max_results,
+                domains: query.domains.clone(),
+            })
+            .await
+            .map_err(|error| {
+                ToolError::execution_failed(format!(
+                    "{} provider-native web search failed: {error}",
+                    client.provider().as_str()
+                ))
+            })?;
+        let results = response
+            .citations
+            .into_iter()
+            .enumerate()
+            .map(|(index, citation)| {
+                SearchResult::new(
+                    index + 1,
+                    citation.title,
+                    citation.url,
+                    citation.snippet,
+                    citation.published,
+                )
+            })
+            .collect();
+        Ok(BackendSearch {
+            backend: BackendId::ProviderNative,
+            source: format!(
+                "provider-native/{}/{}",
+                client.provider().as_str(),
+                client.model()
+            ),
+            backend_detail: Some(host),
+            results,
+            degraded: Vec::new(),
+            note: response.answer,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
@@ -344,6 +464,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn provider_native_is_fail_closed_without_both_fact_and_client() {
+        assert!(!provider_native_is_available(false, false));
+        assert!(!provider_native_is_available(true, false));
+        assert!(!provider_native_is_available(false, true));
+        assert!(provider_native_is_available(true, true));
+    }
+
     #[tokio::test]
     async fn unavailable_api_falls_back_with_explicit_receipts() {
         let api = FakeBackend {
@@ -369,6 +497,52 @@ mod tests {
         assert_eq!(
             response.raw.degraded,
             vec![
+                DegradedReason::BackendUnavailable {
+                    backend: BackendId::Tavily,
+                },
+                DegradedReason::BackendFallback {
+                    from: BackendId::Tavily,
+                    to: BackendId::DuckDuckGo,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_native_to_api_to_scrape_records_every_transition() {
+        let native = FakeBackend {
+            id: BackendId::ProviderNative,
+            result: Err(ToolError::execution_failed("native unavailable")),
+        };
+        let api = FakeBackend {
+            id: BackendId::Tavily,
+            result: Err(ToolError::execution_failed("API unavailable")),
+        };
+        let scrape = FakeBackend {
+            id: BackendId::DuckDuckGo,
+            result: Ok(vec![result()]),
+        };
+
+        let response = run_backend_chain(
+            &[&native, &api, &scrape],
+            &query(),
+            Instant::now() + Duration::from_secs(1),
+            None,
+        )
+        .await
+        .expect("final scrape fallback should succeed");
+
+        assert_eq!(response.raw.backend, BackendId::DuckDuckGo);
+        assert_eq!(
+            response.raw.degraded,
+            vec![
+                DegradedReason::BackendUnavailable {
+                    backend: BackendId::ProviderNative,
+                },
+                DegradedReason::BackendFallback {
+                    from: BackendId::ProviderNative,
+                    to: BackendId::Tavily,
+                },
                 DegradedReason::BackendUnavailable {
                     backend: BackendId::Tavily,
                 },

--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -12,6 +12,7 @@ pub(crate) const MAX_SEARCH_RESULTS: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum BackendId {
+    ProviderNative,
     Bing,
     #[serde(rename = "duckduckgo")]
     DuckDuckGo,
@@ -28,6 +29,7 @@ impl BackendId {
     #[must_use]
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
+            Self::ProviderNative => "provider_native",
             Self::Bing => "bing",
             Self::DuckDuckGo => "duckduckgo",
             Self::Tavily => "tavily",

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -1,6 +1,7 @@
-//! Web search tool backed by a bounded backend chain: configured API search,
-//! then DuckDuckGo HTML scrape with a one-way Bing fallback. Explicit Bing and
-//! private DuckDuckGo-compatible routes remain single-provider. API adapters
+//! Web search tool backed by a bounded backend chain: the active route's
+//! documented provider-native search, configured API search, then DuckDuckGo
+//! HTML scrape with a one-way Bing fallback. Explicit Bing and private
+//! DuckDuckGo-compatible routes remain single-provider. API adapters
 //! include Tavily, Bocha (博查),
 //! Metaso API (<https://metaso.cn>), SearXNG JSON API, Baidu AI Search,
 //! Volcengine Ark, and Sofya (<https://sofya.co>).
@@ -50,7 +51,10 @@ const VOLCENGINE_MIN_TIMEOUT_MS: u64 = 90_000;
 
 /// Returns `Ok(())` if the policy allows the call, or a `ToolError` otherwise.
 /// Falls through silently when no policy is attached (back-compat).
-fn check_policy(decider: Option<&NetworkPolicyDecider>, host: &str) -> Result<(), ToolError> {
+pub(crate) fn check_policy(
+    decider: Option<&NetworkPolicyDecider>,
+    host: &str,
+) -> Result<(), ToolError> {
     let Some(decider) = decider else {
         return Ok(());
     };
@@ -96,7 +100,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web and return ranked results with URLs, snippets, and an execution receipt. Default backend is DuckDuckGo with Bing fallback. Configured API backends are tried first and visibly degrade through DuckDuckGo then Bing when unavailable; configuration and network-policy errors fail closed. Explicit Bing and private DuckDuckGo-compatible routes do not cross providers. Set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml, or `[search] base_url` for a private DuckDuckGo-compatible endpoint or trusted SearXNG instance. For a known canonical URL, prefer `fetch_url` directly."
+        "Search the web and return ranked results with URLs, snippets, and an execution receipt. When the exact active route reports a documented first-party server-side search tool, it is tried first; otherwise the default backend is DuckDuckGo with Bing fallback. Configured API backends visibly degrade through DuckDuckGo then Bing when unavailable, and every hop is recorded. Configuration and network-policy errors fail closed. Explicit Bing and private DuckDuckGo-compatible routes do not cross providers. Set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml, or `[search] base_url` for a private DuckDuckGo-compatible endpoint or trusted SearXNG instance. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {
@@ -723,19 +727,25 @@ pub(crate) async fn execute_search(
         )));
     }
 
-    preflight_search_provider(context)?;
     let chain = SearchBackendChain::from_context(context);
-    debug_assert_eq!(
-        chain.initial_backend().as_str(),
-        context.search_provider.as_str()
-    );
     let initial_backend = chain.initial_backend();
-    let normalized_base_url = normalized_search_base_url(context.search_base_url.as_deref());
+    if initial_backend != BackendId::ProviderNative {
+        debug_assert_eq!(initial_backend.as_str(), context.search_provider.as_str());
+        preflight_search_provider(context)?;
+    }
+    let cache_scope = if initial_backend == BackendId::ProviderNative {
+        context
+            .provider_native_search
+            .as_ref()
+            .map(crate::client::ProviderNativeSearchClient::cache_identity)
+    } else {
+        normalized_search_base_url(context.search_base_url.as_deref())
+    };
 
     if let Some(mut cached) = cache::get_search(
         &context.state_namespace,
         initial_backend,
-        normalized_base_url.as_deref(),
+        cache_scope.as_deref(),
         &query,
     ) {
         validate_cached_search_policy(&cached, context)?;
@@ -759,7 +769,7 @@ pub(crate) async fn execute_search(
     cache::insert_search(
         &context.state_namespace,
         initial_backend,
-        normalized_base_url.as_deref(),
+        cache_scope.as_deref(),
         &query,
         response.clone(),
     );
@@ -835,6 +845,7 @@ fn validate_cached_search_policy(
 
 const fn default_backend_host(backend: BackendId) -> Option<&'static str> {
     match backend {
+        BackendId::ProviderNative => None,
         BackendId::Bing => Some(BING_HOST),
         BackendId::DuckDuckGo => Some("html.duckduckgo.com"),
         BackendId::Tavily => Some("api.tavily.com"),
@@ -854,28 +865,52 @@ fn finalize_search_response(
     started: Instant,
 ) -> SearchResponse {
     let mut honored = HonoredQueryCapabilities {
-        max_results: true,
+        max_results: matches!(
+            capabilities.max_results,
+            super::web::contract::CapabilityState::Supported
+        ),
         ..HonoredQueryCapabilities::default()
     };
 
     if query.recency.is_some() {
-        raw.degraded.push(DegradedReason::KnobIgnored {
-            knob: QueryKnob::Recency,
-        });
+        if matches!(
+            capabilities.recency,
+            super::web::contract::CapabilityState::Supported
+        ) {
+            honored.recency = true;
+        } else {
+            raw.degraded.push(DegradedReason::KnobIgnored {
+                knob: QueryKnob::Recency,
+            });
+        }
     }
     if !query.domains.is_empty() {
+        let before = raw.results.len();
         raw.results
             .retain(|result| domain_matches(&result.url, &query.domains));
         rerank(&mut raw.results);
         honored.domains = true;
-        raw.degraded.push(DegradedReason::PostFiltered {
-            knob: QueryKnob::Domains,
-        });
+        let provider_honored = matches!(
+            capabilities.domains,
+            super::web::contract::CapabilityState::Supported
+        );
+        if !provider_honored || raw.results.len() != before {
+            raw.degraded.push(DegradedReason::PostFiltered {
+                knob: QueryKnob::Domains,
+            });
+        }
     }
     if query.locale.is_some() {
-        raw.degraded.push(DegradedReason::KnobIgnored {
-            knob: QueryKnob::Locale,
-        });
+        if matches!(
+            capabilities.locale,
+            super::web::contract::CapabilityState::Supported
+        ) {
+            honored.locale = true;
+        } else {
+            raw.degraded.push(DegradedReason::KnobIgnored {
+                knob: QueryKnob::Locale,
+            });
+        }
     }
 
     raw.results.truncate(usize::from(query.max_results));
@@ -1823,9 +1858,13 @@ mod tests {
         parse_volcengine_results, run_scrape_search_with_endpoints, sanitize_error_body,
         searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
-    use crate::tools::web::contract::{BackendId, QueryCapabilities, SearchQuery};
+    use crate::tools::web::contract::{
+        BackendId, BackendSearch, CapabilityState, DegradedReason, QueryCapabilities, QueryKnob,
+        Recency, SearchQuery, SearchResult,
+    };
     use crate::tools::web::scrape::{decode_html_entities, normalize_bing_url};
     use serde_json::json;
+    use std::time::Instant;
 
     // Regression guard: Bing /ck/a redirect hrefs are HTML-entity-encoded
     // (`&amp;`). normalize_bing_url must decode entities before extracting the
@@ -2710,6 +2749,59 @@ mod tests {
                 .iter()
                 .any(|item| { item["kind"] == "knob_ignored" && item["knob"] == "locale" })
         );
+    }
+
+    #[test]
+    fn provider_native_domain_filter_is_reported_as_provider_honored() {
+        let query = SearchQuery::new(
+            "current release".to_string(),
+            3,
+            Some(Recency::Week),
+            vec!["example.com".to_string()],
+            None,
+        );
+        let raw = BackendSearch {
+            backend: BackendId::ProviderNative,
+            source: "provider-native/xai/grok-4.5".to_string(),
+            backend_detail: Some("api.x.ai".to_string()),
+            results: vec![SearchResult::new(
+                1,
+                "Exact source".to_string(),
+                "https://docs.example.com/release".to_string(),
+                None,
+                None,
+            )],
+            degraded: Vec::new(),
+            note: Some("Grounded answer.".to_string()),
+        };
+        let response = finalize_search_response(
+            query,
+            QueryCapabilities {
+                max_results: CapabilityState::Supported,
+                recency: CapabilityState::Unsupported,
+                domains: CapabilityState::Supported,
+                locale: CapabilityState::Unsupported,
+                published_date: CapabilityState::Unknown,
+            },
+            raw,
+            Instant::now(),
+        );
+
+        assert!(response.receipt.honored.max_results);
+        assert!(response.receipt.honored.domains);
+        assert!(!response.receipt.honored.recency);
+        assert!(response.receipt.degraded.iter().any(|reason| matches!(
+            reason,
+            DegradedReason::KnobIgnored {
+                knob: QueryKnob::Recency
+            }
+        )));
+        assert!(!response.receipt.degraded.iter().any(|reason| matches!(
+            reason,
+            DegradedReason::PostFiltered {
+                knob: QueryKnob::Domains
+            }
+        )));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Gate provider-native web search on exact three-state route capability facts for documented direct OpenAI, Anthropic, and xAI offerings. Aggregators, custom endpoints, aliases, and nearby model names remain unknown and fail closed.
- Reuse the active authenticated route through a narrow opaque adapter for Responses and Messages search contracts without exposing provider credentials to tool code. Normalize and bound citations, keep generated answers separate, enforce provider domain limits, and scope caches to provider, host, and model.
- Prepend the native backend only when both the exact capability fact and client exist. Preserve the configured API and scrape chain as explicit fallbacks with a receipt for every transition.
- Source capability facts from provider-owned documentation:
  - https://developers.openai.com/api/docs/guides/tools-web-search
  - https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool
  - https://docs.x.ai/developers/tools/web-search

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test -p codewhale-config --locked` — 419 tests plus one compile-fail doc test passed
- [x] `cargo test -p codewhale-tui --locked` — 7,559 unit tests plus all integration and acceptance binaries passed; zero failures
- [x] Targeted provider-native web slice — 166 passed, one intentional helper ignored
- [x] Deterministic xAI authenticated transport test through WireMock, including request shape, citation parsing, and cache identity redaction
- [x] Gitleaks scans of the exact commit delta and staged follow-up — no leaks found
- [ ] `cargo test --workspace --all-features` — not run; the two changed crates were exercised in full
- [ ] Live provider acceptance — deliberately deferred to the exact-head installed-product release gate

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes — no UI change in this PR
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address — no harvested or co-authored code

## Honesty boundary

This PR does not publish, tag, release, deploy, or exercise live credentials. The transport coverage uses only a local deterministic test server and a dummy credential. Live provider acceptance remains a separate exact-head release receipt.