### PR TITLE
feat(tui): persist provider-scoped model pins

### DIFF
--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -270,6 +270,17 @@ fn resolve_tui_prefs_path_from_candidates(
 }
 
 /// User settings with defaults
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PinnedModel {
+    /// Exact configured provider identity; labels never replace this value.
+    pub provider: String,
+    /// Exact provider-owned model id.
+    pub model: String,
+    /// Optional presentation-only label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
@@ -398,6 +409,10 @@ pub struct Settings {
     /// seeded at load time so the migration is additive and non-breaking.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled_models: Option<std::collections::HashMap<String, Vec<String>>>,
+    /// Exact provider/model tuples pinned to the top of model choosers, in
+    /// user-defined order. Stale entries remain persisted and visible.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pinned_models: Vec<PinnedModel>,
     /// Header status indicator next to the effort chip. Cycles through a
     /// per-turn animation keyed off `App::turn_started_at`:
     /// - `"cw"` (default): static typographic Codewhale mark.
@@ -522,6 +537,7 @@ impl Default for Settings {
             sandbox_mode: None,
             provider_models: None,
             enabled_models: None,
+            pinned_models: Vec::new(),
             // The whale lives in the terminal window title (OSC 0). The in-app
             // header defaults to the static typographic `cw` mark so the two
             // surfaces do not compete with a second spinner.
@@ -1527,6 +1543,67 @@ impl Settings {
         {
             models.push(model.to_string());
         }
+    }
+
+    /// Toggle one exact provider/model pin without touching credentials or
+    /// the provider's default route.
+    pub fn toggle_pinned_model(&mut self, provider: &str, model: &str) -> bool {
+        let provider = provider.trim();
+        let model = model.trim();
+        if provider.is_empty() || model.is_empty() || model.eq_ignore_ascii_case("auto") {
+            return false;
+        }
+        if let Some(index) = self.pinned_models.iter().position(|pin| {
+            pin.provider.eq_ignore_ascii_case(provider) && pin.model.eq_ignore_ascii_case(model)
+        }) {
+            self.pinned_models.remove(index);
+            return false;
+        }
+        self.pinned_models.push(PinnedModel {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            label: None,
+        });
+        true
+    }
+
+    #[allow(dead_code)] // label editing surface is exposed through settings serialization first
+    pub fn set_pinned_model_label(
+        &mut self,
+        provider: &str,
+        model: &str,
+        label: Option<String>,
+    ) -> bool {
+        self.pinned_models
+            .iter_mut()
+            .find(|pin| {
+                pin.provider.eq_ignore_ascii_case(provider) && pin.model.eq_ignore_ascii_case(model)
+            })
+            .map(|pin| {
+                pin.label = label.filter(|value| !value.trim().is_empty());
+                true
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn move_pinned_model(&mut self, provider: &str, model: &str, delta: isize) -> bool {
+        let Some(index) = self.pinned_models.iter().position(|pin| {
+            pin.provider.eq_ignore_ascii_case(provider) && pin.model.eq_ignore_ascii_case(model)
+        }) else {
+            return false;
+        };
+        let target = if delta.is_negative() {
+            index.saturating_sub(delta.unsigned_abs())
+        } else {
+            index.saturating_add(delta as usize)
+        };
+        let target = target.min(self.pinned_models.len().saturating_sub(1));
+        if target == index {
+            return false;
+        }
+        let pin = self.pinned_models.remove(index);
+        self.pinned_models.insert(target, pin);
+        true
     }
 
     /// Persist a provider's model selection.
@@ -4001,5 +4078,21 @@ mod tests {
         let got = TuiPrefs::path().expect("path should resolve");
 
         assert_eq!(got, tmp.path().join(".codewhale").join("tui.toml"));
+    }
+
+    #[test]
+    fn pinned_models_are_exact_ordered_and_round_trip() {
+        let mut settings = Settings::default();
+        assert!(settings.toggle_pinned_model("zai", "glm-5.2"));
+        assert!(settings.toggle_pinned_model("openrouter", "glm-5.2"));
+        assert_eq!(settings.pinned_models[0].provider, "zai");
+        assert!(settings.move_pinned_model("openrouter", "glm-5.2", -1));
+        assert_eq!(settings.pinned_models[0].provider, "openrouter");
+        assert!(settings.set_pinned_model_label("openrouter", "glm-5.2", Some("fast".to_string())));
+        let encoded = toml::to_string(&settings).unwrap();
+        let decoded: Settings = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded.pinned_models, settings.pinned_models);
+        assert!(!settings.toggle_pinned_model("openrouter", "glm-5.2"));
+        assert_eq!(settings.pinned_models.len(), 1);
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1026,6 +1026,8 @@ pub struct App {
     /// The catalog remains separately discoverable and selecting from it adds
     /// to this set rather than replacing earlier enabled choices.
     pub enabled_provider_models: HashMap<String, Vec<String>>,
+    /// Exact provider/model pins loaded from settings, in user order.
+    pub pinned_models: Vec<crate::settings::PinnedModel>,
     /// When true, the model is auto-selected based on request complexity
     /// rather than using a fixed model. The `/model auto` command sets this.
     /// `dispatch_user_message` calls `auto_model_heuristic` to resolve the

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -571,6 +571,7 @@ impl App {
             model,
             provider_models,
             enabled_provider_models,
+            pinned_models: settings.pinned_models.clone(),
             auto_model,
             last_effective_model: None,
             last_effective_provider: None,

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -10,7 +10,7 @@
 
 use std::cell::RefCell;
 
-use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -38,6 +38,7 @@ use crate::palette;
 use crate::provider_lake::{
     all_catalog_models_for_provider, catalog_offering_for_model, configured_providers,
 };
+use crate::settings::PinnedModel;
 use crate::tui::app::{App, ReasoningEffort};
 use crate::tui::views::{
     ActionHint, ListDetailLayout, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
@@ -201,6 +202,7 @@ pub struct ModelPickerView {
     last_mouse_selected: Option<(Pane, usize)>,
     /// UI locale captured from the app at construction (#4057 wave 2).
     locale: Locale,
+    pinned_models: Vec<PinnedModel>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -312,6 +314,7 @@ impl ModelPickerView {
             row_hitboxes: RefCell::new(Vec::new()),
             last_mouse_selected: None,
             locale: app.ui_locale,
+            pinned_models: app.pinned_models.clone(),
         };
         view.restore_memory(app.model_picker_memory.as_ref());
         view
@@ -371,7 +374,7 @@ impl ModelPickerView {
             })
             .collect();
         if query.is_empty() {
-            sort_model_rows_for_view(&mut rows, self.view);
+            sort_model_rows_for_view(&mut rows, self.view, &self.pinned_models);
         } else {
             // Rank typed results (#4639): rows whose provider matches the
             // query first (provider drill-down), then exact/prefix id
@@ -974,6 +977,43 @@ fn picker_model_rows_for_app(app: &App, config: &Config) -> Vec<ModelPickerRow> 
 
     for row in &mut rows {
         row.enabled = model_row_enabled_for_app(app, config, row);
+        if let Some(pin) = app.pinned_models.iter().find(|pin| {
+            row.provider.is_some_and(|provider| {
+                provider.as_str().eq_ignore_ascii_case(&pin.provider)
+                    && row.id.eq_ignore_ascii_case(&pin.model)
+            })
+        }) {
+            let label = pin.label.as_deref().unwrap_or("pinned");
+            row.hint = format!(
+                "{label} · exact {} / {} · {}",
+                pin.provider, pin.model, row.hint
+            );
+        }
+    }
+
+    for pin in &app.pinned_models {
+        let provider = ApiProvider::parse(&pin.provider).unwrap_or(ApiProvider::Custom);
+        if rows
+            .iter()
+            .any(|row| row.provider == Some(provider) && row.id.eq_ignore_ascii_case(&pin.model))
+        {
+            continue;
+        }
+        let metadata = effective_picker_metadata(config, Some(provider), &pin.model);
+        push_model_row(
+            &mut rows,
+            pin.model.clone(),
+            Some(provider),
+            format!(
+                "stale pinned · exact {} / {} · unavailable; repair or remove",
+                pin.provider, pin.model
+            ),
+            metadata,
+            false,
+        );
+        if let Some(row) = rows.last_mut() {
+            row.enabled = true;
+        }
     }
 
     rows
@@ -1325,9 +1365,23 @@ fn model_row_visible_by_default(row: &ModelPickerRow) -> bool {
     row.provider.is_none() || row.enabled
 }
 
-fn sort_model_rows_for_view(rows: &mut [&ModelPickerRow], view: ModelListView) {
+fn sort_model_rows_for_view(
+    rows: &mut [&ModelPickerRow],
+    view: ModelListView,
+    pins: &[PinnedModel],
+) {
+    let pin_rank = |row: &ModelPickerRow| {
+        row.provider
+            .and_then(|provider| {
+                pins.iter().position(|pin| {
+                    provider.as_str().eq_ignore_ascii_case(&pin.provider)
+                        && row.id.eq_ignore_ascii_case(&pin.model)
+                })
+            })
+            .unwrap_or(usize::MAX)
+    };
     match view {
-        ModelListView::Configured | ModelListView::Catalog => {}
+        ModelListView::Configured | ModelListView::Catalog => rows.sort_by_key(|row| pin_rank(row)),
         ModelListView::Recent => rows.sort_by(|left, right| {
             offering_fetched_at(right)
                 .cmp(&offering_fetched_at(left))
@@ -1667,6 +1721,7 @@ impl ModelPickerView {
     pub fn re_resolve_from_app(&mut self, app: &App, config: &Config) {
         self.provider_health = app.provider_health.clone();
         self.route_config = config.clone();
+        self.pinned_models = app.pinned_models.clone();
         self.model_rows = picker_model_rows_for_app(app, config);
         self.configured_providers = configured_providers(config, app.api_provider)
             .into_iter()
@@ -1677,6 +1732,23 @@ impl ModelPickerView {
         if self.selected_model_idx >= rows.len() + usize::from(self.show_custom_model_row) {
             self.selected_model_idx = rows.len().saturating_sub(1);
         }
+    }
+}
+
+impl ModelPickerView {
+    fn emit_pin_move(&self, delta: isize) -> ViewAction {
+        let rows = self.visible_model_rows();
+        let Some(row) = rows.get(self.selected_model_idx) else {
+            return ViewAction::None;
+        };
+        let Some(provider) = row.provider else {
+            return ViewAction::None;
+        };
+        ViewAction::Emit(ViewEvent::ModelPickerMovePin {
+            provider,
+            model: row.id.clone(),
+            delta,
+        })
     }
 }
 
@@ -1708,6 +1780,25 @@ impl ModalView for ModelPickerView {
                 self.explain_unselectable_selection()
             }
             KeyCode::Enter => ViewAction::EmitAndClose(self.build_event()),
+            KeyCode::Char('p') if key.modifiers.is_empty() && self.query.is_empty() => {
+                let rows = self.visible_model_rows();
+                let Some(row) = rows.get(self.selected_model_idx) else {
+                    return ViewAction::None;
+                };
+                let Some(provider) = row.provider else {
+                    return ViewAction::None;
+                };
+                ViewAction::Emit(ViewEvent::ModelPickerTogglePin {
+                    provider,
+                    model: row.id.clone(),
+                })
+            }
+            KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) && self.query.is_empty() => {
+                self.emit_pin_move(-1)
+            }
+            KeyCode::Down if key.modifiers.contains(KeyModifiers::ALT) && self.query.is_empty() => {
+                self.emit_pin_move(1)
+            }
             // Cycle catalog views (#4115). Handled before the query-typing arm
             // so `a`/`A` always advances the view instead of filtering.
             KeyCode::Char(c)

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -13715,6 +13715,61 @@ async fn handle_view_events(
                 }
                 app.needs_redraw = true;
             }
+            ViewEvent::ModelPickerTogglePin { provider, model } => {
+                let provider_key = if provider == crate::config::ApiProvider::Custom {
+                    app.provider_identity_for_persistence().to_string()
+                } else {
+                    provider.as_str().to_string()
+                };
+                match crate::settings::Settings::load_persisted().and_then(|mut settings| {
+                    let pinned = settings.toggle_pinned_model(&provider_key, &model);
+                    settings.save()?;
+                    Ok(pinned)
+                }) {
+                    Ok(true) => app.status_message = Some(format!("Pinned {provider_key}/{model}")),
+                    Ok(false) => {
+                        app.status_message = Some(format!("Unpinned {provider_key}/{model}"))
+                    }
+                    Err(error) => {
+                        app.status_message = Some(format!("Could not update pin: {error}"))
+                    }
+                }
+                if let Ok(settings) = crate::settings::Settings::load_persisted() {
+                    app.pinned_models = settings.pinned_models;
+                }
+                if let Some(mut boxed) = app.view_stack.pop() {
+                    if let Some(picker) = boxed
+                        .as_any_mut()
+                        .downcast_mut::<crate::tui::model_picker::ModelPickerView>(
+                    ) {
+                        picker.re_resolve_from_app(app, config);
+                    }
+                    app.view_stack.push_boxed(boxed);
+                }
+                app.needs_redraw = true;
+            }
+            ViewEvent::ModelPickerMovePin {
+                provider,
+                model,
+                delta,
+            } => {
+                let provider_key = if provider == crate::config::ApiProvider::Custom {
+                    app.provider_identity_for_persistence().to_string()
+                } else {
+                    provider.as_str().to_string()
+                };
+                if let Ok(mut settings) = crate::settings::Settings::load_persisted()
+                    && settings.move_pinned_model(&provider_key, &model, delta)
+                {
+                    if let Err(error) = settings.save() {
+                        app.status_message = Some(format!("Could not reorder pin: {error}"));
+                    } else {
+                        app.pinned_models = settings.pinned_models;
+                        app.status_message = Some("Pinned model order updated".into());
+                    }
+                }
+                app.needs_redraw = true;
+            }
             ViewEvent::ModelPickerNeedsAuth {
                 provider,
                 model,

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -721,6 +721,15 @@ pub enum ViewEvent {
     /// blocked and open the provider auth/setup path when possible.
     /// Re-resolve readiness + rebuild catalog rows for the open model picker.
     ModelPickerRefresh,
+    ModelPickerTogglePin {
+        provider: crate::config::ApiProvider,
+        model: String,
+    },
+    ModelPickerMovePin {
+        provider: crate::config::ApiProvider,
+        model: String,
+        delta: isize,
+    },
     ModelPickerNeedsAuth {
         provider: crate::config::ApiProvider,
         model: String,


### PR DESCRIPTION
## Summary
- persist exact `(provider, model)` pins in TUI settings with optional presentation-only labels
- render pinned models first in the model picker while retaining stale unavailable pins for repair/removal
- add keyboard pin/unpin and Alt-arrow ordering controls without changing provider route identity
- keep provider-scoped identity explicit for named custom providers

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --bin codewhale-tui settings --locked` (111 passed)
- `cargo test -p codewhale-tui --bin codewhale-tui model_picker --locked` (95 passed)
- `RUSTFLAGS="-D warnings" cargo check -p codewhale-tui --locked` (passed; known macOS linker diagnostic only)
- `git diff --check`

No-Issue: provider-scoped pin persistence is the P2 slice of the already-closed #4866 blocker; P3 thinking controls and P4 provider-scoped family siblings remain separate follow-ups.
