### PR TITLE
test(ci): stop CI flakes and stale-body reruns from gating the milestone

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   link:
@@ -21,11 +22,20 @@ jobs:
     steps:
       - name: Require a closing keyword or an explicit opt-out
         env:
-          # Read through env, never interpolated into the script body:
-          # a PR body is attacker-controlled text.
-          PR_BODY: ${{ github.event.pull_request.body }}
+          # Fetched live rather than read from the event payload. A rerun
+          # replays the payload the run started with, so a body-only fix could
+          # never turn this check green: the obvious operator move — add the
+          # missing line, rerun the failed check — re-read the old body and
+          # failed again with no hint why. Reading the current body makes a
+          # rerun mean what everyone already assumes it means.
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Through a variable, never interpolated into the script body:
+          # a PR body is attacker-controlled text.
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""')
           # Body only, deliberately. GitHub resolves closing keywords from the
           # PR description; a "Closes #123" in the title auto-closes nothing.
           # Accepting the title here would pass PRs that never close an issue,

--- a/crates/tui/src/runtime_api/tests.rs
+++ b/crates/tui/src/runtime_api/tests.rs
@@ -13,6 +13,24 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::time::sleep;
 use uuid::Uuid;
 
+/// Scale a wait budget for shared CI runners.
+///
+/// These deadlines are tuned for a developer laptop running one test at a
+/// time. CI runs the whole workspace suite on a shared runner, where the same
+/// async progress can legitimately take several times longer. Every budget
+/// guarded by this helper is a deadline on a poll or a oneshot that resolves
+/// as soon as the runtime makes progress, so a larger budget does not slow a
+/// passing run down — it only changes how long a genuinely stuck test waits
+/// before it fails. Keeping the local value tight preserves fast feedback
+/// while the tests stop failing for being unlucky about scheduling.
+fn ci_scaled(base: Duration) -> Duration {
+    if std::env::var_os("CI").is_some() {
+        base * 4
+    } else {
+        base
+    }
+}
+
 struct MockExecutor;
 
 #[test]
@@ -834,7 +852,7 @@ async fn read_first_sse_frame(resp: reqwest::Response) -> Result<String> {
     let mut stream = resp.bytes_stream();
     let mut buf = Vec::new();
     loop {
-        let next = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        let next = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), stream.next())
             .await
             .context("timed out waiting for SSE frame")?
             .context("SSE stream ended unexpectedly")??;
@@ -975,7 +993,7 @@ async fn wait_for_terminal_turn_status(
     turn_id: &str,
     timeout: Duration,
 ) -> Result<String> {
-    let deadline = tokio::time::Instant::now() + timeout;
+    let deadline = tokio::time::Instant::now() + ci_scaled(timeout);
     loop {
         let detail: serde_json::Value = client
             .get(format!("http://{addr}/v1/threads/{thread_id}"))
@@ -1010,7 +1028,7 @@ async fn wait_for_in_progress_item(
     thread_id: &str,
     timeout: Duration,
 ) -> Result<()> {
-    let deadline = tokio::time::Instant::now() + timeout;
+    let deadline = tokio::time::Instant::now() + ci_scaled(timeout);
     loop {
         let detail: serde_json::Value = client
             .get(format!("http://{addr}/v1/threads/{thread_id}"))
@@ -1734,7 +1752,7 @@ async fn fleet_status_runtime_api_exposes_state_and_actions() -> Result<()> {
     assert_eq!(restarted["execution"], "scheduled");
     assert_eq!(restarted["worker"]["status"], "busy");
 
-    let terminal_status = tokio::time::timeout(Duration::from_secs(15), async {
+    let terminal_status = tokio::time::timeout(ci_scaled(Duration::from_secs(15)), async {
         loop {
             let status = manager.run_status(&report.run_id).unwrap();
             if status.queued == 0 && status.running == 0 {
@@ -2050,7 +2068,7 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
         Ok::<_, anyhow::Error>((content_type, body))
     });
 
-    let created = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+    let created = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), hook_rx.recv())
         .await
         .context("compatibility stream did not create its thread")?
         .context("compatibility stream test hook closed")?;
@@ -2113,7 +2131,7 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
         .send(())
         .map_err(|_| anyhow::anyhow!("compatibility stream dropped thread-create handoff"))?;
 
-    let subscribed = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+    let subscribed = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), hook_rx.recv())
         .await
         .context("compatibility stream did not subscribe before replay")?
         .context("compatibility stream test hook closed")?;
@@ -2133,7 +2151,7 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
     release_overlap
         .send(())
         .map_err(|_| anyhow::anyhow!("mock engine dropped overlap release"))?;
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(ci_scaled(Duration::from_secs(2)), async {
         loop {
             if runtime_threads
                 .events_since(&thread_id, None)
@@ -2155,7 +2173,7 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
         .send(())
         .map_err(|_| anyhow::anyhow!("compatibility stream dropped subscribe handoff"))?;
 
-    let replay_loaded = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+    let replay_loaded = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), hook_rx.recv())
         .await
         .context("compatibility stream did not reach its replay/live handoff")?
         .context("compatibility stream test hook closed")?;
@@ -2176,7 +2194,7 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
     release_terminal
         .send(())
         .map_err(|_| anyhow::anyhow!("mock engine dropped terminal release"))?;
-    tokio::time::timeout(Duration::from_secs(2), async {
+    tokio::time::timeout(ci_scaled(Duration::from_secs(2)), async {
         loop {
             if runtime_threads
                 .events_since(&thread_id, None)
@@ -2198,7 +2216,7 @@ async fn compatibility_stream_closes_losslessly_across_replay_live_handoff() -> 
         .send(())
         .map_err(|_| anyhow::anyhow!("compatibility stream dropped replay handoff"))?;
 
-    let (content_type, body) = tokio::time::timeout(Duration::from_secs(3), stream_task)
+    let (content_type, body) = tokio::time::timeout(ci_scaled(Duration::from_secs(3)), stream_task)
         .await
         .context("compatibility stream hung after its terminal event")?
         .context("compatibility stream request task panicked")??;
@@ -2249,7 +2267,7 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
         Ok::<_, anyhow::Error>(response)
     });
 
-    let created = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+    let created = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), hook_rx.recv())
         .await
         .context("compatibility stream did not create its interaction thread")?
         .context("compatibility stream interaction hook closed")?;
@@ -2362,7 +2380,7 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
         .send(())
         .map_err(|_| anyhow::anyhow!("compatibility interaction stream dropped create hook"))?;
 
-    let subscribed = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+    let subscribed = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), hook_rx.recv())
         .await
         .context("compatibility interaction stream did not subscribe")?
         .context("compatibility stream interaction hook closed")?;
@@ -2382,7 +2400,7 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
         .send(())
         .map_err(|_| anyhow::anyhow!("compatibility interaction stream dropped subscribe hook"))?;
 
-    let replay_loaded = tokio::time::timeout(Duration::from_secs(2), hook_rx.recv())
+    let replay_loaded = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), hook_rx.recv())
         .await
         .context("compatibility interaction stream did not load replay")?
         .context("compatibility stream interaction hook closed")?;
@@ -2403,14 +2421,14 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
         .send(())
         .map_err(|_| anyhow::anyhow!("compatibility interaction stream dropped replay hook"))?;
 
-    let response = tokio::time::timeout(Duration::from_secs(2), request_task)
+    let response = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), request_task)
         .await
         .context("compatibility interaction request did not return SSE headers")?
         .context("compatibility interaction request task panicked")??;
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel();
     let body_task = tokio::spawn(collect_sse_frames(response, frame_tx));
 
-    let required_payload = tokio::time::timeout(Duration::from_secs(2), async {
+    let required_payload = tokio::time::timeout(ci_scaled(Duration::from_secs(2)), async {
         loop {
             let (event, payload) = frame_rx
                 .recv()
@@ -2450,7 +2468,7 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
         .await?;
     assert_eq!(submitted["delivered"], true);
     let (submitted_id, submitted_response) =
-        tokio::time::timeout(Duration::from_secs(2), submission_rx)
+        tokio::time::timeout(ci_scaled(Duration::from_secs(2)), submission_rx)
             .await
             .context("mock engine did not receive compatibility user input")?
             .context("mock engine dropped compatibility user input")?
@@ -2461,7 +2479,7 @@ async fn compatibility_stream_exposes_and_resolves_user_input_without_answer_ech
         .send(())
         .map_err(|_| anyhow::anyhow!("mock interaction engine dropped completion release"))?;
 
-    let frames = tokio::time::timeout(Duration::from_secs(3), body_task)
+    let frames = tokio::time::timeout(ci_scaled(Duration::from_secs(3)), body_task)
         .await
         .context("compatibility interaction stream did not terminate")?
         .context("compatibility interaction body task panicked")??;
@@ -4136,7 +4154,7 @@ async fn session_create_from_thread_rejects_active_turn() -> Result<()> {
         .as_str()
         .context("missing turn id")?
         .to_string();
-    tokio::time::timeout(Duration::from_secs(2), active_rx)
+    tokio::time::timeout(ci_scaled(Duration::from_secs(2)), active_rx)
         .await
         .context("timed out waiting for mock active turn")?
         .context("mock active turn sender dropped")?;
@@ -4881,7 +4899,7 @@ async fn decide_approval_delivers_to_runtime() -> Result<()> {
     assert_eq!(body["decision"], "allow");
     assert_eq!(body["delivered"], true);
 
-    let received = tokio::time::timeout(Duration::from_secs(1), rx).await??;
+    let received = tokio::time::timeout(ci_scaled(Duration::from_secs(1)), rx).await??;
     assert_eq!(
         received,
         ExternalApprovalDecision::Allow { remember: false }
@@ -4930,7 +4948,7 @@ async fn dynamic_tool_result_endpoint_delivers_to_runtime() -> Result<()> {
         .await?;
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
 
-    let received = tokio::time::timeout(Duration::from_secs(1), rx).await??;
+    let received = tokio::time::timeout(ci_scaled(Duration::from_secs(1)), rx).await??;
     assert!(received.success);
     assert_eq!(received.content.len(), 1);
     let resolved = runtime_threads

--- a/crates/tui/tests/support/qa_harness/harness.rs
+++ b/crates/tui/tests/support/qa_harness/harness.rs
@@ -13,6 +13,24 @@ use anyhow::{Context, Result, anyhow};
 
 use super::{Frame, PtySession};
 
+/// Scale a wait budget for shared CI runners.
+///
+/// PTY scenarios boot a real binary and wait on real terminal output, and the
+/// budgets in the scenarios are tuned for a developer laptop running one test
+/// at a time. CI runs the whole workspace suite on a shared runner, where the
+/// same output can legitimately arrive several times later. Every budget this
+/// scales is a deadline on a poll that returns as soon as the condition holds,
+/// so a larger budget never slows a passing run — it only changes how long a
+/// genuinely stuck scenario waits before failing. Local runs keep the tight
+/// value so a real hang still surfaces quickly while developing.
+pub fn ci_scaled(base: Duration) -> Duration {
+    if std::env::var_os("CI").is_some() {
+        base * 4
+    } else {
+        base
+    }
+}
+
 pub struct Harness {
     pty: PtySession,
     frame: Frame,
@@ -169,7 +187,8 @@ impl Harness {
     where
         F: FnMut(&Frame) -> bool,
     {
-        let deadline = Instant::now() + timeout;
+        let budget = ci_scaled(timeout);
+        let deadline = Instant::now() + budget;
         loop {
             self.pump();
             if predicate(&self.frame) {
@@ -178,7 +197,7 @@ impl Harness {
             if Instant::now() >= deadline {
                 return Err(anyhow!(
                     "wait_for timed out after {:?}.\n{}",
-                    timeout,
+                    budget,
                     self.frame.debug_dump()
                 ));
             }
@@ -195,7 +214,10 @@ impl Harness {
     /// Wait for stable output: no new bytes for `quiet_for` consecutive
     /// pump ticks, bounded by `max`. Useful for "let the UI settle".
     pub fn wait_for_idle(&mut self, quiet_for: Duration, max: Duration) -> Result<()> {
-        let max_deadline = Instant::now() + max;
+        // Only the ceiling scales: `quiet_for` is the definition of "settled",
+        // not a budget, and stretching it would change what the test asserts.
+        let budget = ci_scaled(max);
+        let max_deadline = Instant::now() + budget;
         let mut quiet_since = Instant::now();
         loop {
             if self.pump() {
@@ -207,7 +229,7 @@ impl Harness {
             if Instant::now() >= max_deadline {
                 return Err(anyhow!(
                     "wait_for_idle: never settled within {:?}\n{}",
-                    max,
+                    budget,
                     self.frame.debug_dump()
                 ));
             }
@@ -239,7 +261,7 @@ impl Harness {
 
     /// Wait for the child process to exit without sending it a signal.
     pub fn wait_for_exit(&mut self, timeout: Duration) -> Option<i32> {
-        self.pty.wait_until(Instant::now() + timeout)
+        self.pty.wait_until(Instant::now() + ci_scaled(timeout))
     }
 
     pub fn debug_dump(&mut self) -> String {


### PR DESCRIPTION
## Summary

Two failures that block reviewable v0.9.2 lanes without saying anything about the code under review.

**Flaky async wait budgets.** `Test (windows-latest)` on #4888 and `Test (macos-latest)` on #4881 both failed on timing, in tests unrelated to either PR's diff — #4888 changes only `crates/tui/src/main.rs`, #4881 touches no PTY or runtime-API path. Every budget involved guards a poll or a oneshot that resolves as soon as the runtime makes progress; they were tuned for a laptop running one test at a time, so a shared runner executing the whole workspace suite fails them for scheduling luck. Scale them four-fold when `CI` is set, inside the two polling helpers and the PTY harness so no scenario opts in. `wait_for_idle` scales only its ceiling — `quiet_for` defines "settled" and stretching it would change the assertion.

**A rerun that could never pass.** `pr-issue-link` read the PR body from `github.event.pull_request.body`, and a rerun replays the payload the run started with. So the obvious operator move — add the missing `No-Issue:` line, rerun the failed check — silently re-read the old body and failed again. Fetch the current body through the API instead; it stays in a variable and is never interpolated into the script, so it remains untrusted text.

No-Issue: CI reliability corrective; both failures are infrastructure, not milestone acceptance work, so this closes no issue.

## Verification

Observed on #4885 — same body, two outcomes:
- rerun of the original run: FAILURE at `2026-07-26T14:04:36Z`
- fresh `edited` event: SUCCESS at `2026-07-26T14:09:10Z`

Local receipts on this branch:
- `cargo test -p codewhale-tui --bin codewhale-tui runtime_api::tests::session_create_from_thread --locked` — 2 passed (includes the test that failed on #4888)
- `CI=1 cargo test -p codewhale-tui --bin codewhale-tui runtime_api::tests:: --locked` — 104 passed in 3.75s, confirming the scaled budgets do not slow a passing run
- `cargo test -p codewhale-tui --test qa_pty long_output_scrolls_and_restores_follow_tail --locked` — 1 passed (the test that failed on #4881)
- `actionlint .github/workflows/pr-issue-link.yml` — clean
- `cargo fmt --all -- --check`, `git diff --check` — clean

No merge, version bump, tag, release, publication, deploy, credential, billing, DNS, or customer-data action.