### PR TITLE
fix(goal): continue durable goals across turns

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -648,10 +648,11 @@ pub struct Engine {
     /// Clone of the op-channel sender, so the engine can self-dispatch ops
     /// (e.g. a goal-continuation `SendMessage` after a turn completes).
     tx_op: mpsc::Sender<Op>,
-    /// At most one continuation waiting for op-channel capacity. Keeping this
-    /// on the sole consumer avoids awaiting a channel that only this engine can
-    /// drain while preserving FIFO behind controls already in the mailbox.
-    pending_goal_continuation: Option<PendingGoalContinuation>,
+    /// At most one engine-owned continuation across capacity-waiting and
+    /// enqueued states. The authoritative dynamic-tool set stays here so a
+    /// later successful turn can refresh it without adding a second token.
+    scheduled_goal_continuation: Option<ScheduledGoalContinuation>,
+    goal_continuation_schedule_seq: u64,
     rx_approval: mpsc::Receiver<ApprovalDecision>,
     rx_user_input: mpsc::Receiver<UserInputDecision>,
     rx_steer: mpsc::Receiver<String>,
@@ -734,8 +735,14 @@ enum GoalContinuationAction {
     },
 }
 
-struct PendingGoalContinuation {
+struct ScheduledGoalContinuation {
+    id: u64,
     dynamic_tools: Vec<DynamicToolSpec>,
+    enqueued: bool,
+    /// Once a full mailbox delays this token, drain operations through the
+    /// token before selecting idle child completions. That preserves controls
+    /// already ahead of it without changing normal run-loop fairness.
+    draining_backpressure: bool,
 }
 
 enum SendMessageOutcome {
@@ -744,6 +751,11 @@ enum SendMessageOutcome {
         status: TurnOutcomeStatus,
         error: Option<String>,
     },
+}
+
+enum EngineRunInput {
+    Operation(Box<Op>),
+    SubAgentCompletion(SubAgentCompletion),
 }
 
 impl SendMessageOutcome {
@@ -1240,7 +1252,8 @@ impl Engine {
             active_route_capabilities: codewhale_config::route::RouteCapabilities::default(),
             rx_op,
             tx_op: tx_op.clone(),
-            pending_goal_continuation: None,
+            scheduled_goal_continuation: None,
+            goal_continuation_schedule_seq: 0,
             rx_approval,
             rx_user_input,
             rx_steer,
@@ -1588,10 +1601,61 @@ impl Engine {
     }
 
     fn schedule_goal_continuation(&mut self, dynamic_tools: Vec<DynamicToolSpec>) {
-        // Coalesce a continuation that could not enter a saturated mailbox.
-        // The most recent completed turn owns the freshest dynamic-tool set.
-        self.pending_goal_continuation = Some(PendingGoalContinuation { dynamic_tools });
+        if let Some(scheduled) = self.scheduled_goal_continuation.as_mut() {
+            // A normal user turn or idle child handoff can finish while the
+            // prior synthetic token is already queued. Refresh that one token
+            // instead of multiplying autonomous turns and provider spend.
+            scheduled.dynamic_tools = dynamic_tools;
+            self.try_flush_pending_goal_continuation();
+            return;
+        }
+
+        self.goal_continuation_schedule_seq =
+            self.goal_continuation_schedule_seq.wrapping_add(1).max(1);
+        self.scheduled_goal_continuation = Some(ScheduledGoalContinuation {
+            id: self.goal_continuation_schedule_seq,
+            dynamic_tools,
+            enqueued: false,
+            draining_backpressure: false,
+        });
         self.try_flush_pending_goal_continuation();
+    }
+
+    fn take_scheduled_goal_continuation(
+        &mut self,
+        engine_schedule_id: Option<u64>,
+        direct_dynamic_tools: Vec<DynamicToolSpec>,
+    ) -> Option<Vec<DynamicToolSpec>> {
+        let Some(schedule_id) = engine_schedule_id else {
+            return Some(direct_dynamic_tools);
+        };
+        let Some(scheduled) = self.scheduled_goal_continuation.take() else {
+            tracing::warn!(
+                schedule_id,
+                "discarding stale engine-owned goal continuation token"
+            );
+            return None;
+        };
+        if scheduled.id != schedule_id {
+            tracing::warn!(
+                schedule_id,
+                current_schedule_id = scheduled.id,
+                "discarding superseded engine-owned goal continuation token"
+            );
+            self.scheduled_goal_continuation = Some(scheduled);
+            return None;
+        }
+
+        // Clear before executing the synthetic turn. A successful execution
+        // may now schedule exactly one replacement; inactive/failed turns do
+        // not leave a phantom outstanding marker behind.
+        Some(scheduled.dynamic_tools)
+    }
+
+    fn draining_goal_continuation_backpressure(&self) -> bool {
+        self.scheduled_goal_continuation
+            .as_ref()
+            .is_some_and(|scheduled| scheduled.draining_backpressure)
     }
 
     fn goal_continuation_failure_message(&self, error: Option<&str>) -> String {
@@ -1623,22 +1687,67 @@ impl Engine {
     }
 
     fn try_flush_pending_goal_continuation(&mut self) {
-        let Some(pending) = self.pending_goal_continuation.take() else {
+        let Some(scheduled) = self.scheduled_goal_continuation.as_ref() else {
             return;
         };
+        if scheduled.enqueued {
+            return;
+        }
+        let schedule_id = scheduled.id;
 
         match self.tx_op.try_send(Op::ContinueGoal {
-            dynamic_tools: pending.dynamic_tools,
+            // The authoritative set stays in `scheduled_goal_continuation` so
+            // later completed turns can refresh it without moving this token.
+            dynamic_tools: Vec::new(),
+            engine_schedule_id: Some(schedule_id),
         }) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(Op::ContinueGoal { dynamic_tools })) => {
-                self.pending_goal_continuation = Some(PendingGoalContinuation { dynamic_tools });
+            Ok(()) => {
+                if let Some(scheduled) = self.scheduled_goal_continuation.as_mut()
+                    && scheduled.id == schedule_id
+                {
+                    scheduled.enqueued = true;
+                }
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 tracing::warn!("goal continuation dropped because the engine mailbox is closed");
+                if self
+                    .scheduled_goal_continuation
+                    .as_ref()
+                    .is_some_and(|scheduled| scheduled.id == schedule_id)
+                {
+                    self.scheduled_goal_continuation = None;
+                }
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
-                unreachable!("goal continuation scheduler only sends ContinueGoal operations")
+                if let Some(scheduled) = self.scheduled_goal_continuation.as_mut()
+                    && scheduled.id == schedule_id
+                {
+                    scheduled.draining_backpressure = true;
+                }
+            }
+        }
+    }
+
+    async fn next_run_input(&mut self, host_managed_turns: bool) -> Option<EngineRunInput> {
+        // A full mailbox means queued controls must run first. Retrying at the
+        // top of each receive appends the continuation behind the remaining
+        // controls as soon as one slot becomes available.
+        self.try_flush_pending_goal_continuation();
+        if self.draining_goal_continuation_backpressure() {
+            // The synthetic token sits behind the controls that filled the
+            // mailbox. Drain through that token before accepting an idle child
+            // completion; consuming the token clears this temporary priority
+            // so normal select fairness resumes immediately.
+            self.rx_op
+                .recv()
+                .await
+                .map(|op| EngineRunInput::Operation(Box::new(op)))
+        } else {
+            tokio::select! {
+                op = self.rx_op.recv() => op.map(|op| EngineRunInput::Operation(Box::new(op))),
+                completion = self.rx_subagent_completion.recv(), if !host_managed_turns => {
+                    completion.map(EngineRunInput::SubAgentCompletion)
+                }
             }
         }
     }
@@ -1646,11 +1755,6 @@ impl Engine {
     /// Run the engine event loop
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) {
-        enum EngineRunInput {
-            Operation(Box<Op>),
-            SubAgentCompletion(SubAgentCompletion),
-        }
-
         // RuntimeThreadManager owns durable turn claims and installs a thread
         // id in runtime services. Only the interactive TUI may autonomously
         // create a new turn while the engine is otherwise idle; a hosted
@@ -1659,17 +1763,7 @@ impl Engine {
         let host_managed_turns = self.host_managed_turns();
 
         loop {
-            // A full mailbox means queued controls must run first. Retrying at
-            // the top of the loop appends the continuation behind the
-            // remaining controls as soon as one slot becomes available.
-            self.try_flush_pending_goal_continuation();
-            let input = tokio::select! {
-                op = self.rx_op.recv() => op.map(|op| EngineRunInput::Operation(Box::new(op))),
-                completion = self.rx_subagent_completion.recv(), if !host_managed_turns => {
-                    completion.map(EngineRunInput::SubAgentCompletion)
-                }
-            };
-            let Some(input) = input else {
+            let Some(input) = self.next_run_input(host_managed_turns).await else {
                 break;
             };
 
@@ -1726,7 +1820,15 @@ impl Engine {
                         )
                         .await;
                     }
-                    Op::ContinueGoal { dynamic_tools } => {
+                    Op::ContinueGoal {
+                        dynamic_tools,
+                        engine_schedule_id,
+                    } => {
+                        let Some(dynamic_tools) = self
+                            .take_scheduled_goal_continuation(engine_schedule_id, dynamic_tools)
+                        else {
+                            continue;
+                        };
                         // Status controls queued while the previous turn was
                         // running are processed before this operation. Re-read
                         // the live goal now so pause/clear/complete/blocked can

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -739,14 +739,12 @@ struct ScheduledGoalContinuation {
     id: u64,
     dynamic_tools: Vec<DynamicToolSpec>,
     enqueued: bool,
-    /// Once a full mailbox delays this token, drain operations through the
-    /// token before selecting idle child completions. That preserves controls
-    /// already ahead of it without changing normal run-loop fairness.
-    draining_backpressure: bool,
 }
 
 enum SendMessageOutcome {
-    NotStarted,
+    NotStarted {
+        error: Option<String>,
+    },
     Finished {
         status: TurnOutcomeStatus,
         error: Option<String>,
@@ -1616,9 +1614,16 @@ impl Engine {
             id: self.goal_continuation_schedule_seq,
             dynamic_tools,
             enqueued: false,
-            draining_backpressure: false,
         });
         self.try_flush_pending_goal_continuation();
+    }
+
+    fn cancel_scheduled_goal_continuation(&mut self) {
+        if self.scheduled_goal_continuation.take().is_some() {
+            tracing::debug!(
+                "cancelled an outstanding goal continuation after a non-completed turn"
+            );
+        }
     }
 
     fn take_scheduled_goal_continuation(
@@ -1652,38 +1657,55 @@ impl Engine {
         Some(scheduled.dynamic_tools)
     }
 
-    fn draining_goal_continuation_backpressure(&self) -> bool {
-        self.scheduled_goal_continuation
-            .as_ref()
-            .is_some_and(|scheduled| scheduled.draining_backpressure)
+    fn has_scheduled_goal_continuation(&self) -> bool {
+        self.scheduled_goal_continuation.is_some()
+    }
+
+    fn bounded_redacted_goal_failure_detail(&self, detail: &str) -> Option<String> {
+        let detail = detail.trim();
+        if detail.is_empty() {
+            return None;
+        }
+        // This message becomes durable goal state. Reuse the model boundary's
+        // exact configured-secret redactor when available; that helper also
+        // applies the config persistence redactor as a universal backstop.
+        let detail = self.deepseek_client.as_ref().map_or_else(
+            || codewhale_config::persistence::redact_secrets(detail),
+            |client| client.redact_model_bound_text(detail),
+        );
+        Some(crate::utils::truncate_with_ellipsis(
+            &detail,
+            GOAL_CONTINUATION_FAILURE_DETAIL_MAX_BYTES,
+            "…",
+        ))
     }
 
     fn goal_continuation_failure_message(&self, error: Option<&str>) -> String {
-        let detail = error.map(str::trim).filter(|detail| !detail.is_empty());
-        match detail {
-            Some(detail) => {
-                // This message becomes durable goal state. Reuse the model
-                // boundary's exact configured-secret redactor when available,
-                // with the config persistence redactor as the universal
-                // backstop, before bounding the retained provider detail.
-                let detail = self.deepseek_client.as_ref().map_or_else(
-                    || codewhale_config::persistence::redact_secrets(detail),
-                    |client| client.redact_model_bound_text(detail),
-                );
-                let detail = crate::utils::truncate_with_ellipsis(
-                    &detail,
-                    GOAL_CONTINUATION_FAILURE_DETAIL_MAX_BYTES,
-                    "…",
-                );
+        self.bounded_redacted_goal_failure_detail(error.unwrap_or_default()).map_or_else(
+            || {
+                "Goal continuation blocked because the model turn failed without a provider reason. Fix the provider route or credentials, then resume the goal."
+                    .to_string()
+            },
+            |detail| {
                 format!(
                     "Goal continuation blocked because the model turn failed: {detail}. Fix the failure, then resume the goal."
                 )
-            }
-            None => {
-                "Goal continuation blocked because the model turn failed without a provider reason. Fix the provider route or credentials, then resume the goal."
+            },
+        )
+    }
+
+    fn goal_turn_not_started_message(&self, error: Option<&str>) -> String {
+        self.bounded_redacted_goal_failure_detail(error.unwrap_or_default()).map_or_else(
+            || {
+                "Goal continuation blocked because the next model turn could not be started. Fix the provider route or credentials, then resume the goal."
                     .to_string()
-            }
-        }
+            },
+            |detail| {
+                format!(
+                    "Goal continuation blocked because the next model turn could not be started: {detail}. Fix the provider route or credentials, then resume the goal."
+                )
+            },
+        )
     }
 
     fn try_flush_pending_goal_continuation(&mut self) {
@@ -1718,13 +1740,7 @@ impl Engine {
                     self.scheduled_goal_continuation = None;
                 }
             }
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                if let Some(scheduled) = self.scheduled_goal_continuation.as_mut()
-                    && scheduled.id == schedule_id
-                {
-                    scheduled.draining_backpressure = true;
-                }
-            }
+            Err(mpsc::error::TrySendError::Full(_)) => {}
         }
     }
 
@@ -1733,11 +1749,12 @@ impl Engine {
         // top of each receive appends the continuation behind the remaining
         // controls as soon as one slot becomes available.
         self.try_flush_pending_goal_continuation();
-        if self.draining_goal_continuation_backpressure() {
-            // The synthetic token sits behind the controls that filled the
-            // mailbox. Drain through that token before accepting an idle child
-            // completion; consuming the token clears this temporary priority
-            // so normal select fairness resumes immediately.
+        if self.has_scheduled_goal_continuation() {
+            // The synthetic token sits behind every operation that was already
+            // queued when it was scheduled. Drain FIFO operations through that
+            // token before accepting an idle child completion, whether or not
+            // the mailbox happened to be full. Consuming or cancelling the
+            // schedule marker restores normal select fairness immediately.
             self.rx_op
                 .recv()
                 .await
@@ -1864,7 +1881,7 @@ impl Engine {
                             }
                         };
 
-                        let outcome = self
+                        let _ = self
                             .handle_send_message(
                                 content,
                                 self.current_mode,
@@ -1889,28 +1906,6 @@ impl Engine {
                                 UserInputProvenance::Runtime,
                             )
                             .await;
-                        match outcome {
-                            SendMessageOutcome::NotStarted => {
-                                self.block_goal_continuation(
-                                    "Goal continuation blocked because the next model turn could not be started. Fix the provider route or credentials, then resume the goal."
-                                        .to_string(),
-                                )
-                                .await;
-                            }
-                            SendMessageOutcome::Finished {
-                                status: TurnOutcomeStatus::Failed,
-                                error,
-                            } => {
-                                let message =
-                                    self.goal_continuation_failure_message(error.as_deref());
-                                self.block_goal_continuation(message).await;
-                            }
-                            SendMessageOutcome::Finished {
-                                status:
-                                    TurnOutcomeStatus::Completed | TurnOutcomeStatus::Interrupted,
-                                ..
-                            } => {}
-                        }
                     }
                     Op::RunShellCommand {
                         command,
@@ -2370,6 +2365,12 @@ impl Engine {
                                         "Cannot edit the last turn because its provider route is no longer valid: {err}"
                                     ))))
                                     .await;
+                                let outcome = SendMessageOutcome::NotStarted {
+                                    error: Some(format!(
+                                        "provider route is no longer valid: {err}"
+                                    )),
+                                };
+                                self.reconcile_non_completed_goal_turn(&outcome).await;
                                 continue;
                             }
                         };
@@ -2812,6 +2813,10 @@ impl Engine {
                         "Cannot resume the turn because its provider route is no longer valid: {err}"
                     ))))
                     .await;
+                let outcome = SendMessageOutcome::NotStarted {
+                    error: Some(format!("provider route is no longer valid: {err}")),
+                };
+                self.reconcile_non_completed_goal_turn(&outcome).await;
                 return;
             }
         };
@@ -2950,6 +2955,64 @@ impl Engine {
         }
     }
 
+    /// Reconcile a turn that did not complete with the autonomous goal loop.
+    /// Hosted engines leave lifecycle decisions to their durable host. The
+    /// interactive engine must cancel any older queued synthetic token first,
+    /// then project an active goal into a truthful non-running state.
+    async fn reconcile_non_completed_goal_turn(&mut self, outcome: &SendMessageOutcome) {
+        if self.host_managed_turns() {
+            return;
+        }
+
+        self.cancel_scheduled_goal_continuation();
+        match outcome {
+            SendMessageOutcome::NotStarted { error } => {
+                let message = self.goal_turn_not_started_message(error.as_deref());
+                self.block_goal_continuation(message).await;
+            }
+            SendMessageOutcome::Finished {
+                status: TurnOutcomeStatus::Failed,
+                error,
+            } => {
+                let message = self.goal_continuation_failure_message(error.as_deref());
+                self.block_goal_continuation(message).await;
+            }
+            SendMessageOutcome::Finished {
+                status: TurnOutcomeStatus::Interrupted,
+                ..
+            } => self.pause_goal_after_interruption().await,
+            SendMessageOutcome::Finished {
+                status: TurnOutcomeStatus::Completed,
+                ..
+            } => {}
+        }
+    }
+
+    /// A route/client rejection can happen before normal turn setup copies the
+    /// host's just-declared goal into SharedGoalState. Seed only that goal
+    /// descriptor so the rejection can publish a truthful Blocked snapshot;
+    /// no user message or provider turn state is mutated here.
+    fn sync_unstarted_goal_for_terminal_projection(
+        &mut self,
+        objective: Option<&str>,
+        token_budget: Option<u32>,
+        status: GoalStatus,
+    ) {
+        let objective = normalized_goal_objective(objective);
+        if objective.is_none() || status != GoalStatus::Active {
+            return;
+        }
+        sync_goal_state_from_host(
+            &self.config.goal_state,
+            objective.as_deref(),
+            token_budget,
+            status,
+        );
+        self.config.goal_objective = objective;
+        self.config.goal_token_budget = token_budget;
+        self.config.goal_status = status;
+    }
+
     /// Transition a still-active interactive goal to Blocked and publish every
     /// host projection in one ordered path. Continuation failures happen
     /// outside a model tool call, so without this bridge the loop can stop while
@@ -2986,6 +3049,41 @@ impl Engine {
         self.emit_session_updated().await;
         let _ = self.tx_event.send(Event::GoalUpdated { snapshot }).await;
         let _ = self.tx_event.send(Event::status(message)).await;
+    }
+
+    /// A user cancellation is neither success nor a provider failure. Pause a
+    /// still-active goal so the sidebar and stable prompt do not claim that an
+    /// autonomous run remains live, and require an explicit `/goal resume`.
+    async fn pause_goal_after_interruption(&mut self) {
+        let snapshot = match self.config.goal_state.lock() {
+            Ok(mut state) => {
+                if !state.is_active() {
+                    return;
+                }
+                let objective = state.objective().map(str::to_string);
+                let budget = state.token_budget();
+                state.sync_from_host_status(objective.as_deref(), budget, GoalStatus::Paused);
+                state.snapshot()
+            }
+            Err(err) => {
+                tracing::warn!("goal state lock poisoned while pausing interruption: {err}");
+                return;
+            }
+        };
+
+        self.config.goal_objective.clone_from(&snapshot.objective);
+        self.config.goal_token_budget = snapshot.token_budget;
+        self.config.goal_status = GoalStatus::Paused;
+        self.refresh_system_prompt();
+        self.emit_session_updated().await;
+        let _ = self.tx_event.send(Event::GoalUpdated { snapshot }).await;
+        let _ = self
+            .tx_event
+            .send(Event::status(
+                "Goal paused because its model turn was interrupted; use /goal resume to continue."
+                    .to_string(),
+            ))
+            .await;
     }
 
     /// Handle `/goal pause|resume|clear|complete|blocked` by writing the new
@@ -3086,7 +3184,14 @@ impl Engine {
                     "Cannot start the turn because its provider route is not ready: {err}"
                 ))))
                 .await;
-            return SendMessageOutcome::NotStarted;
+            self.sync_unstarted_goal_for_terminal_projection(
+                goal_objective.as_deref(),
+                goal_token_budget,
+                goal_status,
+            );
+            let outcome = SendMessageOutcome::NotStarted { error: Some(err) };
+            self.reconcile_non_completed_goal_turn(&outcome).await;
+            return outcome;
         }
 
         let input_policy = effective_input_policy(
@@ -3184,12 +3289,21 @@ impl Engine {
                 .send(Event::TurnComplete {
                     usage: turn.usage.clone(),
                     status: TurnOutcomeStatus::Failed,
-                    error: Some(message),
+                    error: Some(message.clone()),
                     tool_catalog: None,
                     base_url: None,
                 })
                 .await;
-            return SendMessageOutcome::NotStarted;
+            self.sync_unstarted_goal_for_terminal_projection(
+                goal_objective.as_deref(),
+                goal_token_budget,
+                goal_status,
+            );
+            let outcome = SendMessageOutcome::NotStarted {
+                error: Some(message),
+            };
+            self.reconcile_non_completed_goal_turn(&outcome).await;
+            return outcome;
         }
 
         self.session
@@ -3538,13 +3652,24 @@ impl Engine {
         // its own op channel. RuntimeThreadManager engines instead yield here:
         // their host must create the next durable claim before dispatching any
         // further turn. A Failed or Interrupted turn never continues.
-        if !self.host_managed_turns() && status == TurnOutcomeStatus::Completed {
+        let outcome = SendMessageOutcome::Finished { status, error };
+        if !self.host_managed_turns()
+            && matches!(
+                &outcome,
+                SendMessageOutcome::Finished {
+                    status: TurnOutcomeStatus::Completed,
+                    ..
+                }
+            )
+        {
             // Queue a typed continuation instead of freezing an Active goal
             // snapshot into a generic message. The operation re-reads the live
             // state when consumed, after any already-queued goal controls.
             self.schedule_goal_continuation(dynamic_tools);
+        } else {
+            self.reconcile_non_completed_goal_turn(&outcome).await;
         }
-        SendMessageOutcome::Finished { status, error }
+        outcome
     }
 
     async fn handle_manual_compaction(&mut self) {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -81,6 +81,9 @@ use super::session::Session;
 use super::tool_parser;
 use super::turn::{TurnContext, post_turn_snapshot, pre_turn_snapshot};
 
+const ENGINE_OP_CHANNEL_CAPACITY: usize = 32;
+const GOAL_CONTINUATION_FAILURE_DETAIL_MAX_BYTES: usize = 512;
+
 /// Snapshot of parent state that can be passed to forked sub-agents without
 /// rewriting the parent transcript.
 #[derive(Debug, Clone, Default)]
@@ -645,6 +648,10 @@ pub struct Engine {
     /// Clone of the op-channel sender, so the engine can self-dispatch ops
     /// (e.g. a goal-continuation `SendMessage` after a turn completes).
     tx_op: mpsc::Sender<Op>,
+    /// At most one continuation waiting for op-channel capacity. Keeping this
+    /// on the sole consumer avoids awaiting a channel that only this engine can
+    /// drain while preserving FIFO behind controls already in the mailbox.
+    pending_goal_continuation: Option<PendingGoalContinuation>,
     rx_approval: mpsc::Receiver<ApprovalDecision>,
     rx_user_input: mpsc::Receiver<UserInputDecision>,
     rx_steer: mpsc::Receiver<String>,
@@ -725,6 +732,24 @@ enum GoalContinuationAction {
     Stopped {
         message: String,
     },
+}
+
+struct PendingGoalContinuation {
+    dynamic_tools: Vec<DynamicToolSpec>,
+}
+
+enum SendMessageOutcome {
+    NotStarted,
+    Finished {
+        status: TurnOutcomeStatus,
+        error: Option<String>,
+    },
+}
+
+impl SendMessageOutcome {
+    fn started(&self) -> bool {
+        matches!(self, Self::Finished { .. })
+    }
 }
 
 // === Internal tool helpers ===
@@ -1019,7 +1044,7 @@ impl Engine {
             );
         }
 
-        let (tx_op, rx_op) = mpsc::channel(32);
+        let (tx_op, rx_op) = mpsc::channel(ENGINE_OP_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = mpsc::channel(256);
         let (tx_approval, rx_approval) = mpsc::channel(64);
         let (tx_user_input, rx_user_input) = mpsc::channel(32);
@@ -1215,6 +1240,7 @@ impl Engine {
             active_route_capabilities: codewhale_config::route::RouteCapabilities::default(),
             rx_op,
             tx_op: tx_op.clone(),
+            pending_goal_continuation: None,
             rx_approval,
             rx_user_input,
             rx_steer,
@@ -1561,6 +1587,62 @@ impl Engine {
             || self.session.approval_mode == crate::tui::approval::ApprovalMode::Bypass;
     }
 
+    fn schedule_goal_continuation(&mut self, dynamic_tools: Vec<DynamicToolSpec>) {
+        // Coalesce a continuation that could not enter a saturated mailbox.
+        // The most recent completed turn owns the freshest dynamic-tool set.
+        self.pending_goal_continuation = Some(PendingGoalContinuation { dynamic_tools });
+        self.try_flush_pending_goal_continuation();
+    }
+
+    fn goal_continuation_failure_message(&self, error: Option<&str>) -> String {
+        let detail = error.map(str::trim).filter(|detail| !detail.is_empty());
+        match detail {
+            Some(detail) => {
+                // This message becomes durable goal state. Reuse the model
+                // boundary's exact configured-secret redactor when available,
+                // with the config persistence redactor as the universal
+                // backstop, before bounding the retained provider detail.
+                let detail = self.deepseek_client.as_ref().map_or_else(
+                    || codewhale_config::persistence::redact_secrets(detail),
+                    |client| client.redact_model_bound_text(detail),
+                );
+                let detail = crate::utils::truncate_with_ellipsis(
+                    &detail,
+                    GOAL_CONTINUATION_FAILURE_DETAIL_MAX_BYTES,
+                    "…",
+                );
+                format!(
+                    "Goal continuation blocked because the model turn failed: {detail}. Fix the failure, then resume the goal."
+                )
+            }
+            None => {
+                "Goal continuation blocked because the model turn failed without a provider reason. Fix the provider route or credentials, then resume the goal."
+                    .to_string()
+            }
+        }
+    }
+
+    fn try_flush_pending_goal_continuation(&mut self) {
+        let Some(pending) = self.pending_goal_continuation.take() else {
+            return;
+        };
+
+        match self.tx_op.try_send(Op::ContinueGoal {
+            dynamic_tools: pending.dynamic_tools,
+        }) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(Op::ContinueGoal { dynamic_tools })) => {
+                self.pending_goal_continuation = Some(PendingGoalContinuation { dynamic_tools });
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!("goal continuation dropped because the engine mailbox is closed");
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                unreachable!("goal continuation scheduler only sends ContinueGoal operations")
+            }
+        }
+    }
+
     /// Run the engine event loop
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) {
@@ -1577,6 +1659,10 @@ impl Engine {
         let host_managed_turns = self.host_managed_turns();
 
         loop {
+            // A full mailbox means queued controls must run first. Retrying at
+            // the top of the loop appends the continuation behind the
+            // remaining controls as soon as one slot becomes available.
+            self.try_flush_pending_goal_continuation();
             let input = tokio::select! {
                 op = self.rx_op.recv() => op.map(|op| EngineRunInput::Operation(Box::new(op))),
                 completion = self.rx_subagent_completion.recv(), if !host_managed_turns => {
@@ -1676,7 +1762,7 @@ impl Engine {
                             }
                         };
 
-                        let dispatched = self
+                        let outcome = self
                             .handle_send_message(
                                 content,
                                 self.current_mode,
@@ -1701,12 +1787,27 @@ impl Engine {
                                 UserInputProvenance::Runtime,
                             )
                             .await;
-                        if !dispatched {
-                            self.block_goal_continuation(
-                                "Goal continuation blocked because the next model turn could not be started. Fix the provider route or credentials, then resume the goal."
-                                    .to_string(),
-                            )
-                            .await;
+                        match outcome {
+                            SendMessageOutcome::NotStarted => {
+                                self.block_goal_continuation(
+                                    "Goal continuation blocked because the next model turn could not be started. Fix the provider route or credentials, then resume the goal."
+                                        .to_string(),
+                                )
+                                .await;
+                            }
+                            SendMessageOutcome::Finished {
+                                status: TurnOutcomeStatus::Failed,
+                                error,
+                            } => {
+                                let message =
+                                    self.goal_continuation_failure_message(error.as_deref());
+                                self.block_goal_continuation(message).await;
+                            }
+                            SendMessageOutcome::Finished {
+                                status:
+                                    TurnOutcomeStatus::Completed | TurnOutcomeStatus::Interrupted,
+                                ..
+                            } => {}
                         }
                     }
                     Op::RunShellCommand {
@@ -2629,7 +2730,7 @@ impl Engine {
             )))
             .await;
 
-        let recorded = self
+        let outcome = self
             .handle_send_message(
                 content,
                 self.current_mode,
@@ -2654,7 +2755,7 @@ impl Engine {
                 UserInputProvenance::SubAgentHandoff,
             )
             .await;
-        if !recorded {
+        if !outcome.started() {
             for agent_id in claimed_ids {
                 self.delivered_subagent_completion_ids.remove(&agent_id);
             }
@@ -2871,7 +2972,7 @@ impl Engine {
         hook_executor: Option<std::sync::Arc<crate::hooks::HookExecutor>>,
         verbosity: Option<String>,
         provenance: UserInputProvenance,
-    ) -> bool {
+    ) -> SendMessageOutcome {
         let effective_provider = route.identity.provider;
         let provider_identity = route.identity.key.clone();
         let model = route.model.clone();
@@ -2883,7 +2984,7 @@ impl Engine {
                     "Cannot start the turn because its provider route is not ready: {err}"
                 ))))
                 .await;
-            return false;
+            return SendMessageOutcome::NotStarted;
         }
 
         let input_policy = effective_input_policy(
@@ -2986,7 +3087,7 @@ impl Engine {
                     base_url: None,
                 })
                 .await;
-            return false;
+            return SendMessageOutcome::NotStarted;
         }
 
         self.session
@@ -3303,7 +3404,7 @@ impl Engine {
             .send(Event::TurnComplete {
                 usage: turn.usage,
                 status,
-                error,
+                error: error.clone(),
                 tool_catalog: tool_catalog_for_event,
                 base_url: base_url_for_event,
             })
@@ -3339,14 +3440,9 @@ impl Engine {
             // Queue a typed continuation instead of freezing an Active goal
             // snapshot into a generic message. The operation re-reads the live
             // state when consumed, after any already-queued goal controls.
-            let _ = self
-                .tx_op
-                .send(Op::ContinueGoal {
-                    dynamic_tools: dynamic_tools.clone(),
-                })
-                .await;
+            self.schedule_goal_continuation(dynamic_tools);
         }
-        true
+        SendMessageOutcome::Finished { status, error }
     }
 
     async fn handle_manual_compaction(&mut self) {

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -723,7 +723,6 @@ enum GoalContinuationAction {
         snapshot: Box<GoalSnapshot>,
     },
     Stopped {
-        status: GoalStatus,
         message: String,
     },
 }
@@ -1651,18 +1650,8 @@ impl Engine {
                             GoalContinuationAction::Dispatch { content, snapshot } => {
                                 (content, *snapshot)
                             }
-                            GoalContinuationAction::Stopped { status, message } => {
-                                // Keep the host-side mirror and stable prompt in
-                                // sync with the terminal SharedGoalState before
-                                // publishing the stop receipt. This prevents the
-                                // sidebar from claiming an exhausted goal is
-                                // still running and removes stale <session_goal>
-                                // instructions from the persisted session.
-                                self.config.goal_status = status;
-                                self.refresh_system_prompt();
-                                self.emit_session_updated().await;
-                                self.emit_goal_updated().await;
-                                let _ = self.tx_event.send(Event::status(message)).await;
+                            GoalContinuationAction::Stopped { message } => {
+                                self.block_goal_continuation(message).await;
                                 continue;
                             }
                         };
@@ -1673,40 +1662,52 @@ impl Engine {
                         let route = match self.current_runtime_route() {
                             Ok(route) => route,
                             Err(err) => {
+                                let message = format!(
+                                    "Goal continuation blocked because its provider route is no longer valid: {err}. Fix the route, then resume the goal."
+                                );
                                 let _ = self
                                     .tx_event
                                     .send(Event::error(ErrorEnvelope::fatal_auth(format!(
                                         "Goal continuation stopped because its provider route is no longer valid: {err}"
                                     ))))
                                     .await;
+                                self.block_goal_continuation(message).await;
                                 continue;
                             }
                         };
 
-                        self.handle_send_message(
-                            content,
-                            self.current_mode,
-                            route,
-                            self.config.compaction.clone(),
-                            goal_snapshot.objective,
-                            goal_snapshot.token_budget,
-                            GoalStatus::Active,
-                            self.session.reasoning_effort.clone(),
-                            self.session.reasoning_effort_auto,
-                            self.session.auto_model,
-                            self.session.allow_shell,
-                            self.session.trust_mode,
-                            self.session.auto_approve,
-                            self.session.approval_mode,
-                            self.config.translation_enabled,
-                            self.config.show_thinking,
-                            self.config.allowed_tools.clone(),
-                            dynamic_tools,
-                            self.config.hook_executor.clone(),
-                            self.config.verbosity.clone(),
-                            UserInputProvenance::Runtime,
-                        )
-                        .await;
+                        let dispatched = self
+                            .handle_send_message(
+                                content,
+                                self.current_mode,
+                                route,
+                                self.config.compaction.clone(),
+                                goal_snapshot.objective,
+                                goal_snapshot.token_budget,
+                                GoalStatus::Active,
+                                self.session.reasoning_effort.clone(),
+                                self.session.reasoning_effort_auto,
+                                self.session.auto_model,
+                                self.session.allow_shell,
+                                self.session.trust_mode,
+                                self.session.auto_approve,
+                                self.session.approval_mode,
+                                self.config.translation_enabled,
+                                self.config.show_thinking,
+                                self.config.allowed_tools.clone(),
+                                dynamic_tools,
+                                self.config.hook_executor.clone(),
+                                self.config.verbosity.clone(),
+                                UserInputProvenance::Runtime,
+                            )
+                            .await;
+                        if !dispatched {
+                            self.block_goal_continuation(
+                                "Goal continuation blocked because the next model turn could not be started. Fix the provider route or credentials, then resume the goal."
+                                    .to_string(),
+                            )
+                            .await;
+                        }
                     }
                     Op::RunShellCommand {
                         command,
@@ -2741,16 +2742,47 @@ impl Engine {
                         return GoalContinuationAction::Inactive;
                     }
                 };
-                if let Err(err) = state.mark_blocked(message.clone()) {
-                    tracing::warn!("failed to mark stopped goal blocked: {err}");
-                    return GoalContinuationAction::Inactive;
-                }
-                GoalContinuationAction::Stopped {
-                    status: GoalStatus::Blocked,
-                    message,
-                }
+                GoalContinuationAction::Stopped { message }
             }
         }
+    }
+
+    /// Transition a still-active interactive goal to Blocked and publish every
+    /// host projection in one ordered path. Continuation failures happen
+    /// outside a model tool call, so without this bridge the loop can stop while
+    /// the prompt and sidebar continue to claim the goal is actively running.
+    async fn block_goal_continuation(&mut self, message: String) {
+        let snapshot = match self.config.goal_state.lock() {
+            Ok(mut state) => {
+                if state.is_active()
+                    && let Err(err) = state.mark_blocked(message.clone())
+                {
+                    tracing::warn!("failed to mark goal continuation blocked: {err}");
+                    return;
+                }
+                let snapshot = state.snapshot();
+                if snapshot.status != GoalStatus::Blocked.as_str() {
+                    tracing::warn!(
+                        status = %snapshot.status,
+                        "goal changed before continuation blocker could be published"
+                    );
+                    return;
+                }
+                snapshot
+            }
+            Err(err) => {
+                tracing::warn!("goal state lock poisoned while blocking continuation: {err}");
+                return;
+            }
+        };
+
+        self.config.goal_objective.clone_from(&snapshot.objective);
+        self.config.goal_token_budget = snapshot.token_budget;
+        self.config.goal_status = GoalStatus::Blocked;
+        self.refresh_system_prompt();
+        self.emit_session_updated().await;
+        let _ = self.tx_event.send(Event::GoalUpdated { snapshot }).await;
+        let _ = self.tx_event.send(Event::status(message)).await;
     }
 
     /// Handle `/goal pause|resume|clear|complete|blocked` by writing the new

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1646,28 +1646,6 @@ impl Engine {
                         // running are processed before this operation. Re-read
                         // the live goal now so pause/clear/complete/blocked can
                         // cancel a stale continuation without starting a turn.
-                        let goal_is_active = self
-                            .config
-                            .goal_state
-                            .lock()
-                            .map(|state| state.snapshot().is_active())
-                            .unwrap_or(false);
-                        if !goal_is_active {
-                            continue;
-                        }
-
-                        let route = match self.current_runtime_route() {
-                            Ok(route) => route,
-                            Err(err) => {
-                                let _ = self
-                                    .tx_event
-                                    .send(Event::error(ErrorEnvelope::fatal_auth(format!(
-                                        "Goal continuation stopped because its provider route is no longer valid: {err}"
-                                    ))))
-                                    .await;
-                                continue;
-                            }
-                        };
                         let (content, goal_snapshot) = match self.goal_continuation_if_active() {
                             GoalContinuationAction::Inactive => continue,
                             GoalContinuationAction::Dispatch { content, snapshot } => {
@@ -1685,6 +1663,22 @@ impl Engine {
                                 self.emit_session_updated().await;
                                 self.emit_goal_updated().await;
                                 let _ = self.tx_event.send(Event::status(message)).await;
+                                continue;
+                            }
+                        };
+                        // Budget and inactive-state decisions are route
+                        // independent. Resolve the live route only for a real
+                        // dispatch so an exhausted goal still reaches its
+                        // truthful terminal state when provider config drifted.
+                        let route = match self.current_runtime_route() {
+                            Ok(route) => route,
+                            Err(err) => {
+                                let _ = self
+                                    .tx_event
+                                    .send(Event::error(ErrorEnvelope::fatal_auth(format!(
+                                        "Goal continuation stopped because its provider route is no longer valid: {err}"
+                                    ))))
+                                    .await;
                                 continue;
                             }
                         };
@@ -2763,7 +2757,7 @@ impl Engine {
     /// status to `SharedGoalState` so the cross-turn continuation loop respects
     /// it. This does NOT dispatch a model turn — it's a control-plane update.
     async fn handle_set_goal_status(&mut self, status: GoalStatus, clear: bool) {
-        match self.config.goal_state.lock() {
+        let snapshot = match self.config.goal_state.lock() {
             Ok(mut state) => {
                 if clear {
                     // `/goal clear` — wipe the objective entirely.
@@ -2777,11 +2771,34 @@ impl Engine {
                     let budget = state.token_budget();
                     state.sync_from_host_status(objective.as_deref(), budget, status);
                 }
+                state.snapshot()
             }
             Err(err) => {
                 tracing::warn!("goal state lock poisoned during SetGoalStatus: {err}");
+                return;
             }
-        }
+        };
+
+        // Keep every host-side projection aligned with the authoritative
+        // SharedGoalState. In particular, a cleared state must also clear the
+        // configured fallback used by `goal_objective_for_prompt`; otherwise a
+        // prompt refresh would silently restore the old <session_goal> block.
+        self.config.goal_objective.clone_from(&snapshot.objective);
+        self.config.goal_token_budget = snapshot.token_budget;
+        self.config.goal_status = if snapshot.objective.is_some() {
+            status
+        } else {
+            GoalStatus::Active
+        };
+        self.refresh_system_prompt();
+        self.emit_session_updated().await;
+        // Unlike routine end-of-turn updates, an explicit clear must publish
+        // the canonical empty snapshot. Keeping this scoped to the control op
+        // avoids an unrelated no-goal turn racing with a newly declared goal in
+        // the UI while still letting the clear win over a preceding active
+        // TurnComplete snapshot.
+        let _ = self.tx_event.send(Event::GoalUpdated { snapshot }).await;
+
         let label = if clear {
             "cleared"
         } else {
@@ -2796,7 +2813,6 @@ impl Engine {
             .tx_event
             .send(Event::status(format!("Goal {label}.")))
             .await;
-        self.emit_goal_updated().await;
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -2590,7 +2590,7 @@ impl Engine {
     /// There is no continuation cap — a goal runs until the model self-reports
     /// done/blocked, the user pauses or clears, or an optional token/time
     /// budget is exhausted. The loop is "until done," not "until N turns."
-    fn goal_continuation_if_active(&self) -> Option<String> {
+    fn goal_continuation_if_active(&self) -> Option<(String, GoalSnapshot)> {
         let snapshot = self.config.goal_state.lock().ok()?.snapshot();
         if !snapshot.is_active() {
             return None;
@@ -2619,12 +2619,13 @@ impl Engine {
         );
 
         match decision {
-            crate::goal_loop::ContinuationDecision::Continue => {
-                Some(crate::tools::goal::render_continuation_prompt(
+            crate::goal_loop::ContinuationDecision::Continue => Some((
+                crate::tools::goal::render_continuation_prompt(
                     &snapshot,
                     snapshot.continuation_count,
-                ))
-            }
+                ),
+                snapshot,
+            )),
             // All stop reasons → no continuation. The caller (the async turn
             // completion path) emits a status message for budget-exhaustion.
             crate::goal_loop::ContinuationDecision::Stop(reason) => {
@@ -3164,7 +3165,7 @@ impl Engine {
         // further turn. A Failed or Interrupted turn never continues.
         if !self.host_managed_turns()
             && status == TurnOutcomeStatus::Completed
-            && let Some(continuation) = self.goal_continuation_if_active()
+            && let Some((continuation, goal_snapshot)) = self.goal_continuation_if_active()
         {
             // Re-dispatch with the same route/mode/approval settings as
             // the prior turn. The non-Copy values were moved into
@@ -3179,8 +3180,13 @@ impl Engine {
                             mode,
                             route: Box::new(route),
                             compaction: Box::new(self.config.compaction.clone()),
-                            goal_objective: None,
-                            goal_token_budget: None,
+                            // Carry the same authoritative runtime snapshot into
+                            // the synthetic turn. Passing `None` here is a host
+                            // instruction to clear `SharedGoalState`, so it made
+                            // an explicit `/goal <objective>` survive only until
+                            // the first cross-turn continuation.
+                            goal_objective: goal_snapshot.objective,
+                            goal_token_budget: goal_snapshot.token_budget,
                             goal_status: GoalStatus::Active,
                             reasoning_effort: self.session.reasoning_effort.clone(),
                             reasoning_effort_auto,

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -716,6 +716,18 @@ fn claim_subagent_completion(
         .then_some(completion)
 }
 
+enum GoalContinuationAction {
+    Inactive,
+    Dispatch {
+        content: String,
+        snapshot: Box<GoalSnapshot>,
+    },
+    Stopped {
+        status: GoalStatus,
+        message: String,
+    },
+}
+
 // === Internal tool helpers ===
 
 fn subagent_mailbox_message_is_best_effort(message: &MailboxMessage) -> bool {
@@ -1656,9 +1668,25 @@ impl Engine {
                                 continue;
                             }
                         };
-                        let Some((content, goal_snapshot)) = self.goal_continuation_if_active()
-                        else {
-                            continue;
+                        let (content, goal_snapshot) = match self.goal_continuation_if_active() {
+                            GoalContinuationAction::Inactive => continue,
+                            GoalContinuationAction::Dispatch { content, snapshot } => {
+                                (content, *snapshot)
+                            }
+                            GoalContinuationAction::Stopped { status, message } => {
+                                // Keep the host-side mirror and stable prompt in
+                                // sync with the terminal SharedGoalState before
+                                // publishing the stop receipt. This prevents the
+                                // sidebar from claiming an exhausted goal is
+                                // still running and removes stale <session_goal>
+                                // instructions from the persisted session.
+                                self.config.goal_status = status;
+                                self.refresh_system_prompt();
+                                self.emit_session_updated().await;
+                                self.emit_goal_updated().await;
+                                let _ = self.tx_event.send(Event::status(message)).await;
+                                continue;
+                            }
                         };
 
                         self.handle_send_message(
@@ -2640,18 +2668,24 @@ impl Engine {
 
     /// Handle a send message operation
     #[allow(clippy::too_many_arguments)]
-    /// After a turn completes, check whether an active goal should keep going.
-    /// Returns a continuation message to re-dispatch as a new turn, or `None`
-    /// if the goal is complete, blocked, paused, or over an optional budget.
+    /// After a turn completes, decide whether an active goal should keep going.
+    /// Returns a continuation to dispatch, an explicit terminal budget stop,
+    /// or `Inactive` when no follow-up turn belongs in the queue.
     ///
     /// There is no continuation cap — a goal runs until the model self-reports
     /// done/blocked, the user pauses or clears, or an optional token/time
     /// budget is exhausted. The loop is "until done," not "until N turns."
-    fn goal_continuation_if_active(&self) -> Option<(String, GoalSnapshot)> {
-        let mut state = self.config.goal_state.lock().ok()?;
+    fn goal_continuation_if_active(&self) -> GoalContinuationAction {
+        let mut state = match self.config.goal_state.lock() {
+            Ok(state) => state,
+            Err(err) => {
+                tracing::warn!("goal state lock poisoned during continuation check: {err}");
+                return GoalContinuationAction::Inactive;
+            }
+        };
         let snapshot = state.snapshot();
         if !snapshot.is_active() {
-            return None;
+            return GoalContinuationAction::Inactive;
         }
 
         // The snapshot status is a string ("active", "paused", "complete",
@@ -2660,7 +2694,7 @@ impl Engine {
             "active" => crate::goal_loop::GoalRunStatus::Active,
             "complete" => crate::goal_loop::GoalRunStatus::Completed,
             // Paused / Blocked / unknown → no continuation.
-            _ => return None,
+            _ => return GoalContinuationAction::Inactive,
         };
 
         let decision = crate::goal_loop::decide_continuation(
@@ -2684,19 +2718,43 @@ impl Engine {
                 // telemetry, and next host sync all agree on the pass number.
                 state.record_continuation();
                 let snapshot = state.snapshot();
-                Some((
-                    crate::tools::goal::render_continuation_prompt(
+                GoalContinuationAction::Dispatch {
+                    content: crate::tools::goal::render_continuation_prompt(
                         &snapshot,
                         snapshot.continuation_count,
                     ),
-                    snapshot,
-                ))
+                    snapshot: Box::new(snapshot),
+                }
             }
-            // All stop reasons → no continuation. The caller (the async turn
-            // completion path) emits a status message for budget-exhaustion.
             crate::goal_loop::ContinuationDecision::Stop(reason) => {
                 tracing::info!(?reason, "goal continuation stopped");
-                None
+                let message = match reason {
+                    crate::goal_loop::StopReason::TokenBudget => format!(
+                        "Goal token budget reached ({} / {} tokens); automatic continuation stopped and the goal is blocked.",
+                        snapshot.tokens_used,
+                        snapshot.token_budget.unwrap_or_default(),
+                    ),
+                    crate::goal_loop::StopReason::TimeBudget => format!(
+                        "Goal time budget reached ({} seconds); automatic continuation stopped and the goal is blocked.",
+                        snapshot.time_used_seconds,
+                    ),
+                    crate::goal_loop::StopReason::ContinuationLimit => {
+                        "Goal continuation limit reached; automatic continuation stopped and the goal is blocked."
+                            .to_string()
+                    }
+                    crate::goal_loop::StopReason::Completed
+                    | crate::goal_loop::StopReason::Blocked => {
+                        return GoalContinuationAction::Inactive;
+                    }
+                };
+                if let Err(err) = state.mark_blocked(message.clone()) {
+                    tracing::warn!("failed to mark stopped goal blocked: {err}");
+                    return GoalContinuationAction::Inactive;
+                }
+                GoalContinuationAction::Stopped {
+                    status: GoalStatus::Blocked,
+                    message,
+                }
             }
         }
     }

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -1629,6 +1629,63 @@ impl Engine {
                         )
                         .await;
                     }
+                    Op::ContinueGoal { dynamic_tools } => {
+                        // Status controls queued while the previous turn was
+                        // running are processed before this operation. Re-read
+                        // the live goal now so pause/clear/complete/blocked can
+                        // cancel a stale continuation without starting a turn.
+                        let goal_is_active = self
+                            .config
+                            .goal_state
+                            .lock()
+                            .map(|state| state.snapshot().is_active())
+                            .unwrap_or(false);
+                        if !goal_is_active {
+                            continue;
+                        }
+
+                        let route = match self.current_runtime_route() {
+                            Ok(route) => route,
+                            Err(err) => {
+                                let _ = self
+                                    .tx_event
+                                    .send(Event::error(ErrorEnvelope::fatal_auth(format!(
+                                        "Goal continuation stopped because its provider route is no longer valid: {err}"
+                                    ))))
+                                    .await;
+                                continue;
+                            }
+                        };
+                        let Some((content, goal_snapshot)) = self.goal_continuation_if_active()
+                        else {
+                            continue;
+                        };
+
+                        self.handle_send_message(
+                            content,
+                            self.current_mode,
+                            route,
+                            self.config.compaction.clone(),
+                            goal_snapshot.objective,
+                            goal_snapshot.token_budget,
+                            GoalStatus::Active,
+                            self.session.reasoning_effort.clone(),
+                            self.session.reasoning_effort_auto,
+                            self.session.auto_model,
+                            self.session.allow_shell,
+                            self.session.trust_mode,
+                            self.session.auto_approve,
+                            self.session.approval_mode,
+                            self.config.translation_enabled,
+                            self.config.show_thinking,
+                            self.config.allowed_tools.clone(),
+                            dynamic_tools,
+                            self.config.hook_executor.clone(),
+                            self.config.verbosity.clone(),
+                            UserInputProvenance::Runtime,
+                        )
+                        .await;
+                    }
                     Op::RunShellCommand {
                         command,
                         mode,
@@ -2591,7 +2648,8 @@ impl Engine {
     /// done/blocked, the user pauses or clears, or an optional token/time
     /// budget is exhausted. The loop is "until done," not "until N turns."
     fn goal_continuation_if_active(&self) -> Option<(String, GoalSnapshot)> {
-        let snapshot = self.config.goal_state.lock().ok()?.snapshot();
+        let mut state = self.config.goal_state.lock().ok()?;
+        let snapshot = state.snapshot();
         if !snapshot.is_active() {
             return None;
         }
@@ -2619,13 +2677,21 @@ impl Engine {
         );
 
         match decision {
-            crate::goal_loop::ContinuationDecision::Continue => Some((
-                crate::tools::goal::render_continuation_prompt(
-                    &snapshot,
-                    snapshot.continuation_count,
-                ),
-                snapshot,
-            )),
+            crate::goal_loop::ContinuationDecision::Continue => {
+                // A cross-turn dispatch is a real continuation pass just like
+                // the bounded intra-turn retry in `turn_loop`. Record it before
+                // rendering and carrying the snapshot so the durable prompt,
+                // telemetry, and next host sync all agree on the pass number.
+                state.record_continuation();
+                let snapshot = state.snapshot();
+                Some((
+                    crate::tools::goal::render_continuation_prompt(
+                        &snapshot,
+                        snapshot.continuation_count,
+                    ),
+                    snapshot,
+                ))
+            }
             // All stop reasons → no continuation. The caller (the async turn
             // completion path) emits a status message for budget-exhaustion.
             crate::goal_loop::ContinuationDecision::Stop(reason) => {
@@ -3163,57 +3229,16 @@ impl Engine {
         // its own op channel. RuntimeThreadManager engines instead yield here:
         // their host must create the next durable claim before dispatching any
         // further turn. A Failed or Interrupted turn never continues.
-        if !self.host_managed_turns()
-            && status == TurnOutcomeStatus::Completed
-            && let Some((continuation, goal_snapshot)) = self.goal_continuation_if_active()
-        {
-            // Re-dispatch with the same route/mode/approval settings as
-            // the prior turn. The non-Copy values were moved into
-            // `self.config` / `self.session` earlier in this function, so
-            // we clone them back out here.
-            match self.current_runtime_route() {
-                Ok(route) => {
-                    let _ = self
-                        .tx_op
-                        .send(Op::SendMessage {
-                            content: continuation,
-                            mode,
-                            route: Box::new(route),
-                            compaction: Box::new(self.config.compaction.clone()),
-                            // Carry the same authoritative runtime snapshot into
-                            // the synthetic turn. Passing `None` here is a host
-                            // instruction to clear `SharedGoalState`, so it made
-                            // an explicit `/goal <objective>` survive only until
-                            // the first cross-turn continuation.
-                            goal_objective: goal_snapshot.objective,
-                            goal_token_budget: goal_snapshot.token_budget,
-                            goal_status: GoalStatus::Active,
-                            reasoning_effort: self.session.reasoning_effort.clone(),
-                            reasoning_effort_auto,
-                            auto_model,
-                            allow_shell,
-                            trust_mode,
-                            auto_approve,
-                            approval_mode,
-                            translation_enabled,
-                            show_thinking,
-                            allowed_tools: self.config.allowed_tools.clone(),
-                            dynamic_tools: dynamic_tools.clone(),
-                            hook_executor: self.config.hook_executor.clone(),
-                            verbosity: self.config.verbosity.clone(),
-                            provenance: UserInputProvenance::Runtime,
-                        })
-                        .await;
-                }
-                Err(err) => {
-                    let _ = self
-                        .tx_event
-                        .send(Event::error(ErrorEnvelope::fatal_auth(format!(
-                            "Goal continuation stopped because its provider route is no longer valid: {err}"
-                        ))))
-                        .await;
-                }
-            }
+        if !self.host_managed_turns() && status == TurnOutcomeStatus::Completed {
+            // Queue a typed continuation instead of freezing an Active goal
+            // snapshot into a generic message. The operation re-reads the live
+            // state when consumed, after any already-queued goal controls.
+            let _ = self
+                .tx_op
+                .send(Op::ContinueGoal {
+                    dynamic_tools: dynamic_tools.clone(),
+                })
+                .await;
         }
         true
     }

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -299,6 +299,62 @@ struct FirstRequestGatedGoalModelClient {
     release_request: std::sync::Arc<tokio::sync::Notify>,
 }
 
+struct IndexedGatedGoalModelClient {
+    calls: std::sync::atomic::AtomicUsize,
+    gates: HashMap<
+        usize,
+        (
+            std::sync::Arc<tokio::sync::Notify>,
+            std::sync::Arc<tokio::sync::Notify>,
+        ),
+    >,
+    max_calls: usize,
+}
+
+#[async_trait::async_trait]
+impl crate::core::model_client::ModelClient for IndexedGatedGoalModelClient {
+    fn provider_name(&self) -> &str {
+        "deterministic-goal"
+    }
+
+    fn model(&self) -> &str {
+        "local-model"
+    }
+
+    async fn create_message(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::models::MessageResponse> {
+        anyhow::bail!("indexed gate regression uses the streaming model boundary")
+    }
+
+    async fn create_message_stream(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::llm_client::StreamEventBox> {
+        let call = self
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .saturating_add(1);
+        if call > self.max_calls {
+            anyhow::bail!("unexpected indexed goal model request #{call}");
+        }
+        if let Some((entered, release)) = self.gates.get(&call).cloned() {
+            entered.notify_one();
+            release.notified().await;
+        }
+
+        let events = crate::llm_client::mock::canned::simple_text_turn("still working")
+            .into_iter()
+            .map(Ok);
+        Ok(Box::pin(futures_util::stream::iter(events)))
+    }
+
+    async fn health_check(&self) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}
+
 #[async_trait::async_trait]
 impl crate::core::model_client::ModelClient for FirstRequestGatedGoalModelClient {
     fn provider_name(&self) -> &str {
@@ -805,6 +861,233 @@ async fn saturated_mailbox_does_not_deadlock_goal_continuation_self_dispatch() {
 }
 
 #[tokio::test]
+async fn queued_ordinary_turn_does_not_multiply_engine_goal_continuations() {
+    let first_entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_first = std::sync::Arc::new(tokio::sync::Notify::new());
+    let third_entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_third = std::sync::Arc::new(tokio::sync::Notify::new());
+    let model = std::sync::Arc::new(IndexedGatedGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        gates: HashMap::from([
+            (
+                1,
+                (
+                    std::sync::Arc::clone(&first_entered),
+                    std::sync::Arc::clone(&release_first),
+                ),
+            ),
+            (
+                3,
+                (
+                    std::sync::Arc::clone(&third_entered),
+                    std::sync::Arc::clone(&release_third),
+                ),
+            ),
+        ]),
+        max_calls: 3,
+    });
+    let config = goal_custom_route_config();
+    let engine_config = EngineConfig {
+        model: "local-model".to_string(),
+        max_steps: 1,
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("coalesce queued goal turns".to_string()),
+        ..EngineConfig::default()
+    };
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (engine, handle) = Engine::new_with_model_client(engine_config, &config, client);
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+    let send_message = |content: &str| Op::SendMessage {
+        content: content.to_string(),
+        mode: AppMode::Agent,
+        route: resolved_route_for_test(&config, "local-model"),
+        compaction: Box::new(CompactionConfig::default()),
+        goal_objective: Some("coalesce queued goal turns".to_string()),
+        goal_token_budget: None,
+        goal_status: crate::tools::goal::GoalStatus::Active,
+        reasoning_effort: None,
+        reasoning_effort_auto: false,
+        auto_model: false,
+        allow_shell: false,
+        trust_mode: false,
+        auto_approve: false,
+        approval_mode: crate::tui::approval::ApprovalMode::Suggest,
+        translation_enabled: false,
+        show_thinking: false,
+        allowed_tools: None,
+        dynamic_tools: Vec::new(),
+        hook_executor: None,
+        verbosity: None,
+        provenance: UserInputProvenance::ExternalUser,
+    };
+
+    handle
+        .send(send_message("start the goal turn"))
+        .await
+        .expect("send first goal turn");
+    tokio::time::timeout(model_turn_event_timeout(), first_entered.notified())
+        .await
+        .expect("first goal request was never entered");
+
+    // This ordinary user turn is already ahead of the first synthetic token
+    // when the gated turn completes. It may refresh that token's tools, but it
+    // must not create a second autonomous continuation.
+    handle
+        .send(send_message("queued ordinary follow-up"))
+        .await
+        .expect("queue ordinary follow-up");
+    release_first.notify_one();
+
+    tokio::time::timeout(model_turn_event_timeout(), third_entered.notified())
+        .await
+        .expect("coalesced synthetic continuation was never entered");
+    handle
+        .send(Op::SetGoalStatus {
+            status: crate::tools::goal::GoalStatus::Paused,
+            clear: false,
+        })
+        .await
+        .expect("queue goal pause behind synthetic turn");
+    release_third.notify_one();
+
+    let _session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("queued-turn coalescing did not settle")
+        .expect("post-coalescing session snapshot");
+    assert_eq!(
+        model.calls.load(std::sync::atomic::Ordering::SeqCst),
+        3,
+        "one initial turn, one queued user turn, and one synthetic continuation are expected"
+    );
+    assert_eq!(
+        goal_state.lock().expect("goal lock").snapshot().status,
+        "paused"
+    );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    tokio::time::timeout(model_turn_event_timeout(), run_task)
+        .await
+        .expect("engine did not shut down after queued-turn coalescing")
+        .expect("engine task");
+}
+
+#[tokio::test]
+async fn saturated_goal_controls_run_before_ready_idle_child_completion() {
+    use crate::tools::subagent::SubAgentCompletion;
+
+    let stale_tool = DynamicToolSpec {
+        namespace: Some("goal-regression".to_string()),
+        name: "stale".to_string(),
+        description: "stale tool catalog".to_string(),
+        input_schema: json!({"type": "object"}),
+        defer_loading: false,
+    };
+    let fresh_tool = DynamicToolSpec {
+        name: "fresh".to_string(),
+        description: "fresh tool catalog".to_string(),
+        ..stale_tool.clone()
+    };
+    let config = goal_custom_route_config();
+    let (mut engine, handle) = Engine::new(
+        EngineConfig {
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            ..EngineConfig::default()
+        },
+        &config,
+    );
+
+    for index in 0..ENGINE_OP_CHANNEL_CAPACITY {
+        let status = if index + 1 == ENGINE_OP_CHANNEL_CAPACITY {
+            crate::tools::goal::GoalStatus::Paused
+        } else {
+            crate::tools::goal::GoalStatus::Active
+        };
+        handle
+            .tx_op
+            .try_send(Op::SetGoalStatus {
+                status,
+                clear: false,
+            })
+            .unwrap_or_else(|error| panic!("fill ordering mailbox slot {index}: {error}"));
+    }
+    assert_eq!(handle.tx_op.capacity(), 0, "fixture must saturate mailbox");
+    engine
+        .tx_subagent_completion
+        .send(SubAgentCompletion {
+            agent_id: "agent_ready_during_backpressure".to_string(),
+            payload: "ready child completion".to_string(),
+        })
+        .expect("queue ready idle child completion");
+    engine.schedule_goal_continuation(vec![stale_tool]);
+    assert!(
+        engine.draining_goal_continuation_backpressure(),
+        "full mailbox must activate temporary op priority"
+    );
+
+    // Inspect the exact production receive helper without running handlers:
+    // all controls that filled the mailbox, including the final pause, must be
+    // selected before the already-ready idle child completion.
+    for index in 0..ENGINE_OP_CHANNEL_CAPACITY {
+        let input = tokio::time::timeout(model_turn_event_timeout(), engine.next_run_input(false))
+            .await
+            .expect("backpressured operation receive timed out")
+            .expect("engine input");
+        let EngineRunInput::Operation(op) = input else {
+            panic!("idle child completion beat queued control {index}");
+        };
+        let Op::SetGoalStatus { status, clear } = *op else {
+            panic!("unexpected operation before queued control {index}");
+        };
+        assert!(!clear);
+        let expected = if index + 1 == ENGINE_OP_CHANNEL_CAPACITY {
+            crate::tools::goal::GoalStatus::Paused
+        } else {
+            crate::tools::goal::GoalStatus::Active
+        };
+        assert_eq!(status, expected);
+        if index == 0 {
+            // Refresh after capacity opens. The existing token must retain its
+            // FIFO position behind the remaining controls while carrying the
+            // newest runtime tool catalog when it is eventually consumed.
+            engine.schedule_goal_continuation(vec![fresh_tool.clone()]);
+        }
+    }
+
+    let token = engine
+        .next_run_input(false)
+        .await
+        .expect("backpressured continuation token");
+    let EngineRunInput::Operation(token) = token else {
+        panic!("idle child completion beat the backpressured continuation token");
+    };
+    let Op::ContinueGoal {
+        dynamic_tools,
+        engine_schedule_id,
+    } = *token
+    else {
+        panic!("expected engine-owned continuation token");
+    };
+    assert!(dynamic_tools.is_empty());
+    let continued_tools = engine
+        .take_scheduled_goal_continuation(engine_schedule_id, dynamic_tools)
+        .expect("engine-owned continuation token must consume its schedule marker");
+    assert_eq!(continued_tools, vec![fresh_tool]);
+    assert!(!engine.draining_goal_continuation_backpressure());
+
+    let child = engine
+        .next_run_input(false)
+        .await
+        .expect("ready idle child completion");
+    let EngineRunInput::SubAgentCompletion(child) = child else {
+        panic!("unexpected operation after backpressure drain");
+    };
+    assert_eq!(child.agent_id, "agent_ready_during_backpressure");
+}
+
+#[tokio::test]
 async fn cross_turn_token_budget_exhaustion_blocks_goal_and_refreshes_prompt() {
     use crate::llm_client::mock::{MockLlmClient, canned};
 
@@ -977,6 +1260,7 @@ async fn queued_goal_clear_refreshes_prompt_and_cancels_stale_continuation() {
     handle
         .send(Op::ContinueGoal {
             dynamic_tools: Vec::new(),
+            engine_schedule_id: None,
         })
         .await
         .expect("queue stale continuation");
@@ -1108,6 +1392,7 @@ async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
     handle
         .send(Op::ContinueGoal {
             dynamic_tools: Vec::new(),
+            engine_schedule_id: None,
         })
         .await
         .expect("queue exhausted continuation");
@@ -1187,6 +1472,7 @@ async fn invalid_route_blocks_active_goal_and_refreshes_projections() {
     handle
         .send(Op::ContinueGoal {
             dynamic_tools: Vec::new(),
+            engine_schedule_id: None,
         })
         .await
         .expect("queue active continuation");
@@ -1292,6 +1578,7 @@ async fn rejected_continuation_dispatch_blocks_goal_after_failed_turn() {
     handle
         .send(Op::ContinueGoal {
             dynamic_tools: Vec::new(),
+            engine_schedule_id: None,
         })
         .await
         .expect("queue rejected continuation");
@@ -1414,6 +1701,7 @@ async fn started_nonretryable_continuation_failure_blocks_goal_with_bounded_reas
     handle
         .send(Op::ContinueGoal {
             dynamic_tools: Vec::new(),
+            engine_schedule_id: None,
         })
         .await
         .expect("queue failing continuation");

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -291,6 +291,7 @@ struct GatedGoalModelClient {
     requests: std::sync::Mutex<Vec<crate::models::MessageRequest>>,
     second_request_entered: std::sync::Arc<tokio::sync::Notify>,
     release_second_request: std::sync::Arc<tokio::sync::Notify>,
+    first_usage: Option<Usage>,
 }
 
 struct FirstRequestGatedGoalModelClient {
@@ -477,9 +478,16 @@ impl crate::core::model_client::ModelClient for GatedGoalModelClient {
             anyhow::bail!("unexpected goal model request #{call}");
         }
 
-        let events = crate::llm_client::mock::canned::simple_text_turn("still working")
-            .into_iter()
-            .map(Ok);
+        let mut events = crate::llm_client::mock::canned::simple_text_turn("still working");
+        if call == 1
+            && let Some(usage) = self.first_usage.clone()
+            && let Some(crate::models::StreamEvent::MessageDelta { usage: slot, .. }) = events
+                .iter_mut()
+                .find(|event| matches!(event, crate::models::StreamEvent::MessageDelta { .. }))
+        {
+            *slot = Some(usage);
+        }
+        let events = events.into_iter().map(Ok);
         Ok(Box::pin(futures_util::stream::iter(events)))
     }
 
@@ -499,6 +507,11 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
         requests: std::sync::Mutex::new(Vec::new()),
         second_request_entered: std::sync::Arc::clone(&second_request_entered),
         release_second_request: std::sync::Arc::clone(&release_second_request),
+        first_usage: Some(Usage {
+            input_tokens: 3,
+            output_tokens: 2,
+            ..Usage::default()
+        }),
     });
     let mut custom = HashMap::new();
     custom.insert(
@@ -668,7 +681,23 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
     }
     assert_eq!(starts, 2);
     assert!(verified_synthetic_goal);
-    assert_eq!(model.captured_requests().len(), 2);
+    let requests = model.captured_requests();
+    assert_eq!(requests.len(), 2);
+    let first_intra_turn_prompt = requests[1]
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .find_map(|block| match block {
+            ContentBlock::Text { text, .. } if text.contains("Continuation pass #1.") => {
+                Some(text.as_str())
+            }
+            _ => None,
+        })
+        .expect("first intra-turn goal snapshot must survive into the next request");
+    assert!(
+        first_intra_turn_prompt.contains("\"tokens_used\": 5"),
+        "current-turn usage must be rendered without waiting for durable recording: {first_intra_turn_prompt}"
+    );
 
     // The pause was queued while the second turn was still running. Wait for
     // that control operation, then put a snapshot receipt behind the already
@@ -974,6 +1003,291 @@ async fn queued_ordinary_turn_does_not_multiply_engine_goal_continuations() {
 }
 
 #[tokio::test]
+async fn queued_failed_turn_cancels_older_goal_continuation_without_third_call() {
+    let objective = "stop after the intervening failure";
+    let model = std::sync::Arc::new(FailingGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        message: "deterministic queued turn failure".to_string(),
+    });
+    let config = goal_custom_route_config();
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (mut engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some(objective.to_string()),
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "queued turn that will fail",
+            objective,
+            None,
+        ))
+        .await
+        .expect("queue failing ordinary turn");
+    engine.schedule_goal_continuation(Vec::new());
+    assert!(engine.has_scheduled_goal_continuation());
+    let run_task = tokio::spawn(engine.run());
+
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("queued failure did not settle")
+        .expect("post-failure session snapshot");
+    assert_eq!(
+        model.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the stale synthetic token must not make a third provider call"
+    );
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.status, "blocked");
+    assert!(
+        goal.blocker
+            .as_deref()
+            .is_some_and(|blocker| blocker.contains("deterministic queued turn failure")),
+        "{goal:?}"
+    );
+    let prompt = system_prompt_text(session.system_prompt.expect("blocked system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn queued_not_started_turn_cancels_older_goal_continuation() {
+    let objective = "stop when the queued turn cannot start";
+    let model = std::sync::Arc::new(FailingGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        message: "model must never be called".to_string(),
+    });
+    let config = goal_custom_route_config();
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (mut engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some(objective.to_string()),
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+    engine.model_client = None;
+    engine.deepseek_client_error = Some("deterministic missing model client".to_string());
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "queued turn that cannot start",
+            objective,
+            None,
+        ))
+        .await
+        .expect("queue not-started ordinary turn");
+    engine.schedule_goal_continuation(Vec::new());
+    let run_task = tokio::spawn(engine.run());
+
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("not-started turn did not settle")
+        .expect("post-rejection session snapshot");
+    assert_eq!(
+        model.calls.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "neither the rejected turn nor its stale token may call the provider"
+    );
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.status, "blocked");
+    assert!(
+        goal.blocker
+            .as_deref()
+            .is_some_and(|blocker| blocker.contains("could not be started")),
+        "{goal:?}"
+    );
+    let prompt = system_prompt_text(session.system_prompt.expect("blocked system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn queued_interrupted_turn_cancels_older_goal_continuation_without_third_call() {
+    let objective = "pause after the intervening cancellation";
+    let request_entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_request = std::sync::Arc::new(tokio::sync::Notify::new());
+    let model = std::sync::Arc::new(FirstRequestGatedGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        request_entered: std::sync::Arc::clone(&request_entered),
+        release_request,
+    });
+    let config = goal_custom_route_config();
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (mut engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some(objective.to_string()),
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "queued turn that will be cancelled",
+            objective,
+            None,
+        ))
+        .await
+        .expect("queue interruptible ordinary turn");
+    engine.schedule_goal_continuation(Vec::new());
+    let run_task = tokio::spawn(engine.run());
+    tokio::time::timeout(model_turn_event_timeout(), request_entered.notified())
+        .await
+        .expect("queued request was never entered");
+    handle.cancel();
+
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("interrupted turn did not settle")
+        .expect("post-interruption session snapshot");
+    assert_eq!(
+        model.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the stale synthetic token must not make a third provider call"
+    );
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.status, "paused");
+    assert_eq!(goal.blocker, None);
+    let prompt = system_prompt_text(session.system_prompt.expect("paused system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn initial_goal_failure_projects_blocked_state() {
+    let objective = "block the initial failed goal turn";
+    let leaked_secret = "sk-initial-goal-secret-123456";
+    let model = std::sync::Arc::new(FailingGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        message: format!("initial provider failure: {leaked_secret}"),
+    });
+    let config = goal_custom_route_config();
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "start a goal whose first turn fails",
+            objective,
+            None,
+        ))
+        .await
+        .expect("send initial goal turn");
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("initial goal failure did not settle")
+        .expect("post-failure session snapshot");
+
+    assert_eq!(model.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.objective.as_deref(), Some(objective));
+    assert_eq!(goal.status, "blocked");
+    let blocker = goal.blocker.as_deref().expect("failure blocker");
+    assert!(blocker.contains("initial provider failure"), "{blocker}");
+    assert!(!blocker.contains(leaked_secret), "{blocker}");
+    let prompt = system_prompt_text(session.system_prompt.expect("blocked system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn initial_goal_interruption_projects_paused_state() {
+    let objective = "pause the initial interrupted goal turn";
+    let request_entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_request = std::sync::Arc::new(tokio::sync::Notify::new());
+    let model = std::sync::Arc::new(FirstRequestGatedGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        request_entered: std::sync::Arc::clone(&request_entered),
+        release_request,
+    });
+    let config = goal_custom_route_config();
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "start a goal whose first turn is cancelled",
+            objective,
+            None,
+        ))
+        .await
+        .expect("send initial goal turn");
+    tokio::time::timeout(model_turn_event_timeout(), request_entered.notified())
+        .await
+        .expect("initial request was never entered");
+    handle.cancel();
+
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("initial interruption did not settle")
+        .expect("post-interruption session snapshot");
+    assert_eq!(model.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.objective.as_deref(), Some(objective));
+    assert_eq!(goal.status, "paused");
+    assert_eq!(goal.blocker, None);
+    let prompt = system_prompt_text(session.system_prompt.expect("paused system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
 async fn saturated_goal_controls_run_before_ready_idle_child_completion() {
     use crate::tools::subagent::SubAgentCompletion;
 
@@ -1023,8 +1337,8 @@ async fn saturated_goal_controls_run_before_ready_idle_child_completion() {
         .expect("queue ready idle child completion");
     engine.schedule_goal_continuation(vec![stale_tool]);
     assert!(
-        engine.draining_goal_continuation_backpressure(),
-        "full mailbox must activate temporary op priority"
+        engine.has_scheduled_goal_continuation(),
+        "a live schedule must activate temporary op priority"
     );
 
     // Inspect the exact production receive helper without running handlers:
@@ -1075,7 +1389,7 @@ async fn saturated_goal_controls_run_before_ready_idle_child_completion() {
         .take_scheduled_goal_continuation(engine_schedule_id, dynamic_tools)
         .expect("engine-owned continuation token must consume its schedule marker");
     assert_eq!(continued_tools, vec![fresh_tool]);
-    assert!(!engine.draining_goal_continuation_backpressure());
+    assert!(!engine.has_scheduled_goal_continuation());
 
     let child = engine
         .next_run_input(false)
@@ -1085,6 +1399,85 @@ async fn saturated_goal_controls_run_before_ready_idle_child_completion() {
         panic!("unexpected operation after backpressure drain");
     };
     assert_eq!(child.agent_id, "agent_ready_during_backpressure");
+}
+
+#[tokio::test]
+async fn unsaturated_goal_control_runs_before_ready_idle_child_completion() {
+    use crate::tools::subagent::SubAgentCompletion;
+
+    let config = goal_custom_route_config();
+    let (mut engine, handle) = Engine::new(
+        EngineConfig {
+            snapshots_enabled: false,
+            terminal_chrome_enabled: false,
+            ..EngineConfig::default()
+        },
+        &config,
+    );
+
+    handle
+        .tx_op
+        .try_send(Op::SetGoalStatus {
+            status: crate::tools::goal::GoalStatus::Paused,
+            clear: false,
+        })
+        .expect("queue unsaturated pause");
+    engine
+        .tx_subagent_completion
+        .send(SubAgentCompletion {
+            agent_id: "agent_ready_without_backpressure".to_string(),
+            payload: "ready child completion".to_string(),
+        })
+        .expect("queue ready idle child completion");
+    engine.schedule_goal_continuation(Vec::new());
+    assert!(engine.has_scheduled_goal_continuation());
+    assert!(
+        handle.tx_op.capacity() > 0,
+        "fixture must leave the mailbox unsaturated"
+    );
+
+    let first = engine
+        .next_run_input(false)
+        .await
+        .expect("queued pause must be selected");
+    let EngineRunInput::Operation(first) = first else {
+        panic!("ready child completion beat an unsaturated queued pause");
+    };
+    assert!(matches!(
+        *first,
+        Op::SetGoalStatus {
+            status: crate::tools::goal::GoalStatus::Paused,
+            clear: false
+        }
+    ));
+
+    let token = engine
+        .next_run_input(false)
+        .await
+        .expect("scheduled continuation token");
+    let EngineRunInput::Operation(token) = token else {
+        panic!("ready child completion beat the live continuation token");
+    };
+    let Op::ContinueGoal {
+        dynamic_tools,
+        engine_schedule_id,
+    } = *token
+    else {
+        panic!("expected continuation token behind pause");
+    };
+    engine
+        .take_scheduled_goal_continuation(engine_schedule_id, dynamic_tools)
+        .expect("consume live continuation schedule");
+    assert!(!engine.has_scheduled_goal_continuation());
+
+    let child = engine
+        .next_run_input(false)
+        .await
+        .expect("idle child completion after schedule consumption");
+    let EngineRunInput::SubAgentCompletion(child) = child else {
+        panic!("normal child fairness did not resume after schedule consumption");
+    };
+    assert_eq!(child.agent_id, "agent_ready_without_backpressure");
 }
 
 #[tokio::test]
@@ -1198,7 +1591,7 @@ async fn cross_turn_token_budget_exhaustion_blocks_goal_and_refreshes_prompt() {
                 );
                 saw_terminal_goal = true;
             }
-            Event::Status { message } if message.contains("Goal token budget reached") => {
+            Event::Status { message } if message.contains("automatic continuation stopped") => {
                 assert!(message.contains("11 / 10 tokens"), "{message}");
                 assert!(message.contains("goal is blocked"), "{message}");
                 saw_budget_status = true;
@@ -1228,6 +1621,96 @@ async fn cross_turn_token_budget_exhaustion_blocks_goal_and_refreshes_prompt() {
         1,
         "budget stop must not call the model again"
     );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn current_turn_usage_stops_budgeted_goal_after_one_provider_call() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let objective = "stop before an intra-turn budget overspend";
+    let budget_turn = vec![
+        canned::message_start("mock_goal_current_turn_budget"),
+        canned::text_block_start(0),
+        canned::text_delta(0, "budget spent"),
+        canned::block_stop(0),
+        canned::message_delta(
+            "end_turn",
+            Some(Usage {
+                input_tokens: 8,
+                output_tokens: 3,
+                ..Usage::default()
+            }),
+        ),
+        canned::message_stop(),
+    ];
+    let model = std::sync::Arc::new(MockLlmClient::new(vec![budget_turn]));
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let config = goal_custom_route_config();
+    let (engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            subagents_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some(objective.to_string()),
+            goal_token_budget: Some(10),
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "start the budgeted goal",
+            objective,
+            Some(10),
+        ))
+        .await
+        .expect("send budgeted goal turn");
+    let mut saw_terminal_goal = false;
+    while !saw_terminal_goal {
+        let event = tokio::time::timeout(model_turn_event_timeout(), async {
+            handle.rx_event.write().await.recv().await
+        })
+        .await
+        .expect("current-turn budget stop did not settle")
+        .expect("current-turn budget event");
+        if let Event::GoalUpdated { snapshot } = event
+            && snapshot.status == "blocked"
+        {
+            saw_terminal_goal = true;
+        }
+    }
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-budget session snapshot");
+
+    assert_eq!(
+        model.call_count(),
+        1,
+        "current-turn usage must stop all additional provider calls"
+    );
+    assert_eq!(model.remaining_turns(), 0);
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.status, "blocked");
+    assert_eq!(goal.tokens_used, 11);
+    assert_eq!(goal.token_budget, Some(10));
+    assert!(
+        goal.blocker
+            .as_deref()
+            .is_some_and(|blocker| blocker.contains("11 / 10 tokens")),
+        "{goal:?}"
+    );
+    let prompt = system_prompt_text(session.system_prompt.expect("blocked system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
 
     handle.send(Op::Shutdown).await.expect("shutdown engine");
     run_task.await.expect("engine task");
@@ -2535,6 +3018,48 @@ fn resolved_route_for_test(
         resolve_runtime_route(config, config.api_provider(), Some(model))
             .expect("resolve test route"),
     )
+}
+
+fn active_goal_message_op(
+    config: &Config,
+    content: &str,
+    objective: &str,
+    token_budget: Option<u32>,
+) -> Op {
+    Op::SendMessage {
+        content: content.to_string(),
+        mode: AppMode::Agent,
+        route: resolved_route_for_test(config, "local-model"),
+        compaction: Box::new(CompactionConfig::default()),
+        goal_objective: Some(objective.to_string()),
+        goal_token_budget: token_budget,
+        goal_status: crate::tools::goal::GoalStatus::Active,
+        reasoning_effort: None,
+        reasoning_effort_auto: false,
+        auto_model: false,
+        allow_shell: false,
+        trust_mode: false,
+        auto_approve: false,
+        approval_mode: crate::tui::approval::ApprovalMode::Suggest,
+        translation_enabled: false,
+        show_thinking: false,
+        allowed_tools: None,
+        dynamic_tools: Vec::new(),
+        hook_executor: None,
+        verbosity: None,
+        provenance: UserInputProvenance::ExternalUser,
+    }
+}
+
+fn system_prompt_text(prompt: SystemPrompt) -> String {
+    match prompt {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
 }
 
 fn external_user_message_op(content: &str, mode: AppMode, config: &Config) -> Op {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -293,6 +293,89 @@ struct GatedGoalModelClient {
     release_second_request: std::sync::Arc<tokio::sync::Notify>,
 }
 
+struct FirstRequestGatedGoalModelClient {
+    calls: std::sync::atomic::AtomicUsize,
+    request_entered: std::sync::Arc<tokio::sync::Notify>,
+    release_request: std::sync::Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl crate::core::model_client::ModelClient for FirstRequestGatedGoalModelClient {
+    fn provider_name(&self) -> &str {
+        "deterministic-goal"
+    }
+
+    fn model(&self) -> &str {
+        "local-model"
+    }
+
+    async fn create_message(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::models::MessageResponse> {
+        anyhow::bail!("mailbox regression uses the streaming model boundary")
+    }
+
+    async fn create_message_stream(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::llm_client::StreamEventBox> {
+        let call = self
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .saturating_add(1);
+        if call > 1 {
+            anyhow::bail!("unexpected mailbox regression model request #{call}");
+        }
+        self.request_entered.notify_one();
+        self.release_request.notified().await;
+
+        let events = crate::llm_client::mock::canned::simple_text_turn("still working")
+            .into_iter()
+            .map(Ok);
+        Ok(Box::pin(futures_util::stream::iter(events)))
+    }
+
+    async fn health_check(&self) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}
+
+struct FailingGoalModelClient {
+    calls: std::sync::atomic::AtomicUsize,
+    message: String,
+}
+
+#[async_trait::async_trait]
+impl crate::core::model_client::ModelClient for FailingGoalModelClient {
+    fn provider_name(&self) -> &str {
+        "deterministic-goal"
+    }
+
+    fn model(&self) -> &str {
+        "local-model"
+    }
+
+    async fn create_message(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::models::MessageResponse> {
+        anyhow::bail!("failure regression uses the streaming model boundary")
+    }
+
+    async fn create_message_stream(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::llm_client::StreamEventBox> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        anyhow::bail!(self.message.clone())
+    }
+
+    async fn health_check(&self) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}
+
 impl GatedGoalModelClient {
     fn captured_requests(&self) -> Vec<crate::models::MessageRequest> {
         self.requests
@@ -606,6 +689,119 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
 
     handle.send(Op::Shutdown).await.expect("queue shutdown");
     run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn saturated_mailbox_does_not_deadlock_goal_continuation_self_dispatch() {
+    let request_entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_request = std::sync::Arc::new(tokio::sync::Notify::new());
+    let model = std::sync::Arc::new(FirstRequestGatedGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        request_entered: std::sync::Arc::clone(&request_entered),
+        release_request: std::sync::Arc::clone(&release_request),
+    });
+    let config = goal_custom_route_config();
+    let engine_config = EngineConfig {
+        model: "local-model".to_string(),
+        max_steps: 1,
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("survive a saturated mailbox".to_string()),
+        ..EngineConfig::default()
+    };
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (engine, handle) = Engine::new_with_model_client(engine_config, &config, client);
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::SendMessage {
+            content: "start the saturated goal turn".to_string(),
+            mode: AppMode::Agent,
+            route: resolved_route_for_test(&config, "local-model"),
+            compaction: Box::new(CompactionConfig::default()),
+            goal_objective: Some("survive a saturated mailbox".to_string()),
+            goal_token_budget: None,
+            goal_status: crate::tools::goal::GoalStatus::Active,
+            reasoning_effort: None,
+            reasoning_effort_auto: false,
+            auto_model: false,
+            allow_shell: false,
+            trust_mode: false,
+            auto_approve: false,
+            approval_mode: crate::tui::approval::ApprovalMode::Suggest,
+            translation_enabled: false,
+            show_thinking: false,
+            allowed_tools: None,
+            dynamic_tools: Vec::new(),
+            hook_executor: None,
+            verbosity: None,
+            provenance: UserInputProvenance::ExternalUser,
+        })
+        .await
+        .expect("send saturated goal turn");
+    tokio::time::timeout(model_turn_event_timeout(), request_entered.notified())
+        .await
+        .expect("first goal request was never entered");
+
+    // The engine has consumed the SendMessage and is gated inside the model
+    // request, so every slot below belongs to a queued control operation. The
+    // final pause must remain ahead of the synthetic continuation.
+    for index in 0..ENGINE_OP_CHANNEL_CAPACITY {
+        let status = if index + 1 == ENGINE_OP_CHANNEL_CAPACITY {
+            crate::tools::goal::GoalStatus::Paused
+        } else {
+            crate::tools::goal::GoalStatus::Active
+        };
+        handle
+            .tx_op
+            .try_send(Op::SetGoalStatus {
+                status,
+                clear: false,
+            })
+            .unwrap_or_else(|error| panic!("fill op mailbox slot {index}: {error}"));
+    }
+    assert_eq!(handle.tx_op.capacity(), 0, "fixture must saturate mailbox");
+
+    release_request.notify_one();
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("saturated mailbox deadlocked the engine")
+        .expect("post-saturation session snapshot");
+
+    let prompt = match session.system_prompt.expect("paused system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.status, "paused");
+    assert_eq!(
+        model.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the queued pause must suppress the stale continuation"
+    );
+
+    let mut starts = 0;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(event) = events.try_recv() {
+            if matches!(event, Event::TurnStarted { .. }) {
+                starts += 1;
+            }
+        }
+    }
+    assert_eq!(starts, 1, "only the original goal turn may start");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    tokio::time::timeout(model_turn_event_timeout(), run_task)
+        .await
+        .expect("engine did not shut down after mailbox saturation")
+        .expect("engine task");
 }
 
 #[tokio::test]
@@ -1185,6 +1381,125 @@ async fn rejected_continuation_dispatch_blocks_goal_after_failed_turn() {
     );
     assert!(saw_blocked_goal, "sidebar must receive blocked state");
     assert!(saw_blocked_status, "blocked reason must remain visible");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn started_nonretryable_continuation_failure_blocks_goal_with_bounded_reason() {
+    let failure_marker = "HTTP 400 Bad Request: deterministic continuation failure";
+    let leaked_secret = "sk-goal-secret-sentinel-123456";
+    let failure_message = format!(
+        "{failure_marker}: {leaked_secret} {}",
+        "provider detail ".repeat(80)
+    );
+    let model = std::sync::Arc::new(FailingGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        message: failure_message.clone(),
+    });
+    let config = goal_custom_route_config();
+    let engine_config = EngineConfig {
+        model: "local-model".to_string(),
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("block a failed continuation truthfully".to_string()),
+        ..EngineConfig::default()
+    };
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (engine, handle) = Engine::new_with_model_client(engine_config, &config, client);
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::ContinueGoal {
+            dynamic_tools: Vec::new(),
+        })
+        .await
+        .expect("queue failing continuation");
+    let session = tokio::time::timeout(model_turn_event_timeout(), handle.get_session_snapshot())
+        .await
+        .expect("failed continuation did not terminalize")
+        .expect("post-failure session snapshot");
+
+    let prompt = match session.system_prompt.expect("blocked system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+    let snapshot = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(snapshot.status, "blocked");
+    let blocker = snapshot.blocker.as_deref().expect("failure blocker");
+    assert!(blocker.contains(failure_marker), "{blocker}");
+    assert!(blocker.contains("resume the goal"), "{blocker}");
+    assert!(!blocker.contains(leaked_secret), "{blocker}");
+    assert!(
+        blocker.contains(codewhale_config::persistence::REDACTED),
+        "{blocker}"
+    );
+    assert!(
+        blocker.len() <= GOAL_CONTINUATION_FAILURE_DETAIL_MAX_BYTES + 160,
+        "failure reason must remain bounded: {} bytes",
+        blocker.len()
+    );
+    assert!(
+        blocker.len() < failure_message.len(),
+        "long provider detail must be truncated"
+    );
+    assert_eq!(
+        model.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "a nonretryable started failure must not dispatch again"
+    );
+
+    let mut starts = 0;
+    let mut saw_failed_turn = false;
+    let mut saw_provider_error = false;
+    let mut saw_blocked_goal = false;
+    let mut saw_blocked_status = false;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(event) = events.try_recv() {
+            match event {
+                Event::TurnStarted { .. } => starts += 1,
+                Event::TurnComplete { status, error, .. } => {
+                    assert_eq!(status, TurnOutcomeStatus::Failed);
+                    assert!(
+                        error
+                            .as_deref()
+                            .is_some_and(|message| message.contains(failure_marker)),
+                        "{error:?}"
+                    );
+                    saw_failed_turn = true;
+                }
+                Event::Error { envelope, .. } => {
+                    if envelope.message.contains(failure_marker) {
+                        saw_provider_error = true;
+                    }
+                }
+                Event::GoalUpdated { snapshot } if snapshot.status == "blocked" => {
+                    saw_blocked_goal = true;
+                }
+                Event::Status { message } if message.contains(failure_marker) => {
+                    assert!(message.contains("resume the goal"), "{message}");
+                    saw_blocked_status = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert_eq!(starts, 1, "exactly one continuation turn must start");
+    assert!(saw_failed_turn, "failed turn receipt must remain visible");
+    assert!(
+        saw_provider_error,
+        "provider error event must remain visible"
+    );
+    assert!(saw_blocked_goal, "goal must publish its blocked snapshot");
+    assert!(saw_blocked_status, "bounded failure must remain visible");
 
     handle.send(Op::Shutdown).await.expect("shutdown engine");
     run_task.await.expect("engine task");

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -287,7 +287,7 @@ async fn exact_turn_snapshot_restores_custom_endpoint_and_turn_receipt_after_bui
 }
 
 #[tokio::test]
-async fn goal_continuation_resolves_updated_authoritative_route_after_active_turn() {
+async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_route() {
     let mut custom = HashMap::new();
     custom.insert(
         "custom-a".to_string(),
@@ -317,6 +317,7 @@ async fn goal_continuation_resolves_updated_authoritative_route_after_active_tur
     let authoritative = Arc::new(parking_lot::RwLock::new(config.clone()));
     let (mut engine, handle) = Engine::new(engine_config, &config);
     engine.authoritative_route_config = Some(Arc::clone(&authoritative));
+    let goal_state = engine.config.goal_state.clone();
 
     handle
         .send(Op::SendMessage {
@@ -371,6 +372,9 @@ async fn goal_continuation_resolves_updated_authoritative_route_after_active_tur
                 starts += 1;
                 assert_eq!(route.provider_identity, "custom-a");
                 if starts == 2 {
+                    let snapshot = goal_state.lock().expect("goal lock").snapshot();
+                    assert_eq!(snapshot.objective.as_deref(), Some("keep going"));
+                    assert!(snapshot.is_active(), "synthetic turn must retain the goal");
                     handle
                         .send(Op::SetGoalStatus {
                             status: crate::tools::goal::GoalStatus::Paused,

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -1717,6 +1717,111 @@ async fn current_turn_usage_stops_budgeted_goal_after_one_provider_call() {
 }
 
 #[tokio::test]
+async fn tool_response_crossing_goal_budget_does_not_issue_second_provider_request() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let objective = "stop after a budget-crossing goal tool response";
+    let budget_tool_turn = vec![
+        canned::message_start("mock_goal_tool_budget"),
+        canned::tool_use_block_start(0, "call-get-goal", "get_goal"),
+        canned::tool_input_delta(0, "{}"),
+        canned::block_stop(0),
+        canned::message_delta(
+            "tool_use",
+            Some(Usage {
+                input_tokens: 8,
+                output_tokens: 3,
+                ..Usage::default()
+            }),
+        ),
+        canned::message_stop(),
+    ];
+    let model = std::sync::Arc::new(MockLlmClient::new(vec![
+        budget_tool_turn,
+        canned::simple_text_turn("this second provider response must remain unused"),
+    ]));
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let config = goal_custom_route_config();
+    let (engine, handle) = Engine::new_with_model_client(
+        EngineConfig {
+            model: "local-model".to_string(),
+            snapshots_enabled: false,
+            subagents_enabled: false,
+            terminal_chrome_enabled: false,
+            goal_objective: Some(objective.to_string()),
+            goal_token_budget: Some(10),
+            ..EngineConfig::default()
+        },
+        &config,
+        client,
+    );
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(active_goal_message_op(
+            &config,
+            "inspect the goal without overspending",
+            objective,
+            Some(10),
+        ))
+        .await
+        .expect("send budgeted goal tool turn");
+
+    let mut saw_get_goal = false;
+    let mut saw_terminal_goal = false;
+    while !saw_terminal_goal {
+        let event = tokio::time::timeout(model_turn_event_timeout(), async {
+            handle.rx_event.write().await.recv().await
+        })
+        .await
+        .expect("budget-crossing goal tool turn did not settle")
+        .expect("budget-crossing goal tool event");
+        match event {
+            Event::ToolCallComplete { name, result, .. } if name == "get_goal" => {
+                assert!(result.expect("get_goal result").success);
+                saw_get_goal = true;
+            }
+            Event::GoalUpdated { snapshot } if snapshot.status == "blocked" => {
+                saw_terminal_goal = true;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_get_goal, "the first response's goal tool must execute");
+    assert_eq!(
+        model.call_count(),
+        1,
+        "the provider-request boundary must stop the second model call"
+    );
+    assert_eq!(
+        model.remaining_turns(),
+        1,
+        "the second canned response must remain unused"
+    );
+    let goal = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(goal.status, "blocked");
+    assert_eq!(goal.tokens_used, 11, "usage must be durably recorded once");
+    assert_eq!(goal.token_budget, Some(10));
+    assert!(
+        goal.blocker
+            .as_deref()
+            .is_some_and(|blocker| blocker.contains("11 / 10 tokens")),
+        "{goal:?}"
+    );
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-budget tool session snapshot");
+    let prompt = system_prompt_text(session.system_prompt.expect("blocked system prompt"));
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
 async fn queued_goal_clear_refreshes_prompt_and_cancels_stale_continuation() {
     let config = Config::default();
     let engine_config = EngineConfig {

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -286,44 +286,81 @@ async fn exact_turn_snapshot_restores_custom_endpoint_and_turn_receipt_after_bui
     run_task.await.expect("engine task");
 }
 
+struct GatedGoalModelClient {
+    calls: std::sync::atomic::AtomicUsize,
+    requests: std::sync::Mutex<Vec<crate::models::MessageRequest>>,
+    second_request_entered: std::sync::Arc<tokio::sync::Notify>,
+    release_second_request: std::sync::Arc<tokio::sync::Notify>,
+}
+
+impl GatedGoalModelClient {
+    fn captured_requests(&self) -> Vec<crate::models::MessageRequest> {
+        self.requests
+            .lock()
+            .expect("goal model request lock")
+            .clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::core::model_client::ModelClient for GatedGoalModelClient {
+    fn provider_name(&self) -> &str {
+        "deterministic-goal"
+    }
+
+    fn model(&self) -> &str {
+        "local-model"
+    }
+
+    async fn create_message(
+        &self,
+        _request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::models::MessageResponse> {
+        anyhow::bail!("goal regression uses the streaming model boundary")
+    }
+
+    async fn create_message_stream(
+        &self,
+        request: crate::models::MessageRequest,
+    ) -> anyhow::Result<crate::llm_client::StreamEventBox> {
+        let call = self
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .saturating_add(1);
+        self.requests
+            .lock()
+            .expect("goal model request lock")
+            .push(request);
+        if call == 2 {
+            self.second_request_entered.notify_one();
+            self.release_second_request.notified().await;
+        } else if call > 2 {
+            anyhow::bail!("unexpected goal model request #{call}");
+        }
+
+        let events = crate::llm_client::mock::canned::simple_text_turn("still working")
+            .into_iter()
+            .map(Ok);
+        Ok(Box::pin(futures_util::stream::iter(events)))
+    }
+
+    async fn health_check(&self) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}
+
 #[tokio::test]
 async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_route() {
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    let first_server = MockServer::start().await;
-    let second_server = MockServer::start().await;
-    let done_sse = concat!(
-        "data: {\"id\":\"chatcmpl-goal\",\"choices\":[{\"index\":0,",
-        "\"delta\":{\"content\":\"still working\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"id\":\"chatcmpl-goal\",\"choices\":[{\"index\":0,\"delta\":{},",
-        "\"finish_reason\":\"stop\"}]}\n\n",
-        "data: [DONE]\n\n",
-    );
-    Mock::given(method("POST"))
-        .and(path("/v1/chat/completions"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_string(done_sse),
-        )
-        .expect(1)
-        .mount(&first_server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/v1/chat/completions"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_delay(Duration::from_millis(150))
-                .set_body_string(done_sse),
-        )
-        .expect(1)
-        .mount(&second_server)
-        .await;
-
-    let first_base_url = format!("{}/v1", first_server.uri());
-    let second_base_url = format!("{}/v1", second_server.uri());
+    let first_base_url = "http://127.0.0.1:18181/v1".to_string();
+    let second_base_url = "http://127.0.0.1:18182/v1".to_string();
+    let second_request_entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let release_second_request = std::sync::Arc::new(tokio::sync::Notify::new());
+    let model = std::sync::Arc::new(GatedGoalModelClient {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        requests: std::sync::Mutex::new(Vec::new()),
+        second_request_entered: std::sync::Arc::clone(&second_request_entered),
+        release_second_request: std::sync::Arc::clone(&release_second_request),
+    });
     let mut custom = HashMap::new();
     custom.insert(
         "custom-a".to_string(),
@@ -352,7 +389,8 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
         ..EngineConfig::default()
     };
     let authoritative = Arc::new(parking_lot::RwLock::new(config.clone()));
-    let (mut engine, handle) = Engine::new(engine_config, &config);
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let (mut engine, handle) = Engine::new_with_model_client(engine_config, &config, client);
     engine.authoritative_route_config = Some(Arc::clone(&authoritative));
     let goal_state = engine.config.goal_state.clone();
 
@@ -459,6 +497,12 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
                 assert!(system_prompt.contains("keep going"));
                 verified_synthetic_goal = true;
 
+                tokio::time::timeout(
+                    model_turn_event_timeout(),
+                    second_request_entered.notified(),
+                )
+                .await
+                .expect("second goal model request was never entered");
                 handle
                     .send(Op::SetGoalStatus {
                         status: crate::tools::goal::GoalStatus::Paused,
@@ -466,6 +510,10 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
                     })
                     .await
                     .expect("queue goal pause");
+                // The model future cannot finish until the pause operation is
+                // already in the engine mailbox, making the queue-order proof
+                // deterministic under arbitrarily loaded CI runners.
+                release_second_request.notify_one();
             }
             Event::TurnComplete { base_url, .. } => {
                 completes += 1;
@@ -481,6 +529,7 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
     }
     assert_eq!(starts, 2);
     assert!(verified_synthetic_goal);
+    assert_eq!(model.captured_requests().len(), 2);
 
     // The pause was queued while the second turn was still running. Wait for
     // that control operation, then put a snapshot receipt behind the already
@@ -524,6 +573,152 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
     }
 
     handle.send(Op::Shutdown).await.expect("queue shutdown");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn cross_turn_token_budget_exhaustion_blocks_goal_and_refreshes_prompt() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let budget_turn = vec![
+        canned::message_start("mock_goal_budget"),
+        canned::text_block_start(0),
+        canned::text_delta(0, "budget spent"),
+        canned::block_stop(0),
+        canned::message_delta(
+            "end_turn",
+            Some(Usage {
+                input_tokens: 8,
+                output_tokens: 3,
+                ..Usage::default()
+            }),
+        ),
+        canned::message_stop(),
+    ];
+    let model = std::sync::Arc::new(MockLlmClient::new(vec![budget_turn]));
+    let client: crate::core::model_client::SharedModelClient = model.clone();
+    let config = Config::default();
+    let engine_config = EngineConfig {
+        max_steps: 1,
+        snapshots_enabled: false,
+        subagents_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("finish within budget".to_string()),
+        goal_token_budget: Some(10),
+        ..EngineConfig::default()
+    };
+    let (engine, handle) = Engine::new_with_model_client(engine_config, &config, client);
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::SendMessage {
+            content: "start budgeted goal".to_string(),
+            mode: AppMode::Agent,
+            route: resolved_route_for_test(&config, crate::config::DEFAULT_TEXT_MODEL),
+            compaction: Box::new(CompactionConfig::default()),
+            goal_objective: Some("finish within budget".to_string()),
+            goal_token_budget: Some(10),
+            goal_status: crate::tools::goal::GoalStatus::Active,
+            reasoning_effort: None,
+            reasoning_effort_auto: false,
+            auto_model: false,
+            allow_shell: false,
+            trust_mode: false,
+            auto_approve: false,
+            approval_mode: crate::tui::approval::ApprovalMode::Suggest,
+            translation_enabled: false,
+            show_thinking: false,
+            allowed_tools: None,
+            dynamic_tools: Vec::new(),
+            hook_executor: None,
+            verbosity: None,
+            provenance: UserInputProvenance::ExternalUser,
+        })
+        .await
+        .expect("send budgeted goal turn");
+
+    let mut starts = 0;
+    let mut saw_turn_complete = false;
+    let mut saw_terminal_goal = false;
+    let mut saw_prompt_refresh = false;
+    let mut saw_budget_status = false;
+    while !(saw_terminal_goal && saw_prompt_refresh && saw_budget_status) {
+        let event = tokio::time::timeout(model_turn_event_timeout(), async {
+            handle.rx_event.write().await.recv().await
+        })
+        .await
+        .expect("budget goal event timeout")
+        .expect("budget goal event");
+        match event {
+            Event::TurnStarted { .. } => starts += 1,
+            Event::TurnComplete { status, error, .. } => {
+                assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+                saw_turn_complete = true;
+            }
+            Event::SessionUpdated {
+                system_prompt: Some(system_prompt),
+                ..
+            } if saw_turn_complete => {
+                let prompt = match system_prompt {
+                    SystemPrompt::Text(text) => text,
+                    SystemPrompt::Blocks(blocks) => blocks
+                        .into_iter()
+                        .map(|block| block.text)
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                };
+                assert!(
+                    !prompt.contains("<session_goal>"),
+                    "blocked budget goal must leave the active system prompt: {prompt}"
+                );
+                saw_prompt_refresh = true;
+            }
+            Event::GoalUpdated { snapshot } if snapshot.status == "blocked" => {
+                assert_eq!(snapshot.objective.as_deref(), Some("finish within budget"));
+                assert_eq!(snapshot.token_budget, Some(10));
+                assert_eq!(snapshot.tokens_used, 11);
+                assert!(
+                    snapshot
+                        .blocker
+                        .as_deref()
+                        .is_some_and(|blocker| blocker.contains("token budget reached")),
+                    "{snapshot:?}"
+                );
+                saw_terminal_goal = true;
+            }
+            Event::Status { message } if message.contains("Goal token budget reached") => {
+                assert!(message.contains("11 / 10 tokens"), "{message}");
+                assert!(message.contains("goal is blocked"), "{message}");
+                saw_budget_status = true;
+            }
+            _ => {}
+        }
+    }
+
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-budget session snapshot");
+    let prompt = match session.system_prompt.expect("post-budget system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+    let snapshot = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(snapshot.status, "blocked");
+    assert_eq!(starts, 1, "budget stop must not start another turn");
+    assert_eq!(
+        model.call_count(),
+        1,
+        "budget stop must not call the model again"
+    );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
     run_task.await.expect("engine task");
 }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -288,12 +288,48 @@ async fn exact_turn_snapshot_restores_custom_endpoint_and_turn_receipt_after_bui
 
 #[tokio::test]
 async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_route() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let first_server = MockServer::start().await;
+    let second_server = MockServer::start().await;
+    let done_sse = concat!(
+        "data: {\"id\":\"chatcmpl-goal\",\"choices\":[{\"index\":0,",
+        "\"delta\":{\"content\":\"still working\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-goal\",\"choices\":[{\"index\":0,\"delta\":{},",
+        "\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(done_sse),
+        )
+        .expect(1)
+        .mount(&first_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_millis(150))
+                .set_body_string(done_sse),
+        )
+        .expect(1)
+        .mount(&second_server)
+        .await;
+
+    let first_base_url = format!("{}/v1", first_server.uri());
+    let second_base_url = format!("{}/v1", second_server.uri());
     let mut custom = HashMap::new();
     custom.insert(
         "custom-a".to_string(),
         crate::config::ProviderConfig {
             kind: Some("openai-compatible".to_string()),
-            base_url: Some("http://127.0.0.1:18181/v1".to_string()),
+            base_url: Some(first_base_url.clone()),
             model: Some("local-model".to_string()),
             api_key: Some("local-test-key".to_string()),
             ..crate::config::ProviderConfig::default()
@@ -308,10 +344,11 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
         ..Config::default()
     };
     let engine_config = EngineConfig {
-        max_steps: 0,
+        max_steps: 1,
         snapshots_enabled: false,
         terminal_chrome_enabled: false,
         goal_objective: Some("keep going".to_string()),
+        goal_token_budget: Some(50_000),
         ..EngineConfig::default()
     };
     let authoritative = Arc::new(parking_lot::RwLock::new(config.clone()));
@@ -326,7 +363,7 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
             route: resolved_route_for_test(&config, "local-model"),
             compaction: Box::new(CompactionConfig::default()),
             goal_objective: Some("keep going".to_string()),
-            goal_token_budget: None,
+            goal_token_budget: Some(50_000),
             goal_status: crate::tools::goal::GoalStatus::Active,
             reasoning_effort: None,
             reasoning_effort_auto: false,
@@ -352,12 +389,14 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
         .as_mut()
         .and_then(|providers| providers.custom.get_mut("custom-a"))
         .expect("custom route")
-        .base_url = Some("http://127.0.0.1:18182/v1".to_string());
+        .base_url = Some(second_base_url.clone());
     *authoritative.write() = reloaded;
     let run_task = tokio::spawn(engine.run());
 
     let mut starts = 0;
     let mut completes = 0;
+    let mut awaiting_second_sync = false;
+    let mut verified_synthetic_goal = false;
     while completes < 2 {
         let event = tokio::time::timeout(Duration::from_secs(3), async {
             handle.rx_event.write().await.recv().await
@@ -372,25 +411,68 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
                 starts += 1;
                 assert_eq!(route.provider_identity, "custom-a");
                 if starts == 2 {
-                    let snapshot = goal_state.lock().expect("goal lock").snapshot();
-                    assert_eq!(snapshot.objective.as_deref(), Some("keep going"));
-                    assert!(snapshot.is_active(), "synthetic turn must retain the goal");
-                    handle
-                        .send(Op::SetGoalStatus {
-                            status: crate::tools::goal::GoalStatus::Paused,
-                            clear: false,
-                        })
-                        .await
-                        .expect("queue goal pause");
-                    handle.send(Op::Shutdown).await.expect("queue shutdown");
+                    awaiting_second_sync = true;
                 }
+            }
+            Event::SessionUpdated {
+                messages,
+                system_prompt,
+                ..
+            } if awaiting_second_sync => {
+                awaiting_second_sync = false;
+                let snapshot = goal_state.lock().expect("goal lock").snapshot();
+                assert_eq!(snapshot.objective.as_deref(), Some("keep going"));
+                assert_eq!(snapshot.token_budget, Some(50_000));
+                // The first turn records one bounded intra-turn pass, then the
+                // synthetic boundary records the second pass before dispatch.
+                assert_eq!(snapshot.continuation_count, 2);
+                assert!(snapshot.is_active(), "synthetic turn must retain the goal");
+
+                let continuation = messages
+                    .last()
+                    .expect("synthetic continuation message")
+                    .content
+                    .iter()
+                    .find_map(|block| match block {
+                        ContentBlock::Text { text, .. }
+                            if text.contains("## Active Goal State") =>
+                        {
+                            Some(text.as_str())
+                        }
+                        _ => None,
+                    })
+                    .expect("durable goal state in synthetic message");
+                assert!(continuation.contains("\"objective\": \"keep going\""));
+                assert!(continuation.contains("\"token_budget\": 50000"));
+                assert!(continuation.contains("\"continuation_count\": 2"));
+                assert!(continuation.contains("Continuation pass #2."));
+
+                let system_prompt = match system_prompt.expect("synthetic system prompt") {
+                    SystemPrompt::Text(text) => text,
+                    SystemPrompt::Blocks(blocks) => blocks
+                        .into_iter()
+                        .map(|block| block.text)
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                };
+                assert!(system_prompt.contains("<session_goal>"));
+                assert!(system_prompt.contains("keep going"));
+                verified_synthetic_goal = true;
+
+                handle
+                    .send(Op::SetGoalStatus {
+                        status: crate::tools::goal::GoalStatus::Paused,
+                        clear: false,
+                    })
+                    .await
+                    .expect("queue goal pause");
             }
             Event::TurnComplete { base_url, .. } => {
                 completes += 1;
                 let expected = if completes == 1 {
-                    "http://127.0.0.1:18181/v1"
+                    first_base_url.as_str()
                 } else {
-                    "http://127.0.0.1:18182/v1"
+                    second_base_url.as_str()
                 };
                 assert_eq!(base_url.as_deref(), Some(expected));
             }
@@ -398,6 +480,50 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
         }
     }
     assert_eq!(starts, 2);
+    assert!(verified_synthetic_goal);
+
+    // The pause was queued while the second turn was still running. Wait for
+    // that control operation, then put a snapshot receipt behind the already
+    // queued continuation. Receiving the receipt proves the continuation was
+    // consumed; no third TurnStarted may have been emitted.
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(3), async {
+            handle.rx_event.write().await.recv().await
+        })
+        .await
+        .expect("goal pause event timeout")
+        .expect("goal pause event");
+        if matches!(event, Event::Status { ref message } if message == "Goal paused.") {
+            break;
+        }
+        assert!(
+            !matches!(event, Event::TurnStarted { .. }),
+            "queued pause must prevent an additional goal turn"
+        );
+    }
+
+    let (snapshot_tx, snapshot_rx) = tokio::sync::oneshot::channel();
+    handle
+        .send(Op::GetSessionSnapshot {
+            tx: std::sync::Arc::new(std::sync::Mutex::new(Some(snapshot_tx))),
+        })
+        .await
+        .expect("queue post-continuation receipt");
+    tokio::time::timeout(Duration::from_secs(3), snapshot_rx)
+        .await
+        .expect("post-continuation receipt timeout")
+        .expect("post-continuation receipt");
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                !matches!(event, Event::TurnStarted { .. }),
+                "paused goal continuation started a stale turn"
+            );
+        }
+    }
+
+    handle.send(Op::Shutdown).await.expect("queue shutdown");
     run_task.await.expect("engine task");
 }
 

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -853,8 +853,7 @@ async fn queued_goal_clear_refreshes_prompt_and_cancels_stale_continuation() {
     run_task.await.expect("engine task");
 }
 
-#[tokio::test]
-async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
+fn goal_custom_route_config() -> Config {
     let mut custom = HashMap::new();
     custom.insert(
         "custom-a".to_string(),
@@ -866,14 +865,29 @@ async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
             ..crate::config::ProviderConfig::default()
         },
     );
-    let config = Config {
+    Config {
         provider: Some("custom-a".to_string()),
         providers: Some(crate::config::ProvidersConfig {
             custom,
             ..crate::config::ProvidersConfig::default()
         }),
         ..Config::default()
-    };
+    }
+}
+
+fn without_named_custom_route(mut config: Config) -> Config {
+    config
+        .providers
+        .as_mut()
+        .expect("custom providers")
+        .custom
+        .clear();
+    config
+}
+
+#[tokio::test]
+async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
+    let config = goal_custom_route_config();
     let engine_config = EngineConfig {
         model: "local-model".to_string(),
         snapshots_enabled: false,
@@ -886,13 +900,7 @@ async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
     let goal_state = engine.config.goal_state.clone();
     goal_state.lock().expect("goal lock").record_usage(11, 0);
 
-    let mut invalid_route_config = config;
-    invalid_route_config
-        .providers
-        .as_mut()
-        .expect("custom providers")
-        .custom
-        .clear();
+    let invalid_route_config = without_named_custom_route(config);
     engine.authoritative_route_config =
         Some(Arc::new(parking_lot::RwLock::new(invalid_route_config)));
     assert!(
@@ -954,6 +962,229 @@ async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
         goal_state.lock().expect("goal lock").snapshot().status,
         "blocked"
     );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn invalid_route_blocks_active_goal_and_refreshes_projections() {
+    let config = goal_custom_route_config();
+    let engine_config = EngineConfig {
+        model: "local-model".to_string(),
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("keep going across route drift".to_string()),
+        ..EngineConfig::default()
+    };
+    let (mut engine, handle) = Engine::new(engine_config, &config);
+    let goal_state = engine.config.goal_state.clone();
+    engine.authoritative_route_config = Some(Arc::new(parking_lot::RwLock::new(
+        without_named_custom_route(config),
+    )));
+    assert!(
+        engine.current_runtime_route().is_err(),
+        "fixture must fail before dispatch"
+    );
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::ContinueGoal {
+            dynamic_tools: Vec::new(),
+        })
+        .await
+        .expect("queue active continuation");
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-route-failure session snapshot");
+
+    let prompt = match session.system_prompt.expect("blocked system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+    let snapshot = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(snapshot.status, "blocked");
+    assert!(
+        snapshot
+            .blocker
+            .as_deref()
+            .is_some_and(|blocker| blocker.contains("provider route is no longer valid")),
+        "{snapshot:?}"
+    );
+
+    let mut saw_route_error = false;
+    let mut saw_blocked_session = false;
+    let mut saw_blocked_goal = false;
+    let mut saw_blocked_status = false;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(event) = events.try_recv() {
+            match event {
+                Event::TurnStarted { .. } => {
+                    panic!("invalid route must not start a continuation turn")
+                }
+                Event::Error { envelope, .. } => {
+                    assert!(format!("{envelope:?}").contains("provider route is no longer valid"));
+                    saw_route_error = true;
+                }
+                Event::SessionUpdated {
+                    system_prompt: Some(system_prompt),
+                    ..
+                } => {
+                    let prompt = match system_prompt {
+                        SystemPrompt::Text(text) => text,
+                        SystemPrompt::Blocks(blocks) => blocks
+                            .into_iter()
+                            .map(|block| block.text)
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    };
+                    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+                    saw_blocked_session = true;
+                }
+                Event::GoalUpdated { snapshot } if snapshot.status == "blocked" => {
+                    saw_blocked_goal = true;
+                }
+                Event::Status { message }
+                    if message.contains("provider route is no longer valid") =>
+                {
+                    assert!(message.contains("resume the goal"), "{message}");
+                    saw_blocked_status = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(saw_route_error, "route failure must remain visible");
+    assert!(
+        saw_blocked_session,
+        "session prompt projection must refresh"
+    );
+    assert!(saw_blocked_goal, "sidebar must receive blocked state");
+    assert!(saw_blocked_status, "blocked reason must remain visible");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn rejected_continuation_dispatch_blocks_goal_after_failed_turn() {
+    let config = goal_custom_route_config();
+    let engine_config = EngineConfig {
+        model: "local-model".to_string(),
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("keep going after dispatch".to_string()),
+        ..EngineConfig::default()
+    };
+    let (mut engine, handle) = Engine::new(engine_config, &config);
+    let goal_state = engine.config.goal_state.clone();
+    assert!(engine.current_runtime_route().is_ok());
+    // Exercise the continuation caller's `false` boundary deterministically:
+    // the route installs, but the injected-model authority has no client with
+    // which to start the request.
+    engine.model_client_injected = true;
+    engine.model_client = None;
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::ContinueGoal {
+            dynamic_tools: Vec::new(),
+        })
+        .await
+        .expect("queue rejected continuation");
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-rejection session snapshot");
+
+    let prompt = match session.system_prompt.expect("blocked system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+    let snapshot = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(snapshot.status, "blocked");
+    assert!(
+        snapshot
+            .blocker
+            .as_deref()
+            .is_some_and(|blocker| blocker.contains("next model turn could not be started")),
+        "{snapshot:?}"
+    );
+
+    let mut starts = 0;
+    let mut saw_failed_turn = false;
+    let mut saw_dispatch_error = false;
+    let mut saw_blocked_session = false;
+    let mut saw_blocked_goal = false;
+    let mut saw_blocked_status = false;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(event) = events.try_recv() {
+            match event {
+                Event::TurnStarted { .. } => starts += 1,
+                Event::TurnComplete { status, .. } => {
+                    assert_eq!(status, TurnOutcomeStatus::Failed);
+                    saw_failed_turn = true;
+                }
+                Event::Error { .. } => saw_dispatch_error = true,
+                Event::SessionUpdated {
+                    system_prompt: Some(system_prompt),
+                    ..
+                } => {
+                    let prompt = match system_prompt {
+                        SystemPrompt::Text(text) => text,
+                        SystemPrompt::Blocks(blocks) => blocks
+                            .into_iter()
+                            .map(|block| block.text)
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    };
+                    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+                    saw_blocked_session = true;
+                }
+                Event::GoalUpdated { snapshot } if snapshot.status == "blocked" => {
+                    saw_blocked_goal = true;
+                }
+                Event::Status { message }
+                    if message.contains("next model turn could not be started") =>
+                {
+                    assert!(message.contains("resume the goal"), "{message}");
+                    saw_blocked_status = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert_eq!(
+        starts, 1,
+        "dispatch reached exactly one engine turn boundary"
+    );
+    assert!(
+        saw_failed_turn,
+        "rejected dispatch must surface a failed turn"
+    );
+    assert!(
+        saw_dispatch_error,
+        "rejected dispatch must surface its error"
+    );
+    assert!(
+        saw_blocked_session,
+        "session prompt projection must refresh"
+    );
+    assert!(saw_blocked_goal, "sidebar must receive blocked state");
+    assert!(saw_blocked_status, "blocked reason must remain visible");
 
     handle.send(Op::Shutdown).await.expect("shutdown engine");
     run_task.await.expect("engine task");

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -535,6 +535,8 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
     // that control operation, then put a snapshot receipt behind the already
     // queued continuation. Receiving the receipt proves the continuation was
     // consumed; no third TurnStarted may have been emitted.
+    let mut saw_paused_prompt = false;
+    let mut saw_paused_goal = false;
     loop {
         let event = tokio::time::timeout(Duration::from_secs(3), async {
             handle.rx_event.write().await.recv().await
@@ -542,13 +544,43 @@ async fn goal_continuation_preserves_goal_and_resolves_updated_authoritative_rou
         .await
         .expect("goal pause event timeout")
         .expect("goal pause event");
-        if matches!(event, Event::Status { ref message } if message == "Goal paused.") {
-            break;
+        match event {
+            Event::SessionUpdated {
+                system_prompt: Some(system_prompt),
+                ..
+            } => {
+                let prompt = match system_prompt {
+                    SystemPrompt::Text(text) => text,
+                    SystemPrompt::Blocks(blocks) => blocks
+                        .into_iter()
+                        .map(|block| block.text)
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                };
+                if !prompt.contains("<session_goal>") {
+                    saw_paused_prompt = true;
+                }
+            }
+            Event::GoalUpdated { snapshot } if snapshot.status == "paused" => {
+                assert_eq!(snapshot.objective.as_deref(), Some("keep going"));
+                saw_paused_goal = true;
+            }
+            Event::Status { ref message } if message == "Goal paused." => {
+                assert!(
+                    saw_paused_prompt,
+                    "pause status must follow the persisted prompt refresh"
+                );
+                assert!(
+                    saw_paused_goal,
+                    "pause status must follow the visible goal snapshot"
+                );
+                break;
+            }
+            Event::TurnStarted { .. } => {
+                panic!("queued pause must prevent an additional goal turn")
+            }
+            _ => {}
         }
-        assert!(
-            !matches!(event, Event::TurnStarted { .. }),
-            "queued pause must prevent an additional goal turn"
-        );
     }
 
     let (snapshot_tx, snapshot_rx) = tokio::sync::oneshot::channel();
@@ -716,6 +748,211 @@ async fn cross_turn_token_budget_exhaustion_blocks_goal_and_refreshes_prompt() {
         model.call_count(),
         1,
         "budget stop must not call the model again"
+    );
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn queued_goal_clear_refreshes_prompt_and_cancels_stale_continuation() {
+    let config = Config::default();
+    let engine_config = EngineConfig {
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("clear this goal".to_string()),
+        goal_token_budget: Some(42_000),
+        ..EngineConfig::default()
+    };
+    let (engine, handle) = Engine::new(engine_config, &config);
+    let goal_state = engine.config.goal_state.clone();
+    let run_task = tokio::spawn(engine.run());
+
+    // Model the mailbox order produced when the user clears a goal while its
+    // prior turn is still finishing: the control reaches the queue before the
+    // synthetic continuation that TurnComplete schedules.
+    handle
+        .send(Op::SetGoalStatus {
+            status: crate::tools::goal::GoalStatus::Active,
+            clear: true,
+        })
+        .await
+        .expect("queue goal clear");
+    handle
+        .send(Op::ContinueGoal {
+            dynamic_tools: Vec::new(),
+        })
+        .await
+        .expect("queue stale continuation");
+
+    // This receipt sits behind both operations. Once it arrives, a stale
+    // continuation has either incorrectly started a turn or been consumed.
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-clear session snapshot");
+    let prompt = match session.system_prompt.expect("post-clear system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(
+        !prompt.contains("<session_goal>"),
+        "cleared config fallback must not restore the goal prompt: {prompt}"
+    );
+    let snapshot = goal_state.lock().expect("goal lock").snapshot();
+    assert_eq!(snapshot.objective, None);
+    assert_eq!(snapshot.status, "none");
+    assert_eq!(snapshot.token_budget, None);
+
+    let mut saw_clear_session = false;
+    let mut saw_clear_goal = false;
+    let mut saw_clear_status = false;
+    {
+        let mut events = handle.rx_event.write().await;
+        while let Ok(event) = events.try_recv() {
+            match event {
+                Event::TurnStarted { .. } => {
+                    panic!("queued clear must prevent a stale goal continuation")
+                }
+                Event::SessionUpdated { system_prompt, .. } => {
+                    let prompt = match system_prompt.expect("clear SessionUpdated prompt") {
+                        SystemPrompt::Text(text) => text,
+                        SystemPrompt::Blocks(blocks) => blocks
+                            .into_iter()
+                            .map(|block| block.text)
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    };
+                    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+                    saw_clear_session = true;
+                }
+                Event::GoalUpdated { snapshot } => {
+                    assert_eq!(snapshot.objective, None);
+                    assert_eq!(snapshot.status, "none");
+                    saw_clear_goal = true;
+                }
+                Event::Status { message } if message == "Goal cleared." => {
+                    saw_clear_status = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(
+        saw_clear_session,
+        "clear must refresh persisted prompt state"
+    );
+    assert!(saw_clear_goal, "clear must emit a canonical empty snapshot");
+    assert!(saw_clear_status, "clear must remain user-visible");
+
+    handle.send(Op::Shutdown).await.expect("shutdown engine");
+    run_task.await.expect("engine task");
+}
+
+#[tokio::test]
+async fn exhausted_goal_terminalizes_before_invalid_route_resolution() {
+    let mut custom = HashMap::new();
+    custom.insert(
+        "custom-a".to_string(),
+        crate::config::ProviderConfig {
+            kind: Some("openai-compatible".to_string()),
+            base_url: Some("http://127.0.0.1:18181/v1".to_string()),
+            model: Some("local-model".to_string()),
+            api_key: Some("local-test-key".to_string()),
+            ..crate::config::ProviderConfig::default()
+        },
+    );
+    let config = Config {
+        provider: Some("custom-a".to_string()),
+        providers: Some(crate::config::ProvidersConfig {
+            custom,
+            ..crate::config::ProvidersConfig::default()
+        }),
+        ..Config::default()
+    };
+    let engine_config = EngineConfig {
+        model: "local-model".to_string(),
+        snapshots_enabled: false,
+        terminal_chrome_enabled: false,
+        goal_objective: Some("stop at the budget".to_string()),
+        goal_token_budget: Some(10),
+        ..EngineConfig::default()
+    };
+    let (mut engine, handle) = Engine::new(engine_config, &config);
+    let goal_state = engine.config.goal_state.clone();
+    goal_state.lock().expect("goal lock").record_usage(11, 0);
+
+    let mut invalid_route_config = config;
+    invalid_route_config
+        .providers
+        .as_mut()
+        .expect("custom providers")
+        .custom
+        .clear();
+    engine.authoritative_route_config =
+        Some(Arc::new(parking_lot::RwLock::new(invalid_route_config)));
+    assert!(
+        engine.current_runtime_route().is_err(),
+        "fixture must prove route resolution cannot succeed"
+    );
+    let run_task = tokio::spawn(engine.run());
+
+    handle
+        .send(Op::ContinueGoal {
+            dynamic_tools: Vec::new(),
+        })
+        .await
+        .expect("queue exhausted continuation");
+
+    let mut saw_blocked_goal = false;
+    let mut saw_budget_status = false;
+    while !(saw_blocked_goal && saw_budget_status) {
+        let event = tokio::time::timeout(model_turn_event_timeout(), async {
+            handle.rx_event.write().await.recv().await
+        })
+        .await
+        .expect("budget terminal event timeout")
+        .expect("budget terminal event");
+        match event {
+            Event::TurnStarted { .. } => {
+                panic!("an exhausted goal must not attempt an invalid route")
+            }
+            Event::Error { envelope, .. } => {
+                panic!("budget decision must precede route failure: {envelope:?}")
+            }
+            Event::GoalUpdated { snapshot } if snapshot.status == "blocked" => {
+                assert_eq!(snapshot.tokens_used, 11);
+                assert_eq!(snapshot.token_budget, Some(10));
+                saw_blocked_goal = true;
+            }
+            Event::Status { message } if message.contains("Goal token budget reached") => {
+                assert!(message.contains("11 / 10 tokens"), "{message}");
+                saw_budget_status = true;
+            }
+            _ => {}
+        }
+    }
+
+    let session = handle
+        .get_session_snapshot()
+        .await
+        .expect("post-budget session snapshot");
+    let prompt = match session.system_prompt.expect("post-budget system prompt") {
+        SystemPrompt::Text(text) => text,
+        SystemPrompt::Blocks(blocks) => blocks
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    assert!(!prompt.contains("<session_goal>"), "{prompt}");
+    assert_eq!(
+        goal_state.lock().expect("goal lock").snapshot().status,
+        "blocked"
     );
 
     handle.send(Op::Shutdown).await.expect("shutdown engine");

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -1549,6 +1549,7 @@ impl Engine {
                     .goal_continuation_message_if_needed(
                         tool_registry,
                         &mut goal_continuations_this_turn,
+                        &turn.usage,
                     )
                     .await
                 {
@@ -3005,6 +3006,7 @@ impl Engine {
         &self,
         tool_registry: Option<&crate::tools::ToolRegistry>,
         continuations_this_turn: &mut u32,
+        current_turn_usage: &Usage,
     ) -> Option<String> {
         let registry = tool_registry?;
         if !registry.contains("update_goal") {
@@ -3022,6 +3024,14 @@ impl Engine {
         if !snapshot.is_active() {
             return None;
         }
+
+        // GoalState is updated once, after the full engine turn finishes. Add
+        // the current turn's cumulative provider usage only to this transient
+        // decision/prompt snapshot so an already-spent budget cannot authorize
+        // more provider calls, without recording the same tokens twice later.
+        let current_turn_tokens = u64::from(current_turn_usage.input_tokens)
+            .saturating_add(u64::from(current_turn_usage.output_tokens));
+        snapshot.tokens_used = snapshot.tokens_used.saturating_add(current_turn_tokens);
 
         let per_turn_max = crate::tools::goal::MAX_GOAL_CONTINUATIONS_PER_TURN;
         if *continuations_this_turn >= per_turn_max {
@@ -3069,6 +3079,7 @@ impl Engine {
             Ok(mut state) => {
                 state.record_continuation();
                 snapshot = state.snapshot();
+                snapshot.tokens_used = snapshot.tokens_used.saturating_add(current_turn_tokens);
             }
             Err(err) => {
                 tracing::warn!("goal state lock poisoned while recording continuation: {err}")

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -373,6 +373,27 @@ impl Engine {
                 break;
             }
 
+            // A tool-producing response can spend the remaining goal budget
+            // before this loop reaches the no-tool continuation check below.
+            // Stop at the provider-request boundary so tool results remain in
+            // the transcript, but no additional model request is authorized.
+            // GoalState remains untouched here: the outer turn bookkeeping
+            // records this usage once, then the normal cross-turn reconciler
+            // publishes the terminal Blocked projection.
+            if let Some(snapshot) = self.goal_snapshot_with_current_turn_usage(&turn.usage)
+                && let Some(budget) = snapshot.token_budget
+                && snapshot.tokens_used >= u64::from(budget)
+            {
+                let _ = self
+                    .tx_event
+                    .send(Event::status(format!(
+                        "Goal token budget reached ({} / {budget} tokens); ending turn before another provider request.",
+                        snapshot.tokens_used
+                    )))
+                    .await;
+                break;
+            }
+
             let compaction_pins =
                 self.compaction_pins_for_active_turn(turn.active_slop_gate_message.as_ref());
             let compaction_paths = self.session.working_set.top_paths(24);
@@ -3002,6 +3023,31 @@ impl Engine {
         (TurnOutcomeStatus::Completed, None)
     }
 
+    fn goal_snapshot_with_current_turn_usage(
+        &self,
+        current_turn_usage: &Usage,
+    ) -> Option<GoalSnapshot> {
+        let mut snapshot = match self.config.goal_state.lock() {
+            Ok(state) => state.snapshot(),
+            Err(err) => {
+                tracing::warn!("goal state lock poisoned during current-turn budget check: {err}");
+                return None;
+            }
+        };
+        if !snapshot.is_active() {
+            return None;
+        }
+
+        // GoalState is updated once, after the full engine turn finishes. Add
+        // this turn's cumulative provider usage only to a transient snapshot
+        // so request and continuation decisions see already-spent tokens
+        // without recording the same usage twice later.
+        let current_turn_tokens = u64::from(current_turn_usage.input_tokens)
+            .saturating_add(u64::from(current_turn_usage.output_tokens));
+        snapshot.tokens_used = snapshot.tokens_used.saturating_add(current_turn_tokens);
+        Some(snapshot)
+    }
+
     async fn goal_continuation_message_if_needed(
         &self,
         tool_registry: Option<&crate::tools::ToolRegistry>,
@@ -3013,25 +3059,9 @@ impl Engine {
             return None;
         }
 
-        let mut snapshot = match self.config.goal_state.lock() {
-            Ok(state) => state.snapshot(),
-            Err(err) => {
-                tracing::warn!("goal state lock poisoned during continuation check: {err}");
-                return None;
-            }
-        };
-
-        if !snapshot.is_active() {
-            return None;
-        }
-
-        // GoalState is updated once, after the full engine turn finishes. Add
-        // the current turn's cumulative provider usage only to this transient
-        // decision/prompt snapshot so an already-spent budget cannot authorize
-        // more provider calls, without recording the same tokens twice later.
+        let mut snapshot = self.goal_snapshot_with_current_turn_usage(current_turn_usage)?;
         let current_turn_tokens = u64::from(current_turn_usage.input_tokens)
             .saturating_add(u64::from(current_turn_usage.output_tokens));
-        snapshot.tokens_used = snapshot.tokens_used.saturating_add(current_turn_tokens);
 
         let per_turn_max = crate::tools::goal::MAX_GOAL_CONTINUATIONS_PER_TURN;
         if *continuations_this_turn >= per_turn_max {

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -135,6 +135,10 @@ pub enum Op {
         /// Runtime-supplied tools remain available across the synthetic turn
         /// that continues the same logical goal run.
         dynamic_tools: Vec<DynamicToolSpec>,
+        /// Opaque identity for an engine-owned synthetic continuation. Direct
+        /// callers use `None`; the engine uses `Some` to coalesce one token
+        /// across capacity-waiting, enqueued, and running-adjacent states.
+        engine_schedule_id: Option<u64>,
     },
 
     /// Execute a user-submitted composer shell command (`! <command>`) without

--- a/crates/tui/src/core/ops.rs
+++ b/crates/tui/src/core/ops.rs
@@ -127,6 +127,16 @@ pub enum Op {
         provenance: UserInputProvenance,
     },
 
+    /// Re-check and dispatch an interactive goal continuation when this
+    /// operation reaches the front of the engine queue. Keeping this distinct
+    /// from `SendMessage` prevents a queued `/goal pause` or `/goal clear`
+    /// from being overwritten by a stale synthetic Active snapshot.
+    ContinueGoal {
+        /// Runtime-supplied tools remain available across the synthetic turn
+        /// that continues the same logical goal run.
+        dynamic_tools: Vec<DynamicToolSpec>,
+    },
+
     /// Execute a user-submitted composer shell command (`! <command>`) without
     /// sending a model turn. This still routes through `exec_shell`, approval,
     /// sandbox, and command-safety handling.

--- a/crates/tui/src/tools/goal.rs
+++ b/crates/tui/src/tools/goal.rs
@@ -109,6 +109,11 @@ impl GoalState {
             Some(objective) => {
                 let changed = self.objective.as_deref() != Some(objective);
                 let status_changed = self.status != Some(status);
+                let resumed = !changed
+                    && status == GoalStatus::Active
+                    && self
+                        .status
+                        .is_some_and(|previous| previous != GoalStatus::Active);
                 if changed {
                     self.objective = Some(objective.to_string());
                     self.token_budget = token_budget;
@@ -121,6 +126,12 @@ impl GoalState {
                     self.completion_verification = None;
                 } else if self.token_budget != token_budget {
                     self.token_budget = token_budget;
+                }
+
+                if resumed {
+                    self.evidence = None;
+                    self.blocker = None;
+                    self.completion_verification = None;
                 }
 
                 if changed || status_changed || self.status.is_none() {
@@ -719,6 +730,58 @@ mod tests {
                 "status {status:?} must preserve the entire goal snapshot"
             );
         }
+    }
+
+    #[test]
+    fn same_objective_goal_host_resume_clears_terminal_payloads_and_preserves_progress() {
+        let mut blocked = GoalState::default();
+        blocked
+            .create("resume the release goal".to_string(), Some(4_000))
+            .expect("create blocked fixture");
+        blocked.record_usage(750, 44);
+        blocked.record_continuation();
+        blocked
+            .mark_blocked("provider failed".to_string())
+            .expect("block goal");
+
+        blocked.sync_from_host_status(
+            Some("resume the release goal"),
+            Some(4_000),
+            GoalStatus::Active,
+        );
+
+        let resumed = blocked.snapshot();
+        assert_eq!(resumed.status, "active");
+        assert_eq!(resumed.tokens_used, 750);
+        assert_eq!(resumed.time_used_seconds, 44);
+        assert_eq!(resumed.continuation_count, 1);
+        assert_eq!(resumed.evidence, None);
+        assert_eq!(resumed.blocker, None);
+        assert_eq!(resumed.completion_verification, None);
+        let prompt = render_continuation_prompt(&resumed, resumed.continuation_count);
+        assert!(prompt.contains("\"blocker\": null"), "{prompt}");
+
+        let mut completed = GoalState::default();
+        completed
+            .create("resume verified work".to_string(), None)
+            .expect("create completed fixture");
+        completed
+            .mark_complete(
+                "focused tests passed".to_string(),
+                GoalCompletionVerification {
+                    status: "passed".to_string(),
+                    check: "cargo test".to_string(),
+                    summary: "goal tests passed".to_string(),
+                },
+            )
+            .expect("complete goal");
+
+        completed.sync_from_host_status(Some("resume verified work"), None, GoalStatus::Active);
+        let resumed = completed.snapshot();
+        assert_eq!(resumed.status, "active");
+        assert_eq!(resumed.evidence, None);
+        assert_eq!(resumed.blocker, None);
+        assert_eq!(resumed.completion_verification, None);
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8725,12 +8725,32 @@ fn goal_status_from_snapshot(snapshot: &GoalSnapshot) -> Option<GoalStatus> {
 }
 
 pub(crate) fn apply_goal_snapshot_to_app(app: &mut App, snapshot: &GoalSnapshot) -> bool {
+    // An explicit engine-side clear is represented by the one canonical empty
+    // state emitted by GoalState::snapshot. Require both fields so a malformed
+    // objective-less Active/Blocked update cannot erase valid visible state.
+    if snapshot.objective.is_none() && snapshot.status.trim() == "none" {
+        let changed = app.hunt.quarry.is_some()
+            || app.hunt.token_budget.is_some()
+            || app.hunt.tokens_used != 0
+            || app.hunt.time_used_seconds != 0
+            || app.hunt.continuation_count != 0
+            || app.hunt.started_at.is_some()
+            || app.hunt.finished_at.is_some()
+            || app.hunt.verdict != HuntVerdict::default();
+        app.hunt = crate::tui::app::HuntState::default();
+        return changed;
+    }
+
     let Some(objective) = snapshot
         .objective
         .as_deref()
         .map(str::trim)
         .filter(|objective| !objective.is_empty())
     else {
+        tracing::warn!(
+            "ignoring objective-less runtime goal snapshot with non-clear status: {}",
+            snapshot.status
+        );
         return false;
     };
     let Some(status) = goal_status_from_snapshot(snapshot) else {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -6110,6 +6110,66 @@ fn apply_goal_snapshot_updates_visible_goal_status() {
 }
 
 #[test]
+fn canonical_goal_clear_wins_after_stale_active_snapshot() {
+    let mut app = create_test_app();
+    let stale_active = crate::tools::goal::GoalSnapshot {
+        objective: Some("Goal cleared while the prior turn finished".to_string()),
+        status: "active".to_string(),
+        token_budget: Some(10_000),
+        tokens_used: 500,
+        time_used_seconds: 5,
+        continuation_count: 2,
+        elapsed_seconds: Some(5),
+        evidence: None,
+        blocker: None,
+        completion_verification: None,
+    };
+    assert!(apply_goal_snapshot_to_app(&mut app, &stale_active));
+    assert!(app.hunt.quarry.is_some());
+
+    // SetGoalStatus(clear) is processed after the prior turn's active update.
+    // Its canonical empty snapshot must be observable and win the replay.
+    let cleared = crate::tools::goal::GoalSnapshot {
+        objective: None,
+        status: "none".to_string(),
+        token_budget: None,
+        tokens_used: 0,
+        time_used_seconds: 0,
+        continuation_count: 0,
+        elapsed_seconds: None,
+        evidence: None,
+        blocker: None,
+        completion_verification: None,
+    };
+    assert!(apply_goal_snapshot_to_app(&mut app, &cleared));
+    assert!(app.hunt.quarry.is_none());
+    assert!(app.hunt.token_budget.is_none());
+    assert_eq!(app.hunt.tokens_used, 0);
+    assert_eq!(app.hunt.time_used_seconds, 0);
+    assert_eq!(app.hunt.continuation_count, 0);
+    assert!(app.hunt.started_at.is_none());
+    assert!(app.hunt.finished_at.is_none());
+    assert_eq!(app.hunt.verdict, crate::tui::app::HuntVerdict::Hunting);
+    assert!(
+        !apply_goal_snapshot_to_app(&mut app, &cleared),
+        "replaying the same clear receipt must be idempotent"
+    );
+
+    // Only the exact empty/none pair is a clear. A malformed objective-less
+    // active update must not erase subsequently visible goal state.
+    assert!(apply_goal_snapshot_to_app(&mut app, &stale_active));
+    let malformed = crate::tools::goal::GoalSnapshot {
+        status: "active".to_string(),
+        ..cleared
+    };
+    assert!(!apply_goal_snapshot_to_app(&mut app, &malformed));
+    assert_eq!(
+        app.hunt.quarry.as_deref(),
+        Some("Goal cleared while the prior turn finished")
+    );
+}
+
+#[test]
 fn apply_goal_snapshot_resume_clears_frozen_timer() {
     let mut app = create_test_app();
     app.hunt.quarry = Some("Ship the release lane".to_string());


### PR DESCRIPTION
## Summary

- carry the active goal objective, budget, usage, and continuation count across live-session turns
- queue a typed continuation only after a completed turn and re-read the live goal plus authoritative route before dispatch
- make pause, clear, complete, blocked, budget exhaustion, route drift, and rejected dispatch truthfully stop continuation
- synchronize SharedGoalState, config, stable prompt, session events, and the visible goal indicator, including a canonical clear receipt
- use deterministic model gates for queue-race coverage and keep runtime continuation on the same active model route

This is durable within the live session; it does not claim process-restart goal continuation.

## Exact post-approval receipts

- goal_ tests: 40 passed, 0 failed
- full_access tests: 20 passed, 0 failed
- approval_ tests: 108 passed, 0 failed; approval PTY 1 passed
- Auto-Review question catalog, hallucinated question, and stale prompt regressions: 3 passed, 0 failed
- standing Full Access runtime/subagent continuation provenance: 1 passed, 0 failed
- exact long-running plugin/MCP lifecycle: 1 passed, 0 failed
- cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Rebased on de15b5c61, the merged compact-approval and permission-posture fix. No publication or deployment.