### PR TITLE
test(tui): isolate persistent state from unit tests

### DIFF
--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -2380,6 +2380,7 @@ mod tests {
         userprofile: Option<OsString>,
         codewhale_config_path: Option<OsString>,
         deepseek_config_path: Option<OsString>,
+        codewhale_allow_shell: Option<OsString>,
         deepseek_allow_shell: Option<OsString>,
         deepseek_approval_policy: Option<OsString>,
         no_animations: Option<OsString>,
@@ -2398,6 +2399,7 @@ mod tests {
             let userprofile_prev = env::var_os("USERPROFILE");
             let codewhale_config_prev = env::var_os("CODEWHALE_CONFIG_PATH");
             let deepseek_config_prev = env::var_os("DEEPSEEK_CONFIG_PATH");
+            let codewhale_allow_shell_prev = env::var_os("CODEWHALE_ALLOW_SHELL");
             let deepseek_allow_shell_prev = env::var_os("DEEPSEEK_ALLOW_SHELL");
             let deepseek_approval_policy_prev = env::var_os("DEEPSEEK_APPROVAL_POLICY");
             let no_animations_prev = env::var_os("NO_ANIMATIONS");
@@ -2410,6 +2412,7 @@ mod tests {
                 env::set_var("USERPROFILE", &home_str);
                 env::remove_var("CODEWHALE_CONFIG_PATH");
                 env::set_var("DEEPSEEK_CONFIG_PATH", &config_str);
+                env::remove_var("CODEWHALE_ALLOW_SHELL");
                 env::remove_var("DEEPSEEK_ALLOW_SHELL");
                 env::remove_var("DEEPSEEK_APPROVAL_POLICY");
                 env::remove_var("NO_ANIMATIONS");
@@ -2422,6 +2425,7 @@ mod tests {
                 userprofile: userprofile_prev,
                 codewhale_config_path: codewhale_config_prev,
                 deepseek_config_path: deepseek_config_prev,
+                codewhale_allow_shell: codewhale_allow_shell_prev,
                 deepseek_allow_shell: deepseek_allow_shell_prev,
                 deepseek_approval_policy: deepseek_approval_policy_prev,
                 no_animations: no_animations_prev,
@@ -2483,6 +2487,7 @@ mod tests {
             }
 
             for (key, value) in [
+                ("CODEWHALE_ALLOW_SHELL", self.codewhale_allow_shell.take()),
                 ("DEEPSEEK_ALLOW_SHELL", self.deepseek_allow_shell.take()),
                 (
                     "DEEPSEEK_APPROVAL_POLICY",
@@ -3142,10 +3147,10 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
 
     #[test]
     fn config_model_with_save_flag() {
+        let temp_root = tempfile::tempdir().expect("isolated settings dir");
+        let _guard = EnvGuard::new(temp_root.path());
         let mut app = create_test_app();
         let _result = config_command(&mut app, Some("model deepseek-v4-flash --save"));
-        // Note: This test may fail in environments where settings can't be saved
-        // The important thing is that the model is updated
         assert_eq!(app.model, "deepseek-v4-flash");
     }
 
@@ -3282,13 +3287,10 @@ Parse error: permissions.toml at permissions.toml could not be parsed: expected 
 
     #[test]
     fn config_command_allow_shell_save_persists_root_boolean() {
-        let temp_root = env::temp_dir().join(format!(
-            "codewhale-allow-shell-save-app-path-test-{}",
-            std::process::id()
-        ));
-        fs::create_dir_all(&temp_root).unwrap();
+        let temp_root = tempfile::tempdir().expect("isolated config dir");
+        let _guard = EnvGuard::new(temp_root.path());
 
-        let config_path = temp_root.join("custom-config.toml");
+        let config_path = temp_root.path().join("custom-config.toml");
 
         let mut app = create_test_app();
         app.config_path = Some(config_path.clone());

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -2999,6 +2999,36 @@ impl ShellAccessControl {
     }
 }
 
+fn approval_policy_env_is_set() -> bool {
+    let read = || {
+        std::env::var_os("CODEWHALE_APPROVAL_POLICY").is_some()
+            || std::env::var_os("DEEPSEEK_APPROVAL_POLICY").is_some()
+    };
+    #[cfg(test)]
+    {
+        crate::test_support::with_test_env_lock(read)
+    }
+    #[cfg(not(test))]
+    {
+        read()
+    }
+}
+
+fn allow_shell_env_is_set() -> bool {
+    let read = || {
+        std::env::var_os("CODEWHALE_ALLOW_SHELL").is_some()
+            || std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some()
+    };
+    #[cfg(test)]
+    {
+        crate::test_support::with_test_env_lock(read)
+    }
+    #[cfg(not(test))]
+    {
+        read()
+    }
+}
+
 fn project_config_root_bool(workspace: &Path, key: &str) -> Option<bool> {
     [
         workspace
@@ -3253,9 +3283,7 @@ impl Config {
             }
         }
 
-        if std::env::var_os("CODEWHALE_APPROVAL_POLICY").is_some()
-            || std::env::var_os("DEEPSEEK_APPROVAL_POLICY").is_some()
-        {
+        if approval_policy_env_is_set() {
             return ApprovalPolicyControl::Environment;
         }
 
@@ -3332,9 +3360,7 @@ impl Config {
             }
         }
 
-        if std::env::var_os("CODEWHALE_ALLOW_SHELL").is_some()
-            || std::env::var_os("DEEPSEEK_ALLOW_SHELL").is_some()
-        {
+        if allow_shell_env_is_set() {
             return ShellAccessControl::Environment;
         }
 
@@ -5901,6 +5927,26 @@ pub(crate) fn resolve_load_config_path(path: Option<PathBuf>) -> Option<PathBuf>
         return Some(expand_pathbuf(path));
     }
 
+    #[cfg(test)]
+    {
+        let honor_guarded_environment = crate::test_support::current_thread_holds_test_env_lock();
+        return crate::test_support::with_test_env_lock(|| {
+            if honor_guarded_environment {
+                resolve_default_load_config_path()
+            } else {
+                Some(
+                    crate::test_support::isolated_test_state_root()
+                        .join(codewhale_config::CONFIG_FILE_NAME),
+                )
+            }
+        });
+    }
+
+    #[cfg(not(test))]
+    resolve_default_load_config_path()
+}
+
+fn resolve_default_load_config_path() -> Option<PathBuf> {
     if let Some(path) = env_config_path() {
         if path.exists() {
             return Some(path);
@@ -5972,11 +6018,21 @@ fn env_base_url_override() -> Option<String> {
 }
 
 fn first_nonempty_env(names: &[&str]) -> Option<String> {
-    names.iter().find_map(|name| {
-        std::env::var(name)
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-    })
+    let read = || {
+        names.iter().find_map(|name| {
+            std::env::var(name)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+    };
+    #[cfg(test)]
+    {
+        crate::test_support::with_test_env_lock(read)
+    }
+    #[cfg(not(test))]
+    {
+        read()
+    }
 }
 
 /// Return the provider-scoped endpoint override that `apply_env_overrides`
@@ -6041,18 +6097,41 @@ fn codewhale_env_var(
     codewhale_name: &str,
     legacy_name: &str,
 ) -> Result<String, std::env::VarError> {
-    std::env::var(codewhale_name)
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| {
-            std::env::var(legacy_name)
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-        })
-        .ok_or(std::env::VarError::NotPresent)
+    let read = || {
+        std::env::var(codewhale_name)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var(legacy_name)
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .ok_or(std::env::VarError::NotPresent)
+    };
+    #[cfg(test)]
+    {
+        crate::test_support::with_test_env_lock(read)
+    }
+    #[cfg(not(test))]
+    {
+        read()
+    }
 }
 
 fn apply_env_overrides(config: &mut Config) {
+    #[cfg(test)]
+    {
+        return crate::test_support::with_test_env_lock(|| {
+            apply_env_overrides_unlocked(config);
+        });
+    }
+    #[cfg(not(test))]
+    {
+        apply_env_overrides_unlocked(config);
+    }
+}
+
+fn apply_env_overrides_unlocked(config: &mut Config) {
     if let Ok(value) = codewhale_env_var("CODEWHALE_PROVIDER", "DEEPSEEK_PROVIDER") {
         config.provider = Some(value);
     }

--- a/crates/tui/src/config/paths.rs
+++ b/crates/tui/src/config/paths.rs
@@ -19,7 +19,27 @@ use std::path::{Path, PathBuf};
 pub(crate) use super::home::effective_home_dir;
 
 pub(crate) fn default_config_path() -> Option<PathBuf> {
-    env_config_path().or_else(home_config_path)
+    #[cfg(test)]
+    {
+        let honor_guarded_environment = crate::test_support::current_thread_holds_test_env_lock();
+        return crate::test_support::with_test_env_lock(|| {
+            if honor_guarded_environment {
+                default_config_path_from_environment()
+            } else {
+                Some(
+                    crate::test_support::isolated_test_state_root()
+                        .join(codewhale_config::CONFIG_FILE_NAME),
+                )
+            }
+        });
+    }
+
+    #[cfg(not(test))]
+    default_config_path_from_environment()
+}
+
+fn default_config_path_from_environment() -> Option<PathBuf> {
+    env_config_path_unlocked().or_else(home_config_path)
 }
 
 pub(crate) fn codewhale_home_dir() -> Option<PathBuf> {

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -5,6 +5,8 @@ use std::env;
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::sync::mpsc;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -2332,6 +2334,90 @@ fn save_api_key_writes_config_file_under_cfg_test() -> Result<()> {
         assert_eq!(fs::metadata(&expected)?.permissions().mode() & 0o777, 0o600);
     }
     Ok(())
+}
+
+#[test]
+fn policy_control_waits_for_foreign_test_env_overrides_to_restore() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = temp.path().join("config.toml");
+    let workspace = temp.path().join("workspace");
+    let managed_config_path = temp.path().join("missing-managed.toml");
+    let requirements_path = temp.path().join("missing-requirements.toml");
+    let (started_tx, started_rx) = mpsc::channel();
+    let (tx, rx) = mpsc::channel();
+
+    let reader = {
+        let lock = lock_test_env();
+        let shell_override = EnvVarGuard::set("CODEWHALE_ALLOW_SHELL", "false");
+        let approval_override = EnvVarGuard::set("DEEPSEEK_APPROVAL_POLICY", "never");
+        let reader = std::thread::spawn(move || {
+            started_tx.send(()).expect("signal policy read start");
+            let config = Config {
+                managed_config_path: Some(managed_config_path.display().to_string()),
+                requirements_path: Some(requirements_path.display().to_string()),
+                ..Config::default()
+            };
+            tx.send((
+                config.allow_shell_control(Some(&config_path), None, &workspace),
+                config.approval_policy_control(Some(&config_path), None, &workspace),
+            ))
+            .expect("send policy controls");
+        });
+
+        started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader reached policy read");
+        assert!(
+            rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "a foreign reader observed another test's temporary policy overrides"
+        );
+        drop(approval_override);
+        drop(shell_override);
+        drop(lock);
+        reader
+    };
+
+    let (shell, approval) = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("reader resumed after policy overrides were restored");
+    reader.join().expect("reader thread");
+    assert_eq!(shell, ShellAccessControl::Unset);
+    assert_eq!(approval, ApprovalPolicyControl::Unset);
+}
+
+#[test]
+fn base_url_reads_wait_for_foreign_test_env_overrides_to_restore() {
+    let (started_tx, started_rx) = mpsc::channel();
+    let (tx, rx) = mpsc::channel();
+
+    let reader = {
+        let lock = lock_test_env();
+        let expected_after_restore = env_base_url_override();
+        let override_guard =
+            EnvVarGuard::set("CODEWHALE_BASE_URL", "https://temporary.test.invalid/v1");
+        let reader = std::thread::spawn(move || {
+            started_tx.send(()).expect("signal base URL read start");
+            tx.send(env_base_url_override())
+                .expect("send resolved base URL override");
+        });
+
+        started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader reached base URL read");
+        assert!(
+            rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "a foreign reader observed another test's temporary base URL override"
+        );
+        drop(override_guard);
+        drop(lock);
+        (reader, expected_after_restore)
+    };
+
+    let observed = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("reader resumed after base URL override was restored");
+    reader.0.join().expect("reader thread");
+    assert_eq!(observed, reader.1);
 }
 
 #[test]

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -734,14 +734,24 @@ fn apply_exec_provider_override(config: &mut Config, provider_arg: &str) -> Resu
 }
 
 fn exec_model_env_override() -> Option<String> {
-    ["CODEWHALE_MODEL", "DEEPSEEK_MODEL"]
-        .into_iter()
-        .find_map(|key| {
-            std::env::var(key)
-                .ok()
-                .map(|model| model.trim().to_string())
-                .filter(|model| !model.is_empty())
-        })
+    let read = || {
+        ["CODEWHALE_MODEL", "DEEPSEEK_MODEL"]
+            .into_iter()
+            .find_map(|key| {
+                std::env::var(key)
+                    .ok()
+                    .map(|model| model.trim().to_string())
+                    .filter(|model| !model.is_empty())
+            })
+    };
+    #[cfg(test)]
+    {
+        crate::test_support::with_test_env_lock(read)
+    }
+    #[cfg(not(test))]
+    {
+        read()
+    }
 }
 
 fn top_level_prompt_initial_input(parts: &[String]) -> Option<tui::InitialInput> {
@@ -13289,6 +13299,42 @@ mod terminal_mode_tests {
             .expect_err("removed saved provider must fail closed");
         assert!(err.to_string().contains("will not fall back"), "{err}");
         assert_eq!(missing.provider, before);
+    }
+
+    #[test]
+    fn exec_model_reads_wait_for_foreign_test_env_overrides_to_restore() {
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let (reader, expected_after_restore) = {
+            let lock = crate::test_support::lock_test_env();
+            let expected_after_restore = exec_model_env_override();
+            let temporary =
+                crate::test_support::EnvVarGuard::set("CODEWHALE_MODEL", "temporary-model");
+            let reader = std::thread::spawn(move || {
+                started_tx.send(()).expect("signal model read start");
+                tx.send(exec_model_env_override())
+                    .expect("send resolved model override");
+            });
+
+            started_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("reader reached model read");
+            assert!(
+                rx.recv_timeout(std::time::Duration::from_millis(50))
+                    .is_err(),
+                "a foreign reader observed another test's temporary model override"
+            );
+            drop(temporary);
+            drop(lock);
+            (reader, expected_after_restore)
+        };
+
+        let observed = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("reader resumed after model override was restored");
+        reader.join().expect("reader thread");
+        assert_eq!(observed, expected_after_restore);
     }
 
     #[tokio::test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -134,25 +134,21 @@ impl TuiPrefs {
     /// `DEEPSEEK_CONFIG_PATH` environment variable (the parent directory of
     /// the pointed-to config is used instead of `~/.deepseek`).
     pub fn path() -> Result<PathBuf> {
-        // Honour the same env-var escape hatch used by Settings::path so that
-        // integration tests can redirect all config I/O to a temp directory.
-        if let Some(parent) = legacy_config_override_parent() {
-            return Ok(parent.join("tui.toml"));
-        }
-
-        let primary = codewhale_config::codewhale_home()
-            .ok()
-            .map(|home| home.join(TUI_PREFS_FILE_NAME));
-        if codewhale_config::codewhale_home_is_explicit() {
-            return primary.ok_or_else(|| {
-                anyhow::anyhow!("Failed to resolve tui.toml path: no Codewhale home found.")
+        #[cfg(test)]
+        {
+            let honor_guarded_environment =
+                crate::test_support::current_thread_holds_test_env_lock();
+            return crate::test_support::with_test_env_lock(|| {
+                if honor_guarded_environment {
+                    tui_prefs_path_from_environment()
+                } else {
+                    Ok(crate::test_support::isolated_test_state_root().join(TUI_PREFS_FILE_NAME))
+                }
             });
         }
-        let legacy_home = codewhale_config::legacy_deepseek_home()
-            .ok()
-            .map(|home| home.join(TUI_PREFS_FILE_NAME));
 
-        resolve_tui_prefs_path_from_candidates(primary, legacy_home)
+        #[cfg(not(test))]
+        tui_prefs_path_from_environment()
     }
 
     /// Load TUI preferences from `~/.codewhale/tui.toml` or a legacy fallback.
@@ -162,6 +158,15 @@ impl TuiPrefs {
     /// user without crashing the session.
     pub fn load() -> Result<Self> {
         let path = Self::path()?;
+        #[cfg(test)]
+        {
+            return crate::test_support::with_test_state_io_lock(|| Self::load_from_path(&path));
+        }
+        #[cfg(not(test))]
+        Self::load_from_path(&path)
+    }
+
+    fn load_from_path(path: &Path) -> Result<Self> {
         if !path.exists() {
             return Ok(Self::default());
         }
@@ -181,6 +186,15 @@ impl TuiPrefs {
     /// it already exists), creating the target directory if needed.
     pub fn save(&self) -> Result<()> {
         let path = Self::path()?;
+        #[cfg(test)]
+        {
+            return crate::test_support::with_test_state_io_lock(|| self.save_to_path(&path));
+        }
+        #[cfg(not(test))]
+        self.save_to_path(&path)
+    }
+
+    fn save_to_path(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).with_context(|| {
                 format!("Failed to create config directory {}", parent.display())
@@ -210,6 +224,28 @@ impl TuiPrefs {
         self.theme = normalize_theme_setting(&self.theme).map_err(anyhow::Error::msg)?;
         Ok(())
     }
+}
+
+fn tui_prefs_path_from_environment() -> Result<PathBuf> {
+    // Honour the same env-var escape hatch used by Settings::path so that
+    // integration tests can redirect all config I/O to a temp directory.
+    if let Some(parent) = legacy_config_override_parent() {
+        return Ok(parent.join("tui.toml"));
+    }
+
+    let primary = codewhale_config::codewhale_home()
+        .ok()
+        .map(|home| home.join(TUI_PREFS_FILE_NAME));
+    if codewhale_config::codewhale_home_is_explicit() {
+        return primary.ok_or_else(|| {
+            anyhow::anyhow!("Failed to resolve tui.toml path: no Codewhale home found.")
+        });
+    }
+    let legacy_home = codewhale_config::legacy_deepseek_home()
+        .ok()
+        .map(|home| home.join(TUI_PREFS_FILE_NAME));
+
+    resolve_tui_prefs_path_from_candidates(primary, legacy_home)
 }
 
 fn resolve_tui_prefs_path_from_candidates(
@@ -617,6 +653,32 @@ impl Settings {
         legacy_config_dir: Option<PathBuf>,
         migrate_legacy_file: bool,
     ) -> Result<Self> {
+        #[cfg(test)]
+        {
+            return crate::test_support::with_test_state_io_lock(|| {
+                Self::load_persisted_from_candidates_with_migration_unlocked(
+                    primary,
+                    legacy_home,
+                    legacy_config_dir,
+                    migrate_legacy_file,
+                )
+            });
+        }
+        #[cfg(not(test))]
+        Self::load_persisted_from_candidates_with_migration_unlocked(
+            primary,
+            legacy_home,
+            legacy_config_dir,
+            migrate_legacy_file,
+        )
+    }
+
+    fn load_persisted_from_candidates_with_migration_unlocked(
+        primary: Option<PathBuf>,
+        legacy_home: Option<PathBuf>,
+        legacy_config_dir: Option<PathBuf>,
+        migrate_legacy_file: bool,
+    ) -> Result<Self> {
         let write_path = primary
             .as_ref()
             .cloned()
@@ -712,23 +774,37 @@ impl Settings {
     /// Whether the user explicitly persisted an `auto_compact` preference.
     /// When absent, callers may choose a model-aware default.
     pub fn auto_compact_explicitly_configured() -> bool {
-        let (primary, legacy_home, legacy_config_dir) = settings_path_candidates();
-        let Ok(path) =
-            resolve_settings_path_from_candidates(primary, legacy_home, legacy_config_dir)
-        else {
-            return false;
-        };
-        let Ok(content) = std::fs::read_to_string(path) else {
-            return false;
-        };
-        let Ok(value) = toml::from_str::<toml::Value>(&content) else {
-            return false;
-        };
-        value
-            .as_table()
-            .is_some_and(|table| table.contains_key("auto_compact"))
+        let candidates = settings_path_candidates();
+        #[cfg(test)]
+        {
+            return crate::test_support::with_test_state_io_lock(|| {
+                auto_compact_explicitly_configured_from_candidates(candidates)
+            });
+        }
+        #[cfg(not(test))]
+        auto_compact_explicitly_configured_from_candidates(candidates)
     }
+}
 
+fn auto_compact_explicitly_configured_from_candidates(
+    (primary, legacy_home, legacy_config_dir): (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>),
+) -> bool {
+    let Ok(path) = resolve_settings_path_from_candidates(primary, legacy_home, legacy_config_dir)
+    else {
+        return false;
+    };
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = toml::from_str::<toml::Value>(&content) else {
+        return false;
+    };
+    value
+        .as_table()
+        .is_some_and(|table| table.contains_key("auto_compact"))
+}
+
+impl Settings {
     /// Apply environment-driven overlays after disk load. Used for
     /// platform a11y signals that should ignore the user's saved
     /// preference (#450). The env values are consulted at startup;
@@ -825,7 +901,15 @@ impl Settings {
     /// Save settings to disk
     pub fn save(&self) -> Result<()> {
         let path = Self::path()?;
+        #[cfg(test)]
+        {
+            return crate::test_support::with_test_state_io_lock(|| self.save_to_path(&path));
+        }
+        #[cfg(not(test))]
+        self.save_to_path(&path)
+    }
 
+    fn save_to_path(&self, path: &Path) -> Result<()> {
         // Create config directory if it doesn't exist
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).with_context(|| {
@@ -1550,6 +1634,28 @@ fn resolve_settings_path_from_candidates(
 }
 
 fn settings_path_candidates() -> (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>) {
+    #[cfg(test)]
+    {
+        let honor_guarded_environment = crate::test_support::current_thread_holds_test_env_lock();
+        return crate::test_support::with_test_env_lock(|| {
+            if honor_guarded_environment {
+                settings_path_candidates_from_environment()
+            } else {
+                (
+                    Some(crate::test_support::isolated_test_state_root().join(SETTINGS_FILE_NAME)),
+                    None,
+                    None,
+                )
+            }
+        });
+    }
+
+    #[cfg(not(test))]
+    settings_path_candidates_from_environment()
+}
+
+fn settings_path_candidates_from_environment() -> (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>)
+{
     // Allow tests to override the settings directory via the same env var
     // used for config (DEEPSEEK_CONFIG_PATH points at config.toml; the
     // settings file lives as a sibling in the same directory).

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -170,7 +170,7 @@ impl TuiPrefs {
         if !path.exists() {
             return Ok(Self::default());
         }
-        let content = std::fs::read_to_string(&path)
+        let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read tui.toml from {}", path.display()))?;
         let prefs: TuiPrefs = match toml::from_str(&content) {
             Ok(p) => p,
@@ -202,7 +202,7 @@ impl TuiPrefs {
         }
         let serialized = toml::to_string_pretty(self).context("Failed to serialize TuiPrefs")?;
         let body = if path.exists() {
-            let raw = std::fs::read_to_string(&path)
+            let raw = std::fs::read_to_string(path)
                 .with_context(|| format!("Failed to read tui.toml at {}", path.display()))?;
             codewhale_config::merge_and_preserve_comments(&serialized, &raw).unwrap_or_else(|e| {
                 tracing::warn!("failed to merge tui.toml comments, saving without them: {e:#}");
@@ -211,7 +211,7 @@ impl TuiPrefs {
         } else {
             serialized
         };
-        std::fs::write(&path, body)
+        std::fs::write(path, body)
             .with_context(|| format!("Failed to write tui.toml to {}", path.display()))?;
         Ok(())
     }
@@ -919,7 +919,7 @@ impl Settings {
 
         let serialized = toml::to_string_pretty(self).context("Failed to serialize settings")?;
         let body = if path.exists() {
-            let raw = std::fs::read_to_string(&path)
+            let raw = std::fs::read_to_string(path)
                 .with_context(|| format!("Failed to read settings at {}", path.display()))?;
             codewhale_config::merge_and_preserve_comments(&serialized, &raw).unwrap_or_else(|e| {
                 tracing::warn!("failed to merge settings comments, saving without them: {e:#}");
@@ -928,7 +928,7 @@ impl Settings {
         } else {
             serialized
         };
-        std::fs::write(&path, body)
+        std::fs::write(path, body)
             .with_context(|| format!("Failed to write settings to {}", path.display()))?;
         Ok(())
     }

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -3,6 +3,36 @@
 use std::ffi::{OsStr, OsString};
 use std::sync::{Mutex, MutexGuard, OnceLock, TryLockError};
 use std::thread::ThreadId;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Process-wide state root for unit tests that do not intentionally provide an
+/// explicit config/settings path.
+///
+/// The production fallback is the user's real home. That is useful at runtime
+/// and unsafe in a parallel test binary: an unguarded save can otherwise read
+/// or overwrite the developer's config. Tests that exercise path precedence
+/// still hold [`lock_test_env`] and provide explicit temporary environment
+/// values; every other test is confined here.
+pub(crate) fn isolated_test_state_root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "codewhale-tui-test-state-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap_or_else(|error| {
+            panic!(
+                "failed to create isolated unit-test state root {}: {error}",
+                root.display()
+            )
+        });
+        root
+    })
+}
 
 /// Build a syntactically valid, non-secret JWT fixture without embedding a
 /// high-entropy token-shaped literal in Git history.
@@ -14,6 +44,11 @@ pub(crate) fn future_test_jwt(label: &str) -> String {
 }
 
 fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn state_io_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
@@ -82,24 +117,18 @@ pub(crate) fn lock_test_env() -> TestEnvLock {
 /// into it. The owner check makes the barrier re-entrant for a test that reads
 /// its own guarded override.
 pub(crate) fn with_test_env_lock<T>(read: impl FnOnce() -> T) -> T {
-    match env_lock().try_lock() {
-        Ok(_guard) => read(),
-        Err(TryLockError::Poisoned(poisoned)) => {
-            let _guard = poisoned.into_inner();
-            read()
-        }
-        Err(TryLockError::WouldBlock) if current_thread_owns_contended_env_lock() => read(),
-        Err(TryLockError::WouldBlock) => {
-            let _guard = match env_lock().lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            read()
-        }
+    if current_thread_owns_contended_env_lock() {
+        return read();
     }
+
+    // Acquire through the owner-tracking guard so nested environment readers
+    // remain re-entrant. This matters for config loading: the outer override
+    // pass holds the barrier while helper functions read individual variables.
+    let _guard = lock_test_env();
+    read()
 }
 
-fn current_thread_holds_test_env_lock() -> bool {
+pub(crate) fn current_thread_holds_test_env_lock() -> bool {
     match env_lock().try_lock() {
         Ok(guard) => {
             drop(guard);
@@ -111,6 +140,21 @@ fn current_thread_holds_test_env_lock() -> bool {
         }
         Err(TryLockError::WouldBlock) => current_thread_owns_contended_env_lock(),
     }
+}
+
+/// Serialize read/merge/write operations against the process-wide isolated
+/// test state root.
+///
+/// Path isolation protects the developer's files, but parallel tests still
+/// share the same temporary files. Settings persistence is a multi-step
+/// operation, so it needs this second barrier around the complete I/O
+/// transaction rather than only around path resolution.
+pub(crate) fn with_test_state_io_lock<T>(operation: impl FnOnce() -> T) -> T {
+    let _guard = match state_io_lock().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    operation()
 }
 
 /// Restore one environment variable when dropped.
@@ -213,7 +257,106 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    fn unguarded_state_writes_use_isolated_test_root() {
+        const PROBE_ENV: &str = "CODEWHALE_TEST_STATE_ISOLATION_PROBE";
+        const RECEIPT_ENV: &str = "CODEWHALE_TEST_STATE_ISOLATION_RECEIPT";
+
+        if std::env::var_os(PROBE_ENV).is_some() {
+            let config_path =
+                crate::config_persistence::persist_root_bool_key(None, "allow_shell", true)
+                    .expect("write isolated config");
+            let direct_config_path =
+                crate::config::save_workspace_trust(Path::new("/tmp/codewhale-test-workspace"))
+                    .expect("write through direct default config path");
+            crate::settings::Settings::default()
+                .save()
+                .expect("write isolated settings");
+            let settings_path =
+                crate::settings::Settings::path().expect("resolve isolated settings");
+            let root = isolated_test_state_root();
+            assert!(config_path.starts_with(root), "{}", config_path.display());
+            assert!(
+                settings_path.starts_with(root),
+                "{}",
+                settings_path.display()
+            );
+            assert!(
+                direct_config_path.starts_with(root),
+                "{}",
+                direct_config_path.display()
+            );
+            let receipt = std::env::var_os(RECEIPT_ENV).expect("receipt path");
+            std::fs::write(
+                receipt,
+                format!(
+                    "{}\n{}\n{}\n{}\n",
+                    root.display(),
+                    config_path.display(),
+                    settings_path.display(),
+                    direct_config_path.display()
+                ),
+            )
+            .expect("write isolation receipt");
+            return;
+        }
+
+        let sentinel = tempfile::tempdir().expect("sentinel home");
+        let user_state = sentinel.path().join(".codewhale");
+        std::fs::create_dir_all(&user_state).expect("create sentinel state");
+        let config_path = user_state.join("config.toml");
+        let settings_path = user_state.join("settings.toml");
+        let config_sentinel = b"# developer config sentinel\n";
+        let settings_sentinel = b"# developer settings sentinel\n";
+        std::fs::write(&config_path, config_sentinel).expect("seed config");
+        std::fs::write(&settings_path, settings_sentinel).expect("seed settings");
+        let receipt_path = sentinel.path().join("receipt.txt");
+
+        let output = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .arg("--exact")
+            .arg("test_support::tests::unguarded_state_writes_use_isolated_test_root")
+            .arg("--test-threads=1")
+            .env(PROBE_ENV, "1")
+            .env(RECEIPT_ENV, &receipt_path)
+            .env("HOME", sentinel.path())
+            .env("USERPROFILE", sentinel.path())
+            .env_remove("CODEWHALE_HOME")
+            .env_remove("CODEWHALE_CONFIG_PATH")
+            .env_remove("DEEPSEEK_CONFIG_PATH")
+            .output()
+            .expect("run isolated-state probe");
+        assert!(
+            output.status.success(),
+            "probe failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert_eq!(
+            std::fs::read(&config_path).expect("read config sentinel"),
+            config_sentinel
+        );
+        assert_eq!(
+            std::fs::read(&settings_path).expect("read settings sentinel"),
+            settings_sentinel
+        );
+
+        let receipt = std::fs::read_to_string(&receipt_path).expect("read isolation receipt");
+        let mut paths = receipt.lines().map(PathBuf::from);
+        let isolated_root = paths.next().expect("root receipt");
+        let written_config = paths.next().expect("config receipt");
+        let written_settings = paths.next().expect("settings receipt");
+        let direct_config = paths.next().expect("direct config receipt");
+        assert!(!isolated_root.starts_with(sentinel.path()));
+        assert!(written_config.starts_with(&isolated_root));
+        assert!(written_settings.starts_with(&isolated_root));
+        assert!(direct_config.starts_with(&isolated_root));
+        assert!(written_config.exists());
+        assert!(written_settings.exists());
+    }
+
+    #[test]
     fn config_path_read_waits_for_foreign_env_redirect_to_restore() {
+        let (started_tx, started_rx) = mpsc::channel();
         let (tx, rx) = mpsc::channel();
         let redirected = std::env::temp_dir().join(format!(
             "codewhale-config-path-read-barrier-{}",
@@ -224,10 +367,14 @@ mod tests {
             let lock = lock_test_env();
             let redirect = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &redirected);
             let reader = std::thread::spawn(move || {
+                started_tx.send(()).expect("signal config path read start");
                 tx.send(crate::config_persistence::config_toml_path(None))
                     .expect("send resolved config path");
             });
 
+            started_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("reader reached config path resolution");
             assert!(
                 rx.recv_timeout(Duration::from_millis(50)).is_err(),
                 "a foreign reader observed the temporary config redirect"
@@ -243,6 +390,45 @@ mod tests {
             .expect("resolve config path");
         reader.join().expect("reader thread");
         assert_ne!(resolved, redirected);
+    }
+
+    #[test]
+    fn settings_save_waits_for_foreign_state_io_transaction() {
+        let (holder_ready_tx, holder_ready_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            with_test_state_io_lock(|| {
+                holder_ready_tx.send(()).expect("signal state lock held");
+                release_rx.recv().expect("release state lock");
+            });
+        });
+        holder_ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("holder acquired state I/O lock");
+
+        let (started_tx, started_rx) = mpsc::channel();
+        let (saved_tx, saved_rx) = mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            started_tx.send(()).expect("signal settings save start");
+            saved_tx
+                .send(crate::settings::Settings::default().save())
+                .expect("send settings save result");
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("writer reached settings save");
+        assert!(
+            saved_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "settings save did not wait for an in-flight state transaction"
+        );
+
+        release_tx.send(()).expect("release holder");
+        holder.join().expect("holder thread");
+        saved_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("settings save resumed")
+            .expect("settings save succeeded");
+        writer.join().expect("writer thread");
     }
 }
 


### PR DESCRIPTION
## Why

TUI unit tests could resolve default config/settings paths against the developer's real home, while parallel environment guards and persistent-state writes were coordinated test-by-test rather than structurally. That made the suite capable of reading or overwriting `~/.codewhale/config.toml` and `settings.toml`, and made outcomes depend on test scheduling.

## What changed

- confine unguarded test-only config, settings, and TUI preference paths to one process-local temporary state root
- retain explicit environment/path precedence for tests that hold the shared environment guard
- make the process-wide environment guard owner-tracked and reentrant
- serialize complete environment snapshots/overlays and persistent-state I/O transactions in tests
- resolve environment-derived paths before taking the state I/O lock to preserve a single lock order
- add subprocess sentinel and deterministic contention regressions for default writers, config resolution, settings I/O, policy/model overlays, and shell compatibility state

All production path behavior remains behind `cfg(not(test))`.

## Validation

- `cargo fmt --all -- --check`
- targeted contention regressions under `RUSTFLAGS="-D warnings"`
- `RUSTFLAGS="-D warnings" cargo test --workspace --all-features --locked` — pass, including unit, integration, release/PTY QA, and doctests
- real `~/.codewhale/config.toml` and `settings.toml` SHA-256 manifests compared before/after the exact gate — unchanged

Apple ld still emits the pre-existing oversized `__eh_frame` compact-unwind notice; Rust explicitly reports that `linker_messages` ignores `-D warnings`.

Closes #4831
