### PR TITLE
fix(credit): preserve v0.9.1 integration authorship

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -10,6 +10,9 @@
 
 hmbown = Hmbown <101357273+Hmbown@users.noreply.github.com>
 hmbown@gmail.com = Hmbown <101357273+Hmbown@users.noreply.github.com>
+fleitz = Fred Leitz <345780+fleitz@users.noreply.github.com>
+fred.leitz@gmail.com = Fred Leitz <345780+fleitz@users.noreply.github.com>
+fleitzo@gmail.com = Fred Leitz <345780+fleitz@users.noreply.github.com>
 Angel-Hair = Lu Shihan <38780063+Angel-Hair@users.noreply.github.com>
 Angel_Hair@protonmail.com = Lu Shihan <38780063+Angel-Hair@users.noreply.github.com>
 dmitri-0 = dmitri-0 <141411224+dmitri-0@users.noreply.github.com>

--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -9,6 +9,7 @@
 # or local machine email seen in older harvested history.
 
 hmbown = Hmbown <101357273+Hmbown@users.noreply.github.com>
+hmbown@gmail.com = Hmbown <101357273+Hmbown@users.noreply.github.com>
 Angel-Hair = Lu Shihan <38780063+Angel-Hair@users.noreply.github.com>
 Angel_Hair@protonmail.com = Lu Shihan <38780063+Angel-Hair@users.noreply.github.com>
 dmitri-0 = dmitri-0 <141411224+dmitri-0@users.noreply.github.com>

--- a/scripts/check-coauthor-trailers.py
+++ b/scripts/check-coauthor-trailers.py
@@ -76,6 +76,12 @@ PRESERVED_MAPPED_IDENTITY_EXCEPTIONS = {
         "hunter bown",
         "hmbown@gmail.com",
     ),
+    (
+        "6d0ebc881a8bd2469c45b25f2a606fa63681e112",
+        "coauthor",
+        "fleitz",
+        "fleitzo@gmail.com",
+    ),
 }
 
 

--- a/scripts/check-coauthor-trailers.py
+++ b/scripts/check-coauthor-trailers.py
@@ -4,7 +4,8 @@
 The check is intentionally scoped to new commits. Historical commits may carry
 raw or local emails, but new harvested commits should use GitHub's numeric
 `id+login@users.noreply.github.com` address so co-author credit lands in the
-contributor graph.
+contributor graph. Preserved integration commits may resolve a mapped identity
+without a history rewrite only through an exact-SHA exception below.
 """
 
 from __future__ import annotations
@@ -49,6 +50,31 @@ LEGACY_AUTOMATION_TRAILER_EXCEPTIONS = {
         "9a74825cd182a62465943bcbbcbcf591d1ce99ee",
         "codewhale agent",
         "codewhale-agent@hmbown.local",
+    ),
+}
+
+# These public-surface commits were merged into the v0.9.1 integration graph
+# before the credit gate ran. Rewriting them would replace the original commits
+# and every descendant merge. Resolve only their exact Hunter identities through
+# AUTHOR_MAP; a changed SHA, role, name, or email remains a hard failure.
+PRESERVED_MAPPED_IDENTITY_EXCEPTIONS = {
+    (
+        "5087269606fc8847487b0a8b51ef6adffa8eb2ca",
+        "author",
+        "hunter b",
+        "hmbown@gmail.com",
+    ),
+    (
+        "5087269606fc8847487b0a8b51ef6adffa8eb2ca",
+        "coauthor",
+        "hunter bown",
+        "hmbown@gmail.com",
+    ),
+    (
+        "e37df06caeb3064b2bb9263c1c98a903738f3a0a",
+        "coauthor",
+        "hunter bown",
+        "hmbown@gmail.com",
     ),
 }
 
@@ -168,6 +194,15 @@ def lookup_identity(aliases: dict[str, Identity], *values: str) -> Identity | No
     return None
 
 
+def is_preserved_mapped_identity(commit: Commit, role: str, identity: Identity) -> bool:
+    return (
+        commit.sha.strip().lower(),
+        role,
+        norm_key(identity.name),
+        norm_key(identity.email),
+    ) in PRESERVED_MAPPED_IDENTITY_EXCEPTIONS
+
+
 def validate(commits: list[Commit], aliases: dict[str, Identity], check_authors: bool) -> list[str]:
     errors: list[str] = []
     for commit in commits:
@@ -191,6 +226,11 @@ def validate(commits: list[Commit], aliases: dict[str, Identity], check_authors:
                 is_harvested_commit
                 and mapped_author
                 and norm_key(commit.author_email) != norm_key(mapped_author.email)
+                and not is_preserved_mapped_identity(
+                    commit,
+                    "author",
+                    Identity(commit.author_name, commit.author_email),
+                )
             ):
                 errors.append(
                     f"{prefix}: author {commit.author_name} <{commit.author_email}> "
@@ -215,10 +255,11 @@ def validate(commits: list[Commit], aliases: dict[str, Identity], check_authors:
                 continue
             expected = lookup_identity(aliases, coauthor.email, coauthor.name)
             if expected:
-                errors.append(
-                    f"{prefix}: co-author {coauthor.name} <{coauthor.email}> is not "
-                    f"GitHub-mappable. Use `{expected.trailer()}`."
-                )
+                if not is_preserved_mapped_identity(commit, "coauthor", coauthor):
+                    errors.append(
+                        f"{prefix}: co-author {coauthor.name} <{coauthor.email}> is not "
+                        f"GitHub-mappable. Use `{expected.trailer()}`."
+                    )
             else:
                 errors.append(
                     f"{prefix}: co-author {coauthor.name} <{coauthor.email}> is not "
@@ -226,7 +267,12 @@ def validate(commits: list[Commit], aliases: dict[str, Identity], check_authors:
                     "or use `gh api users/<login> --jq '\"\\(.id)+\\(.login)@users.noreply.github.com\"'`."
                 )
 
-        coauthor_emails = {norm_key(coauthor.email) for coauthor in coauthors}
+        coauthor_emails: set[str] = set()
+        for coauthor in coauthors:
+            coauthor_emails.add(norm_key(coauthor.email))
+            expected = lookup_identity(aliases, coauthor.email, coauthor.name)
+            if expected and is_preserved_mapped_identity(commit, "coauthor", coauthor):
+                coauthor_emails.add(norm_key(expected.email))
         for login in harvested_logins:
             expected = lookup_identity(aliases, login)
             if expected is None:

--- a/scripts/test_check_coauthor_trailers.py
+++ b/scripts/test_check_coauthor_trailers.py
@@ -145,6 +145,30 @@ class CheckCoauthorTrailersTests(unittest.TestCase):
         errors = mod.validate([preserved], self.aliases, True)
         self.assertEqual(errors, [])
 
+    def test_preserved_fleitz_credit_resolves_only_for_exact_commit(self) -> None:
+        preserved = mod.Commit(
+            sha="6d0ebc881a8bd2469c45b25f2a606fa63681e112",
+            parents="parent",
+            author_name="Fred Leitz",
+            author_email="fred.leitz@gmail.com",
+            subject="fix(shell): default no-cwd shell commands to context.workspace",
+            body="Co-authored-by: fleitz <fleitzo@gmail.com>",
+        )
+        errors = mod.validate([preserved], self.aliases, True)
+        self.assertEqual(errors, [])
+
+        changed_identity = mod.Commit(
+            sha=preserved.sha,
+            parents=preserved.parents,
+            author_name=preserved.author_name,
+            author_email=preserved.author_email,
+            subject=preserved.subject,
+            body="Co-authored-by: fleitz <different@example.com>",
+        )
+        errors = mod.validate([changed_identity], self.aliases, True)
+        self.assertTrue(errors)
+        self.assertTrue(any("different@example.com" in error for error in errors))
+
 
 if __name__ == "__main__":
     raise SystemExit(unittest.main())

--- a/scripts/test_check_coauthor_trailers.py
+++ b/scripts/test_check_coauthor_trailers.py
@@ -106,6 +106,45 @@ class CheckCoauthorTrailersTests(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("unknown@example.com", errors[0])
 
+    def test_preserved_hunter_credit_resolves_only_for_exact_commit(self) -> None:
+        preserved = mod.Commit(
+            sha="5087269606fc8847487b0a8b51ef6adffa8eb2ca",
+            parents="parent",
+            author_name="Hunter B",
+            author_email="hmbown@gmail.com",
+            subject="docs(public): refresh v0.9.1 product truth",
+            body=(
+                "Harvested from PR #4508 by @Hmbown.\n\n"
+                "Co-authored-by: Hunter Bown <hmbown@gmail.com>"
+            ),
+        )
+        errors = mod.validate([preserved], self.aliases, True)
+        self.assertEqual(errors, [])
+
+        rewritten = mod.Commit(
+            sha="deadbeef" * 5,
+            parents=preserved.parents,
+            author_name=preserved.author_name,
+            author_email=preserved.author_email,
+            subject=preserved.subject,
+            body=preserved.body,
+        )
+        errors = mod.validate([rewritten], self.aliases, True)
+        self.assertTrue(errors)
+        self.assertTrue(any("not GitHub-mappable" in error for error in errors))
+
+    def test_preserved_web_credit_resolves_without_rewriting_commit(self) -> None:
+        preserved = mod.Commit(
+            sha="e37df06caeb3064b2bb9263c1c98a903738f3a0a",
+            parents="parent",
+            author_name="Hunter B",
+            author_email="hmbown@gmail.com",
+            subject="docs(web): make the homepage product first",
+            body="Co-authored-by: Hunter Bown <hmbown@gmail.com>",
+        )
+        errors = mod.validate([preserved], self.aliases, True)
+        self.assertEqual(errors, [])
+
 
 if __name__ == "__main__":
     raise SystemExit(unittest.main())


### PR DESCRIPTION
## What changed

- map Hunter Bown and Fred Leitz to canonical numeric GitHub noreply identities
- resolve only the exact existing public-surface and PR #4673 commit identities through AUTHOR_MAP
- retain the original commits and merge ancestry without rewriting
- add negative tests proving changed SHAs or identities still fail

## Validation

- cargo fmt --all -- --check
- python3 -m unittest scripts/test_check_coauthor_trailers.py
- python3 scripts/check-coauthor-trailers.py --range origin/main..HEAD --check-authors
- git diff --check origin/main...HEAD

This is a narrow prerequisite for direct contributor integration and PR #4675. It does not deploy, publish, tag, or release.