### PR TITLE
feat(skills): unified /skills manager with audit and owned mutations

### DIFF
--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -1489,6 +1489,58 @@ mod tests {
     }
 
     #[test]
+    fn parse_scope_args_and_default_install_target_is_global() {
+        use crate::skills::mutation::SkillTargetScope;
+
+        let (scope, rest) = parse_scope_args("github:o/r").unwrap();
+        assert_eq!(scope, None);
+        assert_eq!(rest, "github:o/r");
+        // Bare install (no --project/--global) maps to the CodeWhale global root.
+        assert_eq!(scope.unwrap_or(SkillTargetScope::Global), SkillTargetScope::Global);
+
+        let (scope, rest) = parse_scope_args("--project my-skill").unwrap();
+        assert_eq!(scope, Some(SkillTargetScope::Project));
+        assert_eq!(rest, "my-skill");
+
+        let (scope, rest) = parse_scope_args("--global my-skill").unwrap();
+        assert_eq!(scope, Some(SkillTargetScope::Global));
+        assert_eq!(rest, "my-skill");
+
+        assert!(parse_scope_args("--project --global x").is_err());
+    }
+
+    #[test]
+    fn uninstall_external_only_skill_refuses_write() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        let ext = tmpdir
+            .path()
+            .join(".claude")
+            .join("skills")
+            .join("ext-only");
+        std::fs::create_dir_all(&ext).unwrap();
+        std::fs::write(
+            ext.join("SKILL.md"),
+            "---\nname: ext-only\ndescription: d\n---\nbody\n",
+        )
+        .unwrap();
+        let sentinel = tmpdir.path().join(".claude").join("skills").join("SENTINEL");
+        std::fs::write(&sentinel, "keep").unwrap();
+
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        app.workspace = tmpdir.path().to_path_buf();
+        let result = run_skill(&mut app, Some("uninstall ext-only"));
+        assert!(result.is_error, "got: {:?}", result.message);
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("compatible external") || msg.contains("not found"),
+            "got: {msg}"
+        );
+        assert_eq!(std::fs::read_to_string(&sentinel).unwrap(), "keep");
+        assert!(ext.join("SKILL.md").is_file());
+    }
+
+    #[test]
     fn test_run_skill_without_name() {
         let tmpdir = TempDir::new().unwrap();
         let _home = IsolatedHome::new(&tmpdir);

--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -4,8 +4,8 @@ use std::fmt::Write;
 
 use crate::network_policy::NetworkPolicy;
 use crate::skills::install::{
-    self, DEFAULT_MAX_SIZE_BYTES, DEFAULT_REGISTRY_URL, InstallOutcome, InstallSource,
-    RegistryFetchResult, SkillSyncOutcome, SyncResult, UpdateResult,
+    self, DEFAULT_MAX_SIZE_BYTES, DEFAULT_REGISTRY_URL, InstallSource, RegistryFetchResult,
+    SkillSyncOutcome, SyncResult,
 };
 use crate::skills::{SkillRegistry, SkillSource};
 use crate::tui::app::{App, AppAction};
@@ -323,7 +323,7 @@ fn run_skill(app: &mut App, name: Option<&str>) -> CommandResult {
         Some(n) => n.trim(),
         None => {
             return CommandResult::error(
-                "Usage: /skill <name>\n\nSubcommands:\n  /skill install <github:owner/repo|https://…|<registry-name>>\n  /skill update <name>\n  /skill uninstall <name>\n  /skill trust <name>",
+                "Usage: /skill <name>\n\nSubcommands:\n  /skill install [--project|--global] <github:owner/repo|https://…|<registry-name>>\n  /skill update [--project|--global] <name>\n  /skill uninstall [--project|--global] <name>\n  /skill trust [--project|--global] <name>",
             );
         }
     };
@@ -343,6 +343,67 @@ fn run_skill(app: &mut App, name: Option<&str>) -> CommandResult {
 
     let task = (!rest.is_empty()).then_some(rest);
     activate_skill_with_task(app, head, task)
+}
+
+/// Parse optional `--project` / `--global` scope prefix from a skill subcommand.
+fn parse_scope_args(
+    args: &str,
+) -> Result<(Option<crate::skills::mutation::SkillTargetScope>, &str), String> {
+    use crate::skills::mutation::SkillTargetScope;
+    let mut scope = None;
+    let mut rest = args.trim();
+    loop {
+        if let Some(next) = rest.strip_prefix("--project") {
+            if scope.is_some() {
+                return Err("specify at most one of --project / --global".into());
+            }
+            scope = Some(SkillTargetScope::Project);
+            rest = next.trim_start();
+            continue;
+        }
+        if let Some(next) = rest.strip_prefix("--global") {
+            if scope.is_some() {
+                return Err("specify at most one of --project / --global".into());
+            }
+            scope = Some(SkillTargetScope::Global);
+            rest = next.trim_start();
+            continue;
+        }
+        break;
+    }
+    Ok((scope, rest.trim()))
+}
+
+fn format_mutation_receipt(receipt: &crate::skills::mutation::SkillMutationReceipt) -> String {
+    use crate::skills::mutation::SkillMutationOutcome;
+    match &receipt.outcome {
+        SkillMutationOutcome::Installed => format!(
+            "Installed skill '{}'.\nLocation: {}\n\nManage skills with /skills.",
+            receipt.name, receipt.safe_target_path
+        ),
+        SkillMutationOutcome::Updated => format!(
+            "Skill '{}' updated.\nLocation: {}",
+            receipt.name, receipt.safe_target_path
+        ),
+        SkillMutationOutcome::NoChange => {
+            format!("Skill '{}': no upstream change.", receipt.name)
+        }
+        SkillMutationOutcome::Removed => format!("Removed skill '{}'.", receipt.name),
+        SkillMutationOutcome::Trusted => format!(
+            "Marked skill '{}' as trusted. The .trusted marker is advisory and digest-bound; it records your review intent but does not sandbox or auto-authorize scripts.",
+            receipt.name
+        ),
+        SkillMutationOutcome::Imported => format!(
+            "Imported skill '{}'.\nLocation: {}",
+            receipt.name, receipt.safe_target_path
+        ),
+        SkillMutationOutcome::AlreadyPresent => format!(
+            "Skill '{}' is already present at {} (exact duplicate).",
+            receipt.name, receipt.safe_target_path
+        ),
+        SkillMutationOutcome::NeedsApproval(host) => needs_approval_message(host),
+        SkillMutationOutcome::NetworkDenied(host) => network_denied_message(host),
+    }
 }
 
 /// Activate a skill and, when the invocation includes a task, send that task
@@ -414,45 +475,62 @@ fn activate_skill(app: &mut App, name: &str) -> CommandResult {
 
 // ─── /skill install ────────────────────────────────────────────────────────
 
-fn install_skill(app: &mut App, spec: &str) -> CommandResult {
+fn install_skill(app: &mut App, args: &str) -> CommandResult {
+    use crate::skills::mutation::{MutationContext, SkillMutationRequest, SkillTargetScope};
+
+    let (scope, spec) = match parse_scope_args(args) {
+        Ok(v) => v,
+        Err(err) => return CommandResult::error(err),
+    };
     if spec.is_empty() {
         return CommandResult::error(
-            "Usage: /skill install <github:owner/repo|https://…|<registry-name>>",
+            "Usage: /skill install [--project|--global] <github:owner/repo|https://…|<registry-name>>",
         );
     }
     let source = match InstallSource::parse(spec) {
         Ok(s) => s,
         Err(err) => return CommandResult::error(format!("Invalid install source: {err}")),
     };
-    let skills_dir = app.skills_dir.clone();
+    // Legacy no-scope install maps to the CodeWhale global owned root.
+    let target = scope.unwrap_or(SkillTargetScope::Global);
+    let workspace = app.workspace.clone();
+    let home = dirs::home_dir();
     let (network, max_size, registry_url) = installer_settings(app);
 
     let outcome = run_async(async move {
-        install::install_with_registry(
-            source,
-            &skills_dir,
+        let ctx = MutationContext {
+            workspace: &workspace,
+            home: home.as_deref(),
+            configured_skills_dir: None,
+            network: &network,
             max_size,
-            &network,
-            false,
-            &registry_url,
+            registry_url: &registry_url,
+        };
+        crate::skills::mutation::execute(
+            SkillMutationRequest::InstallRemote { source, target },
+            &ctx,
         )
         .await
     });
 
     match outcome {
-        Ok(InstallOutcome::Installed(installed)) => {
-            app.refresh_skill_cache();
-            let path_str = path_or_default(&installed.path);
-            CommandResult::message(format!(
-                "Installed skill '{}' from {}.\nLocation: {}\n\nRun /skills to see it in the list.",
-                installed.name, spec, path_str
-            ))
-        }
-        Ok(InstallOutcome::NeedsApproval(host)) => {
-            CommandResult::error(needs_approval_message(&host))
-        }
-        Ok(InstallOutcome::NetworkDenied(host)) => {
-            CommandResult::error(network_denied_message(&host))
+        Ok(receipt) => {
+            if matches!(
+                receipt.outcome,
+                crate::skills::mutation::SkillMutationOutcome::Installed
+            ) {
+                app.refresh_skill_cache();
+            }
+            let message = format_mutation_receipt(&receipt);
+            if matches!(
+                receipt.outcome,
+                crate::skills::mutation::SkillMutationOutcome::NeedsApproval(_)
+                    | crate::skills::mutation::SkillMutationOutcome::NetworkDenied(_)
+            ) {
+                CommandResult::error(message)
+            } else {
+                CommandResult::message(message)
+            }
         }
         Err(err) => CommandResult::error(format!("Install failed: {err:#}")),
     }
@@ -460,32 +538,59 @@ fn install_skill(app: &mut App, spec: &str) -> CommandResult {
 
 // ─── /skill update ─────────────────────────────────────────────────────────
 
-fn update_skill(app: &mut App, name: &str) -> CommandResult {
+fn update_skill(app: &mut App, args: &str) -> CommandResult {
+    use crate::skills::mutation::{MutationContext, SkillMutationRequest};
+
+    let (scope, name) = match parse_scope_args(args) {
+        Ok(v) => v,
+        Err(err) => return CommandResult::error(err),
+    };
     if name.is_empty() {
-        return CommandResult::error("Usage: /skill update <name>");
+        return CommandResult::error("Usage: /skill update [--project|--global] <name>");
     }
-    let skills_dir = app.skills_dir.clone();
+    let workspace = app.workspace.clone();
+    let home = dirs::home_dir();
     let (network, max_size, registry_url) = installer_settings(app);
     let owned_name = name.to_string();
+
     let outcome = run_async(async move {
-        install::update_with_registry(&owned_name, &skills_dir, max_size, &network, &registry_url)
-            .await
+        let ctx = MutationContext {
+            workspace: &workspace,
+            home: home.as_deref(),
+            configured_skills_dir: None,
+            network: &network,
+            max_size,
+            registry_url: &registry_url,
+        };
+        crate::skills::mutation::execute(
+            SkillMutationRequest::UpdateByName {
+                name: owned_name,
+                scope,
+                expected_digest: None,
+            },
+            &ctx,
+        )
+        .await
     });
 
     match outcome {
-        Ok(UpdateResult::NoChange) => {
-            CommandResult::message(format!("Skill '{name}': no upstream change."))
-        }
-        Ok(UpdateResult::Updated(installed)) => CommandResult::message(format!(
-            "Skill '{}' updated. Location: {}",
-            installed.name,
-            path_or_default(&installed.path)
-        )),
-        Ok(UpdateResult::NeedsApproval(host)) => {
-            CommandResult::error(needs_approval_message(&host))
-        }
-        Ok(UpdateResult::NetworkDenied(host)) => {
-            CommandResult::error(network_denied_message(&host))
+        Ok(receipt) => {
+            if matches!(
+                receipt.outcome,
+                crate::skills::mutation::SkillMutationOutcome::Updated
+            ) {
+                app.refresh_skill_cache();
+            }
+            let message = format_mutation_receipt(&receipt);
+            if matches!(
+                receipt.outcome,
+                crate::skills::mutation::SkillMutationOutcome::NeedsApproval(_)
+                    | crate::skills::mutation::SkillMutationOutcome::NetworkDenied(_)
+            ) {
+                CommandResult::error(message)
+            } else {
+                CommandResult::message(message)
+            }
         }
         Err(err) => CommandResult::error(format!("Update failed: {err:#}")),
     }
@@ -493,14 +598,38 @@ fn update_skill(app: &mut App, name: &str) -> CommandResult {
 
 // ─── /skill uninstall ──────────────────────────────────────────────────────
 
-fn uninstall_skill(app: &mut App, name: &str) -> CommandResult {
+fn uninstall_skill(app: &mut App, args: &str) -> CommandResult {
+    use crate::skills::mutation::{MutationContext, SkillMutationRequest};
+
+    let (scope, name) = match parse_scope_args(args) {
+        Ok(v) => v,
+        Err(err) => return CommandResult::error(err),
+    };
     if name.is_empty() {
-        return CommandResult::error("Usage: /skill uninstall <name>");
+        return CommandResult::error("Usage: /skill uninstall [--project|--global] <name>");
     }
-    match install::uninstall(name, &app.skills_dir) {
-        Ok(()) => {
+    let home = dirs::home_dir();
+    let (network, max_size, registry_url) = installer_settings(app);
+    let ctx = MutationContext {
+        workspace: &app.workspace,
+        home: home.as_deref(),
+        configured_skills_dir: None,
+        network: &network,
+        max_size,
+        registry_url: &registry_url,
+    };
+
+    match crate::skills::mutation::execute_sync(
+        SkillMutationRequest::RemoveByName {
+            name: name.to_string(),
+            scope,
+            expected_digest: None,
+        },
+        &ctx,
+    ) {
+        Ok(receipt) => {
             app.refresh_skill_cache();
-            CommandResult::message(format!("Removed skill '{name}'."))
+            CommandResult::message(format_mutation_receipt(&receipt))
         }
         Err(err) => CommandResult::error(format!("Uninstall failed: {err:#}")),
     }
@@ -508,14 +637,36 @@ fn uninstall_skill(app: &mut App, name: &str) -> CommandResult {
 
 // ─── /skill trust ──────────────────────────────────────────────────────────
 
-fn trust_skill(app: &mut App, name: &str) -> CommandResult {
+fn trust_skill(app: &mut App, args: &str) -> CommandResult {
+    use crate::skills::mutation::{MutationContext, SkillMutationRequest};
+
+    let (scope, name) = match parse_scope_args(args) {
+        Ok(v) => v,
+        Err(err) => return CommandResult::error(err),
+    };
     if name.is_empty() {
-        return CommandResult::error("Usage: /skill trust <name>");
+        return CommandResult::error("Usage: /skill trust [--project|--global] <name>");
     }
-    match install::trust(name, &app.skills_dir) {
-        Ok(()) => CommandResult::message(format!(
-            "Marked skill '{name}' as trusted. The .trusted marker is advisory; it records your intent but does not sandbox or auto-authorize scripts."
-        )),
+    let home = dirs::home_dir();
+    let (network, max_size, registry_url) = installer_settings(app);
+    let ctx = MutationContext {
+        workspace: &app.workspace,
+        home: home.as_deref(),
+        configured_skills_dir: None,
+        network: &network,
+        max_size,
+        registry_url: &registry_url,
+    };
+
+    match crate::skills::mutation::execute_sync(
+        SkillMutationRequest::TrustByName {
+            name: name.to_string(),
+            scope,
+            expected_digest: None,
+        },
+        &ctx,
+    ) {
+        Ok(receipt) => CommandResult::message(format_mutation_receipt(&receipt)),
         Err(err) => CommandResult::error(format!("Trust failed: {err:#}")),
     }
 }
@@ -656,6 +807,7 @@ where
     tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
 }
 
+#[allow(dead_code)] // retained for sync/remote listing helpers
 fn path_or_default(path: &std::path::Path) -> String {
     path.file_name()
         .map(|n| {
@@ -1280,27 +1432,41 @@ mod tests {
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         let result = run_skill(&mut app, Some("uninstall absent-skill"));
         let msg = result.message.unwrap();
-        assert!(msg.contains("not installed"), "got: {msg}");
+        assert!(
+            msg.contains("not found") || msg.contains("not installed"),
+            "got: {msg}"
+        );
     }
 
     #[test]
     fn test_skill_trust_message_marks_marker_advisory() {
         let tmpdir = TempDir::new().unwrap();
         let _home = IsolatedHome::new(&tmpdir);
-        create_skill_dir(
-            &tmpdir,
-            "trusted-skill",
-            "---\nname: trusted-skill\ndescription: Trust copy\n---\nbody",
-        );
-        let marker = tmpdir
+        // Mutations only touch CodeWhale-owned roots; place under project scope.
+        let skill_dir = tmpdir
             .path()
+            .join(".codewhale")
             .join("skills")
-            .join("trusted-skill")
-            .join(install::INSTALLED_FROM_MARKER);
-        std::fs::write(marker, "github:owner/repo\n").expect("installed marker");
+            .join("trusted-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: trusted-skill\ndescription: Trust copy\n---\nbody",
+        )
+        .unwrap();
+        install::write_installed_from_v2(
+            &skill_dir,
+            "github:owner/repo",
+            None,
+            "src",
+            "placeholder",
+            "trusted-skill",
+        )
+        .unwrap();
 
         let mut app = create_test_app_with_tmpdir(&tmpdir);
-        let result = run_skill(&mut app, Some("trust trusted-skill"));
+        let result = run_skill(&mut app, Some("trust --project trusted-skill"));
+        assert!(!result.is_error, "got: {:?}", result.message);
         let msg = result.message.expect("trust result");
         assert!(msg.contains("advisory"), "got: {msg}");
         assert!(!msg.contains("may now invoke"), "got: {msg}");

--- a/crates/tui/src/commands/groups/skills/skills.rs
+++ b/crates/tui/src/commands/groups/skills/skills.rs
@@ -180,6 +180,9 @@ fn list_skills(app: &mut App, arg: Option<&str>) -> CommandResult {
             }
             prefix = Some(trimmed.to_ascii_lowercase());
         }
+    } else {
+        // Bare `/skills` opens the unified manager (owned-only, zero network).
+        return CommandResult::action(AppAction::OpenSkillsManager);
     }
     let skills_dir = app.skills_dir.clone();
     let registry = discover_visible_skills(app);
@@ -901,7 +904,7 @@ pub(in crate::commands) const SKILLS_INFO: crate::commands::traits::CommandInfo 
     crate::commands::traits::CommandInfo {
         name: "skills",
         aliases: &["jinengliebiao"],
-        usage: "/skills [--remote|sync|inspect|<prefix>]",
+        usage: "/skills [--remote|sync|inspect|<prefix>]  (bare opens manager)",
         description_id: crate::localization::MessageId::CmdSkillsDescription,
     };
 
@@ -1099,11 +1102,24 @@ mod tests {
     }
 
     #[test]
-    fn test_list_skills_empty_directory() {
+    fn test_bare_skills_opens_manager() {
         let tmpdir = TempDir::new().unwrap();
         let _home = IsolatedHome::new(&tmpdir);
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         let result = list_skills(&mut app, None);
+        assert!(matches!(
+            result.action,
+            Some(AppAction::OpenSkillsManager)
+        ));
+    }
+
+    #[test]
+    fn test_list_skills_empty_directory() {
+        let tmpdir = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmpdir);
+        let mut app = create_test_app_with_tmpdir(&tmpdir);
+        // Empty arg still uses the legacy text inventory (prefix path).
+        let result = list_skills(&mut app, Some(""));
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
         assert!(msg.contains("No skills found"));
@@ -1124,7 +1140,7 @@ mod tests {
             "---\nname: test-skill\ndescription: A test skill\n---\nDo something",
         );
         let mut app = create_test_app_with_tmpdir(&tmpdir);
-        let result = list_skills(&mut app, None);
+        let result = list_skills(&mut app, Some(""));
         assert!(result.message.is_some());
         let msg = result.message.unwrap();
         assert!(msg.contains("Available skills"));
@@ -1245,7 +1261,7 @@ mod tests {
         );
 
         let mut app = create_test_app_with_tmpdir(&tmpdir);
-        let result = list_skills(&mut app, None);
+        let result = list_skills(&mut app, Some(""));
         let msg = result.message.unwrap();
 
         // User-created skills must appear in their own section so they
@@ -1287,7 +1303,7 @@ mod tests {
         );
 
         let mut app = create_test_app_with_tmpdir(&tmpdir);
-        let result = list_skills(&mut app, None);
+        let result = list_skills(&mut app, Some(""));
         let msg = result.message.unwrap();
 
         assert!(msg.contains("/workspace-skill"), "got: {msg}");
@@ -1364,7 +1380,7 @@ mod tests {
         let mut app = create_test_app_with_tmpdir(&tmpdir);
         app.skills_dir = tmpdir.path().join(".codewhale").join("skills");
         app.skills_scan_codewhale_only = true;
-        let result = list_skills(&mut app, None);
+        let result = list_skills(&mut app, Some(""));
         let msg = result.message.unwrap();
 
         assert!(msg.contains("/codewhale-skill"), "got: {msg}");

--- a/crates/tui/src/skills/audit.rs
+++ b/crates/tui/src/skills/audit.rs
@@ -273,10 +273,15 @@ pub fn action_policy(skill: &AuditedSkill) -> Vec<SkillActionKind> {
         }
         SkillSourceKind::CodeWhaleManual => Vec::new(),
         SkillSourceKind::CompatibleExternal => {
-            if skill.import_candidate
-                && matches!(skill.parser, ParserState::Valid | ParserState::Warning(_))
+            // Import is offered for fresh candidates and for same-name owned
+            // peers (exact duplicate → AlreadyPresent, conflict → replace confirm).
+            // The mutation controller remains the authority on scope/conflict policy.
+            let importable = matches!(skill.parser, ParserState::Valid | ParserState::Warning(_))
                 && matches!(skill.digest, DigestState::Known(_))
-            {
+                && (skill.import_candidate
+                    || skill.exact_duplicate_of.is_some()
+                    || !skill.conflicts_with.is_empty());
+            if importable {
                 vec![SkillActionKind::Import]
             } else {
                 Vec::new()
@@ -1081,6 +1086,37 @@ mod tests {
         assert!(skill.import_candidate);
         assert_eq!(skill.available_actions, vec![SkillActionKind::Import]);
         assert_eq!(skill.source_kind, SkillSourceKind::CompatibleExternal);
+    }
+
+    #[test]
+    fn external_conflicting_with_owned_still_offers_import() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_skill(
+            &workspace.join(".codewhale").join("skills"),
+            "shared",
+            "desc",
+            "owned-body",
+        );
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "shared",
+            "desc",
+            "external-body",
+        );
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::Compatible, None);
+        let external = snap
+            .skills
+            .iter()
+            .find(|s| {
+                s.name == "shared" && s.source_kind == SkillSourceKind::CompatibleExternal
+            })
+            .expect("external");
+        assert!(!external.import_candidate);
+        assert!(!external.conflicts_with.is_empty());
+        assert_eq!(external.available_actions, vec![SkillActionKind::Import]);
     }
 
     #[test]

--- a/crates/tui/src/skills/audit.rs
+++ b/crates/tui/src/skills/audit.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 
-use super::install::{DEFAULT_MAX_SIZE_BYTES, INSTALLED_FROM_MARKER, TRUSTED_MARKER};
+use super::install::{INSTALLED_FROM_MARKER, TRUSTED_MARKER};
+use super::package_digest::{self, PackageDigestError};
 use super::roots::{
     SkillRootAccess, SkillRootCatalog, SkillRootDescriptor, SkillRootId, SkillRootKind,
     safe_display_path,
@@ -23,11 +23,13 @@ use super::{SkillRegistry, normalize_skill_name_for_lookup};
 /// Max bytes of `SKILL.md` the auditor will read into memory.
 pub const AUDIT_MAX_SKILL_MD_BYTES: u64 = 512 * 1024;
 /// Max total package bytes considered for digest / integrity.
-pub const AUDIT_MAX_PACKAGE_BYTES: u64 = DEFAULT_MAX_SIZE_BYTES;
+#[allow(dead_code)] // re-exported bound for callers / docs
+pub const AUDIT_MAX_PACKAGE_BYTES: u64 = package_digest::PACKAGE_DIGEST_MAX_BYTES;
 /// Max regular files included in a package digest walk.
-pub const AUDIT_MAX_FILES: usize = 256;
+#[allow(dead_code)]
+pub const AUDIT_MAX_FILES: usize = package_digest::PACKAGE_DIGEST_MAX_FILES;
 /// Max directory depth under a skill package (and under a root when locating packages).
-pub const AUDIT_MAX_DEPTH: usize = 8;
+pub const AUDIT_MAX_DEPTH: usize = package_digest::PACKAGE_DIGEST_MAX_DEPTH;
 
 /// Which roots the auditor visits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,6 +138,7 @@ pub enum ProvenanceState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SkillActionKind {
+    Install,
     Import,
     Update,
     Remove,
@@ -567,190 +570,46 @@ struct PackageAnalysis {
     warnings: Vec<String>,
 }
 
-fn analyze_package(package_dir: &Path, _canonical_root: &Path) -> PackageAnalysis {
-    let Ok(canonical_package) = fs::canonicalize(package_dir) else {
-        return PackageAnalysis {
-            digest: DigestState::Unknown(DigestUnknownReason::Unreadable),
-            path_unsafe: true,
-            warnings: vec!["cannot canonicalize skill package".into()],
-        };
-    };
+/// Compute the bounded package content digest used by audit and mutation.
+#[allow(dead_code)] // public wrapper; mutation uses package_digest directly
+pub fn compute_package_digest(package_dir: &Path) -> Result<String, DigestUnknownReason> {
+    package_digest::compute_package_digest(package_dir).map_err(digest_error_to_unknown)
+}
 
-    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
-    let mut total_bytes: u64 = 0;
-    let mut visited = HashSet::new();
-    let mut path_unsafe = false;
-    let mut warnings = Vec::new();
-    let mut unknown_reason: Option<DigestUnknownReason> = None;
-
-    fn walk(
-        dir: &Path,
-        package_root: &Path,
-        depth: usize,
-        visited: &mut HashSet<PathBuf>,
-        files: &mut Vec<(String, Vec<u8>)>,
-        total_bytes: &mut u64,
-        path_unsafe: &mut bool,
-        warnings: &mut Vec<String>,
-        unknown_reason: &mut Option<DigestUnknownReason>,
-    ) {
-        if unknown_reason.is_some() {
-            return;
-        }
-        if depth > AUDIT_MAX_DEPTH {
-            *unknown_reason = Some(DigestUnknownReason::TooDeep);
-            warnings.push("package exceeded audit depth limit".into());
-            return;
-        }
-        let Ok(meta) = fs::symlink_metadata(dir) else {
-            *unknown_reason = Some(DigestUnknownReason::Unreadable);
-            return;
-        };
-        if meta.file_type().is_symlink() {
-            *path_unsafe = true;
-            *unknown_reason = Some(DigestUnknownReason::SymlinkPresent);
-            warnings.push(format!("symlink at {}", dir.display()));
-            return;
-        }
-        let Ok(canonical) = fs::canonicalize(dir) else {
-            *unknown_reason = Some(DigestUnknownReason::Unreadable);
-            return;
-        };
-        if !canonical.starts_with(package_root) {
-            *path_unsafe = true;
-            *unknown_reason = Some(DigestUnknownReason::EscapedRoot);
-            return;
-        }
-        if !visited.insert(canonical) {
-            *path_unsafe = true;
-            *unknown_reason = Some(DigestUnknownReason::Cycle);
-            return;
-        }
-
-        let Ok(entries) = fs::read_dir(dir) else {
-            *unknown_reason = Some(DigestUnknownReason::Unreadable);
-            return;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
-                continue;
-            };
-
-            // Symlink check before any name-based skip so management markers
-            // cannot hide escape / TOCTOU via a symlink.
-            let Ok(meta) = fs::symlink_metadata(&path) else {
-                *unknown_reason = Some(DigestUnknownReason::Unreadable);
-                return;
-            };
-            if meta.file_type().is_symlink() {
-                *path_unsafe = true;
-                *unknown_reason = Some(DigestUnknownReason::SymlinkPresent);
-                warnings.push(format!("symlink file at {}", path.display()));
-                return;
-            }
-
-            if name == INSTALLED_FROM_MARKER
-                || name == TRUSTED_MARKER
-                || name == ".system-installed-version"
-                || name.ends_with(".bak")
-                || name.ends_with(".tmp")
-            {
-                continue;
-            }
-            // Skip hidden management noise inside packages.
-            if name.starts_with('.') {
-                continue;
-            }
-
-            if meta.is_dir() {
-                walk(
-                    &path,
-                    package_root,
-                    depth + 1,
-                    visited,
-                    files,
-                    total_bytes,
-                    path_unsafe,
-                    warnings,
-                    unknown_reason,
-                );
-                continue;
-            }
-            if !meta.is_file() {
-                continue;
-            }
-            if files.len() >= AUDIT_MAX_FILES {
-                *unknown_reason = Some(DigestUnknownReason::TooManyFiles);
-                warnings.push("package exceeded audit file limit".into());
-                return;
-            }
-            let len = meta.len();
-            if *total_bytes + len > AUDIT_MAX_PACKAGE_BYTES {
-                *unknown_reason = Some(DigestUnknownReason::Oversized);
-                warnings.push("package exceeded audit size limit".into());
-                return;
-            }
-            let bytes = match fs::read(&path) {
-                Ok(b) => b,
-                Err(_) => {
-                    *unknown_reason = Some(DigestUnknownReason::Unreadable);
-                    return;
-                }
-            };
-            *total_bytes += bytes.len() as u64;
-            let rel = path
-                .strip_prefix(package_root)
-                .map(|p| p.to_string_lossy().replace('\\', "/"))
-                .unwrap_or_else(|_| name.to_string());
-            files.push((rel, bytes));
-        }
-    }
-
-    walk(
-        package_dir,
-        &canonical_package,
-        0,
-        &mut visited,
-        &mut files,
-        &mut total_bytes,
-        &mut path_unsafe,
-        &mut warnings,
-        &mut unknown_reason,
-    );
-
-    if let Some(reason) = unknown_reason {
-        return PackageAnalysis {
-            digest: DigestState::Unknown(reason),
-            path_unsafe,
-            warnings,
-        };
-    }
-
-    files.sort_by(|a, b| a.0.cmp(&b.0));
-    let mut hasher = Sha256::new();
-    for (rel, bytes) in &files {
-        hasher.update(rel.as_bytes());
-        hasher.update(b"\0");
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update(bytes);
-    }
-    let digest = hex_digest(hasher.finalize());
-    PackageAnalysis {
-        digest: DigestState::Known(digest),
-        path_unsafe,
-        warnings,
+fn digest_error_to_unknown(err: PackageDigestError) -> DigestUnknownReason {
+    match err {
+        PackageDigestError::Unreadable => DigestUnknownReason::Unreadable,
+        PackageDigestError::SymlinkPresent => DigestUnknownReason::SymlinkPresent,
+        PackageDigestError::EscapedRoot => DigestUnknownReason::EscapedRoot,
+        PackageDigestError::Cycle => DigestUnknownReason::Cycle,
+        PackageDigestError::Oversized => DigestUnknownReason::Oversized,
+        PackageDigestError::TooManyFiles => DigestUnknownReason::TooManyFiles,
+        PackageDigestError::TooDeep => DigestUnknownReason::TooDeep,
     }
 }
 
-fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
-    let bytes = bytes.as_ref();
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        use std::fmt::Write as _;
-        let _ = write!(&mut out, "{byte:02x}");
+fn analyze_package(package_dir: &Path, _canonical_root: &Path) -> PackageAnalysis {
+    match package_digest::compute_package_digest(package_dir) {
+        Ok(digest) => PackageAnalysis {
+            digest: DigestState::Known(digest),
+            path_unsafe: false,
+            warnings: Vec::new(),
+        },
+        Err(err) => {
+            let reason = digest_error_to_unknown(err.clone());
+            let path_unsafe = matches!(
+                err,
+                PackageDigestError::SymlinkPresent
+                    | PackageDigestError::EscapedRoot
+                    | PackageDigestError::Cycle
+            );
+            PackageAnalysis {
+                digest: DigestState::Unknown(reason),
+                path_unsafe,
+                warnings: vec![err.to_string()],
+            }
+        }
     }
-    out
 }
 
 // ── markers ──────────────────────────────────────────────────────────────────

--- a/crates/tui/src/skills/audit.rs
+++ b/crates/tui/src/skills/audit.rs
@@ -1,0 +1,1480 @@
+//! Bounded, read-only skill audit inventory.
+//!
+//! Separates "what is on disk" from runtime [`super::SkillRegistry`] merging.
+//! Never executes skill bodies, never contacts the network, and never writes.
+
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File};
+use std::io::{Read, Take};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use super::install::{DEFAULT_MAX_SIZE_BYTES, INSTALLED_FROM_MARKER, TRUSTED_MARKER};
+use super::roots::{
+    SkillRootAccess, SkillRootCatalog, SkillRootDescriptor, SkillRootId, SkillRootKind,
+    safe_display_path,
+};
+use super::system::is_exact_bundled_skill;
+use super::{SkillRegistry, normalize_skill_name_for_lookup};
+
+/// Max bytes of `SKILL.md` the auditor will read into memory.
+pub const AUDIT_MAX_SKILL_MD_BYTES: u64 = 512 * 1024;
+/// Max total package bytes considered for digest / integrity.
+pub const AUDIT_MAX_PACKAGE_BYTES: u64 = DEFAULT_MAX_SIZE_BYTES;
+/// Max regular files included in a package digest walk.
+pub const AUDIT_MAX_FILES: usize = 256;
+/// Max directory depth under a skill package (and under a root when locating packages).
+pub const AUDIT_MAX_DEPTH: usize = 8;
+
+/// Which roots the auditor visits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillAuditMode {
+    /// CodeWhale-owned project/global roots only.
+    OwnedOnly,
+    /// Owned + compatible roots (including `.codex/skills`). Does not change runtime.
+    Compatible,
+}
+
+/// Stable identity for one on-disk skill copy.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AuditedSkillId {
+    pub root_id: SkillRootId,
+    pub relative_dir: PathBuf,
+    pub canonical_name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SkillSourceKind {
+    CodeWhaleManaged,
+    CodeWhaleManual,
+    CompatibleExternal,
+    BuiltIn,
+    ReviewedPluginSnapshot,
+    RegistryCache,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DigestUnknownReason {
+    Unreadable,
+    SymlinkPresent,
+    EscapedRoot,
+    Cycle,
+    Oversized,
+    TooManyFiles,
+    TooDeep,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DigestState {
+    Known(String),
+    Unknown(DigestUnknownReason),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParserState {
+    Valid,
+    Warning(Vec<String>),
+    Broken(String),
+    Oversized,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrecedenceState {
+    Active,
+    ShadowedBy(AuditedSkillId),
+    InactiveSource,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegrityState {
+    Healthy,
+    LocalContentDrift,
+    BrokenManagedInstall,
+    LegacyMetadataUnknown,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // NotApplicable reserved for non-filesystem rows in later stages
+pub enum TrustState {
+    TrustedForDigest(String),
+    TrustStale,
+    LegacyAdvisory,
+    Untrusted,
+    NotApplicable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Partial / NeedsSetup filled when #4407 readiness cache is wired
+pub enum ReadinessState {
+    Ready,
+    Partial,
+    NeedsSetup,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Unknown reserved for unclassified logical sources
+pub enum ProvenanceState {
+    Managed {
+        spec: Option<String>,
+        safe_url: Option<String>,
+        schema_version: Option<u32>,
+    },
+    Manual,
+    External,
+    BuiltIn,
+    Plugin,
+    Cache,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SkillActionKind {
+    Import,
+    Update,
+    Remove,
+    Trust,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillAuditWarning {
+    Message(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditedSkill {
+    pub id: AuditedSkillId,
+    pub name: String,
+    pub description: Option<String>,
+    pub root: SkillRootDescriptor,
+    pub safe_display_path: String,
+    pub source_kind: SkillSourceKind,
+    pub parser: ParserState,
+    pub digest: DigestState,
+    pub provenance: ProvenanceState,
+    pub trust: TrustState,
+    pub readiness: ReadinessState,
+    pub precedence: PrecedenceState,
+    pub integrity: IntegrityState,
+    pub available_actions: Vec<SkillActionKind>,
+    pub warnings: Vec<SkillAuditWarning>,
+    /// Same canonical name + same digest as another copy.
+    pub exact_duplicate_of: Option<AuditedSkillId>,
+    /// Same canonical name + different digest.
+    pub conflicts_with: Vec<AuditedSkillId>,
+    /// External copy with no owned same-name skill — import candidate.
+    pub import_candidate: bool,
+    /// Package path left the declared skill root (symlink escape, etc.).
+    pub path_unsafe: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillAuditSnapshot {
+    pub scan_mode: SkillAuditMode,
+    pub roots: Vec<SkillRootDescriptor>,
+    pub skills: Vec<AuditedSkill>,
+    pub generated_at: SystemTime,
+}
+
+/// Optional readiness cache from Issue #4407. Missing → [`ReadinessState::Unknown`].
+pub trait SkillReadinessProvider {
+    fn readiness_for(&self, skill: &AuditedSkillId) -> Option<ReadinessState>;
+}
+
+/// Scan skill roots into a full, unmerged inventory.
+#[must_use]
+pub fn scan(
+    workspace: &Path,
+    home: Option<&Path>,
+    mode: SkillAuditMode,
+    readiness: Option<&dyn SkillReadinessProvider>,
+) -> SkillAuditSnapshot {
+    scan_with_configured(workspace, home, None, mode, readiness)
+}
+
+/// Same as [`scan`] with an optional configured `skills_dir`.
+#[must_use]
+pub fn scan_with_configured(
+    workspace: &Path,
+    home: Option<&Path>,
+    configured_skills_dir: Option<&Path>,
+    mode: SkillAuditMode,
+    readiness: Option<&dyn SkillReadinessProvider>,
+) -> SkillAuditSnapshot {
+    let catalog = SkillRootCatalog::build(workspace, home, configured_skills_dir);
+    let root_refs: Vec<SkillRootDescriptor> = match mode {
+        SkillAuditMode::OwnedOnly => catalog
+            .audit_owned_directories()
+            .into_iter()
+            .cloned()
+            .collect(),
+        SkillAuditMode::Compatible => catalog
+            .audit_compatible_directories()
+            .into_iter()
+            .cloned()
+            .collect(),
+    };
+
+    let mut skills = Vec::new();
+    for root in &root_refs {
+        skills.extend(scan_root(root, workspace, home));
+    }
+
+    classify_cross_root(&mut skills);
+    for skill in &mut skills {
+        skill.readiness = readiness
+            .and_then(|p| p.readiness_for(&skill.id))
+            .unwrap_or(ReadinessState::Unknown);
+        skill.available_actions = action_policy(skill);
+    }
+
+    SkillAuditSnapshot {
+        scan_mode: mode,
+        roots: root_refs,
+        skills,
+        generated_at: SystemTime::now(),
+    }
+}
+
+/// Compute available mutations for one audited row (UI and controller share this).
+#[must_use]
+pub fn action_policy(skill: &AuditedSkill) -> Vec<SkillActionKind> {
+    if skill.path_unsafe {
+        return Vec::new();
+    }
+
+    match skill.source_kind {
+        SkillSourceKind::CodeWhaleManaged => {
+            let mut actions = Vec::new();
+            if matches!(skill.parser, ParserState::Valid | ParserState::Warning(_))
+                && !matches!(skill.integrity, IntegrityState::BrokenManagedInstall)
+            {
+                actions.push(SkillActionKind::Update);
+            }
+            actions.push(SkillActionKind::Remove);
+            if matches!(
+                skill.trust,
+                TrustState::Untrusted | TrustState::TrustStale | TrustState::LegacyAdvisory
+            ) && matches!(skill.digest, DigestState::Known(_))
+                && matches!(skill.parser, ParserState::Valid | ParserState::Warning(_))
+            {
+                actions.push(SkillActionKind::Trust);
+            }
+            actions
+        }
+        SkillSourceKind::CodeWhaleManual => Vec::new(),
+        SkillSourceKind::CompatibleExternal => {
+            if skill.import_candidate
+                && matches!(skill.parser, ParserState::Valid | ParserState::Warning(_))
+                && matches!(skill.digest, DigestState::Known(_))
+            {
+                vec![SkillActionKind::Import]
+            } else {
+                Vec::new()
+            }
+        }
+        SkillSourceKind::BuiltIn
+        | SkillSourceKind::ReviewedPluginSnapshot
+        | SkillSourceKind::RegistryCache => Vec::new(),
+    }
+}
+
+// ── per-root scan ────────────────────────────────────────────────────────────
+
+fn scan_root(
+    root: &SkillRootDescriptor,
+    workspace: &Path,
+    home: Option<&Path>,
+) -> Vec<AuditedSkill> {
+    let mut out = Vec::new();
+    let Ok(canonical_root) = fs::canonicalize(&root.path) else {
+        return out;
+    };
+    let mut visited = HashSet::new();
+    let mut packages = Vec::new();
+    find_skill_packages(&root.path, &canonical_root, 0, &mut visited, &mut packages);
+
+    for package_dir in packages {
+        out.push(audit_package(
+            root,
+            &package_dir,
+            &canonical_root,
+            workspace,
+            home,
+        ));
+    }
+    out
+}
+
+fn find_skill_packages(
+    dir: &Path,
+    canonical_root: &Path,
+    depth: usize,
+    visited: &mut HashSet<PathBuf>,
+    out: &mut Vec<PathBuf>,
+) {
+    if depth > AUDIT_MAX_DEPTH {
+        return;
+    }
+    let Ok(meta) = fs::symlink_metadata(dir) else {
+        return;
+    };
+    if meta.file_type().is_symlink() {
+        let Ok(canonical) = fs::canonicalize(dir) else {
+            return;
+        };
+        if !canonical.starts_with(canonical_root) || !canonical.is_dir() {
+            return;
+        }
+        if !visited.insert(canonical) {
+            return;
+        }
+    } else if meta.is_dir() {
+        let Ok(canonical) = fs::canonicalize(dir) else {
+            return;
+        };
+        if !visited.insert(canonical) {
+            return;
+        }
+    } else {
+        return;
+    }
+
+    let skill_md = dir.join("SKILL.md");
+    if skill_md.is_file() || fs::symlink_metadata(&skill_md).is_ok() {
+        out.push(dir.to_path_buf());
+        return; // do not descend into a skill package
+    }
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .is_some_and(|name| name.starts_with('.'))
+        {
+            continue;
+        }
+        let Ok(meta) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.is_dir() || meta.file_type().is_symlink() {
+            find_skill_packages(&path, canonical_root, depth + 1, visited, out);
+        }
+    }
+}
+
+fn audit_package(
+    root: &SkillRootDescriptor,
+    package_dir: &Path,
+    canonical_root: &Path,
+    workspace: &Path,
+    home: Option<&Path>,
+) -> AuditedSkill {
+    let relative_dir = package_dir
+        .strip_prefix(&root.path)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| {
+            package_dir
+                .file_name()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."))
+        });
+
+    let mut warnings = Vec::new();
+    let skill_md = package_dir.join("SKILL.md");
+    let (parser, name, description, skill_md_content) = parse_skill_md_bounded(&skill_md);
+
+    let package = analyze_package(package_dir, canonical_root);
+    let path_unsafe = package.path_unsafe;
+    if path_unsafe {
+        warnings.push(SkillAuditWarning::Message(
+            "package contains a symlink that escapes the skill root or cycles".into(),
+        ));
+    }
+    for w in package.warnings {
+        warnings.push(SkillAuditWarning::Message(w));
+    }
+
+    let canonical_name = name
+        .as_deref()
+        .map(normalize_skill_name_for_lookup)
+        .unwrap_or_else(|| {
+            normalize_skill_name_for_lookup(
+                &relative_dir
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "skill".into()),
+            )
+        });
+
+    let marker = read_installed_from(package_dir);
+    let trust = read_trust_state(package_dir, &package.digest);
+    let (source_kind, provenance, integrity) = classify_source(
+        root,
+        &canonical_name,
+        skill_md_content.as_deref(),
+        &marker,
+        &package.digest,
+        path_unsafe,
+    );
+
+    let display = format!(
+        "{}/{}",
+        safe_display_path(&root.path, Some(workspace), home),
+        relative_dir.display()
+    )
+    .replace('\\', "/");
+
+    AuditedSkill {
+        id: AuditedSkillId {
+            root_id: root.id.clone(),
+            relative_dir,
+            canonical_name: canonical_name.clone(),
+        },
+        name: canonical_name,
+        description,
+        root: root.clone(),
+        safe_display_path: display,
+        source_kind,
+        parser,
+        digest: package.digest,
+        provenance,
+        trust,
+        readiness: ReadinessState::Unknown,
+        precedence: if root.active_for_runtime {
+            PrecedenceState::Unknown // filled in classify_cross_root
+        } else {
+            PrecedenceState::InactiveSource
+        },
+        integrity,
+        available_actions: Vec::new(),
+        warnings,
+        exact_duplicate_of: None,
+        conflicts_with: Vec::new(),
+        import_candidate: false,
+        path_unsafe,
+    }
+}
+
+fn parse_skill_md_bounded(
+    path: &Path,
+) -> (ParserState, Option<String>, Option<String>, Option<String>) {
+    let meta = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(err) => {
+            return (
+                ParserState::Broken(format!("cannot stat SKILL.md: {err}")),
+                None,
+                None,
+                None,
+            );
+        }
+    };
+    if meta.file_type().is_symlink() {
+        return (
+            ParserState::Broken("SKILL.md is a symlink".into()),
+            None,
+            None,
+            None,
+        );
+    }
+    if meta.len() > AUDIT_MAX_SKILL_MD_BYTES {
+        return (ParserState::Oversized, None, None, None);
+    }
+
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(err) => {
+            return (
+                ParserState::Broken(format!("cannot open SKILL.md: {err}")),
+                None,
+                None,
+                None,
+            );
+        }
+    };
+    let mut limited: Take<File> = file.take(AUDIT_MAX_SKILL_MD_BYTES + 1);
+    let mut buf = Vec::new();
+    if let Err(err) = limited.read_to_end(&mut buf) {
+        return (
+            ParserState::Broken(format!("cannot read SKILL.md: {err}")),
+            None,
+            None,
+            None,
+        );
+    }
+    if buf.len() as u64 > AUDIT_MAX_SKILL_MD_BYTES {
+        return (ParserState::Oversized, None, None, None);
+    }
+    let content = match String::from_utf8(buf) {
+        Ok(s) => s,
+        Err(_) => {
+            return (
+                ParserState::Broken("SKILL.md is not valid UTF-8".into()),
+                None,
+                None,
+                None,
+            );
+        }
+    };
+
+    match SkillRegistry::parse_skill(path, &content) {
+        Ok(skill) => {
+            let desc = if skill.description.is_empty() {
+                None
+            } else {
+                Some(truncate_desc(&skill.description))
+            };
+            let mut warnings = Vec::new();
+            if skill.description.is_empty() {
+                warnings.push("missing description".into());
+            }
+            let parser = if warnings.is_empty() {
+                ParserState::Valid
+            } else {
+                ParserState::Warning(warnings)
+            };
+            (parser, Some(skill.name), desc, Some(content))
+        }
+        Err(reason) => (ParserState::Broken(reason), None, None, Some(content)),
+    }
+}
+
+fn truncate_desc(s: &str) -> String {
+    const MAX: usize = 280;
+    let count = s.chars().count();
+    if count <= MAX {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(MAX.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
+struct PackageAnalysis {
+    digest: DigestState,
+    path_unsafe: bool,
+    warnings: Vec<String>,
+}
+
+fn analyze_package(package_dir: &Path, _canonical_root: &Path) -> PackageAnalysis {
+    let Ok(canonical_package) = fs::canonicalize(package_dir) else {
+        return PackageAnalysis {
+            digest: DigestState::Unknown(DigestUnknownReason::Unreadable),
+            path_unsafe: true,
+            warnings: vec!["cannot canonicalize skill package".into()],
+        };
+    };
+
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut total_bytes: u64 = 0;
+    let mut visited = HashSet::new();
+    let mut path_unsafe = false;
+    let mut warnings = Vec::new();
+    let mut unknown_reason: Option<DigestUnknownReason> = None;
+
+    fn walk(
+        dir: &Path,
+        package_root: &Path,
+        depth: usize,
+        visited: &mut HashSet<PathBuf>,
+        files: &mut Vec<(String, Vec<u8>)>,
+        total_bytes: &mut u64,
+        path_unsafe: &mut bool,
+        warnings: &mut Vec<String>,
+        unknown_reason: &mut Option<DigestUnknownReason>,
+    ) {
+        if unknown_reason.is_some() {
+            return;
+        }
+        if depth > AUDIT_MAX_DEPTH {
+            *unknown_reason = Some(DigestUnknownReason::TooDeep);
+            warnings.push("package exceeded audit depth limit".into());
+            return;
+        }
+        let Ok(meta) = fs::symlink_metadata(dir) else {
+            *unknown_reason = Some(DigestUnknownReason::Unreadable);
+            return;
+        };
+        if meta.file_type().is_symlink() {
+            *path_unsafe = true;
+            *unknown_reason = Some(DigestUnknownReason::SymlinkPresent);
+            warnings.push(format!("symlink at {}", dir.display()));
+            return;
+        }
+        let Ok(canonical) = fs::canonicalize(dir) else {
+            *unknown_reason = Some(DigestUnknownReason::Unreadable);
+            return;
+        };
+        if !canonical.starts_with(package_root) {
+            *path_unsafe = true;
+            *unknown_reason = Some(DigestUnknownReason::EscapedRoot);
+            return;
+        }
+        if !visited.insert(canonical) {
+            *path_unsafe = true;
+            *unknown_reason = Some(DigestUnknownReason::Cycle);
+            return;
+        }
+
+        let Ok(entries) = fs::read_dir(dir) else {
+            *unknown_reason = Some(DigestUnknownReason::Unreadable);
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+
+            // Symlink check before any name-based skip so management markers
+            // cannot hide escape / TOCTOU via a symlink.
+            let Ok(meta) = fs::symlink_metadata(&path) else {
+                *unknown_reason = Some(DigestUnknownReason::Unreadable);
+                return;
+            };
+            if meta.file_type().is_symlink() {
+                *path_unsafe = true;
+                *unknown_reason = Some(DigestUnknownReason::SymlinkPresent);
+                warnings.push(format!("symlink file at {}", path.display()));
+                return;
+            }
+
+            if name == INSTALLED_FROM_MARKER
+                || name == TRUSTED_MARKER
+                || name == ".system-installed-version"
+                || name.ends_with(".bak")
+                || name.ends_with(".tmp")
+            {
+                continue;
+            }
+            // Skip hidden management noise inside packages.
+            if name.starts_with('.') {
+                continue;
+            }
+
+            if meta.is_dir() {
+                walk(
+                    &path,
+                    package_root,
+                    depth + 1,
+                    visited,
+                    files,
+                    total_bytes,
+                    path_unsafe,
+                    warnings,
+                    unknown_reason,
+                );
+                continue;
+            }
+            if !meta.is_file() {
+                continue;
+            }
+            if files.len() >= AUDIT_MAX_FILES {
+                *unknown_reason = Some(DigestUnknownReason::TooManyFiles);
+                warnings.push("package exceeded audit file limit".into());
+                return;
+            }
+            let len = meta.len();
+            if *total_bytes + len > AUDIT_MAX_PACKAGE_BYTES {
+                *unknown_reason = Some(DigestUnknownReason::Oversized);
+                warnings.push("package exceeded audit size limit".into());
+                return;
+            }
+            let bytes = match fs::read(&path) {
+                Ok(b) => b,
+                Err(_) => {
+                    *unknown_reason = Some(DigestUnknownReason::Unreadable);
+                    return;
+                }
+            };
+            *total_bytes += bytes.len() as u64;
+            let rel = path
+                .strip_prefix(package_root)
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|_| name.to_string());
+            files.push((rel, bytes));
+        }
+    }
+
+    walk(
+        package_dir,
+        &canonical_package,
+        0,
+        &mut visited,
+        &mut files,
+        &mut total_bytes,
+        &mut path_unsafe,
+        &mut warnings,
+        &mut unknown_reason,
+    );
+
+    if let Some(reason) = unknown_reason {
+        return PackageAnalysis {
+            digest: DigestState::Unknown(reason),
+            path_unsafe,
+            warnings,
+        };
+    }
+
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (rel, bytes) in &files {
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    }
+    let digest = hex_digest(hasher.finalize());
+    PackageAnalysis {
+        digest: DigestState::Known(digest),
+        path_unsafe,
+        warnings,
+    }
+}
+
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+// ── markers ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // optional v2 fields reserved for mutation receipts in #4651 stage 3
+struct InstalledFromFile {
+    #[serde(default)]
+    schema_version: Option<u32>,
+    #[serde(default)]
+    spec: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    /// v1 field name.
+    #[serde(default)]
+    checksum: Option<String>,
+    #[serde(default)]
+    source_checksum: Option<String>,
+    #[serde(default)]
+    content_digest: Option<String>,
+    #[serde(default)]
+    installed_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum MarkerParse {
+    Absent,
+    V1(InstalledFromFile),
+    V2(InstalledFromFile),
+    #[allow(dead_code)] // reason retained for future audit warning surfacing
+    Broken(String),
+}
+
+fn read_installed_from(package_dir: &Path) -> MarkerParse {
+    let path = package_dir.join(INSTALLED_FROM_MARKER);
+    let meta = match fs::symlink_metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return MarkerParse::Absent,
+    };
+    if meta.file_type().is_symlink() {
+        return MarkerParse::Broken("symlink .installed-from".into());
+    }
+    if !meta.is_file() {
+        return MarkerParse::Broken(".installed-from is not a regular file".into());
+    }
+    let Ok(body) = fs::read_to_string(&path) else {
+        return MarkerParse::Broken("unreadable .installed-from".into());
+    };
+    let Ok(parsed) = serde_json::from_str::<InstalledFromFile>(&body) else {
+        return MarkerParse::Broken("malformed .installed-from".into());
+    };
+    match parsed.schema_version {
+        Some(v) if v >= 2 => MarkerParse::V2(parsed),
+        Some(_) | None => MarkerParse::V1(parsed),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TrustFileV2 {
+    #[serde(default)]
+    schema_version: Option<u32>,
+    #[serde(default)]
+    content_digest: Option<String>,
+}
+
+fn read_trust_state(package_dir: &Path, digest: &DigestState) -> TrustState {
+    let path = package_dir.join(TRUSTED_MARKER);
+    let meta = match fs::symlink_metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return TrustState::Untrusted,
+    };
+    if meta.file_type().is_symlink() {
+        // Do not follow symlink trust markers.
+        return TrustState::Unknown;
+    }
+    if !meta.is_file() {
+        return TrustState::Unknown;
+    }
+    let Ok(body) = fs::read_to_string(&path) else {
+        return TrustState::Unknown;
+    };
+    if let Ok(parsed) = serde_json::from_str::<TrustFileV2>(&body)
+        && parsed.schema_version == Some(2)
+    {
+        let Some(trusted_digest) = parsed.content_digest else {
+            return TrustState::Unknown;
+        };
+        return match digest {
+            DigestState::Known(current) if current == &trusted_digest => {
+                TrustState::TrustedForDigest(trusted_digest)
+            }
+            DigestState::Known(_) => TrustState::TrustStale,
+            DigestState::Unknown(_) => TrustState::Unknown,
+        };
+    }
+    TrustState::LegacyAdvisory
+}
+
+fn sanitize_url_for_display(url: &str) -> String {
+    // Strip userinfo, query, and fragment before UI / receipts.
+    let without_fragment = url.split('#').next().unwrap_or(url);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    if let Some(scheme_end) = without_query.find("://") {
+        let scheme = &without_query[..scheme_end];
+        let rest = &without_query[scheme_end + 3..];
+        if let Some(at) = rest.find('@') {
+            return format!("{scheme}://{}", &rest[at + 1..]);
+        }
+    }
+    without_query.to_string()
+}
+
+fn classify_source(
+    root: &SkillRootDescriptor,
+    canonical_name: &str,
+    skill_md_content: Option<&str>,
+    marker: &MarkerParse,
+    digest: &DigestState,
+    _path_unsafe: bool,
+) -> (SkillSourceKind, ProvenanceState, IntegrityState) {
+    if matches!(root.kind, SkillRootKind::RegistryCache) {
+        return (
+            SkillSourceKind::RegistryCache,
+            ProvenanceState::Cache,
+            IntegrityState::Unknown,
+        );
+    }
+    if matches!(root.kind, SkillRootKind::ReviewedPluginSnapshot) {
+        return (
+            SkillSourceKind::ReviewedPluginSnapshot,
+            ProvenanceState::Plugin,
+            IntegrityState::Unknown,
+        );
+    }
+
+    if root.access != SkillRootAccess::WritableOwned {
+        return (
+            SkillSourceKind::CompatibleExternal,
+            ProvenanceState::External,
+            IntegrityState::Unknown,
+        );
+    }
+
+    // Managed markers win over bundled-name heuristics so a registry install
+    // that reuses a bundled command name (e.g. `pdf`) stays Update/Remove/Trust
+    // capable. Exact shipped body without a marker is still BuiltIn.
+    match marker {
+        MarkerParse::V1(_) | MarkerParse::V2(_) | MarkerParse::Broken(_) => {}
+        MarkerParse::Absent => {
+            if let Some(content) = skill_md_content
+                && is_exact_bundled_skill(canonical_name, content)
+            {
+                return (
+                    SkillSourceKind::BuiltIn,
+                    ProvenanceState::BuiltIn,
+                    IntegrityState::Healthy,
+                );
+            }
+        }
+    }
+
+    match marker {
+        MarkerParse::Absent => (
+            SkillSourceKind::CodeWhaleManual,
+            ProvenanceState::Manual,
+            IntegrityState::Unknown,
+        ),
+        MarkerParse::Broken(_) => (
+            SkillSourceKind::CodeWhaleManaged,
+            ProvenanceState::Managed {
+                spec: None,
+                safe_url: None,
+                schema_version: None,
+            },
+            IntegrityState::BrokenManagedInstall,
+        ),
+        MarkerParse::V1(m) => (
+            SkillSourceKind::CodeWhaleManaged,
+            ProvenanceState::Managed {
+                spec: m.spec.clone(),
+                safe_url: m.url.as_deref().map(sanitize_url_for_display),
+                schema_version: m.schema_version.or(Some(1)),
+            },
+            IntegrityState::LegacyMetadataUnknown,
+        ),
+        MarkerParse::V2(m) => {
+            let integrity = match (&m.content_digest, digest) {
+                (Some(expected), DigestState::Known(actual)) if expected == actual => {
+                    IntegrityState::Healthy
+                }
+                (Some(_), DigestState::Known(_)) => IntegrityState::LocalContentDrift,
+                (None, _) => IntegrityState::Unknown,
+                (_, DigestState::Unknown(_)) => IntegrityState::Unknown,
+            };
+            (
+                SkillSourceKind::CodeWhaleManaged,
+                ProvenanceState::Managed {
+                    spec: m.spec.clone(),
+                    safe_url: m.url.as_deref().map(sanitize_url_for_display),
+                    schema_version: m.schema_version,
+                },
+                integrity,
+            )
+        }
+    }
+}
+
+// ── cross-root classification ────────────────────────────────────────────────
+
+fn classify_cross_root(skills: &mut [AuditedSkill]) {
+    // Group by canonical name preserving first-seen order (catalog precedence).
+    let mut by_name: HashMap<String, Vec<usize>> = HashMap::new();
+    for (idx, skill) in skills.iter().enumerate() {
+        by_name
+            .entry(skill.id.canonical_name.clone())
+            .or_default()
+            .push(idx);
+    }
+
+    let owned_names: HashSet<String> = skills
+        .iter()
+        .filter(|s| s.root.is_writable_owned())
+        .map(|s| s.id.canonical_name.clone())
+        .collect();
+
+    for indices in by_name.values() {
+        if indices.is_empty() {
+            continue;
+        }
+
+        // Runtime-active winners: among copies whose root is active_for_runtime,
+        // the earliest in catalog order wins. Audit-only roots stay InactiveSource.
+        let runtime_indices: Vec<usize> = indices
+            .iter()
+            .copied()
+            .filter(|&i| skills[i].root.active_for_runtime)
+            .collect();
+        // Already in scan order which follows catalog precedence.
+        if let Some(&winner) = runtime_indices.first() {
+            let winner_id = skills[winner].id.clone();
+            for &idx in &runtime_indices {
+                if idx == winner {
+                    if !matches!(skills[idx].precedence, PrecedenceState::InactiveSource) {
+                        skills[idx].precedence = PrecedenceState::Active;
+                    }
+                } else {
+                    skills[idx].precedence = PrecedenceState::ShadowedBy(winner_id.clone());
+                }
+            }
+        }
+
+        // Duplicate / conflict among all copies (including inactive).
+        let digests: Vec<(usize, Option<String>)> = indices
+            .iter()
+            .map(|&i| {
+                let d = match &skills[i].digest {
+                    DigestState::Known(s) => Some(s.clone()),
+                    DigestState::Unknown(_) => None,
+                };
+                (i, d)
+            })
+            .collect();
+
+        for &(i, ref di) in &digests {
+            for &(j, ref dj) in &digests {
+                if i >= j {
+                    continue;
+                }
+                match (di, dj) {
+                    (Some(a), Some(b)) if a == b => {
+                        let other = skills[j].id.clone();
+                        if skills[i].exact_duplicate_of.is_none() {
+                            skills[i].exact_duplicate_of = Some(other);
+                        } else {
+                            let other = skills[i].id.clone();
+                            if skills[j].exact_duplicate_of.is_none() {
+                                skills[j].exact_duplicate_of = Some(other);
+                            }
+                        }
+                    }
+                    (Some(_), Some(_)) => {
+                        let id_j = skills[j].id.clone();
+                        let id_i = skills[i].id.clone();
+                        skills[i].conflicts_with.push(id_j);
+                        skills[j].conflicts_with.push(id_i);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    for skill in skills.iter_mut() {
+        if skill.source_kind == SkillSourceKind::CompatibleExternal
+            && !owned_names.contains(&skill.id.canonical_name)
+            && matches!(skill.parser, ParserState::Valid | ParserState::Warning(_))
+            && matches!(skill.digest, DigestState::Known(_))
+            && !skill.path_unsafe
+        {
+            skill.import_candidate = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_skill(dir: &Path, name: &str, description: &str, body: &str) {
+        let skill_dir = dir.join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn owned_only_skips_compatible_and_codex() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_skill(
+            &workspace.join(".codewhale").join("skills"),
+            "owned",
+            "owned skill",
+            "body",
+        );
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "claude",
+            "claude skill",
+            "body",
+        );
+        write_skill(
+            &workspace.join(".codex").join("skills"),
+            "codex",
+            "codex skill",
+            "body",
+        );
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        let names: Vec<_> = snap.skills.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["owned"]);
+        assert!(!snap.roots.iter().any(|r| matches!(
+            r.kind,
+            SkillRootKind::CompatibleProject(_) | SkillRootKind::CompatibleGlobal(_)
+        )));
+    }
+
+    #[test]
+    fn compatible_includes_codex_without_activating_runtime_precedence() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_skill(
+            &workspace.join(".codewhale").join("skills"),
+            "shared",
+            "owned",
+            "owned-body",
+        );
+        write_skill(
+            &workspace.join(".codex").join("skills"),
+            "shared",
+            "codex",
+            "codex-body",
+        );
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::Compatible, None);
+        assert_eq!(snap.skills.len(), 2);
+        let codex = snap
+            .skills
+            .iter()
+            .find(|s| {
+                matches!(
+                    s.root.kind,
+                    SkillRootKind::CompatibleProject(super::super::roots::CompatibleHarness::Codex)
+                )
+            })
+            .expect("codex copy");
+        assert_eq!(codex.precedence, PrecedenceState::InactiveSource);
+        assert!(!codex.root.active_for_runtime);
+
+        let owned = snap
+            .skills
+            .iter()
+            .find(|s| s.root.kind == SkillRootKind::CodeWhaleProject)
+            .expect("owned");
+        assert_eq!(owned.precedence, PrecedenceState::Active);
+    }
+
+    #[test]
+    fn detects_shadow_duplicate_and_conflict() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+
+        // Identical package content → exact duplicate (after shadowing).
+        let identical = "---\nname: shared\ndescription: same\n---\nbody\n";
+        fs::create_dir_all(workspace.join(".agents").join("skills").join("shared")).unwrap();
+        fs::write(
+            workspace
+                .join(".agents")
+                .join("skills")
+                .join("shared")
+                .join("SKILL.md"),
+            identical,
+        )
+        .unwrap();
+        fs::create_dir_all(workspace.join(".claude").join("skills").join("shared")).unwrap();
+        fs::write(
+            workspace
+                .join(".claude")
+                .join("skills")
+                .join("shared")
+                .join("SKILL.md"),
+            identical,
+        )
+        .unwrap();
+        // Different content → conflict with the active copy.
+        write_skill(
+            &workspace.join(".cursor").join("skills"),
+            "shared",
+            "cursor conflict",
+            "different-body",
+        );
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::Compatible, None);
+        let shared: Vec<_> = snap.skills.iter().filter(|s| s.name == "shared").collect();
+        assert_eq!(shared.len(), 3);
+        assert!(
+            shared
+                .iter()
+                .any(|s| matches!(s.precedence, PrecedenceState::Active))
+        );
+        assert!(
+            shared
+                .iter()
+                .any(|s| matches!(s.precedence, PrecedenceState::ShadowedBy(_)))
+        );
+        assert!(shared.iter().any(|s| s.exact_duplicate_of.is_some()));
+        assert!(shared.iter().any(|s| !s.conflicts_with.is_empty()));
+    }
+
+    #[test]
+    fn external_without_owned_peer_is_import_candidate() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        fs::create_dir_all(workspace.join(".codewhale").join("skills")).unwrap();
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "from-claude",
+            "desc",
+            "body",
+        );
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::Compatible, None);
+        let skill = snap
+            .skills
+            .iter()
+            .find(|s| s.name == "from-claude")
+            .expect("skill");
+        assert!(skill.import_candidate);
+        assert_eq!(skill.available_actions, vec![SkillActionKind::Import]);
+        assert_eq!(skill.source_kind, SkillSourceKind::CompatibleExternal);
+    }
+
+    #[test]
+    fn v1_marker_is_legacy_integrity_and_managed_actions() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "desc", "body");
+        fs::write(
+            root.join("managed").join(INSTALLED_FROM_MARKER),
+            r#"{"spec":"github:o/r","url":"https://user:pass@example.com/x?token=1#frag","checksum":"abc"}"#,
+        )
+        .unwrap();
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        let skill = &snap.skills[0];
+        assert_eq!(skill.source_kind, SkillSourceKind::CodeWhaleManaged);
+        assert_eq!(skill.integrity, IntegrityState::LegacyMetadataUnknown);
+        assert!(skill.available_actions.contains(&SkillActionKind::Update));
+        assert!(skill.available_actions.contains(&SkillActionKind::Remove));
+        if let ProvenanceState::Managed { safe_url, .. } = &skill.provenance {
+            let url = safe_url.as_deref().unwrap();
+            assert!(!url.contains("user:pass"));
+            assert!(!url.contains("token"));
+            assert!(!url.contains("frag"));
+        } else {
+            panic!("expected managed provenance");
+        }
+    }
+
+    #[test]
+    fn v2_marker_detects_healthy_and_drift() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "desc", "body");
+
+        // First scan to learn digest, then write matching v2 marker.
+        let preliminary = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        let DigestState::Known(digest) = &preliminary.skills[0].digest else {
+            panic!("expected known digest");
+        };
+        fs::write(
+            root.join("managed").join(INSTALLED_FROM_MARKER),
+            format!(r#"{{"schema_version":2,"spec":"github:o/r","content_digest":"{digest}"}}"#),
+        )
+        .unwrap();
+        let healthy = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(healthy.skills[0].integrity, IntegrityState::Healthy);
+
+        fs::write(
+            root.join("managed").join(INSTALLED_FROM_MARKER),
+            r#"{"schema_version":2,"spec":"github:o/r","content_digest":"deadbeef"}"#,
+        )
+        .unwrap();
+        let drift = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(drift.skills[0].integrity, IntegrityState::LocalContentDrift);
+    }
+
+    #[test]
+    fn legacy_trust_and_digest_bound_trust() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "desc", "body");
+        fs::write(
+            root.join("managed").join(INSTALLED_FROM_MARKER),
+            r#"{"spec":"github:o/r","checksum":"x"}"#,
+        )
+        .unwrap();
+        fs::write(root.join("managed").join(TRUSTED_MARKER), "trusted\n").unwrap();
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(snap.skills[0].trust, TrustState::LegacyAdvisory);
+
+        let DigestState::Known(digest) = &snap.skills[0].digest else {
+            panic!("digest");
+        };
+        fs::write(
+            root.join("managed").join(TRUSTED_MARKER),
+            format!(r#"{{"schema_version":2,"content_digest":"{digest}"}}"#),
+        )
+        .unwrap();
+        let trusted = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert!(matches!(
+            trusted.skills[0].trust,
+            TrustState::TrustedForDigest(_)
+        ));
+
+        fs::write(
+            root.join("managed").join(TRUSTED_MARKER),
+            r#"{"schema_version":2,"content_digest":"stale"}"#,
+        )
+        .unwrap();
+        let stale = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(stale.skills[0].trust, TrustState::TrustStale);
+    }
+
+    #[test]
+    fn oversized_skill_md_is_fail_closed() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let skill_dir = workspace.join(".codewhale").join("skills").join("big");
+        fs::create_dir_all(&skill_dir).unwrap();
+        let huge = format!(
+            "---\nname: big\ndescription: x\n---\n{}",
+            "x".repeat(AUDIT_MAX_SKILL_MD_BYTES as usize + 64)
+        );
+        fs::write(skill_dir.join("SKILL.md"), huge).unwrap();
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(snap.skills[0].parser, ParserState::Oversized);
+        assert!(snap.skills[0].available_actions.is_empty());
+    }
+
+    #[test]
+    fn readiness_missing_stays_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_skill(&workspace.join(".codewhale").join("skills"), "a", "d", "b");
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(snap.skills[0].readiness, ReadinessState::Unknown);
+    }
+
+    #[test]
+    fn bundled_name_alone_is_not_built_in() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        // `pdf` is a bundled name, but custom body must not classify as BuiltIn.
+        write_skill(
+            &workspace.join(".codewhale").join("skills"),
+            "pdf",
+            "user override",
+            "not-the-bundled-body",
+        );
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(snap.skills[0].source_kind, SkillSourceKind::CodeWhaleManual);
+        assert!(snap.skills[0].available_actions.is_empty());
+    }
+
+    #[test]
+    fn managed_marker_wins_over_bundled_name() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let root = workspace.join(".codewhale").join("skills");
+        // Bundled command name + different body + install marker → managed.
+        write_skill(&root, "pdf", "registry pdf", "community-body");
+        fs::write(
+            root.join("pdf").join(INSTALLED_FROM_MARKER),
+            r#"{"spec":"github:o/pdf-skill","checksum":"abc"}"#,
+        )
+        .unwrap();
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(
+            snap.skills[0].source_kind,
+            SkillSourceKind::CodeWhaleManaged
+        );
+        assert!(
+            snap.skills[0]
+                .available_actions
+                .contains(&SkillActionKind::Update)
+        );
+        assert!(
+            snap.skills[0]
+                .available_actions
+                .contains(&SkillActionKind::Remove)
+        );
+        assert!(
+            snap.skills[0]
+                .available_actions
+                .contains(&SkillActionKind::Trust)
+        );
+    }
+
+    #[test]
+    fn exact_bundled_content_is_built_in() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let root = workspace.join(".codewhale").join("skills");
+        fs::create_dir_all(root.join("pdf")).unwrap();
+        fs::write(
+            root.join("pdf").join("SKILL.md"),
+            include_str!("../../assets/skills/pdf/SKILL.md"),
+        )
+        .unwrap();
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert_eq!(snap.skills[0].source_kind, SkillSourceKind::BuiltIn);
+        assert!(snap.skills[0].available_actions.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_installed_from_marker_is_fail_closed() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "desc", "body");
+        let outside = tmp.path().join("outside-marker.json");
+        fs::write(&outside, r#"{"spec":"github:o/r","checksum":"x"}"#).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("managed").join(INSTALLED_FROM_MARKER))
+            .unwrap();
+
+        let snap = scan(&workspace, Some(&home), SkillAuditMode::OwnedOnly, None);
+        assert!(snap.skills[0].path_unsafe);
+        assert!(matches!(
+            snap.skills[0].digest,
+            DigestState::Unknown(DigestUnknownReason::SymlinkPresent)
+        ));
+        assert_eq!(
+            snap.skills[0].integrity,
+            IntegrityState::BrokenManagedInstall
+        );
+        assert!(snap.skills[0].available_actions.is_empty());
+    }
+
+    #[test]
+    fn sanitize_url_strips_secrets() {
+        assert_eq!(
+            sanitize_url_for_display("https://user:pw@host/path?token=1#x"),
+            "https://host/path"
+        );
+    }
+
+    struct AlwaysReady;
+    impl SkillReadinessProvider for AlwaysReady {
+        fn readiness_for(&self, _: &AuditedSkillId) -> Option<ReadinessState> {
+            Some(ReadinessState::Ready)
+        }
+    }
+
+    #[test]
+    fn readiness_provider_is_consulted_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_skill(&workspace.join(".codewhale").join("skills"), "a", "d", "b");
+        let snap = scan(
+            &workspace,
+            Some(&home),
+            SkillAuditMode::OwnedOnly,
+            Some(&AlwaysReady),
+        );
+        assert_eq!(snap.skills[0].readiness, ReadinessState::Ready);
+    }
+}

--- a/crates/tui/src/skills/install.rs
+++ b/crates/tui/src/skills/install.rs
@@ -322,16 +322,17 @@ pub async fn install_with_registry(
 
     // Move the staged dir into its final location. If `update` is set and the
     // destination exists, replace it; otherwise reject.
+    // Keep any backup until content digest + marker write succeed so a failed
+    // finalize can restore the previous install.
     let final_path = skills_dir.join(&staged.skill_name);
+    let mut backup_path: Option<PathBuf> = None;
     if final_path.exists() {
         if !update {
             // Clean up the staging dir before returning the error.
             let _ = fs::remove_dir_all(&staged.staged_path);
             return Err(InstallError::AlreadyInstalled(staged.skill_name).into());
         }
-        // Best-effort backup-then-replace; on failure we restore the original.
         let backup = skills_dir.join(format!("{}.bak", staged.skill_name));
-        // If a previous failed update left a stale `.bak/`, drop it.
         if backup.exists() {
             fs::remove_dir_all(&backup).ok();
         }
@@ -342,12 +343,10 @@ pub async fn install_with_registry(
             )
         })?;
         if let Err(err) = fs::rename(&staged.staged_path, &final_path) {
-            // Roll back: restore the backup so the user isn't left with an
-            // empty skill directory.
             fs::rename(&backup, &final_path).ok();
             return Err(err).context("failed to install staged skill");
         }
-        fs::remove_dir_all(&backup).ok();
+        backup_path = Some(backup);
     } else {
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).with_context(|| {
@@ -358,19 +357,37 @@ pub async fn install_with_registry(
     }
 
     // Write the marker last so a partial install never leaves a stale
-    // .installed-from on disk.
-    let marker_body = serde_json::json!({
-        "spec": source_spec_string(&source),
-        "url": source_url,
-        "checksum": checksum,
-    })
-    .to_string();
-    fs::write(final_path.join(INSTALLED_FROM_MARKER), marker_body).with_context(|| {
-        format!(
-            "failed to write {} marker for skill {}",
-            INSTALLED_FROM_MARKER, staged.skill_name
-        )
-    })?;
+    // .installed-from on disk. Prefer v2 with package content digest.
+    let spec = source_spec_string(&source);
+    let content_digest = match super::package_digest::compute_package_digest(&final_path) {
+        Ok(digest) => digest,
+        Err(err) => {
+            let _ = fs::remove_dir_all(&final_path);
+            if let Some(backup) = backup_path.take() {
+                let _ = fs::rename(&backup, &final_path);
+            }
+            return Err(anyhow::anyhow!(
+                "installed package failed content digest validation: {err}"
+            ));
+        }
+    };
+    if let Err(err) = write_installed_from_v2(
+        &final_path,
+        &spec,
+        Some(&source_url),
+        &checksum,
+        &content_digest,
+        &staged.skill_name,
+    ) {
+        let _ = fs::remove_dir_all(&final_path);
+        if let Some(backup) = backup_path.take() {
+            let _ = fs::rename(&backup, &final_path);
+        }
+        return Err(err);
+    }
+    if let Some(backup) = backup_path {
+        fs::remove_dir_all(&backup).ok();
+    }
 
     Ok(InstallOutcome::Installed(InstalledSkill {
         name: staged.skill_name,
@@ -417,6 +434,13 @@ pub async fn update_with_registry(
         .with_context(|| format!("failed to read {}", marker_path.display()))?;
     let marker: InstalledFromMarker = serde_json::from_str(&marker_body)
         .with_context(|| format!("malformed {INSTALLED_FROM_MARKER} for {name}"))?;
+    if !is_registry_updatable_spec(&marker.spec) {
+        bail!(
+            "skill '{name}' was imported locally (spec '{}') and cannot be updated from a registry; \
+             re-import or remove it first",
+            marker.spec
+        );
+    }
 
     // Re-resolve the URL, taking the existing checksum as a short-circuit hint:
     // we still hit the network so the user gets a useful "no upstream change"
@@ -434,14 +458,25 @@ pub async fn update_with_registry(
     };
 
     let checksum = sha256_hex(&bytes);
-    if checksum == marker.checksum {
+    if checksum == marker.source_checksum() {
         return Ok(UpdateResult::NoChange);
     }
 
     // Bytes changed — fall back to the regular install path with `update = true`
-    // so we get the same atomic-replace semantics.
+    // so we get the same atomic-replace semantics. Content updates must not
+    // inherit a previous trust marker.
+    let trust_path = target.join(TRUSTED_MARKER);
+    let had_trust = trust_path.exists();
     let outcome =
         install_with_registry(source, skills_dir, max_size, network, true, registry_url).await?;
+    match &outcome {
+        InstallOutcome::Installed(installed) => {
+            if had_trust {
+                let _ = fs::remove_file(installed.path.join(TRUSTED_MARKER));
+            }
+        }
+        InstallOutcome::NeedsApproval(_) | InstallOutcome::NetworkDenied(_) => {}
+    }
     match outcome {
         InstallOutcome::Installed(installed) => Ok(UpdateResult::Updated(installed)),
         InstallOutcome::NeedsApproval(host) => Ok(UpdateResult::NeedsApproval(host)),
@@ -467,9 +502,8 @@ pub fn uninstall(name: &str, skills_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Mark a community-installed skill as trusted. Currently a marker file only;
-/// callers that wire tool execution against `<name>/scripts/` consult the file
-/// before invoking anything. No-op if already trusted.
+/// Mark a community-installed skill as trusted, binding the marker to the
+/// current package content digest (schema v2).
 ///
 /// Refuses to mark system skills (no `.installed-from`) so the bundled
 /// `skill-creator` doesn't accidentally inherit elevated tool privileges.
@@ -482,14 +516,9 @@ pub fn trust(name: &str, skills_dir: &Path) -> Result<()> {
     if !target.join(INSTALLED_FROM_MARKER).exists() {
         return Err(InstallError::NotInstalledHere(name.to_string()).into());
     }
-    let marker = target.join(TRUSTED_MARKER);
-    if !marker.exists() {
-        fs::write(
-            &marker,
-            "Skill scripts/ are user-trusted. Delete this file to revoke.\n",
-        )
-        .with_context(|| format!("failed to write {}", marker.display()))?;
-    }
+    let content_digest = super::package_digest::compute_package_digest(&target)
+        .with_context(|| format!("cannot compute content digest for {}", target.display()))?;
+    write_trust_v2(&target, &content_digest)?;
     Ok(())
 }
 
@@ -836,8 +865,77 @@ async fn sync_one_skill(
 #[derive(Debug, Deserialize)]
 struct InstalledFromMarker {
     spec: String,
+    /// v1 download checksum field.
     #[serde(default)]
     checksum: String,
+    #[serde(default)]
+    source_checksum: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    schema_version: Option<u32>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    content_digest: Option<String>,
+}
+
+impl InstalledFromMarker {
+    fn source_checksum(&self) -> &str {
+        self.source_checksum
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(self.checksum.as_str())
+    }
+}
+
+/// Remote/registry update is only valid for install specs that are not local imports.
+#[must_use]
+pub fn is_registry_updatable_spec(spec: &str) -> bool {
+    let spec = spec.trim();
+    !spec.is_empty() && !spec.starts_with("import:")
+}
+
+/// Write schema-v2 `.installed-from` metadata (last step of a successful install).
+pub fn write_installed_from_v2(
+    skill_dir: &Path,
+    spec: &str,
+    url: Option<&str>,
+    source_checksum: &str,
+    content_digest: &str,
+    installed_name: &str,
+) -> Result<()> {
+    let body = serde_json::json!({
+        "schema_version": 2,
+        "spec": spec,
+        "url": url,
+        "source_checksum": source_checksum,
+        "content_digest": content_digest,
+        "installed_name": installed_name,
+        "registry_version": null,
+    });
+    fs::write(skill_dir.join(INSTALLED_FROM_MARKER), body.to_string()).with_context(|| {
+        format!(
+            "failed to write {} for {}",
+            INSTALLED_FROM_MARKER,
+            skill_dir.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Write schema-v2 `.trusted` bound to a package content digest.
+pub fn write_trust_v2(skill_dir: &Path, content_digest: &str) -> Result<()> {
+    let body = serde_json::json!({
+        "schema_version": 2,
+        "content_digest": content_digest,
+    });
+    fs::write(skill_dir.join(TRUSTED_MARKER), body.to_string()).with_context(|| {
+        format!(
+            "failed to write {} for {}",
+            TRUSTED_MARKER,
+            skill_dir.display()
+        )
+    })?;
+    Ok(())
 }
 
 /// Curated-registry document. The shape is intentionally minimal so adding

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -1,6 +1,7 @@
 //! Skill discovery and registry for local SKILL.md files.
 
 pub mod install;
+pub mod roots;
 mod system;
 // Re-exports kept for documentation parity and downstream consumers; the
 // binary itself imports directly from `skills::install`. `#[allow(...)]`
@@ -11,6 +12,11 @@ pub use install::{
     DEFAULT_MAX_SIZE_BYTES, DEFAULT_REGISTRY_URL, INSTALLED_FROM_MARKER, InstallOutcome,
     InstallSource, InstalledSkill, RegistryDocument, RegistryEntry, RegistryFetchResult,
     SkillSyncOutcome, SyncResult, UpdateResult, default_cache_skills_dir,
+};
+#[allow(unused_imports)]
+pub use roots::{
+    CompatibleHarness, SkillRootAccess, SkillRootCatalog, SkillRootDescriptor, SkillRootId,
+    SkillRootKind, SkillScope, classify_configured_skills_dir, safe_display_path,
 };
 pub use system::{install_system_skills, is_bundled_skill_name};
 
@@ -673,7 +679,8 @@ fn normalize_skill_name_segment(name: &str) -> String {
 /// other AI-tool conventions installed in the same workspace
 /// (#432).
 ///
-/// Precedence (first match wins on name conflicts):
+/// Precedence is defined once in [`roots::SkillRootCatalog`] (first
+/// match wins on name conflicts):
 ///
 /// 1. `<workspace>/.agents/skills` — deepseek-native convention.
 /// 2. `<workspace>/skills` — flat, project-local.
@@ -685,6 +692,9 @@ fn normalize_skill_name_segment(name: &str) -> String {
 /// 8. `~/.claude/skills` — Claude-ecosystem global (#902).
 /// 9. `~/.codewhale/skills` — CodeWhale global, primary install target.
 /// 10. `~/.deepseek/skills` — legacy DeepSeek global fallback.
+///
+/// Compatible audit may also observe `.codex/skills`, but that root is
+/// never activated for runtime discovery in this catalog.
 ///
 /// Only directories that exist on disk are returned — callers don't
 /// need to filter further. Returns an empty vec when nothing is
@@ -706,58 +716,10 @@ fn skills_directories_with_home_and_mode(
     home_dir: Option<&Path>,
     mode: SkillDiscoveryMode,
 ) -> Vec<PathBuf> {
-    let mut candidates = match mode {
-        SkillDiscoveryMode::Compatible => vec![
-            workspace.join(".agents").join("skills"),
-            workspace.join("skills"),
-            workspace.join(".opencode").join("skills"),
-            workspace.join(".claude").join("skills"),
-            workspace.join(".cursor").join("skills"),
-            workspace.join(".codewhale").join("skills"),
-        ],
-        SkillDiscoveryMode::CodeWhaleOnly => codewhale_workspace_skills_dir(workspace)
-            .into_iter()
-            .collect(),
-    };
-    if let Some(home) = home_dir {
-        match mode {
-            SkillDiscoveryMode::Compatible => {
-                candidates.push(home.join(".agents").join("skills"));
-                candidates.push(home.join(".claude").join("skills"));
-                candidates.push(home.join(".codewhale").join("skills"));
-                candidates.push(home.join(".deepseek").join("skills"));
-            }
-            SkillDiscoveryMode::CodeWhaleOnly => {
-                candidates.push(home.join(".codewhale").join("skills"));
-            }
-        }
-    } else {
-        candidates.push(PathBuf::from("/tmp/codewhale/skills"));
-    }
-    existing_skill_dirs(candidates)
+    roots::skills_directories_with_home_and_mode(workspace, home_dir, mode)
 }
 
-pub(crate) fn codewhale_workspace_skills_dir(workspace: &Path) -> Option<PathBuf> {
-    let skills_dir = workspace.join(".codewhale").join("skills");
-    let canonical_workspace = fs::canonicalize(workspace).ok()?;
-    let canonical_skills = fs::canonicalize(&skills_dir).ok()?;
-    (canonical_skills.is_dir() && canonical_skills.starts_with(canonical_workspace))
-        .then_some(skills_dir)
-}
-
-fn existing_skill_dirs(candidates: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let mut seen = HashSet::new();
-    for path in candidates {
-        let Ok(canonical_path) = fs::canonicalize(&path) else {
-            continue;
-        };
-        if canonical_path.is_dir() && seen.insert(canonical_path) {
-            out.push(path);
-        }
-    }
-    out
-}
+pub(crate) use roots::{codewhale_workspace_skills_dir, existing_skill_dirs};
 
 /// Walk every candidate skills directory for a workspace and merge
 /// the discovered skills into a single registry. Name conflicts are
@@ -832,7 +794,11 @@ pub fn skill_directories_for_workspace_and_dir(
 }
 
 fn insert_configured_skills_dir(dirs: &mut Vec<PathBuf>, workspace: &Path, skills_dir: &Path) {
-    if !skills_dir.is_dir() || dirs.iter().any(|p| paths_refer_to_same_dir(p, skills_dir)) {
+    if !skills_dir.is_dir()
+        || dirs
+            .iter()
+            .any(|p| roots::paths_refer_to_same_dir(p, skills_dir))
+    {
         return;
     }
 
@@ -845,16 +811,6 @@ fn insert_configured_skills_dir(dirs: &mut Vec<PathBuf>, workspace: &Path, skill
         })
         .unwrap_or(dirs.len());
     dirs.insert(insert_at, skills_dir.to_path_buf());
-}
-
-fn paths_refer_to_same_dir(left: &Path, right: &Path) -> bool {
-    if left == right {
-        return true;
-    }
-    match (fs::canonicalize(left), fs::canonicalize(right)) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => false,
-    }
 }
 
 #[allow(dead_code)]

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod audit;
 pub mod install;
+pub mod mutation;
+mod package_digest;
 pub mod roots;
 mod system;
 // Re-exports kept for documentation parity and downstream consumers; the

--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -1,5 +1,6 @@
 //! Skill discovery and registry for local SKILL.md files.
 
+pub mod audit;
 pub mod install;
 pub mod roots;
 mod system;
@@ -18,6 +19,8 @@ pub use roots::{
     CompatibleHarness, SkillRootAccess, SkillRootCatalog, SkillRootDescriptor, SkillRootId,
     SkillRootKind, SkillScope, classify_configured_skills_dir, safe_display_path,
 };
+#[allow(unused_imports)]
+pub use system::{bundled_skill_body_sha256, is_exact_bundled_skill};
 pub use system::{install_system_skills, is_bundled_skill_name};
 
 use std::fs;
@@ -625,7 +628,7 @@ fn is_valid_skill_name(name: &str) -> bool {
             .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
 }
 
-fn normalize_skill_name_for_lookup(name: &str) -> String {
+pub(crate) fn normalize_skill_name_for_lookup(name: &str) -> String {
     if let Some((plugin, skill)) = name.trim().split_once(':')
         && !plugin.is_empty()
         && !skill.is_empty()

--- a/crates/tui/src/skills/mutation.rs
+++ b/crates/tui/src/skills/mutation.rs
@@ -1306,4 +1306,59 @@ mod tests {
         assert!(err.unwrap_err().to_string().contains("changed since audit"));
         assert!(root.join("managed").exists());
     }
+
+    #[test]
+    fn dual_scope_same_name_requires_explicit_scope() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        write_skill(&workspace.join(".codewhale").join("skills"), "dup", "project");
+        write_skill(&home.join(".codewhale").join("skills"), "dup", "global");
+
+        let err = resolve_owned_skill_by_name(&c, "dup", None).unwrap_err();
+        assert!(
+            err.to_string().contains("--project") && err.to_string().contains("--global"),
+            "got: {err}"
+        );
+
+        let project =
+            resolve_owned_skill_by_name(&c, "dup", Some(SkillTargetScope::Project)).unwrap();
+        let global =
+            resolve_owned_skill_by_name(&c, "dup", Some(SkillTargetScope::Global)).unwrap();
+        assert_ne!(project.id.root_id, global.id.root_id);
+        assert_eq!(project.id.canonical_name, "dup");
+        assert_eq!(global.id.canonical_name, "dup");
+    }
+
+    #[test]
+    fn uninstall_external_only_refuses_and_keeps_sentinel() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        fs::create_dir_all(workspace.join(".codewhale").join("skills")).unwrap();
+        write_skill(&workspace.join(".claude").join("skills"), "only-ext", "body");
+        let sentinel = workspace.join(".claude").join("skills").join("SENTINEL");
+        fs::write(&sentinel, "untouched").unwrap();
+
+        let err = resolve_owned_skill_by_name(&c, "only-ext", None).unwrap_err();
+        assert!(
+            err.to_string().contains("compatible external"),
+            "got: {err}"
+        );
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "untouched");
+        assert!(
+            workspace
+                .join(".claude")
+                .join("skills")
+                .join("only-ext")
+                .join("SKILL.md")
+                .is_file()
+        );
+    }
 }

--- a/crates/tui/src/skills/mutation.rs
+++ b/crates/tui/src/skills/mutation.rs
@@ -40,14 +40,12 @@ impl SkillTargetScope {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // ReplaceConfirmed used by manager confirmation flow (phase 4)
 pub enum ConflictPolicy {
     Reject,
     ReplaceConfirmed,
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Id-based variants used by SkillsManagerView (phase 4)
 pub enum SkillMutationRequest {
     InstallRemote {
         source: InstallSource,
@@ -103,13 +101,16 @@ pub enum SkillMutationOutcome {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // full receipt fields consumed by manager UI / receipts (phase 4)
 pub struct SkillMutationReceipt {
+    #[allow(dead_code)] // surfaced by manager detail / future receipt toast
     pub action: SkillActionKind,
     pub name: String,
+    #[allow(dead_code)] // surfaced by manager detail / future receipt toast
     pub scope: SkillScope,
     pub safe_target_path: String,
+    #[allow(dead_code)] // reserved for digest-diff UI
     pub before_digest: Option<String>,
+    #[allow(dead_code)] // reserved for digest-diff UI
     pub after_digest: Option<String>,
     pub outcome: SkillMutationOutcome,
 }

--- a/crates/tui/src/skills/mutation.rs
+++ b/crates/tui/src/skills/mutation.rs
@@ -1,0 +1,1308 @@
+//! Unique skill mutation controller for CodeWhale-owned roots.
+//!
+//! All install / import / update / remove / trust writes go through this
+//! module. Compatible harness roots, built-ins, and plugin snapshots are
+//! never mutated.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::network_policy::NetworkPolicy;
+
+use super::audit::{
+    AuditedSkill, AuditedSkillId, DigestState, SkillActionKind, SkillAuditMode, SkillSourceKind,
+    scan_with_configured,
+};
+use super::install::{
+    self, InstallOutcome, InstallSource, UpdateResult, write_installed_from_v2, write_trust_v2,
+};
+use super::normalize_skill_name_for_lookup;
+use super::package_digest;
+use super::roots::{SkillRootCatalog, SkillRootKind, SkillScope, safe_display_path};
+
+/// Project vs global CodeWhale-owned install target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillTargetScope {
+    Project,
+    Global,
+}
+
+impl SkillTargetScope {
+    #[must_use]
+    pub fn as_skill_scope(self) -> SkillScope {
+        match self {
+            Self::Project => SkillScope::Project,
+            Self::Global => SkillScope::Global,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // ReplaceConfirmed used by manager confirmation flow (phase 4)
+pub enum ConflictPolicy {
+    Reject,
+    ReplaceConfirmed,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Id-based variants used by SkillsManagerView (phase 4)
+pub enum SkillMutationRequest {
+    InstallRemote {
+        source: InstallSource,
+        target: SkillTargetScope,
+    },
+    ImportExternal {
+        source_id: AuditedSkillId,
+        expected_digest: String,
+        target: SkillTargetScope,
+        conflict_policy: ConflictPolicy,
+    },
+    Update {
+        skill_id: AuditedSkillId,
+        expected_digest: Option<String>,
+    },
+    /// Resolve by name inside owned roots (compatible `/skill update` path).
+    UpdateByName {
+        name: String,
+        scope: Option<SkillTargetScope>,
+        expected_digest: Option<String>,
+    },
+    Remove {
+        skill_id: AuditedSkillId,
+        expected_digest: Option<String>,
+    },
+    RemoveByName {
+        name: String,
+        scope: Option<SkillTargetScope>,
+        expected_digest: Option<String>,
+    },
+    Trust {
+        skill_id: AuditedSkillId,
+        expected_digest: String,
+    },
+    TrustByName {
+        name: String,
+        scope: Option<SkillTargetScope>,
+        expected_digest: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillMutationOutcome {
+    Installed,
+    Updated,
+    NoChange,
+    Removed,
+    Trusted,
+    Imported,
+    AlreadyPresent,
+    NeedsApproval(String),
+    NetworkDenied(String),
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // full receipt fields consumed by manager UI / receipts (phase 4)
+pub struct SkillMutationReceipt {
+    pub action: SkillActionKind,
+    pub name: String,
+    pub scope: SkillScope,
+    pub safe_target_path: String,
+    pub before_digest: Option<String>,
+    pub after_digest: Option<String>,
+    pub outcome: SkillMutationOutcome,
+}
+
+/// Inputs shared by mutation operations.
+pub struct MutationContext<'a> {
+    pub workspace: &'a Path,
+    pub home: Option<&'a Path>,
+    pub configured_skills_dir: Option<&'a Path>,
+    pub network: &'a NetworkPolicy,
+    pub max_size: u64,
+    pub registry_url: &'a str,
+}
+
+/// Resolve the on-disk CodeWhale-owned skills directory for a target scope.
+pub fn resolve_owned_target(
+    workspace: &Path,
+    home: Option<&Path>,
+    target: SkillTargetScope,
+) -> Result<PathBuf> {
+    let catalog = SkillRootCatalog::build(workspace, home, None);
+    let kind = match target {
+        SkillTargetScope::Project => SkillRootKind::CodeWhaleProject,
+        SkillTargetScope::Global => SkillRootKind::CodeWhaleGlobal,
+    };
+    let root = catalog
+        .owned_writable_roots()
+        .into_iter()
+        .find(|r| r.kind == kind)
+        .with_context(|| format!("no owned root for {target:?}"))?;
+    if !root.is_writable_owned() {
+        bail!("refusing to mutate non-owned root {}", root.path.display());
+    }
+    Ok(root.path.clone())
+}
+
+/// Execute a mutation request against CodeWhale-owned roots only.
+pub async fn execute(
+    request: SkillMutationRequest,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    match request {
+        SkillMutationRequest::InstallRemote { source, target } => {
+            install_remote(source, target, ctx).await
+        }
+        SkillMutationRequest::Update {
+            skill_id,
+            expected_digest,
+        } => update_skill(skill_id, expected_digest, ctx).await,
+        SkillMutationRequest::UpdateByName {
+            name,
+            scope,
+            expected_digest,
+        } => {
+            let resolved = resolve_owned_skill_by_name(ctx, &name, scope)?;
+            update_skill(resolved.id, expected_digest.or(Some(resolved.digest)), ctx).await
+        }
+        sync => execute_sync(sync, ctx),
+    }
+}
+
+/// Sync mutations (import / remove / trust) — safe to call without a Tokio runtime.
+pub fn execute_sync(
+    request: SkillMutationRequest,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    match request {
+        SkillMutationRequest::ImportExternal {
+            source_id,
+            expected_digest,
+            target,
+            conflict_policy,
+        } => import_external(source_id, expected_digest, target, conflict_policy, ctx),
+        SkillMutationRequest::Remove {
+            skill_id,
+            expected_digest,
+        } => remove_skill(skill_id, expected_digest, ctx),
+        SkillMutationRequest::RemoveByName {
+            name,
+            scope,
+            expected_digest,
+        } => {
+            let resolved = resolve_owned_skill_by_name(ctx, &name, scope)?;
+            remove_skill(resolved.id, expected_digest.or(Some(resolved.digest)), ctx)
+        }
+        SkillMutationRequest::Trust {
+            skill_id,
+            expected_digest,
+        } => trust_skill(skill_id, expected_digest, ctx),
+        SkillMutationRequest::TrustByName {
+            name,
+            scope,
+            expected_digest,
+        } => {
+            let resolved = resolve_owned_skill_by_name(ctx, &name, scope)?;
+            let digest = expected_digest.unwrap_or(resolved.digest);
+            trust_skill(resolved.id, digest, ctx)
+        }
+        SkillMutationRequest::InstallRemote { .. }
+        | SkillMutationRequest::Update { .. }
+        | SkillMutationRequest::UpdateByName { .. } => {
+            bail!("this mutation requires async execute (network I/O)")
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ResolvedOwnedSkill {
+    id: AuditedSkillId,
+    digest: String,
+}
+
+fn resolve_owned_skill_by_name(
+    ctx: &MutationContext<'_>,
+    name: &str,
+    scope: Option<SkillTargetScope>,
+) -> Result<ResolvedOwnedSkill> {
+    // Match SkillRegistry::get — users may pass frontmatter/dir forms
+    // (Hello_World) while audit stores the folded canonical key (hello-world).
+    let canonical = normalize_skill_name_for_lookup(name);
+    let snap = scan_with_configured(
+        ctx.workspace,
+        ctx.home,
+        ctx.configured_skills_dir,
+        SkillAuditMode::OwnedOnly,
+        None,
+    );
+    let mut matches: Vec<&AuditedSkill> = snap
+        .skills
+        .iter()
+        .filter(|s| s.id.canonical_name == canonical)
+        .filter(|s| s.root.is_writable_owned())
+        .collect();
+
+    if let Some(scope) = scope {
+        let want = match scope {
+            SkillTargetScope::Project => SkillRootKind::CodeWhaleProject,
+            SkillTargetScope::Global => SkillRootKind::CodeWhaleGlobal,
+        };
+        matches.retain(|s| s.root.kind == want);
+    }
+
+    match matches.as_slice() {
+        [] => {
+            // If the name only exists externally, tell the user to import.
+            let compatible = scan_with_configured(
+                ctx.workspace,
+                ctx.home,
+                ctx.configured_skills_dir,
+                SkillAuditMode::Compatible,
+                None,
+            );
+            if compatible.skills.iter().any(|s| {
+                s.id.canonical_name == canonical
+                    && s.source_kind == SkillSourceKind::CompatibleExternal
+            }) {
+                bail!(
+                    "skill '{name}' exists only in a compatible external root; \
+                     import it with /skills (refusing to write external harness directories)"
+                );
+            }
+            bail!("skill '{name}' not found in CodeWhale-owned project/global roots");
+        }
+        [only] => {
+            let DigestState::Known(digest) = &only.digest else {
+                bail!("skill '{name}' has unknown package digest; refusing mutation");
+            };
+            Ok(ResolvedOwnedSkill {
+                id: only.id.clone(),
+                digest: digest.clone(),
+            })
+        }
+        _ => bail!(
+            "skill '{name}' exists in both project and global CodeWhale roots; \
+             specify --project or --global"
+        ),
+    }
+}
+
+fn find_audited_skill(
+    ctx: &MutationContext<'_>,
+    skill_id: &AuditedSkillId,
+) -> Result<(AuditedSkill, PathBuf)> {
+    let snap = scan_with_configured(
+        ctx.workspace,
+        ctx.home,
+        ctx.configured_skills_dir,
+        SkillAuditMode::Compatible,
+        None,
+    );
+    let skill = snap
+        .skills
+        .into_iter()
+        .find(|s| &s.id == skill_id)
+        .with_context(|| format!("audited skill {} not found", skill_id.canonical_name))?;
+    let path = skill.root.path.join(&skill.id.relative_dir);
+    Ok((skill, path))
+}
+
+/// Directory segment under the skills root. Prefer this over `canonical_name`
+/// when calling install helpers that join `skills_dir / name` — installs use
+/// raw frontmatter names, while audit stores a normalized lookup key.
+fn on_disk_package_name(skill_id: &AuditedSkillId) -> Result<&str> {
+    let name = skill_id
+        .relative_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "invalid on-disk package directory for skill '{}'",
+                skill_id.canonical_name
+            )
+        })?;
+    Ok(name)
+}
+
+fn verify_expected_digest(path: &Path, expected: Option<&str>) -> Result<Option<String>> {
+    let current = package_digest::compute_package_digest(path)
+        .with_context(|| format!("cannot digest {}", path.display()))?;
+    if let Some(expected) = expected
+        && expected != current
+    {
+        bail!(
+            "skill content changed since audit (expected {expected}, found {current}); \
+             re-review before mutating"
+        );
+    }
+    Ok(Some(current))
+}
+
+fn ensure_remote_updatable(skill_dir: &Path) -> Result<()> {
+    let marker_path = skill_dir.join(install::INSTALLED_FROM_MARKER);
+    let body = fs::read_to_string(&marker_path)
+        .with_context(|| format!("failed to read {}", marker_path.display()))?;
+    let value: serde_json::Value = serde_json::from_str(&body)
+        .with_context(|| format!("malformed {}", install::INSTALLED_FROM_MARKER))?;
+    let spec = value
+        .get("spec")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    if !install::is_registry_updatable_spec(spec) {
+        bail!(
+            "skill was imported locally (spec '{spec}') and cannot be updated from a registry; \
+             re-import or remove it first"
+        );
+    }
+    Ok(())
+}
+
+async fn install_remote(
+    source: InstallSource,
+    target: SkillTargetScope,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    let skills_dir = resolve_owned_target(ctx.workspace, ctx.home, target)?;
+    fs::create_dir_all(&skills_dir)
+        .with_context(|| format!("failed to create {}", skills_dir.display()))?;
+
+    let outcome = install::install_with_registry(
+        source,
+        &skills_dir,
+        ctx.max_size,
+        ctx.network,
+        false,
+        ctx.registry_url,
+    )
+    .await?;
+
+    match outcome {
+        InstallOutcome::Installed(installed) => {
+            let after = package_digest::compute_package_digest(&installed.path).ok();
+            Ok(SkillMutationReceipt {
+                action: SkillActionKind::Install,
+                name: installed.name,
+                scope: target.as_skill_scope(),
+                safe_target_path: safe_display_path(&installed.path, Some(ctx.workspace), ctx.home),
+                before_digest: None,
+                after_digest: after,
+                outcome: SkillMutationOutcome::Installed,
+            })
+        }
+        InstallOutcome::NeedsApproval(host) => Ok(SkillMutationReceipt {
+            action: SkillActionKind::Install,
+            name: String::new(),
+            scope: target.as_skill_scope(),
+            safe_target_path: safe_display_path(&skills_dir, Some(ctx.workspace), ctx.home),
+            before_digest: None,
+            after_digest: None,
+            outcome: SkillMutationOutcome::NeedsApproval(host),
+        }),
+        InstallOutcome::NetworkDenied(host) => Ok(SkillMutationReceipt {
+            action: SkillActionKind::Install,
+            name: String::new(),
+            scope: target.as_skill_scope(),
+            safe_target_path: safe_display_path(&skills_dir, Some(ctx.workspace), ctx.home),
+            before_digest: None,
+            after_digest: None,
+            outcome: SkillMutationOutcome::NetworkDenied(host),
+        }),
+    }
+}
+
+fn import_external(
+    source_id: AuditedSkillId,
+    expected_digest: String,
+    target: SkillTargetScope,
+    conflict_policy: ConflictPolicy,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    let (source_skill, source_path) = find_audited_skill(ctx, &source_id)?;
+    if source_skill.source_kind != SkillSourceKind::CompatibleExternal {
+        bail!("import source must be a compatible external skill");
+    }
+    if source_skill.path_unsafe {
+        bail!("refusing to import unsafe external skill package");
+    }
+
+    let owned_snap = scan_with_configured(
+        ctx.workspace,
+        ctx.home,
+        ctx.configured_skills_dir,
+        SkillAuditMode::OwnedOnly,
+        None,
+    );
+    let owned_has_name = owned_snap
+        .skills
+        .iter()
+        .any(|s| s.id.canonical_name == source_id.canonical_name);
+
+    if !owned_has_name && !source_skill.import_candidate {
+        bail!("skill is not an import candidate");
+    }
+
+    let before = verify_expected_digest(&source_path, Some(&expected_digest))?;
+
+    let skills_dir = resolve_owned_target(ctx.workspace, ctx.home, target)?;
+    fs::create_dir_all(&skills_dir)
+        .with_context(|| format!("failed to create {}", skills_dir.display()))?;
+
+    let want_kind = match target {
+        SkillTargetScope::Project => SkillRootKind::CodeWhaleProject,
+        SkillTargetScope::Global => SkillRootKind::CodeWhaleGlobal,
+    };
+    let existing_in_target: Vec<&AuditedSkill> = owned_snap
+        .skills
+        .iter()
+        .filter(|s| s.id.canonical_name == source_id.canonical_name)
+        .filter(|s| s.root.kind == want_kind)
+        .collect();
+
+    // Prefer the on-disk directory of an existing same-scope package so we
+    // replace/reject against Hello_World rather than creating a parallel
+    // hello-world next to it.
+    let (dest, dest_segment) = match existing_in_target.as_slice() {
+        [] => {
+            let segment = source_id.canonical_name.clone();
+            (skills_dir.join(&segment), segment)
+        }
+        [only] => {
+            let segment = on_disk_package_name(&only.id)?.to_string();
+            (only.root.path.join(&only.id.relative_dir), segment)
+        }
+        _ => bail!(
+            "skill '{}' has multiple owned packages in the target scope; \
+             remove or consolidate them before importing",
+            source_id.canonical_name
+        ),
+    };
+
+    if dest.exists() {
+        let existing = package_digest::compute_package_digest(&dest).ok();
+        if existing.as_deref() == Some(expected_digest.as_str()) {
+            return Ok(SkillMutationReceipt {
+                action: SkillActionKind::Import,
+                name: source_id.canonical_name.clone(),
+                scope: target.as_skill_scope(),
+                safe_target_path: safe_display_path(&dest, Some(ctx.workspace), ctx.home),
+                before_digest: before,
+                after_digest: existing,
+                outcome: SkillMutationOutcome::AlreadyPresent,
+            });
+        }
+        if conflict_policy == ConflictPolicy::Reject {
+            bail!(
+                "destination {} already exists with different content",
+                dest.display()
+            );
+        }
+    }
+
+    // Re-verify source digest immediately before copy (TOCTOU).
+    let _ = verify_expected_digest(&source_path, Some(&expected_digest))?;
+
+    let staging = skills_dir.join(format!("{dest_segment}.tmp"));
+    if staging.exists() {
+        fs::remove_dir_all(&staging).ok();
+    }
+    copy_skill_package(&source_path, &staging)?;
+    package_digest::compute_package_digest(&staging)
+        .context("staged import package failed digest validation")?;
+
+    let mut backup_path: Option<PathBuf> = None;
+    if dest.exists() {
+        let backup = skills_dir.join(format!("{dest_segment}.bak"));
+        if backup.exists() {
+            fs::remove_dir_all(&backup).ok();
+        }
+        fs::rename(&dest, &backup)
+            .with_context(|| format!("failed to backup {}", dest.display()))?;
+        if let Err(err) = fs::rename(&staging, &dest) {
+            let _ = fs::rename(&backup, &dest);
+            let _ = fs::remove_dir_all(&staging);
+            return Err(err).context("failed to replace destination with imported skill");
+        }
+        backup_path = Some(backup);
+    } else if let Err(err) = fs::rename(&staging, &dest) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err).context("failed to install imported skill");
+    }
+
+    // Keep backup until digest + marker finalize succeed so a failed import
+    // can restore the previous owned skill.
+    let finalize = (|| -> Result<String> {
+        let _ = verify_expected_digest(&source_path, Some(&expected_digest))?;
+        let after = package_digest::compute_package_digest(&dest)?;
+        if after != expected_digest {
+            bail!("imported content digest mismatch after copy; aborted");
+        }
+        write_installed_from_v2(
+            &dest,
+            &format!("import:{}", source_skill.safe_display_path),
+            None,
+            &expected_digest,
+            &after,
+            &source_id.canonical_name,
+        )?;
+        Ok(after)
+    })();
+
+    let after = match finalize {
+        Ok(after) => {
+            if let Some(backup) = backup_path.take() {
+                fs::remove_dir_all(&backup).ok();
+            }
+            after
+        }
+        Err(err) => {
+            let _ = fs::remove_dir_all(&dest);
+            if let Some(backup) = backup_path.take() {
+                let _ = fs::rename(&backup, &dest);
+            }
+            return Err(err);
+        }
+    };
+
+    Ok(SkillMutationReceipt {
+        action: SkillActionKind::Import,
+        name: source_id.canonical_name,
+        scope: target.as_skill_scope(),
+        safe_target_path: safe_display_path(&dest, Some(ctx.workspace), ctx.home),
+        before_digest: before,
+        after_digest: Some(after),
+        outcome: SkillMutationOutcome::Imported,
+    })
+}
+
+fn copy_skill_package(src: &Path, dest: &Path) -> Result<()> {
+    // Fail closed: source must already pass package digest (no symlinks).
+    package_digest::compute_package_digest(src).context("source package is not safe to copy")?;
+    copy_dir_regular_files(src, dest, src)?;
+    Ok(())
+}
+
+fn copy_dir_regular_files(src: &Path, dest: &Path, package_root: &Path) -> Result<()> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let meta = fs::symlink_metadata(&path)?;
+        if meta.file_type().is_symlink() {
+            bail!("refusing to copy symlink {}", path.display());
+        }
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str == install::INSTALLED_FROM_MARKER
+            || name_str == install::TRUSTED_MARKER
+            || name_str == ".system-installed-version"
+        {
+            continue;
+        }
+        let target = dest.join(&name);
+        if meta.is_dir() {
+            if name_str.starts_with('.') {
+                continue;
+            }
+            copy_dir_regular_files(&path, &target, package_root)?;
+        } else if meta.is_file() {
+            if name_str.starts_with('.') {
+                continue;
+            }
+            fs::copy(&path, &target)?;
+        }
+    }
+    Ok(())
+}
+
+async fn update_skill(
+    skill_id: AuditedSkillId,
+    expected_digest: Option<String>,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    let (skill, path) = find_audited_skill(ctx, &skill_id)?;
+    if !skill.root.is_writable_owned() {
+        bail!("refusing to update skill outside CodeWhale-owned roots");
+    }
+    if skill.source_kind != SkillSourceKind::CodeWhaleManaged {
+        bail!("only CodeWhale managed skills can be updated");
+    }
+    // Imported skills carry `import:…` provenance and must not hit the registry.
+    ensure_remote_updatable(&path)?;
+    let before = verify_expected_digest(&path, expected_digest.as_deref())?;
+    let skills_dir = skill.root.path.clone();
+    let scope = match skill.root.kind {
+        SkillRootKind::CodeWhaleProject => SkillScope::Project,
+        SkillRootKind::CodeWhaleGlobal => SkillScope::Global,
+        _ => SkillScope::Logical,
+    };
+
+    let package_name = on_disk_package_name(&skill_id)?;
+    let outcome = install::update_with_registry(
+        package_name,
+        &skills_dir,
+        ctx.max_size,
+        ctx.network,
+        ctx.registry_url,
+    )
+    .await?;
+
+    match outcome {
+        UpdateResult::NoChange => Ok(SkillMutationReceipt {
+            action: SkillActionKind::Update,
+            name: skill_id.canonical_name,
+            scope,
+            safe_target_path: safe_display_path(&path, Some(ctx.workspace), ctx.home),
+            before_digest: before.clone(),
+            after_digest: before,
+            outcome: SkillMutationOutcome::NoChange,
+        }),
+        UpdateResult::Updated(installed) => {
+            let after = package_digest::compute_package_digest(&installed.path).ok();
+            Ok(SkillMutationReceipt {
+                action: SkillActionKind::Update,
+                name: installed.name,
+                scope,
+                safe_target_path: safe_display_path(&installed.path, Some(ctx.workspace), ctx.home),
+                before_digest: before,
+                after_digest: after,
+                outcome: SkillMutationOutcome::Updated,
+            })
+        }
+        UpdateResult::NeedsApproval(host) => Ok(SkillMutationReceipt {
+            action: SkillActionKind::Update,
+            name: skill_id.canonical_name,
+            scope,
+            safe_target_path: safe_display_path(&path, Some(ctx.workspace), ctx.home),
+            before_digest: before,
+            after_digest: None,
+            outcome: SkillMutationOutcome::NeedsApproval(host),
+        }),
+        UpdateResult::NetworkDenied(host) => Ok(SkillMutationReceipt {
+            action: SkillActionKind::Update,
+            name: skill_id.canonical_name,
+            scope,
+            safe_target_path: safe_display_path(&path, Some(ctx.workspace), ctx.home),
+            before_digest: before,
+            after_digest: None,
+            outcome: SkillMutationOutcome::NetworkDenied(host),
+        }),
+    }
+}
+
+fn remove_skill(
+    skill_id: AuditedSkillId,
+    expected_digest: Option<String>,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    let (skill, path) = find_audited_skill(ctx, &skill_id)?;
+    if !skill.root.is_writable_owned() {
+        bail!("refusing to remove skill outside CodeWhale-owned roots");
+    }
+    if skill.source_kind != SkillSourceKind::CodeWhaleManaged {
+        bail!("only CodeWhale managed skills can be removed");
+    }
+    let before = verify_expected_digest(&path, expected_digest.as_deref())?;
+    let scope = match skill.root.kind {
+        SkillRootKind::CodeWhaleProject => SkillScope::Project,
+        SkillRootKind::CodeWhaleGlobal => SkillScope::Global,
+        _ => SkillScope::Logical,
+    };
+    let package_name = on_disk_package_name(&skill_id)?;
+    install::uninstall(package_name, &skill.root.path)?;
+    Ok(SkillMutationReceipt {
+        action: SkillActionKind::Remove,
+        name: skill_id.canonical_name,
+        scope,
+        safe_target_path: safe_display_path(&path, Some(ctx.workspace), ctx.home),
+        before_digest: before,
+        after_digest: None,
+        outcome: SkillMutationOutcome::Removed,
+    })
+}
+
+fn trust_skill(
+    skill_id: AuditedSkillId,
+    expected_digest: String,
+    ctx: &MutationContext<'_>,
+) -> Result<SkillMutationReceipt> {
+    let (skill, path) = find_audited_skill(ctx, &skill_id)?;
+    if !skill.root.is_writable_owned() {
+        bail!("refusing to trust skill outside CodeWhale-owned roots");
+    }
+    if skill.source_kind != SkillSourceKind::CodeWhaleManaged {
+        bail!("only CodeWhale managed skills can be trusted");
+    }
+    let before = verify_expected_digest(&path, Some(&expected_digest))?;
+    write_trust_v2(&path, &expected_digest)?;
+    let scope = match skill.root.kind {
+        SkillRootKind::CodeWhaleProject => SkillScope::Project,
+        SkillRootKind::CodeWhaleGlobal => SkillScope::Global,
+        _ => SkillScope::Logical,
+    };
+    Ok(SkillMutationReceipt {
+        action: SkillActionKind::Trust,
+        name: skill_id.canonical_name,
+        scope,
+        safe_target_path: safe_display_path(&path, Some(ctx.workspace), ctx.home),
+        before_digest: before.clone(),
+        after_digest: before,
+        outcome: SkillMutationOutcome::Trusted,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network_policy::NetworkPolicy;
+    use tempfile::TempDir;
+
+    fn write_skill(dir: &Path, name: &str, body: &str) {
+        let skill_dir = dir.join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: d\n---\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    fn ctx<'a>(
+        workspace: &'a Path,
+        home: &'a Path,
+        network: &'a NetworkPolicy,
+    ) -> MutationContext<'a> {
+        MutationContext {
+            workspace,
+            home: Some(home),
+            configured_skills_dir: None,
+            network,
+            max_size: install::DEFAULT_MAX_SIZE_BYTES,
+            registry_url: install::DEFAULT_REGISTRY_URL,
+        }
+    }
+
+    #[test]
+    fn resolve_owned_target_project_and_global() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&home).unwrap();
+
+        let project =
+            resolve_owned_target(&workspace, Some(&home), SkillTargetScope::Project).unwrap();
+        let global =
+            resolve_owned_target(&workspace, Some(&home), SkillTargetScope::Global).unwrap();
+        assert_eq!(project, workspace.join(".codewhale").join("skills"));
+        assert_eq!(global, home.join(".codewhale").join("skills"));
+    }
+
+    #[test]
+    fn remove_and_trust_require_managed_owned() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        write_skill(
+            &workspace.join(".codewhale").join("skills"),
+            "manual",
+            "body",
+        );
+        let err = resolve_owned_skill_by_name(&c, "manual", Some(SkillTargetScope::Project));
+        // Manual skill resolves, but remove/trust should fail source_kind check.
+        let resolved = err.unwrap();
+        let remove = remove_skill(resolved.id.clone(), Some(resolved.digest.clone()), &c);
+        assert!(remove.is_err());
+
+        write_skill(&workspace.join(".claude").join("skills"), "ext", "body");
+        // Place sentinel in external root.
+        let sentinel = workspace.join(".claude").join("skills").join("SENTINEL");
+        fs::write(&sentinel, "do-not-touch").unwrap();
+
+        let err = resolve_owned_skill_by_name(&c, "ext", None);
+        assert!(err.unwrap_err().to_string().contains("compatible external"));
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "do-not-touch");
+    }
+
+    #[test]
+    fn import_external_copies_into_project_owned() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        fs::create_dir_all(workspace.join(".codewhale").join("skills")).unwrap();
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "from-claude",
+            "import-me",
+        );
+        let sentinel = workspace.join(".claude").join("skills").join("SENTINEL");
+        fs::write(&sentinel, "keep").unwrap();
+
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::Compatible,
+            None,
+        );
+        let external = snap
+            .skills
+            .iter()
+            .find(|s| s.name == "from-claude")
+            .unwrap();
+        let DigestState::Known(digest) = &external.digest else {
+            panic!("digest");
+        };
+
+        let receipt = import_external(
+            external.id.clone(),
+            digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::Reject,
+            &c,
+        )
+        .unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::Imported);
+        assert!(
+            workspace
+                .join(".codewhale")
+                .join("skills")
+                .join("from-claude")
+                .join("SKILL.md")
+                .is_file()
+        );
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "keep");
+        // Source untouched.
+        assert!(
+            workspace
+                .join(".claude")
+                .join("skills")
+                .join("from-claude")
+                .join("SKILL.md")
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn import_exact_duplicate_is_already_present() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        let content = "---\nname: shared\ndescription: d\n---\nbody\n";
+        let owned = workspace.join(".codewhale").join("skills").join("shared");
+        let external = workspace.join(".claude").join("skills").join("shared");
+        fs::create_dir_all(&owned).unwrap();
+        fs::create_dir_all(&external).unwrap();
+        fs::write(owned.join("SKILL.md"), content).unwrap();
+        fs::write(external.join("SKILL.md"), content).unwrap();
+
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::Compatible,
+            None,
+        );
+        let external = snap
+            .skills
+            .iter()
+            .find(|s| s.name == "shared" && s.source_kind == SkillSourceKind::CompatibleExternal)
+            .unwrap();
+        let DigestState::Known(digest) = &external.digest else {
+            panic!("digest");
+        };
+
+        let receipt = import_external(
+            external.id.clone(),
+            digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::Reject,
+            &c,
+        )
+        .unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::AlreadyPresent);
+    }
+
+    #[test]
+    fn trust_writes_v2_digest_binding() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "body");
+        let digest = package_digest::compute_package_digest(&root.join("managed")).unwrap();
+        write_installed_from_v2(
+            &root.join("managed"),
+            "github:o/r",
+            None,
+            "src",
+            &digest,
+            "managed",
+        )
+        .unwrap();
+
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::OwnedOnly,
+            None,
+        );
+        let skill = &snap.skills[0];
+        let receipt = trust_skill(skill.id.clone(), digest.clone(), &c).unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::Trusted);
+        let trust_body =
+            fs::read_to_string(root.join("managed").join(install::TRUSTED_MARKER)).unwrap();
+        assert!(trust_body.contains("schema_version"));
+        assert!(trust_body.contains(&digest));
+    }
+
+    #[test]
+    fn remove_managed_skill() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "body");
+        let digest = package_digest::compute_package_digest(&root.join("managed")).unwrap();
+        write_installed_from_v2(
+            &root.join("managed"),
+            "github:o/r",
+            None,
+            "src",
+            &digest,
+            "managed",
+        )
+        .unwrap();
+
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::OwnedOnly,
+            None,
+        );
+        let skill = &snap.skills[0];
+        let receipt = remove_skill(skill.id.clone(), Some(digest), &c).unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::Removed);
+        assert!(!root.join("managed").exists());
+    }
+
+    #[test]
+    fn resolve_by_name_normalizes_like_registry() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "Hello_World", "body");
+        let digest = package_digest::compute_package_digest(&root.join("Hello_World")).unwrap();
+        write_installed_from_v2(
+            &root.join("Hello_World"),
+            "github:o/r",
+            None,
+            "src",
+            &digest,
+            "Hello_World",
+        )
+        .unwrap();
+
+        let resolved =
+            resolve_owned_skill_by_name(&c, "Hello_World", Some(SkillTargetScope::Project))
+                .unwrap();
+        assert_eq!(resolved.id.canonical_name, "hello-world");
+        assert_eq!(
+            resolve_owned_skill_by_name(&c, "hello-world", Some(SkillTargetScope::Project))
+                .unwrap()
+                .id,
+            resolved.id
+        );
+    }
+
+    #[test]
+    fn remove_uses_on_disk_dir_not_canonical_name() {
+        // Frontmatter/dir keep underscores+case; audit canonicalizes to dashes+lower.
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+        let root = workspace.join(".codewhale").join("skills");
+        let dir_name = "Hello_World";
+        write_skill(&root, dir_name, "body");
+        let digest = package_digest::compute_package_digest(&root.join(dir_name)).unwrap();
+        write_installed_from_v2(
+            &root.join(dir_name),
+            "github:o/r",
+            None,
+            "src",
+            &digest,
+            dir_name,
+        )
+        .unwrap();
+
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::OwnedOnly,
+            None,
+        );
+        let skill = snap
+            .skills
+            .iter()
+            .find(|s| s.id.canonical_name == "hello-world")
+            .expect("canonical name should fold Hello_World → hello-world");
+        assert_ne!(skill.id.canonical_name, dir_name);
+        assert_eq!(
+            skill.id.relative_dir.file_name().unwrap().to_str().unwrap(),
+            dir_name
+        );
+
+        let receipt = remove_skill(skill.id.clone(), Some(digest), &c).unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::Removed);
+        assert!(!root.join(dir_name).exists());
+    }
+
+    #[test]
+    fn imported_skill_rejects_registry_update() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        fs::create_dir_all(workspace.join(".codewhale").join("skills")).unwrap();
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "from-claude",
+            "import-me",
+        );
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::Compatible,
+            None,
+        );
+        let external = snap
+            .skills
+            .iter()
+            .find(|s| s.name == "from-claude")
+            .unwrap();
+        let DigestState::Known(digest) = &external.digest else {
+            panic!("digest");
+        };
+        import_external(
+            external.id.clone(),
+            digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::Reject,
+            &c,
+        )
+        .unwrap();
+
+        let owned = workspace
+            .join(".codewhale")
+            .join("skills")
+            .join("from-claude");
+        assert!(ensure_remote_updatable(&owned).is_err());
+        assert!(!install::is_registry_updatable_spec(
+            "import:<workspace>/.claude/skills/from-claude"
+        ));
+        assert!(install::is_registry_updatable_spec("github:owner/repo"));
+    }
+
+    #[test]
+    fn import_rejects_when_owned_dir_differs_from_canonical() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        let owned_root = workspace.join(".codewhale").join("skills");
+        write_skill(&owned_root, "Hello_World", "original-owned");
+        let original_digest =
+            package_digest::compute_package_digest(&owned_root.join("Hello_World")).unwrap();
+        write_installed_from_v2(
+            &owned_root.join("Hello_World"),
+            "github:o/r",
+            None,
+            "src",
+            &original_digest,
+            "Hello_World",
+        )
+        .unwrap();
+
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "Hello_World",
+            "external-different",
+        );
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::Compatible,
+            None,
+        );
+        let external = snap
+            .skills
+            .iter()
+            .find(|s| {
+                s.id.canonical_name == "hello-world"
+                    && s.source_kind == SkillSourceKind::CompatibleExternal
+            })
+            .unwrap();
+        let DigestState::Known(ext_digest) = &external.digest else {
+            panic!("digest");
+        };
+
+        let err = import_external(
+            external.id.clone(),
+            ext_digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::Reject,
+            &c,
+        );
+        assert!(err.unwrap_err().to_string().contains("already exists"));
+        assert!(owned_root.join("Hello_World").exists());
+        assert!(!owned_root.join("hello-world").exists());
+        let still =
+            package_digest::compute_package_digest(&owned_root.join("Hello_World")).unwrap();
+        assert_eq!(still, original_digest);
+
+        let receipt = import_external(
+            external.id.clone(),
+            ext_digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::ReplaceConfirmed,
+            &c,
+        )
+        .unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::Imported);
+        assert!(owned_root.join("Hello_World").exists());
+        assert!(!owned_root.join("hello-world").exists());
+        assert!(!owned_root.join("Hello_World.bak").exists());
+        let after =
+            package_digest::compute_package_digest(&owned_root.join("Hello_World")).unwrap();
+        assert_eq!(after, *ext_digest);
+    }
+
+    #[test]
+    fn import_conflict_reject_keeps_owned_and_replace_cleans_backup() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+
+        let owned_root = workspace.join(".codewhale").join("skills");
+        write_skill(&owned_root, "shared", "original-owned");
+        let original_digest =
+            package_digest::compute_package_digest(&owned_root.join("shared")).unwrap();
+        write_installed_from_v2(
+            &owned_root.join("shared"),
+            "github:o/r",
+            None,
+            "src",
+            &original_digest,
+            "shared",
+        )
+        .unwrap();
+
+        write_skill(
+            &workspace.join(".claude").join("skills"),
+            "shared",
+            "external-different",
+        );
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::Compatible,
+            None,
+        );
+        let external = snap
+            .skills
+            .iter()
+            .find(|s| s.name == "shared" && s.source_kind == SkillSourceKind::CompatibleExternal)
+            .unwrap();
+        let DigestState::Known(ext_digest) = &external.digest else {
+            panic!("digest");
+        };
+
+        let err = import_external(
+            external.id.clone(),
+            ext_digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::Reject,
+            &c,
+        );
+        assert!(err.is_err());
+        let still = package_digest::compute_package_digest(&owned_root.join("shared")).unwrap();
+        assert_eq!(still, original_digest);
+
+        let receipt = import_external(
+            external.id.clone(),
+            ext_digest.clone(),
+            SkillTargetScope::Project,
+            ConflictPolicy::ReplaceConfirmed,
+            &c,
+        )
+        .unwrap();
+        assert_eq!(receipt.outcome, SkillMutationOutcome::Imported);
+        let after = package_digest::compute_package_digest(&owned_root.join("shared")).unwrap();
+        assert_eq!(after, *ext_digest);
+        assert!(!owned_root.join("shared.bak").exists());
+    }
+
+    #[test]
+    fn digest_mismatch_rejects_remove() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let network = NetworkPolicy::default();
+        let c = ctx(&workspace, &home, &network);
+        let root = workspace.join(".codewhale").join("skills");
+        write_skill(&root, "managed", "body");
+        let digest = package_digest::compute_package_digest(&root.join("managed")).unwrap();
+        write_installed_from_v2(
+            &root.join("managed"),
+            "github:o/r",
+            None,
+            "src",
+            &digest,
+            "managed",
+        )
+        .unwrap();
+
+        let snap = scan_with_configured(
+            &workspace,
+            Some(&home),
+            None,
+            SkillAuditMode::OwnedOnly,
+            None,
+        );
+        let err = remove_skill(snap.skills[0].id.clone(), Some("deadbeef".into()), &c);
+        assert!(err.unwrap_err().to_string().contains("changed since audit"));
+        assert!(root.join("managed").exists());
+    }
+}

--- a/crates/tui/src/skills/package_digest.rs
+++ b/crates/tui/src/skills/package_digest.rs
@@ -1,0 +1,158 @@
+//! Bounded package content digest shared by audit and mutation.
+//!
+//! Kept separate so `install` can write metadata v2 without depending on the
+//! audit module (which itself depends on install marker constants).
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use super::install::{DEFAULT_MAX_SIZE_BYTES, INSTALLED_FROM_MARKER, TRUSTED_MARKER};
+
+pub const PACKAGE_DIGEST_MAX_BYTES: u64 = DEFAULT_MAX_SIZE_BYTES;
+pub const PACKAGE_DIGEST_MAX_FILES: usize = 256;
+pub const PACKAGE_DIGEST_MAX_DEPTH: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageDigestError {
+    Unreadable,
+    SymlinkPresent,
+    EscapedRoot,
+    Cycle,
+    Oversized,
+    TooManyFiles,
+    TooDeep,
+}
+
+impl std::fmt::Display for PackageDigestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Unreadable => "unreadable package file",
+            Self::SymlinkPresent => "symlink present in package",
+            Self::EscapedRoot => "path escaped package root",
+            Self::Cycle => "symlink/directory cycle",
+            Self::Oversized => "package exceeded size limit",
+            Self::TooManyFiles => "package exceeded file limit",
+            Self::TooDeep => "package exceeded depth limit",
+        })
+    }
+}
+
+impl std::error::Error for PackageDigestError {}
+
+/// SHA-256 hex of the normalized package manifest (relative path + len + bytes).
+pub fn compute_package_digest(package_dir: &Path) -> Result<String, PackageDigestError> {
+    let canonical_package =
+        fs::canonicalize(package_dir).map_err(|_| PackageDigestError::Unreadable)?;
+
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut total_bytes: u64 = 0;
+    let mut visited = HashSet::new();
+
+    walk(
+        package_dir,
+        &canonical_package,
+        0,
+        &mut visited,
+        &mut files,
+        &mut total_bytes,
+    )?;
+
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (rel, bytes) in &files {
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    }
+    Ok(hex_digest(hasher.finalize()))
+}
+
+/// Whether the package tree is safe (no symlink / escape / cycle) under limits.
+#[allow(dead_code)] // used by future import/validation paths
+pub fn package_is_path_safe(package_dir: &Path) -> bool {
+    compute_package_digest(package_dir).is_ok()
+}
+
+fn walk(
+    dir: &Path,
+    package_root: &Path,
+    depth: usize,
+    visited: &mut HashSet<PathBuf>,
+    files: &mut Vec<(String, Vec<u8>)>,
+    total_bytes: &mut u64,
+) -> Result<(), PackageDigestError> {
+    if depth > PACKAGE_DIGEST_MAX_DEPTH {
+        return Err(PackageDigestError::TooDeep);
+    }
+    let meta = fs::symlink_metadata(dir).map_err(|_| PackageDigestError::Unreadable)?;
+    if meta.file_type().is_symlink() {
+        return Err(PackageDigestError::SymlinkPresent);
+    }
+    let canonical = fs::canonicalize(dir).map_err(|_| PackageDigestError::Unreadable)?;
+    if !canonical.starts_with(package_root) {
+        return Err(PackageDigestError::EscapedRoot);
+    }
+    if !visited.insert(canonical) {
+        return Err(PackageDigestError::Cycle);
+    }
+
+    let entries = fs::read_dir(dir).map_err(|_| PackageDigestError::Unreadable)?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+
+        let meta = fs::symlink_metadata(&path).map_err(|_| PackageDigestError::Unreadable)?;
+        if meta.file_type().is_symlink() {
+            return Err(PackageDigestError::SymlinkPresent);
+        }
+
+        if name == INSTALLED_FROM_MARKER
+            || name == TRUSTED_MARKER
+            || name == ".system-installed-version"
+            || name.ends_with(".bak")
+            || name.ends_with(".tmp")
+            || name.starts_with('.')
+        {
+            continue;
+        }
+
+        if meta.is_dir() {
+            walk(&path, package_root, depth + 1, visited, files, total_bytes)?;
+            continue;
+        }
+        if !meta.is_file() {
+            continue;
+        }
+        if files.len() >= PACKAGE_DIGEST_MAX_FILES {
+            return Err(PackageDigestError::TooManyFiles);
+        }
+        let len = meta.len();
+        if *total_bytes + len > PACKAGE_DIGEST_MAX_BYTES {
+            return Err(PackageDigestError::Oversized);
+        }
+        let bytes = fs::read(&path).map_err(|_| PackageDigestError::Unreadable)?;
+        *total_bytes += bytes.len() as u64;
+        let rel = path
+            .strip_prefix(package_root)
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| name.to_string());
+        files.push((rel, bytes));
+    }
+    Ok(())
+}
+
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}

--- a/crates/tui/src/skills/roots.rs
+++ b/crates/tui/src/skills/roots.rs
@@ -1,0 +1,870 @@
+//! Single source of truth for skill root enumeration, ownership, scope, and
+//! runtime precedence.
+//!
+//! Runtime discovery and (later) audit/mutation share this catalog so
+//! precedence cannot drift between modules. Discovery directories are not
+//! write targets: only explicitly owned CodeWhale roots are writable.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Stable identifier for a skill root within a catalog snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SkillRootId(String);
+
+impl SkillRootId {
+    #[must_use]
+    #[allow(dead_code)] // consumed by audit/mutation in later #4651 stages
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SkillRootId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// External harness layouts that CodeWhale can discover/audit but never owns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompatibleHarness {
+    Agents,
+    Claude,
+    Cursor,
+    OpenCode,
+    Codex,
+    DeepSeekLegacy,
+    /// Flat `<workspace>/skills` layout.
+    FlatProjectSkills,
+}
+
+impl CompatibleHarness {
+    #[must_use]
+    #[allow(dead_code)] // consumed by audit UI labels in later #4651 stages
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Agents => "agents",
+            Self::Claude => "claude",
+            Self::Cursor => "cursor",
+            Self::OpenCode => "opencode",
+            Self::Codex => "codex",
+            Self::DeepSeekLegacy => "deepseek",
+            Self::FlatProjectSkills => "flat-skills",
+        }
+    }
+}
+
+/// Kind of skill root on disk (or logical source).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)] // BuiltIn / ReviewedPluginSnapshot used by later #4651 stages
+pub enum SkillRootKind {
+    CodeWhaleProject,
+    CodeWhaleGlobal,
+    CompatibleProject(CompatibleHarness),
+    CompatibleGlobal(CompatibleHarness),
+    /// Explicitly configured `skills_dir` that is not one of the owned roots.
+    Configured,
+    BuiltIn,
+    ReviewedPluginSnapshot,
+    RegistryCache,
+}
+
+/// Whether CodeWhale may mutate files under this root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)] // Immutable used by later #4651 stages
+pub enum SkillRootAccess {
+    /// CodeWhale-owned project/global install targets.
+    WritableOwned,
+    /// Compatible harness roots and unclassified configured dirs — read only.
+    ReadOnlyExternal,
+    /// Built-in / reviewed plugin snapshot content.
+    Immutable,
+    /// Registry download cache — not an active install target.
+    CacheOnly,
+}
+
+/// Project vs global scope for owned and compatible roots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SkillScope {
+    Project,
+    Global,
+    /// Logical / non-filesystem sources (built-in, plugin snapshot, cache).
+    Logical,
+}
+
+/// One enumerated skill root with ownership and precedence metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillRootDescriptor {
+    pub id: SkillRootId,
+    pub kind: SkillRootKind,
+    pub access: SkillRootAccess,
+    pub scope: SkillScope,
+    pub path: PathBuf,
+    pub canonical_path: Option<PathBuf>,
+    /// Lower value = higher precedence for first-wins runtime merge.
+    pub precedence: Option<usize>,
+    /// When true, runtime skill discovery includes this root.
+    pub active_for_runtime: bool,
+    /// When true, owned-only / compatible audit may include this root.
+    pub active_for_audit: bool,
+}
+
+impl SkillRootDescriptor {
+    #[must_use]
+    pub fn is_writable_owned(&self) -> bool {
+        self.access == SkillRootAccess::WritableOwned
+    }
+
+    /// Home-relative or workspace-relative path for UI / receipts.
+    #[must_use]
+    #[allow(dead_code)] // consumed by manager receipts in later #4651 stages
+    pub fn safe_display_path(&self, workspace: Option<&Path>, home: Option<&Path>) -> String {
+        safe_display_path(&self.path, workspace, home)
+    }
+}
+
+/// Catalog of skill roots for a workspace (+ optional HOME override for tests).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillRootCatalog {
+    roots: Vec<SkillRootDescriptor>,
+}
+
+impl SkillRootCatalog {
+    /// Build the full catalog: owned + compatible (including Codex audit-only)
+    /// plus optional configured dir and logical sources.
+    #[must_use]
+    pub fn build(
+        workspace: &Path,
+        home_dir: Option<&Path>,
+        configured_skills_dir: Option<&Path>,
+    ) -> Self {
+        let mut roots = Vec::new();
+        let mut precedence = 0usize;
+
+        // Runtime-compatible workspace roots (existing order — do not reorder).
+        push_existing(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CompatibleProject(CompatibleHarness::Agents),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+            workspace.join(".agents").join("skills"),
+            true,
+            true,
+            "project-agents",
+        );
+        push_existing(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CompatibleProject(CompatibleHarness::FlatProjectSkills),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+            workspace.join("skills"),
+            true,
+            true,
+            "project-flat-skills",
+        );
+        push_existing(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CompatibleProject(CompatibleHarness::OpenCode),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+            workspace.join(".opencode").join("skills"),
+            true,
+            true,
+            "project-opencode",
+        );
+        push_existing(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CompatibleProject(CompatibleHarness::Claude),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+            workspace.join(".claude").join("skills"),
+            true,
+            true,
+            "project-claude",
+        );
+        push_existing(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CompatibleProject(CompatibleHarness::Cursor),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+            workspace.join(".cursor").join("skills"),
+            true,
+            true,
+            "project-cursor",
+        );
+
+        // CodeWhale project root — always listed for ownership; runtime
+        // CodeWhale-only mode additionally requires the path stay inside the
+        // workspace (symlink escape check happens in path selection helpers).
+        let project_owned = workspace.join(".codewhale").join("skills");
+        push_descriptor(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CodeWhaleProject,
+            SkillRootAccess::WritableOwned,
+            SkillScope::Project,
+            project_owned,
+            true,
+            true,
+            "project-codewhale",
+            true, // include even if missing — owned target may be created later
+        );
+
+        // Codex project: audit-compatible only; never active for runtime in #4651.
+        push_existing(
+            &mut roots,
+            &mut precedence,
+            SkillRootKind::CompatibleProject(CompatibleHarness::Codex),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+            workspace.join(".codex").join("skills"),
+            false,
+            true,
+            "project-codex",
+        );
+
+        if let Some(home) = home_dir {
+            push_existing(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::CompatibleGlobal(CompatibleHarness::Agents),
+                SkillRootAccess::ReadOnlyExternal,
+                SkillScope::Global,
+                home.join(".agents").join("skills"),
+                true,
+                true,
+                "global-agents",
+            );
+            push_existing(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::CompatibleGlobal(CompatibleHarness::Claude),
+                SkillRootAccess::ReadOnlyExternal,
+                SkillScope::Global,
+                home.join(".claude").join("skills"),
+                true,
+                true,
+                "global-claude",
+            );
+
+            let global_owned = home.join(".codewhale").join("skills");
+            push_descriptor(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::CodeWhaleGlobal,
+                SkillRootAccess::WritableOwned,
+                SkillScope::Global,
+                global_owned,
+                true,
+                true,
+                "global-codewhale",
+                true,
+            );
+
+            push_existing(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::CompatibleGlobal(CompatibleHarness::DeepSeekLegacy),
+                SkillRootAccess::ReadOnlyExternal,
+                SkillScope::Global,
+                home.join(".deepseek").join("skills"),
+                true,
+                true,
+                "global-deepseek",
+            );
+
+            // Codex global: audit-compatible only.
+            push_existing(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::CompatibleGlobal(CompatibleHarness::Codex),
+                SkillRootAccess::ReadOnlyExternal,
+                SkillScope::Global,
+                home.join(".codex").join("skills"),
+                false,
+                true,
+                "global-codex",
+            );
+
+            // Registry cache is never an active skill root.
+            let cache = home.join(".codewhale").join("cache").join("skills");
+            push_descriptor(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::RegistryCache,
+                SkillRootAccess::CacheOnly,
+                SkillScope::Logical,
+                cache,
+                false,
+                false,
+                "registry-cache",
+                false,
+            );
+        } else {
+            // Match legacy fallback when HOME is unavailable.
+            push_descriptor(
+                &mut roots,
+                &mut precedence,
+                SkillRootKind::CodeWhaleGlobal,
+                SkillRootAccess::WritableOwned,
+                SkillScope::Global,
+                PathBuf::from("/tmp/codewhale/skills"),
+                true,
+                true,
+                "global-codewhale-fallback",
+                true,
+            );
+        }
+
+        if let Some(configured) = configured_skills_dir {
+            insert_configured_root(&mut roots, workspace, home_dir, configured, &mut precedence);
+        }
+
+        Self { roots }
+    }
+
+    #[must_use]
+    #[allow(dead_code)] // consumed by audit scanners in later #4651 stages
+    pub fn roots(&self) -> &[SkillRootDescriptor] {
+        &self.roots
+    }
+
+    /// Paths used by runtime discovery for the given mode (existing dirs only,
+    /// first-wins order preserved). CodeWhale-only applies the workspace
+    /// containment check for the project owned root.
+    #[must_use]
+    pub fn runtime_directories(
+        &self,
+        workspace: &Path,
+        mode: super::SkillDiscoveryMode,
+    ) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        let mut seen = HashSet::new();
+
+        for root in &self.roots {
+            if !root.active_for_runtime {
+                continue;
+            }
+            match mode {
+                super::SkillDiscoveryMode::Compatible => {}
+                super::SkillDiscoveryMode::CodeWhaleOnly => {
+                    if !matches!(
+                        root.kind,
+                        SkillRootKind::CodeWhaleProject
+                            | SkillRootKind::CodeWhaleGlobal
+                            | SkillRootKind::Configured
+                    ) {
+                        continue;
+                    }
+                    if root.kind == SkillRootKind::CodeWhaleProject
+                        && !codewhale_project_root_is_inside_workspace(workspace, &root.path)
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            if !path_is_existing_dir(&root.path) {
+                continue;
+            }
+            let Ok(canonical) = fs::canonicalize(&root.path) else {
+                continue;
+            };
+            if !canonical.is_dir() || !seen.insert(canonical) {
+                continue;
+            }
+            out.push(root.path.clone());
+        }
+        out
+    }
+
+    /// Owned CodeWhale project + global roots (may not exist yet).
+    #[must_use]
+    pub fn owned_writable_roots(&self) -> Vec<&SkillRootDescriptor> {
+        self.roots
+            .iter()
+            .filter(|r| r.is_writable_owned())
+            .collect()
+    }
+
+    /// Roots eligible for owned-only audit (writable owned roots that exist).
+    #[must_use]
+    #[allow(dead_code)] // consumed by owned audit mode in later #4651 stages
+    pub fn audit_owned_directories(&self) -> Vec<&SkillRootDescriptor> {
+        self.roots
+            .iter()
+            .filter(|r| {
+                r.is_writable_owned() && r.active_for_audit && path_is_existing_dir(&r.path)
+            })
+            .collect()
+    }
+
+    /// Owned + compatible roots for explicit `--compatible` audit, including
+    /// Codex. Does not change runtime activation.
+    #[must_use]
+    pub fn audit_compatible_directories(&self) -> Vec<&SkillRootDescriptor> {
+        self.roots
+            .iter()
+            .filter(|r| {
+                r.active_for_audit
+                    && !matches!(
+                        r.kind,
+                        SkillRootKind::RegistryCache
+                            | SkillRootKind::BuiltIn
+                            | SkillRootKind::ReviewedPluginSnapshot
+                    )
+                    && path_is_existing_dir(&r.path)
+            })
+            .collect()
+    }
+}
+
+/// Resolve candidate skill directories for runtime discovery (existing paths
+/// only), preserving historical precedence.
+#[must_use]
+pub fn skills_directories_with_home_and_mode(
+    workspace: &Path,
+    home_dir: Option<&Path>,
+    mode: super::SkillDiscoveryMode,
+) -> Vec<PathBuf> {
+    SkillRootCatalog::build(workspace, home_dir, None).runtime_directories(workspace, mode)
+}
+
+/// CodeWhale project skills dir when it exists and stays inside the workspace.
+#[must_use]
+pub fn codewhale_workspace_skills_dir(workspace: &Path) -> Option<PathBuf> {
+    let skills_dir = workspace.join(".codewhale").join("skills");
+    codewhale_project_root_is_inside_workspace(workspace, &skills_dir).then_some(skills_dir)
+}
+
+/// Filter candidate paths to existing directories, preserving order and
+/// de-duplicating by canonical path.
+#[must_use]
+pub fn existing_skill_dirs(candidates: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for path in candidates {
+        let Ok(canonical_path) = fs::canonicalize(&path) else {
+            continue;
+        };
+        if canonical_path.is_dir() && seen.insert(canonical_path) {
+            out.push(path);
+        }
+    }
+    out
+}
+
+/// Classify a configured `skills_dir`: owned only when it is exactly a
+/// CodeWhale project/global root; compatible harness paths stay read-only.
+#[must_use]
+pub fn classify_configured_skills_dir(
+    workspace: &Path,
+    home_dir: Option<&Path>,
+    skills_dir: &Path,
+) -> (SkillRootKind, SkillRootAccess, SkillScope) {
+    let project_owned = workspace.join(".codewhale").join("skills");
+    if paths_refer_to_same_dir(&project_owned, skills_dir) {
+        return (
+            SkillRootKind::CodeWhaleProject,
+            SkillRootAccess::WritableOwned,
+            SkillScope::Project,
+        );
+    }
+    if let Some(home) = home_dir {
+        let global_owned = home.join(".codewhale").join("skills");
+        if paths_refer_to_same_dir(&global_owned, skills_dir) {
+            return (
+                SkillRootKind::CodeWhaleGlobal,
+                SkillRootAccess::WritableOwned,
+                SkillScope::Global,
+            );
+        }
+    }
+
+    if let Some(harness) = match_compatible_project(workspace, skills_dir) {
+        return (
+            SkillRootKind::CompatibleProject(harness),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Project,
+        );
+    }
+    if let Some(home) = home_dir
+        && let Some(harness) = match_compatible_global(home, skills_dir)
+    {
+        return (
+            SkillRootKind::CompatibleGlobal(harness),
+            SkillRootAccess::ReadOnlyExternal,
+            SkillScope::Global,
+        );
+    }
+
+    // Unknown configured path: treat as external until an explicit owned-root
+    // marker exists (Issue #4651 first cut — do not guess writability).
+    let scope = fs::canonicalize(workspace)
+        .ok()
+        .map_or(SkillScope::Global, |root| {
+            fs::canonicalize(skills_dir)
+                .ok()
+                .filter(|p| p.starts_with(&root))
+                .map_or(SkillScope::Global, |_| SkillScope::Project)
+        });
+    (
+        SkillRootKind::Configured,
+        SkillRootAccess::ReadOnlyExternal,
+        scope,
+    )
+}
+
+#[must_use]
+pub fn safe_display_path(path: &Path, workspace: Option<&Path>, home: Option<&Path>) -> String {
+    // Prefer workspace when both apply so project roots stay distinct from
+    // `~/...` global paths that happen to live under the same home tree.
+    if let Some(workspace) = workspace
+        && let Ok(stripped) = path.strip_prefix(workspace)
+    {
+        return format!("<workspace>/{}", stripped.display()).replace('\\', "/");
+    }
+    if let Some(home) = home
+        && let Ok(stripped) = path.strip_prefix(home)
+    {
+        return format!("~/{}", stripped.display()).replace('\\', "/");
+    }
+    // Last resort: basename chain without expanding unrelated absolute parents.
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+#[must_use]
+pub fn paths_refer_to_same_dir(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn codewhale_project_root_is_inside_workspace(workspace: &Path, skills_dir: &Path) -> bool {
+    let Ok(canonical_workspace) = fs::canonicalize(workspace) else {
+        return false;
+    };
+    let Ok(canonical_skills) = fs::canonicalize(skills_dir) else {
+        return false;
+    };
+    canonical_skills.is_dir() && canonical_skills.starts_with(canonical_workspace)
+}
+
+fn path_is_existing_dir(path: &Path) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            fs::canonicalize(path).ok().is_some_and(|p| p.is_dir())
+        }
+        Ok(meta) => meta.is_dir(),
+        Err(_) => false,
+    }
+}
+
+fn match_compatible_project(workspace: &Path, skills_dir: &Path) -> Option<CompatibleHarness> {
+    let candidates = [
+        (
+            CompatibleHarness::Agents,
+            workspace.join(".agents").join("skills"),
+        ),
+        (
+            CompatibleHarness::FlatProjectSkills,
+            workspace.join("skills"),
+        ),
+        (
+            CompatibleHarness::OpenCode,
+            workspace.join(".opencode").join("skills"),
+        ),
+        (
+            CompatibleHarness::Claude,
+            workspace.join(".claude").join("skills"),
+        ),
+        (
+            CompatibleHarness::Cursor,
+            workspace.join(".cursor").join("skills"),
+        ),
+        (
+            CompatibleHarness::Codex,
+            workspace.join(".codex").join("skills"),
+        ),
+    ];
+    for (harness, candidate) in candidates {
+        if paths_refer_to_same_dir(&candidate, skills_dir) {
+            return Some(harness);
+        }
+    }
+    None
+}
+
+fn match_compatible_global(home: &Path, skills_dir: &Path) -> Option<CompatibleHarness> {
+    let candidates = [
+        (
+            CompatibleHarness::Agents,
+            home.join(".agents").join("skills"),
+        ),
+        (
+            CompatibleHarness::Claude,
+            home.join(".claude").join("skills"),
+        ),
+        (
+            CompatibleHarness::DeepSeekLegacy,
+            home.join(".deepseek").join("skills"),
+        ),
+        (CompatibleHarness::Codex, home.join(".codex").join("skills")),
+    ];
+    for (harness, candidate) in candidates {
+        if paths_refer_to_same_dir(&candidate, skills_dir) {
+            return Some(harness);
+        }
+    }
+    None
+}
+
+fn push_existing(
+    roots: &mut Vec<SkillRootDescriptor>,
+    precedence: &mut usize,
+    kind: SkillRootKind,
+    access: SkillRootAccess,
+    scope: SkillScope,
+    path: PathBuf,
+    active_for_runtime: bool,
+    active_for_audit: bool,
+    id: &str,
+) {
+    push_descriptor(
+        roots,
+        precedence,
+        kind,
+        access,
+        scope,
+        path,
+        active_for_runtime,
+        active_for_audit,
+        id,
+        false,
+    );
+}
+
+fn push_descriptor(
+    roots: &mut Vec<SkillRootDescriptor>,
+    precedence: &mut usize,
+    kind: SkillRootKind,
+    access: SkillRootAccess,
+    scope: SkillScope,
+    path: PathBuf,
+    active_for_runtime: bool,
+    active_for_audit: bool,
+    id: &str,
+    include_missing: bool,
+) {
+    let exists = path_is_existing_dir(&path);
+    if !include_missing && !exists {
+        return;
+    }
+    let canonical_path = fs::canonicalize(&path).ok();
+    let slot = *precedence;
+    *precedence += 1;
+    roots.push(SkillRootDescriptor {
+        id: SkillRootId(id.to_string()),
+        kind,
+        access,
+        scope,
+        path,
+        canonical_path,
+        precedence: Some(slot),
+        active_for_runtime,
+        active_for_audit,
+    });
+}
+
+fn insert_configured_root(
+    roots: &mut Vec<SkillRootDescriptor>,
+    workspace: &Path,
+    home_dir: Option<&Path>,
+    skills_dir: &Path,
+    precedence: &mut usize,
+) {
+    if !path_is_existing_dir(skills_dir) {
+        return;
+    }
+    if roots
+        .iter()
+        .any(|root| paths_refer_to_same_dir(&root.path, skills_dir))
+    {
+        return;
+    }
+
+    let (kind, access, scope) = classify_configured_skills_dir(workspace, home_dir, skills_dir);
+    let workspace_root = fs::canonicalize(workspace).ok();
+    let insert_at = workspace_root
+        .as_ref()
+        .and_then(|root| {
+            roots.iter().position(|dir| {
+                fs::canonicalize(&dir.path).map_or(true, |dir| !dir.starts_with(root))
+            })
+        })
+        .unwrap_or(roots.len());
+
+    let canonical_path = fs::canonicalize(skills_dir).ok();
+    let slot = *precedence;
+    *precedence += 1;
+    let descriptor = SkillRootDescriptor {
+        id: SkillRootId(format!("configured-{slot}")),
+        kind,
+        access,
+        scope,
+        path: skills_dir.to_path_buf(),
+        canonical_path,
+        precedence: Some(slot),
+        active_for_runtime: true,
+        active_for_audit: true,
+    };
+    roots.insert(insert_at, descriptor);
+    // Re-number precedence after insertion so catalog order stays consistent.
+    for (idx, root) in roots.iter_mut().enumerate() {
+        root.precedence = Some(idx);
+    }
+    *precedence = roots.len();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::SkillDiscoveryMode;
+    use tempfile::TempDir;
+
+    fn write_dir(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn runtime_compatible_preserves_historical_workspace_order() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_dir(&workspace.join(".agents").join("skills"));
+        write_dir(&workspace.join("skills"));
+        write_dir(&workspace.join(".claude").join("skills"));
+        write_dir(&workspace.join(".cursor").join("skills"));
+        write_dir(&workspace.join(".codewhale").join("skills"));
+        write_dir(&workspace.join(".codex").join("skills"));
+        write_dir(&home.join(".codewhale").join("skills"));
+
+        let catalog = SkillRootCatalog::build(&workspace, Some(&home), None);
+        let dirs = catalog.runtime_directories(&workspace, SkillDiscoveryMode::Compatible);
+
+        assert_eq!(
+            dirs,
+            vec![
+                workspace.join(".agents").join("skills"),
+                workspace.join("skills"),
+                workspace.join(".claude").join("skills"),
+                workspace.join(".cursor").join("skills"),
+                workspace.join(".codewhale").join("skills"),
+                home.join(".codewhale").join("skills"),
+            ]
+        );
+        assert!(
+            !dirs
+                .iter()
+                .any(|p| p == &workspace.join(".codex").join("skills")),
+            "codex must not activate for runtime"
+        );
+    }
+
+    #[test]
+    fn audit_compatible_includes_codex_without_runtime_activation() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_dir(&workspace.join(".codewhale").join("skills"));
+        write_dir(&workspace.join(".codex").join("skills"));
+        write_dir(&home.join(".codewhale").join("skills"));
+        write_dir(&home.join(".codex").join("skills"));
+
+        let catalog = SkillRootCatalog::build(&workspace, Some(&home), None);
+        let audit: Vec<_> = catalog
+            .audit_compatible_directories()
+            .into_iter()
+            .map(|r| r.path.clone())
+            .collect();
+        assert!(audit.contains(&workspace.join(".codex").join("skills")));
+        assert!(audit.contains(&home.join(".codex").join("skills")));
+
+        let runtime = catalog.runtime_directories(&workspace, SkillDiscoveryMode::Compatible);
+        assert!(!runtime.contains(&workspace.join(".codex").join("skills")));
+        assert!(!runtime.contains(&home.join(".codex").join("skills")));
+    }
+
+    #[test]
+    fn owned_roots_are_writable_and_codewhale_only() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        write_dir(&workspace.join(".agents").join("skills"));
+        write_dir(&workspace.join(".codewhale").join("skills"));
+        write_dir(&home.join(".codewhale").join("skills"));
+        write_dir(&home.join(".agents").join("skills"));
+
+        let catalog = SkillRootCatalog::build(&workspace, Some(&home), None);
+        let owned = catalog.owned_writable_roots();
+        assert_eq!(owned.len(), 2);
+        assert!(owned.iter().all(|r| r.is_writable_owned()));
+
+        let runtime = catalog.runtime_directories(&workspace, SkillDiscoveryMode::CodeWhaleOnly);
+        assert_eq!(
+            runtime,
+            vec![
+                workspace.join(".codewhale").join("skills"),
+                home.join(".codewhale").join("skills"),
+            ]
+        );
+    }
+
+    #[test]
+    fn configured_compatible_path_stays_read_only() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        let agents = workspace.join(".agents").join("skills");
+        write_dir(&workspace);
+        write_dir(&agents);
+
+        let (kind, access, scope) =
+            classify_configured_skills_dir(&workspace, Some(&home), &agents);
+        assert_eq!(
+            kind,
+            SkillRootKind::CompatibleProject(CompatibleHarness::Agents)
+        );
+        assert_eq!(access, SkillRootAccess::ReadOnlyExternal);
+        assert_eq!(scope, SkillScope::Project);
+    }
+
+    #[test]
+    fn safe_display_path_prefers_home_then_workspace() {
+        let home = PathBuf::from("/home/user");
+        let workspace = home.join("proj");
+        let path = home.join(".codewhale").join("skills");
+        assert_eq!(
+            safe_display_path(&path, Some(&workspace), Some(&home)),
+            "~/.codewhale/skills"
+        );
+        let project = workspace.join(".codewhale").join("skills");
+        assert_eq!(
+            safe_display_path(&project, Some(&workspace), Some(&home)),
+            "<workspace>/.codewhale/skills"
+        );
+    }
+}

--- a/crates/tui/src/skills/system.rs
+++ b/crates/tui/src/skills/system.rs
@@ -92,9 +92,40 @@ const BUNDLED_SKILLS: &[BundledSkill] = &[
 /// Used by `/skills` to distinguish user-created skills (which should be
 /// surfaced prominently) from the always-installed bundle (which can be
 /// rendered compactly when many skills are present).
+///
+/// Prefer [`is_exact_bundled_skill`] when classifying audit rows — name-only
+/// matches can collide with user overrides of the same command name.
 #[must_use]
 pub fn is_bundled_skill_name(name: &str) -> bool {
     BUNDLED_SKILLS.iter().any(|s| s.name == name)
+}
+
+/// True when `name` is a bundled skill **and** `skill_md_content` exactly
+/// matches the shipped asset body (byte-for-byte).
+///
+/// Used by the skill audit inventory so a user-edited copy of a bundled name
+/// is not misclassified as built-in.
+#[must_use]
+pub fn is_exact_bundled_skill(name: &str, skill_md_content: &str) -> bool {
+    BUNDLED_SKILLS
+        .iter()
+        .any(|s| s.name == name && s.body == skill_md_content)
+}
+
+/// SHA-256 (hex) of the shipped `SKILL.md` body for a bundled skill, if any.
+#[must_use]
+#[allow(dead_code)] // available for managers / docs that prefer digest over body compare
+pub fn bundled_skill_body_sha256(name: &str) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    BUNDLED_SKILLS.iter().find(|s| s.name == name).map(|s| {
+        let digest = Sha256::digest(s.body.as_bytes());
+        let mut out = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            use std::fmt::Write as _;
+            let _ = write!(&mut out, "{byte:02x}");
+        }
+        out
+    })
 }
 
 /// Attempt to install a single bundled skill into `skills_dir`.

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -7540,6 +7540,8 @@ pub enum AppAction {
     OpenFeedbackPicker,
     /// Open the `/theme` picker modal with live preview of every preset.
     OpenThemePicker,
+    /// Open the `/skills` manager — audit inventory + owned mutations.
+    OpenSkillsManager,
     /// Open the `/fleet` roster — the saved-party view of the agent team.
     OpenFleetRoster,
     /// Open the `/fleet` profile authoring wizard.

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -10738,6 +10738,13 @@ async fn apply_command_result(
                     );
                 }
             }
+            AppAction::OpenSkillsManager => {
+                if app.view_stack.top_kind() != Some(ModalKind::SkillsManager) {
+                    app.view_stack.push(
+                        crate::tui::views::skills_manager::SkillsManagerView::new(app),
+                    );
+                }
+            }
             AppAction::OpenFleetRoster => {
                 if app.view_stack.top_kind() != Some(ModalKind::FleetRoster) {
                     app.view_stack
@@ -12674,6 +12681,119 @@ fn refresh_config_view_if_open(app: &mut App, focus_key: &str) {
     }
 }
 
+fn refresh_skills_manager_if_open(
+    app: &mut App,
+    status: Option<String>,
+    focus: Option<&crate::skills::audit::AuditedSkillId>,
+) {
+    if app.view_stack.top_kind() != Some(ModalKind::SkillsManager) {
+        return;
+    }
+    let Some(mut boxed) = app.view_stack.pop() else {
+        return;
+    };
+    let rebuilt = if let Some(prev) = boxed
+        .as_any_mut()
+        .downcast_mut::<crate::tui::views::skills_manager::SkillsManagerView>()
+    {
+        crate::tui::views::skills_manager::SkillsManagerView::rebuild_preserving(
+            app, prev, status, focus,
+        )
+    } else {
+        crate::tui::views::skills_manager::SkillsManagerView::new(app)
+    };
+    app.view_stack.push(rebuilt);
+}
+
+async fn handle_skill_mutation_requested(
+    app: &mut App,
+    request: crate::skills::mutation::SkillMutationRequest,
+) {
+    use crate::skills::install::{DEFAULT_MAX_SIZE_BYTES, DEFAULT_REGISTRY_URL};
+    use crate::skills::mutation::{MutationContext, SkillMutationOutcome, SkillMutationRequest};
+
+    let focus = match &request {
+        SkillMutationRequest::ImportExternal { source_id, .. } => Some(source_id.clone()),
+        SkillMutationRequest::Update { skill_id, .. }
+        | SkillMutationRequest::Remove { skill_id, .. }
+        | SkillMutationRequest::Trust { skill_id, .. } => Some(skill_id.clone()),
+        SkillMutationRequest::InstallRemote { .. }
+        | SkillMutationRequest::UpdateByName { .. }
+        | SkillMutationRequest::RemoveByName { .. }
+        | SkillMutationRequest::TrustByName { .. } => None,
+    };
+
+    let workspace = app.workspace.clone();
+    let home = dirs::home_dir();
+    let cfg = crate::config::Config::load(None, None).unwrap_or_default();
+    let network = cfg
+        .network
+        .clone()
+        .map(|policy| policy.into_runtime())
+        .unwrap_or_default();
+    let skills_cfg = cfg.skills.as_ref();
+    let max_size = skills_cfg
+        .and_then(|s| s.max_install_size_bytes)
+        .unwrap_or(DEFAULT_MAX_SIZE_BYTES);
+    let registry_url = skills_cfg
+        .and_then(|s| s.registry_url.clone())
+        .unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string());
+
+    let skills_dir = app.skills_dir.clone();
+    let result = {
+        let ctx = MutationContext {
+            workspace: &workspace,
+            home: home.as_deref(),
+            configured_skills_dir: Some(skills_dir.as_path()),
+            network: &network,
+            max_size,
+            registry_url: &registry_url,
+        };
+        crate::skills::mutation::execute(request, &ctx).await
+    };
+
+    let (status, refresh_skills) = match result {
+        Ok(receipt) => {
+            let msg = match &receipt.outcome {
+                SkillMutationOutcome::Installed => {
+                    format!("Installed '{}' → {}", receipt.name, receipt.safe_target_path)
+                }
+                SkillMutationOutcome::Updated => format!("Updated '{}'", receipt.name),
+                SkillMutationOutcome::NoChange => {
+                    format!("'{}': no upstream change", receipt.name)
+                }
+                SkillMutationOutcome::Removed => format!("Removed '{}'", receipt.name),
+                SkillMutationOutcome::Trusted => format!("Trusted '{}'", receipt.name),
+                SkillMutationOutcome::Imported => {
+                    format!("Imported '{}' → {}", receipt.name, receipt.safe_target_path)
+                }
+                SkillMutationOutcome::AlreadyPresent => {
+                    format!("'{}' already present (exact duplicate)", receipt.name)
+                }
+                SkillMutationOutcome::NeedsApproval(host) => {
+                    format!("Needs network approval for {host}")
+                }
+                SkillMutationOutcome::NetworkDenied(host) => {
+                    format!("Network denied for {host}")
+                }
+            };
+            let refresh = !matches!(
+                receipt.outcome,
+                SkillMutationOutcome::NeedsApproval(_) | SkillMutationOutcome::NetworkDenied(_)
+            );
+            (msg, refresh)
+        }
+        Err(err) => (format!("Skill mutation failed: {err:#}"), false),
+    };
+
+    app.status_message = Some(status.clone());
+    if refresh_skills {
+        app.refresh_skill_cache();
+    }
+    refresh_skills_manager_if_open(app, Some(status), focus.as_ref());
+    app.needs_redraw = true;
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_config_updated(
     terminal: &mut AppTerminal,
@@ -13592,6 +13712,22 @@ async fn handle_view_events(
                 }
             }
             ViewEvent::ContextMenuSelected { action } => handle_context_menu_action(app, action),
+            ViewEvent::SkillMutationRequested { request } => {
+                handle_skill_mutation_requested(app, request).await;
+            }
+            ViewEvent::SkillsManagerToggleCompatible => {
+                if app.view_stack.top_kind() == Some(ModalKind::SkillsManager)
+                    && let Some(mut boxed) = app.view_stack.pop()
+                {
+                    if let Some(view) = boxed
+                        .as_any_mut()
+                        .downcast_mut::<crate::tui::views::skills_manager::SkillsManagerView>()
+                    {
+                        crate::tui::views::skills_manager::apply_toggle_compatible(view, app);
+                    }
+                    app.view_stack.push_boxed(boxed);
+                }
+            }
         }
     }
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -28,6 +28,7 @@ use crate::tui::widgets::agent_card::AgentLifecycle;
 pub mod fleet_roster;
 pub mod fleet_setup;
 pub mod mode_picker;
+pub mod skills_manager;
 pub mod status_picker;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,6 +57,7 @@ pub enum ModalKind {
     ThemePicker,
     ContextMenu,
     ContextInspector,
+    SkillsManager,
 }
 
 /// Clear and paint a modal popup with an opaque surface.
@@ -904,6 +906,14 @@ pub enum ViewEvent {
         text: String,
         label: String,
     },
+    /// Emitted by the skills manager when the user confirms an install /
+    /// import / update / remove / trust action. The host runs the mutation
+    /// controller and rebuilds the open manager view.
+    SkillMutationRequested {
+        request: crate::skills::mutation::SkillMutationRequest,
+    },
+    /// Toggle owned-only vs compatible audit scan inside the skills manager.
+    SkillsManagerToggleCompatible,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/tui/src/tui/views/skills_manager.rs
+++ b/crates/tui/src/tui/views/skills_manager.rs
@@ -3,7 +3,7 @@
 //! This view never writes files. Keys emit [`ViewEvent::SkillMutationRequested`];
 //! the host runs [`crate::skills::mutation`] and rebuilds the view.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -741,7 +741,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::tui::app::{App, TuiOptions};
-    use crossterm::event::KeyEventKind;
+    use crossterm::event::{KeyEventKind, KeyModifiers};
     use std::ffi::OsString;
     use std::fs;
     use tempfile::TempDir;
@@ -898,5 +898,102 @@ mod tests {
             }
         }
         assert!(found, "expected Skills title on 80x24 surface");
+    }
+
+    #[test]
+    fn import_replace_confirm_is_scoped_to_import_target() {
+        let tmp = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmp);
+        let workspace = tmp.path().join("ws");
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+
+        // Project-owned conflict only — Global import must not prompt replace.
+        write_skill_pkg(
+            &workspace.join(".codewhale").join("skills").join("shared"),
+            "shared",
+            "owned-project",
+        );
+        write_skill_pkg(
+            &workspace.join(".claude").join("skills").join("shared"),
+            "shared",
+            "external-different",
+        );
+
+        let mut app = app_in(&tmp);
+        app.workspace = workspace;
+        // Force HOME for scan so global root is the isolated home.
+        let mut view = SkillsManagerView::from_scan(
+            &app,
+            ManagerMode::Compatible,
+            SkillTargetScope::Global,
+            None,
+            None,
+        );
+        // Select the external row.
+        let ext_idx = view
+            .skills
+            .iter()
+            .position(|s| s.source_kind == SkillSourceKind::CompatibleExternal)
+            .expect("external skill");
+        view.selected = ext_idx;
+
+        let action = view.handle_key(key(KeyCode::Char('i')));
+        assert!(
+            matches!(
+                action,
+                ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                    request: SkillMutationRequest::ImportExternal {
+                        conflict_policy: ConflictPolicy::Reject,
+                        ..
+                    },
+                })
+            ),
+            "global import must not treat project-owned peer as replace: {action:?}"
+        );
+        assert!(view.pending.is_none());
+
+        view.import_scope = SkillTargetScope::Project;
+        let action = view.handle_key(key(KeyCode::Char('i')));
+        assert!(matches!(action, ViewAction::None));
+        assert!(
+            matches!(view.pending, Some(PendingConfirm::ImportReplace { .. })),
+            "project import should confirm replace against project-owned peer"
+        );
+        assert!(home.exists());
+    }
+
+    #[test]
+    fn compatible_scan_includes_configured_skills_dir() {
+        let tmp = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmp);
+        let workspace = tmp.path().join("ws");
+        let configured = tmp.path().join("custom-skills");
+        write_skill_pkg(&configured.join("custom-one"), "custom-one", "from-config");
+
+        let mut app = app_in(&tmp);
+        app.workspace = workspace;
+        app.skills_dir = configured;
+
+        let view = SkillsManagerView::from_scan(
+            &app,
+            ManagerMode::Compatible,
+            SkillTargetScope::Global,
+            None,
+            None,
+        );
+        assert!(
+            view.skills.iter().any(|s| s.name == "custom-one"),
+            "configured skills_dir rows must appear in compatible scan"
+        );
+    }
+
+    fn write_skill_pkg(dir: &std::path::Path, name: &str, body: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: d\n---\n{body}\n"),
+        )
+        .unwrap();
     }
 }

--- a/crates/tui/src/tui/views/skills_manager.rs
+++ b/crates/tui/src/tui/views/skills_manager.rs
@@ -1,0 +1,902 @@
+//! Unified `/skills` manager — audit inventory + mutation actions.
+//!
+//! This view never writes files. Keys emit [`ViewEvent::SkillMutationRequested`];
+//! the host runs [`crate::skills::mutation`] and rebuilds the view.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
+};
+
+use crate::palette;
+use crate::skills::audit::{
+    AuditedSkill, AuditedSkillId, DigestState, IntegrityState, ParserState, PrecedenceState,
+    ProvenanceState, SkillActionKind, SkillAuditMode, SkillAuditSnapshot, SkillSourceKind,
+    TrustState, scan_with_configured,
+};
+use crate::skills::mutation::{ConflictPolicy, SkillMutationRequest, SkillTargetScope};
+use crate::skills::roots::SkillRootKind;
+use crate::tui::app::App;
+use super::{
+    ActionHint, EmptyState, ListDetailLayout, ModalKind, ModalView, ViewAction, ViewEvent,
+    render_modal_footer, render_underwater_surface, truncate_view_text,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ManagerMode {
+    OwnedOnly,
+    Compatible,
+}
+
+impl ManagerMode {
+    fn audit_mode(self) -> SkillAuditMode {
+        match self {
+            Self::OwnedOnly => SkillAuditMode::OwnedOnly,
+            Self::Compatible => SkillAuditMode::Compatible,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::OwnedOnly => "owned",
+            Self::Compatible => "compatible",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PendingConfirm {
+    Remove {
+        skill_id: AuditedSkillId,
+        digest: Option<String>,
+    },
+    ImportReplace {
+        skill_id: AuditedSkillId,
+        digest: String,
+    },
+}
+
+pub struct SkillsManagerView {
+    mode: ManagerMode,
+    skills: Vec<AuditedSkill>,
+    selected: usize,
+    detail_scroll: usize,
+    import_scope: SkillTargetScope,
+    pending: Option<PendingConfirm>,
+    status: Option<String>,
+}
+
+impl SkillsManagerView {
+    #[must_use]
+    pub fn new(app: &App) -> Self {
+        Self::from_scan(app, ManagerMode::OwnedOnly, SkillTargetScope::Global, None, None)
+    }
+
+    #[must_use]
+    pub fn rebuild_preserving(
+        app: &App,
+        previous: &Self,
+        status: Option<String>,
+        focus: Option<&AuditedSkillId>,
+    ) -> Self {
+        let mut view = Self::from_scan(
+            app,
+            previous.mode,
+            previous.import_scope,
+            status,
+            focus.or_else(|| previous.selected_skill().map(|s| &s.id)),
+        );
+        view.detail_scroll = 0;
+        view
+    }
+
+    fn from_scan(
+        app: &App,
+        mode: ManagerMode,
+        import_scope: SkillTargetScope,
+        status: Option<String>,
+        focus: Option<&AuditedSkillId>,
+    ) -> Self {
+        let snap = scan_snapshot(app, mode);
+        let mut view = Self {
+            mode,
+            skills: snap.skills,
+            selected: 0,
+            detail_scroll: 0,
+            import_scope,
+            pending: None,
+            status,
+        };
+        if let Some(id) = focus {
+            if let Some(idx) = view.skills.iter().position(|s| &s.id == id) {
+                view.selected = idx;
+            }
+        }
+        view.clamp_selection();
+        view
+    }
+
+    fn selected_skill(&self) -> Option<&AuditedSkill> {
+        self.skills.get(self.selected)
+    }
+
+    fn clamp_selection(&mut self) {
+        if self.skills.is_empty() {
+            self.selected = 0;
+            return;
+        }
+        self.selected = self.selected.min(self.skills.len() - 1);
+    }
+
+    fn move_sel(&mut self, delta: isize) {
+        if self.skills.is_empty() {
+            return;
+        }
+        let len = self.skills.len() as isize;
+        let next = (self.selected as isize + delta).rem_euclid(len) as usize;
+        self.selected = next;
+        self.detail_scroll = 0;
+        self.pending = None;
+    }
+
+    fn toggle_mode(&mut self, app: &App) {
+        self.mode = match self.mode {
+            ManagerMode::OwnedOnly => ManagerMode::Compatible,
+            ManagerMode::Compatible => ManagerMode::OwnedOnly,
+        };
+        let snap = scan_with_configured(
+            &app.workspace,
+            dirs::home_dir().as_deref(),
+            Some(&app.skills_dir),
+            self.mode.audit_mode(),
+            None,
+        );
+        let focus = self.selected_skill().map(|s| s.id.clone());
+        self.skills = snap.skills;
+        self.pending = None;
+        self.detail_scroll = 0;
+        self.status = Some(format!("Scan mode: {}", self.mode.label()));
+        if let Some(id) = focus {
+            if let Some(idx) = self.skills.iter().position(|s| s.id == id) {
+                self.selected = idx;
+            } else {
+                self.selected = 0;
+            }
+        } else {
+            self.selected = 0;
+        }
+        self.clamp_selection();
+    }
+
+    fn cycle_import_scope(&mut self) {
+        self.import_scope = match self.import_scope {
+            SkillTargetScope::Global => SkillTargetScope::Project,
+            SkillTargetScope::Project => SkillTargetScope::Global,
+        };
+        self.status = Some(format!(
+            "Import target: {}",
+            scope_label(self.import_scope)
+        ));
+    }
+
+    fn emit_action(&mut self, kind: SkillActionKind) -> ViewAction {
+        let Some(skill) = self.selected_skill().cloned() else {
+            return ViewAction::None;
+        };
+        if !skill.available_actions.contains(&kind) {
+            self.status = Some(format!(
+                "{} is not available for '{}'",
+                action_label(kind),
+                skill.name
+            ));
+            return ViewAction::None;
+        }
+
+        match kind {
+            SkillActionKind::Remove => {
+                let digest = match &skill.digest {
+                    DigestState::Known(d) => Some(d.clone()),
+                    DigestState::Unknown(_) => None,
+                };
+                self.pending = Some(PendingConfirm::Remove {
+                    skill_id: skill.id.clone(),
+                    digest,
+                });
+                self.status = Some(format!(
+                    "Remove '{}'? Press Enter to confirm, Esc to cancel.",
+                    skill.name
+                ));
+                ViewAction::None
+            }
+            SkillActionKind::Import => {
+                let DigestState::Known(digest) = &skill.digest else {
+                    self.status = Some("Import requires a known package digest".into());
+                    return ViewAction::None;
+                };
+                let want_kind = match self.import_scope {
+                    SkillTargetScope::Project => SkillRootKind::CodeWhaleProject,
+                    SkillTargetScope::Global => SkillRootKind::CodeWhaleGlobal,
+                };
+                // Only treat same-scope owned peers as replace conflicts — the
+                // mutation controller replaces inside `import_scope` alone.
+                let owned_conflict = self.skills.iter().any(|peer| {
+                    peer.id.canonical_name == skill.id.canonical_name
+                        && peer.root.is_writable_owned()
+                        && peer.root.kind == want_kind
+                        && peer.id != skill.id
+                        && match &peer.digest {
+                            DigestState::Known(other) => other != digest,
+                            DigestState::Unknown(_) => true,
+                        }
+                });
+                if owned_conflict {
+                    self.pending = Some(PendingConfirm::ImportReplace {
+                        skill_id: skill.id.clone(),
+                        digest: digest.clone(),
+                    });
+                    self.status = Some(format!(
+                        "'{}' conflicts with {} owned copy. Enter = replace, Esc = cancel.",
+                        skill.name,
+                        scope_label(self.import_scope)
+                    ));
+                    return ViewAction::None;
+                }
+                ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                    request: SkillMutationRequest::ImportExternal {
+                        source_id: skill.id.clone(),
+                        expected_digest: digest.clone(),
+                        target: self.import_scope,
+                        conflict_policy: ConflictPolicy::Reject,
+                    },
+                })
+            }
+            SkillActionKind::Update => ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                request: SkillMutationRequest::Update {
+                    skill_id: skill.id.clone(),
+                    expected_digest: known_digest(&skill),
+                },
+            }),
+            SkillActionKind::Trust => {
+                let Some(digest) = known_digest(&skill) else {
+                    self.status = Some("Trust requires a known package digest".into());
+                    return ViewAction::None;
+                };
+                ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                    request: SkillMutationRequest::Trust {
+                        skill_id: skill.id.clone(),
+                        expected_digest: digest,
+                    },
+                })
+            }
+            SkillActionKind::Install => {
+                self.status = Some(
+                    "Install from registry: /skill install [--project|--global] <spec>".into(),
+                );
+                ViewAction::None
+            }
+        }
+    }
+
+    fn confirm_pending(&mut self) -> ViewAction {
+        match self.pending.take() {
+            Some(PendingConfirm::Remove { skill_id, digest }) => {
+                ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                    request: SkillMutationRequest::Remove {
+                        skill_id,
+                        expected_digest: digest,
+                    },
+                })
+            }
+            Some(PendingConfirm::ImportReplace { skill_id, digest }) => {
+                ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                    request: SkillMutationRequest::ImportExternal {
+                        source_id: skill_id,
+                        expected_digest: digest,
+                        target: self.import_scope,
+                        conflict_policy: ConflictPolicy::ReplaceConfirmed,
+                    },
+                })
+            }
+            None => {
+                // Primary action for selection.
+                let Some(skill) = self.selected_skill() else {
+                    return ViewAction::None;
+                };
+                let Some(kind) = skill.available_actions.first().copied() else {
+                    self.status = Some(format!("No actions available for '{}'", skill.name));
+                    return ViewAction::None;
+                };
+                self.emit_action(kind)
+            }
+        }
+    }
+
+    fn footer_hints(&self) -> Vec<ActionHint> {
+        if self.pending.is_some() {
+            return vec![
+                ActionHint::new("Enter", "confirm"),
+                ActionHint::new("Esc", "cancel"),
+            ];
+        }
+        let mut hints = vec![
+            ActionHint::new("↑/↓", "select"),
+            ActionHint::new("Enter", "action"),
+            ActionHint::new("c", "scan mode"),
+            ActionHint::new("s", "import scope"),
+            ActionHint::new("Esc", "close"),
+        ];
+        if let Some(skill) = self.selected_skill() {
+            for action in &skill.available_actions {
+                match action {
+                    SkillActionKind::Import => hints.insert(2, ActionHint::new("i", "import")),
+                    SkillActionKind::Update => hints.insert(2, ActionHint::new("u", "update")),
+                    SkillActionKind::Remove => hints.insert(2, ActionHint::new("r", "remove")),
+                    SkillActionKind::Trust => hints.insert(2, ActionHint::new("t", "trust")),
+                    SkillActionKind::Install => {}
+                }
+            }
+        }
+        hints
+    }
+
+    fn render_list(&self, area: Rect, buf: &mut Buffer) {
+        let block = Block::default()
+            .title(Line::from(Span::styled(
+                format!(" Skills ({}) ", self.skills.len()),
+                Style::default()
+                    .fg(palette::WHALE_ACTION)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::WHALE_BG));
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        if self.skills.is_empty() {
+            EmptyState::new(
+                "No skills in this scan",
+                "Press c to include compatible roots, or /skill install <spec>.",
+            )
+            .render(inner, buf);
+            return;
+        }
+
+        let visible = usize::from(inner.height).max(1);
+        let offset = self
+            .selected
+            .saturating_add(1)
+            .saturating_sub(visible);
+        let end = (offset + visible).min(self.skills.len());
+
+        for (row, idx) in (offset..end).enumerate() {
+            let skill = &self.skills[idx];
+            let y = inner.y + row as u16;
+            if y >= inner.y + inner.height {
+                break;
+            }
+            let selected = idx == self.selected;
+            let style = if selected {
+                Style::default()
+                    .bg(palette::SURFACE_ELEVATED)
+                    .fg(palette::WHALE_INFO)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(palette::TEXT_PRIMARY)
+            };
+            let mark = if selected { "›" } else { " " };
+            let line = format!(
+                "{mark} {}  {}  {}",
+                truncate_view_text(&skill.name, 22),
+                precedence_label(&skill.precedence),
+                source_label(skill.source_kind),
+            );
+            buf.set_stringn(inner.x, y, line, usize::from(inner.width), style);
+        }
+    }
+
+    fn render_detail(&self, area: Rect, buf: &mut Buffer) {
+        let block = Block::default()
+            .title(Line::from(Span::styled(
+                " Detail ",
+                Style::default()
+                    .fg(palette::WHALE_ACTION)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::WHALE_BG));
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        let Some(skill) = self.selected_skill() else {
+            EmptyState::new("Nothing selected", "Install or import a skill to get started.")
+                .render(inner, buf);
+            return;
+        };
+
+        let mut lines = vec![
+            Line::from(Span::styled(
+                skill.name.clone(),
+                Style::default()
+                    .fg(palette::WHALE_INFO)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            kv_line("Path", &skill.safe_display_path),
+            kv_line("Source", source_label(skill.source_kind)),
+            kv_line("Status", &precedence_label(&skill.precedence)),
+            kv_line("Integrity", integrity_label(&skill.integrity)),
+            kv_line("Trust", trust_label(&skill.trust)),
+            kv_line("Parser", &parser_label(&skill.parser)),
+            kv_line("Digest", &digest_label(&skill.digest)),
+            kv_line("Provenance", &provenance_label(&skill.provenance)),
+            kv_line("Readiness", "unknown"),
+            kv_line("Import to", scope_label(self.import_scope)),
+            kv_line("Scan", self.mode.label()),
+        ];
+
+        if let Some(desc) = skill.description.as_deref() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Description",
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+            lines.push(Line::from(truncate_view_text(desc, 240)));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Actions",
+            Style::default().fg(palette::TEXT_MUTED),
+        )));
+        if skill.available_actions.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "(none — read-only or not managed)",
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        } else {
+            let labels: Vec<&str> = skill
+                .available_actions
+                .iter()
+                .map(|a| action_label(*a))
+                .collect();
+            lines.push(Line::from(labels.join(", ")));
+        }
+
+        if !skill.warnings.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Warnings",
+                Style::default().fg(palette::STATUS_WARNING),
+            )));
+            for w in &skill.warnings {
+                match w {
+                    crate::skills::audit::SkillAuditWarning::Message(msg) => {
+                        lines.push(Line::from(format!("• {msg}")));
+                    }
+                }
+            }
+        }
+
+        if let Some(status) = &self.status {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                status.clone(),
+                Style::default().fg(palette::WHALE_ACTION),
+            )));
+        }
+
+        let scroll = self.detail_scroll.min(lines.len().saturating_sub(1));
+        let visible: Vec<Line> = lines.into_iter().skip(scroll).collect();
+        Paragraph::new(visible)
+            .wrap(Wrap { trim: false })
+            .style(Style::default().fg(palette::TEXT_PRIMARY))
+            .render(inner, buf);
+    }
+}
+
+fn scan_snapshot(app: &App, mode: ManagerMode) -> SkillAuditSnapshot {
+    scan_with_configured(
+        &app.workspace,
+        dirs::home_dir().as_deref(),
+        Some(&app.skills_dir),
+        mode.audit_mode(),
+        None,
+    )
+}
+
+fn known_digest(skill: &AuditedSkill) -> Option<String> {
+    match &skill.digest {
+        DigestState::Known(d) => Some(d.clone()),
+        DigestState::Unknown(_) => None,
+    }
+}
+
+fn scope_label(scope: SkillTargetScope) -> &'static str {
+    match scope {
+        SkillTargetScope::Project => "project",
+        SkillTargetScope::Global => "global",
+    }
+}
+
+fn action_label(kind: SkillActionKind) -> &'static str {
+    match kind {
+        SkillActionKind::Install => "install",
+        SkillActionKind::Import => "import",
+        SkillActionKind::Update => "update",
+        SkillActionKind::Remove => "remove",
+        SkillActionKind::Trust => "trust",
+    }
+}
+
+fn source_label(kind: SkillSourceKind) -> &'static str {
+    match kind {
+        SkillSourceKind::CodeWhaleManaged => "managed",
+        SkillSourceKind::CodeWhaleManual => "manual",
+        SkillSourceKind::CompatibleExternal => "external",
+        SkillSourceKind::BuiltIn => "built-in",
+        SkillSourceKind::ReviewedPluginSnapshot => "plugin",
+        SkillSourceKind::RegistryCache => "cache",
+    }
+}
+
+fn precedence_label(state: &PrecedenceState) -> String {
+    match state {
+        PrecedenceState::Active => "active".into(),
+        PrecedenceState::ShadowedBy(id) => format!("shadowed:{}", id.canonical_name),
+        PrecedenceState::InactiveSource => "inactive".into(),
+        PrecedenceState::Unknown => "unknown".into(),
+    }
+}
+
+fn integrity_label(state: &IntegrityState) -> &'static str {
+    match state {
+        IntegrityState::Healthy => "healthy",
+        IntegrityState::LocalContentDrift => "drift",
+        IntegrityState::BrokenManagedInstall => "broken",
+        IntegrityState::LegacyMetadataUnknown => "legacy",
+        IntegrityState::Unknown => "unknown",
+    }
+}
+
+fn trust_label(state: &TrustState) -> &'static str {
+    match state {
+        TrustState::TrustedForDigest(_) => "trusted",
+        TrustState::TrustStale => "stale",
+        TrustState::LegacyAdvisory => "legacy",
+        TrustState::Untrusted => "untrusted",
+        TrustState::NotApplicable => "n/a",
+        TrustState::Unknown => "unknown",
+    }
+}
+
+fn parser_label(state: &ParserState) -> String {
+    match state {
+        ParserState::Valid => "valid".into(),
+        ParserState::Warning(ws) => format!("warning({})", ws.len()),
+        ParserState::Broken(msg) => format!("broken:{msg}"),
+        ParserState::Oversized => "oversized".into(),
+    }
+}
+
+fn digest_label(state: &DigestState) -> String {
+    match state {
+        DigestState::Known(d) => {
+            if d.len() > 12 {
+                format!("{}…", &d[..12])
+            } else {
+                d.clone()
+            }
+        }
+        DigestState::Unknown(reason) => format!("unknown:{reason:?}"),
+    }
+}
+
+fn provenance_label(state: &ProvenanceState) -> String {
+    match state {
+        ProvenanceState::Managed { spec, .. } => {
+            spec.clone().unwrap_or_else(|| "managed".into())
+        }
+        ProvenanceState::Manual => "manual".into(),
+        ProvenanceState::External => "external".into(),
+        ProvenanceState::BuiltIn => "built-in".into(),
+        ProvenanceState::Plugin => "plugin".into(),
+        ProvenanceState::Cache => "cache".into(),
+        ProvenanceState::Unknown => "unknown".into(),
+    }
+}
+
+fn kv_line(key: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{key:<11}"),
+            Style::default().fg(palette::TEXT_MUTED),
+        ),
+        Span::raw(value.to_string()),
+    ])
+}
+
+impl ModalView for SkillsManagerView {
+    fn kind(&self) -> ModalKind {
+        ModalKind::SkillsManager
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> ViewAction {
+        if self.pending.is_some() {
+            return match key.code {
+                KeyCode::Esc => {
+                    self.pending = None;
+                    self.status = Some("Cancelled.".into());
+                    ViewAction::None
+                }
+                KeyCode::Enter => self.confirm_pending(),
+                _ => ViewAction::None,
+            };
+        }
+
+        match key.code {
+            KeyCode::Esc => ViewAction::Close,
+            KeyCode::Char('q') | KeyCode::Char('Q') if key.modifiers.is_empty() => {
+                ViewAction::Close
+            }
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => {
+                self.move_sel(-1);
+                ViewAction::None
+            }
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
+                self.move_sel(1);
+                ViewAction::None
+            }
+            KeyCode::PageUp => {
+                self.detail_scroll = self.detail_scroll.saturating_sub(8);
+                ViewAction::None
+            }
+            KeyCode::PageDown => {
+                self.detail_scroll = self.detail_scroll.saturating_add(8);
+                ViewAction::None
+            }
+            KeyCode::Home => {
+                self.detail_scroll = 0;
+                ViewAction::None
+            }
+            KeyCode::Enter => self.confirm_pending(),
+            KeyCode::Char('i') | KeyCode::Char('I') if key.modifiers.is_empty() => {
+                self.emit_action(SkillActionKind::Import)
+            }
+            KeyCode::Char('u') | KeyCode::Char('U') if key.modifiers.is_empty() => {
+                self.emit_action(SkillActionKind::Update)
+            }
+            KeyCode::Char('r') | KeyCode::Char('R') if key.modifiers.is_empty() => {
+                self.emit_action(SkillActionKind::Remove)
+            }
+            KeyCode::Char('t') | KeyCode::Char('T') if key.modifiers.is_empty() => {
+                self.emit_action(SkillActionKind::Trust)
+            }
+            KeyCode::Char('c') | KeyCode::Char('C') if key.modifiers.is_empty() => {
+                ViewAction::Emit(ViewEvent::SkillsManagerToggleCompatible)
+            }
+            KeyCode::Char('s') | KeyCode::Char('S') if key.modifiers.is_empty() => {
+                self.cycle_import_scope();
+                ViewAction::None
+            }
+            _ => ViewAction::None,
+        }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        let body = render_underwater_surface(area, buf, "Skills Manager");
+        let hints = self.footer_hints();
+        let content = render_modal_footer(body, buf, &hints);
+
+        let header_h = 2u16.min(content.height);
+        let header = Rect {
+            x: content.x,
+            y: content.y,
+            width: content.width,
+            height: header_h,
+        };
+        let mode_line = format!(
+            "  scan={}   import-target={}   {}",
+            self.mode.label(),
+            scope_label(self.import_scope),
+            self.status.as_deref().unwrap_or("j/k move · actions in footer")
+        );
+        buf.set_stringn(
+            header.x,
+            header.y,
+            truncate_view_text(&mode_line, usize::from(header.width)),
+            usize::from(header.width),
+            Style::default().fg(palette::TEXT_SECONDARY),
+        );
+
+        let panel = Rect {
+            x: content.x,
+            y: content.y.saturating_add(header_h),
+            width: content.width,
+            height: content.height.saturating_sub(header_h),
+        };
+        let layout = ListDetailLayout::split(panel, 34);
+        self.render_list(layout.list, buf);
+        self.render_detail(layout.detail, buf);
+    }
+}
+
+/// Apply scan-mode toggle using the live app workspace (host-driven).
+pub fn apply_toggle_compatible(view: &mut SkillsManagerView, app: &App) {
+    view.toggle_mode(app);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::tui::app::{App, TuiOptions};
+    use crossterm::event::KeyEventKind;
+    use std::ffi::OsString;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        }
+    }
+
+    struct IsolatedHome {
+        _lock: crate::test_support::TestEnvLock,
+        home_prev: Option<OsString>,
+        userprofile_prev: Option<OsString>,
+    }
+
+    impl IsolatedHome {
+        fn new(tmpdir: &TempDir) -> Self {
+            let lock = crate::test_support::lock_test_env();
+            let home = tmpdir.path().join("home");
+            fs::create_dir_all(&home).unwrap();
+            let home_prev = std::env::var_os("HOME");
+            let userprofile_prev = std::env::var_os("USERPROFILE");
+            // SAFETY: serialized by TestEnvLock in this crate's tests.
+            unsafe {
+                std::env::set_var("HOME", &home);
+                std::env::set_var("USERPROFILE", &home);
+            }
+            Self {
+                _lock: lock,
+                home_prev,
+                userprofile_prev,
+            }
+        }
+    }
+
+    impl Drop for IsolatedHome {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.home_prev {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+                match &self.userprofile_prev {
+                    Some(v) => std::env::set_var("USERPROFILE", v),
+                    None => std::env::remove_var("USERPROFILE"),
+                }
+            }
+        }
+    }
+
+    fn app_in(tmp: &TempDir) -> App {
+        let workspace = tmp.path().join("ws");
+        fs::create_dir_all(&workspace).unwrap();
+        let options = TuiOptions {
+            model: "deepseek-v4-pro".to_string(),
+            workspace,
+            config_path: None,
+            config_profile: None,
+            allow_shell: false,
+            use_alt_screen: true,
+            use_mouse_capture: false,
+            use_bracketed_paste: true,
+            max_subagents: 1,
+            skills_dir: tmp.path().join("skills"),
+            memory_path: tmp.path().join("memory.md"),
+            notes_path: tmp.path().join("notes.txt"),
+            mcp_config_path: tmp.path().join("mcp.json"),
+            use_memory: false,
+            start_in_agent_mode: false,
+            skip_onboarding: true,
+            yolo: false,
+            resume_session_id: None,
+            initial_input: None,
+        };
+        App::new(options, &Config::default())
+    }
+
+    #[test]
+    fn opens_owned_scan_and_closes_on_esc() {
+        let tmp = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmp);
+        let app = app_in(&tmp);
+        let mut view = SkillsManagerView::new(&app);
+        assert_eq!(view.mode, ManagerMode::OwnedOnly);
+        assert_eq!(view.kind(), ModalKind::SkillsManager);
+        assert!(matches!(view.handle_key(key(KeyCode::Esc)), ViewAction::Close));
+    }
+
+    #[test]
+    fn remove_requires_confirm_then_emits() {
+        let tmp = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmp);
+        let workspace = tmp.path().join("ws");
+        let skill_dir = workspace.join(".codewhale").join("skills").join("demo");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: demo\ndescription: d\n---\nbody\n",
+        )
+        .unwrap();
+        let digest = crate::skills::audit::compute_package_digest(&skill_dir).unwrap();
+        crate::skills::install::write_installed_from_v2(
+            &skill_dir,
+            "github:o/r",
+            None,
+            "src",
+            &digest,
+            "demo",
+        )
+        .unwrap();
+
+        let mut app = app_in(&tmp);
+        app.workspace = workspace;
+        let mut view = SkillsManagerView::new(&app);
+        assert!(!view.skills.is_empty());
+        let action = view.handle_key(key(KeyCode::Char('r')));
+        assert!(matches!(action, ViewAction::None));
+        assert!(view.pending.is_some());
+        let action = view.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            action,
+            ViewAction::Emit(ViewEvent::SkillMutationRequested {
+                request: SkillMutationRequest::Remove { .. },
+            })
+        ));
+    }
+
+    #[test]
+    fn render_fits_narrow_terminal() {
+        let tmp = TempDir::new().unwrap();
+        let _home = IsolatedHome::new(&tmp);
+        let app = app_in(&tmp);
+        let view = SkillsManagerView::new(&app);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+        let mut found = false;
+        for y in 0..area.height {
+            let mut row = String::new();
+            for x in 0..area.width {
+                row.push(
+                    buf.cell((x, y))
+                        .map(|c| c.symbol().chars().next().unwrap_or(' '))
+                        .unwrap_or(' '),
+                );
+            }
+            if row.contains("Skills") {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "expected Skills title on 80x24 surface");
+    }
+}

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -1142,14 +1142,19 @@ fn cancelled_bang_shell_settles_transcript_card() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Regression: `/skills` should reflect the same merged discovery set as the
-/// slash menu and model-visible skills block, not just the first selected
-/// skills directory.
+/// Bare `/skills` opens the unified Skills Manager (owned-only, zero network).
+/// Compatible roots (e.g. `.agents/skills`) appear only after toggling scan mode.
 #[test]
-fn skills_menu_shows_local_and_global_skills() -> anyhow::Result<()> {
+fn skills_opens_manager_owned_then_compatible() -> anyhow::Result<()> {
     let _guard = qa_pty_test_lock();
     let ws = make_sealed_workspace()?;
-    write_skill(ws.user_skills_dir(), "global-alpha", "Global alpha skill")?;
+    // Owned global root — visible in the default owned-only manager scan.
+    write_skill(
+        ws.home().join(".codewhale").join("skills"),
+        "global-alpha",
+        "Global alpha skill",
+    )?;
+    // Compatible external root — hidden until the user presses `c`.
     write_skill(
         ws.workspace().join(".agents").join("skills"),
         "workspace-beta",
@@ -1178,16 +1183,46 @@ fn skills_menu_shows_local_and_global_skills() -> anyhow::Result<()> {
     h.wait_for_text("/skills", KEY_TIMEOUT)?;
     h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(2))?;
     h.send(keys::key::enter())?;
-    h.wait_for_text("Available skills", KEY_TIMEOUT)?;
+    h.wait_for_text("Skills Manager", KEY_TIMEOUT)?;
     h.wait_for_text("global-alpha", KEY_TIMEOUT)?;
-    h.wait_for_text("workspace-beta", KEY_TIMEOUT)?;
 
-    let f = h.frame();
-    let dump = f.debug_dump();
-    assert!(f.contains("global-alpha"), "global skill missing:\n{dump}");
+    let owned = h.frame();
+    let owned_dump = owned.debug_dump();
     assert!(
-        f.contains("workspace-beta"),
-        "workspace skill missing:\n{dump}"
+        owned.contains("global-alpha"),
+        "owned global skill missing:\n{owned_dump}"
+    );
+    assert!(
+        !owned.contains("workspace-beta"),
+        "compatible skill must stay hidden in owned-only scan:\n{owned_dump}"
+    );
+    assert!(
+        !owned.contains("Available skills"),
+        "bare /skills must open manager, not the legacy text list:\n{owned_dump}"
+    );
+    assert!(
+        !owned.contains("Fetching registry") && !owned.contains("registry.json"),
+        "default manager must stay zero-network:\n{owned_dump}"
+    );
+
+    // Toggle to compatible scan so external roots appear.
+    h.send(keys::key::ch('c'))?;
+    h.wait_for_text("workspace-beta", KEY_TIMEOUT)?;
+    let compat = h.frame();
+    let compat_dump = compat.debug_dump();
+    assert!(
+        compat.contains("workspace-beta"),
+        "compatible skill missing after toggle:\n{compat_dump}"
+    );
+
+    h.send(keys::key::esc())?;
+    h.wait_for_idle(Duration::from_millis(300), Duration::from_secs(2))?;
+    h.wait_for_text(COMPOSER_READY_TEXT, KEY_TIMEOUT)?;
+    let after = h.frame();
+    assert!(
+        !after.contains("Skills Manager"),
+        "Esc should close the skills manager:\n{}",
+        after.debug_dump()
     );
 
     let _ = h.shutdown();

--- a/crates/tui/tests/skill_cli.rs
+++ b/crates/tui/tests/skill_cli.rs
@@ -20,10 +20,14 @@ use tiny_http::{Method, Response, Server};
 // Pull the production source files into this test binary so the test can
 // reach `install`'s public surface without a dedicated library crate.
 //
-// `install.rs` only references `crate::network_policy` so we just need that
-// one helper module alongside `install` itself.
+// `install.rs` references `crate::network_policy` and `super::package_digest`
+// (sibling under `skills::`), so both are pulled in alongside `install`.
 #[path = "../src/network_policy.rs"]
 mod network_policy;
+
+#[path = "../src/skills/package_digest.rs"]
+#[allow(dead_code)]
+mod package_digest;
 
 #[path = "../src/skills/install.rs"]
 #[allow(dead_code)]
@@ -175,6 +179,16 @@ async fn install_happy_path_writes_skill_and_marker() {
     assert!(
         installed_dir.join(install::INSTALLED_FROM_MARKER).is_file(),
         ".installed-from marker present"
+    );
+    let marker = std::fs::read_to_string(installed_dir.join(install::INSTALLED_FROM_MARKER))
+        .expect("read marker");
+    assert!(
+        marker.contains("\"schema_version\": 2") || marker.contains("\"schema_version\":2"),
+        "install must write metadata v2: {marker}"
+    );
+    assert!(
+        marker.contains("content_digest"),
+        "install must bind content_digest: {marker}"
     );
 
     shutdown(tx, handle);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,7 +273,12 @@ ordinary durable tasks.
 
 1. Create skill directory with `SKILL.md`
 2. Define skill prompt and optional scripts
-3. Place in `~/.codewhale/skills/`
+3. Place in a CodeWhale-owned root (`~/.codewhale/skills/` or
+   `<workspace>/.codewhale/skills/`), or import from a compatible harness root
+   through `/skills`
+
+See [SKILLS.md](SKILLS.md) for the Skills Manager, audit inventory, and the
+rule that compatible roots (`.claude`, `.agents`, …) are never mutated in place.
 
 ### Adding Hooks
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1453,14 +1453,23 @@ If you are upgrading from older releases:
   agentskills.io-compatible `~/.agents/skills` and the broader Claude-ecosystem
   `~/.claude/skills`. First launch installs versioned bundled skills for common
   workflows including skill creation, delegation, MCP/plugin scaffolding,
-  documents, presentations, spreadsheets, PDFs, and Feishu/Lark. See
+  documents, presentations, spreadsheets, PDFs, and Feishu/Lark. Only
+  CodeWhale-owned roots (`<workspace>/.codewhale/skills` and
+  `~/.codewhale/skills`) are writable install/import targets; compatible harness
+  roots stay read-only. Bare `/skills` opens the Skills Manager (owned-only,
+  zero network). See [SKILLS.md](SKILLS.md) for the manager, audit statuses,
+  provenance markers, and mutation rules, and
   [CLAUDE_PLUGIN_COMPAT.md](CLAUDE_PLUGIN_COMPAT.md) for the supported boundary
   between portable `SKILL.md` bundles and Claude Code plugin runtimes.
 - `[skills].scan_codewhale_only` (bool, default `false`): when `true`, session
   skill discovery ignores cross-tool roots such as `.claude/skills`,
   `.opencode/skills`, `.cursor/skills`, and `~/.agents/skills`. Codewhale still
   scans `<workspace>/.codewhale/skills`, `~/.codewhale/skills`, and any explicit
-  `skills_dir` override.
+  `skills_dir` override. The Skills Manager can still toggle a local compatible
+  audit scan independently of this runtime knob — see [SKILLS.md](SKILLS.md).
+- `[skills].registry_url` / `[skills].max_install_size_bytes` (optional): used by
+  `/skills --remote`, `/skills sync`, and `/skill install|update`. The default
+  manager open path does not contact the registry.
 - `[verifier].enabled` (bool, default `false`): enables automatic
   claim-of-done verifier preview once that runtime trigger is active. The
   manual `run_verifiers` tool is still available when this is false.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -435,8 +435,10 @@ Use skills when a task has a repeatable process:
 - Following a team release checklist.
 - Using a project-specific memory or wiki workflow.
 
-Inside the TUI, `/skill` activates a skill when one is available, and `/skills`
-lists installed skills. The command palette can also surface skill entries
+Inside the TUI, `/skill <name>` activates a skill when one is available, and
+bare `/skills` opens the Skills Manager (owned-only inventory, no network). Use
+`/skills <prefix>`, `/skills inspect`, `/skills --remote`, or `/skills sync`
+for the text/registry paths. The command palette can also surface skill entries
 alongside normal slash commands.
 
 Good skills are narrow. They should tell the model what workflow to follow,
@@ -447,9 +449,10 @@ If a repository has its own instructions, treat them as part of the active
 work. Read the local guidance before editing, and keep any contribution within
 the repository's conventions.
 
-Next: see [CLAUDE_PLUGIN_COMPAT.md](CLAUDE_PLUGIN_COMPAT.md) for
-Claude Code skill/plugin compatibility, and [CONFIGURATION.md](CONFIGURATION.md)
-for config paths and project authority.
+Next: see [SKILLS.md](SKILLS.md) for the manager, ownership, and provenance
+rules; [CLAUDE_PLUGIN_COMPAT.md](CLAUDE_PLUGIN_COMPAT.md) for Claude Code
+skill/plugin compatibility; and [CONFIGURATION.md](CONFIGURATION.md) for config
+paths and project authority.
 
 ## 10. Getting Help
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,0 +1,196 @@
+# Skills Manager
+
+Skills are reusable `SKILL.md` instruction packs. Codewhale discovers them from
+several roots, but **only CodeWhale-owned directories are writable**. The unified
+`/skills` manager is the interactive surface for audit and mutation; slash
+aliases share the same write path.
+
+For Claude Code plugin boundaries, see [CLAUDE_PLUGIN_COMPAT.md](CLAUDE_PLUGIN_COMPAT.md).
+For `skills_dir` and `[skills]` config keys, see [CONFIGURATION.md](CONFIGURATION.md).
+
+## Architecture (four layers)
+
+| Layer | Role |
+| --- | --- |
+| **Root catalog** | Single source of precedence and ownership (`SkillRootCatalog`). |
+| **Audit** | Read-only, unmerged on-disk inventory (status, digest, actions). |
+| **Mutation controller** | Only writer for install / import / update / remove / trust. |
+| **Skills manager view** | TUI: emits events only; never writes files itself. |
+
+Runtime discovery (`SkillRegistry`) still merges skills for the model. Audit
+intentionally does **not** merge — it shows every on-disk copy so conflicts and
+shadowing stay visible.
+
+## Ownership and roots
+
+**Writable (CodeWhale-owned)**
+
+| Scope | Path |
+| --- | --- |
+| Project | `<workspace>/.codewhale/skills/` |
+| Global | `~/.codewhale/skills/` |
+
+**Read-only compatible** (discover / import source only — never mutated in place)
+
+Examples: `<workspace>/.agents/skills`, `./skills`, `.claude/skills`,
+`.cursor/skills`, `.opencode/skills`, `~/.agents/skills`, `~/.claude/skills`,
+and similar harness layouts.
+
+**Audit-only (not runtime-active)**
+
+- `.codex/skills` appears in **compatible** audit scans so operators can see it.
+  It does **not** join the runtime discovery set.
+
+Configured `skills_dir` that is not one of the owned CodeWhale roots stays
+read-only. Discovery and the manager can list it; mutations still target owned
+project/global roots only.
+
+## Slash commands
+
+| Command | Behavior |
+| --- | --- |
+| `/skills` | Opens the Skills Manager (owned-only scan, **no network**). |
+| `/skills <prefix>` | Text list filtered by name prefix. |
+| `/skills inspect` | Text discovery mode, searched directories, and source paths. |
+| `/skills --remote` | Explicit registry listing (network). |
+| `/skills sync` | Explicit registry → local cache sync (network). |
+| `/skill <name>` | Activate a skill for the next turn. |
+| `/skill install [--project\|--global] <spec>` | Install via mutation controller. |
+| `/skill update [--project\|--global] <name>` | Update a managed skill from its registry provenance. |
+| `/skill uninstall [--project\|--global] <name>` | Remove a managed skill. |
+| `/skill trust [--project\|--global] <name>` | Write digest-bound advisory trust. |
+
+Notes:
+
+- There is **no** `/skills audit` subcommand. Use the manager (and `c` to toggle
+  compatible roots) or `/skills inspect` for discovery details.
+- Bare `/skill install <spec>` (no scope flag) installs into the CodeWhale
+  **global** owned root.
+- If the same name exists in both project and global owned roots, update /
+  uninstall / trust require `--project` or `--global`.
+- If a name exists only under a compatible external root, writes are refused;
+  import it through `/skills` instead of editing harness directories.
+
+## Skills Manager (TUI)
+
+Default open path: type `/skills` and confirm. The surface is zero-network on
+open (owned-only audit).
+
+| Key | Action |
+| --- | --- |
+| `↑`/`↓` or `j`/`k` | Move selection |
+| `Enter` | Primary available action / confirm pending prompt |
+| `i` | Import (external → owned) |
+| `u` | Update (managed + registry provenance) |
+| `r` | Remove (managed; confirms first) |
+| `t` | Trust (managed; digest-bound) |
+| `s` | Toggle import target: project ↔ global |
+| `c` | Toggle scan: owned-only ↔ compatible (still local disk only) |
+| `Esc` | Cancel confirm, or close the manager |
+
+The view never calls install helpers or touches the filesystem. It emits a
+mutation request; the host runs the controller, shows a receipt, and rebuilds
+the inventory.
+
+## Audit statuses
+
+Each audited row carries precedence and relationship flags:
+
+| Status | Meaning |
+| --- | --- |
+| **Active** | Highest-precedence copy for that canonical name in the scan. |
+| **Shadowed** | Same name exists at a higher-precedence root. |
+| **Duplicate** | Same canonical name and same package digest as another copy. |
+| **Conflict** | Same canonical name, different package digest. |
+
+External skills with no owned peer (and a valid digest) are **import
+candidates**. Externals that conflict with or exactly duplicate an owned copy
+can still offer Import — duplicate → already present; conflict → confirm replace
+in the selected import scope.
+
+## Provenance and markers
+
+Managed installs write schema **v2** metadata under the skill directory:
+
+**`.installed-from` (v2)** — written last on successful install/import:
+
+```json
+{
+  "schema_version": 2,
+  "spec": "github:owner/repo",
+  "url": "https://…",
+  "source_checksum": "…",
+  "content_digest": "…",
+  "installed_name": "my-skill",
+  "registry_version": null
+}
+```
+
+- `content_digest` is a bounded package tree hash (not SKILL.md alone).
+- Display of URLs strips userinfo, query, and fragment.
+- Imports use a local `import:…` provenance and **cannot** be updated from a
+  registry; re-import or remove them instead.
+- Legacy v1 markers are recognized as managed with
+  `LegacyMetadataUnknown` integrity until refreshed.
+
+**`.trusted` (v2)** — advisory, digest-bound:
+
+```json
+{
+  "schema_version": 2,
+  "content_digest": "…"
+}
+```
+
+Trust records review intent. It does **not** sandbox the skill or auto-approve
+tools. Content updates clear trust so a stale marker cannot outlive the bytes.
+
+Manual skills (owned root, no managed marker) are visible but not
+update/remove/trust through the managed actions.
+
+## Package digest and safety
+
+Audit and mutation share a bounded package digest:
+
+- Regular files only; symlinks that escape the skill root or cycle → fail closed.
+- Caps on total size, file count, and depth.
+- Mutations re-check an expected digest before write (TOCTOU).
+- Import/replace keeps a `.bak` until digest + marker finalize succeed; failure
+  restores the previous owned package.
+
+## Readiness
+
+The audit model has a readiness field and optional provider hook for a future
+readiness cache ([#4407](https://github.com/Hmbown/CodeWhale/issues/4407)).
+Today, when no cache is wired, readiness is always **`Unknown`**. The manager
+does not run readiness probes and does not block mutations on readiness.
+
+## Config knobs
+
+```toml
+# Optional override for discovery preference (not automatically a write target
+# unless it is the CodeWhale project/global owned path).
+skills_dir = "/path/to/skills"
+
+[skills]
+# When true, runtime discovery skips cross-tool roots (.claude, .agents, …).
+# Owned CodeWhale roots and an explicit skills_dir override still apply.
+scan_codewhale_only = false
+
+# Optional registry / install size overrides used by --remote, sync, and install.
+# registry_url = "https://…"
+# max_install_size_bytes = 5242880
+```
+
+See [CONFIGURATION.md](CONFIGURATION.md) for the full config surface.
+
+## Operator checklist
+
+1. Prefer `/skills` for day-to-day management; keep `--remote` / `sync` explicit.
+2. Never hand-edit `.claude` / `.agents` / `.cursor` trees to “install” for
+   Codewhale — import into `.codewhale/skills` instead.
+3. Treat `.trusted` as advisory documentation of review, not a security boundary.
+4. After registry updates that change content, re-trust if you still want the
+   advisory marker.
+5. Dual project+global copies of the same name need an explicit scope flag on
+   CLI mutations.

--- a/docs/architecture/command-dispatch.md
+++ b/docs/architecture/command-dispatch.md
@@ -50,7 +50,7 @@ intentional:
 | `plugins` | Read-only bundle discovery/validation plus explicit trust, enable, disable, revoke, and reload lifecycle commands; legacy executable tools remain separate. |
 | `project` | Project initialization, sharing, LSP, and goal/hunt commands. |
 | `session` | Rename, save, fork/new/load sessions, compaction, purge, relay, and export. |
-| `skills` | Skill listing, execution, review, and restore. |
+| `skills` | Skills Manager (`/skills`), text inspect/remote/sync paths, activation (`/skill`), and managed install/update/uninstall/trust. |
 | `utility` | Attachments, tasks/jobs, MCP, and network. |
 
 ## User Commands

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -4,10 +4,14 @@ GitHub-stewardship and release-QA workflows for maintaining Codewhale, codified 
 `SKILL.md` skills (same format Claude Code and Codewhale both load). They encode the
 workflows used to assemble the v0.8.61 release.
 
+For end-user Skills Manager behavior (ownership, audit, import, trust), see
+[../SKILLS.md](../SKILLS.md).
+
 To activate:
 - **Claude Code:** copy a skill dir into `.claude/skills/` (project) or your user skills dir.
-- **Codewhale:** copy into Codewhale's `skills_dir` (e.g. `~/.codewhale/skills/`), or bundle
-  into `crates/tui/assets/skills/` + register in `crates/tui/src/skills/system.rs` to ship it.
+- **Codewhale:** copy into a CodeWhale-owned root (e.g. `~/.codewhale/skills/`), import via
+  `/skills`, or bundle into `crates/tui/assets/skills/` + register in
+  `crates/tui/src/skills/system.rs` to ship it.
 
 Skills: gh-file-issue, gh-compile-issues, gh-assign-issues, gh-plan-issues, gh-find-prs,
 gh-treasure-hunt, gh-close-issues, gh-credit-harvest, codew-release-qa-sweep.


### PR DESCRIPTION
## Summary

Delivers the Skills lane tracked on the v0.9.1 completion board ([#4650](https://github.com/Hmbown/CodeWhale/issues/4650)): one `/skills` manager for inventory, audit, install/import, update, remove, and trust across CodeWhale-owned and compatible roots.

Refs [#4650](https://github.com/Hmbown/CodeWhale/issues/4650) (board: Skills / `#4651` checkbox).  
Refs [#4651](https://github.com/Hmbown/CodeWhale/issues/4651) (original product contract; issue was closed after `load_skill` listing mode — this PR completes the remaining manager / audit / mutation surface).

- **Root catalog** — single precedence/ownership source; only `.codewhale/skills` (project + global) is writable; `.codex/skills` is audit-only (not runtime).
- **Bounded audit** — unmerged inventory with Active / Shadowed / Duplicate / Conflict, package digests, provenance/trust classification, action policy; readiness stays `Unknown` until #4407.
- **Mutation controller** — sole write path for Install / Import / Update / Remove / Trust; metadata + trust v2; TOCTOU digest checks; external roots never mutated.
- **Skills Manager TUI** — bare `/skills` opens owned-only, zero-network manager; view emits events only; host runs mutations and refreshes.
- **Aliases** — `/skill install|update|uninstall|trust` share the same controller; default install target is global owned.
- **Docs/tests** — `docs/SKILLS.md`, CONFIGURATION/GUIDE links; unit + `skill_cli` + Unix `qa_pty` coverage.

## Commits

1. `refactor(skills): centralize root catalog and precedence`
2. `feat(skills): add bounded audit inventory and status model`
3. `feat(skills): unify validated mutations and managed metadata`
4. `feat(tui): add unified skills manager view`
5. `test(skills): cover roots conflicts mutations and pty behavior`
6. `docs(skills): document manager audit provenance and readiness`

## Test plan

- [ ] `cargo test -p codewhale-tui --bin codewhale-tui --locked skills::roots skills::audit skills::mutation skills_manager`
- [ ] `cargo test -p codewhale-tui --test skill_cli --locked`
- [ ] `cargo test -p codewhale-tui --test qa_pty --locked skills_opens_manager -- --test-threads=1` (Unix)
- [ ] Manual: bare `/skills` opens manager (no registry); `c` shows compatible; Esc closes
- [ ] Manual: import external → owned; remove/trust managed only; sentinel under `.claude/skills` untouched
- [ ] Manual: dual project+global same name requires `--project` / `--global`
- [ ] Confirm docs in `docs/SKILLS.md` match shipped behavior

## Out of scope

- `/skills audit` CLI subcommand (manager + `/skills inspect` cover the need)
- #4407 readiness probes (surface stays `Unknown`)
- Semantic skill comparison / second mutation stack / mutating harness roots