### PR TITLE
perf(tui): take the workspace scan off the event loop when opening /files (#3905)

### DIFF
--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "Rule  ",
     "FilePickerMatchSingular": "@ attach · 1 match",
     "FilePickerMatchesPlural": "@ attach · {count} matches",
+    "FilePickerScanning": "Scanning workspace…",
     "BehavioralTipPlanning": "Planning? {key} cycles to Plan mode",
     "BehavioralTipBackgroundReceipt": "Receipts live in the Work panel — {key} opens the inspector",
     "BehavioralTipClearedInput": "Cleared · {chord} restores",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "Regla  ",
     "FilePickerMatchSingular": "@ adjuntar · 1 coincidencia",
     "FilePickerMatchesPlural": "@ adjuntar · {count} coincidencias",
+    "FilePickerScanning": "Escaneando el espacio de trabajo…",
     "BehavioralTipPlanning": "¿Planificando? {key} cambia al modo Plan",
     "BehavioralTipBackgroundReceipt": "Los recibos están en el panel Work — {key} abre el inspector",
     "BehavioralTipClearedInput": "Borrado · {chord} restaura",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "ルール  ",
     "FilePickerMatchSingular": "@ 添付 · 1 件一致",
     "FilePickerMatchesPlural": "@ 添付 · {count} 件一致",
+    "FilePickerScanning": "ワークスペースをスキャン中…",
     "BehavioralTipPlanning": "計画中ですか？ {key} で Plan モードへ切り替えられます",
     "BehavioralTipBackgroundReceipt": "レシートは Work パネルにあります — {key} でインスペクターを開く",
     "BehavioralTipClearedInput": "クリアしました · {chord} で復元",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "규칙  ",
     "FilePickerMatchSingular": "@ 첨부 · 일치 1개",
     "FilePickerMatchesPlural": "@ 첨부 · 일치 {count}개",
+    "FilePickerScanning": "작업 공간 스캔 중…",
     "BehavioralTipPlanning": "계획 중인가요? {key} 키로 Plan 모드로 전환합니다",
     "BehavioralTipBackgroundReceipt": "영수증은 Work 패널에 있습니다 — {key} 키로 검사기를 엽니다",
     "BehavioralTipClearedInput": "지움 · {chord} 키로 복원",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "Regra  ",
     "FilePickerMatchSingular": "@ anexar · 1 resultado",
     "FilePickerMatchesPlural": "@ anexar · {count} resultados",
+    "FilePickerScanning": "Varrendo o workspace…",
     "BehavioralTipPlanning": "Planejando? {key} alterna para o modo Plan",
     "BehavioralTipBackgroundReceipt": "Os recibos ficam no painel Work — {key} abre o inspetor",
     "BehavioralTipClearedInput": "Limpo · {chord} restaura",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "Quy tắc  ",
     "FilePickerMatchSingular": "@ đính kèm · 1 kết quả",
     "FilePickerMatchesPlural": "@ đính kèm · {count} kết quả",
+    "FilePickerScanning": "Đang quét không gian làm việc…",
     "BehavioralTipPlanning": "Đang lập kế hoạch? {key} chuyển sang chế độ Plan",
     "BehavioralTipBackgroundReceipt": "Biên nhận nằm trong bảng Work — {key} mở trình kiểm tra",
     "BehavioralTipClearedInput": "Đã xóa · {chord} để khôi phục",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -1122,6 +1122,7 @@
     "ApprovalRepoLawRuleLabel": "规则  ",
     "FilePickerMatchSingular": "@ 附加 · 1 个匹配",
     "FilePickerMatchesPlural": "@ 附加 · {count} 个匹配",
+    "FilePickerScanning": "正在扫描工作区…",
     "BehavioralTipPlanning": "在规划？按 {key} 可切换到 Plan 模式",
     "BehavioralTipBackgroundReceipt": "回执在 Work 面板中 — 按 {key} 打开检查器",
     "BehavioralTipClearedInput": "已清空 · 按 {chord} 恢复",

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -1262,6 +1262,7 @@ pub enum MessageId {
     // Fuzzy file picker (@ attach overlay).
     FilePickerMatchSingular,
     FilePickerMatchesPlural,
+    FilePickerScanning,
     // Quiet action-triggered product guidance.
     BehavioralTipPlanning,
     BehavioralTipBackgroundReceipt,
@@ -2396,6 +2397,7 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::ApprovalRepoLawRuleLabel,
     MessageId::FilePickerMatchSingular,
     MessageId::FilePickerMatchesPlural,
+    MessageId::FilePickerScanning,
     MessageId::BehavioralTipPlanning,
     MessageId::BehavioralTipBackgroundReceipt,
     MessageId::BehavioralTipClearedInput,

--- a/crates/tui/src/tui/file_picker.rs
+++ b/crates/tui/src/tui/file_picker.rs
@@ -13,6 +13,7 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ignore::WalkBuilder;
@@ -132,6 +133,21 @@ pub struct FilePickerView {
     last_row_hitboxes: RefCell<Vec<(u16, usize)>>,
     /// UI locale captured from the app at construction (#4057 wave 2).
     locale: Locale,
+    /// True until the background workspace scan delivers (#3905). The picker
+    /// paints immediately in this state instead of blocking the event loop on
+    /// a `git status` subprocess and a 20k-file walk.
+    is_loading: bool,
+    /// Where the background scan drops its result. `None` once drained, or
+    /// when the scan ran synchronously (no tokio runtime, i.e. unit tests).
+    loading_cell: Option<Arc<Mutex<Option<WorkspaceScan>>>>,
+}
+
+/// What the off-thread workspace scan produces: the candidate paths and the
+/// git-reported modified paths, which are the only two blocking parts of
+/// building this picker.
+struct WorkspaceScan {
+    candidates: Vec<String>,
+    modified: Vec<String>,
 }
 
 impl FilePickerView {
@@ -158,9 +174,52 @@ impl FilePickerView {
         } else {
             Some(walk_depth)
         };
-        let candidates = collect_candidates(workspace_root, max_depth);
+
+        // Outside a tokio runtime (plain unit tests) do the work inline, so
+        // tests keep observing a fully-populated picker from the constructor.
+        if tokio::runtime::Handle::try_current().is_err() {
+            let candidates = collect_candidates(workspace_root, max_depth);
+            let mut relevance = relevance;
+            for path in crate::tui::file_picker_relevance::modified_workspace_paths(workspace_root)
+            {
+                relevance.mark_modified(path);
+            }
+            let mut view = Self {
+                candidates,
+                relevance,
+                filtered: Vec::new(),
+                query: String::new(),
+                selected: 0,
+                scroll: 0,
+                last_row_hitboxes: RefCell::new(Vec::new()),
+                locale,
+                is_loading: false,
+                loading_cell: None,
+            };
+            view.refilter();
+            return view;
+        }
+
+        // Both halves of the scan are blocking: `git status` is a subprocess,
+        // and the walk visits up to MAX_CANDIDATES paths. Neither belongs on
+        // the event loop — Ctrl+P used to freeze the whole TUI until both
+        // finished (#3905), the same failure #3899/#3900 fixed for the
+        // adjacent @-mention and file-tree paths.
+        let loading_cell = Arc::new(Mutex::new(None));
+        let cell = loading_cell.clone();
+        let root = workspace_root.to_path_buf();
+        crate::utils::spawn_blocking_supervised("file-picker-scan", move || {
+            let scan = WorkspaceScan {
+                candidates: collect_candidates(&root, max_depth),
+                modified: crate::tui::file_picker_relevance::modified_workspace_paths(&root),
+            };
+            if let Ok(mut guard) = cell.lock() {
+                *guard = Some(scan);
+            }
+        });
+
         let mut view = Self {
-            candidates,
+            candidates: Vec::new(),
             relevance,
             filtered: Vec::new(),
             query: String::new(),
@@ -168,9 +227,38 @@ impl FilePickerView {
             scroll: 0,
             last_row_hitboxes: RefCell::new(Vec::new()),
             locale,
+            is_loading: true,
+            loading_cell: Some(loading_cell),
         };
         view.refilter();
         view
+    }
+
+    /// Drain the background scan if it has landed. Called from `tick`, which
+    /// the view stack runs on the top view every loop iteration.
+    fn poll_loading(&mut self) {
+        if !self.is_loading {
+            return;
+        }
+        // Take the Arc out temporarily to avoid a double-borrow of self.
+        let Some(cell) = self.loading_cell.take() else {
+            self.is_loading = false;
+            return;
+        };
+        let scan = cell.lock().ok().and_then(|mut guard| guard.take());
+        match scan {
+            Some(scan) => {
+                self.candidates = scan.candidates;
+                for path in scan.modified {
+                    self.relevance.mark_modified(path);
+                }
+                self.is_loading = false;
+                // The user may already have typed while the scan ran; refilter
+                // against the query they actually have, not an empty one.
+                self.refilter();
+            }
+            None => self.loading_cell = Some(cell),
+        }
     }
 
     fn refilter(&mut self) {
@@ -363,6 +451,11 @@ impl ModalView for FilePickerView {
         }
     }
 
+    fn tick(&mut self) -> ViewAction {
+        self.poll_loading();
+        ViewAction::None
+    }
+
     fn render(&self, area: Rect, buf: &mut Buffer) {
         let match_count = self.filtered.len();
         let title = if match_count == 1 {
@@ -408,7 +501,13 @@ impl ModalView for FilePickerView {
 
         let end = (self.scroll + visible).min(self.filtered.len());
         self.last_row_hitboxes.borrow_mut().clear();
-        if self.filtered.is_empty() {
+        if self.is_loading {
+            // "No matches" would be a lie while the walk is still running.
+            lines.push(Line::from(Span::styled(
+                format!("  {}", tr(self.locale, MessageId::FilePickerScanning)),
+                Style::default().fg(palette::TEXT_MUTED),
+            )));
+        } else if self.filtered.is_empty() {
             lines.push(Line::from(Span::styled(
                 "  No matches",
                 Style::default().fg(palette::TEXT_MUTED),
@@ -626,6 +725,7 @@ pub fn score(query: &str, path: &str) -> Option<i32> {
 mod tests {
     use super::*;
     use std::fs;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     #[test]
@@ -951,5 +1051,105 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// #3905: opening the picker used to block the event loop on a `git status`
+    /// subprocess plus a walk of up to MAX_CANDIDATES paths, freezing the whole
+    /// TUI between Ctrl+P and the picker appearing.
+    ///
+    /// Asserting "fast" by wall clock would be a flaky proxy for the real
+    /// contract, so this asserts the structural property instead: inside a
+    /// runtime the constructor returns a paintable view that has not yet done
+    /// the scan, and the results arrive later through `tick`.
+    #[tokio::test]
+    async fn opening_the_picker_does_not_block_on_the_workspace_scan() {
+        let ws = TempDir::new().unwrap();
+        fs::create_dir_all(ws.path().join("src")).unwrap();
+        for i in 0..200 {
+            fs::write(ws.path().join("src").join(format!("f{i}.rs")), "x").unwrap();
+        }
+
+        let mut view = FilePickerView::new_with_relevance_and_depth(
+            ws.path(),
+            FilePickerRelevance::default(),
+            WALK_DEPTH,
+            Locale::En,
+        );
+
+        assert!(
+            view.is_loading,
+            "the constructor must hand back a paintable view, not a finished scan"
+        );
+        assert!(
+            view.candidates.is_empty(),
+            "no walk may have run on the calling thread"
+        );
+
+        // The view is renderable in the loading state — this is the frame the
+        // user sees immediately after Ctrl+P.
+        let area = Rect::new(0, 0, 60, 20);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        for _ in 0..500 {
+            view.tick();
+            if !view.is_loading {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        assert!(!view.is_loading, "the background scan must land via tick");
+        assert_eq!(
+            view.candidates.len(),
+            200,
+            "every workspace file is discovered once the scan lands"
+        );
+        assert_eq!(
+            view.filtered.len(),
+            200,
+            "results are refiltered after the scan, not left empty"
+        );
+    }
+
+    /// A query typed while the scan was still running must survive it.
+    #[tokio::test]
+    async fn a_query_typed_during_the_scan_is_applied_when_results_land() {
+        let ws = TempDir::new().unwrap();
+        fs::write(ws.path().join("alpha.rs"), "x").unwrap();
+        fs::write(ws.path().join("beta.rs"), "x").unwrap();
+
+        let mut view = FilePickerView::new_with_relevance_and_depth(
+            ws.path(),
+            FilePickerRelevance::default(),
+            WALK_DEPTH,
+            Locale::En,
+        );
+        assert!(view.is_loading);
+
+        for ch in "alpha".chars() {
+            view.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+
+        for _ in 0..500 {
+            view.tick();
+            if !view.is_loading {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        assert!(!view.is_loading);
+        assert_eq!(view.query, "alpha");
+        let matched: Vec<&str> = view
+            .filtered
+            .iter()
+            .map(|i| view.candidates[*i].as_str())
+            .collect();
+        assert_eq!(
+            matched,
+            vec!["alpha.rs"],
+            "the scan must refilter against the query the user already typed"
+        );
     }
 }

--- a/crates/tui/src/tui/file_picker_relevance.rs
+++ b/crates/tui/src/tui/file_picker_relevance.rs
@@ -40,12 +40,13 @@ pub(super) fn open_file_picker(app: &mut App) {
         ));
 }
 
+/// Compose the in-memory relevance signals (@-mentions, tool-touched paths).
+///
+/// The git-reported `modified` signal is deliberately *not* gathered here: it
+/// costs a subprocess, so the picker folds it in from its background scan
+/// (#3905).
 pub(super) fn build_relevance(app: &App) -> FilePickerRelevance {
     let mut relevance = FilePickerRelevance::default();
-
-    for path in modified_workspace_paths(&app.workspace) {
-        relevance.mark_modified(path);
-    }
 
     for record in app.session_context_references.iter().rev().take(64) {
         let reference = &record.reference;
@@ -75,7 +76,12 @@ pub(super) fn build_relevance(app: &App) -> FilePickerRelevance {
     relevance
 }
 
-fn modified_workspace_paths(workspace: &Path) -> Vec<String> {
+/// Paths git reports as staged/unstaged/untracked.
+///
+/// Blocking: spawns `git status` and waits. The picker runs this on a blocking
+/// task rather than the event loop (#3905), so it lives here but is called
+/// from `file_picker.rs`.
+pub(super) fn modified_workspace_paths(workspace: &Path) -> Vec<String> {
     let Some(mut cmd) = Git::command() else {
         return Vec::new();
     };


### PR DESCRIPTION
Closes #3905.

Ctrl+P blocked the async event loop on two things before the picker could
paint: a `git status` subprocess waited on with `.output()`
(`file_picker_relevance.rs`), and a synchronous WalkBuilder traversal of up to
`MAX_CANDIDATES` (20 000) paths (`file_picker.rs`). On a large repo, a cold
page cache, or a network filesystem, the whole TUI froze — no redraws, no
input — between the keypress and the picker appearing.

Same failure #3899/#3900 fixed for the adjacent @-mention and file-tree paths
in #3902, so this takes the same shape:

- the constructor hands back a **paintable** view immediately,
- `spawn_blocking_supervised("file-picker-scan", …)` runs both blocking halves,
- the top view's existing `tick` hook drains the result and refilters.

Splitting the relevance signals is what makes that possible. `build_relevance`
now gathers only the in-memory hints (@-mentions, tool-touched paths), which
cost nothing; `modified_workspace_paths` moves into the background scan
alongside the walk, since it was the only part of relevance that shelled out.

## Two details worth review attention

**Loading copy.** The loading state renders "Scanning workspace…" rather than
reusing "No matches". "No matches" would be a false statement about a
workspace we have not looked at yet, and it is the answer a user acts on by
retyping. New `FilePickerScanning` id, translated into all six complete packs
(`check-tui-locale-parity.py` PASS at 1129 keys); zh-Hant left partial per
#4057.

**Query survival.** `poll_loading` refilters rather than assuming an empty
query — the scan can land after the user has already typed, and dropping their
query on arrival would be a visible glitch. Covered by
`a_query_typed_during_the_scan_is_applied_when_results_land`.

## Test approach

The tests assert the structural contract, not a wall-clock bound — "opened in
under X ms" would be a flaky proxy for the real property. Inside a runtime the
constructor returns a view that is renderable and has provably not walked
anything (`is_loading` set, `candidates` empty), and results arrive through
`tick`.

Outside a tokio runtime the scan still runs inline, so every existing unit
test keeps observing a fully-populated picker straight from the constructor —
that is why the 15 pre-existing picker tests are unchanged.

## Not covered

I did not verify this against a live TUI on a slow filesystem; the claim I am
making is structural (no blocking call is reachable from the calling thread),
not a measured latency improvement.

## Gates

- `cargo test -p codewhale-tui --bin codewhale-tui` — 8216 passed, 0 failed
- CI-shaped clippy (workspace, all-features, the five CI `-A` allows) — clean
- `cargo fmt --all -- --check`, `git diff --check` — clean
- `python3 scripts/check-tui-locale-parity.py` — PASS
