### PR TITLE
refactor(cli): remove the retired --no-alt-screen compatibility flag

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -189,8 +189,6 @@ struct Cli {
     /// Workspace directory for TUI file tools
     #[arg(short = 'C', long = "workspace", alias = "cd", value_name = "DIR")]
     workspace: Option<PathBuf>,
-    #[arg(long = "no-alt-screen", hide = true)]
-    no_alt_screen: bool,
     #[arg(long = "mouse-capture", conflicts_with = "no_mouse_capture")]
     mouse_capture: bool,
     #[arg(long = "no-mouse-capture", conflicts_with = "mouse_capture")]
@@ -4303,9 +4301,6 @@ fn build_tui_command_with_paths(
     if let Some(workspace) = workspace_path {
         cmd.arg("--workspace").arg(workspace);
     }
-    // Accepted for older scripts, but no longer forwarded: the interactive TUI
-    // always owns the alternate screen to avoid host scrollback hijacking.
-    let _ = cli.no_alt_screen;
     if cli.mouse_capture {
         cmd.arg("--mouse-capture");
     }
@@ -7492,7 +7487,6 @@ model = "qwen-2.5-7b"
             "sk-test",
             "--workspace",
             "/tmp/workspace",
-            "--no-alt-screen",
             "--no-mouse-capture",
             "--skip-onboarding",
             "model",
@@ -7516,7 +7510,6 @@ model = "qwen-2.5-7b"
         );
         assert_eq!(cli.api_key.as_deref(), Some("sk-test"));
         assert_eq!(cli.workspace, Some(PathBuf::from("/tmp/workspace")));
-        assert!(cli.no_alt_screen);
         assert!(cli.no_mouse_capture);
         assert!(!cli.mouse_capture);
         assert!(cli.skip_onboarding);

--- a/crates/tui/src/main.rs
+++ b/crates/tui/src/main.rs
@@ -213,11 +213,6 @@ struct Cli {
     #[arg(short = 'c', long = "continue")]
     continue_session: bool,
 
-    /// Deprecated compatibility flag; the interactive TUI always owns the
-    /// alternate screen so terminal scrollback cannot hijack the viewport.
-    #[arg(long = "no-alt-screen", hide = true)]
-    no_alt_screen: bool,
-
     /// Enable TUI mouse capture for internal scrolling, transcript selection,
     /// and scrollbar dragging
     /// (default off on Windows)
@@ -14504,11 +14499,16 @@ mod terminal_mode_tests {
     }
 
     #[test]
-    fn no_alt_screen_flag_is_accepted_but_keeps_alternate_screen() {
-        let cli = parse_cli(&["codewhale", "--no-alt-screen"]);
-        let config = Config::default();
-
-        assert!(should_use_alt_screen(&cli, &config));
+    fn removed_no_alt_screen_flag_is_rejected() {
+        // Negative test: the retired compatibility flag must not be silently
+        // accepted and must not reach the alternate-screen decision at all.
+        let error = Cli::try_parse_from(["codewhale", "--no-alt-screen"])
+            .expect_err("--no-alt-screen must no longer parse");
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::UnknownArgument,
+            "retired flag should fail as an unknown argument, not be absorbed"
+        );
     }
 
     #[test]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -190,8 +190,7 @@ Known limitations:
   prefer provider environment variables when file-backed plaintext storage is
   not acceptable.
 - Terminal rendering varies by Android terminal app. The TUI always owns the
-  alternate screen; `--no-alt-screen` is accepted only as a deprecated
-  compatibility no-op. If a terminal app cannot render the full-screen TUI,
+  alternate screen. If a terminal app cannot render the full-screen TUI,
   use `codewhale exec` for headless runs instead.
 
 ---


### PR DESCRIPTION
## What was broken

`--no-alt-screen` was a hidden flag on both CLI surfaces that could not
influence anything. Verified against this branch's base (`32e6dec6a`):

`crates/tui/src/main.rs:8348-8350`

```rust
fn should_use_alt_screen(_cli: &Cli, _config: &Config) -> bool {
    true
}
```

Both parameters are ignored; the function returns `true` unconditionally.
It has exactly one production caller, `crates/tui/src/main.rs:8968`
(`let use_alt_screen = should_use_alt_screen(cli, config);`).

`crates/cli/src/lib.rs:192-193` declared the flag:

```rust
#[arg(long = "no-alt-screen", hide = true)]
no_alt_screen: bool,
```

and `crates/cli/src/lib.rs:4308`, inside `build_tui_command_with_paths`,
was the only read of it:

```rust
// Accepted for older scripts, but no longer forwarded: the interactive TUI
// always owns the alternate screen to avoid host scrollback hijacking.
let _ = cli.no_alt_screen;
```

So the dispatcher parsed the flag and dropped it on the floor, and even if
it had forwarded it, the TUI's decision function would have ignored it.

## Why the fix is shaped this way

A hidden argument that cannot affect behavior is worse than no argument: it
lets scripts and docs keep asserting an intent the program silently discards.
Rather than wiring the flag up to real behavior — the TUI owning the
alternate screen unconditionally is a deliberate decision, not an accident —
this removes the flag end-to-end so the contract is honest.

`should_use_alt_screen` itself is left in place. Collapsing it is a separate,
larger refactor of the terminal-mode setup path and is deliberately out of
scope here.

The accepted-but-ignored test becomes a negative test,
`terminal_mode_tests::removed_no_alt_screen_flag_is_rejected`, asserting the
flag fails as `clap::error::ErrorKind::UnknownArgument`. That pins the
removal so the flag cannot be quietly reabsorbed later as another no-op.

`docs/INSTALL.md` drops the "accepted only as a deprecated compatibility
no-op" hedge from the Termux rendering note.
`docs/CHANGELOG_ARCHIVE.md` keeps its historical mention on purpose — it
records what a past release did, not current guidance.

## Compatibility note (read this before filing a bug)

**BREAKING for scripts:** any script or CI job still passing
`--no-alt-screen` now fails with an `UnknownArgument` error instead of being
silently accepted. **This is intended.** No value of the flag could ever
reach behavior in this version line — passing it and not passing it produced
byte-identical terminal setup. The correct fix for such a script is to delete
the flag. There is no stored config, no env var, and no migration involved.

## Gates actually run

All from the worktree at this branch's head:

```
cargo fmt --all
cargo fmt --all -- --check          # clean, no output
git diff --check                    # clean, no output
cargo clippy -p codewhale-cli --all-targets --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.80s

cargo test -p codewhale-cli --lib --locked
    test result: ok. 169 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p codewhale-tui --bin codewhale-tui --locked terminal_mode_tests
    test result: ok. 83 passed; 0 failed; 0 ignored; 0 measured; 8088 filtered out

cargo test -p codewhale-tui --bin codewhale-tui --locked alt_screen
    test terminal_mode_tests::removed_no_alt_screen_flag_is_rejected ... ok
    test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 8170 filtered out
```

## What I could NOT verify

- `cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings`
  **does not pass on this machine.** It reports 40 lint errors under the local toolchain
  (clippy 1.97): `redundant_field_names`, `collapsible_if`,
  `unnecessary_to_owned`, `needless_return`, `items_after_test_module`,
  `too_many_arguments`, `assertions_on_constants`. Every one is in a file this
  PR does not touch (`fleet/host.rs`, `tui/ambient_life.rs`,
  `tui/setup/tools_mcp.rs`, `settings.rs`, `config.rs`,
  `commands/groups/**`, `test_support.rs`). Neither `crates/tui/src/main.rs`
  nor `crates/cli/src/lib.rs` appears in the output, so none of them are
  attributable to this diff. To be precise about what I actually ran: I did
  **not** re-run clippy on the untouched base commit to produce a
  before/after receipt — the "pre-existing" claim rests on the error
  locations being in files this PR does not modify, not on a baseline run.
  I did not fix them —
  that is a separate lint-baseline concern. So there is **no clean
  `-D warnings` clippy receipt for `codewhale-tui`** here; the cli receipt
  above is clean.
- The tui build emits a pre-existing `linker_messages` warning
  (`__eh_frame section too large`) on this machine, unrelated to this change.
- I did not run `cargo test --workspace` (build-slot contention with parallel
  lanes). Beyond the two targeted tui filters above, the rest of the tui suite
  is unverified by me — though this diff removes only a clap field and a
  discarded local, so the blast radius is argument parsing.
- I did not exercise a real terminal to confirm alternate-screen behavior is
  unchanged; the argument for that is static (`should_use_alt_screen` is
  unchanged and already ignored its inputs), not empirical.

