### PR TITLE
fix(tui): stop writing terminal control bytes to non-terminals

### DIFF
--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -286,12 +286,41 @@ pub fn notify_done(
 ///
 /// Other terminals (iTerm2, WezTerm) ignore the sequence silently.
 /// Best-effort — write failures are ignored.
+/// Build the OSC 9;4 taskbar-progress sequence. Split from the write so the
+/// bytes can be asserted without depending on whether the test runner owns a
+/// terminal.
+#[must_use]
+fn taskbar_progress_sequence(state: u8, progress: Option<u8>) -> String {
+    match progress {
+        Some(pct) => format!("\x1b]9;4;{state};{pct}\x07"),
+        None => format!("\x1b]9;4;{state}\x07"),
+    }
+}
+
+/// Build the OSC 0 window-title sequence. Split from the write for the same
+/// reason as [`taskbar_progress_sequence`].
+#[must_use]
+fn terminal_title_sequence(title: &str) -> String {
+    format!("\x1b]0;{title}\x07")
+}
+
+/// Whether raw terminal control sequences may be written to stdout.
+///
+/// OSC 9;4 (taskbar progress) and OSC 0 (window title) are *control* bytes,
+/// not content. A terminal that understands them renders nothing visible; a
+/// pipe, a file, or a CI log renders them literally, so `cargo test` output
+/// and redirected sessions pick up stray `]9;4;1]0;` noise. Gate on stdout
+/// actually being a TTY — there is no one to control otherwise.
+fn stdout_accepts_control_sequences() -> bool {
+    use std::io::IsTerminal;
+    io::stdout().is_terminal()
+}
+
 pub fn set_taskbar_progress(state: u8, progress: Option<u8>) {
-    let seq = if let Some(pct) = progress {
-        format!("\x1b]9;4;{state};{pct}\x07")
-    } else {
-        format!("\x1b]9;4;{state}\x07")
-    };
+    if !stdout_accepts_control_sequences() {
+        return;
+    }
+    let seq = taskbar_progress_sequence(state, progress);
     let mut stdout = io::stdout();
     let _ = stdout.write_all(seq.as_bytes());
     let _ = stdout.flush();
@@ -391,7 +420,10 @@ fn title_activity_label(base: &str, elapsed: Duration, focused: bool, motion: bo
 
 /// Write OSC 0 (set window title) sequence.
 fn set_terminal_title(title: &str) {
-    let seq = format!("\x1b]0;{title}\x07");
+    if !stdout_accepts_control_sequences() {
+        return;
+    }
+    let seq = terminal_title_sequence(title);
     let mut stdout = io::stdout();
     let _ = stdout.write_all(seq.as_bytes());
     let _ = stdout.flush();
@@ -979,6 +1011,23 @@ mod tests {
     fn off_mode_emits_nothing() {
         let out = capture(Method::Off, false, "ignored", 0, 9999);
         assert!(out.is_empty());
+    }
+
+    /// #4847 follow-up: OSC 9;4 and OSC 0 are *control* bytes, not content.
+    /// A terminal renders nothing visible; a pipe, a file, or a CI log renders
+    /// them literally — which is why `cargo test` output carried stray
+    /// `]9;4;1]0;` noise. The write is now gated on stdout being a TTY; these
+    /// assertions pin the bytes themselves so the gate cannot be "fixed" by
+    /// quietly changing what gets emitted.
+    #[test]
+    fn control_sequences_have_the_exact_documented_bytes() {
+        assert_eq!(taskbar_progress_sequence(1, None), "\x1b]9;4;1\x07");
+        assert_eq!(taskbar_progress_sequence(1, Some(42)), "\x1b]9;4;1;42\x07");
+        assert_eq!(taskbar_progress_sequence(0, None), "\x1b]9;4;0\x07");
+        assert_eq!(
+            terminal_title_sequence("🐳 working…"),
+            "\x1b]0;🐳 working…\x07"
+        );
     }
 
     #[test]


### PR DESCRIPTION
No-Issue: partial fix toward #4847 — the leaked control bytes; the .app bundle attribution stays open.

Refs #4847.

## What I could reproduce

OSC 9;4 (taskbar progress) and OSC 0 (window title) were written to stdout **unconditionally**. A terminal that understands them renders nothing visible — but a pipe, a file, or a CI log renders them literally. It was polluting our own test output on every run:

```
]9;4;1]0;🐳 working…test core::engine::tests::yolo_mode_does_not_prompt_for_background_shell ... ok
```

Both writes are now gated on stdout actually being a TTY; there is nothing to control otherwise. Sequence construction is split from the write so the exact bytes stay asserted without the test depending on whether the runner owns a terminal.

## What this does *not* fix

The missing app icon is a different cause and is still open as #4847: `display notification` runs through `/usr/bin/osascript`, which is unbundled, so macOS attributes the banner to Script Editor and shows *its* icon. No amount of AppleScript changes that — it needs a real signed `.app` bundle to post on Codewhale's behalf. I did not attempt that here.

## Receipts (macOS)

- `control_sequences_have_the_exact_documented_bytes` — pins OSC 9;4 with and without a percentage, and OSC 0 including a multibyte title, so the gate cannot be "fixed" by quietly changing what is emitted.
- `tui::notifications` — 23 passed / 0 failed.
- `codewhale-tui` — 8345 passed / 0 failed.
- Piped test output now contains **zero** OSC 9;4 sequences.
- CI's exact clippy invocation, `cargo fmt --all -- --check`, `git diff --check` — clean.