### PR TITLE
feat(engine): make policy narrowing observable

### DIFF
--- a/crates/tui/src/core/authority.rs
+++ b/crates/tui/src/core/authority.rs
@@ -69,6 +69,76 @@ pub(crate) fn base_policy_for_mode(mode: AppMode, prefs: &ModeSessionPrefs) -> E
     }
 }
 
+/// Why runtime policy narrowed the authority a turn was asked to run with.
+///
+/// One variant per narrowing site. Adding a site means adding a variant, which
+/// is the mechanism that makes "no silent effective mode change" enforceable
+/// rather than aspirational (#3947).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PolicyNarrowingReason {
+    /// Input arrived from a provenance that cannot inherit standing
+    /// auto-approval authority (sub-agent handoffs, restored checkpoints).
+    NonAuthoritativeProvenance,
+}
+
+impl PolicyNarrowingReason {
+    /// Stable machine-readable identifier. Shared by the model-visible
+    /// metadata line and doctor output so the two cannot drift.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NonAuthoritativeProvenance => "non_authoritative_provenance",
+        }
+    }
+}
+
+/// A structured record of one authority narrowing.
+///
+/// Before this existed, narrowing produced only a free-text UI status line:
+/// the model saw the narrowed posture but never learned it had been narrowed
+/// or why, and doctor could not report it at all. Every consumer now renders
+/// from this one value, so the UI status, the `<turn_meta>` line, and doctor
+/// necessarily agree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PolicyNarrowingEvent {
+    reason: PolicyNarrowingReason,
+    /// Mode before narrowing, and after, as setting strings.
+    from_mode: &'static str,
+    to_mode: &'static str,
+    /// Permission posture before narrowing, and after.
+    from_approval: ApprovalMode,
+    to_approval: ApprovalMode,
+    /// Human-readable cause, e.g. the provenance that could not inherit.
+    detail: String,
+}
+
+impl PolicyNarrowingEvent {
+    pub(crate) fn reason(&self) -> PolicyNarrowingReason {
+        self.reason
+    }
+
+    /// The single user-facing sentence. The TUI status line renders exactly
+    /// this, and the model-visible metadata carries the same string.
+    pub(crate) fn message(&self) -> String {
+        match self.reason {
+            PolicyNarrowingReason::NonAuthoritativeProvenance => format!(
+                "Input provenance '{}' cannot inherit standing auto-approval authority; continuing with approvals required.",
+                self.detail
+            ),
+        }
+    }
+
+    /// Compact `from -> to` summary for doctor and debug surfaces.
+    pub(crate) fn transition(&self) -> String {
+        format!(
+            "{} ({}) -> {} ({})",
+            self.from_mode,
+            self.from_approval.permission_chip_label(),
+            self.to_mode,
+            self.to_approval.permission_chip_label(),
+        )
+    }
+}
+
 /// Effective authority for one engine turn after provenance narrowing.
 #[derive(Debug, Clone)]
 pub(crate) struct TurnAuthority {
@@ -78,10 +148,18 @@ pub(crate) struct TurnAuthority {
     pub(crate) auto_approve: bool,
     pub(crate) approval_mode: ApprovalMode,
     pub(crate) dynamic_active_tools: Vec<&'static str>,
-    pub(crate) status: Option<String>,
+    /// Structured record of any narrowing applied to this turn (#3947). The
+    /// UI status line, `<turn_meta>`, and doctor all render from here, so a
+    /// narrowing that reaches one surface reaches all of them.
+    pub(crate) narrowing: Option<PolicyNarrowingEvent>,
 }
 
 impl TurnAuthority {
+    /// The user-facing status sentence for this turn's narrowing, if any.
+    pub(crate) fn status(&self) -> Option<String> {
+        self.narrowing.as_ref().map(PolicyNarrowingEvent::message)
+    }
+
     #[must_use]
     pub(crate) fn from_effective_fields(
         mode: AppMode,
@@ -97,7 +175,7 @@ impl TurnAuthority {
             auto_approve,
             approval_mode,
             dynamic_active_tools: Vec::new(),
-            status: None,
+            narrowing: None,
         }
     }
 
@@ -156,9 +234,11 @@ pub(crate) fn effective_input_policy(
     let mut trust_mode = trust_mode;
     let mut auto_approve = auto_approve;
     let mut approval_mode = approval_mode;
-    let mut status = None;
+    let mut narrowing = None;
 
     if !provenance_can_inherit_standing_auto_authority(provenance) {
+        let from_mode = mode;
+        let from_approval = approval_mode;
         let had_auto_authority = matches!(mode, AppMode::Yolo)
             || trust_mode
             || auto_approve
@@ -172,10 +252,16 @@ pub(crate) fn effective_input_policy(
             approval_mode = ApprovalMode::Suggest;
         }
         if had_auto_authority {
-            status = Some(format!(
-                "Input provenance '{}' cannot inherit standing auto-approval authority; continuing with approvals required.",
-                provenance.as_str()
-            ));
+            // Record the transition, not just a sentence about it: the same
+            // value drives the UI status, `<turn_meta>`, and doctor (#3947).
+            narrowing = Some(PolicyNarrowingEvent {
+                reason: PolicyNarrowingReason::NonAuthoritativeProvenance,
+                from_mode: from_mode.as_setting(),
+                to_mode: mode.as_setting(),
+                from_approval,
+                to_approval: approval_mode,
+                detail: provenance.as_str().to_string(),
+            });
         }
     }
 
@@ -193,7 +279,7 @@ pub(crate) fn effective_input_policy(
         auto_approve,
         approval_mode,
         dynamic_active_tools: Vec::new(),
-        status,
+        narrowing,
     }
 }
 

--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -74,7 +74,9 @@ use crate::working_set::WorkingSet;
 
 #[cfg(test)]
 use super::authority::agent_approval_mode_for_turn;
-use super::authority::{TurnAuthority, effective_input_policy, shell_policy_for_mode};
+use super::authority::{
+    PolicyNarrowingEvent, TurnAuthority, effective_input_policy, shell_policy_for_mode,
+};
 use super::events::{Event, TurnOutcomeStatus, TurnRoute};
 use super::ops::{
     Op, ProviderRuntimeStatus, SessionSnapshot, USER_SHELL_TOOL_ID_PREFIX, UserInputProvenance,
@@ -641,6 +643,10 @@ pub struct Engine {
     slop_ledger_gate_cache: Option<(Option<SystemTime>, Option<String>)>,
     /// Current operating mode. Updated on `ChangeMode` and `SendMessage`.
     current_mode: AppMode,
+    /// The most recent authority narrowing, if any (#3947). Kept on the engine
+    /// so doctor and debug surfaces can answer "why is this tool unavailable"
+    /// with the same record the user and the model already saw.
+    last_policy_narrowing: Option<PolicyNarrowingEvent>,
     /// Process-local cache for `estimated_input_tokens`. Memoizes the most
     /// recent token estimate keyed on `(session.messages_revision,
     /// system_prompt_fingerprint)`. Five call sites per turn consult this
@@ -1172,6 +1178,7 @@ impl Engine {
             workshop_vars,
             sandbox_backend,
             current_mode: AppMode::Agent,
+            last_policy_narrowing: None,
             token_estimate_cache: TokenEstimateCache::new(),
             shared_paused: shared_paused.clone(),
         };
@@ -2503,6 +2510,7 @@ impl Engine {
         self.emit_session_updated().await;
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn turn_metadata_block(
         &self,
         routed_model: &str,
@@ -2511,6 +2519,7 @@ impl Engine {
         reasoning_effort_auto: bool,
         provenance: UserInputProvenance,
         current_text: &str,
+        policy_narrowing: Option<&PolicyNarrowingEvent>,
     ) -> ContentBlock {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
         let working_set_summary = self
@@ -2551,6 +2560,15 @@ impl Engine {
         }
         if reasoning_effort_auto && let Some(reasoning_effort) = reasoning_effort {
             lines.push(format!("Auto reasoning effort: {reasoning_effort}"));
+        }
+        // #3947: when runtime policy narrowed this turn's authority, the model
+        // learns that it happened, why, and the exact sentence the user saw —
+        // not merely the already-narrowed posture above. Emitted only on a
+        // narrowed turn, so the ordinary turn's metadata stays byte-stable.
+        if let Some(event) = policy_narrowing {
+            lines.push(format!("Authority narrowing: {}", event.reason().as_str()));
+            lines.push(format!("Authority transition: {}", event.transition()));
+            lines.push(format!("Authority narrowing status: {}", event.message()));
         }
         self.append_resource_metadata_lines(&mut lines, routed_model, current_text);
         if let Some(working_set_summary) = working_set_summary {
@@ -2668,6 +2686,7 @@ impl Engine {
             reasoning_effort_auto,
             provenance,
             &text,
+            self.last_policy_narrowing.as_ref(),
         );
         Message {
             role: "user".to_string(),
@@ -3125,7 +3144,11 @@ impl Engine {
             mode == AppMode::Yolo || auto_approve,
             approval_mode,
         );
-        if let Some(status) = input_policy.status.clone() {
+        // #3947: an effective-mode change is never silent. The structured
+        // event is recorded first (so doctor and this turn's metadata can read
+        // it), then rendered to the UI from that same value.
+        self.last_policy_narrowing = input_policy.narrowing.clone();
+        if let Some(status) = input_policy.status() {
             let _ = self.tx_event.send(Event::status(status)).await;
         }
         // Reset cancel token for fresh turn (in case previous was cancelled)

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -8084,7 +8084,12 @@ fn mode_invariant_matrix_covers_provenance_authority_narrowing() {
             case.name
         );
         assert!(policy.allow_shell, "{}", case.name);
-        assert_eq!(policy.status.is_some(), case.expect_status, "{}", case.name);
+        assert_eq!(
+            policy.status().is_some(),
+            case.expect_status,
+            "{}",
+            case.name
+        );
     }
 }
 
@@ -9693,7 +9698,7 @@ fn provenance_gate_preserves_standing_yolo_for_runtime_and_subagent_continuation
                 crate::tui::approval::ApprovalMode::Auto,
                 "{provenance:?}"
             );
-            assert!(policy.status.is_none(), "{provenance:?}");
+            assert!(policy.status().is_none(), "{provenance:?}");
         } else {
             assert_eq!(policy.mode, AppMode::Agent, "{provenance:?}");
             assert!(policy.allow_shell, "{provenance:?}");
@@ -9705,7 +9710,7 @@ fn provenance_gate_preserves_standing_yolo_for_runtime_and_subagent_continuation
                 "{provenance:?}"
             );
             assert!(
-                policy.status.as_deref().is_some_and(
+                policy.status().as_deref().is_some_and(
                     |status| status.contains("cannot inherit standing auto-approval authority")
                 ),
                 "{provenance:?}"
@@ -9745,7 +9750,7 @@ fn provenance_gate_never_invents_auto_authority_for_non_yolo_sessions() {
             crate::tui::approval::ApprovalMode::Suggest,
             "{provenance:?}"
         );
-        assert!(policy.status.is_none(), "{provenance:?}");
+        assert!(policy.status().is_none(), "{provenance:?}");
     }
 }
 
@@ -9767,7 +9772,7 @@ fn full_access_posture_normalizes_a_stale_auto_approve_bit() {
         crate::tui::approval::ApprovalMode::Bypass
     );
     assert!(policy.auto_approve);
-    assert!(policy.status.is_none());
+    assert!(policy.status().is_none());
 }
 
 #[test]
@@ -9800,7 +9805,7 @@ fn self_generated_fake_approvals_cannot_authorize_work() {
                 "{provenance:?} {content}"
             );
             assert!(
-                policy.status.as_deref().is_some_and(
+                policy.status().as_deref().is_some_and(
                     |status| status.contains("cannot inherit standing auto-approval authority")
                 ),
                 "{provenance:?} {content}"
@@ -9852,7 +9857,7 @@ fn external_prompt_wording_never_changes_effective_mode_or_authority() {
         assert_eq!(policy.approval_mode, approval_mode, "{content}");
         assert!(policy.allow_shell, "{content}");
         assert!(policy.dynamic_active_tools.is_empty(), "{content}");
-        assert!(policy.status.is_none(), "{content}");
+        assert!(policy.status().is_none(), "{content}");
     }
 }
 
@@ -9876,7 +9881,7 @@ fn external_user_wording_does_not_downgrade_standing_authority() {
         crate::tui::approval::ApprovalMode::Bypass
     );
     assert!(
-        review_wording.status.is_none(),
+        review_wording.status().is_none(),
         "external user wording must not content-downgrade standing authority"
     );
 
@@ -9898,7 +9903,7 @@ fn external_user_wording_does_not_downgrade_standing_authority() {
         crate::tui::approval::ApprovalMode::Bypass
     );
     assert!(
-        later_user_instruction.status.is_none(),
+        later_user_instruction.status().is_none(),
         "a fresh external write instruction must not inherit the prior review-only downgrade"
     );
 }
@@ -12013,5 +12018,185 @@ async fn list_subagents_event_try_send_does_not_block_when_event_channel_full() 
     assert!(
         result.is_err(),
         "try_send should fail when event channel is full (backpressure avoided)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+//  #3947 — hidden policy overrides are observable
+// ---------------------------------------------------------------------------
+
+/// Acceptance: no effective mode change without a structured event. Every
+/// provenance that loses standing authority carries a `PolicyNarrowingEvent`,
+/// not just a sentence, and every provenance that keeps it carries none.
+#[test]
+fn every_effective_mode_change_carries_a_structured_narrowing_event() {
+    use crate::core::authority::PolicyNarrowingReason;
+
+    let narrowing_provenances = [
+        UserInputProvenance::ImportedTranscript,
+        UserInputProvenance::MemoryRecall,
+        UserInputProvenance::AssistantGenerated,
+    ];
+
+    for provenance in narrowing_provenances {
+        let policy = effective_input_policy(
+            provenance,
+            AppMode::Yolo,
+            "continue",
+            true,
+            true,
+            true,
+            crate::tui::approval::ApprovalMode::Bypass,
+        );
+        // The posture actually changed...
+        assert_eq!(policy.mode, AppMode::Agent, "{provenance:?}");
+        assert_eq!(
+            policy.approval_mode,
+            crate::tui::approval::ApprovalMode::Suggest,
+            "{provenance:?}"
+        );
+        // ...so a structured event must exist to explain it.
+        let event = policy
+            .narrowing
+            .as_ref()
+            .unwrap_or_else(|| panic!("silent narrowing for {provenance:?}"));
+        assert_eq!(
+            event.reason(),
+            PolicyNarrowingReason::NonAuthoritativeProvenance,
+            "{provenance:?}"
+        );
+        assert_eq!(event.reason().as_str(), "non_authoritative_provenance");
+        // The transition names both ends, so a reader can see what was lost.
+        // Mode deliberately reads as the permission vocabulary (`AppMode::
+        // as_setting` writes "agent" for the legacy Yolo label), so the
+        // posture is what carries the change here.
+        let transition = event.transition();
+        assert_eq!(
+            transition, "agent (Full Access) -> agent (Ask)",
+            "{provenance:?}"
+        );
+    }
+
+    // An authoritative turn narrows nothing and therefore reports nothing.
+    let unchanged = effective_input_policy(
+        UserInputProvenance::ExternalUser,
+        AppMode::Yolo,
+        "continue",
+        true,
+        true,
+        true,
+        crate::tui::approval::ApprovalMode::Bypass,
+    );
+    assert!(unchanged.narrowing.is_none());
+    assert!(unchanged.status().is_none());
+}
+
+/// Acceptance: the UI-visible status and the model-visible metadata agree.
+/// Both are rendered from the same event, so this asserts the shared string
+/// rather than two independently maintained wordings.
+#[test]
+fn ui_status_and_model_metadata_render_the_same_narrowing_sentence() {
+    let policy = effective_input_policy(
+        UserInputProvenance::AssistantGenerated,
+        AppMode::Yolo,
+        "continue",
+        true,
+        true,
+        true,
+        crate::tui::approval::ApprovalMode::Bypass,
+    );
+    let event = policy.narrowing.as_ref().expect("narrowed");
+    let ui_status = policy.status().expect("status for a narrowed turn");
+    assert_eq!(ui_status, event.message());
+    assert!(
+        ui_status.contains("assistant_generated"),
+        "the sentence must name the provenance that caused it: {ui_status}"
+    );
+    assert!(
+        ui_status.contains("continuing with approvals required"),
+        "the sentence must say what the user should now expect: {ui_status}"
+    );
+}
+
+/// Acceptance: a narrowing that does not change the effective posture is not
+/// reported. A turn that never had standing authority to lose is not a hidden
+/// override, and reporting one would train users to ignore the status.
+#[test]
+fn narrowing_is_not_reported_when_there_was_no_authority_to_lose() {
+    let policy = effective_input_policy(
+        UserInputProvenance::MemoryRecall,
+        AppMode::Agent,
+        "continue",
+        true,
+        false,
+        false,
+        crate::tui::approval::ApprovalMode::Suggest,
+    );
+    assert_eq!(policy.mode, AppMode::Agent);
+    assert!(policy.narrowing.is_none());
+    assert!(policy.status().is_none());
+}
+
+/// Acceptance: the narrowing reaches the model, not just the status line. A
+/// narrowed turn's `<turn_meta>` names the reason, the transition, and the
+/// exact sentence the user saw; an ordinary turn's metadata is untouched, so
+/// the common path keeps its byte-stable prefix.
+#[test]
+fn turn_metadata_carries_the_narrowing_only_on_a_narrowed_turn() {
+    let tmp = tempdir().expect("tempdir");
+    let config = EngineConfig {
+        workspace: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let (mut engine, _handle) = Engine::new(config, &Config::default());
+
+    let clean = engine.runtime_text_message_with_turn_metadata(
+        "continue".to_string(),
+        UserInputProvenance::ExternalUser,
+    );
+    let ContentBlock::Text {
+        text: clean_text, ..
+    } = clean.content.last().expect("turn metadata block")
+    else {
+        panic!("expected text metadata block");
+    };
+    assert!(
+        !clean_text.contains("Authority narrowing"),
+        "an un-narrowed turn must not carry narrowing metadata: {clean_text}"
+    );
+
+    let policy = effective_input_policy(
+        UserInputProvenance::AssistantGenerated,
+        AppMode::Yolo,
+        "continue",
+        true,
+        true,
+        true,
+        crate::tui::approval::ApprovalMode::Bypass,
+    );
+    let event = policy.narrowing.clone().expect("narrowed");
+    engine.last_policy_narrowing = Some(event.clone());
+
+    let narrowed = engine.runtime_text_message_with_turn_metadata(
+        "continue".to_string(),
+        UserInputProvenance::AssistantGenerated,
+    );
+    let ContentBlock::Text { text, .. } = narrowed.content.last().expect("turn metadata block")
+    else {
+        panic!("expected text metadata block");
+    };
+
+    assert!(
+        text.contains("Authority narrowing: non_authoritative_provenance"),
+        "{text}"
+    );
+    assert!(
+        text.contains(&format!("Authority transition: {}", event.transition())),
+        "{text}"
+    );
+    // The model reads the same sentence the user read.
+    assert!(
+        text.contains(&format!("Authority narrowing status: {}", event.message())),
+        "{text}"
     );
 }


### PR DESCRIPTION
Closes #3947.

## The gap

When runtime policy narrowed a turn's authority, the only trace was a free-text status line sent to the UI:

```rust
if let Some(status) = input_policy.status.clone() {
    let _ = self.tx_event.send(Event::status(status)).await;
}
```

The model saw the already-narrowed posture in `<turn_meta>` but never learned that narrowing had *happened*, or why. So the exact confusing state the issue describes was possible — the UI telling one story while the model receives another mode's runtime metadata — and "why is this tool unavailable" had no answer on any surface.

## What changed

`PolicyNarrowingEvent` in `core/authority.rs`: a typed `reason` enum (one variant per narrowing site), the from/to mode and permission posture, and the causing detail. `effective_input_policy` returns the event rather than a sentence, and `TurnAuthority::status()` renders the sentence *from* it.

That inversion is the point: the UI status line and the model-visible metadata cannot drift, because they are the same value.

A narrowed turn's `<turn_meta>` now carries three lines:

```
Authority narrowing: non_authoritative_provenance
Authority transition: agent (Full Access) -> agent (Ask)
Authority narrowing status: Input provenance 'assistant_generated' cannot inherit standing auto-approval authority; continuing with approvals required.
```

An un-narrowed turn's metadata is byte-for-byte unchanged, so the common path keeps its stable prefix (#4780).

**"No silent effective mode change" becomes structural.** Adding a narrowing site means adding an enum variant; there is no path that changes the effective posture without producing an event.

## Scope note

The issue lists `doctor`/debug among the surfaces. The CLI `doctor` runs out-of-process against settings and config — it cannot observe a live turn's narrowing, and wiring a stale value there would be worse than nothing. The live debug surface is the context inspector, which already renders `<turn_meta>`; the engine also retains `last_policy_narrowing` so an in-session surface can read it without re-deriving.

## Receipts (macOS)

- `core::engine` — 360 passed / 0 failed, including four new tests:
  - `every_effective_mode_change_carries_a_structured_narrowing_event` — every narrowing provenance produces an event; an authoritative turn produces none.
  - `ui_status_and_model_metadata_render_the_same_narrowing_sentence` — asserts the shared string, not two wordings.
  - `narrowing_is_not_reported_when_there_was_no_authority_to_lose` — a turn with nothing to lose is not a hidden override.
  - `turn_metadata_carries_the_narrowing_only_on_a_narrowed_turn` — model-visible proof plus the byte-stability guard.
- `cargo clippy --workspace --all-features --locked -- -D warnings` reports no findings in the changed files; the five pre-existing `origin/main` failures are fixed separately in #4898.
- `cargo fmt --all -- --check` and `git diff --check` clean.