### PR TITLE
docs(web): real product pages for the docs index + Work surface

### DIFF
--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -1,0 +1,121 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/configuration",
+    locale,
+    title: isZh ? "配置 · Codewhale 文档" : "Configuration · Codewhale Docs",
+    description: isZh
+      ? "config.toml 的查找顺序、项目级覆盖、凭据优先级和旧版路径迁移。"
+      : "Where config.toml is read from, the per-project overlay, credential precedence, and legacy path migration.",
+  });
+}
+
+export default async function ConfigurationPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "配置" : "Configuration"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Codewhale 从 ~/.codewhale/config.toml 读取配置（旧版 ~/.deepseek/config.toml 仍作为回退读取）。--config 标志和 CODEWHALE_CONFIG_PATH 环境变量可以指定别的路径，两者同时设置时 --config 优先；文件加载之后再应用环境变量覆盖。"
+            : "Codewhale reads its configuration from ~/.codewhale/config.toml (the legacy ~/.deepseek/config.toml is still read as a fallback). The --config flag and the CODEWHALE_CONFIG_PATH environment variable can point elsewhere; --config wins when both are set, and environment variable overrides are applied after the file is loaded."}
+        </p>
+        <pre className="code-block mt-4">{`codewhale --config /path/to/config.toml
+CODEWHALE_CONFIG_PATH=/path/to/config.toml`}</pre>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              在 TUI 里运行 <code className="inline">/config audit</code>{" "}
+              可以查看哪些文档化的键能在当前会话修改、哪些能持久化、哪些只能改文件或需要重启——改动前以它输出的
+              “Command / reason” 列为准。
+            </>
+          ) : (
+            <>
+              Inside the TUI, <code className="inline">/config audit</code> shows which documented keys
+              can change in the current session, which can also be persisted, and which stay file-only or
+              restart-only — treat its “Command / reason” column as the source of truth before editing by
+              hand.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="project-overlay" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "项目级覆盖" : "Per-project overlay"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "当工作区包含常规文件 <workspace>/.codewhale/config.toml 时，其中声明的安全取值会合并到全局配置之上（旧版 <workspace>/.deepseek/config.toml 在新路径缺失时仍会读取；符号链接的项目配置会被拒绝）。这让仓库可以建议模型或收紧本地安全姿态，而不动用户的全局配置。单次启动可用 --no-project-config 跳过覆盖。"
+            : "When a workspace contains a regular-file <workspace>/.codewhale/config.toml, the safe values it declares are merged on top of the global config (legacy <workspace>/.deepseek/config.toml files are still read when the Codewhale path is absent; symlinked project configs are rejected). This lets a repository suggest a model or tighten the local safety posture without touching the user's global config. Pass --no-project-config to skip the overlay for one launch."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "覆盖层有意保持狭窄：支持 model、reasoning_effort、approval_policy 与 sandbox_mode（只能收紧）、notes_path、max_subagents（夹紧到 1..=20）、allow_shell（false 生效，true 被忽略）。凭据、端点、提供商选择、MCP 配置、hooks、skills 和 instructions = [...] 始终属于用户全局配置——仓库里的 config.toml 声明 api_key、base_url 或 provider 会被忽略，克隆的仓库无法借此选择任意本地文件进入提示词。"
+            : "The overlay is intentionally narrow: it supports model, reasoning_effort, approval_policy and sandbox_mode (tightening values only), notes_path, max_subagents (clamped to 1..=20), and allow_shell (false applies, true is ignored). Credentials, endpoints, provider selection, MCP config, hooks, skills, and instructions = [...] stay user-global — a repo-local config.toml that declares api_key, base_url, or provider is ignored, so a cloned repository cannot pick arbitrary local files into the prompt."}
+        </p>
+      </section>
+
+      <section id="credentials" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "凭据查找" : "Credential lookup"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              在显式 <code className="inline">--api-key</code> 之后，凭据按 config → keyring → env
+              的顺序解析。<code className="inline">codewhale auth status</code>{" "}
+              可以查看当前提供商的配置文件、系统 keyring 后端、环境变量、生效来源和末四位标签，而不会打印密钥本身。托管、OpenAI 兼容、自托管或 Anthropic 原生路由用{" "}
+              <code className="inline">{"provider = \"<id>\""}</code> 或{" "}
+              <code className="inline">codewhale --provider &lt;id&gt;</code>{" "}
+              选择；完整注册表见模型与提供商页和 docs/PROVIDERS.md。
+            </>
+          ) : (
+            <>
+              After any explicit <code className="inline">--api-key</code>, credentials resolve in
+              config → keyring → env order. <code className="inline">codewhale auth status</code>{" "}
+              inspects the active provider's config file, OS keyring backend, environment variable,
+              winning source, and last-four label without printing the key itself. Hosted, generic
+              OpenAI-compatible, self-hosted, or native Anthropic routes are selected with{" "}
+              <code className="inline">{"provider = \"<id>\""}</code> or{" "}
+              <code className="inline">codewhale --provider &lt;id&gt;</code>; the full registry lives on
+              the Models &amp; providers page and in docs/PROVIDERS.md.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="legacy-paths" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "旧版 .deepseek/ 路径" : "Legacy .deepseek/ paths"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Codewhale 由 DeepSeek-TUI 更名而来。为了不破坏既有安装，运行时从新的 ~/.codewhale/ 位置读取状态，但在只有旧目录存在时回退到 ~/.deepseek/，并且始终写入 ~/.codewhale/——读取带回退、写入新位置。状态目录解析集中在 crates/config/src/lib.rs 的 resolve_state_dir / ensure_state_dir 中，每一处旧路径引用都有审计过的保留决定。"
+            : "Codewhale was renamed from DeepSeek-TUI. To avoid breaking existing installs, the runtime reads state from the new ~/.codewhale/ location but falls back to ~/.deepseek/ when only the legacy directory exists, and always writes to ~/.codewhale/ — read-with-fallback, write-to-new. State-dir resolution is consolidated in resolve_state_dir / ensure_state_dir in crates/config/src/lib.rs, and every legacy path reference carries an audited keep decision."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/CONFIGURATION.md, docs/LEGACY_PATHS.md · 更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/CONFIGURATION.md, docs/LEGACY_PATHS.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/fleet/page.tsx
+++ b/web/app/[locale]/docs/fleet/page.tsx
@@ -1,0 +1,120 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/fleet",
+    locale,
+    title: isZh ? "Fleet 与 Workflow · Codewhale 文档" : "Fleet & Workflow · Codewhale Docs",
+    description: isZh
+      ? "持久多 worker 运行的本地控制平面，以及可选的 Workflow 编排层。"
+      : "The local-first control plane for durable multi-worker runs, plus the optional Workflow orchestration overlay.",
+  });
+}
+
+export default async function FleetPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const vocabulary = isZh
+    ? [
+        { term: "Fleet", definition: "谁来做工作：配置好的 worker、角色、模型、主机和信任边界。" },
+        { term: "Workflow", definition: "工作按什么顺序进行：阶段、门禁、预算、回放和汇总。" },
+        { term: "Lane", definition: "一个正在运行的 Workflow 实例及其实时进度。" },
+        { term: "Runtime", definition: "Lane 在哪里、如何执行：本地或远程进程、提供商路由、沙箱和 API 边界。" },
+      ]
+    : [
+        { term: "Fleet", definition: "Who does the work: the configured workers, roles, models, hosts, and trust boundaries." },
+        { term: "Workflow", definition: "What order the work follows: phases, gates, budgets, replay, and fan-in." },
+        { term: "Lane", definition: "One running Workflow instance and its live progress." },
+        { term: "Runtime", definition: "Where and how a Lane executes: local or remote process, provider route, sandbox, and API boundary." },
+      ];
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "Fleet 与 Workflow" : "Fleet & Workflow"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Fleet 是面向持久多 worker 运行的本地优先控制平面。它不是独立的执行引擎：一个 Fleet worker 就是一次由 Fleet 启动并持久跟踪的 codewhale exec 无头运行。当工作需要重试、睡眠/重启后存活、远程执行、收据或可审计的台账时，使用 Fleet 而不是短寿命的 agent 扇出。"
+            : "Fleet is the local-first control plane for durable multi-worker runs. It is not a separate execution engine: a fleet worker is a headless codewhale exec run that the fleet launches and tracks durably. Reach for Fleet instead of short-lived agent fan-out whenever the work needs retry, sleep/restart survival, remote execution, receipts, or a ledgered audit trail."}
+        </p>
+        <div className="hairline-t mt-6">
+          {vocabulary.map((row) => (
+            <section key={row.term} className="py-4 hairline-b">
+              <h3 className="font-display text-xl">{row.term}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{row.definition}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="cli" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "运行一次 Fleet" : "Run a fleet"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Fleet 状态存放在工作区的 .codewhale/fleet.jsonl 台账中，worker 日志在 .codewhale/fleet/ 下。codewhale fleet resume <run-id> 是重启恢复命令：它重放台账、调和停止心跳的在途租约，且幂等——在管理进程退出、笔记本睡眠或运行时重启后都可以安全运行。"
+            : "Fleet state lives in the workspace's .codewhale/fleet.jsonl ledger, with worker logs under .codewhale/fleet/. codewhale fleet resume <run-id> is the restart-recovery verb: it replays the ledger, reconciles in-flight leases whose workers stopped heartbeating, and is idempotent — safe after a manager exit, laptop sleep, or runtime restart."}
+        </p>
+        <pre className="code-block mt-4">{`codewhale fleet init
+codewhale fleet run tasks.json --max-workers 4
+codewhale fleet status
+codewhale fleet inspect <worker-id>
+codewhale fleet logs <worker-id>
+codewhale fleet interrupt <worker-id>
+codewhale fleet resume <run-id>
+codewhale fleet stop --all`}</pre>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              注意两个同名状态面：TUI 里的 <code className="inline">/fleet status</code>（或{" "}
+              <code className="inline">/subagents</code>）只显示当前交互会话的子 Agent；shell 里的{" "}
+              <code className="inline">codewhale fleet status</code> 才读取持久 Fleet 台账。
+            </>
+          ) : (
+            <>
+              Two similarly named status surfaces exist: in the TUI,{" "}
+              <code className="inline">/fleet status</code> (or <code className="inline">/subagents</code>)
+              shows the sub-agents attached to the current interactive session; in a shell,{" "}
+              <code className="inline">codewhale fleet status</code> reads the durable Fleet ledger.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="profiles" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "角色与 /fleet setup" : "Roles and /fleet setup"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "/fleet setup 打开一个渐进式向导，编写可复用的 agent 团队档案：一次只做一个选择——角色，然后是模型（可继承，或任何已配置提供商的具体模型），再是思考档位（inherit、off、low、medium、high、max 或 auto）——最后在审查页确认完整姿态（路由、思考、权限、工具、范围与审查策略）。档案可以写在项目级（.codewhale/agents/<role>.toml，随仓库走）或个人级（$CODEWHALE_HOME/agents/<role>.toml，本机所有仓库可用）；同名项目档案优先。档案的存储范围不会扩大运行操作的权限。"
+            : "/fleet setup opens a progressive wizard for authoring a reusable agent-team profile: one focused choice at a time — a role, then a model (inherit, or a concrete model from any configured provider), then a thinking tier (inherit, off, low, medium, high, max, or auto) — and a review of the full posture (route, thinking, permissions, tools, scope, and review policy) before anything is saved. Profiles live in project scope (.codewhale/agents/<role>.toml, travels with the repo) or personal scope ($CODEWHALE_HOME/agents/<role>.toml, available in every repo on the machine); a same-id project profile wins. Profile storage scope never widens the authority of a running operation."}
+        </p>
+      </section>
+
+      <section id="workflow" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "Workflow 编排" : "Workflow orchestration"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "普通多 Agent 工作不需要 Workflow：在 Operate 里直接发消息，需要并行、隔离或长时间工作时让 Codewhale 优先委派后台 worker 即可。只有当工作需要有序阶段、门禁、共享预算、回放或确定性汇总时才用 Workflow。Workflow 脚本是纯协调者：没有自己的文件系统和 shell，真正的工作由它启动的子 Agent 完成。脚本以编译专用的声明式 JS 子集编写，降低到类型化的 WorkflowSpec 后由 Rust 校验与执行；import、fetch、process、eval、async/await 等会产生副作用的写法会被编译器拒绝。"
+            : "Ordinary multi-agent work does not need Workflow: send normal messages in Operate and let Codewhale prefer background workers when parallelism, isolation, or duration makes delegation useful. Use Workflow when ordered phases, gates, shared budgets, replay, or deterministic fan-in matter. A Workflow script is a coordinator only: it has no filesystem or shell of its own; real work happens in the sub-agents it launches. Scripts are written in a declarative compile-only JS subset that lowers to a typed WorkflowSpec validated and executed by Rust; effectful constructs such as import, fetch, process, eval, and async/await are rejected by the compiler."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "默认校验边界：每次 Workflow 运行最多 100 个 worker Agent、最多 5 层递归 Fleet 环、循环必须声明 max_iterations、动态 expand 节点必须声明 max_children 和模板。这些是数量上限而非并发要求——一个合法的 100 Agent Workflow 仍会按配置好的 Fleet worker 池排水执行。Workflow JS 沙箱内单 run 最多 16 个并发存活 Agent、整个 VM 生命周期最多 1,000 次启动。"
+            : "Default validation bounds: up to 100 worker agents per workflow run, up to 5 recursive Fleet rings, loops must declare max_iterations, and dynamic expand nodes must declare max_children plus a template. These are population limits, not launch concurrency — a valid 100-agent workflow still drains through the configured Fleet worker pool. Inside the Workflow JS sandbox, one run keeps at most 16 concurrent live agents and at most 1,000 spawns over the VM lifetime."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/FLEET.md, docs/WORKFLOW_AUTHORING.md · 更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/FLEET.md, docs/WORKFLOW_AUTHORING.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/hooks/page.tsx
+++ b/web/app/[locale]/docs/hooks/page.tsx
@@ -1,0 +1,121 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/hooks",
+    locale,
+    title: isZh ? "钩子 · Codewhale 文档" : "Hooks · Codewhale Docs",
+    description: isZh
+      ? "已发布的生命周期钩子：可变 message_submit、tool_call_before 决策、turn_end 与子 Agent 观察事件。"
+      : "The shipped lifecycle hooks: mutable message_submit, tool_call_before decisions, turn_end, and sub-agent observer events.",
+  });
+}
+
+export default async function HooksPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const events = isZh
+    ? [
+        {
+          name: "message_submit（可变）",
+          detail:
+            "在用户消息进入历史或发给模型之前运行。钩子从 stdin 收到 JSON；exit 0 且 stdout 打印含非空 text 字段的 JSON 时替换提交文本；exit 2 在回合开始前阻止提交。多个钩子按配置顺序串行执行，每个钩子收到上一个钩子的输出文本。标记 background = true 的钩子只能观察，不能改写或阻止。",
+        },
+        {
+          name: "tool_call_before（决策）",
+          detail:
+            "在每次工具调用执行前运行。除 exit 2 硬拒绝（始终生效）外，前台钩子可在 exit 0 时用 stdout JSON 给出决策：allow / deny / ask，并可附带 updatedInput 改写工具输入、additionalContext 追加进给模型的工具结果。多个钩子命中时优先级为 deny > ask > allow；tool_name 条件支持 * 通配（如 mcp__* 匹配所有 MCP 工具）。Full Access 不打开工具审批提示，因此 ask 不会降低该姿态。",
+        },
+        {
+          name: "turn_end（观察）",
+          detail:
+            "在每个模型回合结束后触发，此时用量、成本、通知、收据和队列恢复状态都已更新。stdin 收到包含 status、duration_ms、usage、totals、queued_message_count 等字段的 JSON。stdout 被忽略，失败只记警告——不能阻止输入、改写 transcript 或改变下一个排队消息。",
+        },
+        {
+          name: "subagent_spawn / subagent_complete（观察）",
+          detail:
+            "观察子 Agent 的启动与完成，stdin 收到有界的 JSON 元数据（agent_id、状态、截断后的 prompt/result 预览）。失败只记警告，不阻塞调度、不改 prompt 或结果；需要完整细节时使用 agent 返回的 transcript 句柄。",
+        },
+      ]
+    : [
+        {
+          name: "message_submit (mutable)",
+          detail:
+            "Runs before a submitted message is added to history or sent to the model. The hook receives JSON on stdin; exit 0 with stdout JSON carrying a non-empty text field replaces the submitted text, and exit 2 blocks the submission before the turn starts. Multiple hooks run serially in config order, each receiving the previous hook's output. Hooks marked background = true are observer-only and cannot transform or block.",
+        },
+        {
+          name: "tool_call_before (decision)",
+          detail:
+            "Runs before each tool call executes. Beyond the exit-2 hard deny (which always wins), a foreground hook may print a JSON decision on stdout with exit 0: allow / deny / ask, plus updatedInput to rewrite the tool input and additionalContext appended to the tool result the model sees. When several hooks match, precedence is deny > ask > allow; tool_name conditions support * globs (mcp__* matches every MCP tool). Full Access does not open tool-approval prompts, so ask does not downgrade that posture.",
+        },
+        {
+          name: "turn_end (observer)",
+          detail:
+            "Fires after each model turn ends, once usage, cost, notifications, receipts, and queue-recovery state have settled. The stdin JSON carries fields such as status, duration_ms, usage, totals, and queued_message_count. Stdout is ignored and failures are warn-only — the hook cannot block input, mutate the transcript, or change the next queued follow-up.",
+        },
+        {
+          name: "subagent_spawn / subagent_complete (observer)",
+          detail:
+            "Observe sub-agent start and completion with bounded JSON metadata on stdin (agent_id, status, truncated prompt/result previews). Failures are warn-only and never block scheduling or change prompts or results; use the transcript handle returned by agent when full detail is needed.",
+        },
+      ];
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "钩子" : "Hooks"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "钩子让你把自己的命令挂进 Codewhale 的生命周期：在消息提交前注入上下文、在工具调用前执行策略、在回合结束或子 Agent 启停时做审计。本页描述当前已发布的行为；docs/rfcs/1364-hooks-lifecycle.md 是这组能力的设计 RFC，完整配置 schema 见 docs/CONFIGURATION.md。"
+            : "Hooks attach your own commands to Codewhale's lifecycle: inject context before a message is submitted, enforce policy before a tool call, and audit turns or sub-agent activity. This page describes what currently ships; docs/rfcs/1364-hooks-lifecycle.md is the design RFC for this surface, and docs/CONFIGURATION.md carries the full configuration schema."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              钩子配置在 config.toml 的 <code className="inline">[[hooks.hooks]]</code> 条目下；TUI 里运行{" "}
+              <code className="inline">/hooks</code> 可以按事件分组查看每个钩子的名称、命令预览、超时和条件，以及{" "}
+              <code className="inline">[hooks].enabled</code> 的全局开关状态。
+            </>
+          ) : (
+            <>
+              Hooks are configured under <code className="inline">[[hooks.hooks]]</code> entries in
+              config.toml; run <code className="inline">/hooks</code> in the TUI to see every configured
+              hook grouped by event — name, command preview, timeout, and condition — plus the global{" "}
+              <code className="inline">[hooks].enabled</code> state.
+            </>
+          )}
+        </p>
+        <div className="hairline-t mt-6">
+          {events.map((row) => (
+            <section key={row.name} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{row.name}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="project" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "项目级钩子" : "Project-local hooks"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "仓库可以在 <workspace>/.codewhale/hooks.toml 中携带策略。因为项目钩子是可执行的 shell 配置，Codewhale 只有在工作区通过信任提示或用户配置中的 trust_level = \"trusted\" 被信任后才加载它们——会话内的 /trust on 和旧版 .deepseek/trusted 标记都不会单独启用项目钩子。受信任后，项目钩子追加在 config.toml 的全局钩子之后运行，因此对 updatedInput 而言最后生效。格式错误但已受信任的项目文件会记警告并回退到只用全局钩子。"
+            : "Repositories can ship policy in <workspace>/.codewhale/hooks.toml. Because project hooks are executable shell configuration, Codewhale loads them only after the workspace is trusted through the trust prompt or a trust_level = \"trusted\" entry in user-owned config — session /trust on and legacy .deepseek/trusted markers do not enable project hooks by themselves. Once trusted, project hooks are appended after the global hooks from config.toml, so they run last and win updatedInput ties. A malformed trusted project file logs a warning and startup falls back to global hooks only."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/rfcs/1364-hooks-lifecycle.md（设计 RFC）, docs/CONFIGURATION.md（配置 schema）· 更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/rfcs/1364-hooks-lifecycle.md (design RFC), docs/CONFIGURATION.md (configuration schema) · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/layout.tsx
+++ b/web/app/[locale]/docs/layout.tsx
@@ -28,8 +28,8 @@ export default async function DocsLayout({
           <h1>{isZh ? "查找准确的使用说明。" : "Find the guidance you need."}</h1>
           <p>
             {isZh
-              ? "从安装和首次运行开始，或者直接查找模式、权限、工具、提供商、Fleet、MCP 与运行时 API。网站页面提供简明入口，仓库中的源文档保留完整细节。"
-              : "Start with installation and first run, or go straight to modes, permissions, tools, providers, Fleet, MCP, and the Runtime API. These pages provide a clear index while the source documents in the repository carry the full detail."}
+              ? "从安装和首次运行开始，或者直接查找模式、权限、工具、提供商、Fleet、MCP 与运行时 API。这些页面就是正式的产品文档；每页都链接仓库中的源文档，方便查阅完整细节。"
+              : "Start with installation and first run, or go straight to modes, permissions, tools, providers, Fleet, MCP, and the Runtime API. These pages are the product documentation; each one cites the source documents in the repository for full detail."}
           </p>
           <div className="portal-actions">
             <Link href={`/${locale}/install`} className="portal-button portal-button-primary">

--- a/web/app/[locale]/docs/mcp/page.tsx
+++ b/web/app/[locale]/docs/mcp/page.tsx
@@ -1,0 +1,161 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/mcp",
+    locale,
+    title: isZh ? "MCP · Codewhale 文档" : "MCP · Codewhale Docs",
+    description: isZh
+      ? "通过 Model Context Protocol 消费外部工具服务器，或把 Codewhale 作为 MCP 服务器暴露。"
+      : "Consume external tool servers over the Model Context Protocol, or expose Codewhale itself as an MCP server.",
+  });
+}
+
+export default async function McpPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">MCP</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Codewhale 可以通过 MCP（Model Context Protocol）加载额外的工具。MCP 服务器可以是由 TUI 启动的本地 stdio 进程，也可以是远程 URL 服务器（Streamable HTTP，带旧版 SSE 回退）。连接成功的服务器会把工具注册进模型目录；失败或被禁用的服务器不会作为可用工具呈现给模型。"
+            : "Codewhale can load additional tools via MCP (Model Context Protocol). MCP servers can be local stdio processes that the TUI starts, or remote URL-based servers that speak Streamable HTTP with legacy SSE fallback. A successfully connected server registers its tools into the model catalog; a failed or disabled server is never presented as an available tool."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              配置文件默认在 <code className="inline">~/.codewhale/mcp.json</code>
+              （新文件缺失时仍读取旧版 <code className="inline">~/.deepseek/mcp.json</code>），可用{" "}
+              <code className="inline">mcp_config_path</code> 或{" "}
+              <code className="inline">DEEPSEEK_MCP_CONFIG</code> 覆盖。也兼容其他客户端使用的{" "}
+              <code className="inline">mcpServers</code> 键名。
+            </>
+          ) : (
+            <>
+              The config file defaults to <code className="inline">~/.codewhale/mcp.json</code> (the
+              legacy <code className="inline">~/.deepseek/mcp.json</code> is still read when the
+              Codewhale file is absent), overridable with{" "}
+              <code className="inline">mcp_config_path</code> or{" "}
+              <code className="inline">DEEPSEEK_MCP_CONFIG</code>. The{" "}
+              <code className="inline">mcpServers</code> key used by other clients is accepted too.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="setup" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "配置与管理" : "Setup and management"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              用 <code className="inline">codewhale-tui mcp init</code> 生成初始配置；TUI 内的{" "}
+              <code className="inline">/mcp</code>{" "}
+              打开紧凑管理器，显示每个服务器的启用状态、传输方式、命令或 URL、超时和连接错误。常用命令：
+            </>
+          ) : (
+            <>
+              Bootstrap a starter config with <code className="inline">codewhale-tui mcp init</code>;
+              inside the TUI, <code className="inline">/mcp</code> opens a compact manager showing each
+              server's enabled state, transport, command or URL, timeouts, and connection errors. Common
+              commands:
+            </>
+          )}
+        </p>
+        <pre className="code-block mt-4">{`codewhale-tui mcp add <name> --command "<cmd>" --arg "<arg>"
+codewhale-tui mcp add <name> --url "https://example.com/mcp" --bearer-token-env-var MCP_TOKEN
+codewhale-tui mcp login <name>      # OAuth for remote servers
+codewhale-tui mcp list
+codewhale-tui mcp validate`}</pre>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "在 TUI 里做的配置编辑会立即写盘，但模型可见的 MCP 工具池不会热加载——管理器会把它标记为需要重启。/mcp validate 和 /mcp reload 会重新连接以刷新界面快照。"
+            : "Config edits made from the TUI are written immediately, but the model-visible MCP tool pool is not hot-reloaded — the manager marks it restart-required. /mcp validate and /mcp reload reconnect to refresh the on-screen snapshot."}
+        </p>
+      </section>
+
+      <section id="auth" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "远程认证" : "Remote authentication"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "URL 服务器可以使用静态 headers、从环境变量派生的 env_headers、bearer_token_env_var 或 OAuth。优先级是保守的：先应用 headers 和 env_headers；bearer_token_env_var 只在尚未设置 Authorization 时添加；OAuth 登录获取的令牌同样不会覆盖已有的显式 header。应避免提交字面量 Authorization header——优先用 env_headers、bearer_token_env_var 或 OAuth 登录，让秘密留在 MCP 文件之外。"
+            : "URL-based servers can use static headers, env-derived env_headers, bearer_token_env_var, or OAuth. Precedence is conservative: headers and env_headers apply first; bearer_token_env_var adds an Authorization header only when one is not already set; OAuth login tokens likewise never override an explicit header. Avoid committing literal Authorization headers — prefer env_headers, bearer_token_env_var, or OAuth login so secrets stay outside the MCP file."}
+        </p>
+      </section>
+
+      <section id="tools" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "工具命名与安全" : "Tool naming and safety"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              发现的 MCP 工具以 <code className="inline">mcp_&lt;server&gt;_&lt;tool&gt;</code>{" "}
+              的形式暴露给模型——例如名为 <code className="inline">git</code> 的服务器的{" "}
+              <code className="inline">status</code> 工具会变成{" "}
+              <code className="inline">mcp_git_status</code>。MCP
+              工具和内置工具走同一套审批框架：只读的 MCP 辅助工具在策略允许时可免提示运行，有副作用的 MCP
+              工具需要审批，Full Access 也不会绕过硬策略拦截。
+            </>
+          ) : (
+            <>
+              Discovered MCP tools are exposed to the model as{" "}
+              <code className="inline">mcp_&lt;server&gt;_&lt;tool&gt;</code> — a server named{" "}
+              <code className="inline">git</code> with a <code className="inline">status</code> tool
+              becomes <code className="inline">mcp_git_status</code>. MCP tools flow through the same
+              approval framework as built-in tools: read-only MCP helpers can run without prompts when
+              policy permits, side-effectful MCP tools require approval, and Full Access does not bypass
+              hard policy holds.
+            </>
+          )}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "只配置你信任的 MCP 服务器，并把 MCP 服务器配置视为等同于在本机运行代码。经过审查的本地插件包也可以贡献 MCP 服务器：它们复用同一个 MCP 管理器、审批和网络策略路径，以 <plugin>-<server> 的命名空间身份出现，边界比手写的 mcp.json 更严格。"
+            : "Only configure MCP servers you trust, and treat MCP server configuration as equivalent to running code on your machine. Reviewed local plugin bundles can also contribute MCP servers: they reuse the same MCP manager, approval, and network-policy paths, appear under namespaced <plugin>-<server> identities, and are held to a stricter boundary than hand-written mcp.json."}
+        </p>
+      </section>
+
+      <section id="server" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "把 Codewhale 作为 MCP 服务器" : "Codewhale as an MCP server"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              <code className="inline">codewhale-tui serve --mcp</code> 会把 Codewhale
+              作为 stdio MCP 服务器运行，让其他会话（或任何 MCP 客户端）调用它的工具；
+              <code className="inline">codewhale mcp-server</code> 是 dispatcher
+              暴露的等价入口。<code className="inline">codewhale-tui mcp add-self</code>{" "}
+              会自动解析当前二进制路径并把服务器写进你的 MCP 配置。注意区分：
+              <code className="inline">serve --http</code> 是运行时 HTTP/SSE API，是另一种模式。
+            </>
+          ) : (
+            <>
+              <code className="inline">codewhale-tui serve --mcp</code> runs Codewhale as an stdio MCP
+              server so other sessions (or any MCP client) can call its tools;{" "}
+              <code className="inline">codewhale mcp-server</code> is the equivalent dispatcher
+              entrypoint. <code className="inline">codewhale-tui mcp add-self</code> resolves the current
+              binary path and writes the server into your MCP config. Keep the modes distinct:{" "}
+              <code className="inline">serve --http</code> is the runtime HTTP/SSE API, a separate
+              surface.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/MCP.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/MCP.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/runtime-api/page.tsx
+++ b/web/app/[locale]/docs/runtime-api/page.tsx
@@ -1,0 +1,116 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/runtime-api",
+    locale,
+    title: isZh ? "运行时 API · Codewhale 文档" : "Runtime API · Codewhale Docs",
+    description: isZh
+      ? "面向集成、桥接和自动化的本地 HTTP/SSE、JSON-RPC stdio 与 ACP 入口。"
+      : "Local HTTP/SSE, JSON-RPC stdio, and ACP entrypoints for integrations, bridges, and automation.",
+  });
+}
+
+export default async function RuntimeApiPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const entries = isZh
+    ? [
+        { cmd: "codewhale app-server --http", detail: "完整 /v1/* HTTP/SSE 运行时 API（canonical 入口），默认 127.0.0.1:7878。" },
+        { cmd: "codewhale app-server --mobile", detail: "运行时 API 加 /mobile 手机控制页。" },
+        { cmd: "codewhale app-server --stdio", detail: "换行分隔的 JSON-RPC 2.0 控制传输，无监听端口，适合本地 SDK 和探针。" },
+        { cmd: "codewhale web [--port 7878]", detail: "仅回环的浏览器客户端，内嵌于二进制并打开默认浏览器。" },
+        { cmd: "codewhale doctor --json", detail: "机器可读的健康与能力报告。" },
+        { cmd: "codewhale serve --acp", detail: "面向 Zed 等编辑器的 ACP（Agent Client Protocol）stdio 适配器。" },
+        { cmd: "codewhale exec [args]", detail: "一次性无头 worker（stream-json、Fleet 子进程、CI 原语）——不属于本 API，但共享同一运行时与事件词汇。" },
+      ]
+    : [
+        { cmd: "codewhale app-server --http", detail: "The full /v1/* HTTP/SSE runtime API (canonical entry), default 127.0.0.1:7878." },
+        { cmd: "codewhale app-server --mobile", detail: "The runtime API plus the /mobile phone control page." },
+        { cmd: "codewhale app-server --stdio", detail: "Newline-delimited JSON-RPC 2.0 control transport with no listener, for local SDKs and probes." },
+        { cmd: "codewhale web [--port 7878]", detail: "The loopback-only browser client, embedded in the binary and opened in the default browser." },
+        { cmd: "codewhale doctor --json", detail: "Machine-readable health and capability report." },
+        { cmd: "codewhale serve --acp", detail: "ACP (Agent Client Protocol) stdio adapter for editors such as Zed." },
+        { cmd: "codewhale exec [args]", detail: "The one-shot headless worker (stream-json, fleet subprocess, CI primitive) — not part of this API, but it shares the same runtime and event vocabulary." },
+      ];
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "运行时 API" : "Runtime API"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "codewhale app-server 是 canonical 的本地运行时 API 与控制平面。本地 SDK、移动/远控客户端和编辑器集成直接与它对话，而不是抓终端输出。引擎只作为本地进程运行：所有 API 默认绑定 localhost——没有托管中继，不托管 provider 令牌，不泄露秘密。codewhale serve --http / --mobile 保留为 app-server --http / --mobile 的兼容别名，启动的是同一个服务器；新集成应面向 app-server。"
+            : "codewhale app-server is the canonical local runtime API and control plane. Local SDKs, mobile/remote-control clients, and editor integrations talk to it instead of screen-scraping terminal output. The engine runs as a local-only process: every API binds to localhost by default — no hosted relay, no provider-token custody, no secret leakage. codewhale serve --http / --mobile remain compatibility aliases for app-server --http / --mobile and launch the identical server; new integrations should target app-server."}
+        </p>
+        <div className="hairline-t mt-6">
+          {entries.map((row) => (
+            <section key={row.cmd} className="py-4 hairline-b">
+              <h3 className="font-mono text-sm font-semibold">{row.cmd}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="stdio" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "零成本探测" : "Probe without model tokens"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "stdio 控制传输可以不花模型 token 地探测。capabilities 返回声明的方法族（thread/*、app/*、prompt/*）和完整方法列表；方法集由 crates/app-server/src/lib.rs 中的漂移测试固定，SDK 和本地集成可以放心依赖它不会悄悄变化。"
+            : "The stdio control transport can be probed without spending model tokens. capabilities returns the advertised method families (thread/*, app/*, prompt/*) and the full method list; the method set is pinned by a drift test in crates/app-server/src/lib.rs, so SDK and local integration clients can rely on it not changing silently."}
+        </p>
+        <pre className="code-block mt-4">{`printf '%s\n' \\
+  '{"jsonrpc":"2.0","id":1,"method":"healthz"}' \\
+  '{"jsonrpc":"2.0","id":2,"method":"capabilities"}' \\
+  '{"jsonrpc":"2.0","id":3,"method":"shutdown"}' \\
+  | codewhale app-server --stdio`}</pre>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "进行中的回合可以用 thread/interrupt（或 HTTP 的 POST /v1/threads/{id}/turns/{turn_id}/interrupt）请求中断；没有正在流式输出的回合时返回 interrupted: false——这不是错误，只是没有可停的东西。"
+            : "A live turn can be asked to stop with thread/interrupt (or POST /v1/threads/{id}/turns/{turn_id}/interrupt over HTTP); when no turn is streaming the reply carries interrupted: false — not an error, just nothing to stop."}
+        </p>
+      </section>
+
+      <section id="security" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "安全边界" : "Security boundary"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              运行时 API 令牌按 <code className="inline">--auth-token</code>、
+              <code className="inline">CODEWHALE_RUNTIME_TOKEN</code>、
+              <code className="inline">DEEPSEEK_RUNTIME_TOKEN</code> 的顺序读取；
+              <code className="inline">--insecure-no-auth</code> 只允许与回环绑定一起使用。浏览器侧的跨源请求会被
+              CORS 允许列表拒绝。选择非回环绑定（尤其是{" "}
+              <code className="inline">app-server --mobile</code>）之前，请阅读 docs/RUNTIME_API.md
+              的完整部署与认证约定。
+            </>
+          ) : (
+            <>
+              The runtime API token is read from <code className="inline">--auth-token</code>, then{" "}
+              <code className="inline">CODEWHALE_RUNTIME_TOKEN</code>, then{" "}
+              <code className="inline">DEEPSEEK_RUNTIME_TOKEN</code>;{" "}
+              <code className="inline">--insecure-no-auth</code> is only accepted with a loopback bind.
+              Cross-origin browser requests are rejected by the CORS allow-list. Before selecting a
+              non-loopback bind — especially <code className="inline">app-server --mobile</code> — read
+              the full deployment and authentication contract in docs/RUNTIME_API.md.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/RUNTIME_API.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/RUNTIME_API.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/sandbox/page.tsx
+++ b/web/app/[locale]/docs/sandbox/page.tsx
@@ -1,0 +1,148 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/sandbox",
+    locale,
+    title: isZh ? "沙箱与审批 · Codewhale 文档" : "Sandbox & Approval · Codewhale Docs",
+    description: isZh
+      ? "macOS Seatbelt、Linux 可选 bubblewrap、平台缺口和审批策略的真实边界。"
+      : "The honest boundary: macOS Seatbelt, opt-in Linux bubblewrap, platform gaps, and approval policy.",
+  });
+}
+
+export default async function SandboxPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const platforms = isZh
+    ? [
+        {
+          name: "macOS · Seatbelt",
+          detail:
+            "Codewhale 探测 /usr/bin/sandbox-exec；探测成功且策略要求沙箱时，子命令会被包上运行时生成的 Seatbelt profile：广泛的文件系统读取、按策略限制的写入、仅在策略允许时放行网络。探测失败则如实报告无 OS 沙箱。",
+        },
+        {
+          name: "Linux · 可选 bubblewrap",
+          detail:
+            "Linux 命令沙箱是显式启用的：设置 prefer_bwrap = true，且 /usr/bin/bwrap 是可执行文件时才选用。子命令得到只读根视图，writable 挂载来自解析后的策略；默认隔离网络命名空间，仅在策略开启 network_access 时加 --share-net。未启用或未安装 bwrap 时报告 none。",
+        },
+        {
+          name: "Windows · 无 OS 沙箱",
+          detail:
+            "Windows 命令路径目前报告无 OS 沙箱。主机权限和审批策略仍然有效，但它们不是 Codewhale 的 OS 命令沙箱。",
+        },
+        {
+          name: "外部 OpenSandbox 执行",
+          detail:
+            "配置 sandbox_backend = \"opensandbox\" 后，shell 执行会发往配置的 OpenSandbox 兼容 HTTP 端点，而不是启动本地子进程。隔离保证属于所配置的服务及其运营者。",
+        },
+      ]
+    : [
+        {
+          name: "macOS · Seatbelt",
+          detail:
+            "Codewhale probes /usr/bin/sandbox-exec; when the probe succeeds and the policy requests a sandbox, the child command is wrapped in a generated Seatbelt profile: broad filesystem reads, policy-limited writes, and network only when the policy enables it. A failed probe is reported honestly as no OS sandbox.",
+        },
+        {
+          name: "Linux · opt-in bubblewrap",
+          detail:
+            "Linux command sandboxing is opt-in: set prefer_bwrap = true and keep /usr/bin/bwrap executable. The child gets a read-only root view with writable mounts derived from the resolved policy; the network namespace is isolated by default and --share-net is added only when the policy enables network access. Without the opt-in, Codewhale reports none.",
+        },
+        {
+          name: "Windows · no OS sandbox",
+          detail:
+            "The Windows command path currently reports no OS sandbox. Host permissions and approval policy still apply, but they are not a Codewhale OS command sandbox.",
+        },
+        {
+          name: "External OpenSandbox execution",
+          detail:
+            "With sandbox_backend = \"opensandbox\", shell execution is sent to the configured OpenSandbox-compatible HTTP endpoint instead of starting a local child. Isolation guarantees belong to the configured service and its operator.",
+        },
+      ];
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "沙箱与审批" : "Sandbox & Approval"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Codewhale 可以启动由模型提出的 shell 命令。审批策略、感知工作区的文件工具和操作系统命令包装器是三个独立的控制：一次审批不是沙箱，选择 workspace-write 也不代表当前平台有可用的 OS 包装器。本页只描述已经接入命令执行路径的行为。"
+            : "Codewhale can launch shell commands proposed by a model. Approval policy, workspace-aware tools, and an operating-system command wrapper are separate controls: an approval is not a sandbox, and selecting workspace-write does not prove the current platform has an OS wrapper available. This page describes only behavior wired into the command execution path."}
+        </p>
+        <div className="hairline-t mt-6">
+          {platforms.map((row) => (
+            <section key={row.name} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{row.name}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="policies" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "策略与回退" : "Policies and fallbacks"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              本地 <code className="inline">sandbox_mode</code> 取值为{" "}
+              <code className="inline">read-only</code>、<code className="inline">workspace-write</code>、
+              <code className="inline">danger-full-access</code> 或{" "}
+              <code className="inline">external-sandbox</code>。前两者只在选中且可用的 Seatbelt 或
+              bubblewrap 包装器下被强制执行；<code className="inline">danger-full-access</code>{" "}
+              有意绕过本地 OS 包装器；<code className="inline">external-sandbox</code>{" "}
+              声明执行已被外部隔离。没有选中包装器时，shell 命令在没有 Codewhale OS 隔离的情况下运行——审批规则和感知工作区的原生文件工具仍是独立的控制。
+            </>
+          ) : (
+            <>
+              The local <code className="inline">sandbox_mode</code> values are{" "}
+              <code className="inline">read-only</code>, <code className="inline">workspace-write</code>,{" "}
+              <code className="inline">danger-full-access</code>, and{" "}
+              <code className="inline">external-sandbox</code>. The first two are enforced by Seatbelt or
+              bubblewrap only when that wrapper is selected and available;{" "}
+              <code className="inline">danger-full-access</code> deliberately bypasses the local OS
+              wrapper; <code className="inline">external-sandbox</code> declares that execution is already
+              externally isolated. When no wrapper is selected, the shell command runs without Codewhale
+              OS isolation — approval rules and workspace-aware native file tools remain separate controls.
+            </>
+          )}
+        </p>
+        <pre className="code-block mt-4">{`# config.toml
+sandbox_mode = "workspace-write"
+prefer_bwrap = true            # Linux opt-in
+
+# Canonical environment overrides
+CODEWHALE_SANDBOX_MODE
+CODEWHALE_SANDBOX_BACKEND
+CODEWHALE_SANDBOX_URL
+CODEWHALE_SANDBOX_API_KEY`}</pre>
+      </section>
+
+      <section id="diagnostics" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "诊断与限制" : "Diagnostics and limits"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "codewhale setup --status、codewhale doctor、codewhale doctor --json 和 diagnostics 工具会报告应用 bubblewrap 偏好后本地可用的包装器。拒绝归因是保守的：子命令的通用 Permission denied 本身并不能证明是 Codewhale 的沙箱拦截了它，未沙箱化的命令失败永远不会被标记为沙箱拒绝。"
+            : "codewhale setup --status, codewhale doctor, codewhale doctor --json, and the diagnostics tool report the locally available wrapper after applying the resolved bubblewrap preference. Denial attribution is intentionally conservative: a child command's generic Permission denied is not by itself proof that Codewhale's sandbox blocked it, and unsandboxed command failures are never labeled sandbox denials."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "限制同样如实说明：可用性在启动前检查，选中的包装器仍可能因主机策略、容器限制或竞态而失败；bubblewrap 会忽略缺失或不是目录的可写根；没有任何沙箱能防御内核漏洞或所有资源耗尽与侧信道攻击。"
+            : "The limitations are stated just as plainly: availability is checked before launch, yet the selected wrapper can still fail because of host policy, container restrictions, or a race after the probe; bubblewrap ignores a configured writable root that is missing or not a directory; and no sandbox protects against kernel vulnerabilities or all resource-exhaustion and side-channel attacks."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/SANDBOX.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/SANDBOX.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/subagents/page.tsx
+++ b/web/app/[locale]/docs/subagents/page.tsx
@@ -1,0 +1,142 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/subagents",
+    locale,
+    title: isZh ? "子 Agent · Codewhale 文档" : "Sub-Agents · Codewhale Docs",
+    description: isZh
+      ? "agent 工具、Fleet 角色、上下文分叉、worktree 隔离和并发上限。"
+      : "The agent tool, Fleet roles, context forking, worktree isolation, and concurrency caps.",
+  });
+}
+
+export default async function SubagentsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const roles = isZh
+    ? [
+        { name: "worker", detail: "灵活执行父级交代的多步任务；可写、可用 shell。默认角色。" },
+        { name: "scout", detail: "只读，快速摸清相关代码——例如“找出 Foo 的所有调用点”。" },
+        { name: "planner", detail: "分析并产出策略，不执行——“设计迁移方案，不要动手”。" },
+        { name: "reviewer", detail: "只读审查并按严重度打分——“审一遍这个 PR 的 bug”。" },
+        { name: "builder", detail: "以最小改动落地一个明确的变更；可写、可用 shell。" },
+        { name: "verifier", detail: "运行测试和校验并汇报结果，不写代码。" },
+        { name: "custom", detail: "手工指定狭窄的工具白名单，用于锁定的派发。" },
+      ]
+    : [
+        { name: "worker", detail: "Flexible multi-step execution of the parent's brief; writes and shell allowed. The default role." },
+        { name: "scout", detail: "Read-only, maps the relevant code fast — “find every call site of Foo.”" },
+        { name: "planner", detail: "Analyse and produce a strategy without executing — “design the migration; don't run it.”" },
+        { name: "reviewer", detail: "Read-and-grade with severity scores — “audit this PR for bugs.”" },
+        { name: "builder", detail: "Land a specific change with minimal edits; writes and shell allowed." },
+        { name: "verifier", detail: "Run tests and validation gates and report the outcome; no code edits." },
+        { name: "custom", detail: "An explicit narrow tool allowlist for locked-down dispatch." },
+      ];
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "子 Agent" : "Sub-Agents"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "父会话通过 agent 工具启动一个有明确职责的子 Agent，并立即拿回 agent_id、compact 收据和 transcript 句柄；子 Agent 在后台运行。子 Agent 默认继承父级的工具注册表，但它们是叶子 worker：不会再拿到 agent 或嵌套生命周期工具。agent 启动的是分离的后台工作——取消父回合会停止父级的等待路径，但不会杀死已经启动的子运行。"
+            : "A parent session launches one focused sub-agent through the agent tool and immediately gets back an agent_id, a compact receipt, and a transcript handle while the worker runs in the background. Sub-agents inherit the parent's tool registry by default, but they are leaf workers: they do not receive agent or nested lifecycle tools. agent launches detached background work — cancelling the parent turn stops the parent's wait path, but it does not kill already-opened child runs."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "对于必须跨进程重启、睡眠或远程执行存活的工作，优先选择 Fleet 或 Workflow 支撑的 Fleet 运行，而不是会话内的短寿命 agent 调用。"
+            : "For work that must survive process restarts, sleep, or remote execution, prefer Fleet or a Workflow-backed fleet run over a short in-session agent call."}
+        </p>
+        <div className="hairline-t mt-6">
+          {roles.map((row) => (
+            <section key={row.name} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{row.name}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="fork" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "上下文分叉" : "Context forking"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              <code className="inline">agent</code> 默认开启全新会话：子 Agent 只拿到角色提示词和你给的任务。当任务依赖父
+              transcript 里已有的决定、文件、待办或计划状态时，用{" "}
+              <code className="inline">fork_context: true</code>
+              ——运行时在可用时保持父级前缀逐字节一致（保留前缀缓存复用），追加一份结构化状态快照，再把子
+              Agent 的角色说明和任务放在末尾。独立探索用新会话，延续、审查、总结或压缩类工作用分叉会话。
+            </>
+          ) : (
+            <>
+              <code className="inline">agent</code> starts fresh by default: the child gets its role
+              prompt plus the task you pass. When the task depends on decisions, files, todos, or plan
+              state already in the parent transcript, use{" "}
+              <code className="inline">fork_context: true</code> — the runtime keeps the parent's
+              request prefix byte-identical where available (preserving prefix-cache reuse), appends a
+              structured state snapshot, then adds the sub-agent role instructions and task at the tail.
+              Use fresh sessions for independent exploration and forked sessions for continuation,
+              review, summarization, or compaction work.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="worktree" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "Worktree 隔离" : "Worktree isolation"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              并行编辑通道用 <code className="inline">worktree: true</code> 启动：Codewhale
+              为子 Agent 创建新的 git worktree 和分支（默认{" "}
+              <code className="inline">codex/agent-&lt;name&gt;-&lt;id&gt;</code>，检出在父仓库旁的{" "}
+              <code className="inline">.codewhale-worktrees/</code> 下），父检出保持干净。隔离不等于写权限：只带
+              prompt 的 worker 从只读开始；要写代码的子 Agent 还需声明{" "}
+              <code className="inline">write_authority</code> 和至少一个规范化的{" "}
+              <code className="inline">write_roots</code>、<code className="inline">exact_files</code>{" "}
+              或 <code className="inline">coordination_contracts</code>
+              值；重叠的共享写声明会在任何改动之前失败。
+            </>
+          ) : (
+            <>
+              Launch parallel edit lanes with <code className="inline">worktree: true</code>: Codewhale
+              creates a fresh git worktree and branch for the child (default{" "}
+              <code className="inline">codex/agent-&lt;name&gt;-&lt;id&gt;</code>, checked out beside the
+              parent repo under <code className="inline">.codewhale-worktrees/</code>) so the parent
+              checkout stays clean. Isolation is not write authority: a prompt-only worker starts
+              read-only, and a writer also declares{" "}
+              <code className="inline">write_authority</code> plus at least one normalized{" "}
+              <code className="inline">write_roots</code>, <code className="inline">exact_files</code>,
+              or <code className="inline">coordination_contracts</code> value. Overlapping shared write
+              claims fail before any mutation.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="capacity" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "并发上限" : "Concurrency caps"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "子 Agent 容量的权威来源是 crates/tui/src/config/subagent_limits.rs：默认配置并发 64，最大配置并发 128，运行加排队的最大准入 1024。这些是容量上限，不是建议把每个槽位都派出去——管理者应使用最小的有效扇出，保持单一汇总负责人，并在汇报整体完成前验证 worker 收据。"
+            : "The sub-agent capacity source of truth is crates/tui/src/config/subagent_limits.rs: default configured concurrency is 64, maximum configured concurrency is 128, and maximum admitted running-plus-queued work is 1024. These are capacity ceilings, not advice to dispatch every slot — a manager should use the smallest useful fan-out, keep a single fan-in owner, and verify worker receipts before reporting combined completion."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/SUBAGENTS.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/SUBAGENTS.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/troubleshooting/page.tsx
+++ b/web/app/[locale]/docs/troubleshooting/page.tsx
@@ -1,0 +1,132 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/troubleshooting",
+    locale,
+    title: isZh ? "排障 · Codewhale 文档" : "Troubleshooting · Codewhale Docs",
+    description: isZh
+      ? "常见问题的快速分诊：挂起的回合、离线队列、崩溃恢复、schema 错误、MCP 故障与 Docker 说明。"
+      : "Quick triage for common issues: hung turns, the offline queue, crash recovery, schema errors, MCP failures, and Docker notes.",
+  });
+}
+
+export default async function TroubleshootingPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const incidents = isZh
+    ? [
+        {
+          name: "回合挂起或流停止",
+          detail:
+            "前台 shell 命令还在跑时按 Ctrl+B 把它移到后台（回合继续，命令变成 /jobs 下的后台任务）；想取消回合本身用 Esc 或 Ctrl+C。检查 deepseek_cli::client 的重试日志和端点连通性，重启后确认此前在途的回合被标记为中断，而不是停在运行态。",
+        },
+        {
+          name: "网络中断 / 离线行为",
+          detail:
+            "离线时新提示词会排队，队列持久化在 ~/.codewhale/sessions/checkpoints/offline_queue.json。用 /queue list 查看，恢复连接后重新发送（/queue edit <n> 加回车，或走正常输入流程），队列清空后文件随之清除。",
+        },
+        {
+          name: "崩溃恢复",
+          detail:
+            "检查点保存在 ~/.codewhale/sessions/checkpoints/latest.json；除非传入 --resume/--continue，启动会开新会话。用 codewhale --resume <id> 或 TUI 里的 Ctrl+R 显式恢复；若检查点 schema 比二进制新，升级二进制或移除过期检查点。",
+        },
+        {
+          name: "持久状态 schema 错误",
+          detail:
+            "形如 schema vX is newer than supported vY 的错误涉及 sessions、运行时 thread/turn/item 记录和 tasks。先确认二进制版本，编辑前备份状态目录，然后用更新的兼容二进制运行，或归档不兼容记录并重建状态。",
+        },
+        {
+          name: "MCP / 工具执行失败",
+          detail:
+            "校验 ~/.codewhale/mcp.json 的 schema 和服务器命令路径，手动确认服务器进程能启动，并在 TUI 历史/日志中检查沙箱拒绝。用 /mcp validate 诊断，可暂时禁用出问题的服务器隔离原因，验证后再启用。",
+        },
+      ]
+    : [
+        {
+          name: "Turn hangs or the stream stops",
+          detail:
+            "If a foreground shell command is still running, press Ctrl+B to move it to the background (the turn keeps running and the command becomes a background job under /jobs); use Esc or Ctrl+C to cancel the turn itself. Inspect deepseek_cli::client retry logs and endpoint connectivity, and after a restart confirm the previously in-flight turn shows as interrupted rather than running.",
+        },
+        {
+          name: "Network outage / offline behavior",
+          detail:
+            "New prompts queue while offline, persisted to ~/.codewhale/sessions/checkpoints/offline_queue.json. Inspect with /queue list, restore connectivity, then re-send queued entries (/queue edit <n> plus Enter, or the normal input flow); the queue file clears when the queue empties.",
+        },
+        {
+          name: "Crash recovery",
+          detail:
+            "The checkpoint lives at ~/.codewhale/sessions/checkpoints/latest.json; startup begins a fresh session unless --resume/--continue is supplied. Resume explicitly with codewhale --resume <id> or Ctrl+R in the TUI; if the checkpoint schema is newer than the binary supports, upgrade the binary or remove the stale checkpoint.",
+        },
+        {
+          name: "Persistent state schema errors",
+          detail:
+            "Errors like schema vX is newer than supported vY affect sessions, runtime thread/turn/item records, and tasks. Confirm the binary version, back up the state directory before editing, then either run a newer compatible binary or archive the incompatible records and regenerate state.",
+        },
+        {
+          name: "MCP / tool execution failures",
+          detail:
+            "Validate the ~/.codewhale/mcp.json schema and server command paths, confirm the server process starts manually, and check sandbox denials in TUI history/logs. Use /mcp validate for diagnostics, temporarily disable a failing server to isolate the issue, and re-enable after verification.",
+        },
+      ];
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "排障" : "Troubleshooting"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "先快速分诊：确认二进制与配置（codewhale --version、~/.codewhale/config.toml），需要更详细日志时用 RUST_LOG=deepseek_cli=debug 启动（HTTP 重试/重连用 RUST_LOG=deepseek_cli::client=debug），并看一眼 ~/.codewhale/sessions 与 ~/.codewhale/tasks 的当前状态。"
+            : "Start with quick triage: confirm the binary and config (codewhale --version, ~/.codewhale/config.toml), enable verbose logs with RUST_LOG=deepseek_cli=debug when needed (RUST_LOG=deepseek_cli::client=debug for HTTP retries/reconnects), and capture the current state of ~/.codewhale/sessions and ~/.codewhale/tasks."}
+        </p>
+        <div className="hairline-t mt-6">
+          {incidents.map((row) => (
+            <section key={row.name} className="py-4 hairline-b">
+              <h3 className="font-display text-lg">{row.name}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{row.detail}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="docker" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "Docker 说明" : "Docker notes"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "每个发布都会向 GitHub Container Registry 推送多架构 Linux 镜像。默认镜像是保守的运行时镜像：以非 root 的 codewhale 用户（UID/GID 1000:1000）运行，不授予免密 sudo，用户状态放在挂载到 /home/codewhale/.codewhale 的卷里。可复现的安装请固定发布标签而不是 latest。"
+            : "Each release publishes a multi-arch Linux image to GitHub Container Registry. The default image is a conservative runtime image: it runs as the non-root codewhale user (UID/GID 1000:1000), grants no passwordless sudo, and keeps user state in a volume mounted at /home/codewhale/.codewhale. Pin a release tag instead of latest for reproducible installs."}
+        </p>
+        <pre className="code-block mt-4">{`docker volume create codewhale-home
+
+docker run --rm -it \\
+  -e DEEPSEEK_API_KEY="your-api-key-here" \\
+  -v codewhale-home:/home/codewhale/.codewhale \\
+  -v "$PWD:/workspace" \\
+  -w /workspace \\
+  ghcr.io/hmbown/codewhale:latest`}</pre>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "需要在容器内使用 apt-get、编译工具链或包管理器时，不要改默认镜像约定——基于 docs/examples/Dockerfile.toolbox 构建显式的 toolbox 镜像，并为每个项目使用独立的命名状态卷，避免会话、配置和离线队列跨工作区串扰。不要把 API 密钥或 SSH 私钥烘进自定义镜像。"
+            : "When a project needs apt-get, compiler toolchains, or package managers inside the container, do not change the default image contract — build an explicit toolbox image from docs/examples/Dockerfile.toolbox, and use one named state volume per project so sessions, config, and the offline queue do not bleed across workspaces. Never bake API keys or SSH private keys into custom images."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/OPERATIONS_RUNBOOK.md, docs/DOCKER.md · 更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/OPERATIONS_RUNBOOK.md, docs/DOCKER.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/web/page.tsx
+++ b/web/app/[locale]/docs/web/page.tsx
@@ -1,0 +1,110 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/web",
+    locale,
+    title: isZh ? "浏览器客户端 · Codewhale 文档" : "Browser Client · Codewhale Docs",
+    description: isZh
+      ? "仅回环的内嵌浏览器客户端：一次性引导、会话 Cookie 与本地信任边界。"
+      : "The loopback-only embedded browser client: one-time bootstrap, session cookie, and the local trust boundary.",
+  });
+}
+
+export default async function WebClientPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "浏览器客户端" : "Browser Client"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              <code className="inline">codewhale web</code> 在 canonical 运行时 API
+              之上打开 Codewhale 内嵌的浏览器客户端。它是一个纯本地界面：服务器始终绑定{" "}
+              <code className="inline">127.0.0.1</code>，无法改绑到局域网地址，也无法在关闭运行时认证的情况下运行。默认地址是{" "}
+              <code className="inline">http://127.0.0.1:7878</code>；端口冲突时用{" "}
+              <code className="inline">codewhale web --port 8788</code>{" "}
+              换一个回环端口。Ctrl+C 停止进程，浏览器会话随之结束。
+            </>
+          ) : (
+            <>
+              <code className="inline">codewhale web</code> opens Codewhale's embedded browser client
+              over the canonical Runtime API. It is a local surface: the server always binds to{" "}
+              <code className="inline">127.0.0.1</code>, cannot be rebound to a LAN address, and cannot
+              run with Runtime authentication disabled. The default address is{" "}
+              <code className="inline">http://127.0.0.1:7878</code>; on a port collision, pick another
+              loopback port with <code className="inline">codewhale web --port 8788</code>. Stop the
+              process with Ctrl+C and the browser session ends with it.
+            </>
+          )}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "当前客户端提供响应式的线程与搜索侧栏、由运行时持有的会话事实、transcript 与工具收据，以及输入区。它可以创建、选择、重命名和归档线程；发起或引导回合；中断工作；处理审批；回答运行时的用户输入请求。浏览器只是同一个本地运行时的另一视图——不会创建第二个云账号，不会把 provider 凭据复制进浏览器存储，也不会削弱已配置的审批与沙箱策略。"
+            : "The current client provides a responsive thread and search rail, Runtime-owned session facts, transcript and tool receipts, and a composer. It can create, select, rename, and archive threads; start or steer turns; interrupt work; resolve approvals; and answer Runtime user-input requests. The browser is another view of the same local Runtime — it does not create a second cloud account, copy provider credentials into browser storage, or weaken the configured approval and sandbox policies."}
+        </p>
+      </section>
+
+      <section id="auth" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "认证边界" : "Authentication boundary"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "启动 URL 携带的是一个随机、短寿命、一次性的引导凭证——绝不是运行时 bearer 令牌。一次回环请求把它换成 HttpOnly、SameSite=Strict、进程本地的会话 Cookie，并立即使该凭证失效。重用、过期、畸形或非回环的引导尝试都会失败关闭。运行时令牌不会出现在渲染的 HTML、浏览器存储、URL 查询或片段、或浏览器启动参数中。携带 Cookie 的状态变更请求还必须出示精确的本地 web 源；跨源浏览器请求会被拒绝。"
+            : "The browser-launch URL carries a random, short-lived, one-time bootstrap capability — never the Runtime bearer token. A loopback request exchanges it for an HttpOnly, SameSite=Strict, process-local session cookie and immediately invalidates the capability. Reused, expired, malformed, and non-loopback bootstrap attempts fail closed. The Runtime token is never placed in rendered HTML, browser storage, URL queries or fragments, or browser-launch arguments. Cookie-authenticated state-changing requests must also present the exact local web origin; cross-origin browser requests are rejected."}
+        </p>
+      </section>
+
+      <section id="local" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "本地就是本地" : "Local means local"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              <code className="inline">codewhale web</code> 只接受{" "}
+              <code className="inline">--port</code>——没有 <code className="inline">--host</code>
+              ，也没有关闭认证的选项。不要把它当公开网站，也不要通过路由器转发、公开反向代理或隧道暴露它的端口。单独的{" "}
+              <code className="inline">codewhale app-server --mobile</code> 和{" "}
+              <code className="inline">--http</code>{" "}
+              模式有不同的部署与认证约定，操作它们（尤其是选择非回环绑定）之前请阅读运行时 API 文档。
+            </>
+          ) : (
+            <>
+              <code className="inline">codewhale web</code> accepts only{" "}
+              <code className="inline">--port</code> — there is no <code className="inline">--host</code>{" "}
+              and no insecure-auth option on this command. Do not treat it as a public website or expose
+              its port through router forwarding, a public reverse proxy, or a tunnel. The separate{" "}
+              <code className="inline">codewhale app-server --mobile</code> and{" "}
+              <code className="inline">--http</code> modes carry different deployment and authentication
+              contracts; read the Runtime API documentation before operating either one, especially
+              before selecting a non-loopback bind.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="troubleshooting" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "常见问题" : "Troubleshooting"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "端口 7878 被占用时用 --port 换一个。浏览器无法打开时命令会报错退出，而不会留下可重用的引导凭证；检查系统默认浏览器设置后重新启动。页面能打开但 provider 不可用时，查 codewhale doctor 和 /provider——web 命令不配置也不迁移 provider 凭据。会话过期后重启 codewhale web 以签发新的进程本地会话；重用旧的引导 URL 本来就会失败。"
+            : "If port 7878 is occupied, pass an unused --port. If the browser cannot be opened, the command exits with an error rather than leaving a reusable bootstrap capability behind; check the OS default-browser setup and start again. If the page loads but a provider is unavailable, inspect codewhale doctor and /provider — the web command does not configure or move provider credentials. If a session expired, restart codewhale web to mint a new process-local session; reusing an old bootstrap URL is expected to fail."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/WEB.md · 更新时请同步修改 docs-map.ts。"
+            : "Source document: docs/WEB.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/work/page.tsx
+++ b/web/app/[locale]/docs/work/page.tsx
@@ -1,0 +1,175 @@
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/work",
+    locale,
+    title: isZh ? "工作面板 · Codewhale 文档" : "Work Surface · Codewhale Docs",
+    description: isZh
+      ? "带计数的 To-do 执行台账、update_plan 策略上下文，以及同一份工作状态的延续路径。"
+      : "The counted To-do execution ledger, update_plan strategy context, and how one work state stays continuous.",
+  });
+}
+
+export default async function WorkSurfacePage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "工作面板" : "The Work surface"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "Codewhale 的 TUI 侧栏有一块 Work 区域，显示当前工作的实时状态。它不只是视觉上的待办清单：同一份工作状态同时由模型可见的工具、会话接力（relay）和子 Agent 交接共同维护。它由两层构成——一个带计数的执行台账（To-do），和一层可选的策略上下文（update_plan 元数据）。"
+            : "The TUI sidebar has a Work area that shows live state for the current job. It is more than a visual to-do list: the same work state is maintained by model-visible tools, session relay, and sub-agent handoff. It has two layers — a counted execution ledger (the To-do) and an optional strategy context (update_plan metadata)."}
+        </p>
+      </section>
+
+      <section id="checklist" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "To-do：带计数的执行台账" : "Checklist: the counted execution ledger"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              To-do 是具体工作的进度台账：一组带状态的条目（pending / in_progress / completed /
+              cancelled），外加完成百分比和当前进行中的条目。模型通过 canonical 的{" "}
+              <code className="inline">work_update</code> 工具替换活动线程或持久任务的
+              To-do 投影——这是模型可见的进度表面。旧的{" "}
+              <code className="inline">checklist_*</code> 和 <code className="inline">todo_*</code>{" "}
+              名字仍是隐藏的兼容别名：它们对同一份 To-do 状态保持可派发，以便旧 transcript
+              回放，但不会出现在模型目录里。
+            </>
+          ) : (
+            <>
+              The To-do is the progress ledger for concrete work: a list of items with status
+              (pending / in_progress / completed / cancelled), a completion percentage, and the item
+              currently in progress. The model replaces this projection for the active thread or
+              durable task through the canonical <code className="inline">work_update</code> tool —
+              the model-visible progress surface. The legacy{" "}
+              <code className="inline">checklist_*</code> and <code className="inline">todo_*</code>{" "}
+              names remain hidden compatibility aliases: they stay dispatchable against the same To-do
+              state so old transcripts replay, but they are not advertised to the model catalog.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="strategy" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "策略上下文：update_plan 元数据" : "Strategy context: update_plan metadata"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "update_plan 承载的是可选的高层策略，不是第二个清单。它的字段面向阶段级理解：标题、目标、上下文摘要、说明、来源、关键文件、约束、推荐方案、验证计划、风险与未知、交接包，以及一组步骤。它帮助父会话或后续 worker 理解“为什么这么做”；具体执行进度始终属于 To-do 台账。侧栏有意不把策略状态渲染成第二条进度列表——两份进度并存只会制造歧义。"
+            : "update_plan carries optional high-level strategy — it is not a second checklist. Its fields serve phase-level understanding: title, objective, context summary, explanation, sources, critical files, constraints, recommended approach, verification plan, risks and unknowns, a handoff packet, and a list of steps. It helps a parent session or a later worker understand the approach; concrete execution progress always belongs to the To-do ledger. The sidebar deliberately does not render strategy state as a second progress list — two competing progress surfaces would only create ambiguity."}
+        </p>
+      </section>
+
+      <section id="continuity" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "延续性：同一份状态流向各处" : "Continuity: one state, many surfaces"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "同一份工作状态喂给多个出口：侧栏的 To-do 区域实时渲染它；/relay 让模型把 To-do 快照和 update_plan 策略元数据写进交接文件，供下一个线程接续；分叉（fork_context）的子 Agent 会在其前缀里收到一份结构化状态块，其中的 Work 小节就是这份 To-do 快照——子 Agent 因此从父级真实的进度位置继续，而不是从转述的摘要开始。"
+            : "The same work state feeds several surfaces: the sidebar's To-do area renders it live; /relay has the model write the To-do snapshot and the update_plan strategy metadata into a handoff artifact for the next thread; and a forked (fork_context) sub-agent receives a structured state block in its prefix whose Work section is this To-do snapshot — the child continues from the parent's real progress position instead of a paraphrased summary."}
+        </p>
+      </section>
+
+      <section id="capture" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "终端实拍（文本复原）" : "Terminal capture (faithful text)"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "下面的文本块按 crates/tui/src/tui/sidebar.rs 的渲染逻辑逐行复原侧栏 Work 区域：目标是带 ◆ 图标的 Goal 行、耗时、token 预算条；然后是完成度计数和带编号的状态条目。"
+            : "This text block reproduces the sidebar Work area line-for-line from the rendering logic in crates/tui/src/tui/sidebar.rs: the goal row with its ◆ icon, elapsed time, and token budget bar, then the settled counter and the numbered status items."}
+        </p>
+        <pre className="code-block mt-4">{`To-do
+◆ Goal: Land the v0.9.2 website docs cluster
+elapsed: 18m
+[█████████░░░░░░░░░░░] 45%
+50% settled (2/4)
+[✓] #1 Read docs-map.ts and the Modes page pattern
+[✓] #2 Draft the Fleet and Sandbox pages
+[~] #3 Write the Work surface page
+[ ] #4 Run check:docs, tests, and the build`}</pre>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              条目前缀对应四种状态：<code className="inline">[ ]</code> 待办、
+              <code className="inline">[~]</code> 进行中、<code className="inline">[✓]</code> 完成、
+              <code className="inline">[-]</code> 取消。空间不够时侧栏窗口化到进行中条目附近，并用
+              “+N more To-do items” 标注被省略的条目。
+            </>
+          ) : (
+            <>
+              The item prefixes map to the four statuses: <code className="inline">[ ]</code> pending,{" "}
+              <code className="inline">[~]</code> in progress, <code className="inline">[✓]</code>{" "}
+              completed, <code className="inline">[-]</code> cancelled. When space runs out, the sidebar
+              windows around the in-progress item and marks the omission with “+N more To-do items”.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="model-facing" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "哪些是模型可见的，哪些只是界面" : "What is model-facing vs. visual-only"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "已被实现和测试证实的模型可见路径有三条：work_update 工具本身是模型目录里的活跃工具；分叉子 Agent 的结构化状态块（<codewhale:fork_state> 中的 Work 小节，有针对它的引擎测试）；以及 /relay 输出，它把同一份 To-do 快照和策略元数据注入交接指令。侧栏渲染是视觉呈现——它给人看，不注入模型上下文。"
+            : "Three model-facing paths are implemented and covered by tests: the work_update tool itself, which is active in the model catalog; the forked sub-agent's structured state block (the Work section inside <codewhale:fork_state>, pinned by an engine test); and /relay output, which injects the same To-do snapshot and strategy metadata into the handoff instruction. The sidebar rendering is a visual presentation — it informs the operator and is not injected into model context."}
+        </p>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh ? (
+            <>
+              有一项能力我们刻意不宣称：把当前 Work 状态注入普通父回合的模型上下文（父回合级
+              grounding）。它取决于{" "}
+              <a
+                href="https://github.com/Hmbown/CodeWhale/issues/3983"
+                target="_blank"
+                rel="noreferrer"
+                className="body-link"
+              >
+                issue #3983
+              </a>{" "}
+              的运行时测试落地；在那之前，本页只描述已证实的行为。
+            </>
+          ) : (
+            <>
+              One capability is deliberately not claimed: injecting the current Work state into a
+              normal parent turn's model context (parent-turn grounding). That depends on the runtime
+              test tracked in{" "}
+              <a
+                href="https://github.com/Hmbown/CodeWhale/issues/3983"
+                target="_blank"
+                rel="noreferrer"
+                className="body-link"
+              >
+                issue #3983
+              </a>
+              ; until it lands, this page describes only proven behavior.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/TOOL_SURFACE.md, docs/TOOL_LIFECYCLE.md · 更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/TOOL_SURFACE.md, docs/TOOL_LIFECYCLE.md · Update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from "@/lib/page-meta";
 
 // Public, indexable routes (locale-prefixed). /admin and /api are
 // intentionally excluded; see app/robots.ts.
-const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/web", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
+const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/web", "/docs/work", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from "@/lib/page-meta";
 
 // Public, indexable routes (locale-prefixed). /admin and /api are
 // intentionally excluded; see app/robots.ts.
-const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/constitution", "/docs/modes", "/docs/tools", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
+const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/web", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -118,6 +118,18 @@ export const DOC_TOPICS: DocTopic[] = [
     category: "core-concepts",
   },
   {
+    id: "work",
+    slug: "work",
+    label: { en: "Work Surface", zh: "工作面板" },
+    description: {
+      en: "The counted To-do ledger, update_plan strategy context, and how work state flows to the sidebar, relay, and sub-agents.",
+      zh: "带计数的 To-do 台账、update_plan 策略上下文，以及工作状态如何流向侧栏、relay 和子 Agent。",
+    },
+    repoSource: ["docs/TOOL_SURFACE.md", "docs/TOOL_LIFECYCLE.md"],
+    hasPage: true,
+    category: "core-concepts",
+  },
+  {
     id: "subagents",
     slug: "subagents",
     label: { en: "Sub-Agents", zh: "子 Agent" },

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -126,7 +126,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "并行执行、角色类型、transcript 句柄和嵌套。",
     },
     repoSource: "docs/SUBAGENTS.md",
-    hasPage: false,
+    hasPage: true,
     category: "core-concepts",
   },
   {
@@ -138,7 +138,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "Model Context Protocol — 通过 stdio 和 HTTP/SSE 消费和暴露工具。",
     },
     repoSource: "docs/MCP.md",
-    hasPage: false,
+    hasPage: true,
     category: "extending",
   },
   {
@@ -149,8 +149,8 @@ export const DOC_TOPICS: DocTopic[] = [
       en: "Lifecycle hooks for pre/post tool execution, mode changes, and session events.",
       zh: "工具执行前后、模式切换和会话事件的生命周期钩子。",
     },
-    repoSource: "docs/rfcs/1364-hooks-lifecycle.md",
-    hasPage: false,
+    repoSource: ["docs/rfcs/1364-hooks-lifecycle.md", "docs/CONFIGURATION.md"],
+    hasPage: true,
     category: "extending",
   },
   {

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -65,7 +65,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "config.toml 参考、环境变量、项目覆盖和旧版路径。",
     },
     repoSource: ["docs/CONFIGURATION.md", "docs/LEGACY_PATHS.md"],
-    hasPage: false,
+    hasPage: true,
     category: "getting-started",
   },
   {
@@ -162,7 +162,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "可用的 Seatbelt（macOS）、显式启用的 bubblewrap（Linux）、平台缺口和审批策略。",
     },
     repoSource: "docs/SANDBOX.md",
-    hasPage: false,
+    hasPage: true,
     category: "core-concepts",
   },
   {
@@ -198,7 +198,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "持久任务执行、Fleet 管理和 Workflow 编写。",
     },
     repoSource: ["docs/FLEET.md", "docs/WORKFLOW_AUTHORING.md"],
-    hasPage: false,
+    hasPage: true,
     category: "operations",
   },
   {

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -174,7 +174,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "用于集成、桥接和自动化的公开 HTTP API。",
     },
     repoSource: "docs/RUNTIME_API.md",
-    hasPage: false,
+    hasPage: true,
     category: "extending",
   },
   {
@@ -186,7 +186,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "仅在本机回环地址运行内置浏览器客户端，了解一次性引导与会话边界。",
     },
     repoSource: "docs/WEB.md",
-    hasPage: false,
+    hasPage: true,
     category: "extending",
   },
   {
@@ -210,7 +210,7 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "常见问题、诊断、运维手册和 Docker 说明。",
     },
     repoSource: ["docs/OPERATIONS_RUNBOOK.md", "docs/DOCKER.md"],
-    hasPage: false,
+    hasPage: true,
     category: "operations",
   },
   {

--- a/web/lib/docs-navigation.test.ts
+++ b/web/lib/docs-navigation.test.ts
@@ -29,6 +29,12 @@ describe("docsTopicIsCurrent", () => {
   });
 
   it("never marks source-document links as local pages", () => {
-    expect(docsTopicIsCurrent(topic("runtime-api"), "en", "/en/docs/runtime-api")).toBe(false);
+    expect(docsTopicIsCurrent(topic("guide"), "en", "/en/docs/guide")).toBe(false);
+  });
+
+  it("routes former link-out topics to their dedicated docs pages", () => {
+    expect(docTopicHref(topic("runtime-api"), "en")).toBe("/en/docs/runtime-api");
+    expect(docsTopicIsCurrent(topic("runtime-api"), "en", "/en/docs/runtime-api")).toBe(true);
+    expect(docTopicIsExternal(topic("runtime-api"))).toBe(false);
   });
 });


### PR DESCRIPTION
Part of #4800 and #3984.

Replaces the docs-index link-outs with real product pages written for a reader, following the established Modes-page pattern (docs-map entries + source-document citations so check:docs parity holds):
- Fleet / Sandbox / Configuration
- MCP / Hooks / Sub-agents
- Runtime API / Browser client / Troubleshooting
- Dynamic Work surface showcase (#3984)

This PR lands the **English docs-page half** of #4800. The website-locale issues #3091 (JA/VI parity), #3092 (RU + Cyrillic QA), #3093 (KO/ES/PT-BR) are the remaining half and are tracked separately.

No auto-close: #4800 and #3984 stay open until reviewed; locales tracked under #3091-#3093.