### PR TITLE
ci(release): replace the unusable recovery input with a standalone workflow

### DIFF
--- a/.github/workflows/release-republish.yml
+++ b/.github/workflows/release-republish.yml
@@ -1,0 +1,214 @@
+name: Release Republish Channels
+
+# Recovery for derived distribution channels — the container image and the
+# Homebrew tap — when a released tag has them missing or stale.
+#
+# This is a separate workflow, dispatched from the DEFAULT BRANCH, on purpose.
+# `workflow_dispatch` reads its input schema from the workflow file at the ref
+# being dispatched, and `release.yml` requires being dispatched from the tag
+# itself. Any recovery option added to `release.yml` is therefore unusable on
+# tags that predate it — which is every tag that could ever need recovery.
+# Taking the tag as an input sidesteps that entirely.
+#
+# It never writes GitHub Release bytes. `release.yml` owns those, and they stay
+# immutable; this only (re)publishes channels derived from an existing release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released version to republish, without v (e.g. 0.9.1). The tag must already exist and have a published GitHub Release.'
+        required: true
+        type: string
+      channels:
+        description: 'Which derived channels to republish.'
+        required: true
+        default: 'docker+homebrew'
+        type: choice
+        options:
+          - docker+homebrew
+          - docker
+          - homebrew
+
+concurrency:
+  group: release-republish-${{ inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      sha: ${{ steps.release.outputs.sha }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+      - name: Resolve released tag
+        id: release
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${INPUT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '${INPUT_VERSION}' must use X.Y.Z." >&2
+            exit 1
+          fi
+          tag="v${INPUT_VERSION}"
+
+          if ! git rev-parse --verify "refs/tags/${tag}^{commit}" >/dev/null 2>&1; then
+            echo "::error::Tag ${tag} does not exist." >&2
+            exit 1
+          fi
+          sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+
+          {
+            echo "tag=${tag}"
+            echo "sha=${sha}"
+            echo "version=${INPUT_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "Resolved ${tag} -> ${sha}"
+      - name: Require an existing published release
+        # The inverse of release.yml's immutability guard. That one refuses to
+        # run when assets exist; this one refuses to run when they do not,
+        # because there is nothing to derive a channel from.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          count="$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets | length')"
+          if [[ "${count}" -eq 0 ]]; then
+            echo "::error::${TAG} has no published assets. Run release.yml, not this recovery workflow." >&2
+            exit 1
+          fi
+          echo "${TAG} has ${count} published assets."
+      - name: Verify the remote tag still points at this commit
+        env:
+          EXPECTED_SHA: ${{ steps.release.outputs.sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          ./scripts/release/verify-remote-tag.sh \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "${TAG}" \
+            "${EXPECTED_SHA}"
+
+  docker:
+    needs: resolve
+    if: ${{ contains(inputs.channels, 'docker') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          path: source
+      - name: Checkout release infrastructure
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          path: infra
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Normalize image name
+        id: image
+        shell: bash
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+      - name: Revalidate release tag before container publish
+        env:
+          EXPECTED_SHA: ${{ needs.resolve.outputs.sha }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          ./infra/scripts/release/verify-remote-tag.sh \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "${TAG}" \
+            "${EXPECTED_SHA}"
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+          DOCKER_BUILD_SUMMARY: false
+        with:
+          context: source
+          file: infra/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            DEEPSEEK_BUILD_SHA=${{ needs.resolve.outputs.sha }}
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ needs.resolve.outputs.tag }}
+            ${{ steps.image.outputs.name }}:${{ needs.resolve.outputs.version }}
+            ${{ steps.image.outputs.name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke published container entrypoints
+        shell: bash
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}:${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE}"
+          docker run --rm --entrypoint codewhale "${IMAGE}" --version
+          docker run --rm --entrypoint codew "${IMAGE}" --version
+          docker run --rm --entrypoint codewhale-tui "${IMAGE}" --version
+
+  homebrew:
+    needs: resolve
+    if: ${{ contains(inputs.channels, 'homebrew') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check Homebrew tap token
+        id: homebrew-token
+        env:
+          TOKEN: ${{ secrets.HOMEBREW_TAP_PAT || secrets.RELEASE_TAG_PAT }}
+        run: |
+          if [[ -z "${TOKEN:-}" ]]; then
+            echo "::error::No Homebrew tap token configured; cannot republish the tap." >&2
+            exit 1
+          fi
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+      - name: Download checksum manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ needs.resolve.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'codewhale-artifacts-sha256.txt' \
+            --dir /tmp
+      - name: Revalidate release tag before Homebrew tap write
+        env:
+          EXPECTED_SHA: ${{ needs.resolve.outputs.sha }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          ./scripts/release/verify-remote-tag.sh \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "${TAG}" \
+            "${EXPECTED_SHA}"
+      - name: Update Homebrew tap
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          MANIFEST: /tmp/codewhale-artifacts-sha256.txt
+          TAP_REPO: Hmbown/homebrew-deepseek-tui
+          TOKEN: ${{ secrets.HOMEBREW_TAP_PAT || secrets.RELEASE_TAG_PAT }}
+        run: bash .github/scripts/update-homebrew-tap.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,6 @@ on:
         description: 'Release version, without v; dispatch from the matching existing vX.Y.Z tag ref'
         required: true
         type: string
-      republish_channels:
-        description: 'Recovery: skip build/asset publication and only (re)publish the container image and Homebrew tap for an already-released tag.'
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: release-${{ github.ref_name }}
@@ -108,10 +103,6 @@ jobs:
       - name: Require release source on main
         run: ./scripts/release/ensure-release-on-main.sh "${{ steps.release.outputs.sha }}"
       - name: Refuse an existing public asset set
-        # In recovery mode the assets are *expected* to exist -- that is the
-        # whole premise -- and nothing downstream writes them, so this guard
-        # would only deadlock the recovery it is meant to protect.
-        if: ${{ !inputs.republish_channels }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
@@ -119,7 +110,6 @@ jobs:
 
   parity:
     needs: resolve
-    if: ${{ !inputs.republish_channels }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -178,7 +168,7 @@ jobs:
 
   artifacts:
     needs: [parity, resolve]
-    if: ${{ !cancelled() && !inputs.republish_channels && needs.resolve.result == 'success' && needs.parity.result == 'success' }}
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.parity.result == 'success' }}
     uses: ./.github/workflows/release-artifacts.yml
     with:
       source_sha: ${{ needs.resolve.outputs.sha }}
@@ -187,10 +177,7 @@ jobs:
 
   docker:
     needs: [artifacts, resolve]
-    if: >-
-      ${{ !cancelled() && needs.resolve.result == 'success'
-      && (needs.artifacts.result == 'success'
-          || (inputs.republish_channels && needs.artifacts.result == 'skipped')) }}
+    if: ${{ !cancelled() && needs.artifacts.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -275,9 +262,7 @@ jobs:
 
   release:
     needs: [artifacts, docker, resolve]
-    # Never runs in recovery mode: the GitHub Release already exists and its
-    # bytes are immutable. Recovery republishes only the derived channels.
-    if: ${{ !cancelled() && !inputs.republish_channels && needs.artifacts.result == 'success' && needs.docker.result == 'success' }}
+    if: ${{ !cancelled() && needs.artifacts.result == 'success' && needs.docker.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -325,10 +310,7 @@ jobs:
 
   homebrew:
     needs: [release, resolve]
-    if: >-
-      ${{ !cancelled() && needs.resolve.result == 'success'
-      && (needs.release.result == 'success'
-          || (inputs.republish_channels && needs.release.result == 'skipped')) }}
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fixes the approach I shipped in #4801. It cannot work, and dispatching it fails outright:

```
HTTP 422: Unexpected inputs provided: ["republish_channels"]
```

## Why #4801 was wrong

`workflow_dispatch` reads its input schema from the workflow file **at the ref being dispatched**. And `release.yml`'s `resolve` hard-requires that ref to be the tag:

```bash
if [[ "${GITHUB_REF}" != "refs/tags/${tag}" ]]; then
  echo "::error::Dispatch release.yml from --ref ${tag}, not ${GITHUB_REF}."
```

Those two facts are incompatible. Any recovery option added to `release.yml` is only visible on tags cut *after* it lands — which excludes every tag that could ever need recovery. It was unusable for precisely the case it was written for.

This reverts that change and moves recovery into its own workflow, dispatched from the **default branch**, taking the tag as an *input* rather than as the dispatch ref.

## `release-republish.yml`

| Input | |
|---|---|
| `version` | released version without `v` (e.g. `0.9.1`) |
| `channels` | `docker+homebrew` (default), `docker`, or `homebrew` |

It republishes **only derived channels**. It never writes GitHub Release bytes — `release.yml` owns those and they stay immutable.

Guards kept and added:

- **Inverse immutability guard.** `release.yml` refuses to run when public assets exist; this refuses to run when they *don't*, because there is nothing to derive a channel from. Pointing it at an unreleased tag fails with a message telling you to use `release.yml`.
- Tag must exist and resolve to a commit.
- `verify-remote-tag.sh` runs in `resolve`, and again in **each** job immediately before it writes — so a tag that moves mid-run cannot slip through.
- Homebrew fails loudly with no token instead of silently skipping, since here the tap update *is* the point.

## Why we need it

v0.9.1's GHCR image and Homebrew tap are still at **0.9.0** — the Release run was cancelled during `docker`, and the GitHub Release was then published out of band. Without this there is no way to fix that short of deleting published assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)