### PR TITLE
perf(tui): stop issuing filesystem syscalls from inside render (#3908)

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1620,6 +1620,13 @@ pub struct App {
     pub workspace_context_cell: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     /// Timestamp for cached workspace context.
     pub workspace_context_refreshed_at: Option<Instant>,
+    /// Cached size of the memory file, formatted for the Session sidebar.
+    ///
+    /// Rendered every frame the Session/Context panel is visible, so the
+    /// `stat` behind it is refreshed on the workspace-context TTL tick
+    /// instead of inside the draw closure (#3908) — tens of ms per frame on
+    /// NFS/SSHFS/cloud-synced homes otherwise.
+    pub memory_size_hint: Option<String>,
     /// Cached background tasks for sidebar rendering.
     pub task_panel: Vec<TaskPanelEntry>,
     /// Session-local quieting and command detectors for event-driven tips.

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -802,6 +802,7 @@ impl App {
             workspace_context: None,
             workspace_context_cell: std::sync::Arc::new(std::sync::Mutex::new(None)),
             workspace_context_refreshed_at: None,
+            memory_size_hint: None,
             task_panel: Vec::new(),
             behavioral_tips: crate::tui::behavioral_tips::BehavioralTipState::default(),
             decision_card: None,

--- a/crates/tui/src/tui/sidebar.rs
+++ b/crates/tui/src/tui/sidebar.rs
@@ -3102,18 +3102,14 @@ fn render_context_panel(f: &mut Frame, area: Rect, app: &mut App) {
 
     // ── Memory ───────────────────────────────────────────────────
     if app.use_memory {
-        let size_hint = std::fs::metadata(&app.memory_path)
-            .map(|m| m.len())
-            .map(|bytes| {
-                if bytes >= 1024 * 1024 {
-                    format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
-                } else if bytes >= 1024 {
-                    format!("{:.1} KB", bytes as f64 / 1024.0)
-                } else {
-                    format!("{bytes} B")
-                }
-            })
-            .unwrap_or_else(|_| "—".to_string());
+        // Cached by `workspace_context::refresh_if_needed` on its TTL tick.
+        // This used to `stat` inline, on every frame the panel was visible
+        // (#3908). Before the first refresh lands there is nothing to show,
+        // which reads the same as an unreadable file.
+        let size_hint = app
+            .memory_size_hint
+            .clone()
+            .unwrap_or_else(|| "—".to_string());
         lines.push(Line::from(Span::styled(
             format!("memory: {} ({})", app.memory_path.display(), size_hint),
             Style::default().fg(theme.text_muted),

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -398,6 +398,13 @@ pub struct FleetSetupView {
     model_idx: usize,
     thinking_idx: usize,
     profile_scope: FleetProfileScope,
+    /// Cached `profile_file_status` for the Review step.
+    ///
+    /// `render_review` used to recompute this on every paint — `exists()` +
+    /// `is_dir()` + a full `read_dir` extension count, inside the draw closure
+    /// (#3908). Recomputed on entry to Review and when the scope toggles,
+    /// which are the only inputs it depends on.
+    profile_status: Option<(String, String)>,
     review_scroll: usize,
     /// A model-drafted profile awaiting save (already sanitized and
     /// bounded by the untrusted gate). Cleared when the selection changes so
@@ -471,6 +478,7 @@ impl FleetSetupView {
             model_idx: 0,
             thinking_idx: 0,
             profile_scope: FleetProfileScope::Project,
+            profile_status: None,
             review_scroll: 0,
             model_draft: None,
             model_draft_label: None,
@@ -670,6 +678,16 @@ impl FleetSetupView {
     }
 
     /// Advance to the next step, or — on the review step — preview the exact
+    /// Re-stat the profile directory. Called on the two transitions that can
+    /// change the answer — entering Review, and toggling project/user scope —
+    /// so the Review step never touches the filesystem while painting.
+    fn refresh_profile_status(&mut self) {
+        self.profile_status = Some(profile_file_status(
+            self.profile_scope,
+            &self.snapshot.workspace,
+        ));
+    }
+
     /// starter profile TOML the next save keypress would persist.
     fn advance(&mut self) -> ViewAction {
         match self.step {
@@ -688,6 +706,7 @@ impl FleetSetupView {
                     // Thinking defaults to inherit; adjust on review with `t`.
                     self.step = Step::Review;
                     self.review_scroll = 0;
+                    self.refresh_profile_status();
                 }
                 ViewAction::None
             }
@@ -882,6 +901,7 @@ impl ModalView for FleetSetupView {
                 self.profile_scope = self.profile_scope.toggled();
                 self.discard_model_draft();
                 self.review_scroll = 0;
+                self.refresh_profile_status();
                 ViewAction::None
             }
             KeyCode::Char('t') if self.step == Step::Review => {
@@ -1108,7 +1128,12 @@ impl FleetSetupView {
         }
 
         let role = &ROLES[self.role_idx.min(ROLES.len() - 1)];
-        let (profile_value, _) = profile_file_status(self.profile_scope, &self.snapshot.workspace);
+        // Cached on entry to this step and on scope toggle; see `profile_status`.
+        let profile_value = self
+            .profile_status
+            .as_ref()
+            .map(|(value, _)| value.clone())
+            .unwrap_or_default();
         let file_stem = profile_file_stem(&role.label);
         let mut lines: Vec<Line> = Vec::new();
         let section = |lines: &mut Vec<Line>, label: &str, body: String| {
@@ -1862,6 +1887,46 @@ mod tests {
                 .iter()
                 .any(|(_, idx)| *idx == ROLES.len() - 1),
             "selected row needs an aligned mouse hitbox"
+        );
+    }
+
+    /// #3908: `render_review` recomputed `profile_file_status` — `exists()` +
+    /// `is_dir()` + a full `read_dir` extension count — on every paint. It is
+    /// now computed on the transitions that can change it, so the value the
+    /// Review step paints must be present and must track a scope toggle.
+    #[test]
+    fn review_profile_status_is_cached_on_transitions_not_recomputed_per_paint() {
+        let mut view = FleetSetupView::from_snapshot(snapshot());
+        assert!(
+            view.profile_status.is_none(),
+            "nothing is stat-ed before the user reaches Review"
+        );
+
+        view.advance();
+        view.advance();
+        assert_eq!(view.step, Step::Review);
+        let on_entry = view
+            .profile_status
+            .clone()
+            .expect("entering Review must populate the cached status");
+
+        // Painting repeatedly must not change the cached value — that is the
+        // whole point — and must not panic on the cached-read path.
+        let area = Rect::new(0, 0, 80, 24);
+        for _ in 0..3 {
+            let mut buf = Buffer::empty(area);
+            view.render(area, &mut buf);
+        }
+        assert_eq!(view.profile_status.as_ref(), Some(&on_entry));
+
+        // Toggling scope changes which directory is described, so the cache
+        // has to be refreshed on that keypress.
+        let before_scope = view.profile_scope;
+        view.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_ne!(view.profile_scope, before_scope);
+        assert!(
+            view.profile_status.is_some(),
+            "a scope toggle must leave a freshly computed status behind"
         );
     }
 

--- a/crates/tui/src/tui/workspace_context.rs
+++ b/crates/tui/src/tui/workspace_context.rs
@@ -47,6 +47,13 @@ pub(super) fn refresh_if_needed(app: &mut App, now: Instant, allow_refresh: bool
         return;
     }
 
+    // The Session sidebar shows the memory file's size every frame it is
+    // visible. Stat it here, on the same TTL as the git context, so the draw
+    // closure reads a cached string instead of issuing a syscall per frame
+    // (#3908). Cheap on a local disk; tens of ms on NFS/SSHFS/cloud-synced
+    // home directories, which is exactly where the stutter was reported.
+    refresh_memory_size_hint(app);
+
     // Offload git query to a background thread when a Tokio runtime is
     // available. Fall back to synchronous execution for tests and other
     // non-async contexts (#399 S1).
@@ -65,6 +72,37 @@ pub(super) fn refresh_if_needed(app: &mut App, now: Instant, allow_refresh: bool
         app.workspace_context = collect(&app.workspace);
     }
     app.workspace_context_refreshed_at = Some(now);
+}
+
+/// Re-read the memory file's size into [`App::memory_size_hint`].
+///
+/// A missing or unreadable file renders as an em dash, matching what the
+/// sidebar showed when it stat-ed inline.
+fn refresh_memory_size_hint(app: &mut App) {
+    let hint = if app.use_memory {
+        Some(
+            std::fs::metadata(&app.memory_path)
+                .map(|meta| format_size(meta.len()))
+                .unwrap_or_else(|_| "\u{2014}".to_string()),
+        )
+    } else {
+        None
+    };
+    if app.memory_size_hint != hint {
+        app.needs_redraw = true;
+        app.memory_size_hint = hint;
+    }
+}
+
+/// Human-readable byte size, in the exact shape the sidebar rendered inline.
+fn format_size(bytes: u64) -> String {
+    if bytes >= 1024 * 1024 {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else if bytes >= 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 /// Force a workspace-context re-query on the next render tick, bypassing the
@@ -279,6 +317,44 @@ fn run_git(workspace: &Path, args: &[&str]) -> std::io::Result<String> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn memory_size_hint_is_cached_off_the_render_path() {
+        // #3908: the Session sidebar rendered this by stat-ing the memory file
+        // inside the draw closure, once per frame. The stat now happens here,
+        // on the workspace-context TTL, so the sidebar reads a plain String.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let memory = dir.path().join("MEMORY.md");
+        std::fs::write(&memory, vec![b'x'; 2048]).unwrap();
+
+        let mut app = crate::tui::app::App::new(
+            crate::test_support::test_tui_options(dir.path().to_path_buf()),
+            &crate::config::Config::default(),
+        );
+        app.use_memory = true;
+        app.memory_path = memory.clone();
+
+        refresh_memory_size_hint(&mut app);
+        assert_eq!(app.memory_size_hint.as_deref(), Some("2.0 KB"));
+
+        // A file that is not there reads the same as one we cannot stat: the
+        // sidebar's original em dash, not a crash or a stale number.
+        std::fs::remove_file(&memory).unwrap();
+        refresh_memory_size_hint(&mut app);
+        assert_eq!(app.memory_size_hint.as_deref(), Some("\u{2014}"));
+
+        // Memory off means nothing to show at all.
+        app.use_memory = false;
+        refresh_memory_size_hint(&mut app);
+        assert_eq!(app.memory_size_hint, None);
+    }
+
+    #[test]
+    fn memory_size_formats_match_the_sidebar_original() {
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1024), "1.0 KB");
+        assert_eq!(format_size(1024 * 1024), "1.0 MB");
+    }
 
     #[test]
     fn identity_in_git_repo_carries_name_and_branch() {


### PR DESCRIPTION
Closes #3908.

Two render functions did blocking I/O inside the ratatui draw closure, at
animation cadence:

- `render_context_panel` (`sidebar.rs`) — `std::fs::metadata` on the memory
  file, every frame the Session/Context panel was visible with `use_memory`.
- `render_review` (`views/fleet_setup.rs`) — `profile_file_status` on every
  paint of the Review step: `exists()` + `is_dir()` + a full `read_dir`
  extension-filter count.

Microseconds on a local disk; tens of milliseconds per call on NFS, SSHFS, or a
cloud-synced home — every frame — which is the setup the stutter was reported
on.

## Approach

Each site is fixed on the input that actually changes it, rather than bolting
the same TTL onto both:

**Memory size** is cached on `App::memory_size_hint`, refreshed by
`workspace_context::refresh_if_needed` — which already runs on a 15 s TTL in
the event loop, not the draw closure. The sidebar reads a `String`. A missing
or unreadable file still renders the same em dash as before, and
`use_memory = false` caches nothing.

**Fleet profile status** is computed on the two transitions that can change the
answer — entering Review, and toggling project/user scope — and stored on the
view. Nothing is stat-ed before the user reaches Review.

## Acceptance criterion

Grep-verifiable, per the issue, and it holds — neither render fn now contains
any `std::fs` call, `read_dir`, `exists()`, or call to `profile_file_status`:

```
$ awk '/fn render_context_panel/,/^}/' crates/tui/src/tui/sidebar.rs \
    | grep -n 'std::fs\|fs::'
(none)
$ awk '/fn render_review/,/^    }/' crates/tui/src/tui/views/fleet_setup.rs \
    | grep -n 'std::fs\|fs::\|profile_file_status\|read_dir\|exists()'
(none)
```

## Behaviour notes for review

- The memory hint is `None` until the first TTL refresh lands, which renders as
  the same em dash an unreadable file always produced. I chose that over
  seeding it eagerly at startup, which would have put the stat back on a
  startup path for a value that is only visible if the panel is open.
- The 15 s TTL means a memory file that grows mid-session shows a stale size
  for up to that long. The issue's proposed approach explicitly accepts a TTL
  here; the displayed value is a size hint, not a correctness surface.

## Gates

- `cargo test -p codewhale-tui --bin codewhale-tui` — 8218 passed, 0 failed
- CI-shaped clippy (workspace, all-features, the five CI `-A` allows) — clean
- `cargo fmt --all -- --check`, `git diff --check` — clean
