### PR TITLE
ci(triage): stop over-labelling well-specified issues

### DIFF
--- a/.github/workflows/agent-task-labels.yml
+++ b/.github/workflows/agent-task-labels.yml
@@ -33,7 +33,16 @@ jobs:
             const text = `${title}\n${body}`;
 
             if (/\bworkflow\b|whaleflow|workflow-runtime/.test(text)) labels.add('workflow-runtime');
-            if (/crates\/tui|\btui\b|ratatui/.test(text)) labels.add('tui');
+            // `tui` means "touches the terminal UI layer", not "mentions the TUI
+            // in passing". A bare \btui\b over-fired on every issue that merely
+            // referenced the UI — the v0.9.2 localization issues all describe TUI
+            // locale packs in prose and were labelled on that alone.
+            //
+            // Anchor on signals that survive the single-binary refactor (#4747):
+            // the crate path and the rendering framework stay put when
+            // codewhale-tui is lib-ized, whereas the `codewhale-tui` *binary*
+            // name goes away. Do not reintroduce a bare word match here.
+            if (/crates\/tui\b|ratatui|\bcodewhale-tui\b/.test(text)) labels.add('tui');
             if (/fleet|subagent|sub-agent/.test(text)) labels.add('subagents');
             if (/catalog|openrouter|model.?picker|provider.?lake/.test(text)) labels.add('reliability');
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -22,11 +22,19 @@ jobs:
             const text = `${title}\n${body}`;
             const labels = new Set();
 
-            // Type
-            if (/\b(bug|crash|panic|broken|stack ?trace|regression|err(?:or)?|fail(?:ed|ure)?)\b/.test(text)) labels.add('bug');
-            if (/\b(feat(?:ure)?|request|enhancement|wishlist|proposal|please add|would be nice|support for)\b/.test(text)) labels.add('enhancement');
-            if (/\b(docs?|readme|documentation|typo|grammar|wording|spelling)\b/.test(text)) labels.add('documentation');
-            if (/\b(question|how (?:do|to)|why does|what does|is it possible)\b/.test(text)) labels.add('question');
+            // Type — matched against the TITLE only.
+            //
+            // These ran against title+body and mislabelled long, well-specified
+            // issues. Any body containing an acceptance criterion like "fails
+            // when a pack drifts" matched the bug rule, and a "How to add a
+            // locale" heading matched the question rule, so planned work landed
+            // tagged `bug, question`. A title states the type; a body just
+            // discusses it. `error`/`fail` are dropped entirely — they describe
+            // what almost every issue talks about, not what any issue *is*.
+            if (/\b(bug|crash|panic|broken|stack ?trace|regression)\b/.test(title)) labels.add('bug');
+            if (/\b(feat(?:ure)?|request|enhancement|wishlist|proposal|please add|would be nice|support for)\b/.test(title)) labels.add('enhancement');
+            if (/\b(docs?|readme|documentation|typo|grammar|wording|spelling)\b/.test(title)) labels.add('documentation');
+            if (/\b(question|how (?:do|to)|why does|what does|is it possible)\b/.test(title)) labels.add('question');
 
             // Locale — title contains CJK (Chinese, Japanese, Korean) characters
             if (/[぀-ヿ㐀-鿿가-힯]/.test(issue.title || '')) labels.add('lang:zh');


### PR DESCRIPTION
Both auto-labellers classify issues from full body text, so the better-specified an issue is, the more wrong labels it collects. #4787 and #4790 landed tagged `bug, question` because their acceptance criteria said *"fails when a pack drifts"* and a scope heading said *"How to add a locale"*.

## Changes

**`triage.yml`** — type labels (`bug`, `enhancement`, `documentation`, `question`) now match the **title only**. A title states what an issue *is*; a body just discusses it. `error` and `fail(ed|ure)` are dropped from the bug rule outright — they describe what nearly every issue mentions.

**`agent-task-labels.yml`** — `tui` required only a bare `\btui\b`, so any passing reference to the terminal UI tagged the issue as touching it. Now anchored on `crates/tui`, `ratatui`, `codewhale-tui`.

Those anchors are deliberately the ones that **survive the single-binary refactor (#4747)**: the crate path and the rendering framework stay when `codewhale-tui` is lib-ized, while the binary name goes away. A comment in the file says not to reintroduce a bare word match.

## Verification

Replayed both regex sets over the real title+body of the four issues that misfired:

| Issue | Before | After |
|---|---|---|
| #4787 foundation | `bug, question, tui` | `tui` |
| #4790 Hindi | `bug, question, tui` | `tui` |
| #4786 schema defect | `bug, tui` | `tui` |
| #4791 Ukrainian | `tui` | `tui` |

Regression guards: a synthetic `Crash on startup: panic in ratatui render loop` still classifies `bug, tui`; `Docs: explain how the tui differs from the web UI` no longer fires `tui`.

Both workflows re-validated: YAML parses and the embedded `github-script` bodies pass `node --check`.

## Known tradeoff

Title-only typing trades recall for precision. #4786 is a real bug whose title doesn't contain a type keyword, so it would no longer be auto-tagged `bug` — it was labelled by hand. Under-labelling is the cheaper error here; a wrong `bug` label on planned work actively misleads triage.

## Separate finding — not fixed here, needs your call

Every area/OS rule in `triage.yml` (lines 32–44) is **inert**. It emits `area:tui`, `area:core`, `area:mcp`, `area:state`, `area:execpolicy`, `area:tools`, `area:install`, `os:windows`, `os:macos`, `os:linux`, `lang:zh` — and none of those 11 labels exist on the repo, so the existing-label filter drops all of them. That classification has never worked. Two options, both out of scope for this PR:

1. Create the 11 labels — but `area:tui` would duplicate the `tui` label this PR just tightened, and the area taxonomy needs rethinking against the single-binary layout anyway.
2. Delete the dead rules.

I'd lean (2), then reintroduce a deliberate area taxonomy once #4747 settles what the areas actually are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)