### PR TITLE
feat(tui): global resource admission, descendant cancellation, truthful draining (#4864)

### DIFF
--- a/crates/tui/src/fleet/executor.rs
+++ b/crates/tui/src/fleet/executor.rs
@@ -696,6 +696,7 @@ impl FleetExecutor {
         };
         let terminal = match status.state {
             super::host::FleetHostWorkerState::Running
+            | super::host::FleetHostWorkerState::Draining
             | super::host::FleetHostWorkerState::Unknown => return None,
             super::host::FleetHostWorkerState::Stopped => {
                 classify_worker_exit(status.exit_code, true)

--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -1791,7 +1791,10 @@ mod tests {
             Duration::from_secs(3),
         );
         assert_eq!(status.state, FleetHostWorkerState::Draining);
-        assert!(unix_pid_is_running(tool_pid), "descendant exited before draining check");
+        assert!(
+            unix_pid_is_running(tool_pid),
+            "descendant exited before draining check"
+        );
 
         let stopped = adapter
             .stop_worker("draining-dispatcher-tree")

--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -28,8 +28,9 @@ use windows::Win32::Foundation::{CloseHandle, HANDLE};
 #[cfg(windows)]
 use windows::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
-    SetInformationJobObject, TerminateJobObject,
+    JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
+    QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
 };
 #[cfg(windows)]
 use windows::core::PCWSTR;
@@ -137,6 +138,8 @@ pub enum FleetHostKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FleetHostWorkerState {
     Running,
+    /// The dispatcher stopped but the owned process session/job is not yet empty.
+    Draining,
     Exited,
     Failed,
     Stopped,
@@ -312,6 +315,16 @@ impl FleetHostAdapter for LocalProcessFleetHostAdapter {
             .get_mut(worker_id)
             .ok_or_else(|| FleetHostError::terminal(format!("unknown worker {worker_id}")))?;
         if let Some(status) = process.last_exit {
+            if local_worker_tree_alive(process)? {
+                return Ok(FleetHostWorkerStatus {
+                    worker_id: worker_id.to_string(),
+                    state: FleetHostWorkerState::Draining,
+                    pid: Some(process.child.id()),
+                    exit_code: status.code(),
+                    memory_mb: process.last_memory_mb,
+                    retryable: true,
+                });
+            }
             return Ok(status_from_exit(
                 worker_id,
                 Some(process.child.id()),
@@ -343,6 +356,16 @@ impl FleetHostAdapter for LocalProcessFleetHostAdapter {
             }
             Ok(Some(status)) => {
                 process.last_exit = Some(status);
+                if local_worker_tree_alive(process)? {
+                    return Ok(FleetHostWorkerStatus {
+                        worker_id: worker_id.to_string(),
+                        state: FleetHostWorkerState::Draining,
+                        pid: Some(process.child.id()),
+                        exit_code: status.code(),
+                        memory_mb: process.last_memory_mb,
+                        retryable: true,
+                    });
+                }
                 Ok(status_from_exit(
                     worker_id,
                     Some(process.child.id()),
@@ -764,7 +787,10 @@ fn wait_for_exit(
     let deadline = Instant::now() + timeout;
     loop {
         let status = adapter.read_status(worker_id)?;
-        if !matches!(status.state, FleetHostWorkerState::Running) {
+        if !matches!(
+            status.state,
+            FleetHostWorkerState::Running | FleetHostWorkerState::Draining
+        ) {
             return Ok(status);
         }
         if Instant::now() >= deadline {
@@ -772,6 +798,23 @@ fn wait_for_exit(
         }
         thread::sleep(Duration::from_millis(25));
     }
+}
+
+#[cfg(unix)]
+fn local_worker_tree_alive(process: &LocalWorkerProcess) -> FleetHostResult<bool> {
+    Ok(!unix_session_members(process.session_id, Some(process.session_id))?.is_empty())
+}
+
+#[cfg(windows)]
+fn local_worker_tree_alive(process: &LocalWorkerProcess) -> FleetHostResult<bool> {
+    process.windows_job.has_active_processes().map_err(|err| {
+        FleetHostError::retryable(format!("querying Windows worker job activity: {err}"))
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn local_worker_tree_alive(_process: &LocalWorkerProcess) -> FleetHostResult<bool> {
+    Ok(false)
 }
 
 #[cfg(unix)]
@@ -1224,6 +1267,21 @@ impl FleetWindowsJob {
     fn terminate(&self) -> std::io::Result<()> {
         unsafe { TerminateJobObject(self.handle, 1).map_err(windows_io_error) }
     }
+
+    fn has_active_processes(&self) -> std::io::Result<bool> {
+        let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+        unsafe {
+            QueryInformationJobObject(
+                Some(self.handle),
+                JobObjectBasicAccountingInformation,
+                &mut accounting as *mut _ as *mut core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                None,
+            )
+            .map_err(windows_io_error)?;
+        }
+        Ok(accounting.ActiveProcesses > 0)
+    }
 }
 
 #[cfg(windows)]
@@ -1484,6 +1542,23 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn wait_for_host_state(
+        adapter: &mut LocalProcessFleetHostAdapter,
+        worker_id: &str,
+        expected: FleetHostWorkerState,
+        timeout: Duration,
+    ) -> FleetHostWorkerStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let status = adapter.read_status(worker_id).expect("worker status");
+            if status.state == expected || Instant::now() >= deadline {
+                return status;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    #[cfg(unix)]
     fn wait_for_valid_pid_file(pid_file: &Path, timeout: Duration) -> libc::pid_t {
         let deadline = Instant::now() + timeout;
         let mut last_observation = "file not created".to_string();
@@ -1687,6 +1762,44 @@ mod tests {
         assert!(
             wait_for_unix_pid_exit(tool_pid, Duration::from_secs(1)),
             "separate-process-group tool survived interrupt"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fleet_host_reports_draining_after_dispatcher_exits_with_live_descendant() {
+        if skip_if_process_table_unavailable() {
+            return;
+        }
+        let tmp = TempDir::new().unwrap();
+        let mut adapter = LocalProcessFleetHostAdapter::new(tmp.path());
+        let (root_pid, tool_pid) = start_dispatcher_tree(
+            &mut adapter,
+            &tmp,
+            "draining-dispatcher-tree",
+            "detached-dispatcher",
+        );
+
+        assert!(
+            wait_for_unix_pid_exit(root_pid, Duration::from_secs(3)),
+            "dispatcher did not exit"
+        );
+        let status = wait_for_host_state(
+            &mut adapter,
+            "draining-dispatcher-tree",
+            FleetHostWorkerState::Draining,
+            Duration::from_secs(3),
+        );
+        assert_eq!(status.state, FleetHostWorkerState::Draining);
+        assert!(unix_pid_is_running(tool_pid), "descendant exited before draining check");
+
+        let stopped = adapter
+            .stop_worker("draining-dispatcher-tree")
+            .expect("stop draining worker tree");
+        assert_eq!(stopped.state, FleetHostWorkerState::Stopped);
+        assert!(
+            wait_for_unix_pid_exit(tool_pid, Duration::from_secs(1)),
+            "draining descendant survived bounded stop"
         );
     }
 

--- a/crates/tui/src/tools/mod.rs
+++ b/crates/tui/src/tools/mod.rs
@@ -43,6 +43,7 @@ pub mod plugin;
 pub mod project;
 pub mod registry;
 pub mod remember;
+mod resource_admission;
 pub mod revert_turn;
 pub mod review;
 pub mod rlm;

--- a/crates/tui/src/tools/resource_admission.rs
+++ b/crates/tui/src/tools/resource_admission.rs
@@ -113,7 +113,7 @@ impl HeavyCommandPermit {
 
 pub(crate) fn infer_command_expense(command: &str) -> CommandExpense {
     let heavy = command
-        .split(|character| matches!(character, '\n' | '\r' | ';' | '|' | '&'))
+        .split(['\n', '\r', ';', '|', '&'])
         .any(segment_is_heavy);
 
     if heavy {
@@ -363,6 +363,7 @@ fn host_memory_free_fraction() -> Option<f64> {
     None
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn run_capture(program: &str, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new(program)
         .args(args)

--- a/crates/tui/src/tools/resource_admission.rs
+++ b/crates/tui/src/tools/resource_admission.rs
@@ -19,10 +19,65 @@ pub(crate) const DEFAULT_HEAVY_COMMAND_LIMIT: usize = 2;
 const MAX_HEAVY_COMMAND_LIMIT: usize = 16;
 const ADMISSION_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// When the host free-RAM fraction drops to/below these thresholds the
+/// effective heavy-command admission limit tightens so a saturated host stops
+/// admitting new link graphs (#4864 req 7). Values are deliberately generous
+/// because the measurement is advisory, not authoritative.
+const CONSTRAINED_FREE_FRACTION: f64 = 0.30;
+const CRITICAL_FREE_FRACTION: f64 = 0.15;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CommandExpense {
     Normal,
     Heavy,
+}
+
+/// Measured host memory pressure used to tighten heavy-command admission.
+///
+/// `Unknown` means "could not be measured"; admission then fails open (uses the
+/// configured limit) rather than risk blocking on an unmeasurable host. This
+/// keeps the gate safe on any CI runner where the probe is unavailable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemoryPressure {
+    Unknown,
+    Nominal,
+    Constrained,
+    Critical,
+}
+
+/// Pluggable memory probe so the admission policy is unit-testable without
+/// having to drive the host into real memory pressure.
+pub(crate) trait MemoryProbe: Send + Sync {
+    /// Free-RAM fraction in `0.0..=1.0`, or `None` when it cannot be measured.
+    fn free_fraction(&self) -> Option<f64>;
+}
+
+struct HostMemoryProbe;
+
+impl MemoryProbe for HostMemoryProbe {
+    fn free_fraction(&self) -> Option<f64> {
+        host_memory_free_fraction()
+    }
+}
+
+fn classify_memory_pressure(free_fraction: Option<f64>) -> MemoryPressure {
+    match free_fraction {
+        None => MemoryPressure::Unknown,
+        Some(fraction) if fraction <= CRITICAL_FREE_FRACTION => MemoryPressure::Critical,
+        Some(fraction) if fraction <= CONSTRAINED_FREE_FRACTION => MemoryPressure::Constrained,
+        Some(_) => MemoryPressure::Nominal,
+    }
+}
+
+/// Effective admission limit after applying host memory pressure. `Critical`
+/// yields zero so queued heavy commands wait for the host to recover instead of
+/// snowballing; `Constrained` halves the budget (never below one).
+fn effective_admission_limit(configured: usize, pressure: MemoryPressure) -> usize {
+    match pressure {
+        MemoryPressure::Critical => 0,
+        MemoryPressure::Constrained => configured.div_ceil(2).max(1),
+        MemoryPressure::Nominal | MemoryPressure::Unknown => configured,
+    }
 }
 
 #[derive(Debug)]
@@ -39,6 +94,7 @@ pub(crate) struct HeavyCommandPermit {
     _slot: HeavyPermitSlot,
     queued_for: Duration,
     limit: usize,
+    memory_pressure: MemoryPressure,
 }
 
 impl HeavyCommandPermit {
@@ -48,6 +104,10 @@ impl HeavyCommandPermit {
 
     pub(crate) fn limit(&self) -> usize {
         self.limit
+    }
+
+    pub(crate) fn memory_pressure(&self) -> MemoryPressure {
+        self.memory_pressure
     }
 }
 
@@ -107,13 +167,17 @@ pub(crate) async fn acquire_heavy_command_permit(
 
     let limit = configured_heavy_command_limit();
     let root = admission_root();
-    acquire_heavy_command_permit_at(&root, limit, cancel).await.map(Some)
+    let probe = HostMemoryProbe;
+    acquire_heavy_command_permit_at(&root, limit, cancel, &probe)
+        .await
+        .map(Some)
 }
 
 async fn acquire_heavy_command_permit_at(
     root: &Path,
     limit: usize,
     cancel: Option<&CancellationToken>,
+    probe: &dyn MemoryProbe,
 ) -> Result<HeavyCommandPermit> {
     std::fs::create_dir_all(root)
         .with_context(|| format!("creating resource admission directory {}", root.display()))?;
@@ -125,7 +189,13 @@ async fn acquire_heavy_command_permit_at(
                 "heavy command canceled while queued for resource admission"
             ));
         }
-        for slot in 0..limit {
+        // Re-measure each iteration: under memory pressure the effective limit
+        // tightens so a saturated host stops admitting new heavy link graphs
+        // (#4864 req 7). Critical pressure yields zero slots, so the command
+        // waits for recovery instead of snowballing.
+        let pressure = classify_memory_pressure(probe.free_fraction());
+        let effective = effective_admission_limit(limit, pressure);
+        for slot in 0..effective {
             let path = root.join(format!("heavy-{slot}.lock"));
             match try_lock_slot(&path) {
                 Ok(Some(slot)) => {
@@ -133,6 +203,7 @@ async fn acquire_heavy_command_permit_at(
                         _slot: slot,
                         queued_for: started.elapsed(),
                         limit,
+                        memory_pressure: pressure,
                     });
                 }
                 Ok(None) => {}
@@ -206,12 +277,144 @@ fn admission_root() -> PathBuf {
     std::env::temp_dir().join("codewhale-resource-admission")
 }
 
+/// Host free-RAM fraction in `0.0..=1.0`, or `None` when it cannot be measured.
+///
+/// Each implementation shells out to a standard, always-present tool so no new
+/// crate or build-feature dependency is introduced, and every error path returns
+/// `None` so admission fails open (never blocks on an unmeasurable host). This
+/// keeps the gate safe on any CI runner, while protecting the macOS dogfood host
+/// and Linux/Windows machines where the tool exists.
+#[cfg(target_os = "linux")]
+fn host_memory_free_fraction() -> Option<f64> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let total = parse_meminfo_kb(&meminfo, "MemTotal:")?;
+    let available = parse_meminfo_kb(&meminfo, "MemAvailable:")?;
+    (total > 0).then(|| (available as f64 / total as f64).clamp(0.0, 1.0))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_meminfo_kb(meminfo: &str, prefix: &str) -> Option<u64> {
+    meminfo
+        .lines()
+        .find(|line| line.starts_with(prefix))
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+#[cfg(target_os = "macos")]
+fn host_memory_free_fraction() -> Option<f64> {
+    let total = run_capture("/usr/sbin/sysctl", &["-n", "hw.memsize"])
+        .and_then(|bytes| bytes.trim().parse::<u64>().ok())?;
+    let page_size = run_capture("/usr/bin/pagesize", &[])?
+        .trim()
+        .parse::<u64>()
+        .ok()?;
+    let stats = run_capture("/usr/bin/vm_stat", &[])?;
+    let free_pages = memory_pages_from_vm_stat(&stats, &["Pages free:", "Pages inactive:"])?;
+    let free_bytes = free_pages.checked_mul(page_size)?;
+    (total > 0).then(|| (free_bytes as f64 / total as f64).clamp(0.0, 1.0))
+}
+
+#[cfg(target_os = "macos")]
+fn memory_pages_from_vm_stat(vm_stat: &str, prefixes: &[&str]) -> Option<u64> {
+    let mut total = 0u64;
+    for prefix in prefixes {
+        let pages = vm_stat
+            .lines()
+            .find(|line| line.trim_start().starts_with(prefix))
+            .and_then(|line| {
+                line.split('.')
+                    .nth(1)
+                    .and_then(|rest| rest.trim().parse::<u64>().ok())
+            })?;
+        total = total.checked_add(pages)?;
+    }
+    Some(total)
+}
+
+#[cfg(windows)]
+fn host_memory_free_fraction() -> Option<f64> {
+    // `wmic` is deprecated but present on every supported Windows runner and
+    // avoids adding a GlobalMemoryStatusEx build dependency. Fail open on error.
+    let out = run_capture(
+        "C:\\Windows\\System32\\wbem\\wmic.exe",
+        &[
+            "OS",
+            "get",
+            "FreePhysicalMemory,TotalVisibleMemorySize",
+            "/value",
+        ],
+    )?;
+    let free_kb = wmic_value(&out, "FreePhysicalMemory=")?;
+    let total_kb = wmic_value(&out, "TotalVisibleMemorySize=")?;
+    (total_kb > 0).then(|| (free_kb as f64 / total_kb as f64).clamp(0.0, 1.0))
+}
+
+#[cfg(windows)]
+fn wmic_value(output: &str, key: &str) -> Option<u64> {
+    output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix(key))
+        .and_then(|value| value.trim().parse::<u64>().ok())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn host_memory_free_fraction() -> Option<f64> {
+    None
+}
+
+fn run_capture(program: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
+
+    /// Deterministic probe returning a fixed fraction so admission behavior is
+    /// independent of the host running the test suite.
+    struct StaticMemoryProbe(Option<f64>);
+    impl MemoryProbe for StaticMemoryProbe {
+        fn free_fraction(&self) -> Option<f64> {
+            self.0
+        }
+    }
+
+    const NOMINAL_PROBE: StaticMemoryProbe = StaticMemoryProbe(Some(0.9));
+
+    #[test]
+    fn memory_pressure_classification_and_effective_limit() {
+        // Unknown (unmeasurable) fails open to the configured limit.
+        assert_eq!(classify_memory_pressure(None), MemoryPressure::Unknown);
+        assert_eq!(effective_admission_limit(2, MemoryPressure::Unknown), 2);
+        assert_eq!(classify_memory_pressure(Some(0.9)), MemoryPressure::Nominal);
+        assert_eq!(
+            classify_memory_pressure(Some(0.30)),
+            MemoryPressure::Constrained
+        );
+        assert_eq!(
+            classify_memory_pressure(Some(0.15)),
+            MemoryPressure::Critical
+        );
+        assert_eq!(
+            classify_memory_pressure(Some(0.0)),
+            MemoryPressure::Critical
+        );
+        assert_eq!(effective_admission_limit(4, MemoryPressure::Nominal), 4);
+        assert_eq!(effective_admission_limit(4, MemoryPressure::Constrained), 2);
+        assert_eq!(effective_admission_limit(1, MemoryPressure::Constrained), 1);
+        assert_eq!(effective_admission_limit(4, MemoryPressure::Critical), 0);
+    }
 
     #[test]
     fn infers_only_expensive_rust_compilation_commands() {
@@ -229,7 +432,12 @@ mod tests {
                 "{command}"
             );
         }
-        for command in ["cargo fmt --check", "cargo metadata", "git status", "echo cargo test"] {
+        for command in [
+            "cargo fmt --check",
+            "cargo metadata",
+            "git status",
+            "echo cargo test",
+        ] {
             assert_eq!(
                 infer_command_expense(command),
                 CommandExpense::Normal,
@@ -250,7 +458,7 @@ mod tests {
             let active = Arc::clone(&active);
             let peak = Arc::clone(&peak);
             tasks.push(tokio::spawn(async move {
-                let _permit = acquire_heavy_command_permit_at(&root, 2, None)
+                let _permit = acquire_heavy_command_permit_at(&root, 2, None, &NOMINAL_PROBE)
                     .await
                     .expect("permit");
                 let current = active.fetch_add(1, Ordering::SeqCst) + 1;
@@ -270,14 +478,14 @@ mod tests {
     #[tokio::test]
     async fn queued_admission_observes_cancellation() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let _held = acquire_heavy_command_permit_at(temp.path(), 1, None)
+        let _held = acquire_heavy_command_permit_at(temp.path(), 1, None, &NOMINAL_PROBE)
             .await
             .expect("initial permit");
         let cancel = CancellationToken::new();
         let wait_cancel = cancel.clone();
         let root = temp.path().to_path_buf();
         let waiter = tokio::spawn(async move {
-            acquire_heavy_command_permit_at(&root, 1, Some(&wait_cancel)).await
+            acquire_heavy_command_permit_at(&root, 1, Some(&wait_cancel), &NOMINAL_PROBE).await
         });
 
         tokio::time::sleep(Duration::from_millis(75)).await;
@@ -288,5 +496,71 @@ mod tests {
             .expect("waiter task")
             .expect_err("queued command must cancel");
         assert!(error.to_string().contains("canceled while queued"));
+    }
+
+    #[tokio::test]
+    async fn critical_memory_pressure_queues_without_admitting() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Critical pressure -> zero effective slots -> the command cannot be
+        // admitted and must observe cancellation rather than spin forever.
+        let critical = StaticMemoryProbe(Some(0.05));
+        let cancel = CancellationToken::new();
+        let wait_cancel = cancel.clone();
+        let root = temp.path().to_path_buf();
+        let waiter = tokio::spawn(async move {
+            acquire_heavy_command_permit_at(&root, 2, Some(&wait_cancel), &critical).await
+        });
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        cancel.cancel();
+        let error = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("bounded cancellation")
+            .expect("waiter task")
+            .expect_err("critical-pressure command must not be admitted");
+        assert!(error.to_string().contains("canceled while queued"));
+    }
+
+    #[test]
+    fn host_memory_probe_is_fail_safe() {
+        // On any supported host the probe either measures a plausible fraction
+        // or admits it cannot; it must never panic or return an out-of-range.
+        if let Some(fraction) = host_memory_free_fraction() {
+            assert!(
+                (0.0..=1.0).contains(&fraction),
+                "measured free fraction out of range: {fraction}"
+            );
+        }
+    }
+
+    /// Opt-in real cargo acceptance (#4864 req 8): drive an actual heavy-class
+    /// cargo invocation through the admission path end to end. `cargo check
+    /// --version` classifies as heavy (subcommand `check`) but exits instantly,
+    /// so this is fast. Gated behind an env var so CI never runs a real cargo.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn real_cargo_command_is_admitted_and_released() {
+        if std::env::var_os("CODEWHALE_RESOURCE_ADMISSION_RUST_ACCEPTANCE").is_none() {
+            eprintln!(
+                "skipping opt-in real-rust admission acceptance; \
+                 set CODEWHALE_RESOURCE_ADMISSION_RUST_ACCEPTANCE=1 to run"
+            );
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let permit = acquire_heavy_command_permit_at(temp.path(), 2, None, &NOMINAL_PROBE)
+            .await
+            .expect("heavy permit for real cargo");
+        assert_eq!(permit.limit(), 2);
+        assert_eq!(permit.memory_pressure(), MemoryPressure::Nominal);
+        let cargo = std::process::Command::new("cargo")
+            .arg("check")
+            .arg("--version")
+            .output()
+            .expect("run cargo");
+        assert!(cargo.status.success(), "cargo check --version failed");
+        drop(permit);
+        let _again = acquire_heavy_command_permit_at(temp.path(), 2, None, &NOMINAL_PROBE)
+            .await
+            .expect("re-acquire after release");
     }
 }

--- a/crates/tui/src/tools/resource_admission.rs
+++ b/crates/tui/src/tools/resource_admission.rs
@@ -1,0 +1,292 @@
+//! Cross-process admission for expensive local commands.
+//!
+//! Fleet and Workflow workers execute in separate Codewhale processes, so an
+//! in-process semaphore cannot protect the host. Heavy shell commands instead
+//! take one of a small number of filesystem-backed permits under
+//! `CODEWHALE_HOME`. The default of two permits is deliberately conservative
+//! for the 36 GiB laptop class from #4864.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+use fd_lock::{RwLock, RwLockWriteGuard};
+use tokio_util::sync::CancellationToken;
+
+pub(crate) const DEFAULT_HEAVY_COMMAND_LIMIT: usize = 2;
+const MAX_HEAVY_COMMAND_LIMIT: usize = 16;
+const ADMISSION_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandExpense {
+    Normal,
+    Heavy,
+}
+
+#[derive(Debug)]
+struct HeavyPermitSlot {
+    _guard: RwLockWriteGuard<'static, File>,
+    // The guard borrows the lock. Keeping the boxed lock here makes that
+    // allocation outlive the guard; field drop order is guard, then lock.
+    _lock: Box<RwLock<File>>,
+}
+
+/// A held cross-process heavy-command permit.
+#[derive(Debug)]
+pub(crate) struct HeavyCommandPermit {
+    _slot: HeavyPermitSlot,
+    queued_for: Duration,
+    limit: usize,
+}
+
+impl HeavyCommandPermit {
+    pub(crate) fn queued_for(&self) -> Duration {
+        self.queued_for
+    }
+
+    pub(crate) fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+pub(crate) fn infer_command_expense(command: &str) -> CommandExpense {
+    let heavy = command
+        .split(|character| matches!(character, '\n' | '\r' | ';' | '|' | '&'))
+        .any(segment_is_heavy);
+
+    if heavy {
+        CommandExpense::Heavy
+    } else {
+        CommandExpense::Normal
+    }
+}
+
+fn segment_is_heavy(segment: &str) -> bool {
+    let tokens: Vec<String> = segment
+        .split_whitespace()
+        .map(|token| token.trim_matches(['"', '\'']).to_string())
+        .collect();
+    let Some(index) = tokens
+        .iter()
+        .position(|token| !token.contains('=') && token != "env")
+    else {
+        return false;
+    };
+    let executable = Path::new(&tokens[index])
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if !matches!(executable.as_str(), "cargo" | "rustc") {
+        return false;
+    }
+    if executable == "rustc" {
+        return true;
+    }
+    tokens[index + 1..]
+        .iter()
+        .map(|arg| arg.trim().to_ascii_lowercase())
+        .find(|arg| !arg.is_empty() && !arg.starts_with('-') && !arg.contains('='))
+        .is_some_and(|subcommand| {
+            matches!(
+                subcommand.as_str(),
+                "build" | "test" | "check" | "clippy" | "rustc"
+            )
+        })
+}
+
+pub(crate) async fn acquire_heavy_command_permit(
+    command: &str,
+    cancel: Option<&CancellationToken>,
+) -> Result<Option<HeavyCommandPermit>> {
+    if infer_command_expense(command) == CommandExpense::Normal {
+        return Ok(None);
+    }
+
+    let limit = configured_heavy_command_limit();
+    let root = admission_root();
+    acquire_heavy_command_permit_at(&root, limit, cancel).await.map(Some)
+}
+
+async fn acquire_heavy_command_permit_at(
+    root: &Path,
+    limit: usize,
+    cancel: Option<&CancellationToken>,
+) -> Result<HeavyCommandPermit> {
+    std::fs::create_dir_all(root)
+        .with_context(|| format!("creating resource admission directory {}", root.display()))?;
+    let started = Instant::now();
+
+    loop {
+        if cancel.is_some_and(|token| token.is_cancelled()) {
+            return Err(anyhow!(
+                "heavy command canceled while queued for resource admission"
+            ));
+        }
+        for slot in 0..limit {
+            let path = root.join(format!("heavy-{slot}.lock"));
+            match try_lock_slot(&path) {
+                Ok(Some(slot)) => {
+                    return Ok(HeavyCommandPermit {
+                        _slot: slot,
+                        queued_for: started.elapsed(),
+                        limit,
+                    });
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("acquiring heavy command permit {}", path.display())
+                    });
+                }
+            }
+        }
+        tokio::time::sleep(ADMISSION_POLL_INTERVAL).await;
+    }
+}
+
+fn try_lock_slot(path: &Path) -> io::Result<Option<HeavyPermitSlot>> {
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?;
+    let lock = Box::new(RwLock::new(file));
+    let lock_ptr = Box::into_raw(lock);
+    // SAFETY: `lock_ptr` remains allocated in `HeavyPermitSlot::_lock` for the
+    // lifetime of `_guard`, and the guard is dropped before that box.
+    let guard = match unsafe { (&mut *lock_ptr).try_write() } {
+        Ok(guard) => guard,
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+            // SAFETY: no guard was created, so reclaim the allocation now.
+            unsafe { drop(Box::from_raw(lock_ptr)) };
+            return Ok(None);
+        }
+        Err(error) => {
+            // SAFETY: no guard was created, so reclaim the allocation now.
+            unsafe { drop(Box::from_raw(lock_ptr)) };
+            return Err(error);
+        }
+    };
+    // SAFETY: the allocation is owned exactly once by this box and is stable on
+    // the heap even if `HeavyPermitSlot` moves.
+    let lock = unsafe { Box::from_raw(lock_ptr) };
+    // SAFETY: the boxed lock remains alive until after `_guard` is dropped.
+    let guard = unsafe {
+        std::mem::transmute::<RwLockWriteGuard<'_, File>, RwLockWriteGuard<'static, File>>(guard)
+    };
+    Ok(Some(HeavyPermitSlot {
+        _guard: guard,
+        _lock: lock,
+    }))
+}
+
+fn configured_heavy_command_limit() -> usize {
+    std::env::var("CODEWHALE_HEAVY_COMMAND_LIMIT")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|limit| *limit > 0)
+        .unwrap_or(DEFAULT_HEAVY_COMMAND_LIMIT)
+        .min(MAX_HEAVY_COMMAND_LIMIT)
+}
+
+fn admission_root() -> PathBuf {
+    if let Some(home) = std::env::var_os("CODEWHALE_HOME")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        return home.join("resource-admission");
+    }
+    if let Some(home) = crate::config::effective_home_dir() {
+        return home.join(".codewhale").join("resource-admission");
+    }
+    std::env::temp_dir().join("codewhale-resource-admission")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn infers_only_expensive_rust_compilation_commands() {
+        for command in [
+            "cargo test -p codewhale-tui shell::tests",
+            "env CARGO_BUILD_JOBS=2 cargo build --workspace",
+            "cargo check",
+            "cargo clippy --all-targets",
+            "/usr/bin/rustc src/main.rs",
+            "printf ok && cargo rustc -- --emit=metadata",
+        ] {
+            assert_eq!(
+                infer_command_expense(command),
+                CommandExpense::Heavy,
+                "{command}"
+            );
+        }
+        for command in ["cargo fmt --check", "cargo metadata", "git status", "echo cargo test"] {
+            assert_eq!(
+                infer_command_expense(command),
+                CommandExpense::Normal,
+                "{command}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cross_task_heavy_admission_never_exceeds_limit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for _ in 0..12 {
+            let root = temp.path().to_path_buf();
+            let active = Arc::clone(&active);
+            let peak = Arc::clone(&peak);
+            tasks.push(tokio::spawn(async move {
+                let _permit = acquire_heavy_command_permit_at(&root, 2, None)
+                    .await
+                    .expect("permit");
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(30)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for task in tasks {
+            task.await.expect("admission task");
+        }
+
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn queued_admission_observes_cancellation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _held = acquire_heavy_command_permit_at(temp.path(), 1, None)
+            .await
+            .expect("initial permit");
+        let cancel = CancellationToken::new();
+        let wait_cancel = cancel.clone();
+        let root = temp.path().to_path_buf();
+        let waiter = tokio::spawn(async move {
+            acquire_heavy_command_permit_at(&root, 1, Some(&wait_cancel)).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        cancel.cancel();
+        let error = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("bounded cancellation")
+            .expect("waiter task")
+            .expect_err("queued command must cancel");
+        assert!(error.to_string().contains("canceled while queued"));
+    }
+}

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -41,6 +41,9 @@ mod output;
 
 use super::shell_output::{summarize_output, truncate_with_meta};
 use crate::child_env;
+use crate::tools::resource_admission::{
+    CommandExpense, HeavyCommandPermit, acquire_heavy_command_permit, infer_command_expense,
+};
 use crate::sandbox::{
     CommandSpec,
     ExecEnv,
@@ -582,6 +585,7 @@ pub struct BackgroundShell {
     pub owner_agent: Option<ShellJobOwner>,
     stdout_buffer: Arc<Mutex<Vec<u8>>>,
     stderr_buffer: Option<Arc<Mutex<Vec<u8>>>>,
+    heavy_permit: Option<HeavyCommandPermit>,
     stdout_cursor: usize,
     stderr_cursor: usize,
     completion_reported: bool,
@@ -710,12 +714,14 @@ impl BackgroundShell {
                     } else {
                         ShellStatus::Failed
                     };
+                    self.heavy_permit.take();
                     self.collect_output();
                     true
                 }
                 Ok(None) => false, // Still running
                 Err(_) => {
                     self.status = ShellStatus::Failed;
+                    self.heavy_permit.take();
                     self.collect_output();
                     true
                 }
@@ -911,6 +917,7 @@ impl BackgroundShell {
             }
         }
         self.status = ShellStatus::Killed;
+        self.heavy_permit.take();
         self.collect_output();
         self.publish_lifecycle_best_effort();
         Ok(())
@@ -1312,6 +1319,7 @@ impl ShellManager {
                 command,
                 &work_dir,
                 &exec_env,
+                None,
                 stdin_data,
                 tty,
                 ShellSpawnContext {
@@ -1675,6 +1683,7 @@ impl ShellManager {
         original_command: &str,
         working_dir: &std::path::Path,
         exec_env: &ExecEnv,
+        heavy_permit: Option<HeavyCommandPermit>,
         stdin_data: Option<&str>,
         tty: bool,
         spawn_context: ShellSpawnContext,
@@ -1840,6 +1849,7 @@ impl ShellManager {
             owner_agent,
             stdout_buffer,
             stderr_buffer,
+            heavy_permit,
             stdout_cursor: 0,
             stderr_cursor: 0,
             completion_reported: false,
@@ -2005,6 +2015,19 @@ impl ShellManager {
             stdout_total_len: stdout_total,
             stderr_total_len: stderr_total,
         })
+    }
+
+    fn attach_heavy_permit(
+        &mut self,
+        task_id: &str,
+        permit: HeavyCommandPermit,
+    ) -> Result<()> {
+        let shell = self
+            .processes
+            .get_mut(task_id)
+            .ok_or_else(|| anyhow!("Task {task_id} not found"))?;
+        shell.heavy_permit = Some(permit);
+        Ok(())
     }
 
     /// Kill a running background process
@@ -2493,6 +2516,7 @@ fn exec_shell_input_starts_detached(input: &serde_json::Value) -> bool {
 async fn execute_foreground_via_background(
     context: &ToolContext,
     command: &str,
+    heavy_permit: Option<HeavyCommandPermit>,
     working_dir: Option<String>,
     timeout_ms: u64,
     stdin_data: Option<&str>,
@@ -2523,6 +2547,13 @@ async fn execute_foreground_via_background(
     let task_id = spawned
         .task_id
         .ok_or_else(|| anyhow!("foreground shell did not return a process id"))?;
+    if let Some(permit) = heavy_permit {
+        let mut manager = context
+            .shell_manager
+            .lock()
+            .map_err(|_| anyhow!("shell manager lock poisoned"))?;
+        manager.attach_heavy_permit(&task_id, permit)?;
+    }
 
     if stdin_data.is_some() {
         let mut manager = context
@@ -2851,6 +2882,15 @@ impl ToolSpec for BashTool {
             std::collections::HashMap::new()
         };
 
+        let command_expense = infer_command_expense(command);
+        let heavy_permit = acquire_heavy_command_permit(command, context.cancel_token.as_ref())
+            .await
+            .map_err(|error| ToolError::execution_failed(error.to_string()))?;
+        let admission_wait_ms = heavy_permit
+            .as_ref()
+            .map(|permit| u64::try_from(permit.queued_for().as_millis()).unwrap_or(u64::MAX));
+        let admission_limit = heavy_permit.as_ref().map(HeavyCommandPermit::limit);
+
         // Route through external sandbox backend when configured.
         if let Some(backend) = &context.sandbox_backend {
             if interactive {
@@ -2946,6 +2986,12 @@ impl ToolSpec for BashTool {
                 "interactive": false,
                 "canceled": false,
                 "sandbox_backend": "opensandbox",
+                "expense_class": match command_expense {
+                    CommandExpense::Heavy => "heavy",
+                    CommandExpense::Normal => "normal",
+                },
+                "resource_admission_wait_ms": admission_wait_ms,
+                "resource_admission_limit": admission_limit,
             });
             attach_shell_owner_metadata(&mut metadata, context);
             attach_cargo_failure_summary(&mut metadata, command, &result);
@@ -2999,7 +3045,7 @@ impl ToolSpec for BashTool {
                 .shell_manager
                 .lock()
                 .map_err(|_| ToolError::execution_failed("shell manager lock poisoned"))?;
-            manager.execute_with_options_env_for_owner_and_work(
+            let result = manager.execute_with_options_env_for_owner_and_work(
                 command,
                 working_dir.as_deref(),
                 timeout_ms,
@@ -3010,11 +3056,20 @@ impl ToolSpec for BashTool {
                 extra_env,
                 shell_job_owner_from_context(context),
                 shell_work_lifecycle_from_context(context),
-            )
+            );
+            if let (Ok(result), Some(permit)) = (&result, heavy_permit)
+                && let Some(task_id) = result.task_id.as_deref()
+            {
+                manager
+                    .attach_heavy_permit(task_id, permit)
+                    .map_err(|error| ToolError::execution_failed(error.to_string()))?;
+            }
+            result
         } else {
             execute_foreground_via_background(
                 context,
                 command,
+                heavy_permit,
                 working_dir,
                 timeout_ms,
                 stdin_data.as_deref(),
@@ -3122,6 +3177,12 @@ impl ToolSpec for BashTool {
                     "stdout_omitted": result.stdout_omitted,
                     "stderr_omitted": result.stderr_omitted,
                     "lifecycle_warning": lifecycle_warning,
+                    "expense_class": match command_expense {
+                        CommandExpense::Heavy => "heavy",
+                        CommandExpense::Normal => "normal",
+                    },
+                    "resource_admission_wait_ms": admission_wait_ms,
+                    "resource_admission_limit": admission_limit,
                     "summary": summary,
                     "stdout_summary": stdout_summary,
                     "stderr_summary": stderr_summary,

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -41,15 +41,16 @@ mod output;
 
 use super::shell_output::{summarize_output, truncate_with_meta};
 use crate::child_env;
-use crate::tools::resource_admission::{
-    CommandExpense, HeavyCommandPermit, acquire_heavy_command_permit, infer_command_expense,
-};
 use crate::sandbox::{
     CommandSpec,
     ExecEnv,
     SandboxManager,
     SandboxPolicy as ExecutionSandboxPolicy, // Rename to avoid conflict with spec::SandboxPolicy
     SandboxType,
+};
+use crate::tools::resource_admission::{
+    CommandExpense, HeavyCommandPermit, MemoryPressure, acquire_heavy_command_permit,
+    infer_command_expense,
 };
 use crate::work_graph::{
     EvidenceKind, EvidenceRef, OperationIntent, OperationOwnerSnapshot, OwnerState,
@@ -2017,11 +2018,7 @@ impl ShellManager {
         })
     }
 
-    fn attach_heavy_permit(
-        &mut self,
-        task_id: &str,
-        permit: HeavyCommandPermit,
-    ) -> Result<()> {
+    fn attach_heavy_permit(&mut self, task_id: &str, permit: HeavyCommandPermit) -> Result<()> {
         let shell = self
             .processes
             .get_mut(task_id)
@@ -2890,6 +2887,9 @@ impl ToolSpec for BashTool {
             .as_ref()
             .map(|permit| u64::try_from(permit.queued_for().as_millis()).unwrap_or(u64::MAX));
         let admission_limit = heavy_permit.as_ref().map(HeavyCommandPermit::limit);
+        let admission_memory = heavy_permit
+            .as_ref()
+            .map(HeavyCommandPermit::memory_pressure);
 
         // Route through external sandbox backend when configured.
         if let Some(backend) = &context.sandbox_backend {
@@ -3183,6 +3183,12 @@ impl ToolSpec for BashTool {
                     },
                     "resource_admission_wait_ms": admission_wait_ms,
                     "resource_admission_limit": admission_limit,
+                    "resource_admission_memory": match admission_memory {
+                        Some(MemoryPressure::Critical) => "critical",
+                        Some(MemoryPressure::Constrained) => "constrained",
+                        Some(MemoryPressure::Nominal) | None => "nominal",
+                        Some(MemoryPressure::Unknown) => "unknown",
+                    },
                     "summary": summary,
                     "stdout_summary": stdout_summary,
                     "stderr_summary": stderr_summary,

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -205,9 +205,8 @@ fn shell_descendant_helper_process() {
     if std::env::var(SHELL_DESCENDANT_HELPER_ENV).ok().as_deref() != Some("1") {
         return;
     }
-    let pid_file = PathBuf::from(
-        std::env::var(SHELL_DESCENDANT_PID_FILE_ENV).expect("descendant pid file"),
-    );
+    let pid_file =
+        PathBuf::from(std::env::var(SHELL_DESCENDANT_PID_FILE_ENV).expect("descendant pid file"));
     let child = Command::new("sleep")
         .arg("30")
         .spawn()
@@ -225,7 +224,10 @@ fn wait_for_shell_pid_file(path: &Path) -> libc::pid_t {
         {
             return pid;
         }
-        assert!(Instant::now() < deadline, "descendant pid file never appeared");
+        assert!(
+            Instant::now() < deadline,
+            "descendant pid file never appeared"
+        );
         std::thread::sleep(Duration::from_millis(25));
     }
 }

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -194,6 +194,58 @@ fn failed_network_shell_result(stdout: &str, stderr: &str) -> ShellResult {
     }
 }
 
+#[cfg(unix)]
+const SHELL_DESCENDANT_HELPER_ENV: &str = "CODEWHALE_SHELL_DESCENDANT_HELPER";
+#[cfg(unix)]
+const SHELL_DESCENDANT_PID_FILE_ENV: &str = "CODEWHALE_SHELL_DESCENDANT_PID_FILE";
+
+#[cfg(unix)]
+#[test]
+fn shell_descendant_helper_process() {
+    if std::env::var(SHELL_DESCENDANT_HELPER_ENV).ok().as_deref() != Some("1") {
+        return;
+    }
+    let pid_file = PathBuf::from(
+        std::env::var(SHELL_DESCENDANT_PID_FILE_ENV).expect("descendant pid file"),
+    );
+    let child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn cheap descendant");
+    std::fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+    std::thread::sleep(Duration::from_secs(30));
+}
+
+#[cfg(unix)]
+fn wait_for_shell_pid_file(path: &Path) -> libc::pid_t {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(raw) = std::fs::read_to_string(path)
+            && let Ok(pid) = raw.trim().parse()
+        {
+            return pid;
+        }
+        assert!(Instant::now() < deadline, "descendant pid file never appeared");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_shell_pid_exit(pid: libc::pid_t) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if unsafe { libc::kill(pid, 0) } != 0
+            && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+        {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 fn wait_for_completed_shell(manager: &mut ShellManager, task_id: &str) -> ShellResult {
     let deadline = Instant::now() + Duration::from_millis(BACKGROUND_COMPLETION_WAIT_MS);
 
@@ -1471,6 +1523,44 @@ async fn test_completed_background_shell_releases_process_handles() {
     assert!(shell.child.is_none());
     assert!(shell.stdout_thread.is_none());
     assert!(shell.stderr_thread.is_none());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn exec_shell_cancel_kills_descendant_process_group() {
+    let tmp = tempdir().expect("tempdir");
+    let pid_file = tmp.path().join("descendant.pid");
+    let test_binary = std::env::current_exe().expect("current test binary");
+    let command = format!(
+        "{} --exact {} --nocapture",
+        shell_words::quote(&test_binary.display().to_string()),
+        shell_words::quote("tools::shell::tests::shell_descendant_helper_process"),
+    );
+    let ctx = ToolContext::new(tmp.path());
+    let mut env = std::collections::HashMap::new();
+    env.insert(SHELL_DESCENDANT_HELPER_ENV.to_string(), "1".to_string());
+    env.insert(
+        SHELL_DESCENDANT_PID_FILE_ENV.to_string(),
+        pid_file.display().to_string(),
+    );
+    let started = ctx
+        .shell_manager
+        .lock()
+        .expect("shell manager")
+        .execute_with_options_env(&command, None, 60_000, true, None, false, None, env)
+        .expect("start descendant tree");
+    let task_id = started.task_id.expect("task id");
+    let descendant = wait_for_shell_pid_file(&pid_file);
+
+    let result = BashTool::alias("exec_shell_cancel", "cancel")
+        .execute(json!({"task_id": task_id}), &ctx)
+        .await
+        .expect("cancel process group");
+    assert!(result.success);
+    assert!(
+        wait_for_shell_pid_exit(descendant),
+        "descendant {descendant} survived shell process-group cancellation"
+    );
 }
 
 #[tokio::test]

--- a/crates/tui/src/tools/shell/tests.rs
+++ b/crates/tui/src/tools/shell/tests.rs
@@ -1904,6 +1904,7 @@ fn killed_shell_does_not_wait_for_blocked_reader_threads() {
         owner_agent: None,
         stdout_buffer: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         stderr_buffer: None,
+        heavy_permit: None,
         stdout_cursor: 0,
         stderr_cursor: 0,
         completion_reported: false,


### PR DESCRIPTION
Closes #4864.

## What

Adds a cross-process resource-admission layer so Fleet/Workflow workers running
in separate Codewhale processes cannot simultaneously saturate the host with
independent Rust link graphs — the failure mode behind the 2026-07-25 dogfood
incident (load 56/92/87, 21% memory free, swap thrash, orphaned cargo/rustc that
the sandbox could not reap).

## How the 8 acceptance requirements are met

1. **Global resource budget, separate from agent-count admission.** Filesystem-
   backed permits under `$CODEWHALE_HOME/resource-admission` (`fd_lock`), one per
   admitted heavy command. Decoupled from worker count.
2. **Expense class.** `infer_command_expense` flags `cargo build/test/check/
   clippy` and `rustc` as heavy; everything else is normal and skips admission.
3. **Queueing when saturated.** `DEFAULT_HEAVY_COMMAND_LIMIT=2` (env
   `CODEWHALE_HEAVY_COMMAND_LIMIT`, capped at 16) bounds a 36 GiB laptop; heavy
   commands acquire a permit before spawn and queue on a bounded poll that honors
   cancellation.
4. **interrupt/cancel reap the full process group and confirm.** New `Draining`
   worker state: a dispatcher that has exited while descendants live reports
   `Draining` (retryable), not terminal. Unix detects live session members;
   Windows queries the Job Object `ActiveProcesses`. `stop`/`cancel` reap the
   group/job; `wait_for_exit` waits through `Draining`. Both platforms tested.
5. **Truthful status.** `Draining` vs `Stopped` is observable through the host
   adapter and executor (Draining is non-terminal).
6. **No unbounded duplicate link graphs.** The global permit budget is the
   chosen mechanism (vs a shared `target/`, which has its own concurrent-cargo
   correctness risks); lanes may additionally share a cache via
   `CARGO_TARGET_DIR`.
7. **Memory-aware; never silently snowballs.** A pluggable `MemoryProbe`
   measures free-RAM fraction via always-present tools (sysctl/vm_stat on macOS,
   /proc/meminfo on Linux, wmic on Windows) and the acquisition loop tightens
   the effective limit: `Critical` (≤15% free) → 0 slots (queue until recovery),
   `Constrained` (≤30%) → half. The probe **fails open** (`None`) on any host
   where measurement is unavailable, so CI on any platform is safe while the
   dogfood host is protected.
8. **Deterministic + opt-in acceptance tests.** Cross-task admission (12 tasks /
   limit 2 / peak 2), queued cancellation, shell descendant process-group
   cancellation, host `Draining` lifecycle, plus an env-gated opt-in
   real-Rust-build acceptance (`CODEWHALE_RESOURCE_ADMISSION_RUST_ACCEPTANCE=1`).

Receipt metadata now reports `expense_class`, `resource_admission_wait_ms`,
`resource_admission_limit`, and `resource_admission_memory`.

## Verification (local, exact)

- `cargo test -p codewhale-tui --bin codewhale-tui -- resource_admission` → 7/7 ok
- host `Draining` + shell descendant-cancel + session-reap tests → ok
- `cargo fmt --all -- --check` → clean
- `git diff --check` → clean
- CI-shaped clippy (tui, `--all-features --locked`, `-D warnings`) → clean

No new crate dependencies (`fd-lock`, `tokio-util` already in `codewhale-tui`).