### PR TITLE
fix(tui): keep long-running tools live

### DIFF
--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -6,6 +6,7 @@
 
 use std::{
     fs::OpenOptions,
+    future::Future,
     io::Write,
     path::{Path, PathBuf},
     sync::Arc,
@@ -13,6 +14,46 @@ use std::{
 };
 
 use super::*;
+
+const TOOL_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Await one tool future while emitting best-effort liveness pulses.
+///
+/// The pulse is deliberately nonblocking: a full or closed UI event channel
+/// must never delay the tool itself. The first tick is consumed before the
+/// select loop so fast tools emit no heartbeat, and missed ticks are skipped
+/// instead of bursting after a temporarily starved runtime resumes.
+async fn await_tool_with_heartbeat<F, T>(tx_event: mpsc::Sender<Event>, future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    await_tool_with_heartbeat_interval(tx_event, future, TOOL_HEARTBEAT_INTERVAL).await
+}
+
+async fn await_tool_with_heartbeat_interval<F, T>(
+    tx_event: mpsc::Sender<Event>,
+    future: F,
+    interval: Duration,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    tokio::pin!(future);
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            biased;
+
+            result = &mut future => return result,
+            _ = ticker.tick() => {
+                let _ = tx_event.try_send(Event::ToolCallHeartbeat);
+            }
+        }
+    }
+}
 
 /// RAII guard that pauses the TUI's terminal-state ownership for the duration
 /// of an interactive tool, then restores it on drop.
@@ -312,6 +353,38 @@ impl Engine {
         mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
         context_override: Option<crate::tools::ToolContext>,
     ) -> Result<ToolResult, ToolError> {
+        let heartbeat_tx = tx_event.clone();
+        await_tool_with_heartbeat(
+            heartbeat_tx,
+            Self::execute_tool_with_lock_inner(
+                lock,
+                supports_parallel,
+                interactive,
+                tx_event,
+                tool_name,
+                tool_input,
+                workspace,
+                registry,
+                mcp_pool,
+                context_override,
+            ),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn execute_tool_with_lock_inner(
+        lock: Arc<RwLock<()>>,
+        supports_parallel: bool,
+        interactive: bool,
+        tx_event: mpsc::Sender<Event>,
+        tool_name: String,
+        tool_input: serde_json::Value,
+        workspace: PathBuf,
+        registry: Option<&crate::tools::ToolRegistry>,
+        mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
+        context_override: Option<crate::tools::ToolContext>,
+    ) -> Result<ToolResult, ToolError> {
         let started_at = std::time::Instant::now();
         let dispatch = if McpPool::is_mcp_tool(&tool_name) {
             "mcp"
@@ -417,6 +490,92 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::time::Duration;
+
+    const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(10);
+
+    #[tokio::test]
+    async fn tool_heartbeat_emits_for_slow_future() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let task = tokio::spawn(await_tool_with_heartbeat_interval(
+            tx,
+            async {
+                tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 3).await;
+                "done"
+            },
+            TEST_HEARTBEAT_INTERVAL,
+        ));
+
+        let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("heartbeat before slow future completes")
+            .expect("event channel stays open");
+        assert!(matches!(event, Event::ToolCallHeartbeat));
+        assert_eq!(task.await.expect("heartbeat task joined"), "done");
+    }
+
+    #[tokio::test]
+    async fn tool_heartbeat_is_delayed_for_fast_future() {
+        let (tx, mut rx) = mpsc::channel(4);
+
+        let result =
+            await_tool_with_heartbeat_interval(tx, async { "done" }, TEST_HEARTBEAT_INTERVAL).await;
+
+        assert_eq!(result, "done");
+        assert!(rx.try_recv().is_err(), "fast tool emitted a heartbeat");
+    }
+
+    #[tokio::test]
+    async fn tool_heartbeat_stops_after_future_completes() {
+        let (tx, mut rx) = mpsc::channel(8);
+
+        let result = await_tool_with_heartbeat_interval(
+            tx,
+            async {
+                tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 2).await;
+                "done"
+            },
+            TEST_HEARTBEAT_INTERVAL,
+        )
+        .await;
+
+        assert_eq!(result, "done");
+        let mut heartbeat_count = 0;
+        while let Ok(event) = rx.try_recv() {
+            assert!(matches!(event, Event::ToolCallHeartbeat));
+            heartbeat_count += 1;
+        }
+        assert!(heartbeat_count > 0, "slow tool emitted no heartbeat");
+
+        tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 2).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "heartbeat continued after tool completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_event_channel_never_blocks_tool_heartbeat() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.try_send(Event::status("filler")).expect("fill channel");
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            await_tool_with_heartbeat_interval(
+                tx,
+                async {
+                    tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 3).await;
+                    "done"
+                },
+                TEST_HEARTBEAT_INTERVAL,
+            ),
+        )
+        .await
+        .expect("full event channel must not block tool completion");
+
+        assert_eq!(result, "done");
+        assert!(matches!(rx.recv().await, Some(Event::Status { .. })));
+        assert!(rx.try_recv().is_err(), "heartbeat displaced queued event");
+    }
 
     #[tokio::test]
     async fn terminal_guard_queues_resume_when_event_channel_is_full() {

--- a/crates/tui/src/core/engine/tool_execution.rs
+++ b/crates/tui/src/core/engine/tool_execution.rs
@@ -6,7 +6,6 @@
 
 use std::{
     fs::OpenOptions,
-    future::Future,
     io::Write,
     path::{Path, PathBuf},
     sync::Arc,
@@ -17,41 +16,50 @@ use super::*;
 
 const TOOL_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 
-/// Await one tool future while emitting best-effort liveness pulses.
+/// Emits delayed, best-effort liveness pulses for one running tool.
 ///
-/// The pulse is deliberately nonblocking: a full or closed UI event channel
-/// must never delay the tool itself. The first tick is consumed before the
-/// select loop so fast tools emit no heartbeat, and missed ticks are skipped
-/// instead of bursting after a temporarily starved runtime resumes.
-async fn await_tool_with_heartbeat<F, T>(tx_event: mpsc::Sender<Event>, future: F) -> T
-where
-    F: Future<Output = T>,
-{
-    await_tool_with_heartbeat_interval(tx_event, future, TOOL_HEARTBEAT_INTERVAL).await
+/// Keep the ticker in its own task instead of embedding `tokio::time::Interval`
+/// in the already-large engine turn future. Besides keeping the turn future
+/// compact, this leaves pre-execution MCP discovery and approval scheduling
+/// untouched. Dropping the guard cancels and aborts the ticker synchronously.
+struct ToolHeartbeatGuard {
+    cancel: tokio_util::sync::CancellationToken,
+    task: tokio::task::JoinHandle<()>,
 }
 
-async fn await_tool_with_heartbeat_interval<F, T>(
-    tx_event: mpsc::Sender<Event>,
-    future: F,
-    interval: Duration,
-) -> T
-where
-    F: Future<Output = T>,
-{
-    tokio::pin!(future);
-    let mut ticker = tokio::time::interval(interval);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    ticker.tick().await;
+impl ToolHeartbeatGuard {
+    fn start(tx_event: mpsc::Sender<Event>, interval: Duration) -> Self {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // Tokio intervals tick immediately once. Consume that tick so fast
+            // tools do not produce a pulse and the first heartbeat is delayed.
+            ticker.tick().await;
 
-    loop {
-        tokio::select! {
-            biased;
+            loop {
+                tokio::select! {
+                    biased;
 
-            result = &mut future => return result,
-            _ = ticker.tick() => {
-                let _ = tx_event.try_send(Event::ToolCallHeartbeat);
+                    () = task_cancel.cancelled() => break,
+                    _ = ticker.tick() => {
+                        match tx_event.try_send(Event::ToolCallHeartbeat) {
+                            Ok(()) | Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
+                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => break,
+                        }
+                    }
+                }
             }
-        }
+        });
+        Self { cancel, task }
+    }
+}
+
+impl Drop for ToolHeartbeatGuard {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.task.abort();
     }
 }
 
@@ -353,38 +361,9 @@ impl Engine {
         mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
         context_override: Option<crate::tools::ToolContext>,
     ) -> Result<ToolResult, ToolError> {
-        let heartbeat_tx = tx_event.clone();
-        await_tool_with_heartbeat(
-            heartbeat_tx,
-            Self::execute_tool_with_lock_inner(
-                lock,
-                supports_parallel,
-                interactive,
-                tx_event,
-                tool_name,
-                tool_input,
-                workspace,
-                registry,
-                mcp_pool,
-                context_override,
-            ),
-        )
-        .await
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn execute_tool_with_lock_inner(
-        lock: Arc<RwLock<()>>,
-        supports_parallel: bool,
-        interactive: bool,
-        tx_event: mpsc::Sender<Event>,
-        tool_name: String,
-        tool_input: serde_json::Value,
-        workspace: PathBuf,
-        registry: Option<&crate::tools::ToolRegistry>,
-        mcp_pool: Option<Arc<AsyncMutex<McpPool>>>,
-        context_override: Option<crate::tools::ToolContext>,
-    ) -> Result<ToolResult, ToolError> {
+        // This guard starts before lock acquisition, so contention as well as
+        // registry/MCP/interpreter execution remains visibly live.
+        let _heartbeat = ToolHeartbeatGuard::start(tx_event.clone(), TOOL_HEARTBEAT_INTERVAL);
         let started_at = std::time::Instant::now();
         let dispatch = if McpPool::is_mcp_tool(&tool_name) {
             "mcp"
@@ -494,58 +473,44 @@ mod tests {
     const TEST_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(10);
 
     #[tokio::test]
-    async fn tool_heartbeat_emits_for_slow_future() {
+    async fn tool_heartbeat_emits_for_slow_tool() {
         let (tx, mut rx) = mpsc::channel(4);
-        let task = tokio::spawn(await_tool_with_heartbeat_interval(
-            tx,
-            async {
-                tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 3).await;
-                "done"
-            },
-            TEST_HEARTBEAT_INTERVAL,
-        ));
+        let guard = ToolHeartbeatGuard::start(tx, TEST_HEARTBEAT_INTERVAL);
 
         let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
-            .expect("heartbeat before slow future completes")
+            .expect("heartbeat before slow tool completes")
             .expect("event channel stays open");
+
         assert!(matches!(event, Event::ToolCallHeartbeat));
-        assert_eq!(task.await.expect("heartbeat task joined"), "done");
+        drop(guard);
     }
 
     #[tokio::test]
-    async fn tool_heartbeat_is_delayed_for_fast_future() {
+    async fn tool_heartbeat_is_delayed_for_fast_tool() {
         let (tx, mut rx) = mpsc::channel(4);
 
-        let result =
-            await_tool_with_heartbeat_interval(tx, async { "done" }, TEST_HEARTBEAT_INTERVAL).await;
+        let guard = ToolHeartbeatGuard::start(tx, TEST_HEARTBEAT_INTERVAL);
+        drop(guard);
+        tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 2).await;
 
-        assert_eq!(result, "done");
         assert!(rx.try_recv().is_err(), "fast tool emitted a heartbeat");
     }
 
     #[tokio::test]
-    async fn tool_heartbeat_stops_after_future_completes() {
+    async fn tool_heartbeat_stops_after_tool_completes() {
         let (tx, mut rx) = mpsc::channel(8);
+        let guard = ToolHeartbeatGuard::start(tx, TEST_HEARTBEAT_INTERVAL);
 
-        let result = await_tool_with_heartbeat_interval(
-            tx,
-            async {
-                tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 2).await;
-                "done"
-            },
-            TEST_HEARTBEAT_INTERVAL,
-        )
-        .await;
+        let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("heartbeat before slow tool completes")
+            .expect("event channel stays open");
+        assert!(matches!(event, Event::ToolCallHeartbeat));
 
-        assert_eq!(result, "done");
-        let mut heartbeat_count = 0;
-        while let Ok(event) = rx.try_recv() {
-            assert!(matches!(event, Event::ToolCallHeartbeat));
-            heartbeat_count += 1;
-        }
-        assert!(heartbeat_count > 0, "slow tool emitted no heartbeat");
-
+        drop(guard);
+        tokio::task::yield_now().await;
+        while rx.try_recv().is_ok() {}
         tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 2).await;
         assert!(
             rx.try_recv().is_err(),
@@ -558,17 +523,12 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         tx.try_send(Event::status("filler")).expect("fill channel");
 
-        let result = tokio::time::timeout(
-            Duration::from_secs(1),
-            await_tool_with_heartbeat_interval(
-                tx,
-                async {
-                    tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 3).await;
-                    "done"
-                },
-                TEST_HEARTBEAT_INTERVAL,
-            ),
-        )
+        let result = tokio::time::timeout(Duration::from_secs(1), async {
+            let guard = ToolHeartbeatGuard::start(tx, TEST_HEARTBEAT_INTERVAL);
+            tokio::time::sleep(TEST_HEARTBEAT_INTERVAL * 3).await;
+            drop(guard);
+            "done"
+        })
         .await
         .expect("full event channel must not block tool completion");
 

--- a/crates/tui/src/core/events.rs
+++ b/crates/tui/src/core/events.rs
@@ -89,6 +89,13 @@ pub enum Event {
         input: Value,
     },
 
+    /// Best-effort liveness pulse while a tool future remains pending.
+    ///
+    /// This carries no output and must not change user-visible status or the
+    /// transcript. It only prevents the TUI from declaring a healthy,
+    /// deliberately long-running tool turn stale.
+    ToolCallHeartbeat,
+
     /// Tool call completed
     ToolCallComplete {
         id: String,

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -3091,6 +3091,9 @@ pub struct ShellWaitTool {
     name: &'static str,
 }
 
+/// Maximum deliberate dependency-barrier wait accepted by `exec_shell_wait`.
+pub(crate) const EXEC_SHELL_WAIT_MAX_TIMEOUT_MS: u64 = 600_000;
+
 impl ShellWaitTool {
     pub const fn new(name: &'static str) -> Self {
         Self { name }
@@ -3207,7 +3210,7 @@ async fn wait_for_shell_delta_cancellable(
     task_id: &str,
     timeout_ms: u64,
 ) -> Result<(ShellDeltaResult, bool), ToolError> {
-    let timeout_ms = timeout_ms.clamp(1000, 600_000);
+    let timeout_ms = timeout_ms.clamp(1000, EXEC_SHELL_WAIT_MAX_TIMEOUT_MS);
     let deadline = Instant::now() + Duration::from_millis(timeout_ms);
     let mut stdout_accum = String::new();
     let mut stderr_accum = String::new();

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2733,6 +2733,9 @@ async fn run_event_loop(
                         }
                         handle_tool_call_started(app, &id, &name, &input);
                     }
+                    // Liveness only. `record_turn_activity` above consumes the
+                    // pulse; it must not alter transcript or status copy.
+                    EngineEvent::ToolCallHeartbeat => {}
                     EngineEvent::ToolCallComplete { id, name, result } => {
                         if name == "update_plan" {
                             app.plan_tool_used_in_turn = true;
@@ -13536,6 +13539,7 @@ fn suppress_engine_event_after_local_cancel(event: &EngineEvent) -> bool {
             | EngineEvent::ThinkingDelta { .. }
             | EngineEvent::ThinkingComplete { .. }
             | EngineEvent::ToolCallStarted { .. }
+            | EngineEvent::ToolCallHeartbeat
             | EngineEvent::ToolCallComplete { .. }
             | EngineEvent::ApprovalRequired { .. }
             | EngineEvent::UserInputRequired { .. }
@@ -13554,6 +13558,7 @@ fn ignore_stale_stream_event_while_idle(event: &EngineEvent) -> bool {
             | EngineEvent::ThinkingDelta { .. }
             | EngineEvent::ThinkingComplete { .. }
             | EngineEvent::ToolCallStarted { .. }
+            | EngineEvent::ToolCallHeartbeat
             | EngineEvent::ToolCallComplete { .. }
             | EngineEvent::ApprovalRequired { .. }
             | EngineEvent::UserInputRequired { .. }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -6439,6 +6439,52 @@ fn turn_liveness_does_not_abort_running_tool_with_recent_heartbeat() {
 }
 
 #[test]
+fn turn_liveness_keeps_max_duration_exec_shell_wait_alive_with_heartbeat() {
+    // `exec_shell_wait` accepts exactly 600_000ms. Before the heartbeat was
+    // restored, that supported boundary raced the identically timed tool-hang
+    // watchdog and falsely made the UI idle while the engine still owned the
+    // turn.
+    const EXEC_SHELL_WAIT_MAX: Duration =
+        Duration::from_millis(crate::tools::shell::EXEC_SHELL_WAIT_MAX_TIMEOUT_MS);
+    assert_eq!(TOOL_HANG_WATCHDOG_TIMEOUT, EXEC_SHELL_WAIT_MAX);
+
+    let mut app = create_test_app();
+    let started_at = Instant::now();
+    let wait_deadline = started_at + EXEC_SHELL_WAIT_MAX;
+    let now = wait_deadline + Duration::from_secs(1);
+    app.is_loading = true;
+    app.runtime_turn_status = Some("in_progress".to_string());
+    app.runtime_turn_id = Some("max-shell-wait-turn".to_string());
+    app.turn_started_at = Some(started_at);
+    app.turn_last_activity_at = Some(started_at);
+    let mut active = ActiveCell::new();
+    active.push_tool(
+        "shell-wait",
+        HistoryCell::Tool(ToolCell::Generic(GenericToolCell {
+            name: "exec_shell_wait".to_string(),
+            status: ToolStatus::Running,
+            input_summary: Some("task_id: shell-test, wait: true, timeout_ms: 600000".to_string()),
+            output: None,
+            prompts: None,
+            spillover_path: None,
+            output_summary: None,
+            is_diff: false,
+        })),
+    );
+    app.active_cell = Some(active);
+
+    record_turn_activity(&mut app, &EngineEvent::ToolCallHeartbeat, wait_deadline);
+    let recovered = reconcile_turn_liveness(&mut app, now, false);
+
+    assert!(!recovered);
+    assert!(app.is_loading);
+    assert_eq!(app.runtime_turn_status.as_deref(), Some("in_progress"));
+    assert_eq!(app.runtime_turn_id.as_deref(), Some("max-shell-wait-turn"));
+    assert!(app.status_message.is_none());
+    assert!(app.status_toasts.is_empty());
+}
+
+#[test]
 fn turn_liveness_respects_stream_idle_budget_for_quiet_model_waits() {
     let mut app = create_test_app();
     let started_at = Instant::now();


### PR DESCRIPTION
## What

Restore liveness-only heartbeats around the complete tool execution boundary so a healthy long dependency wait cannot race the ten-minute TUI stall watchdog and strand follow-up input.

The ticker runs in a cancellable guard task: first pulse delayed, missed ticks skipped, full channels nonblocking/non-displacing, and no transcript or runtime receipt. This covers execution-lock waits plus registry, MCP, and interpreter futures.

## Regression boundary

- exec_shell_wait accepts exactly 600,000 ms, matching the watchdog boundary.
- The first future-wrapping implementation exposed a sealed plugin preapproval scheduling hang (0/5); the guard-task implementation is 3/3 targeted plus the full plugin binary and full TUI gate.

## Verification

- Full locked TUI suite: 7,750 unit tests green; plugin 5/5; QA PTY 17/0/1; release runtime 5/0/1; all remaining integration targets green.
- Strict workspace clippy, all targets/features, warnings denied.
- Focused heartbeat 4/4, turn liveness 10/10, shell wait 4/4, interpreter 1/1.
- Fresh immutable audit ACCEPT at b9460aaea0b0ffeb000f835abd37c1d9bbb750ff.

No provider credentials, publication, deployment, or release action is involved.