### PR TITLE
fix(tui): show complete edit previews in details

### DIFF
--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -818,12 +818,12 @@ fn edit_file_preview_lines(params: &Value, max_lines: usize) -> Option<Vec<Strin
     Some(lines)
 }
 
-fn exact_edit_file_preview_lines(params: &Value) -> Option<Vec<String>> {
+fn exact_edit_file_preview_lines(params: &Value, locale: Locale) -> Option<Vec<String>> {
     let search = param_text(params, &["search"])?;
     let replace = param_text(params, &["replace"])?;
-    let mut lines = vec!["replace this".to_string()];
+    let mut lines = vec![tr(locale, MessageId::ApprovalLabelReplaceThis).into_owned()];
     lines.extend(exact_preview_body_lines("- ", &search));
-    lines.push("with this".to_string());
+    lines.push(tr(locale, MessageId::ApprovalLabelWithThis).into_owned());
     lines.extend(exact_preview_body_lines("+ ", &replace));
     Some(lines)
 }
@@ -1409,12 +1409,12 @@ impl ApprovalView {
         }
         content.push('\n');
         if canonical_action_alias(&self.request.tool_name, &self.request.params) == "edit_file"
-            && let Some(preview_lines) = exact_edit_file_preview_lines(&self.request.params)
+            && let Some(preview_lines) = exact_edit_file_preview_lines(&self.request.params, locale)
         {
-            content.push_str(&localize_detail_label("Preview", locale));
+            content.push_str(&tr(locale, MessageId::ApprovalLabelPreview));
             content.push_str(":\n");
             for line in preview_lines {
-                content.push_str(&localize_preview_shell_line("edit_file", &line, locale));
+                content.push_str(&line);
                 content.push('\n');
             }
             content.push('\n');
@@ -3141,6 +3141,40 @@ diff --git a/src/b.rs b/src/b.rs
             displayed.contains(&expected_preview),
             "details pager display changed exact whitespace or line endings:\n{displayed}"
         );
+    }
+
+    #[test]
+    fn edit_file_details_pager_localizes_preview_headers_for_every_locale() {
+        for &locale in Locale::shipped() {
+            let request = ApprovalRequest::new(
+                "test-id",
+                "edit_file",
+                "Edit a file on disk",
+                &json!({
+                    "path": "src/lib.rs",
+                    "search": "old();",
+                    "replace": "new();"
+                }),
+                "tool:edit_file",
+            );
+            let mut view = ApprovalView::new_for_locale(request, locale);
+
+            let action = view.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::ALT));
+            let ViewAction::Emit(ViewEvent::OpenTextPager { content, .. }) = action else {
+                panic!("Alt+V should open the edit details pager for {locale:?}");
+            };
+            let expected_headers = format!(
+                "{}:\n{}\n- \"old();\"\n{}\n+ \"new();\"",
+                tr(locale, MessageId::ApprovalLabelPreview),
+                tr(locale, MessageId::ApprovalLabelReplaceThis),
+                tr(locale, MessageId::ApprovalLabelWithThis),
+            );
+
+            assert!(
+                content.contains(&expected_headers),
+                "details pager did not localize edit preview headers for {locale:?}:\n{content}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -818,6 +818,56 @@ fn edit_file_preview_lines(params: &Value, max_lines: usize) -> Option<Vec<Strin
     Some(lines)
 }
 
+fn exact_edit_file_preview_lines(params: &Value) -> Option<Vec<String>> {
+    let search = param_text(params, &["search"])?;
+    let replace = param_text(params, &["replace"])?;
+    let mut lines = vec!["replace this".to_string()];
+    lines.extend(exact_preview_body_lines("- ", &search));
+    lines.push("with this".to_string());
+    lines.extend(exact_preview_body_lines("+ ", &replace));
+    Some(lines)
+}
+
+fn exact_preview_body_lines(prefix: &str, content: &str) -> Vec<String> {
+    if content.is_empty() {
+        return vec![format!("{prefix}\"\"")];
+    }
+
+    content
+        .split_inclusive('\n')
+        .map(|chunk| {
+            let (body, ending) = if let Some(body) = chunk.strip_suffix("\r\n") {
+                (body, "\\r\\n")
+            } else if let Some(body) = chunk.strip_suffix('\n') {
+                (body, "\\n")
+            } else {
+                (chunk, "")
+            };
+            exact_preview_body_line(prefix, body, ending)
+        })
+        .collect()
+}
+
+fn exact_preview_body_line(prefix: &str, body: &str, ending: &str) -> String {
+    let mut line = String::with_capacity(prefix.len() + body.len() + ending.len() + 2);
+    line.push_str(prefix);
+    line.push('"');
+    for ch in body.chars() {
+        match ch {
+            '\\' => line.push_str("\\\\"),
+            '"' => line.push_str("\\\""),
+            ' ' => line.push_str("\\x20"),
+            '\t' => line.push_str("\\t"),
+            '\r' => line.push_str("\\r"),
+            ch if ch.is_whitespace() || ch.is_control() => line.extend(ch.escape_unicode()),
+            ch => line.push(ch),
+        }
+    }
+    line.push_str(ending);
+    line.push('"');
+    line
+}
+
 fn prefixed_preview_lines(
     header: &str,
     prefix: &str,
@@ -1359,7 +1409,7 @@ impl ApprovalView {
         }
         content.push('\n');
         if canonical_action_alias(&self.request.tool_name, &self.request.params) == "edit_file"
-            && let Some(preview_lines) = edit_file_preview_lines(&self.request.params, usize::MAX)
+            && let Some(preview_lines) = exact_edit_file_preview_lines(&self.request.params)
         {
             content.push_str(&localize_detail_label("Preview", locale));
             content.push_str(":\n");
@@ -3052,8 +3102,8 @@ diff --git a/src/b.rs b/src/b.rs
             "Edit a file on disk",
             &json!({
                 "path": "src/lib.rs",
-                "search": "old_1();\nold_2();\nold_3();\nold_4();\nold_5();",
-                "replace": "new_1();\nnew_2();\nnew_3();\nnew_4();\nnew_5();"
+                "search": "  old_1();\r\n\told_2();\nold  3();\nold_4();\nold_5();\n",
+                "replace": "\tnew_1();\nnew  2();\r\nnew_3();\nnew_4();\nnew_5();"
             }),
             "tool:edit_file",
         );
@@ -3064,22 +3114,32 @@ diff --git a/src/b.rs b/src/b.rs
             panic!("Alt+V should open the edit details pager");
         };
 
-        let expected_preview = "Preview:\n\
-replace this\n\
-- old_1();\n\
-- old_2();\n\
-- old_3();\n\
-- old_4();\n\
-- old_5();\n\
-with this\n\
-+ new_1();\n\
-+ new_2();\n\
-+ new_3();\n\
-+ new_4();\n\
-+ new_5();";
+        let expected_preview = [
+            "Preview:",
+            "replace this",
+            "- \"\\x20\\x20old_1();\\r\\n\"",
+            "- \"\\told_2();\\n\"",
+            "- \"old\\x20\\x203();\\n\"",
+            "- \"old_4();\\n\"",
+            "- \"old_5();\\n\"",
+            "with this",
+            "+ \"\\tnew_1();\\n\"",
+            "+ \"new\\x20\\x202();\\r\\n\"",
+            "+ \"new_3();\\n\"",
+            "+ \"new_4();\\n\"",
+            "+ \"new_5();\"",
+        ]
+        .join("\n");
         assert!(
-            content.contains(expected_preview),
+            content.contains(&expected_preview),
             "details pager omitted part of the edit preview:\n{content}"
+        );
+
+        let pager = crate::tui::pager::PagerView::from_text("Tool Params", &content, 200);
+        let displayed = pager.body_text();
+        assert!(
+            displayed.contains(&expected_preview),
+            "details pager display changed exact whitespace or line endings:\n{displayed}"
         );
     }
 

--- a/crates/tui/src/tui/approval.rs
+++ b/crates/tui/src/tui/approval.rs
@@ -783,12 +783,9 @@ fn file_write_preview_lines(tool_name: &str, params: &Value) -> Option<Vec<Strin
             ))
         }
         "edit_file" => {
-            let search = param_text(params, &["search"])?;
-            let replace = param_text(params, &["replace"])?;
-            let mut lines = Vec::new();
-            lines.extend(prefixed_preview_lines("replace this", "- ", &search, 3));
-            lines.extend(prefixed_preview_lines("with this", "+ ", &replace, 3));
-            Some(lines)
+            // Keep the per-frame card preview bounded. The details pager builds the
+            // complete version lazily when the reviewer asks for it.
+            edit_file_preview_lines(params, 3)
         }
         "apply_patch" => match normalize_apply_patch_input(params) {
             Ok(NormalizedApplyPatchInput::Patch(patch)) => apply_patch_preview_lines(patch),
@@ -800,6 +797,25 @@ fn file_write_preview_lines(tool_name: &str, params: &Value) -> Option<Vec<Strin
         _ => None,
     }
     .filter(|lines| !lines.is_empty())
+}
+
+fn edit_file_preview_lines(params: &Value, max_lines: usize) -> Option<Vec<String>> {
+    let search = param_text(params, &["search"])?;
+    let replace = param_text(params, &["replace"])?;
+    let mut lines = Vec::new();
+    lines.extend(prefixed_preview_lines(
+        "replace this",
+        "- ",
+        &search,
+        max_lines,
+    ));
+    lines.extend(prefixed_preview_lines(
+        "with this",
+        "+ ",
+        &replace,
+        max_lines,
+    ));
+    Some(lines)
 }
 
 fn prefixed_preview_lines(
@@ -1342,6 +1358,17 @@ impl ApprovalView {
             content.push('\n');
         }
         content.push('\n');
+        if canonical_action_alias(&self.request.tool_name, &self.request.params) == "edit_file"
+            && let Some(preview_lines) = edit_file_preview_lines(&self.request.params, usize::MAX)
+        {
+            content.push_str(&localize_detail_label("Preview", locale));
+            content.push_str(":\n");
+            for line in preview_lines {
+                content.push_str(&localize_preview_shell_line("edit_file", &line, locale));
+                content.push('\n');
+            }
+            content.push('\n');
+        }
         content.push_str(
             &serde_json::to_string_pretty(&self.request.params)
                 .unwrap_or_else(|_| self.request.params.to_string()),
@@ -3015,6 +3042,45 @@ diff --git a/src/b.rs b/src/b.rs
             action,
             ViewAction::Emit(ViewEvent::OpenTextPager { .. })
         ));
+    }
+
+    #[test]
+    fn edit_file_details_pager_includes_complete_search_replace_preview() {
+        let request = ApprovalRequest::new(
+            "test-id",
+            "edit_file",
+            "Edit a file on disk",
+            &json!({
+                "path": "src/lib.rs",
+                "search": "old_1();\nold_2();\nold_3();\nold_4();\nold_5();",
+                "replace": "new_1();\nnew_2();\nnew_3();\nnew_4();\nnew_5();"
+            }),
+            "tool:edit_file",
+        );
+        let mut view = ApprovalView::new(request);
+
+        let action = view.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::ALT));
+        let ViewAction::Emit(ViewEvent::OpenTextPager { content, .. }) = action else {
+            panic!("Alt+V should open the edit details pager");
+        };
+
+        let expected_preview = "Preview:\n\
+replace this\n\
+- old_1();\n\
+- old_2();\n\
+- old_3();\n\
+- old_4();\n\
+- old_5();\n\
+with this\n\
++ new_1();\n\
++ new_2();\n\
++ new_3();\n\
++ new_4();\n\
++ new_5();";
+        assert!(
+            content.contains(expected_preview),
+            "details pager omitted part of the edit preview:\n{content}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

- Keep the compact `edit_file` approval card bounded.
- Build and render the complete localized `-/+` search/replace preview lazily in the Alt+V details pager.
- Add a regression test covering both sides beyond the previous three-line summary.

## Why

The card preview intentionally stays compact, but the details pager previously fell back to raw JSON. That left multiline replacement boundaries difficult to review. Building the full preview only when the pager opens avoids adding unbounded work to the per-frame render path.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui --locked edit_file` — 21 passed
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tui::approval::tests::` — 99 passed
- `cargo check -p codewhale-tui --all-targets --locked`
- `cargo test --workspace --doc --locked`
- Workspace unit suite otherwise passed locally; isolated Windows baselines were `echo` being a shell built-in, PowerShell redirection producing UTF-16, and a user-home instruction fixture. The parallel-only external approval count failure passed in isolation.
- The exact CI Clippy command reaches two unrelated Windows-only main-branch lints; upstream main's Linux Lint job is green.

Fixes #4659