### PR TITLE
perf(tui): cache context estimates between frames

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1,6 +1,7 @@
 //! Application state for the `DeepSeek` TUI.
 
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -85,6 +86,14 @@ pub struct ActiveTurnMetadata {
     pub route: Option<TurnRoute>,
     /// Auto decision metadata captured with this exact authoritative route.
     pub auto_route_receipt: Option<crate::model_routing::AutoRouteReceipt>,
+}
+
+/// Per-message context estimates used by the render-time context meter.
+/// Messages are append-only in the steady state; only the streaming tail is
+/// mutable, so the tail is refreshed while older entries remain cached.
+#[derive(Debug, Default)]
+pub(crate) struct ContextTokenCache {
+    pub(crate) message_tokens: Vec<usize>,
 }
 
 /// State machine for onboarding new users.
@@ -978,6 +987,7 @@ pub struct App {
     /// Monotonic counter used to issue fresh per-cell revisions.
     pub next_history_revision: u64,
     pub api_messages: Vec<Message>,
+    pub(crate) context_token_cache: RefCell<ContextTokenCache>,
     pub is_loading: bool,
     /// Sender for spawned dispatch tasks to report completion back to the
     /// event loop. The closure is called with `&mut App` so the async phase

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -551,6 +551,7 @@ impl App {
             history_revisions: Vec::new(),
             next_history_revision: 1,
             api_messages: Vec::new(),
+            context_token_cache: std::cell::RefCell::new(Default::default()),
             is_loading: false,
             dispatch_completion_tx: None,
             dispatch_in_flight: false,

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -52,7 +52,7 @@ use crate::client::{
 };
 use crate::commands;
 use crate::compaction::CompactionConfig;
-use crate::compaction::estimate_input_tokens_conservative;
+use crate::compaction::{estimate_input_tokens_conservative, estimate_tokens};
 use crate::config::{
     ApiProvider, Config, ProviderConfig, ProviderIdentity, ProvidersConfig, StatusItem,
     UpdateConfig, persist_external_credential_consent_for_at,
@@ -15837,11 +15837,37 @@ fn jump_to_adjacent_tool_cell(app: &mut App, direction: SearchDirection) -> bool
 }
 
 fn estimated_context_tokens(app: &App) -> Option<i64> {
-    i64::try_from(estimate_input_tokens_conservative(
-        &app.api_messages,
-        app.system_prompt.as_ref(),
-    ))
-    .ok()
+    let message_count = app.api_messages.len();
+    let mut cache = app.context_token_cache.borrow_mut();
+    if cache.message_tokens.len() > message_count {
+        cache.message_tokens.truncate(message_count);
+    }
+    while cache.message_tokens.len() < message_count {
+        let index = cache.message_tokens.len();
+        cache
+            .message_tokens
+            .push(estimate_tokens(&app.api_messages[index..=index]));
+    }
+    // The final assistant/tool message may grow while streaming. Recompute
+    // only that tail entry; historical messages remain O(1) on steady frames.
+    if message_count > 0 {
+        let last = message_count - 1;
+        cache.message_tokens[last] = estimate_tokens(&app.api_messages[last..=last]);
+    }
+    let message_tokens = cache
+        .message_tokens
+        .iter()
+        .copied()
+        .sum::<usize>()
+        .saturating_mul(3)
+        .div_ceil(2);
+    let system_tokens =
+        estimate_input_tokens_conservative(&[], app.system_prompt.as_ref()).saturating_sub(48);
+    let estimated = message_tokens
+        .saturating_add(system_tokens)
+        .saturating_add(message_count.saturating_mul(12))
+        .saturating_add(48);
+    i64::try_from(estimated).ok()
 }
 
 pub(crate) fn context_usage_snapshot(app: &App) -> Option<(i64, u32, f64)> {

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -9211,6 +9211,34 @@ fn context_usage_snapshot_prefers_estimate_when_reported_exceeds_window() {
 }
 
 #[test]
+fn context_usage_cache_tracks_append_and_compaction_lengths() {
+    let mut app = create_test_app();
+    app.api_messages = vec![Message {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "first".to_string(),
+            cache_control: None,
+        }],
+    }];
+    context_usage_snapshot(&app).expect("context usage should be available");
+    assert_eq!(app.context_token_cache.borrow().message_tokens.len(), 1);
+
+    app.api_messages.push(Message {
+        role: "assistant".to_string(),
+        content: vec![ContentBlock::Text {
+            text: "second".to_string(),
+            cache_control: None,
+        }],
+    });
+    context_usage_snapshot(&app).expect("context usage should be available");
+    assert_eq!(app.context_token_cache.borrow().message_tokens.len(), 2);
+
+    app.api_messages.truncate(1);
+    context_usage_snapshot(&app).expect("context usage should be available");
+    assert_eq!(app.context_token_cache.borrow().message_tokens.len(), 1);
+}
+
+#[test]
 fn context_usage_snapshot_prefers_estimate_when_reported_is_inflated_by_old_reasoning() {
     let mut app = create_test_app();
     app.session.last_prompt_tokens = Some(980_000);


### PR DESCRIPTION
Closes #3906

## Summary

- cache per-message conservative context estimates on `App`;
- truncate the cache naturally when compaction/purge shortens `api_messages`;
- compute only newly appended messages and refresh the mutable streaming tail;
- preserve the existing system-prompt and framing accounting;
- share the cache through header/footer/context-meter callers.

This removes the steady-state full-history token scan and repeated ToolUse JSON serialization from render-time context meters.

## Verification

- `cargo test -p codewhale-tui --bin codewhale-tui context_usage_snapshot --locked`
- cache append/compaction regression test (passed)
- CI-shaped TUI clippy (passed)
- `cargo fmt --all` and `git diff --check` (passed)
