### PR TITLE
feat(skills): default CodeWhale skill pack (bundled v5)

### DIFF
--- a/crates/tui/assets/skills/batch/SKILL.md
+++ b/crates/tui/assets/skills/batch/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: batch
+description: Break a large, parallelizable goal into bounded work units, coordinate existing agent/worktree machinery, integrate, and verify. Explicit-only.
+invocation: explicit-only
+---
+
+# Batch
+
+## Invocation
+Explicit-only. Do not start from ambient wording alone.
+
+## When to use
+Use for large parallelizable goals that need coordinated sub-work.
+
+## Non-goals
+- Do not invent a second orchestration engine; reuse delegate/fleet.
+- Do not publish or deploy as part of batching.
+
+## Workflow
+1. Partition into bounded units.
+2. Run units with existing agent/worktree tools.
+3. Integrate results and verify.

--- a/crates/tui/assets/skills/dataviz/SKILL.md
+++ b/crates/tui/assets/skills/dataviz/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: dataviz
+description: Choose and produce an appropriate chart/dashboard/visual explanation from data, with legible encodings and source/assumption notes.
+invocation: model+user
+---
+
+# Dataviz
+
+## When to use
+Use when the user needs a chart, dashboard, or visual explanation of data.
+
+## Non-goals
+- Do not choose chart types that hide uncertainty.
+- Do not invent data.
+
+## Workflow
+1. Inspect the data and questions.
+2. Choose encodings for the comparison at hand.
+3. Produce the visual with source/assumption notes.
+4. Sanity-check axes, units, and missing values.

--- a/crates/tui/assets/skills/debug/SKILL.md
+++ b/crates/tui/assets/skills/debug/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: debug
+description: Reproduce, minimize, localize, identify root cause, and distinguish diagnosis from an authorized fix. Prefer root-cause over symptom patches.
+invocation: model+user
+---
+
+# Debug
+
+## When to use
+Use for failures, flakes, wrong outputs, crashes, and regressions.
+
+## Non-goals
+- Do not jump to a fix before reproduction/localization when the bug is unclear.
+- Do not treat “run all tests” as debugging by default.
+
+## Workflow
+1. Reproduce or gather the strongest available failure signal.
+2. Minimize the case.
+3. Localize to component/file/line.
+4. State root cause vs symptoms.
+5. Fix only when authorized; otherwise hand back a diagnosis with evidence.
+
+## Output shape
+- Symptom
+- Reproduction
+- Localization
+- Root cause
+- Fix status / next step

--- a/crates/tui/assets/skills/dependency-update/SKILL.md
+++ b/crates/tui/assets/skills/dependency-update/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: dependency-update
+description: Read release notes/changelogs, update a defined dependency scope, handle breaking changes, and verify. Explicit-only; no broad update-everything by inference.
+invocation: explicit-only
+---
+
+# Dependency Update
+
+## Invocation
+Explicit-only with a defined dependency scope.
+
+## Non-goals
+- No inferred “update everything”.
+- No publish/release.
+
+## Workflow
+1. Identify the dependency set and current versions.
+2. Read release notes/changelogs.
+3. Apply updates and fix breakages.
+4. Verify with the project’s test/build gates.

--- a/crates/tui/assets/skills/document/SKILL.md
+++ b/crates/tui/assets/skills/document/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: document
+description: Write or update repository/product documentation: README, user guides, API docs, architecture, migration notes, and changelog material. This is not the Word-document artifact skill.
+invocation: model+user
+---
+
+# Document
+
+## When to use
+Use for repo/product docs: README, guides, API docs, architecture, migrations, changelog notes.
+
+## Non-goals
+- Not Word/DOCX authoring (use docx).
+- Not release publication (use release only when explicit).
+
+## Workflow
+1. Identify the doc audience and location.
+2. Prefer updating existing docs over creating duplicates.
+3. Keep commands and paths verified.
+4. Call out unknowns instead of inventing them.

--- a/crates/tui/assets/skills/documents/SKILL.md
+++ b/crates/tui/assets/skills/documents/SKILL.md
@@ -1,31 +1,11 @@
 ---
 name: documents
-description: Create, edit, inspect, or convert Word documents and DOCX deliverables such as memos, reports, letters, templates, and forms.
+description: Compatibility alias for the docx skill. Prefer loading docx.
+aliases-for: docx
 ---
 
-# Documents
+# documents (alias)
 
-Use this skill when the user wants a `.docx` or Word-style document, or when an
-existing document needs edits, comments, extraction, or conversion.
+This skill is a compatibility alias for **docx**.
 
-## Workflow
-
-1. Clarify the output path if needed. Prefer a `.docx` file in the workspace.
-2. Preserve existing documents. Write edited copies instead of overwriting
-   originals unless the user asked for an in-place edit.
-3. Use the best available local tool:
-   - `python-docx` for creation and structured edits
-   - `pandoc` for Markdown/HTML to DOCX conversion
-   - OOXML inspection with `unzip` only for targeted low-level fixes
-4. For new documents, choose a simple professional structure: title, metadata
-   when useful, clear headings, readable body text, and tables only for real
-   row/column data.
-5. For edits, make the smallest change that satisfies the request and keep the
-   original formatting where practical.
-6. Verify by reopening the file with a parser such as `python-docx`, checking
-   paragraph/table counts, and extracting representative text. If LibreOffice
-   or another renderer is available, render or export a quick visual check.
-
-If required dependencies are missing, ask before installing packages. If the
-user only needs content and a DOCX cannot be produced in the environment, offer
-Markdown or HTML as a fallback and clearly state the limitation.
+Load and follow the `docx` skill body for the actual workflow.

--- a/crates/tui/assets/skills/docx/SKILL.md
+++ b/crates/tui/assets/skills/docx/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: docx
+description: Create/edit/inspect Word documents using available managed or host capabilities.
+invocation: model+user
+---
+
+# Docx
+
+## When to use
+Use for `.docx` / Word-style documents (memos, reports, letters, templates).
+
+## Compatibility
+`documents` is a compatibility alias for this skill.
+
+## Workflow
+1. Prefer `.docx` in the workspace.
+2. Preserve originals unless in-place edit is requested.
+3. Use python-docx/pandoc when available.
+4. Verify by reopening and extracting representative text.

--- a/crates/tui/assets/skills/frontend-design/SKILL.md
+++ b/crates/tui/assets/skills/frontend-design/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: frontend-design
+description: Produce intentional, responsive, accessible UI work and perform visual QA instead of generic component assembly.
+invocation: model+user
+---
+
+# Frontend Design
+
+## When to use
+Use for UI that must feel intentional, responsive, and accessible.
+
+## Non-goals
+- Do not ship generic placeholder layouts as finished design.
+- Do not ignore accessibility.
+
+## Workflow
+1. Clarify audience and constraints.
+2. Design hierarchy, spacing, and states.
+3. Implement with responsive/accessible patterns.
+4. Visual QA against the acceptance criteria.

--- a/crates/tui/assets/skills/implement/SKILL.md
+++ b/crates/tui/assets/skills/implement/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: implement
+description: Carry an authorized, defined request or approved plan through scoped edits and proportionate verification. Skill loading is not write authorization by itself.
+invocation: model+user
+---
+
+# Implement
+
+## When to use
+Use for scoped implementation of a clear request or approved plan.
+
+## Non-goals
+- Loading this skill is not write authorization by itself.
+- Do not expand scope without saying so.
+- Do not skip verification after risky edits.
+
+## Workflow
+1. Confirm scope and acceptance criteria.
+2. Make the smallest coherent change set.
+3. Run the narrowest useful verification.
+4. Report what changed and what remains.
+
+## Failure mode
+If blocked by missing permissions or failing verification, stop and report evidence.

--- a/crates/tui/assets/skills/interview/SKILL.md
+++ b/crates/tui/assets/skills/interview/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: interview
+description: Ask one useful structured question at a time only when material product/implementation choices are genuinely missing; remember answers and produce a brief/spec. Discoverable facts should be investigated instead of asked.
+invocation: model+user
+---
+
+# Interview
+
+## When to use
+Use when the request lacks a material product or implementation choice that cannot be discovered from the workspace or tools.
+
+## Non-goals
+- Do not interview for facts you can read, search, or measure.
+- Do not ask multi-question dumps. One focused question at a time.
+- Do not invent requirements.
+
+## Workflow
+1. State the missing decision and why it blocks progress.
+2. Offer concrete options when possible.
+3. Record the answer and continue the work.
+4. Produce a short brief/spec only when enough answers exist.
+
+## Failure mode
+If the user declines to answer, proceed with explicit assumptions and label them.

--- a/crates/tui/assets/skills/plan/SKILL.md
+++ b/crates/tui/assets/skills/plan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: plan
+description: Turn a sufficiently understood task into an ordered implementation plan with dependencies and verification. Orchestrate CodeWhale’s native plan state; do not build a parallel planner.
+invocation: model+user
+---
+
+# Plan
+
+## When to use
+Use when the task is understood well enough to sequence work, but not yet a single obvious next edit.
+
+## Non-goals
+- Do not plan while key goals are still unknown — use interview first.
+- Do not create a second planner outside CodeWhale plan/Work state.
+
+## Workflow
+1. Restate the goal and constraints.
+2. List ordered steps with dependencies.
+3. Mark verification for each risky step.
+4. Write the plan into CodeWhale’s native plan/Work surface.
+5. Wait for authorization before broad implementation.
+
+## Output shape
+- Goal
+- Steps (ordered)
+- Verification
+- Risks / open questions

--- a/crates/tui/assets/skills/pptx/SKILL.md
+++ b/crates/tui/assets/skills/pptx/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: pptx
+description: Create/edit/inspect/verify slide decks and PPTX presentations.
+invocation: model+user
+---
+
+# Pptx
+
+## When to use
+Use for PowerPoint / `.pptx` slide decks.
+
+## Compatibility
+`presentations` is a compatibility alias for this skill.
+
+## Workflow
+1. Choose a simple layout system and stick to it.
+2. Prefer fewer denser slides over slide spam.
+3. Verify by reopening the deck and checking slide count/titles.

--- a/crates/tui/assets/skills/presentations/SKILL.md
+++ b/crates/tui/assets/skills/presentations/SKILL.md
@@ -1,29 +1,11 @@
 ---
 name: presentations
-description: Create, edit, inspect, or convert PowerPoint decks and PPTX slide presentations with practical layout and verification steps.
+description: Compatibility alias for the pptx skill. Prefer loading pptx.
+aliases-for: pptx
 ---
 
-# Presentations
+# presentations (alias)
 
-Use this skill when the user asks for slides, a deck, a PowerPoint file, or a
-`.pptx` deliverable.
+This skill is a compatibility alias for **pptx**.
 
-## Workflow
-
-1. Determine the deck purpose, audience, slide count, and output path.
-2. Build an outline with one clear claim or job per slide.
-3. Use available local tools:
-   - `python-pptx` for editable PPTX creation and edits
-   - LibreOffice for conversion or preview export when installed
-   - Existing images, screenshots, charts, or generated assets only when they
-     improve the slide's job
-4. Keep slides editable. Prefer native text boxes, tables, charts, and images
-   over flattened screenshots of text.
-5. Use restrained layouts: clear title, concise body, enough whitespace, and
-   consistent type sizes. Avoid cramming paragraphs onto slides.
-6. Verify the PPTX by reopening it, checking slide count and visible text, and
-   exporting previews when a renderer is available.
-
-If `python-pptx` or a renderer is missing, ask before installing dependencies.
-Do not claim visual QA passed unless previews were actually generated and
-inspected.
+Load and follow the `pptx` skill body for the actual workflow.

--- a/crates/tui/assets/skills/release/SKILL.md
+++ b/crates/tui/assets/skills/release/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: release
+description: Prepare a named version: preflight, version consistency, build/package, smoke test, checksums/notes, and release readiness. Publishing/tagging/deploy need separate authorization. Explicit-only.
+invocation: explicit-only
+---
+
+# Release
+
+## Invocation
+Explicit-only for a named version. Loading this skill is not publish authority.
+
+## Non-goals
+- Do not tag, publish, deploy, or ship packages without separate authorization.
+- Do not invent version numbers.
+
+## Workflow
+1. Preflight version consistency and changelog readiness.
+2. Build/package with locked release commands.
+3. Smoke test artifacts.
+4. Produce checksums/notes and a readiness report.
+5. Stop before any public release action unless explicitly authorized.

--- a/crates/tui/assets/skills/research/SKILL.md
+++ b/crates/tui/assets/skills/research/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: research
+description: Current external research using available web tools, primary sources where possible, links/citations, date awareness, synthesis, and unresolved uncertainty.
+invocation: model+user
+---
+
+# Research
+
+## When to use
+Use for external facts: release notes, docs, prior art, ecosystem changes.
+
+## Non-goals
+- Do not invent citations.
+- Degrade clearly when web tools are unavailable.
+
+## Workflow
+1. Prefer primary sources.
+2. Note dates and version pins.
+3. Synthesize; separate fact from inference.
+4. List open questions.

--- a/crates/tui/assets/skills/review/SKILL.md
+++ b/crates/tui/assets/skills/review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: review
+description: Read-only correctness review with actionable findings first, tight file/line evidence, severity, and a concise residual-risk summary.
+invocation: model+user
+---
+
+# Review
+
+## When to use
+Use for correctness review of a diff, PR, or named change set.
+
+## Non-goals
+- Read-only by default. Do not edit unless asked.
+- Do not bury findings under style nits.
+
+## Workflow
+1. Establish the change scope.
+2. List findings by severity with file/line evidence.
+3. Call out residual risk and missing tests.
+4. End with a short merge/risk summary.

--- a/crates/tui/assets/skills/security-review/SKILL.md
+++ b/crates/tui/assets/skills/security-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: security-review
+description: Review trust boundaries, auth/authz, injection, secrets, filesystem/network exposure, dependencies, and exploitability without pretending a shallow lint is an audit.
+invocation: model+user
+---
+
+# Security Review
+
+## When to use
+Use when looking for vulnerabilities, auth holes, secret leaks, or unsafe trust boundaries.
+
+## Non-goals
+- This is not a formal audit certificate.
+- Do not claim exploitability without evidence.
+
+## Workflow
+1. Map trust boundaries and entry points.
+2. Check auth/authz, injection, secrets, FS/network exposure, deps.
+3. Rank findings by exploitability and impact.
+4. Recommend fixes and verification steps.

--- a/crates/tui/assets/skills/simplify/SKILL.md
+++ b/crates/tui/assets/skills/simplify/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: simplify
+description: Improve clarity and reduce needless complexity after behavior is understood; preserve behavior and keep cleanup separate from correctness fixes.
+invocation: model+user
+---
+
+# Simplify
+
+## When to use
+Use after behavior is understood and the user wants clarity or less complexity.
+
+## Non-goals
+- Do not mix cleanup with speculative refactors that change behavior.
+- Do not “simplify” by deleting necessary safety checks.
+
+## Workflow
+1. Confirm current behavior with tests or reproduction.
+2. Reduce complexity in small, reviewable steps.
+3. Keep behavior-preserving verification green.

--- a/crates/tui/assets/skills/spreadsheets/SKILL.md
+++ b/crates/tui/assets/skills/spreadsheets/SKILL.md
@@ -1,31 +1,11 @@
 ---
 name: spreadsheets
-description: Create, edit, analyze, clean, or convert spreadsheets including XLSX, CSV, TSV, formulas, charts, and tabular reports.
+description: Compatibility alias for the xlsx skill. Prefer loading xlsx.
+aliases-for: xlsx
 ---
 
-# Spreadsheets
+# spreadsheets (alias)
 
-Use this skill when the input or deliverable is a spreadsheet: `.xlsx`, `.xlsm`,
-`.csv`, `.tsv`, or a table that should become one of those formats.
+This skill is a compatibility alias for **xlsx**.
 
-## Workflow
-
-1. Identify whether the task is cleaning, analysis, formatting, charting, or
-   workbook generation.
-2. Preserve source files. Write a new output workbook unless the user asked for
-   an in-place edit.
-3. Use appropriate tools:
-   - Python `csv` or `pandas` for data cleaning and analysis
-   - `openpyxl` for XLSX formulas, styles, tables, filters, freeze panes, and
-     charts
-   - LibreOffice only when conversion or recalculation is needed and available
-4. Keep raw data separate from summary sheets when that helps auditability.
-5. Use formulas when the workbook should remain interactive; use fixed values
-   when the result must be stable and reproducible.
-6. Verify by loading the workbook, checking sheet names, row/column counts,
-   formulas, and representative cell values. For CSV/TSV, check delimiters,
-   quoting, headers, and row widths.
-
-If dependencies are missing, ask before installing packages. Never silently
-drop rows, change date/time semantics, or coerce IDs with leading zeroes into
-numbers.
+Load and follow the `xlsx` skill body for the actual workflow.

--- a/crates/tui/assets/skills/test/SKILL.md
+++ b/crates/tui/assets/skills/test/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: test
+description: Detect the project’s test stack, run the narrowest useful tests, create tests when authorized, and report coverage/gaps honestly.
+invocation: model+user
+---
+
+# Test
+
+## When to use
+Use when the user wants tests run, added, or improved for a concrete surface.
+
+## Non-goals
+- Do not invent a test framework the repo does not use.
+- Do not claim coverage you did not measure.
+
+## Workflow
+1. Detect the repo’s test runner and conventions.
+2. Run the narrowest useful suite for the change.
+3. Add or update tests only when authorized.
+4. Report pass/fail with commands and residual gaps.

--- a/crates/tui/assets/skills/verify/SKILL.md
+++ b/crates/tui/assets/skills/verify/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: verify
+description: Exercise the real app/API/CLI and collect observable evidence; tests alone do not count as end-to-end verification.
+invocation: model+user
+---
+
+# Verify
+
+## When to use
+Use when the user wants proof the real surface works, not only unit tests.
+
+## Non-goals
+- Unit tests alone are not end-to-end verification.
+- Do not fake success without observable evidence.
+
+## Workflow
+1. Identify the real entrypoint (CLI binary, API, UI).
+2. Exercise it with realistic inputs.
+3. Capture outputs, exit codes, logs, or screenshots.
+4. Report evidence and remaining uncertainty.

--- a/crates/tui/assets/skills/webapp-testing/SKILL.md
+++ b/crates/tui/assets/skills/webapp-testing/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: webapp-testing
+description: Start/reuse a local app, wait for readiness, inspect rendered state/console/network, act from observed selectors, and verify with evidence.
+invocation: model+user
+---
+
+# Webapp Testing
+
+## When to use
+Use to prove a web app flow works in a real browser/runtime context.
+
+## Non-goals
+- Do not claim success from unit tests alone.
+- Do not hardcode fragile selectors without observation.
+
+## Workflow
+1. Start or reuse the local app.
+2. Wait for readiness.
+3. Inspect DOM/console/network.
+4. Drive the flow from observed state.
+5. Record evidence of pass/fail.

--- a/crates/tui/assets/skills/xlsx/SKILL.md
+++ b/crates/tui/assets/skills/xlsx/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: xlsx
+description: Create/edit/analyze/verify spreadsheet workbooks including XLSX/CSV/TSV.
+invocation: model+user
+---
+
+# Xlsx
+
+## When to use
+Use for spreadsheets, tabular analysis, formulas, and charts in workbooks.
+
+## Compatibility
+`spreadsheets` is a compatibility alias for this skill.
+
+## Workflow
+1. Prefer structured tables with clear headers.
+2. Keep formulas auditable.
+3. Verify by reopening and checking key cells/aggregates.

--- a/crates/tui/src/skills/system.rs
+++ b/crates/tui/src/skills/system.rs
@@ -4,19 +4,51 @@
 use std::fs;
 use std::path::Path;
 
-const BUNDLED_SKILL_VERSION: &str = "4";
+/// Bundled catalog generation for the default CodeWhale skill pack (#4691).
+const BUNDLED_SKILL_VERSION: &str = "5";
+
+// ── system & extension (meta) ───────────────────────────────────────────────
 const SKILL_CREATOR_BODY: &str = include_str!("../../assets/skills/skill-creator/SKILL.md");
 const DELEGATE_BODY: &str = include_str!("../../assets/skills/delegate/SKILL.md");
-const V4_BEST_PRACTICES_BODY: &str = include_str!("../../assets/skills/v4-best-practices/SKILL.md");
 const PLUGIN_CREATOR_BODY: &str = include_str!("../../assets/skills/plugin-creator/SKILL.md");
 const SKILL_INSTALLER_BODY: &str = include_str!("../../assets/skills/skill-installer/SKILL.md");
 const MCP_BUILDER_BODY: &str = include_str!("../../assets/skills/mcp-builder/SKILL.md");
 const FLEET_MANAGER_BODY: &str = include_str!("../../assets/skills/fleet-manager/SKILL.md");
-const DOCUMENTS_BODY: &str = include_str!("../../assets/skills/documents/SKILL.md");
-const PRESENTATIONS_BODY: &str = include_str!("../../assets/skills/presentations/SKILL.md");
-const SPREADSHEETS_BODY: &str = include_str!("../../assets/skills/spreadsheets/SKILL.md");
+
+// ── end-user workflows ──────────────────────────────────────────────────────
+const INTERVIEW_BODY: &str = include_str!("../../assets/skills/interview/SKILL.md");
+const PLAN_BODY: &str = include_str!("../../assets/skills/plan/SKILL.md");
+const IMPLEMENT_BODY: &str = include_str!("../../assets/skills/implement/SKILL.md");
+const DEBUG_BODY: &str = include_str!("../../assets/skills/debug/SKILL.md");
+const TEST_BODY: &str = include_str!("../../assets/skills/test/SKILL.md");
+const REVIEW_BODY: &str = include_str!("../../assets/skills/review/SKILL.md");
+const SECURITY_REVIEW_BODY: &str = include_str!("../../assets/skills/security-review/SKILL.md");
+const SIMPLIFY_BODY: &str = include_str!("../../assets/skills/simplify/SKILL.md");
+const VERIFY_BODY: &str = include_str!("../../assets/skills/verify/SKILL.md");
+const RESEARCH_BODY: &str = include_str!("../../assets/skills/research/SKILL.md");
+const FRONTEND_DESIGN_BODY: &str = include_str!("../../assets/skills/frontend-design/SKILL.md");
+const WEBAPP_TESTING_BODY: &str = include_str!("../../assets/skills/webapp-testing/SKILL.md");
+const DOCUMENT_BODY: &str = include_str!("../../assets/skills/document/SKILL.md");
+const DATAVIZ_BODY: &str = include_str!("../../assets/skills/dataviz/SKILL.md");
+const DOCX_BODY: &str = include_str!("../../assets/skills/docx/SKILL.md");
 const PDF_BODY: &str = include_str!("../../assets/skills/pdf/SKILL.md");
+const PPTX_BODY: &str = include_str!("../../assets/skills/pptx/SKILL.md");
+const XLSX_BODY: &str = include_str!("../../assets/skills/xlsx/SKILL.md");
+const DOCUMENTS_ALIAS_BODY: &str = include_str!("../../assets/skills/documents/SKILL.md");
+const PRESENTATIONS_ALIAS_BODY: &str = include_str!("../../assets/skills/presentations/SKILL.md");
+const SPREADSHEETS_ALIAS_BODY: &str = include_str!("../../assets/skills/spreadsheets/SKILL.md");
+
+// ── power / explicit-only ───────────────────────────────────────────────────
+const BATCH_BODY: &str = include_str!("../../assets/skills/batch/SKILL.md");
+const DEPENDENCY_UPDATE_BODY: &str = include_str!("../../assets/skills/dependency-update/SKILL.md");
+const RELEASE_BODY: &str = include_str!("../../assets/skills/release/SKILL.md");
+
+// Optional integration (not auto-installed for every user): Feishu body kept for
+// digest/migration helpers only.
 const FEISHU_BODY: &str = include_str!("../../assets/skills/feishu/SKILL.md");
+
+// Legacy v4 body retained solely for digest-based safe retirement (#4691).
+const V4_BEST_PRACTICES_BODY: &str = include_str!("../../assets/skills/v4-best-practices/SKILL.md");
 
 struct BundledSkill {
     name: &'static str,
@@ -24,7 +56,9 @@ struct BundledSkill {
     introduced_in: u32,
 }
 
+/// Skills auto-installed for every user on fresh install / upgrade.
 const BUNDLED_SKILLS: &[BundledSkill] = &[
+    // System & extension
     BundledSkill {
         name: "skill-creator",
         body: SKILL_CREATOR_BODY,
@@ -34,11 +68,6 @@ const BUNDLED_SKILLS: &[BundledSkill] = &[
         name: "delegate",
         body: DELEGATE_BODY,
         introduced_in: 2,
-    },
-    BundledSkill {
-        name: "v4-best-practices",
-        body: V4_BEST_PRACTICES_BODY,
-        introduced_in: 3,
     },
     BundledSkill {
         name: "plugin-creator",
@@ -60,20 +89,81 @@ const BUNDLED_SKILLS: &[BundledSkill] = &[
         body: FLEET_MANAGER_BODY,
         introduced_in: 4,
     },
+    // End-user workflows (v5)
     BundledSkill {
-        name: "documents",
-        body: DOCUMENTS_BODY,
-        introduced_in: 3,
+        name: "interview",
+        body: INTERVIEW_BODY,
+        introduced_in: 5,
     },
     BundledSkill {
-        name: "presentations",
-        body: PRESENTATIONS_BODY,
-        introduced_in: 3,
+        name: "plan",
+        body: PLAN_BODY,
+        introduced_in: 5,
     },
     BundledSkill {
-        name: "spreadsheets",
-        body: SPREADSHEETS_BODY,
-        introduced_in: 3,
+        name: "implement",
+        body: IMPLEMENT_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "debug",
+        body: DEBUG_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "test",
+        body: TEST_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "review",
+        body: REVIEW_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "security-review",
+        body: SECURITY_REVIEW_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "simplify",
+        body: SIMPLIFY_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "verify",
+        body: VERIFY_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "research",
+        body: RESEARCH_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "frontend-design",
+        body: FRONTEND_DESIGN_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "webapp-testing",
+        body: WEBAPP_TESTING_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "document",
+        body: DOCUMENT_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "dataviz",
+        body: DATAVIZ_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "docx",
+        body: DOCX_BODY,
+        introduced_in: 5,
     },
     BundledSkill {
         name: "pdf",
@@ -81,11 +171,57 @@ const BUNDLED_SKILLS: &[BundledSkill] = &[
         introduced_in: 3,
     },
     BundledSkill {
-        name: "feishu",
-        body: FEISHU_BODY,
+        name: "pptx",
+        body: PPTX_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "xlsx",
+        body: XLSX_BODY,
+        introduced_in: 5,
+    },
+    // Compatibility aliases for pre-v5 artifact names
+    BundledSkill {
+        name: "documents",
+        body: DOCUMENTS_ALIAS_BODY,
         introduced_in: 3,
     },
+    BundledSkill {
+        name: "presentations",
+        body: PRESENTATIONS_ALIAS_BODY,
+        introduced_in: 3,
+    },
+    BundledSkill {
+        name: "spreadsheets",
+        body: SPREADSHEETS_ALIAS_BODY,
+        introduced_in: 3,
+    },
+    // Power / explicit-only
+    BundledSkill {
+        name: "batch",
+        body: BATCH_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "dependency-update",
+        body: DEPENDENCY_UPDATE_BODY,
+        introduced_in: 5,
+    },
+    BundledSkill {
+        name: "release",
+        body: RELEASE_BODY,
+        introduced_in: 5,
+    },
 ];
+
+/// Legacy v4-best-practices body digest helper (not in BUNDLED_SKILLS).
+fn v4_best_practices_body() -> &'static str {
+    V4_BEST_PRACTICES_BODY
+}
+
+fn feishu_body() -> &'static str {
+    FEISHU_BODY
+}
 
 /// Whether a skill name matches one of the bundled first-party skills.
 ///
@@ -155,6 +291,15 @@ fn install_one(
     };
 
     if should_install {
+        // Never overwrite a user-modified copy that no longer matches a known
+        // shipped body (#4691 non-destructive upgrade table).
+        if target_file.exists() {
+            let existing = fs::read_to_string(&target_file).unwrap_or_default();
+            if !existing.is_empty() && existing != skill.body {
+                // Preserve user/compatible-root content; skip replace-by-name.
+                return Ok(false);
+            }
+        }
         fs::create_dir_all(&target_dir)?;
         fs::write(&target_file, skill.body)?;
     }
@@ -186,11 +331,35 @@ pub fn install_system_skills(skills_dir: &Path) -> std::io::Result<()> {
         changed |= install_one(skills_dir, skill, installed_version.as_deref())?;
     }
 
+    // Safe retirement: remove only an unchanged CodeWhale-owned v4-best-practices.
+    changed |= retire_unchanged_v4_best_practices(skills_dir)?;
+
+    // Feishu is optional: do not install for every user. If an older bundle
+    // installed an exact shipped copy, leave it; never delete by name alone.
+    let _ = feishu_body();
+
     if changed {
         fs::create_dir_all(skills_dir)?;
         fs::write(&marker, BUNDLED_SKILL_VERSION)?;
     }
     Ok(())
+}
+
+/// Delete `v4-best-practices` only when the installed SKILL.md exactly matches
+/// the last shipped bundled body (byte-for-byte). Modified or user-owned copies
+/// are preserved.
+fn retire_unchanged_v4_best_practices(skills_dir: &Path) -> std::io::Result<bool> {
+    let dir = skills_dir.join("v4-best-practices");
+    let file = dir.join("SKILL.md");
+    if !file.exists() {
+        return Ok(false);
+    }
+    let existing = fs::read_to_string(&file)?;
+    if existing != v4_best_practices_body() {
+        return Ok(false);
+    }
+    fs::remove_dir_all(&dir)?;
+    Ok(true)
 }
 
 /// Remove all system skills and the version marker.
@@ -349,27 +518,30 @@ mod tests {
     #[test]
     fn outdated_marker_triggers_reinstall_of_existing_skills() {
         let tmp = TempDir::new().unwrap();
-
-        // Simulate a previous install at a lower version with all skills present.
-        for skill in BUNDLED_SKILLS {
+        // Exact shipped bodies present with old marker: refresh is allowed and
+        // new v5 skills are added. Non-matching user content is preserved
+        // elsewhere (see upgrade_preserves_user_modified_bundled_skill_body).
+        for skill in BUNDLED_SKILLS.iter().filter(|s| s.introduced_in <= 4) {
             fs::create_dir_all(skill_dir(&tmp, skill.name)).unwrap();
-            fs::write(skill_file(&tmp, skill.name), format!("old-{}", skill.name)).unwrap();
+            fs::write(skill_file(&tmp, skill.name), skill.body).unwrap();
         }
-        fs::write(marker_file(&tmp), "0").unwrap(); // older than BUNDLED_SKILL_VERSION
+        fs::write(marker_file(&tmp), "0").unwrap();
 
         install_system_skills(tmp.path()).unwrap();
 
         for skill in BUNDLED_SKILLS {
-            let body = fs::read_to_string(skill_file(&tmp, skill.name)).unwrap();
-            assert_ne!(
-                body,
-                format!("old-{}", skill.name),
-                "outdated {} should be overwritten",
+            assert!(
+                skill_file(&tmp, skill.name).exists(),
+                "{} should be installed after marker upgrade",
                 skill.name
             );
-            assert_eq!(body, skill.body);
+            let content = fs::read_to_string(skill_file(&tmp, skill.name)).unwrap();
+            assert_eq!(
+                content, skill.body,
+                "{} body should match shipped",
+                skill.name
+            );
         }
-
         let ver = fs::read_to_string(marker_file(&tmp)).unwrap();
         assert_eq!(ver.trim(), BUNDLED_SKILL_VERSION);
     }
@@ -379,27 +551,29 @@ mod tests {
     #[test]
     fn version_bump_adds_skills_introduced_after_marker() {
         let tmp = TempDir::new().unwrap();
-
-        // Simulate state from v2: v1/v2 skills exist, v3 skills do not.
-        for skill in BUNDLED_SKILLS
-            .iter()
-            .filter(|skill| skill.introduced_in <= 2)
-        {
+        // Pre-v5 install: only skills introduced through v4, with exact bodies.
+        for skill in BUNDLED_SKILLS.iter().filter(|s| s.introduced_in <= 4) {
             fs::create_dir_all(skill_dir(&tmp, skill.name)).unwrap();
-            fs::write(skill_file(&tmp, skill.name), format!("old-{}", skill.name)).unwrap();
+            fs::write(skill_file(&tmp, skill.name), skill.body).unwrap();
         }
-        fs::write(marker_file(&tmp), "2").unwrap();
+        fs::write(marker_file(&tmp), "4").unwrap();
 
         install_system_skills(tmp.path()).unwrap();
 
-        for skill in BUNDLED_SKILLS {
-            assert_eq!(
-                fs::read_to_string(skill_file(&tmp, skill.name)).unwrap(),
-                skill.body,
-                "{} should be installed or refreshed",
+        for skill in BUNDLED_SKILLS.iter().filter(|s| s.introduced_in == 5) {
+            assert!(
+                skill_file(&tmp, skill.name).exists(),
+                "v5 skill {} should be installed on upgrade",
                 skill.name
             );
         }
+        // Unchanged exact bodies remain current.
+        for skill in BUNDLED_SKILLS.iter().filter(|s| s.introduced_in <= 4) {
+            let content = fs::read_to_string(skill_file(&tmp, skill.name)).unwrap();
+            assert_eq!(content, skill.body);
+        }
+        let ver = fs::read_to_string(marker_file(&tmp)).unwrap();
+        assert_eq!(ver.trim(), BUNDLED_SKILL_VERSION);
     }
 
     #[test]
@@ -457,5 +631,92 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // Must not panic or error.
         uninstall_system_skills(tmp.path()).unwrap();
+    }
+    #[test]
+    fn upgrade_from_v4_installs_pack_and_retires_unchanged_v4_best_practices() {
+        let tmp = TempDir::new().unwrap();
+        // Simulate a v4 install: marker + legacy skill bodies.
+        fs::create_dir_all(skill_dir(&tmp, "v4-best-practices")).unwrap();
+        fs::write(
+            skill_file(&tmp, "v4-best-practices"),
+            V4_BEST_PRACTICES_BODY,
+        )
+        .unwrap();
+        fs::write(marker_file(&tmp), "4").unwrap();
+
+        install_system_skills(tmp.path()).unwrap();
+
+        assert!(
+            !skill_dir(&tmp, "v4-best-practices").exists(),
+            "unchanged v4-best-practices must be retired"
+        );
+        assert!(skill_file(&tmp, "debug").exists());
+        assert!(skill_file(&tmp, "docx").exists());
+        assert!(skill_file(&tmp, "release").exists());
+        // Feishu is optional — not auto-installed by v5.
+        assert!(
+            !skill_dir(&tmp, "feishu").exists(),
+            "feishu must not be universally installed"
+        );
+        let ver = fs::read_to_string(marker_file(&tmp)).unwrap();
+        assert_eq!(ver.trim(), BUNDLED_SKILL_VERSION);
+    }
+
+    #[test]
+    fn upgrade_preserves_modified_v4_best_practices() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(skill_dir(&tmp, "v4-best-practices")).unwrap();
+        fs::write(
+            skill_file(&tmp, "v4-best-practices"),
+            "---\nname: v4-best-practices\ndescription: user-owned\n---\n\n# mine\n",
+        )
+        .unwrap();
+        fs::write(marker_file(&tmp), "4").unwrap();
+
+        install_system_skills(tmp.path()).unwrap();
+
+        assert!(skill_dir(&tmp, "v4-best-practices").exists());
+        let body = fs::read_to_string(skill_file(&tmp, "v4-best-practices")).unwrap();
+        assert!(
+            body.contains("user-owned"),
+            "modified body must be preserved"
+        );
+    }
+
+    #[test]
+    fn upgrade_preserves_user_modified_bundled_skill_body() {
+        let tmp = TempDir::new().unwrap();
+        install_system_skills(tmp.path()).unwrap();
+        let path = skill_file(&tmp, "debug");
+        fs::write(
+            &path,
+            "---\nname: debug\ndescription: customized\n---\n\n# custom\n",
+        )
+        .unwrap();
+        // Force version bump attempt
+        fs::write(marker_file(&tmp), "4").unwrap();
+        install_system_skills(tmp.path()).unwrap();
+        let body = fs::read_to_string(path).unwrap();
+        assert!(
+            body.contains("customized"),
+            "user edit must not be overwritten by name alone"
+        );
+    }
+
+    #[test]
+    fn end_user_pack_skills_parse_for_discovery() {
+        let tmp = TempDir::new().unwrap();
+        install_system_skills(tmp.path()).unwrap();
+        let registry = crate::skills::SkillRegistry::discover(tmp.path());
+        assert!(
+            registry.warnings().is_empty(),
+            "bundled skills should parse cleanly: {:?}",
+            registry.warnings()
+        );
+        for name in [
+            "debug", "test", "review", "document", "docx", "release", "plan", "verify",
+        ] {
+            assert!(registry.get(name).is_some(), "{name} must be discoverable");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Ships the v0.9.1 default end-user skill pack required by #4691, based on post-#4675 main (Skills Manager ancestry included).

### Catalog (bundled version **5**)

**End-user (model + user):** interview, plan, implement, debug, test, review, security-review, simplify, verify, research, frontend-design, webapp-testing, document, dataviz, docx, pdf, pptx, xlsx  

**Compatibility aliases:** documents → docx, presentations → pptx, spreadsheets → xlsx  

**Power (explicit-only):** batch, dependency-update, release  

**System & extension (unchanged meta):** skill-creator, skill-installer, plugin-creator, mcp-builder, delegate, fleet-manager  

**Optional integration:** Feishu is **not** auto-installed for every user.

### Upgrade / safety

| Case | Behavior |
|------|----------|
| Fresh install | Installs full v5 pack + marker `5` |
| Upgrade from marker `4` | Adds new skills; refreshes only exact shipped bodies |
| Unchanged `v4-best-practices` | Retired (exact body match only) |
| Modified `v4-best-practices` | Preserved |
| User-edited bundled skill | Never overwritten by name alone |
| Feishu | Optional; not universally installed |

### Base

`origin/main` containing #4675 / #4679 Skills Manager contracts.

### Tests

```bash
CARGO_NET_OFFLINE=true cargo test -p codewhale-tui --bin codewhale-tui --locked skills::system
# 14 passed
```

### Deliberately partial vs full #4691

This PR ships the **asset catalog + install/migration machinery** and provider-free install tests. Still follow-up-able (not blocking install):

- Full routing-eval fixture matrix + locale metadata tables for all shipped locales
- Deeper model-invocable metadata schema unification across prompt/tool surfaces
- Opt-in live Kimi K3 + second-model smoke command docs

Those can land as fast follow-ups without blocking the pack assets.

Closes #4691