### PR TITLE
docs(agents): adopt "intent is the artifact" as the operating stance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,52 @@
 # Repository Agent Guidance
 
-## Where to work right now (read this first)
+## Intent is the artifact (read this first)
+
+We have crossed the threshold where **writing the code again is cheaper than
+recovering the code we wrote.** Assume that is true by default and act on it.
+
+- **The durable asset is intent** — what a change was *for*, the behavior it
+  promised, the constraint it honored. The diff that expressed it is disposable.
+  When you find work that is stranded, stale, or hard to reconcile, recover the
+  intent and re-implement it against today's code. Do not archaeology your way
+  through a merge you can retype in less time.
+- **Rewriting any part of this project is always in scope**, up to and including
+  the whole thing. A module, a crate, a subsystem, the TUI's 16k-line `ui.rs` —
+  none of it is load-bearing by virtue of existing. If the current shape is
+  fighting you, the rewrite is a legitimate first option, not a last resort.
+  Argue it on merit, not on sunk cost.
+- **Use git; do not be governed by it.** Branches, merge bases, and patch-ids
+  are bookkeeping, not authority. A branch that is 600 commits behind is not a
+  debt to be paid — it is a note describing something we once wanted. Read the
+  note, decide if we still want it, then either build it fresh or close it.
+  Conflict count is a signal to rewrite, not a task list.
+- **A stranded lane becomes an issue, not a merge.** Default disposition for
+  drifted work: open an issue that states the intent, the behavior we wanted,
+  and any evidence worth keeping (repro, test, linked report); reference the
+  dead branch for provenance; delete or abandon the branch. Then implement it
+  from current `main` when it comes up the queue.
+- **Verify before you rebuild.** The one thing that must not be lazy is the
+  check for whether main *already* does it. Grep for the symbols and behavior,
+  not the commit. Re-landing work that already landed is the failure mode this
+  ethos creates, and it is the one you own.
+
+### What this does not license
+
+- **`main` stays protected and releases stay reproducible.** Rewrite freely in a
+  branch or worktree; do not rewrite published history, retag a shipped release,
+  or force-push a shared ref.
+- **Stewardship obligations survive a rewrite.** Contributor credit, the
+  `Co-authored-by` / `Harvested from PR #N` machinery, and the licensing that
+  comes with community work are not artifacts of the old diff — carry them onto
+  the new implementation. Re-implementing someone's contribution does not
+  launder away their authorship.
+- **The do-not-delete guardrail below still applies.** "Rewriting is in scope"
+  is not "this looks dead to me." Verify consumers with `rg` first.
+- **Don't rewrite to avoid understanding.** Rewrite because you know what the
+  code should do and the current shape is in the way — not because reading it
+  is tedious.
+
+## Where to work right now
 
 - **Repo:** `Hmbown/CodeWhale`. This repo lives on multiple devices, so work in
   whichever local checkout you have — keep paths here device-agnostic and always
@@ -84,6 +130,13 @@
   agents intact.
 
 ## Release PR Integration
+
+The guidance below is for **live** work — open PRs and branches close enough to
+`main` to reconcile honestly. For work that has drifted far enough that the merge
+is an excavation, see "Intent is the artifact" above: capture the intent as an
+issue, drop the branch, rebuild from current `main`. A useful rule of thumb — if
+the conflicts are in the files the branch most wanted to change, you are
+reconstructing intent anyway; do it in the editor, not the merge tool.
 
 - Use scratch integration branches when triaging a crowded release queue. A
   branch such as `scratch/vX.Y.Z-pr-train-YYYYMMDD` may merge or cherry-pick

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,27 @@
 Read `AGENTS.md` first. This file exists as a compatibility instruction source
 for Claude-based agents working in this repository.
 
+## Intent is the artifact
+
+See `AGENTS.md` → "Intent is the artifact" for the full statement. The short
+version, because it governs almost every judgment call you will make here:
+
+- Generating code against current `main` is now **cheaper and faster** than
+  recovering, rebasing, or reconciling old code. Default to that.
+- **Rewriting any part of this project is always in scope**, including the whole
+  project. Nothing is load-bearing merely because it exists.
+- **Use git; do not be governed by it.** A far-behind branch is a note about
+  something we once wanted — not a debt. High conflict count is a signal to
+  rewrite, not a task list.
+- Stranded work becomes an **issue describing the intent**, plus a deleted
+  branch — not a heroic merge.
+- The non-negotiable check: **confirm main doesn't already do it.** Grep the
+  symbols and behavior, not the commit history. Re-landing landed work is the
+  failure mode this ethos creates.
+- Limits: `main` stays protected, published history and shipped tags stay
+  immutable, contributor credit carries onto the rewrite, and the
+  do-not-delete guardrail in `AGENTS.md` still binds.
+
 ## Stewardship Defaults
 
 - Treat community PRs and issues as maintainer evidence. Inspect code, tests,
@@ -20,6 +41,9 @@ for Claude-based agents working in this repository.
   (Claude, codex, cursor), so use a plain commit body to note agent assistance.
 
 ## Scratch Integration Branches
+
+Applies to **live** queue work. Once a branch has drifted far enough that the
+merge is an excavation, stop and apply "Intent is the artifact" instead.
 
 - For release queues, create disposable local branches from the real landing
   branch, for example `scratch/vX.Y.Z-pr-train-YYYYMMDD`.


### PR DESCRIPTION
Records the stance that now governs how agents work in this repo: generating code against current `main` is cheaper and faster than recovering, rebasing, or reconciling old code.

New lead section in `AGENTS.md`, condensed mirror in `CLAUDE.md`, placed above the branch/merge guidance it reframes.

**The principles**

- The durable asset is intent — what a change was *for*. The diff that expressed it is disposable.
- Rewriting any part of the project is always in scope, up to the whole thing. Argued on merit, never sunk cost.
- Use git; do not be governed by it. A far-behind branch is a note about something we once wanted, not a debt. High conflict count is a signal to rewrite, not a task list.
- Stranded work becomes an issue stating the intent, plus a deleted branch — not a heroic merge.
- The check that cannot be lazy: confirm `main` does not already implement it. Grep symbols and behavior, not commits.

**Bounded so it cannot erode what it should not touch**

`main` stays protected; published history and shipped tags stay immutable; contributor credit and the `Co-authored-by` / `Harvested from PR #N` trailers carry onto the new implementation; the do-not-delete guardrail still binds; and "rewriting is in scope" is never "reading this is tedious."

**What prompted it**

During the v0.9.1 release, two lanes were believed stranded and unmerged — `agent/091-routing-observability` (22 files, 1,232 insertions) and `agent/091-keyless-local-onboarding` (19 files, 787 insertions), both ~640 commits behind. A dry-run merge produced 12 and 18 conflicts, concentrated in exactly the files each branch most wanted to change.

Both intents had already been re-implemented against current code and landed by other routes: `auto_route_receipt` wired through `ui.rs`, `AutoRouteSource::FlashRouter` and `ClassifierFallback` in `model_routing.rs`, `ModelAuthSource::KeylessLocal` in `model_inventory.rs` with tests. The patch-ids no longer matched because the code had been rewritten — which is why the branches still read as unmerged.

The rewrite was faster than the merge, and it happened without anyone deciding it should. This makes it the default.

Hence the heuristic now in both files: if the conflicts are in the files the branch most wanted to change, you are reconstructing intent anyway — do it in the editor, not the merge tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)