### PR TITLE
chore(tui): CODEWHALE_* precedence and product-identity cleanup

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4286,10 +4286,16 @@ fn build_tui_command_with_paths(
         );
     }
 
+    // For every forwarded flag below, set both the canonical CODEWHALE_* name
+    // and the legacy DEEPSEEK_* alias so an inherited CODEWHALE_* shell export
+    // cannot outrank the explicit CLI flag when the TUI applies its
+    // CODEWHALE-first environment overrides.
     if let Some(model) = cli.model.as_ref() {
+        cmd.env("CODEWHALE_MODEL", model);
         cmd.env("DEEPSEEK_MODEL", model);
     }
     if let Some(output_mode) = cli.output_mode.as_ref() {
+        cmd.env("CODEWHALE_OUTPUT_MODE", output_mode);
         cmd.env("DEEPSEEK_OUTPUT_MODE", output_mode);
     }
     if let Some(v) = verbosity.as_ref() {
@@ -4297,18 +4303,23 @@ fn build_tui_command_with_paths(
         cmd.env("DEEPSEEK_VERBOSITY", v);
     }
     if let Some(log_level) = cli.log_level.as_ref() {
+        cmd.env("CODEWHALE_LOG_LEVEL", log_level);
         cmd.env("DEEPSEEK_LOG_LEVEL", log_level);
     }
     if let Some(telemetry) = cli.telemetry {
+        cmd.env("CODEWHALE_TELEMETRY", telemetry.to_string());
         cmd.env("DEEPSEEK_TELEMETRY", telemetry.to_string());
     }
     if let Some(policy) = cli.approval_policy.as_ref() {
+        cmd.env("CODEWHALE_APPROVAL_POLICY", policy);
         cmd.env("DEEPSEEK_APPROVAL_POLICY", policy);
     }
     if let Some(mode) = cli.sandbox_mode.as_ref() {
+        cmd.env("CODEWHALE_SANDBOX_MODE", mode);
         cmd.env("DEEPSEEK_SANDBOX_MODE", mode);
     }
     if cli.yolo {
+        cmd.env("CODEWHALE_YOLO", "true");
         cmd.env("DEEPSEEK_YOLO", "true");
     }
     if let Some(api_key) = cli.api_key.as_ref() {
@@ -4330,6 +4341,7 @@ fn build_tui_command_with_paths(
         cmd.env("DEEPSEEK_API_KEY_SOURCE", "cli");
     }
     if let Some(base_url) = cli.base_url.as_ref() {
+        cmd.env("CODEWHALE_BASE_URL", base_url);
         cmd.env("DEEPSEEK_BASE_URL", base_url);
     }
 
@@ -4381,8 +4393,8 @@ to execute it. Common fixes:\n\
 come from the same install directory.\n\
   - If you downloaded release assets manually, keep both `codewhale` and \
 `codewhale-tui` binaries together and make sure the TUI binary is executable.\n\
-  - Set DEEPSEEK_TUI_BIN to the absolute path of a working `codewhale-tui` \
-binary.",
+  - Set CODEWHALE_TUI_BIN (legacy alias: DEEPSEEK_TUI_BIN) to the absolute \
+path of a working `codewhale-tui` binary.",
         tui.display()
     )
 }
@@ -4392,20 +4404,22 @@ binary.",
 /// the npm-distributed Windows package — which ships
 /// `bin/downloads/codewhale-tui.exe` — is found by `Path::exists` (#247).
 ///
-/// `DEEPSEEK_TUI_BIN` is consulted first as an explicit override for
-/// custom installs and CI test layouts. On Windows we additionally try
-/// the suffix-less name as a fallback for users who already manually
-/// renamed the file before this fix landed.
+/// `CODEWHALE_TUI_BIN` (legacy alias: `DEEPSEEK_TUI_BIN`) is consulted first
+/// as an explicit override for custom installs and CI test layouts. On
+/// Windows we additionally try the suffix-less name as a fallback for users
+/// who already manually renamed the file before this fix landed.
 fn locate_sibling_tui_binary() -> Result<PathBuf> {
-    if let Ok(override_path) = std::env::var("DEEPSEEK_TUI_BIN") {
-        let candidate = PathBuf::from(override_path);
-        if candidate.is_file() {
-            return Ok(candidate);
+    for var in ["CODEWHALE_TUI_BIN", "DEEPSEEK_TUI_BIN"] {
+        if let Ok(override_path) = std::env::var(var) {
+            let candidate = PathBuf::from(override_path);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+            bail!(
+                "{var} points at {}, which is not a regular file.",
+                candidate.display()
+            );
         }
-        bail!(
-            "DEEPSEEK_TUI_BIN points at {}, which is not a regular file.",
-            candidate.display()
-        );
     }
 
     let current = std::env::current_exe().context("failed to locate current executable path")?;
@@ -4427,7 +4441,8 @@ The `codewhale` dispatcher delegates interactive sessions to a sibling \
 `codewhale-tui-<platform>` from https://github.com/Hmbown/CodeWhale/releases/latest \
 and place them in the same directory.\n\
 \n\
-Or set DEEPSEEK_TUI_BIN to the absolute path of an existing `codewhale-tui` binary.",
+Or set CODEWHALE_TUI_BIN (legacy alias: DEEPSEEK_TUI_BIN) to the absolute path \
+of an existing `codewhale-tui` binary.",
         expected.display()
     );
 }
@@ -8305,5 +8320,30 @@ model = "qwen-2.5-7b"
 
         let resolved = locate_sibling_tui_binary().expect("override must resolve");
         assert_eq!(resolved, custom);
+    }
+
+    /// `CODEWHALE_TUI_BIN` is the canonical override name and outranks the
+    /// legacy `DEEPSEEK_TUI_BIN` alias when both are set.
+    #[test]
+    fn locate_sibling_tui_binary_prefers_codewhale_env_override() {
+        let _lock = env_lock();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let canonical = dir
+            .path()
+            .join(format!("canonical-tui{}", std::env::consts::EXE_SUFFIX));
+        let legacy = dir
+            .path()
+            .join(format!("legacy-tui{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&canonical, b"").unwrap();
+        std::fs::write(&legacy, b"").unwrap();
+        let _canonical_bin = ScopedEnvVar::set(
+            "CODEWHALE_TUI_BIN",
+            &canonical.to_string_lossy().into_owned(),
+        );
+        let _legacy_bin =
+            ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &legacy.to_string_lossy().into_owned());
+
+        let resolved = locate_sibling_tui_binary().expect("override must resolve");
+        assert_eq!(resolved, canonical);
     }
 }

--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -823,11 +823,14 @@ fn print_human(rollup: &Rollup) {
 // ──────────────────────────────────────────────────────────────────────────────
 
 fn deepseek_home() -> PathBuf {
-    // Respect DEEPSEEK_HOME env override; fall back to ~/.deepseek.
-    if let Ok(v) = std::env::var("DEEPSEEK_HOME")
-        && !v.is_empty()
-    {
-        return PathBuf::from(v);
+    // Respect CODEWHALE_HOME (canonical) then DEEPSEEK_HOME (legacy alias)
+    // env overrides; fall back to ~/.deepseek.
+    for var in ["CODEWHALE_HOME", "DEEPSEEK_HOME"] {
+        if let Ok(v) = std::env::var(var)
+            && !v.trim().is_empty()
+        {
+            return PathBuf::from(v);
+        }
     }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4769,35 +4769,48 @@ impl EnvRuntimeOverrides {
             verbosity: std::env::var("CODEWHALE_VERBOSITY")
                 .or_else(|_| std::env::var("DEEPSEEK_VERBOSITY"))
                 .ok(),
-            output_mode: std::env::var("DEEPSEEK_OUTPUT_MODE").ok(),
-            auth_mode: std::env::var("DEEPSEEK_AUTH_MODE").ok(),
-            log_level: std::env::var("DEEPSEEK_LOG_LEVEL").ok(),
-            telemetry: std::env::var("DEEPSEEK_TELEMETRY")
+            output_mode: std::env::var("CODEWHALE_OUTPUT_MODE")
+                .or_else(|_| std::env::var("DEEPSEEK_OUTPUT_MODE"))
+                .ok(),
+            auth_mode: std::env::var("CODEWHALE_AUTH_MODE")
+                .or_else(|_| std::env::var("DEEPSEEK_AUTH_MODE"))
+                .ok(),
+            log_level: std::env::var("CODEWHALE_LOG_LEVEL")
+                .or_else(|_| std::env::var("DEEPSEEK_LOG_LEVEL"))
+                .ok(),
+            telemetry: std::env::var("CODEWHALE_TELEMETRY")
+                .or_else(|_| std::env::var("DEEPSEEK_TELEMETRY"))
                 .ok()
                 .and_then(|v| match parse_bool(&v) {
                     Ok(b) => Some(b),
                     Err(_) => {
-                        tracing::warn!("Invalid DEEPSEEK_TELEMETRY value '{v}', expected true/false");
+                        tracing::warn!("Invalid CODEWHALE_TELEMETRY/DEEPSEEK_TELEMETRY value '{v}', expected true/false");
                         None
                     }
                 }),
-            approval_policy: std::env::var("DEEPSEEK_APPROVAL_POLICY").ok(),
-            sandbox_mode: std::env::var("DEEPSEEK_SANDBOX_MODE").ok(),
-            yolo: std::env::var("DEEPSEEK_YOLO")
+            approval_policy: std::env::var("CODEWHALE_APPROVAL_POLICY")
+                .or_else(|_| std::env::var("DEEPSEEK_APPROVAL_POLICY"))
+                .ok(),
+            sandbox_mode: std::env::var("CODEWHALE_SANDBOX_MODE")
+                .or_else(|_| std::env::var("DEEPSEEK_SANDBOX_MODE"))
+                .ok(),
+            yolo: std::env::var("CODEWHALE_YOLO")
+                .or_else(|_| std::env::var("DEEPSEEK_YOLO"))
                 .ok()
                 .and_then(|v| match parse_bool(&v) {
                     Ok(b) => Some(b),
                     Err(_) => {
-                        tracing::warn!("Invalid DEEPSEEK_YOLO value '{v}', expected true/false");
+                        tracing::warn!("Invalid CODEWHALE_YOLO/DEEPSEEK_YOLO value '{v}', expected true/false");
                         None
                     }
                 }),
-            http_headers: std::env::var("DEEPSEEK_HTTP_HEADERS")
+            http_headers: std::env::var("CODEWHALE_HTTP_HEADERS")
+                .or_else(|_| std::env::var("DEEPSEEK_HTTP_HEADERS"))
                 .ok()
                 .and_then(|value| match parse_http_headers(&value) {
                     Ok(h) => Some(h),
                     Err(_) => {
-                        tracing::warn!("Invalid DEEPSEEK_HTTP_HEADERS value, expected format: header1=val1,header2=val2");
+                        tracing::warn!("Invalid CODEWHALE_HTTP_HEADERS/DEEPSEEK_HTTP_HEADERS value, expected format: header1=val1,header2=val2");
                         None
                     }
                 })

--- a/crates/tui/src/automation_manager.rs
+++ b/crates/tui/src/automation_manager.rs
@@ -1154,10 +1154,12 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 
 pub fn default_automations_dir() -> PathBuf {
     // Most-specific override: an explicit automations dir.
-    if let Ok(path) = std::env::var("DEEPSEEK_AUTOMATIONS_DIR") {
-        let trimmed = path.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
+    for var in ["CODEWHALE_AUTOMATIONS_DIR", "DEEPSEEK_AUTOMATIONS_DIR"] {
+        if let Ok(path) = std::env::var(var) {
+            let trimmed = path.trim();
+            if !trimmed.is_empty() {
+                return PathBuf::from(trimmed);
+            }
         }
     }
     // $CODEWHALE_HOME is a hard override of the base data directory

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -192,7 +192,9 @@ const RECOVERY_PROBE_COOLDOWN: Duration = Duration::from_secs(15);
 
 const DEFAULT_CLIENT_RATE_LIMIT_RPS: f64 = 8.0;
 const DEFAULT_CLIENT_RATE_LIMIT_BURST: f64 = 16.0;
-const ALLOW_INSECURE_HTTP_ENV: &str = "DEEPSEEK_ALLOW_INSECURE_HTTP";
+const ALLOW_INSECURE_HTTP_ENV: &str = "CODEWHALE_ALLOW_INSECURE_HTTP";
+/// Legacy alias for [`ALLOW_INSECURE_HTTP_ENV`].
+const LEGACY_ALLOW_INSECURE_HTTP_ENV: &str = "DEEPSEEK_ALLOW_INSECURE_HTTP";
 
 fn client_user_agent(api_provider: ApiProvider) -> &'static str {
     // The ChatGPT Codex backend is the sole route with a documented
@@ -621,6 +623,7 @@ fn validate_base_url_security(base_url: &str) -> Result<()> {
 
     if base_url.starts_with("http://")
         && std::env::var(ALLOW_INSECURE_HTTP_ENV)
+            .or_else(|_| std::env::var(LEGACY_ALLOW_INSECURE_HTTP_ENV))
             .ok()
             .as_deref()
             .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -637,9 +640,9 @@ fn validate_base_url_security(base_url: &str) -> Result<()> {
              \n\
              Loopback hosts (localhost, 127.0.0.1, [::1]) are auto-allowed.\n\
              For other trusted local hosts (LAN, llama.cpp on a private IP, etc.)\n\
-             set the env var `{ALLOW_INSECURE_HTTP_ENV}=1` in the shell that runs deepseek and re-run.\n\
+             set the env var `{ALLOW_INSECURE_HTTP_ENV}=1` in the shell that runs codewhale and re-run.\n\
              \n\
-             Example: `{ALLOW_INSECURE_HTTP_ENV}=1 deepseek` (note the underscores).",
+             Example: `{ALLOW_INSECURE_HTTP_ENV}=1 codewhale` (note the underscores).",
         );
     }
 
@@ -6249,12 +6252,18 @@ mod tests {
 
     struct AllowInsecureHttpEnvGuard {
         prior: Option<std::ffi::OsString>,
+        prior_legacy: Option<std::ffi::OsString>,
     }
     impl AllowInsecureHttpEnvGuard {
         fn capture() -> Self {
-            Self {
+            let guard = Self {
                 prior: std::env::var_os(ALLOW_INSECURE_HTTP_ENV),
-            }
+                prior_legacy: std::env::var_os(LEGACY_ALLOW_INSECURE_HTTP_ENV),
+            };
+            // Clear the legacy alias so ambient shell state cannot satisfy
+            // the CODEWHALE-first fallback chain behind a test's back.
+            unsafe { std::env::remove_var(LEGACY_ALLOW_INSECURE_HTTP_ENV) };
+            guard
         }
     }
     impl Drop for AllowInsecureHttpEnvGuard {
@@ -6262,6 +6271,10 @@ mod tests {
             match &self.prior {
                 Some(v) => unsafe { std::env::set_var(ALLOW_INSECURE_HTTP_ENV, v) },
                 None => unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) },
+            }
+            match &self.prior_legacy {
+                Some(v) => unsafe { std::env::set_var(LEGACY_ALLOW_INSECURE_HTTP_ENV, v) },
+                None => unsafe { std::env::remove_var(LEGACY_ALLOW_INSECURE_HTTP_ENV) },
             }
         }
     }

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -307,12 +307,14 @@ impl Drop for ProviderRequestPermit {
 
 impl TokenBucket {
     fn from_env() -> Self {
-        let rps = std::env::var("DEEPSEEK_RATE_LIMIT_RPS")
+        let rps = std::env::var("CODEWHALE_RATE_LIMIT_RPS")
+            .or_else(|_| std::env::var("DEEPSEEK_RATE_LIMIT_RPS"))
             .ok()
             .and_then(|v| v.parse::<f64>().ok())
             .unwrap_or(DEFAULT_CLIENT_RATE_LIMIT_RPS)
             .max(0.0);
-        let burst = std::env::var("DEEPSEEK_RATE_LIMIT_BURST")
+        let burst = std::env::var("CODEWHALE_RATE_LIMIT_BURST")
+            .or_else(|_| std::env::var("DEEPSEEK_RATE_LIMIT_BURST"))
             .ok()
             .and_then(|v| v.parse::<f64>().ok())
             .unwrap_or(DEFAULT_CLIENT_RATE_LIMIT_BURST)
@@ -830,12 +832,14 @@ fn build_speech_synthesis_body(
 
 // === DeepSeekClient ===
 
-/// Returns true when DEEPSEEK_FORCE_HTTP1 is set to a truthy value
-/// (`1`, `true`, `yes`, `on`, case-insensitive). Used by `build_http_client`
-/// to opt out of HTTP/2 entirely when DeepSeek's edge mishandles long-lived H2
-/// streams (#103). Anything else (unset, `0`, `false`, ...) leaves HTTP/2 on.
+/// Returns true when CODEWHALE_FORCE_HTTP1 (legacy alias: DEEPSEEK_FORCE_HTTP1)
+/// is set to a truthy value (`1`, `true`, `yes`, `on`, case-insensitive). Used
+/// by `build_http_client` to opt out of HTTP/2 entirely when a provider's edge
+/// mishandles long-lived H2 streams (#103). Anything else (unset, `0`,
+/// `false`, ...) leaves HTTP/2 on.
 fn force_http1_from_env() -> bool {
-    std::env::var("DEEPSEEK_FORCE_HTTP1")
+    std::env::var("CODEWHALE_FORCE_HTTP1")
+        .or_else(|_| std::env::var("DEEPSEEK_FORCE_HTTP1"))
         .ok()
         .map(|v| v.trim().to_ascii_lowercase())
         .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))

--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -25,13 +25,15 @@ use crate::config::{
 /// hang before any stream chunk exists, leaving the UI stuck at "Working...".
 const DEFAULT_STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(45);
 
-/// Reads `DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS` as a bounded override for the
+/// Reads `CODEWHALE_STREAM_OPEN_TIMEOUT_SECS` (legacy alias:
+/// `DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS`) as a bounded override for the
 /// response-header wait. This is intentionally shorter than the per-chunk idle
 /// timeout because it only covers connection setup and upstream header return,
 /// not model thinking time after streaming has started.
 fn stream_open_timeout() -> Duration {
     stream_open_timeout_from_env(
-        std::env::var("DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS")
+        std::env::var("CODEWHALE_STREAM_OPEN_TIMEOUT_SECS")
+            .or_else(|_| std::env::var("DEEPSEEK_STREAM_OPEN_TIMEOUT_SECS"))
             .ok()
             .as_deref(),
     )

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3237,7 +3237,9 @@ impl Config {
             }
         }
 
-        if std::env::var_os("DEEPSEEK_APPROVAL_POLICY").is_some() {
+        if std::env::var_os("CODEWHALE_APPROVAL_POLICY").is_some()
+            || std::env::var_os("DEEPSEEK_APPROVAL_POLICY").is_some()
+        {
             return ApprovalPolicyControl::Environment;
         }
 
@@ -3314,7 +3316,9 @@ impl Config {
             }
         }
 
-        if std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some() {
+        if std::env::var_os("CODEWHALE_ALLOW_SHELL").is_some()
+            || std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some()
+        {
             return ShellAccessControl::Environment;
         }
 
@@ -3389,7 +3393,8 @@ impl Config {
 
     #[must_use]
     pub fn search_provider_resolution(&self) -> SearchProviderResolution {
-        if let Ok(raw) = std::env::var("DEEPSEEK_SEARCH_PROVIDER")
+        if let Ok(raw) = std::env::var("CODEWHALE_SEARCH_PROVIDER")
+            .or_else(|_| std::env::var("DEEPSEEK_SEARCH_PROVIDER"))
             && let Some(provider) = SearchProvider::parse(&raw)
         {
             return SearchProviderResolution {
@@ -5555,8 +5560,9 @@ impl Config {
 
     /// Resolved per-SSE-chunk idle timeout in seconds.
     ///
-    /// Reads `[tui].stream_chunk_timeout_secs`, falling back to the legacy
-    /// `DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS` env var when the config key is
+    /// Reads `[tui].stream_chunk_timeout_secs`, falling back to the
+    /// `CODEWHALE_STREAM_IDLE_TIMEOUT_SECS` env var (legacy alias:
+    /// `DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS`) when the config key is
     /// omitted. `None` or `0` resolve to the default 900 seconds; explicit
     /// values are clamped to `1..=3600`.
     #[must_use]
@@ -5567,6 +5573,7 @@ impl Config {
             .and_then(|cfg| cfg.stream_chunk_timeout_secs)
             .or_else(|| {
                 std::env::var(STREAM_CHUNK_TIMEOUT_ENV)
+                    .or_else(|_| std::env::var(LEGACY_STREAM_CHUNK_TIMEOUT_ENV))
                     .ok()
                     .and_then(|value| value.parse::<u64>().ok())
             })
@@ -6428,7 +6435,8 @@ fn apply_env_overrides(config: &mut Config) {
             .xai
             .base_url = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_HTTP_HEADERS")
+    if let Ok(value) =
+        std::env::var("CODEWHALE_HTTP_HEADERS").or_else(|_| std::env::var("DEEPSEEK_HTTP_HEADERS"))
         && let Ok(headers) = parse_http_headers(&value)
         && !headers.is_empty()
     {
@@ -6758,19 +6766,29 @@ fn apply_env_overrides(config: &mut Config) {
     {
         config.default_text_model = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SKILLS_DIR") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_SKILLS_DIR").or_else(|_| std::env::var("DEEPSEEK_SKILLS_DIR"))
+    {
         config.skills_dir = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_MCP_CONFIG") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_MCP_CONFIG").or_else(|_| std::env::var("DEEPSEEK_MCP_CONFIG"))
+    {
         config.mcp_config_path = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_NOTES_PATH") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_NOTES_PATH").or_else(|_| std::env::var("DEEPSEEK_NOTES_PATH"))
+    {
         config.notes_path = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_MEMORY_PATH") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_MEMORY_PATH").or_else(|_| std::env::var("DEEPSEEK_MEMORY_PATH"))
+    {
         config.memory_path = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_MEMORY") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_MEMORY").or_else(|_| std::env::var("DEEPSEEK_MEMORY"))
+    {
         let on = matches!(
             value.trim().to_ascii_lowercase().as_str(),
             "1" | "on" | "true" | "yes" | "y" | "enabled"
@@ -6780,16 +6798,22 @@ fn apply_env_overrides(config: &mut Config) {
             .get_or_insert_with(MemoryConfig::default)
             .enabled = Some(on);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_ALLOW_SHELL") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_ALLOW_SHELL").or_else(|_| std::env::var("DEEPSEEK_ALLOW_SHELL"))
+    {
         config.allow_shell = Some(value == "1" || value.eq_ignore_ascii_case("true"));
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_APPROVAL_POLICY") {
+    if let Ok(value) = std::env::var("CODEWHALE_APPROVAL_POLICY")
+        .or_else(|_| std::env::var("DEEPSEEK_APPROVAL_POLICY"))
+    {
         config.approval_policy = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SANDBOX_MODE") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_SANDBOX_MODE").or_else(|_| std::env::var("DEEPSEEK_SANDBOX_MODE"))
+    {
         config.sandbox_mode = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_YOLO") {
+    if let Ok(value) = std::env::var("CODEWHALE_YOLO").or_else(|_| std::env::var("DEEPSEEK_YOLO")) {
         config.yolo = Some(value == "1" || value.eq_ignore_ascii_case("true"));
     }
     if let Ok(value) =
@@ -6797,19 +6821,28 @@ fn apply_env_overrides(config: &mut Config) {
     {
         config.verbosity = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SANDBOX_BACKEND") {
+    if let Ok(value) = std::env::var("CODEWHALE_SANDBOX_BACKEND")
+        .or_else(|_| std::env::var("DEEPSEEK_SANDBOX_BACKEND"))
+    {
         config.sandbox_backend = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SANDBOX_URL") {
+    if let Ok(value) =
+        std::env::var("CODEWHALE_SANDBOX_URL").or_else(|_| std::env::var("DEEPSEEK_SANDBOX_URL"))
+    {
         config.sandbox_url = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SANDBOX_API_KEY") {
+    if let Ok(value) = std::env::var("CODEWHALE_SANDBOX_API_KEY")
+        .or_else(|_| std::env::var("DEEPSEEK_SANDBOX_API_KEY"))
+    {
         config.sandbox_api_key = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_MANAGED_CONFIG_PATH") {
+    if let Ok(value) = std::env::var("CODEWHALE_MANAGED_CONFIG_PATH")
+        .or_else(|_| std::env::var("DEEPSEEK_MANAGED_CONFIG_PATH"))
+    {
         config.managed_config_path = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_SEARCH_API_KEY")
+    if let Ok(value) = std::env::var("CODEWHALE_SEARCH_API_KEY")
+        .or_else(|_| std::env::var("DEEPSEEK_SEARCH_API_KEY"))
         && !value.trim().is_empty()
     {
         config
@@ -6823,10 +6856,13 @@ fn apply_env_overrides(config: &mut Config) {
             .get_or_insert_with(SearchConfig::default)
             .base_url = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_REQUIREMENTS_PATH") {
+    if let Ok(value) = std::env::var("CODEWHALE_REQUIREMENTS_PATH")
+        .or_else(|_| std::env::var("DEEPSEEK_REQUIREMENTS_PATH"))
+    {
         config.requirements_path = Some(value);
     }
-    if let Ok(value) = std::env::var("DEEPSEEK_MAX_SUBAGENTS")
+    if let Ok(value) = std::env::var("CODEWHALE_MAX_SUBAGENTS")
+        .or_else(|_| std::env::var("DEEPSEEK_MAX_SUBAGENTS"))
         && let Ok(parsed) = value.parse::<usize>()
     {
         config.max_subagents = Some(parsed.clamp(1, MAX_SUBAGENTS));

--- a/crates/tui/src/config/subagent_limits.rs
+++ b/crates/tui/src/config/subagent_limits.rs
@@ -44,7 +44,9 @@ pub const DEFAULT_STREAM_CHUNK_TIMEOUT_SECS: u64 = 900;
 pub const MIN_STREAM_CHUNK_TIMEOUT_SECS: u64 = 1;
 /// Maximum accepted stream chunk timeout.
 pub const MAX_STREAM_CHUNK_TIMEOUT_SECS: u64 = 3600;
-pub(crate) const STREAM_CHUNK_TIMEOUT_ENV: &str = "DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS";
+pub(crate) const STREAM_CHUNK_TIMEOUT_ENV: &str = "CODEWHALE_STREAM_IDLE_TIMEOUT_SECS";
+/// Legacy alias for [`STREAM_CHUNK_TIMEOUT_ENV`].
+pub(crate) const LEGACY_STREAM_CHUNK_TIMEOUT_ENV: &str = "DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS";
 
 pub(crate) fn resolve_subagent_api_timeout_secs(raw: Option<u64>) -> u64 {
     let raw = raw.unwrap_or(DEFAULT_SUBAGENT_API_TIMEOUT_SECS);

--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -126,7 +126,9 @@ impl Drop for InteractiveTerminalGuard {
 }
 
 pub(super) fn emit_tool_audit(event: serde_json::Value) {
-    let Some(path) = std::env::var_os("DEEPSEEK_TOOL_AUDIT_LOG") else {
+    let Some(path) = std::env::var_os("CODEWHALE_TOOL_AUDIT_LOG")
+        .or_else(|| std::env::var_os("DEEPSEEK_TOOL_AUDIT_LOG"))
+    else {
         return;
     };
     emit_tool_audit_to_path(&PathBuf::from(path), event);

--- a/crates/tui/src/logging.rs
+++ b/crates/tui/src/logging.rs
@@ -27,7 +27,8 @@ pub fn restore_verbose_state() {
     set_verbose(VERBOSE_SNAPSHOT.load(Ordering::SeqCst));
 }
 
-/// Return true when `DEEPSEEK_LOG_LEVEL` requests verbose output.
+/// Return true when `CODEWHALE_LOG_LEVEL` (legacy alias: `DEEPSEEK_LOG_LEVEL`)
+/// requests verbose output.
 ///
 /// Note: `RUST_LOG` is intentionally NOT checked here — it controls the
 /// `tracing` subscriber filter in `runtime_log.rs` (file logging) and
@@ -36,7 +37,8 @@ pub fn restore_verbose_state() {
 /// messages to leak into the TUI alt-screen.
 #[must_use]
 pub fn env_requests_verbose_logging() -> bool {
-    std::env::var("DEEPSEEK_LOG_LEVEL")
+    std::env::var("CODEWHALE_LOG_LEVEL")
+        .or_else(|_| std::env::var("DEEPSEEK_LOG_LEVEL"))
         .ok()
         .is_some_and(|value| log_value_enables_verbose(&value))
 }

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -7876,7 +7876,7 @@ async fn run_mcp_command(
             );
             save_mcp_config(&config_path, &cfg)?;
             println!(
-                "Registered DeepSeek as MCP server '{name}' in {}",
+                "Registered Codewhale as MCP server '{name}' in {}",
                 config_path.display()
             );
             println!("  command: {exe_str}");

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -1494,8 +1494,11 @@ async fn run_async_main(
                     let _ = parse_sandbox_policy(sandbox, true, Vec::new(), false, false)?;
                     config.sandbox_mode = Some(sandbox.to_ascii_lowercase());
                 }
-                // Honour DEEPSEEK_BASE_URL forwarded by the CLI dispatcher from --base-url.
-                if let Ok(env_url) = std::env::var("DEEPSEEK_BASE_URL") {
+                // Honour CODEWHALE_BASE_URL / DEEPSEEK_BASE_URL forwarded by
+                // the CLI dispatcher from --base-url.
+                if let Ok(env_url) = std::env::var("CODEWHALE_BASE_URL")
+                    .or_else(|_| std::env::var("DEEPSEEK_BASE_URL"))
+                {
                     let trimmed = env_url.trim();
                     if !trimmed.is_empty() {
                         config.base_url = Some(trimmed.to_string());
@@ -5892,7 +5895,8 @@ fn run_doctor_json(
     // until the two PRs land and it can be replaced with a single
     // method call.)
     let memory_path = config.memory_path();
-    let memory_enabled_env = std::env::var("DEEPSEEK_MEMORY")
+    let memory_enabled_env = std::env::var("CODEWHALE_MEMORY")
+        .or_else(|_| std::env::var("DEEPSEEK_MEMORY"))
         .ok()
         .map(|raw| {
             matches!(
@@ -6829,6 +6833,7 @@ fn load_config_from_cli(cli: &Cli) -> Result<Config> {
 fn effective_config_profile(cli: &Cli) -> Option<String> {
     cli.profile
         .clone()
+        .or_else(|| std::env::var("CODEWHALE_PROFILE").ok())
         .or_else(|| std::env::var("DEEPSEEK_PROFILE").ok())
 }
 
@@ -8682,7 +8687,8 @@ fn merge_user_workspace_config(
         return;
     }
     let allow_shell_before = config.allow_shell;
-    let allow_shell_from_env = std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some();
+    let allow_shell_from_env = std::env::var_os("CODEWHALE_ALLOW_SHELL").is_some()
+        || std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some();
     let Some(path) = crate::config::resolve_load_config_path(config_path) else {
         return;
     };
@@ -9404,7 +9410,9 @@ async fn run_workflow_tool_command_inner(
     let workspace = resolve_workspace(cli);
     let mut config = load_config_from_cli(cli)?;
     merge_user_workspace_config(&mut config, cli.config.clone(), &workspace);
-    if let Ok(env_url) = std::env::var("DEEPSEEK_BASE_URL") {
+    if let Ok(env_url) =
+        std::env::var("CODEWHALE_BASE_URL").or_else(|_| std::env::var("DEEPSEEK_BASE_URL"))
+    {
         let trimmed = env_url.trim();
         if !trimmed.is_empty() {
             config.base_url = Some(trimmed.to_string());

--- a/crates/tui/src/mcp_server.rs
+++ b/crates/tui/src/mcp_server.rs
@@ -177,13 +177,13 @@ impl McpServer {
                 "deepseek" => {
                     tools.push(json!({
                         "name": "deepseek",
-                        "description": "Send a prompt to DeepSeek and get a response. Creates a new conversation thread.",
+                        "description": "Send a prompt to Codewhale and get a response. Creates a new conversation thread.",
                         "inputSchema": {
                             "type": "object",
                             "properties": {
                                 "prompt": {
                                     "type": "string",
-                                    "description": "The user prompt to send to DeepSeek"
+                                    "description": "The user prompt to send to Codewhale"
                                 },
                                 "model": {
                                     "type": "string",
@@ -201,7 +201,7 @@ impl McpServer {
                 "deepseek-reply" => {
                     tools.push(json!({
                         "name": "deepseek-reply",
-                        "description": "Continue an existing conversation thread with DeepSeek. Requires a thread_id from a previous deepseek call.",
+                        "description": "Continue an existing conversation thread with Codewhale. Requires a thread_id from a previous deepseek call.",
                         "inputSchema": {
                             "type": "object",
                             "properties": {

--- a/crates/tui/src/route_budget.rs
+++ b/crates/tui/src/route_budget.rs
@@ -55,7 +55,8 @@ pub(crate) fn route_output_limit_tokens(route_limits: Option<RouteLimits>) -> Op
 /// Effective `max_tokens` for a model before provider/route caps are applied.
 #[must_use]
 pub(crate) fn effective_max_output_tokens(model: &str) -> u32 {
-    if let Ok(raw) = std::env::var("DEEPSEEK_MAX_OUTPUT_TOKENS")
+    if let Ok(raw) = std::env::var("CODEWHALE_MAX_OUTPUT_TOKENS")
+        .or_else(|_| std::env::var("DEEPSEEK_MAX_OUTPUT_TOKENS"))
         && let Ok(tokens) = raw.trim().parse::<u32>()
         && tokens > 0
     {

--- a/crates/tui/src/runtime_threads.rs
+++ b/crates/tui/src/runtime_threads.rs
@@ -1170,15 +1170,11 @@ pub struct RuntimeThreadManagerConfig {
 impl RuntimeThreadManagerConfig {
     #[must_use]
     pub fn from_task_data_dir(task_data_dir: PathBuf) -> Self {
-        let data_dir = if let Ok(override_dir) = std::env::var("DEEPSEEK_RUNTIME_DIR") {
-            if override_dir.trim().is_empty() {
-                task_data_dir.join("runtime")
-            } else {
-                PathBuf::from(override_dir)
-            }
-        } else {
-            task_data_dir.join("runtime")
-        };
+        let data_dir = std::env::var("CODEWHALE_RUNTIME_DIR")
+            .or_else(|_| std::env::var("DEEPSEEK_RUNTIME_DIR"))
+            .ok()
+            .filter(|override_dir| !override_dir.trim().is_empty())
+            .map_or_else(|| task_data_dir.join("runtime"), PathBuf::from);
         Self {
             data_dir,
             task_data_dir,

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -1443,12 +1443,15 @@ fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathB
 
 fn legacy_config_override_parent() -> Option<PathBuf> {
     fn read() -> Option<PathBuf> {
-        let config_path = std::env::var("DEEPSEEK_CONFIG_PATH").ok()?;
-        let config_path = config_path.trim();
-        if config_path.is_empty() {
-            return None;
+        for var in ["CODEWHALE_CONFIG_PATH", "DEEPSEEK_CONFIG_PATH"] {
+            if let Ok(config_path) = std::env::var(var) {
+                let config_path = config_path.trim();
+                if !config_path.is_empty() {
+                    return expand_path(config_path).parent().map(Path::to_path_buf);
+                }
+            }
         }
-        expand_path(config_path).parent().map(Path::to_path_buf)
+        None
     }
 
     #[cfg(test)]

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -1847,10 +1847,12 @@ fn default_auto_approve() -> bool {
 /// `~/.deepseek/tasks` when only the legacy directory exists).
 #[must_use]
 pub fn default_tasks_dir() -> PathBuf {
-    if let Ok(path) = std::env::var("DEEPSEEK_TASKS_DIR")
-        && !path.trim().is_empty()
-    {
-        return PathBuf::from(path);
+    for var in ["CODEWHALE_TASKS_DIR", "DEEPSEEK_TASKS_DIR"] {
+        if let Ok(path) = std::env::var(var)
+            && !path.trim().is_empty()
+        {
+            return PathBuf::from(path);
+        }
     }
     dirs::home_dir()
         .map(|home| default_tasks_dir_for_home(&home))

--- a/crates/tui/src/task_manager.rs
+++ b/crates/tui/src/task_manager.rs
@@ -1,4 +1,4 @@
-//! Persistent background task manager for DeepSeek agent work.
+//! Persistent background task manager for Codewhale agent work.
 //!
 //! Tasks are durable across restarts and execute with a bounded worker pool.
 //! Execution stays DeepSeek-only and now links every task to runtime

--- a/crates/tui/src/tools/finance.rs
+++ b/crates/tui/src/tools/finance.rs
@@ -30,9 +30,11 @@ struct FinanceEndpoints {
 impl Default for FinanceEndpoints {
     fn default() -> Self {
         Self {
-            quote_base: std::env::var("DEEPSEEK_FINANCE_QUOTE_BASE_URL")
+            quote_base: std::env::var("CODEWHALE_FINANCE_QUOTE_BASE_URL")
+                .or_else(|_| std::env::var("DEEPSEEK_FINANCE_QUOTE_BASE_URL"))
                 .unwrap_or_else(|_| "https://query1.finance.yahoo.com/v7/finance/quote".into()),
-            chart_base: std::env::var("DEEPSEEK_FINANCE_CHART_BASE_URL")
+            chart_base: std::env::var("CODEWHALE_FINANCE_CHART_BASE_URL")
+                .or_else(|_| std::env::var("DEEPSEEK_FINANCE_CHART_BASE_URL"))
                 .unwrap_or_else(|_| "https://query1.finance.yahoo.com/v8/finance/chart".into()),
         }
     }

--- a/crates/tui/src/tools/github.rs
+++ b/crates/tui/src/tools/github.rs
@@ -392,7 +392,8 @@ fn close_github_thread(
 }
 
 fn gh_bin() -> String {
-    if let Ok(bin) = std::env::var("DEEPSEEK_GH_BIN") {
+    if let Ok(bin) = std::env::var("CODEWHALE_GH_BIN").or_else(|_| std::env::var("DEEPSEEK_GH_BIN"))
+    {
         return bin;
     }
     for path in FALLBACK_GH_PATHS {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -9893,7 +9893,7 @@ async fn apply_command_result(
                 app.status_message = Some(message);
             }
             AppAction::CacheWarmup => {
-                app.status_message = Some("Warming DeepSeek cache...".to_string());
+                app.status_message = Some("Warming prompt cache...".to_string());
                 match run_cache_warmup(app, config).await {
                     Ok((usage, base_url, inspection)) => {
                         app.session.last_base_url = Some(base_url.clone());

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -731,47 +731,36 @@ Remaining variables:
 - `OLLAMA_BASE_URL`
 - `OLLAMA_MODEL`
 - `OLLAMA_API_KEY` (optional; many localhost Ollama servers do not require auth)
-- `DEEPSEEK_LOG_LEVEL` or `RUST_LOG` (`info`/`debug`/`trace` enables lightweight verbose logs)
-- `DEEPSEEK_SKILLS_DIR`
-- `DEEPSEEK_MCP_CONFIG`
-- `DEEPSEEK_NOTES_PATH`
-- `DEEPSEEK_MEMORY` (`1|on|true|yes|y|enabled` turns user memory on)
-- `DEEPSEEK_MEMORY_PATH`
-- `DEEPSEEK_ALLOW_SHELL` (`1`/`true` enables)
-- `DEEPSEEK_APPROVAL_POLICY` (`on-request|untrusted|never`)
-- `DEEPSEEK_SANDBOX_MODE` (`read-only|workspace-write|danger-full-access|external-sandbox`)
-- `DEEPSEEK_MANAGED_CONFIG_PATH`
-- `DEEPSEEK_REQUIREMENTS_PATH`
-- `DEEPSEEK_MAX_SUBAGENTS` (clamped to `1..=20`)
-- `DEEPSEEK_TASKS_DIR` (runtime task queue/artifact storage, default
+For every product-level `CODEWHALE_*` variable below, the matching legacy
+`DEEPSEEK_*` name is still read as a compatibility fallback; when both are set,
+the `CODEWHALE_*` value wins.
+
+- `CODEWHALE_LOG_LEVEL` or `RUST_LOG` (`info`/`debug`/`trace` enables lightweight verbose logs)
+- `CODEWHALE_SKILLS_DIR`
+- `CODEWHALE_MCP_CONFIG`
+- `CODEWHALE_NOTES_PATH`
+- `CODEWHALE_MEMORY` (`1|on|true|yes|y|enabled` turns user memory on)
+- `CODEWHALE_MEMORY_PATH`
+- `CODEWHALE_ALLOW_SHELL` (`1`/`true` enables)
+- `CODEWHALE_APPROVAL_POLICY` (`on-request|untrusted|never`)
+- `CODEWHALE_SANDBOX_MODE` (`read-only|workspace-write|danger-full-access|external-sandbox`)
+- `CODEWHALE_MANAGED_CONFIG_PATH`
+- `CODEWHALE_REQUIREMENTS_PATH`
+- `CODEWHALE_MAX_SUBAGENTS` (clamped to `1..=20`)
+- `CODEWHALE_TASKS_DIR` (runtime task queue/artifact storage, default
   `~/.codewhale/tasks`, with legacy `~/.deepseek/tasks` fallback when only the
   legacy directory exists)
-- `DEEPSEEK_ALLOW_INSECURE_HTTP` (`1`/`true` allows non-local `http://` base URLs; default is reject)
-- `DEEPSEEK_FORCE_HTTP1` (`1|true|yes|on` pins the HTTP client to HTTP/1.1, disabling HTTP/2; useful on Windows or behind proxies that mishandle long-lived H2 streams)
+- `CODEWHALE_ALLOW_INSECURE_HTTP` (`1`/`true` allows non-local `http://` base URLs; default is reject)
+- `CODEWHALE_FORCE_HTTP1` (`1|true|yes|on` pins the HTTP client to HTTP/1.1, disabling HTTP/2; useful on Windows or behind proxies that mishandle long-lived H2 streams)
 - `CODEWHALE_HOME` (override the base data directory; defaults to `~/.codewhale`).
   If you previously exported `DEEPSEEK_HOME`, rename it to `CODEWHALE_HOME`;
   the old env var is not used for new Codewhale state paths.
 - `CODEWHALE_RELEASE_BASE_URL` (release asset mirror used by `codewhale update`
   and by TUI startup update checks when `[update].update_uri` is not set, or as
   a fallback when that configured URI cannot be fetched)
-- `DEEPSEEK_AUTOMATIONS_DIR` (override the automations storage directory; uses
+- `CODEWHALE_AUTOMATIONS_DIR` (override the automations storage directory; uses
   `~/.codewhale/automations` by default, with legacy `~/.deepseek/automations`
   fallback when only the legacy directory exists)
-- `DEEPSEEK_CAPACITY_ENABLED`
-- `DEEPSEEK_CAPACITY_LOW_RISK_MAX`
-- `DEEPSEEK_CAPACITY_MEDIUM_RISK_MAX`
-- `DEEPSEEK_CAPACITY_SEVERE_MIN_SLACK`
-- `DEEPSEEK_CAPACITY_SEVERE_VIOLATION_RATIO`
-- `DEEPSEEK_CAPACITY_REFRESH_COOLDOWN_TURNS`
-- `DEEPSEEK_CAPACITY_REPLAN_COOLDOWN_TURNS`
-- `DEEPSEEK_CAPACITY_MAX_REPLAY_PER_TURN`
-- `DEEPSEEK_CAPACITY_MIN_TURNS_BEFORE_GUARDRAIL`
-- `DEEPSEEK_CAPACITY_PROFILE_WINDOW`
-- `DEEPSEEK_CAPACITY_PRIOR_CHAT`
-- `DEEPSEEK_CAPACITY_PRIOR_REASONER`
-- `DEEPSEEK_CAPACITY_PRIOR_V4_PRO`
-- `DEEPSEEK_CAPACITY_PRIOR_V4_FLASH`
-- `DEEPSEEK_CAPACITY_PRIOR_FALLBACK`
 - `NO_ANIMATIONS` (`1|true|yes|on` forces `low_motion = true` and
   `fancy_animations = false` at startup, regardless of the saved
   settings; see [`docs/ACCESSIBILITY.md`](./ACCESSIBILITY.md)).


### PR DESCRIPTION
v0.9.1 queue item: identity/plugin/naming remainder. Three parts; part 3 is a survey with a gap report (no feature work landed for it).

## 1. `CODEWHALE_*` env precedence (primary) with `DEEPSEEK_*` fallback

No `DEEPSEEK_*` variable was removed; every site keeps the legacy name as a working fallback. `CODEWHALE_*` now wins when both are set.

**`codewhale-config` (`EnvRuntimeOverrides::load`)** — added missing `CODEWHALE_*` primaries for: `OUTPUT_MODE`, `AUTH_MODE`, `LOG_LEVEL`, `TELEMETRY`, `APPROVAL_POLICY`, `SANDBOX_MODE`, `YOLO`, `HTTP_HEADERS`.

**`codewhale-cli`**
- Dispatcher → TUI handoff now exports both names for `--model`, `--output-mode`, `--log-level`, `--telemetry`, `--approval-policy`, `--sandbox-mode`, `--yolo`, `--base-url` (matching the existing `PROVIDER`/`VERBOSITY` pattern). Without this, an inherited `CODEWHALE_*` shell export would outrank an explicit CLI flag under CODEWHALE-first reads in the child.
- `CODEWHALE_TUI_BIN` now consulted before `DEEPSEEK_TUI_BIN` (precedence test added); spawn-failure copy names the canonical var.
- `codewhale metrics` honors `CODEWHALE_HOME` before `DEEPSEEK_HOME` (no-env default unchanged).

**`codewhale-tui`** — added `CODEWHALE_*` primaries for: `HTTP_HEADERS`, `SKILLS_DIR`, `MCP_CONFIG`, `NOTES_PATH`, `MEMORY_PATH`, `MEMORY`, `ALLOW_SHELL`, `APPROVAL_POLICY`, `SANDBOX_MODE`, `YOLO`, `SANDBOX_BACKEND`, `SANDBOX_URL`, `SANDBOX_API_KEY`, `MANAGED_CONFIG_PATH`, `SEARCH_API_KEY`, `SEARCH_PROVIDER`, `REQUIREMENTS_PATH`, `MAX_SUBAGENTS`, `STREAM_IDLE_TIMEOUT_SECS`, `STREAM_OPEN_TIMEOUT_SECS`, `LOG_LEVEL`, `MAX_OUTPUT_TOKENS`, `RATE_LIMIT_RPS`/`RATE_LIMIT_BURST`, `FORCE_HTTP1`, `ALLOW_INSECURE_HTTP`, `TASKS_DIR`, `AUTOMATIONS_DIR`, `RUNTIME_DIR`, `GH_BIN`, `FINANCE_QUOTE_BASE_URL`/`FINANCE_CHART_BASE_URL`, `TOOL_AUDIT_LOG`, `PROFILE`, `BASE_URL` (dispatcher handoff reads), `CONFIG_PATH` (settings sibling override). The approval-policy/allow-shell *control classifiers* treat either name as an Environment source so `/config` editability reporting matches the override that actually applies.

Side effect worth noting: `remote_setup` bundles already emit `CODEWHALE_ALLOW_SHELL=true` in generated env files — that key was previously write-only (nothing read it); it now takes effect. `CODEWHALE_AUTO_APPROVE` in the same bundle template still has no reader anywhere (pre-existing; left for a follow-up, see below).

**Deliberately left alone (not product identity):**
- Provider-scoped vars where DeepSeek is the *provider*: `DEEPSEEK_API_KEY`, provider `DEEPSEEK_BASE_URL` slot semantics, `DEEPSEEK_ANTHROPIC_*`/`DEEPSEEK_CLAUDE_BASE_URL`, model/alias/context-window vars (`DEEPSEEK_MODELS`, `DEEPSEEK_V4_*`, `DEEPSEEK_ALIAS_*`, `DEEPSEEK_TEST_MODEL`, …).
- Internal dispatcher↔TUI handshake `DEEPSEEK_API_KEY_SOURCE` (paired with the existing `CODEWHALE_CLI_API_KEY` slot).
- Hook/child-env *exports* (`DEEPSEEK_MODE`, `DEEPSEEK_WORKSPACE`, `DEEPSEEK_TOOL_*`, `DEEPSEEK_SANDBOX` marker): these are an output contract with user hook scripts, not precedence reads. Adding duplicate `CODEWHALE_*` exports is a follow-up decision, not a precedence bug.
- Test-only vars and build metadata (`DEEPSEEK_BUILD_*`, `DEEPSEEK_TUI_VERSION`, `*_TEST_SECRET`).

**Docs:** `docs/CONFIGURATION.md` env list now shows the canonical `CODEWHALE_*` names with a fallback note, and drops the stale `DEEPSEEK_CAPACITY_*` bullets (the capacity system was removed; `rg` finds zero readers in `crates/`).

## 2. DeepSeek product-identity stragglers (fixed)

Only product-presenting strings changed; DeepSeek as a provider/model name and internal type names (`DeepSeekClient`, …) are untouched.

- `crates/tui/src/tui/ui.rs` — `/cache warmup` status `"Warming DeepSeek cache..."` → `"Warming prompt cache..."` (warmup runs on the active provider route, not only DeepSeek).
- `crates/tui/src/main.rs` — `codewhale mcp register` confirmation `"Registered DeepSeek as MCP server '{name}'"` → `"Registered Codewhale as MCP server '{name}'"`.
- `crates/tui/src/mcp_server.rs` — MCP tool descriptions `"Send a prompt to DeepSeek…"`, `"The user prompt to send to DeepSeek"`, `"Continue an existing conversation thread with DeepSeek…"` → Codewhale. Wire-level tool names `deepseek`/`deepseek-reply` and `serverInfo.name = "deepseek-mcp-server"` intentionally kept as compatibility identifiers (renaming them breaks existing MCP client configs).
- `crates/tui/src/client.rs` — insecure-HTTP refusal told users to re-run `deepseek`; now says `codewhale` and names `CODEWHALE_ALLOW_INSECURE_HTTP`.
- `crates/tui/src/task_manager.rs` — module doc "DeepSeek agent work" → "Codewhale agent work".

## 3. Plugin installer registry/GitHub flow — survey (no code landed)

**What exists today (`crates/tui/src/plugins/` + `/plugin` command):**
- Filesystem discovery only: user dir (`~/.codewhale/plugins`, via `codewhale_home()`, fail-closed when home cannot be resolved), workspace plugins dir, and an empty built-in list (v0.9.1 deliberately activates no packaged bundle).
- A complete local trust pipeline: manifest validation (`plugin.toml`, `deny_unknown_fields`, capability declarations including `network_hosts` normalization), content/capability hashing, staged roots, symlink/reparse-point identity checks, and a two-step trust confirmation (`/plugin trust <selector>` renders a capability review, then `/plugin trust <selector> <token>` records a hash-bound trust receipt with review history; `enable`/`disable`/`revoke`/`reload` complete the lifecycle).

**What is missing for a registry/GitHub install flow (all of it):**
- No `install` subcommand on `/plugin` or the `codewhale` CLI; no registry client, no registry index format/endpoint, no GitHub fetch/clone/download path; zero network code under `crates/tui/src/plugins/` (verified by grep for reqwest/http/download/clone).
- Therefore also missing: network-approval prompt for the fetch itself, artifact verification (checksum/signature/pinned ref), an unpack-to-staging step that lands the bundle untrusted, and post-install handoff into the existing trust review.

**Assessment:** this is genuine feature work (network client + registry contract + fetch approval UX + artifact verification), not a small bounded gap — so per the task scope nothing was built. The hard part already exists: an installer only needs to (1) gate the fetch behind an explicit network approval, (2) verify and unpack into the user plugins dir as *untrusted*, and (3) route the user into the existing `/plugin trust` capability-review/token flow, which already provides the trust confirmation. Related pre-existing loose end spotted during the survey: `CODEWHALE_AUTO_APPROVE` is emitted by remote-setup bundles but read nowhere.

## Gates

- `cargo fmt` — clean (`cargo fmt --check` passes)
- `cargo test -p codewhale-config --locked` — 419 + 1 doc test passed
- `cargo test -p codewhale-cli --locked` — 168 passed across targets (includes new `locate_sibling_tui_binary_prefers_codewhale_env_override`)
- `cargo test -p codewhale-tui --bin codewhale-tui --locked` — 7617 passed, 0 failed, 3 ignored
- `cargo clippy -p codewhale-tui --all-targets --all-features --locked -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k4QdrM6vV3HSGggqjXpY6
