### PR TITLE
fix: bypass MCP tool deferral when trust_mode or Bypass approval is active

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3005,10 +3005,16 @@ impl Engine {
             if self.config.features.enabled(Feature::Mcp) {
                 always_load.insert("start_mcp_server".to_string());
             }
+            let bypass = input_policy.auto_approve
+                || input_policy.approval_mode == crate::tui::approval::ApprovalMode::Bypass;
             let mut catalog = build_model_tool_catalog_with_surface(
                 registry.to_api_tools_with_cache(true),
                 mcp_tools,
-                input_policy.mode,
+                if bypass {
+                    AppMode::Yolo
+                } else {
+                    input_policy.mode
+                },
                 &always_load,
                 capability.tool_surface_budget,
             );


### PR DESCRIPTION
## Summary

When working in Full Access Agent mode (trust_mode=true, auto_approve=true), MCP tools are still marked defer_loading=true and do not appear in the model's available tool list. Although the user is functionally equivalent to YOLO mode for approval purposes, MCP tool visibility does not receive the same bypass treatment. This forces every session to manually discover MCP tools via tool_search (e.g. mcp_playwright_browser_navigate), which itself depends on the MCP server having completed its handshake — for slow-starting servers like Firefox-driven Playwright, the first tool_search call may return zero results, creating a false impression that "MCP is unavailable."

## Root Cause

apply_mcp_tool_deferral in crates/tui/src/core/engine/tool_catalog.rs only checks mode != AppMode::Yolo to decide whether to defer. The break in the pipeline is in engine.rs: build_model_tool_catalog_with_surface receives only input_policy.mode (i.e. AppMode::Agent), discarding the trust_mode / auto_approve / approval_mode bypass semantics already present on TurnAuthority. TurnAuthority carries the full set of fields, and EffectiveModePolicy populates them correctly, but build_model_tool_catalog_with_surface's signature accepts only AppMode — the bypass semantics are lost mid-pipeline.

## Fix

Map the bypass condition to AppMode::Yolo inline at the call site in engine.rs, with zero function signature changes. #3736 landed in v0.8.67: the auto_approve || trust_mode bypass semantics were replaced with approval_mode == Bypass. The auto_approve field remains as a compat shim, so both must be checked:

```rust
let bypass = input_policy.auto_approve
    || input_policy.approval_mode == ApprovalMode::Bypass;
// …
if bypass { AppMode::Yolo } else { input_policy.mode },
```

## Version

Reproducible on v0.9.0.

## Testing

- [x] cargo fmt --all -- --check
- [x] cargo check -p codewhale-tui
- [x] cargo test -p codewhale-tui (27 defer/MCP-related tests pass; 34 pre-existing Windows TUI UI failures unrelated)
- [x] cargo clippy --workspace --all-targets --all-features (1 pre-existing warning in mcp.rs:261, unrelated)

## Checklist

- [x] Updated docs or comments as needed (single-site logic fix, no API surface change)
- [ ] Added or updated tests where relevant (existing defer tests cover this path)
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address