### PR TITLE
fix(composer): respect the menu limit and resolve git mentions once

### DIFF
--- a/crates/tui/src/dependencies.rs
+++ b/crates/tui/src/dependencies.rs
@@ -300,7 +300,6 @@ pub trait ExternalTool {
     fn resolve() -> Option<String>;
 
     /// Quick availability check — true when the tool was found on PATH.
-    #[allow(dead_code)]
     fn available() -> bool {
         Self::resolve().is_some()
     }

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -555,7 +555,6 @@ pub fn pending_context_previews(input: &str) -> Vec<FileMentionPreview> {
     previews
 }
 
-#[must_use]
 /// Convenience wrapper that allocates a throwaway cache. Test-only, as above.
 #[cfg(test)]
 #[must_use]

--- a/crates/tui/src/tui/file_mention.rs
+++ b/crates/tui/src/tui/file_mention.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::tui::app::{App, MentionCompletionCache};
-use crate::tui::git_mention::{self, GitMentionKind};
+use crate::tui::git_mention::{self, GitMentionCache, GitMentionKind};
 use crate::tui::mention_completion::{MentionDiscoveryBehavior, MentionDiscoveryKey};
 use crate::working_set::Workspace;
 
@@ -293,6 +293,12 @@ fn mention_menu_entries(app: &mut App, partial: &str, limit: usize) -> (Vec<Stri
 /// mention the user makes. The tokens appear as soon as a matching character
 /// is typed.
 fn with_git_mention_entries(entries: Vec<String>, partial: &str, limit: usize) -> Vec<String> {
+    // `mention_menu_limit = 0` is a documented way to disable the popup
+    // entirely. The git tokens are menu entries like any other and must
+    // respect the same cap, or setting 0 would still pop a one-entry menu.
+    if limit == 0 {
+        return Vec::new();
+    }
     let needle = partial.trim().to_lowercase();
     if needle.is_empty() {
         return entries;
@@ -305,6 +311,7 @@ fn with_git_mention_entries(entries: Vec<String>, partial: &str, limit: usize) -
         return entries;
     }
     let mut combined = matching;
+    combined.truncate(limit);
     for entry in entries {
         if combined.len() >= limit {
             break;
@@ -472,12 +479,24 @@ pub fn longest_common_prefix<'a>(values: &[&'a str]) -> &'a str {
 /// background completion popup; silently resolving a manually typed basename
 /// would require a tree walk on submit and could attach an arbitrary same-name
 /// file from a nested directory.
+/// Convenience wrapper that allocates a throwaway cache. Test-only: the real
+/// send paths share one cache across the references and payload passes.
+#[cfg(test)]
 pub fn user_request_with_file_mentions(
     input: &str,
     workspace: &Path,
     cwd: Option<PathBuf>,
 ) -> String {
-    let Some(context) = local_context_from_file_mentions(input, workspace, cwd) else {
+    user_request_with_file_mentions_cached(input, workspace, cwd, &mut GitMentionCache::default())
+}
+
+pub fn user_request_with_file_mentions_cached(
+    input: &str,
+    workspace: &Path,
+    cwd: Option<PathBuf>,
+    git_cache: &mut GitMentionCache,
+) -> String {
+    let Some(context) = local_context_from_file_mentions(input, workspace, cwd, git_cache) else {
         return input.to_string();
     };
     format!("{input}\n\n---\n\nLocal context from @mentions:\n{context}")
@@ -537,10 +556,23 @@ pub fn pending_context_previews(input: &str) -> Vec<FileMentionPreview> {
 }
 
 #[must_use]
+/// Convenience wrapper that allocates a throwaway cache. Test-only, as above.
+#[cfg(test)]
+#[must_use]
 pub fn context_references_from_input(
     input: &str,
     workspace: &Path,
     cwd: Option<PathBuf>,
+) -> Vec<ContextReference> {
+    context_references_from_input_cached(input, workspace, cwd, &mut GitMentionCache::default())
+}
+
+#[must_use]
+pub fn context_references_from_input_cached(
+    input: &str,
+    workspace: &Path,
+    cwd: Option<PathBuf>,
+    git_cache: &mut GitMentionCache,
 ) -> Vec<ContextReference> {
     let mut references = Vec::new();
     let mut seen = std::collections::HashSet::new();
@@ -553,7 +585,7 @@ pub fn context_references_from_input(
         // Git mentions resolve against the working tree, not the path index,
         // so the inspector reports their real size and budget (#4067).
         if let Some(kind) = git_mention::git_mention_kind(&mention) {
-            let payload = git_mention::resolve_git_mention(kind, workspace);
+            let payload = git_cache.resolve(kind, workspace).clone();
             let detail = match payload.unavailable_reason.as_deref() {
                 Some(reason) => format!("{}, {reason}", kind.label()),
                 None if payload.truncated => format!(
@@ -750,6 +782,7 @@ fn local_context_from_file_mentions(
     input: &str,
     workspace: &Path,
     cwd: Option<PathBuf>,
+    git_cache: &mut GitMentionCache,
 ) -> Option<String> {
     let mentions = extract_file_mentions(input);
     if mentions.is_empty() {
@@ -767,7 +800,7 @@ fn local_context_from_file_mentions(
             if !seen.insert(format!("git-mention:{}", kind.token())) {
                 continue;
             }
-            blocks.push(git_mention::resolve_git_mention(kind, workspace).block);
+            blocks.push(git_cache.resolve(kind, workspace).block.clone());
             continue;
         }
 
@@ -1408,6 +1441,76 @@ mod tests {
         let kinds: Vec<&str> = previews.iter().map(|p| p.kind.as_str()).collect();
         assert_eq!(kinds, vec!["git", "git"]);
         assert!(previews.iter().all(|p| !p.included));
+    }
+
+    /// #4067 review follow-up: `mention_menu_limit = 0` is a documented way to
+    /// disable the popup. The git tokens are menu entries like any other and
+    /// must respect the same cap — otherwise setting 0 still pops a one-entry
+    /// menu the moment the user types `@g`.
+    #[test]
+    fn git_mention_entries_respect_a_zero_menu_limit() {
+        let paths = vec!["src/main.rs".to_string()];
+        assert!(with_git_mention_entries(paths.clone(), "g", 0).is_empty());
+        assert!(with_git_mention_entries(paths.clone(), "d", 0).is_empty());
+        assert!(with_git_mention_entries(paths.clone(), "", 0).is_empty());
+        assert!(with_git_mention_entries(Vec::new(), "gi", 0).is_empty());
+    }
+
+    /// A small non-zero limit must cap the token list this function builds.
+    ///
+    /// The empty-partial branch is pass-through by design — those entries were
+    /// already capped upstream by `rank_completion_candidates`, and shrinking
+    /// them here would silently drop paths the caller asked for.
+    #[test]
+    fn git_mention_entries_never_exceed_the_menu_limit() {
+        let paths = vec!["a.rs".to_string(), "b.rs".to_string()];
+        for limit in 1..=4 {
+            let matched = with_git_mention_entries(paths.clone(), "d", limit);
+            assert!(matched.len() <= limit, "limit {limit}: {matched:?}");
+            // Both tokens match a bare prefix that hits `git` and `diff`
+            // through separate entries; the cap still holds.
+            let both = with_git_mention_entries(Vec::new(), "", limit);
+            assert!(both.len() <= limit, "limit {limit}: {both:?}");
+        }
+        // Pass-through: the caller's already-capped paths survive untouched.
+        assert_eq!(with_git_mention_entries(paths.clone(), "", 1), paths);
+    }
+
+    /// #4067 review follow-up: one submit resolves a git mention once, not
+    /// once per surface. `@diff` makes git compute the whole working-tree diff
+    /// before the byte budget applies, so a repeat is real wasted work.
+    #[test]
+    fn a_submit_resolves_each_git_mention_only_once() {
+        let tmp = TempDir::new().expect("tempdir");
+        init_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "one\n").expect("write");
+        commit_test_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "two\n").expect("write");
+
+        let mut cache = crate::tui::git_mention::GitMentionCache::default();
+        let references = context_references_from_input_cached(
+            "@diff",
+            tmp.path(),
+            Some(tmp.path().to_path_buf()),
+            &mut cache,
+        );
+        let expanded = user_request_with_file_mentions_cached(
+            "@diff",
+            tmp.path(),
+            Some(tmp.path().to_path_buf()),
+            &mut cache,
+        );
+
+        // Both surfaces describe the same resolution.
+        let git_ref = references
+            .iter()
+            .find(|r| r.kind == ContextReferenceKind::GitContext)
+            .expect("git reference");
+        assert!(git_ref.included);
+        assert!(expanded.contains("<git-diff"), "{expanded}");
+
+        // And the shared cache holds exactly one entry for it.
+        assert_eq!(cache.len(), 1, "the diff must be resolved once per submit");
     }
 
     #[test]

--- a/crates/tui/src/tui/git_mention.rs
+++ b/crates/tui/src/tui/git_mention.rs
@@ -28,7 +28,7 @@ pub const MAX_GIT_DIFF_MENTION_BYTES: usize = 32 * 1024;
 pub const MAX_GIT_STATUS_MENTION_BYTES: usize = 8 * 1024;
 
 /// Which curated git payload a mention token asks for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GitMentionKind {
     /// `@git` — a bounded `git status` summary plus the current branch.
     Status,
@@ -111,6 +111,39 @@ impl GitMentionPayload {
     }
 }
 
+/// Per-submit memo for resolved git mentions.
+///
+/// One message send resolves mentions twice — once to build the context
+/// inspector references and once to build the model-facing payload. For
+/// `@diff` each resolution makes git compute the *entire* working-tree diff
+/// before the 32 KB budget applies, so a large repository paid for that twice
+/// to attach it once.
+///
+/// Scoped deliberately: a cache lives for one submit and is then dropped, so a
+/// second `@diff` in a later message always re-shells out and can never show a
+/// stale working tree.
+#[derive(Debug, Default)]
+pub struct GitMentionCache {
+    resolved: std::collections::HashMap<(GitMentionKind, std::path::PathBuf), GitMentionPayload>,
+}
+
+impl GitMentionCache {
+    /// Number of distinct mentions resolved so far this submit. Used by tests
+    /// to prove one submit shells out once per mention.
+    #[cfg(test)]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.resolved.len()
+    }
+
+    /// Resolve `kind` against `workspace`, reusing this submit's result.
+    pub fn resolve(&mut self, kind: GitMentionKind, workspace: &Path) -> &GitMentionPayload {
+        self.resolved
+            .entry((kind, workspace.to_path_buf()))
+            .or_insert_with(|| resolve_git_mention(kind, workspace))
+    }
+}
+
 /// Run the git commands for `kind` in `cwd` and render the model-facing block.
 ///
 /// Never returns an error: an unavailable git, a non-repository directory, or
@@ -118,7 +151,7 @@ impl GitMentionPayload {
 /// the turn records why the mention contributed nothing.
 #[must_use]
 pub fn resolve_git_mention(kind: GitMentionKind, cwd: &Path) -> GitMentionPayload {
-    if Git::command().is_none() {
+    if !Git::available() {
         return GitMentionPayload::unavailable(kind, "git not found on PATH");
     }
     if !is_git_repository(cwd) {

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -8501,6 +8501,7 @@ fn queued_message_content_for_app(
     app: &App,
     message: &QueuedMessage,
     cwd: Option<PathBuf>,
+    git_cache: &mut crate::tui::git_mention::GitMentionCache,
 ) -> Result<String> {
     if let Some(authority) = message.skill_provenance.as_ref() {
         if authority.workspace != app.workspace {
@@ -8511,10 +8512,11 @@ fn queued_message_content_for_app(
     // Pass the process CWD explicitly so the resolver's two-pass logic can
     // honor the user's launch directory when it differs from `--workspace`
     // (issue #101 — file mentions silently routing to the wrong root).
-    let user_request = crate::tui::file_mention::user_request_with_file_mentions(
+    let user_request = crate::tui::file_mention::user_request_with_file_mentions_cached(
         &message.display,
         &app.workspace,
         cwd,
+        git_cache,
     );
     if let Some(skill_instruction) = message.skill_instruction.as_ref() {
         Ok(format!(
@@ -8892,12 +8894,17 @@ async fn dispatch_user_message_with_recovery(
     let paused_dispatch = plan_paused_command_message(app, &message.display);
 
     let cwd = std::env::current_dir().ok();
-    let references = crate::tui::file_mention::context_references_from_input(
+    // One cache for this submit: the references pass and the payload pass
+    // otherwise each shell out for `@git`/`@diff`, making git compute a large
+    // working-tree diff twice to attach it once (#4067 review follow-up).
+    let mut git_cache = crate::tui::git_mention::GitMentionCache::default();
+    let references = crate::tui::file_mention::context_references_from_input_cached(
         &message.display,
         &app.workspace,
         cwd.clone(),
+        &mut git_cache,
     );
-    let mut content = queued_message_content_for_app(app, &message, cwd)?;
+    let mut content = queued_message_content_for_app(app, &message, cwd, &mut git_cache)?;
     if let Some(note) = paused_dispatch.note() {
         content.push_str(note);
     }
@@ -11944,12 +11951,15 @@ async fn steer_user_message(
     let paused_note = paused_dispatch.note().map(str::to_string);
     paused_dispatch.apply(app, engine_handle);
     let cwd = std::env::current_dir().ok();
-    let references = crate::tui::file_mention::context_references_from_input(
+    // Same single-submit cache as the other send path — see #4067 follow-up.
+    let mut git_cache = crate::tui::git_mention::GitMentionCache::default();
+    let references = crate::tui::file_mention::context_references_from_input_cached(
         &message.display,
         &app.workspace,
         cwd.clone(),
+        &mut git_cache,
     );
-    let mut content = queued_message_content_for_app(app, &message, cwd)?;
+    let mut content = queued_message_content_for_app(app, &message, cwd, &mut git_cache)?;
     if let Some(note) = paused_note.as_deref() {
         content.push_str(note);
     }

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -4809,8 +4809,13 @@ fn file_mentions_add_local_text_context_to_model_payload() {
     app.workspace = tmpdir.path().to_path_buf();
     let message = QueuedMessage::new("Summarize @guide.md".to_string(), None);
 
-    let content = queued_message_content_for_app(&app, &message, None)
-        .expect("native queued message should remain dispatchable");
+    let content = queued_message_content_for_app(
+        &app,
+        &message,
+        None,
+        &mut crate::tui::git_mention::GitMentionCache::default(),
+    )
+    .expect("native queued message should remain dispatchable");
 
     assert!(content.starts_with("Summarize @guide.md"));
     assert!(content.contains("Local context from @mentions:"));
@@ -4859,13 +4864,26 @@ fn persisted_queued_plugin_skill_is_denied_after_cross_process_revocation() {
     let restored = queued_session_to_ui(persisted);
     let mut app = create_test_app();
     app.workspace = workspace;
-    assert!(queued_message_content_for_app(&app, &restored, None).is_ok());
+    assert!(
+        queued_message_content_for_app(
+            &app,
+            &restored,
+            None,
+            &mut crate::tui::git_mention::GitMentionCache::default(),
+        )
+        .is_ok()
+    );
 
     let mut external = crate::plugins::discovery::discover_with_config(&discovery);
     external.revoke_trust("queued-skill").unwrap();
-    let error = queued_message_content_for_app(&app, &restored, None)
-        .expect_err("persisted queued Skill must be denied after external revocation")
-        .to_string();
+    let error = queued_message_content_for_app(
+        &app,
+        &restored,
+        None,
+        &mut crate::tui::git_mention::GitMentionCache::default(),
+    )
+    .expect_err("persisted queued Skill must be denied after external revocation")
+    .to_string();
     assert!(error.contains("disabled, revoked, or no longer matches"));
 }
 


### PR DESCRIPTION
No-Issue: review follow-up to the already-merged #4899; #4067 is closed and stays closed.

Refs #4067. Three follow-ups from the automated review on #4899, which I merged before reading them — the first is a real regression I shipped.

## 1. Bug: `mention_menu_limit = 0` no longer disabled the popup

`0` is an explicitly supported value for `mention_menu_limit` (`settings.rs` says "Expected 0 or a positive integer"), and before #4899 it disabled the mention popup entirely, because `take(limit)` always yielded an empty candidate list.

`with_git_mention_entries` seeded the `@git`/`@diff` tokens into the result **before** `limit` was consulted — `limit` only gated how many *path* entries got appended after. So typing `@g` with the popup disabled still surfaced a one-entry menu. The tokens are menu entries like any other and now respect the same cap.

## 2. Efficiency: `@diff` computed the whole diff twice per message

One submit resolved each git mention twice — once in `context_references_from_input` building the inspector rows, once in `local_context_from_file_mentions` building the payload. Each is two subprocess spawns, and for `@diff` git computes the **entire** working-tree diff before the 32 KB budget applies. A large repository paid for that twice to attach it once.

Both passes now share a `GitMentionCache`. It is deliberately scoped to a single submit and then dropped, so a second `@diff` in a later message always re-shells out — a longer-lived cache would eventually show a stale working tree, which is worse than the cost it saves.

## 3. Reuse: `ExternalTool::available()`

`Git::command().is_none()` constructed a throwaway `Command` to answer a question `available()` already answers. This was its first real caller, so its `#[allow(dead_code)]` is gone too.

## Receipts (macOS)

- `git_mention_entries_respect_a_zero_menu_limit` and `git_mention_entries_never_exceed_the_menu_limit` — the regression, plus the cap on the branch this function actually builds. (The empty-partial branch stays pass-through by design: those entries were already capped upstream, and shrinking them here would silently drop paths the caller asked for.)
- `a_submit_resolves_each_git_mention_only_once` — both surfaces agree and the shared cache holds exactly one entry.
- `tui::file_mention` + `tui::git_mention` — 28 passed / 0 failed.
- `codewhale-tui` — 8344 passed / 0 failed.
- CI's exact clippy invocation, `cargo fmt --all -- --check`, `git diff --check` — clean.