### PR TITLE
fix(tui): present built-in Fleet as ready

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "no git",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Fleet setup",
+    "EmptyStateFleetSetupLabel": "Fleet ready",
     "EmptyStateHelpHint": "— see everything",
     "SessionsSurfaceTitle": "sessions",
     "SessionsPaneTitle": " sessions (1-9) ",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "sin git",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Configuración de Fleet",
+    "EmptyStateFleetSetupLabel": "Fleet lista",
     "EmptyStateHelpHint": "— ver todo",
     "SessionsSurfaceTitle": "sesiones",
     "SessionsPaneTitle": " sesiones (1-9) ",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "git なし",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Fleet 設定",
+    "EmptyStateFleetSetupLabel": "Fleet 準備完了",
     "EmptyStateHelpHint": "— すべてを表示",
     "SessionsSurfaceTitle": "セッション",
     "SessionsPaneTitle": " セッション (1-9) ",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "git 없음",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Fleet 설정",
+    "EmptyStateFleetSetupLabel": "Fleet 준비 완료",
     "EmptyStateHelpHint": "— 모두 보기",
     "SessionsSurfaceTitle": "세션",
     "SessionsPaneTitle": " 세션 (1-9) ",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "sem git",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Setup da Fleet",
+    "EmptyStateFleetSetupLabel": "Fleet pronta",
     "EmptyStateHelpHint": "— ver tudo",
     "SessionsSurfaceTitle": "sessões",
     "SessionsPaneTitle": " sessões (1-9) ",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "không có git",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Thiết lập Fleet",
+    "EmptyStateFleetSetupLabel": "Fleet sẵn sàng",
     "EmptyStateHelpHint": "— xem mọi thứ",
     "SessionsSurfaceTitle": "phiên",
     "SessionsPaneTitle": " phiên (1-9) ",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -846,7 +846,7 @@
     "EmptyStateNoGit": "无 git",
     "EmptyStateMcpLabel": "mcp",
     "EmptyStateFleetLabel": "Fleet",
-    "EmptyStateFleetSetupLabel": "Fleet 设置",
+    "EmptyStateFleetSetupLabel": "Fleet 已就绪",
     "EmptyStateHelpHint": "— 查看所有功能",
     "SessionsSurfaceTitle": "会话",
     "SessionsPaneTitle": " 会话 (1-9) ",

--- a/crates/tui/src/tui/underwater.rs
+++ b/crates/tui/src/tui/underwater.rs
@@ -976,12 +976,24 @@ pub fn empty_state_lines(app: &App, area: Rect) -> Vec<Line<'static>> {
     )));
     if area.height >= 6 {
         lines.push(Line::from(""));
-        let fleet_label = if tier == ShellTier::Compact {
-            tr(app.ui_locale, MessageId::EmptyStateFleetLabel)
+        let (fleet_label, fleet_action) = if app.onboarding_needs_api_key {
+            // `--skip-onboarding` can expose the launch shell without a usable
+            // provider route. Do not claim that Fleet is ready in that state;
+            // point at the boundary that can actually make it runnable.
+            (
+                tr(app.ui_locale, MessageId::EmptyStateFleetLabel),
+                "/provider",
+            )
         } else {
-            tr(app.ui_locale, MessageId::EmptyStateFleetSetupLabel)
+            // Built-in roles are immediately usable with the active route.
+            // Keep this truth at every responsive tier so `/fleet setup`
+            // reads as optional customization instead of required setup.
+            (
+                tr(app.ui_locale, MessageId::EmptyStateFleetSetupLabel),
+                "/fleet setup",
+            )
         };
-        let fleet = format!("{fleet_label}  /fleet setup");
+        let fleet = format!("{fleet_label}  {fleet_action}");
         let inset = " ".repeat(width.saturating_sub(fleet.width()) / 2);
         lines.push(Line::from(Span::styled(
             format!("{inset}{fleet}"),

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -5889,6 +5889,7 @@ mod tests {
     #[test]
     fn empty_state_shows_startup_context() {
         let mut app = create_test_app();
+        app.onboarding_needs_api_key = false;
         app.workspace = PathBuf::from("/tmp/codewhale-test-workspace");
         app.mcp_configured_count = 2;
 
@@ -5905,10 +5906,32 @@ mod tests {
             .join("\n");
 
         assert!(rendered.contains("codewhale · /tmp/codewhale-test-workspace · no git · mcp 2"));
-        assert!(rendered.contains("Fleet setup  /fleet setup"));
+        assert!(rendered.contains("Fleet ready  /fleet setup"));
+        assert!(
+            !rendered.contains("Fleet setup  /fleet setup"),
+            "the idle action must not imply that built-in Fleet roles still require setup"
+        );
         assert!(rendered.contains("/help or Ctrl+K"));
         assert!(!rendered.contains("Model  /model"));
         assert!(!rendered.contains("Rules  /constitution"));
+    }
+
+    #[test]
+    fn empty_state_does_not_claim_fleet_ready_without_a_provider_route() {
+        let mut app = create_test_app();
+        app.onboarding_needs_api_key = true;
+
+        for area in [Rect::new(0, 0, 40, 12), Rect::new(0, 0, 100, 20)] {
+            let rendered = build_empty_state_lines(&app, area)
+                .iter()
+                .flat_map(|line| line.spans.iter())
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+
+            assert!(rendered.contains("Fleet  /provider"), "{rendered}");
+            assert!(!rendered.contains("Fleet ready"), "{rendered}");
+            assert!(!rendered.contains("/fleet setup"), "{rendered}");
+        }
     }
 
     #[test]
@@ -5973,15 +5996,16 @@ mod tests {
     }
 
     #[test]
-    fn compact_launch_keeps_fleet_setup_without_ambient_clutter() {
-        let app = create_test_app();
+    fn compact_launch_states_that_fleet_is_ready_without_ambient_clutter() {
+        let mut app = create_test_app();
+        app.onboarding_needs_api_key = false;
         let rendered = build_empty_state_lines(&app, Rect::new(0, 0, 40, 12))
             .iter()
             .flat_map(|line| line.spans.iter())
             .map(|span| span.content.as_ref())
             .collect::<String>();
 
-        assert!(rendered.contains("/fleet setup"));
+        assert!(rendered.contains("Fleet ready  /fleet setup"));
         assert!(!rendered.contains("▗▄▄"));
     }
 
@@ -5989,6 +6013,7 @@ mod tests {
     fn launch_hierarchy_survives_responsive_gate_sizes() {
         for (width, height) in [(40, 12), (60, 16), (80, 24), (100, 32), (140, 40)] {
             let mut app = create_test_app();
+            app.onboarding_needs_api_key = false;
             app.low_motion = false;
             app.fancy_animations = true;
             let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
@@ -6003,8 +6028,8 @@ mod tests {
             let rendered = buffer_text(terminal.backend().buffer(), area);
 
             assert!(
-                rendered.contains("Fleet") && rendered.contains("/fleet setup"),
-                "Fleet must remain the launch priority at {width}x{height}:\n{rendered}"
+                rendered.contains("Fleet ready") && rendered.contains("/fleet setup"),
+                "Fleet readiness must remain explicit at {width}x{height}:\n{rendered}"
             );
             if height < 14 {
                 assert!(


### PR DESCRIPTION
## Summary

- replace the idle Fleet setup label with truthful localized Fleet ready copy when Fleet is configured
- keep missing-provider startup fail-closed as Fleet plus the real /provider route
- keep /fleet setup visible and actionable at compact and larger viewport tiers

Closes #4612.

This deliberately does not close #4604; repeated onboarding is being investigated independently.

## Verification

- cargo test -p codewhale-tui --lib empty_state_ --locked
- cargo test -p codewhale-tui --lib launch_ --locked
- cargo test -p codewhale-tui --lib --locked: 7,672 passed, 0 failed, 3 ignored
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- independent exact-head audit: approve, no findings
