### PR TITLE
feat(model): expose routed image-input capability

### DIFF
--- a/crates/config/src/catalog.rs
+++ b/crates/config/src/catalog.rs
@@ -151,6 +151,7 @@ impl CatalogOffering {
                 .unwrap_or_default(),
             capabilities: crate::route::RouteCapabilities {
                 attachments: crate::route::CapabilityState::from_optional_bool(self.attachment),
+                image_input: crate::models_dev::image_input_support(self.modalities.as_ref()),
                 reasoning: crate::route::CapabilityState::from_optional_bool(self.reasoning),
                 native_tool_calls: crate::route::CapabilityState::from_optional_bool(
                     self.tool_call,

--- a/crates/config/src/models_dev.rs
+++ b/crates/config/src/models_dev.rs
@@ -139,6 +139,7 @@ impl ModelsDevCatalog {
 fn route_capabilities(provider_id: &str, model: &ModelsDevProviderModel) -> RouteCapabilities {
     RouteCapabilities {
         attachments: CapabilityState::from_optional_bool(model.attachment),
+        image_input: image_input_support(model.modalities.as_ref()),
         reasoning: CapabilityState::from_optional_bool(model.reasoning),
         native_tool_calls: CapabilityState::from_optional_bool(model.tool_call),
         structured_output: CapabilityState::from_optional_bool(model.structured_output),
@@ -148,6 +149,25 @@ fn route_capabilities(provider_id: &str, model: &ModelsDevProviderModel) -> Rout
         ),
         ..RouteCapabilities::default()
     }
+}
+
+/// Resolve the exact image-input fact from a provider-owned modality block.
+/// Missing or empty input metadata remains unknown; stated text-only input is
+/// unsupported rather than silently treated as unknown.
+#[must_use]
+pub fn image_input_support(modalities: Option<&ModelsDevModalities>) -> CapabilityState {
+    let Some(modalities) = modalities else {
+        return CapabilityState::Unknown;
+    };
+    if modalities.input.is_empty() {
+        return CapabilityState::Unknown;
+    }
+    CapabilityState::from_optional_bool(Some(
+        modalities
+            .input
+            .iter()
+            .any(|modality| modality.trim().eq_ignore_ascii_case("image")),
+    ))
 }
 
 /// Provider-agnostic model facts from `models.json` / `catalog.models`.
@@ -656,6 +676,29 @@ mod tests {
             ..Default::default()
         };
         assert!(!audio_only.supports_text_chat());
+    }
+
+    #[test]
+    fn image_input_support_preserves_unknown_and_text_only_facts() {
+        assert_eq!(image_input_support(None), CapabilityState::Unknown);
+        assert_eq!(
+            image_input_support(Some(&ModelsDevModalities::default())),
+            CapabilityState::Unknown
+        );
+        assert_eq!(
+            image_input_support(Some(&ModelsDevModalities {
+                input: vec!["text".to_string()],
+                output: vec!["text".to_string()],
+            })),
+            CapabilityState::Unsupported
+        );
+        assert_eq!(
+            image_input_support(Some(&ModelsDevModalities {
+                input: vec!["text".to_string(), "image".to_string()],
+                output: vec!["text".to_string()],
+            })),
+            CapabilityState::Supported
+        );
     }
 
     #[test]

--- a/crates/config/src/route/capabilities.rs
+++ b/crates/config/src/route/capabilities.rs
@@ -92,6 +92,9 @@ pub(crate) fn documented_server_side_web_search(
 pub struct RouteCapabilities {
     #[serde(default)]
     pub attachments: CapabilityState,
+    /// Whether the exact offering explicitly accepts image input.
+    #[serde(default)]
+    pub image_input: CapabilityState,
     #[serde(default)]
     pub reasoning: CapabilityState,
     #[serde(default)]

--- a/crates/tui/src/model_profile.rs
+++ b/crates/tui/src/model_profile.rs
@@ -48,6 +48,7 @@ pub struct IntrinsicCapabilityProfile {
     pub structured_output: SupportState,
     pub streaming: SupportState,
     pub prompt_caching: SupportState,
+    pub image_input: SupportState,
     pub tool_surface_budget: ToolSurfaceBudget,
 }
 
@@ -73,6 +74,7 @@ pub struct CapabilityOverride {
     pub structured_output: Option<SupportState>,
     pub streaming: Option<SupportState>,
     pub prompt_caching: Option<SupportState>,
+    pub image_input: Option<SupportState>,
     pub tool_surface_budget: Option<ToolSurfaceBudget>,
 }
 
@@ -91,6 +93,7 @@ pub struct CapabilityProfile {
     pub structured_output: SupportState,
     pub streaming: SupportState,
     pub prompt_caching: SupportState,
+    pub image_input: SupportState,
     pub tool_surface_budget: ToolSurfaceBudget,
     pub provenance: Vec<FactProvenance>,
 }
@@ -99,6 +102,11 @@ impl CapabilityProfile {
     #[must_use]
     pub fn supports_reasoning(&self) -> bool {
         self.reasoning.is_supported()
+    }
+
+    #[must_use]
+    pub fn supports_image_input(&self) -> bool {
+        self.image_input.is_supported()
     }
 
     #[must_use]
@@ -153,6 +161,7 @@ pub fn model_profile(model: &str) -> ModelProfile {
                     structured_output: SupportState::Unknown,
                     streaming: SupportState::Supported,
                     prompt_caching: SupportState::Unknown,
+                    image_input: SupportState::Unknown,
                     tool_surface_budget: tool_surface_for_window(meta.context_window),
                 },
                 provenance,
@@ -172,6 +181,7 @@ pub fn model_profile(model: &str) -> ModelProfile {
                 structured_output: SupportState::Unknown,
                 streaming: SupportState::Unknown,
                 prompt_caching: SupportState::Unknown,
+                image_input: SupportState::Unknown,
                 tool_surface_budget: ToolSurfaceBudget::Compact,
             },
             provenance: FactProvenance::ConservativeUnknownFallback,
@@ -218,6 +228,7 @@ pub fn resolved_capability_profile_with_overrides(
     let prompt_caching = overrides
         .prompt_caching
         .unwrap_or_else(|| bool_state(provider_cap.cache_telemetry_supported));
+    let image_input = overrides.image_input.unwrap_or(SupportState::Unknown);
     let native_tool_calls = overrides
         .native_tool_calls
         .unwrap_or_else(|| native_tool_support_for_payload(request_payload_mode));
@@ -250,6 +261,7 @@ pub fn resolved_capability_profile_with_overrides(
         structured_output,
         streaming,
         prompt_caching,
+        image_input,
         tool_surface_budget,
         provenance,
     }
@@ -292,6 +304,8 @@ pub fn resolved_capability_profile_for_route(
     profile.streaming = route_fact_or_fallback(route_capabilities.streaming, profile.streaming);
     profile.prompt_caching =
         route_fact_or_fallback(route_capabilities.prompt_caching, profile.prompt_caching);
+    profile.image_input =
+        route_fact_or_fallback(route_capabilities.image_input, profile.image_input);
     profile.tool_surface_budget = tool_surface_for_window(profile.context_window);
     profile
         .provenance
@@ -337,6 +351,9 @@ pub fn resolved_capability_profile_for_route_with_overrides(
     }
     if let Some(prompt_caching) = overrides.prompt_caching {
         profile.prompt_caching = prompt_caching;
+    }
+    if let Some(image_input) = overrides.image_input {
+        profile.image_input = image_input;
     }
     profile.tool_surface_budget = overrides
         .tool_surface_budget
@@ -496,6 +513,7 @@ mod tests {
         assert_eq!(profile.max_output, Some(7_000));
         assert_eq!(profile.reasoning, SupportState::Unsupported);
         assert_eq!(profile.native_tool_calls, SupportState::Unsupported);
+        assert_eq!(profile.image_input, SupportState::Unknown);
         assert_eq!(profile.structured_output, SupportState::Supported);
         assert!(
             profile
@@ -530,5 +548,31 @@ mod tests {
             profile.provenance.last(),
             Some(&FactProvenance::UserOverride)
         );
+    }
+
+    #[test]
+    fn image_input_route_fact_and_override_are_explicit() {
+        let sourced = resolved_capability_profile_for_route(
+            ApiProvider::Openai,
+            "vision-fixture",
+            RouteCapabilities {
+                image_input: SupportState::Supported,
+                ..RouteCapabilities::default()
+            },
+            RouteLimits::default(),
+        );
+        assert!(sourced.supports_image_input());
+
+        let overridden = resolved_capability_profile_for_route_with_overrides(
+            ApiProvider::Openai,
+            "vision-fixture",
+            RouteCapabilities::default(),
+            RouteLimits::default(),
+            CapabilityOverride {
+                image_input: Some(SupportState::Supported),
+                ..CapabilityOverride::default()
+            },
+        );
+        assert!(overridden.supports_image_input());
     }
 }

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -223,6 +223,7 @@ struct EffectivePickerMetadata {
     max_output: Option<u32>,
     tool_calls: Option<bool>,
     reasoning: bool,
+    vision: SupportState,
     pricing: PickerPricing,
     source: Option<CatalogSource>,
 }
@@ -1500,6 +1501,7 @@ fn effective_picker_metadata_with_codex(
             reasoning: registry
                 .as_ref()
                 .is_some_and(|meta| meta.supports_reasoning),
+            vision: SupportState::Unknown,
             pricing: if crate::pricing::has_pricing_for_model(id) {
                 PickerPricing::Known("priced".to_string())
             } else {
@@ -1584,6 +1586,7 @@ fn effective_picker_metadata_with_codex(
             .and_then(|offering| offering.reasoning)
             .unwrap_or_else(|| profile.supports_reasoning())
     };
+    let vision = profile.image_input;
     let card_price = card.as_ref().and_then(|card| {
         let label = card.price_label();
         (label != "unknown").then_some(label)
@@ -1603,6 +1606,7 @@ fn effective_picker_metadata_with_codex(
         max_output,
         tool_calls,
         reasoning,
+        vision,
         pricing,
         source: card.map(|card| card.source),
     }
@@ -1672,6 +1676,12 @@ fn render_picker_model_hint(
 
     if metadata.reasoning {
         parts.push("reasoning".to_string());
+    }
+
+    match metadata.vision {
+        SupportState::Supported => parts.push("vision".to_string()),
+        SupportState::Unsupported => parts.push("no vision".to_string()),
+        SupportState::Unknown => {}
     }
 
     match &metadata.pricing {

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -273,6 +273,7 @@ pub struct ProviderCapabilityBadges {
     pub structured: SupportState,
     pub streaming: SupportState,
     pub cache: SupportState,
+    pub vision: SupportState,
 }
 
 impl ProviderCapabilityBadges {
@@ -297,6 +298,7 @@ impl ProviderCapabilityBadges {
             structured: cap.structured_output,
             streaming: cap.streaming,
             cache: cap.prompt_caching,
+            vision: cap.image_input,
         }
     }
 
@@ -309,6 +311,7 @@ impl ProviderCapabilityBadges {
             structured: SupportState::Unknown,
             streaming: SupportState::Unknown,
             cache: SupportState::Unknown,
+            vision: SupportState::Unknown,
         }
     }
 
@@ -316,7 +319,7 @@ impl ProviderCapabilityBadges {
     /// render `?` when unknown rather than being silently dropped.
     fn label(&self) -> String {
         format!(
-            "ctx:{}({}) out:{} tools:{} json:{} stream:{} cache:{}",
+            "ctx:{}({}) out:{} tools:{} json:{} stream:{} cache:{} vision:{}",
             humanize_token_count(self.context_window),
             self.context_window_source.as_deref().unwrap_or("?"),
             humanize_token_count(self.max_output),
@@ -324,6 +327,7 @@ impl ProviderCapabilityBadges {
             support_glyph(self.structured),
             support_glyph(self.streaming),
             support_glyph(self.cache),
+            support_glyph(self.vision),
         )
     }
 }


### PR DESCRIPTION
Closes #4794

Make image-input support a first-class exact-route capability sourced from provider-owned modality facts. Preserve unknown versus unsupported, expose the fact in model and provider picker surfaces, and keep user overrides explicit.

Verification:
- cargo fmt --all -- --check
- cargo test -p codewhale-config models_dev::tests::image_input_support --locked
- cargo test -p codewhale-tui --bin codewhale-tui model_profile::tests::image_input --locked
- cargo test -p codewhale-tui --bin codewhale-tui tui::model_picker::tests --locked (89 passed)
- git diff --check