### PR TITLE
ci: require every PR to close an issue or say why it doesn't

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,61 @@
+name: PR closes an issue
+
+# 342 open issues, 329 of them touched within the month: nothing here is rotting,
+# the drain is just clogged. Only 8 of 35 open PRs carried a closing keyword, so
+# work ships and its issue stays open, and nobody can tell which of the 342 are
+# already done. That is how 121 issues end up on one milestone.
+#
+# This check asks every PR to either close an issue or say why it doesn't. The
+# opt-out is one line, so this is a prompt, not a wall.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a closing keyword or an explicit opt-out
+        env:
+          # Read through env, never interpolated into the script body:
+          # a PR body is attacker-controlled text.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # Body only, deliberately. GitHub resolves closing keywords from the
+          # PR description; a "Closes #123" in the title auto-closes nothing.
+          # Accepting the title here would pass PRs that never close an issue,
+          # which is the exact false-assurance this check exists to prevent.
+          text="${PR_BODY:-}"
+
+          # GitHub's own closing-keyword set, plus the #N it must attach to.
+          if grep -qiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]]*:?[[:space:]]*#[0-9]+' <<<"$text"; then
+            echo "Closing keyword found — this PR will close its issue on merge."
+            exit 0
+          fi
+
+          # One-line escape hatch. Anything after the marker is the reason.
+          if grep -qiE '^[[:space:]]*No-Issue:[[:space:]]*\S' <<<"$text"; then
+            reason=$(grep -iE '^[[:space:]]*No-Issue:' <<<"$text" | head -1)
+            echo "Opted out — ${reason}"
+            exit 0
+          fi
+
+          cat >&2 <<'MSG'
+          This PR neither closes an issue nor says why it doesn't.
+
+          Add one of these to the PR body:
+
+            Closes #1234              (or Fixes / Resolves — any of GitHub's keywords)
+            No-Issue: <one-line why>  (chores, docs typos, revert, dependency bump)
+
+          Why this is a required check: work here ships faster than issues close,
+          so an unlinked PR leaves its issue open forever and the backlog stops
+          reflecting reality. Either line takes five seconds and keeps the
+          milestone honest.
+          MSG
+          exit 1


### PR DESCRIPTION
No-Issue: repo-hygiene automation, filed from a backlog measurement rather than a report.

## What the numbers said

342 issues open, **329 of them touched this month**. Nothing is rotting — the backlog isn't stale, it's *unclosed*. `stale.yml` runs green daily but is scoped to `only-labels: needs-info`, which is **8 issues out of 342**.

The leak: **only 8 of 35 open PRs carry a closing keyword.** The other 27 will merge and leave their issues open. That's how 121 issues land on one milestone and why the backlog stopped saying which work is actually done.

## What this does

Reads the PR **body** for a GitHub closing keyword attached to an issue number, or a one-line opt-out:

```
Closes #1234
No-Issue: dependency bump
```

Either satisfies it. It's a prompt, not a wall.

**Body only, deliberately.** GitHub resolves closing keywords from the PR description — `Closes #123` in the *title* auto-closes nothing. Accepting the title would pass PRs that close no issue: a green check guarding nothing, which is the shape this repo already has in `cache_guard.rs` and in the `protected_invariants` nothing enforces.

The body is read through `env:` rather than interpolated into the script, since it's attacker-controlled.

## Verification

Matcher tested against 13 cases. All six closing-keyword spellings match (`close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved`), multiline bodies match, indented opt-outs match. Correctly rejected: bare `#1234` with no keyword, prose `"this fixes the parser"` with no number, an empty `No-Issue:`, and an unmarked chore. YAML validated.

## Also changed, outside this diff

`delete_branch_on_merge` and `allow_auto_merge` are now enabled on the repo — merged branches stop accumulating (4 were sitting merged-but-undeleted).

## Note on existing PRs

`pull_request` fires on `opened/edited/reopened/synchronize`, so the 27 unlinked PRs stay green until someone pushes to them. No retroactive red wall.