### PR TITLE
fix(fleet): validate pinned model routes before leasing workers (#4866 P1)

### DIFF
--- a/crates/tui/src/fleet/manager.rs
+++ b/crates/tui/src/fleet/manager.rs
@@ -299,6 +299,12 @@ impl FleetManager {
         validate_task_spec_document(&doc)?;
         let roster = self.agent_roster();
         worker_runtime::validate_task_agent_profiles(&doc.tasks, roster.members())?;
+        worker_runtime::validate_fleet_task_routes(
+            &doc.tasks,
+            roster.members(),
+            self.session_model(),
+            self.route_config.as_ref(),
+        )?;
         let max_workers = max_workers.clamp(1, 128);
         let run_id = FleetRunId::from(format!(
             "fleet-{}",

--- a/crates/tui/src/fleet/worker_runtime.rs
+++ b/crates/tui/src/fleet/worker_runtime.rs
@@ -39,6 +39,57 @@ pub fn validate_task_agent_profiles(
     Ok(())
 }
 
+/// Validate that every task's pinned model route actually resolves before any
+/// worker is leased (#4866).
+///
+/// Catches the "provider-less model pin" failure mode: a profile that pins a
+/// concrete model without an explicit provider resolves against the
+/// session/default provider, which may not carry that model — causing a silent
+/// launch failure (e.g. selecting `gpt-5.6-luna` as a Fleet Builder model with
+/// no provider, when Luna lives on a different configured provider). The
+/// runtime never infers a provider from a model's spelling (#4093/#2608), so a
+/// pinned model that does not resolve is rejected here with a clear error
+/// instead of failing silently inside the worker. Models inherited from the
+/// session/run route (`run.model`) are not pins and are left alone.
+pub fn validate_fleet_task_routes(
+    tasks: &[FleetTaskSpec],
+    agent_profiles: &[AgentProfile],
+    session_model: Option<&str>,
+    config: Option<&Config>,
+) -> Result<()> {
+    let run_model = session_model.unwrap_or("auto");
+    for task in tasks {
+        let agent_profile = resolve_task_agent_profile(task, agent_profiles)
+            .ok()
+            .flatten();
+        let (model, source) =
+            effective_fleet_model_with_source(run_model, task.worker.as_ref(), agent_profile);
+        if !matches!(source, "task.model" | "agent_profile.model") {
+            continue;
+        }
+        // A concrete model is pinned at the task/profile level; it must resolve
+        // to a real provider route or the worker cannot launch.
+        if resolve_fleet_route_with_config(task, agent_profiles, session_model, config).is_some() {
+            continue;
+        }
+        let provider = explicit_fleet_provider_id(agent_profile)
+            .map(|provider| format!("provider=`{provider}`"))
+            .unwrap_or_else(|| {
+                "no explicit provider (resolves against the session/default provider)".to_string()
+            });
+        bail!(
+            "Fleet task `{}` pins model `{}` with {} (source={source}), but that route does not \
+             resolve to a real model on any configured provider, so the worker cannot launch. \
+             The runtime never infers a provider from a model's spelling — set an explicit \
+             provider for this model in the profile, or switch the role to `inherit`.",
+            task.id,
+            model,
+            provider
+        );
+    }
+    Ok(())
+}
+
 /// Build a sub-agent worker spec after resolving workspace Fleet profile input.
 ///
 /// This keeps Fleet and sub-agents on the same runtime substrate: profile files
@@ -1734,6 +1785,87 @@ mod tests {
             .expect("pinned route should resolve");
         assert_eq!(pinned.model_source.as_deref(), Some("agent_profile.model"));
         assert_eq!(pinned.wire_model_id, "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn validate_fleet_task_routes_rejects_unresolvable_providerless_pin() {
+        // #4866 Luna failure mode: a profile pins a concrete model with no
+        // explicit provider. The runtime never infers a provider from spelling,
+        // so a model that does not resolve on the default provider must be
+        // rejected at run creation with a clear error, not fail silently later.
+        let mut profile = agent_profile(
+            "builder-luna",
+            "builder",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        profile.profile.model = Some("gpt-5.6-luna".to_string());
+        let task = fleet_task(
+            "luna-build",
+            Some(worker_profile(
+                Some("builder-luna"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+
+        let err = validate_fleet_task_routes(&[task], &[profile], None, None)
+            .expect_err("provider-less unresolvable pin must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("gpt-5.6-luna"), "error names the model: {msg}");
+        assert!(
+            msg.contains("provider") || msg.contains("inherit"),
+            "error tells the user how to fix it: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_fleet_task_routes_accepts_resolvable_pin_and_inherit() {
+        // A real default-provider model resolves fine without an explicit pin.
+        let mut good = agent_profile(
+            "builder-ds",
+            "builder",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        good.profile.model = Some("deepseek-v4-flash".to_string());
+        let good_task = fleet_task(
+            "ds-build",
+            Some(worker_profile(
+                Some("builder-ds"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+        validate_fleet_task_routes(&[good_task], &[good], None, None)
+            .expect("resolvable default-provider model must pass");
+
+        // Inherit (no model pin) is never rejected.
+        let inherit = agent_profile(
+            "inherit-role",
+            "builder",
+            None,
+            codewhale_config::FleetLoadout::Inherit,
+        );
+        let inherit_task = fleet_task(
+            "inherit-build",
+            Some(worker_profile(
+                Some("inherit-role"),
+                None,
+                None,
+                None,
+                None,
+                vec![],
+            )),
+        );
+        validate_fleet_task_routes(&[inherit_task], &[inherit], None, None)
+            .expect("inherit (no model pin) must pass");
     }
 
     #[test]


### PR DESCRIPTION
Addresses **P1** of #4866 — the Fleet Builder "did not launch" dogfood blocker (Luna). Does **not** close #4866 (P2–P4 remain).

## Root cause (diagnosed, then verified against code)
A worker profile saved as `model = "gpt-5.6-luna"` with **no explicit `provider`** yields `explicit_fleet_provider_id = None`. At spawn the runtime never infers a provider from a model's spelling (#4093/#2608), so the unqualified model resolves against the session/default provider — which does not carry Luna — and the worker fails to launch **silently**, with no pre-spawn check to catch it.

The structured `/fleet setup` picker already pairs model+provider, so this hole is entered via the model-draft `m` flow (`FleetProfileDraft::from_untrusted_json` hardcodes `provider: None`; the untrusted-JSON schema and drafting prompt deliberately forbid a provider for safety) or hand-edited/legacy profiles.

## Fix
New `validate_fleet_task_routes` in `fleet/worker_runtime.rs`, called from `FleetManager::create_run` with `session_model` + `route_config` **before any worker is leased**. For each task pinning a concrete model at the task/profile level, it resolves the `(provider, model)` route with the **same live resolver used at spawn** and rejects — with a clear, actionable error naming the model and how to fix it (set an explicit provider or use `inherit`) — any pinned model that does not resolve to a real route. Inherited (session/run) models are not pins and are left alone.

This is fail-loud at run creation instead of fail-silent at spawn. It deliberately does **not** blanket-require a provider: a model that genuinely resolves on the default provider (e.g. `deepseek-v4-flash`) still passes without one.

## Verification (local)
- `cargo test -p codewhale-tui --bin codewhale-tui -- validate_fleet_task_routes` → 2/2 ok
  - `…rejects_unresolvable_providerless_pin` (the Luna mode now errors clearly)
  - `…accepts_resolvable_pin_and_inherit` (real default-provider model + inherit pass)
- `cargo fmt -p codewhale-tui -- --check` → clean
- `cargo clippy -p codewhale-tui --all-features --locked -- -D warnings …` → clean
- Rebased on current `main` (07c938624, post-#4868); no overlap with #4868.

## Remaining (#4866 stays open)
P2 provider-scoped pins/labels, P3 per-role thinking controls (`inherit/auto/off/low/medium/high/max`, receipts), P4 provider-scoped family siblings. Built on the existing `AgentProfile { model, provider (#4093), thinking (#4137) }` infra and the `cross_provider_model_routes` picker.