### PR TITLE
fix(cli): make `model resolve` report the real route, with provenance (#4832)

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1753,7 +1753,17 @@ fn run() -> Result<()> {
         Some(Commands::McpServer) => run_mcp_server_command(&mut store),
         Some(Commands::Config(args)) => run_config_command(&mut store, args.command),
         Some(Commands::Model(args)) => {
-            run_model_command(&mut store, args.command, runtime_overrides.provider)
+            // `model resolve` is a diagnostic: it must report the same route
+            // the runtime would take, so it resolves through the same
+            // read-only path `doctor` uses rather than looking only at flags.
+            let resolved_runtime =
+                resolve_runtime_for_diagnostic_dispatch(&store, &runtime_overrides);
+            run_model_command(
+                &mut store,
+                args.command,
+                runtime_overrides.provider,
+                &resolved_runtime,
+            )
         }
         Some(Commands::Thread(args)) => run_thread_command(args.command),
         Some(Commands::Sandbox(args)) => run_sandbox_command(args.command),
@@ -3571,10 +3581,19 @@ fn model_command_provider_hint(
         .or(top_level_provider)
 }
 
+fn provider_source_label(source: ProviderSource) -> String {
+    match source {
+        ProviderSource::Cli => "--provider".to_string(),
+        ProviderSource::Env(name) => format!("environment ({name})"),
+        ProviderSource::Config => "config".to_string(),
+    }
+}
+
 fn run_model_command(
     store: &mut ConfigStore,
     command: ModelCommand,
     top_level_provider: Option<ProviderKind>,
+    resolved_runtime: &ResolvedRuntimeOptions,
 ) -> Result<()> {
     let registry = ModelRegistry::default();
     match command {
@@ -3589,12 +3608,60 @@ fn run_model_command(
             Ok(())
         }
         ModelCommand::Resolve { model, provider } => {
-            let provider = model_command_provider_hint(provider, top_level_provider);
-            let resolved = registry.resolve(model.as_deref(), provider);
+            let subcommand_provider = model_command_provider_hint(provider, top_level_provider);
+            let queried = model.as_deref().map(str::trim).filter(|m| !m.is_empty());
+
+            // With no explicit query, this reports the route the runtime would
+            // actually take — the same answer `doctor` gives — rather than
+            // re-deriving one from an empty flag set. Re-deriving is what made
+            // a Z.ai config report `provider: deepseek` (#4832).
+            if queried.is_none() && subcommand_provider.is_none() {
+                let source = resolved_runtime.model_source;
+                println!(
+                    "requested: {}",
+                    if source.is_explicit() {
+                        resolved_runtime.model.as_str()
+                    } else {
+                        ""
+                    }
+                );
+                println!("resolved: {}", resolved_runtime.model);
+                println!("provider: {}", resolved_runtime.provider.as_str());
+                println!("used_fallback: {}", !source.is_explicit());
+                println!(
+                    "provider_source: {}",
+                    provider_source_label(resolved_runtime.provider_source)
+                );
+                println!("model_source: {}", source.as_str());
+                return Ok(());
+            }
+
+            // An explicit model or provider makes this a hypothetical query
+            // ("what would this name resolve to"), so answer it against the
+            // registry — but default the provider to the configured one rather
+            // than to any single vendor.
+            let provider_hint = subcommand_provider.or(Some(resolved_runtime.provider));
+            let resolved = registry.resolve(queried, provider_hint);
             println!("requested: {}", resolved.requested.unwrap_or_default());
             println!("resolved: {}", resolved.resolved.id);
             println!("provider: {}", resolved.resolved.provider.as_str());
             println!("used_fallback: {}", resolved.used_fallback);
+            println!(
+                "provider_source: {}",
+                if subcommand_provider.is_some() {
+                    "--provider".to_string()
+                } else {
+                    provider_source_label(resolved_runtime.provider_source)
+                }
+            );
+            println!(
+                "model_source: {}",
+                if queried.is_some() {
+                    "argument"
+                } else {
+                    resolved_runtime.model_source.as_str()
+                }
+            );
             Ok(())
         }
         ModelCommand::Set { model } => {
@@ -4506,7 +4573,7 @@ fn read_api_key_from_stdin() -> Result<String> {
 mod tests {
     use super::*;
     use clap::error::ErrorKind;
-    use codewhale_config::ProviderSource;
+    use codewhale_config::{ModelSource, ProviderSource};
     use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
 
@@ -4651,6 +4718,7 @@ mod tests {
             provider,
             provider_source,
             model: "test-model".to_string(),
+            model_source: ModelSource::ProviderDefault,
             api_key: None,
             api_key_source: None,
             base_url: "http://localhost:8000/v1".to_string(),
@@ -7550,6 +7618,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::Openai,
             provider_source: ProviderSource::Cli,
+            model_source: ModelSource::ProviderDefault,
             model: "glm-5".to_string(),
             api_key: Some("resolved-openai-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::Keyring),
@@ -7641,6 +7710,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::Openai,
             provider_source: ProviderSource::Cli,
+            model_source: ModelSource::ProviderDefault,
             model: "glm-5".to_string(),
             api_key: Some("resolved-openai-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::Keyring),
@@ -7692,6 +7762,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::OpenaiCodex,
             provider_source: ProviderSource::Config,
+            model_source: ModelSource::ProviderDefault,
             model: "gpt-5.5".to_string(),
             api_key: None,
             api_key_source: None,
@@ -7733,6 +7804,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::OpenaiCodex,
             provider_source: ProviderSource::Cli,
+            model_source: ModelSource::ProviderDefault,
             model: "gpt-5.5".to_string(),
             api_key: None,
             api_key_source: None,
@@ -7834,6 +7906,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::Deepseek,
             provider_source: ProviderSource::Config,
+            model_source: ModelSource::ProviderDefault,
             model: "deepseek-v4-pro".to_string(),
             api_key: Some("config-file-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::ConfigFile),
@@ -7941,6 +8014,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::Moonshot,
             provider_source: ProviderSource::Cli,
+            model_source: ModelSource::ProviderDefault,
             model: "kimi-k2.7-code".to_string(),
             api_key: Some("resolved-kimi-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::Keyring),
@@ -8008,6 +8082,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::Volcengine,
             provider_source: ProviderSource::Cli,
+            model_source: ModelSource::ProviderDefault,
             model: "DeepSeek-V4-Pro".to_string(),
             api_key: Some("resolved-ark-key".to_string()),
             api_key_source: Some(RuntimeApiKeySource::Keyring),
@@ -8076,6 +8151,7 @@ model = "qwen-2.5-7b"
         let resolved = ResolvedRuntimeOptions {
             provider: ProviderKind::Openai,
             provider_source: ProviderSource::Cli,
+            model_source: ModelSource::ProviderDefault,
             model: "glm-5".to_string(),
             api_key: None,
             api_key_source: None,
@@ -8124,6 +8200,7 @@ model = "qwen-2.5-7b"
             let resolved = ResolvedRuntimeOptions {
                 provider,
                 provider_source: ProviderSource::Config,
+                model_source: ModelSource::ProviderDefault,
                 model: "test-model".to_string(),
                 api_key: Some("test-key".to_string()),
                 api_key_source: Some(RuntimeApiKeySource::Keyring),

--- a/crates/cli/tests/model_resolve_provenance.rs
+++ b/crates/cli/tests/model_resolve_provenance.rs
@@ -1,0 +1,175 @@
+//! `model resolve` must report the route the runtime would actually take.
+//!
+//! Regression coverage for #4832, where a Z.ai config reported
+//! `provider: deepseek` because the subcommand read only the CLI flags and
+//! never consulted the resolved runtime. A diagnostic that confidently
+//! reports the wrong provider is worse than one that reports nothing, so
+//! every provider is asserted here rather than DeepSeek alone.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Run `model resolve` against a sealed HOME containing `config`.
+///
+/// `env_clear` plus a temporary HOME keeps this off the real
+/// `~/.codewhale/config.toml`; the suite has written to real user state before
+/// (#4831) and this test must never be the one that does it again.
+fn resolve_with_config(config: &str, args: &[&str]) -> BTreeMap<String, String> {
+    let fixture = TempDir::new().expect("fixture root");
+    let home = fixture.path().join("sealed-home");
+    fs::create_dir_all(home.join(".codewhale")).expect("sealed config dir");
+    fs::write(home.join(".codewhale").join("config.toml"), config).expect("seed config");
+
+    let mut command = Command::new(codewhale_binary());
+    command.arg("model").arg("resolve").args(args);
+    let output = command
+        .env_clear()
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("CODEWHALE_HOME", home.join(".codewhale"))
+        .env("CODEWHALE_SECRET_BACKEND", "file")
+        .output()
+        .expect("run model resolve");
+
+    assert!(
+        output.status.success(),
+        "model resolve {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once(": "))
+        .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+        .collect()
+}
+
+#[test]
+fn resolve_reports_the_configured_provider_not_a_deepseek_fallback() {
+    let report = resolve_with_config(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+        &[],
+    );
+
+    assert_eq!(
+        report.get("provider").map(String::as_str),
+        Some("zai"),
+        "configured provider must survive to the diagnostic: {report:?}"
+    );
+    assert_eq!(
+        report.get("provider_source").map(String::as_str),
+        Some("config"),
+        "provenance must name the config file: {report:?}"
+    );
+}
+
+#[test]
+fn resolve_reports_a_provider_scoped_model_as_explicitly_configured() {
+    let report = resolve_with_config(
+        "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\nmodel = \"kimi-k3-turbo\"\n",
+        &[],
+    );
+
+    assert_eq!(report.get("provider").map(String::as_str), Some("moonshot"));
+    assert_eq!(
+        report.get("requested").map(String::as_str),
+        Some("kimi-k3-turbo"),
+        "a configured model is a request, not a fallback: {report:?}"
+    );
+    assert_eq!(
+        report.get("used_fallback").map(String::as_str),
+        Some("false"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("model_source").map(String::as_str),
+        Some("config [providers.*].model"),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn resolve_admits_when_nothing_was_configured() {
+    // The honest answer to "what did the user ask for" is "nothing". The
+    // built-in default may still be shown, but it must be labelled as ours.
+    let report = resolve_with_config("", &[]);
+
+    assert_eq!(
+        report.get("requested").map(String::as_str),
+        Some(""),
+        "an unconfigured model must not be presented as a request: {report:?}"
+    );
+    assert_eq!(
+        report.get("used_fallback").map(String::as_str),
+        Some("true"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("model_source").map(String::as_str),
+        Some("provider default"),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn an_explicit_model_argument_still_answers_the_hypothetical() {
+    // Naming a model asks "what would this resolve to", which must keep
+    // working even when the configured provider is something else.
+    let report = resolve_with_config(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+        &["deepseek-v4-flash"],
+    );
+
+    assert_eq!(
+        report.get("requested").map(String::as_str),
+        Some("deepseek-v4-flash"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("model_source").map(String::as_str),
+        Some("argument"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("used_fallback").map(String::as_str),
+        Some("false"),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn an_explicit_provider_flag_is_reported_as_the_source() {
+    let report = resolve_with_config(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+        &["--provider", "moonshot"],
+    );
+
+    assert_eq!(report.get("provider").map(String::as_str), Some("moonshot"));
+    assert_eq!(
+        report.get("provider_source").map(String::as_str),
+        Some("--provider"),
+        "{report:?}"
+    );
+}
+
+fn codewhale_binary() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_codewhale") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_codewhale") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("current test executable path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("codewhale{}", std::env::consts::EXE_SUFFIX));
+    path
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2526,12 +2526,22 @@ impl ConfigToml {
         };
 
         let env_provider_model = env.model_for(provider, &base_url);
-        let explicit_model = cli.model.is_some()
-            || env.model.is_some()
-            || env_provider_model.is_some()
-            || provider_cfg.model.is_some()
-            || root_deepseek_model.is_some()
-            || self.model.is_some();
+        // Derived from the same chain as `model` below so the reported
+        // provenance cannot drift from the id that is actually used.
+        let model_source = if cli.model.is_some() {
+            ModelSource::Cli
+        } else if env.model.is_some() || env_provider_model.is_some() {
+            ModelSource::Env
+        } else if provider_cfg.model.is_some() {
+            ModelSource::ProviderConfig
+        } else if root_deepseek_model.is_some() {
+            ModelSource::RootDefaultTextModel
+        } else if self.model.is_some() {
+            ModelSource::RootModel
+        } else {
+            ModelSource::ProviderDefault
+        };
+        let explicit_model = model_source.is_explicit();
         let model = cli
             .model
             .clone()
@@ -2610,6 +2620,7 @@ impl ConfigToml {
             provider,
             provider_source,
             model,
+            model_source,
             api_key,
             api_key_source,
             base_url,
@@ -3613,11 +3624,55 @@ pub enum ProviderSource {
     Config,
 }
 
+/// Where the resolved runtime model id came from.
+///
+/// This mirrors the precedence chain in
+/// [`ConfigToml::resolve_runtime_options_with_secrets`] so diagnostics can say
+/// *why* a model was chosen instead of presenting a built-in default as if the
+/// user had asked for it. [`Self::ProviderDefault`] is the only variant that
+/// means "nothing was configured".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelSource {
+    /// `--model` on the command line.
+    Cli,
+    /// A `CODEWHALE_*` environment variable.
+    Env,
+    /// `[providers.<name>].model`.
+    ProviderConfig,
+    /// The root `default_text_model` key, which is DeepSeek-scoped.
+    RootDefaultTextModel,
+    /// The provider-neutral root `model` key.
+    RootModel,
+    /// Nothing was configured; this is the built-in default for the provider.
+    ProviderDefault,
+}
+
+impl ModelSource {
+    /// Whether the id was chosen by the user rather than substituted by us.
+    #[must_use]
+    pub fn is_explicit(self) -> bool {
+        !matches!(self, Self::ProviderDefault)
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "--model",
+            Self::Env => "environment",
+            Self::ProviderConfig => "config [providers.*].model",
+            Self::RootDefaultTextModel => "config default_text_model",
+            Self::RootModel => "config model",
+            Self::ProviderDefault => "provider default",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ResolvedRuntimeOptions {
     pub provider: ProviderKind,
     pub provider_source: ProviderSource,
     pub model: String,
+    pub model_source: ModelSource,
     pub api_key: Option<String>,
     pub api_key_source: Option<RuntimeApiKeySource>,
     pub base_url: String,


### PR DESCRIPTION
Closes #4832.

## The bug

`codew model resolve` read only the CLI flags. With no `--model`/`--provider` it called `ModelRegistry::resolve(None, None)`, and that function's no-hint branch is `provider_hint.unwrap_or(ProviderKind::Deepseek)`. So a Z.ai config reported a confident DeepSeek answer while `doctor` — reading the same file — was correct.

Reproduced on `239c04f81` with a sealed HOME:

```
$ cat $HOME/.codewhale/config.toml
provider = "zai"
default_text_model = "GLM-5.2"

[providers.zai]
api_key = "k"

$ codewhale model resolve
requested:
resolved: deepseek-v4-pro
provider: deepseek
used_fallback: true
```

## The fix

`model resolve` now goes through `resolve_runtime_for_diagnostic_dispatch` — the same read-only path `doctor` uses, so the two cannot disagree. With no explicit query it reports the runtime's decision verbatim; naming a model or passing `--provider` still answers the hypothetical, but defaults the provider to the configured one rather than to any single vendor.

Two new lines report where each value came from. `ModelSource` is derived from the same precedence chain that picks the model id, so provenance cannot drift from the id actually in use.

```
$ codewhale model resolve
requested:
resolved: GLM-5.2
provider: zai
used_fallback: true
provider_source: config
model_source: provider default
```

The four original lines keep their exact keys, so anything parsing this output still works.

## It surfaces a second defect rather than hiding it

`used_fallback: true` above is now *correct*, and worth reading carefully. Root `default_text_model` is DeepSeek-scoped — `root_deepseek_model` at `crates/config/src/lib.rs` is only `Some` when `provider == Deepseek` — so for Z.ai it is genuinely ignored and the `GLM-5.2` shown is the built-in Z.ai default arriving by coincidence.

That makes `codew model set` a silent no-op for every non-DeepSeek provider:

```
$ codewhale model set GLM-4.6
Default model set to 'GLM-4.6'      # writes default_text_model = "GLM-4.6"
$ codewhale model resolve
resolved: GLM-5.2                    # ignored
model_source: provider default
```

That is a routing bug, not a diagnostic one, so it is filed separately and left for its own reviewable change. This PR only stops the diagnostic from lying about it.

## Verification

- `cargo test -p codewhale-cli` — 169 + 5 new pass, 0 fail
- `cargo test -p codewhale-config` — pass
- `cargo clippy -p codewhale-cli -p codewhale-config --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `git diff --check` — clean

New tests run the real binary against a sealed `HOME`/`CODEWHALE_HOME`; real `~/.codewhale/config.toml` was hash-verified unchanged before and after (`7146b5268e…`), per #4831.