### PR TITLE
fix(lint): clear clippy failures on current stable Rust

### DIFF
--- a/crates/tui/src/fleet/host.rs
+++ b/crates/tui/src/fleet/host.rs
@@ -1079,12 +1079,12 @@ fn unix_process_ids_uncached() -> FleetHostResult<Vec<libc::pid_t>> {
 
 #[cfg(all(unix, not(target_os = "linux")))]
 fn unix_process_ids() -> FleetHostResult<Vec<libc::pid_t>> {
-    if let Some(available) = process_table_probe_cell().get() {
-        if !*available {
-            return Err(FleetHostError::retryable(
-                "listing Fleet session with ps: process-table inspection unavailable",
-            ));
-        }
+    if let Some(available) = process_table_probe_cell().get()
+        && !*available
+    {
+        return Err(FleetHostError::retryable(
+            "listing Fleet session with ps: process-table inspection unavailable",
+        ));
     }
     match unix_process_ids_uncached() {
         Ok(pids) => {
@@ -1154,10 +1154,10 @@ fn signal_unix_session(
     // Prefer known leader first so stop/interrupt still works when the full
     // process table cannot be enumerated under a restricted sandbox.
     let mut candidates = unix_session_members(session_id, known_leader)?;
-    if candidates.is_empty() {
-        if let Some(leader) = known_leader.filter(|pid| *pid > 0) {
-            candidates.push(leader);
-        }
+    if candidates.is_empty()
+        && let Some(leader) = known_leader.filter(|pid| *pid > 0)
+    {
+        candidates.push(leader);
     }
     for pid in candidates {
         // Verify identity again immediately before signalling. Session IDs

--- a/crates/tui/src/tools/shell.rs
+++ b/crates/tui/src/tools/shell.rs
@@ -1679,6 +1679,7 @@ impl ShellManager {
     }
 
     /// Spawn a background process (sandboxed).
+    #[allow(clippy::too_many_arguments)]
     fn spawn_background_sandboxed(
         &mut self,
         original_command: &str,

--- a/crates/tui/src/tui/ambient_life.rs
+++ b/crates/tui/src/tui/ambient_life.rs
@@ -151,6 +151,7 @@ pub struct WhaleCameo {
 const WHALE_CAMEO_MS: u128 = 2_400;
 
 /// Render ambient life into empty water cells of `area`.
+#[allow(clippy::too_many_arguments)]
 pub fn render_ambient_life(
     area: Rect,
     buf: &mut Buffer,

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -410,10 +410,10 @@ pub fn start_title_animation(original: &str) {
     if let Ok(mut base) = title_animation_base().lock() {
         original.clone_into(&mut base);
     }
-    if let Ok(mut verb) = title_activity_verb().lock() {
-        if verb.is_empty() {
-            "working…".clone_into(&mut *verb);
-        }
+    if let Ok(mut verb) = title_activity_verb().lock()
+        && verb.is_empty()
+    {
+        "working…".clone_into(&mut *verb);
     }
     COMPLETION_MARKER_SHOWN.store(false, Ordering::SeqCst);
     TITLE_ANIMATION_RUNNING.store(true, Ordering::SeqCst);


### PR DESCRIPTION
No-Issue: CI-infrastructure corrective; unblocks the Lint gate for every open PR.

## The problem

`rust-toolchain.toml` pins `channel = "stable"`, so CI moved to Rust 1.97.0. Five pre-existing patterns on `origin/main` are now hard errors under CI's exact gate:

```
cargo clippy --workspace --all-features --locked -- -D warnings
```

Reproduced on clean `origin/main` (`a2cb83514`), not just on a feature branch — three `collapsible_if` in `fleet/host.rs` and `tui/notifications.rs`, and two `too_many_arguments` (8/7) in `tools/shell.rs` and `tui/ambient_life.rs`. This is why Lint is red on PRs that touch none of those files (e.g. #4894).

## What changed

- Collapsed the three nested `if`s using edition-2024 let-chains. Behavior is identical; the conditions were already `&&`-shaped.
- Marked the two 8-argument functions with `#[allow(clippy::too_many_arguments)]` — the convention this repository already uses in ten other places — rather than reshaping working signatures to satisfy a lint threshold.

## Receipts (macOS, Rust 1.97.0)

- `cargo clippy --workspace --all-features --locked -- -D warnings` — clean.
- `fleet::host` 17 passed / 0 failed; `tui::notifications` 22 passed / 0 failed; ambient-life widget tests 12 passed / 0 failed.
- `cargo fmt --all -- --check` and `git diff --check` clean.