### PR TITLE
ci(web): auto-deploy codewhale.net on every push to main

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -56,7 +56,20 @@ jobs:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
     needs: lint
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    # Auto-deploy every push to main once `lint` is green, and still allow a
+    # manual dispatch for redeploys that do not correspond to a new commit
+    # (rotated secrets, a reverted KV namespace, a Cloudflare-side incident).
+    # `needs: lint` is the gate: facts drift, docs parity, tests, ESLint, tsc,
+    # and a production build all pass before anything reaches Cloudflare.
+    if: >-
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && github.ref == 'refs/heads/main'
+    # Serialize deploys so two pushes landing close together cannot race and
+    # leave Cloudflare serving the older bundle. Never cancel in progress: a
+    # half-finished OpenNext upload is worse than a queued one.
+    concurrency:
+      group: deploy-codewhale-web
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: web
@@ -73,8 +86,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Record deployed/source drift
-        # Read-only and credential-free. A mismatch is expected before a
-        # maintainer-approved deployment, so this step reports without gating.
+        # Read-only and credential-free. A mismatch is the normal state here —
+        # it is the gap this run is about to close — so this step reports
+        # without gating. The real assertion is the post-deploy verification
+        # below, which must observe this exact revision on the public receipt.
         run: npm run compare:deployed-facts -- --expected-revision "$GITHUB_SHA"
       - name: Check Cloudflare deploy environment
         run: npm run check:deploy-env


### PR DESCRIPTION
The deploy job already existed and was already correct. It was gated to `workflow_dispatch` only:

```yaml
if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
```

So it ran when someone remembered to run it. Nobody did, and the live site drifted behind `main` — the TUI-look ocean home (`1cb501d7c`) and the rewritten README tone (`705b79eb0`) both shipped to `main` and never reached codewhale.net. Live copy still reads "coding agents run on code. CodeWhale also runs on law," a string that no longer exists anywhere in `web/`.

## Change

Deploy on push to `main` once `lint` is green. Keep `workflow_dispatch` for redeploys with no new commit behind them — rotated secrets, a reverted KV namespace, a Cloudflare-side incident.

Added a non-cancelling concurrency group so two pushes landing close together cannot race and leave Cloudflare serving the older bundle. Never cancel in progress: a half-finished OpenNext upload is worse than a queued one.

## Why this is safe to automate

The gate is unchanged — `needs: lint` still requires facts drift, docs parity, tests, ESLint, `tsc --noEmit`, and a full production build to pass before anything reaches Cloudflare.

The post-deploy step is what actually makes it safe: the public `/api/facts` receipt must report this exact revision within ten attempts or the run fails. A silently stale deploy cannot pass.

Publish-time facts are unaffected. `web/data/latest-published-release.json` stays **manually advanced only after publication** by design, so auto-deploy still cannot advertise an unpublished tag — install commands keep pointing at the last real GitHub Release.

## Note on the manual gate

The old gate looks deliberate — the drift step described a "maintainer-approved deployment." That intent is preserved, just moved: approval now happens at PR-merge time rather than as a second manual step after merge. Anything reaching `main` has already been approved. I updated that comment so it no longer describes a workflow that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)