### PR TITLE
perf(tui): coalesce repeated read-only calls

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -4511,6 +4511,7 @@ use context::{
 use context::{context_input_budget_for_provider, effective_max_output_tokens};
 mod dispatch;
 mod lsp_hooks;
+mod read_repeat_guard;
 mod streaming;
 mod stuck_guard;
 mod token_estimate_cache;

--- a/crates/tui/src/core/engine/dispatch.rs
+++ b/crates/tui/src/core/engine/dispatch.rs
@@ -15,6 +15,8 @@
 //! All items are `pub(super)`-only: the public engine surface (Op/Event,
 //! `EngineHandle`, `spawn_engine`) stays in `core/engine.rs`.
 
+use std::collections::HashMap;
+
 use serde_json::json;
 
 use crate::models::{Tool, ToolCaller};
@@ -24,6 +26,7 @@ use crate::tools::spec::{
 use crate::tui::app::AppMode;
 
 use super::ToolUseState;
+use super::read_repeat_guard::{ReadRepeatGuard, ReadRepeatOccurrence};
 
 // === Types ============================================================
 
@@ -59,6 +62,18 @@ pub(super) struct ToolExecutionPlan {
 pub(super) enum ToolExecutionBatch {
     Parallel(Vec<ToolExecutionPlan>),
     Serial(Box<ToolExecutionPlan>),
+}
+
+pub(super) struct CoalescedReadPlan {
+    pub(super) leader_index: usize,
+    pub(super) follower: ToolExecutionPlan,
+    pub(super) occurrence: ReadRepeatOccurrence,
+}
+
+pub(super) struct ReadRepeatExecutionPlan {
+    pub(super) executable: Vec<ToolExecutionPlan>,
+    pub(super) coalesced: Vec<CoalescedReadPlan>,
+    pub(super) occurrences: HashMap<usize, ReadRepeatOccurrence>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -520,6 +535,61 @@ pub(super) fn tool_plan_can_join_parallel_batch(plan: &ToolExecutionPlan) -> boo
     plan.blocked_error.is_none()
         && (tool_plan_is_parallel_safe(plan)
             || (plan.detached_start && !plan.approval_required && !plan.interactive))
+}
+
+/// Register finalized read-only calls and remove same-batch duplicates from
+/// physical execution. Every removed follower is retained so the turn loop can
+/// fan the leader's terminal result back out under the follower's own tool ID.
+pub(super) fn plan_read_repeat_execution(
+    plans: Vec<ToolExecutionPlan>,
+    guard: &mut ReadRepeatGuard,
+) -> ReadRepeatExecutionPlan {
+    let mut executable = Vec::with_capacity(plans.len());
+    let mut coalesced = Vec::new();
+    let mut occurrences = HashMap::new();
+    let mut leaders = HashMap::new();
+
+    for mut plan in plans {
+        let eligible = plan.read_only
+            && !plan.interactive
+            && !plan.detached_start
+            && plan.blocked_error.is_none()
+            && plan.guard_result.is_none();
+        if !eligible {
+            // A write, interactive call, detached start, denial, or other
+            // execution barrier may change what a later read observes. Do not
+            // subscribe a post-barrier read to a pre-barrier result.
+            leaders.clear();
+            executable.push(plan);
+            continue;
+        }
+
+        let occurrence = guard.register(&plan.name, &plan.input);
+        occurrences.insert(plan.index, occurrence.clone());
+
+        if let Some(receipt) = guard.prior_receipt(&occurrence) {
+            plan.guard_result = Some(receipt);
+            executable.push(plan);
+            continue;
+        }
+
+        if let Some(leader_index) = leaders.get(&occurrence.key).copied() {
+            coalesced.push(CoalescedReadPlan {
+                leader_index,
+                follower: plan,
+                occurrence,
+            });
+        } else {
+            leaders.insert(occurrence.key.clone(), plan.index);
+            executable.push(plan);
+        }
+    }
+
+    ReadRepeatExecutionPlan {
+        executable,
+        coalesced,
+        occurrences,
+    }
 }
 
 pub(super) fn plan_tool_execution_batches(

--- a/crates/tui/src/core/engine/read_repeat_guard.rs
+++ b/crates/tui/src/core/engine/read_repeat_guard.rs
@@ -1,0 +1,331 @@
+//! Per-user-turn protection against repeated identical read-only tool calls.
+//!
+//! The ordinary stuck guard detects consecutive no-progress steps. This guard
+//! is narrower and deliberately non-consecutive: it keys finalized read-only
+//! calls by resolved tool name plus canonical arguments, survives interleaved
+//! model steps, and resets when `handle_deepseek_turn` returns.
+
+use std::collections::HashMap;
+
+use serde_json::{Value, json};
+
+use crate::tools::spec::{ToolError, ToolResult};
+
+pub(super) const NUDGE_THRESHOLD: usize = 3;
+pub(super) const RECEIPT_THRESHOLD: usize = 5;
+pub(super) const STOP_THRESHOLD: usize = 8;
+
+const CORRECTIVE_NUDGE: &str = "[codewhale read-repeat guard] This identical read-only call has already been requested multiple times in the current user turn. Reuse the result already in context, change the arguments, or switch methods; do not issue the same read unchanged.";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct ReadRepeatKey {
+    tool_name: String,
+    arguments_sha256: String,
+}
+
+impl ReadRepeatKey {
+    pub(super) fn tool_name(&self) -> &str {
+        &self.tool_name
+    }
+
+    pub(super) fn arguments_sha256(&self) -> &str {
+        &self.arguments_sha256
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ReadRepeatOccurrence {
+    pub(super) key: ReadRepeatKey,
+    pub(super) count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PriorSuccess {
+    tool_use_id: String,
+    content_sha256: String,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct ReadRepeatGuard {
+    counts: HashMap<ReadRepeatKey, usize>,
+    prior_successes: HashMap<ReadRepeatKey, PriorSuccess>,
+}
+
+impl ReadRepeatGuard {
+    pub(super) fn register(&mut self, tool_name: &str, arguments: &Value) -> ReadRepeatOccurrence {
+        let key = ReadRepeatKey {
+            tool_name: tool_name.to_string(),
+            arguments_sha256: crate::hashing::sha256_hex(
+                canonical_json(arguments).to_string().as_bytes(),
+            ),
+        };
+        let count = self.counts.entry(key.clone()).or_default();
+        *count = count.saturating_add(1);
+        ReadRepeatOccurrence { key, count: *count }
+    }
+
+    pub(super) fn prior_receipt(&self, occurrence: &ReadRepeatOccurrence) -> Option<ToolResult> {
+        if occurrence.count < RECEIPT_THRESHOLD {
+            return None;
+        }
+        let prior = self.prior_successes.get(&occurrence.key)?;
+        Some(receipt_result(
+            occurrence,
+            &prior.tool_use_id,
+            &prior.content_sha256,
+            "prior_result",
+        ))
+    }
+
+    pub(super) fn remember_success(
+        &mut self,
+        occurrence: &ReadRepeatOccurrence,
+        tool_use_id: &str,
+        result: &ToolResult,
+    ) {
+        if !result.success || !result_was_executed(result) {
+            return;
+        }
+        self.prior_successes.insert(
+            occurrence.key.clone(),
+            PriorSuccess {
+                tool_use_id: tool_use_id.to_string(),
+                content_sha256: crate::hashing::sha256_hex(result.content.as_bytes()),
+            },
+        );
+    }
+
+    pub(super) fn coalesced_result(
+        &self,
+        occurrence: &ReadRepeatOccurrence,
+        leader_tool_use_id: &str,
+        leader_result: &Result<ToolResult, ToolError>,
+    ) -> Result<ToolResult, ToolError> {
+        let Ok(leader_result) = leader_result else {
+            return leader_result.clone();
+        };
+        if !leader_result.success {
+            let mut result = leader_result.clone();
+            stamp_repeat_metadata(
+                &mut result,
+                occurrence,
+                false,
+                "coalesced_error",
+                Some(leader_tool_use_id),
+                None,
+            );
+            return Ok(result);
+        }
+
+        let content_sha256 = crate::hashing::sha256_hex(leader_result.content.as_bytes());
+        if occurrence.count >= RECEIPT_THRESHOLD {
+            return Ok(receipt_result(
+                occurrence,
+                leader_tool_use_id,
+                &content_sha256,
+                "same_batch_receipt",
+            ));
+        }
+
+        let mut result = leader_result.clone();
+        stamp_repeat_metadata(
+            &mut result,
+            occurrence,
+            false,
+            "same_batch_subscription",
+            Some(leader_tool_use_id),
+            Some(&content_sha256),
+        );
+        Ok(result)
+    }
+
+    pub(super) fn decorate_model_result(
+        &self,
+        occurrence: &ReadRepeatOccurrence,
+        result: &mut ToolResult,
+    ) {
+        if occurrence.count < NUDGE_THRESHOLD {
+            return;
+        }
+        if !result.content.contains("[codewhale read-repeat guard]") {
+            if !result.content.is_empty() {
+                result.content.push_str("\n\n");
+            }
+            result.content.push_str(CORRECTIVE_NUDGE);
+        }
+        if let Some(repeat) = result
+            .metadata
+            .as_mut()
+            .and_then(Value::as_object_mut)
+            .and_then(|metadata| metadata.get_mut("read_repeat"))
+            .and_then(Value::as_object_mut)
+        {
+            repeat.insert("nudged".to_string(), Value::Bool(true));
+            return;
+        }
+        let executed = result_was_executed(result);
+        stamp_repeat_metadata(result, occurrence, executed, "nudge", None, None);
+    }
+
+    pub(super) fn corrective_nudge(occurrence: &ReadRepeatOccurrence) -> Option<&'static str> {
+        (occurrence.count >= NUDGE_THRESHOLD).then_some(CORRECTIVE_NUDGE)
+    }
+
+    pub(super) fn should_stop(occurrence: &ReadRepeatOccurrence) -> bool {
+        occurrence.count >= STOP_THRESHOLD
+    }
+}
+
+fn receipt_result(
+    occurrence: &ReadRepeatOccurrence,
+    source_tool_use_id: &str,
+    source_content_sha256: &str,
+    action: &str,
+) -> ToolResult {
+    let mut result = ToolResult::success(format!(
+        "[read-only result receipt]\nIdentical call occurrence {} was not executed. Reuse tool result `{source_tool_use_id}` (content sha256 `{source_content_sha256}`).",
+        occurrence.count
+    ));
+    stamp_repeat_metadata(
+        &mut result,
+        occurrence,
+        false,
+        action,
+        Some(source_tool_use_id),
+        Some(source_content_sha256),
+    );
+    result
+}
+
+fn result_was_executed(result: &ToolResult) -> bool {
+    result
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("executed"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+fn stamp_repeat_metadata(
+    result: &mut ToolResult,
+    occurrence: &ReadRepeatOccurrence,
+    executed: bool,
+    action: &str,
+    source_tool_use_id: Option<&str>,
+    source_content_sha256: Option<&str>,
+) {
+    let repeat = json!({
+        "tool_name": occurrence.key.tool_name(),
+        "arguments_sha256": occurrence.key.arguments_sha256(),
+        "count": occurrence.count,
+        "action": action,
+        "source_tool_use_id": source_tool_use_id,
+        "source_content_sha256": source_content_sha256,
+    });
+    let metadata = result.metadata.get_or_insert_with(|| json!({}));
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert("executed".to_string(), Value::Bool(executed));
+        object.insert("read_repeat".to_string(), repeat);
+    } else {
+        let prior = std::mem::replace(metadata, json!({}));
+        let object = metadata
+            .as_object_mut()
+            .expect("replacement metadata is an object");
+        object.insert("_prior".to_string(), prior);
+        object.insert("executed".to_string(), Value::Bool(executed));
+        object.insert("read_repeat".to_string(), repeat);
+    }
+}
+
+fn canonical_json(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut entries: Vec<_> = object.iter().collect();
+            entries.sort_by_key(|(key, _)| *key);
+            let mut canonical = serde_json::Map::new();
+            for (key, value) in entries {
+                canonical.insert(key.clone(), canonical_json(value));
+            }
+            Value::Object(canonical)
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonical_json).collect()),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_argument_order_shares_one_counter() {
+        let mut guard = ReadRepeatGuard::default();
+        let first = guard.register("read_file", &json!({"path": "a", "limit": 10}));
+        let second = guard.register("read_file", &json!({"limit": 10, "path": "a"}));
+
+        assert_eq!(first.key, second.key);
+        assert_eq!(second.count, 2);
+    }
+
+    #[test]
+    fn counts_survive_interleaving_with_other_reads() {
+        let mut guard = ReadRepeatGuard::default();
+        let a1 = guard.register("read_file", &json!({"path": "a"}));
+        let _b1 = guard.register("read_file", &json!({"path": "b"}));
+        let a2 = guard.register("read_file", &json!({"path": "a"}));
+        let _b2 = guard.register("grep_files", &json!({"pattern": "needle"}));
+        let a3 = guard.register("read_file", &json!({"path": "a"}));
+
+        assert_eq!(a1.count, 1);
+        assert_eq!(a2.count, 2);
+        assert_eq!(a3.count, NUDGE_THRESHOLD);
+    }
+
+    #[test]
+    fn fifth_call_reuses_prior_success_and_eighth_stops() {
+        let mut guard = ReadRepeatGuard::default();
+        let arguments = json!({"path": "a"});
+        let first = guard.register("read_file", &arguments);
+        guard.remember_success(&first, "tool-1", &ToolResult::success("contents"));
+
+        for expected in 2..RECEIPT_THRESHOLD {
+            assert_eq!(guard.register("read_file", &arguments).count, expected);
+        }
+        let fifth = guard.register("read_file", &arguments);
+        let mut receipt = guard
+            .prior_receipt(&fifth)
+            .expect("fifth identical read should reuse the prior result");
+        guard.decorate_model_result(&fifth, &mut receipt);
+        assert_eq!(receipt.metadata.as_ref().unwrap()["executed"], false);
+        assert_eq!(
+            receipt.metadata.as_ref().unwrap()["read_repeat"]["action"],
+            "prior_result"
+        );
+        assert_eq!(
+            receipt.metadata.as_ref().unwrap()["read_repeat"]["nudged"],
+            true
+        );
+        assert!(receipt.content.contains("tool-1"));
+
+        let _sixth = guard.register("read_file", &arguments);
+        let _seventh = guard.register("read_file", &arguments);
+        let eighth = guard.register("read_file", &arguments);
+        assert!(ReadRepeatGuard::should_stop(&eighth));
+    }
+
+    #[test]
+    fn nudge_is_added_once_and_is_replay_stable() {
+        let mut guard = ReadRepeatGuard::default();
+        let arguments = json!({"path": "a"});
+        let _first = guard.register("read_file", &arguments);
+        let _second = guard.register("read_file", &arguments);
+        let third = guard.register("read_file", &arguments);
+        let mut result = ToolResult::success("contents");
+
+        guard.decorate_model_result(&third, &mut result);
+        guard.decorate_model_result(&third, &mut result);
+
+        assert_eq!(result.content.matches(CORRECTIVE_NUDGE).count(), 1);
+        assert_eq!(result.metadata.as_ref().unwrap()["read_repeat"]["count"], 3);
+    }
+}

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1286,6 +1286,105 @@ async fn injected_model_drives_real_engine_navigation_trajectory() {
 }
 
 #[tokio::test]
+async fn injected_model_duplicate_reads_execute_once_and_close_both_tool_ids() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    fs::write(workspace.path().join("README.md"), "coalesced-read-proof\n").expect("write fixture");
+    let duplicate_read_turn = vec![
+        canned::message_start("mock_msg_duplicate_read"),
+        canned::tool_use_block_start(0, "call-read-1", "read_file"),
+        canned::tool_input_delta(0, r#"{"path":"README.md"}"#),
+        canned::block_stop(0),
+        canned::tool_use_block_start(1, "call-read-2", "read_file"),
+        canned::tool_input_delta(1, r#"{"path":"README.md"}"#),
+        canned::block_stop(1),
+        canned::message_delta("tool_use", None),
+        canned::message_stop(),
+    ];
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![
+        duplicate_read_turn,
+        canned::simple_text_turn("Duplicate read complete."),
+    ]));
+    let client: crate::core::model_client::SharedModelClient = mock.clone();
+    let (engine, handle) = Engine::new_with_model_client(
+        deterministic_engine_config(workspace.path()),
+        &Config::default(),
+        client,
+    );
+    let task = tokio::spawn(engine.run());
+    handle
+        .send(external_user_message_op(
+            "Issue the duplicate read batch.",
+            AppMode::Agent,
+            &Config::default(),
+        ))
+        .await
+        .expect("send duplicate-read trajectory");
+
+    let mut results = HashMap::new();
+    let mut rx = handle.rx_event.write().await;
+    while let Some(event) = tokio::time::timeout(model_turn_event_timeout(), rx.recv())
+        .await
+        .expect("timed out waiting for duplicate-read trajectory")
+    {
+        match event {
+            Event::ToolCallComplete {
+                id, name, result, ..
+            } if name == "read_file" => {
+                results.insert(id, result.expect("read result"));
+            }
+            Event::TurnComplete { status, error, .. } => {
+                assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+                break;
+            }
+            _ => {}
+        }
+    }
+    drop(rx);
+
+    assert_eq!(results.len(), 2, "every tool ID needs one terminal result");
+    let leader = &results["call-read-1"];
+    let follower = &results["call-read-2"];
+    assert!(leader.content.contains("coalesced-read-proof"));
+    assert_eq!(
+        leader
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("executed"))
+            .and_then(serde_json::Value::as_bool),
+        None,
+        "the first read is the physical execution"
+    );
+    assert_eq!(follower.metadata.as_ref().unwrap()["executed"], false);
+    assert_eq!(
+        follower.metadata.as_ref().unwrap()["read_repeat"]["action"],
+        "same_batch_subscription"
+    );
+    assert_eq!(
+        follower.metadata.as_ref().unwrap()["read_repeat"]["source_tool_use_id"],
+        "call-read-1"
+    );
+
+    let requests = mock.captured_requests();
+    assert_eq!(requests.len(), 2);
+    let result_ids = requests[1]
+        .messages
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .filter_map(|block| match block {
+            ContentBlock::ToolResult { tool_use_id, .. } => Some(tool_use_id.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(result_ids.contains(&"call-read-1"));
+    assert!(result_ids.contains(&"call-read-2"));
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    task.await.expect("engine task");
+}
+
+#[tokio::test]
 async fn injected_model_receives_malformed_tool_feedback_and_recovers() {
     use crate::llm_client::mock::{MockLlmClient, canned};
 
@@ -2078,6 +2177,77 @@ fn parallel_batch_requires_read_only_parallel_tools() {
     let mut gated_background = make_plan(false, false, true, false);
     gated_background.detached_start = true;
     assert!(!should_parallelize_tool_batch(&[gated_background]));
+}
+
+#[test]
+fn identical_read_only_calls_share_one_same_batch_execution() {
+    let mut first = make_plan_at(0, true, true, false, false);
+    first.name = "read_file".to_string();
+    first.input = json!({"path": "src/lib.rs", "limit": 50});
+    let mut duplicate = make_plan_at(1, true, true, false, false);
+    duplicate.name = "read_file".to_string();
+    duplicate.input = json!({"limit": 50, "path": "src/lib.rs"});
+    let mut guard = read_repeat_guard::ReadRepeatGuard::default();
+
+    let planned = dispatch::plan_read_repeat_execution(vec![first, duplicate], &mut guard);
+
+    assert_eq!(planned.executable.len(), 1);
+    assert_eq!(planned.coalesced.len(), 1);
+    assert_eq!(planned.coalesced[0].leader_index, 0);
+    assert_eq!(planned.coalesced[0].follower.index, 1);
+    assert_eq!(planned.occurrences[&0].count, 1);
+    assert_eq!(planned.occurrences[&1].count, 2);
+}
+
+#[test]
+fn write_barrier_prevents_stale_same_batch_read_subscription() {
+    let mut read_before = make_plan_at(0, true, true, false, false);
+    read_before.name = "read_file".to_string();
+    read_before.input = json!({"path": "src/lib.rs"});
+    let mut write = make_plan_at(1, false, false, false, false);
+    write.name = "write_file".to_string();
+    write.input = json!({"path": "src/lib.rs", "content": "changed"});
+    let mut read_after = make_plan_at(2, true, true, false, false);
+    read_after.name = "read_file".to_string();
+    read_after.input = json!({"path": "src/lib.rs"});
+    let mut guard = read_repeat_guard::ReadRepeatGuard::default();
+
+    let planned =
+        dispatch::plan_read_repeat_execution(vec![read_before, write, read_after], &mut guard);
+
+    assert_eq!(planned.executable.len(), 3);
+    assert!(planned.coalesced.is_empty());
+    assert_eq!(planned.occurrences[&0].count, 1);
+    assert_eq!(planned.occurrences[&2].count, 2);
+}
+
+#[test]
+fn fifth_cross_step_read_becomes_a_nonexecuting_receipt() {
+    let mut guard = read_repeat_guard::ReadRepeatGuard::default();
+    let mut first_occurrence = None;
+
+    for index in 0..read_repeat_guard::RECEIPT_THRESHOLD {
+        let mut plan = make_plan_at(index, true, true, false, false);
+        plan.name = "read_file".to_string();
+        plan.input = json!({"path": "src/lib.rs"});
+        let mut planned = dispatch::plan_read_repeat_execution(vec![plan], &mut guard);
+        let occurrence = planned.occurrences[&index].clone();
+        if index == 0 {
+            guard.remember_success(&occurrence, "tool-0", &ToolResult::success("file contents"));
+            first_occurrence = Some(occurrence);
+        }
+
+        let plan = planned.executable.pop().expect("one cross-step plan");
+        if index + 1 < read_repeat_guard::RECEIPT_THRESHOLD {
+            assert!(plan.guard_result.is_none());
+        } else {
+            let receipt = plan.guard_result.expect("fifth read receipt");
+            assert_eq!(receipt.metadata.as_ref().unwrap()["executed"], false);
+            assert!(receipt.content.contains("tool-0"));
+        }
+    }
+
+    assert_eq!(first_occurrence.expect("first occurrence").count, 1);
 }
 
 #[test]

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1385,6 +1385,62 @@ async fn injected_model_duplicate_reads_execute_once_and_close_both_tool_ids() {
 }
 
 #[tokio::test]
+async fn coalesced_raw_read_error_touches_working_set_once() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    let duplicate_read_turn = vec![
+        canned::message_start("mock_msg_duplicate_missing_read"),
+        canned::tool_use_block_start(0, "call-missing-1", "read_file"),
+        canned::tool_input_delta(0, r#"{"path":"missing.rs"}"#),
+        canned::block_stop(0),
+        canned::tool_use_block_start(1, "call-missing-2", "read_file"),
+        canned::tool_input_delta(1, r#"{"path":"missing.rs"}"#),
+        canned::block_stop(1),
+        canned::message_delta("tool_use", None),
+        canned::message_stop(),
+    ];
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![
+        duplicate_read_turn,
+        canned::simple_text_turn("Missing read handled."),
+    ]));
+    let client: crate::core::model_client::SharedModelClient = mock;
+    let (mut engine, _handle) = Engine::new_with_model_client(
+        deterministic_engine_config(workspace.path()),
+        &Config::default(),
+        client,
+    );
+    let context = crate::tools::ToolContext::new(workspace.path().to_path_buf());
+    let mut registry = crate::tools::ToolRegistry::new(context);
+    registry.register(std::sync::Arc::new(crate::tools::file::ReadFileTool));
+    let tools = Some(registry.to_api_tools_with_cache(true));
+    let mut turn = crate::core::turn::TurnContext::new(8);
+
+    let (status, error) = engine
+        .handle_deepseek_turn(
+            &mut turn,
+            Some(&registry),
+            tools,
+            AppMode::Agent,
+            false,
+            Vec::new(),
+        )
+        .await;
+
+    assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+    let entry = engine
+        .session
+        .working_set
+        .entries
+        .get("missing.rs")
+        .expect("leader error should record the attempted path");
+    // The generic extractor records this path-shaped value once from its
+    // extension and once from the explicit `path` key. One physical tool
+    // observation is therefore two touches; the old follower bug made four.
+    assert_eq!(entry.touches, 2, "the follower must not add another touch");
+}
+
+#[tokio::test]
 async fn injected_model_receives_malformed_tool_feedback_and_recovers() {
     use crate::llm_client::mock::{MockLlmClient, canned};
 

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -5,6 +5,8 @@
 //! event handling, tool planning/execution, LSP post-edit hooks, capacity
 //! checkpoints, and loop termination.
 
+use super::dispatch::{ReadRepeatExecutionPlan, plan_read_repeat_execution};
+use super::read_repeat_guard::{RECEIPT_THRESHOLD, ReadRepeatGuard};
 use super::stuck_guard::{
     RUNTIME_NOTICE as STUCK_RUNTIME_NOTICE, StepFingerprint, StuckGuard, StuckSignal,
 };
@@ -14,6 +16,7 @@ use crate::prompt_zones::PinnedPrefix;
 use crate::runtime_handoff::{
     subagent_completion_runtime_message, waiting_for_subagents_runtime_message,
 };
+use crate::tools::spec::ToolTerminalStatus;
 
 const MAX_APPROVAL_INTENT_SUMMARY_CHARS: usize = 2_000;
 const TOOL_ERROR_DEGRADATION_THRESHOLD: u32 = 2;
@@ -278,6 +281,9 @@ impl Engine {
 
         let mut consecutive_tool_error_steps = 0u32;
         let mut stuck_guard = StuckGuard::default();
+        // Scoped to this external user turn: counts survive all model/tool
+        // steps below, then reset before the next user prompt.
+        let mut read_repeat_guard = ReadRepeatGuard::default();
         let mut turn_error: Option<String> = None;
         let mut context_recovery_attempts = 0u8;
         let mut tool_catalog = tools.unwrap_or_default();
@@ -2016,7 +2022,21 @@ impl Engine {
             };
 
             let plan_count = plans.len();
-            let batches = plan_tool_execution_batches(plans);
+            let ReadRepeatExecutionPlan {
+                executable,
+                coalesced: coalesced_read_plans,
+                occurrences: read_repeat_occurrences,
+            } = plan_read_repeat_execution(plans, &mut read_repeat_guard);
+            if !coalesced_read_plans.is_empty() {
+                let _ = self
+                    .tx_event
+                    .send(Event::status(format!(
+                        "Coalesced {} duplicate read-only call(s) onto the first execution",
+                        coalesced_read_plans.len()
+                    )))
+                    .await;
+            }
+            let batches = plan_tool_execution_batches(executable);
             let parallel_chunks = batches
                 .iter()
                 .filter_map(|batch| match batch {
@@ -2601,6 +2621,64 @@ impl Engine {
                 }
             }
 
+            // Same-batch read-only duplicates subscribe to the first physical
+            // execution, but retain their own provider tool-call/result pair.
+            // Counts five and above receive a compact pointer instead of a
+            // repeated body; cancellation retains its explicit terminal state.
+            for coalesced in coalesced_read_plans {
+                let occurrence = &coalesced.occurrence;
+                let follower = coalesced.follower;
+                let leader = outcomes
+                    .get(coalesced.leader_index)
+                    .and_then(Option::as_ref);
+                let (leader_id, leader_status, leader_result) = match leader {
+                    Some(leader) => (
+                        leader.id.clone(),
+                        Some(leader.terminal.status),
+                        leader.terminal.legacy_result(),
+                    ),
+                    None => (
+                        format!("missing-leader-{}", coalesced.leader_index),
+                        None,
+                        Err(ToolError::execution_failed(
+                            "coalesced read leader did not produce a terminal result",
+                        )),
+                    ),
+                };
+                let result =
+                    read_repeat_guard.coalesced_result(occurrence, &leader_id, &leader_result);
+                emit_tool_audit(json!({
+                    "event": "tool.read_repeat_coalesced",
+                    "tool_id": follower.id.clone(),
+                    "tool_name": follower.name.clone(),
+                    "leader_tool_id": leader_id,
+                    "count": occurrence.count,
+                    "receipt": occurrence.count >= RECEIPT_THRESHOLD,
+                }));
+                let _ = self
+                    .tx_event
+                    .send(Event::ToolCallComplete {
+                        id: follower.id.clone(),
+                        name: follower.name.clone(),
+                        result: result.clone(),
+                    })
+                    .await;
+                let terminal = match result {
+                    Ok(result) if leader_status == Some(ToolTerminalStatus::Cancelled) => {
+                        ToolExecutionOutcome::cancelled(result)
+                    }
+                    result => ToolExecutionOutcome::from_legacy(result),
+                };
+                outcomes[follower.index] = Some(ToolExecOutcome {
+                    index: follower.index,
+                    id: follower.id,
+                    name: follower.name,
+                    input: follower.input,
+                    started_at: Instant::now(),
+                    terminal,
+                });
+            }
+
             let mut step_error_count = 0usize;
             // Categorized tool errors collected this step. Feeds the capacity
             // controller's error-escalation checkpoint so it can distinguish
@@ -2617,27 +2695,44 @@ impl Engine {
             // goal-loop turn while get_goal already reflects the new objective.
             let mut goal_tool_ran = false;
             let mut stuck_signal = None;
+            let mut read_repeat_stop: Option<(String, usize)> = None;
 
             for outcome in outcomes.into_iter().flatten() {
                 let tool_input = outcome.input.clone();
                 let tool_name_for_ws = outcome.name.clone();
                 let terminal_status = outcome.terminal.status;
-                let result = outcome.terminal.into_legacy_result();
-                let observed_signal = match &result {
-                    Ok(output) if output.success => {
-                        stuck_guard.observe(StepFingerprint::tool(&outcome.name, &tool_input, None))
+                let mut result = outcome.terminal.into_legacy_result();
+                if let Some(occurrence) = read_repeat_occurrences.get(&outcome.index) {
+                    if let Ok(output) = result.as_mut() {
+                        read_repeat_guard.remember_success(occurrence, &outcome.id, output);
+                        read_repeat_guard.decorate_model_result(occurrence, output);
                     }
-                    Ok(output) => stuck_guard.observe(StepFingerprint::tool(
-                        &outcome.name,
-                        &tool_input,
-                        Some(&output.content),
-                    )),
-                    Err(error) => stuck_guard.observe(StepFingerprint::tool(
-                        &outcome.name,
-                        &tool_input,
-                        Some(&error.to_string()),
-                    )),
-                };
+                    if ReadRepeatGuard::should_stop(occurrence) {
+                        read_repeat_stop = Some((outcome.name.clone(), occurrence.count));
+                    }
+                }
+                // Read-only repetition has its own non-consecutive 3/5/8
+                // policy. Feeding the same calls into the older consecutive
+                // stuck guard would stop at five and defeat the receipt lane.
+                let observed_signal =
+                    if read_repeat_occurrences.contains_key(&outcome.index) {
+                        None
+                    } else {
+                        match &result {
+                            Ok(output) if output.success => stuck_guard
+                                .observe(StepFingerprint::tool(&outcome.name, &tool_input, None)),
+                            Ok(output) => stuck_guard.observe(StepFingerprint::tool(
+                                &outcome.name,
+                                &tool_input,
+                                Some(&output.content),
+                            )),
+                            Err(error) => stuck_guard.observe(StepFingerprint::tool(
+                                &outcome.name,
+                                &tool_input,
+                                Some(&error.to_string()),
+                            )),
+                        }
+                    };
                 if matches!(observed_signal, Some(StuckSignal::Stop)) {
                     stuck_signal = Some(StuckSignal::Stop);
                 } else if matches!(observed_signal, Some(StuckSignal::Warn))
@@ -2673,12 +2768,14 @@ impl Engine {
                             .and_then(|metadata| metadata.get("executed"))
                             .and_then(serde_json::Value::as_bool)
                             .unwrap_or(true);
-                        self.session.working_set.observe_tool_call(
-                            &tool_name_for_ws,
-                            &tool_input,
-                            Some(&output_for_context),
-                            &self.session.workspace,
-                        );
+                        if tool_was_executed {
+                            self.session.working_set.observe_tool_call(
+                                &tool_name_for_ws,
+                                &tool_input,
+                                Some(&output_for_context),
+                                &self.session.workspace,
+                            );
+                        }
 
                         // #136: post-edit LSP diagnostics hook. We only run
                         // this on success — failed edits leave the file
@@ -2729,7 +2826,14 @@ impl Engine {
                             .iter()
                             .find(|tool| tool.name == outcome.name)
                             .map(|tool| &tool.input_schema);
-                        let error = format_tool_error_with_schema(&e, &outcome.name, input_schema);
+                        let mut error =
+                            format_tool_error_with_schema(&e, &outcome.name, input_schema);
+                        if let Some(occurrence) = read_repeat_occurrences.get(&outcome.index)
+                            && let Some(nudge) = ReadRepeatGuard::corrective_nudge(occurrence)
+                        {
+                            error.push_str("\n\n");
+                            error.push_str(nudge);
+                        }
                         self.session.working_set.observe_tool_call(
                             &tool_name_for_ws,
                             &tool_input,
@@ -2758,6 +2862,19 @@ impl Engine {
             // applies it behind a `changed` guard).
             if goal_tool_ran {
                 self.emit_goal_updated().await;
+            }
+
+            if let Some((tool_name, count)) = read_repeat_stop {
+                let reason = format!(
+                    "read-only repetition limit reached for '{tool_name}' at occurrence {count}; stopping turn deterministically"
+                );
+                emit_tool_audit(json!({
+                    "event": "tool.read_repeat_stopped",
+                    "tool_name": tool_name,
+                    "count": count,
+                }));
+                let _ = self.tx_event.send(Event::status(reason.clone())).await;
+                return (TurnOutcomeStatus::Failed, Some(reason));
             }
 
             if let Some(signal) = stuck_signal {

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -2027,6 +2027,10 @@ impl Engine {
                 coalesced: coalesced_read_plans,
                 occurrences: read_repeat_occurrences,
             } = plan_read_repeat_execution(plans, &mut read_repeat_guard);
+            let coalesced_read_indices = coalesced_read_plans
+                .iter()
+                .map(|plan| plan.follower.index)
+                .collect::<std::collections::HashSet<_>>();
             if !coalesced_read_plans.is_empty() {
                 let _ = self
                     .tx_event
@@ -2834,12 +2838,18 @@ impl Engine {
                             error.push_str("\n\n");
                             error.push_str(nudge);
                         }
-                        self.session.working_set.observe_tool_call(
-                            &tool_name_for_ws,
-                            &tool_input,
-                            Some(&error),
-                            &self.session.workspace,
-                        );
+                        // A raw ToolError has no result metadata where the
+                        // coalescer can record `executed: false`. Keep the
+                        // follower model-visible, but do not count it as a
+                        // second physical working-set touch.
+                        if !coalesced_read_indices.contains(&outcome.index) {
+                            self.session.working_set.observe_tool_call(
+                                &tool_name_for_ws,
+                                &tool_input,
+                                Some(&error),
+                                &self.session.workspace,
+                            );
+                        }
                         self.add_session_message(Message {
                             role: "user".to_string(),
                             content: vec![ContentBlock::ToolResult {


### PR DESCRIPTION
## Summary

- track finalized read-only calls per external user turn by resolved tool name plus canonical argument hash
- coalesce eligible same-batch duplicates behind one physical execution while preserving one result, event, and provider tool ID closure per request
- add a replay-stable corrective nudge at occurrence 3, reuse a compact prior-result receipt at occurrence 5, and stop deterministically at occurrence 8
- treat writes, approvals, detached calls, conflicts, and other ineligible executions as barriers; retain the existing stuck guard outside this seam

## Safety contract

- counters reset at the next top-level user turn
- interleaved model steps do not reset identical-read counts
- write/read ordering cannot reuse stale same-batch results
- skipped receipts carry `executed: false` and do not mutate the working set or trigger post-edit diagnostics
- every provider tool-call ID receives exactly one terminal result, including the stop path
- cancellation remains a terminal cancellation outcome

## Verification

- 4 pure read-repeat guard tests
- 2 same-batch and write-barrier planner tests
- cross-step fifth-occurrence receipt test
- injected-model duplicate-read lifecycle test
- 7 legacy stuck-guard tests
- strict all-target/all-feature TUI clippy with warnings denied
- fmt and diff checks
- exact-commit gitleaks scan

No provider or model routing behavior changes.