### PR TITLE
fix(tui): archive completed background shell output

### DIFF
--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -2047,7 +2047,7 @@ fn refresh_shell_exec_live_output(app: &mut App) -> bool {
 
     let mut changed = false;
     for index in 0..app.virtual_cell_count() {
-        let Some((task_id, next_status, next_live, next_duration)) =
+        let Some((task_id, next_status, next_live, next_duration, finalized)) =
             shell_exec_live_update(app, index, &jobs)
         else {
             continue;
@@ -2060,8 +2060,17 @@ fn refresh_shell_exec_live_output(app: &mut App) -> bool {
             continue;
         }
         exec.status = next_status;
-        exec.live_output = next_live;
         exec.duration_ms = Some(next_duration);
+        if finalized {
+            exec.output = next_live;
+            exec.output_summary = exec
+                .output
+                .as_deref()
+                .map(super::history::summarize_tool_output);
+            exec.live_output = None;
+        } else {
+            exec.live_output = next_live;
+        }
         changed = true;
     }
     changed
@@ -2071,7 +2080,7 @@ fn shell_exec_live_update(
     app: &App,
     index: usize,
     jobs: &std::collections::HashMap<String, ShellJobSnapshot>,
-) -> Option<(String, ToolStatus, Option<String>, u64)> {
+) -> Option<(String, ToolStatus, Option<String>, u64, bool)> {
     let HistoryCell::Tool(ToolCell::Exec(exec)) = app.cell_at_virtual_index(index)? else {
         return None;
     };
@@ -2082,13 +2091,20 @@ fn shell_exec_live_update(
     let job = jobs.get(task_id)?;
     let next_status = shell_job_tool_status(&job.status);
     let next_live = shell_job_live_output(job).or_else(|| exec.live_output.clone());
+    let finalized = !matches!(job.status, ShellStatus::Running);
     if exec.status == next_status
         && exec.live_output == next_live
         && exec.duration_ms == Some(job.elapsed_ms)
     {
         return None;
     }
-    Some((task_id.to_string(), next_status, next_live, job.elapsed_ms))
+    Some((
+        task_id.to_string(),
+        next_status,
+        next_live,
+        job.elapsed_ms,
+        finalized,
+    ))
 }
 
 fn shell_job_tool_status(status: &ShellStatus) -> ToolStatus {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4619,15 +4619,93 @@ fn shell_live_output_update_matches_exact_task_id_only() {
     );
 
     assert!(shell_exec_live_update(&app, 0, &jobs).is_none());
-    let (_task_id, status, output, duration) =
+    let (_task_id, status, output, duration, finalized) =
         shell_exec_live_update(&app, 1, &jobs).expect("matching task id updates");
 
     assert_eq!(status, ToolStatus::Running);
     assert_eq!(duration, 777);
+    assert!(!finalized);
     assert_eq!(
         output.as_deref(),
         Some("stdout tail\n\n\nSTDERR:\nstderr tail\n")
     );
+}
+
+#[test]
+fn shell_live_output_update_finalizes_background_exec_output() {
+    let mut app = create_test_app();
+    app.push_history_cell(HistoryCell::Tool(ToolCell::Exec(ExecCell {
+        command: "cargo test --workspace".to_string(),
+        status: ToolStatus::Running,
+        output: None,
+        live_output: Some("previous output".to_string()),
+        shell_task_id: Some("shell_a".to_string()),
+        owner_agent_id: None,
+        owner_agent_name: None,
+        started_at: None,
+        duration_ms: None,
+        source: ExecSource::Assistant,
+        interaction: None,
+        output_summary: None,
+    })));
+
+    let mut jobs = std::collections::HashMap::new();
+    jobs.insert(
+        "shell_a".to_string(),
+        ShellJobSnapshot {
+            id: "shell_a".to_string(),
+            job_id: "shell_a".to_string(),
+            command: "cargo test --workspace".to_string(),
+            cwd: PathBuf::from("/tmp/repo"),
+            status: ShellStatus::Completed,
+            exit_code: Some(0),
+            elapsed_ms: 999,
+            stdout_tail: "final stdout\n".to_string(),
+            stderr_tail: "final stderr\n".to_string(),
+            stdout_len: 13,
+            stderr_len: 13,
+            stdin_available: false,
+            stale: false,
+            elapsed_since_output_ms: None,
+            linked_task_id: None,
+            owner_agent_id: None,
+            owner_agent_name: None,
+        },
+    );
+
+    let (task_id, status, output, duration, finalized) =
+        shell_exec_live_update(&app, 0, &jobs).expect("completed shell updates");
+    assert_eq!(task_id, "shell_a");
+    assert_eq!(status, ToolStatus::Success);
+    assert_eq!(duration, 999);
+    assert!(finalized);
+    assert_eq!(
+        output.as_deref(),
+        Some("final stdout\n\n\nSTDERR:\nfinal stderr\n")
+    );
+
+    let HistoryCell::Tool(ToolCell::Exec(exec)) =
+        app.cell_at_virtual_index_mut(0).expect("exec cell")
+    else {
+        panic!("expected exec cell");
+    };
+    exec.status = status;
+    exec.duration_ms = Some(duration);
+    exec.output = output;
+    exec.output_summary = exec
+        .output
+        .as_deref()
+        .map(crate::tui::history::summarize_tool_output);
+    exec.live_output = None;
+
+    assert_eq!(exec.status, ToolStatus::Success);
+    assert_eq!(
+        exec.output.as_deref(),
+        Some("final stdout\n\n\nSTDERR:\nfinal stderr\n")
+    );
+    assert!(exec.live_output.is_none());
+    assert_eq!(exec.duration_ms, Some(999));
+    assert!(exec.output_summary.is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Summary:
- Archive a background Shell job's final visible stdout/stderr tail into its
  originating ExecCell when the job reaches a terminal state.
- Clear live_output and build the existing output summary on finalization.
- Freeze the displayed duration at the terminal snapshot.

## Why:
Completed jobs remained in ShellManager for up to one hour. Their snapshots
compute elapsed_ms from started_at, so an ExecCell with no final output kept
accepting later snapshots and its displayed time continued to grow after the
process had already ended.

## Scope:
- TUI synchronization of existing background Shell jobs only.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## Checklist

- [x] Updated docs or comments as needed
- [x] Added or updated tests where relevant
- [x] Verified TUI behavior manually if UI changes
- [ ] Harvested/co-authored credit uses a GitHub numeric noreply address