### PR TITLE
chore(credit): map five contributors missing from AUTHOR_MAP

### DIFF
--- a/.github/AUTHOR_MAP
+++ b/.github/AUTHOR_MAP
@@ -198,3 +198,8 @@ Sh1Zuku = Sh1Zuku <125943630+SparkofSpike@users.noreply.github.com>
 # v0.9.1 provider harvests.
 baendlorel = baendlorel <50111870+baendlorel@users.noreply.github.com>
 futami16237@gmail.com = baendlorel <50111870+baendlorel@users.noreply.github.com>
+EvanProgramming = Evan <170803900+EvanProgramming@users.noreply.github.com>
+adity982 = ADITYA <59918965+adity982@users.noreply.github.com>
+vibecoding-skills = Harsh Dattani <209214219+vibecoding-skills@users.noreply.github.com>
+XhesicaFrost = XhesicaFrost <142909332+XhesicaFrost@users.noreply.github.com>
+ffaacceelee = ffaacceelee <11267580+ffaacceelee@users.noreply.github.com>


### PR DESCRIPTION
Adds `.github/AUTHOR_MAP` entries for five contributors triaged during the v0.9.2 PR pass.

Three of them had equivalent work reach `main` **without** a `Co-authored-by` trailer, specifically because they were not in this file:

| Contributor | PR | Landed as | Trailer? |
| --- | --- | --- | --- |
| @EvanProgramming | #4760 | `0d7312736` | missing |
| @adity982 | #4756 | `cccaa4f3f` | missing |
| @vibecoding-skills | #4743 | `a374d196e` | missing |
| @XhesicaFrost | #4610 | pending harvest for #4520 | n/a yet |
| @ffaacceelee | #4686 | closed, no harvest | pre-emptive |

I committed to adding these in the close comments on those PRs, so this is the follow-through.

Numeric noreply ids were verified against `gh api users/<login>` rather than inferred — a wrong id doesn't fail the gate, it just silently drops the credit out of the contributor graph.

Docs-only change; no code paths touched.