### PR TITLE
fix(tui): hide empty coordination work before v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.1] - Unreleased candidate
+## [0.9.1] - 2026-07-22
 
 The Codewhale v0.9.1 source candidate includes a first-class local web client over the Runtime API,
 first-class OpenCode Go and TelecomJS TokenHub providers and restored xAI device login,
@@ -3959,7 +3959,7 @@ overflow report and `/theme` picker edge-wrapping patch in #1814.
 Older releases (v0.8.39 and earlier) are archived in [docs/CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).
 
 [Unreleased]: https://github.com/Hmbown/CodeWhale/compare/v0.9.0...HEAD
-[0.9.1]: https://github.com/Hmbown/CodeWhale/compare/v0.9.0...main
+[0.9.1]: https://github.com/Hmbown/CodeWhale/compare/v0.9.0...v0.9.1
 [0.8.68]: https://github.com/Hmbown/CodeWhale/compare/v0.8.67...v0.8.68
 [0.8.67]: https://github.com/Hmbown/CodeWhale/compare/v0.8.66...v0.8.67
 [0.8.66]: https://github.com/Hmbown/CodeWhale/compare/v0.8.65...v0.8.66

--- a/crates/tui/CHANGELOG.md
+++ b/crates/tui/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.1] - Unreleased candidate
+## [0.9.1] - 2026-07-22
 
 The Codewhale v0.9.1 source candidate includes a first-class local web client over the Runtime API,
 first-class OpenCode Go and TelecomJS TokenHub providers and restored xAI device login,

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -297,6 +297,86 @@ mod tests {
     }
 
     #[test]
+    fn empty_coordination_projection_does_not_create_work_chrome() {
+        use crate::tools::subagent::CoordinationDetailProjection;
+        use crate::tools::subagent::coord::{ContextProjectionReceipt, CoordinationDetailMetrics};
+
+        let mut app = app();
+        app.coordination_detail = Some(CoordinationDetailProjection {
+            schema_version: 1,
+            sequence: 3,
+            decisions: Vec::new(),
+            write_claims: Vec::new(),
+            reconciliations: Vec::new(),
+            context_projections: ["agent-a", "agent-b", "agent-c"]
+                .into_iter()
+                .enumerate()
+                .map(|(index, child_id)| ContextProjectionReceipt {
+                    child_id: child_id.to_string(),
+                    decision_ids: Vec::new(),
+                    projected_bytes: 0,
+                    deduplicated: 0,
+                    omitted: 0,
+                    sequence: u64::try_from(index + 1).expect("small fixture sequence"),
+                })
+                .collect(),
+            contentions: Vec::new(),
+            metrics: CoordinationDetailMetrics {
+                hottest_paths: Vec::new(),
+                package_or_module_growth: None,
+                route_or_cost: None,
+                note: "growth and route/cost stay null when the coordination ledger has no authoritative source".to_string(),
+            },
+            bounded: true,
+            limit: 24,
+        });
+
+        let rows = super::model::project(&mut app);
+        assert!(
+            rows.is_empty(),
+            "zero-byte, no-decision coordination receipts must not create Work chrome: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn nonempty_context_projection_remains_inspectable_work() {
+        use crate::tools::subagent::CoordinationDetailProjection;
+        use crate::tools::subagent::coord::{ContextProjectionReceipt, CoordinationDetailMetrics};
+
+        let mut app = app();
+        app.coordination_detail = Some(CoordinationDetailProjection {
+            schema_version: 1,
+            sequence: 1,
+            decisions: Vec::new(),
+            write_claims: Vec::new(),
+            reconciliations: Vec::new(),
+            context_projections: vec![ContextProjectionReceipt {
+                child_id: "agent-a".to_string(),
+                decision_ids: vec!["decision-a".to_string()],
+                projected_bytes: 32,
+                deduplicated: 0,
+                omitted: 0,
+                sequence: 1,
+            }],
+            contentions: Vec::new(),
+            metrics: CoordinationDetailMetrics {
+                hottest_paths: Vec::new(),
+                package_or_module_growth: None,
+                route_or_cost: None,
+                note: String::new(),
+            },
+            bounded: true,
+            limit: 24,
+        });
+
+        let rows = super::model::project(&mut app);
+        assert!(
+            rows.iter().any(|row| row.id.0 == "coordination"),
+            "non-empty context projection must remain inspectable: {rows:?}"
+        );
+    }
+
+    #[test]
     fn current_blocked_contention_uses_attention_bucket_mark_and_tone() {
         use crate::tools::subagent::CoordinationDetailProjection;
         use crate::tools::subagent::coord::{

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -616,11 +616,21 @@ fn sanitize_summary_title(raw: &str) -> String {
 
 fn coordination_row(app: &App) -> Option<RankedWorkRow> {
     let projection = app.coordination_detail.as_ref()?;
+    let has_context_receipt = projection.context_projections.iter().any(|receipt| {
+        !receipt.decision_ids.is_empty()
+            || receipt.projected_bytes > 0
+            || receipt.deduplicated > 0
+            || receipt.omitted > 0
+    });
+    let has_metrics = !projection.metrics.hottest_paths.is_empty()
+        || projection.metrics.package_or_module_growth.is_some()
+        || projection.metrics.route_or_cost.is_some();
     if projection.decisions.is_empty()
         && projection.write_claims.is_empty()
         && projection.reconciliations.is_empty()
-        && projection.context_projections.is_empty()
         && projection.contentions.is_empty()
+        && !has_context_receipt
+        && !has_metrics
     {
         return None;
     }

--- a/web/lib/public-surface-contract.test.ts
+++ b/web/lib/public-surface-contract.test.ts
@@ -173,7 +173,9 @@ describe("public surface contracts", () => {
     ]) {
       expect(npmArtifacts).toContain(binary);
     }
-    expect(changelog).toContain("## [0.9.1] - Unreleased candidate");
+    expect(changelog).toMatch(
+      /^## \[0\.9\.1\] - (?:Unreleased candidate|\d{4}-\d{2}-\d{2})$/m,
+    );
     expect(changelog).toContain("v0.9.1 source candidate");
     expect(changelog).not.toContain("compare/v0.9.1...HEAD");
   });


### PR DESCRIPTION
## What changed

- treat all-empty coordination snapshots as absent so first-open Work chrome stays hidden
- preserve inspectable Work for real decisions, claims, contentions, reconciliations, non-empty context receipts, and metrics
- date the v0.9.1 changelog entry for 2026-07-22 and bind its compare link to the release tag
- allow the public-surface contract to cover both candidate and dated-release headings

## Root cause

Persisted context-projection receipts were counted as Coordination Work even when every receipt contained no decision ids, zero projected bytes, zero deduplication, and zero omissions. That promoted a semantically empty ledger into `1 recent` Work chrome on startup.

## Validation

- exact zero-byte/no-decision three-agent regression fixture
- non-empty context receipt preservation fixture
- 48 filtered Work-surface tests
- `cargo fmt --all -- --check`
- `bash scripts/release/check-versions.sh --require-dated-release`
- 25 Layer 5.1 registry tests
- 163 sidebar/Agent Details tests
- six tool-lifecycle acceptance scenarios
- real Unix PTY tool-lifecycle test
- web facts/docs checks, 119 tests, lint, TypeScript, and production build
- `git diff --check`

No tag, GitHub Release, registry publication, or deployment is performed by this PR.