### PR TITLE
fix(mcp): spawn configured MCP servers instead of answering from a stub

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3867,7 +3867,17 @@ fn run_mcp_server_command(store: &mut ConfigStore) -> Result<()> {
 }
 
 fn load_mcp_server_definitions(store: &ConfigStore) -> Vec<McpServerDefinition> {
-    let Some(raw) = store.config.get_value(MCP_SERVER_DEFINITIONS_KEY) else {
+    // `get_raw_string` first: `get_value` re-renders the extras entry as TOML,
+    // which quotes a JSON payload into `'[{"config":…}]'` and makes it
+    // unparseable — so every persisted definition was silently dropped and
+    // `mcp-server` started with an empty server list (#4727). `get_value`
+    // remains as the fallback for keys that are not plain extras strings.
+    let raw = store
+        .config
+        .get_raw_string(MCP_SERVER_DEFINITIONS_KEY)
+        .map(ToOwned::to_owned)
+        .or_else(|| store.config.get_value(MCP_SERVER_DEFINITIONS_KEY));
+    let Some(raw) = raw else {
         return Vec::new();
     };
 

--- a/crates/cli/tests/mcp_server_proxy.rs
+++ b/crates/cli/tests/mcp_server_proxy.rs
@@ -1,0 +1,235 @@
+//! `codewhale mcp-server` must proxy to the user's configured servers.
+//!
+//! Regression coverage for #4727, where every configured server was wired to
+//! an in-process stub: `command`/`args`/`env` were never executed, `health`
+//! and `capabilities` answered `{"status": "ok"}` from a hardcoded literal,
+//! and every real tool came back "not found". A client had no way to tell a
+//! working integration from a fabricated one, which is why these tests assert
+//! on the *origin* of the answer, not merely that an answer arrived.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+/// A minimal MCP server in POSIX sh, so the test depends on nothing beyond the
+/// shell already present on every unix runner.
+const FAKE_SERVER: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ -z "$id" ]; then
+    continue
+  fi
+  case "$method" in
+    initialize)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake-mcp","version":"0"}}}\n' "$id"
+      ;;
+    tools/list)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"whoami","description":"report the spawned process"}]}}\n' "$id"
+      ;;
+    tools/call)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"spawned-child"}]}}\n' "$id"
+      ;;
+    *)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"unsupported method"}}\n' "$id"
+      ;;
+  esac
+done
+"#;
+
+struct Fixture {
+    _root: TempDir,
+    home: PathBuf,
+}
+
+impl Fixture {
+    /// Seal HOME before anything writes config. The suite has written to the
+    /// real `~/.codewhale/config.toml` before (#4831); this test must never be
+    /// the one that does it again.
+    fn new() -> Self {
+        let root = TempDir::new().expect("fixture root");
+        let home = root.path().join("sealed-home");
+        fs::create_dir_all(home.join(".codewhale")).expect("sealed config dir");
+        fs::write(home.join(".codewhale").join("config.toml"), "").expect("seed config");
+        Self { _root: root, home }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(codewhale_binary());
+        command
+            .env_clear()
+            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env("CODEWHALE_HOME", self.home.join(".codewhale"))
+            .env("CODEWHALE_SECRET_BACKEND", "file");
+        command
+    }
+
+    fn write_fake_server(&self) -> PathBuf {
+        let script = self.home.join("fake-mcp-server.sh");
+        fs::write(&script, FAKE_SERVER).expect("write fake MCP server");
+        script
+    }
+
+    fn configure_servers(&self, definitions: Value) {
+        let output = self
+            .command()
+            .args(["config", "set", "mcp.server_definitions"])
+            .arg(definitions.to_string())
+            .output()
+            .expect("run config set");
+        assert!(
+            output.status.success(),
+            "config set failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Drive `codewhale mcp-server` over stdio with `requests`, returning the
+    /// parsed JSON-RPC responses plus stderr.
+    fn run_mcp_server(&self, requests: &[Value]) -> (Vec<Value>, String) {
+        let mut child = self
+            .command()
+            .arg("mcp-server")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn codewhale mcp-server");
+
+        {
+            let stdin = child.stdin.as_mut().expect("mcp-server stdin");
+            for request in requests {
+                writeln!(stdin, "{request}").expect("write request");
+            }
+        }
+
+        let output = child.wait_with_output().expect("mcp-server output");
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let responses = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .collect();
+        (responses, stderr)
+    }
+}
+
+fn codewhale_binary() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_codewhale") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_codewhale") {
+        return PathBuf::from(path);
+    }
+    let mut path = std::env::current_exe().expect("current test executable path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.join("codewhale")
+}
+
+fn response_for(responses: &[Value], id: i64) -> &Value {
+    responses
+        .iter()
+        .find(|response| response["id"] == json!(id))
+        .unwrap_or_else(|| panic!("no response with id {id} in {responses:?}"))
+}
+
+#[test]
+fn mcp_server_proxies_tools_from_the_configured_child_process() {
+    let fixture = Fixture::new();
+    let script = fixture.write_fake_server();
+    fixture.configure_servers(json!([{
+        "config": {
+            "name": "fake",
+            "command": "/bin/sh",
+            "args": [script.to_str().expect("utf-8 script path")],
+        }
+    }]));
+
+    let (responses, stderr) = fixture.run_mcp_server(&[
+        json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "mcp__fake__whoami", "arguments": {}}
+        }),
+        json!({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    ]);
+
+    let tools = response_for(&responses, 1)["result"]["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("tools/list returned no array; stderr:\n{stderr}"))
+        .clone();
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|tool| tool["tool_name"].as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["whoami"],
+        "only the child's real tools may be exposed; the stub's fabricated \
+         `health`/`capabilities` must be gone. stderr:\n{stderr}"
+    );
+
+    let call = response_for(&responses, 2);
+    assert_eq!(
+        call["result"]["result"]["content"][0]["text"], "spawned-child",
+        "the tool result must come from the spawned process: {call}"
+    );
+}
+
+#[test]
+fn mcp_server_reports_a_server_it_could_not_spawn() {
+    let fixture = Fixture::new();
+    fixture.configure_servers(json!([{
+        "config": {
+            "name": "broken",
+            "command": "codewhale-nonexistent-mcp-server-binary",
+        }
+    }]));
+
+    let (responses, stderr) = fixture.run_mcp_server(&[
+        json!({"jsonrpc": "2.0", "id": 1, "method": "server/list"}),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "mcp__broken__health", "arguments": {}}
+        }),
+        json!({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    ]);
+
+    let server = response_for(&responses, 1)["result"]["lifecycle"]["servers"][0].clone();
+    assert_eq!(
+        server["running"],
+        json!(false),
+        "an unspawnable server must not report as running: {server}"
+    );
+    assert!(
+        server["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("failed to spawn command")),
+        "the lifecycle must carry the spawn failure: {server}"
+    );
+    assert!(
+        stderr.contains("is not available"),
+        "the failure must also be loud on stderr, got:\n{stderr}"
+    );
+
+    let call = response_for(&responses, 2);
+    assert!(
+        call["error"].is_object(),
+        "a dead server must return an error, never a fabricated success: {call}"
+    );
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2120,6 +2120,19 @@ impl ConfigToml {
         }
     }
 
+    /// The unquoted contents of an extras key that holds a TOML string.
+    ///
+    /// [`Config::get_value`] renders extras through `toml::Value::to_string`,
+    /// which re-applies TOML quoting — and switches to a single-quoted literal
+    /// string whenever the payload contains a `"`. A JSON blob written with
+    /// [`Config::set_value`] therefore comes back as `'[{"a":1}]'` and no
+    /// longer parses as JSON (#4727). Callers that stored structured text want
+    /// the payload, not its TOML rendering.
+    #[must_use]
+    pub fn get_raw_string(&self, key: &str) -> Option<&str> {
+        self.extras.get(key).and_then(toml::Value::as_str)
+    }
+
     #[must_use]
     pub fn get_display_value(&self, key: &str) -> Option<String> {
         if let Some((provider, field)) = parse_provider_config_key(key) {

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 mod stdio_client;
-#[cfg(test)]
+// Unix-gated as well as test-gated: every helper in here builds and spawns a
+// POSIX-sh script, so the tests that use it are `#[cfg(unix)]` and on Windows
+// the whole module compiles to dead code, which `-D warnings` rejects.
+#[cfg(all(test, unix))]
 mod test_support;
 
 pub use stdio_client::ChildProcessMcpClient;

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -7,6 +7,12 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+mod stdio_client;
+#[cfg(test)]
+mod test_support;
+
+pub use stdio_client::ChildProcessMcpClient;
+
 /// Configuration for a single MCP server process.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerConfig {
@@ -130,7 +136,12 @@ pub trait McpManagedClient: Send + Sync {
     fn read_resource(&self, uri: &str) -> Result<Value>;
 }
 
-/// A simple in-memory MCP client for testing and default server stubs.
+/// A simple in-memory MCP client for tests and embedding callers.
+///
+/// This is **not** wired into `codewhale mcp-server`: that path spawns
+/// [`ChildProcessMcpClient`] and reports a typed error when the configured
+/// command cannot be run. Serving canned values there made a broken
+/// integration look identical to a working one (#4727).
 #[derive(Debug, Default)]
 pub struct InMemoryMcpClient {
     tools: HashMap<String, Value>,
@@ -585,7 +596,43 @@ struct StdioMcpState {
     manager: McpManager,
     definitions: HashMap<String, McpServerDefinition>,
     running: HashMap<String, bool>,
+    /// Why a defined server is not running, surfaced in every lifecycle
+    /// snapshot so a failed spawn cannot be mistaken for a healthy server.
+    errors: HashMap<String, String>,
     lifecycle_state: String,
+}
+
+impl StdioMcpState {
+    /// Spawn `definition`'s configured command and register the resulting
+    /// connection, recording the failure reason when the server cannot be
+    /// brought up.
+    ///
+    /// This is the only way a server enters `manager`, and it has no stub
+    /// branch: there is no configuration under which a registered server
+    /// answers from anything but its own process.
+    fn start_definition(&mut self, definition: &McpServerDefinition) -> Result<()> {
+        let name = definition.config.name.clone();
+        let outcome = ChildProcessMcpClient::spawn(&definition.config).and_then(|client| {
+            self.manager.register_server(
+                definition.config.clone(),
+                definition.filter.clone(),
+                Box::new(client),
+            )
+        });
+        match outcome {
+            Ok(()) => {
+                self.errors.remove(&name);
+                self.running.insert(name, true);
+                Ok(())
+            }
+            Err(err) => {
+                let message = format!("{err:#}");
+                self.errors.insert(name.clone(), message.clone());
+                self.running.insert(name, false);
+                Err(err)
+            }
+        }
+    }
 }
 
 /// Run an MCP stdio server that reads JSON-RPC requests from stdin and writes responses to stdout.
@@ -670,83 +717,32 @@ pub fn run_stdio_server(
 }
 
 fn build_stdio_state(initial_definitions: Vec<McpServerDefinition>) -> StdioMcpState {
-    let mut manager = McpManager::default();
-    let mut definitions = HashMap::new();
-    let mut running = HashMap::new();
+    let mut state = StdioMcpState {
+        manager: McpManager::default(),
+        definitions: HashMap::new(),
+        running: HashMap::new(),
+        errors: HashMap::new(),
+        lifecycle_state: "running".to_string(),
+    };
 
     for definition in initial_definitions {
         let name = definition.config.name.clone();
-        let should_start = definition.config.enabled;
-        definitions.insert(name.clone(), definition.clone());
-        let registered = should_start
-            && match manager.register_server(
-                definition.config.clone(),
-                definition.filter.clone(),
-                default_stdio_client(&name),
-            ) {
-                Ok(()) => true,
-                Err(err) => {
-                    // A name collision must not silently shadow the server
-                    // already holding that qualified prefix. Leave it stopped.
-                    tracing::warn!("skipping MCP server '{name}': {err}");
-                    false
-                }
-            };
-        running.insert(name, registered);
+        state.definitions.insert(name.clone(), definition.clone());
+        if !definition.config.enabled {
+            state.running.insert(name, false);
+            continue;
+        }
+        // A server that cannot be spawned stays stopped and says so on stderr.
+        // stdout is the JSON-RPC channel, so the warning goes to stderr where
+        // it will not corrupt the protocol stream but is still visible to the
+        // operator; `lifecycle` carries the same text for programmatic clients.
+        if let Err(err) = state.start_definition(&definition) {
+            tracing::warn!("MCP server '{name}' is not available: {err:#}");
+            eprintln!("codewhale mcp-server: server '{name}' is not available: {err:#}");
+        }
     }
 
-    StdioMcpState {
-        manager,
-        definitions,
-        running,
-        lifecycle_state: "running".to_string(),
-    }
-}
-
-fn default_stdio_client(server_name: &str) -> Box<dyn McpManagedClient> {
-    let health_uri = format!("mcp://{server_name}/health");
-    let capabilities_uri = format!("mcp://{server_name}/capabilities");
-    Box::new(
-        InMemoryMcpClient::default()
-            .with_tool(
-                "health",
-                json!({
-                    "status": "ok",
-                    "server_name": server_name
-                }),
-            )
-            .with_tool(
-                "capabilities",
-                json!({
-                    "tools": ["health", "capabilities"],
-                    "resources": [health_uri.clone(), capabilities_uri.clone()]
-                }),
-            )
-            .with_resource(
-                &health_uri,
-                json!({
-                    "status": "ok",
-                    "server_name": server_name
-                }),
-            )
-            .with_resource(
-                &capabilities_uri,
-                json!({
-                    "server_name": server_name,
-                    "methods": [
-                        "tools/list",
-                        "tools/call",
-                        "resources/list",
-                        "resources/read",
-                        "server/list",
-                        "server/register",
-                        "server/start",
-                        "server/stop",
-                        "server/unregister"
-                    ]
-                }),
-            ),
-    )
+    state
 }
 
 fn default_rpc_methods() -> Vec<&'static str> {
@@ -779,6 +775,10 @@ fn lifecycle_snapshot(state: &StdioMcpState) -> Value {
                 "running": is_running,
                 "command": definition.config.command.clone(),
                 "args": definition.config.args.clone(),
+                // Null when the server is healthy. A client polling
+                // `server/list` must be able to tell "up" from "never
+                // started" without guessing.
+                "error": state.errors.get(name).cloned(),
             })
         })
         .collect();
@@ -924,25 +924,22 @@ fn dispatch_stdio_request(
             if state.definitions.contains_key(&name) {
                 let _ = state.manager.unregister_server(&name);
             }
-            state.definitions.insert(
-                name.clone(),
-                McpServerDefinition {
-                    config: parsed.server.clone(),
-                    filter: parsed.filter.clone(),
-                },
-            );
-            let should_run = parsed.start && parsed.server.enabled;
-            if should_run {
+            let definition = McpServerDefinition {
+                config: parsed.server.clone(),
+                filter: parsed.filter.clone(),
+            };
+            state.definitions.insert(name.clone(), definition.clone());
+            state.errors.remove(&name);
+            if parsed.start && parsed.server.enabled {
+                // Registration is only "ok" if the configured command actually
+                // came up. Reporting success here and answering later tool
+                // calls from a stub is what #4727 was.
                 state
-                    .manager
-                    .register_server(
-                        parsed.server.clone(),
-                        parsed.filter.clone(),
-                        default_stdio_client(&name),
-                    )
-                    .map_err(|err| JsonRpcError::invalid_params(err.to_string()))?;
+                    .start_definition(&definition)
+                    .map_err(|err| JsonRpcError::internal(format!("{err:#}")))?;
+            } else {
+                state.running.insert(name, false);
             }
-            state.running.insert(name, should_run);
             Ok((json!({ "lifecycle": lifecycle_snapshot(state) }), false))
         }
         "server/start" | "servers/start" => {
@@ -961,14 +958,8 @@ fn dispatch_stdio_request(
             }
             if !state.running.get(&parsed.name).copied().unwrap_or(false) {
                 state
-                    .manager
-                    .register_server(
-                        definition.config.clone(),
-                        definition.filter.clone(),
-                        default_stdio_client(&parsed.name),
-                    )
-                    .map_err(|err| JsonRpcError::invalid_params(err.to_string()))?;
-                state.running.insert(parsed.name, true);
+                    .start_definition(&definition)
+                    .map_err(|err| JsonRpcError::internal(format!("{err:#}")))?;
             }
             Ok((json!({ "lifecycle": lifecycle_snapshot(state) }), false))
         }
@@ -980,6 +971,9 @@ fn dispatch_stdio_request(
                     .stop_server(&parsed.name)
                     .map_err(|err| JsonRpcError::internal(err.to_string()))?;
             }
+            // A deliberate stop is not a failure, so it clears any recorded
+            // startup error rather than leaving a stale one on display.
+            state.errors.remove(&parsed.name);
             state.running.insert(parsed.name, false);
             Ok((json!({ "lifecycle": lifecycle_snapshot(state) }), false))
         }
@@ -993,6 +987,7 @@ fn dispatch_stdio_request(
             }
             let _ = state.manager.unregister_server(&parsed.name);
             state.running.remove(&parsed.name);
+            state.errors.remove(&parsed.name);
             Ok((json!({ "lifecycle": lifecycle_snapshot(state) }), false))
         }
         "shutdown" => {
@@ -1678,6 +1673,107 @@ mod tests {
     fn jsonrpc_notifications_do_not_require_responses() {
         assert!(!should_respond_to_jsonrpc(&None));
         assert!(should_respond_to_jsonrpc(&Some(json!(1))));
+    }
+
+    // ── stdio dispatch: no stub may answer for a configured server ─────
+
+    fn definition(name: &str, command: &str, args: &[&str]) -> McpServerDefinition {
+        McpServerDefinition {
+            config: McpServerConfig {
+                name: name.to_string(),
+                command: command.to_string(),
+                args: args.iter().map(|arg| (*arg).to_string()).collect(),
+                env: HashMap::new(),
+                enabled: true,
+            },
+            filter: ToolFilter::default(),
+        }
+    }
+
+    fn call(state: &mut StdioMcpState, method: &str, params: Value) -> Value {
+        dispatch_stdio_request(state, method, params)
+            .unwrap_or_else(|err| panic!("{method} failed: {}", err.message))
+            .0
+    }
+
+    #[test]
+    fn a_server_that_cannot_be_spawned_is_reported_not_running() {
+        // #4727: this used to register a stub and report `running: true`, so a
+        // typo in `command` was indistinguishable from a working server.
+        let mut state = build_stdio_state(vec![definition(
+            "broken",
+            "codewhale-nonexistent-mcp-server-binary",
+            &[],
+        )]);
+
+        let lifecycle = call(&mut state, "server/list", json!({}))["lifecycle"].clone();
+        assert_eq!(lifecycle["servers"][0]["running"], json!(false));
+        let error = lifecycle["servers"][0]["error"]
+            .as_str()
+            .expect("a stopped server must carry its failure reason");
+        assert!(
+            error.contains("failed to spawn command"),
+            "unexpected error: {error}"
+        );
+
+        // And nothing answers on its behalf.
+        let err = dispatch_stdio_request(
+            &mut state,
+            "tools/call",
+            json!({"name": "mcp__broken__health", "arguments": {}}),
+        )
+        .expect_err("a server that never started must not answer tool calls");
+        assert_eq!(err.code, -32603);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tools_come_from_the_spawned_process_not_a_stub() {
+        let script = crate::test_support::write_fake_mcp_server("dispatch_tools");
+        let mut state = build_stdio_state(vec![definition(
+            "fake",
+            "/bin/sh",
+            &[script.path().to_str().expect("utf-8 script path")],
+        )]);
+
+        let tools = call(&mut state, "tools/list", json!({}))["tools"].clone();
+        let names: Vec<&str> = tools
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .filter_map(|tool| tool["tool_name"].as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["add"],
+            "only the child's real tools may be listed, got {names:?}"
+        );
+
+        let result = call(
+            &mut state,
+            "tools/call",
+            json!({"name": "mcp__fake__add", "arguments": {"a": 2, "b": 3}}),
+        );
+        assert_eq!(result["result"]["content"][0]["text"], "5");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn server_register_fails_when_the_command_cannot_be_started() {
+        let mut state = build_stdio_state(Vec::new());
+        let err = dispatch_stdio_request(
+            &mut state,
+            "server/register",
+            json!({"server": {"name": "late", "command": "/bin/sh", "args": ["-c", "exit 1"]}}),
+        )
+        .expect_err("registering an unstartable server must not report success");
+        assert_eq!(err.code, -32603);
+        assert!(
+            err.message.contains("initialize"),
+            "unexpected error: {}",
+            err.message
+        );
+        assert_eq!(state.running.get("late"), Some(&false));
     }
 
     // ── McpServerConfig serialization ──────────────────────────────────

--- a/crates/mcp/src/stdio_client.rs
+++ b/crates/mcp/src/stdio_client.rs
@@ -36,6 +36,10 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 /// before it kills the child.
 const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
+/// How long a failure path waits for a dying child's exit status before giving
+/// up and reporting the failure without one.
+const EXIT_STATUS_GRACE: Duration = Duration::from_millis(200);
+
 /// Upper bound on `*/list` pagination follow-ups, so a server that keeps
 /// echoing the same cursor cannot pin us in a loop.
 const MAX_LIST_PAGES: usize = 100;
@@ -320,13 +324,27 @@ impl Connection {
     ) -> Result<Value> {
         let id = self.next_id;
         self.next_id += 1;
-        self.send(&json!({
+        if let Err(err) = self.send(&json!({
             "jsonrpc": "2.0",
             "id": id,
             "method": method,
             "params": params
-        }))
-        .with_context(|| format!("MCP server '{server}': failed to send {method}"))?;
+        })) {
+            // A child that has already exited leaves us racing two symptoms of
+            // the same fact: either the reader thread sees EOF first, or our
+            // write loses the race and returns EPIPE. Which one wins is
+            // platform- and timing-dependent (macOS reliably reports the write
+            // error where Linux reports the EOF), so both report the death the
+            // same way rather than leaking a bare "Broken pipe".
+            if is_broken_pipe(&err) {
+                bail!(
+                    "MCP server '{server}': process closed stdin before answering {method}{}",
+                    self.exit_note()
+                );
+            }
+            return Err(err)
+                .with_context(|| format!("MCP server '{server}': failed to send {method}"));
+        }
 
         let deadline = Instant::now() + timeout;
         loop {
@@ -363,12 +381,34 @@ impl Connection {
         }
     }
 
+    /// The child's exit status, when it has one, for appending to a failure
+    /// message. Polls briefly because both callers run at the moment the child
+    /// is dying: the write can return EPIPE, or stdout can hit EOF, before the
+    /// kernel has finished reaping the process. Bounded and error-path-only,
+    /// so the cost buys a real diagnostic ("exited with status 127" is the
+    /// difference between a crashed server and a missing one).
     fn exit_note(&mut self) -> String {
-        match self.child.try_wait() {
-            Ok(Some(status)) => format!(" (process exited with {status})"),
-            _ => String::new(),
+        let deadline = Instant::now() + EXIT_STATUS_GRACE;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return format!(" (process exited with {status})"),
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                _ => return String::new(),
+            }
         }
     }
+}
+
+/// Whether an error chain bottoms out in a broken-pipe I/O error, i.e. we wrote
+/// to a child that had already closed its end.
+fn is_broken_pipe(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
+    })
 }
 
 impl Drop for Connection {
@@ -440,8 +480,31 @@ mod tests {
     fn spawn_fails_when_the_child_exits_without_answering_initialize() {
         let err = ChildProcessMcpClient::spawn(&config("/bin/sh", &["-c", "exit 0"])).unwrap_err();
         let message = format!("{err:#}");
+        // Which end reports the death first is a race the OS arbitrates —
+        // stdout EOF on Linux, an EPIPE write on macOS — so assert on what is
+        // actually contractual: the server is named, the failure is attributed
+        // to the child dying before it answered, and no raw io::Error leaks.
         assert!(
-            message.contains("closed stdout before answering initialize"),
+            message.contains("probe") && message.contains("before answering initialize"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !message.contains("Broken pipe"),
+            "a dead child must not surface as a raw pipe error: {message}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_child_that_dies_mid_handshake_reports_its_exit_status() {
+        // The child closes both pipes and exits nonzero: the diagnostic has to
+        // carry the status, because "exited with 127" is what distinguishes a
+        // crashed server from a missing one.
+        let err =
+            ChildProcessMcpClient::spawn(&config("/bin/sh", &["-c", "exit 127"])).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("before answering initialize") && message.contains("127"),
             "unexpected error: {message}"
         );
     }

--- a/crates/mcp/src/stdio_client.rs
+++ b/crates/mcp/src/stdio_client.rs
@@ -1,0 +1,487 @@
+//! A real MCP client that speaks JSON-RPC to a spawned child process.
+//!
+//! `codewhale mcp-server` used to wire every configured server to an
+//! in-memory stub, so a user's `command`/`args`/`env` were never executed and
+//! every health probe answered `{"status": "ok"}` from a hardcoded literal
+//! (#4727). A fabricated success is the worst possible answer here: it is
+//! indistinguishable from a working integration. This module replaces it with
+//! an actual subprocess connection, and every failure path below returns an
+//! error naming the server rather than a plausible-looking value.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Mutex;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde_json::{Value, json};
+
+use crate::{McpManagedClient, McpResourceDescriptor, McpServerConfig, McpToolDescriptor};
+
+/// Protocol revision advertised during the handshake. Matches the revision the
+/// TUI's MCP pool negotiates (`crates/tui/src/mcp.rs`), so a server that works
+/// in the TUI works here.
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Budget for spawn + `initialize` + `notifications/initialized`. Generous
+/// because a first `npx`/`uvx` launch may download the server package.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Budget for a single request once the server is up.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How long a dropped client waits for a graceful exit after closing stdin
+/// before it kills the child.
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
+
+/// Upper bound on `*/list` pagination follow-ups, so a server that keeps
+/// echoing the same cursor cannot pin us in a loop.
+const MAX_LIST_PAGES: usize = 100;
+
+/// What the server said it supports in its `initialize` response.
+///
+/// `None` means the server sent no `capabilities` object at all. Those are
+/// treated as legacy servers and probed optimistically; an explicit
+/// capabilities object is honoured, because a tools-only server answers
+/// `resources/list` with a "method not found" error that would otherwise fail
+/// the whole aggregated listing.
+#[derive(Debug, Clone, Copy)]
+struct ServerCapabilities {
+    tools: bool,
+    resources: bool,
+}
+
+/// A live connection to one MCP server subprocess.
+pub struct ChildProcessMcpClient {
+    server_name: String,
+    capabilities: Option<ServerCapabilities>,
+    connection: Mutex<Connection>,
+    request_timeout: Duration,
+}
+
+impl std::fmt::Debug for ChildProcessMcpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChildProcessMcpClient")
+            .field("server_name", &self.server_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ChildProcessMcpClient {
+    /// Spawn `config.command` with `config.args`/`config.env` and complete the
+    /// MCP handshake.
+    ///
+    /// Returns `Err` — never a degraded-but-usable client — when the command
+    /// cannot be executed, exits immediately, or does not answer `initialize`
+    /// within [`HANDSHAKE_TIMEOUT`].
+    pub fn spawn(config: &McpServerConfig) -> Result<Self> {
+        Self::spawn_with_timeouts(config, HANDSHAKE_TIMEOUT, REQUEST_TIMEOUT)
+    }
+
+    fn spawn_with_timeouts(
+        config: &McpServerConfig,
+        handshake_timeout: Duration,
+        request_timeout: Duration,
+    ) -> Result<Self> {
+        let server_name = config.name.clone();
+        if config.command.trim().is_empty() {
+            bail!("MCP server '{server_name}' has no command configured");
+        }
+
+        let mut command = Command::new(&config.command);
+        command
+            .args(&config.args)
+            .envs(&config.env)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // The child's diagnostics belong on our stderr: stdout is the
+            // JSON-RPC channel and must not be polluted, and swallowing the
+            // child's stderr is how a misconfigured server becomes a silent
+            // one.
+            .stderr(Stdio::inherit());
+
+        let mut child = command.spawn().with_context(|| {
+            format!(
+                "MCP server '{server_name}': failed to spawn command '{}'",
+                config.command
+            )
+        })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .with_context(|| format!("MCP server '{server_name}': child stdin unavailable"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .with_context(|| format!("MCP server '{server_name}': child stdout unavailable"))?;
+
+        // A dedicated reader thread keeps `recv_timeout` able to bound a wait
+        // that a blocking `read_line` on the child would not.
+        let (sender, responses) = channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                match line {
+                    Ok(line) => {
+                        if sender.send(line).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let mut connection = Connection {
+            child,
+            stdin: Some(stdin),
+            responses,
+            next_id: 1,
+        };
+
+        let initialize = connection.request(
+            &server_name,
+            "initialize",
+            json!({
+                "protocolVersion": PROTOCOL_VERSION,
+                "clientInfo": {
+                    "name": "codewhale-mcp-server",
+                    "version": env!("CARGO_PKG_VERSION")
+                },
+                "capabilities": {
+                    "tools": {},
+                    "resources": {}
+                }
+            }),
+            handshake_timeout,
+        )?;
+
+        connection
+            .send(&json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized"
+            }))
+            .with_context(|| {
+                format!("MCP server '{server_name}': failed to confirm initialization")
+            })?;
+
+        let capabilities = initialize
+            .get("capabilities")
+            .and_then(Value::as_object)
+            .map(|caps| ServerCapabilities {
+                tools: caps.contains_key("tools"),
+                resources: caps.contains_key("resources"),
+            });
+
+        Ok(Self {
+            server_name,
+            capabilities,
+            connection: Mutex::new(connection),
+            request_timeout,
+        })
+    }
+
+    fn supports_tools(&self) -> bool {
+        self.capabilities.is_none_or(|caps| caps.tools)
+    }
+
+    fn supports_resources(&self) -> bool {
+        self.capabilities.is_none_or(|caps| caps.resources)
+    }
+
+    fn request(&self, method: &str, params: Value) -> Result<Value> {
+        let mut connection = self.connection.lock().map_err(|_| {
+            anyhow!(
+                "MCP server '{}': connection poisoned by an earlier panic",
+                self.server_name
+            )
+        })?;
+        connection.request(&self.server_name, method, params, self.request_timeout)
+    }
+
+    /// Drive a paginated `*/list` method to exhaustion, collecting `field`.
+    fn list_paginated(&self, method: &str, field: &str) -> Result<Vec<Value>> {
+        let mut items = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..MAX_LIST_PAGES {
+            let params = match &cursor {
+                Some(cursor) => json!({ "cursor": cursor }),
+                None => json!({}),
+            };
+            let page = self.request(method, params)?;
+            if let Some(values) = page.get(field).and_then(Value::as_array) {
+                items.extend(values.iter().cloned());
+            }
+            let next = page
+                .get("nextCursor")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            match next {
+                // A repeated cursor is a server bug; stop rather than spin.
+                Some(next) if Some(&next) != cursor.as_ref() => cursor = Some(next),
+                _ => break,
+            }
+        }
+        Ok(items)
+    }
+}
+
+impl McpManagedClient for ChildProcessMcpClient {
+    fn list_tools(&self) -> Result<Vec<McpToolDescriptor>> {
+        if !self.supports_tools() {
+            return Ok(Vec::new());
+        }
+        let tools = self.list_paginated("tools/list", "tools")?;
+        Ok(tools
+            .iter()
+            .filter_map(|tool| {
+                let tool_name = tool.get("name")?.as_str()?.to_string();
+                Some(McpToolDescriptor {
+                    server_name: self.server_name.clone(),
+                    // The manager owns qualification; report the raw name and
+                    // let it build `mcp__server__tool`.
+                    qualified_name: tool_name.clone(),
+                    tool_name,
+                    description: tool
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                })
+            })
+            .collect())
+    }
+
+    fn call_tool(&self, tool_name: &str, arguments: Value) -> Result<Value> {
+        // The server's result is returned verbatim, including an `isError`
+        // content payload: reinterpreting it here would replace what the
+        // server actually said with our guess about it.
+        self.request(
+            "tools/call",
+            json!({
+                "name": tool_name,
+                "arguments": arguments
+            }),
+        )
+    }
+
+    fn list_resources(&self) -> Result<Vec<McpResourceDescriptor>> {
+        if !self.supports_resources() {
+            return Ok(Vec::new());
+        }
+        let resources = self.list_paginated("resources/list", "resources")?;
+        Ok(resources
+            .iter()
+            .filter_map(|resource| {
+                Some(McpResourceDescriptor {
+                    server_name: self.server_name.clone(),
+                    uri: resource.get("uri")?.as_str()?.to_string(),
+                    description: resource
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                })
+            })
+            .collect())
+    }
+
+    fn read_resource(&self, uri: &str) -> Result<Value> {
+        self.request("resources/read", json!({ "uri": uri }))
+    }
+}
+
+struct Connection {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    responses: Receiver<String>,
+    next_id: u64,
+}
+
+impl Connection {
+    fn send(&mut self, message: &Value) -> Result<()> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .context("connection stdin already closed")?;
+        let mut line = serde_json::to_string(message)?;
+        line.push('\n');
+        stdin.write_all(line.as_bytes())?;
+        stdin.flush()?;
+        Ok(())
+    }
+
+    fn request(
+        &mut self,
+        server: &str,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        }))
+        .with_context(|| format!("MCP server '{server}': failed to send {method}"))?;
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                bail!("MCP server '{server}': {method} timed out after {timeout:?}");
+            }
+            let line = match self.responses.recv_timeout(remaining) {
+                Ok(line) => line,
+                Err(RecvTimeoutError::Timeout) => {
+                    bail!("MCP server '{server}': {method} timed out after {timeout:?}");
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    bail!(
+                        "MCP server '{server}': process closed stdout before answering {method}{}",
+                        self.exit_note()
+                    );
+                }
+            };
+
+            // Servers occasionally emit banners or log lines on stdout, and
+            // notifications carry no id. Both are skipped; only the matching
+            // response ends the wait.
+            let Ok(message) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if message.get("id").and_then(Value::as_u64) != Some(id) {
+                continue;
+            }
+            if let Some(error) = message.get("error") {
+                bail!("MCP server '{server}': {method} failed: {error}");
+            }
+            return Ok(message.get("result").cloned().unwrap_or(Value::Null));
+        }
+    }
+
+    fn exit_note(&mut self) -> String {
+        match self.child.try_wait() {
+            Ok(Some(status)) => format!(" (process exited with {status})"),
+            _ => String::new(),
+        }
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // Closing stdin is the protocol-level shutdown signal for a stdio MCP
+        // server; kill only the ones that ignore it, so servers get a chance
+        // to flush state.
+        self.stdin.take();
+        let deadline = Instant::now() + SHUTDOWN_GRACE;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                _ => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn config(command: &str, args: &[&str]) -> McpServerConfig {
+        McpServerConfig {
+            name: "probe".to_string(),
+            command: command.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            env: HashMap::new(),
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn spawn_fails_loudly_when_the_command_does_not_exist() {
+        let err = ChildProcessMcpClient::spawn(&config(
+            "codewhale-nonexistent-mcp-server-binary",
+            &["--stdio"],
+        ))
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("failed to spawn command"),
+            "spawn failure must name the command, got: {message}"
+        );
+        assert!(
+            message.contains("probe"),
+            "spawn failure must name the server, got: {message}"
+        );
+    }
+
+    #[test]
+    fn spawn_rejects_an_empty_command() {
+        let err = ChildProcessMcpClient::spawn(&config("   ", &[])).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("no command configured"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_fails_when_the_child_exits_without_answering_initialize() {
+        let err = ChildProcessMcpClient::spawn(&config("/bin/sh", &["-c", "exit 0"])).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("closed stdout before answering initialize"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handshake_times_out_when_the_child_never_answers() {
+        let err = ChildProcessMcpClient::spawn_with_timeouts(
+            &config("/bin/sh", &["-c", "sleep 30"]),
+            Duration::from_millis(250),
+            Duration::from_millis(250),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("initialize timed out"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_real_child_answers_tools_list_and_tools_call() {
+        let script = crate::test_support::write_fake_mcp_server("stdio_client_roundtrip");
+        let client = ChildProcessMcpClient::spawn(&config(
+            "/bin/sh",
+            &[script.path().to_str().expect("utf-8 script path")],
+        ))
+        .expect("fake MCP server should complete the handshake");
+
+        let tools = client.list_tools().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].tool_name, "add");
+
+        let result = client.call_tool("add", json!({"a": 2, "b": 3})).unwrap();
+        assert_eq!(
+            result["content"][0]["text"], "5",
+            "the answer must come from the child process: {result}"
+        );
+
+        // The stub's fabricated tools must be gone.
+        assert!(client.call_tool("health", json!({})).is_err());
+    }
+}

--- a/crates/mcp/src/test_support.rs
+++ b/crates/mcp/src/test_support.rs
@@ -1,0 +1,70 @@
+//! Test-only helpers. Compiled under `#[cfg(test)]` only, so nothing here can
+//! be reached by a real `codewhale mcp-server` run.
+
+use std::path::{Path, PathBuf};
+
+/// A minimal POSIX-sh MCP server used to prove that responses come from a
+/// spawned process rather than from an in-process stub.
+///
+/// It is written in `sh` rather than Rust or Python so the test depends on
+/// nothing beyond the shell every unix CI runner already has.
+pub const FAKE_MCP_SERVER_SH: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  if [ -z "$id" ]; then
+    continue
+  fi
+  case "$method" in
+    initialize)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"fake-mcp","version":"0"}}}\n' "$id"
+      ;;
+    tools/list)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"add","description":"add two numbers"}]}}\n' "$id"
+      ;;
+    tools/call)
+      name=$(printf '%s' "$line" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p')
+      if [ "$name" = "add" ]; then
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"5"}]}}\n' "$id"
+      else
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"unknown tool: '"$name"'"}}\n' "$id"
+      fi
+      ;;
+    *)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"unsupported method"}}\n' "$id"
+      ;;
+  esac
+done
+"#;
+
+/// Owns a temporary directory holding [`FAKE_MCP_SERVER_SH`], removing it on
+/// drop.
+pub struct FakeServerScript {
+    dir: PathBuf,
+    script: PathBuf,
+}
+
+impl FakeServerScript {
+    pub fn path(&self) -> &Path {
+        &self.script
+    }
+}
+
+impl Drop for FakeServerScript {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Write the fake server to a unique temp directory and return a guard.
+pub fn write_fake_mcp_server(label: &str) -> FakeServerScript {
+    let dir = std::env::temp_dir().join(format!(
+        "codewhale-mcp-{label}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).expect("fake MCP server dir");
+    let script = dir.join("server.sh");
+    std::fs::write(&script, FAKE_MCP_SERVER_SH).expect("write fake MCP server");
+    FakeServerScript { dir, script }
+}

--- a/crates/mcp/src/test_support.rs
+++ b/crates/mcp/src/test_support.rs
@@ -1,5 +1,7 @@
-//! Test-only helpers. Compiled under `#[cfg(test)]` only, so nothing here can
-//! be reached by a real `codewhale mcp-server` run.
+//! Test-only helpers. Compiled under `#[cfg(all(test, unix))]` only, so
+//! nothing here can be reached by a real `codewhale mcp-server` run, and
+//! Windows — where the POSIX-sh fixture cannot run and its consumers are
+//! `#[cfg(unix)]` — does not compile it as dead code.
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Fixes #4727.

## What was broken

I confirmed the reported behavior on current `main` (84eb23dc5) before changing anything. It is real, and there are two compounding defects.

**1. Every configured server was wired to a stub.** `build_stdio_state`, `server/register` and `server/start` all called `default_stdio_client` (`crates/mcp/src/lib.rs:706` on main), an `InMemoryMcpClient` carrying two fabricated tools. `command`/`args`/`env` were read only to be echoed into the lifecycle blob — never spawned. `InMemoryMcpClient` was the sole `impl McpManagedClient` in the tree.

Reproduced against `main`'s binary under a sealed HOME, registering a server whose command does not exist:

```
$ printf '%s\n' \
 '{"jsonrpc":"2.0","id":1,"method":"server/register","params":{"server":{"name":"ghost","command":"codewhale-nonexistent-binary","args":[]}}}' \
 '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
 '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"mcp__ghost__health","arguments":{}}}' \
 | codewhale mcp-server

{"id":1,...,"servers":[{"command":"codewhale-nonexistent-binary","name":"ghost","running":true}],"status":"running"}
{"id":2,...,"tools":[{"qualified_name":"mcp__ghost__capabilities",...},{"qualified_name":"mcp__ghost__health",...}]}
{"id":3,...,"result":{"result":{"server_name":"ghost","status":"ok"}}}
```

A binary that does not exist reported `running: true` and passed a health check.

**2. Persisted definitions never loaded at all.** `load_mcp_server_definitions` read the payload via `Config::get_value`, which re-renders an extras entry through `toml::Value::to_string`. A JSON blob containing `"` comes back as a TOML *literal* string — `'[{"config":…}]'` — which then fails both branches of `parse_mcp_server_definitions`. Every startup printed `warning: failed to parse persisted MCP server definitions` and continued with an empty list. So even the stub never saw the user's servers.

## Why the fix is shaped this way

`ChildProcessMcpClient` (`crates/mcp/src/stdio_client.rs`) spawns the configured command and speaks JSON-RPC over the child's stdio: `initialize` + `notifications/initialized` at protocol `2024-11-05` (the same revision the TUI's MCP pool negotiates, so a server that works in the TUI works here), then `tools/list`, `tools/call`, `resources/list`, `resources/read` with cursor pagination and bounded timeouts. A reader thread feeds a channel so a hung child times out instead of blocking forever. The child's stderr is inherited — swallowing it is how a misconfigured server becomes a silent one — while its stdout stays a pure protocol channel.

The design constraint I took from the issue is that fabricated success is worse than a hard failure, so:

- `StdioMcpState::start_definition` is the **only** path into the manager and has **no stub branch**. There is no configuration under which a registered server answers from anything but its own process. The stub factory is gone entirely rather than hidden behind a flag.
- A server that cannot be spawned, exits before answering, or times out stays stopped, prints to our stderr, and carries its reason in a new per-server `error` field on every lifecycle snapshot. `server/register` / `server/start` return a JSON-RPC `-32603` instead of reporting success.
- Tool results are returned verbatim, `isError` payloads included. Reinterpreting them would substitute our guess for what the server actually said.
- `InMemoryMcpClient` stays public (it is API, and unit tests use it) but is unreachable from the CLI command.

`Config::get_raw_string` is added next to `get_value` for callers that stored structured text and want the payload rather than its TOML rendering. `get_value` is kept as a fallback in the load path.

## Verification

The new end-to-end test was run against `main`'s implementation first (I stashed the fix and kept the test): both cases **fail** on `main` and pass with the fix.

Gates run locally, exactly as listed in `.github/workflows/ci.yml:229-235`:

```
$ cargo fmt --all && cargo fmt --all -- --check
FMT OK
$ git diff --check
DIFFCHECK OK
$ cargo clippy --workspace --all-features --locked -- -D warnings \
    -A clippy::uninlined_format_args -A clippy::too_many_arguments \
    -A clippy::unnecessary_map_or -A clippy::collapsible_if \
    -A clippy::assertions_on_constants
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 28s      # no warnings

$ cargo test -p codewhale-mcp --locked
test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p codewhale-cli --locked mcp
test result: ok. 2 passed; 0 failed; 0 ignored     # tests/mcp_server_proxy.rs
# (other cli test binaries in the filter: 1 passed, rest filtered out, 0 failed)
```

Because I touched `crates/config`, I also ran the crate it lives in, outside the required gate list:

```
$ cargo test -p codewhale-config --locked
test result: ok. 428 passed; 0 failed
```

`cargo test --workspace` was **not** run (30+ min, shared build slot), and `--all-targets` was not added to clippy.

## What I could NOT verify

- **No real third-party MCP server was exercised.** Nothing here has been run against `@modelcontextprotocol/server-filesystem`, a GitHub MCP server, or anything from the ecosystem. The evidence is a POSIX-sh server I wrote, which speaks the handshake and the four methods this client uses. Real servers will exercise capability negotiation, pagination, and error shapes that my fixture does not.
- **Unix only, in practice.** Every process-spawning test is `#[cfg(unix)]` because the fixture is a `sh` script. The spawn-failure assertions run on all platforms, but Windows has no coverage of a successful spawn or round-trip, and I have no Windows machine here. The implementation uses only `std::process`, so I expect it to work, but "expect" is the accurate word.
- **`env` handling is by inspection, not test.** `Command::envs` layers the configured vars over the inherited environment; no test asserts that.
- **Resource proxying is untested end-to-end.** `resources/list` / `resources/read` are implemented and capability-gated, but my fixture advertises only `tools`, so those paths are exercised only by the capability guard.
- **Out of scope, noticed in passing:** `docs/MCP.md:337-341` describes `codewhale mcp-server` as "the equivalent" of `codewhale-tui serve --mcp`. Those are not equivalent — one serves Codewhale's own tools, the other proxies configured downstream servers. I did not change the docs; that looks like a separate accuracy issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjC3M6j689RFunVzC7d9aN
