### PR TITLE
fix(tui): give palette detection evidence and enforce a contrast floor (#4833)

### DIFF
--- a/crates/tui/src/palette/contrast.rs
+++ b/crates/tui/src/palette/contrast.rs
@@ -1,0 +1,205 @@
+//! WCAG relative-luminance and contrast enforcement.
+//!
+//! The palette's dark→light adaptation ([`super::adapt`]) is an equality
+//! whitelist: a token that isn't literally listed passes through unchanged.
+//! That is fine when the surface is the one the tokens were tuned for, and
+//! illegible when it isn't — a near-white body token landing on a near-white
+//! terminal background (#4833).
+//!
+//! This module is the enumeration-independent backstop. It works on the pair
+//! that actually matters — *resolved foreground* and *effective surface* — and
+//! lifts any foreground that falls under the floor, whether or not anyone
+//! remembered to add it to a whitelist.
+//!
+//! Everything here is a pure function over colors, so contrast can be asserted
+//! in unit tests without a terminal.
+
+use ratatui::style::Color;
+
+use super::adapt::blend;
+
+/// WCAG 2.x AA contrast floor for body text. Applied to every resolved
+/// foreground we can reason about.
+pub const AA_BODY_CONTRAST: f32 = 4.5;
+
+/// Relative luminance per WCAG 2.x, in `0.0..=1.0`.
+///
+/// Returns `None` for colors whose true RGB we cannot know:
+/// - [`Color::Reset`] — the terminal decides.
+/// - Named ANSI colors and `Indexed(0..=15)` — remapped by the user's terminal
+///   profile, so any RGB we assumed would be a guess.
+///
+/// `Indexed(16..=255)` is resolvable: the 6x6x6 cube and the grayscale ramp are
+/// fixed by the xterm specification, not user-configurable.
+#[must_use]
+pub fn relative_luminance(color: Color) -> Option<f32> {
+    let (r, g, b) = resolvable_rgb(color)?;
+    Some(luminance_rgb(r, g, b))
+}
+
+/// The RGB triple a color is *known* to render as, or `None` when the terminal
+/// owns that decision. See [`relative_luminance`].
+#[must_use]
+pub fn resolvable_rgb(color: Color) -> Option<(u8, u8, u8)> {
+    match color {
+        Color::Rgb(r, g, b) => Some((r, g, b)),
+        Color::Indexed(index) if index >= 16 => Some(indexed_rgb(index)),
+        _ => None,
+    }
+}
+
+fn luminance_rgb(r: u8, g: u8, b: u8) -> f32 {
+    fn channel(value: u8) -> f32 {
+        let c = f32::from(value) / 255.0;
+        if c <= 0.03928 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+/// Contrast ratio between two relative luminances, in `1.0..=21.0`.
+#[must_use]
+pub fn contrast_from_luminance(a: f32, b: f32) -> f32 {
+    let (hi, lo) = if a >= b { (a, b) } else { (b, a) };
+    (hi + 0.05) / (lo + 0.05)
+}
+
+/// WCAG contrast ratio between two colors, or `None` if either side is
+/// terminal-defined (see [`relative_luminance`]).
+#[must_use]
+pub fn contrast_ratio(fg: Color, bg: Color) -> Option<f32> {
+    Some(contrast_from_luminance(
+        relative_luminance(fg)?,
+        relative_luminance(bg)?,
+    ))
+}
+
+/// `true` when the pair is known to clear `min_ratio`. An unknowable pair is
+/// *not* reported as passing — callers use this to decide whether to intervene,
+/// and we only intervene on evidence.
+#[must_use]
+pub fn meets_contrast(fg: Color, bg: Color, min_ratio: f32) -> bool {
+    contrast_ratio(fg, bg).is_some_and(|ratio| ratio >= min_ratio)
+}
+
+/// Lift `fg` until it clears `min_ratio` against `surface`, preserving hue as
+/// far as the floor allows.
+///
+/// Returns `fg` unchanged when:
+/// - the pair already clears the floor,
+/// - either side is terminal-defined (we refuse to rewrite colors whose
+///   rendering the user's terminal profile owns — that is what the `Terminal`
+///   theme is *for*),
+/// - or `fg` is not [`Color::Rgb`], since blending an indexed color would
+///   silently opt it out of the depth-adaptation stage.
+///
+/// Otherwise the color is blended toward whichever pole (black or white) has
+/// more contrast headroom against the surface, by the smallest amount that
+/// satisfies the floor. Blending is monotonic in luminance, so a bisection
+/// finds that minimum. If even the pole cannot reach `min_ratio` — a
+/// mid-luminance surface — the pole is returned as the best available.
+#[must_use]
+pub fn enforce_contrast(fg: Color, surface: Color, min_ratio: f32) -> Color {
+    if !matches!(fg, Color::Rgb(..)) {
+        return fg;
+    }
+    let (Some(fg_luma), Some(bg_luma)) = (relative_luminance(fg), relative_luminance(surface))
+    else {
+        return fg;
+    };
+    if contrast_from_luminance(fg_luma, bg_luma) >= min_ratio {
+        return fg;
+    }
+
+    const BLACK: Color = Color::Rgb(0, 0, 0);
+    const WHITE: Color = Color::Rgb(255, 255, 255);
+    let black_ratio = contrast_from_luminance(0.0, bg_luma);
+    let white_ratio = contrast_from_luminance(1.0, bg_luma);
+    let (pole, pole_ratio) = if white_ratio >= black_ratio {
+        (WHITE, white_ratio)
+    } else {
+        (BLACK, black_ratio)
+    };
+    if pole_ratio < min_ratio {
+        return pole;
+    }
+
+    // Bisect the blend factor: 0.0 keeps `fg`, 1.0 is the pole. Contrast is
+    // monotonically non-decreasing along this path, so the invariant "lo fails,
+    // hi passes" holds and converges on the least-shifted compliant color.
+    let mut lo = 0.0_f32;
+    let mut hi = 1.0_f32;
+    let mut best = pole;
+    for _ in 0..20 {
+        let mid = f32::midpoint(lo, hi);
+        let candidate = blend(pole, fg, mid);
+        if meets_contrast(candidate, surface, min_ratio) {
+            best = candidate;
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+    best
+}
+
+/// Pick the surface a foreground is actually drawn on.
+///
+/// Cells frequently carry [`Color::Reset`] for the background — meaning "let
+/// the terminal show through". In that case the real surface is the terminal's
+/// own background, which is exactly what [`super::detect::TerminalBackground`]
+/// carries.
+///
+/// There is deliberately no theme-surface fallback. The theme surface is what
+/// we *intended* to paint; on a `Reset` cell it is precisely what the user is
+/// not seeing, and #4833 is what happens when you reason against it. With no
+/// painted background and no measurement we return `None` and leave the color
+/// alone — declining to act beats acting on a guess.
+#[must_use]
+pub fn effective_surface(cell_bg: Color, detected_background: Option<Color>) -> Option<Color> {
+    if resolvable_rgb(cell_bg).is_some() {
+        return Some(cell_bg);
+    }
+    detected_background.filter(|color| resolvable_rgb(*color).is_some())
+}
+
+/// Whether a cell's symbol carries text, and therefore needs the body-text
+/// contrast floor.
+///
+/// Box-drawing, block, and geometric-shape glyphs are frame chrome. This
+/// palette uses deliberately quiet borders (`BORDER_COLOR` sits at 1.9:1 on the
+/// dark stage — a design choice, not a defect), and clamping them to a text
+/// floor would rewrite the visual weight of every frame. Blank cells have no
+/// foreground to speak of. #4833 is a body-text bug; the floor stays on text.
+#[must_use]
+pub fn symbol_needs_text_contrast(symbol: &str) -> bool {
+    symbol.chars().any(|ch| {
+        !ch.is_whitespace()
+            && !matches!(
+                ch,
+                // Box Drawing, Block Elements, Geometric Shapes,
+                // Miscellaneous Symbols/Arrows drawing glyphs, Braille.
+                '\u{2500}'..='\u{259F}'
+                | '\u{25A0}'..='\u{25FF}'
+                | '\u{2800}'..='\u{28FF}'
+            )
+    })
+}
+
+/// RGB for an xterm palette index `>= 16` (6x6x6 cube then grayscale ramp).
+fn indexed_rgb(index: u8) -> (u8, u8, u8) {
+    const CUBE_LEVELS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+    if index < 232 {
+        let i = u16::from(index) - 16;
+        let r = CUBE_LEVELS[(i / 36) as usize];
+        let g = CUBE_LEVELS[((i / 6) % 6) as usize];
+        let b = CUBE_LEVELS[(i % 6) as usize];
+        (r, g, b)
+    } else {
+        let level = 8 + 10 * (index - 232);
+        (level, level, level)
+    }
+}

--- a/crates/tui/src/palette/detect.rs
+++ b/crates/tui/src/palette/detect.rs
@@ -1,7 +1,20 @@
 //! Terminal palette-mode and color-depth detection.
+//!
+//! Detection returns *evidence*, not just a verdict: [`TerminalBackground`]
+//! carries the background color we actually learned (when we learned one) and
+//! [`BackgroundSource`] records how. The contrast floor in [`super::contrast`]
+//! needs the color — a mode enum cannot tell you whether text clears 4.5:1 —
+//! and the provenance is what lets us distinguish "measured dark" from
+//! "assumed dark because nothing answered".
 
 #[cfg(target_os = "macos")]
 use std::process::Command;
+use std::sync::OnceLock;
+
+use ratatui::style::Color;
+
+use super::contrast::relative_luminance;
+use super::osc11;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaletteMode {
@@ -11,40 +24,191 @@ pub enum PaletteMode {
     SolarizedLight,
 }
 
+/// How the terminal background was learned. Ordered strongest-first: an
+/// answered OSC 11 query is a measurement, `COLORFGBG` is a hint, macOS
+/// appearance is an inference about the OS rather than the terminal, and
+/// `Unknown` means we are guessing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundSource {
+    /// The terminal answered an OSC 11 query with its background color.
+    Osc11,
+    /// `COLORFGBG` was set. Carries a palette index, not an RGB value.
+    ColorFgBg,
+    /// macOS `AppleInterfaceStyle`. Describes the system, not the terminal —
+    /// a dark-mode Mac can still be running a light-profile terminal.
+    MacOsAppearance,
+    /// No evidence at all. Callers must not treat this as "dark" for anything
+    /// but choosing a default theme.
+    Unknown,
+}
+
+/// What we know about the surface the TUI is drawing onto.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalBackground {
+    mode: PaletteMode,
+    color: Option<Color>,
+    source: BackgroundSource,
+}
+
+impl TerminalBackground {
+    #[must_use]
+    pub const fn new(mode: PaletteMode, color: Option<Color>, source: BackgroundSource) -> Self {
+        Self {
+            mode,
+            color,
+            source,
+        }
+    }
+
+    /// The evidence-free default. Stays [`PaletteMode::Dark`] so terminals we
+    /// cannot measure keep exactly the theme they get today, and carries no
+    /// color so the contrast floor declines to act rather than acting on a
+    /// guess.
+    #[must_use]
+    pub const fn unknown() -> Self {
+        Self::new(PaletteMode::Dark, None, BackgroundSource::Unknown)
+    }
+
+    #[must_use]
+    pub const fn mode(&self) -> PaletteMode {
+        self.mode
+    }
+
+    /// The measured background, or `None` when the source could not supply one
+    /// (`COLORFGBG` indices 0–15, macOS appearance, no evidence).
+    #[must_use]
+    pub const fn color(&self) -> Option<Color> {
+        self.color
+    }
+
+    #[must_use]
+    pub const fn source(&self) -> BackgroundSource {
+        self.source
+    }
+}
+
+/// Luminance at which black text and white text have equal contrast against a
+/// surface. Above it a surface is light; at or below it, dark. Derived from
+/// the WCAG contrast formula: `(L+0.05)/0.05 == 1.05/(L+0.05)`.
+const LIGHT_SURFACE_LUMINANCE: f32 = 0.179_129_5;
+
+/// Classify a background color as light or dark by relative luminance. This is
+/// the only place polarity is decided, so `#FFFFFF` and a pale ivory reach the
+/// same verdict without anyone maintaining a list.
+#[must_use]
+pub fn palette_mode_for_background(color: Color) -> Option<PaletteMode> {
+    let luminance = relative_luminance(color)?;
+    Some(if luminance > LIGHT_SURFACE_LUMINANCE {
+        PaletteMode::Light
+    } else {
+        PaletteMode::Dark
+    })
+}
+
 impl PaletteMode {
     /// Parse `COLORFGBG`, whose last numeric segment is the terminal
     /// background color. Values >= 8 conventionally indicate a light profile.
     #[must_use]
     pub fn from_colorfgbg(value: &str) -> Option<Self> {
-        let bg = value
-            .split(';')
-            .rev()
-            .find_map(|part| part.parse::<u16>().ok())?;
+        let bg = colorfgbg_index(value)?;
         Some(if bg >= 8 { Self::Light } else { Self::Dark })
     }
 
-    /// Detect the active palette mode. `COLORFGBG` wins when present; macOS
-    /// appearance is a fallback for terminals that omit terminal color hints.
-    /// Missing or unparsable values default to dark so existing terminal setups
-    /// keep the tuned theme.
+    /// Detect the active palette mode. See [`terminal_background`] for the
+    /// resolution order; this is the mode-only view of the same evidence.
     #[must_use]
     pub fn detect() -> Self {
-        Self::detect_from_sources(
-            std::env::var("COLORFGBG").ok().as_deref(),
-            detect_macos_palette_mode(),
-        )
+        terminal_background().mode()
     }
+}
 
-    #[must_use]
-    pub(crate) fn detect_from_sources(
-        colorfgbg: Option<&str>,
-        macos_fallback: Option<Self>,
-    ) -> Self {
-        colorfgbg
-            .and_then(Self::from_colorfgbg)
-            .or(macos_fallback)
-            .unwrap_or(Self::Dark)
+/// The background segment of `COLORFGBG` — the last numeric field.
+fn colorfgbg_index(value: &str) -> Option<u16> {
+    value
+        .split(';')
+        .rev()
+        .find_map(|part| part.parse::<u16>().ok())
+}
+
+/// Split `COLORFGBG` into a palette mode and, when the index is resolvable,
+/// the background's actual RGB.
+///
+/// Indices 0–15 are remapped by the user's terminal profile, so we report the
+/// mode without a color rather than inventing one. Indices >= 16 are fixed by
+/// the xterm specification and can be resolved exactly.
+fn colorfgbg_background(value: &str) -> Option<(PaletteMode, Option<Color>)> {
+    let index = colorfgbg_index(value)?;
+    if let Ok(index) = u8::try_from(index)
+        && index >= 16
+        && let Some(mode) = palette_mode_for_background(Color::Indexed(index))
+    {
+        return Some((mode, Some(Color::Indexed(index))));
     }
+    Some((PaletteMode::from_colorfgbg(value)?, None))
+}
+
+/// Combine the available evidence into a single [`TerminalBackground`].
+///
+/// Pure, so every branch is testable without a terminal. Strongest evidence
+/// wins: a measured color beats a palette index, which beats an OS appearance
+/// setting, which beats nothing.
+#[must_use]
+pub fn resolve_terminal_background(
+    osc11_rgb: Option<(u8, u8, u8)>,
+    colorfgbg: Option<&str>,
+    macos_fallback: Option<PaletteMode>,
+) -> TerminalBackground {
+    if let Some((r, g, b)) = osc11_rgb {
+        let color = Color::Rgb(r, g, b);
+        if let Some(mode) = palette_mode_for_background(color) {
+            return TerminalBackground::new(mode, Some(color), BackgroundSource::Osc11);
+        }
+    }
+    if let Some((mode, color)) = colorfgbg.and_then(colorfgbg_background) {
+        return TerminalBackground::new(mode, color, BackgroundSource::ColorFgBg);
+    }
+    if let Some(mode) = macos_fallback {
+        return TerminalBackground::new(mode, None, BackgroundSource::MacOsAppearance);
+    }
+    TerminalBackground::unknown()
+}
+
+static TERMINAL_BACKGROUND: OnceLock<TerminalBackground> = OnceLock::new();
+
+/// The detected terminal background, without querying the terminal.
+///
+/// Returns the probed result once [`probe_terminal_background`] has run;
+/// before that it answers from the environment alone. It deliberately does not
+/// populate the cache, so an early caller cannot lock in an env-only answer
+/// that the probe would have improved.
+#[must_use]
+pub fn terminal_background() -> TerminalBackground {
+    if let Some(background) = TERMINAL_BACKGROUND.get() {
+        return *background;
+    }
+    resolve_terminal_background(
+        None,
+        std::env::var("COLORFGBG").ok().as_deref(),
+        detect_macos_palette_mode(),
+    )
+}
+
+/// Query the terminal for its background and cache the result.
+///
+/// Call this once, from the TUI entry point, after raw mode is enabled and
+/// before the event loop starts — see the caveat on
+/// [`osc11::query_terminal_background`]. Safe to call more than once; only the
+/// first result is kept, so the answer stays stable for the process.
+pub fn probe_terminal_background() -> TerminalBackground {
+    if let Some(background) = TERMINAL_BACKGROUND.get() {
+        return *background;
+    }
+    let background = resolve_terminal_background(
+        osc11::query_terminal_background(osc11::OSC11_QUERY_TIMEOUT),
+        std::env::var("COLORFGBG").ok().as_deref(),
+        detect_macos_palette_mode(),
+    );
+    *TERMINAL_BACKGROUND.get_or_init(|| background)
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/tui/src/palette/mod.rs
+++ b/crates/tui/src/palette/mod.rs
@@ -10,7 +10,9 @@
 //!    delegate to the current Whale palette constants.
 
 mod adapt;
+mod contrast;
 mod detect;
+mod osc11;
 mod themes;
 mod tokens;
 mod user_theme;
@@ -21,7 +23,11 @@ mod tests;
 #[allow(unused_imports)]
 pub use adapt::*;
 #[allow(unused_imports)]
+pub use contrast::*;
+#[allow(unused_imports)]
 pub use detect::*;
+#[allow(unused_imports)]
+pub use osc11::*;
 #[allow(unused_imports)]
 pub use themes::*;
 pub use tokens::*;

--- a/crates/tui/src/palette/osc11.rs
+++ b/crates/tui/src/palette/osc11.rs
@@ -1,0 +1,188 @@
+//! OSC 11 terminal-background query.
+//!
+//! `COLORFGBG` is the only background signal the palette had before this
+//! module, and most modern terminals never set it — Windows Terminal, conhost,
+//! VS Code, GNOME Terminal, Alacritty and Ghostty all omit it. Without it a
+//! white terminal was indistinguishable from a black one, so detection fell
+//! back to `Dark` and painted dark-tuned text onto a light surface (#4833).
+//!
+//! OSC 11 (`ESC ] 11 ; ? BEL`) asks the terminal for its actual background
+//! color and is answered by every terminal listed above. The reply is an
+//! `xterm`-style color spec, e.g.
+//!
+//! ```text
+//! ESC ] 11 ; rgb:ffff/ffff/ffff ESC \
+//! ```
+//!
+//! The parse is a pure function so it can be tested without a terminal; the
+//! query itself is Unix-only, bounded by a short deadline, and never runs when
+//! stdin/stdout are not both TTYs.
+
+/// Upper bound on how long startup will wait for a terminal that never
+/// answers. A terminal that supports OSC 11 replies in well under a
+/// millisecond; anything past this is a terminal that will never reply, and
+/// startup latency matters more than the answer.
+pub const OSC11_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(120);
+
+/// The query sequence. `ESC \` (ST) is the terminator we prefer in the reply,
+/// but terminals may answer with BEL instead, so the reader accepts both.
+const OSC11_QUERY: &[u8] = b"\x1b]11;?\x1b\\";
+
+/// Extract an RGB triple from an OSC 11 reply body.
+///
+/// Accepts the shapes terminals actually emit:
+/// - `rgb:RRRR/GGGG/BBBB` (xterm, 1–4 hex digits per channel, any width)
+/// - `#RRGGBB` / `#RGB` / `#RRRRGGGGBBBB`
+///
+/// Leading `ESC ] 11 ;` and the trailing BEL/ST are optional — anything
+/// outside the color spec is ignored, so a reply that arrived interleaved with
+/// other terminal chatter still parses.
+///
+/// Returns `None` when no color spec is present or a channel is malformed.
+/// Channels wider than 8 bits are scaled down, not truncated, so `ffff` is
+/// `255` rather than `0`.
+#[must_use]
+pub fn parse_osc11_reply(reply: &str) -> Option<(u8, u8, u8)> {
+    if let Some(idx) = reply.find("rgb:") {
+        return parse_slash_separated(&reply[idx + 4..]);
+    }
+    if let Some(idx) = reply.find('#') {
+        return parse_hash_hex(&reply[idx + 1..]);
+    }
+    None
+}
+
+fn parse_slash_separated(spec: &str) -> Option<(u8, u8, u8)> {
+    let spec: String = spec
+        .chars()
+        .take_while(|c| c.is_ascii_hexdigit() || *c == '/')
+        .collect();
+    let mut parts = spec.split('/');
+    let r = scale_hex_channel(parts.next()?)?;
+    let g = scale_hex_channel(parts.next()?)?;
+    let b = scale_hex_channel(parts.next()?)?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((r, g, b))
+}
+
+fn parse_hash_hex(spec: &str) -> Option<(u8, u8, u8)> {
+    let digits: String = spec.chars().take_while(char::is_ascii_hexdigit).collect();
+    if !digits.len().is_multiple_of(3) || digits.is_empty() || digits.len() > 12 {
+        return None;
+    }
+    let width = digits.len() / 3;
+    let r = scale_hex_channel(&digits[..width])?;
+    let g = scale_hex_channel(&digits[width..width * 2])?;
+    let b = scale_hex_channel(&digits[width * 2..])?;
+    Some((r, g, b))
+}
+
+/// Normalize a hex channel of arbitrary width (1–4 digits) to 8 bits by
+/// rescaling across the channel's full range: `f` → `255`, `ffff` → `255`,
+/// `8000` → `128`.
+fn scale_hex_channel(digits: &str) -> Option<u8> {
+    if digits.is_empty() || digits.len() > 4 || !digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let value = u32::from_str_radix(digits, 16).ok()?;
+    let max = (1u32 << (4 * digits.len() as u32)) - 1;
+    Some(((value * 255 + max / 2) / max) as u8)
+}
+
+/// Ask the terminal for its background color, giving up after `timeout`.
+///
+/// Returns `None` — never blocks past `timeout`, never panics — when:
+/// - stdin and stdout are not both TTYs (piped output, CI, `codewhale < file`),
+/// - the platform has no supported query path (non-Unix; see the module docs),
+/// - the terminal does not answer, or answers with something unparsable.
+///
+/// # Caveat
+///
+/// This reads from stdin, so it must only be called while the terminal is in
+/// raw mode and before the event loop starts. Bytes that arrive during the
+/// window and are not part of the reply are discarded — at startup that window
+/// is sub-millisecond on any terminal that answers at all.
+#[must_use]
+pub fn query_terminal_background(timeout: std::time::Duration) -> Option<(u8, u8, u8)> {
+    query_impl(timeout)
+}
+
+#[cfg(unix)]
+fn query_impl(timeout: std::time::Duration) -> Option<(u8, u8, u8)> {
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let in_fd = stdin.as_raw_fd();
+    let out_fd = stdout.as_raw_fd();
+
+    // SAFETY: `isatty` only inspects the descriptor; both fds are owned by the
+    // std handles held above for the duration of the call.
+    let both_tty = unsafe { libc::isatty(in_fd) == 1 && libc::isatty(out_fd) == 1 };
+    if !both_tty {
+        return None;
+    }
+
+    {
+        let mut out = stdout.lock();
+        out.write_all(OSC11_QUERY).ok()?;
+        out.flush().ok()?;
+    }
+
+    let deadline = Instant::now() + timeout;
+    let mut reply = Vec::with_capacity(32);
+    let mut stdin = stdin.lock();
+    let mut byte = [0u8; 1];
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        if !wait_readable(in_fd, remaining) {
+            return None;
+        }
+        match stdin.read(&mut byte) {
+            Ok(1) => {}
+            _ => return None,
+        }
+        // BEL, or the ESC of a `ESC \` string terminator, ends the reply.
+        if byte[0] == 0x07 || (byte[0] == 0x1b && !reply.is_empty()) {
+            break;
+        }
+        reply.push(byte[0]);
+        if reply.len() >= 128 {
+            return None;
+        }
+    }
+
+    parse_osc11_reply(&String::from_utf8_lossy(&reply))
+}
+
+/// Block until `fd` has data or `timeout` elapses. `true` means readable.
+#[cfg(unix)]
+fn wait_readable(fd: std::os::fd::RawFd, timeout: std::time::Duration) -> bool {
+    let mut pollfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let millis = i32::try_from(timeout.as_millis())
+        .unwrap_or(i32::MAX)
+        .max(1);
+    // SAFETY: `pollfd` is a live, correctly-initialized single-element array
+    // and the count matches.
+    let rc = unsafe { libc::poll(std::ptr::addr_of_mut!(pollfd), 1, millis) };
+    rc > 0 && (pollfd.revents & libc::POLLIN) != 0
+}
+
+/// Non-Unix platforms have no portable way to read a raw OSC reply back off
+/// the console handle, so detection falls through to the environment-based
+/// sources. Callers treat `None` as "no evidence", never as "dark".
+#[cfg(not(unix))]
+fn query_impl(_timeout: std::time::Duration) -> Option<(u8, u8, u8)> {
+    None
+}

--- a/crates/tui/src/palette/osc11.rs
+++ b/crates/tui/src/palette/osc11.rs
@@ -26,6 +26,9 @@ pub const OSC11_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_m
 
 /// The query sequence. `ESC \` (ST) is the terminator we prefer in the reply,
 /// but terminals may answer with BEL instead, so the reader accepts both.
+///
+/// Only the Unix query path writes it — see the note on [`parse_osc11_reply`].
+#[cfg_attr(not(unix), allow(dead_code))]
 const OSC11_QUERY: &[u8] = b"\x1b]11;?\x1b\\";
 
 /// Extract an RGB triple from an OSC 11 reply body.

--- a/crates/tui/src/palette/osc11.rs
+++ b/crates/tui/src/palette/osc11.rs
@@ -41,6 +41,13 @@ const OSC11_QUERY: &[u8] = b"\x1b]11;?\x1b\\";
 /// Returns `None` when no color spec is present or a channel is malformed.
 /// Channels wider than 8 bits are scaled down, not truncated, so `ffff` is
 /// `255` rather than `0`.
+// The parser is deliberately cross-platform while the query is Unix-only:
+// there is no portable way to read a raw OSC reply off a Windows console
+// handle yet, so on Windows nothing calls these. They are kept (rather than
+// cfg'd out) because they are pure, fully tested on every platform, and are
+// exactly what a future Windows read path would need — but that leaves them
+// dead in a non-test Windows build, which `-D warnings` rejects.
+#[cfg_attr(not(unix), allow(dead_code))]
 #[must_use]
 pub fn parse_osc11_reply(reply: &str) -> Option<(u8, u8, u8)> {
     if let Some(idx) = reply.find("rgb:") {
@@ -52,6 +59,7 @@ pub fn parse_osc11_reply(reply: &str) -> Option<(u8, u8, u8)> {
     None
 }
 
+#[cfg_attr(not(unix), allow(dead_code))]
 fn parse_slash_separated(spec: &str) -> Option<(u8, u8, u8)> {
     let spec: String = spec
         .chars()
@@ -67,6 +75,7 @@ fn parse_slash_separated(spec: &str) -> Option<(u8, u8, u8)> {
     Some((r, g, b))
 }
 
+#[cfg_attr(not(unix), allow(dead_code))]
 fn parse_hash_hex(spec: &str) -> Option<(u8, u8, u8)> {
     let digits: String = spec.chars().take_while(char::is_ascii_hexdigit).collect();
     if !digits.len().is_multiple_of(3) || digits.is_empty() || digits.len() > 12 {
@@ -82,6 +91,7 @@ fn parse_hash_hex(spec: &str) -> Option<(u8, u8, u8)> {
 /// Normalize a hex channel of arbitrary width (1–4 digits) to 8 bits by
 /// rescaling across the channel's full range: `f` → `255`, `ffff` → `255`,
 /// `8000` → `128`.
+#[cfg_attr(not(unix), allow(dead_code))]
 fn scale_hex_channel(digits: &str) -> Option<u8> {
     if digits.is_empty() || digits.len() > 4 || !digits.chars().all(|c| c.is_ascii_hexdigit()) {
         return None;

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -3,7 +3,10 @@ use super::adapt::{
     adapt_fg_for_depth, adapt_fg_for_palette_mode, adapt_fg_for_theme, blend, luma, nearest_ansi16,
     pulse_brightness, reasoning_surface_tint, rgb_to_ansi256,
 };
-use super::detect::{PaletteMode, palette_mode_from_apple_interface_style};
+use super::detect::{
+    BackgroundSource, PaletteMode, palette_mode_for_background,
+    palette_mode_from_apple_interface_style, resolve_terminal_background,
+};
 use super::themes::{
     CATPPUCCIN_MOCHA_UI_THEME, GRAYSCALE_UI_THEME, LIGHT_UI_THEME, MATRIX_UI_THEME,
     SELECTABLE_THEMES, SOLARIZED_LIGHT_UI_THEME, TERMINAL_UI_THEME, TOKYO_NIGHT_UI_THEME, ThemeId,
@@ -42,11 +45,11 @@ fn palette_mode_parses_colorfgbg_background_slot() {
 #[test]
 fn palette_mode_detect_prefers_colorfgbg_over_macos_fallback() {
     assert_eq!(
-        PaletteMode::detect_from_sources(Some("0;15"), Some(PaletteMode::Dark)),
+        resolve_terminal_background(None, Some("0;15"), Some(PaletteMode::Dark)).mode(),
         PaletteMode::Light
     );
     assert_eq!(
-        PaletteMode::detect_from_sources(Some("15;0"), Some(PaletteMode::Light)),
+        resolve_terminal_background(None, Some("15;0"), Some(PaletteMode::Light)).mode(),
         PaletteMode::Dark
     );
 }
@@ -54,15 +57,15 @@ fn palette_mode_detect_prefers_colorfgbg_over_macos_fallback() {
 #[test]
 fn palette_mode_detect_uses_macos_fallback_when_colorfgbg_missing_or_invalid() {
     assert_eq!(
-        PaletteMode::detect_from_sources(None, Some(PaletteMode::Light)),
+        resolve_terminal_background(None, None, Some(PaletteMode::Light)).mode(),
         PaletteMode::Light
     );
     assert_eq!(
-        PaletteMode::detect_from_sources(Some("not-a-color"), Some(PaletteMode::Light)),
+        resolve_terminal_background(None, Some("not-a-color"), Some(PaletteMode::Light)).mode(),
         PaletteMode::Light
     );
     assert_eq!(
-        PaletteMode::detect_from_sources(None, None),
+        resolve_terminal_background(None, None, None).mode(),
         PaletteMode::Dark
     );
 }
@@ -608,4 +611,350 @@ fn color_depth_detect_is_safe_without_env() {
     // exercise the path so a panic would surface.
     let _ = ColorDepth::detect();
     let _ = adapt_color(WHALE_BG, ColorDepth::detect());
+}
+
+// === #4833: contrast floor ===
+
+use super::contrast::{
+    AA_BODY_CONTRAST, contrast_ratio, effective_surface, enforce_contrast, meets_contrast,
+    relative_luminance, symbol_needs_text_contrast,
+};
+use super::detect::TerminalBackground;
+use super::osc11::parse_osc11_reply;
+use super::tokens::{
+    MODE_OPERATE, STATUS_SUCCESS, TEXT_MUTED, TEXT_SECONDARY, TEXT_SOFT, USER_BODY,
+};
+
+const WHITE: Color = Color::Rgb(0xFF, 0xFF, 0xFF);
+const BLACK: Color = Color::Rgb(0x00, 0x00, 0x00);
+
+/// Every dark-palette token that renders *text*. Frame chrome (`BORDER_COLOR`)
+/// is deliberately absent — see `symbol_needs_text_contrast`.
+const DARK_TEXT_TOKENS: &[Color] = &[
+    TEXT_BODY,
+    TEXT_SOFT,
+    TEXT_SECONDARY,
+    TEXT_MUTED,
+    TEXT_HINT,
+    TEXT_REASONING,
+    TEXT_TOOL_OUTPUT,
+    USER_BODY,
+    WHALE_ACTION,
+    WHALE_INFO,
+    WHALE_LIVE,
+    WHALE_HUMAN,
+    WHALE_ERROR,
+    WHALE_ACCENT_PRIMARY,
+    MODE_AGENT,
+    MODE_PLAN,
+    MODE_OPERATE,
+    MODE_YOLO,
+    STATUS_ERROR,
+    STATUS_WARNING,
+    STATUS_SUCCESS,
+    DIFF_ADDED,
+];
+
+fn approx(actual: f32, expected: f32, tolerance: f32) {
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "expected {expected} ± {tolerance}, got {actual}"
+    );
+}
+
+#[test]
+fn relative_luminance_matches_wcag_reference_values() {
+    approx(relative_luminance(WHITE).unwrap(), 1.0, 1e-4);
+    approx(relative_luminance(BLACK).unwrap(), 0.0, 1e-4);
+    // WCAG worked example: #808080 has relative luminance 0.2159.
+    approx(
+        relative_luminance(Color::Rgb(0x80, 0x80, 0x80)).unwrap(),
+        0.2159,
+        1e-3,
+    );
+    // Terminal-defined colors have no knowable RGB, so no luminance.
+    assert_eq!(relative_luminance(Color::Reset), None);
+    assert_eq!(relative_luminance(Color::White), None);
+    assert_eq!(relative_luminance(Color::Indexed(7)), None);
+    // The xterm cube and gray ramp are fixed by spec, so they are knowable.
+    assert!(relative_luminance(Color::Indexed(231)).is_some());
+}
+
+#[test]
+fn contrast_ratio_matches_known_pairs() {
+    approx(contrast_ratio(BLACK, WHITE).unwrap(), 21.0, 1e-3);
+    approx(contrast_ratio(WHITE, WHITE).unwrap(), 1.0, 1e-4);
+    // #767676 on white is the canonical "smallest AA-passing gray".
+    approx(
+        contrast_ratio(Color::Rgb(0x76, 0x76, 0x76), WHITE).unwrap(),
+        4.54,
+        0.01,
+    );
+    // Symmetric in its arguments.
+    assert_eq!(
+        contrast_ratio(TEXT_BODY, WHALE_BG),
+        contrast_ratio(WHALE_BG, TEXT_BODY)
+    );
+    // An unknowable side yields no ratio, and `meets_contrast` refuses to call
+    // that a pass.
+    assert_eq!(contrast_ratio(TEXT_BODY, Color::Reset), None);
+    assert!(!meets_contrast(TEXT_BODY, Color::Reset, AA_BODY_CONTRAST));
+}
+
+#[test]
+fn light_surface_lifts_body_text_that_no_whitelist_adapted() {
+    // The #4833 shape: dark-tuned ivory body text reaching a near-white
+    // terminal with no light adaptation applied, because detection said Dark.
+    let before = contrast_ratio(TEXT_BODY, WHITE).unwrap();
+    assert!(
+        before < AA_BODY_CONTRAST,
+        "precondition: unadapted body text is illegible on white ({before})"
+    );
+
+    let lifted = enforce_contrast(TEXT_BODY, WHITE, AA_BODY_CONTRAST);
+    let after = contrast_ratio(lifted, WHITE).unwrap();
+    assert!(
+        after >= AA_BODY_CONTRAST,
+        "body text must clear AA on a light surface, got {after}"
+    );
+
+    // The same holds for the reporter's paler surface and for the secondary
+    // tiers that collapsed alongside body text.
+    let reported_surface = Color::Rgb(0xF7, 0xF7, 0xF5);
+    for token in [TEXT_BODY, TEXT_SOFT, TEXT_SECONDARY, TEXT_HINT] {
+        let lifted = enforce_contrast(token, reported_surface, AA_BODY_CONTRAST);
+        let ratio = contrast_ratio(lifted, reported_surface).unwrap();
+        assert!(
+            ratio >= AA_BODY_CONTRAST,
+            "{token:?} still below floor on light surface: {ratio}"
+        );
+    }
+}
+
+#[test]
+fn enforce_contrast_lifts_by_the_smallest_amount_that_clears_the_floor() {
+    let lifted = enforce_contrast(TEXT_BODY, WHITE, AA_BODY_CONTRAST);
+    let ratio = contrast_ratio(lifted, WHITE).unwrap();
+    assert!(
+        (AA_BODY_CONTRAST..AA_BODY_CONTRAST + 0.1).contains(&ratio),
+        "expected a minimal lift to ~{AA_BODY_CONTRAST}, got {ratio}"
+    );
+    // Already-compliant colors are returned byte-identical.
+    assert_eq!(
+        enforce_contrast(LIGHT_TEXT_BODY, WHITE, AA_BODY_CONTRAST),
+        LIGHT_TEXT_BODY
+    );
+}
+
+#[test]
+fn dark_surface_leaves_every_text_token_untouched() {
+    // The no-regression guarantee for today's users: on the surfaces a dark
+    // terminal actually presents, no shipped text token is rewritten.
+    for surface in [
+        WHALE_BG,
+        WHALE_PANEL,
+        BLACK,
+        Color::Rgb(0x1E, 0x1E, 0x1E), // VS Code dark
+        Color::Rgb(0x0C, 0x0C, 0x0C), // Windows Terminal default
+    ] {
+        for token in DARK_TEXT_TOKENS {
+            assert_eq!(
+                enforce_contrast(*token, surface, AA_BODY_CONTRAST),
+                *token,
+                "{token:?} was rewritten on dark surface {surface:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn light_theme_tokens_already_clear_the_floor_on_their_own_surfaces() {
+    for surface in [LIGHT_SURFACE, LIGHT_PANEL, LIGHT_ELEVATED] {
+        for token in [
+            LIGHT_TEXT_BODY,
+            LIGHT_TEXT_HINT,
+            LIGHT_ACTION,
+            LIGHT_LIVE,
+            LIGHT_HUMAN,
+            LIGHT_WARNING,
+            LIGHT_DANGER,
+            LIGHT_SUCCESS_FG,
+        ] {
+            let ratio = contrast_ratio(token, surface).unwrap();
+            assert!(
+                ratio >= AA_BODY_CONTRAST,
+                "{token:?} on {surface:?} is {ratio}, below the floor"
+            );
+            assert_eq!(enforce_contrast(token, surface, AA_BODY_CONTRAST), token);
+        }
+    }
+}
+
+#[test]
+fn enforce_contrast_declines_when_it_cannot_know_the_colors() {
+    // Named/indexed colors are remapped by the user's terminal profile, and
+    // `Reset` is the terminal's own choice. Rewriting either would be a guess.
+    assert_eq!(
+        enforce_contrast(Color::White, WHITE, AA_BODY_CONTRAST),
+        Color::White
+    );
+    assert_eq!(
+        enforce_contrast(Color::Indexed(250), WHITE, AA_BODY_CONTRAST),
+        Color::Indexed(250)
+    );
+    assert_eq!(
+        enforce_contrast(TEXT_BODY, Color::Reset, AA_BODY_CONTRAST),
+        TEXT_BODY
+    );
+    // 4.5:1 is reachable from *every* surface — the worst case is the
+    // luminance where black and white tie, and even there the better pole
+    // clears 4.58:1. So the floor never silently gives up.
+    for gray in (0u8..=255).step_by(5) {
+        let surface = Color::Rgb(gray, gray, gray);
+        let lifted = enforce_contrast(TEXT_BODY, surface, AA_BODY_CONTRAST);
+        let ratio = contrast_ratio(lifted, surface).unwrap();
+        assert!(
+            ratio >= AA_BODY_CONTRAST,
+            "gray {gray:#04x} left body text at {ratio}:1"
+        );
+    }
+
+    // An unreachable floor (AAA on a mid-gray) returns the better pole rather
+    // than pretending it succeeded.
+    let mid = Color::Rgb(0x80, 0x80, 0x80);
+    assert_eq!(enforce_contrast(TEXT_BODY, mid, 7.0), BLACK);
+}
+
+#[test]
+fn effective_surface_prefers_painted_background_then_measurement() {
+    // A painted cell knows its own surface.
+    assert_eq!(
+        effective_surface(WHALE_PANEL, Some(WHITE)),
+        Some(WHALE_PANEL)
+    );
+    // An unpainted cell falls through to what detection measured.
+    assert_eq!(effective_surface(Color::Reset, Some(WHITE)), Some(WHITE));
+    // With no measurement there is no surface — the floor stands down.
+    assert_eq!(effective_surface(Color::Reset, None), None);
+    // A measurement we cannot resolve is not a measurement.
+    assert_eq!(effective_surface(Color::Reset, Some(Color::Reset)), None);
+}
+
+#[test]
+fn text_contrast_floor_applies_to_glyphs_not_frame_chrome() {
+    assert!(symbol_needs_text_contrast("a"));
+    assert!(symbol_needs_text_contrast("字"));
+    assert!(symbol_needs_text_contrast("→"));
+    assert!(!symbol_needs_text_contrast(" "));
+    assert!(!symbol_needs_text_contrast(""));
+    assert!(!symbol_needs_text_contrast("─"));
+    assert!(!symbol_needs_text_contrast("│"));
+    assert!(!symbol_needs_text_contrast("█"));
+    assert!(!symbol_needs_text_contrast("▏"));
+    assert!(!symbol_needs_text_contrast("●"));
+}
+
+#[test]
+fn background_luminance_decides_polarity_without_a_color_list() {
+    assert_eq!(palette_mode_for_background(WHITE), Some(PaletteMode::Light));
+    assert_eq!(palette_mode_for_background(BLACK), Some(PaletteMode::Dark));
+    assert_eq!(
+        palette_mode_for_background(LIGHT_SURFACE),
+        Some(PaletteMode::Light)
+    );
+    assert_eq!(
+        palette_mode_for_background(SOLARIZED_SURFACE),
+        Some(PaletteMode::Light)
+    );
+    assert_eq!(
+        palette_mode_for_background(WHALE_BG),
+        Some(PaletteMode::Dark)
+    );
+    assert_eq!(
+        palette_mode_for_background(Color::Rgb(0x28, 0x2C, 0x34)),
+        Some(PaletteMode::Dark)
+    );
+    assert_eq!(palette_mode_for_background(Color::Reset), None);
+}
+
+#[test]
+fn unknown_background_keeps_the_dark_default_and_offers_no_surface() {
+    let unknown = TerminalBackground::unknown();
+    assert_eq!(unknown.mode(), PaletteMode::Dark);
+    assert_eq!(unknown.color(), None);
+    assert_eq!(unknown.source(), BackgroundSource::Unknown);
+    // This is the #4833 trigger environment: a terminal that sets no
+    // COLORFGBG and is not macOS. Detection still answers Dark — but it says
+    // so with `Unknown` provenance and no color, so nothing downstream
+    // mistakes the guess for a measurement.
+    let resolved = resolve_terminal_background(None, None, None);
+    assert_eq!(resolved, unknown);
+    assert_eq!(effective_surface(Color::Reset, resolved.color()), None);
+}
+
+#[test]
+fn measured_background_outranks_env_hints_and_records_provenance() {
+    // A white terminal that also exports a dark-looking COLORFGBG: the
+    // measurement wins, and it carries the color the floor needs.
+    let measured = resolve_terminal_background(Some((0xFF, 0xFF, 0xFF)), Some("15;0"), None);
+    assert_eq!(measured.mode(), PaletteMode::Light);
+    assert_eq!(measured.color(), Some(WHITE));
+    assert_eq!(measured.source(), BackgroundSource::Osc11);
+
+    // COLORFGBG with a resolvable xterm index yields a real color too.
+    let indexed = resolve_terminal_background(None, Some("0;231"), None);
+    assert_eq!(indexed.mode(), PaletteMode::Light);
+    assert_eq!(indexed.color(), Some(Color::Indexed(231)));
+    assert_eq!(indexed.source(), BackgroundSource::ColorFgBg);
+
+    // Indices 0..=15 are terminal-profile defined: mode only, no color.
+    let ansi = resolve_terminal_background(None, Some("0;15"), None);
+    assert_eq!(ansi.mode(), PaletteMode::Light);
+    assert_eq!(ansi.color(), None);
+    assert_eq!(ansi.source(), BackgroundSource::ColorFgBg);
+
+    // macOS appearance describes the OS, not the terminal — no color.
+    let macos = resolve_terminal_background(None, None, Some(PaletteMode::Light));
+    assert_eq!(macos.mode(), PaletteMode::Light);
+    assert_eq!(macos.color(), None);
+    assert_eq!(macos.source(), BackgroundSource::MacOsAppearance);
+}
+
+#[test]
+fn osc11_replies_parse_across_the_shapes_terminals_emit() {
+    assert_eq!(
+        parse_osc11_reply("\u{1b}]11;rgb:ffff/ffff/ffff"),
+        Some((255, 255, 255))
+    );
+    assert_eq!(
+        parse_osc11_reply("]11;rgb:0000/0000/0000\u{7}"),
+        Some((0, 0, 0))
+    );
+    // 8-bit channels, and a mid value that must scale rather than truncate.
+    assert_eq!(parse_osc11_reply("rgb:1e/1e/1e"), Some((30, 30, 30)));
+    assert_eq!(
+        parse_osc11_reply("rgb:8000/8000/8000"),
+        Some((128, 128, 128))
+    );
+    assert_eq!(parse_osc11_reply("rgb:f/f/f"), Some((255, 255, 255)));
+    // Hash forms.
+    assert_eq!(parse_osc11_reply("]11;#282c34"), Some((0x28, 0x2C, 0x34)));
+    assert_eq!(parse_osc11_reply("#fff"), Some((255, 255, 255)));
+    // Anything we cannot read is `None`, never a fabricated color.
+    assert_eq!(parse_osc11_reply(""), None);
+    assert_eq!(parse_osc11_reply("\u{1b}]11;"), None);
+    assert_eq!(parse_osc11_reply("rgb:ff/ff"), None);
+    assert_eq!(parse_osc11_reply("rgb:ff/ff/ff/ff"), None);
+    assert_eq!(parse_osc11_reply("rgb:zz/zz/zz"), None);
+    assert_eq!(parse_osc11_reply("#ff00"), None);
+}
+
+#[test]
+fn measured_light_background_selects_the_light_theme_end_to_end() {
+    // Detection → mode → theme: an OSC 11 answer of white must reach the
+    // light UiTheme, which is what actually repaints the frame.
+    let measured = resolve_terminal_background(Some((0xFA, 0xFA, 0xFA)), None, None);
+    assert_eq!(UiTheme::for_mode(measured.mode()), LIGHT_UI_THEME);
+    let dark = resolve_terminal_background(Some((0x1E, 0x1E, 0x1E)), None, None);
+    assert_eq!(UiTheme::for_mode(dark.mode()), UI_THEME);
 }

--- a/crates/tui/src/tui/color_compat.rs
+++ b/crates/tui/src/tui/color_compat.rs
@@ -51,6 +51,12 @@ pub(crate) struct ColorCompatBackend<W: Write> {
     terminal_size: Option<Size>,
     render_debug: Option<RenderDebugLog>,
     ascii_safe: bool,
+    /// The terminal's own background, when detection measured one
+    /// (`BackgroundSource::Osc11` or a resolvable `COLORFGBG` index). This is
+    /// the surface a `Color::Reset` cell is really drawn on, so it is what the
+    /// contrast floor reasons against. `None` means "no evidence" and disables
+    /// the floor for unpainted cells rather than guessing.
+    detected_background: Option<ratatui::style::Color>,
 }
 
 impl<W: Write> ColorCompatBackend<W> {
@@ -69,7 +75,13 @@ impl<W: Write> ColorCompatBackend<W> {
             terminal_size: None,
             render_debug: RenderDebugLog::from_env(),
             ascii_safe: ascii_safe_enabled(),
+            detected_background: None,
         }
+    }
+
+    /// Record the measured terminal background. See the field docs.
+    pub(crate) fn set_detected_background(&mut self, color: Option<ratatui::style::Color>) {
+        self.detected_background = color;
     }
 
     pub(crate) fn force_size(&mut self, size: Size) {
@@ -120,6 +132,7 @@ impl<W: Write> Backend for ColorCompatBackend<W> {
                     self.palette_mode,
                     self.theme_id,
                     &self.active_ui_theme,
+                    self.detected_background,
                 );
                 if self.ascii_safe {
                     adapt_cell_symbol_for_ascii(&mut cell);
@@ -346,12 +359,42 @@ fn render_debug_line(
     line
 }
 
+/// Apply the WCAG contrast floor to a cell that is about to be drawn.
+///
+/// This runs *after* the palette-mode remap and *before* depth downsampling,
+/// because the floor has to reason about the color the user will actually see
+/// while it is still full-precision RGB.
+///
+/// Two guards keep the blast radius at exactly the #4833 failure:
+///
+/// - Presets that own their own palette (`theme_remap_active`: Terminal,
+///   Catppuccin, Matrix, …) are exempt. Their authors tuned those pairs, some
+///   deliberately below 4.5:1, and a user who typed `/theme matrix` asked for
+///   that. The floor guards the auto-detected default path.
+/// - Only text cells are clamped; frame chrome keeps its intended weight.
+///   See [`palette::symbol_needs_text_contrast`].
+fn enforce_cell_contrast(
+    cell: &mut Cell,
+    theme_id: ThemeId,
+    detected_background: Option<ratatui::style::Color>,
+) {
+    if palette::theme_remap_active(theme_id) || !palette::symbol_needs_text_contrast(cell.symbol())
+    {
+        return;
+    }
+    let Some(surface) = palette::effective_surface(cell.bg, detected_background) else {
+        return;
+    };
+    cell.fg = palette::enforce_contrast(cell.fg, surface, palette::AA_BODY_CONTRAST);
+}
+
 fn adapt_cell_colors(
     cell: &mut Cell,
     depth: ColorDepth,
     palette_mode: PaletteMode,
     theme_id: ThemeId,
     ui_theme: &UiTheme,
+    detected_background: Option<ratatui::style::Color>,
 ) {
     let source_fg = cell.fg;
     // Stage 1: community-theme remap (dark palette → preset slots). No-op
@@ -365,6 +408,12 @@ fn adapt_cell_colors(
     let original_bg = cell.bg;
     cell.fg = palette::adapt_fg_for_palette_mode(cell.fg, original_bg, palette_mode);
     cell.bg = palette::adapt_bg_for_palette_mode(cell.bg, palette_mode);
+    // Stage 2.5: contrast floor. Stages 1 and 2 are equality whitelists — a
+    // token nobody listed reaches here unadapted, which is exactly how
+    // near-white body text ends up on a near-white terminal (#4833). This
+    // stage is membership-independent: it looks at the pair that will be
+    // rendered and lifts it if the numbers fail.
+    enforce_cell_contrast(cell, theme_id, detected_background);
     // Stage 3: depth (truecolor / 256 / 16) downsampling.
     cell.fg = palette::adapt_fg_for_depth(source_fg, cell.fg, depth, ui_theme);
     cell.bg = palette::adapt_bg(cell.bg, depth);
@@ -432,6 +481,7 @@ mod tests {
             PaletteMode::Dark,
             ThemeId::System,
             &palette::UI_THEME,
+            None,
         );
 
         assert!(matches!(cell.fg, Color::Indexed(_)));
@@ -450,6 +500,7 @@ mod tests {
             PaletteMode::Dark,
             ThemeId::System,
             &palette::UI_THEME,
+            None,
         );
 
         assert_eq!(cell.fg, Color::Rgb(53, 120, 229));
@@ -505,6 +556,7 @@ mod tests {
             PaletteMode::Light,
             ThemeId::WhaleLight,
             &palette::LIGHT_UI_THEME,
+            None,
         );
 
         assert_eq!(cell.fg, palette::LIGHT_TEXT_BODY);
@@ -523,6 +575,7 @@ mod tests {
             PaletteMode::Grayscale,
             ThemeId::Grayscale,
             &palette::GRAYSCALE_UI_THEME,
+            None,
         );
 
         assert_eq!(cell.fg, palette::GRAYSCALE_TEXT_SOFT);
@@ -544,6 +597,7 @@ mod tests {
             PaletteMode::Dark,
             ThemeId::TokyoNight,
             &active,
+            None,
         );
 
         assert_eq!(cell.bg, Color::Rgb(0, 0, 0));
@@ -569,6 +623,7 @@ mod tests {
                     theme.mode,
                     theme_id,
                     &theme,
+                    None,
                 );
                 assert_eq!(
                     cell.fg,
@@ -588,7 +643,7 @@ mod tests {
     ) -> Color {
         let mut cell = Cell::default();
         cell.set_fg(source);
-        adapt_cell_colors(&mut cell, depth, theme.mode, theme_id, theme);
+        adapt_cell_colors(&mut cell, depth, theme.mode, theme_id, theme, None);
         cell.fg
     }
 
@@ -1042,6 +1097,149 @@ mod tests {
         assert_eq!(
             linked_visible, baseline_visible,
             "OSC 8 insertion must not move or alter any rendered cell"
+        );
+    }
+
+    /// Render one cell the way `draw()` does and hand back the foreground.
+    fn cell_fg_after_adaptation(
+        symbol: &str,
+        fg: Color,
+        bg: Color,
+        palette_mode: PaletteMode,
+        theme_id: ThemeId,
+        detected_background: Option<Color>,
+    ) -> Color {
+        let mut cell = Cell::default();
+        cell.set_symbol(symbol).set_fg(fg).set_bg(bg);
+        adapt_cell_colors(
+            &mut cell,
+            ColorDepth::TrueColor,
+            palette_mode,
+            theme_id,
+            &theme_id.ui_theme(),
+            detected_background,
+        );
+        cell.fg
+    }
+
+    /// #4833. A white terminal that reports no `COLORFGBG` was detected as
+    /// Dark, so the light whitelist never ran and ivory body text landed on a
+    /// near-white surface. With the background measured, the contrast floor
+    /// catches it even when the palette mode is still Dark.
+    #[test]
+    fn measured_light_background_lifts_body_text_off_the_surface() {
+        let white = Color::Rgb(0xFF, 0xFF, 0xFF);
+        let rendered = cell_fg_after_adaptation(
+            "x",
+            palette::TEXT_BODY,
+            Color::Reset,
+            PaletteMode::Dark,
+            ThemeId::System,
+            Some(white),
+        );
+
+        assert_ne!(
+            rendered,
+            palette::TEXT_BODY,
+            "body text must not pass through unadapted onto a white surface"
+        );
+        let ratio = palette::contrast_ratio(rendered, white).unwrap();
+        assert!(
+            ratio >= palette::AA_BODY_CONTRAST,
+            "rendered body text is {ratio}:1 against the measured surface"
+        );
+    }
+
+    /// The no-regression half of #4833: on a measured dark terminal every
+    /// rendered cell comes out byte-identical to what v0.9.1 emitted.
+    #[test]
+    fn measured_dark_background_changes_nothing() {
+        for surface in [
+            Color::Rgb(0x00, 0x00, 0x00),
+            Color::Rgb(0x1E, 0x1E, 0x1E),
+            palette::WHALE_BG,
+        ] {
+            for token in [
+                palette::TEXT_BODY,
+                palette::TEXT_HINT,
+                palette::TEXT_TOOL_OUTPUT,
+                palette::WHALE_ACTION,
+                palette::WHALE_HUMAN,
+                palette::STATUS_ERROR,
+                palette::DIFF_ADDED,
+                // Frame chrome sits below 4.5:1 by design and must survive.
+                palette::BORDER_COLOR,
+            ] {
+                let symbol = if token == palette::BORDER_COLOR {
+                    "\u{2500}"
+                } else {
+                    "x"
+                };
+                assert_eq!(
+                    cell_fg_after_adaptation(
+                        symbol,
+                        token,
+                        Color::Reset,
+                        PaletteMode::Dark,
+                        ThemeId::System,
+                        Some(surface),
+                    ),
+                    token,
+                    "{token:?} was rewritten on measured dark surface {surface:?}"
+                );
+            }
+        }
+    }
+
+    /// No measurement means no intervention: an unpainted cell on a terminal
+    /// we could not query renders exactly as before.
+    #[test]
+    fn unknown_background_leaves_unpainted_cells_alone() {
+        assert_eq!(
+            cell_fg_after_adaptation(
+                "x",
+                palette::TEXT_BODY,
+                Color::Reset,
+                PaletteMode::Dark,
+                ThemeId::System,
+                None,
+            ),
+            palette::TEXT_BODY
+        );
+    }
+
+    /// Frame chrome keeps its intended weight even where the floor is active.
+    #[test]
+    fn contrast_floor_skips_frame_chrome_on_a_light_surface() {
+        let white = Color::Rgb(0xFF, 0xFF, 0xFF);
+        assert_eq!(
+            cell_fg_after_adaptation(
+                "\u{2502}",
+                palette::LIGHT_BORDER,
+                Color::Reset,
+                PaletteMode::Light,
+                ThemeId::WhaleLight,
+                Some(white),
+            ),
+            palette::LIGHT_BORDER
+        );
+    }
+
+    /// Presets own their palette. A user who chose Matrix asked for its
+    /// deliberately dim greens; the floor must not repaint them.
+    #[test]
+    fn explicit_presets_are_exempt_from_the_floor() {
+        let matrix = ThemeId::Matrix.ui_theme();
+        assert_eq!(
+            cell_fg_after_adaptation(
+                "x",
+                matrix.text_muted,
+                Color::Reset,
+                PaletteMode::Dark,
+                ThemeId::Matrix,
+                Some(Color::Rgb(0x00, 0x00, 0x00)),
+            ),
+            matrix.text_muted
         );
     }
 }

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -1023,13 +1023,21 @@ pub async fn run_tui(
         defused: false,
     };
     let color_depth = palette::ColorDepth::detect();
-    let palette_mode = palette::PaletteMode::detect();
+    // Raw mode is on and the event loop has not started, which is the only
+    // window where the OSC 11 background query is safe to issue — see
+    // `palette::probe_terminal_background`. The result is cached process-wide,
+    // so every later `PaletteMode::detect()` sees the same answer.
+    let background = palette::probe_terminal_background();
+    let palette_mode = background.mode();
     tracing::debug!(
         ?color_depth,
         ?palette_mode,
+        background_source = ?background.source(),
+        background_color = ?background.color(),
         "terminal color profile detected"
     );
-    let backend = ColorCompatBackend::new(stdout, color_depth, palette_mode);
+    let mut backend = ColorCompatBackend::new(stdout, color_depth, palette_mode);
+    backend.set_detected_background(background.color());
     let mut terminal = Terminal::new(backend)?;
     // At this point Settings hasn't loaded yet, so we can't read the
     // user's `synchronized_output` knob. Use the same env-based terminal


### PR DESCRIPTION
Fixes #4833.

## What was broken

`crates/tui/src/palette/detect.rs` had exactly two detection sources: `COLORFGBG` parsing and, on macOS only, `defaults read -g AppleInterfaceStyle`. `detect_macos_palette_mode()` returns `None` off macOS, and the chain ended `.unwrap_or(Self::Dark)`.

Windows Terminal, conhost, VS Code, GNOME Terminal, Alacritty and Ghostty all omit `COLORFGBG`. So on Linux/Windows a **white** terminal was detected as `Dark`, the light adaptation stage never ran, and dark-tuned ivory body text rendered at **1.12:1** against a near-white surface. That is the reporter's screenshot.

The light adaptation stage would not have rescued it anyway. `adapt_fg_for_light_palette` is an equality whitelist with no contrast floor — a token nobody literally listed passes through unadapted onto whatever surface it lands on.

There was no OSC 11 query anywhere in the codebase.

## Why the fix is shaped this way

**Detection carries evidence, not a verdict.** `TerminalBackground` holds the background color we actually learned plus a `BackgroundSource` (`Osc11` / `ColorFgBg` / `MacOsAppearance` / `Unknown`). `Unknown` still answers `Dark`, so terminals we cannot measure keep exactly the theme they have today — but it carries **no color**, which is what lets everything downstream distinguish a measurement from a guess. A mode enum alone cannot tell you whether text clears 4.5:1.

**OSC 11 is what makes light terminals measurable.** `palette::probe_terminal_background()` runs once from `ui.rs`, after raw mode is enabled and before the event loop starts. It is bounded by a 120 ms deadline (`poll(2)` per byte against a monotonic deadline), returns `None` unless `isatty(0) && isatty(1)`, and caches its result process-wide so later `PaletteMode::detect()` calls agree. Unix only — there is no portable way to read a raw OSC reply off a Windows console handle, so Windows keeps the environment sources and the `Unknown`→`Dark` default. The parser is a pure function over the reply string, so `rgb:ffff/ffff/ffff`, `rgb:1e/1e/1e`, `#282c34`, `#fff` and every malformed shape are tested with no terminal involved.

**The floor is membership-independent.** `palette::enforce_contrast` computes WCAG relative luminance for the resolved foreground and the effective surface, and lifts any failing foreground to 4.5:1 by the *smallest* blend toward whichever pole has more headroom (bisection over a monotonic path). It does not consult any list. It declines to act when either side is terminal-defined (`Color::Reset`, named ANSI, `Indexed(0..=15)`) — rewriting a color whose rendering the user's terminal profile owns would be a guess. `Indexed(16..=255)` is resolvable and is resolved.

**Two guards keep the blast radius at the actual bug:**

- *Text cells only.* This palette puts `BORDER_COLOR` at **1.9:1** on the dark stage as a design choice. Clamping frame chrome to a text floor would rewrite the visual mass of every frame. `symbol_needs_text_contrast` excludes box-drawing, blocks, geometric shapes and braille.
- *Presets are exempt* (`theme_remap_active`). A user who typed `/theme matrix` asked for its deliberately dim greens (`#005500` at 2.3:1). The floor guards the auto-detected default path, which is where #4833 lives.

**No theme-surface fallback for the surface.** `effective_surface` takes the painted cell background if resolvable, else the measured terminal background, else `None`. The theme surface is what we *intended* to paint; on a `Color::Reset` cell it is precisely what the user is not seeing, and reasoning against it is how #4833 happened. No painted background and no measurement means we leave the color alone.

Stage order in `adapt_cell_colors` is now: theme remap → palette-mode remap → **contrast floor** → depth downsampling. The floor runs while colors are still full-precision RGB.

## Tests

Contrast is asserted directly against pure functions — no terminal, no snapshot:

- `relative_luminance_matches_wcag_reference_values` — white 1.0, black 0.0, `#808080` 0.2159; `Reset`/named/`Indexed(<16)` yield `None`.
- `contrast_ratio_matches_known_pairs` — black/white 21.0, `#767676` on white 4.54, symmetry, and `meets_contrast` refusing to call an unknowable pair a pass.
- `light_surface_lifts_body_text_that_no_whitelist_adapted` — the #4833 pair: asserts the precondition (below floor), then that `TEXT_BODY`, `TEXT_SOFT`, `TEXT_SECONDARY` and `TEXT_HINT` all clear 4.5:1 on white and on the reporter's paler surface.
- `dark_surface_leaves_every_text_token_untouched` — 22 shipped dark text tokens × 5 real dark surfaces (`WHALE_BG`, `WHALE_PANEL`, `#000000`, VS Code `#1e1e1e`, Windows Terminal `#0c0c0c`), all byte-identical.
- `enforce_contrast_lifts_by_the_smallest_amount_that_clears_the_floor` — lands in `[4.5, 4.6)`, and sweeps all 52 gray surfaces to show 4.5:1 is reachable from every one.
- `unknown_background_keeps_the_dark_default_and_offers_no_surface` — the trigger environment: `Dark` mode, `Unknown` provenance, no color, no surface, no intervention.
- `measured_background_outranks_env_hints_and_records_provenance`, `background_luminance_decides_polarity_without_a_color_list`, `osc11_replies_parse_across_the_shapes_terminals_emit`, `light_theme_tokens_already_clear_the_floor_on_their_own_surfaces`, `text_contrast_floor_applies_to_glyphs_not_frame_chrome`, `measured_light_background_selects_the_light_theme_end_to_end`.

Backend-level, through `adapt_cell_colors`: `measured_light_background_lifts_body_text_off_the_surface`, `measured_dark_background_changes_nothing` (including `BORDER_COLOR` on a box-drawing cell), `unknown_background_leaves_unpainted_cells_alone`, `contrast_floor_skips_frame_chrome_on_a_light_surface`, `explicit_presets_are_exempt_from_the_floor`.

## Gates run — exact output

```
$ cargo clippy --workspace --all-features --locked -- -D warnings \
    -A clippy::uninlined_format_args -A clippy::too_many_arguments \
    -A clippy::unnecessary_map_or -A clippy::collapsible_if \
    -A clippy::assertions_on_constants
    Checking codewhale-tui v0.9.1 (.../crates/tui)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 49.31s
```

```
$ cargo fmt --all && cargo fmt --all -- --check
FMT OK
$ git diff --check
DIFFCHECK OK
```

```
$ cargo test -p codewhale-tui --bin codewhale-tui --locked -- \
    palette::tests:: tui::color_compat:: tui::ocean:: tui::widgets:: \
    tui::markdown_render:: tui::transcript:: tui::history:: tui::sidebar:: tui::file_tree::
test result: ok. 695 passed; 0 failed; 0 ignored; 0 measured; 7495 filtered out; finished in 10.23s
```

All 53 `palette::tests::*` pass, including the 12 new ones.

## What I could NOT verify

- **No manual repro on a light terminal.** I did not run the built TUI against a white Windows Terminal / GNOME Terminal / VS Code terminal. Acceptance-criterion 1 in the issue ("reproduce on at least one light-background terminal") is unmet; I reproduced it numerically instead — `contrast_ratio(TEXT_BODY, #FFFFFF) == 1.12` is asserted as a test precondition.
- **The live OSC 11 round trip is untested.** `query_terminal_background` reads real fds, so nothing in the suite exercises it end to end. Only the parser and the resolution logic are covered. Its failure mode is `None` → today's behavior, but "Windows Terminal actually answers within 120 ms" is an untested claim.
- **Windows is not fixed by the OSC 11 half.** Windows keeps env-only detection, so a white Windows Terminal without `COLORFGBG` still resolves to `Dark`. It gains nothing from this PR unless the cell background happens to be painted.
- **No `cargo test --workspace`** (per lane instructions — another agent needed the build slot). Only the targeted filters above ran.
- **Reporter environment still unrecorded** — OS, terminal, `COLORFGBG` are unknown, so I could not confirm which of the two paths in the issue's "Investigation targets" they actually hit. The fix addresses path 1 (wrong mode detected) and hardens path 2 (token bypassed adaptation).

## Overlap with #4813

**This does not land any part of #4813.** That issue asks for status to carry a *luminance ramp* alongside hue (pending dim → running mid → done bright-neutral → failed bright-warm) sourced from `palette/tokens.rs`. This PR adds no ramp and does not touch status token identity.

It does supply infrastructure #4813 will want: `palette::relative_luminance`, `contrast_ratio` and `contrast_from_luminance` are the primitives for defining and testing a luminance ramp, and the "grayscale the frame and all states remain distinguishable" acceptance test can be written against them directly. Worth noting for whoever picks up #4813 that the contrast floor is a *lower bound only* — it will not flatten a ramp built above 4.5:1, but a ramp whose "pending dim" step lands below the floor on the default path would get lifted.
