### PR TITLE
fix(tui): make provider onboarding navigable and escapable (#4763)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "Press 1-9 to choose, or Enter to keep the current setting",
     "OnboardProviderTitle": "Choose your model provider",
     "OnboardProviderBlurb": "Pick where your model runs. Hosted providers need a key; local runtimes can continue without one.",
-    "OnboardProviderFooter": "Press 0-9 to choose, ↑/↓ to move, Enter to continue, Esc to go back.",
+    "OnboardProviderFooter": "Enter opens the provider list · Esc goes back · Ctrl+C quits.",
     "OnboardApiKeyTitle": "Connect your API key",
     "OnboardApiKeyStep1": "Step 1.  Open your provider credential page and create a key for",
     "OnboardApiKeyLocalHint": "Local runtimes usually need no pasted key — start the server, then press Enter.",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "Presiona 1-9 para elegir, o Enter para mantener la configuración actual",
     "OnboardProviderTitle": "Elige tu proveedor de modelos",
     "OnboardProviderBlurb": "Elige dónde se ejecutará tu modelo. Los proveedores alojados necesitan una clave; los runtimes locales pueden continuar sin ella.",
-    "OnboardProviderFooter": "Presiona 0-9 para elegir, ↑/↓ para mover, Enter para continuar, Esc para volver.",
+    "OnboardProviderFooter": "Enter abre la lista de proveedores · Esc vuelve · Ctrl+C sale.",
     "OnboardApiKeyTitle": "Conecta tu clave API",
     "OnboardApiKeyStep1": "Paso 1.  Abre la página de credenciales de tu proveedor y crea una clave para",
     "OnboardApiKeyLocalHint": "Los runtimes locales normalmente no requieren pegar una clave — inicia el servidor y presiona Enter.",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "1〜9 で選択、または Enter で現在の設定を維持",
     "OnboardProviderTitle": "モデルプロバイダーを選択",
     "OnboardProviderBlurb": "モデルの実行先を選びます。ホステッドプロバイダーにはキーが必要ですが、ローカルランタイムはキーなしで続行できます。",
-    "OnboardProviderFooter": "0-9 で選択、↑/↓ で移動、Enter で続行、Esc で戻る。",
+    "OnboardProviderFooter": "Enter でプロバイダー一覧を開く · Esc で戻る · Ctrl+C で終了。",
     "OnboardApiKeyTitle": "API キーを接続",
     "OnboardApiKeyStep1": "ステップ 1.  プロバイダーの認証情報ページを開き、次のキーを作成:",
     "OnboardApiKeyLocalHint": "ローカルランタイムは通常キーの貼り付け不要 — サーバーを起動して Enter。",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "1-9를 눌러 선택하거나 Enter로 현재 설정을 유지하세요",
     "OnboardProviderTitle": "모델 프로바이더를 선택하세요",
     "OnboardProviderBlurb": "모델이 실행될 위치를 선택하세요. 호스팅 프로바이더는 키가 필요하지만 로컬 런타임은 키 없이 계속할 수 있습니다.",
-    "OnboardProviderFooter": "0-9를 눌러 선택하거나 ↑/↓로 이동, Enter로 계속, Esc로 뒤로 가세요.",
+    "OnboardProviderFooter": "Enter로 프로바이더 목록을 열고 · Esc로 뒤로 가며 · Ctrl+C로 종료합니다.",
     "OnboardApiKeyTitle": "API 키를 연결하세요",
     "OnboardApiKeyStep1": "1단계.  프로바이더의 자격 증명 페이지를 열고 다음의 키를 생성하세요:",
     "OnboardApiKeyLocalHint": "로컬 런타임은 보통 키를 붙여넣을 필요가 없습니다. 서버를 시작한 뒤 Enter를 누르세요.",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "Pressione 1-9 para escolher, ou Enter para manter a configuração atual",
     "OnboardProviderTitle": "Escolha seu provedor de modelos",
     "OnboardProviderBlurb": "Escolha onde o modelo será executado. Provedores hospedados precisam de chave; runtimes locais podem continuar sem uma.",
-    "OnboardProviderFooter": "Pressione 0-9 para escolher, ↑/↓ para mover, Enter para continuar, Esc para voltar.",
+    "OnboardProviderFooter": "Enter abre a lista de provedores · Esc volta · Ctrl+C sai.",
     "OnboardApiKeyTitle": "Conecte sua chave API",
     "OnboardApiKeyStep1": "Passo 1.  Abra a página de credenciais do provedor e crie uma chave para",
     "OnboardApiKeyLocalHint": "Runtimes locais geralmente não precisam de chave colada — inicie o servidor e pressione Enter.",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "Nhấn phím từ 1-9 để chọn, hoặc Enter để giữ cài đặt hiện tại",
     "OnboardProviderTitle": "Chọn nhà cung cấp mô hình",
     "OnboardProviderBlurb": "Chọn nơi mô hình chạy. Nhà cung cấp được lưu trữ cần khóa; runtime cục bộ có thể tiếp tục mà không cần khóa.",
-    "OnboardProviderFooter": "Nhấn 0-9 để chọn, ↑/↓ để di chuyển, Enter để tiếp tục, Esc để quay lại.",
+    "OnboardProviderFooter": "Enter mở danh sách nhà cung cấp · Esc quay lại · Ctrl+C thoát.",
     "OnboardApiKeyTitle": "Kết nối khóa API của bạn",
     "OnboardApiKeyStep1": "Bước 1.  Mở trang thông tin xác thực của nhà cung cấp và tạo khóa cho",
     "OnboardApiKeyLocalHint": "Runtime cục bộ thường không cần dán khóa — khởi động máy chủ rồi nhấn Enter.",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -414,7 +414,7 @@
     "OnboardLanguageFooter": "按 1-9 选择，或按 Enter 保留当前设置",
     "OnboardProviderTitle": "选择模型提供商",
     "OnboardProviderBlurb": "选择模型运行的位置。托管提供商需要密钥；本地运行时无需密钥即可继续。",
-    "OnboardProviderFooter": "按 0-9 选择，↑/↓ 移动，Enter 继续，Esc 返回。",
+    "OnboardProviderFooter": "Enter 打开提供商列表 · Esc 返回 · Ctrl+C 退出。",
     "OnboardApiKeyTitle": "连接你的 API 密钥",
     "OnboardApiKeyStep1": "步骤 1.  打开你的提供商凭据页面并为",
     "OnboardApiKeyLocalHint": "本地运行时通常无需粘贴密钥——启动服务器后按 Enter。",

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -1458,6 +1458,31 @@ impl ProviderPickerView {
         config: &Config,
         runtime_status: Option<ProviderRuntimeStatus>,
     ) -> Self {
+        Self::new_for_setup_inner(active, target, config, runtime_status, true)
+    }
+
+    /// Open the setup catalog for first-run/recovery onboarding (#4763).
+    /// Identical to [`Self::new_for_setup`] except that a missing-auth
+    /// `target` is only *focused*: onboarding must show the navigable
+    /// provider list before it asks for a secret, so key/OAuth entry is
+    /// reached by picking a row, never by opening straight into it.
+    #[must_use]
+    pub fn new_for_onboarding(
+        active: ApiProvider,
+        target: Option<ApiProvider>,
+        config: &Config,
+        runtime_status: Option<ProviderRuntimeStatus>,
+    ) -> Self {
+        Self::new_for_setup_inner(active, target, config, runtime_status, false)
+    }
+
+    fn new_for_setup_inner(
+        active: ApiProvider,
+        target: Option<ApiProvider>,
+        config: &Config,
+        runtime_status: Option<ProviderRuntimeStatus>,
+        key_entry_for_missing_auth: bool,
+    ) -> Self {
         let mut picker = Self::new_with_runtime_status(active, config, runtime_status);
         picker.view = ProviderListView::Catalog;
         picker.setup_mode = true;
@@ -1465,7 +1490,7 @@ impl ProviderPickerView {
             && let Some(idx) = picker.rows.iter().position(|row| row.provider == target)
         {
             picker.selected_idx = idx;
-            if !picker.selected_has_key() {
+            if key_entry_for_missing_auth && !picker.selected_has_key() {
                 picker.enter_key_entry();
             }
         }
@@ -5119,6 +5144,68 @@ mod tests {
         assert_eq!(picker.stage, Stage::KeyEntry);
         assert_eq!(picker.selected_provider(), ApiProvider::Anthropic);
         assert!(picker.api_key_input.is_empty());
+    }
+
+    /// #4763: onboarding focuses the persisted route but must still open on
+    /// the navigable list. Jumping straight into key/OAuth entry hid the
+    /// provider catalog from returning users with a missing key.
+    #[test]
+    fn onboarding_catalog_focuses_missing_provider_without_leaving_the_list() {
+        let _lock = crate::test_support::lock_test_env();
+        let _anthropic_key = crate::test_support::EnvVarGuard::remove("ANTHROPIC_API_KEY");
+        let config = Config::default();
+        let picker = ProviderPickerView::new_for_onboarding(
+            ApiProvider::Deepseek,
+            Some(ApiProvider::Anthropic),
+            &config,
+            None,
+        );
+
+        assert_eq!(picker.stage, Stage::List);
+        assert_eq!(picker.view, ProviderListView::Catalog);
+        assert_eq!(picker.selected_provider(), ApiProvider::Anthropic);
+        assert_eq!(
+            picker.visible_row_count(),
+            picker.rows.len(),
+            "onboarding must show the whole provider catalog"
+        );
+    }
+
+    /// #4763: Escape backs out one stage at a time — key entry returns to the
+    /// list, and only the list dismisses the picker.
+    #[test]
+    fn onboarding_escape_walks_key_entry_back_to_the_list_then_dismisses() {
+        let _lock = crate::test_support::lock_test_env();
+        let _anthropic_key = crate::test_support::EnvVarGuard::remove("ANTHROPIC_API_KEY");
+        let config = Config::default();
+        let mut picker = ProviderPickerView::new_for_onboarding(
+            ApiProvider::Deepseek,
+            Some(ApiProvider::Anthropic),
+            &config,
+            None,
+        );
+        assert_eq!(picker.stage, Stage::List);
+
+        picker.enter_key_entry();
+        assert_eq!(picker.stage, Stage::KeyEntry);
+
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Esc)),
+            ViewAction::None
+        ));
+        assert_eq!(
+            picker.stage,
+            Stage::List,
+            "Escape from key entry returns to the provider list"
+        );
+
+        assert!(
+            matches!(
+                picker.handle_key(key(KeyCode::Esc)),
+                ViewAction::EmitAndClose(ViewEvent::ProviderPickerDismissed { .. })
+            ),
+            "Escape from the list dismisses the picker"
+        );
     }
 
     #[test]

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -804,6 +804,41 @@ fn back_from_api_key_onboarding(app: &mut App) {
     app.status_message = None;
 }
 
+/// Where a key goes while onboarding owns the screen (#4763).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OnboardingKeyRoute {
+    /// Terminate the session. Ctrl+C is unconditional during onboarding.
+    Quit,
+    /// Hand the key to the provider picker on the view stack.
+    ProviderPicker,
+    /// Fall through to the legacy onboarding key switch.
+    Legacy,
+}
+
+/// Decide the onboarding route for one key press.
+///
+/// Two invariants this encodes, both regressions reported in #4763:
+/// Ctrl+C quits from *any* onboarding state — a modal on the stack must not
+/// swallow it — and Escape is never intercepted on the picker's behalf, so
+/// the picker can back out one stage at a time instead of the shell popping
+/// the whole modal from a key/OAuth sub-stage.
+fn onboarding_key_route(
+    onboarding: OnboardingState,
+    top_kind: Option<ModalKind>,
+    key: &KeyEvent,
+) -> OnboardingKeyRoute {
+    if onboarding == OnboardingState::None {
+        return OnboardingKeyRoute::Legacy;
+    }
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        return OnboardingKeyRoute::Quit;
+    }
+    if onboarding == OnboardingState::Provider && top_kind == Some(ModalKind::ProviderPicker) {
+        return OnboardingKeyRoute::ProviderPicker;
+    }
+    OnboardingKeyRoute::Legacy
+}
+
 fn back_from_provider_onboarding(app: &mut App) {
     if app.onboarding_missing_key_recovery {
         // A returning user declined missing-key recovery: leave onboarding
@@ -4960,35 +4995,39 @@ async fn run_event_loop(
             // parallel ten-provider key handler. Route its keys before the
             // legacy onboarding switch so List/Key/Model/Confirm retain the
             // same behavior as `/provider` and `/setup`.
-            if app.onboarding == OnboardingState::Provider
-                && app.view_stack.top_kind() == Some(ModalKind::ProviderPicker)
-            {
-                if key.code == KeyCode::Esc {
-                    // Onboarding has no committed provider choice yet. A
-                    // single Escape always abandons the whole setup modal and
-                    // returns to Language; do not let an inner key/model
-                    // stage mutate config or mark onboarding complete.
-                    app.view_stack.pop();
-                    back_from_provider_onboarding(app);
-                    app.needs_redraw = true;
-                    continue;
-                }
-                let events = app.view_stack.handle_key(key);
-                app.needs_redraw = true;
-                if handle_view_events_boxed(
-                    terminal,
-                    app,
-                    config,
-                    &task_manager,
-                    &mut engine_handle,
-                    &mut web_config_session,
-                    events,
-                )
-                .await?
-                {
+            match onboarding_key_route(app.onboarding, app.view_stack.top_kind(), &key) {
+                // #4763: onboarding must never be a trap. Ctrl+C terminates
+                // from every onboarding state, including while the picker
+                // owns the keys — the legacy handler below is unreachable
+                // once a modal is on the stack.
+                OnboardingKeyRoute::Quit => {
+                    let _ = engine_handle.send(Op::Shutdown).await;
                     return Ok(());
                 }
-                continue;
+                // Every other key, Escape included, belongs to the picker.
+                // The picker's own per-stage Escape walks key/OAuth entry
+                // back to the list and only dismisses from the list, where
+                // `ProviderPickerDismissed` runs the same non-mutating
+                // onboarding back-transition the shell used to force.
+                OnboardingKeyRoute::ProviderPicker => {
+                    let events = app.view_stack.handle_key(key);
+                    app.needs_redraw = true;
+                    if handle_view_events_boxed(
+                        terminal,
+                        app,
+                        config,
+                        &task_manager,
+                        &mut engine_handle,
+                        &mut web_config_session,
+                        events,
+                    )
+                    .await?
+                    {
+                        return Ok(());
+                    }
+                    continue;
+                }
+                OnboardingKeyRoute::Legacy => {}
             }
 
             // Handle onboarding flow
@@ -10155,7 +10194,9 @@ async fn query_provider_runtime_status(
 /// Open the one canonical provider setup surface for onboarding.  Fresh
 /// onboarding starts at the full catalog; missing-key recovery focuses the
 /// current route so an exact Kimi Code K3 configuration can expose its plan
-/// route before a secret is entered.
+/// route before a secret is entered.  Either way the picker opens on the
+/// navigable list (#4763): onboarding never drops a user straight into a
+/// key/OAuth prompt for a route they were not shown.
 async fn open_onboarding_provider_picker(
     app: &mut App,
     config: &Config,
@@ -10169,7 +10210,7 @@ async fn open_onboarding_provider_picker(
     }
     let runtime_status = query_provider_runtime_status(engine_handle).await;
     app.view_stack.push(
-        crate::tui::provider_picker::ProviderPickerView::new_for_setup(
+        crate::tui::provider_picker::ProviderPickerView::new_for_onboarding(
             app.api_provider,
             focus_current_route.then_some(app.onboarding_provider),
             config,
@@ -13809,7 +13850,16 @@ async fn handle_view_events(
                         .replace("{provider}", provider.as_str());
                     app.push_status_toast(toast, StatusToastLevel::Success, Some(8_000));
                     let model_override = provider_picker_model_override(app, config, provider);
-                    switch_provider(app, engine_handle, config, provider, model_override).await;
+                    let switched =
+                        switch_provider(app, engine_handle, config, provider, model_override).await;
+                    // #4763: reusing an external CLI grant completes provider
+                    // onboarding exactly like a submitted key or an applied
+                    // route. Without this the picker closes on success and
+                    // the user is returned to the provider step they just
+                    // satisfied — the second half of the reported loop.
+                    if switched && app.onboarding == OnboardingState::Provider {
+                        complete_provider_picker_onboarding(app, provider);
+                    }
                     refresh_config_view_if_open(app, "provider");
                 }
                 Err(error) => app.push_status_toast(

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -10978,6 +10978,102 @@ fn mental_models_backtracks_to_the_last_first_run_decision() {
     assert_eq!(app.onboarding, OnboardingState::Language);
 }
 
+// ---- Issue #4763: provider onboarding must never be a trap ----
+
+/// Ctrl+C quits from every onboarding state, including while the provider
+/// picker owns the keys. Before #4763 the picker swallowed it and the only
+/// exit was Escape-then-Ctrl+C.
+#[test]
+fn onboarding_ctrl_c_quits_even_with_the_provider_picker_on_the_view_stack() {
+    let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+    assert_eq!(
+        onboarding_key_route(
+            OnboardingState::Provider,
+            Some(ModalKind::ProviderPicker),
+            &ctrl_c,
+        ),
+        OnboardingKeyRoute::Quit,
+    );
+    assert_eq!(
+        onboarding_key_route(OnboardingState::Provider, None, &ctrl_c),
+        OnboardingKeyRoute::Quit,
+    );
+    assert_eq!(
+        onboarding_key_route(OnboardingState::Language, None, &ctrl_c),
+        OnboardingKeyRoute::Quit,
+    );
+    assert_eq!(
+        onboarding_key_route(
+            OnboardingState::MentalModels,
+            Some(ModalKind::Help),
+            &ctrl_c,
+        ),
+        OnboardingKeyRoute::Quit,
+    );
+}
+
+/// Escape is no longer intercepted on the picker's behalf, so the picker can
+/// back out one stage (key/OAuth entry → list) and only dismiss from the
+/// list. Non-onboarding keys still reach the legacy switch.
+#[test]
+fn onboarding_escape_is_routed_to_the_provider_picker_not_intercepted() {
+    let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+
+    assert_eq!(
+        onboarding_key_route(
+            OnboardingState::Provider,
+            Some(ModalKind::ProviderPicker),
+            &esc
+        ),
+        OnboardingKeyRoute::ProviderPicker,
+        "the picker owns Escape so it can back out one stage at a time"
+    );
+    assert_eq!(
+        onboarding_key_route(OnboardingState::Provider, None, &esc),
+        OnboardingKeyRoute::Legacy,
+        "without the picker the legacy onboarding switch still handles Escape"
+    );
+    assert_eq!(
+        onboarding_key_route(
+            OnboardingState::ApiKey,
+            Some(ModalKind::ProviderPicker),
+            &esc
+        ),
+        OnboardingKeyRoute::Legacy,
+    );
+    assert_eq!(
+        onboarding_key_route(OnboardingState::None, Some(ModalKind::ProviderPicker), &esc),
+        OnboardingKeyRoute::Legacy,
+        "a picker outside onboarding is not an onboarding route"
+    );
+}
+
+/// #4763: reusing an external Grok CLI grant must finish provider onboarding
+/// the same way a submitted key does. The consent handler used to switch the
+/// route and stop there, returning the user to the provider step they had
+/// just satisfied.
+#[test]
+fn external_grant_reuse_completes_provider_onboarding() {
+    let mut app = create_test_app();
+    app.onboarding = OnboardingState::Provider;
+    app.onboarding_needs_api_key = true;
+    app.onboarding_missing_key_recovery = true;
+    app.offline_mode = true;
+    app.trust_mode = true;
+
+    complete_provider_picker_onboarding(&mut app, crate::config::ApiProvider::Xai);
+
+    assert_ne!(
+        app.onboarding,
+        OnboardingState::Provider,
+        "a satisfied provider must not return to the provider step"
+    );
+    assert_eq!(app.onboarding_provider, crate::config::ApiProvider::Xai);
+    assert!(!app.onboarding_needs_api_key);
+    assert!(!app.offline_mode);
+}
+
 #[test]
 fn api_key_escape_returns_to_provider_step() {
     let mut app = create_test_app();

--- a/crates/tui/src/xai_oauth.rs
+++ b/crates/tui/src/xai_oauth.rs
@@ -1440,6 +1440,85 @@ mod tests {
         );
     }
 
+    /// #4763 root trigger. A returning xAI-OAuth user whose only material is
+    /// an external Grok CLI grant loses readiness the moment that CLI's
+    /// short-lived access token expires, even though a refresh token sits
+    /// right beside it — read-only consent deliberately never refreshes or
+    /// rewrites another CLI's file, so there is nothing to renew it with.
+    /// `needs_api_key` therefore flips to true and onboarding reopens. That
+    /// is the intended invariant, not a leak; this test pins it so the
+    /// onboarding entry point stays explainable.
+    #[test]
+    fn expired_external_grok_grant_reads_as_missing_key_despite_refresh_token() {
+        let _guard = crate::test_support::lock_test_env();
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().canonicalize().expect("canonical temp root");
+        let path = root.join("external-grok-auth.json");
+        let scope = format!("https://auth.x.ai::{GROK_OIDC_CLIENT_ID}");
+        fs::write(
+            &path,
+            serde_json::json!({
+                scope.clone(): {
+                    "key": "expired-external-access",
+                    "refresh_token": "present-but-unusable-under-read-only-consent",
+                    "expires_at": rfc3339_from_unix(now_unix_secs().unwrap_or(0) - 3600),
+                    "oidc_client_id": GROK_OIDC_CLIENT_ID,
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let _home_guard =
+            crate::test_support::EnvVarGuard::set("CODEWHALE_HOME", root.join("codewhale-owned"));
+        let _path_guard = crate::test_support::EnvVarGuard::set("GROK_AUTH_PATH", &path);
+        let _key_guard = crate::test_support::EnvVarGuard::remove("XAI_API_KEY");
+        let config = Config {
+            provider: Some(ApiProvider::Xai.as_str().to_string()),
+            providers: Some(crate::config::ProvidersConfig {
+                xai: crate::config::ProviderConfig {
+                    auth_mode: Some("oauth".to_string()),
+                    external_credentials: Some(
+                        codewhale_config::ExternalCredentialConsentToml::read_only(
+                            codewhale_config::ProviderKind::Xai,
+                            codewhale_config::ExternalCredentialSource::GrokCli,
+                            path.clone(),
+                        ),
+                    ),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(
+            !credentials_present(&config),
+            "an expired external access token is not usable material"
+        );
+        assert!(
+            !crate::config::has_api_key_for(&config, ApiProvider::Xai),
+            "expired external xAI OAuth must fall through to the missing-key path"
+        );
+
+        // The same file with a live access token is ready, so the check is
+        // expiry-driven rather than a blanket rejection of external grants.
+        fs::write(
+            &path,
+            serde_json::json!({
+                scope: {
+                    "key": "fresh-external-access",
+                    "refresh_token": "unused",
+                    "expires_at": rfc3339_from_now(3600),
+                    "oidc_client_id": GROK_OIDC_CLIENT_ID,
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(credentials_present(&config));
+        assert!(crate::config::has_api_key_for(&config, ApiProvider::Xai));
+    }
+
     #[test]
     fn native_login_storage_is_codewhale_owned() {
         let _guard = crate::test_support::lock_test_env();

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -741,7 +741,7 @@ model = "k3"
 
     h.wait_for_text("Moonshot/Kimi", BOOT_TIMEOUT)?;
     h.wait_for_text("api.kimi.com", BOOT_TIMEOUT)?;
-    h.wait_for_text("does not import Kimi CLI credentials", BOOT_TIMEOUT)?;
+    h.wait_for_text("missing MOONSHOT_API_KEY / KIMI_API_KEY", BOOT_TIMEOUT)?;
 
     // The picker rendered without mutating the configured route.
     assert_eq!(


### PR DESCRIPTION
Closes #4763.

## The trap

A returning user on the xAI OAuth route hit a closed loop at startup: an
empty Step 3/4 backdrop → the OAuth modal → back to the empty backdrop.
Ctrl+C was swallowed, so the only exit was Esc-then-Ctrl+C.

## What changed

**1. The provider list is visible and navigable.** `open_onboarding_provider_picker`
now uses a new `ProviderPickerView::new_for_onboarding`, which focuses the
persisted route but stays on `Stage::List`. Key/OAuth entry is reached by
picking a row, never by opening straight into it. `/setup` and `/provider`
keep the existing `new_for_setup` jump-to-key-entry behavior.

**2. Esc backs out one stage.** `ui.rs` no longer intercepts Esc on the
picker's behalf. The picker already had correct per-stage Esc handling
(KeyEntry → List, ModelPick → KeyEntry, Confirm → ModelPick); it just never
saw the key. Dismissal from `Stage::List` emits `ProviderPickerDismissed`,
whose handler already calls `back_from_provider_onboarding` — so the
missing-key-recovery semantics at `ui.rs:807` are preserved on the final
pop, and the non-mutating "Esc during onboarding never touches config"
invariant still holds (no picker sub-stage Esc mutates config or emits).

**3. Ctrl+C quits from anywhere.** Key routing during onboarding now goes
through one pure function, `onboarding_key_route`, which returns `Quit` for
Ctrl+C in *any* onboarding state before any modal gets a chance to swallow it.

**4. The backdrop tells the truth.** The footer said "Press 0-9 to choose,
↑/↓ to move, Enter to continue" next to no list. It now reads "Enter opens
the provider list · Esc goes back · Ctrl+C quits", updated in all 7 locale
files that carry `OnboardProviderFooter` (`zh-Hant.json` does not define it).

**5. External CLI grant reuse completes onboarding.** Found while verifying
the issue's open question about the `E` path. `ProviderPickerExternalConsentConfirmed`
persisted consent and switched the provider but never called
`complete_provider_picker_onboarding`, unlike its siblings
`ProviderPickerApplied` and `ProviderPickerSetupConfirmed`. Since the picker
closes on `EmitAndClose`, a *successful* grant left `onboarding == Provider`
with an empty view stack — i.e. it dumped the user back onto the empty
backdrop. This is the second half of the reported loop.

## Investigation: why `needs_api_key` was true

**This is working as designed — no fix needed, and I did not change it.**

The reporter's `~/.grok/auth.json` was fresh (<24h) but that is not the
relevant clock. The entry carries `expires_at` roughly 6 hours after issue;
the file I inspected showed a 6-hour access-token lifetime with a
`refresh_token` sitting right beside it.

`credentials_valid` (`xai_oauth.rs:225`) accepts a *refresh token* for
Codewhale-owned storage, but for an **external** grant it requires
`entry_access_token_is_fresh` — an access token that has not expired. That
asymmetry is deliberate and load-bearing: read-only external consent never
refreshes, rewrites, or makes network calls against another CLI's file. It
is pinned by the existing tests
`expired_read_only_external_credentials_never_refresh_rewrite_or_network`
and `disabled_external_grok_credentials_cause_zero_external_io`.

So: Grok CLI token expires after ~6h → external grant stops counting →
`has_api_key_for` false → `needs_api_key` true → onboarding opens. Correct
behavior; the defect was that onboarding was a trap, not that it opened.

I added `expired_external_grok_grant_reads_as_missing_key_despite_refresh_token`
to pin this so the entry condition stays explainable, asserting both
directions (expired external grant → missing; fresh → ready).

**Follow-up worth filing separately:** this state deserves an explanation in
the UI ("your reused Grok CLI token expired — run `grok login`, or use
Codewhale-owned device login"). Right now the user gets a bare provider step
with no hint that a 6-hour timer is what moved. I left it out to keep this
PR scoped.

**On the `E` path specifically** (the issue's second open question): it
completes onboarding *only when the grant actually yields a working route*.
With an already-expired token — the reporter's exact case — pressing `E`
re-affirms consent that is already recorded, `switch_provider` fails, and
the user lands back on the backdrop. So the workaround in the issue
("press E to reuse existing Grok CLI credentials") does **not** work for an
expired token; device login or `grok login` is required. The backdrop is at
least now honest and escapable in that case.

## Tests

Six new tests, all in existing patterns:

| Test | Pins |
|---|---|
| `onboarding_catalog_focuses_missing_provider_without_leaving_the_list` | picker opens at `Stage::List` during onboarding |
| `onboarding_escape_walks_key_entry_back_to_the_list_then_dismisses` | Esc: key-entry → list → dismiss |
| `onboarding_ctrl_c_quits_even_with_the_provider_picker_on_the_view_stack` | Ctrl+C quits with the picker on the stack |
| `onboarding_escape_is_routed_to_the_provider_picker_not_intercepted` | Esc reaches the picker; non-onboarding keys still hit the legacy switch |
| `external_grant_reuse_completes_provider_onboarding` | a satisfied provider does not return to the provider step |
| `expired_external_grok_grant_reads_as_missing_key_despite_refresh_token` | the root trigger, both directions |

## Verification

PTY reproduction (`pty` + `pyte`, 120×40) against the built binary with a
synthetic HOME reproducing the reported config — `provider = "xai"`,
`auth_mode = "oauth"`, read-only `grok_cli` consent, expired
`~/.grok/auth.json`:

- Provider step renders the full navigable catalog, focused on xAI.
- Enter on xAI → "OAuth login — xAI"; **Esc returns to the list** (previously
  popped the whole modal).
- **Ctrl+C exits** from the list *and* from inside the OAuth sub-stage — the
  exact reported trap. PTY closes, process exits.
- A/B on one fixture (fresh Grok token, consent granted via `E`):
  before this change `E` → empty Step 3/6 backdrop; after, onboarding
  advances to Step 5/6.

Gates, all run on this branch:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants` — clean
- `cargo test -p codewhale-tui --bin codewhale-tui` — **8146 passed, 0 failed, 4 ignored** (8140 on main, +6 new)
- `./scripts/release/check-versions.sh` — `workspace=0.9.1, npm=0.9.1, lockfile in sync`

No version bumps, tag moves, or publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HniWoNaNt9K9pkxTrGx1zd
