### PR TITLE
perf(tui): keep debt gate out of system prefix

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2414,7 +2414,11 @@ impl Engine {
         )
     }
 
-    fn with_slop_ledger_gate_for_external_turn(
+    /// Snapshot the mutable completion gate once for a new top-level user
+    /// turn. Mid-turn steers stay inside the same `handle_deepseek_turn` and
+    /// reuse this already-present block; reinjecting it on every steer would
+    /// duplicate debt text and erase the token-economy benefit of this seam.
+    fn with_slop_ledger_gate_for_initial_user_turn(
         &mut self,
         message: Message,
         provenance: UserInputProvenance,
@@ -2817,7 +2821,7 @@ impl Engine {
             reasoning_effort_auto,
             provenance,
         );
-        let user_msg = self.with_slop_ledger_gate_for_external_turn(user_msg, provenance);
+        let user_msg = self.with_slop_ledger_gate_for_initial_user_turn(user_msg, provenance);
         self.session.add_message(user_msg);
 
         let previous_goal_objective = self.config.goal_objective.clone();

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -691,8 +691,8 @@ pub struct Engine {
     /// and forwarded as a synthetic user message before the next API call.
     pending_lsp_blocks: Vec<crate::lsp::DiagnosticBlock>,
     /// Cached SlopLedger gate block keyed by the ledger file's modified time.
-    /// This keeps prompt refreshes cheap while still noticing append/update
-    /// writes from slop ledger tools during the same session.
+    /// This keeps user-turn tail assembly cheap while still noticing
+    /// append/update writes from slop ledger tools during the same session.
     slop_ledger_gate_cache: Option<(Option<SystemTime>, Option<String>)>,
     /// Current operating mode. Updated on `ChangeMode` and `SendMessage`.
     current_mode: AppMode,
@@ -2414,6 +2414,36 @@ impl Engine {
         )
     }
 
+    fn with_slop_ledger_gate_for_external_turn(
+        &mut self,
+        message: Message,
+        provenance: UserInputProvenance,
+    ) -> Message {
+        if provenance != UserInputProvenance::ExternalUser {
+            return message;
+        }
+        Self::attach_slop_ledger_gate(message, self.slop_ledger_gate_block())
+    }
+
+    fn attach_slop_ledger_gate(mut message: Message, gate_block: Option<String>) -> Message {
+        let Some(gate_block) = gate_block else {
+            return message;
+        };
+
+        // Preserve the stable user-text prefix and keep `<turn_meta>` last.
+        // The debt gate changes with local ledger state, so placing it here
+        // avoids invalidating the fingerprinted system prompt for every turn.
+        let insert_at = message.content.len().saturating_sub(1);
+        message.content.insert(
+            insert_at,
+            ContentBlock::Text {
+                text: gate_block,
+                cache_control: None,
+            },
+        );
+        message
+    }
+
     fn user_text_message_with_turn_metadata_for_route_and_provenance(
         &self,
         text: String,
@@ -2787,6 +2817,7 @@ impl Engine {
             reasoning_effort_auto,
             provenance,
         );
+        let user_msg = self.with_slop_ledger_gate_for_external_turn(user_msg, provenance);
         self.session.add_message(user_msg);
 
         let previous_goal_objective = self.config.goal_objective.clone();
@@ -3890,29 +3921,8 @@ impl Engine {
                 plugin_registry: Some(self.plugin_registry.as_ref()),
             },
         );
-        let mut stable_prompt =
+        let stable_prompt =
             merge_system_prompts(Some(&base), self.session.compaction_summary_prompt.clone());
-
-        // SlopLedger completion-gate: inject unresolved slop entries into the
-        // system prompt so the agent can autonomously review them before
-        // claiming the task is done (#2127).
-        let gate_block = self.slop_ledger_gate_block();
-        if let Some(ref block) = gate_block {
-            match &mut stable_prompt {
-                Some(SystemPrompt::Text(prompt_text)) => {
-                    prompt_text.push_str("\n\n");
-                    prompt_text.push_str(block);
-                }
-                Some(SystemPrompt::Blocks(blocks)) => {
-                    blocks.push(crate::models::SystemBlock {
-                        block_type: "text".to_string(),
-                        text: block.clone(),
-                        cache_control: None,
-                    });
-                }
-                None => {}
-            }
-        }
 
         let stable_hash = system_prompt_hash(stable_prompt.as_ref());
         if self.session.system_prompt_override {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2821,7 +2821,10 @@ impl Engine {
             reasoning_effort_auto,
             provenance,
         );
+        let base_content_blocks = user_msg.content.len();
         let user_msg = self.with_slop_ledger_gate_for_initial_user_turn(user_msg, provenance);
+        turn.active_slop_gate_message =
+            (user_msg.content.len() > base_content_blocks).then(|| user_msg.clone());
         self.session.add_message(user_msg);
 
         let previous_goal_objective = self.config.goal_objective.clone();
@@ -3412,10 +3415,39 @@ impl Engine {
         removed
     }
 
+    /// Merge working-set pins with the mutable completion gate carried by the
+    /// current top-level user turn. The exact message identity matters: an
+    /// unchanged ledger can produce identical gate text on older turns, and
+    /// pinning every historical copy would defeat compaction.
+    fn compaction_pins_for_active_turn(
+        &self,
+        active_slop_gate_message: Option<&Message>,
+    ) -> Vec<usize> {
+        let mut pins = self
+            .session
+            .working_set
+            .pinned_message_indices(&self.session.messages, &self.session.workspace);
+
+        if let Some(active_message) = active_slop_gate_message
+            && let Some(index) = self
+                .session
+                .messages
+                .iter()
+                .rposition(|message| message == active_message)
+        {
+            pins.push(index);
+        }
+
+        pins.sort_unstable();
+        pins.dedup();
+        pins
+    }
+
     async fn recover_context_overflow(
         &mut self,
         client: &dyn crate::core::model_client::ModelClient,
         reason: &str,
+        active_slop_gate_message: Option<&Message>,
     ) -> bool {
         let Some(target_budget) = context_input_budget_for_route(
             self.api_provider,
@@ -3449,10 +3481,7 @@ impl Engine {
         // Previously this passed None/None, so a compaction routed here (which,
         // on large windows, is the path that actually fires) could summarize
         // away pinned errors, patches, and the files the user is editing.
-        let compaction_pins = self
-            .session
-            .working_set
-            .pinned_message_indices(&self.session.messages, &self.session.workspace);
+        let compaction_pins = self.compaction_pins_for_active_turn(active_slop_gate_message);
         let compaction_paths = self.session.working_set.top_paths(24);
 
         match compact_messages_safe(

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -7442,7 +7442,7 @@ fn slop_gate_does_not_change_the_stable_system_prompt() {
 }
 
 #[test]
-fn slop_gate_is_an_external_user_turn_tail_block() {
+fn slop_gate_is_an_initial_external_user_turn_tail_block() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {
         workspace: tmp.path().to_path_buf(),
@@ -7477,10 +7477,21 @@ fn slop_gate_is_an_external_user_turn_tail_block() {
         Some(marker.to_string()),
     ));
     let runtime =
-        engine.with_slop_ledger_gate_for_external_turn(runtime, UserInputProvenance::Runtime);
+        engine.with_slop_ledger_gate_for_initial_user_turn(runtime, UserInputProvenance::Runtime);
     assert_eq!(runtime.content.len(), 2);
     assert!(
         !runtime
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Text { text, .. } if text == marker))
+    );
+
+    // `turn_loop` uses this plain constructor for mid-turn steers. The gate
+    // from the initial message is already in that turn's transcript, so a
+    // steer must not duplicate the mutable block.
+    let steer = engine.user_text_message_with_turn_metadata("mid-turn steer".to_string());
+    assert!(
+        !steer
             .content
             .iter()
             .any(|block| matches!(block, ContentBlock::Text { text, .. } if text == marker))

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -7406,6 +7406,88 @@ fn refresh_system_prompt_is_noop_when_unchanged() {
 }
 
 #[test]
+fn slop_gate_does_not_change_the_stable_system_prompt() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    let marker = "SLOP_GATE_SYSTEM_FINGERPRINT_REGRESSION";
+    engine.slop_ledger_gate_cache = Some((
+        Some(std::time::SystemTime::UNIX_EPOCH),
+        Some(marker.to_string()),
+    ));
+
+    engine.refresh_system_prompt();
+
+    let prompt = match engine.session.system_prompt.as_ref() {
+        Some(SystemPrompt::Text(text)) => text.clone(),
+        Some(SystemPrompt::Blocks(blocks)) => blocks
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        None => panic!("expected system prompt"),
+    };
+    assert!(!prompt.contains(marker));
+    assert_eq!(
+        engine
+            .slop_ledger_gate_cache
+            .as_ref()
+            .and_then(|(_, block)| block.as_deref()),
+        Some(marker),
+        "system prompt refresh must not consult or rewrite the user-turn gate cache"
+    );
+}
+
+#[test]
+fn slop_gate_is_an_external_user_turn_tail_block() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    let marker = "## debt gate test marker";
+
+    let message = engine.user_text_message_with_turn_metadata("finish the task".to_string());
+    let message = Engine::attach_slop_ledger_gate(message, Some(marker.to_string()));
+
+    assert_eq!(message.content.len(), 3);
+    assert!(matches!(
+        message.content.first(),
+        Some(ContentBlock::Text { text, .. }) if text == "finish the task"
+    ));
+    assert!(matches!(
+        message.content.get(1),
+        Some(ContentBlock::Text { text, .. }) if text == marker
+    ));
+    assert!(matches!(
+        message.content.last(),
+        Some(ContentBlock::Text { text, .. }) if text.starts_with("<turn_meta>\n")
+    ));
+
+    let runtime = engine.runtime_text_message_with_turn_metadata(
+        "runtime continuation".to_string(),
+        UserInputProvenance::Runtime,
+    );
+    engine.slop_ledger_gate_cache = Some((
+        Some(std::time::SystemTime::UNIX_EPOCH),
+        Some(marker.to_string()),
+    ));
+    let runtime =
+        engine.with_slop_ledger_gate_for_external_turn(runtime, UserInputProvenance::Runtime);
+    assert_eq!(runtime.content.len(), 2);
+    assert!(
+        !runtime
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Text { text, .. } if text == marker))
+    );
+}
+
+#[test]
 fn engine_prompt_respects_hidden_thinking_config() {
     let tmp = tempdir().expect("tempdir");
     let config = EngineConfig {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -7498,6 +7498,96 @@ fn slop_gate_is_an_initial_external_user_turn_tail_block() {
     );
 }
 
+#[tokio::test]
+async fn slop_gate_survives_mid_turn_compaction_without_reinjection() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+    let marker = "## active turn debt gate";
+
+    let message = Message {
+        role: "user".to_string(),
+        content: vec![
+            ContentBlock::Text {
+                text: "finish this long task".to_string(),
+                cache_control: None,
+            },
+            ContentBlock::Text {
+                text: "<turn_meta>\nInput provenance: external_user\n</turn_meta>".to_string(),
+                cache_control: None,
+            },
+        ],
+    };
+    let active_gate_message = Engine::attach_slop_ledger_gate(message, Some(marker.to_string()));
+    engine.session.add_message(active_gate_message.clone());
+
+    // Move the initial message outside the always-retained tail. A newer user
+    // message also prevents the generic chat-template fallback from pinning it
+    // accidentally, so this test exercises the active-turn pin specifically.
+    for index in 0..12 {
+        engine.session.add_message(Message {
+            role: if index == 10 { "user" } else { "assistant" }.to_string(),
+            content: vec![ContentBlock::Text {
+                text: format!("history {index} {}", "x".repeat(1_024)),
+                cache_control: None,
+            }],
+        });
+    }
+
+    let unpinned_plan = crate::compaction::plan_compaction(
+        &engine.session.messages,
+        Some(&engine.session.workspace),
+        4,
+        None,
+        None,
+    );
+    assert!(
+        unpinned_plan.summarize_indices.contains(&0),
+        "fixture must prove the gate would otherwise be summarized away: {unpinned_plan:?}"
+    );
+
+    let pins = engine.compaction_pins_for_active_turn(Some(&active_gate_message));
+    assert!(pins.contains(&0));
+
+    let compaction = CompactionConfig {
+        enabled: true,
+        token_threshold: 1,
+        ..CompactionConfig::default()
+    };
+    let mock = MockLlmClient::new(vec![canned::simple_text_turn("bounded history summary")]);
+    assert!(should_compact(
+        &engine.session.messages,
+        &compaction,
+        Some(&engine.session.workspace),
+        Some(&pins),
+        None,
+    ));
+
+    let result = compact_messages_safe(
+        &mock,
+        &engine.session.messages,
+        &compaction,
+        Some(&engine.session.workspace),
+        Some(&pins),
+        None,
+    )
+    .await
+    .expect("mid-turn compaction");
+
+    assert!(result.messages.contains(&active_gate_message));
+    assert!(result.messages.iter().any(|message| {
+        message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Text { text, .. } if text == marker))
+    }));
+}
+
 #[test]
 fn engine_prompt_respects_hidden_thinking_config() {
     let tmp = tempdir().expect("tempdir");

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -351,10 +351,8 @@ impl Engine {
                 break;
             }
 
-            let compaction_pins = self
-                .session
-                .working_set
-                .pinned_message_indices(&self.session.messages, &self.session.workspace);
+            let compaction_pins =
+                self.compaction_pins_for_active_turn(turn.active_slop_gate_message.as_ref());
             let compaction_paths = self.session.working_set.top_paths(24);
 
             if self.config.compaction.enabled
@@ -458,7 +456,11 @@ impl Engine {
                     }
 
                     if self
-                        .recover_context_overflow(client.as_ref(), "preflight token budget")
+                        .recover_context_overflow(
+                            client.as_ref(),
+                            "preflight token budget",
+                            turn.active_slop_gate_message.as_ref(),
+                        )
                         .await
                     {
                         context_recovery_attempts = context_recovery_attempts.saturating_add(1);
@@ -653,6 +655,7 @@ impl Engine {
                             .recover_context_overflow(
                                 client.as_ref(),
                                 "provider context-length rejection",
+                                turn.active_slop_gate_message.as_ref(),
                             )
                             .await
                     {

--- a/crates/tui/src/core/turn.rs
+++ b/crates/tui/src/core/turn.rs
@@ -13,7 +13,7 @@
 //! `/restore N` and the `revert_turn` tool both consume these
 //! snapshots.
 
-use crate::models::Usage;
+use crate::models::{Message, Usage};
 use crate::snapshot::SnapshotRepo;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -43,6 +43,11 @@ pub struct TurnContext {
 
     /// Usage for this turn
     pub usage: Usage,
+
+    /// Exact initial user message carrying the mutable SlopLedger gate, when
+    /// one was attached. Compaction uses this turn-scoped identity as an
+    /// authoritative pin without retaining matching gates from older turns.
+    pub(crate) active_slop_gate_message: Option<Message>,
 }
 
 impl TurnContext {
@@ -60,6 +65,7 @@ impl TurnContext {
                 output_tokens: 0,
                 ..Usage::default()
             },
+            active_slop_gate_message: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- remove the changing SlopLedger completion gate from the fingerprinted system prompt
- attach it once to each top-level external user-turn tail, between user text and final `<turn_meta>`
- let mid-turn steers reuse that already-present transcript block instead of duplicating debt text
- leave runtime-origin user messages untouched so continuations do not reinject token debt
- keep the existing modified-time cache and completion-gate semantics

## Verification

- `cargo test -p codewhale-tui slop_gate_ --all-features` (2 passed)
- `cargo test -p codewhale-tui refresh_system_prompt --all-features` (3 passed)
- `cargo test -p codewhale-tui --test cache_guard --all-features` (9 passed)
- `cargo clippy -p codewhale-tui --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts=origin/main..HEAD --no-banner`

No publication, deploy, release, registry, or branch-deletion action is included.