### PR TITLE
feat(tui): make Blue Stage the default grammar

### DIFF
--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -82,7 +82,7 @@ impl Theme {
             plan_summary_color: palette::TEXT_MUTED,
             plan_explanation_color: palette::TEXT_DIM,
             plan_pending_color: palette::TEXT_MUTED,
-            plan_in_progress_color: palette::WHALE_HUMAN,
+            plan_in_progress_color: palette::MODE_PLAN,
             plan_completed_color: palette::STATUS_SUCCESS,
         }
     }
@@ -108,7 +108,7 @@ impl Theme {
             plan_summary_color: palette::LIGHT_TEXT_MUTED,
             plan_explanation_color: palette::LIGHT_TEXT_HINT,
             plan_pending_color: palette::LIGHT_TEXT_MUTED,
-            plan_in_progress_color: palette::LIGHT_HUMAN,
+            plan_in_progress_color: palette::LIGHT_MODE_PLAN,
             plan_completed_color: palette::LIGHT_SUCCESS_FG,
         }
     }
@@ -134,7 +134,7 @@ impl Theme {
             plan_summary_color: palette::SOLARIZED_TEXT_MUTED,
             plan_explanation_color: palette::SOLARIZED_TEXT_DIM,
             plan_pending_color: palette::SOLARIZED_TEXT_MUTED,
-            plan_in_progress_color: palette::SOLARIZED_ORANGE,
+            plan_in_progress_color: palette::SOLARIZED_BLUE,
             plan_completed_color: palette::SOLARIZED_BLUE,
         }
     }
@@ -243,7 +243,7 @@ mod tests {
         assert_eq!(theme.tool_running_accent, palette::ACCENT_TOOL_LIVE);
         assert_eq!(theme.tool_success_accent, palette::STATUS_SUCCESS);
         assert_eq!(theme.tool_failed_accent, palette::STATUS_ERROR);
-        assert_eq!(theme.plan_in_progress_color, palette::WHALE_HUMAN);
+        assert_eq!(theme.plan_in_progress_color, palette::MODE_PLAN);
     }
 
     #[test]

--- a/crates/tui/src/deepseek_theme.rs
+++ b/crates/tui/src/deepseek_theme.rs
@@ -134,7 +134,7 @@ impl Theme {
             plan_summary_color: palette::SOLARIZED_TEXT_MUTED,
             plan_explanation_color: palette::SOLARIZED_TEXT_DIM,
             plan_pending_color: palette::SOLARIZED_TEXT_MUTED,
-            plan_in_progress_color: palette::SOLARIZED_BLUE,
+            plan_in_progress_color: palette::SOLARIZED_CYAN,
             plan_completed_color: palette::SOLARIZED_BLUE,
         }
     }
@@ -269,6 +269,21 @@ mod tests {
         assert_eq!(theme.tool_running_accent, palette::GRAYSCALE_TEXT_SOFT);
         assert_eq!(theme.tool_failed_accent, palette::GRAYSCALE_TEXT_BODY);
         assert_eq!(theme.plan_summary_color, palette::GRAYSCALE_TEXT_MUTED);
+    }
+
+    #[test]
+    fn every_theme_distinguishes_active_and_completed_plan_steps() {
+        for (name, theme) in [
+            ("dark", Theme::dark()),
+            ("light", Theme::light()),
+            ("solarized-light", Theme::solarized_light()),
+            ("grayscale", Theme::grayscale()),
+        ] {
+            assert_ne!(
+                theme.plan_in_progress_color, theme.plan_completed_color,
+                "{name} must keep active and completed Plan steps visually distinct"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/palette/adapt.rs
+++ b/crates/tui/src/palette/adapt.rs
@@ -41,11 +41,11 @@ fn adapt_fg_for_light_palette(color: Color) -> Color {
         LIGHT_BORDER
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         LIGHT_LIVE
-    } else if color == WHALE_INFO || color == WHALE_ACTION {
+    } else if color == WHALE_INFO || color == WHALE_ACTION || color == WHALE_ACCENT_PRIMARY {
         LIGHT_ACTION
     } else if color == MODE_AGENT {
         LIGHT_UI_THEME.mode_agent
-    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_HUMAN {
         LIGHT_HUMAN
     } else if color == MODE_PLAN {
         LIGHT_UI_THEME.mode_plan
@@ -114,11 +114,11 @@ fn adapt_fg_for_solarized_light_palette(color: Color) -> Color {
         SOLARIZED_BORDER
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         SOLARIZED_CYAN
-    } else if color == WHALE_INFO || color == WHALE_ACTION {
+    } else if color == WHALE_INFO || color == WHALE_ACTION || color == WHALE_ACCENT_PRIMARY {
         SOLARIZED_BLUE
     } else if color == MODE_AGENT {
         SOLARIZED_LIGHT_UI_THEME.mode_agent
-    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_HUMAN {
         SOLARIZED_ORANGE
     } else if color == MODE_PLAN {
         SOLARIZED_LIGHT_UI_THEME.mode_plan
@@ -252,11 +252,11 @@ pub fn adapt_fg_for_theme(color: Color, theme: ThemeId, ui: &UiTheme) -> Color {
         ui.border
     } else if color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         ui.status_working
-    } else if color == WHALE_INFO || color == WHALE_ACTION {
+    } else if color == WHALE_INFO || color == WHALE_ACTION || color == WHALE_ACCENT_PRIMARY {
         ui.accent_primary
     } else if color == MODE_AGENT {
         ui.mode_agent
-    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_HUMAN {
         ui.accent_action
     } else if color == MODE_PLAN {
         ui.mode_plan
@@ -356,6 +356,7 @@ fn adapt_fg_for_grayscale_palette(color: Color) -> Color {
         || color == TEXT_ACCENT
         || color == WHALE_INFO
         || color == WHALE_ACCENT_PRIMARY
+        || color == WHALE_HUMAN
         || color == ACCENT_TOOL_LIVE
         || color == STATUS_SUCCESS
         || color == STATUS_INFO
@@ -538,11 +539,15 @@ fn raw_semantic_foreground_role(color: Color) -> Option<SemanticForegroundRole> 
         Some(SemanticForegroundRole::ModeOperate)
     } else if color == MODE_YOLO {
         Some(SemanticForegroundRole::ModeYolo)
-    } else if color == WHALE_ACTION || color == WHALE_INFO || color == STATUS_INFO {
+    } else if color == WHALE_ACTION
+        || color == WHALE_INFO
+        || color == STATUS_INFO
+        || color == WHALE_ACCENT_PRIMARY
+    {
         Some(SemanticForegroundRole::Action)
     } else if color == WHALE_LIVE || color == TEXT_ACCENT || color == ACCENT_TOOL_LIVE {
         Some(SemanticForegroundRole::Live)
-    } else if color == WHALE_HUMAN || color == WHALE_ACCENT_PRIMARY {
+    } else if color == WHALE_HUMAN {
         Some(SemanticForegroundRole::Human)
     } else if color == STATUS_WARNING {
         Some(SemanticForegroundRole::Warning)

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -427,8 +427,8 @@ fn adapt_color_drops_to_named_on_ansi16() {
 }
 
 #[test]
-fn semantic_tokens_keep_brand_compatibility_distinct_from_action() {
-    assert_eq!(WHALE_ACCENT_PRIMARY, WHALE_HUMAN);
+fn semantic_tokens_align_primary_accent_with_action_not_human_gold() {
+    assert_eq!(WHALE_ACCENT_PRIMARY, WHALE_ACTION);
     assert_eq!(WHALE_ACTION, WHALE_INFO);
     assert_ne!(WHALE_ACTION, WHALE_HUMAN);
 }

--- a/crates/tui/src/palette/themes.rs
+++ b/crates/tui/src/palette/themes.rs
@@ -394,7 +394,7 @@ pub const DRACULA_UI_THEME: UiTheme = UiTheme {
 /// (the terminal's own default bg) and most text uses `Color::Reset`
 /// (terminal's own default fg). Accents are ANSI named colors so they
 /// also inherit the user's terminal palette (Solarized, Nord, custom
-/// schemes, etc.) rather than DeepSeek brand RGB.
+/// schemes, etc.) rather than Codewhale brand RGB.
 pub const TERMINAL_UI_THEME: UiTheme = UiTheme {
     name: "terminal",
     // Mode is reported as Dark to avoid the dark→light cell remap kicking
@@ -731,8 +731,8 @@ impl ThemeId {
         match self {
             Self::System => "Follow terminal background (COLORFGBG / macOS appearance)",
             Self::Terminal => "Inherit terminal colors fully (transparent surfaces, ANSI accents)",
-            Self::Whale => "Whale dark — deep navy & gold",
-            Self::WhaleLight => "DeepSeek light, paper-ish",
+            Self::Whale => "Whale dark — Blue Stage navy & action blue",
+            Self::WhaleLight => "Whale light — Blue Stage paper & cobalt",
             Self::Grayscale => "Color-minimal high contrast",
             Self::CatppuccinMocha => "Soft pastels on warm dark",
             Self::TokyoNight => "Deep blue/violet night palette",

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -15,16 +15,22 @@ pub const WHALE_TEXT_MUTED_RGB: (u8, u8, u8) = (147, 160, 184); // #93A0B8
 pub const WHALE_TEXT_HINT_RGB: (u8, u8, u8) = (132, 145, 170); // #8491AA
 #[allow(dead_code)]
 pub const WHALE_TEXT_DIM_RGB: (u8, u8, u8) = (105, 119, 145); // #697791
-pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Cobalt action blue
+pub const WHALE_ACTION_RGB: (u8, u8, u8) = (106, 174, 242); // #6AAEF2 Blue — owns interaction on dark
+#[allow(dead_code)]
+pub const WHALE_COBALT_RGB: (u8, u8, u8) = (49, 95, 216); // #315FD8 Cobalt — light-mode action
+#[allow(dead_code)]
+pub const WHALE_ICE_RGB: (u8, u8, u8) = (209, 235, 244); // #D1EBF4 Ice — structure on dark
+#[allow(dead_code)]
+pub const WHALE_CYAN_RGB: (u8, u8, u8) = (72, 215, 255); // #48D7FF Cyan — bounded accents only
 pub const WHALE_ACCENT_SECONDARY_RGB: (u8, u8, u8) = (79, 209, 197); // #4FD1C5 Seafoam
 pub const WHALE_HUMAN_RGB: (u8, u8, u8) = (246, 196, 83); // #F6C453 Signal Gold
-/// Compatibility name retained for downstream callers that used the original
-/// Codewhale brand accent. New action/focus call sites should use
-/// [`WHALE_ACTION_RGB`] instead.
-pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
+/// Blue Stage grammar: the primary accent is the interaction blue. Signal Gold
+/// is reserved for the whale mark and human-attention roles
+/// ([`WHALE_HUMAN_RGB`]), never for general interaction.
+pub const WHALE_ACCENT_PRIMARY_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
 pub const WHALE_WORKING_GREEN_RGB: (u8, u8, u8) = (155, 214, 111); // #9BD66F Working Green
 #[allow(dead_code)]
-pub const WHALE_ACCENT_ACTION_RGB: (u8, u8, u8) = WHALE_HUMAN_RGB;
+pub const WHALE_ACCENT_ACTION_RGB: (u8, u8, u8) = WHALE_ACTION_RGB;
 pub const WHALE_ERROR_RGB: (u8, u8, u8) = (255, 134, 178); // #FF86B2 Rose danger
 pub const WHALE_ERROR_HOVER_RGB: (u8, u8, u8) = (255, 156, 194); // #FF9CC2
 pub const WHALE_ERROR_SURFACE_RGB: (u8, u8, u8) = (43, 21, 34); // #2B1522
@@ -68,7 +74,7 @@ pub const WHALE_DIFF_ADDED_BG_RGB: (u8, u8, u8) = (18, 42, 34); // #122A22
 pub const WHALE_DIFF_DELETED_BG_RGB: (u8, u8, u8) = (52, 24, 39); // #341827
 pub const WHALE_MODE_AGENT_RGB: (u8, u8, u8) = (118, 181, 245); // #76B5F5
 pub const WHALE_MODE_YOLO_RGB: (u8, u8, u8) = (255, 112, 160); // #FF70A0
-pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = (255, 208, 106); // #FFD06A
+pub const WHALE_MODE_PLAN_RGB: (u8, u8, u8) = (185, 220, 236); // #B9DCEC Structural Ice
 pub const WHALE_MODE_OPERATE_RGB: (u8, u8, u8) = (173, 136, 255); // #AD88FF
 pub const WHALE_TOOL_LIVE_RGB: (u8, u8, u8) = WHALE_ACCENT_SECONDARY_RGB;
 pub const WHALE_TOOL_ISSUE_RGB: (u8, u8, u8) = WHALE_ERROR_RGB;
@@ -98,7 +104,7 @@ pub const LIGHT_DANGER_RGB: (u8, u8, u8) = (180, 35, 90); // #B4235A
 // adaptation can preserve it.
 pub const LIGHT_MODE_AGENT_RGB: (u8, u8, u8) = (50, 95, 216); // #325FD8
 pub const LIGHT_MODE_YOLO_RGB: (u8, u8, u8) = (181, 35, 90); // #B5235A
-pub const LIGHT_MODE_PLAN_RGB: (u8, u8, u8) = (123, 85, 0); // #7B5500
+pub const LIGHT_MODE_PLAN_RGB: (u8, u8, u8) = (52, 92, 128); // #345C80 Structural steel-blue
 pub const LIGHT_OPERATE_RGB: (u8, u8, u8) = (112, 71, 184); // #7047B8
 
 // Solarized Light palette colors
@@ -482,7 +488,6 @@ pub const SURFACE_TOOL: Color = Color::Rgb(
     WHALE_TOOL_SURFACE_RGB.1,
     WHALE_TOOL_SURFACE_RGB.2,
 );
-#[allow(dead_code)]
 pub const SURFACE_TOOL_ACTIVE: Color = Color::Rgb(
     WHALE_TOOL_ACTIVE_RGB.0,
     WHALE_TOOL_ACTIVE_RGB.1,

--- a/crates/tui/src/tui/plan_prompt.rs
+++ b/crates/tui/src/tui/plan_prompt.rs
@@ -46,7 +46,7 @@ fn modal_block() -> Block<'static> {
     Block::default()
         .title(Line::from(vec![Span::styled(
             " Plan Confirmation ",
-            Style::default().fg(palette::WHALE_HUMAN).bold(),
+            Style::default().fg(palette::MODE_PLAN).bold(),
         )]))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(palette::BORDER_COLOR))
@@ -905,6 +905,22 @@ mod tests {
 
         assert!(rendered.contains("> [2/y] Accept plan (Full Access)"));
         assert!(rendered.contains("Start implementation in Act without approval prompts"));
+    }
+
+    #[test]
+    fn plan_prompt_title_uses_structural_plan_ink_not_signal_gold() {
+        let area = Rect::new(0, 0, 110, 36);
+        let popup_area = centered_rect(72, 52, area);
+        let buf = render_buffer(&PlanPromptView::new(None), area.width, area.height);
+        let title_x = (popup_area.x..popup_area.x.saturating_add(popup_area.width))
+            .find(|x| {
+                buf[(*x, popup_area.y)].symbol() == "P"
+                    && buf[(x.saturating_add(1), popup_area.y)].symbol() == "l"
+            })
+            .expect("plan title should render");
+
+        assert_eq!(buf[(title_x, popup_area.y)].fg, palette::MODE_PLAN);
+        assert_ne!(buf[(title_x, popup_area.y)].fg, palette::WHALE_HUMAN);
     }
 
     #[test]

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -27,8 +27,6 @@ use crate::tui::views::{
 };
 use unicode_width::UnicodeWidthStr;
 
-const STATUS_PICKER_SELECTION_BG: ratatui::style::Color = ratatui::style::Color::Rgb(54, 72, 104);
-
 /// Picker state. We hold both the user's working selection AND the original
 /// snapshot so Esc can perfectly revert the live preview.
 pub struct StatusPickerView {
@@ -253,7 +251,7 @@ impl ModalView for StatusPickerView {
             if is_cursor {
                 let selected_style = Style::default()
                     .fg(palette::SELECTION_TEXT)
-                    .bg(STATUS_PICKER_SELECTION_BG)
+                    .bg(palette::SELECTION_BG)
                     .add_modifier(Modifier::BOLD);
                 let line = status_row_text(pointer, mark, item, content.width as usize);
                 lines.push(Line::from(Span::styled(line, selected_style)));

--- a/crates/tui/src/tui/widgets/decision_card.rs
+++ b/crates/tui/src/tui/widgets/decision_card.rs
@@ -11,9 +11,11 @@
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{Block, Borders, Widget},
 };
+
+use crate::palette;
 
 use super::renderable::Renderable;
 
@@ -113,13 +115,13 @@ impl Renderable for DecisionCard {
             return;
         }
 
-        let border_style = Style::default().fg(Color::Rgb(100, 160, 220));
+        let border_style = Style::default().fg(palette::WHALE_ACTION);
         let question_style = Style::default()
-            .fg(Color::Rgb(220, 220, 240))
+            .fg(palette::TEXT_BODY)
             .add_modifier(Modifier::BOLD);
-        let dim_style = Style::default().fg(Color::Rgb(140, 140, 160));
+        let dim_style = Style::default().fg(palette::TEXT_MUTED);
         let selected_style = Style::default()
-            .fg(Color::Rgb(80, 200, 255))
+            .fg(palette::WHALE_ACTION)
             .add_modifier(Modifier::BOLD);
 
         let block = Block::default()

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -3044,7 +3044,7 @@ fn apply_send_flash(
         return;
     };
 
-    let flash_bg = Color::Rgb(30, 40, 55); // subtle dark-blue tint
+    let flash_bg = palette::SURFACE_TOOL_ACTIVE; // subtle dark-blue tint
 
     for (idx, line) in lines.iter_mut().enumerate() {
         let line_index = top + idx;
@@ -4322,7 +4322,10 @@ mod tests {
 
         apply_send_flash(&mut lines, 0, &history, &line_meta, &original_index_map);
 
-        assert_eq!(lines[0].spans[0].style.bg, Some(Color::Rgb(30, 40, 55)));
+        assert_eq!(
+            lines[0].spans[0].style.bg,
+            Some(palette::SURFACE_TOOL_ACTIVE)
+        );
     }
 
     #[test]

--- a/crates/tui/tests/palette_audit.rs
+++ b/crates/tui/tests/palette_audit.rs
@@ -98,11 +98,11 @@ fn whale_roles_are_pinned_and_non_colliding() {
     assert_eq!(palette::WHALE_ERROR_RGB, (255, 134, 178));
     assert_eq!(palette::WHALE_MODE_AGENT_RGB, (118, 181, 245));
     assert_eq!(palette::WHALE_MODE_YOLO_RGB, (255, 112, 160));
-    assert_eq!(palette::WHALE_MODE_PLAN_RGB, (255, 208, 106));
+    assert_eq!(palette::WHALE_MODE_PLAN_RGB, (185, 220, 236));
     assert_eq!(palette::WHALE_MODE_OPERATE_RGB, (173, 136, 255));
     assert_eq!(palette::LIGHT_SUCCESS_FG_RGB, (20, 118, 61));
     assert_eq!(palette::LIGHT_MODE_AGENT_RGB, (50, 95, 216));
-    assert_eq!(palette::LIGHT_MODE_PLAN_RGB, (123, 85, 0));
+    assert_eq!(palette::LIGHT_MODE_PLAN_RGB, (52, 92, 128));
     assert_eq!(palette::LIGHT_OPERATE_RGB, (112, 71, 184));
     assert_eq!(palette::LIGHT_MODE_YOLO_RGB, (181, 35, 90));
     assert_eq!(palette::LIGHT_USER_BODY, palette::LIGHT_SUCCESS_FG);
@@ -115,6 +115,10 @@ fn whale_roles_are_pinned_and_non_colliding() {
     assert_eq!(ui.warning, palette::STATUS_WARNING);
     assert_eq!(ui.error_fg, palette::WHALE_ERROR);
     assert_eq!(ui.mode_operate, palette::MODE_OPERATE);
+    assert_ne!(
+        ui.mode_plan, ui.accent_action,
+        "Plan is structural; Signal Gold is reserved for human attention"
+    );
     assert_ne!(
         ui.status_working, ui.success,
         "live and done need separate ink"
@@ -226,7 +230,10 @@ fn contrast_guardrails_for_key_ui_pairs() {
         ("human", palette::UI_THEME.accent_action),
         ("warning", palette::UI_THEME.warning),
         ("danger", palette::UI_THEME.error_fg),
+        ("act mode", palette::UI_THEME.mode_agent),
+        ("plan mode", palette::UI_THEME.mode_plan),
         ("operate", palette::UI_THEME.mode_operate),
+        ("full-access mode", palette::UI_THEME.mode_yolo),
         ("success", palette::UI_THEME.success),
     ] {
         assert_min_contrast(label, foreground, palette::SURFACE_ELEVATED, min_readable);


### PR DESCRIPTION
## Summary

- make action blue (`#6AAEF2`) the primary interaction accent
- reserve Signal Gold for whale and human-attention moments
- give Plan a structural ice identity distinct from both action and human gold
- replace remaining widget literals with semantic roles and pin theme/contrast contracts

## Product decision

Plan is structural information, not a human-attention event. Its dark-theme identity is ice (`#B9DCEC`), while Signal Gold remains exclusive to whale/human moments.

## Verification

- `cargo test -p codewhale-tui --all-features --locked --test palette_audit` (45 passed)
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts=origin/main..HEAD --no-banner` (1 commit, no leaks)

The source branch must be preserved after merge.