### PR TITLE
fix(tui): auto-fit composer height to its content (#4809 part 2/2)

### DIFF
--- a/crates/tui/src/tui/composer_chrome.rs
+++ b/crates/tui/src/tui/composer_chrome.rs
@@ -1,32 +1,30 @@
 //! Ocean composer chrome policy.
 //!
-//! Keeps the prompt roomy by default and sheds padding before content when
-//! the terminal is short. Content-driven growth still wins once the user
-//! types past the baseline.
+//! The composer auto-fits its content: one input row when empty or
+//! single-line, growing with typed content up to the density cap. Density
+//! no longer forces a multi-row baseline — it only bounds how tall the
+//! composer may grow. Content-driven growth still wins once the user
+//! types past one row, and submit/clear collapses the composer back to
+//! a single input row.
 
 use crate::tui::app::ComposerDensity;
 
 /// Top/bottom chrome rows for the quiet rule (TOP border only) or the
-/// enclosed panel (TOP + BOTTOM).
+/// enclosed panel (TOP + BOTTOM), plus the total-row growth cap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ComposerChrome {
     pub border_rows: u16,
-    pub min_content_rows: usize,
     pub max_total_rows: u16,
 }
 
 impl ComposerChrome {
     /// Baseline for the given density. Panel shape gets both borders;
     /// quiet shape keeps a single top rule so the prompt still has a
-    /// clear ledge without reading as a card.
+    /// clear ledge without reading as a card. Density picks the growth
+    /// cap only — the composer starts at one content row regardless.
     #[must_use]
     pub fn for_density(density: ComposerDensity, enclosed_panel: bool) -> Self {
         let border_rows = if enclosed_panel { 2 } else { 1 };
-        let min_content_rows = match density {
-            ComposerDensity::Compact => 2,
-            ComposerDensity::Comfortable => 3,
-            ComposerDensity::Spacious => 4,
-        };
         let max_total_rows = match density {
             ComposerDensity::Compact => 7,
             ComposerDensity::Comfortable => 9,
@@ -34,29 +32,18 @@ impl ComposerChrome {
         };
         Self {
             border_rows,
-            min_content_rows,
             max_total_rows,
         }
-    }
-
-    /// Absolute floor so the composer never collapses to a one-line
-    /// afterthought when any vertical room remains.
-    #[must_use]
-    pub fn absolute_min_total(self) -> u16 {
-        u16::try_from(
-            self.min_content_rows
-                .saturating_add(usize::from(self.border_rows)),
-        )
-        .unwrap_or(3)
-        .max(2)
     }
 }
 
 /// Decide how many rows the composer should occupy.
 ///
-/// Compact terminals shed padding (drop forced baseline down toward
-/// content) before they shed typed content. When height allows, the
-/// density minimum always applies — including the empty quiet composer.
+/// The height follows the content: one input row when the composer is
+/// empty or holds a single line, growing one row per content line up to
+/// the density cap (`max_total_rows`) or the available height, whichever
+/// is smaller. Menu rows and the border chrome add on top. Compact
+/// terminals shed the border before they shed typed content.
 #[must_use]
 pub fn desired_height(
     content_lines: usize,
@@ -70,15 +57,6 @@ pub fn desired_height(
     let content = content_lines.max(1);
     let wants_panel = enclosed_panel && available >= 3;
 
-    // Shed padding first: if the full baseline does not fit, fall back to
-    // content (+ menu) + whatever border still fits, never inventing a
-    // cramped one-row total while two rows are available.
-    let baseline_content = if available >= chrome.absolute_min_total() {
-        content.max(chrome.min_content_rows)
-    } else {
-        content
-    };
-
     let border = if wants_panel {
         usize::from(chrome.border_rows)
     } else if available >= 2 {
@@ -87,7 +65,7 @@ pub fn desired_height(
         0
     };
 
-    let total = baseline_content
+    let total = content
         .saturating_add(extra_menu_lines)
         .saturating_add(border);
     let max_height = usize::from(available.min(chrome.max_total_rows).max(1));
@@ -95,7 +73,7 @@ pub fn desired_height(
 }
 
 /// Top padding inside the content budget. Keep at least one quiet row below a
-/// short prompt when the density baseline has room, instead of bottom-pinning
+/// short prompt when the budget has room, instead of bottom-pinning
 /// the caret directly against the phase footer. Compact heights naturally
 /// report zero padding once the budget collapses.
 #[must_use]
@@ -110,37 +88,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn comfortable_empty_composer_keeps_multi_line_baseline() {
+    fn empty_composer_fits_one_input_row_plus_chrome() {
+        // Auto-fit: an empty/single-line composer takes exactly one input
+        // row plus the quiet-rule border, regardless of density.
         let height = desired_height(1, 0, 8, ComposerDensity::Comfortable, false);
-        assert!(
-            height >= 4,
-            "expected roomy baseline, got {height} (1 border + 3 content)"
-        );
+        assert_eq!(height, 2, "1 content row + 1 border row");
     }
 
     #[test]
-    fn compact_height_sheds_padding_before_content() {
-        // Only two rows available: keep a border + one content row rather
-        // than forcing the comfortable 3-line baseline.
+    fn compact_height_sheds_border_before_content() {
+        // Only two rows available: keep a border + one content row.
         let height = desired_height(1, 0, 2, ComposerDensity::Comfortable, false);
         assert_eq!(height, 2);
     }
 
     #[test]
-    fn content_growth_still_expands_past_baseline() {
+    fn content_growth_expands_up_to_the_density_cap() {
+        // Six content rows + border fits under the Comfortable cap of 9.
         let height = desired_height(6, 0, 12, ComposerDensity::Comfortable, false);
-        assert!(
-            height >= 7,
-            "typed content must grow the composer: {height}"
-        );
+        assert_eq!(height, 7, "typed content must grow the composer: {height}");
+
+        // Past the cap the density setting wins, not the content.
+        let capped = desired_height(20, 0, 30, ComposerDensity::Comfortable, false);
+        assert_eq!(capped, 9, "Comfortable caps total rows at 9");
+        let spacious = desired_height(20, 0, 30, ComposerDensity::Spacious, false);
+        assert_eq!(spacious, 12, "Spacious caps total rows at 12");
     }
 
     #[test]
-    fn spacious_panel_keeps_four_content_rows() {
+    fn single_line_panel_is_one_input_row_plus_both_borders() {
         let height = desired_height(1, 0, 12, ComposerDensity::Spacious, true);
-        assert!(
-            height >= 6,
-            "spacious panel = 2 borders + 4 content, got {height}"
-        );
+        assert_eq!(height, 3, "panel = 2 borders + 1 content row, got {height}");
     }
 }

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -3305,11 +3305,6 @@ pub(crate) fn empty_composer_visual_rows(
     1
 }
 
-#[cfg(test)]
-fn composer_min_input_rows(density: ComposerDensity) -> usize {
-    crate::tui::composer_chrome::ComposerChrome::for_density(density, false).min_content_rows
-}
-
 fn composer_max_height(density: ComposerDensity) -> u16 {
     crate::tui::composer_chrome::ComposerChrome::for_density(density, false).max_total_rows
 }
@@ -4146,9 +4141,9 @@ mod tests {
         SlashMenuEntry, active_entry_revision, apply_detail_target_highlight,
         apply_selection_to_line, apply_send_flash, approval_palette, approval_truncation_hint,
         build_empty_state_lines, composer_content_geometry, composer_empty_hint_text,
-        composer_height, composer_max_height, composer_min_input_rows, composer_top_padding,
-        cursor_row_col, empty_composer_visual_rows, enclosed_composer_panel_fits, fish_flee_offset,
-        fish_heading, fish_mark, history_entry_revision, layout_input, layout_input_with_scroll,
+        composer_height, composer_max_height, composer_top_padding, cursor_row_col,
+        empty_composer_visual_rows, enclosed_composer_panel_fits, fish_flee_offset, fish_heading,
+        fish_mark, history_entry_revision, layout_input, layout_input_with_scroll,
         pad_lines_to_bottom, placeholder_visual_lines, push_command_entry, receipt_is_settling,
         revision_in_domain, should_render_empty_state, slash_completion_hints,
         tool_run_summary_revision, wrap_input_lines, wrap_input_lines_for_mouse, wrap_text,
@@ -5494,7 +5489,7 @@ mod tests {
     #[test]
     fn composer_height_prefers_panel_shape_when_space_allows() {
         let height = composer_height("", 40, 8, 0, ComposerDensity::Comfortable, true);
-        assert_eq!(height, 5);
+        assert_eq!(height, 3);
     }
 
     #[test]
@@ -5507,7 +5502,7 @@ mod tests {
         let widget = ComposerWidget::new(&app, 8, &slash_menu_entries, &mention_menu_entries);
 
         for (width, expected_panel, expected_height) in
-            [(11, false, 4), (12, true, 5), (13, true, 5), (14, true, 5)]
+            [(11, false, 2), (12, true, 3), (13, true, 3), (14, true, 3)]
         {
             let height = widget.desired_height(width);
             let area = Rect::new(0, 0, width, height);
@@ -5516,8 +5511,9 @@ mod tests {
             assert_eq!(widget.has_panel(area), expected_panel, "width={width}");
             assert_eq!(
                 widget.inner_area(area).height,
-                3,
-                "width={width} must reserve every rendered border row"
+                1,
+                "width={width} auto-fit composer reserves one input row plus \
+                 every rendered border row"
             );
 
             let mut buf = Buffer::empty(area);
@@ -5539,8 +5535,69 @@ mod tests {
         let expanded = height_for("one\ntwo\nthree\nfour\nfive\nsix");
         let collapsed_again = height_for("short");
 
+        // Auto-fit: one input row + top/bottom panel borders.
+        assert_eq!(collapsed, 3);
+        // Six content rows + two borders, still under the Comfortable cap of 9.
+        assert_eq!(expanded, 8);
         assert!(expanded > collapsed);
         assert_eq!(collapsed_again, collapsed);
+    }
+
+    /// Issue #4809 acceptance: the composer auto-fits its content through the
+    /// real widget path — typed input, `submit_input`, `clear_input` — not just
+    /// through the pure height helper.
+    #[test]
+    fn composer_auto_fits_typed_lines_and_returns_to_one_row_on_submit_or_clear() {
+        const WIDTH: u16 = 40;
+        const AVAILABLE: u16 = 24;
+
+        fn measure(app: &App) -> (u16, u16) {
+            let slash_menu_entries = Vec::<SlashMenuEntry>::new();
+            let mention_menu_entries = Vec::<String>::new();
+            let widget =
+                ComposerWidget::new(app, AVAILABLE, &slash_menu_entries, &mention_menu_entries);
+            let total = widget.desired_height(WIDTH);
+            let inner = widget.inner_area(Rect::new(0, 0, WIDTH, total)).height;
+            (total, inner)
+        }
+
+        let mut app = create_test_app();
+        app.composer_border = true;
+        app.composer_density = ComposerDensity::Comfortable;
+
+        // Empty composer: one input row inside the panel borders.
+        assert_eq!(measure(&app), (3, 1), "empty composer");
+
+        app.insert_str("one line");
+        assert_eq!(measure(&app), (3, 1), "single-line composer");
+
+        // Typing N lines grows the composer to N input rows while N is under
+        // the Comfortable cap of 9 total rows (7 input rows + 2 borders).
+        for n in 2..=7u16 {
+            app.clear_input();
+            let text = (1..=n)
+                .map(|i| format!("line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            app.insert_str(&text);
+            assert_eq!(measure(&app), (n + 2, n), "{n} typed lines");
+        }
+
+        // Past the cap the density setting wins, not the content.
+        app.clear_input();
+        app.insert_str(&vec!["over"; 40].join("\n"));
+        let cap = composer_max_height(ComposerDensity::Comfortable);
+        assert_eq!(measure(&app), (cap, cap - 2), "content beyond the cap");
+
+        // Submitting returns the composer to a single input row.
+        assert!(app.submit_input().is_some());
+        assert_eq!(measure(&app), (3, 1), "after submit");
+
+        // So does clearing a fresh multi-line draft.
+        app.insert_str("a\nb\nc\nd");
+        assert_eq!(measure(&app), (6, 4), "four-line draft");
+        app.clear_input();
+        assert_eq!(measure(&app), (3, 1), "after clear");
     }
 
     #[test]
@@ -5548,18 +5605,15 @@ mod tests {
         let with_border = composer_height("", 40, 8, 0, ComposerDensity::Comfortable, true);
         let without_border = composer_height("", 40, 8, 0, ComposerDensity::Comfortable, false);
 
-        // Quiet composer keeps a single top rule but still reserves the
-        // density baseline (3 content rows) so it never collapses to a
-        // one-line afterthought when height allows.
-        assert_eq!(with_border, 5);
-        assert_eq!(without_border, 4);
+        // Quiet composer keeps a single top rule over the one auto-fit
+        // input row; the panel shape adds its bottom border.
+        assert_eq!(with_border, 3);
+        assert_eq!(without_border, 2);
         assert!(without_border < with_border);
     }
 
     #[test]
-    fn composer_density_changes_min_rows_and_height_cap() {
-        assert_eq!(composer_min_input_rows(ComposerDensity::Compact), 2);
-        assert_eq!(composer_min_input_rows(ComposerDensity::Spacious), 4);
+    fn composer_density_changes_height_cap() {
         assert!(
             composer_max_height(ComposerDensity::Spacious)
                 > composer_max_height(ComposerDensity::Compact)


### PR DESCRIPTION
Finishes #4809. Part 1 (dropping the muted `Draft` title) landed in #4824; this is the height half.

## What was broken

`ComposerChrome::for_density` carried a `min_content_rows` floor (Compact 2 / Comfortable 3 / Spacious 4) and `desired_height` applied it whenever the terminal was tall enough. Consequences:

- an empty composer on a fresh session rendered 3 blank input rows plus chrome (Comfortable), spending vertical space on nothing;
- height was a function of the density setting, not of the draft, so it never came back down to one row after submit or clear — the floor was already the height.

## Why the fix is shaped this way

Density becomes a *cap*, not a floor. `min_content_rows` and `absolute_min_total` are deleted; `ComposerChrome` keeps `border_rows` and `max_total_rows`. `desired_height` is then just `content_lines (>=1) + menu rows + border`, clamped by `min(available_height, max_total_rows)`. That gives all three acceptance behaviors from one expression rather than special cases:

- empty / single-line -> `content_lines == 1` -> one input row;
- N typed lines -> N input rows until the density cap clamps -> `min(N, cap)`;
- submit or clear empties `app.input` -> back to `content_lines == 1` -> one row.

The compact-terminal rule is preserved: the border is shed before typed content. Menus, the panel-vs-quiet-rule shape decision, top-right chrome, and `top_padding` are untouched. No new per-frame work — the wrap/line count was already computed for `desired_height`.

## Tests

Rewrote the four `composer_chrome` unit tests around the new contract (exact equalities instead of `>=` floors) and updated the widget tests that asserted the old baseline heights. Added one end-to-end acceptance test that goes through the real widget and the real `App` mutators (`insert_str`, `submit_input`, `clear_input`) rather than the pure helper:

`tui::widgets::tests::composer_auto_fits_typed_lines_and_returns_to_one_row_on_submit_or_clear`

It asserts: empty -> (3 total, 1 inner); single line -> (3, 1); N=2..7 typed lines -> (N+2, N); 40 lines -> clamped to the Comfortable cap of 9; after `submit_input()` -> (3, 1); a fresh 4-line draft -> (6, 4); after `clear_input()` -> (3, 1).

## Gates actually run (macOS, local)

```
cargo fmt --all && cargo fmt --all -- --check   # clean
git diff --check                                # clean
cargo test -p codewhale-tui --bin codewhale-tui --locked composer
  -> test result: ok. 109 passed; 0 failed; 8063 filtered out
cargo test -p codewhale-tui --bin codewhale-tui --locked widgets::
  -> test result: ok. 268 passed; 0 failed; 7904 filtered out
cargo test -p codewhale-tui --bin codewhale-tui --locked height / layout / chrome
  -> ok. 15 passed / 7 passed / 16 passed; 0 failed
```

`cargo clippy -p codewhale-tui --all-targets --locked -- -D warnings` does **not** pass on this machine — but it does not pass on the base commit either. I measured both: 42 `^error` lines on `32e6dec` (stashed working tree) and 42 with this change, and none of them are in `composer_chrome.rs` or `widgets/mod.rs` (they are `settings.rs`, `ambient_life.rs`, `setup/tools_mcp.rs`, `commands/groups/**`, etc. — local clippy is newer than CI's). So this PR adds zero lint findings, but I cannot claim a green clippy run.

## Not verified

- No `cargo test --workspace` and no `RUSTFLAGS="-D warnings" cargo test -p codewhale-tui --all-features` run (parallel agents are sharing the build slot); other crates' tests are unexercised, though nothing outside `crates/tui` is touched and `min_content_rows`/`absolute_min_total` had no other referents (`rg` across the repo).
- No visual dogfood pass in a real terminal — the evidence here is buffer-level assertions, not a screenshot.