### PR TITLE
perf(tui): cache tool-run detection

### DIFF
--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -975,6 +975,10 @@ pub struct App {
     pub history_version: u64,
     /// Per-cell revision counter, kept in lockstep with `history`.
     pub history_revisions: Vec<u64>,
+    /// Cached tool-run grouping for transcript collapse. The detector is
+    /// keyed by the same mutation generation that invalidates transcript
+    /// cells, so idle frames do not rescan the full history.
+    pub(crate) tool_run_cache: ToolRunCache,
     /// Monotonic counter used to issue fresh per-cell revisions.
     pub next_history_revision: u64,
     pub api_messages: Vec<Message>,
@@ -1721,6 +1725,30 @@ pub struct App {
     pub receipt_started_at: Option<Instant>,
     /// Tool evidence collected during the current turn for the receipt.
     pub tool_evidence: Vec<ToolEvidence>,
+}
+
+pub(crate) struct ToolRunCache {
+    pub(crate) history_version: u64,
+    pub(crate) active_cell_revision: u64,
+    pub(crate) active_len: usize,
+    pub(crate) threshold: usize,
+    pub(crate) mode: ToolCollapseMode,
+    pub(crate) calm_mode: bool,
+    pub(crate) runs: Vec<crate::tui::history::ToolRun>,
+}
+
+impl Default for ToolRunCache {
+    fn default() -> Self {
+        Self {
+            history_version: u64::MAX,
+            active_cell_revision: u64::MAX,
+            active_len: usize::MAX,
+            threshold: usize::MAX,
+            mode: ToolCollapseMode::Expanded,
+            calm_mode: false,
+            runs: Vec::new(),
+        }
+    }
 }
 
 // === Deref to ComposerState for backward compat ===

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -549,6 +549,7 @@ impl App {
             history: Vec::new(),
             history_version: 0,
             history_revisions: Vec::new(),
+            tool_run_cache: ToolRunCache::default(),
             next_history_revision: 1,
             api_messages: Vec::new(),
             is_loading: false,

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -203,11 +203,26 @@ impl ChatWidget {
 
         let history_len = app.history.len();
         let tool_runs = if app.tool_collapse_active() {
-            crate::tui::history::detect_tool_runs_from_slices(
-                &app.history,
-                active_entries,
-                app.tool_collapse_threshold,
-            )
+            let cache_key_matches = app.tool_run_cache.history_version == app.history_version
+                && app.tool_run_cache.active_cell_revision == app.active_cell_revision
+                && app.tool_run_cache.active_len == active_entries.len()
+                && app.tool_run_cache.threshold == app.tool_collapse_threshold
+                && app.tool_run_cache.mode == app.tool_collapse_mode
+                && app.tool_run_cache.calm_mode == app.calm_mode;
+            if !cache_key_matches {
+                app.tool_run_cache.runs = crate::tui::history::detect_tool_runs_from_slices(
+                    &app.history,
+                    active_entries,
+                    app.tool_collapse_threshold,
+                );
+                app.tool_run_cache.history_version = app.history_version;
+                app.tool_run_cache.active_cell_revision = app.active_cell_revision;
+                app.tool_run_cache.active_len = active_entries.len();
+                app.tool_run_cache.threshold = app.tool_collapse_threshold;
+                app.tool_run_cache.mode = app.tool_collapse_mode;
+                app.tool_run_cache.calm_mode = app.calm_mode;
+            }
+            app.tool_run_cache.runs.clone()
         } else {
             Vec::new()
         };


### PR DESCRIPTION
## Summary
- cache tool-run detection by transcript and active-cell generation
- avoid full-history scans on idle transcript frames
- preserve existing collapse behavior and focused coverage

Closes #3907

## Verification
- cargo fmt --all
- cargo test -p codewhale-tui --bin codewhale-tui collapse_path_stable_across_frames --locked
- cargo clippy -p codewhale-tui --all-features --locked -- -D warnings -A clippy::uninlined_format_args -A clippy::too_many_arguments -A clippy::unnecessary_map_or -A clippy::collapsible_if -A clippy::assertions_on_constants