### PR TITLE
fix(tui): restore durable Work surface progress

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "debrief: {done}/{total} settled · {failed} failed · {cancelled} cancelled · {elapsed}",
     "SidebarTasksLabel": "Tasks",
     "SidebarTodoLabel": "To-do",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · {remaining} left",
     "SidebarStopControl": "stop",
     "SidebarDestructiveArmed": "Destructive action armed — press Enter to confirm or clear the draft to cancel",
     "WorkSurfaceStopConfirmHint": "confirm stop · Esc cancels",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "resumen: {done}/{total} resueltos · {failed} fallidos · {cancelled} cancelados · {elapsed}",
     "SidebarTasksLabel": "Tareas",
     "SidebarTodoLabel": "Pendientes",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · {remaining} restantes",
     "SidebarStopControl": "detener",
     "SidebarDestructiveArmed": "Acción destructiva armada — presiona Enter para confirmar o limpia el borrador para cancelar",
     "WorkSurfaceStopConfirmHint": "confirmar detención · Esc cancela",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "総括: {done}/{total} 確定 · {failed} 失敗 · {cancelled} キャンセル · {elapsed}",
     "SidebarTasksLabel": "タスク",
     "SidebarTodoLabel": "To-do",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · 残り{remaining}",
     "SidebarStopControl": "停止",
     "SidebarDestructiveArmed": "破壊的操作が実行待ちです — Enter で確定、取り消すには下書きをクリアしてください",
     "WorkSurfaceStopConfirmHint": "停止を確認 · Esc でキャンセル",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "결과 보고: {done}/{total} 종결 · {failed} 실패 · {cancelled} 취소 · {elapsed}",
     "SidebarTasksLabel": "작업",
     "SidebarTodoLabel": "할 일",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · {remaining}개 남음",
     "SidebarStopControl": "중지",
     "SidebarDestructiveArmed": "파괴적 작업이 준비되었습니다 — Enter를 누르면 확인, 초안을 지우면 취소됩니다",
     "WorkSurfaceStopConfirmHint": "중지 확인 · Esc로 취소",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "balanço: {done}/{total} encerrados · {failed} falhou · {cancelled} cancelado · {elapsed}",
     "SidebarTasksLabel": "Tarefas",
     "SidebarTodoLabel": "A fazer",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · {remaining} restantes",
     "SidebarStopControl": "parar",
     "SidebarDestructiveArmed": "Ação destrutiva armada — pressione Enter para confirmar ou limpe o rascunho para cancelar",
     "WorkSurfaceStopConfirmHint": "confirmar parada · Esc cancela",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "tổng kết: {done}/{total} đã chốt · {failed} thất bại · {cancelled} đã hủy · {elapsed}",
     "SidebarTasksLabel": "Nhiệm vụ",
     "SidebarTodoLabel": "Cần làm",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · còn {remaining}",
     "SidebarStopControl": "dừng",
     "SidebarDestructiveArmed": "Thao tác phá hủy đã kích hoạt — nhấn Enter để xác nhận hoặc xóa bản nháp để hủy",
     "WorkSurfaceStopConfirmHint": "xác nhận dừng · Esc để hủy",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -992,6 +992,7 @@
     "WorkflowDebrief": "复盘：{done}/{total} 已完结 · {failed} 失败 · {cancelled} 已取消 · {elapsed}",
     "SidebarTasksLabel": "任务",
     "SidebarTodoLabel": "待办",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · 剩余 {remaining}",
     "SidebarStopControl": "停止",
     "SidebarDestructiveArmed": "破坏性操作已就绪 — 按 Enter 确认，或清空草稿以取消",
     "WorkSurfaceStopConfirmHint": "确认停止 · Esc 取消",

--- a/crates/tui/locales/zh-Hant.json
+++ b/crates/tui/locales/zh-Hant.json
@@ -1,6 +1,7 @@
 {
     "SidebarStopControl": "停止",
     "WorkSurfaceStopConfirmHint": "確認停止 · Esc 取消",
+    "WorkSurfaceTodoProgress": "{label} {completed}/{total} · 剩餘 {remaining}",
     "ComposerDispatchFailedRestored": "訊息未傳送（{error}）；已還原到輸入框。",
     "CmdAuthDescription": "管理提供者驗證流程",
     "CmdRelayDescription": "為新執行緒建立會話接力摘要",

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1131,6 +1131,7 @@ pub enum MessageId {
     SidebarTodoLabel,
     SidebarStopControl,
     SidebarDestructiveArmed,
+    WorkSurfaceTodoProgress,
     WorkSurfaceStopConfirmHint,
     // Composer slash menu.
     ComposerSlashMenuHint,
@@ -2148,6 +2149,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::SidebarTodoLabel,
     MessageId::SidebarStopControl,
     MessageId::SidebarDestructiveArmed,
+    MessageId::WorkSurfaceTodoProgress,
     MessageId::WorkSurfaceStopConfirmHint,
     MessageId::ComposerSlashMenuHint,
     MessageId::ApprovalRepoLawBadge,

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -199,6 +199,7 @@ mod tests {
         let rows = super::model::project(&mut app);
 
         assert!(rows[0].label.starts_with("Work · 1 running · 3 ready"));
+        assert_eq!(rows[1].label, "To-do 0/4 · 4 left");
         for index in 0..4 {
             assert!(
                 rows.iter()
@@ -206,6 +207,21 @@ mod tests {
             );
         }
         assert!(rows.iter().all(|row| !row.id.0.starts_with("todo:")));
+    }
+
+    #[test]
+    fn todo_heading_reports_completed_total_and_remaining() {
+        let mut app = app();
+        {
+            let mut todos = app.todos.try_lock().expect("todos");
+            todos.add("finished".to_string(), TodoStatus::Completed);
+            todos.add("current".to_string(), TodoStatus::InProgress);
+            todos.add("next".to_string(), TodoStatus::Pending);
+        }
+
+        let rows = super::model::project(&mut app);
+
+        assert_eq!(rows[1].label, "To-do 1/3 · 2 left");
     }
 
     #[test]
@@ -461,6 +477,101 @@ mod tests {
         assert!(outcome.consumed);
         assert_eq!(app.viewport.pending_scroll_delta, transcript_delta);
         assert!(app.work_surface.scroll_offset > 0);
+    }
+
+    #[test]
+    fn mouse_wheel_reaches_last_todo_across_top_surface_heights() {
+        for height in [3, 5, 6, 8] {
+            let mut app = app();
+            add_todos(&mut app, 10);
+            let _ = render_text(&mut app, 80, height);
+            assert!(app.work_surface.total_rows > app.work_surface.visible_rows);
+            let transcript_delta = app.viewport.pending_scroll_delta;
+
+            let mut text = String::new();
+            for _ in 0..16 {
+                let outcome = super::handle_mouse(
+                    &mut app,
+                    MouseEvent {
+                        kind: MouseEventKind::ScrollDown,
+                        column: 10,
+                        row: 1,
+                        modifiers: KeyModifiers::NONE,
+                    },
+                );
+                assert!(outcome.consumed, "height {height}");
+                text = render_text(&mut app, 80, height);
+            }
+
+            assert!(
+                text.contains("work item 9"),
+                "last To-do was unreachable at surface height {height}: {text:?}"
+            );
+            assert_eq!(
+                app.work_surface.scroll_offset,
+                app.work_surface
+                    .total_rows
+                    .saturating_sub(app.work_surface.visible_rows.max(1)),
+                "wheel did not reach the legal tail at surface height {height}"
+            );
+            assert_eq!(app.viewport.pending_scroll_delta, transcript_delta);
+        }
+    }
+
+    #[test]
+    fn mouse_wheel_reaches_last_todo_in_side_rail_placements() {
+        for placement in [
+            super::WorkSurfacePlacement::Left,
+            super::WorkSurfacePlacement::Right,
+        ] {
+            let mut app = app();
+            add_todos(&mut app, 10);
+            app.work_surface.placement = placement;
+            app.work_surface.effective_placement = placement;
+            let _ = render_text(&mut app, 30, 6);
+
+            let mut text = String::new();
+            for _ in 0..16 {
+                let outcome = super::handle_mouse(
+                    &mut app,
+                    MouseEvent {
+                        kind: MouseEventKind::ScrollDown,
+                        column: 10,
+                        row: 1,
+                        modifiers: KeyModifiers::NONE,
+                    },
+                );
+                assert!(outcome.consumed, "placement {placement:?}");
+                text = render_text(&mut app, 30, 6);
+            }
+
+            assert!(
+                text.contains("work item 9"),
+                "last To-do was unreachable in {placement:?}: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn keyboard_end_reveals_last_todo_after_redraw() {
+        let mut app = app();
+        add_todos(&mut app, 10);
+        let _ = render_text(&mut app, 80, 5);
+        let _ = super::handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT),
+        );
+        let _ = super::handle_key(&mut app, KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
+
+        let text = render_text(&mut app, 80, 5);
+
+        assert!(text.contains("work item 9"), "{text:?}");
+        assert_eq!(
+            app.work_surface.scroll_offset,
+            app.work_surface
+                .total_rows
+                .saturating_sub(app.work_surface.visible_rows.max(1))
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -3,6 +3,7 @@ use std::fmt::Write as _;
 
 use ratatui::layout::Rect;
 
+use crate::localization::MessageId;
 use crate::tui::app::{App, SidebarRowAction};
 use crate::work_graph::{
     AcceptanceRequirement, EdgeKind, EvidenceKind, EvidenceKindTag, NodeKind, NodeState,
@@ -145,7 +146,11 @@ impl WorkSurfaceState {
             .and_then(|selected| rows.iter().position(|row| &row.id == selected))
     }
 
-    pub(super) fn clamp_selection(&mut self, rows: &[WorkRow]) {
+    /// Keep row identity and the viewport offset valid without moving the
+    /// viewport to the remembered keyboard selection. Mouse-wheel scrolling
+    /// is allowed to leave that selection off-screen until keyboard
+    /// navigation resumes.
+    pub(super) fn clamp_viewport(&mut self, rows: &[WorkRow]) {
         let selectable = rows.iter().filter(|row| row.selectable).collect::<Vec<_>>();
         if selectable.is_empty() {
             self.selected = None;
@@ -159,7 +164,19 @@ impl WorkSurfaceState {
         {
             self.selected = Some(selectable[0].id.clone());
         }
-        let selected = self.selected_index(rows).unwrap_or_default();
+        self.scroll_offset = self
+            .scroll_offset
+            .min(rows.len().saturating_sub(self.visible_rows.max(1)));
+    }
+
+    /// Reveal the remembered selection after keyboard navigation. Rendering
+    /// alone must use `clamp_viewport`; otherwise every redraw undoes a mouse
+    /// wheel offset when the selection is above the viewport.
+    pub(super) fn clamp_selection(&mut self, rows: &[WorkRow]) {
+        self.clamp_viewport(rows);
+        let Some(selected) = self.selected_index(rows) else {
+            return;
+        };
         if selected < self.scroll_offset {
             self.scroll_offset = selected;
         } else if self.visible_rows > 0
@@ -174,6 +191,9 @@ impl WorkSurfaceState {
 }
 
 pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
+    let todo_label = app.tr(MessageId::SidebarTodoLabel).into_owned();
+    let todo_progress = app.tr(MessageId::WorkSurfaceTodoProgress).into_owned();
+    let plan_label = app.tr(MessageId::AppModePlan).into_owned();
     let active_session = app.current_session_id.is_some();
     let capture = app.runtime_services.work.as_ref().map(|work| {
         work.try_capture(app.current_session_id.as_deref())
@@ -200,9 +220,16 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
     };
 
     let rows = match graph {
-        Some(graph) => graph_rows(&graph, source_state.as_ref()),
+        Some(graph) => graph_rows(
+            &graph,
+            source_state.as_ref(),
+            &todo_label,
+            &todo_progress,
+            &plan_label,
+        ),
         None => source_state.map_or_else(Vec::new, |state| {
-            vec![heading(
+            vec![section_heading(
+                "work",
                 &format!("Work · {}", state.label()),
                 state.detail(),
             )]
@@ -220,6 +247,9 @@ pub(super) fn project(app: &mut App) -> Vec<WorkRow> {
 fn graph_rows(
     snapshot: &WorkGraphSnapshot,
     source_state: Option<&WorkSourceState>,
+    todo_label: &str,
+    todo_progress: &str,
+    plan_label: &str,
 ) -> Vec<WorkRow> {
     let visible = snapshot
         .nodes
@@ -230,6 +260,7 @@ fn graph_rows(
                 NodeKind::PlanStep | NodeKind::Operation | NodeKind::Blocker
             )
         })
+        .filter(|node| !is_settled_transient_operation(node))
         .collect::<Vec<_>>();
     let running = visible
         .iter()
@@ -259,21 +290,110 @@ fn graph_rows(
     } else {
         String::new()
     };
-    let mut rows = vec![heading(
+    let mut rows = vec![section_heading(
+        "work",
         &format!("Work · {running} running{waiting} · {ready} ready · {blocked} blocked{status}"),
         &detail,
     )];
+
+    // Runtime operations and blockers are live/attention state. Cleanly
+    // settled non-durable operations are graph receipts, not permanent chrome,
+    // and were filtered above. Keep the remaining operational rows first.
     rows.extend(
         visible
-            .into_iter()
+            .iter()
+            .copied()
+            .filter(|node| node.kind != NodeKind::PlanStep)
             .map(|node| graph_node_row(snapshot, node)),
     );
+
+    // The Work Graph is authoritative, but the explicit To-do grouping is a
+    // useful projection contract. Preserve compat ordering and do not flatten
+    // durable checklist rows into transient shell activity.
+    let mut rendered_plan_nodes = HashSet::new();
+    let todo_nodes = snapshot
+        .compat
+        .todos
+        .iter()
+        .filter_map(|binding| snapshot.node(&binding.node))
+        .filter(|node| visible.iter().any(|candidate| candidate.id == node.id))
+        .collect::<Vec<_>>();
+    if !todo_nodes.is_empty() {
+        let completed = todo_nodes
+            .iter()
+            .filter(|node| matches!(node.state, NodeState::Completed | NodeState::Verified))
+            .count();
+        let total = todo_nodes.len();
+        let progress = todo_progress
+            .replace("{label}", todo_label)
+            .replace("{completed}", &completed.to_string())
+            .replace("{total}", &total.to_string())
+            .replace("{remaining}", &total.saturating_sub(completed).to_string());
+        rows.push(section_heading("todo", &progress, todo_label));
+        for node in todo_nodes {
+            rendered_plan_nodes.insert(node.id.clone());
+            rows.push(graph_node_row(snapshot, node));
+        }
+    }
+
+    // Plan-only steps remain visible without duplicating nodes that also back
+    // the To-do compatibility projection.
+    let mut strategy_nodes = snapshot
+        .compat
+        .plan_order
+        .iter()
+        .filter(|id| !rendered_plan_nodes.contains(*id))
+        .filter_map(|id| snapshot.node(id))
+        .filter(|node| visible.iter().any(|candidate| candidate.id == node.id))
+        .collect::<Vec<_>>();
+    for node in visible
+        .iter()
+        .copied()
+        .filter(|node| node.kind == NodeKind::PlanStep)
+    {
+        if !rendered_plan_nodes.contains(&node.id)
+            && !strategy_nodes
+                .iter()
+                .any(|candidate| candidate.id == node.id)
+        {
+            strategy_nodes.push(node);
+        }
+    }
+    if !strategy_nodes.is_empty() {
+        let completed = strategy_nodes
+            .iter()
+            .filter(|node| matches!(node.state, NodeState::Completed | NodeState::Verified))
+            .count();
+        rows.push(section_heading(
+            "strategy",
+            &format!("{plan_label} {completed}/{}", strategy_nodes.len()),
+            plan_label,
+        ));
+        rows.extend(
+            strategy_nodes
+                .into_iter()
+                .map(|node| graph_node_row(snapshot, node)),
+        );
+    }
     rows
 }
 
-fn heading(label: &str, detail: &str) -> WorkRow {
+fn is_settled_transient_operation(node: &WorkNode) -> bool {
+    node.kind == NodeKind::Operation
+        && node
+            .binding
+            .as_ref()
+            .is_some_and(|binding| !binding.durable)
+        && match node.state {
+            NodeState::Completed => node.acceptance.is_empty(),
+            NodeState::Verified | NodeState::Superseded | NodeState::Cancelled => true,
+            _ => false,
+        }
+}
+
+fn section_heading(id: &str, label: &str, detail: &str) -> WorkRow {
     WorkRow {
-        id: WorkRowId("section:work".to_string()),
+        id: WorkRowId(format!("section:{id}")),
         mark: "▾",
         label: label.to_string(),
         detail: detail.to_string(),
@@ -703,7 +823,7 @@ fn section_list(out: &mut String, title: &str, items: Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::work_graph::{OperationBinding, WorkNodeId};
+    use crate::work_graph::{CompatTodoBinding, OperationBinding, WorkNodeId};
 
     fn operation(state: NodeState, suffix: &str) -> WorkNode {
         WorkNode {
@@ -736,11 +856,108 @@ mod tests {
             operation(NodeState::Ready, "ready"),
         ];
 
-        let rows = graph_rows(&snapshot, None);
+        let rows = graph_rows(
+            &snapshot,
+            None,
+            "To-do",
+            "{label} {completed}/{total} · {remaining} left",
+            "Plan",
+        );
 
         assert_eq!(
             rows.first().map(|row| row.label.as_str()),
             Some("Work · 2 running · 1 ready · 0 blocked")
         );
+    }
+
+    #[test]
+    fn live_projection_hides_clean_transient_receipts_and_restores_todo_group() {
+        let todo_id = WorkNodeId::derive("work-surface-test", "todo:1");
+        let todo = WorkNode {
+            id: todo_id.clone(),
+            kind: NodeKind::PlanStep,
+            title: "Keep the durable checklist visible".to_string(),
+            state: NodeState::Ready,
+            acceptance: Vec::new(),
+            binding: None,
+            evidence: None,
+            provenance: Provenance::ToolUpdate {
+                tool: "work_update".to_string(),
+                call_id: "todo-1".to_string(),
+            },
+            created_at: 1,
+            updated_at: 1,
+        };
+        let mut snapshot = WorkGraphSnapshot::new();
+        snapshot.nodes = vec![
+            operation(NodeState::Completed, "settled"),
+            operation(NodeState::Active, "running"),
+            todo,
+        ];
+        snapshot.compat.todos.push(CompatTodoBinding {
+            legacy_id: 1,
+            node: todo_id,
+            plan_index: None,
+        });
+
+        let rows = graph_rows(
+            &snapshot,
+            None,
+            "To-do",
+            "{label} {completed}/{total} · {remaining} left",
+            "Plan",
+        );
+        let labels = rows
+            .iter()
+            .map(|row| row.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(labels.contains(&"operation running"), "{labels:?}");
+        assert!(!labels.contains(&"operation settled"), "{labels:?}");
+        assert!(labels.contains(&"To-do 0/1 · 1 left"), "{labels:?}");
+        assert!(
+            labels.contains(&"Keep the durable checklist visible"),
+            "{labels:?}"
+        );
+        assert!(
+            snapshot
+                .nodes
+                .iter()
+                .any(|node| node.title == "operation settled"),
+            "projection filtering must retain the historical graph receipt"
+        );
+    }
+
+    #[test]
+    fn projection_keeps_durable_and_attention_terminal_operations() {
+        let mut durable = operation(NodeState::Completed, "durable");
+        durable.binding.as_mut().expect("binding").durable = true;
+        let failed = operation(NodeState::Failed, "failed");
+        let mut evidence_pending = operation(NodeState::Completed, "evidence-pending");
+        evidence_pending.acceptance = vec![AcceptanceRequirement::EvidenceOfKind {
+            kind: EvidenceKindTag::ToolRun,
+        }];
+        let mut snapshot = WorkGraphSnapshot::new();
+        snapshot.nodes = vec![durable, failed, evidence_pending];
+
+        let rows = graph_rows(
+            &snapshot,
+            None,
+            "To-do",
+            "{label} {completed}/{total} · {remaining} left",
+            "Plan",
+        );
+        let labels = rows
+            .iter()
+            .map(|row| row.label.as_str())
+            .collect::<Vec<_>>();
+
+        for expected in [
+            "operation durable",
+            "operation failed",
+            "operation evidence-pending",
+        ] {
+            assert!(labels.contains(&expected), "missing {expected}: {labels:?}");
+        }
     }
 }

--- a/crates/tui/src/tui/work_surface/render.rs
+++ b/crates/tui/src/tui/work_surface/render.rs
@@ -175,7 +175,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
 
     app.work_surface.visible_rows = body_height;
     app.work_surface.total_rows = rows.len();
-    app.work_surface.clamp_selection(&rows);
+    // A redraw may clamp an obsolete offset, but it must not reveal the
+    // remembered keyboard selection: doing so undoes mouse-wheel scrolling
+    // whenever that selection is above the viewport (#4594).
+    app.work_surface.clamp_viewport(&rows);
     let max_offset = rows.len().saturating_sub(body_height.max(1));
     app.work_surface.scroll_offset = app.work_surface.scroll_offset.min(max_offset);
 

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -602,7 +602,11 @@ fn work_surface_real_rows_own_click_wheel_and_resize() -> anyhow::Result<()> {
         .frame()
         .find_text("todo-mouse-00")
         .expect("real rendered first To-do row");
-    h.send(keys::mouse::wheel_down(first_row, first_col))?;
+    for _ in 0..8 {
+        h.send(keys::mouse::wheel_down(first_row, first_col))?;
+        h.wait_for_idle(Duration::from_millis(40), Duration::from_secs(1))?;
+    }
+    h.wait_for_text("todo-mouse-13", KEY_TIMEOUT)?;
     h.wait_for_idle(Duration::from_millis(200), Duration::from_secs(3))?;
     assert!(
         !h.debug_dump().contains("[<65"),
@@ -612,11 +616,8 @@ fn work_surface_real_rows_own_click_wheel_and_resize() -> anyhow::Result<()> {
 
     h.resize(24, 80)?;
     h.wait_for_idle(Duration::from_millis(200), Duration::from_secs(3))?;
-    let target = if h.frame().contains("todo-mouse-02") {
-        "todo-mouse-02"
-    } else {
-        "todo-mouse-00"
-    };
+    h.wait_for_text("todo-mouse-13", KEY_TIMEOUT)?;
+    let target = "todo-mouse-13";
     let (row, col) = h.frame().find_text(target).expect("row survived resize");
     h.send(keys::mouse::click(row, col))?;
     h.wait_for_text("Work", KEY_TIMEOUT)?;


### PR DESCRIPTION
## Summary

- stop redraws from snapping wheel-scrolled Work surfaces back to the remembered keyboard selection
- hide clean transient completed operations from live chrome while retaining graph receipts and attention-worthy terminal work
- restore a localized To-do section with completed/total/remaining progress across top and side placements

Fixes #4594.

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [x] `cargo clippy -p codewhale-tui --bin codewhale-tui --tests --locked -- -D warnings`
- [x] Work surface unit tests: 24 passed
- [x] Localization tests: 19 passed
- [x] Real PTY wheel/resize tail regression passed

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [x] No harvested/co-authored credit in this change
