### PR TITLE
fix(config): validate default_text_model against the active provider (#4829)

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -3595,14 +3595,30 @@ impl Config {
                 }
             }
         }
+        // Validate the model against the *active provider's* name space, not
+        // against DeepSeek's. `canonical_model_id_for_provider` is the
+        // equal-treatment resolver: it applies each family's own canonical map
+        // (GLM via Z.ai, Kimi, MiniMax, …) and passes unknown ids through, so
+        // it rejects only what the provider genuinely cannot serve. Validating
+        // with the DeepSeek-only `normalize_model_name` bricked every config
+        // whose provider owns a non-DeepSeek family — including ones our own
+        // setup wizard writes (`provider = "zai"`, `GLM-5.2`). (#4829)
         if let Some(model) = self.default_text_model.as_deref()
             && !model.trim().eq_ignore_ascii_case("auto")
             && !provider_passes_model_through(self.api_provider())
             && !self.active_provider_preserves_custom_base_url_model()
-            && normalize_model_name(model).is_none()
+            && canonical_model_id_for_provider(self.api_provider(), model).is_none()
         {
+            let provider = self.api_provider();
+            let known = model_completion_names_for_provider(provider);
+            let hint = if known.is_empty() {
+                String::new()
+            } else {
+                format!(" (for example: {})", known.join(", "))
+            };
             anyhow::bail!(
-                "Invalid default_text_model '{model}': expected auto or a DeepSeek model ID (for example: deepseek-v4-pro, deepseek-v4-flash, deepseek-ai/deepseek-v4-pro)."
+                "Invalid default_text_model '{model}' for provider '{}': expected auto or a model ID this provider serves{hint}.",
+                provider.as_str()
             );
         }
         if let Some(policy) = self.approval_policy.as_deref() {

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -9990,3 +9990,61 @@ fn picker_consent_persists_only_confirmed_exact_scope_and_revoke_is_one_step() {
         (0, 0, 0, 0, 0)
     );
 }
+
+/// Every provider must accept the model ids it advertises for itself.
+///
+/// Regression for #4829: `validate()` checked `default_text_model` against the
+/// DeepSeek-only normalizer, so a config our own setup wizard writes
+/// (`provider = "zai"`, `default_text_model = "GLM-5.2"`) was rejected on every
+/// startup — the CLI could not launch at all. This asserts the equal-treatment
+/// contract from CLAUDE.md: no provider's own models are second-class.
+#[test]
+fn validate_accepts_every_providers_own_advertised_models() {
+    for &provider in ApiProvider::all() {
+        for model in model_completion_names_for_provider(provider) {
+            let config = Config {
+                provider: Some(provider.as_str().to_string()),
+                default_text_model: Some(model.to_string()),
+                ..Default::default()
+            };
+            assert!(
+                config.validate().is_ok(),
+                "provider {} rejected its own advertised model {model}: {:?}",
+                provider.as_str(),
+                config.validate().unwrap_err().to_string(),
+            );
+        }
+    }
+}
+
+/// The exact config that bricked the CLI in the field.
+#[test]
+fn validate_accepts_zai_glm_model_from_setup_wizard() {
+    let config = Config {
+        provider: Some("zai".to_string()),
+        default_text_model: Some(DEFAULT_ZAI_MODEL.to_string()),
+        ..Default::default()
+    };
+    config
+        .validate()
+        .expect("setup-wizard zai/GLM config must validate");
+}
+
+/// The official DeepSeek gate is the one legitimate per-family rejection and
+/// must survive the fix — this is what keeps the validation meaningful.
+#[test]
+fn validate_still_rejects_unknown_model_on_official_deepseek() {
+    let config = Config {
+        provider: Some("deepseek".to_string()),
+        default_text_model: Some("definitely-not-a-deepseek-model".to_string()),
+        ..Default::default()
+    };
+    let err = config
+        .validate()
+        .expect_err("official DeepSeek must reject foreign ids")
+        .to_string();
+    assert!(
+        err.contains("definitely-not-a-deepseek-model") && err.contains("deepseek"),
+        "error should name the model and the active provider, got: {err}"
+    );
+}


### PR DESCRIPTION
Closes #4829.

## The bug

`codew` refuses to launch — every invocation — against a config our own setup wizard writes:

```
$ codew
Error: Invalid default_text_model 'GLM-5.2': expected auto or a DeepSeek model ID (for example: deepseek-v4-pro, deepseek-v4-flash, deepseek-ai/deepseek-v4-pro).
```

`setup_state.json` records `provider=zai, model=GLM-5.2, ... health=attemptable`, and the next launch fails with no recovery path except hand-editing `config.toml`.

## Root cause

`Config::validate()` validated the model with the DeepSeek-only `normalize_model_name`, fronted by the hand-maintained `provider_passes_model_through` allowlist — which omits `Zai`, along with every other provider whose family map lives in `canonical_model_id_for_provider` (`Stepfun`, `Minimax`, `LongCat`, `Sakana`, `OpencodeGo`, …).

Z.ai is otherwise fully first-class: `canonical_zai_model_id`, `DEFAULT_ZAI_MODEL`, `DEFAULT_ZAI_BASE_URL`, model list, concurrency defaults. Config validation alone rejected it, contradicting the equal-treatment rule in `CLAUDE.md` — *"every model/provider first-class — none privileged."*

## The fix

Validate against the **active provider's** name space using the resolver that already exists, `canonical_model_id_for_provider`. It applies each family's own canonical map and passes unknown ids through, so it rejects only what a provider genuinely cannot serve.

- The official-DeepSeek gate — the one legitimate per-family rejection — is preserved.
- The error message now names the active provider and its advertised models instead of hardcoding DeepSeek.
- Only *acceptance* widens; nothing previously accepted is now rejected.

## Tests

`validate_accepts_every_providers_own_advertised_models` is the general form: for every `ApiProvider::all()`, each id in `model_completion_names_for_provider` must survive `validate()`. It fails pre-fix for more than just Z.ai. Plus a pinned test for the exact field config, and one holding the official-DeepSeek rejection in place.

Verified non-vacuous — reverting the `config.rs` change makes both new tests fail with precisely the reported error, and they pass with it.

## Verification

`RUSTFLAGS="-D warnings" cargo test --workspace --all-features --locked` → exit 0, zero failures.

One unrelated flake, `config_command_allow_shell_save_persists_root_boolean`, failed on a first run and passed on re-run and in isolation; it is cross-test interference, not this change. Worth noting separately: something in the full suite writes to the real `~/.codewhale/config.toml` (it gained an `approval_policy` line mid-run), which likely explains that flake and the "known config flake" failures reported previously. Filing separately.