### PR TITLE
fix(fetch_url): 修复非 UTF-8 网页解码

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "cucumber",
  "dirs",
  "dotenvy",
+ "encoding_rs",
  "fd-lock",
  "flate2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ chrono = { version = "0.4.43", features = ["serde"] }
 clap = { version = "4.5.54", features = ["derive"] }
 clap_complete = "4.5"
 dirs = "6.0.0"
+encoding_rs = "0.8.35"
 jsonschema = { version = "0.48", default-features = false }
 reqwest = { version = "0.13.1", default-features = false, features = ["json", "rustls-no-provider", "socks"] }
 # NOT "parallel": the Workflow VM stays single-threaded and bridges to the

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -43,6 +43,7 @@ clap_complete.workspace = true
 colored = "3.0.0"
 crossterm = "0.29"
 dotenvy = "0.15.7"
+encoding_rs.workspace = true
 fd-lock = "4.0.4"
 dirs.workspace = true
 futures-util = "0.3.31"

--- a/crates/tui/src/tools/fetch_url.rs
+++ b/crates/tui/src/tools/fetch_url.rs
@@ -11,7 +11,9 @@ use super::handle::query_jsonpath;
 use super::spec::{
     ApprovalRequirement, ToolCapability, ToolContext, ToolError, ToolResult, ToolSpec, optional_u64,
 };
-use super::web::extract::{DocumentKind, ExtractedDocument, extract_document};
+use super::web::extract::{
+    DocumentKind, ExtractedDocument, decode_response_body, extract_document,
+};
 use super::web::fetch::{
     DEFAULT_MAX_BYTES, DEFAULT_TIMEOUT, FetchOptions, HARD_MAX_BYTES, HARD_MAX_TIMEOUT, fetch,
 };
@@ -172,8 +174,14 @@ impl ToolSpec for FetchUrlTool {
         )
         .await?;
         let is_success = (200..300).contains(&fetched.status);
-        let mut body_text = (!requested_fields.is_empty())
-            .then(|| String::from_utf8_lossy(&fetched.bytes).into_owned());
+        let body_text = if requested_fields.is_empty() {
+            None
+        } else {
+            Some(decode_response_body(
+                &fetched.bytes,
+                Some(&fetched.content_type),
+            ))
+        };
         let fields = match body_text.as_deref() {
             Some(body) => project_json_fields(body, &fetched.content_type, &requested_fields)?,
             None => None,
@@ -184,9 +192,10 @@ impl ToolSpec for FetchUrlTool {
                 Err(_error)
                     if format == Format::Raw && is_declared_textual(&fetched.content_type) =>
                 {
-                    let body_text = body_text
-                        .get_or_insert_with(|| String::from_utf8_lossy(&fetched.bytes).into_owned())
-                        .clone();
+                    let body_text = match body_text.as_ref() {
+                        Some(body_text) => body_text.clone(),
+                        None => decode_response_body(&fetched.bytes, Some(&fetched.content_type)),
+                    };
                     ExtractedDocument {
                         kind: DocumentKind::Text,
                         title: None,
@@ -198,9 +207,10 @@ impl ToolSpec for FetchUrlTool {
                     }
                 }
                 Err(_error) if !is_success => {
-                    let body_text = body_text
-                        .get_or_insert_with(|| String::from_utf8_lossy(&fetched.bytes).into_owned())
-                        .clone();
+                    let body_text = match body_text.as_ref() {
+                        Some(body_text) => body_text.clone(),
+                        None => decode_response_body(&fetched.bytes, Some(&fetched.content_type)),
+                    };
                     ExtractedDocument {
                         kind: DocumentKind::Text,
                         title: None,
@@ -327,7 +337,7 @@ fn render_extracted(
     }
 
     let content = match format {
-        Format::Raw => String::from_utf8_lossy(bytes).into_owned(),
+        Format::Raw => decode_response_body(bytes, Some(content_type)),
         Format::Text => document.text,
         Format::Markdown => document.markdown,
     };

--- a/crates/tui/src/tools/web/extract.rs
+++ b/crates/tui/src/tools/web/extract.rs
@@ -9,6 +9,7 @@ use std::sync::OnceLock;
 #[cfg(feature = "pdf")]
 use std::fmt::Display;
 
+use encoding_rs::Encoding;
 use regex::Regex;
 
 use crate::tools::spec::ToolError;
@@ -54,6 +55,8 @@ static FALLBACK_RE: OnceLock<Vec<Regex>> = OnceLock::new();
 static PAGE_CHROME_RE: OnceLock<Regex> = OnceLock::new();
 static TAG_RE: OnceLock<Regex> = OnceLock::new();
 static WHITESPACE_RE: OnceLock<Regex> = OnceLock::new();
+static CHARSET_RE: OnceLock<Regex> = OnceLock::new();
+static META_CHARSET_RE: OnceLock<Regex> = OnceLock::new();
 
 pub(crate) fn extract_document(
     url: &str,
@@ -117,7 +120,7 @@ pub(crate) fn extract_document(
         )));
     }
 
-    let body = decode_text(bytes)?;
+    let body = decode_text(bytes, content_type)?;
     if is_html(declared, url, &body) {
         return extract_html(url, &body);
     }
@@ -289,13 +292,50 @@ fn js_required_error(url: &str) -> ToolError {
     ))
 }
 
-fn decode_text(bytes: &[u8]) -> Result<String, ToolError> {
+fn decode_text(bytes: &[u8], content_type: Option<&str>) -> Result<String, ToolError> {
     if bytes.iter().take(8_192).any(|byte| *byte == 0) {
         return Err(ToolError::execution_failed(
             "Unsupported binary response contained NUL bytes",
         ));
     }
-    Ok(String::from_utf8_lossy(bytes).into_owned())
+    Ok(decode_response_body(bytes, content_type))
+}
+
+pub(crate) fn decode_response_body(bytes: &[u8], content_type: Option<&str>) -> String {
+    let declared_encoding = content_type
+        .and_then(charset_label)
+        .or_else(|| html_meta_charset_label(bytes));
+    if let Some(encoding) =
+        declared_encoding.and_then(|label| Encoding::for_label(label.as_bytes()))
+    {
+        let (decoded, _, _) = encoding.decode(bytes);
+        return decoded.into_owned();
+    }
+
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn charset_label(value: &str) -> Option<String> {
+    CHARSET_RE
+        .get_or_init(|| {
+            Regex::new(r#"(?i)\bcharset\s*=\s*["']?\s*([a-z0-9._-]+)"#).expect("charset regex")
+        })
+        .captures(value)
+        .and_then(|captures| captures.get(1))
+        .map(|label| label.as_str().to_ascii_lowercase())
+}
+
+fn html_meta_charset_label(bytes: &[u8]) -> Option<String> {
+    let sniff_len = bytes.len().min(8 * 1024);
+    let prefix = String::from_utf8_lossy(&bytes[..sniff_len]);
+    META_CHARSET_RE
+        .get_or_init(|| {
+            Regex::new(r#"(?is)<meta\b[^>]*\bcharset\s*=\s*["']?\s*([a-z0-9._-]+)"#)
+                .expect("meta charset regex")
+        })
+        .captures(&prefix)
+        .and_then(|captures| captures.get(1))
+        .map(|label| label.as_str().to_ascii_lowercase())
 }
 
 fn normalized_content_type(content_type: Option<&str>) -> Option<String> {
@@ -632,6 +672,35 @@ mod tests {
 
         assert_eq!(document.kind, DocumentKind::Text);
         assert_eq!(document.text, r#"{"status":"ok"}"#);
+    }
+
+    #[test]
+    fn declared_and_sniffed_non_utf8_charsets_decode_before_extraction() {
+        let html = r#"<html><head><title>央广网要闻</title><meta charset="gb2312"></head>
+            <body><article><h1>央广网要闻</h1>
+            <p>这是 一段 包含 足够 中文 词语 的 新闻 内容 用于 验证 网页 解码。</p>
+            </article></body></html>"#;
+        let (gbk_bytes, _, _) = encoding_rs::GBK.encode(html);
+
+        let from_http_header = decode_response_body(&gbk_bytes, Some("text/html; charset=gb2312"));
+        assert!(from_http_header.contains("央广网要闻"));
+        assert!(!from_http_header.contains('\u{fffd}'));
+
+        let from_html_meta = decode_response_body(&gbk_bytes, Some("text/html"));
+        assert!(from_html_meta.contains("央广网要闻"));
+        assert!(!from_html_meta.contains('\u{fffd}'));
+
+        let (gbk_plain_bytes, _, _) = encoding_rs::GBK.encode("要闻_央广网");
+        let plain_text = extract_document(
+            "https://example.com/news.txt",
+            Some("text/plain; charset=gbk"),
+            &gbk_plain_bytes,
+        )
+        .expect("extract declared non-utf8 text");
+        assert!(plain_text.text.contains("要闻_央广网"));
+
+        let utf8 = decode_response_body("保持 UTF-8".as_bytes(), Some("text/plain"));
+        assert_eq!(utf8, "保持 UTF-8");
     }
 
     #[test]


### PR DESCRIPTION
## 概述

修复 `fetch_url` 和共享网页提取链路对 GB2312、GBK 等非 UTF-8 页面解码后出现乱码的问题，同时保持 UTF-8 与二进制响应的原有行为。

## 背景

当前网页响应统一通过 `String::from_utf8_lossy` 转换；当站点通过 HTTP `Content-Type` 或 HTML `<meta charset>` 声明其他编码时，中文内容会被替换为乱码字符。上游 `main` 已让 `fetch_url` 与 `web.run` 共用提取层，因此修复放在共享解码入口。

## 变更

- 根据 HTTP `Content-Type` 的 `charset` 参数选择响应编码。
- 响应头未声明编码时，从 HTML 前 8 KiB 的 `<meta charset>` 回退识别。
- 让共享网页提取、`fetch_url` raw 输出、JSON 字段投影及错误响应回退复用一致的解码逻辑。
- 增加 GB2312/GBK 响应头、HTML meta 与 UTF-8 回归测试。

## 验证

- `cargo test -p codewhale-tui --bin codewhale-tui --locked tools::web::extract::tests`：11 项通过。
- `cargo test -p codewhale-tui --bin codewhale-tui --locked tools::fetch_url::tests`：10 项通过。
- `cargo fmt --all -- --check`：通过。
- `cargo clippy -p codewhale-tui --bin codewhale-tui --locked`：通过，只有 `crates/tui/src/tui/ui.rs:5300` 的既有 `collapsible_match` 告警；该文件不在本 PR diff 中。

## 备注

`cargo clippy ... -- -D warnings` 会被上述上游基线告警拦截，本 PR 未修改对应 UI 文件，也未新增 Clippy 告警。

No-Issue: 修复来自实际网页抓取回归，提交前未单独创建 issue。
