### PR TITLE
re-land: v0.9.1 lane remnants (contracts doc, prompts home-root scrub)

### DIFF
--- a/crates/tui/src/skills/mod.rs
+++ b/crates/tui/src/skills/mod.rs
@@ -1067,6 +1067,18 @@ fn sanitize_prompt_path_text(text: &str, workspace: &Path) -> String {
             out.replace_range(start..user_start + user_len, "~");
         }
     }
+    // Environment variables are process-global, and concurrent embedders or
+    // tests may temporarily redirect HOME after discovery recorded a warning.
+    // Scrub conventional home roots by shape as a final privacy boundary.
+    for marker in ["/Users/", "/home/"] {
+        while let Some(start) = out.find(marker) {
+            let user_start = start + marker.len();
+            let user_len = out[user_start..]
+                .find(|ch: char| ch == '/' || ch.is_whitespace())
+                .unwrap_or(out.len() - user_start);
+            out.replace_range(start..user_start + user_len, "~");
+        }
+    }
     out
 }
 


### PR DESCRIPTION
Recovered from the stale local v0.9.1 lane (local main was ~44K lines skewed from origin/main; surgery archived the lane to backups/ and backup/local-main-pre-sync-20260725).

Two of five stranded commits cherry-picked clean onto origin/main:
- `docs(release): record final v0.9.1 contracts` (CHANGELOG.md)
- `fix(prompts): scrub stale home roots in skill warnings` (skills/mod.rs)

The other three (changelog sync, the Edit tool-collapse refactor + its catalog test) conflicted with current origin/main and are being resolved by intent in a follow-up; this PR banks the two that were clean. No issue — lane-recovery work (see V092_CAMPAIGN.md).