### PR TITLE
fix(config): resolve the active model the same way the TUI does (#4832)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2381,9 +2381,6 @@ impl ConfigToml {
         let root_deepseek_base_url = (provider == ProviderKind::Deepseek)
             .then(|| self.base_url.clone())
             .flatten();
-        let root_deepseek_model = (provider == ProviderKind::Deepseek)
-            .then(|| self.default_text_model.clone())
-            .flatten();
         let auth_mode = cli
             .auth_mode
             .clone()
@@ -2526,6 +2523,22 @@ impl ConfigToml {
         };
 
         let env_provider_model = env.model_for(provider, &base_url);
+        // Root `default_text_model` is the key `codewhale model set` writes and
+        // the setup wizard writes, for every provider. It used to enter this
+        // chain only when `provider == Deepseek`, which made this resolver
+        // disagree with `Config::default_model()` in the TUI — the chain that
+        // actually builds the request — for every non-DeepSeek provider
+        // (#4832, #4838). The user's model still shipped; only this resolver,
+        // and therefore `codewhale model resolve`, reported a provider default.
+        //
+        // It is honoured for any provider now, minus the one case the DeepSeek
+        // gate was accidentally covering: a stale DeepSeek id left behind by a
+        // provider switch must not be forwarded to an endpoint that cannot
+        // serve it.
+        let root_default_model = self
+            .default_text_model
+            .clone()
+            .filter(|model| !root_default_model_is_foreign_to_provider(provider, model, &base_url));
         // Derived from the same chain as `model` below so the reported
         // provenance cannot drift from the id that is actually used.
         let model_source = if cli.model.is_some() {
@@ -2534,7 +2547,7 @@ impl ConfigToml {
             ModelSource::Env
         } else if provider_cfg.model.is_some() {
             ModelSource::ProviderConfig
-        } else if root_deepseek_model.is_some() {
+        } else if root_default_model.is_some() {
             ModelSource::RootDefaultTextModel
         } else if self.model.is_some() {
             ModelSource::RootModel
@@ -2548,7 +2561,7 @@ impl ConfigToml {
             .or_else(|| env.model.clone())
             .or(env_provider_model)
             .or_else(|| provider_cfg.model.clone())
-            .or(root_deepseek_model)
+            .or(root_default_model)
             .or_else(|| self.model.clone())
             .unwrap_or_else(|| {
                 if provider == ProviderKind::Moonshot
@@ -2816,6 +2829,134 @@ fn project_config_candidate_exists(path: &Path) -> bool {
         let file_type = metadata.file_type();
         file_type.is_file() || file_type.is_symlink()
     })
+}
+
+/// Canonical id for a DeepSeek-family model name, or `None` for anything else.
+///
+/// Kept behaviourally identical to `normalize_model_name` in
+/// `crates/tui/src/config.rs`, which is the definition the TUI's own model
+/// chain uses. It exists here only so this crate can answer "is this root
+/// default a DeepSeek id?" without depending on the TUI.
+fn deepseek_family_model_id(model: &str) -> Option<String> {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "pro" | "deepseek-v4pro" => return Some("deepseek-v4-pro".to_string()),
+        "flash" | "deepseek-v4flash" => return Some("deepseek-v4-flash".to_string()),
+        _ => {}
+    }
+
+    let normalized = trimmed.to_ascii_lowercase();
+    if !normalized.starts_with("deepseek") && !normalized.contains("/deepseek") {
+        return None;
+    }
+    if trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/'))
+    {
+        return Some(trimmed.to_string());
+    }
+    None
+}
+
+/// Providers whose model id is forwarded verbatim, because the upstream
+/// service — not this crate — is the authority on what ids it serves.
+///
+/// Mirrors `provider_passes_model_through` in `crates/tui/src/config.rs`.
+fn provider_passes_model_through(provider: ProviderKind) -> bool {
+    matches!(
+        provider,
+        ProviderKind::Openai
+            | ProviderKind::Atlascloud
+            | ProviderKind::WanjieArk
+            | ProviderKind::Volcengine
+            | ProviderKind::XiaomiMimo
+            | ProviderKind::Moonshot
+            | ProviderKind::Qianfan
+            | ProviderKind::Openmodel
+            | ProviderKind::Ollama
+            | ProviderKind::Huggingface
+            | ProviderKind::Meta
+            | ProviderKind::Xai
+            | ProviderKind::Telecomjs
+            | ProviderKind::Custom
+    )
+}
+
+/// Whether a root `default_text_model` would be foreign to the active
+/// provider's endpoint, i.e. honouring it would send an id the endpoint cannot
+/// serve.
+///
+/// This is the narrow case the old `provider == Deepseek` gate was covering by
+/// accident: a user switches `provider` and leaves a DeepSeek id behind in
+/// `default_text_model`. Forwarding `deepseek-chat` to Z.ai fails every
+/// request, so the root default is dropped and the provider default used
+/// instead — matching the decision `Config::default_model()` makes via
+/// `root_deepseek_model_is_foreign_to_direct_provider`
+/// (`crates/tui/src/config.rs`), whose provider lists this mirrors.
+fn root_default_model_is_foreign_to_provider(
+    provider: ProviderKind,
+    model: &str,
+    base_url: &str,
+) -> bool {
+    // Not a DeepSeek id at all: nothing to protect against here. A model the
+    // provider does not serve for some other reason is the provider's error to
+    // report, not ours to silently rewrite.
+    if deepseek_family_model_id(model).is_none() {
+        return false;
+    }
+    // DeepSeek's own endpoints serve DeepSeek ids.
+    if matches!(
+        provider,
+        ProviderKind::Deepseek | ProviderKind::DeepseekAnthropic
+    ) {
+        return false;
+    }
+    // A custom base URL may be any OpenAI-compatible proxy, and a proxy may
+    // legitimately serve DeepSeek ids (#1519). Full pass-through.
+    if provider_preserves_custom_base_url_model(provider, base_url) {
+        return false;
+    }
+    // Vendor-locked official endpoints. These pass model ids through, but
+    // api.x.ai will never answer to `deepseek-v4-pro`, so pass-through does not
+    // make the id servable — this is the #3227 contamination case.
+    if matches!(
+        provider,
+        ProviderKind::Xai | ProviderKind::Openai | ProviderKind::Moonshot
+    ) {
+        return true;
+    }
+    // Remaining pass-through providers forward the id verbatim to a service
+    // that is the authority on its own catalog.
+    if provider_passes_model_through(provider) {
+        return false;
+    }
+    // Aggregators, local runtimes, and multi-vendor clouds host DeepSeek
+    // models under their own catalogs, so a DeepSeek id is valid there.
+    if matches!(
+        provider,
+        ProviderKind::NvidiaNim
+            | ProviderKind::Openrouter
+            | ProviderKind::Novita
+            | ProviderKind::Fireworks
+            | ProviderKind::Siliconflow
+            | ProviderKind::SiliconflowCN
+            | ProviderKind::Deepinfra
+            | ProviderKind::Together
+            | ProviderKind::Sglang
+            | ProviderKind::Vllm
+            | ProviderKind::Volcengine
+            | ProviderKind::Atlascloud
+            | ProviderKind::OpencodeGo
+            | ProviderKind::WanjieArk
+    ) {
+        return false;
+    }
+    // Everything else is a vendor serving only its own family (Z.ai, Stepfun,
+    // MiniMax, Anthropic, …): a DeepSeek id there is the stale-config case.
+    true
 }
 
 fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {

--- a/crates/tui/src/config_persistence.rs
+++ b/crates/tui/src/config_persistence.rs
@@ -1267,4 +1267,153 @@ slot = 1
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "config.toml can hold api keys");
     }
+
+    /// Clears every model override the dispatcher's env layer reads for the
+    /// providers exercised below, so the assertion is about config precedence
+    /// and cannot be flipped by an ambient variable on a developer machine.
+    struct ModelEnvGuard {
+        saved: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl ModelEnvGuard {
+        const VARS: &'static [&'static str] = &[
+            "CODEWHALE_MODEL",
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_DEFAULT_TEXT_MODEL",
+            "GLM_MODEL",
+            "BIGMODEL_MODEL",
+            "ZAI_MODEL",
+            "XAI_MODEL",
+            "GROK_MODEL",
+            "OPENROUTER_MODEL",
+            "OLLAMA_MODEL",
+        ];
+
+        fn new() -> Self {
+            let saved = Self::VARS
+                .iter()
+                .map(|name| (*name, env::var_os(name)))
+                .collect();
+            // Safety: test-only environment mutation; the caller holds the
+            // process-wide test-env lock via `EnvGuard`.
+            unsafe {
+                for name in Self::VARS {
+                    env::remove_var(name);
+                }
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for ModelEnvGuard {
+        fn drop(&mut self) {
+            // Safety: test-only environment restoration under the same lock.
+            unsafe {
+                for (name, value) in &self.saved {
+                    match value {
+                        Some(value) => env::set_var(name, value),
+                        None => env::remove_var(name),
+                    }
+                }
+            }
+        }
+    }
+
+    /// The active model must be one answer, not two.
+    ///
+    /// The TUI resolves it with `Config::default_model()`, which is what
+    /// `client.rs` puts on the wire and what `doctor` reports. The dispatcher
+    /// resolves it independently in `codewhale-config`'s
+    /// `resolve_runtime_options`, which is what `codewhale model resolve`
+    /// reports and what the app-server and route descriptors consume. The two
+    /// silently disagreed for every non-DeepSeek provider (#4832, #4838): the
+    /// dispatcher gated root `default_text_model` behind `provider == Deepseek`
+    /// and so reported a provider default while the wire carried the user's
+    /// chosen model.
+    ///
+    /// A diagnostic that contradicts the request it is diagnosing is worse than
+    /// no diagnostic, so this pins the two chains together by construction
+    /// rather than asserting either one's internals.
+    #[test]
+    fn the_dispatcher_and_the_tui_resolve_the_same_active_model() {
+        // (case, config body, what both chains must answer)
+        let cases: &[(&str, &str, &str)] = &[
+            (
+                "a non-DeepSeek provider honours the user's chosen model",
+                "provider = \"zai\"\ndefault_text_model = \"GLM-4.6\"\n\n[providers.zai]\napi_key = \"k\"\n",
+                "GLM-4.6",
+            ),
+            (
+                "a stale DeepSeek id must not be forwarded to a native non-DeepSeek endpoint",
+                "provider = \"zai\"\ndefault_text_model = \"deepseek-chat\"\n\n[providers.zai]\napi_key = \"k\"\n",
+                crate::config::DEFAULT_ZAI_MODEL,
+            ),
+            (
+                "no root default falls through to the provider default",
+                "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+                crate::config::DEFAULT_ZAI_MODEL,
+            ),
+            (
+                "a provider-scoped model outranks the root default",
+                "provider = \"zai\"\ndefault_text_model = \"GLM-4.6\"\n\n[providers.zai]\napi_key = \"k\"\nmodel = \"GLM-4.5-Air\"\n",
+                "GLM-4.5-Air",
+            ),
+            (
+                "DeepSeek itself keeps honouring the root default",
+                "provider = \"deepseek\"\ndefault_text_model = \"deepseek-v4-pro\"\n\n[providers.deepseek]\napi_key = \"k\"\n",
+                "deepseek-v4-pro",
+            ),
+            (
+                "a vendor-locked endpoint refuses a DeepSeek id (#3227)",
+                "provider = \"xai\"\ndefault_text_model = \"deepseek-v4-pro\"\n\n[providers.xai]\napi_key = \"k\"\n",
+                crate::config::DEFAULT_XAI_MODEL,
+            ),
+            (
+                "an aggregator legitimately serves DeepSeek ids",
+                "provider = \"openrouter\"\ndefault_text_model = \"deepseek/deepseek-v4-pro\"\n\n[providers.openrouter]\napi_key = \"k\"\n",
+                "deepseek/deepseek-v4-pro",
+            ),
+            (
+                "a local runtime passes its own tag through",
+                "provider = \"ollama\"\ndefault_text_model = \"qwen3-coder:30b\"\n",
+                "qwen3-coder:30b",
+            ),
+            (
+                "a custom base URL keeps full pass-through (#1519)",
+                "provider = \"zai\"\ndefault_text_model = \"deepseek-chat\"\n\n[providers.zai]\napi_key = \"k\"\nbase_url = \"https://proxy.example.invalid/v1\"\n",
+                "deepseek-chat",
+            ),
+        ];
+
+        for (case, body, expected) in cases {
+            let temp_root = temp_root("codewhale-model-chain-agreement");
+            fs::create_dir_all(&temp_root).unwrap();
+            let _guard = EnvGuard::new(&temp_root);
+            let _model_guard = ModelEnvGuard::new();
+            let path = temp_root.join(".deepseek").join("config.toml");
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, body).unwrap();
+
+            let tui = crate::config::Config::load(Some(path.clone()), None)
+                .expect("the TUI must parse this config");
+            let tui_model = tui.default_model();
+
+            let dispatcher = codewhale_config::ConfigStore::load(Some(path.clone()))
+                .expect("the dispatcher must parse the same config");
+            let runtime = dispatcher
+                .config
+                .resolve_runtime_options(&codewhale_config::CliRuntimeOverrides::default());
+
+            assert_eq!(
+                tui_model, *expected,
+                "{case}: the TUI chain (what actually reaches the provider) is wrong"
+            );
+            assert_eq!(
+                runtime.model, *expected,
+                "{case}: the dispatcher chain (what `model resolve` reports) is wrong"
+            );
+
+            let _ = fs::remove_dir_all(&temp_root);
+        }
+    }
 }


### PR DESCRIPTION
Closes #4832.

`codewhale model resolve` and `codewhale doctor` disagreed about the active
model for every non-DeepSeek provider, and `model resolve` was the wrong one.

## Evidence

Sealed `HOME` on `ff04c4336`, `providers.zai.base_url` pointed at a local
recording endpoint (real config untouched, sha256 identical before and after):

```
$ codewhale model set GLM-4.6
$ codewhale exec "say ok"
POST /v1/chat/completions   model=GLM-4.6     ← the user's choice ships
$ codewhale doctor
  · model: GLM-4.6                             ← agrees with the wire
$ codewhale model resolve
resolved: GLM-5.2  model_source: provider default    ← wrong
```

## Cause

Two chains resolve the active model independently:

- `Config::default_model()` (`crates/tui/src/config.rs`) — what `client.rs:957`
  puts on the wire and what `doctor` reports. Honours root
  `default_text_model` for any provider, guarded against stale DeepSeek ids.
- `resolve_runtime_options` (`crates/config/src/lib.rs`) — what `model resolve`
  reports, and what the app-server and `route/descriptor.rs` consume. It gated
  root `default_text_model` behind `provider == ProviderKind::Deepseek`, so for
  every other provider the key was dropped before the chain saw it.

#4837 wired `model resolve` to the second one believing it was the doctor path
(see the comment it added at `crates/cli/src/lib.rs:3620`), which is why the
fix for #4832 did not take.

## Change

Root `default_text_model` is honoured for any provider in the dispatcher too,
minus the one case the DeepSeek gate was covering by accident: a stale DeepSeek
id left behind by a provider switch must not be forwarded to an endpoint that
cannot serve it. `root_default_model_is_foreign_to_provider` mirrors the
provider lists in the TUI's `root_deepseek_model_is_foreign_to_direct_provider`,
so `deepseek-chat` under `provider = "zai"` still falls through to the Z.ai
default, while aggregators, local runtimes, and custom base URLs keep full
pass-through.

## Test

The regression test asserts the **two chains return the same answer** across
nine provider/model shapes, rather than asserting either one's internals —
the defect was disagreement, not a wrong constant. It fails on the parent
commit with `left: "GLM-5.2", right: "GLM-4.6"`.

Covered: chosen model honoured · stale DeepSeek id rejected · no root default ·
provider-scoped model outranks root · DeepSeek itself · vendor-locked endpoint
(#3227) · aggregator serving DeepSeek ids · local runtime tag · custom base URL
(#1519).

## Scope note

This **narrows #4838 rather than fixing it as filed.** `model set` was never a
no-op for the runtime — the `exec` line above is the disproof. The
user-visible symptom was a lying diagnostic, not a dropped setting. I have
commented to that effect on #4838 and reopened #4832.

Two model-resolution chains still exist; this PR makes them agree on the shapes
the test covers and pins them there, but it does not merge them. The durable
fix is one owner for the equal-treatment resolver — filed separately.

## Gates

- `cargo test -p codewhale-config` — 428 passed
- `cargo test -p codewhale-cli` — 176 passed
- `cargo test -p codewhale-tui --bin codewhale-tui` — 8215 passed, 0 failed
- CI-shaped clippy (workspace, all-features, the five CI `-A` allows) — clean
- `cargo fmt --all -- --check`, `git diff --check` — clean
