### PR TITLE
fix(tui): respect umask for workspace atomic writes

### DIFF
--- a/crates/tui/src/tools/apply_patch.rs
+++ b/crates/tui/src/tools/apply_patch.rs
@@ -1092,7 +1092,7 @@ fn apply_pending_writes(pending: &[PendingWrite]) -> Result<(), ToolError> {
             };
 
             parent_result.and_then(|()| {
-                crate::utils::write_atomic(&entry.path, content.as_bytes()).map_err(|e| {
+                crate::utils::write_atomic_workspace(&entry.path, content.as_bytes()).map_err(|e| {
                     ToolError::execution_failed(format!(
                         "Failed to write {}: {}",
                         entry.path.display(),
@@ -1127,7 +1127,7 @@ fn rollback_pending_writes(applied: &[PendingWrite]) {
     for entry in applied.iter().rev() {
         match entry.original.as_ref() {
             Some(content) => {
-                let _ = crate::utils::write_atomic(&entry.path, content.as_bytes());
+                let _ = crate::utils::write_atomic_workspace(&entry.path, content.as_bytes());
             }
             None => {
                 let _ = fs::remove_file(&entry.path);

--- a/crates/tui/src/tools/file.rs
+++ b/crates/tui/src/tools/file.rs
@@ -734,7 +734,7 @@ impl ToolSpec for WriteFileTool {
             })?;
         }
 
-        crate::utils::write_atomic(&file_path, file_content.as_bytes()).map_err(|e| {
+        crate::utils::write_atomic_workspace(&file_path, file_content.as_bytes()).map_err(|e| {
             ToolError::execution_failed(format!("Failed to write {}: {}", file_path.display(), e))
         })?;
         context.note_file_read(&file_path);
@@ -891,7 +891,7 @@ impl ToolSpec for EditFileTool {
             (contents.replace(search, replace), count, None)
         };
 
-        crate::utils::write_atomic(&file_path, updated.as_bytes()).map_err(|e| {
+        crate::utils::write_atomic_workspace(&file_path, updated.as_bytes()).map_err(|e| {
             ToolError::execution_failed(format!("Failed to write {}: {}", file_path.display(), e))
         })?;
         context.note_file_read(&file_path);
@@ -1928,6 +1928,93 @@ mod tests {
         // Verify nested file was created
         let written = fs::read_to_string(tmp.path().join("subdir/nested/file.txt")).expect("read");
         assert_eq!(written, "nested content");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_file_tool_new_file_matches_standard_creation_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+
+        let control = tmp.path().join("control.txt");
+        fs::write(&control, b"control").expect("write control");
+
+        WriteFileTool
+            .execute(
+                json!({"path": "created.txt", "content": "from write_file"}),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        let control_mode = fs::metadata(&control)
+            .expect("control metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        let created_mode = fs::metadata(tmp.path().join("created.txt"))
+            .expect("created metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(created_mode, control_mode);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_file_tool_preserves_existing_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let path = tmp.path().join("shared.txt");
+        fs::write(&path, b"before").expect("initial write");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o664))
+            .expect("set shared permissions");
+
+        WriteFileTool
+            .execute(json!({"path": "shared.txt", "content": "after"}), &ctx)
+            .await
+            .expect("execute");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o664);
+        assert_eq!(fs::read_to_string(&path).expect("read"), "after");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn edit_file_tool_preserves_executable_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let ctx = ToolContext::new(tmp.path().to_path_buf());
+        let path = tmp.path().join("script.sh");
+        fs::write(&path, b"#!/bin/sh\nexit 0\n").expect("initial write");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            .expect("set executable permissions");
+        read_before_edit(&ctx, "script.sh").await;
+
+        EditFileTool
+            .execute(
+                json!({
+                    "path": "script.sh",
+                    "search": "exit 0",
+                    "replace": "exit 1"
+                }),
+                &ctx,
+            )
+            .await
+            .expect("execute");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+        assert_eq!(
+            fs::read_to_string(&path).expect("read"),
+            "#!/bin/sh\nexit 1\n"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tools/fim.rs
+++ b/crates/tui/src/tools/fim.rs
@@ -162,7 +162,7 @@ impl ToolSpec for FimEditTool {
         // 7. Build the new content and write it back
         let generated_len = generated_text.len();
         let new_content = format!("{fim_prompt}{generated_text}{fim_suffix}");
-        crate::utils::write_atomic(&resolved, new_content.as_bytes()).map_err(|e| {
+        crate::utils::write_atomic_workspace(&resolved, new_content.as_bytes()).map_err(|e| {
             ToolError::execution_failed(format!("Failed to write {}: {}", resolved.display(), e))
         })?;
 

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -228,7 +228,23 @@ pub fn project_tree(root: &Path, max_depth: usize, follow_symlinks: bool) -> Str
 
 // === Filesystem Helpers ===
 
+/// Permission policy for atomic writes.
+///
+/// - [`AtomicWritePermissions::Private`]: keep tempfile's owner-only defaults
+///   (used for CodeWhale internal persistence such as session/history/trust).
+/// - [`AtomicWritePermissions::Workspace`]: match ordinary workspace file
+///   semantics — new files request mode `0666` (kernel applies umask); existing
+///   files retain ordinary `rwx` bits (not setuid/setgid/sticky).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AtomicWritePermissions {
+    Private,
+    Workspace,
+}
+
 /// Atomically write `contents` to `path` using a temporary file + fsync + rename.
+///
+/// Uses a **private** permission policy (Unix tempfile default `0600`). Prefer
+/// [`write_atomic_workspace`] for user workspace source/config files.
 ///
 /// 1. Creates a `NamedTempFile` in the same directory as `path` (same filesystem).
 /// 2. Writes `contents` to the temp file.
@@ -244,15 +260,86 @@ pub fn project_tree(root: &Path, max_depth: usize, follow_symlinks: bool) -> Str
 /// Returns `io::Error` if the parent directory cannot be determined, the temp
 /// file cannot be created, the write fails, or the rename fails.
 pub fn write_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    write_atomic_with_permissions(path, contents, AtomicWritePermissions::Private)
+}
+
+/// Atomically write `contents` to a **user workspace** path.
+///
+/// On Unix:
+/// - New files request creation mode `0666`; the OS applies the process umask
+///   (same candidate mode as ordinary `std::fs::write`).
+/// - Existing files keep ordinary permission bits (`mode & 0o777`), including
+///   executable bits. setuid/setgid/sticky are intentionally not restored.
+///
+/// On Windows this matches [`write_atomic`] (no POSIX mode simulation).
+///
+/// # Errors
+/// Same failure modes as [`write_atomic`].
+pub fn write_atomic_workspace(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    write_atomic_with_permissions(path, contents, AtomicWritePermissions::Workspace)
+}
+
+fn write_atomic_with_permissions(
+    path: &Path,
+    contents: &[u8],
+    #[cfg_attr(not(unix), allow(unused_variables))] permission_policy: AtomicWritePermissions,
+) -> std::io::Result<()> {
     let parent = path.parent().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("path has no parent directory: {}", path.display()),
         )
     })?;
+
+    // Capture ordinary rwx bits before replacement. Use symlink_metadata so we
+    // do not follow links: an inaccessible or dangling symlink target must not
+    // abort the write — rename still replaces the directory entry, matching
+    // the pre-#4606 private write_atomic behavior. Symlink entries themselves
+    // are treated as "no mode to preserve" (new ordinary file after rename);
+    // only regular-file modes are restored. Mask with 0o777 so setuid/setgid/
+    // sticky are never restored after rewriting content.
+    #[cfg(unix)]
+    let existing_workspace_mode = if permission_policy == AtomicWritePermissions::Workspace {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => None,
+            Ok(metadata) => {
+                use std::os::unix::fs::PermissionsExt;
+                Some(metadata.permissions().mode() & 0o777)
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+            Err(err) => return Err(err),
+        }
+    } else {
+        None
+    };
+
     // Use parent directory so the rename is on the same filesystem.
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    #[cfg(unix)]
+    let mut builder = tempfile::Builder::new();
+    #[cfg(not(unix))]
+    let builder = tempfile::Builder::new();
+
+    // New workspace files should behave like ordinary files opened with
+    // creation mode 0666. The kernel applies the inherited process umask.
+    // Do NOT chmod after create: set_permissions bypasses umask.
+    #[cfg(unix)]
+    if permission_policy == AtomicWritePermissions::Workspace && existing_workspace_mode.is_none() {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(fs::Permissions::from_mode(0o666));
+    }
+
+    let mut tmp = builder.tempfile_in(parent)?;
     std::io::Write::write_all(&mut tmp, contents)?;
+
+    // Atomic replacement creates a new inode. Restore ordinary access /
+    // executable bits of an existing workspace file before persisting.
+    #[cfg(unix)]
+    if let Some(mode) = existing_workspace_mode {
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(fs::Permissions::from_mode(mode))?;
+    }
+
     tmp.as_file().sync_all()?;
     #[cfg(windows)]
     {
@@ -792,6 +879,189 @@ mod atomic_write_tests {
             tmp_files.is_empty(),
             "temp files left behind: {tmp_files:?}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_workspace_new_file_matches_standard_creation_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let control = dir.path().join("control.txt");
+        let actual = dir.path().join("actual.txt");
+
+        fs::write(&control, b"control").expect("write control");
+        write_atomic_workspace(&actual, b"actual").expect("atomic workspace write");
+
+        let control_mode = fs::metadata(&control)
+            .expect("control metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        let actual_mode = fs::metadata(&actual)
+            .expect("actual metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(actual_mode, control_mode);
+        assert_eq!(fs::read(&actual).expect("read"), b"actual");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_workspace_preserves_existing_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("shared.txt");
+        fs::write(&path, b"before").expect("initial write");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o664))
+            .expect("set shared permissions");
+
+        write_atomic_workspace(&path, b"after").expect("atomic workspace write");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o664);
+        assert_eq!(fs::read(&path).expect("read"), b"after");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_workspace_preserves_executable_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("script.sh");
+        fs::write(&path, b"#!/bin/sh\nexit 0\n").expect("initial write");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            .expect("set executable permissions");
+
+        write_atomic_workspace(&path, b"#!/bin/sh\nexit 1\n").expect("atomic workspace write");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+        assert_eq!(fs::read(&path).expect("read"), b"#!/bin/sh\nexit 1\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_workspace_does_not_restore_special_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("special.sh");
+        fs::write(&path, b"#!/bin/sh\n").expect("initial write");
+        // Request sticky + setgid + rwxr-xr-x. Filesystems may clear some
+        // special bits; we only assert that after rewrite we never keep
+        // bits outside the ordinary 0o777 mask.
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o6755));
+        let before = fs::metadata(&path)
+            .expect("metadata before")
+            .permissions()
+            .mode();
+        let expected_ordinary = before & 0o777;
+
+        write_atomic_workspace(&path, b"#!/bin/sh\necho rewritten\n")
+            .expect("atomic workspace write");
+
+        let after = fs::metadata(&path)
+            .expect("metadata after")
+            .permissions()
+            .mode();
+        assert_eq!(after & 0o777, expected_ordinary);
+        assert_eq!(after & !0o777, 0, "special bits must not be restored");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_workspace_replaces_symlink_without_following_target() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("target.txt");
+        let link = dir.path().join("link.txt");
+        fs::write(&target, b"target-body").expect("write target");
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600))
+            .expect("lock down target mode");
+        symlink(&target, &link).expect("create symlink");
+
+        write_atomic_workspace(&link, b"replaced-link")
+            .expect("workspace write must replace symlink directory entry");
+
+        let link_meta = fs::symlink_metadata(&link).expect("link metadata");
+        assert!(
+            link_meta.file_type().is_file() && !link_meta.file_type().is_symlink(),
+            "rename should replace the symlink with a regular file"
+        );
+        assert_eq!(fs::read(&link).expect("read link path"), b"replaced-link");
+        // Target inode must remain untouched (old private write_atomic semantics).
+        assert_eq!(fs::read(&target).expect("read target"), b"target-body");
+        assert_eq!(
+            fs::metadata(&target)
+                .expect("target metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_workspace_replaces_symlink_when_target_is_unreadable() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = tempdir().expect("tempdir");
+        let secret_dir = dir.path().join("secret");
+        fs::create_dir(&secret_dir).expect("create secret dir");
+        let secret_file = secret_dir.join("hidden.txt");
+        fs::write(&secret_file, b"hidden").expect("write hidden");
+        // Remove search permission so following the symlink fails with EACCES,
+        // while lstat on the symlink itself still succeeds.
+        fs::set_permissions(&secret_dir, fs::Permissions::from_mode(0o000))
+            .expect("lock secret dir");
+
+        let link = dir.path().join("to-hidden.txt");
+        symlink(&secret_file, &link).expect("symlink to hidden file");
+
+        // Following metadata must fail; workspace write must still succeed.
+        assert!(
+            fs::metadata(&link).is_err(),
+            "precondition: following the symlink must fail"
+        );
+
+        let result = write_atomic_workspace(&link, b"new-content");
+
+        // Restore dir perms so tempdir cleanup can remove nested files.
+        let _ = fs::set_permissions(&secret_dir, fs::Permissions::from_mode(0o700));
+
+        result.expect("workspace write must not abort when symlink target is unreadable");
+        let link_meta = fs::symlink_metadata(&link).expect("link metadata");
+        assert!(link_meta.file_type().is_file() && !link_meta.file_type().is_symlink());
+        assert_eq!(fs::read(&link).expect("read"), b"new-content");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_private_new_file_does_not_gain_group_or_other_access() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("private.json");
+
+        write_atomic(&path, b"{}").expect("private atomic write");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode & 0o077, 0);
+    }
+
+    #[test]
+    fn write_atomic_workspace_writes_content() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("workspace.txt");
+        write_atomic_workspace(&path, b"workspace").expect("write_atomic_workspace");
+        assert_eq!(fs::read(&path).expect("read"), b"workspace");
     }
 
     #[test]

--- a/crates/tui/src/utils.rs
+++ b/crates/tui/src/utils.rs
@@ -970,7 +970,10 @@ mod atomic_write_tests {
             .permissions()
             .mode();
         assert_eq!(after & 0o777, expected_ordinary);
-        assert_eq!(after & !0o777, 0, "special bits must not be restored");
+        // `PermissionsExt::mode()` also contains the regular-file type bit on
+        // macOS/BSD. Check only the Unix special permission bits rather than
+        // treating every non-rwx bit as a restored permission.
+        assert_eq!(after & 0o7000, 0, "special bits must not be restored");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Fixes #4606 by separating atomic-write permission policy for user workspace
files from CodeWhale's private internal persistence.

Workspace tools (`write_file`, `edit_file`, `apply_patch`, FIM) previously used
the shared `write_atomic()` helper. That helper creates a `NamedTempFile` whose
Unix default mode is `0600`, then atomically renames that inode over the
destination. Because umask can only remove permission bits, `umask 002` cannot
turn the tempfile's `0600` into the expected `0664`. Atomic replacement also
replaced the mode of existing files, so editing an existing `0664` or `0755`
file changed it to `0600`.

## Changes

- Added `write_atomic_workspace()` with a shared `write_atomic_with_permissions()`
  implementation; kept `write_atomic()` private (tempfile default `0600`).
- New Unix workspace files request mode `0666`; the kernel applies the inherited
  process umask (same candidate mode as ordinary `std::fs::write`).
- Existing workspace files retain ordinary `rwx` bits (`mode & 0o777`), including
  executable bits. setuid/setgid/sticky are intentionally not restored.
- Migrated workspace call sites:
  - `WriteFileTool` / `EditFileTool` (`tools/file.rs`)
  - `apply_patch` success path and rollback (`tools/apply_patch.rs`)
  - FIM write-back (`tools/fim.rs`)
- Kept internal persistence on private `write_atomic()`:
  session, history, stash, trust, task, truncate/spillover, terminal session,
  MCP config, session export, artifacts, slop ledger, runtime preset restore, etc.
- Symlink-safe mode capture: use `symlink_metadata` (do not follow links). Symlink
  directory entries are treated as “no mode to preserve” so inaccessible or
  dangling targets do not abort the write; rename still replaces the directory
  entry (pre-#4606 semantics).
- Preserved Windows persist retries and existing file/parent `sync_all` behavior.

## Tests

- Utils: new workspace file mode matches same-directory `fs::write` control file.
- Utils: existing `0664` mode preserved on overwrite.
- Utils: existing `0755` executable mode preserved.
- Utils: special bits are not restored (`& 0o777`).
- Utils: private `write_atomic` new files do not gain group/other access.
- Utils: symlink replacement does not follow target; unreadable target still writes.
- Tool-level: `WriteFileTool` / `EditFileTool` permission regressions (Unix).
- Windows: existing atomic replace / contention retry tests still pass.

**Local verification (Windows):**
- `cargo fmt -p codewhale-tui -- --check` — pass
- `utils::atomic_write_tests` — pass (Unix-only permission/symlink tests cfg’d out)
- `tools::file::tests` — pass
- Full `cargo test -p codewhale-tui`: unrelated i18n/UI failures observed; none tied to this diff
- `cargo clippy -p codewhale-tui --all-targets --all-features -- -D warnings`: blocked by pre-existing `mcp.rs` `needless_return`, not this change

Unix permission/symlink coverage should be confirmed on Linux/macOS CI.

## Known limits

This change preserves ordinary Unix mode bits. It does not claim to preserve
arbitrary ACLs, xattrs, ownership, group ownership, or to redesign symlink
semantics beyond avoiding a follow-metadata abort regression.

Temporary workspace files created with `Builder::permissions(0666)` may be
group-visible from creation (consistent with final umask-applied mode).

## Test plan

- [ ] On Linux with `umask 002`, `write_file` creates a new file with mode `664`
- [ ] Overwrite an existing `664` file via `write_file` / `edit_file`; mode stays `664`
- [ ] Edit an existing `755` script via `edit_file`; mode stays `755`
- [ ] Confirm session/history/trust files remain owner-only (`mode & 077 == 0`)
- [ ] Confirm Windows atomic replace behavior has no regression
- [ ] CI green for `codewhale-tui` Unix permission tests