### PR TITLE
fix(config): align root model fallback with TUI

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -525,7 +525,7 @@ pub struct ConfigToml {
     /// Optional extra HTTP headers forwarded to model API requests.
     #[serde(default, skip_serializing_if = "http_headers_are_effectively_empty")]
     pub http_headers: BTreeMap<String, String>,
-    /// TUI-compatible default DeepSeek model.
+    /// Legacy TUI-compatible default model, resolved against the active route.
     pub default_text_model: Option<String>,
     #[serde(default, deserialize_with = "deserialize_root_provider")]
     pub provider: ProviderKind,
@@ -2394,9 +2394,6 @@ impl ConfigToml {
         let root_deepseek_base_url = (provider == ProviderKind::Deepseek)
             .then(|| self.base_url.clone())
             .flatten();
-        let root_deepseek_model = (provider == ProviderKind::Deepseek)
-            .then(|| self.default_text_model.clone())
-            .flatten();
         let auth_mode = cli
             .auth_mode
             .clone()
@@ -2488,6 +2485,37 @@ impl ConfigToml {
                 ProviderKind::Custom => provider.provider().default_base_url().to_string(),
             })
         };
+        // The TUI request path treats the legacy root `default_text_model` as
+        // an active-route fallback, not as a DeepSeek-only field. Apply the
+        // same route guard here so RuntimeConfig consumers (including
+        // `model resolve`) agree with the model that the TUI actually sends.
+        let root_default_text_model = self.default_text_model.clone().filter(|model| {
+            root_default_text_model_is_compatible_with_route(
+                provider,
+                &base_url,
+                auth_mode.as_deref(),
+                model,
+            )
+        });
+        // A project-level/provider-neutral `model` overrides the legacy root
+        // fallback on non-DeepSeek routes. Keep DeepSeek's released ordering
+        // unchanged, where `default_text_model` has always won.
+        let (primary_root_model, primary_root_source, fallback_root_model, fallback_root_source) =
+            if provider == ProviderKind::Deepseek {
+                (
+                    root_default_text_model,
+                    ModelSource::RootDefaultTextModel,
+                    self.model.clone(),
+                    ModelSource::RootModel,
+                )
+            } else {
+                (
+                    self.model.clone(),
+                    ModelSource::RootModel,
+                    root_default_text_model,
+                    ModelSource::RootDefaultTextModel,
+                )
+            };
         // `auth_mode = "none"` is an endpoint contract, so it suppresses every
         // credential source (including explicit CLI/config values). Otherwise
         // CLI and route-local config win outright. Ambient provider credentials
@@ -2547,10 +2575,10 @@ impl ConfigToml {
             ModelSource::Env
         } else if provider_cfg.model.is_some() {
             ModelSource::ProviderConfig
-        } else if root_deepseek_model.is_some() {
-            ModelSource::RootDefaultTextModel
-        } else if self.model.is_some() {
-            ModelSource::RootModel
+        } else if primary_root_model.is_some() {
+            primary_root_source
+        } else if fallback_root_model.is_some() {
+            fallback_root_source
         } else {
             ModelSource::ProviderDefault
         };
@@ -2561,8 +2589,8 @@ impl ConfigToml {
             .or_else(|| env.model.clone())
             .or(env_provider_model)
             .or_else(|| provider_cfg.model.clone())
-            .or(root_deepseek_model)
-            .or_else(|| self.model.clone())
+            .or(primary_root_model)
+            .or(fallback_root_model)
             .unwrap_or_else(|| {
                 if provider == ProviderKind::Moonshot
                     && (auth_mode
@@ -2575,7 +2603,11 @@ impl ConfigToml {
                     default_model_for_provider(provider).to_string()
                 }
             });
-        let model = if provider == ProviderKind::OpencodeGo {
+        let model = if provider != ProviderKind::Deepseek
+            && model_source == ModelSource::RootDefaultTextModel
+        {
+            normalize_root_default_text_model_for_provider(provider, &base_url, &model)
+        } else if provider == ProviderKind::OpencodeGo {
             // OpenCode Go's `/models` response also contains models that only
             // speak Anthropic Messages. This provider is deliberately bound to
             // Chat Completions, so even custom endpoint/env overrides cannot
@@ -2829,6 +2861,323 @@ fn project_config_candidate_exists(path: &Path) -> bool {
         let file_type = metadata.file_type();
         file_type.is_file() || file_type.is_symlink()
     })
+}
+
+fn root_default_text_model_is_compatible_with_route(
+    provider: ProviderKind,
+    base_url: &str,
+    auth_mode: Option<&str>,
+    model: &str,
+) -> bool {
+    // Preserve the released DeepSeek behavior byte-for-byte. This helper only
+    // widens the root fallback to routes on which the TUI already accepts it.
+    if provider == ProviderKind::Deepseek {
+        return true;
+    }
+
+    // These protocol-specific routes choose their own model family before the
+    // TUI considers the legacy root default.
+    if provider == ProviderKind::OpenaiCodex
+        || (provider == ProviderKind::Moonshot
+            && (auth_mode.is_some_and(auth_mode_uses_kimi_imported_token)
+                || moonshot_base_url_uses_kimi_code(base_url)))
+    {
+        return false;
+    }
+
+    if model.trim().eq_ignore_ascii_case("auto") {
+        return true;
+    }
+
+    // Xiaomi and OpenCode expose strict, protocol-specific model rosters.
+    if provider == ProviderKind::XiaomiMimo {
+        return canonical_xiaomi_mimo_model_id(model).is_some();
+    }
+    if provider == ProviderKind::OpencodeGo {
+        return opencode_go_chat_model_id(model).is_some();
+    }
+
+    // A custom endpoint owns its model namespace and may legitimately serve
+    // any identifier, including a DeepSeek-family id.
+    if provider_preserves_custom_base_url_model(provider, base_url) {
+        return true;
+    }
+
+    if provider == ProviderKind::DeepseekAnthropic {
+        return is_deepseek_family_model_id(model);
+    }
+
+    // These pass-through providers are vendor-locked on their official
+    // endpoints. Match the TUI's extra guard before applying the general
+    // direct-provider classification below.
+    if matches!(
+        provider,
+        ProviderKind::Openai | ProviderKind::Moonshot | ProviderKind::Xai
+    ) && is_deepseek_family_model_id(model)
+    {
+        return false;
+    }
+
+    if !provider_passes_root_model_through(provider)
+        && (model.trim().is_empty() || model.chars().any(char::is_control))
+    {
+        return false;
+    }
+
+    !root_deepseek_model_is_foreign_to_direct_provider(provider, model)
+}
+
+fn root_deepseek_model_is_foreign_to_direct_provider(provider: ProviderKind, model: &str) -> bool {
+    if matches!(
+        provider,
+        ProviderKind::Deepseek | ProviderKind::DeepseekAnthropic
+    ) || provider_passes_root_model_through(provider)
+    {
+        return false;
+    }
+    if provider_hosts_deepseek_models(provider) {
+        return false;
+    }
+    is_deepseek_family_model_id(model)
+}
+
+fn provider_passes_root_model_through(provider: ProviderKind) -> bool {
+    matches!(
+        provider,
+        ProviderKind::Openai
+            | ProviderKind::Atlascloud
+            | ProviderKind::WanjieArk
+            | ProviderKind::Volcengine
+            | ProviderKind::XiaomiMimo
+            | ProviderKind::Moonshot
+            | ProviderKind::Qianfan
+            | ProviderKind::Openmodel
+            | ProviderKind::Ollama
+            | ProviderKind::Huggingface
+            | ProviderKind::Meta
+            | ProviderKind::Xai
+            | ProviderKind::Telecomjs
+            | ProviderKind::Custom
+    )
+}
+
+fn provider_hosts_deepseek_models(provider: ProviderKind) -> bool {
+    matches!(
+        provider,
+        ProviderKind::NvidiaNim
+            | ProviderKind::Openrouter
+            | ProviderKind::Novita
+            | ProviderKind::Fireworks
+            | ProviderKind::Siliconflow
+            | ProviderKind::SiliconflowCN
+            | ProviderKind::Deepinfra
+            | ProviderKind::Together
+            | ProviderKind::Sglang
+            | ProviderKind::Vllm
+            | ProviderKind::Volcengine
+            | ProviderKind::Atlascloud
+            | ProviderKind::OpencodeGo
+            | ProviderKind::WanjieArk
+    )
+}
+
+fn is_deepseek_family_model_id(model: &str) -> bool {
+    let trimmed = model.trim();
+    let normalized = trimmed.to_ascii_lowercase();
+    if matches!(
+        normalized.as_str(),
+        "pro" | "flash" | "deepseek-v4pro" | "deepseek-v4flash"
+    ) {
+        return true;
+    }
+    if !normalized.starts_with("deepseek") && !normalized.contains("/deepseek") {
+        return false;
+    }
+    trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/'))
+}
+
+fn normalize_root_default_text_model_for_provider(
+    provider: ProviderKind,
+    base_url: &str,
+    model: &str,
+) -> String {
+    let trimmed = model.trim();
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return "auto".to_string();
+    }
+    if provider == ProviderKind::XiaomiMimo {
+        return canonical_xiaomi_mimo_model_id(trimmed)
+            .unwrap_or(DEFAULT_XIAOMI_MIMO_MODEL)
+            .to_string();
+    }
+    if provider == ProviderKind::OpencodeGo {
+        // OpenCode's Chat-Completions protocol boundary remains strict even
+        // when its endpoint is overridden, matching the config route resolver.
+        return opencode_go_chat_model_id(trimmed)
+            .unwrap_or(DEFAULT_OPENCODE_GO_MODEL)
+            .to_string();
+    }
+    if provider_preserves_custom_base_url_model(provider, base_url)
+        || provider_passes_root_model_through(provider)
+    {
+        return trimmed.to_string();
+    }
+    if provider == ProviderKind::DeepseekAnthropic {
+        return normalize_direct_deepseek_root_model(trimmed);
+    }
+
+    let canonical = canonical_root_model_id_for_provider(provider, trimmed);
+    root_wire_model_for_provider(provider, canonical)
+}
+
+fn canonical_root_model_id_for_provider(provider: ProviderKind, model: &str) -> String {
+    if let Some(canonical) = match provider {
+        ProviderKind::Openrouter => canonical_openrouter_root_model_id(model),
+        ProviderKind::Arcee => canonical_arcee_root_model_id(model),
+        ProviderKind::Zai => canonical_zai_model_id(model),
+        ProviderKind::Minimax | ProviderKind::MinimaxAnthropic => canonical_minimax_model_id(model),
+        _ => None,
+    } {
+        return canonical.to_string();
+    }
+    if matches!(
+        provider,
+        ProviderKind::NvidiaNim
+            | ProviderKind::Novita
+            | ProviderKind::Fireworks
+            | ProviderKind::Siliconflow
+            | ProviderKind::SiliconflowCN
+            | ProviderKind::Sglang
+            | ProviderKind::Vllm
+            | ProviderKind::Deepinfra
+            | ProviderKind::WanjieArk
+            | ProviderKind::Volcengine
+    ) && let Some(canonical) = canonical_official_deepseek_root_model(model)
+    {
+        return canonical.to_string();
+    }
+    model.to_string()
+}
+
+fn canonical_openrouter_root_model_id(model: &str) -> Option<&'static str> {
+    let normalized = model.trim().to_ascii_lowercase();
+    let normalized = normalized.replace(['_', ' '], "-");
+    match normalized.as_str() {
+        "z-ai/glm-5-turbo" | "glm-5-turbo" | "glm-5turbo" | "zai-glm-5-turbo" => {
+            Some("z-ai/glm-5-turbo")
+        }
+        "nvidia/nemotron-3-ultra-550b-a55b"
+        | "nvidia/nemotron-3-ultra"
+        | "nemotron-3-ultra"
+        | "nemotron-3-ultra-550b-a55b"
+        | "nvidia-nemotron-3-ultra"
+        | "nvidia-nemotron-3-ultra-550b-a55b" => Some("nvidia/nemotron-3-ultra-550b-a55b"),
+        _ => canonical_openrouter_recent_model_id(model),
+    }
+}
+
+fn canonical_arcee_root_model_id(model: &str) -> Option<&'static str> {
+    let normalized = model.trim().to_ascii_lowercase();
+    let normalized = normalized.replace(['_', ' '], "-");
+    match normalized.as_str() {
+        "trinity" | "arcee-trinity" | "trinity-large-thinking" | "arcee-trinity-large-thinking" => {
+            Some(DEFAULT_ARCEE_MODEL)
+        }
+        "arcee-trinity-mini" | ARCEE_TRINITY_MINI_MODEL => Some(ARCEE_TRINITY_MINI_MODEL),
+        "arcee-trinity-large-preview" | ARCEE_TRINITY_LARGE_PREVIEW_MODEL => {
+            Some(ARCEE_TRINITY_LARGE_PREVIEW_MODEL)
+        }
+        _ => None,
+    }
+}
+
+fn canonical_official_deepseek_root_model(model: &str) -> Option<&'static str> {
+    match model.trim().to_ascii_lowercase().as_str() {
+        "pro"
+        | "deepseek-v4-pro"
+        | "deepseek-v4pro"
+        | "deepseek-ai/deepseek-v4-pro"
+        | "deepseek-ai/deepseek-v4pro"
+        | "deepseek/deepseek-v4-pro"
+        | "deepseek/deepseek-v4pro" => Some("deepseek-v4-pro"),
+        "flash"
+        | "deepseek-v4-flash"
+        | "deepseek-v4flash"
+        | "deepseek-ai/deepseek-v4-flash"
+        | "deepseek-ai/deepseek-v4flash"
+        | "deepseek/deepseek-v4-flash"
+        | "deepseek/deepseek-v4flash" => Some("deepseek-v4-flash"),
+        _ => None,
+    }
+}
+
+fn root_wire_model_for_provider(provider: ProviderKind, model: String) -> String {
+    let lowered = model.to_ascii_lowercase();
+    match (provider, lowered.as_str()) {
+        (ProviderKind::NvidiaNim, "deepseek-v4-pro") => DEFAULT_NVIDIA_NIM_MODEL.to_string(),
+        (ProviderKind::NvidiaNim, "deepseek-v4-flash") => {
+            DEFAULT_NVIDIA_NIM_FLASH_MODEL.to_string()
+        }
+        (ProviderKind::Openrouter, "deepseek-v4-pro") => DEFAULT_OPENROUTER_MODEL.to_string(),
+        (ProviderKind::Openrouter, "deepseek-v4-flash") => {
+            DEFAULT_OPENROUTER_FLASH_MODEL.to_string()
+        }
+        (ProviderKind::Novita, "deepseek-v4-pro") => DEFAULT_NOVITA_MODEL.to_string(),
+        (ProviderKind::Novita, "deepseek-v4-flash") => DEFAULT_NOVITA_FLASH_MODEL.to_string(),
+        (ProviderKind::Fireworks, "deepseek-v4-pro") => DEFAULT_FIREWORKS_MODEL.to_string(),
+        (
+            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN,
+            "deepseek-v4-pro" | "deepseek-reasoner" | "deepseek-r1",
+        ) => DEFAULT_SILICONFLOW_MODEL.to_string(),
+        (
+            ProviderKind::Siliconflow | ProviderKind::SiliconflowCN,
+            "deepseek-v4-flash" | "deepseek-chat" | "deepseek-v3",
+        ) => DEFAULT_SILICONFLOW_FLASH_MODEL.to_string(),
+        (ProviderKind::Sglang, "deepseek-v4-pro") => DEFAULT_SGLANG_MODEL.to_string(),
+        (ProviderKind::Sglang, "deepseek-v4-flash") => DEFAULT_SGLANG_FLASH_MODEL.to_string(),
+        (ProviderKind::Vllm, "deepseek-v4-pro") => DEFAULT_VLLM_MODEL.to_string(),
+        (ProviderKind::Vllm, "deepseek-v4-flash") => DEFAULT_VLLM_FLASH_MODEL.to_string(),
+        (ProviderKind::Deepinfra, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_DEEPINFRA_MODEL.to_string()
+        }
+        (ProviderKind::Deepinfra, "deepseek-v4-flash" | "deepseek-chat" | "deepseek-reasoner") => {
+            DEFAULT_DEEPINFRA_FLASH_MODEL.to_string()
+        }
+        (ProviderKind::Together, "deepseek-v4-pro" | "deepseek-v4pro") => {
+            DEFAULT_TOGETHER_MODEL.to_string()
+        }
+        (
+            ProviderKind::Together,
+            "deepseek-v4-flash" | "deepseek-v4flash" | "deepseek-chat" | "deepseek-reasoner",
+        ) => DEFAULT_TOGETHER_FLASH_MODEL.to_string(),
+        (ProviderKind::Together, "inkling" | "together-inkling" | "thinkingmachines/inkling") => {
+            "thinkingmachines/inkling".to_string()
+        }
+        _ => model,
+    }
+}
+
+fn normalize_direct_deepseek_root_model(model: &str) -> String {
+    let trimmed = model.trim();
+    match trimmed.to_ascii_lowercase().as_str() {
+        "pro"
+        | "deepseek-v4pro"
+        | "deepseek-ai/deepseek-v4-pro"
+        | "deepseek-ai/deepseek-v4pro"
+        | "deepseek/deepseek-v4-pro"
+        | "deepseek/deepseek-v4pro" => "deepseek-v4-pro".to_string(),
+        "flash"
+        | "deepseek-v4flash"
+        | "deepseek-chat"
+        | "deepseek-reasoner"
+        | "deepseek-ai/deepseek-v4-flash"
+        | "deepseek-ai/deepseek-v4flash"
+        | "deepseek/deepseek-v4-flash"
+        | "deepseek/deepseek-v4flash" => "deepseek-v4-flash".to_string(),
+        _ => trimmed.to_string(),
+    }
 }
 
 fn normalize_model_for_provider(provider: ProviderKind, model: &str) -> String {
@@ -3652,7 +4001,8 @@ pub enum ModelSource {
     Env,
     /// `[providers.<name>].model`.
     ProviderConfig,
-    /// The root `default_text_model` key, which is DeepSeek-scoped.
+    /// The legacy root `default_text_model` key, when compatible with the
+    /// active provider route.
     RootDefaultTextModel,
     /// The provider-neutral root `model` key.
     RootModel,

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -4925,6 +4925,341 @@ fn config_provider_records_provider_source() {
     assert_eq!(resolved.provider_source, ProviderSource::Config);
 }
 
+#[test]
+fn runtime_config_honors_zai_root_default_text_model() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let config = ConfigToml {
+        provider: ProviderKind::Zai,
+        default_text_model: Some("GLM-4.6".to_string()),
+        ..ConfigToml::default()
+    };
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::Zai);
+    assert_eq!(resolved.model, "GLM-4.6");
+    assert_eq!(resolved.model_source, ModelSource::RootDefaultTextModel);
+
+    let cli = CliRuntimeOverrides {
+        provider: Some(ProviderKind::Zai),
+        ..CliRuntimeOverrides::default()
+    };
+    let overridden = ConfigToml {
+        provider: ProviderKind::Deepseek,
+        default_text_model: Some("GLM-4.6".to_string()),
+        ..ConfigToml::default()
+    }
+    .resolve_runtime_options(&cli);
+    assert_eq!(overridden.provider, ProviderKind::Zai);
+    assert_eq!(overridden.model, "GLM-4.6");
+    assert_eq!(overridden.model_source, ModelSource::RootDefaultTextModel);
+}
+
+#[test]
+fn runtime_config_rejects_stale_deepseek_root_model_for_zai() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let config = ConfigToml {
+        provider: ProviderKind::Zai,
+        default_text_model: Some("deepseek-chat".to_string()),
+        ..ConfigToml::default()
+    };
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.provider, ProviderKind::Zai);
+    assert_eq!(resolved.model, DEFAULT_ZAI_MODEL);
+    assert_eq!(resolved.model_source, ModelSource::ProviderDefault);
+
+    let cli = CliRuntimeOverrides {
+        provider: Some(ProviderKind::Zai),
+        ..CliRuntimeOverrides::default()
+    };
+    let overridden = ConfigToml {
+        provider: ProviderKind::Deepseek,
+        default_text_model: Some("deepseek-chat".to_string()),
+        ..ConfigToml::default()
+    }
+    .resolve_runtime_options(&cli);
+    assert_eq!(overridden.provider, ProviderKind::Zai);
+    assert_eq!(overridden.model, DEFAULT_ZAI_MODEL);
+    assert_eq!(overridden.model_source, ModelSource::ProviderDefault);
+}
+
+#[test]
+fn runtime_config_root_model_keeps_precedence_over_legacy_fallback() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+    let config = ConfigToml {
+        provider: ProviderKind::Zai,
+        default_text_model: Some("GLM-4.6".to_string()),
+        model: Some("project-choice".to_string()),
+        ..ConfigToml::default()
+    };
+
+    let resolved = config.resolve_runtime_options(&CliRuntimeOverrides::default());
+
+    assert_eq!(resolved.model, "project-choice");
+    assert_eq!(resolved.model_source, ModelSource::RootModel);
+}
+
+#[test]
+fn runtime_config_gates_official_deepseek_anthropic_root_models() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    let foreign = ConfigToml {
+        provider: ProviderKind::DeepseekAnthropic,
+        default_text_model: Some("GLM-4.6".to_string()),
+        ..ConfigToml::default()
+    }
+    .resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(foreign.model, DEFAULT_DEEPSEEK_ANTHROPIC_MODEL);
+    assert_eq!(foreign.model_source, ModelSource::ProviderDefault);
+
+    let alias = ConfigToml {
+        provider: ProviderKind::DeepseekAnthropic,
+        default_text_model: Some("pro".to_string()),
+        ..ConfigToml::default()
+    }
+    .resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(alias.model, "deepseek-v4-pro");
+    assert_eq!(alias.model_source, ModelSource::RootDefaultTextModel);
+
+    let mut custom_endpoint = ConfigToml {
+        provider: ProviderKind::DeepseekAnthropic,
+        default_text_model: Some("pro".to_string()),
+        ..ConfigToml::default()
+    };
+    custom_endpoint.providers.deepseek_anthropic.base_url =
+        Some("https://proxy.example.test/anthropic".to_string());
+    let custom = custom_endpoint.resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(custom.model, "pro");
+    assert_eq!(custom.model_source, ModelSource::RootDefaultTextModel);
+}
+
+#[test]
+fn runtime_config_keeps_protocol_specific_root_model_fallbacks() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    let codex = ConfigToml {
+        provider: ProviderKind::OpenaiCodex,
+        default_text_model: Some("auto".to_string()),
+        ..ConfigToml::default()
+    }
+    .resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(codex.model, DEFAULT_OPENAI_CODEX_MODEL);
+    assert_eq!(codex.model_source, ModelSource::ProviderDefault);
+
+    let mut kimi_code_config = ConfigToml {
+        provider: ProviderKind::Moonshot,
+        default_text_model: Some("deepseek-v4-pro".to_string()),
+        ..ConfigToml::default()
+    };
+    kimi_code_config.providers.moonshot.base_url = Some(DEFAULT_KIMI_CODE_BASE_URL.to_string());
+    let kimi_code = kimi_code_config.resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(kimi_code.model, DEFAULT_KIMI_CODE_MODEL);
+    assert_eq!(kimi_code.model_source, ModelSource::ProviderDefault);
+
+    for (model, expected, source) in [
+        (
+            "mimo-v2-5-pro",
+            DEFAULT_XIAOMI_MIMO_MODEL,
+            ModelSource::RootDefaultTextModel,
+        ),
+        ("auto", "auto", ModelSource::RootDefaultTextModel),
+        (
+            "deepseek-chat",
+            DEFAULT_XIAOMI_MIMO_MODEL,
+            ModelSource::ProviderDefault,
+        ),
+    ] {
+        let resolved = ConfigToml {
+            provider: ProviderKind::XiaomiMimo,
+            default_text_model: Some(model.to_string()),
+            ..ConfigToml::default()
+        }
+        .resolve_runtime_options(&CliRuntimeOverrides::default());
+        assert_eq!(resolved.model, expected, "Xiaomi root model {model}");
+        assert_eq!(resolved.model_source, source, "Xiaomi root model {model}");
+    }
+
+    for (model, expected, source) in [
+        (
+            OPENCODE_GO_GLM_5_2_MODEL,
+            OPENCODE_GO_GLM_5_2_MODEL,
+            ModelSource::RootDefaultTextModel,
+        ),
+        ("auto", "auto", ModelSource::RootDefaultTextModel),
+        (
+            "claude-sonnet-4",
+            DEFAULT_OPENCODE_GO_MODEL,
+            ModelSource::ProviderDefault,
+        ),
+    ] {
+        let resolved = ConfigToml {
+            provider: ProviderKind::OpencodeGo,
+            default_text_model: Some(model.to_string()),
+            ..ConfigToml::default()
+        }
+        .resolve_runtime_options(&CliRuntimeOverrides::default());
+        assert_eq!(resolved.model, expected, "OpenCode root model {model}");
+        assert_eq!(resolved.model_source, source, "OpenCode root model {model}");
+    }
+}
+
+#[test]
+fn runtime_config_isolates_foreign_root_models_on_official_routes() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    for (provider, expected) in [
+        (ProviderKind::Openai, DEFAULT_OPENAI_MODEL),
+        (ProviderKind::Moonshot, DEFAULT_MOONSHOT_MODEL),
+        (ProviderKind::Xai, DEFAULT_XAI_MODEL),
+    ] {
+        let resolved = ConfigToml {
+            provider,
+            default_text_model: Some("deepseek-v4-pro".to_string()),
+            ..ConfigToml::default()
+        }
+        .resolve_runtime_options(&CliRuntimeOverrides::default());
+        assert_eq!(resolved.model, expected, "official {provider:?}");
+        assert_eq!(
+            resolved.model_source,
+            ModelSource::ProviderDefault,
+            "official {provider:?}"
+        );
+    }
+
+    let mut custom_xiaomi = ConfigToml {
+        provider: ProviderKind::XiaomiMimo,
+        default_text_model: Some("mimo-v2-5-pro".to_string()),
+        ..ConfigToml::default()
+    };
+    custom_xiaomi.providers.xiaomi_mimo.base_url =
+        Some("https://proxy.example.test/v1".to_string());
+    let custom_xiaomi = custom_xiaomi.resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(custom_xiaomi.model, DEFAULT_XIAOMI_MIMO_MODEL);
+    assert_eq!(
+        custom_xiaomi.model_source,
+        ModelSource::RootDefaultTextModel
+    );
+
+    let mut custom_xai = ConfigToml {
+        provider: ProviderKind::Xai,
+        default_text_model: Some("deepseek-v4-pro".to_string()),
+        ..ConfigToml::default()
+    };
+    custom_xai.providers.xai.base_url = Some("https://proxy.example.test/v1".to_string());
+    let resolved = custom_xai.resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(resolved.model, "deepseek-v4-pro");
+    assert_eq!(resolved.model_source, ModelSource::RootDefaultTextModel);
+}
+
+#[test]
+fn runtime_config_matches_tui_root_models_on_hosting_providers() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    for (provider, model, expected) in [
+        (ProviderKind::Openrouter, "deepseek-chat", "deepseek-chat"),
+        (ProviderKind::Openrouter, "glm-5-turbo", "z-ai/glm-5-turbo"),
+        (
+            ProviderKind::Openrouter,
+            "nemotron-3-ultra",
+            "nvidia/nemotron-3-ultra-550b-a55b",
+        ),
+        (
+            ProviderKind::Arcee,
+            "TRINITY_LARGE_PREVIEW",
+            ARCEE_TRINITY_LARGE_PREVIEW_MODEL,
+        ),
+        (ProviderKind::NvidiaNim, "pro", DEFAULT_NVIDIA_NIM_MODEL),
+        (ProviderKind::NvidiaNim, "deepseek-chat", "deepseek-chat"),
+        (
+            ProviderKind::Together,
+            "inkling",
+            "thinkingmachines/inkling",
+        ),
+        (
+            ProviderKind::Siliconflow,
+            "deepseek-chat",
+            DEFAULT_SILICONFLOW_FLASH_MODEL,
+        ),
+    ] {
+        let resolved = ConfigToml {
+            provider,
+            default_text_model: Some(model.to_string()),
+            ..ConfigToml::default()
+        }
+        .resolve_runtime_options(&CliRuntimeOverrides::default());
+        assert_eq!(resolved.model, expected, "{provider:?}: {model}");
+        assert_eq!(
+            resolved.model_source,
+            ModelSource::RootDefaultTextModel,
+            "{provider:?}: {model}"
+        );
+    }
+}
+
+#[test]
+fn runtime_config_preserves_root_models_on_tui_passthrough_providers() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    for (provider, model) in [
+        (ProviderKind::Huggingface, "deepseek-chat"),
+        (ProviderKind::Moonshot, "kimi"),
+        (ProviderKind::Volcengine, "deepseek-v4pro"),
+    ] {
+        let resolved = ConfigToml {
+            provider,
+            default_text_model: Some(model.to_string()),
+            ..ConfigToml::default()
+        }
+        .resolve_runtime_options(&CliRuntimeOverrides::default());
+        assert_eq!(resolved.model, model, "{provider:?}");
+        assert_eq!(
+            resolved.model_source,
+            ModelSource::RootDefaultTextModel,
+            "{provider:?}"
+        );
+    }
+}
+
+#[test]
+fn runtime_config_rejects_malformed_root_models_on_normalized_routes() {
+    let _lock = env_lock();
+    let _env = EnvGuard::without_deepseek_runtime_overrides();
+
+    for model in ["", "bad\nmodel"] {
+        let resolved = ConfigToml {
+            provider: ProviderKind::Zai,
+            default_text_model: Some(model.to_string()),
+            ..ConfigToml::default()
+        }
+        .resolve_runtime_options(&CliRuntimeOverrides::default());
+        assert_eq!(resolved.model, DEFAULT_ZAI_MODEL, "{model:?}");
+        assert_eq!(
+            resolved.model_source,
+            ModelSource::ProviderDefault,
+            "{model:?}"
+        );
+    }
+
+    let spaced = ConfigToml {
+        provider: ProviderKind::Zai,
+        default_text_model: Some("  GLM-4.6  ".to_string()),
+        ..ConfigToml::default()
+    }
+    .resolve_runtime_options(&CliRuntimeOverrides::default());
+    assert_eq!(spaced.model, "GLM-4.6");
+    assert_eq!(spaced.model_source, ModelSource::RootDefaultTextModel);
+}
+
 /// `CODEWHALE_MODEL` is the user-facing env alias for picking a model
 /// against the active provider. It must be honored by the runtime
 /// resolver in place of `DEEPSEEK_MODEL`.


### PR DESCRIPTION
## Summary

- resolve the legacy root default_text_model against the effective provider route in RuntimeConfig, matching the TUI request path
- preserve provider-neutral root model precedence on non-DeepSeek routes and keep released DeepSeek behavior unchanged
- carry over the TUI's route-specific normalization and foreign-DeepSeek guard so stale IDs do not leak onto vendor-locked endpoints

## Root cause

The TUI request path already honored root default_text_model for the active provider, but ConfigToml::resolve_runtime_options_with_secrets only admitted that value when the provider was DeepSeek. As the issue owner's wire-level follow-up established, the user-selected model was sent correctly by the TUI; RuntimeConfig consumers such as model resolve, app-server, and route descriptors were the divergent chain.

This change deliberately leaves model set persistence and the TUI request path untouched. It filters and normalizes the root fallback using the effective provider/base URL/auth route before assigning both the model and its ModelSource.

## Regression coverage

- Z.ai + root GLM-4.6 resolves to GLM-4.6 with RootDefaultTextModel provenance
- stale root deepseek-chat on Z.ai falls back to the Z.ai default
- CLI-effective provider overrides use the same compatibility decision
- root model retains precedence over the legacy fallback on non-DeepSeek routes
- Codex, Kimi Code, Xiaomi, OpenCode, DeepSeek Anthropic, custom endpoints, hosting providers, and pass-through providers retain their TUI route semantics
- malformed direct-route root values fall back safely

## Testing

- cargo fmt --all -- --check
- cargo test -p codewhale-config --locked (432 tests + doctest)
- cargo clippy -p codewhale-config --all-targets --locked -- -D warnings
- cargo test -p codewhale-cli --test model_resolve_provenance --locked (5 tests)

Fixes #4838