### PR TITLE
docs(localization): describe the TUI packs and gate locale drift in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,12 @@ jobs:
       - name: Check README translations stay in sync
         if: github.event_name != 'schedule'
         run: python3 scripts/check-readme-translations.py
+      - name: Check README locale link symmetry
+        if: github.event_name != 'schedule'
+        run: bash scripts/check-readme-locales.sh
+      - name: Check TUI locale pack parity
+        if: github.event_name != 'schedule'
+        run: python3 scripts/check-tui-locale-parity.py
       - name: Check harvested contributor credit
         if: github.event_name != 'schedule'
         shell: bash

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -3,12 +3,13 @@
 Canonical tracking document for every locale Codewhale ships, is actively
 building, is planning, or has explicitly deferred.
 
-> **Scope note (2026-07-12):** this matrix tracks the website/README surface.
-> The TUI ships its own locale packs under `crates/tui/locales/`
-> (en, es-419, ja, ko, pt-BR, vi, zh-Hans complete; zh-Hant intentionally
-> partial per #4057), guarded by raw key-parity tests in
-> `crates/tui/src/localization.rs`. Keep the two surfaces distinct when
-> updating status here.
+> **Scope note (2026-07-12):** this matrix covers three surfaces — the TUI
+> locale packs (`crates/tui/locales/`), the translated READMEs (repo root),
+> and the website (`web/`). The three ship on different cadences, so a
+> locale can be **shipped** on one surface and **planned** on another; the
+> per-surface tables below are the per-surface truth. The website registry
+> is `web/lib/i18n/config.ts` (`ALL_LOCALES`): the locale switcher and route
+> generation both derive from it.
 
 Customer-visible copy also follows the [Codewhale voice and terminal
 charter](VOICE.md); commands, key names, and glyphs remain code-owned around
@@ -27,6 +28,26 @@ Source-of-truth README: `README.md` (English, post-#3087).
 | **deferred** | Acknowledged as wanted but not yet scheduled; needs layout QA, bridge support, or community champion |
 
 ---
+
+## TUI locale packs
+
+The TUI packs under `crates/tui/locales/` are the largest translation
+surface in the repo. `en.json` is the reference; a pack is **complete**
+only at exact raw key parity with it, enforced by
+`scripts/check-tui-locale-parity.py` (CI) and the parity tests in
+`crates/tui/src/localization.rs`. See `crates/tui/locales/AGENTS.md` for the
+authoring contract.
+
+| Locale | File | Keys vs `en.json` (1128) | Status | Notes |
+|--------|------|--------------------------|--------|-------|
+| English | `en.json` | 1128/1128 | **shipped** | Reference pack. |
+| Japanese | `ja.json` | 1128/1128 | **shipped** | Complete. |
+| Simplified Chinese | `zh-Hans.json` | 1128/1128 | **shipped** | Complete. |
+| Traditional Chinese | `zh-Hant.json` | 478/1128 | **partial** | Setup core only; missing keys fall back to English at runtime. Deliberate scope per #4057. |
+| Brazilian Portuguese | `pt-BR.json` | 1128/1128 | **shipped** | Complete. |
+| Latin American Spanish | `es-419.json` | 1128/1128 | **shipped** | Complete. Note the website tracks `es` as deferred — the shipped TUI pack is Latin American Spanish, not `es-ES`. |
+| Vietnamese | `vi.json` | 1128/1128 | **shipped** | Complete. |
+| Korean | `ko.json` | 1128/1128 | **shipped** | Complete. |
 
 ## Website locales
 
@@ -57,18 +78,96 @@ Source-of-truth README: `README.md` (English, post-#3087).
 
 | Check | Tool | Status |
 |-------|------|--------|
-| README locale links symmetric | `scripts/check-readme-locales.sh` | Planned |
-| Website dictionaries cover all shipped locales | `npm run check:locales` (vitest) | Planned |
-| Accept-Language routes to all shipped locales | Middleware test | Planned |
-| Locale selector lists all shipped locales | Component test | Planned |
+| TUI pack key parity with `en.json` (complete packs) | `scripts/check-tui-locale-parity.py` + parity tests in `crates/tui/src/localization.rs` | **Shipped** (CI Lint job) |
+| README translations stay in sync with `README.md` | `scripts/check-readme-translations.py` | **Shipped** (CI Lint job) |
+| README locale links symmetric | `scripts/check-readme-locales.sh` | **Shipped** (CI Lint job) |
+| Website dictionaries cover all shipped locales | `npm run check:locales` (vitest) | Planned — tracked by #3091 |
+| Accept-Language routes to all shipped locales | Middleware test | Planned — tracked by #3091 |
+| Locale selector lists all shipped locales | Component test | Planned — tracked by #3091 |
 
 ## How to add a locale
 
-1. Add the locale code to `locales` array in `web/lib/i18n/config.ts`.
-2. Add label to `LOCALE_LABELS` in `web/components/locale-switcher.tsx`.
-3. Scaffold translation dictionaries under `web/lib/i18n/dictionaries/<code>/`.
-4. Add a locale route segment — Next.js `[locale]` will pick it up automatically once the `locales` array includes it.
-5. Update this matrix.
+A locale is not "added" until all three surfaces below either ship it or
+carry an explicit `planned`/`partial`/`deferred` row in this matrix.
+
+### 1. TUI pack
+
+1. Create `crates/tui/locales/<tag>.json` with every key in `en.json`,
+   following `crates/tui/locales/AGENTS.md` (placeholders stay literal;
+   product terms stay English per pack convention; preserve intentional
+   leading/trailing spaces).
+2. Add the `Locale` variant plus its `tag`/`translation_target_name`/
+   `parse_locale`/`shipped`/`shipped_complete` arms in
+   `crates/tui/src/localization.rs`, and the `include_str!` arm in the
+   test module.
+3. Wire the pickers and displays that enumerate locales: onboarding
+   language picker (`crates/tui/src/tui/onboarding/language.rs` — a test
+   forces every shipped locale to be offered), setup-wizard match arms,
+   and the locale display arms in the `/config` and changelog commands.
+4. Run `python3 scripts/check-tui-locale-parity.py` and
+   `cargo test -p codewhale-tui localization`.
+5. If the pack must ship incomplete, declare it partial (see `zh-Hant` /
+   #4057): keep it out of `shipped_complete()`, mark it in
+   `is_partial_pack()`, and add it to `PARTIAL_PACKS` in
+   `scripts/check-tui-locale-parity.py` with a tracking issue.
+
+### 2. README
+
+1. Translate `README.md` into `README.<tag>.md`, preserving structure,
+   commands, and the #3087 factual history.
+2. Cross-link it from the language line in `README.md` and from the other
+   translated READMEs.
+3. Restamp per `scripts/check-readme-translations.py`, then run
+   `python3 scripts/check-readme-translations.py` and
+   `bash scripts/check-readme-locales.sh`.
+
+### 3. Website
+
+1. Add the locale to `ALL_LOCALES` in `web/lib/i18n/config.ts` — the
+   switcher and routes derive from it, so no per-locale switcher edit is
+   needed. Use the `partial` status for locales that ship incomplete
+   (e.g. a `zh-Hant`-style scoped pack).
+2. Scaffold translation dictionaries under
+   `web/lib/i18n/dictionaries/<code>/` (#3091 layer).
+3. Verify `web/middleware.ts` routes the tag (base tags route with no
+   middleware change).
+4. Run `cd web && npm run check:locales && npm test && npm run build`.
+
+### 4. Matrix
+
+Update the TUI, README, and Website tables above — one row per surface,
+with per-surface status.
+
+## Assessments
+
+### Galician (`gl`) and Basque (`eu`) — 2026-07-25, per #4749
+
+Assessed alongside the Catalan pack (#4749 / #4788), which asked whether
+Galician and Basque are "similar-value European additions" worth shipping
+in the same wave.
+
+**Decision: defer both.** Rationale:
+
+- The case #4788 makes for Catalan is specifically that it "has an
+  unusually strong software-localization tradition and an active volunteer
+  community" — a review-capacity argument, not a market-size one. That
+  argument does not transfer: Galician and Basque have materially smaller
+  localization communities, so a pack for either would ship with no
+  realistic path to native-speaker review.
+- Galician speakers have a workable fallback already: the shipped
+  `es-419` pack (and `pt-BR` is lexically close). Basque is a language
+  isolate with no fallback proximity — its per-string review cost is the
+  highest of the three, and machine-translated Basque is the least
+  trustworthy of the three.
+- There is no natural "ship together" grouping: the v0.9.2 wave already
+  bundles the locales that share acceptance criteria (Latin-script
+  fr/de/ca/id, Cyrillic uk, Devanagari hi). gl/eu share only the
+  review-capacity constraint, which neither clears.
+
+Revisit when a native-speaker champion appears for either language, or if
+Catalan uptake after v0.9.2 suggests demand. Both base tags (`gl`, `eu`)
+route through `web/middleware.ts` with no middleware change when that
+happens.
 
 ## Related issues
 
@@ -76,3 +175,10 @@ Source-of-truth README: `README.md` (English, post-#3087).
 - #3092 — Russian README + website localization
 - #3093 — Korean, Spanish, Brazilian Portuguese next-wave locales
 - #3087 — Post-rebrand README source text refresh
+- #4057 — `zh-Hant` scoped as a partial TUI pack with English fallback
+- #4787 — This matrix's TUI table + the locale-drift CI gates
+- #4788 — French, German, Catalan TUI localization
+- #4789 — Indonesian localization
+- #4790 — Hindi localization + Devanagari terminal-shaping spike
+- #4791 — Ukrainian localization alongside Russian
+- #4749 — Catalan UI language + Galician/Basque assessment

--- a/scripts/check-tui-locale-parity.py
+++ b/scripts/check-tui-locale-parity.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""check-tui-locale-parity.py — CI gate against TUI locale pack drift.
+
+`en.json` is the reference pack. Every pack that claims completeness must
+hold exact raw key-set parity with it in both directions, and every
+`{named}` placeholder must survive translation (call sites substitute with
+`.replace()`, so a dropped placeholder renders literal braces at runtime).
+
+Declared partial packs (PARTIAL_PACKS, mirroring `Locale::is_partial_pack()`
+in `crates/tui/src/localization.rs`) are exempt from completeness but must
+not define keys English lacks — an extra key in a partial pack is drift the
+English fallback can never surface.
+
+This gate is the CI-visible half of the Rust parity tests
+(`shipped_complete_packs_have_raw_key_parity_with_english`,
+`message_id_list_english_pack_stay_in_exact_sync`). It exists so that pack
+files on disk — including packs whose `Locale` wiring has not landed yet —
+are held to the same contract, and so the failure is attributable to a file
+rather than buried in a test binary.
+
+Exits non-zero on any parity violation.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCALES_DIR = ROOT / "crates" / "tui" / "locales"
+REFERENCE = "en"
+
+# Packs that ship deliberately incomplete, with English fallback for the
+# missing keys. Mirrors `Locale::is_partial_pack()`. Every entry needs an
+# issue reference; a partial pack without a tracking issue is silent drift.
+PARTIAL_PACKS = {
+    "zh-Hant": "#4057",  # Setup core only; English fallback for the rest.
+}
+
+PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+def load_pack(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"[tui-locale-parity] FAIL — {path.name}: unreadable JSON: {exc}")
+        sys.exit(1)
+    if not isinstance(data, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in data.items()
+    ):
+        print(f"[tui-locale-parity] FAIL — {path.name}: must be a flat string map")
+        sys.exit(1)
+    return data
+
+
+def placeholders(value: str) -> set:
+    return set(PLACEHOLDER_RE.findall(value))
+
+
+def main() -> int:
+    ref_path = LOCALES_DIR / f"{REFERENCE}.json"
+    if not ref_path.is_file():
+        print(f"[tui-locale-parity] FAIL — reference pack {ref_path} missing")
+        return 1
+    reference = load_pack(ref_path)
+    ref_keys = set(reference)
+    print(f"[tui-locale-parity] reference {REFERENCE}.json: {len(ref_keys)} keys")
+
+    failures = []
+    pack_files = sorted(
+        p for p in LOCALES_DIR.glob("*.json") if p.stem != REFERENCE
+    )
+    for path in pack_files:
+        tag = path.stem
+        pack = load_pack(path)
+        keys = set(pack)
+        partial_issue = PARTIAL_PACKS.get(tag)
+
+        missing = sorted(ref_keys - keys)
+        extra = sorted(keys - ref_keys)
+
+        if extra:
+            failures.append(
+                f"{tag}: defines {len(extra)} key(s) {REFERENCE}.json lacks: {extra[:10]}"
+            )
+        if partial_issue:
+            print(
+                f"[tui-locale-parity] {tag}: {len(keys)}/{len(ref_keys)} keys "
+                f"(declared partial, {partial_issue})"
+            )
+        else:
+            if missing:
+                failures.append(
+                    f"{tag}: claims completeness but lacks {len(missing)} key(s); "
+                    f"the English fallback hides these at runtime: {missing[:10]}"
+                )
+            # Placeholder parity only makes sense on complete packs: a
+            # partial pack legitimately omits keys wholesale.
+            for key in sorted(ref_keys & keys):
+                ref_ph = placeholders(reference[key])
+                if placeholders(pack[key]) != ref_ph:
+                    failures.append(
+                        f"{tag}: {key} changed placeholders "
+                        f"(expected {sorted(ref_ph)}, got {sorted(placeholders(pack[key]))})"
+                    )
+            if not missing:
+                print(f"[tui-locale-parity] {tag}: {len(keys)}/{len(ref_keys)} keys — complete")
+
+    if failures:
+        print("[tui-locale-parity] FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print("[tui-locale-parity] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What was broken

`docs/LOCALIZATION.md` is the stated single source of truth for every locale the project ships, plans, or has deferred — but it only had tables for the website and README surfaces. The TUI locale packs under `crates/tui/locales/` are the largest translation surface in the repo (8 packs, 1128 keys each) and were absent entirely.

Consequences, all verified against the tree:

- Complete `ko`, `es-419`, and `pt-BR` TUI packs ship, while the website table marks `es` and `pt-BR` `deferred` — the doc reads as though no Latin-American work exists.
- `zh-Hant` ships as a deliberate 478/1128 partial with English fallback (#4057) and appeared nowhere in the matrix.
- Four drift checks were listed **Planned** and unbuilt, including `scripts/check-readme-locales.sh`, which already existed and simply was not wired into CI.

The v0.9.2 locale wave (#4788, #4789, #4790, #4791, #4749) adds six more locales. Each one added to a matrix that already misdescribes reality compounds the drift.

## Why the fix is shaped this way

**The parity gate is file-based, not a Rust test.** `crates/tui/src/localization.rs` already has `shipped_complete_packs_have_raw_key_parity_with_english`, but it can only see packs that have a `Locale` variant. During a locale wave the pack JSON lands before (or in a different PR from) the Rust wiring, and that window is exactly when a pack silently drifts. `scripts/check-tui-locale-parity.py` reads the directory, so it covers packs whose wiring has not landed — and a failure names a file instead of being buried in a test binary.

**Placeholder parity is checked, not just keys.** Call sites substitute `{named}` placeholders with `.replace()`, so a translator who drops or renames one produces literal braces at runtime with no test failure. The gate compares placeholder sets per key.

**Partials are a declared status, not an escape hatch.** `PARTIAL_PACKS` mirrors `Locale::is_partial_pack()` and requires a tracking issue per entry. A partial is exempt from completeness but still may not define keys English lacks, because the English fallback can never surface those.

**Galician/Basque (#4749) is recorded as an assessment, not a pack.** #4749 asked whether `gl`/`eu` are "similar-value European additions" worth shipping with Catalan. The answer is no, and the reasoning is written down in the matrix rather than left in a PR comment: the case #4788 makes for Catalan is about *review capacity* ("an unusually strong software-localization tradition and an active volunteer community"), not market size, and that argument does not transfer to either language.

## Gates I actually ran

```
$ python3 scripts/check-tui-locale-parity.py
[tui-locale-parity] reference en.json: 1128 keys
[tui-locale-parity] es-419: 1128/1128 keys — complete
[tui-locale-parity] ja: 1128/1128 keys — complete
[tui-locale-parity] ko: 1128/1128 keys — complete
[tui-locale-parity] pt-BR: 1128/1128 keys — complete
[tui-locale-parity] vi: 1128/1128 keys — complete
[tui-locale-parity] zh-Hans: 1128/1128 keys — complete
[tui-locale-parity] zh-Hant: 478/1128 keys (declared partial, #4057)
[tui-locale-parity] PASS

$ bash scripts/check-readme-locales.sh
[check-readme-locales] OK — all linked locale READMEs exist
[check-readme-locales] OK — no orphaned locale READMEs
[check-readme-locales] PASS

$ git diff --check
(no output)

$ python3 -c "import yaml; ..."   # ci.yml parses; both new steps appear in jobs.lint.steps
Check README locale link symmetry
Check TUI locale pack parity
```

`cargo fmt` / `clippy` / `cargo test` were **not** run for this PR and are not applicable: the diff touches only `docs/LOCALIZATION.md`, `.github/workflows/ci.yml`, and a new Python script. No Rust source is modified.

## What I could NOT verify

- **The CI job itself has not run.** I validated `ci.yml` parses and that both new steps land in the `lint` job's step list, and I ran both scripts locally on this tree. I did not observe them execute on GitHub Actions.
- **The two remaining #4787 scope items are deliberately not in this PR.** `npm run check:locales` (website dictionary parity) and switching `zh-Hant` to the existing `"partial"` `LocaleStatus` in `web/lib/i18n/config.ts` both depend on the #3091 dictionary layer, which does not exist yet. They stay Planned in the matrix, now explicitly attributed to #3091 instead of sitting unattributed.
- **Key counts are measured, not asserted from the issue.** #4787 says 1123 keys per pack; the tree actually has 1128. The matrix and the gate both use the measured 1128.

Closes #4787
Refs #4749