### PR TITLE
feat(provider): ask Kimi Code plan tier during setup

### DIFF
--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -9173,6 +9173,35 @@ pub(crate) fn save_provider_model_for_identity(
     Ok(config_path)
 }
 
+/// Persist a guided-setup context-window choice without replacing the user's
+/// surrounding TOML comments or formatting.
+pub(crate) fn save_provider_context_window_for_identity(
+    identity: &ProviderIdentity,
+    _route_config: &Config,
+    context_window: u32,
+) -> Result<PathBuf> {
+    anyhow::ensure!(context_window > 0, "context window must be greater than 0");
+    let config_path = default_config_path()
+        .context("Failed to resolve config path: home directory not found.")?;
+    ensure_parent_dir(&config_path)?;
+    let key_inside = if identity.provider == ApiProvider::Custom {
+        let key = identity.key.trim();
+        anyhow::ensure!(!key.is_empty(), "custom provider id cannot be empty");
+        key
+    } else {
+        provider_config_key(identity.provider).context("provider context window table")?
+    };
+    crate::config_persistence::mutate_config_document(&config_path, |doc| {
+        crate::config_persistence::set_document_value(
+            doc,
+            &["providers", key_inside, "context_window"],
+            i64::from(context_window),
+        )
+    })
+    .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+    Ok(config_path)
+}
+
 /// Persist an explicitly confirmed read-only external credential grant and
 /// update the live mirror only after the comment-preserving disk mutation
 /// succeeds. This function never inspects the external path.

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -72,6 +72,8 @@ enum Stage {
     ExternalConsentConfirm,
     /// Default model pick after a key has been live-validated (#3875).
     ModelPick,
+    /// Kimi Code membership plan selection for the exact `api.kimi.com` route.
+    PlanTier,
     /// Confirmation summary before any secret or model is persisted (#3875).
     Confirm,
     CustomForm,
@@ -82,6 +84,12 @@ enum ExternalConsentChoice {
     Disabled,
     ReadOnly,
     ManagedUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KimiCodePlanTier {
+    Safe262k,
+    OneMillion,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,6 +129,8 @@ pub struct ProviderPickerView {
     model_selected_idx: usize,
     /// Model chosen on the model-pick stage (and shown on confirm).
     selected_model: Option<String>,
+    selected_context_window: Option<u32>,
+    kimi_code_plan_tier: KimiCodePlanTier,
     custom_provider_field: CustomProviderField,
     custom_provider_id: String,
     custom_provider_base_url: String,
@@ -1383,6 +1393,8 @@ impl ProviderPickerView {
             model_options: Vec::new(),
             model_selected_idx: 0,
             selected_model: None,
+            selected_context_window: None,
+            kimi_code_plan_tier: KimiCodePlanTier::Safe262k,
             custom_provider_field: CustomProviderField::Name,
             custom_provider_id: String::new(),
             custom_provider_base_url: String::new(),
@@ -1703,6 +1715,7 @@ impl ProviderPickerView {
 
     fn enter_model_pick(&mut self) {
         self.stage = Stage::ModelPick;
+        self.selected_context_window = None;
         let provider = self.selected_provider();
         let route = &self.rows[self.selected_idx].default_route;
         let kimi_code_k3 = crate::config::is_exact_kimi_code_k3_route(
@@ -1751,6 +1764,30 @@ impl ProviderPickerView {
         self.stage = Stage::Confirm;
     }
 
+    fn selected_kimi_code_k3(&self) -> bool {
+        let Some(model) = self.selected_model.as_deref() else {
+            return false;
+        };
+        crate::config::is_exact_kimi_code_k3_route(
+            self.selected_provider(),
+            &self.rows[self.selected_idx].base_url,
+            model,
+        )
+    }
+
+    fn enter_plan_tier(&mut self) {
+        self.stage = Stage::PlanTier;
+        self.kimi_code_plan_tier = KimiCodePlanTier::Safe262k;
+    }
+
+    fn apply_plan_tier(&mut self) {
+        self.selected_context_window = Some(match self.kimi_code_plan_tier {
+            KimiCodePlanTier::Safe262k => crate::models::KIMI_CODE_K3_CONTEXT_WINDOW_TOKENS,
+            KimiCodePlanTier::OneMillion => 1_048_576,
+        });
+        self.enter_confirm();
+    }
+
     fn move_model_selection(&mut self, delta: isize) {
         let len = self.model_options.len();
         if len == 0 {
@@ -1777,6 +1814,7 @@ impl ProviderPickerView {
             provider_id: self.selected_provider_id(),
             api_key: api_key.to_string(),
             model: model.to_string(),
+            context_window: self.selected_context_window,
         })
     }
 
@@ -2607,6 +2645,47 @@ impl ProviderPickerView {
         Paragraph::new(lines).render(list_area, buf);
     }
 
+    fn render_plan_tier(&self, area: Rect, buf: &mut Buffer) {
+        let outer = Block::default()
+            .title(Line::from(Span::styled(
+                " Kimi Code plan tier ",
+                Style::default()
+                    .fg(palette::WHALE_INFO)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(palette::BORDER_COLOR))
+            .style(Style::default().bg(palette::WHALE_BG));
+        let inner = outer.inner(area);
+        outer.render(area, buf);
+        let content = render_modal_footer(
+            inner,
+            buf,
+            &[
+                ActionHint::new("↑↓", "choose"),
+                ActionHint::new("Enter", "continue"),
+                ActionHint::new("Esc", "back"),
+            ],
+        );
+        let selected = self.kimi_code_plan_tier;
+        let marker = |tier| crate::tui::glyphs::selection_marker(selected == tier);
+        Paragraph::new(vec![
+            Line::from("Kimi Code plan limits determine the context window used for k3."),
+            Line::from("Choose the tier you actually have; the safe floor is selected by default."),
+            Line::from(""),
+            Line::from(format!(
+                "{} 1. 262K context (safe default)",
+                marker(KimiCodePlanTier::Safe262k)
+            )),
+            Line::from(format!(
+                "{} 2. 1M context (only with an eligible plan)",
+                marker(KimiCodePlanTier::OneMillion)
+            )),
+        ])
+        .wrap(Wrap { trim: false })
+        .render(content, buf);
+    }
+
     fn render_confirm(&self, area: Rect, buf: &mut Buffer) {
         let row = &self.rows[self.selected_idx];
         let outer = Block::default()
@@ -2669,6 +2748,11 @@ impl ProviderPickerView {
                         .add_modifier(Modifier::BOLD),
                 ),
             ]),
+            if let Some(context_window) = self.selected_context_window {
+                Line::from(format!("Context:  {} tokens", context_window))
+            } else {
+                Line::from("")
+            },
         ];
         Paragraph::new(lines).render(content, buf);
     }
@@ -2835,6 +2919,7 @@ impl ModalView for ProviderPickerView {
             | Stage::ExternalConsentChoice
             | Stage::ExternalConsentConfirm
             | Stage::ModelPick
+            | Stage::PlanTier
             | Stage::Confirm => false,
         }
     }
@@ -3111,14 +3196,48 @@ impl ModalView for ProviderPickerView {
                         return ViewAction::None;
                     }
                     self.selected_model = self.model_options.get(self.model_selected_idx).cloned();
-                    self.enter_confirm();
+                    if self.selected_kimi_code_k3() {
+                        self.enter_plan_tier();
+                    } else {
+                        self.enter_confirm();
+                    }
+                    ViewAction::None
+                }
+                _ => ViewAction::None,
+            },
+            Stage::PlanTier => match key.code {
+                KeyCode::Esc => {
+                    self.stage = Stage::ModelPick;
+                    ViewAction::None
+                }
+                KeyCode::Up | KeyCode::Down => {
+                    self.kimi_code_plan_tier = match self.kimi_code_plan_tier {
+                        KimiCodePlanTier::Safe262k => KimiCodePlanTier::OneMillion,
+                        KimiCodePlanTier::OneMillion => KimiCodePlanTier::Safe262k,
+                    };
+                    ViewAction::None
+                }
+                KeyCode::Char('1') => {
+                    self.kimi_code_plan_tier = KimiCodePlanTier::Safe262k;
+                    ViewAction::None
+                }
+                KeyCode::Char('2') => {
+                    self.kimi_code_plan_tier = KimiCodePlanTier::OneMillion;
+                    ViewAction::None
+                }
+                KeyCode::Enter => {
+                    self.apply_plan_tier();
                     ViewAction::None
                 }
                 _ => ViewAction::None,
             },
             Stage::Confirm => match key.code {
                 KeyCode::Esc => {
-                    self.stage = Stage::ModelPick;
+                    self.stage = if self.selected_kimi_code_k3() {
+                        Stage::PlanTier
+                    } else {
+                        Stage::ModelPick
+                    };
                     ViewAction::None
                 }
                 KeyCode::Enter => self
@@ -3181,7 +3300,8 @@ impl ModalView for ProviderPickerView {
                 MouseEventKind::ScrollDown => self.move_model_selection(1),
                 _ => {}
             },
-            Stage::KeyEntry
+            Stage::PlanTier
+            | Stage::KeyEntry
             | Stage::ExternalConsentChoice
             | Stage::ExternalConsentConfirm
             | Stage::Confirm
@@ -3208,6 +3328,7 @@ impl ModalView for ProviderPickerView {
             Stage::ExternalConsentChoice => 12,
             Stage::ExternalConsentConfirm => 13,
             Stage::ModelPick => 12,
+            Stage::PlanTier => 10,
             Stage::Confirm => 10,
             Stage::CustomForm => 12,
         };
@@ -3221,6 +3342,7 @@ impl ModalView for ProviderPickerView {
             Stage::ExternalConsentChoice => self.render_external_consent_choice(popup_area, buf),
             Stage::ExternalConsentConfirm => self.render_external_consent_confirm(popup_area, buf),
             Stage::ModelPick => self.render_model_pick(popup_area, buf),
+            Stage::PlanTier => self.render_plan_tier(popup_area, buf),
             Stage::Confirm => self.render_confirm(popup_area, buf),
             Stage::CustomForm => self.render_custom_form(popup_area, buf),
         }
@@ -5255,6 +5377,7 @@ mod tests {
                 provider_id,
                 api_key,
                 model,
+                ..
             }) => {
                 assert_eq!(provider, ApiProvider::Openrouter);
                 assert_eq!(provider_id, None);
@@ -5262,6 +5385,56 @@ mod tests {
                 assert_eq!(model, selected_model);
             }
             other => panic!("expected ProviderPickerSetupConfirmed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exact_kimi_code_setup_asks_for_plan_and_emits_selected_context_window() {
+        let config = Config {
+            providers: Some(crate::config::ProvidersConfig {
+                moonshot: crate::config::ProviderConfig {
+                    base_url: Some(crate::config::DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+                    model: Some(crate::config::KIMI_CODE_K3_MODEL.to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut picker = ProviderPickerView::new_for_model_pick_after_validation(
+            ApiProvider::Deepseek,
+            ApiProvider::Moonshot,
+            &config,
+            None,
+            "sk-kimi-plan".to_string(),
+        )
+        .expect("Moonshot has a picker row");
+
+        assert_eq!(picker.stage, Stage::ModelPick);
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Enter)),
+            ViewAction::None
+        ));
+        assert_eq!(picker.stage, Stage::PlanTier);
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Char('2'))),
+            ViewAction::None
+        ));
+        assert!(matches!(
+            picker.handle_key(key(KeyCode::Enter)),
+            ViewAction::None
+        ));
+        assert_eq!(picker.stage, Stage::Confirm);
+        match picker.handle_key(key(KeyCode::Enter)) {
+            ViewAction::EmitAndClose(ViewEvent::ProviderPickerSetupConfirmed {
+                context_window,
+                model,
+                ..
+            }) => {
+                assert_eq!(model, crate::config::KIMI_CODE_K3_MODEL);
+                assert_eq!(context_window, Some(1_048_576));
+            }
+            other => panic!("expected Kimi Code setup confirmation, got {other:?}"),
         }
     }
 

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -13933,6 +13933,7 @@ async fn handle_view_events(
                 provider_id,
                 api_key,
                 model,
+                context_window,
             } => {
                 let identity = picker_provider_identity(config, provider, provider_id.as_deref())
                     .map_err(anyhow::Error::msg)?;
@@ -13943,6 +13944,7 @@ async fn handle_view_events(
                     identity,
                     api_key,
                     model,
+                    context_window,
                 )
                 .await;
                 if completed && app.onboarding == OnboardingState::Provider {
@@ -14865,8 +14867,12 @@ async fn apply_provider_picker_setup_confirmed(
     identity: crate::config::ProviderIdentity,
     api_key: String,
     model: String,
+    context_window: Option<u32>,
 ) -> bool {
-    use crate::config::{save_api_key_for_identity, save_provider_model_for_identity};
+    use crate::config::{
+        save_api_key_for_identity, save_provider_context_window_for_identity,
+        save_provider_model_for_identity,
+    };
 
     let provider = identity.provider;
 
@@ -14894,6 +14900,24 @@ async fn apply_provider_picker_setup_confirmed(
                         path.display()
                     ),
                 });
+            } else if let Some(context_window) = context_window {
+                if let Err(err) =
+                    save_provider_context_window_for_identity(&identity, config, context_window)
+                {
+                    app.add_message(HistoryCell::System {
+                        content: format!(
+                            "Saved {} API key and model to {}, but failed to save context window: {err}",
+                            provider.as_str(),
+                            path.display()
+                        ),
+                    });
+                } else {
+                    app.status_message = Some(format!(
+                        "Saved {} API key, model, and context window to {}",
+                        provider.as_str(),
+                        path.display()
+                    ));
+                }
             } else {
                 app.status_message = Some(format!(
                     "Saved {} API key and model to {}",
@@ -14917,6 +14941,9 @@ async fn apply_provider_picker_setup_confirmed(
     config.provider = Some(identity.key);
     mirror_saved_api_key_in_config(config, provider, api_key);
     mirror_saved_model_in_config(config, provider, model.clone());
+    if let Some(context_window) = context_window {
+        mirror_saved_context_window_in_config(config, provider, context_window);
+    }
     switch_provider(app, engine_handle, config, provider, Some(model)).await
 }
 
@@ -14926,6 +14953,21 @@ fn mirror_saved_model_in_config(config: &mut Config, provider: ApiProvider, mode
         return;
     }
     config.set_provider_model_override(provider, Some(model));
+}
+
+fn mirror_saved_context_window_in_config(
+    config: &mut Config,
+    provider: ApiProvider,
+    context_window: u32,
+) {
+    let providers = config
+        .providers
+        .get_or_insert_with(ProvidersConfig::default);
+    let entry = match provider {
+        ApiProvider::Moonshot => &mut providers.moonshot,
+        _ => return,
+    };
+    entry.context_window = Some(context_window);
 }
 
 fn mirror_saved_api_key_in_config(config: &mut Config, provider: ApiProvider, api_key: String) {
@@ -16858,6 +16900,7 @@ auth_mode = "kimi_oauth"
             identity,
             "sk-kimi-supported".to_string(),
             crate::config::DEFAULT_KIMI_CODE_MODEL.to_string(),
+            None,
         )
         .await;
 
@@ -16910,6 +16953,7 @@ base_url = "https://mock.openrouter.test/v1"
             identity,
             "sk-confirmed".to_string(),
             model.clone(),
+            None,
         )
         .await;
 
@@ -17063,6 +17107,7 @@ model = "model-b"
             identity,
             "saved-b-key".to_string(),
             "model-b-confirmed".to_string(),
+            None,
         )
         .await;
 

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -769,6 +769,7 @@ pub enum ViewEvent {
         provider_id: Option<String>,
         api_key: String,
         model: String,
+        context_window: Option<u32>,
     },
     /// Emitted by the `/provider` picker after the custom provider form is
     /// completed. The handler persists a named OpenAI-compatible provider


### PR DESCRIPTION
Closes #4758

## Summary
- add an explicit Kimi Code membership plan choice for exact `api.kimi.com/coding/v1` + `k3` setup
- default to the conservative 262K context floor and allow an explicit 1M choice
- persist and display the selected context window with the provider key and model
- leave generic Moonshot setup unchanged

## Verification
- `cargo fmt --all`
- `cargo check -p codewhale-tui --locked`
- `cargo test -p codewhale-tui exact_kimi_code_setup_asks_for_plan --locked`
- `cargo test -p codewhale-tui model_pick_enter_advances_to_confirm_and_confirm_emits_setup --locked`
- `git diff --check`

No live provider credentials or production state used.