### PR TITLE
fix(tui): expose every shipped locale in settings

### DIFF
--- a/crates/tui/locales/AGENTS.md
+++ b/crates/tui/locales/AGENTS.md
@@ -37,9 +37,10 @@ zh-Hant is **intentionally partial** (#4057, Setup core only).
 Mirror what PR #4347 (Korean) did: pack JSON with full parity, `Locale`
 variant + tag/display/parse arms in `localization.rs`, onboarding picker
 entry (`language.rs` — a test forces every shipped locale to be offered),
-setup-wizard match arms, and locale display arms in the config/change
-commands. The `/config` hint and invalid-locale error derive from
-`Locale::shipped()` automatically.
+the typed `UiLocale` schema in `config_ui.rs`, setup-wizard match arms, and
+locale display arms in the config/change commands. The `/config` hint and
+invalid-locale error derive from `Locale::shipped()` automatically; the
+schema agreement test must keep `UiLocale` aligned with that registry.
 
 ## READMEs
 

--- a/crates/tui/locales/en.json
+++ b/crates/tui/locales/en.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "Hint: ",
     "ConfigEditNewLabel": "New: ",
     "ConfigEditFooter": " Enter=apply, Esc=cancel, Ctrl+U=clear, Ctrl+A=all, ←,/→,=move ",
+    "ConfigLocalePartialBadge": "partial",
+    "ConfigLocalePartialDetail": "Partial translation pack; missing strings fall back to English.",
     "ConfigRowEffective": " (effective {currency})",
     "ConfigDefaultValue": "(default)",
     "ConfigDefaultReasoning": "(config/default)",

--- a/crates/tui/locales/es-419.json
+++ b/crates/tui/locales/es-419.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "Pista: ",
     "ConfigEditNewLabel": "Nuevo: ",
     "ConfigEditFooter": " Enter=aplicar, Esc=cancelar, Ctrl+U=limpiar, Ctrl+A=todo, ←,/→,=mover ",
+    "ConfigLocalePartialBadge": "parcial",
+    "ConfigLocalePartialDetail": "Paquete de traducción parcial; los textos sin traducir se muestran en inglés.",
     "ConfigRowEffective": " (efectivo {currency})",
     "ConfigDefaultValue": "(predeterminado)",
     "ConfigDefaultReasoning": "(config/predeterminado)",

--- a/crates/tui/locales/ja.json
+++ b/crates/tui/locales/ja.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "ヒント: ",
     "ConfigEditNewLabel": "新規: ",
     "ConfigEditFooter": " Enter=適用, Esc=キャンセル, Ctrl+U=クリア, Ctrl+A=全選択, ←,/→,=移動 ",
+    "ConfigLocalePartialBadge": "一部翻訳",
+    "ConfigLocalePartialDetail": "一部のみ翻訳された言語パックです。未翻訳の文字列は英語にフォールバックします。",
     "ConfigRowEffective": " (実効 {currency})",
     "ConfigDefaultValue": "(デフォルト)",
     "ConfigDefaultReasoning": "(設定/デフォルト)",

--- a/crates/tui/locales/ko.json
+++ b/crates/tui/locales/ko.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "힌트: ",
     "ConfigEditNewLabel": "새 값: ",
     "ConfigEditFooter": " Enter=적용, Esc=취소, Ctrl+U=지우기, Ctrl+A=전체, ←,/→,=이동 ",
+    "ConfigLocalePartialBadge": "부분 번역",
+    "ConfigLocalePartialDetail": "일부만 번역된 언어 팩입니다. 누락된 문자열은 영어로 대체됩니다.",
     "ConfigRowEffective": " (적용 통화 {currency})",
     "ConfigDefaultValue": "(기본값)",
     "ConfigDefaultReasoning": "(설정/기본값)",

--- a/crates/tui/locales/pt-BR.json
+++ b/crates/tui/locales/pt-BR.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "Dica: ",
     "ConfigEditNewLabel": "Novo: ",
     "ConfigEditFooter": " Enter=aplicar, Esc=cancelar, Ctrl+U=limpar, Ctrl+A=tudo, ←,/→,=mover ",
+    "ConfigLocalePartialBadge": "parcial",
+    "ConfigLocalePartialDetail": "Pacote de tradução parcial; textos sem tradução são exibidos em inglês.",
     "ConfigRowEffective": " (efetivo {currency})",
     "ConfigDefaultValue": "(padrão)",
     "ConfigDefaultReasoning": "(config/padrão)",

--- a/crates/tui/locales/vi.json
+++ b/crates/tui/locales/vi.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "Gợi ý: ",
     "ConfigEditNewLabel": "Mới: ",
     "ConfigEditFooter": " Enter=áp dụng, Esc=hủy, Ctrl+U=xóa, Ctrl+A=tất cả, ←/→=di chuyển ",
+    "ConfigLocalePartialBadge": "dịch một phần",
+    "ConfigLocalePartialDetail": "Gói ngôn ngữ chỉ được dịch một phần; các chuỗi còn thiếu sẽ dùng tiếng Anh.",
     "ConfigRowEffective": " (hiệu lực {currency})",
     "ConfigDefaultValue": "(mặc định)",
     "ConfigDefaultReasoning": "(cấu hình/mặc định)",

--- a/crates/tui/locales/zh-Hans.json
+++ b/crates/tui/locales/zh-Hans.json
@@ -87,6 +87,8 @@
     "ConfigEditHintLabel": "提示: ",
     "ConfigEditNewLabel": "新值: ",
     "ConfigEditFooter": " Enter=应用, Esc=取消, Ctrl+U=清除, Ctrl+A=全选, ←/→=移动 ",
+    "ConfigLocalePartialBadge": "部分翻译",
+    "ConfigLocalePartialDetail": "此语言包仅有部分翻译；未翻译的文本将使用英文版本。",
     "ConfigRowEffective": " (实际 {currency})",
     "ConfigDefaultValue": "(默认)",
     "ConfigDefaultReasoning": "(配置/默认)",

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -71,6 +71,10 @@ pub struct SettingsSection {
     pub show_thinking: bool,
     pub show_tool_details: bool,
     pub inline_diffs: InlineDiffValue,
+    #[schemars(
+        title = "UI locale",
+        description = "Locale used by the TUI. zh-Hant is a partial pack; missing strings fall back to English."
+    )]
     pub locale: UiLocale,
     pub theme: UiThemeValue,
     #[schemars(
@@ -201,12 +205,21 @@ pub enum UiLocale {
     #[serde(rename = "zh-Hans")]
     #[schemars(rename = "zh-Hans")]
     ZhHans,
+    #[serde(rename = "zh-Hant")]
+    #[schemars(rename = "zh-Hant")]
+    ZhHant,
     #[serde(rename = "pt-BR")]
     #[schemars(rename = "pt-BR")]
     PtBr,
     #[serde(rename = "es-419")]
     #[schemars(rename = "es-419")]
     Es419,
+    #[serde(rename = "vi")]
+    #[schemars(rename = "vi")]
+    Vi,
+    #[serde(rename = "ko")]
+    #[schemars(rename = "ko")]
+    Ko,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -916,8 +929,11 @@ impl UiLocale {
             Self::En => "en",
             Self::Ja => "ja",
             Self::ZhHans => "zh-Hans",
+            Self::ZhHant => "zh-Hant",
             Self::PtBr => "pt-BR",
             Self::Es419 => "es-419",
+            Self::Vi => "vi",
+            Self::Ko => "ko",
         }
     }
 
@@ -927,8 +943,11 @@ impl UiLocale {
             Some("en") => Ok(Self::En),
             Some("ja") => Ok(Self::Ja),
             Some("zh-Hans") => Ok(Self::ZhHans),
+            Some("zh-Hant") => Ok(Self::ZhHant),
             Some("pt-BR") => Ok(Self::PtBr),
             Some("es-419") => Ok(Self::Es419),
+            Some("vi") => Ok(Self::Vi),
+            Some("ko") => Ok(Self::Ko),
             Some(other) => bail!("unsupported locale '{other}'"),
             None => bail!("invalid locale '{value}'"),
         }
@@ -1490,6 +1509,35 @@ background_color = "#1A1B26"
     }
 
     #[test]
+    fn build_document_accepts_every_shipped_locale_from_settings() {
+        let _lock = lock_test_env();
+        let temp_root = tempfile::tempdir().expect("isolated Codewhale home");
+        let codewhale_home = temp_root.path().join(".codewhale");
+        fs::create_dir_all(&codewhale_home).expect("settings dir");
+        let settings_path = codewhale_home.join("settings.toml");
+        fs::write(&settings_path, "").expect("seed settings");
+        let _home = EnvVarGuard::set("CODEWHALE_HOME", &codewhale_home);
+
+        let app = app();
+        let config = Config::default();
+        for tag in std::iter::once("auto").chain(
+            crate::localization::Locale::shipped()
+                .iter()
+                .map(|locale| locale.tag()),
+        ) {
+            fs::write(&settings_path, format!("locale = \"{tag}\"\n"))
+                .unwrap_or_else(|err| panic!("persist locale {tag}: {err}"));
+            let doc = build_document(&app, &config)
+                .unwrap_or_else(|err| panic!("build config document for {tag}: {err}"));
+            assert_eq!(
+                doc.settings.locale.as_setting(),
+                tag,
+                "typed config document must preserve persisted locale {tag}"
+            );
+        }
+    }
+
+    #[test]
     fn custom_theme_round_trips_through_typed_config_document() {
         let _lock = lock_test_env();
         let temp_root = tempfile::tempdir().expect("isolated Codewhale home");
@@ -1540,6 +1588,15 @@ background_color = "#1A1B26"
                 .as_str()
                 .is_some_and(|copy| copy.contains("Blue Stage"))
         );
+        assert!(
+            schema["$defs"]["SettingsSection"]["properties"]["locale"]["description"]
+                .as_str()
+                .is_some_and(|copy| {
+                    copy.contains("zh-Hant")
+                        && copy.contains("partial")
+                        && copy.contains("fall back to English")
+                })
+        );
         let approval_mode = &schema["$defs"]["ApprovalModeValue"]["enum"];
         assert_eq!(
             approval_mode,
@@ -1571,9 +1628,17 @@ background_color = "#1A1B26"
         let inline_diffs = &schema["$defs"]["InlineDiffValue"]["enum"];
         assert_eq!(inline_diffs, &serde_json::json!(["full", "summary", "off"]));
         let locale = &schema["$defs"]["UiLocale"]["enum"];
+        let expected_locales = std::iter::once("auto")
+            .chain(
+                crate::localization::Locale::shipped()
+                    .iter()
+                    .map(|locale| locale.tag()),
+            )
+            .collect::<Vec<_>>();
         assert_eq!(
             locale,
-            &serde_json::json!(["auto", "en", "ja", "zh-Hans", "pt-BR", "es-419"])
+            &serde_json::json!(expected_locales),
+            "UiLocale schema must match Locale::shipped()"
         );
         let theme = &schema["$defs"]["UiThemeValue"]["enum"];
         assert_eq!(
@@ -1592,6 +1657,28 @@ background_color = "#1A1B26"
                 "custom"
             ])
         );
+    }
+
+    #[test]
+    fn ui_locale_round_trips_every_shipped_locale() {
+        for locale in crate::localization::Locale::shipped() {
+            let tag = locale.tag();
+            let ui_locale = UiLocale::from_setting(tag)
+                .unwrap_or_else(|err| panic!("UiLocale must accept shipped locale {tag}: {err}"));
+            assert_eq!(
+                ui_locale.as_setting(),
+                tag,
+                "UiLocale must preserve shipped locale {tag}"
+            );
+            let serialized = serde_json::to_value(ui_locale)
+                .unwrap_or_else(|err| panic!("serialize UiLocale {tag}: {err}"));
+            assert_eq!(serialized, serde_json::json!(tag));
+            assert_eq!(
+                serde_json::from_value::<UiLocale>(serialized)
+                    .unwrap_or_else(|err| panic!("deserialize UiLocale {tag}: {err}")),
+                ui_locale
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/localization.rs
+++ b/crates/tui/src/localization.rs
@@ -45,7 +45,6 @@ impl Locale {
     }
 
     /// Every locale the TUI exposes in pickers and runtime resolution.
-    #[allow(dead_code)]
     pub fn shipped() -> &'static [Self] {
         &[
             Self::En,
@@ -62,7 +61,6 @@ impl Locale {
     /// Complete UI packs held to `en.json` parity. `zh-Hant` is intentionally
     /// excluded — it remains selectable but falls back to English for missing
     /// keys until the pack catches up (#4057).
-    #[allow(dead_code)]
     pub fn shipped_complete() -> &'static [Self] {
         &[
             Self::En,
@@ -76,7 +74,6 @@ impl Locale {
     }
 
     #[must_use]
-    #[allow(dead_code)]
     pub fn is_partial_pack(self) -> bool {
         matches!(self, Self::ZhHant)
     }
@@ -179,6 +176,8 @@ pub enum MessageId {
     ConfigEditHintLabel,
     ConfigEditNewLabel,
     ConfigEditFooter,
+    ConfigLocalePartialBadge,
+    ConfigLocalePartialDetail,
     ConfigRowEffective,
     ConfigDefaultValue,
     ConfigDefaultReasoning,
@@ -1366,6 +1365,8 @@ pub const ALL_MESSAGE_IDS: &[MessageId] = &[
     MessageId::ConfigEditHintLabel,
     MessageId::ConfigEditNewLabel,
     MessageId::ConfigEditFooter,
+    MessageId::ConfigLocalePartialBadge,
+    MessageId::ConfigLocalePartialDetail,
     MessageId::ConfigRowEffective,
     MessageId::ConfigDefaultValue,
     MessageId::ConfigDefaultReasoning,
@@ -2482,6 +2483,21 @@ pub fn normalize_configured_locale(input: &str) -> Option<&'static str> {
     parse_locale(&normalized).map(Locale::tag)
 }
 
+/// Whether a configured locale selects a shipped pack that intentionally
+/// relies on English fallback for missing messages.
+#[must_use]
+pub fn configured_locale_is_partial_pack(input: &str) -> bool {
+    let normalized = normalize_locale_input(input);
+    if matches!(normalized.as_str(), "" | "auto" | "system") {
+        return false;
+    }
+    parse_locale(&normalized).is_some_and(|locale| {
+        Locale::shipped().contains(&locale)
+            && locale.is_partial_pack()
+            && !Locale::shipped_complete().contains(&locale)
+    })
+}
+
 /// Human-facing list of accepted `locale` setting values, derived from the
 /// shipped packs so config hints and error messages cannot go stale as new
 /// locales land. `separator` is `", "` for prose and `" | "` for hints.
@@ -2613,6 +2629,31 @@ mod tests {
         assert_eq!(normalize_configured_locale("pt-PT"), Some("pt-BR"));
         assert_eq!(normalize_configured_locale("es"), Some("es-419"));
         assert_eq!(normalize_configured_locale("es-MX"), Some("es-419"));
+    }
+
+    #[test]
+    fn partial_pack_status_tracks_the_shipped_locale_registry() {
+        assert!(!configured_locale_is_partial_pack("auto"));
+        assert!(!configured_locale_is_partial_pack("system"));
+        assert!(configured_locale_is_partial_pack("zh-Hant"));
+        assert!(configured_locale_is_partial_pack("zh_TW.UTF-8"));
+        assert!(!configured_locale_is_partial_pack("vi"));
+        assert!(!configured_locale_is_partial_pack("ko"));
+
+        for locale in Locale::shipped() {
+            assert_eq!(
+                configured_locale_is_partial_pack(locale.tag()),
+                locale.is_partial_pack(),
+                "{} partial-pack classification drifted",
+                locale.tag()
+            );
+            assert_ne!(
+                Locale::shipped_complete().contains(locale),
+                locale.is_partial_pack(),
+                "{} must be exactly one of complete or partial",
+                locale.tag()
+            );
+        }
     }
 
     #[test]

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -327,7 +327,8 @@ pub struct Settings {
     /// This affects inline presentation only; exact evidence remains available
     /// through the tool-details route in every mode.
     pub inline_diffs: String,
-    /// UI locale: auto, en, ja, zh-Hans, pt-BR, es-419
+    /// UI locale: auto, en, ja, zh-Hans, zh-Hant, pt-BR, es-419, vi, ko.
+    /// zh-Hant is a partial pack; missing strings fall back to English.
     pub locale: String,
     /// Named UI theme. Accepts `"system"` (follow terminal background),
     /// `"dark"`, `"light"`, `"grayscale"`, or one of the community
@@ -1429,7 +1430,7 @@ impl Settings {
             ),
             (
                 "locale",
-                "UI locale and default model language: auto, en, ja, zh-Hans, pt-BR, es-419",
+                "UI locale and default model language: auto, en, ja, zh-Hans, zh-Hant, pt-BR, es-419, vi, ko; zh-Hant is partial and missing strings fall back to English",
             ),
             (
                 "theme",
@@ -2306,8 +2307,20 @@ mod tests {
     #[test]
     fn locale_normalizes_supported_values_and_rejects_unknowns() {
         let mut settings = Settings::default();
-        settings.set("locale", "ja_JP.UTF-8").expect("set ja");
-        assert_eq!(settings.locale, "ja");
+        for (input, expected) in [
+            ("ja_JP.UTF-8", "ja"),
+            ("zh-CN", "zh-Hans"),
+            ("zh-TW", "zh-Hant"),
+            ("zh-Hant", "zh-Hant"),
+            ("es-MX", "es-419"),
+            ("vi_VN.UTF-8", "vi"),
+            ("ko-KR", "ko"),
+        ] {
+            settings
+                .set("locale", input)
+                .unwrap_or_else(|err| panic!("set locale {input}: {err}"));
+            assert_eq!(settings.locale, expected);
+        }
 
         settings.set("language", "pt-PT").expect("set pt fallback");
         assert_eq!(settings.locale, "pt-BR");

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -13,7 +13,9 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::config::{ApiProvider, ApprovalPolicyControl, Config};
 use crate::features::{FEATURES, Stage};
-use crate::localization::{Locale, MessageId, tr};
+use crate::localization::{
+    Locale, MessageId, configured_locale_is_partial_pack, normalize_configured_locale, tr,
+};
 use crate::palette;
 use crate::settings::Settings;
 use crate::tools::UserInputResponse;
@@ -2470,9 +2472,12 @@ impl ConfigView {
         if let Some(runtime_value) = runtime_value
             && row.value.parse::<bool>().ok() != Some(runtime_value)
         {
-            let saved =
-                config_choice_label(&row.key, &canonical_config_choice(&row.key, &row.value));
-            let effective = config_choice_label(&row.key, &runtime_value.to_string());
+            let saved = config_choice_label(
+                self.locale,
+                &row.key,
+                &canonical_config_choice(&row.key, &row.value),
+            );
+            let effective = config_choice_label(self.locale, &row.key, &runtime_value.to_string());
             return format!(
                 "{}{}",
                 saved,
@@ -2498,7 +2503,7 @@ impl ConfigView {
                 return "Provider default".to_string();
             }
             let canonical = canonical_config_choice(&row.key, &row.value);
-            return config_choice_label(&row.key, &canonical);
+            return config_choice_label(self.locale, &row.key, &canonical);
         }
 
         row.value.clone()
@@ -2946,12 +2951,15 @@ fn canonical_config_choice(key: &str, value: &str) -> String {
             // startup workspace; permission posture is shown separately.
             _ => "agent".to_string(),
         },
+        "locale" => normalize_configured_locale(value)
+            .unwrap_or(value)
+            .to_string(),
         _ => normalized,
     }
 }
 
-fn config_choice_label(key: &str, value: &str) -> String {
-    match (key, value) {
+fn config_choice_label(locale: Locale, key: &str, value: &str) -> String {
+    let label = match (key, value) {
         (key, "true") if config_boolean_key(key) => "On".to_string(),
         (key, "false") if config_boolean_key(key) => "Off".to_string(),
         ("approval_mode" | "permission_posture" | "approval_policy", "ask") => "Ask".to_string(),
@@ -2978,11 +2986,24 @@ fn config_choice_label(key: &str, value: &str) -> String {
         ("sidebar_focus", "tasks") => "Activity".to_string(),
         ("sidebar_focus", "agents") => "Workers".to_string(),
         _ => value.to_string(),
+    };
+
+    if key == "locale" && configured_locale_is_partial_pack(value) {
+        format!(
+            "{label} ({})",
+            tr(locale, MessageId::ConfigLocalePartialBadge)
+        )
+    } else {
+        label
     }
 }
 
-fn config_choice_detail(key: &str, value: &str) -> &'static str {
-    match (key, value) {
+fn config_choice_detail(locale: Locale, key: &str, value: &str) -> Cow<'static, str> {
+    if key == "locale" && configured_locale_is_partial_pack(value) {
+        return tr(locale, MessageId::ConfigLocalePartialDetail);
+    }
+
+    Cow::Borrowed(match (key, value) {
         ("approval_mode" | "permission_posture" | "approval_policy", "ask") => {
             "Ask before tools that can make consequential changes."
         }
@@ -3018,7 +3039,7 @@ fn config_choice_detail(key: &str, value: &str) -> &'static str {
         ("ocean_treatment", "ombre") => "Use one continuous ocean color field.",
         ("ocean_treatment", "flat") => "Use a single flat background color.",
         _ => "",
-    }
+    })
 }
 
 fn render_config_editor_value_line(
@@ -3342,8 +3363,8 @@ impl ModalView for ConfigView {
                 // only the slice that is actually visible.
                 let selected_detail = choices
                     .get(edit.selected_choice)
-                    .map(|choice| config_choice_detail(&edit.key, choice))
-                    .unwrap_or("");
+                    .map(|choice| config_choice_detail(self.locale, &edit.key, choice))
+                    .unwrap_or_default();
                 let available_rows =
                     usize::from(inner.height).saturating_sub(reserved_footer_lines + lines.len());
                 // At the minimum supported height, the choices themselves are
@@ -3363,7 +3384,7 @@ impl ModalView for ConfigView {
                 for (choice_idx, choice) in choices.iter().enumerate().take(end).skip(start) {
                     let selected = choice_idx == edit.selected_choice;
                     let marker = if selected { "›" } else { " " };
-                    let label = config_choice_label(&edit.key, choice);
+                    let label = config_choice_label(self.locale, &edit.key, choice);
                     let line_y = inner.y.saturating_add(lines.len() as u16);
                     hitboxes.push((line_y, choice_idx));
                     let mut line = Line::from(format!(
@@ -3388,7 +3409,7 @@ impl ModalView for ConfigView {
                 {
                     lines.push(Line::from(Span::styled(
                         crate::tui::ui_text::semantic_truncate(
-                            selected_detail,
+                            selected_detail.as_ref(),
                             usize::from(inner.width),
                         ),
                         Style::default().fg(palette::TEXT_MUTED),
@@ -4261,9 +4282,9 @@ mod tests {
         ActionHint, ConfigListItem, ConfigScope, ConfigTab, ConfigView, EmptyState, HelpView,
         ListDetailLayout, ModalKind, ModalView, SettingKind, SettingsRegistry, ViewAction,
         ViewEvent, ViewStack, action_footer_lines, canonical_config_choice, centered_modal_area,
-        config_choice_values, config_label_for_key, config_label_for_key_for_locale,
-        render_modal_footer_with_gutter, render_underwater_surface, subagent_view_agents,
-        truncate_view_text,
+        config_choice_detail, config_choice_label, config_choice_values, config_label_for_key,
+        config_label_for_key_for_locale, render_modal_footer_with_gutter,
+        render_underwater_surface, subagent_view_agents, truncate_view_text,
     };
     use crate::config::Config;
     use crate::localization::{Locale, MessageId, tr};
@@ -5745,6 +5766,94 @@ base_url = "https://api.xiaomimimo.com/v1"
             }
             other => panic!("expected startup choice update, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn locale_choices_cover_shipped_registry_and_mark_partial_packs() {
+        let choices = config_choice_values("locale", crate::config::ApiProvider::Deepseek)
+            .expect("locale choices");
+        let expected = std::iter::once("auto".to_string())
+            .chain(
+                Locale::shipped()
+                    .iter()
+                    .map(|locale| locale.tag().to_string()),
+            )
+            .collect::<Vec<_>>();
+        assert_eq!(
+            choices, expected,
+            "native locale choices must match Locale::shipped()"
+        );
+
+        let partial_badge = tr(Locale::En, MessageId::ConfigLocalePartialBadge);
+        let partial_detail = tr(Locale::En, MessageId::ConfigLocalePartialDetail);
+        for locale in Locale::shipped() {
+            let canonical = canonical_config_choice("locale", locale.tag());
+            assert_eq!(canonical, locale.tag());
+
+            let label = config_choice_label(Locale::En, "locale", &canonical);
+            assert_eq!(
+                label.contains(partial_badge.as_ref()),
+                locale.is_partial_pack(),
+                "{} partial-pack badge drifted",
+                locale.tag()
+            );
+
+            let detail = config_choice_detail(Locale::En, "locale", &canonical);
+            assert_eq!(
+                !detail.is_empty(),
+                locale.is_partial_pack(),
+                "{} partial-pack detail drifted",
+                locale.tag()
+            );
+            if locale.is_partial_pack() {
+                assert_eq!(detail, partial_detail);
+            }
+        }
+    }
+
+    #[test]
+    fn locale_choice_editor_submits_newly_admitted_locales() {
+        for tag in ["ko", "vi", "zh-Hant"] {
+            let mut view = create_config_view(Locale::En);
+            view.focus_key("locale");
+            view.start_edit();
+            let edit = view.editing.as_mut().expect("locale choice editor");
+            edit.selected_choice = edit
+                .choices
+                .as_ref()
+                .and_then(|choices| choices.iter().position(|choice| choice == tag))
+                .unwrap_or_else(|| panic!("locale choices must include {tag}"));
+
+            match view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)) {
+                ViewAction::Emit(ViewEvent::ConfigUpdated { key, value, .. }) => {
+                    assert_eq!(key, "locale");
+                    assert_eq!(value, tag);
+                }
+                other => panic!("selecting locale {tag} must submit ConfigUpdated, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn partial_locale_badge_survives_minimum_terminal_layout() {
+        let mut view = create_config_view(Locale::En);
+        view.focus_key("locale");
+        view.start_edit();
+        let edit = view.editing.as_mut().expect("locale choice editor");
+        edit.selected_choice = edit
+            .choices
+            .as_ref()
+            .and_then(|choices| choices.iter().position(|choice| choice == "zh-Hant"))
+            .expect("zh-Hant choice");
+
+        let area = Rect::new(0, 0, 40, 12);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+        let dump = buffer_text(&buf, area);
+        assert!(
+            dump.contains("zh-Hant (partial)"),
+            "partial-pack badge must remain visible when detail is shed: {dump:?}"
+        );
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1188,13 +1188,15 @@ Common settings keys:
   the exact applied change in the selected File receipt's Alt/Option+V detail.
   Failure and cancellation never render a successful diff. Save the choice
   with `/config inline_diffs <mode> --save`.
-- `locale` (`auto`, `en`, `ja`, `zh-Hans`, `pt-BR`; default `auto`): UI chrome
-  locale. `auto` checks `LC_ALL`, `LC_MESSAGES`, then `LANG`; unsupported or
-  missing locales fall back to English. The runtime also exposes the resolved
-  locale in the system prompt as the fallback natural language for V4 reasoning
-  and replies when the latest user message is ambiguous. Clear user language
-  still takes priority; Chinese turns should produce Chinese `reasoning_content`
-  and Chinese final replies even when the resolved locale is English.
+- `locale` (`auto`, `en`, `ja`, `zh-Hans`, `zh-Hant`, `pt-BR`, `es-419`, `vi`,
+  `ko`; default `auto`): UI chrome locale. `auto` checks `LC_ALL`,
+  `LC_MESSAGES`, then `LANG`; unsupported locale selections resolve to English.
+  `zh-Hant` is a shipped partial pack, so strings it does not yet provide fall
+  back to English. The runtime also exposes the resolved locale in the system
+  prompt as the fallback natural language for V4 reasoning and replies when the
+  latest user message is ambiguous. Clear user language still takes priority;
+  Chinese turns should produce Chinese `reasoning_content` and Chinese final
+  replies even when the resolved locale is English.
 - `background_color` (`#RRGGBB`, `RRGGBB`, or `default`): optional main TUI
   background color applied to the root, header, transcript, and footer
   surfaces while preserving panel contrast.

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -38,16 +38,16 @@ only at exact raw key parity with it, enforced by
 `crates/tui/src/localization.rs`. See `crates/tui/locales/AGENTS.md` for the
 authoring contract.
 
-| Locale | File | Keys vs `en.json` (1128) | Status | Notes |
+| Locale | File | Keys vs `en.json` (1131) | Status | Notes |
 |--------|------|--------------------------|--------|-------|
-| English | `en.json` | 1128/1128 | **shipped** | Reference pack. |
-| Japanese | `ja.json` | 1128/1128 | **shipped** | Complete. |
-| Simplified Chinese | `zh-Hans.json` | 1128/1128 | **shipped** | Complete. |
-| Traditional Chinese | `zh-Hant.json` | 478/1128 | **partial** | Setup core only; missing keys fall back to English at runtime. Deliberate scope per #4057. |
-| Brazilian Portuguese | `pt-BR.json` | 1128/1128 | **shipped** | Complete. |
-| Latin American Spanish | `es-419.json` | 1128/1128 | **shipped** | Complete. Note the website tracks `es` as deferred — the shipped TUI pack is Latin American Spanish, not `es-ES`. |
-| Vietnamese | `vi.json` | 1128/1128 | **shipped** | Complete. |
-| Korean | `ko.json` | 1128/1128 | **shipped** | Complete. |
+| English | `en.json` | 1131/1131 | **shipped** | Reference pack. |
+| Japanese | `ja.json` | 1131/1131 | **shipped** | Complete. |
+| Simplified Chinese | `zh-Hans.json` | 1131/1131 | **shipped** | Complete. |
+| Traditional Chinese | `zh-Hant.json` | 478/1131 | **partial** | Setup core only; missing keys fall back to English at runtime. Deliberate scope per #4057. |
+| Brazilian Portuguese | `pt-BR.json` | 1131/1131 | **shipped** | Complete. |
+| Latin American Spanish | `es-419.json` | 1131/1131 | **shipped** | Complete. Note the website tracks `es` as deferred — the shipped TUI pack is Latin American Spanish, not `es-ES`. |
+| Vietnamese | `vi.json` | 1131/1131 | **shipped** | Complete. |
+| Korean | `ko.json` | 1131/1131 | **shipped** | Complete. |
 
 ## Website locales
 
@@ -100,10 +100,13 @@ carry an explicit `planned`/`partial`/`deferred` row in this matrix.
    `parse_locale`/`shipped`/`shipped_complete` arms in
    `crates/tui/src/localization.rs`, and the `include_str!` arm in the
    test module.
-3. Wire the pickers and displays that enumerate locales: onboarding
-   language picker (`crates/tui/src/tui/onboarding/language.rs` — a test
-   forces every shipped locale to be offered), setup-wizard match arms,
-   and the locale display arms in the `/config` and changelog commands.
+3. Wire the typed settings schema (`UiLocale` in
+   `crates/tui/src/config_ui.rs`) plus the pickers and displays that enumerate
+   locales: onboarding language picker
+   (`crates/tui/src/tui/onboarding/language.rs` — a test forces every shipped
+   locale to be offered), setup-wizard match arms, and the locale display arms
+   in the `/config` and changelog commands. Keep the schema/round-trip invariant
+   tied to `Locale::shipped()` so these surfaces cannot silently drift.
 4. Run `python3 scripts/check-tui-locale-parity.py` and
    `cargo test -p codewhale-tui localization`.
 5. If the pack must ship incomplete, declare it partial (see `zh-Hant` /


### PR DESCRIPTION
Fixes #4786

## Summary

- admit `ko`, `vi`, and `zh-Hant` in the typed settings schema, Serde mapping, persisted-document path, and native locale chooser
- tie schema values and native choices to `Locale::shipped()` with regression tests so the registries cannot silently drift again
- mark `zh-Hant` as partial in the always-visible choice label and explain its English fallback in localized detail copy
- keep complete/partial classification independent, update every complete locale pack, and refresh configuration plus locale-authoring documentation

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `python scripts/check-tui-locale-parity.py` (complete packs 1131/1131; `zh-Hant` 478/1131 partial)
- [x] `cargo check -p codewhale-tui --tests --locked`
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked locale` (45 passed)
- [x] `cargo test -p codewhale-tui --bin codewhale-tui --locked config_ui` (13 passed)
- [x] production-bin clippy with the CI allowlist plus `clippy::needless_return` (clean)
- [x] `git diff --check`

On Windows/Rust 1.96, strict clippy without that final baseline allow stops at the unchanged Windows-only `crates/tui/src/mcp.rs:262`; `--all-targets` additionally reports existing lints in untouched test modules. No clippy finding originates in this patch.

## Review notes

Two independent read-only reviews checked the final rebased diff. One caught an initially tautological complete/partial invariant; the final implementation keeps the registries independent and tests that every shipped locale is exactly one of complete or partial. The second final-head review found no P1/P2 issues.

## Checklist

- [x] Updated docs and locale-authoring guidance
- [x] Added schema, persistence, selection, minimum-terminal render, and parity regressions
- [x] Rebased and reverified on current `main`
- [ ] Manually exercised the interactive TUI in Korean and Vietnamese