### PR TITLE
test(cli): satisfy strict borrowed-path lint

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4630,7 +4630,7 @@ mod tests {
             .path()
             .join(format!("custom-tui{}", std::env::consts::EXE_SUFFIX));
         std::fs::write(&custom, b"").unwrap();
-        let custom_str = custom.to_string_lossy().into_owned();
+        let custom_str = custom.to_string_lossy();
         let bin = ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &custom_str);
         (dir, bin)
     }
@@ -8336,12 +8336,8 @@ model = "qwen-2.5-7b"
             .join(format!("legacy-tui{}", std::env::consts::EXE_SUFFIX));
         std::fs::write(&canonical, b"").unwrap();
         std::fs::write(&legacy, b"").unwrap();
-        let _canonical_bin = ScopedEnvVar::set(
-            "CODEWHALE_TUI_BIN",
-            &canonical.to_string_lossy().into_owned(),
-        );
-        let _legacy_bin =
-            ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &legacy.to_string_lossy().into_owned());
+        let _canonical_bin = ScopedEnvVar::set("CODEWHALE_TUI_BIN", &canonical.to_string_lossy());
+        let _legacy_bin = ScopedEnvVar::set("DEEPSEEK_TUI_BIN", &legacy.to_string_lossy());
 
         let resolved = locate_sibling_tui_binary().expect("override must resolve");
         assert_eq!(resolved, canonical);


### PR DESCRIPTION
## What changed

- keep lossy path conversions borrowed in scoped environment-variable tests
- clear the current strict workspace clippy failure without changing runtime behavior

## Verification

- `cargo test -p codewhale-cli --lib --locked` (166 passed)
- `cargo clippy -p codewhale-cli --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

This is a bounded pre-publication gate repair. It does not tag, publish, or release v0.9.1.