### PR TITLE
feat(web): add tool-wide citation evidence

### DIFF
--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -53,6 +53,7 @@ impl Format {
 
 #[derive(Debug, Serialize)]
 struct FetchResponse {
+    ref_id: String,
     url: String,
     status: u16,
     headers: BTreeMap<String, String>,
@@ -91,7 +92,7 @@ impl ToolSpec for FetchUrlTool {
     }
 
     fn description(&self) -> &'static str {
-        "Fetch a known URL directly (HTTP GET) and return its content. Use this instead of `curl` in `exec_shell` — sandboxed, network-policy aware, and properly decoded. Plain-text endpoints (`.md`, `.txt`, `.json`, `.yaml`, `raw.githubusercontent.com`, public APIs) prefer this over the browser/automation stack. For unknown queries, use `web_search` first."
+        "Fetch a known URL directly (HTTP GET) and return its content with a session-scoped citation ref_id. Use this instead of `curl` in `exec_shell` — sandboxed, network-policy aware, and properly decoded. Plain-text endpoints (`.md`, `.txt`, `.json`, `.yaml`, `raw.githubusercontent.com`, public APIs) prefer this over the browser/automation stack. For unknown queries, use `web_search` first. If a login or authorization wall is returned, treat the wall as the result; do not claim the protected page was read."
     }
 
     fn input_schema(&self) -> Value {
@@ -209,6 +210,7 @@ impl ToolSpec for FetchUrlTool {
                 Err(error) => return Err(error),
             };
 
+        let citation_title = extracted.title.clone();
         let (processed, artifact_write) = render_extracted(
             &fetched.url,
             &fetched.content_type,
@@ -221,8 +223,15 @@ impl ToolSpec for FetchUrlTool {
             .as_ref()
             .map(|write| crate::artifacts::format_artifact_relative_path(&write.relative_path));
 
+        let citation = super::web::citations::register(
+            &context.state_namespace,
+            &fetched.url,
+            citation_title.as_deref(),
+        )
+        .ok_or_else(|| ToolError::execution_failed("fetched URL could not be registered"))?;
         let response = FetchResponse {
-            url: fetched.url,
+            ref_id: citation.ref_id,
+            url: citation.url,
             status: fetched.status,
             headers: fetched.headers,
             content_type: fetched.content_type,

--- a/crates/tui/src/tools/web/citations.rs
+++ b/crates/tui/src/tools/web/citations.rs
@@ -1,0 +1,279 @@
+//! Session-scoped web citation registry shared by every web-tool surface.
+//!
+//! Ref IDs are opaque, deterministic within one session, and useless in a
+//! foreign session. The registry stores only a normalized HTTP(S) URL, an
+//! optional title, and the retrieval timestamp needed by Work Graph evidence.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+const CITATION_TTL: Duration = Duration::from_secs(30 * 60);
+const MAX_CITATIONS: usize = 4_096;
+
+static CITATIONS: OnceLock<Mutex<HashMap<CitationKey, CitationEntry>>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CitationKey {
+    namespace: String,
+    ref_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct CitationEntry {
+    citation: WebCitation,
+    touched_at: Instant,
+}
+
+/// Inspectable, secret-free web evidence metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WebCitation {
+    pub(crate) ref_id: String,
+    pub(crate) url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) title: Option<String>,
+    pub(crate) retrieved_at: String,
+}
+
+impl WebCitation {
+    pub(crate) fn evidence_ref(&self) -> Result<crate::work_graph::EvidenceRef, String> {
+        crate::work_graph::EvidenceRef::new(
+            crate::work_graph::EvidenceKind::WebCitation {
+                ref_id: self.ref_id.clone(),
+                url: self.url.clone(),
+                retrieved_at: self.retrieved_at.clone(),
+            },
+            self.ref_id.clone(),
+            None,
+            false,
+        )
+        .map_err(|error| error.to_string())
+    }
+}
+
+/// Register a URL under a deterministic, session-scoped ref ID.
+pub(crate) fn register(namespace: &str, url: &str, title: Option<&str>) -> Option<WebCitation> {
+    let normalized = normalize_http_url(url)?;
+    let ref_id = ref_id_for(namespace, &normalized);
+    register_with_ref(namespace, &ref_id, &normalized, title)
+}
+
+/// Register a URL under a surface-owned ref ID (for example a `web.run` view).
+pub(crate) fn register_with_ref(
+    namespace: &str,
+    ref_id: &str,
+    url: &str,
+    title: Option<&str>,
+) -> Option<WebCitation> {
+    if namespace.trim().is_empty()
+        || ref_id.trim().is_empty()
+        || ref_id
+            .chars()
+            .any(|ch| ch.is_whitespace() || ch.is_control())
+    {
+        return None;
+    }
+    let url = normalize_http_url(url)?;
+    let key = CitationKey {
+        namespace: namespace.to_string(),
+        ref_id: ref_id.to_string(),
+    };
+    let now = Instant::now();
+    let mut registry = CITATIONS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    cleanup(&mut registry, now);
+    if let Some(existing) = registry.get_mut(&key) {
+        if existing.citation.url != url {
+            return None;
+        }
+        existing.touched_at = now;
+        if existing.citation.title.is_none() {
+            existing.citation.title = normalized_title(title);
+        }
+        return Some(existing.citation.clone());
+    }
+    if registry.len() >= MAX_CITATIONS
+        && let Some(oldest) = registry
+            .iter()
+            .min_by_key(|(_, entry)| entry.touched_at)
+            .map(|(key, _)| key.clone())
+    {
+        registry.remove(&oldest);
+    }
+    let citation = WebCitation {
+        ref_id: ref_id.to_string(),
+        url,
+        title: normalized_title(title),
+        retrieved_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+    };
+    citation.evidence_ref().ok()?;
+    registry.insert(
+        key,
+        CitationEntry {
+            citation: citation.clone(),
+            touched_at: now,
+        },
+    );
+    Some(citation)
+}
+
+/// Resolve a ref only inside the session that minted it.
+pub(crate) fn resolve(namespace: &str, ref_id: &str) -> Option<WebCitation> {
+    let key = CitationKey {
+        namespace: namespace.to_string(),
+        ref_id: ref_id.to_string(),
+    };
+    let now = Instant::now();
+    let mut registry = CITATIONS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    cleanup(&mut registry, now);
+    let entry = registry.get_mut(&key)?;
+    entry.touched_at = now;
+    Some(entry.citation.clone())
+}
+
+fn ref_id_for(namespace: &str, url: &str) -> String {
+    let identity = format!("{namespace}\0{url}");
+    let digest = crate::hashing::sha256_hex(identity.as_bytes());
+    format!("web_{}", &digest[..16])
+}
+
+fn normalize_http_url(url: &str) -> Option<String> {
+    let mut parsed = reqwest::Url::parse(url.trim()).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return None;
+    }
+    let query_pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .filter(|(name, _)| !is_sensitive_query_name(name))
+        .map(|(name, value)| (name.into_owned(), value.into_owned()))
+        .collect();
+    let query_was_sanitized = parsed.query_pairs().count() != query_pairs.len();
+    if query_was_sanitized {
+        parsed.set_query(None);
+        if !query_pairs.is_empty() {
+            parsed.query_pairs_mut().extend_pairs(query_pairs);
+        }
+    }
+    parsed.set_fragment(None);
+    if !parsed.username().is_empty() {
+        parsed.set_username("").ok()?;
+    }
+    if parsed.password().is_some() {
+        parsed.set_password(None).ok()?;
+    }
+    Some(parsed.to_string())
+}
+
+fn is_sensitive_query_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "access_token"
+            | "api_key"
+            | "authorization"
+            | "auth"
+            | "credential"
+            | "key"
+            | "session"
+            | "session_id"
+            | "sig"
+            | "signature"
+            | "token"
+            | "x-amz-credential"
+            | "x-amz-signature"
+            | "x-goog-credential"
+            | "x-goog-signature"
+    ) || name.ends_with("_token")
+        || name.ends_with("_key")
+}
+
+fn normalized_title(title: Option<&str>) -> Option<String> {
+    title
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(|title| title.chars().take(240).collect())
+}
+
+fn cleanup(registry: &mut HashMap<CitationKey, CitationEntry>, now: Instant) {
+    registry.retain(|_, entry| now.duration_since(entry.touched_at) <= CITATION_TTL);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refs_are_stable_within_a_session_and_scoped_between_sessions() {
+        let first = register(
+            "session-a",
+            "https://example.com/page#section",
+            Some("Page"),
+        )
+        .expect("valid citation");
+        let repeated =
+            register("session-a", "https://example.com/page", None).expect("same citation");
+        let foreign =
+            register("session-b", "https://example.com/page", None).expect("foreign citation");
+
+        assert_eq!(first.ref_id, repeated.ref_id);
+        assert_eq!(first.retrieved_at, repeated.retrieved_at);
+        assert_ne!(first.ref_id, foreign.ref_id);
+        assert_eq!(first.url, "https://example.com/page");
+        assert!(resolve("session-b", &first.ref_id).is_none());
+        let evidence = first.evidence_ref().expect("citation evidence");
+        assert_eq!(evidence.reference(), first.ref_id);
+    }
+
+    #[test]
+    fn registry_rejects_non_web_urls_and_strips_url_credentials() {
+        assert!(register("session", "javascript:alert(1)", None).is_none());
+        let citation = register(
+            "session",
+            "https://user:password@example.com/path#private",
+            None,
+        )
+        .expect("http citation");
+        assert_eq!(citation.url, "https://example.com/path");
+        assert!(!citation.url.contains("password"));
+        let signed = register(
+            "session",
+            "https://example.com/path?access_token=sensitive&view=full",
+            None,
+        )
+        .expect("credential values are removed from citation metadata");
+        assert_eq!(signed.url, "https://example.com/path?view=full");
+        assert!(!signed.url.contains("sensitive"));
+    }
+
+    #[test]
+    fn explicit_refs_are_validated_and_session_scoped() {
+        assert!(register_with_ref("session", "two words", "https://example.com", None).is_none());
+        let citation = register_with_ref(
+            "session",
+            "s1_turn0view1",
+            "https://example.com",
+            Some("Example"),
+        )
+        .expect("explicit ref");
+        assert_eq!(citation.ref_id, "s1_turn0view1");
+        assert!(resolve("other", "s1_turn0view1").is_none());
+        assert!(
+            register_with_ref(
+                "session",
+                "s1_turn0view1",
+                "https://other.example.com",
+                None
+            )
+            .is_none(),
+            "an existing ref must never be rebound to another URL"
+        );
+    }
+}

--- a/crates/tui/src/tools/web/contract.rs
+++ b/crates/tui/src/tools/web/contract.rs
@@ -219,6 +219,9 @@ impl DegradedReason {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct SearchResult {
     pub(crate) rank: u8,
+    /// Session-scoped citation handle. Backends leave this empty; the shared
+    /// execution surface mints it before any result crosses the tool boundary.
+    pub(crate) ref_id: String,
     pub(crate) title: String,
     pub(crate) url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -243,6 +246,7 @@ impl SearchResult {
             .unwrap_or_default();
         Self {
             rank: u8::try_from(rank.clamp(1, 255)).unwrap_or(u8::MAX),
+            ref_id: String::new(),
             title,
             url,
             snippet,

--- a/crates/tui/src/tools/web/mod.rs
+++ b/crates/tui/src/tools/web/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod backend;
 pub(crate) mod cache;
+pub(crate) mod citations;
 pub(crate) mod contract;
 pub(crate) mod extract;
 pub(crate) mod fetch;

--- a/crates/tui/src/tools/web_run.rs
+++ b/crates/tui/src/tools/web_run.rs
@@ -301,6 +301,7 @@ struct ScreenshotResult {
 
 #[derive(Debug, Clone, Serialize)]
 struct ImageResultEntry {
+    ref_id: String,
     image: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     thumbnail: Option<String>,
@@ -554,8 +555,20 @@ impl ToolSpec for WebRunTool {
                     })
                     .unwrap_or_default();
 
-                let (entries, warning) =
+                let (mut entries, warning) =
                     run_image_search(&query, max_results, timeout_ms, &domains).await?;
+                entries.retain_mut(|entry| {
+                    let canonical_url = entry.url.as_deref().unwrap_or(&entry.image);
+                    let Some(citation) = super::web::citations::register(
+                        &context.state_namespace,
+                        canonical_url,
+                        entry.title.as_deref(),
+                    ) else {
+                        return false;
+                    };
+                    entry.ref_id = citation.ref_id;
+                    true
+                });
 
                 let mut warnings = Vec::new();
                 if recency > 0 {
@@ -733,6 +746,12 @@ fn scoped_ref_prefix(namespace: &str) -> String {
 }
 
 fn store_page(namespace: &str, ref_id: &str, page: WebPage) {
+    let _ = super::web::citations::register_with_ref(
+        namespace,
+        ref_id,
+        &page.url,
+        page.title.as_deref(),
+    );
     with_state(|state| {
         state.store_page(namespace, ref_id, page);
     });
@@ -775,6 +794,11 @@ async fn resolve_or_fetch_page(
 ) -> Result<Arc<WebPage>, ToolError> {
     if let Some(page) = get_page(&context.state_namespace, ref_id) {
         return Ok(page);
+    }
+    if let Some(citation) = super::web::citations::resolve(&context.state_namespace, ref_id) {
+        return fetch_page(&citation.url, timeout_ms, context)
+            .await
+            .map(Arc::new);
     }
     if looks_like_url(ref_id) {
         return fetch_page(ref_id, timeout_ms, context).await.map(Arc::new);
@@ -924,6 +948,7 @@ async fn run_image_search(
         .into_iter()
         .filter(|item| !item.image.trim().is_empty())
         .map(|item| ImageResultEntry {
+            ref_id: String::new(),
             image: item.image,
             thumbnail: item.thumbnail,
             title: item.title,
@@ -1944,6 +1969,29 @@ mod tests {
             format!("{err}").contains("restricted address"),
             "expected restricted-address error; got {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn open_resolves_shared_citation_refs_only_in_their_session() {
+        let namespace = "shared-citation-open-session";
+        let citation = crate::tools::web::citations::register(
+            namespace,
+            "http://127.0.0.1/private",
+            Some("Private target"),
+        )
+        .expect("valid HTTP citation metadata");
+        let owner_context = ToolContext::new(PathBuf::from(".")).with_state_namespace(namespace);
+        let owner_error = resolve_or_fetch_page(&citation.ref_id, 5_000, &owner_context)
+            .await
+            .expect_err("resolved citation must still use the SSRF guard");
+        assert!(format!("{owner_error}").contains("restricted address"));
+
+        let foreign_context = ToolContext::new(PathBuf::from("."))
+            .with_state_namespace("shared-citation-foreign-session");
+        let foreign_error = resolve_or_fetch_page(&citation.ref_id, 5_000, &foreign_context)
+            .await
+            .expect_err("foreign session must not resolve citation ref");
+        assert!(format!("{foreign_error}").contains("Unknown ref_id"));
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/web_search.rs
+++ b/crates/tui/src/tools/web_search.rs
@@ -100,7 +100,7 @@ impl ToolSpec for WebSearchTool {
     }
 
     fn description(&self) -> &'static str {
-        "Search the web and return ranked results with URLs, snippets, and an execution receipt. When the exact active route reports a documented first-party server-side search tool, it is tried first; otherwise the default backend is DuckDuckGo with Bing fallback. Configured API backends visibly degrade through DuckDuckGo then Bing when unavailable, and every hop is recorded. Configuration and network-policy errors fail closed. Explicit Bing and private DuckDuckGo-compatible routes do not cross providers. Set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml, or `[search] base_url` for a private DuckDuckGo-compatible endpoint or trusted SearXNG instance. For a known canonical URL, prefer `fetch_url` directly."
+        "Search the web and return ranked results with URLs, snippets, session-scoped ref_ids, and an execution receipt. Open a result ref_id with `web.run` when the short summary is not enough; fetch only the few sources needed. When the exact active route reports a documented first-party server-side search tool, it is tried first; otherwise the default backend is DuckDuckGo with Bing fallback. Configured API backends visibly degrade through DuckDuckGo then Bing when unavailable, and every hop is recorded. Configuration and network-policy errors fail closed. Explicit Bing and private DuckDuckGo-compatible routes do not cross providers. Set `[search] provider = \"bing\" | \"tavily\" | \"bocha\" | \"metaso\" | \"searxng\" | \"baidu\" | \"volcengine\" | \"sofya\"` in config.toml, or `[search] base_url` for a private DuckDuckGo-compatible endpoint or trusted SearXNG instance. For a known canonical URL, prefer `fetch_url` directly."
     }
 
     fn input_schema(&self) -> Value {
@@ -749,6 +749,7 @@ pub(crate) async fn execute_search(
         &query,
     ) {
         validate_cached_search_policy(&cached, context)?;
+        register_search_citations(&mut cached, context);
         cached.receipt.cache_hit = true;
         cached.receipt.latency_ms = 0;
         return Ok(cached);
@@ -764,8 +765,9 @@ pub(crate) async fn execute_search(
     };
     let deadline = started + total_timeout;
     let chained = chain.search(&query, deadline, first_attempt_budget).await?;
-    let response =
+    let mut response =
         finalize_search_response(query.clone(), chained.capabilities, chained.raw, started);
+    register_search_citations(&mut response, context);
     cache::insert_search(
         &context.state_namespace,
         initial_backend,
@@ -774,6 +776,31 @@ pub(crate) async fn execute_search(
         response.clone(),
     );
     Ok(response)
+}
+
+fn register_search_citations(response: &mut SearchResponse, context: &ToolContext) {
+    let mut seen = std::collections::HashSet::new();
+    response.results.retain_mut(|result| {
+        let Some(citation) = super::web::citations::register(
+            &context.state_namespace,
+            &result.url,
+            Some(&result.title),
+        ) else {
+            return false;
+        };
+        result.ref_id = citation.ref_id;
+        result.url = citation.url;
+        seen.insert(result.ref_id.clone())
+    });
+    if response.count != response.results.len() {
+        rerank(&mut response.results);
+        response.count = response.results.len();
+        response.message = if response.count == 0 {
+            "No usable web citations found".to_string()
+        } else {
+            format!("Found {} result(s)", response.count)
+        };
+    }
 }
 
 fn preflight_search_provider(context: &ToolContext) -> Result<(), ToolError> {
@@ -1855,8 +1882,8 @@ mod tests {
         bocha_error_message, duckduckgo_search_url, extract_search_query, finalize_search_response,
         optional_search_max_results, parse_baidu_results, parse_bocha_results,
         parse_metaso_results, parse_searxng_results, parse_sofya_results, parse_tavily_results,
-        parse_volcengine_results, run_scrape_search_with_endpoints, sanitize_error_body,
-        searxng_search_url, truncate_error_body, volcengine_extract_text,
+        parse_volcengine_results, register_search_citations, run_scrape_search_with_endpoints,
+        sanitize_error_body, searxng_search_url, truncate_error_body, volcengine_extract_text,
     };
     use crate::tools::web::contract::{
         BackendId, BackendSearch, CapabilityState, DegradedReason, QueryCapabilities, QueryKnob,
@@ -2802,6 +2829,63 @@ mod tests {
                 knob: QueryKnob::Domains
             }
         )));
+    }
+
+    #[test]
+    fn search_results_receive_session_scoped_refs_and_sanitize_credential_urls() {
+        let query = SearchQuery::new("sources".to_string(), 5, None, Vec::new(), None);
+        let raw = BackendSearch {
+            backend: BackendId::DuckDuckGo,
+            source: "duckduckgo".to_string(),
+            backend_detail: None,
+            results: vec![
+                SearchResult::new(
+                    1,
+                    "Valid".to_string(),
+                    "https://example.com/source#section".to_string(),
+                    None,
+                    None,
+                ),
+                SearchResult::new(
+                    2,
+                    "Protected".to_string(),
+                    "https://example.com/protected?access_token=sensitive&view=full".to_string(),
+                    None,
+                    None,
+                ),
+            ],
+            degraded: Vec::new(),
+            note: None,
+        };
+        let mut response =
+            finalize_search_response(query, QueryCapabilities::count_only(), raw, Instant::now());
+        let context = crate::tools::spec::ToolContext::new(std::path::PathBuf::from("."))
+            .with_state_namespace("search-citation-session");
+
+        register_search_citations(&mut response, &context);
+
+        assert_eq!(response.count, 2);
+        assert_eq!(response.results[0].url, "https://example.com/source");
+        assert_eq!(
+            response.results[1].url,
+            "https://example.com/protected?view=full"
+        );
+        assert!(!response.results[1].url.contains("sensitive"));
+        assert!(response.results[0].ref_id.starts_with("web_"));
+        assert!(
+            crate::tools::web::citations::resolve(
+                "search-citation-session",
+                &response.results[0].ref_id
+            )
+            .is_some()
+        );
+        assert!(
+            crate::tools::web::citations::resolve(
+                "foreign-search-citation-session",
+                &response.results[0].ref_id
+            )
+            .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/history.rs
+++ b/crates/tui/src/tui/history.rs
@@ -1248,6 +1248,9 @@ pub struct WebSearchCell {
     pub query: String,
     pub status: ToolStatus,
     pub summary: Option<String>,
+    pub source: Option<String>,
+    pub degraded: Option<String>,
+    pub ref_count: usize,
 }
 
 impl WebSearchCell {
@@ -1268,6 +1271,30 @@ impl WebSearchCell {
             tool_value_style(),
             width,
         ));
+        if let Some(source) = self.source.as_ref() {
+            lines.extend(render_compact_kv(
+                "source",
+                source,
+                tool_value_style(),
+                width,
+            ));
+        }
+        if let Some(degraded) = self.degraded.as_ref() {
+            lines.extend(render_compact_kv(
+                "degraded",
+                degraded,
+                tool_value_style(),
+                width,
+            ));
+        }
+        if self.ref_count > 0 {
+            lines.extend(render_compact_kv(
+                "citations",
+                &self.ref_count.to_string(),
+                tool_value_style(),
+                width,
+            ));
+        }
         if let Some(summary) = self.summary.as_ref() {
             lines.extend(render_compact_kv(
                 "result",

--- a/crates/tui/src/tui/history/tests.rs
+++ b/crates/tui/src/tui/history/tests.rs
@@ -2,7 +2,7 @@ use super::{
     ASSISTANT_GLYPH, ExecCell, ExecSource, GenericToolCell, HistoryCell, PlanUpdateCell,
     REASONING_CURSOR, REASONING_OPENER, REASONING_RAIL, TOOL_RUNNING_SYMBOLS,
     TOOL_STATUS_SYMBOL_MS, ToolCell, ToolStatus, TranscriptRenderOptions, USER_GLYPH,
-    assistant_label_style_for, extract_reasoning_summary, render_thinking,
+    WebSearchCell, assistant_label_style_for, extract_reasoning_summary, render_thinking,
     running_status_label_with_elapsed,
 };
 use crate::deepseek_theme::Theme;
@@ -12,6 +12,30 @@ use crate::tools::plan::{PlanSnapshot, StepStatus};
 use crate::tui::ui_text::{line_to_plain, slice_text, text_display_width};
 use ratatui::style::Modifier;
 use std::time::{Duration, Instant};
+
+#[test]
+fn web_search_cell_renders_receipt_source_degradation_and_citations() {
+    let cell = WebSearchCell {
+        query: "current release".to_string(),
+        status: ToolStatus::Success,
+        summary: Some("Found 2 results".to_string()),
+        source: Some("provider-native/xai/grok-4.5".to_string()),
+        degraded: Some("provider_native -> duckduckgo".to_string()),
+        ref_count: 2,
+    };
+    let rendered = cell
+        .lines_with_motion(120, true)
+        .iter()
+        .map(line_to_plain)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("source"));
+    assert!(rendered.contains("provider-native/xai/grok-4.5"));
+    assert!(rendered.contains("degraded"));
+    assert!(rendered.contains("provider_native -> duckduckgo"));
+    assert!(rendered.contains("citations"));
+}
 
 // ---- elapsed-seconds badge for long-running tools ----
 //

--- a/crates/tui/src/tui/tool_routing.rs
+++ b/crates/tui/src/tui/tool_routing.rs
@@ -246,6 +246,9 @@ pub(super) fn handle_tool_call_started(
                 query,
                 status: ToolStatus::Running,
                 summary: None,
+                source: None,
+                degraded: None,
+                ref_count: 0,
             })),
         );
         return;
@@ -700,6 +703,10 @@ pub(super) fn handle_tool_call_complete(
                 match result.as_ref() {
                     Ok(tool_result) => {
                         search.summary = Some(summarize_tool_output(&tool_result.content));
+                        let presentation = web_search_presentation(&tool_result.content);
+                        search.source = presentation.source;
+                        search.degraded = presentation.degraded;
+                        search.ref_count = presentation.ref_count;
                     }
                     Err(err) => {
                         search.summary = Some(err.to_string());
@@ -788,6 +795,100 @@ pub(super) fn handle_tool_call_complete(
         tool_name: name.to_string(),
         summary: evidence_summary,
     });
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct WebSearchPresentation {
+    source: Option<String>,
+    degraded: Option<String>,
+    ref_count: usize,
+}
+
+fn web_search_presentation(content: &str) -> WebSearchPresentation {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        return WebSearchPresentation::default();
+    };
+    let surfaces = if value.get("receipt").is_some() {
+        vec![&value]
+    } else {
+        value
+            .get("search_query")
+            .and_then(serde_json::Value::as_array)
+            .map(|items| items.iter().collect())
+            .unwrap_or_default()
+    };
+    let source = surfaces
+        .iter()
+        .filter_map(|surface| surface.get("source").and_then(serde_json::Value::as_str))
+        .map(str::to_string)
+        .next();
+    let mut degraded = Vec::new();
+    let mut ref_count = 0usize;
+    for surface in surfaces {
+        if let Some(results) = surface.get("results").and_then(serde_json::Value::as_array) {
+            ref_count = ref_count.saturating_add(
+                results
+                    .iter()
+                    .filter(|result| {
+                        result
+                            .get("ref_id")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(|ref_id| !ref_id.is_empty())
+                    })
+                    .count(),
+            );
+        }
+        if let Some(reasons) = surface
+            .pointer("/receipt/degraded")
+            .and_then(serde_json::Value::as_array)
+        {
+            for reason in reasons {
+                if let Some(label) = degraded_reason_label(reason)
+                    && !degraded.contains(&label)
+                {
+                    degraded.push(label);
+                }
+            }
+        }
+    }
+    WebSearchPresentation {
+        source,
+        degraded: (!degraded.is_empty()).then(|| degraded.join("; ")),
+        ref_count,
+    }
+}
+
+fn degraded_reason_label(reason: &serde_json::Value) -> Option<String> {
+    let kind = reason.get("kind")?.as_str()?;
+    let backend = |field: &str| {
+        reason
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown")
+    };
+    Some(match kind {
+        "backend_unavailable" => format!("{} unavailable", backend("backend")),
+        "no_usable_results" => format!("{} returned no usable results", backend("backend")),
+        "backend_fallback" => format!("{} -> {}", backend("from"), backend("to")),
+        "challenge_detected" => format!("{} challenge", backend("backend")),
+        "scrape_fallback" => format!("{} -> {} scrape", backend("from"), backend("to")),
+        "knob_ignored" => format!(
+            "{} ignored",
+            reason
+                .get("knob")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("filter")
+        ),
+        "post_filtered" => format!(
+            "{} post-filtered",
+            reason
+                .get("knob")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("results")
+        ),
+        "synthesized_results" => "synthesized results".to_string(),
+        other => other.replace('_', " "),
+    })
 }
 
 /// Hydrate or advance the WorkflowPanel from a workflow tool JSON payload.
@@ -1554,6 +1655,56 @@ mod tests {
     use super::*;
     use crate::tools::plan::StepStatus;
     use serde_json::json;
+
+    #[test]
+    fn web_search_presentation_reads_source_degradation_and_citation_count() {
+        let presentation = web_search_presentation(
+            &json!({
+                "source": "provider-native/xai/grok-4.5",
+                "results": [
+                    {"ref_id": "web_a", "url": "https://example.com/a"},
+                    {"ref_id": "web_b", "url": "https://example.com/b"}
+                ],
+                "receipt": {
+                    "degraded": [
+                        {"kind": "backend_unavailable", "backend": "provider_native"},
+                        {"kind": "backend_fallback", "from": "provider_native", "to": "tavily"}
+                    ]
+                }
+            })
+            .to_string(),
+        );
+
+        assert_eq!(
+            presentation.source.as_deref(),
+            Some("provider-native/xai/grok-4.5")
+        );
+        assert_eq!(
+            presentation.degraded.as_deref(),
+            Some("provider_native unavailable; provider_native -> tavily")
+        );
+        assert_eq!(presentation.ref_count, 2);
+    }
+
+    #[test]
+    fn web_run_presentation_reads_nested_search_receipts() {
+        let presentation = web_search_presentation(
+            &json!({
+                "search_query": [{
+                    "source": "duckduckgo",
+                    "results": [{"ref_id": "web_a"}],
+                    "receipt": {
+                        "degraded": [{"kind": "knob_ignored", "knob": "recency"}]
+                    }
+                }]
+            })
+            .to_string(),
+        );
+
+        assert_eq!(presentation.source.as_deref(), Some("duckduckgo"));
+        assert_eq!(presentation.degraded.as_deref(), Some("recency ignored"));
+        assert_eq!(presentation.ref_count, 1);
+    }
 
     #[test]
     fn parse_plan_input_accepts_legacy_payload() {

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -546,6 +546,7 @@ fn acceptance_label(requirement: &AcceptanceRequirement) -> String {
                 EvidenceKindTag::Receipt => "receipt",
                 EvidenceKindTag::Approval => "approval",
                 EvidenceKindTag::Route => "route",
+                EvidenceKindTag::WebCitation => "web citation",
             };
             format!("evidence of kind {kind}")
         }
@@ -655,12 +656,15 @@ fn last_output_ref(snapshot: &WorkGraphSnapshot, node: &WorkNode) -> Option<Stri
 
 fn format_evidence_ref(evidence: &crate::work_graph::EvidenceRef) -> String {
     let kind = match evidence.kind() {
-        EvidenceKind::ToolRun => "tool run",
-        EvidenceKind::Artifact { .. } => "artifact",
-        EvidenceKind::TestSummary => "test summary",
-        EvidenceKind::Receipt { .. } => "receipt",
-        EvidenceKind::Approval => "approval",
-        EvidenceKind::Route => "route",
+        EvidenceKind::ToolRun => "tool run".to_string(),
+        EvidenceKind::Artifact { .. } => "artifact".to_string(),
+        EvidenceKind::TestSummary => "test summary".to_string(),
+        EvidenceKind::Receipt { .. } => "receipt".to_string(),
+        EvidenceKind::Approval => "approval".to_string(),
+        EvidenceKind::Route => "route".to_string(),
+        EvidenceKind::WebCitation {
+            url, retrieved_at, ..
+        } => format!("web citation · {url} · retrieved {retrieved_at}"),
     };
     let bytes = evidence
         .raw_bytes()

--- a/crates/tui/src/work_graph/model.rs
+++ b/crates/tui/src/work_graph/model.rs
@@ -150,17 +150,27 @@ pub enum EvidenceKindTag {
     Receipt,
     Approval,
     Route,
+    WebCitation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceKind {
     ToolRun,
-    Artifact { digest: String },
+    Artifact {
+        digest: String,
+    },
     TestSummary,
-    Receipt { owner: String },
+    Receipt {
+        owner: String,
+    },
     Approval,
     Route,
+    WebCitation {
+        ref_id: String,
+        url: String,
+        retrieved_at: String,
+    },
 }
 
 impl EvidenceKind {
@@ -173,6 +183,7 @@ impl EvidenceKind {
             EvidenceKind::Receipt { .. } => EvidenceKindTag::Receipt,
             EvidenceKind::Approval => EvidenceKindTag::Approval,
             EvidenceKind::Route => EvidenceKindTag::Route,
+            EvidenceKind::WebCitation { .. } => EvidenceKindTag::WebCitation,
         }
     }
 }
@@ -186,6 +197,9 @@ pub enum EvidenceRefError {
     HomeRelativePath,
     ContainsWhitespaceOrControl,
     LooksLikeKeyMaterial,
+    WebCitationReferenceMismatch,
+    InvalidWebCitationUrl,
+    InvalidWebCitationTimestamp,
 }
 
 impl std::fmt::Display for EvidenceRefError {
@@ -210,6 +224,15 @@ impl std::fmt::Display for EvidenceRefError {
             EvidenceRefError::LooksLikeKeyMaterial => {
                 write!(f, "evidence reference must not embed key material")
             }
+            EvidenceRefError::WebCitationReferenceMismatch => {
+                write!(f, "web citation reference must match its ref_id")
+            }
+            EvidenceRefError::InvalidWebCitationUrl => {
+                write!(f, "web citation URL must be HTTP(S) without credentials")
+            }
+            EvidenceRefError::InvalidWebCitationTimestamp => {
+                write!(f, "web citation retrieved_at must be RFC 3339")
+            }
         }
     }
 }
@@ -217,6 +240,31 @@ impl std::fmt::Display for EvidenceRefError {
 impl std::error::Error for EvidenceRefError {}
 
 const EVIDENCE_REFERENCE_MAX_LEN: usize = 512;
+
+fn web_citation_url_has_sensitive_query(url: &reqwest::Url) -> bool {
+    url.query_pairs().any(|(name, _)| {
+        let name = name.to_ascii_lowercase();
+        matches!(
+            name.as_ref(),
+            "access_token"
+                | "api_key"
+                | "authorization"
+                | "auth"
+                | "credential"
+                | "key"
+                | "session"
+                | "session_id"
+                | "sig"
+                | "signature"
+                | "token"
+                | "x-amz-credential"
+                | "x-amz-signature"
+                | "x-goog-credential"
+                | "x-goog-signature"
+        ) || name.ends_with("_token")
+            || name.ends_with("_key")
+    })
+}
 
 /// Summary/reference-only pointer to evidence: a logical artifact ID, run ID,
 /// or receipt handle — never absolute paths, never secrets, never raw logs or
@@ -277,6 +325,28 @@ impl EvidenceRef {
         }
         if reference.contains("-----BEGIN") {
             return Err(EvidenceRefError::LooksLikeKeyMaterial);
+        }
+        if let EvidenceKind::WebCitation {
+            ref_id,
+            url,
+            retrieved_at,
+        } = &kind
+        {
+            if ref_id != &reference {
+                return Err(EvidenceRefError::WebCitationReferenceMismatch);
+            }
+            let parsed = reqwest::Url::parse(url)
+                .ok()
+                .filter(|url| matches!(url.scheme(), "http" | "https"))
+                .filter(|url| url.host_str().is_some())
+                .filter(|url| url.username().is_empty() && url.password().is_none())
+                .filter(|url| !web_citation_url_has_sensitive_query(url));
+            if parsed.is_none() {
+                return Err(EvidenceRefError::InvalidWebCitationUrl);
+            }
+            if chrono::DateTime::parse_from_rfc3339(retrieved_at).is_err() {
+                return Err(EvidenceRefError::InvalidWebCitationTimestamp);
+            }
         }
         Ok(Self {
             kind,

--- a/crates/tui/src/work_graph/tests.rs
+++ b/crates/tui/src/work_graph/tests.rs
@@ -853,3 +853,59 @@ fn evidence_ref_rejects_paths_and_key_material() {
     assert_eq!(ok.raw_bytes(), Some(4096));
     assert!(ok.truncated());
 }
+
+#[test]
+fn web_citation_evidence_is_typed_inspectable_and_fail_closed() {
+    let kind = EvidenceKind::WebCitation {
+        ref_id: "web_0123456789abcdef".to_string(),
+        url: "https://example.com/source".to_string(),
+        retrieved_at: "2026-07-19T18:00:00Z".to_string(),
+    };
+    let evidence = EvidenceRef::new(kind, "web_0123456789abcdef", None, false)
+        .expect("valid web citation evidence");
+    assert_eq!(evidence.kind().tag(), EvidenceKindTag::WebCitation);
+
+    let serialized = serde_json::to_value(&evidence).expect("serialize citation evidence");
+    let restored: EvidenceRef =
+        serde_json::from_value(serialized).expect("deserialize citation evidence");
+    assert_eq!(restored, evidence);
+
+    let mismatched = EvidenceRef::new(
+        EvidenceKind::WebCitation {
+            ref_id: "web_other".to_string(),
+            url: "https://example.com/source".to_string(),
+            retrieved_at: "2026-07-19T18:00:00Z".to_string(),
+        },
+        "web_0123456789abcdef",
+        None,
+        false,
+    )
+    .expect_err("mismatched ref must fail");
+    assert_eq!(mismatched, EvidenceRefError::WebCitationReferenceMismatch);
+
+    let credentialed = EvidenceRef::new(
+        EvidenceKind::WebCitation {
+            ref_id: "web_0123456789abcdef".to_string(),
+            url: "https://user:password@example.com/source".to_string(),
+            retrieved_at: "2026-07-19T18:00:00Z".to_string(),
+        },
+        "web_0123456789abcdef",
+        None,
+        false,
+    )
+    .expect_err("credentialed URL must fail");
+    assert_eq!(credentialed, EvidenceRefError::InvalidWebCitationUrl);
+
+    let query_credential = EvidenceRef::new(
+        EvidenceKind::WebCitation {
+            ref_id: "web_0123456789abcdef".to_string(),
+            url: "https://example.com/source?access_token=sensitive".to_string(),
+            retrieved_at: "2026-07-19T18:00:00Z".to_string(),
+        },
+        "web_0123456789abcdef",
+        None,
+        false,
+    )
+    .expect_err("credential-bearing query must fail");
+    assert_eq!(query_credential, EvidenceRefError::InvalidWebCitationUrl);
+}


### PR DESCRIPTION
## Summary

- mint deterministic, session-scoped citation refs for search, fetch, image, and web.run results
- sanitize credential-bearing URL metadata, deduplicate canonical refs, and resolve opens through the shared SSRF-guarded fetch path
- add a typed Work Graph WebCitation evidence kind and render backend source, degradation, and citation counts in the search cell

## Exact revision

- base: `b2c2eab2d23f2f3b71433af760055597d240d195`
- head: `d0749b6437f2c91b897e564ec3bbf048386092a9`

## Verification

- `cargo fmt --all -- --check`
- full locked TUI unit suite: 7,568 passed, 0 failed, 3 intentional ignores
- citation-focused tests: 9 passed
- web slice: 154 passed, 0 failed, 1 intentional helper ignored
- strict locked workspace clippy with all targets/features and `-D warnings`
- `git diff --check`
- exact-commit gitleaks: no leaks
- added-line private-path/credential scan: clean apart from explicit `sensitive` test sentinels

The post-rebase and post-message-amend commit trees are byte-identical to the fully tested tree.