### PR TITLE
feat(tui): auto-fork read-only same-route children onto the parent's cached prefix

### DIFF
--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -2983,7 +2983,9 @@ mod tests {
             // sentinel, workflow, and fork-context invariant. Keep the budget
             // tight so procedural detail stays out of the system prefix.
             let max_words = if name == "agent" { 580 } else { 350 };
-            let max_tokens = if name == "agent" { 1350 } else { 700 };
+            // The auto-fork contract sentence (#4599-adjacent cache work)
+            // costs a handful of tokens over the original compression target.
+            let max_tokens = if name == "agent" { 1360 } else { 700 };
 
             assert!(
                 word_count <= max_words,

--- a/crates/tui/src/prompts.rs
+++ b/crates/tui/src/prompts.rs
@@ -3320,7 +3320,8 @@ mod tests {
             assert!(haystack.contains("byte-identical"));
             assert!(haystack.contains("DeepSeek prefix-cache reuse"));
         }
-        assert!(AGENT_MODE.contains("Fresh sessions are the default"));
+        assert!(AGENT_MODE.contains("`fork_context` is auto-chosen"));
+        assert!(AGENT_MODE.contains("write-capable, isolated, or re-routed children start fresh"));
     }
 
     #[test]

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -29,7 +29,7 @@ Never poll status or `sleep` to wait — completion sentinels arrive on their ow
 
 Use `type: "explore"` for read-only scouting (defaults to `model_strength: "faster"`; use `model_strength: "same"` when the child needs parent-level capability). Open 2-4 `type: "explore"` sub-agents in parallel only when their outputs are independent. Brief sub-agents with a compact Subagent Brief: `QUESTION`, `SCOPE`, `ALREADY_KNOWN`, `EFFORT`, `STOP_CONDITION`, and `OUTPUT` (`VERDICT`, `EVIDENCE`, `GAPS`, `NEXT`). Explore briefs default to `quick`, read-only, about 3-5 tool calls. Review/verifier children stop after decisive evidence.
 
-`fork_context` is auto-chosen: read-only children on the parent's exact route fork the byte-identical parent prefix (shared context, DeepSeek prefix-cache reuse); write-capable, isolated, or re-routed children start fresh. Set `fork_context` only to override.
+`fork_context` is auto-chosen: read-only children on the parent's exact route fork the byte-identical parent prefix (shared context, DeepSeek prefix-cache reuse); write-capable, isolated, or re-routed children start fresh; set it explicitly only to override.
 
 ###### Large Context Tools
 

--- a/crates/tui/src/prompts/modes/agent.md
+++ b/crates/tui/src/prompts/modes/agent.md
@@ -47,7 +47,7 @@ Use `type: "explore"` for read-only scouting; it defaults to `model_strength: "f
 
 Brief sub-agents with a compact Subagent Brief: `QUESTION`, `SCOPE`, `ALREADY_KNOWN`, `EFFORT`, `STOP_CONDITION`, and `OUTPUT` containing `VERDICT`, `EVIDENCE`, `GAPS`, `NEXT`. Explore briefs default to `quick`, read-only, about 3-5 tool calls. Review/verifier children stop after decisive evidence.
 
-Fresh sessions are the default. Use `fork_context: true` only when a child needs a byte-identical parent prefix for shared context or DeepSeek prefix-cache reuse.
+`fork_context` is auto-chosen: read-only children on the parent's exact route fork the byte-identical parent prefix (shared context, DeepSeek prefix-cache reuse); write-capable, isolated, or re-routed children start fresh. Set `fork_context` only to override.
 
 ###### Large Context Tools
 

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -7936,8 +7936,10 @@ fn parse_items_text(input: &Value, key: &str) -> Result<Option<String>, ToolErro
 /// own conversation), (b) runs the exact parent provider+model route (any
 /// other route pays a full cold prefill of the entire parent context),
 /// (c) has a read-only posture (explore/plan/review/verifier, or an explicit
-/// `read_only` write authority), and (d) stays in the parent workspace with
-/// no worktree isolation. Everything else keeps the fresh-brief default.
+/// `read_only` write authority), (d) stays in the parent workspace with
+/// no worktree isolation, and (e) the parent prefix is not so large that
+/// even cached fork reads (~10% of the prefix per child step) would exceed
+/// a fresh brief. Everything else keeps the fresh-brief default.
 /// An explicit `fork_context` from the caller always wins.
 fn auto_fork_context_default(
     agent_type: &SubAgentType,
@@ -7948,7 +7950,13 @@ fn auto_fork_context_default(
     child_provider: crate::config::ApiProvider,
     effective_model: &str,
 ) -> bool {
-    if parent_runtime.fork_context.is_none() || parent_runtime.parent_agent_id.is_some() {
+    let Some(fork_snapshot) = parent_runtime.fork_context.as_ref() else {
+        return false;
+    };
+    if parent_runtime.parent_agent_id.is_some() {
+        return false;
+    }
+    if estimated_fork_prefix_tokens(fork_snapshot) > AUTO_FORK_MAX_PARENT_PREFIX_TOKENS {
         return false;
     }
     let read_only_posture = matches!(
@@ -7960,6 +7968,41 @@ fn auto_fork_context_default(
         && !has_cwd_override
         && child_provider == parent_runtime.client.api_provider()
         && effective_model == parent_runtime.model
+}
+
+/// Above this estimated parent-prefix size, auto-fork stops paying for a
+/// short read-only child: every child step re-reads the whole prefix at the
+/// provider's cached-read rate, so a very large parent context costs more
+/// than a fresh brief plus re-discovery. Explicit `fork_context: true` is
+/// not subject to this ceiling.
+const AUTO_FORK_MAX_PARENT_PREFIX_TOKENS: usize = 200_000;
+
+fn estimated_fork_prefix_tokens(snapshot: &SubAgentForkContext) -> usize {
+    let mut total = snapshot
+        .structured_state_block
+        .as_deref()
+        .map(crate::compaction::estimate_text_tokens_conservative)
+        .unwrap_or(0);
+    for message in &snapshot.messages {
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text, .. } => {
+                    total += crate::compaction::estimate_text_tokens_conservative(text);
+                }
+                ContentBlock::Thinking { thinking, .. } => {
+                    total += crate::compaction::estimate_text_tokens_conservative(thinking);
+                }
+                ContentBlock::ToolResult { content, .. } => {
+                    total += crate::compaction::estimate_text_tokens_conservative(content);
+                }
+                ContentBlock::ToolUse { input, .. } => {
+                    total += input.to_string().len() / 4;
+                }
+                _ => {}
+            }
+        }
+    }
+    total
 }
 
 fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -1499,9 +1499,11 @@ struct SpawnRequest {
     /// locality. A global ownership table prevents two agents from holding
     /// a resident lease on the same file simultaneously.
     resident_file: Option<String>,
-    /// When true, seed the child with the parent's system prompt and message
-    /// prefix before appending the child task.
-    fork_context: bool,
+    /// `Some(true)`: seed the child with the parent's system prompt and
+    /// message prefix before appending the child task. `Some(false)`: force a
+    /// fresh isolated context. `None` (caller omitted the field): resolved by
+    /// [`auto_fork_context_default`] at spawn time.
+    fork_context: Option<bool>,
     /// Legacy recursion budget for descendants. The model-facing child tool
     /// surface is leaf-only; this remains for persisted/internal records.
     max_depth: Option<u32>,
@@ -5052,7 +5054,7 @@ impl ToolSpec for AgentTool {
                 },
                 "fork_context": {
                     "type": "boolean",
-                    "description": "false (default): fresh child context. true: include the current parent context prefix when the child needs shared context or a byte-identical parent prefix for DeepSeek prefix-cache reuse."
+                    "description": "Unset (default): auto — a read-only child (explore/plan/review/verifier or read_only write authority) running the parent's exact model route in the parent workspace forks the parent's cached context prefix; anything else starts fresh. true: force the parent prefix (cheap only on the parent's model route). false: force a fresh isolated context."
                 },
                 "max_depth": {
                     "type": "integer",
@@ -5790,6 +5792,17 @@ async fn spawn_subagent_from_input(
         workflow_child_index: None,
     };
 
+    let fork_context = spawn_request.fork_context.unwrap_or_else(|| {
+        auto_fork_context_default(
+            &spawn_request.agent_type,
+            spawn_request.write_authority,
+            spawn_request.worktree.is_some(),
+            spawn_request.cwd.is_some(),
+            &runtime,
+            child_runtime.client.api_provider(),
+            &effective_model,
+        )
+    });
     let mut manager_guard = manager.write().await;
 
     let result = manager_guard
@@ -5805,7 +5818,7 @@ async fn spawn_subagent_from_input(
                 model: Some(effective_model),
                 model_route: Some(model_route),
                 nickname: None,
-                fork_context: spawn_request.fork_context,
+                fork_context,
                 token_budget: spawn_request.token_budget,
                 max_steps: spawn_request.max_steps,
                 wall_time: spawn_request.wall_time,
@@ -7913,6 +7926,42 @@ fn parse_items_text(input: &Value, key: &str) -> Result<Option<String>, ToolErro
     Ok(Some(lines.join("\n")))
 }
 
+/// Decide `fork_context` when the caller left it unset.
+///
+/// Forking seeds the child with the byte-identical parent prefix, enabling
+/// provider prefix caching (DeepSeek prefix-cache reuse, Anthropic cache
+/// breakpoints) to serve the parent context instead of cold-prefilling. Only
+/// cheaper — and only coherent — when the child (a) is spawned directly by
+/// the engine turn (a nested spawner's snapshot is the root prefix, not its
+/// own conversation), (b) runs the exact parent provider+model route (any
+/// other route pays a full cold prefill of the entire parent context),
+/// (c) has a read-only posture (explore/plan/review/verifier, or an explicit
+/// `read_only` write authority), and (d) stays in the parent workspace with
+/// no worktree isolation. Everything else keeps the fresh-brief default.
+/// An explicit `fork_context` from the caller always wins.
+fn auto_fork_context_default(
+    agent_type: &SubAgentType,
+    write_authority: Option<SpawnWriteAuthority>,
+    has_worktree: bool,
+    has_cwd_override: bool,
+    parent_runtime: &SubAgentRuntime,
+    child_provider: crate::config::ApiProvider,
+    effective_model: &str,
+) -> bool {
+    if parent_runtime.fork_context.is_none() || parent_runtime.parent_agent_id.is_some() {
+        return false;
+    }
+    let read_only_posture = matches!(
+        agent_type,
+        SubAgentType::Explore | SubAgentType::Plan | SubAgentType::Review | SubAgentType::Verifier
+    ) || write_authority == Some(SpawnWriteAuthority::ReadOnly);
+    read_only_posture
+        && !has_worktree
+        && !has_cwd_override
+        && child_provider == parent_runtime.client.api_provider()
+        && effective_model == parent_runtime.model
+}
+
 fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
     let prompt = parse_text_or_items(
         input,
@@ -8027,8 +8076,7 @@ fn parse_spawn_request(input: &Value) -> Result<SpawnRequest, ToolError> {
         .map(str::to_string)
         .filter(|s| !s.trim().is_empty());
     let fork_context =
-        parse_optional_bool(input, &["fork_context", "forkContext", "inherit_context"])
-            .unwrap_or(false);
+        parse_optional_bool(input, &["fork_context", "forkContext", "inherit_context"]);
     let max_depth = input
         .get("max_depth")
         .or_else(|| input.get("maxDepth"))

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1959,6 +1959,33 @@ fn auto_fork_context_default_forks_only_same_route_read_only_engine_children() {
         provider,
         "some-other-model"
     ));
+    // A huge parent prefix stays fresh: cached fork reads on every child
+    // step would cost more than a fresh brief.
+    let huge_text = "token ".repeat(400_000);
+    runtime.fork_context = Some(SubAgentForkContext {
+        messages: vec![crate::models::Message {
+            role: "user".to_string(),
+            content: vec![crate::models::ContentBlock::Text {
+                text: huge_text,
+                cache_control: None,
+            }],
+        }],
+        structured_state_block: None,
+    });
+    assert!(!auto_fork_context_default(
+        &SubAgentType::Explore,
+        None,
+        false,
+        false,
+        &runtime,
+        provider,
+        &model
+    ));
+    runtime.fork_context = Some(SubAgentForkContext {
+        messages: Vec::new(),
+        structured_state_block: None,
+    });
+
     // Nested spawners stay fresh — their snapshot is the root prefix, not
     // their own conversation.
     runtime.parent_agent_id = Some("agent_parent".to_string());

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1253,14 +1253,19 @@ fn test_parse_spawn_request_accepts_fork_context() {
         "fork_context": true
     });
     let parsed = parse_spawn_request(&input).expect("spawn request should parse");
-    assert!(parsed.fork_context);
+    assert_eq!(parsed.fork_context, Some(true));
 
     let input = json!({
         "prompt": "continue from here",
         "inherit_context": true
     });
     let parsed = parse_spawn_request(&input).expect("spawn request should parse");
-    assert!(parsed.fork_context);
+    assert_eq!(parsed.fork_context, Some(true));
+
+    // Omitted entirely: deferred to the spawn-time auto policy.
+    let input = json!({ "prompt": "continue from here" });
+    let parsed = parse_spawn_request(&input).expect("spawn request should parse");
+    assert_eq!(parsed.fork_context, None);
 }
 
 #[test]
@@ -1399,7 +1404,7 @@ fn test_parse_spawn_request_accepts_session_name_for_agent() {
     });
     let parsed = parse_spawn_request(&input).expect("agent request should parse");
     assert_eq!(parsed.session_name.as_deref(), Some("review.parser"));
-    assert!(parsed.fork_context);
+    assert_eq!(parsed.fork_context, Some(true));
     assert_eq!(parsed.max_depth, Some(0));
 }
 
@@ -1864,14 +1869,108 @@ async fn interrupted_projection_exposes_checkpoint_metadata_and_messages() {
 fn test_delegate_defaults_to_fork_context() {
     let input = with_default_fork_context(json!({ "prompt": "review current work" }), true);
     let parsed = parse_spawn_request(&input).expect("delegate request should parse");
-    assert!(parsed.fork_context);
+    assert_eq!(parsed.fork_context, Some(true));
 
     let input = with_default_fork_context(
         json!({ "prompt": "fresh exploration", "fork_context": false }),
         true,
     );
     let parsed = parse_spawn_request(&input).expect("delegate override should parse");
-    assert!(!parsed.fork_context);
+    assert_eq!(parsed.fork_context, Some(false));
+}
+
+#[test]
+fn auto_fork_context_default_forks_only_same_route_read_only_engine_children() {
+    let mut runtime = stub_runtime();
+    let provider = runtime.client.api_provider();
+    let model = runtime.model.clone();
+
+    // No captured parent snapshot: never auto-fork.
+    assert!(!auto_fork_context_default(
+        &SubAgentType::Explore,
+        None,
+        false,
+        false,
+        &runtime,
+        provider,
+        &model
+    ));
+
+    runtime.fork_context = Some(SubAgentForkContext {
+        messages: Vec::new(),
+        structured_state_block: None,
+    });
+
+    // Read-only postures on the parent route in the parent workspace fork.
+    for agent_type in [
+        SubAgentType::Explore,
+        SubAgentType::Plan,
+        SubAgentType::Review,
+        SubAgentType::Verifier,
+    ] {
+        assert!(
+            auto_fork_context_default(&agent_type, None, false, false, &runtime, provider, &model),
+            "{agent_type:?} should auto-fork"
+        );
+    }
+    // Explicit read_only authority upgrades a General child.
+    assert!(auto_fork_context_default(
+        &SubAgentType::General,
+        Some(SpawnWriteAuthority::ReadOnly),
+        false,
+        false,
+        &runtime,
+        provider,
+        &model
+    ));
+    // Write-capable children stay fresh.
+    for agent_type in [SubAgentType::General, SubAgentType::Implementer] {
+        assert!(
+            !auto_fork_context_default(&agent_type, None, false, false, &runtime, provider, &model),
+            "{agent_type:?} must stay fresh"
+        );
+    }
+    // Worktree or cwd isolation stays fresh.
+    assert!(!auto_fork_context_default(
+        &SubAgentType::Explore,
+        None,
+        true,
+        false,
+        &runtime,
+        provider,
+        &model
+    ));
+    assert!(!auto_fork_context_default(
+        &SubAgentType::Explore,
+        None,
+        false,
+        true,
+        &runtime,
+        provider,
+        &model
+    ));
+    // A different model route pays a cold prefill of the parent context.
+    assert!(!auto_fork_context_default(
+        &SubAgentType::Explore,
+        None,
+        false,
+        false,
+        &runtime,
+        provider,
+        "some-other-model"
+    ));
+    // Nested spawners stay fresh — their snapshot is the root prefix, not
+    // their own conversation.
+    runtime.parent_agent_id = Some("agent_parent".to_string());
+    assert!(!auto_fork_context_default(
+        &SubAgentType::Explore,
+        None,
+        false,
+        false,
+        &runtime,
+        provider,
+        &model
+    ));
 }
 
 #[test]

--- a/crates/tui/tests/release_runtime_qa.rs
+++ b/crates/tui/tests/release_runtime_qa.rs
@@ -86,6 +86,12 @@ fn fanout_tool_call_sse_n(count: usize) -> String {
                     "arguments": serde_json::to_string(&json!({
                         "message": format!("stay busy worker {worker} until the parent QA turn is cancelled"),
                         "agent_type": "explorer",
+                        // Explicit fresh context: this harness dispatches mock
+                        // responses on request content, and an auto-forked
+                        // child would carry the parent conversation (including
+                        // the parent prompt) in its requests. Explicit false
+                        // always wins over the auto-fork policy.
+                        "fork_context": false,
                         "session_name": format!("qa-worker-{worker}")
                     }))
                     .expect("agent arguments")


### PR DESCRIPTION
Token-cost driver #1 from the 2026-07-19 investigation: every subagent cold-started by default, re-prefilling system prompt + tools + a re-discovery crawl of context the parent already paid for (~100K input per child observed), even though the fork mechanism (per-turn engine snapshot + `with_fork_context`) was fully wired — the only `fork_context: true` in the tree was a unit test.

## Design

`fork_context` is now **tri-state** at the `agent` tool boundary:
- **explicit `true`/`false`** — unchanged, always wins;
- **omitted** — resolved at spawn time by `auto_fork_context_default`, which forks only when it is both *cheaper* and *coherent*:
  1. the spawner is the engine turn itself (a nested spawner's snapshot is the root prefix, not its own conversation);
  2. the child resolved to the **exact parent provider+model route** (any other route pays a full cold prefill of the parent context);
  3. the child posture is **read-only** (explore/plan/review/verifier, or explicit `read_only` write authority);
  4. the child stays in the parent workspace (no worktree/cwd isolation);
  5. the estimated parent prefix is ≤ **200K tokens** — above that, cached fork reads (~10% of the prefix per child step) cost more than a fresh brief.

Everything else keeps the fresh-brief default. The tool schema documents the tri-state so the model is aware of the tradeoff in one sentence; the Agent-mode prompt contract moved from "Fresh sessions are the default" to the auto-chosen contract (test updated with it).

## Related findings (no code needed)

- Driver #2 (breakpoint budget) is already satisfied on main: `client/anthropic.rs::apply_anthropic_cache_breakpoints` places tools/system + latest-user-turn breakpoints with the 4-cap at the wire layer.
- Driver #4 (compaction): system/tools breakpoints survive compaction by construction; the post-compaction miss on shortened history is inherent to compaction, not a defect.

## Evidence

- New matrix test: postures, `read_only` authority upgrade, worktree/cwd isolation, cross-model, cross-spawner, oversized-prefix ceiling.
- Parse tri-state coverage (explicit true / `inherit_context` / omitted → None).
- Full locked TUI suite **7,612 passed / 0 failed / 3 ignored** pre-merge and 515 focused prompts/subagent tests post-merge with main (post-#4597 prompt reconciled); strict all-target/all-feature locked clippy clean.