### PR TITLE
fix: stop applying the 45s SSE open timeout to non-streaming chat requests

### DIFF
--- a/crates/tui/src/client/chat.rs
+++ b/crates/tui/src/client/chat.rs
@@ -48,6 +48,32 @@ fn stream_open_timeout_from_env(value: Option<&str>) -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Default timeout for a complete non-streaming chat response.
+///
+/// Unlike the SSE open wait, a non-streaming server (Ollama, llama-server,
+/// vLLM without stream) only returns response headers after the FULL
+/// generation finishes, so this budget must cover model thinking and
+/// generation time, not just connection setup.
+const DEFAULT_NONSTREAM_RESPONSE_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Reads `CODEWHALE_NONSTREAM_TIMEOUT_SECS` as a bounded override for the
+/// non-streaming full-response wait.
+fn nonstream_response_timeout() -> Duration {
+    nonstream_response_timeout_from_env(
+        std::env::var("CODEWHALE_NONSTREAM_TIMEOUT_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn nonstream_response_timeout_from_env(value: Option<&str>) -> Duration {
+    let secs = value
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_NONSTREAM_RESPONSE_TIMEOUT.as_secs())
+        .clamp(30, 3600);
+    Duration::from_secs(secs)
+}
+
 fn stream_idle_timeout_message(
     idle: Duration,
     bytes_received: usize,
@@ -470,20 +496,23 @@ impl DeepSeekClient {
             self.path_suffix.as_deref(),
             &body,
         );
-        let open_timeout = stream_open_timeout();
-        let response = match tokio_timeout(open_timeout, self.send_json_with_retry(&url, &body))
-            .await
-        {
-            Ok(result) => result?,
-            Err(_elapsed) => {
-                anyhow::bail!(
-                    "SSE stream request did not receive response headers after {}s. \
-                     `codewhale doctor` can still pass when non-streaming requests work; \
-                     on Windows or proxy networks, try `DEEPSEEK_FORCE_HTTP1=1` and rerun `codewhale`.",
-                    open_timeout.as_secs()
-                );
-            }
-        };
+        // A non-streaming server holds the response (headers included) until
+        // the full generation is done, so this wait is bounded by the
+        // generation budget, not the SSE open timeout.
+        let response_timeout = nonstream_response_timeout();
+        let response =
+            match tokio_timeout(response_timeout, self.send_json_with_retry(&url, &body)).await {
+                Ok(result) => result?,
+                Err(_elapsed) => {
+                    anyhow::bail!(
+                        "Non-streaming chat request did not complete after {}s. \
+                     The server generates the entire response before replying, so slow \
+                     local models can legitimately take minutes; raise \
+                     `CODEWHALE_NONSTREAM_TIMEOUT_SECS` to wait longer.",
+                        response_timeout.as_secs()
+                    );
+                }
+            };
 
         let status = response.status();
         if !status.is_success() {
@@ -628,7 +657,23 @@ impl DeepSeekClient {
             self.path_suffix.as_deref(),
             &body,
         );
-        let response = self.send_json_with_retry(&url, &body).await?;
+        // Streaming servers send headers before generating, so a bounded open
+        // wait only guards connection setup — the hang this timeout was
+        // written for — and never races model thinking time.
+        let open_timeout = stream_open_timeout();
+        let response = match tokio_timeout(open_timeout, self.send_json_with_retry(&url, &body))
+            .await
+        {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                anyhow::bail!(
+                    "SSE stream request did not receive response headers after {}s. \
+                     `codewhale doctor` can still pass when non-streaming requests work; \
+                     on Windows or proxy networks, try `DEEPSEEK_FORCE_HTTP1=1` and rerun `codewhale`.",
+                    open_timeout.as_secs()
+                );
+            }
+        };
 
         let status = response.status();
         if !status.is_success() {
@@ -3254,6 +3299,30 @@ mod stream_diagnostics_tests {
         assert_eq!(
             stream_open_timeout_from_env(Some("999")),
             Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn nonstream_response_timeout_defaults_and_clamps_env_values() {
+        assert_eq!(
+            nonstream_response_timeout_from_env(None),
+            Duration::from_secs(600)
+        );
+        assert_eq!(
+            nonstream_response_timeout_from_env(Some("not-a-number")),
+            Duration::from_secs(600)
+        );
+        assert_eq!(
+            nonstream_response_timeout_from_env(Some("1")),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            nonstream_response_timeout_from_env(Some("1200")),
+            Duration::from_secs(1200)
+        );
+        assert_eq!(
+            nonstream_response_timeout_from_env(Some("99999")),
+            Duration::from_secs(3600)
         );
     }
 


### PR DESCRIPTION
## Problem

`codewhale exec` (plain, non-`--auto`) against any non-streaming backend aborts with a misleading error whenever generation takes longer than 45 seconds:

```
Error: SSE stream request did not receive response headers after 45s. `codewhale doctor` can still
pass when non-streaming requests work; on Windows or proxy networks, try `DEEPSEEK_FORCE_HTTP1=1`
and rerun `codewhale`.
```

This makes plain `exec` effectively unusable with local models (Ollama, llama-server, vLLM without streaming) on any real-world prompt: short prompts finish under the wire, but e.g. a "rewrite this 300-line file" task is killed mid-generation. On the server side Ollama logs a canceled request (`error reading llama-server chat response: context canceled`).

### Reproduction

```bash
codewhale --provider ollama --model <local model> exec "<prompt whose completion takes > 45s>"
```

Packet capture shows the request is delivered in full immediately; the client then closes the connection 45s later while the server is still generating. `DEEPSEEK_FORCE_HTTP1=1` (which the error suggests) does not help — the transport is fine.

## Cause

The bounded header wait was attached to the wrong path in `crates/tui/src/client/chat.rs`:

- `create_message_chat` — the **non-streaming** path (no `"stream": true` in the body) — wraps `send_json_with_retry` in `tokio_timeout(stream_open_timeout(), …)`. But a non-streaming server only returns response headers **after the entire generation completes**, so the 45s "connection setup" budget races the model's full thinking + generation time. The doc comment on `stream_open_timeout` itself says the timeout "only covers connection setup and upstream header return, not model thinking time after streaming has started" — which is only true when streaming is actually requested.
- `handle_chat_completion_stream` — the **SSE** path the timeout was written for — had no open timeout at all, so the Windows/proxy header hang described in that comment was still unbounded there.

## Fix

- `create_message_chat` now uses a non-streaming response budget: default **600s**, overridable via `CODEWHALE_NONSTREAM_TIMEOUT_SECS` (clamped 30..3600), with an error message that explains that non-streaming servers legitimately hold the response for the whole generation.
- `handle_chat_completion_stream` now applies `stream_open_timeout()` to its header wait, as originally intended (existing 45s default and `CODEWHALE_STREAM_OPEN_TIMEOUT_SECS` override unchanged).
- Adds a clamp unit test for the new env override, mirroring `stream_open_timeout_defaults_and_clamps_env_values`.

## Testing

- `cargo check -p codewhale-tui` clean
- `cargo fmt` applied; `cargo clippy -p codewhale-tui --bin codewhale-tui` clean
- `cargo test -p codewhale-tui --bin codewhale-tui timeout` — 53 passed, 0 failed (includes the new test)
- Manually verified against Ollama on macOS with a ~5k-token prompt whose completion takes several minutes: released 0.9.0 aborts at exactly 45s with the SSE error above (packet capture shows the client closing the connection mid-generation); a debug build of this branch runs the identical `exec` invocation for 2m42s and exits 0.
