### PR TITLE
fix(kimi): fail closed on K3 model-ID cross-pairings

### DIFF
--- a/crates/tui/src/commands/groups/core/core.rs
+++ b/crates/tui/src/commands/groups/core/core.rs
@@ -1042,13 +1042,19 @@ mod tests {
             Some(u64::from(crate::config::KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS))
         );
 
-        // The same bare model ID on Moonshot's direct API must retain the
-        // generic route limits rather than inheriting Kimi Code entitlement.
+        // Switching to the direct platform endpoint requires the direct model
+        // id (`kimi-k3`); bare `k3` is fail-closed (#4687).
         app.active_route_base_url = crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string();
-        let direct = model(&mut app, Some(crate::config::KIMI_CODE_K3_MODEL));
+        let rejected = model(&mut app, Some(crate::config::KIMI_CODE_K3_MODEL));
+        assert!(
+            rejected.is_error,
+            "bare k3 on direct Moonshot must fail closed: {rejected:?}"
+        );
+
+        let direct = model(&mut app, Some(crate::config::MOONSHOT_KIMI_K3_MODEL));
         assert!(
             !direct.is_error,
-            "direct Moonshot route remains valid: {direct:?}"
+            "direct Moonshot kimi-k3 remains valid: {direct:?}"
         );
         assert_ne!(
             app.active_route_limits

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -7345,25 +7345,64 @@ pub(crate) fn is_exact_kimi_code_k3_route(
         && model.trim().eq_ignore_ascii_case(KIMI_CODE_K3_MODEL)
 }
 
-/// Reject the Claude Code-only `k3[1m]` context hint when it is supplied as a
-/// Kimi Code API model id. Codewhale has a first-class context-window field,
-/// so silently rewriting this value would both send the wrong wire id and
-/// claim a plan entitlement the user may not have.
+/// Fail closed on known-bad K3 model/endpoint pairings (#4687).
+///
+/// - Reject Claude Code's `k3[1m]` context hint as a Kimi Code API model id.
+/// - Reject `kimi-k3` on the exact Kimi Code membership endpoint (use `k3`).
+/// - Reject bare `k3` on the exact Moonshot direct platform endpoint (use `kimi-k3`).
+///
+/// Custom Moonshot-compatible gateways are left alone: only the two canonical
+/// endpoints enforce the documented model IDs.
 pub(crate) fn validate_kimi_code_api_model_id(
     provider: ApiProvider,
     base_url: &str,
     model: &str,
 ) -> std::result::Result<(), String> {
-    if provider == ApiProvider::Moonshot
-        && moonshot_base_url_is_exact_kimi_code(base_url)
-        && model.trim().eq_ignore_ascii_case("k3[1m]")
+    if provider != ApiProvider::Moonshot {
+        return Ok(());
+    }
+    let model = model.trim();
+    if model.is_empty() {
+        return Ok(());
+    }
+
+    if moonshot_base_url_is_exact_kimi_code(base_url) {
+        if model.eq_ignore_ascii_case("k3[1m]") {
+            return Err(
+                "Kimi Code model `k3[1m]` is a Claude Code environment convention, not an API model id. Use model = \"k3\". If your Kimi Code plan includes 1M context, also set context_window = 1048576; otherwise keep the 262144 safe default."
+                    .to_string(),
+            );
+        }
+        if model.eq_ignore_ascii_case(MOONSHOT_KIMI_K3_MODEL) {
+            return Err(
+                "Kimi Code membership route (api.kimi.com/coding/v1) does not accept model = \"kimi-k3\". Use model = \"k3\" for this base_url. Direct Moonshot pay-as-you-go uses base_url = \"https://api.moonshot.ai/v1\" with model = \"kimi-k3\"."
+                    .to_string(),
+            );
+        }
+        return Ok(());
+    }
+
+    if moonshot_base_url_is_exact_direct_platform(base_url)
+        && model.eq_ignore_ascii_case(KIMI_CODE_K3_MODEL)
     {
         return Err(
-            "Kimi Code model `k3[1m]` is a Claude Code environment convention, not an API model id. Use model = \"k3\". If your Kimi Code plan includes 1M context, also set context_window = 1048576; otherwise keep the 262144 safe default."
+            "Moonshot direct route (api.moonshot.ai/v1) does not accept bare model = \"k3\". Use model = \"kimi-k3\" for this base_url. Kimi Code membership uses base_url = \"https://api.kimi.com/coding/v1\" with model = \"k3\"."
                 .to_string(),
         );
     }
+
     Ok(())
+}
+
+/// Short route label for header/diagnostics without credentials (#4687).
+pub(crate) fn moonshot_k3_route_display_name(base_url: &str, model: &str) -> Option<&'static str> {
+    if is_exact_kimi_code_k3_route(ApiProvider::Moonshot, base_url, model) {
+        return Some("Kimi Code membership / k3");
+    }
+    if is_exact_direct_moonshot_k3_route(ApiProvider::Moonshot, base_url, model) {
+        return Some("Moonshot direct / kimi-k3");
+    }
+    None
 }
 
 /// Credential help for a concrete provider route.

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -6209,11 +6209,15 @@ fn doctor_route_report(config: &Config) -> serde_json::Value {
         })
     });
 
+    let route_identity =
+        crate::config::moonshot_k3_route_display_name(&target.base_url, &target.model);
+
     json!({
         "provider": target.provider,
         "provider_source": doctor_provider_source(config),
         "provider_config_table": doctor_provider_config_table(config, provider),
         "model": target.model,
+        "route_identity": route_identity,
         "wire_protocol": doctor_wire_protocol(provider),
         "base_url": {
             "redacted": redacted_base_url,

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -745,7 +745,7 @@ mod tests {
             ContextWindowSource::StaticKimiCodeSafeFloor
         );
 
-        let generic = resolve_route_candidate_with_context_metadata(
+        let generic_err = resolve_route_candidate_with_context_metadata(
             ApiProvider::Moonshot,
             Some("k3"),
             None,
@@ -756,11 +756,10 @@ mod tests {
                 observed_at: Utc::now(),
             }),
         )
-        .expect("generic Moonshot route");
-        assert_ne!(
-            generic.context_window.source,
-            ContextWindowSource::ProviderReported,
-            "Moonshot metadata may not promote bare K3 outside the exact Kimi Code route"
+        .expect_err("bare k3 is rejected on the direct Moonshot endpoint (#4687)");
+        assert!(
+            generic_err.contains("kimi-k3"),
+            "error should guide the user to kimi-k3: {generic_err}"
         );
     }
 
@@ -807,6 +806,91 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn k3_route_rejects_cross_paired_model_ids_and_allows_canonical_pairs() {
+        use crate::config::{
+            DEFAULT_KIMI_CODE_BASE_URL, DEFAULT_MOONSHOT_BASE_URL, KIMI_CODE_K3_MODEL,
+            MOONSHOT_KIMI_K3_MODEL, moonshot_k3_route_display_name, validate_kimi_code_api_model_id,
+        };
+
+        // Canonical pairs succeed.
+        validate_kimi_code_api_model_id(
+            ApiProvider::Moonshot,
+            DEFAULT_KIMI_CODE_BASE_URL,
+            KIMI_CODE_K3_MODEL,
+        )
+        .expect("kimi code + k3");
+        validate_kimi_code_api_model_id(
+            ApiProvider::Moonshot,
+            DEFAULT_MOONSHOT_BASE_URL,
+            MOONSHOT_KIMI_K3_MODEL,
+        )
+        .expect("direct + kimi-k3");
+
+        // Trailing slash normalization still enforces.
+        let err = validate_kimi_code_api_model_id(
+            ApiProvider::Moonshot,
+            "https://api.kimi.com/coding/v1/",
+            "kimi-k3",
+        )
+        .expect_err("kimi code + kimi-k3");
+        assert!(err.contains("k3"), "{err}");
+        assert!(err.contains("kimi-k3"), "{err}");
+
+        let err = validate_kimi_code_api_model_id(
+            ApiProvider::Moonshot,
+            "https://api.moonshot.ai/v1/",
+            "k3",
+        )
+        .expect_err("direct + k3");
+        assert!(err.contains("kimi-k3"), "{err}");
+
+        // Custom gateway is not rejected for either model id.
+        validate_kimi_code_api_model_id(
+            ApiProvider::Moonshot,
+            "https://gateway.example.com/v1",
+            "k3",
+        )
+        .expect("custom + k3");
+        validate_kimi_code_api_model_id(
+            ApiProvider::Moonshot,
+            "https://gateway.example.com/v1",
+            "kimi-k3",
+        )
+        .expect("custom + kimi-k3");
+
+        // Runtime resolve fails closed the same way.
+        let err = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("kimi-k3"),
+            None,
+            Some(DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+            None,
+        )
+        .expect_err("resolve kimi code + kimi-k3");
+        assert!(err.contains("k3"), "{err}");
+
+        let err = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("k3"),
+            None,
+            Some(DEFAULT_MOONSHOT_BASE_URL.to_string()),
+            None,
+        )
+        .expect_err("resolve direct + k3");
+        assert!(err.contains("kimi-k3"), "{err}");
+
+        assert_eq!(
+            moonshot_k3_route_display_name(DEFAULT_KIMI_CODE_BASE_URL, "k3"),
+            Some("Kimi Code membership / k3")
+        );
+        assert_eq!(
+            moonshot_k3_route_display_name(DEFAULT_MOONSHOT_BASE_URL, "kimi-k3"),
+            Some("Moonshot direct / kimi-k3")
+        );
+    }
+
     #[test]
     fn kimi_code_k3_baseline_does_not_leak_to_other_moonshot_routes() {
         let kimi_code_endpoint = Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string());
@@ -820,9 +904,21 @@ mod tests {
         .expect("direct Moonshot K3 route");
         assert_eq!(direct_moonshot.limits().context_tokens, Some(1_048_576));
 
-        let generic_moonshot = resolve_route_candidate(
+        // Bare k3 on the direct platform endpoint is fail-closed (#4687).
+        let generic_err = resolve_route_candidate(
             ApiProvider::Moonshot,
             Some("k3"),
+            None,
+            Some(crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string()),
+            None,
+        )
+        .expect_err("bare k3 on direct Moonshot must fail closed");
+        assert!(generic_err.contains("kimi-k3"), "{generic_err}");
+
+        // A non-K3 direct model must not inherit the Kimi Code 262k floor.
+        let generic_moonshot = resolve_route_candidate(
+            ApiProvider::Moonshot,
+            Some("moonshot-v1-128k"),
             None,
             Some(crate::config::DEFAULT_MOONSHOT_BASE_URL.to_string()),
             None,

--- a/crates/tui/src/route_runtime.rs
+++ b/crates/tui/src/route_runtime.rs
@@ -806,12 +806,12 @@ mod tests {
         }
     }
 
-
     #[test]
     fn k3_route_rejects_cross_paired_model_ids_and_allows_canonical_pairs() {
         use crate::config::{
             DEFAULT_KIMI_CODE_BASE_URL, DEFAULT_MOONSHOT_BASE_URL, KIMI_CODE_K3_MODEL,
-            MOONSHOT_KIMI_K3_MODEL, moonshot_k3_route_display_name, validate_kimi_code_api_model_id,
+            MOONSHOT_KIMI_K3_MODEL, moonshot_k3_route_display_name,
+            validate_kimi_code_api_model_id,
         };
 
         // Canonical pairs succeed.


### PR DESCRIPTION
## Summary

Implements #4687: treat base URL + model ID as one route identity and fail closed on the two documented cross-pairings.

| Endpoint | Wrong model | Correct model |
|---|---|---|
| `https://api.kimi.com/coding/v1` | `kimi-k3` | `k3` |
| `https://api.moonshot.ai/v1` | bare `k3` | `kimi-k3` |

Custom Moonshot-compatible gateways are not rejected. No credentials are logged.

## Changes

- Expand `validate_kimi_code_api_model_id` (already called from config load + `route_runtime`)
- Add `moonshot_k3_route_display_name` for `Kimi Code membership / k3` vs `Moonshot direct / kimi-k3`
- Update tests that previously exercised bare `k3` on the direct endpoint (now correctly fail closed)

Base: post-#4675 `origin/main` (`bbd0d8ba2…`).

## Tests

```bash
CARGO_NET_OFFLINE=true cargo test -p codewhale-tui --bin codewhale-tui --locked k3_route
# 11 passed
CARGO_NET_OFFLINE=true cargo test -p codewhale-tui --bin codewhale-tui --locked kimi_code
# 35 passed
```

Closes #4687