### PR TITLE
feat(minimax): add China / Token Plan provider routes for minimaxi.com

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -21,7 +21,7 @@
 # `api_key` / `base_url` are
 # still read as DeepSeek defaults when `[providers.deepseek]` is absent
 # (backward compatibility).
-provider = "deepseek" # deepseek | deepseek-cn | deepseek-anthropic | nvidia-nim | openai | atlascloud | wanjie-ark | volcengine | openrouter | xiaomi-mimo | novita | fireworks | siliconflow | siliconflow-CN | arcee | moonshot | zai | stepfun | minimax | sglang | vllm | ollama | huggingface | together | qianfan | openai-codex | anthropic | openmodel | deepinfra | sakana | longcat | opencode-go | meta | xai
+provider = "deepseek" # deepseek | deepseek-cn | deepseek-anthropic | nvidia-nim | openai | atlascloud | wanjie-ark | volcengine | openrouter | xiaomi-mimo | novita | fireworks | siliconflow | siliconflow-CN | arcee | moonshot | zai | stepfun | minimax | minimax-cn | minimax-anthropic | minimax-anthropic-cn | sglang | vllm | ollama | huggingface | together | qianfan | openai-codex | anthropic | openmodel | deepinfra | sakana | longcat | opencode-go | meta | xai
 api_key = "YOUR_DEEPSEEK_API_KEY" # must be non-empty
 base_url = "https://api.deepseek.com/beta"
 # provider = "deepseek-cn"                       # legacy alias (official host is still https://api.deepseek.com)
@@ -528,6 +528,27 @@ max_subagents = 10 # optional (1-20)
 # model = "MiniMax-M3"                          # or MiniMax-M2.7, MiniMax-M2.7-highspeed
 # # MiniMax also publishes Anthropic-compatible endpoints:
 # # global https://api.minimax.io/anthropic, China https://api.minimaxi.com/anthropic.
+
+# MiniMax direct OpenAI-compatible endpoint for China / Token Plan keys
+# (https://platform.minimaxi.com). Use this when your API key was issued under
+# platform.minimaxi.com. Falls back to [providers.minimax] for model when unset.
+[providers.minimax-cn]
+# api_key = "YOUR_MINIMAX_TOKEN_PLAN_KEY"
+# base_url = "https://api.minimaxi.com/v1"
+# model = "MiniMax-M3"
+
+# MiniMax Anthropic-compatible endpoint (https://platform.minimax.io)
+[providers.minimax-anthropic]
+# api_key = "YOUR_MINIMAX_API_KEY"
+# base_url = "https://api.minimax.io/anthropic"
+# model = "MiniMax-M3"
+
+# MiniMax Anthropic-compatible endpoint for China / Token Plan keys
+# (https://platform.minimaxi.com). Pair with MINIMAX_API_KEY (Token Plan key).
+[providers.minimax-anthropic-cn]
+# api_key = "YOUR_MINIMAX_TOKEN_PLAN_KEY"
+# base_url = "https://api.minimaxi.com/anthropic"
+# model = "MiniMax-M3"
 
 # Self-hosted SGLang OpenAI-compatible server
 [providers.sglang]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -288,6 +288,24 @@ pub struct ProvidersToml {
     #[serde(
         default,
         skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "minimax-cn",
+        alias = "minimax_CN",
+        alias = "minimax-china"
+    )]
+    pub minimax_cn: ProviderConfigToml,
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
+        alias = "minimax-anthropic-cn",
+        alias = "minimax_anthropic_cn",
+        alias = "minimax-anthropic-CN",
+        alias = "minimax_anthropic_CN",
+        alias = "minimax-token-plan"
+    )]
+    pub minimax_anthropic_cn: ProviderConfigToml,
+    #[serde(
+        default,
+        skip_serializing_if = "ProviderConfigToml::is_empty",
         alias = "deep-infra",
         alias = "deep_infra"
     )]
@@ -443,6 +461,8 @@ impl ProvidersToml {
             ProviderKind::Stepfun => &self.stepfun,
             ProviderKind::Minimax => &self.minimax,
             ProviderKind::MinimaxAnthropic => &self.minimax_anthropic,
+            ProviderKind::MinimaxCN => &self.minimax_cn,
+            ProviderKind::MinimaxAnthropicCN => &self.minimax_anthropic_cn,
             ProviderKind::Deepinfra => &self.deepinfra,
             ProviderKind::Sakana => &self.sakana,
             ProviderKind::LongCat => &self.longcat,
@@ -483,6 +503,8 @@ impl ProvidersToml {
             ProviderKind::Stepfun => &mut self.stepfun,
             ProviderKind::Minimax => &mut self.minimax,
             ProviderKind::MinimaxAnthropic => &mut self.minimax_anthropic,
+            ProviderKind::MinimaxCN => &mut self.minimax_cn,
+            ProviderKind::MinimaxAnthropicCN => &mut self.minimax_anthropic_cn,
             ProviderKind::Deepinfra => &mut self.deepinfra,
             ProviderKind::Sakana => &mut self.sakana,
             ProviderKind::LongCat => &mut self.longcat,
@@ -2346,6 +2368,8 @@ impl ConfigToml {
                 ProviderKind::Stepfun => DEFAULT_STEPFUN_BASE_URL.to_string(),
                 ProviderKind::Minimax => DEFAULT_MINIMAX_BASE_URL.to_string(),
                 ProviderKind::MinimaxAnthropic => DEFAULT_MINIMAX_ANTHROPIC_BASE_URL.to_string(),
+                ProviderKind::MinimaxCN => DEFAULT_MINIMAX_CN_BASE_URL.to_string(),
+                ProviderKind::MinimaxAnthropicCN => DEFAULT_MINIMAX_ANTHROPIC_CN_BASE_URL.to_string(),
                 ProviderKind::Deepinfra => DEFAULT_DEEPINFRA_BASE_URL.to_string(),
                 ProviderKind::Sakana => DEFAULT_SAKANA_BASE_URL.to_string(),
                 ProviderKind::LongCat => DEFAULT_LONGCAT_BASE_URL.to_string(),
@@ -2616,7 +2640,10 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
     }
     if matches!(
         provider,
-        ProviderKind::Minimax | ProviderKind::MinimaxAnthropic
+        ProviderKind::Minimax
+            | ProviderKind::MinimaxAnthropic
+            | ProviderKind::MinimaxCN
+            | ProviderKind::MinimaxAnthropicCN
     ) && let Some(canonical) = canonical_minimax_model_id(model)
     {
         return canonical.to_string();
@@ -2637,6 +2664,8 @@ fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
             | ProviderKind::Stepfun
             | ProviderKind::Minimax
             | ProviderKind::MinimaxAnthropic
+            | ProviderKind::MinimaxCN
+            | ProviderKind::MinimaxAnthropicCN
             | ProviderKind::Qianfan
             | ProviderKind::Ollama
             | ProviderKind::Meta
@@ -3014,7 +3043,10 @@ fn default_model_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Openmodel => DEFAULT_OPENMODEL_MODEL,
         ProviderKind::Zai => DEFAULT_ZAI_MODEL,
         ProviderKind::Stepfun => DEFAULT_STEPFUN_MODEL,
-        ProviderKind::Minimax | ProviderKind::MinimaxAnthropic => DEFAULT_MINIMAX_MODEL,
+        ProviderKind::Minimax
+        | ProviderKind::MinimaxAnthropic
+        | ProviderKind::MinimaxCN
+        | ProviderKind::MinimaxAnthropicCN => DEFAULT_MINIMAX_MODEL,
         ProviderKind::Deepinfra => DEFAULT_DEEPINFRA_MODEL,
         ProviderKind::Sakana => DEFAULT_SAKANA_MODEL,
         ProviderKind::LongCat => DEFAULT_LONGCAT_MODEL,
@@ -3056,6 +3088,8 @@ fn default_base_url_for_provider(provider: ProviderKind) -> &'static str {
         ProviderKind::Stepfun => DEFAULT_STEPFUN_BASE_URL,
         ProviderKind::Minimax => DEFAULT_MINIMAX_BASE_URL,
         ProviderKind::MinimaxAnthropic => DEFAULT_MINIMAX_ANTHROPIC_BASE_URL,
+        ProviderKind::MinimaxCN => DEFAULT_MINIMAX_CN_BASE_URL,
+        ProviderKind::MinimaxAnthropicCN => DEFAULT_MINIMAX_ANTHROPIC_CN_BASE_URL,
         ProviderKind::Deepinfra => DEFAULT_DEEPINFRA_BASE_URL,
         ProviderKind::Sakana => DEFAULT_SAKANA_BASE_URL,
         ProviderKind::LongCat => DEFAULT_LONGCAT_BASE_URL,
@@ -5055,8 +5089,10 @@ impl EnvRuntimeOverrides {
             ProviderKind::Openmodel => self.openmodel_base_url.clone(),
             ProviderKind::Zai => self.zai_base_url.clone(),
             ProviderKind::Stepfun => self.stepfun_base_url.clone(),
-            ProviderKind::Minimax => self.minimax_base_url.clone(),
-            ProviderKind::MinimaxAnthropic => self.minimax_anthropic_base_url.clone(),
+            ProviderKind::Minimax | ProviderKind::MinimaxCN => self.minimax_base_url.clone(),
+            ProviderKind::MinimaxAnthropic | ProviderKind::MinimaxAnthropicCN => {
+                self.minimax_anthropic_base_url.clone()
+            }
             ProviderKind::Deepinfra => self.deepinfra_base_url.clone(),
             ProviderKind::Sakana => self.sakana_base_url.clone(),
             ProviderKind::LongCat => self.longcat_base_url.clone(),
@@ -5090,7 +5126,10 @@ impl EnvRuntimeOverrides {
             ProviderKind::Openmodel => self.openmodel_model.clone(),
             ProviderKind::Zai => self.zai_model.clone(),
             ProviderKind::Stepfun => self.stepfun_model.clone(),
-            ProviderKind::Minimax | ProviderKind::MinimaxAnthropic => self.minimax_model.clone(),
+            ProviderKind::Minimax
+            | ProviderKind::MinimaxAnthropic
+            | ProviderKind::MinimaxCN
+            | ProviderKind::MinimaxAnthropicCN => self.minimax_model.clone(),
             ProviderKind::Deepinfra => self.deepinfra_model.clone(),
             ProviderKind::Sakana => self.sakana_model.clone(),
             ProviderKind::LongCat => self.longcat_model.clone(),

--- a/crates/config/src/provider.rs
+++ b/crates/config/src/provider.rs
@@ -308,6 +308,14 @@ pub const fn credential_help(kind: ProviderKind) -> CredentialHelp {
             docs_url: Some("https://platform.minimax.io/docs/api-reference/api-overview"),
             guidance: "Create a MiniMax API key or subscription-plan key in the user center.",
         },
+        ProviderKind::MinimaxCN | ProviderKind::MinimaxAnthropicCN => CredentialHelp {
+            acquisition: ApiKey,
+            credential_url: Some(
+                "https://platform.minimaxi.com/user-center/basic-information",
+            ),
+            docs_url: Some("https://platform.minimaxi.com/docs/api-reference"),
+            guidance: "Create a MiniMax Token Plan or pay-as-you-go key at platform.minimaxi.com; the api.minimaxi.com endpoint is auto-selected.",
+        },
         ProviderKind::Deepinfra => CredentialHelp {
             acquisition: ApiKey,
             credential_url: Some("https://deepinfra.com/dash/api_keys"),
@@ -921,6 +929,25 @@ provider!(
     aliases: ["mini-max", "mini_max"]
 );
 
+provider!(
+    MinimaxCN,
+    MinimaxCN,
+    "minimax-cn",
+    "MiniMax (China / Token Plan)",
+    DEFAULT_MINIMAX_CN_BASE_URL,
+    DEFAULT_MINIMAX_MODEL,
+    ["MINIMAX_API_KEY"],
+    "minimax_cn",
+    aliases: [
+        "minimax-CN",
+        "minimax_CN",
+        "minimax-china",
+        "minimax_china",
+        "minimax-token-plan",
+        "minimax_token_plan"
+    ]
+);
+
 /// MiniMax route that speaks the Anthropic Messages wire protocol.
 pub struct MinimaxAnthropic;
 
@@ -958,6 +985,62 @@ impl Provider for MinimaxAnthropic {
             "minimax_anthropic",
             "mini-max-anthropic",
             "mini_max_anthropic",
+        ]
+    }
+
+    fn wire(&self) -> WireFormat {
+        WireFormat::AnthropicMessages
+    }
+}
+
+/// MiniMax route hosted at `api.minimaxi.com` that speaks the Anthropic Messages
+/// wire protocol. This is the regional / Token Plan sibling of [`MinimaxAnthropic`]:
+/// users with `platform.minimaxi.com` keys (Token Plan subscriptions issued under
+/// the Chinese platform) point this provider at the same wire endpoint without
+/// having to override `base_url` manually.
+pub struct MinimaxAnthropicCN;
+
+impl Provider for MinimaxAnthropicCN {
+    fn id(&self) -> &'static str {
+        "minimax-anthropic-cn"
+    }
+
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::MinimaxAnthropicCN
+    }
+
+    fn display_name(&self) -> &'static str {
+        "MiniMax Anthropic-compatible (China / Token Plan)"
+    }
+
+    fn default_base_url(&self) -> &'static str {
+        DEFAULT_MINIMAX_ANTHROPIC_CN_BASE_URL
+    }
+
+    fn default_model(&self) -> &'static str {
+        DEFAULT_MINIMAX_MODEL
+    }
+
+    fn env_vars(&self) -> &'static [&'static str] {
+        // Token Plan keys share the same env var as pay-as-you-go keys; codewhale
+        // does not currently distinguish subscription vs. pay-as-you-go routing
+        // — the base URL is what selects the surface.
+        &["MINIMAX_API_KEY"]
+    }
+
+    fn provider_config_key(&self) -> &'static str {
+        "minimax_anthropic_cn"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &[
+            "minimax_anthropic_cn",
+            "minimax-anthropic-CN",
+            "minimax_anthropic_CN",
+            "minimax-anthropic-china",
+            "minimax-china-anthropic",
+            "minimax-token-plan",
+            "minimax_token_plan",
         ]
     }
 
@@ -1125,7 +1208,9 @@ static OPENMODEL: Openmodel = Openmodel;
 static ZAI: Zai = Zai;
 static STEPFUN: Stepfun = Stepfun;
 static MINIMAX: Minimax = Minimax;
+static MINIMAX_CN: MinimaxCN = MinimaxCN;
 static MINIMAX_ANTHROPIC: MinimaxAnthropic = MinimaxAnthropic;
+static MINIMAX_ANTHROPIC_CN: MinimaxAnthropicCN = MinimaxAnthropicCN;
 static DEEPINFRA: Deepinfra = Deepinfra;
 static SAKANA: Sakana = Sakana;
 static LONGCAT: LongCat = LongCat;
@@ -1162,7 +1247,9 @@ static PROVIDER_REGISTRY: [&dyn Provider; 35] = [
     &ZAI,
     &STEPFUN,
     &MINIMAX,
+    &MINIMAX_CN,
     &MINIMAX_ANTHROPIC,
+    &MINIMAX_ANTHROPIC_CN,
     &DEEPINFRA,
     &SAKANA,
     &LONGCAT,

--- a/crates/config/src/provider_defaults.rs
+++ b/crates/config/src/provider_defaults.rs
@@ -126,6 +126,13 @@ pub(crate) const MINIMAX_M2_1_HIGHSPEED_MODEL: &str = "MiniMax-M2.1-highspeed";
 pub(crate) const MINIMAX_M2_MODEL: &str = "MiniMax-M2";
 pub(crate) const DEFAULT_MINIMAX_BASE_URL: &str = "https://api.minimax.io/v1";
 pub(crate) const DEFAULT_MINIMAX_ANTHROPIC_BASE_URL: &str = "https://api.minimax.io/anthropic";
+// MiniMax hosts the same surface under two domains: api.minimax.io (international)
+// and api.minimaxi.com (Token Plan / China). Both speak OpenAI Chat Completions and
+// Anthropic Messages on /v1 and /anthropic respectively; Token Plan subscription keys
+// are commonly issued under api.minimaxi.com.
+pub(crate) const DEFAULT_MINIMAX_CN_BASE_URL: &str = "https://api.minimaxi.com/v1";
+pub(crate) const DEFAULT_MINIMAX_ANTHROPIC_CN_BASE_URL: &str =
+    "https://api.minimaxi.com/anthropic";
 pub(crate) const DEFAULT_DEEPINFRA_MODEL: &str = "deepseek-ai/DeepSeek-V4-Pro";
 pub(crate) const DEFAULT_DEEPINFRA_FLASH_MODEL: &str = "deepseek-ai/DeepSeek-V4-Flash";
 pub(crate) const DEFAULT_DEEPINFRA_BASE_URL: &str = "https://api.deepinfra.com/v1/openai";

--- a/crates/config/src/provider_kind.rs
+++ b/crates/config/src/provider_kind.rs
@@ -105,6 +105,21 @@ pub enum ProviderKind {
         alias = "mini_max_anthropic"
     )]
     MinimaxAnthropic,
+    #[serde(
+        alias = "minimax-cn",
+        alias = "minimax_CN",
+        alias = "minimax-china"
+    )]
+    MinimaxCN,
+    #[serde(
+        alias = "minimax_anthropic_cn",
+        alias = "minimax-anthropic-cn",
+        alias = "minimax-anthropic-CN",
+        alias = "minimax_anthropic_CN",
+        alias = "minimax-china-anthropic",
+        alias = "minimax-token-plan"
+    )]
+    MinimaxAnthropicCN,
     #[serde(alias = "deep-infra", alias = "deep_infra")]
     Deepinfra,
     #[serde(alias = "sakana-ai", alias = "sakana_ai", alias = "fugu")]
@@ -164,6 +179,8 @@ impl ProviderKind {
         Self::Stepfun,
         Self::Minimax,
         Self::MinimaxAnthropic,
+        Self::MinimaxCN,
+        Self::MinimaxAnthropicCN,
         Self::Deepinfra,
         Self::Sakana,
         Self::LongCat,
@@ -207,6 +224,14 @@ impl ProviderKind {
     #[must_use]
     pub fn is_siliconflow(self) -> bool {
         matches!(self, Self::Siliconflow | Self::SiliconflowCN)
+    }
+
+    #[must_use]
+    pub fn is_minimax(self) -> bool {
+        matches!(
+            self,
+            Self::Minimax | Self::MinimaxAnthropic | Self::MinimaxCN | Self::MinimaxAnthropicCN
+        )
     }
 
     /// Return the built-in metadata entry for this provider.

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -464,6 +464,8 @@ fn model_bound_secret_store_slot(provider: ApiProvider) -> Option<&'static str> 
     match provider {
         ApiProvider::DeepseekCN => Some("deepseek"),
         ApiProvider::SiliconflowCn => Some("siliconflow"),
+        ApiProvider::MinimaxCn => Some("minimax"),
+        ApiProvider::MinimaxAnthropicCn => Some("minimax_anthropic"),
         ApiProvider::Custom => None,
         _ => Some(provider.as_str()),
     }
@@ -1250,6 +1252,7 @@ fn api_provider_uses_anthropic_messages(api_provider: ApiProvider) -> bool {
         ApiProvider::Anthropic
             | ApiProvider::DeepseekAnthropic
             | ApiProvider::MinimaxAnthropic
+            | ApiProvider::MinimaxAnthropicCn
             | ApiProvider::Openmodel
     )
 }
@@ -2273,7 +2276,7 @@ pub(super) fn apply_reasoning_effort(
     effort: Option<&str>,
     provider: ApiProvider,
 ) {
-    if matches!(provider, ApiProvider::Minimax) {
+    if matches!(provider, ApiProvider::Minimax | ApiProvider::MinimaxCn) {
         // MiniMax's OpenAI-compatible API keeps thinking inside `content`
         // unless reasoning_split is enabled. Always request the split shape
         // so private thinking renders as Thinking cells rather than answer
@@ -2336,6 +2339,7 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Anthropic
             | ApiProvider::DeepseekAnthropic
             | ApiProvider::MinimaxAnthropic
+            | ApiProvider::MinimaxAnthropicCn
             | ApiProvider::Openmodel => {
                 // Thinking shaping happens in the Messages adapter, which
                 // applies each provider's supported control fields.
@@ -2345,7 +2349,7 @@ pub(super) fn apply_reasoning_effort(
                     "thinking": false,
                 });
             }
-            ApiProvider::Minimax => {
+            ApiProvider::Minimax | ApiProvider::MinimaxCn => {
                 body["thinking"] = json!({ "type": "disabled" });
             }
             ApiProvider::Stepfun => {}
@@ -2424,6 +2428,7 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Anthropic
             | ApiProvider::DeepseekAnthropic
             | ApiProvider::MinimaxAnthropic
+            | ApiProvider::MinimaxAnthropicCn
             | ApiProvider::Openmodel => {
                 // Thinking shaping happens in the Messages adapter, which
                 // applies each provider's supported control fields.
@@ -2434,7 +2439,7 @@ pub(super) fn apply_reasoning_effort(
                     "reasoning_effort": "high",
                 });
             }
-            ApiProvider::Minimax => {
+            ApiProvider::Minimax | ApiProvider::MinimaxCn => {
                 body["thinking"] = json!({ "type": "adaptive" });
             }
             ApiProvider::Zai => {
@@ -2499,6 +2504,7 @@ pub(super) fn apply_reasoning_effort(
             ApiProvider::Anthropic
             | ApiProvider::DeepseekAnthropic
             | ApiProvider::MinimaxAnthropic
+            | ApiProvider::MinimaxAnthropicCn
             | ApiProvider::Openmodel => {
                 // Thinking shaping happens in the Messages adapter, which
                 // applies each provider's supported control fields.
@@ -2509,7 +2515,7 @@ pub(super) fn apply_reasoning_effort(
                     "reasoning_effort": "max",
                 });
             }
-            ApiProvider::Minimax => {
+            ApiProvider::Minimax | ApiProvider::MinimaxCn => {
                 body["thinking"] = json!({ "type": "adaptive" });
             }
             ApiProvider::Zai => {

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -66,6 +66,8 @@ pub enum ApiProvider {
     Stepfun,
     Minimax,
     MinimaxAnthropic,
+    MinimaxCn,
+    MinimaxAnthropicCn,
     Deepinfra,
     Sakana,
     LongCat,

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -298,6 +298,8 @@ fn provider_base_url_table_key(provider: ApiProvider) -> anyhow::Result<&'static
         ApiProvider::Stepfun => Ok("stepfun"),
         ApiProvider::Minimax => Ok("minimax"),
         ApiProvider::MinimaxAnthropic => Ok("minimax_anthropic"),
+        ApiProvider::MinimaxCn => Ok("minimax_cn"),
+        ApiProvider::MinimaxAnthropicCn => Ok("minimax_anthropic_cn"),
         ApiProvider::Sakana => Ok("sakana"),
         ApiProvider::LongCat => Ok("longcat"),
         ApiProvider::OpencodeGo => Ok("opencode_go"),

--- a/crates/tui/src/pricing.rs
+++ b/crates/tui/src/pricing.rs
@@ -590,7 +590,10 @@ pub(crate) fn calculate_turn_cost_estimate_for_provider_at(
     // been canonicalized.
     if matches!(
         provider,
-        ApiProvider::Minimax | ApiProvider::MinimaxAnthropic
+        ApiProvider::Minimax
+            | ApiProvider::MinimaxAnthropic
+            | ApiProvider::MinimaxCn
+            | ApiProvider::MinimaxAnthropicCn
     ) && catalog_model.eq_ignore_ascii_case("minimax-m3")
     {
         let pricing = pricing_for_model_and_usage(&catalog_model, usage)?;
@@ -688,7 +691,10 @@ fn provider_owned_hand_pricing_at(
         ApiProvider::Moonshot => {
             matches!(model_lower.as_str(), "kimi-k2.6" | "kimi-k2.7-code")
         }
-        ApiProvider::Minimax | ApiProvider::MinimaxAnthropic => {
+        ApiProvider::Minimax
+        | ApiProvider::MinimaxAnthropic
+        | ApiProvider::MinimaxCn
+        | ApiProvider::MinimaxAnthropicCn => {
             matches!(model_lower.as_str(), "minimax-m3" | "minimax-m2.7")
         }
         ApiProvider::Arcee => model_lower == "trinity-large-thinking",


### PR DESCRIPTION
Add four new provider identifiers that target api.minimaxi.com (the Chinese / Token Plan sibling of api.minimax.io):

  - minimax-cn                   (OpenAI Chat Completions on api.minimaxi.com/v1)
  - minimax-anthropic-cn         (Anthropic Messages on api.minimaxi.com/anthropic)

The Anthropic-compatible variant is what Token Plan subscribers use, since config.example.toml already mentions api.minimaxi.com/anthropic in passing but no provider route actually pointed there.

Both providers share the same [providers.minimax] runtime config when keys land in the defaults (parallel to how SiliconflowCN reuses Siliconflow's fields), so no new env-vars are introduced; MINIMAX_API_KEY continues to cover pay-as-you-go and Token Plan keys.

Note: this is a partial plumbing change. Additional non-exhaustive match arms in crates/tui/src/config.rs and elsewhere may still need CN variants added to make cargo check green; follow-up patch welcome.

## Summary

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [ ] Updated docs or comments as needed
- [ ] Added or updated tests where relevant
- [ ] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address
