### PR TITLE
feat(fleet): add Oracle, a read-only high-reasoning advisor role (#4752)

### DIFF
--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -824,6 +824,9 @@ pub(crate) fn fleet_role_to_agent_type(role: Option<&str>) -> FleetRole {
         Some("builder") => FleetRole::Builder,
         Some("verifier") | Some("tester") => FleetRole::Verifier,
         Some("planner") => FleetRole::Planner,
+        // Advisory counsel (#4752). "advisor" is accepted because that is what
+        // people call it before they learn the roster name.
+        Some("oracle") | Some("advisor") => FleetRole::Oracle,
         Some("explorer") => FleetRole::Scout,
         // Coordination happens through delegation, which needs the full
         // General surface (#fleet-roster cutover (v0.8.67)). The operator is

--- a/crates/tui/src/tools/subagent/mod.rs
+++ b/crates/tui/src/tools/subagent/mod.rs
@@ -328,10 +328,10 @@ const VALID_ROLE_ALIASES: &str = "default; worker; scout; planner; reviewer; bui
 /// closed `enum` advertised on the Agent tool's `type` property. Legacy
 /// aliases are accepted only at replay/deserialization boundaries
 /// ([`migrate_legacy_role_token`]) and are never advertised to models.
-const FLEET_ROLE_SCHEMA_VALUES: [&str; 7] = [
-    "worker", "scout", "planner", "reviewer", "builder", "verifier", "custom",
+const FLEET_ROLE_SCHEMA_VALUES: [&str; 8] = [
+    "worker", "scout", "planner", "reviewer", "builder", "verifier", "oracle", "custom",
 ];
-const SUBAGENT_TYPE_DESCRIPTION: &str = "Fleet role for this delegated worker. worker: full tool access for multi-step tasks. scout: fast read-only exploration. planner: analysis-only planning. reviewer: reads and grades code. builder: lands focused code changes. verifier: runs tests/validation gates and reports evidence. custom: exactly the tools listed in allowed_tools.";
+const SUBAGENT_TYPE_DESCRIPTION: &str = "Fleet role for this delegated worker. worker: full tool access for multi-step tasks. scout: fast read-only exploration. planner: analysis-only planning. reviewer: reads and grades code. builder: lands focused code changes. verifier: runs tests/validation gates and reports evidence. oracle: read-only high-reasoning advisor for judgement calls and design critique. custom: exactly the tools listed in allowed_tools.";
 /// Whale species used as friendly names for sub-agents in the UI. The full
 /// Cetacea infraorder — baleen whales (Mysticeti), toothed whales
 /// (Odontoceti), plus select dolphin species (family Delphinidae) that
@@ -743,6 +743,15 @@ pub enum FleetRole {
     /// Distinct from `Reviewer` in that Reviewer reads code and grades it;
     /// Verifier *runs* tests and reports the outcome (#404).
     Verifier,
+    /// Advisory counsel — a strong-model second opinion the operator can ask
+    /// for guidance, judgement calls, and design critique (#4752).
+    ///
+    /// Read-only and shell-less by construction: an Oracle reasons about the
+    /// code and says what it thinks. It is distinct from `Reviewer`, which
+    /// grades a specific change against a standard, and from `Planner`, which
+    /// produces a plan to execute. An Oracle answers "what should we do here,
+    /// and what are we not seeing".
+    Oracle,
     /// Custom tool access defined at spawn time.
     Custom,
 }
@@ -803,6 +812,7 @@ impl FleetRole {
             "reviewer" => Some(Self::Reviewer),
             "builder" => Some(Self::Builder),
             "verifier" => Some(Self::Verifier),
+            "oracle" => Some(Self::Oracle),
             "custom" => Some(Self::Custom),
             _ => None,
         }
@@ -818,6 +828,7 @@ impl FleetRole {
             Self::Reviewer => "reviewer",
             Self::Builder => "builder",
             Self::Verifier => "verifier",
+            Self::Oracle => "oracle",
             Self::Custom => "custom",
         }
     }
@@ -833,6 +844,8 @@ impl FleetRole {
             Self::Reviewer => "review",
             Self::Builder => "implementer",
             Self::Verifier => "verifier",
+            // Oracle is post-Fleet; it never had a pre-Fleet override table key.
+            Self::Oracle => "oracle",
             Self::Custom => "custom",
         }
     }
@@ -847,6 +860,7 @@ impl FleetRole {
             Self::Reviewer => REVIEW_AGENT_INTRO,
             Self::Builder => IMPLEMENTER_AGENT_INTRO,
             Self::Verifier => VERIFIER_AGENT_INTRO,
+            Self::Oracle => ORACLE_AGENT_INTRO,
             Self::Custom => CUSTOM_AGENT_INTRO,
         };
         format!("{role_intro}{SUBAGENT_OUTPUT_FORMAT}")
@@ -7260,7 +7274,11 @@ fn spawn_request_is_write_capable(request: &SpawnRequest) -> bool {
             request.write_authority,
             Some(SpawnWriteAuthority::WorkspaceWrite | SpawnWriteAuthority::WorktreeWrite)
         ),
-        FleetRole::Scout | FleetRole::Planner | FleetRole::Reviewer | FleetRole::Verifier => false,
+        FleetRole::Scout
+        | FleetRole::Planner
+        | FleetRole::Reviewer
+        | FleetRole::Verifier
+        | FleetRole::Oracle => false,
     }
 }
 
@@ -9714,7 +9732,11 @@ fn validate_spawn_write_contract(
 ) -> Result<(), ToolError> {
     if matches!(
         request.agent_type,
-        FleetRole::Scout | FleetRole::Planner | FleetRole::Reviewer | FleetRole::Verifier
+        FleetRole::Scout
+            | FleetRole::Planner
+            | FleetRole::Reviewer
+            | FleetRole::Verifier
+            | FleetRole::Oracle
     ) && request
         .write_authority
         .is_some_and(|authority| authority != SpawnWriteAuthority::ReadOnly)
@@ -11918,6 +11940,16 @@ const WRITE_CHILD_VERIFY_CONTRACT: &str = concat!(
     "   COMMANDS: <exact commands run, one per line, or NONE with reason>\n",
     "   EVIDENCE: <exit codes, failing assertion, or concise proof of PASS>\n",
     "3. Do not claim PASS without command or inspection evidence. If you cannot run checks, report FAIL or BLOCKED with the blocker — never invent success.\n",
+);
+
+const ORACLE_AGENT_INTRO: &str = concat!(
+    "You are a trusted Fleet oracle (role: `oracle`). You are asked for judgement, not for labour.\n",
+    "You are read-only and have no shell. Read what you need, then give counsel.\n",
+    "Lead with your actual recommendation, not a survey of options. If you would do something different from what was proposed, say so first and say why.\n",
+    "Name what the asker appears not to have considered: the failure mode, the constraint, the cheaper alternative, the reason this is harder than it looks.\n",
+    "Distinguish what you verified by reading from what you are inferring. An unverified hunch is still useful — labelled as one.\n",
+    "If the question is underspecified in a way that changes the answer, say which detail decides it rather than answering both ways at length.\n",
+    "CHANGES will always be \"None.\" for an oracle.\n\n"
 );
 
 const VERIFIER_AGENT_INTRO: &str = concat!(

--- a/crates/tui/src/tools/subagent/tests.rs
+++ b/crates/tui/src/tools/subagent/tests.rs
@@ -1809,7 +1809,7 @@ fn fleet_role_deserialize_rejects_unknown_values_with_canonical_hint() {
         "error should name the rejected token: {message}"
     );
     for canonical in [
-        "worker", "scout", "planner", "reviewer", "builder", "verifier", "custom",
+        "worker", "scout", "planner", "reviewer", "builder", "verifier", "oracle", "custom",
     ] {
         assert!(
             message.contains(canonical),
@@ -2175,6 +2175,45 @@ fn read_only_roles_reject_write_authority_but_implementers_can_be_narrowed() {
         implementer.write_authority,
         Some(SpawnWriteAuthority::ReadOnly)
     );
+}
+
+/// #4752: Oracle must be a role, not a special-cased code path — so it has to
+/// travel the same spawn/schema machinery as every other role, and be refused
+/// write authority by the same guard that refuses reviewer.
+#[test]
+fn oracle_spawns_as_a_first_class_read_only_role() {
+    let oracle = parse_spawn_request(&json!({
+        "prompt": "is this design sound?",
+        "type": "oracle"
+    }))
+    .expect("oracle parses through the normal spawn path");
+    assert_eq!(oracle.agent_type, FleetRole::Oracle);
+
+    let escalation = parse_spawn_request(&json!({
+        "prompt": "advise, and also patch it",
+        "type": "oracle",
+        "write_authority": "workspace_write",
+        "write_roots": ["src"]
+    }))
+    .expect_err("an oracle must not be able to request writes")
+    .to_string();
+    assert!(escalation.contains("read-only role"), "{escalation}");
+}
+
+/// The role name has to survive the wire, or receipts and resumed sessions
+/// silently reclassify an oracle as the default worker.
+#[test]
+fn oracle_round_trips_through_the_role_schema() {
+    assert_eq!(FleetRole::from_str("oracle"), Some(FleetRole::Oracle));
+    assert_eq!(FleetRole::Oracle.as_str(), "oracle");
+
+    let json = serde_json::to_string(&FleetRole::Oracle).expect("serialize");
+    assert_eq!(json, "\"oracle\"");
+    let back: FleetRole = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, FleetRole::Oracle);
+
+    // Advertised in the tool schema, so the model can actually pick it.
+    assert!(FLEET_ROLE_SCHEMA_VALUES.contains(&"oracle"));
 }
 
 #[test]
@@ -3296,7 +3335,7 @@ fn subagent_tool_schemas_advertise_real_type_and_role_vocabulary() {
 
     let description = schema_property_description(&agent_schema, "type");
     for alias in [
-        "worker", "scout", "planner", "reviewer", "builder", "verifier", "custom",
+        "worker", "scout", "planner", "reviewer", "builder", "verifier", "oracle", "custom",
     ] {
         assert!(
             description.contains(alias),
@@ -3339,7 +3378,7 @@ fn agent_tool_role_schema_is_a_closed_canonical_enum() {
     // Exact canonical values, exact order. New models are told the closed
     // Fleet vocabulary and nothing else.
     let expected = json!([
-        "worker", "scout", "planner", "reviewer", "builder", "verifier", "custom"
+        "worker", "scout", "planner", "reviewer", "builder", "verifier", "oracle", "custom"
     ]);
     assert_eq!(
         agent_schema["properties"]["type"]["enum"], expected,
@@ -3377,7 +3416,7 @@ fn provider_schema_sanitizers_preserve_the_closed_fleet_role_enum() {
     let manager = new_shared_subagent_manager(tmp.path().to_path_buf(), 1);
     let agent_schema = AgentTool::new(manager, stub_runtime()).input_schema();
     let expected = json!([
-        "worker", "scout", "planner", "reviewer", "builder", "verifier", "custom"
+        "worker", "scout", "planner", "reviewer", "builder", "verifier", "oracle", "custom"
     ]);
 
     // Generic Chat Completions sanitize pass.

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -4197,7 +4197,8 @@ fn agent_type_order(agent_type: &FleetRole) -> u8 {
         FleetRole::Builder => 3,
         FleetRole::Verifier => 4,
         FleetRole::Reviewer => 5,
-        FleetRole::Custom => 6,
+        FleetRole::Oracle => 6,
+        FleetRole::Custom => 7,
     }
 }
 

--- a/crates/tui/src/worker_profile.rs
+++ b/crates/tui/src/worker_profile.rs
@@ -169,9 +169,11 @@ impl WorkerRuntimeProfile {
     #[must_use]
     pub const fn default_max_steps(role: FleetRole) -> u32 {
         match role {
-            FleetRole::Scout | FleetRole::Reviewer | FleetRole::Planner | FleetRole::Verifier => {
-                Self::READ_ONLY_MAX_STEPS
-            }
+            FleetRole::Scout
+            | FleetRole::Reviewer
+            | FleetRole::Planner
+            | FleetRole::Verifier
+            | FleetRole::Oracle => Self::READ_ONLY_MAX_STEPS,
             FleetRole::Builder | FleetRole::Worker | FleetRole::Custom => Self::GENERAL_MAX_STEPS,
         }
     }
@@ -188,6 +190,9 @@ impl WorkerRuntimeProfile {
             }
             // Planner: analysis only, no shell.
             FleetRole::Planner => (PermissionSet::read_only(), ShellPolicy::None),
+            // Oracle: counsel only. Reads to ground its advice; never acts on
+            // the workspace, so no shell either (#4752).
+            FleetRole::Oracle => (PermissionSet::read_only(), ShellPolicy::None),
             // Verifier: doesn't modify code, but runs the test suite.
             FleetRole::Verifier => (PermissionSet::read_only(), ShellPolicy::Full),
             // Doers.
@@ -202,7 +207,11 @@ impl WorkerRuntimeProfile {
             tools: ToolScope::Inherit,
             model: ModelRoute::Inherit,
             provider: None,
-            reasoning_effort: None,
+            // An Oracle is asked for judgement, so it defaults to the highest
+            // reasoning tier rather than inheriting the session's (#4752).
+            // Still only a default: an explicit spawn-time or profile value
+            // wins via `derive_child`, same as every other role.
+            reasoning_effort: matches!(role, FleetRole::Oracle).then(|| "high".to_string()),
             denied_tools: Vec::new(),
             max_spawn_depth: codewhale_config::DEFAULT_SPAWN_DEPTH,
             max_steps: Self::default_max_steps(role.clone()),
@@ -391,6 +400,53 @@ mod tests {
                 WorkerRuntimeProfile::default_max_steps(role)
             );
         }
+    }
+
+    /// #4752: Oracle is counsel, not labour. Its posture has to be read-only
+    /// and shell-less by construction, not by the caller remembering to pass
+    /// `write_authority: read-only`.
+    #[test]
+    fn oracle_is_read_only_shell_less_and_high_reasoning_by_default() {
+        let oracle = WorkerRuntimeProfile::for_role(FleetRole::Oracle);
+
+        assert!(
+            !oracle.permissions.write,
+            "an oracle advises, it never writes"
+        );
+        assert_eq!(
+            oracle.shell,
+            ShellPolicy::None,
+            "an oracle has no reason to run commands"
+        );
+        assert_eq!(
+            oracle.reasoning_effort.as_deref(),
+            Some("high"),
+            "the point of asking an oracle is the reasoning tier"
+        );
+        assert_eq!(
+            oracle.model,
+            ModelRoute::Inherit,
+            "tier is a reasoning-effort default, not a hardcoded model"
+        );
+        assert_eq!(
+            oracle.max_steps,
+            WorkerRuntimeProfile::READ_ONLY_MAX_STEPS,
+            "read-mostly budget, like the other read-only roles"
+        );
+    }
+
+    /// The reasoning default must not become a ceiling: an explicit request
+    /// still wins, exactly as it does for every other role.
+    #[test]
+    fn an_explicit_reasoning_tier_overrides_the_oracle_default() {
+        let parent = WorkerRuntimeProfile::for_role(FleetRole::Worker);
+        let mut requested = WorkerRuntimeProfile::for_role(FleetRole::Oracle);
+        requested.reasoning_effort = Some("max".to_string());
+
+        let child = parent.derive_child(&requested);
+
+        assert_eq!(child.reasoning_effort.as_deref(), Some("max"));
+        assert!(!child.permissions.write, "still read-only");
     }
 
     #[test]


### PR DESCRIPTION
Closes #4752.

Adds `FleetRole::Oracle` — a strong-model second opinion the operator can
dispatch for judgement calls, design critique, and "what are we not seeing".

Built as a **role, not a special-cased code path**, which is what the issue
asked for: it travels the same spawn request, schema enum, receipt, and profile
machinery as scout/builder/verifier. The enum's exhaustive matches meant the
compiler enumerated every site that had to learn about it, which is why the
diff touches the places the FleetRole rename touched and nothing else.

## Posture is structural, not caller-supplied

Read-only and shell-less **by construction**, rather than by the caller
remembering to pass `write_authority: read_only`:

- `WorkerRuntimeProfile::for_role` → `PermissionSet::read_only()` +
  `ShellPolicy::None`. It reads to ground its advice; it never acts.
- Both write-capability predicates in `subagent/mod.rs` classify it with the
  other read-only roles, so `validate_spawn_write_contract` **refuses** a spawn
  that declares write authority — the same guard that already refuses reviewer.
  Tested.
- `default_max_steps` → the read-mostly budget.

## The reasoning tier is a default, not a ceiling

`for_role` seeds `reasoning_effort: "high"` — the whole point of asking an
oracle is the depth of the answer. But `derive_child` still lets an explicit
spawn-time or profile value win, exactly as for every other role, and there is
a test for that.

`ModelRoute` stays `Inherit`. The tier is expressed as reasoning effort rather
than by hardcoding a model id, so this does not privilege a provider — which
matters given the repo's equal-treatment rule.

## Role prompt

Written to make the advice worth asking for: lead with the recommendation
rather than a survey of options, say so first when you disagree with what was
proposed, name what the asker appears not to have considered, and distinguish
what was verified by reading from what is being inferred.

## Note on the three failing guard tests

`agent_tool_role_schema_is_a_closed_canonical_enum` and two siblings assert the
exact closed role vocabulary and **failed on this change**. That is them doing
their job, so I updated them to the new closed set rather than loosening the
assertion.

## Not covered

I did not exercise a live Oracle spawn end-to-end against a provider — that
needs credentials. The claims tested here are structural: posture, spawn-guard
refusal, schema round-trip, and tier precedence.

## Gates

- `cargo test -p codewhale-tui --bin codewhale-tui` — 8224 passed, 0 failed
- CI-shaped clippy (workspace, all-features, the five CI `-A` allows) — clean
- `cargo fmt --all -- --check`, `git diff --check` — clean
