### PR TITLE
fix(shell): default no-cwd shell commands to context.workspace

### DIFF
--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -2459,6 +2459,7 @@ fn exec_shell_input_starts_detached(input: &serde_json::Value) -> bool {
 async fn execute_foreground_via_background(
     context: &ToolContext,
     command: &str,
+    working_dir: Option<String>,
     timeout_ms: u64,
     stdin_data: Option<&str>,
     tty: bool,
@@ -2474,7 +2475,7 @@ async fn execute_foreground_via_background(
         manager.clear_foreground_background_request();
         manager.execute_with_options_env_for_owner_and_work(
             command,
-            None,
+            working_dir.as_deref(),
             timeout_ms,
             true,
             stdin_data,
@@ -2797,7 +2798,10 @@ impl ToolSpec for BashTool {
                 let resolved = context.resolve_path(dir)?;
                 Some(resolved.to_string_lossy().to_string())
             }
-            None => None,
+            // Default to the tool context's workspace (which reflects the
+            // child agent's worktree when `worktree: true` was used), not the
+            // shared ShellManager's parent-workspace default_workspace.
+            None => Some(context.workspace.display().to_string()),
         };
 
         // #456 — collect env from any configured `shell_env` hooks. Runs
@@ -2977,6 +2981,7 @@ impl ToolSpec for BashTool {
             execute_foreground_via_background(
                 context,
                 command,
+                working_dir,
                 timeout_ms,
                 stdin_data.as_deref(),
                 combined_output,

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1892,18 +1892,26 @@ async fn default_cwd_uses_context_workspace_not_shell_manager_default() {
         // ...but whose ShellManager's default_workspace is sm_dir.
         .with_shell_manager(new_shared_shell_manager(sm_dir.path().to_path_buf()));
 
+    // Assert directory identity through marker files instead of comparing the
+    // shell's printed path. PowerShell and `canonicalize` can spell the same
+    // Windows path differently (for example, with a verbatim-path prefix).
+    let command = if cfg!(windows) {
+        "if (Test-Path -LiteralPath 'I_AM_CTX_DIR') { Write-Output 'context-workspace' } elseif (Test-Path -LiteralPath 'I_AM_SM_DIR') { Write-Output 'manager-workspace' } else { Write-Output 'missing-workspace' }"
+    } else {
+        "if [ -f I_AM_CTX_DIR ]; then printf 'context-workspace'; elif [ -f I_AM_SM_DIR ]; then printf 'manager-workspace'; else printf 'missing-workspace'; fi"
+    };
     let result = BashTool::new("Bash")
-        .execute(json!({"command": "pwd"}), &ctx)
+        .execute(json!({"command": command}), &ctx)
         .await
         .expect("shell execute");
     assert!(result.success, "command failed: {:?}", result.content);
 
-    let cwd = result.content.trim();
-    let ctx_path = std::fs::canonicalize(ctx_dir.path()).unwrap();
-    let ctx_str = ctx_path.to_string_lossy().to_string();
-
     assert!(
-        cwd.contains(&ctx_str),
-        "Expected cwd to be context.workspace ({ctx_str}), but was: {cwd}"
+        result
+            .content
+            .lines()
+            .any(|line| line.trim() == "context-workspace"),
+        "expected context.workspace marker, but shell reported: {:?}",
+        result.content
     );
 }

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1871,3 +1871,39 @@ fn issue_1691_quoted_commit_message_round_trips() {
         .collect();
     assert_eq!(got, spec.args);
 }
+
+/// When no `cwd` is provided, the shell should run in `context.workspace`,
+/// not in the ShellManager's default_workspace. This ensures sub-agents in
+/// worktrees run commands in the worktree directory rather than the parent.
+///
+/// Without the `context.workspace` default (stashed): runs in sm_dir → FAILS
+/// With the `context.workspace` default (unstashed): runs in ctx_dir → PASSES
+#[tokio::test]
+async fn default_cwd_uses_context_workspace_not_shell_manager_default() {
+    let ctx_dir = tempdir().expect("ctx tempdir");
+    let sm_dir = tempdir().expect("sm tempdir");
+
+    // Create distinct dirs — write a marker in each so we can tell them apart.
+    std::fs::write(ctx_dir.path().join("I_AM_CTX_DIR"), "").unwrap();
+    std::fs::write(sm_dir.path().join("I_AM_SM_DIR"), "").unwrap();
+
+    // ToolContext whose workspace is ctx_dir...
+    let ctx = ToolContext::new(ctx_dir.path())
+        // ...but whose ShellManager's default_workspace is sm_dir.
+        .with_shell_manager(new_shared_shell_manager(sm_dir.path().to_path_buf()));
+
+    let result = BashTool::new("Bash")
+        .execute(json!({"command": "pwd"}), &ctx)
+        .await
+        .expect("shell execute");
+    assert!(result.success, "command failed: {:?}", result.content);
+
+    let cwd = result.content.trim();
+    let ctx_path = std::fs::canonicalize(ctx_dir.path()).unwrap();
+    let ctx_str = ctx_path.to_string_lossy().to_string();
+
+    assert!(
+        cwd.contains(&ctx_str),
+        "Expected cwd to be context.workspace ({ctx_str}), but was: {cwd}"
+    );
+}


### PR DESCRIPTION
When the BashTool receives no explicit `cwd`, the working directory now defaults to `context.workspace` (the sub-agent's worktree when `worktree: true` was used) instead of `None`, which fell through to the shared ShellManager's parent-workspace default.

This ensures sub-agents in isolated worktrees run shell commands in their worktree directory rather than the parent checkout.

The fix threads the resolved `working_dir` through `execute_foreground_via_background` (which previously always passed `None`) and adds a test that verifies the context.workspace priority over the ShellManager's default_workspace.

Closes #4674