### PR TITLE
fix(tui): make onboarding completion durable

### DIFF
--- a/crates/tui/src/tui/onboarding/mod.rs
+++ b/crates/tui/src/tui/onboarding/mod.rs
@@ -148,17 +148,36 @@ pub fn tips_lines(app: &App) -> Vec<ratatui::text::Line<'static>> {
 }
 
 pub fn default_marker_path() -> Option<PathBuf> {
-    crate::config::effective_home_dir().map(|home| marker_path_with_home(&home))
+    let primary_home = codewhale_config::codewhale_home().ok()?;
+    let legacy_home = if codewhale_config::codewhale_home_is_explicit() {
+        None
+    } else {
+        codewhale_config::legacy_deepseek_home().ok()
+    };
+    Some(marker_path_with_roots(
+        &primary_home,
+        legacy_home.as_deref(),
+    ))
 }
 
+#[cfg(test)]
 fn marker_path_with_home(home: &Path) -> PathBuf {
-    let primary = home.join(".codewhale").join(ONBOARDED_MARKER_FILE);
+    marker_path_with_roots(
+        &home.join(".codewhale"),
+        Some(home.join(".deepseek").as_path()),
+    )
+}
+
+fn marker_path_with_roots(primary_home: &Path, legacy_home: Option<&Path>) -> PathBuf {
+    let primary = primary_home.join(ONBOARDED_MARKER_FILE);
     if primary.exists() {
         return primary;
     }
-    let legacy = home.join(".deepseek").join(ONBOARDED_MARKER_FILE);
-    if legacy.exists() {
-        return legacy;
+    if let Some(legacy_home) = legacy_home {
+        let legacy = legacy_home.join(ONBOARDED_MARKER_FILE);
+        if legacy.exists() {
+            return legacy;
+        }
     }
     primary
 }
@@ -168,14 +187,22 @@ pub fn is_onboarded() -> bool {
 }
 
 pub fn mark_onboarded() -> std::io::Result<PathBuf> {
-    let home = crate::config::effective_home_dir().ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::NotFound, "Home directory not found")
+    let path = default_marker_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Codewhale home directory not found",
+        )
     })?;
-    mark_onboarded_at_home(&home)
+    mark_onboarded_at_path(path)
 }
 
+#[cfg(test)]
 fn mark_onboarded_at_home(home: &Path) -> std::io::Result<PathBuf> {
     let path = marker_path_with_home(home);
+    mark_onboarded_at_path(path)
+}
+
+fn mark_onboarded_at_path(path: PathBuf) -> std::io::Result<PathBuf> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -477,6 +504,37 @@ mod tests {
         }
 
         assert_eq!(marker_path_with_home(tmp.path()), primary);
+    }
+
+    #[test]
+    fn explicit_codewhale_home_marker_survives_restart_resolution() {
+        let _env_lock = crate::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ambient_home = tmp.path().join("ambient profile");
+        let isolated_home = tmp.path().join("isolated Codewhale state");
+        let ambient_legacy = ambient_home.join(".deepseek").join(ONBOARDED_MARKER_FILE);
+        std::fs::create_dir_all(ambient_legacy.parent().expect("legacy parent"))
+            .expect("mkdir legacy");
+        std::fs::write(&ambient_legacy, "").expect("seed ambient legacy marker");
+        let _home = crate::test_support::EnvVarGuard::set("HOME", &ambient_home);
+        let _userprofile = crate::test_support::EnvVarGuard::set("USERPROFILE", &ambient_home);
+        let _codewhale_home =
+            crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", &isolated_home);
+
+        let expected = isolated_home.join(ONBOARDED_MARKER_FILE);
+        assert_eq!(default_marker_path().as_deref(), Some(expected.as_path()));
+        assert!(!is_onboarded());
+
+        let written = mark_onboarded().expect("mark onboarded");
+
+        assert_eq!(written, expected);
+        assert!(is_onboarded());
+        assert_eq!(default_marker_path().as_deref(), Some(expected.as_path()));
+        assert!(ambient_legacy.exists(), "legacy marker remains untouched");
+        assert!(
+            !ambient_home.join(".codewhale").exists(),
+            "an explicit state root must not write into the ambient profile"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/setup/mod.rs
+++ b/crates/tui/src/tui/setup/mod.rs
@@ -1787,12 +1787,16 @@ impl SetupWizardView {
         state.set_step(spec.id(), entry);
         if spec.id() == SetupStep::Constitution && status == StepStatus::Skipped {
             // `S` is a durable response to the versioned checkpoint, just like
-            // choosing the explicit defer action. Without this completion
-            // marker startup opens the same checkpoint again on every launch.
-            state.complete_constitution_checkpoint(
-                CONSTITUTION_CHECKPOINT_VERSION,
-                ConstitutionChoice::Deferred,
-            );
+            // choosing the explicit defer action. It only skips this setup
+            // checkpoint, though; it must not replace an already active
+            // bundled or custom Constitution choice. A fresh state has no
+            // active choice, so keep the bundled floor by recording Deferred.
+            let choice = if state.constitution_choice.is_explicit() {
+                state.constitution_choice
+            } else {
+                ConstitutionChoice::Deferred
+            };
+            state.complete_constitution_checkpoint(CONSTITUTION_CHECKPOINT_VERSION, choice);
         }
         self.state = state.clone();
         if advance {
@@ -4136,6 +4140,54 @@ mod tests {
             StepStatus::NeedsAction
         );
         assert!(message.contains("retry"));
+    }
+
+    #[test]
+    fn skipping_checkpoint_preserves_active_custom_constitution() {
+        let mut state = SetupState {
+            constitution_choice: ConstitutionChoice::GuidedCustom,
+            constitution_source: ConstitutionSource::UserGlobal,
+            constitution_validity: ConstitutionValidity::Valid,
+            constitution_authoring: Some(ConstitutionAuthoring::Guided),
+            constitution_preview_hash: Some("sha256:existing-custom-preview".to_string()),
+            constitution_preview_version: 7,
+            ..SetupState::default()
+        };
+        state.constitution_checkpoint_completed_for = Some("0.8.66".to_string());
+        let mut view = SetupWizardView::new_at_with_facts(
+            state,
+            Locale::En,
+            SetupStep::Constitution,
+            SetupRuntimeFacts::default(),
+        );
+
+        let action = view.handle_key(key(KeyCode::Char('s')));
+
+        let ViewAction::Emit(ViewEvent::SetupStateCommitRequested { state, message }) = action
+        else {
+            panic!("expected skipped setup-state commit event");
+        };
+        assert_eq!(state.status(SetupStep::Constitution), StepStatus::Skipped);
+        assert_eq!(
+            state.constitution_checkpoint_completed_for.as_deref(),
+            Some(CONSTITUTION_CHECKPOINT_VERSION)
+        );
+        assert_eq!(state.constitution_choice, ConstitutionChoice::GuidedCustom);
+        assert_eq!(state.constitution_source, ConstitutionSource::UserGlobal);
+        assert_eq!(state.constitution_validity, ConstitutionValidity::Valid);
+        assert_eq!(
+            state.constitution_authoring,
+            Some(ConstitutionAuthoring::Guided)
+        );
+        assert_eq!(
+            state.constitution_preview_hash.as_deref(),
+            Some("sha256:existing-custom-preview")
+        );
+        assert_eq!(state.constitution_preview_version, 7);
+        assert!(message.contains("skipped"));
+
+        let restarted = SetupWizardView::new(state, Locale::En);
+        assert_eq!(restarted.selected_step(), SetupStep::Language);
     }
 
     #[test]

--- a/crates/tui/src/tui/setup/mod.rs
+++ b/crates/tui/src/tui/setup/mod.rs
@@ -1785,6 +1785,15 @@ impl SetupWizardView {
         }
         let mut state = self.state.clone();
         state.set_step(spec.id(), entry);
+        if spec.id() == SetupStep::Constitution && status == StepStatus::Skipped {
+            // `S` is a durable response to the versioned checkpoint, just like
+            // choosing the explicit defer action. Without this completion
+            // marker startup opens the same checkpoint again on every launch.
+            state.complete_constitution_checkpoint(
+                CONSTITUTION_CHECKPOINT_VERSION,
+                ConstitutionChoice::Deferred,
+            );
+        }
         self.state = state.clone();
         if advance {
             self.move_next();
@@ -4106,8 +4115,15 @@ mod tests {
             panic!("expected skipped setup-state commit event");
         };
         assert_eq!(state.status(SetupStep::Constitution), StepStatus::Skipped);
+        assert_eq!(
+            state.constitution_checkpoint_completed_for.as_deref(),
+            Some(CONSTITUTION_CHECKPOINT_VERSION)
+        );
+        assert_eq!(state.constitution_choice, ConstitutionChoice::Deferred);
         assert!(message.contains("skipped"));
         assert_eq!(view.selected_step(), SetupStep::OperateFleet);
+        let restarted = SetupWizardView::new(state, Locale::En);
+        assert_eq!(restarted.selected_step(), SetupStep::Language);
 
         let action = view.handle_key(key(KeyCode::Char('r')));
 


### PR DESCRIPTION
## Summary

- resolve the first-run marker through the Codewhale state-root contract so explicit CODEWHALE_HOME stays isolated from ambient legacy state
- persist generic S as completion of the current Constitution checkpoint so setup does not reopen after restart
- preserve every already active explicit Constitution choice and its provenance when the checkpoint is skipped; only fresh Unset state becomes Deferred

Closes #4604.

Reported by @bevis-wong.

## Verification

- cargo test -p codewhale-tui --bins --locked: 7,685 passed, 0 failed, 3 ignored
- cargo test -p codewhale-tui --test qa_pty --locked: 17 passed, 0 failed, 1 ignored
- cargo test -p codewhale-tui --test release_runtime_qa --locked: 5 passed, 0 failed, 1 ignored
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- independent exact-head audit at 850a592cc65e7769c2e6dcced39f38a6ee969c49: ACCEPT, no findings
