### PR TITLE
feat(composer): add @git and @diff mentions

### DIFF
--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -28,6 +28,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::tui::app::{App, MentionCompletionCache};
+use crate::tui::git_mention::{self, GitMentionKind};
 use crate::tui::mention_completion::{MentionDiscoveryBehavior, MentionDiscoveryKey};
 use crate::working_set::Workspace;
 
@@ -86,6 +87,8 @@ pub enum ContextReferenceKind {
     Unsupported,
     MediaMention,
     MediaAttachment,
+    /// `@git` / `@diff` — curated git context rather than a path (#4067).
+    GitContext,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -264,6 +267,8 @@ fn mention_menu_entries(app: &mut App, partial: &str, limit: usize) -> (Vec<Stri
         }
     };
 
+    let entries = with_git_mention_entries(entries, partial, limit);
+
     app.composer.mention_completion_cache = Some(MentionCompletionCache {
         workspace,
         cwd,
@@ -276,6 +281,39 @@ fn mention_menu_entries(app: &mut App, partial: &str, limit: usize) -> (Vec<Stri
     });
 
     (entries, true)
+}
+
+/// Prepend the `@git` / `@diff` tokens that prefix-match `partial` to the path
+/// completions, so curated git context is discoverable from the same menu as
+/// files (#4067). They lead because a two-entry prefix match is what the user
+/// meant when they typed `gi` or `di`, and paths still fill the rest.
+///
+/// A bare `@` is deliberately left alone: that menu is the file picker, and
+/// pushing two fixed tokens above every path would cost a slot on every
+/// mention the user makes. The tokens appear as soon as a matching character
+/// is typed.
+fn with_git_mention_entries(entries: Vec<String>, partial: &str, limit: usize) -> Vec<String> {
+    let needle = partial.trim().to_lowercase();
+    if needle.is_empty() {
+        return entries;
+    }
+    let matching: Vec<String> = GitMentionKind::iter_all()
+        .filter(|kind| kind.token().starts_with(&needle))
+        .map(|kind| kind.token().to_string())
+        .collect();
+    if matching.is_empty() {
+        return entries;
+    }
+    let mut combined = matching;
+    for entry in entries {
+        if combined.len() >= limit {
+            break;
+        }
+        if !combined.contains(&entry) {
+            combined.push(entry);
+        }
+    }
+    combined
 }
 
 /// Apply the currently selected `@`-mention popup entry to the composer
@@ -456,6 +494,19 @@ pub fn pending_context_previews(input: &str) -> Vec<FileMentionPreview> {
         if !seen.insert(mention.clone()) {
             continue;
         }
+        // Composer previews stay lexical (no git subprocess from the render
+        // loop, same rule as #4365 for path stats); the payload is resolved
+        // once at submit time.
+        if let Some(kind) = git_mention::git_mention_kind(&mention) {
+            previews.push(FileMentionPreview {
+                kind: "git".to_string(),
+                label: kind.label().to_string(),
+                detail: Some("resolved on send".to_string()),
+                included: false,
+                removable: false,
+            });
+            continue;
+        }
         let media = is_media_path(Path::new(&mention));
         previews.push(FileMentionPreview {
             kind: if media { "media" } else { "mention" }.to_string(),
@@ -499,6 +550,36 @@ pub fn context_references_from_input(
         .into_iter()
         .take(MAX_FILE_MENTIONS_PER_MESSAGE)
     {
+        // Git mentions resolve against the working tree, not the path index,
+        // so the inspector reports their real size and budget (#4067).
+        if let Some(kind) = git_mention::git_mention_kind(&mention) {
+            let payload = git_mention::resolve_git_mention(kind, workspace);
+            let detail = match payload.unavailable_reason.as_deref() {
+                Some(reason) => format!("{}, {reason}", kind.label()),
+                None if payload.truncated => format!(
+                    "{}, {} bytes truncated at {} budget",
+                    kind.label(),
+                    payload.bytes,
+                    kind.byte_budget()
+                ),
+                None => format!("{}, {} bytes", kind.label(), payload.bytes),
+            };
+            let reference = ContextReference {
+                kind: ContextReferenceKind::GitContext,
+                source: ContextReferenceSource::AtMention,
+                badge: "git".to_string(),
+                label: kind.token().to_string(),
+                target: workspace.display().to_string(),
+                included: payload.unavailable_reason.is_none(),
+                expanded: false,
+                detail: Some(detail),
+            };
+            if seen.insert(format!("git-mention:{}", kind.token())) {
+                references.push(reference);
+            }
+            continue;
+        }
+
         let (path, display_path, exists) = match ws.resolve_exact(&mention) {
             Ok(path) => {
                 let display = path.display().to_string();
@@ -680,6 +761,16 @@ fn local_context_from_file_mentions(
     let ws = Workspace::with_cwd(workspace.to_path_buf(), cwd);
 
     for mention in mentions.into_iter().take(MAX_FILE_MENTIONS_PER_MESSAGE) {
+        // `@git` / `@diff` resolve to curated git context, not to a path, so
+        // they short-circuit before any workspace path resolution (#4067).
+        if let Some(kind) = git_mention::git_mention_kind(&mention) {
+            if !seen.insert(format!("git-mention:{}", kind.token())) {
+                continue;
+            }
+            blocks.push(git_mention::resolve_git_mention(kind, workspace).block);
+            continue;
+        }
+
         // `Workspace::resolve_exact` already returns absolute paths when the root
         // is absolute (TUI always runs from an absolute workspace), so we
         // skip `canonicalize()` here — it's per-mention I/O on the
@@ -1162,5 +1253,177 @@ mod tests {
             !text.contains('\u{FFFD}'),
             "truncated text must not contain replacement characters; got: {text:?}",
         );
+    }
+    // ---------------------------------------------------------------------
+    //  #4067 — @git / @diff composer mentions
+    // ---------------------------------------------------------------------
+
+    fn init_test_repo(dir: &Path) {
+        for args in [
+            vec!["init", "--initial-branch=main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            let out = std::process::Command::new("git")
+                .args(&args)
+                .current_dir(dir)
+                .output()
+                .expect("git available in tests");
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+    }
+
+    fn commit_test_repo(dir: &Path) {
+        for args in [vec!["add", "-A"], vec!["commit", "-m", "initial"]] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(dir)
+                .output()
+                .expect("git available in tests");
+        }
+    }
+
+    #[test]
+    fn git_and_diff_mentions_inline_curated_context_not_paths() {
+        let tmp = TempDir::new().expect("tempdir");
+        init_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "one\n").expect("write");
+        commit_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "two\n").expect("write");
+
+        let expanded = user_request_with_file_mentions(
+            "look at @git and @diff",
+            tmp.path(),
+            Some(tmp.path().to_path_buf()),
+        );
+
+        assert!(expanded.contains("<git-status"), "{expanded}");
+        assert!(expanded.contains("<git-diff"), "{expanded}");
+        assert!(expanded.contains("a.txt"), "{expanded}");
+        // The tokens are not treated as paths, so no missing-file block.
+        assert!(!expanded.contains("<missing-file"), "{expanded}");
+    }
+
+    #[test]
+    fn git_mentions_outside_a_repository_say_so_explicitly() {
+        let tmp = TempDir::new().expect("tempdir");
+        let expanded = user_request_with_file_mentions(
+            "status? @git",
+            tmp.path(),
+            Some(tmp.path().to_path_buf()),
+        );
+        assert!(expanded.contains("<git-unavailable"), "{expanded}");
+        assert!(expanded.contains("not a git repository"), "{expanded}");
+    }
+
+    #[test]
+    fn git_mention_is_deduplicated_within_one_message() {
+        let tmp = TempDir::new().expect("tempdir");
+        init_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "one\n").expect("write");
+        commit_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "two\n").expect("write");
+
+        let expanded = user_request_with_file_mentions(
+            "@diff and again @diff",
+            tmp.path(),
+            Some(tmp.path().to_path_buf()),
+        );
+        assert_eq!(expanded.matches("<git-diff").count(), 1, "{expanded}");
+    }
+
+    #[test]
+    fn paths_that_merely_start_with_git_stay_file_mentions() {
+        let tmp = TempDir::new().expect("tempdir");
+        std::fs::write(tmp.path().join("diff.txt"), "plain file").expect("write");
+
+        let expanded = user_request_with_file_mentions(
+            "see @diff.txt",
+            tmp.path(),
+            Some(tmp.path().to_path_buf()),
+        );
+        assert!(expanded.contains("plain file"), "{expanded}");
+        assert!(!expanded.contains("<git-diff"), "{expanded}");
+    }
+
+    #[test]
+    fn large_diff_is_truncated_and_the_inspector_reports_the_budget() {
+        let tmp = TempDir::new().expect("tempdir");
+        init_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("big.txt"), "seed\n").expect("write");
+        commit_test_repo(tmp.path());
+        let bulk: String = (0..40_000).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(tmp.path().join("big.txt"), bulk).expect("write");
+
+        let expanded =
+            user_request_with_file_mentions("@diff", tmp.path(), Some(tmp.path().to_path_buf()));
+        assert!(
+            expanded.contains("truncated=\"true\""),
+            "expected truncation marker"
+        );
+
+        let references =
+            context_references_from_input("@diff", tmp.path(), Some(tmp.path().to_path_buf()));
+        let git_ref = references
+            .iter()
+            .find(|r| r.kind == ContextReferenceKind::GitContext)
+            .expect("git reference present in the inspector");
+        assert_eq!(git_ref.label, "diff");
+        assert!(git_ref.included);
+        let detail = git_ref.detail.clone().unwrap_or_default();
+        assert!(detail.contains("truncated at"), "{detail}");
+        assert!(
+            detail.contains(&crate::tui::git_mention::MAX_GIT_DIFF_MENTION_BYTES.to_string()),
+            "{detail}"
+        );
+    }
+
+    #[test]
+    fn empty_repository_reference_is_visible_but_not_included() {
+        let tmp = TempDir::new().expect("tempdir");
+        init_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "one\n").expect("write");
+        commit_test_repo(tmp.path());
+
+        let references =
+            context_references_from_input("@diff", tmp.path(), Some(tmp.path().to_path_buf()));
+        let git_ref = references
+            .iter()
+            .find(|r| r.kind == ContextReferenceKind::GitContext)
+            .expect("git reference present even when there is nothing to show");
+        assert!(!git_ref.included);
+        assert!(
+            git_ref
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("no working-tree changes")),
+            "{:?}",
+            git_ref.detail
+        );
+    }
+
+    #[test]
+    fn composer_preview_lists_git_mentions_without_running_git() {
+        let previews = pending_context_previews("@git @diff");
+        let kinds: Vec<&str> = previews.iter().map(|p| p.kind.as_str()).collect();
+        assert_eq!(kinds, vec!["git", "git"]);
+        assert!(previews.iter().all(|p| !p.included));
+    }
+
+    #[test]
+    fn completion_offers_git_and_diff_alongside_paths() {
+        let paths = vec!["src/main.rs".to_string(), "docs/guide.md".to_string()];
+        // A bare `@` stays the file picker.
+        assert_eq!(with_git_mention_entries(paths.clone(), "", 8), paths);
+
+        let narrowed = with_git_mention_entries(paths.clone(), "di", 8);
+        assert_eq!(narrowed.first().map(String::as_str), Some("diff"));
+        assert!(narrowed.contains(&"src/main.rs".to_string()));
+
+        let git_only = with_git_mention_entries(paths.clone(), "g", 8);
+        assert_eq!(git_only.first().map(String::as_str), Some("git"));
+
+        // A partial that matches no token leaves path completion untouched.
+        assert_eq!(with_git_mention_entries(paths.clone(), "src", 8), paths);
     }
 }

--- a/crates/tui/src/tui/git_mention.rs
+++ b/crates/tui/src/tui/git_mention.rs
@@ -1,0 +1,338 @@
+//! `@git` and `@diff` composer mentions (#4067).
+//!
+//! The `@` mention system is otherwise path-centric: every token resolves to
+//! a file or directory. These two tokens resolve to *curated git context*
+//! instead, so a user can attach "what is going on in this working tree"
+//! inline rather than making the model spend a round-trip on `git_diff` or a
+//! shell command that may need approval.
+//!
+//! Two deliberate boundaries:
+//!
+//! * **Read-only and bounded.** Only `git status` and `git diff` run, always
+//!   with an explicit byte budget. A repository with a huge working-tree diff
+//!   truncates with a visible marker rather than flooding the turn.
+//! * **Honest when unavailable.** No git binary, or a directory that is not a
+//!   repository, produces an explicit `<git-unavailable>` block. A mention
+//!   never silently contributes nothing.
+
+use std::path::Path;
+
+use crate::dependencies::{ExternalTool, Git};
+
+/// Byte ceiling for the inlined `@diff` payload. Documented here because the
+/// context inspector reports the budget alongside actual size.
+pub const MAX_GIT_DIFF_MENTION_BYTES: usize = 32 * 1024;
+/// Byte ceiling for the inlined `@git` status summary. Status output is
+/// bounded in practice, but an unignored `node_modules` can still produce
+/// tens of thousands of lines.
+pub const MAX_GIT_STATUS_MENTION_BYTES: usize = 8 * 1024;
+
+/// Which curated git payload a mention token asks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitMentionKind {
+    /// `@git` — a bounded `git status` summary plus the current branch.
+    Status,
+    /// `@diff` — the working-tree diff, staged and unstaged.
+    Diff,
+}
+
+impl GitMentionKind {
+    /// The mention token that selects this payload, without the `@`.
+    #[must_use]
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::Status => "git",
+            Self::Diff => "diff",
+        }
+    }
+
+    /// Byte budget for the inlined payload.
+    #[must_use]
+    pub fn byte_budget(self) -> usize {
+        match self {
+            Self::Status => MAX_GIT_STATUS_MENTION_BYTES,
+            Self::Diff => MAX_GIT_DIFF_MENTION_BYTES,
+        }
+    }
+
+    /// Every git mention kind, in completion-menu order.
+    pub fn iter_all() -> impl Iterator<Item = Self> {
+        GIT_MENTION_KINDS.into_iter()
+    }
+
+    /// Short label for composer previews and the context inspector.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Status => "git status",
+            Self::Diff => "working-tree diff",
+        }
+    }
+}
+
+/// Every git mention token, in completion-menu order.
+pub const GIT_MENTION_KINDS: [GitMentionKind; 2] = [GitMentionKind::Status, GitMentionKind::Diff];
+
+/// Classify a raw mention token. Case-insensitive so `@Git` and `@Diff`
+/// behave like the lowercase spellings; a path that merely *starts* with
+/// `git` (`@git/config`, `@diff.txt`) stays a file mention.
+#[must_use]
+pub fn git_mention_kind(raw: &str) -> Option<GitMentionKind> {
+    let token = raw.trim();
+    GIT_MENTION_KINDS
+        .into_iter()
+        .find(|kind| token.eq_ignore_ascii_case(kind.token()))
+}
+
+/// Outcome of resolving a git mention against a working directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitMentionPayload {
+    /// The model-facing block, already wrapped in its tag.
+    pub block: String,
+    /// Byte size of the payload actually inlined (the tag itself excluded).
+    pub bytes: usize,
+    /// Whether the payload hit its budget and was cut.
+    pub truncated: bool,
+    /// Present when git could not produce the payload at all.
+    pub unavailable_reason: Option<String>,
+}
+
+impl GitMentionPayload {
+    fn unavailable(kind: GitMentionKind, reason: &str) -> Self {
+        Self {
+            block: format!(
+                "<git-unavailable mention=\"@{token}\" reason=\"{reason}\" />",
+                token = kind.token(),
+            ),
+            bytes: 0,
+            truncated: false,
+            unavailable_reason: Some(reason.to_string()),
+        }
+    }
+}
+
+/// Run the git commands for `kind` in `cwd` and render the model-facing block.
+///
+/// Never returns an error: an unavailable git, a non-repository directory, or
+/// a failing command all resolve to an explicit `<git-unavailable>` block so
+/// the turn records why the mention contributed nothing.
+#[must_use]
+pub fn resolve_git_mention(kind: GitMentionKind, cwd: &Path) -> GitMentionPayload {
+    if Git::command().is_none() {
+        return GitMentionPayload::unavailable(kind, "git not found on PATH");
+    }
+    if !is_git_repository(cwd) {
+        return GitMentionPayload::unavailable(kind, "not a git repository");
+    }
+
+    let raw = match kind {
+        GitMentionKind::Status => git_status_payload(cwd),
+        GitMentionKind::Diff => git_output(&["diff", "HEAD"], cwd),
+    };
+    let Some(raw) = raw else {
+        return GitMentionPayload::unavailable(kind, "git command failed");
+    };
+
+    if raw.trim().is_empty() {
+        let reason = match kind {
+            GitMentionKind::Status => "working tree clean",
+            GitMentionKind::Diff => "no working-tree changes",
+        };
+        return GitMentionPayload::unavailable(kind, reason);
+    }
+
+    let (body, truncated) = truncate_on_char_boundary(&raw, kind.byte_budget());
+    let tag = match kind {
+        GitMentionKind::Status => "git-status",
+        GitMentionKind::Diff => "git-diff",
+    };
+    let truncated_attr = if truncated {
+        format!(
+            " truncated=\"true\" budget-bytes=\"{}\"",
+            kind.byte_budget()
+        )
+    } else {
+        String::new()
+    };
+    let block = format!(
+        "<{tag} mention=\"@{token}\" bytes=\"{bytes}\"{truncated_attr}>\n{body}\n</{tag}>",
+        token = kind.token(),
+        bytes = body.len(),
+    );
+
+    GitMentionPayload {
+        block,
+        bytes: body.len(),
+        truncated,
+        unavailable_reason: None,
+    }
+}
+
+/// `git status` plus the branch line, so the model does not have to infer the
+/// branch from a porcelain listing.
+fn git_status_payload(cwd: &Path) -> Option<String> {
+    let status = git_output(&["status", "--short", "--branch"], cwd)?;
+    Some(status)
+}
+
+/// True when `cwd` is inside a git work tree.
+fn is_git_repository(cwd: &Path) -> bool {
+    git_output(&["rev-parse", "--is-inside-work-tree"], cwd).is_some_and(|out| out.trim() == "true")
+}
+
+/// Run git and return stdout, or `None` when the binary is missing or the
+/// command exits non-zero.
+fn git_output(args: &[&str], cwd: &Path) -> Option<String> {
+    let output = Git::output(args, cwd).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Cut `text` to at most `budget` bytes without splitting a UTF-8 scalar.
+/// Returns the slice and whether anything was dropped.
+fn truncate_on_char_boundary(text: &str, budget: usize) -> (&str, bool) {
+    if text.len() <= budget {
+        return (text, false);
+    }
+    let mut end = budget;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&text[..end], true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn init_repo(dir: &Path) {
+        for args in [
+            vec!["init", "--initial-branch=main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            let status = Command::new("git")
+                .args(&args)
+                .current_dir(dir)
+                .output()
+                .expect("git available in tests");
+            assert!(status.status.success(), "git {args:?} failed");
+        }
+    }
+
+    fn commit_all(dir: &Path, message: &str) {
+        Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
+
+    #[test]
+    fn only_exact_tokens_are_git_mentions() {
+        assert_eq!(git_mention_kind("git"), Some(GitMentionKind::Status));
+        assert_eq!(git_mention_kind("Diff"), Some(GitMentionKind::Diff));
+        // Paths that merely start with the token stay file mentions.
+        assert_eq!(git_mention_kind("git/config"), None);
+        assert_eq!(git_mention_kind("diff.txt"), None);
+        assert_eq!(git_mention_kind("gitignore"), None);
+    }
+
+    #[test]
+    fn non_repository_directory_is_explicitly_unavailable() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = resolve_git_mention(GitMentionKind::Diff, dir.path());
+        assert_eq!(payload.bytes, 0);
+        assert!(payload.block.contains("git-unavailable"));
+        assert!(
+            payload
+                .unavailable_reason
+                .as_deref()
+                .is_some_and(|r| r.contains("not a git repository")),
+            "unexpected reason: {:?}",
+            payload.unavailable_reason
+        );
+    }
+
+    #[test]
+    fn empty_repository_reports_clean_rather_than_an_empty_block() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        std::fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+        commit_all(dir.path(), "initial");
+
+        let payload = resolve_git_mention(GitMentionKind::Diff, dir.path());
+        assert_eq!(payload.bytes, 0);
+        assert!(payload.block.contains("no working-tree changes"));
+    }
+
+    #[test]
+    fn status_reports_branch_and_dirty_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        std::fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+        commit_all(dir.path(), "initial");
+        std::fs::write(dir.path().join("b.txt"), "new\n").unwrap();
+
+        let payload = resolve_git_mention(GitMentionKind::Status, dir.path());
+        assert!(payload.unavailable_reason.is_none());
+        assert!(payload.block.starts_with("<git-status mention=\"@git\""));
+        assert!(payload.block.contains("b.txt"), "{}", payload.block);
+        assert!(!payload.truncated);
+    }
+
+    #[test]
+    fn diff_covers_staged_and_unstaged_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        std::fs::write(dir.path().join("a.txt"), "one\n").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "one\n").unwrap();
+        commit_all(dir.path(), "initial");
+
+        std::fs::write(dir.path().join("a.txt"), "staged\n").unwrap();
+        Command::new("git")
+            .args(["add", "a.txt"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::fs::write(dir.path().join("b.txt"), "unstaged\n").unwrap();
+
+        let payload = resolve_git_mention(GitMentionKind::Diff, dir.path());
+        assert!(payload.unavailable_reason.is_none());
+        assert!(payload.block.contains("staged"), "{}", payload.block);
+        assert!(payload.block.contains("unstaged"), "{}", payload.block);
+    }
+
+    #[test]
+    fn large_diff_truncates_at_the_documented_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        std::fs::write(dir.path().join("big.txt"), "seed\n").unwrap();
+        commit_all(dir.path(), "initial");
+
+        let bulk: String = (0..40_000).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(dir.path().join("big.txt"), bulk).unwrap();
+
+        let payload = resolve_git_mention(GitMentionKind::Diff, dir.path());
+        assert!(payload.truncated, "expected truncation");
+        assert!(payload.bytes <= MAX_GIT_DIFF_MENTION_BYTES);
+        assert!(payload.block.contains("truncated=\"true\""));
+        assert!(payload.block.contains("budget-bytes=\"32768\""));
+    }
+
+    #[test]
+    fn truncation_never_splits_a_utf8_scalar() {
+        // Budget lands mid-scalar: "é" is two bytes starting at index 1.
+        let (cut, truncated) = truncate_on_char_boundary("aéb", 2);
+        assert!(truncated);
+        assert_eq!(cut, "a");
+    }
+}

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -41,6 +41,7 @@ pub mod file_tree;
 pub mod footer_ui;
 pub mod format_helpers;
 pub mod frame_rate_limiter;
+pub mod git_mention;
 pub mod git_status;
 pub mod glyphs;
 pub mod history;

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -115,6 +115,15 @@ Fresh configs resolve to this default bar unless `[[hotbar]]` overrides it or `h
 
 Type `@<partial>` to open the file mention popup. `↑`/`↓` cycle the entries, `Tab` or `Enter` accepts. `Esc` hides the popup. As of v0.8.10 (#441), completions are re-ranked by mention frecency — files you mention often + recently float to the top.
 
+Two mentions resolve to curated git context instead of a path (v0.9.2, #4067):
+
+| Mention | Inlines | Byte budget |
+|---------|---------|-------------|
+| `@git`  | `git status --short --branch` for the workspace | 8 KB |
+| `@diff` | The working-tree diff, staged and unstaged (`git diff HEAD`) | 32 KB |
+
+Both appear in the completion popup alongside paths, and both show up in the context inspector with their resolved size and, when the diff exceeds its budget, the truncation marker. When git is missing, the workspace is not a repository, or there is nothing to show, the turn carries an explicit `<git-unavailable>` note rather than silently contributing nothing. A path that merely starts with the token (`@diff.txt`, `@git/config`) stays a file mention.
+
 ### `#` quick-add (memory)
 
 When `[memory] enabled = true`, typing `# foo` and pressing `Enter` appends `foo` as a timestamped bullet to your memory file *without* sending a turn. See `docs/MEMORY.md`.


### PR DESCRIPTION
Closes #4067.

## The gap

The `@` mention system is mature but path-centric — every token resolves to a file or directory. Attaching curated git context meant the model spending a round-trip on `git_diff` or a shell command that may need approval.

## What changed

New `crates/tui/src/tui/git_mention.rs`, wired into the four mention surfaces:

| Mention | Inlines | Budget |
|---|---|---|
| `@git` | `git status --short --branch` for the workspace | 8 KB |
| `@diff` | Working-tree diff, staged and unstaged (`git diff HEAD`) | 32 KB |

- **Send-time expansion** — resolved once at submit, deduplicated within a message, alongside existing file blocks.
- **Context inspector** — a `GitContext` reference row reporting resolved byte size and, past budget, the truncation marker.
- **Composer preview** — listed lexically; no git subprocess runs from the render loop (same rule as #4365 for path stats).
- **Tab completion** — the tokens lead the menu as soon as a matching prefix is typed. A bare `@` is deliberately unchanged: that menu is the file picker, and two fixed tokens above every path would cost a slot on every mention.

Two boundaries worth calling out:

- **Truncation is UTF-8-safe and visible.** Payloads cut on a scalar boundary and carry `truncated="true" budget-bytes="…"`.
- **Unavailability is explicit.** No git binary, a non-repository directory, or nothing to show produce a `<git-unavailable reason="…">` block. A mention never silently contributes nothing. A path that merely starts with the token (`@diff.txt`, `@git/config`) stays a file mention.

Documented in `docs/KEYBINDINGS.md`.

## Receipts (macOS)

- `tui::git_mention::tests` + `tui::file_mention::tests` + `tui::context_inspector` — 36 passed / 0 failed, covering the acceptance list: non-repository, clean repo, staged+unstaged, large-diff truncation at the documented budget, inspector visibility, preview, and completion.
- `tui::ui::tests` — 619 passed / 0 failed (no regression in the existing mention-popup behavior).
- `cargo fmt --all -- --check` and `git diff --check` clean.
- `cargo clippy --workspace --all-features --locked -- -D warnings` reports no findings in the changed files; the five pre-existing failures on `origin/main` are fixed separately in #4898.