### PR TITLE
docs: sanity check — is there a deterministic verification surface be…

### DIFF
--- a/Surf-ace/Surf_Bigger_Picture.md
+++ b/Surf-ace/Surf_Bigger_Picture.md
@@ -1,0 +1,132 @@
+# The Bigger Picture — Where Surf Fits in the CodeWhale Trajectory
+
+**Date:** 2026-07-26
+**Scope:** Connecting Jay's hunches about vocabulary convergence, Shannon Labs, Model Lab, and the plugin/workset architecture to the Surf proof-of-concept
+
+---
+
+## Your Hunches, Verified
+
+### 1. "The architecture is already moving with me"
+
+**Confirmed.** Hmbown's issue labeling uses "Wave A, B1, B2, B3" — your surf/wave metaphor has literally entered the project's organizational vocabulary. The roadmap page on codewhale.net lists each release as a wave of shipped work. This wasn't your doing alone, but the terminology converged. You're pushing in the same direction the project is already heading.
+
+### 2. "Shannon Labs — since v0.9.0 it's the public-facing open-source project of a lab"
+
+**Confirmed.** From the roadmap: *"Codewhale is the public product from Shannon Labs."* This is a significant structural shift. CodeWhale is no longer just "a terminal coding harness" — it's the public open-source surface of a lab that has research ambitions, a product roadmap, and presumably commercial goals. The lab identity was established during the v0.9.0 cycle — around the same time your constitutional testbed push (#4032) was happening.
+
+### 3. "The constitutional testbed was a legal/scoping/business-case exploration"
+
+**Plausible and consistent.** Issue #4032 (constitutional crisis — "Codewhale not following the constitution") arrived at a pivotal moment. When a project transitions from "community tool" to "lab product," the question of deterministic enforcement becomes existential. If CodeWhale can't guarantee it follows its own rules, it can't be trusted as a lab instrument. The push for structural enforcement (tool restrictions, gate chains, deterministic scripts) aligns with what a lab *needs*: reproducible, auditable, receipt-producing verification. The resolution of #4032 — structural enforcement through `--disallowed-tools` and gate chains — is exactly the foundation Model Lab needs to claim "these eval results are reproducible."
+
+### 4. "Real plugin support with proper sandboxing/trust management"
+
+**Confirmed — it's the Workset architecture.** From `docs/MODEL_LAB.md` and issue #1977:
+
+> *"Worksets are curated optional capability packs that bring open-source ML tooling into the lab loop. Each one installs on-demand and declares license, telemetry posture, network egress, GPU / Python deps, and what data leaves the machine if any."*
+
+This is the plugin system you sensed. HuggingFace, Unsloth, NeMo, Arcee, Serving, Eval, Observability, Training Infra — each is a workset with declared boundaries, explicit consent, and no silent exfiltration. The sandboxing/trust management is built into the architecture: worksets declare what they touch, and the lab enforces it.
+
+### 5. "Model Lab v10.0.0 — the larger vision"
+
+**Confirmed and mapped.** The Model Lab flow (#1977, `docs/MODEL_LAB.md`) is:
+
+```
+/model-lab capture     → mark session as candidate trace
+/model-lab redact      → local PII/secret scrubbing
+/model-lab dataset     → curated JSONL on disk
+/model-lab finetune    → Unsloth / NeMo / Arcee adapter
+/model-lab eval        → reproducible benchmark run
+/model-lab promote     → swap default model if eval clears
+```
+
+This is a **verification pipeline**. Every step produces evidence. Every step needs a receipt. Every step is a candidate for the Surf primitive.
+
+---
+
+## Where Surf Fits
+
+Surf — the receipt-producing, JSON-emitting, pipe-friendly verification surface — is the connective tissue between Model Lab steps:
+
+```
+capture ───→ Surf verifies trace validity ───→ receipt
+    ↓
+redact ────→ Surf verifies PII removal ──────→ receipt
+    ↓
+dataset ───→ Surf verifies format/shape ──────→ receipt
+    ↓
+finetune ──→ Surf verifies adapter integrity ─→ receipt
+    ↓
+eval ──────→ Surf verifies reproducibility ───→ receipt
+    ↓
+promote ───→ Surf verifies improvement ───────→ receipt
+```
+
+The "quiet stream" Jay described — receipts flowing between tools without either needing to know about the other — is exactly the architecture Model Lab needs. A workset produces output. Surf verifies it. The receipt feeds the next step. No step trusts the previous step's claims; every step produces its own evidence.
+
+### Surf + Fleet + Worksets
+
+The two-stream vision maps cleanly onto Model Lab:
+
+| Stream | What it is | Model Lab role |
+|---|---|---|
+| **Fleet-stream** | Durable workers, JSONL ledger, retry/resume | Runs the workset: `fleet run unsloth-finetune.json` |
+| **Surf-stream** | Deterministic verification, JSON receipts | Verifies the workset output: `surf verify --receipt finetune-receipt.json` |
+| **Bridge** | `surf ride --json \| fleet run -` | Verification triggers execution, execution produces evidence for verification |
+
+And the LLM sits *outside* the verification loop:
+
+> *"Surf using a deterministic shell-script that encapsulates Fleet to do a LLM verification/quality pass."*
+
+Meaning: Surf wraps Fleet. Fleet runs the workset. The LLM reads the receipt and adds context ("this finetune improved coding benchmarks by 12% but regressed on function-calling by 3%"). The LLM never touches the verification — it only annotates the evidence. This is the "LLM optional" principle from the original Surf design doc, scaled to the entire Model Lab.
+
+---
+
+## The Trajectory
+
+| Milestone | What shipped | What it means for Surf |
+|---|---|---|
+| v0.8.x | Constitutional enforcement (#4032), tool sandboxing (#4042) | Surf's "deterministic by default" principle is now structurally enforceable |
+| v0.9.0 | Shannon Labs identity, Fleet + Workflow foundations | Surf has a Fleet substrate to pipe into |
+| v0.9.1 | Current release | Stability; the verification gate chain works |
+| v0.9.2 | (In progress — your #4227 lives here) | Contributor onboarding; Surf's tutorial surface |
+| v0.10.0 | Model Lab: capture → redact → dataset → finetune → eval → promote | Surf becomes the verification primitive between every step |
+
+The arc is: **constitutional enforcement → contributor tooling → lab instrumentation.** You started at step 1 (#4032), prototyped step 2 (#4227 / #4762), and are now seeing step 3 come into focus (#1977 / Model Lab). This isn't coincidence — it's the same geometry at different scales.
+
+---
+
+## The Meta-Pattern
+
+Jay's instinct that he's "encountering very similar structures on multiple levels" was right. The pattern is:
+
+```
+deterministic verification → receipt → next action
+```
+
+It appears at:
+- **Turn level:** `cargo fmt --check` → pass → commit
+- **Session level:** `surf ride` → receipt → "environment is clean"
+- **Contributor level:** clone → pull → verify → "ready to submit PR"
+- **Fleet level:** worker runs → receipt → next worker
+- **Lab level:** capture → redact → dataset → finetune → eval → promote (each gated by verification)
+
+The same shape, repeating. That's what Jay sensed when he said *"the geometry is begging the question."* The question isn't "what should I build next." The answer is: **the same verification primitive, at whatever scale the moment calls for.**
+
+---
+
+## What This Means for the Tutorial PR
+
+Hmbown asked to fold the spirit into "grok tutorial docs." Whether that means "onboarding docs" or "contributor tutorial" or something else, the content is clear:
+
+1. **Start from `CONTRIBUTING.md`'s existing loop:** clone, build, fmt, clippy, test
+2. **Show the automated version:** the four Surf bash scripts as a reference implementation
+3. **Don't brand it "Surf":** call it "contributor verification" or "environment check" or "pre-push gate"
+4. **Keep the receipt concept:** structured JSON output that CI, Fleet, or a human can read
+5. **Future-proof it:** note that the same verification pattern scales to Fleet workers and Model Lab worksets
+
+The tutorial is step 2 in the arc. The lab is step 3. Both need the same primitive.
+
+---
+
+*Sources: issue #1977 (Model Lab), `docs/MODEL_LAB.md`, `codewhale.net/en/roadmap`, issue #4032 (constitutional crisis), issue #4042 (tool sandboxing), PR #4762 (Surf), `docs/FLEET.md`, `docs/SUBAGENTS.md`*

--- a/Surf-ace/Surf_Handoff.md
+++ b/Surf-ace/Surf_Handoff.md
@@ -1,0 +1,130 @@
+# Surf — Hand-off
+
+**Date:** 2026-07-26
+**Branch:** `wip/onboarding_suit` (PR #4762 — closed)
+**Status:** Concluded. This document captures the outcome, the landscape, and the path forward.
+
+---
+
+## What Happened
+
+PR #4762 was opened as a draft, reviewed by the audit trail (three documents), and closed by Hmbown with this guidance:
+
+> *"closing this draft so we can fold the spirit of it into the existing grok tutorial docs rather than introduce 'Surf' as a new product term. The goal you're chasing (a simple, discoverable, deterministic testbed/onboarding story) is exactly right; we just want to keep the vocabulary minimal so people can find it easily. We'll capture the useful parts as a tutorial under the existing docs/onboarding surface. If you'd like to help shape that tutorial directly, a fresh PR against the tutorial docs (no new branded term) would be very welcome."*
+
+**Translation:** The architecture is right. The name is not. Build it, but call it what it is — onboarding docs, tutorial, contributor setup — so new contributors find it instantly.
+
+---
+
+## What Was Learned
+
+Over four documents and three days of code tracing, this chase produced:
+
+| Document | What it captured |
+|---|---|
+| `Surf_Skill_Flow_Design.md` | The blueprint — state machine, 4 bash scripts, receipt format |
+| `Surf_Audit_2026-07-24.md` | The reality check — `execute:` frontmatter gap, discovery path, SKILL.md drift, codebase traces |
+| `Surf_PR4762_Response_Report.md` | The map — 7 existing CodeWhale structures Surf echoes (Fleet, worktrees, constitution, hooks, memory, #4032, #4042) |
+| `Surf_Closing_Reflection.md` | The shape — composable verification primitive, three operating modes, pipeable JSON |
+
+**The irreducible insight:** The pipeline is simple. Four bash scripts. `git pull --ff-only` → `cargo fmt --check` → `cargo clippy` → `cargo test --workspace` → print JSON receipt. The vision — "receipts running along the quiet stream" — is standard Unix composition. `surf ride --json | whatever`. The documentation weight came from proving this fits alongside Fleet, not from the tool itself being complicated.
+
+---
+
+## The Landscape Going Forward
+
+### What already exists
+
+`CONTRIBUTING.md` already describes the contributor loop: clone, build, `cargo fmt`, `cargo clippy`, `cargo test`. It's manual — a human reads prose and runs commands. The Surf proof-of-concept automates that loop into one deterministic script.
+
+There is no `docs/onboarding/` directory yet. No tutorial docs for new contributors beyond `CONTRIBUTING.md`. Hmbown's "existing grok tutorial docs" is aspirational — it's a surface that *should* exist, and this is the invitation to help create it.
+
+### The two-stream vision
+
+Jay's closing comments from the PR sketch a layered model:
+
+> *"I envision a 'fleet-stream' (the Fleet JSON/vocabulary) and also a 'surf-stream/layer' (Verification layer)."*
+
+This maps cleanly to what the audit found:
+
+- **Fleet-stream** — Durable workers, JSONL ledger, `fleet run` / `fleet inspect` / `fleet resume`. The heavy orchestration layer. Owned by CodeWhale core.
+- **Surf-stream** — Deterministic shell scripts, JSON receipts, `surf status` / `surf ride` / `surf inspect`. The lightweight verification layer. Can run standalone or feed Fleet.
+
+And the bridge between them:
+
+> *"Surf using a deterministic shell-script that encapsulates Fleet to do a LLM verification/quality pass."*
+
+Meaning: Surf's bash scripts can call `codewhale fleet run` with a task spec, capture the Fleet receipt, and present a human-readable summary. The LLM never touches the verification — Surf owns the deterministic wrapper, Fleet owns the execution, the LLM is optional flavor on top. This is exactly the "LLM optional" principle from the original design doc, applied at the Fleet integration layer.
+
+### Where the name lives
+
+Hmbown asked to drop "Surf" as a product term. Fair. But as Jay noted:
+
+> *"The technical term will stick. For me, and probably for the project. Naming stuff helps compartmentalise."*
+
+The name can live as internal vocabulary — a directory name, a script prefix, a commit-message tag — without being a user-facing product term. Internally: "the surf scripts." Externally: "the contributor verification tutorial." Same tool, two namespaces.
+
+---
+
+## Concrete Next Steps
+
+### Immediate (this branch)
+
+- [ ] Archive or delete `SKILL.md` (stale, references old onboarding-suite naming)
+- [ ] Archive or delete `Skill_Flow_Design (old).md` (superseded by v2.0 design)
+- [ ] Archive or delete `surf.md` and `surf-setup.md` (`execute:` frontmatter doesn't work)
+- [ ] Keep the 4 bash scripts, the design doc, the audit, the response report, and the closing reflection
+- [ ] The branch can stay as a reference; no need to delete it
+
+### Short-term (new PR against tutorial docs)
+
+- [ ] Check whether a `docs/onboarding/` or `docs/tutorial/` directory has been created since this hand-off was written
+- [ ] Draft a contributor verification tutorial that covers the `clone → pull → fmt → clippy → test → receipt` loop
+- [ ] Use the Surf bash scripts as reference implementation, but write the tutorial in plain prose a human follows manually (no new tool required)
+- [ ] Link from `CONTRIBUTING.md` to the tutorial
+- [ ] Do not introduce "Surf" as a branded term in user-facing docs
+
+### Medium-term (tooling)
+
+- [ ] Add `--json` flag to the bash scripts so they emit machine-readable receipts
+- [ ] Replace `read -p` in `catch-wave.sh` with positional args
+- [ ] Test the pipe: `surf ride --json | codewhale fleet run` (once Fleet supports stdin task specs, or via temp file)
+- [ ] Consider contributing a `codewhale fleet run --stdin` feature if the pipe path proves useful
+
+### Long-term (vision)
+
+- [ ] A contributor runs one command and gets a receipt: "your environment is clean, main is at abc123, all 6384 tests pass, here's what changed since yesterday"
+- [ ] That receipt feeds into Fleet for deeper verification, or into `jq` for scripting, or into a CI check — same JSON, same stream, different destinations
+- [ ] The "quiet stream" flows between Surf, Fleet, Workflow, and CI without any tool needing to know about the others'
+
+---
+
+## The Shape (Final)
+
+> **Surf is a receipt-producing, JSON-emitting, pipe-friendly verification surface that sits between a contributor's local checkout and the Fleet/CI infrastructure. It mirrors Fleet's verb vocabulary without depending on Fleet's internals. It produces structured evidence that any downstream tool — Fleet, `jq`, a Workflow, a CI runner, a human reading a terminal — can consume.**
+
+That's the geometry. The proof of concept is four bash scripts doing `git pull --ff-only`, `cargo fmt`, `cargo clippy`, `cargo test`. The name is internal. The next step is a tutorial PR that captures the spirit in contributor-facing docs.
+
+---
+
+## Documents in This Branch
+
+| File | Keep? | Reason |
+|---|---|---|
+| `Surf_Skill_Flow_Design.md` | ✅ Keep | Canonical design reference |
+| `Surf_Audit_2026-07-24.md` | ✅ Keep | Codebase-grounded gap analysis |
+| `Surf_PR4762_Response_Report.md` | ✅ Keep | Maps existing CodeWhale structures |
+| `Surf_Closing_Reflection.md` | ✅ Keep | Closes the arc, defines the shape |
+| `Surf_Handoff.md` | ✅ Keep | This document — hand-off / outcome |
+| `surf.sh`, `check-wave.sh`, `catch-wave.sh`, `ride-wave.sh` | ✅ Keep | Working proof-of-concept scripts |
+| `surf.md`, `surf-setup.md` | ❌ Archive | `execute:` frontmatter unsupported |
+| `SKILL.md` | ❌ Archive | Stale, references old onboarding-suite naming |
+| `Skill_Flow_Design (old).md` | ❌ Archive | Superseded by v2.0 design doc |
+
+---
+
+*Sources: PR #4762 conversation (closed by Hmbown 2026-07-26), issues #4227/#4032/#4042, `docs/FLEET.md`, `docs/SUBAGENTS.md`, `docs/CONFIGURATION.md`, `CONTRIBUTING.md`, `crates/tui/src/commands/user_registry.rs`, `crates/tui/src/skills/mod.rs`*
+
+*Credit: written with CodeWhale (deepseek-v4-pro) assistant, guided by Jay, and shaped by multiple agents and assistants, human and otherwise.*
+
+*All of it. Fine.* 🏄🐋

--- a/Surf-ace/Surf_So_What_Even_Is_This.md
+++ b/Surf-ace/Surf_So_What_Even_Is_This.md
@@ -1,0 +1,111 @@
+# So… What Even Is This?
+
+**Date:** 2026-07-27
+**Author:** Jay
+
+---
+
+## The Thing I Built
+
+I wrote four bash scripts. About 150 lines total. Here's what they do:
+
+1. Check if a directory is a git repo with a marker file (`.surf-config`)
+2. If it's clean, `git pull --ff-only`
+3. Run `cargo fmt --check`, `cargo clippy`, `cargo test --workspace`
+4. Print a JSON receipt with the commit hash and a status
+
+That's it. `check-wave.sh` → `ride-wave.sh` → `receipts/latest_receipt.json`.
+
+The cleverest thing about it is the name. "Surf." Because the repo moves like a wave, and you're trying to stay on top of it. That metaphor did more heavy lifting than any of the bash logic.
+
+This is not a complex tool. It is not novel. Every project with a CI pipeline does something like this. `CONTRIBUTING.md` already tells you to run `cargo fmt` and `cargo clippy` and `cargo test`. I just wrapped it in a script and added a JSON receipt.
+
+So why did I spend three days tracing this through the entire CodeWhale codebase? Why eight documents? Why a closed PR and a handoff and a constitutional trace and a deeper thread?
+
+I'm trying to figure out if I built something, or if I just *noticed* something.
+
+---
+
+## The "Am I Stating the Obvious?" Problem
+
+Here's the part I can't shake.
+
+The pattern — `verify → receipt → proceed` — is everywhere. It's in `cargo fmt`. It's in CI pipelines. It's in Fleet worker artifacts. It's in the Model Lab `capture → redact → dataset → finetune → eval → promote` loop. It's in the constitutional enforcement gates that shipped in v0.9.1. It's so obvious that pointing it out feels like saying "water is wet."
+
+But then I look at the issues I traced. #4032 — the constitutional crisis. stream2stream spent weeks escalating prompt instructions because the LLM kept writing temp scripts. The solution, when it landed, wasn't a better prompt. It was *structural enforcement.* Binding gates. Tool restrictions. Remove the tool from the toolbox.
+
+That's the same pattern. `constraint → enforcement → receipt.` But it took a crisis to discover it.
+
+And #3965 — my first issue. I asked for per-sub-agent provider routing. Explicit assignment. "I tell you which provider, you use it." That's the same pattern too. `assignment → routing → execution.` A simpler version, but the same shape.
+
+The audit I commissioned found the `execute:` frontmatter gap — the exact point where the design (Surf as a TUI command) collided with the runtime reality (user commands can't execute shell scripts). That gap wasn't a bug. It was the same pattern asserting itself: *the architecture won't let you do it that way.*
+
+So maybe I'm not stating the obvious. Maybe the obvious is the point.
+
+---
+
+## Two Ways to Read This
+
+**Reading A: I just discovered CI pipelines.**
+
+The Surf scripts do what every `Makefile` and `justfile` and `.github/workflows/ci.yml` already does. The receipt is just structured stdout. The state machine is just `git status --porcelain`. Four bash scripts, 150 lines, a clever name. I'm a new contributor who got excited about build automation and wrote a lot of documentation about it.
+
+This reading is probably correct, on one level.
+
+**Reading B: I traced a geometry that repeats at every scale.**
+
+The pattern `deterministic verification → receipt → next action` is the structural loop of the entire project. It's in the turn-level `cargo fmt` check. It's in the session-level Fleet worker lifecycle. It's in the constitutional enforcement gates. It's in the Model Lab pipeline. It's the same beats  — at every zoom level.
+
+This reading is also probably correct, on another level.
+
+I don't know which reading is more useful. I don't know if I'm supposed to pick one.
+
+---
+
+## Why I'm Writing This
+
+I love working on this project. Thinking about it. Contributing what I can. The CodeWhale repo is the most interesting thing I've stumbled into, and I'm genuinely grateful for the chance to poke at its internals.
+
+But I'm still new here. I opened my first issue three weeks ago. I still don't really know Rust. When Hmbown closed my PR with "fold the spirit of it into existing tutorial docs," I had to search the entire repo to confirm that "existing grok tutorial docs" didn't exist yet. I wasn't sure if I was missing something obvious or if I'd found a gap.
+
+That's the feeling I keep having. *Am I pointing at something everyone already knows? Or am I the first person to trace this particular thread?*
+
+I think the answer is: both. The thing is obvious. The geometry is everywhere. But nobody had written it down in this particular way, with these particular receipts, at this particular moment in the project's trajectory. And maybe that's enough.
+
+---
+
+## What I Actually Want
+
+I want to be able to say: 
+
+> "Here's a thing I noticed. It's simple — four bash scripts, `git pull`, `cargo test`, a JSON receipt. But the shape of it — `verify → receipt → proceed` — runs through Fleet, through the constitutional gates, through Model Lab, through everything. I don't know if that's useful to anyone else. I just wanted to write it down."
+
+That's it. I'm not pitching a product. I'm not asking for a merge. I'm not even sure it needs to be a tool. It might just be an observation — a pattern that's already there, already working, already doing its thing, and I happened to notice it and give it a name.
+
+The name is "Surf." Hmbown asked me to drop it as a product term. That's fine. The name can live internally — in this branch, in these documents, in my own head. The pattern doesn't need a brand. It just is.
+
+---
+
+## The Hesitation
+
+I'm posting this because I'm not sure what to do with it.
+
+I could write a tutorial. I could contribute a `docs/onboarding/` page. I could clean up the scripts and ship them as a reference implementation. I could do nothing and let the branch sit as an artifact.
+
+But every time I try to package it — to make it *useful* — I hit the same wall: *this is already obvious.* The `CONTRIBUTING.md` already says to run `cargo fmt` and `cargo test`. Fleet already has worktree isolation. The constitutional gates already enforce structural constraints. Model Lab already has a verification pipeline. What am I adding?
+
+Maybe nothing. Maybe that's the point. Maybe the value isn't in the tool — it's in the *tracing.* The fact that I can show you the same shape at five different scales, in four different issues, across three weeks of contributions. That's not a feature. That's a map.
+
+And maps are useful even when the territory is obvious.
+
+---
+
+## So… What Even Is This?
+
+It's four bash scripts and a question.
+
+The question is: *if the same pattern repeats at every scale — verify, receipt, proceed — does pointing it out matter?*
+
+I don't know. But I wrote it down anyway.
+
+*All of it. Fine.* 🏄🐋

--- a/Surf-ace/Surf_So_What_Even_Is_This_v2.md
+++ b/Surf-ace/Surf_So_What_Even_Is_This_v2.md
@@ -1,0 +1,102 @@
+# So… What Even Is This? (v2)
+
+**Date:** 2026-07-27
+**Author:** Jay
+**Note:** This is a companion to v1 — same question, different posture. v1 is the hesitation. v2 is the thing I actually want.
+
+---
+
+## The Thing I Built (Still Simple)
+
+I wrote four bash scripts. About 150 lines total:
+
+1. Check if a directory is a git repo with a marker file
+2. If it's clean, `git pull --ff-only`
+3. Run `cargo fmt --check`, `cargo clippy`, `cargo test --workspace`
+4. Print a JSON receipt
+
+That's it. Not novel. Not complex. Every CI pipeline does this. `CONTRIBUTING.md` already tells you the same thing. I just wrapped it in a script and added structured output.
+
+But here's the thing: I actually *want* this. Not as a contribution to prove I can trace architecture. Not as a map of a geometry. As a tool. A surface I can stand on.
+
+---
+
+## The Surf-ace I Need
+
+Between Fleet operations, there's a gap.
+
+Fleet runs a worker. The worker finishes. Fleet writes a receipt. Then what? The next worker spins up. Or the workflow continues. Or you inspect the artifact. But there's no point in between where I can deterministically say: *stop. Verify. Decide.*
+
+I want a surface between Fleet operations where I can:
+
+- **Verify** — did the last worker actually produce what it claimed? Run a deterministic check. Not an LLM judgment. A bash script. A test suite. A diff. Something that says "yes, this is real" or "no, something's wrong."
+
+- **Block** — if the verification fails, stop the pipeline. Don't spin up the next worker. Don't proceed. The receipt says "blocked at surf-check." Human intervenes. Or a fallback triggers. But nothing continues blindly.
+
+- **Pause** — if the verification is inconclusive, hold. Don't fail. Don't proceed. Just… wait. Leave the receipt open. Let a human decide. Or let a higher-level orchestrator decide. But don't pretend the step is done.
+
+- **Run a script** — any script. Not just `cargo test`. Anything deterministic. A custom verifier. A diff against a baseline. A schema validator. A canary deploy check. The surf-ace doesn't care what the script does. It just runs it, captures the output, and writes a receipt.
+
+- **Redirect** — based on the receipt, decide which agent spins up next. Verification passed → spin up the promoter. Verification failed → spin up the debugger. Verification inconclusive → spin up the investigator. The surf-ace is a routing decision point, not a passive checkpoint.
+
+This is not a test suite. It's not a CI pipeline. It's an **interstice** — a deliberate gap between automated steps where deterministic verification happens, receipts are produced, and the next action is chosen based on evidence. (Still, LLM would stay optional the surf-ace could open/contain a quick fleet/LLM assessment in itself.)
+
+---
+
+## Why I Need This (While Keeping It Vague)
+
+I cannot share real specifics. But the shape seems to requires a surface like this. *Still attempting more in depth:* I don't know what margins would ask for this, but even figuring that out suggests we need this, no?
+
+Imagine a workflow where Fleet workers do complex things — code generation, model finetuning, dataset curation, evaluation runs. Between each worker (or some specific ones), I need to verify that the output is real. Not "the LLM said it's fine." Not "the exit code was zero." But: *a deterministic script ran, compared the output against known-good criteria, and produced a receipt that says what happened.*
+
+If the verification passes, the next worker spins up — maybe a different worker than originally planned, because the receipt contains information that changes the trajectory.
+
+If the verification fails, the pipeline stops. Not crashes. Stops. With a receipt that says why.
+
+If the verification is inconclusive, the pipeline pauses. Holds. Waits for a human — or for another system — to decide.
+
+This is not science fiction. It's four bash scripts and a JSON receipt, placed between Fleet workers. The plumbing exists. The `execute:` frontmatter doesn't, but that's a solvable problem — or a sign that the TUI command path is the wrong integration point. The scripts can run standalone. The receipts are pipeable. The surface works today.
+
+---
+
+## The Honest Part
+
+I still don't know if pointing this out matters.
+
+The pattern — `verify → receipt → proceed` — is everywhere. It's in Fleet. It's in CI. It's in the constitutional gates. It's in Model Lab. It's so obvious that saying "I want a deterministic verification surface between Fleet operations" might be like saying "I want the car to have brakes."
+
+But here's the difference: the brakes are already there. `cargo test` exists. Fleet receipts exist. The constitutional gates exist. What doesn't exist — what I haven't seen anyone else describe — is the *surf-ace* itself. The deliberate gap. The interstice. The point between steps where you can deterministically verify, block, pause, redirect — not as an emergency brake, but as a *designed feature of the workflow.*
+
+Maybe that's obvious too. Maybe every workflow designer already thinks this way. But I've been reading the Fleet docs, the Workflow tutorial, the Model Lab roadmap, and I don't see this surface described. I see workers. I see receipts. I see `fleet inspect`. But I don't see: *between worker A and worker B, insert a deterministic verification step that decides whether worker B runs at all, and which worker B it is.*
+
+That's the surf-ace. That's what I want. That's what the four bash scripts are a proof-of-concept for.
+
+---
+
+## Two Ways to Read This (Revisited)
+
+**Reading A: I want Fleet to have a `--verify` flag.**
+
+I want to be able to say: `fleet run tasks.json --verify surf-ride.sh` and have every worker gated by a deterministic check. Simple. Obvious. Probably already implementable.
+
+**Reading B: I want a new architectural primitive.**
+
+I want the surf-ace to be a first-class concept — not a flag, not a script, not a tutorial. A *surface.* Something you can stand on. Something that sits between every Fleet operation and says: *evidence before action. Receipt before progress. Verification before trust.*
+
+Both readings are correct. I'm pretty sure which one to advocate for. And I know which one I'm building toward.
+
+---
+
+## What I'm Actually Asking
+
+Not "should I contribute this?" Not "is this useful?" Not "does anyone else want this?"
+
+Just: *does this surface exist already, or am I describing a gap?*
+
+If it exists — if Fleet workflows or Model Lab or some other part of CodeWhale already has a deterministic, script-driven, receipt-producing, traffic-routing interstice between steps — tell me. I'll use it. I'll stop inventing names for it. I'll be grateful.
+
+If it doesn't exist — then I'm not stating the obvious. I'm pointing at something that should be there, and isn't, and needs to be.
+
+I don't know which answer is true. But I want the surf-ace either way.
+
+*All of it. Fine.* 🏄🐋

--- a/Surf-ace/Surf_Surf-ace_Verification.md
+++ b/Surf-ace/Surf_Surf-ace_Verification.md
@@ -1,0 +1,161 @@
+# Surf-ace Verification — Does the Interstice Exist?
+
+**Date:** 2026-07-27
+**Scope:** Verifying the "Honest Part" of `Surf_So_What_Even_Is_This_v2.md` — does CodeWhale already have a deterministic, script-driven, receipt-producing, traffic-routing surface between Fleet/Workflow operations?
+
+---
+
+## The Claim (from v2)
+
+> *"Between Fleet operations, there's a gap. Fleet runs a worker. The worker finishes. Fleet writes a receipt. Then what? The next worker spins up. But there's no point in between where I can deterministically say: stop. Verify. Decide."*
+
+> *"I want a surface between Fleet operations where I can: verify, block, pause, run a script, redirect."*
+
+> *"I haven't seen anyone else describe the surf-ace itself. The deliberate gap. The interstice. The point between steps where you can deterministically verify, block, pause, redirect — not as an emergency brake, but as a designed feature of the workflow."*
+
+---
+
+## What Exists: Workflow Gates
+
+CodeWhale **does** have a gate system in the Workflow IR.
+
+Source: `crates/workflow/src/gates.rs` (505 lines, committed to `main`)
+
+### Gate Architecture
+
+```rust
+pub struct GateSpec {
+    pub id: String,
+    pub role: String,          // Role whose completion triggers this gate
+    pub on: GateOn,            // RoleComplete or RoleStart
+    pub gate: GateKind,        // Verify, Review, or Approve
+    pub on_fail: GateOnFail,   // Retry, Block, or Escalate
+    pub blocks_role: Option<String>,  // Downstream role blocked until gate passes
+    pub max_retries: u32,
+    pub artifact_kind: Option<String>,
+    pub require_explicit_verdict: bool,
+}
+```
+
+### Gate States
+
+A gate can be: `Pending`, `Passed`, `Blocked { reason }`, `Retrying { attempt, reason }`, or `Escalated { reason }`.
+
+### Gate Outcomes
+
+A gate receives: `Pass`, `Fail { reason }`, or `HumanApprove { note }`.
+
+### Canonical Pipeline (hardcoded in Rust)
+
+```rust
+pub fn stopship_gate_pipeline() -> Vec<GateSpec> {
+    // scout-findings (Approve) → blocks implementer
+    // reviewer-diff (Review)    → blocks verifier
+    // verifier-suite (Verify)   → blocks release_lead
+}
+```
+
+### Lane-Scoped Handoffs
+
+Artifacts flow between roles: `HandoffArtifact { from_role, to_role, kind, payload }`. These are lane-scoped, not fleet-scoped.
+
+---
+
+## The Gap: Where the Surf-ace Would Go
+
+### Gap 1: No deterministic script execution in gates
+
+The `GateKind::Verify` says: "Compile/test/lint suite (verifier role; #4013)." But the verifier is a **Fleet role** — an LLM sub-agent. It is not a bash script. It does not run `cargo test` deterministically. It is an LLM that reads the implementer's output and decides whether it passes.
+
+From the staged bugfix workflow (`wf_a2_staged_bugfix.workflow.js`):
+
+```js
+const verify = await task({
+    type: "verifier",
+    prompt: [
+        "Read the implementer result and validate its reported path and diff summary.",
+        "Confirm the intended one-line clarification was made only in the isolated worktree.",
+        "Confirm the parent workspace remains unchanged.",
+        "Do not implement further edits. Return PASS/FAIL with evidence.",
+    ].join("\n"),
+});
+```
+
+The verifier is an LLM. It reads text. It decides. It can hallucinate. It can rationalize. It can miss things. This is the **same problem** that issue #4032 identified: *"The LLM lies, writes temp scripts, rationalizes post-hoc."* A gate gated by an LLM is not a deterministic gate.
+
+**What's missing:** A `GateKind::Script` or `GateKind::Check` that runs a user-supplied command (bash script, test suite, diff checker) and uses its exit code + stdout as the gate outcome. The infrastructure for blocking, retrying, escalating, and handoff artifacts already exists in the gate board. Only the evaluation source is missing.
+
+### Gap 2: No user-supplied script execution in workflows
+
+The Workflow VM has **no** filesystem, shell, network, env, imports, clock, or randomness (see `docs/AUTOMATIC_WORKFLOWS.md:72-77`). The supported host calls are: `task`, `parallel`, `pipeline`, `phase`, `log`, `budget`, `args`. There is no `exec` or `check` or `verify_script` host call.
+
+The supported node wrappers in `docs/WORKFLOW_AUTHORING.md:83-85` are: `agent`, `branch`, `sequence`, `reduce`, `teacher_review`, `loop_until`, `cond`, and `expand`. There is no `gate` or `script` or `check` node exposed to JS authoring.
+
+**What's missing:** A workflow node or host call that runs a deterministic script and uses its result (exit code, stdout JSON) as a gate outcome or routing decision.
+
+### Gap 3: No traffic routing based on verification results
+
+Workflow nodes can branch (`branch`, `cond`) and loop (`loop_until`), but these are compile-time structures — the branching logic is written into the workflow definition. There is no runtime mechanism to say: *"the verifier script returned 'degraded_function_calling' → spin up the debugging agent instead of the promoter."*
+
+The `cond` node is a static branch. The `reduce` node aggregates results into a summary. Neither one dynamically routes traffic based on a receipt's contents.
+
+**What's missing:** A `route` or `dispatch` node that reads a receipt (from a script or from a gate outcome) and selects the next worker dynamically.
+
+### Gap 4: The `require_explicit_verdict` field defaults to false
+
+In the canonical stopship pipeline, all three gates have `require_explicit_verdict: false`. When enabled (per the docs in `gates.rs:75-79`), it requires *"a standalone first-line PASS/APPROVE/BLOCK/FAIL verdict from a successfully completed role."* But this verdict still comes from an LLM role, not from a deterministic script. The field is about format, not about source.
+
+**What's missing:** A field or mechanism that says *"this gate's outcome comes from a deterministic script, not from an LLM role."*
+
+---
+
+## What This Means
+
+### The Gate Infrastructure Exists
+
+CodeWhale already has:
+- ✅ Gate specs (block, retry, escalate)
+- ✅ Gate state tracking (pending, passed, blocked, retrying, escalated)
+- ✅ Role blocking (downstream role can't start until gate passes)
+- ✅ Handoff artifacts (structured data flowing between roles)
+- ✅ Lane-scoped gate boards (persisted to JSON)
+
+### The Verification Source Does Not
+
+CodeWhale does **not** have:
+- ❌ A gate that runs a deterministic script instead of an LLM role
+- ❌ A workflow host call that executes a user-supplied command
+- ❌ A mechanism to route traffic based on script output
+- ❌ A gate outcome that comes from a bash exit code rather than an LLM verdict
+
+### The Surf-ace Fits in an Existing Seam
+
+The gate infrastructure (`GateSpec`, `LaneGateBoard`, `GateOnFail::Block/Retry/Escalate`) provides the structural scaffolding for exactly what Jay wants: block, retry, escalate, handoff artifacts. What's missing is the **evaluation source** — a way to say "this gate is evaluated by running a script, not by asking an LLM."
+
+A `GateKind::Script` that takes a command, runs it, and maps exit-code-0 to `GateOutcome::Pass` and non-zero to `GateOutcome::Fail { reason: stdout }` would slot directly into the existing gate board without changing any of the blocking/retry/escalation/handoff logic.
+
+This would give Jay's surf-ace five verbs:
+
+| Verb | Existing Mechanism | Missing Piece |
+|---|---|---|
+| **Verify** | Gate evaluation (`GateOutcome::Pass/Fail`) | Script as evaluation source |
+| **Block** | `GateOnFail::Block` + `blocks_role` | Already exists |
+| **Pause** | `GateOnFail::Escalate` (surfaces to human) | Already exists |
+| **Run a script** | N/A | Needs `GateKind::Script` or Workflow `exec` host call |
+| **Redirect** | `HandoffArtifact` + `cond` (static) | Dynamic routing based on receipt contents |
+
+---
+
+## The Honest Verdict
+
+Jay's claim in v2 — *"there's no point in between where I can deterministically say: stop. Verify. Decide."* — is **substantially correct.**
+
+The scaffolding for "stop" (block/retry/escalate) and "decide" (handoff artifacts, role blocking) already exists in the gate system. The "verify" part exists only through LLM sub-agents — which is the same non-deterministic path that #4032 identified as unreliable. A deterministic script-execution gate does not exist.
+
+This is not a criticism of the gate system. The gate infrastructure is well-designed and the right foundation. It's just missing one evaluation source: a script that produces a Pass/Fail outcome without going through an LLM.
+
+**The gap is real. It is specific. It is addressable.** Adding `GateKind::Script` (or an equivalent mechanism) would close it without redesigning the gate board, the lane system, or the Workflow IR.
+
+---
+
+*Sources: `crates/workflow/src/gates.rs` (full file, 505 lines), `docs/WORKFLOW_AUTHORING.md`, `docs/AUTOMATIC_WORKFLOWS.md`, `docs/examples/dogfood-automatic/wf_a2_staged_bugfix.workflow.js`, `docs/examples/dogfood-automatic/wf_a3_partial_failure_synthesis.workflow.js`*


### PR DESCRIPTION
# Is Surf a Think? _Why Make Mink?_ 🥺 

## Sanity Check: What Even Is This V2 🚀

### When in Doubt, Calmly Stay Hysterical

---

**Type:** Draft PR — a question, not a contribution. Close whenever.
**Author:** Jay
**Branch:** `wip/onboarding_suit`

No-Issue: Related to #4227 but does not close it. scoping docs.

---

## I'm (Not) Trying to Land Anything (per se)

This is a sanity check. I've been tracing a shape through the CodeWhale codebase for a few weeks, and I think I found something — but I've been wrong before, and I'm new here, so I'm asking.

The previous PR (#4762) was closed with good guidance: fold the spirit into existing docs, no branded term. That made sense. This isn't a second attempt at that. It's a different thing: a question backed by code traces, with some supporting documents if anyone wants to dig deeper.

If the answer is "this already exists, it's called X" — great, I'll use X. If the answer is "this isn't a thing" — also fine, I'll stop overthinking it. No hard feelings either way.

---

## The Question

Does CodeWhale already have a deterministic, script-driven, receipt-producing surface between Fleet/Workflow operations?

Not "can you run `cargo test`?" (you can). Not "is there a verifier role?" (there is, and it's an LLM). But: between worker A and worker B, is there a point where a deterministic script runs, produces a receipt, and the receipt can decide whether worker B runs — and which worker B?

I don't know the answer. I just know what I found when I looked.

---

## Food for Thought

Years ago I had a small revelation, encountering lambda calculus, by learning and messing with function pointers in C. The flash of realisation: the function itself can be passed as an argument, or returned as output. It's not just that input and output are the same kind of thing — the *function* is too! You can hand a function to another function. You can get a function back. They're all the same shape, just moving through the system at different speeds.

The pattern I keep seeing in CodeWhale feels like the same thing: **input → verify → receipt.** The receipt becomes the input to the next step. But the verification itself — the script that checks the output — is also an input (you hand it to the gate) and also an output (the gate produces a new receipt, which might become a new verification). They're all the same shape. Just moving at different speeds through the pipeline.

I don't know if that's profound or obvious. But it's why I can't shake the feeling that a deterministic verification surface — something that sits between steps and says "yes, this output is real" before anything else touches it — is not a feature. It's a missing primitive.

---

## What I Traced

I read `crates/workflow/src/gates.rs` (505 lines). The Workflow gate system has solid infrastructure:

- Gates can block downstream roles from starting
- Gates can retry on failure, escalate to a human
- Gates produce handoff artifacts between roles
- Gate state is tracked per lane and persisted to JSON

But the evaluation source for every gate is an LLM sub-agent — a Fleet role of type `"verifier"` that reads text and renders a verdict. From one of the workflow examples:

```js
const verify = await task({
    type: "verifier",
    prompt: [
        "Read the implementer result and validate its reported path and diff summary.",
        "Return PASS/FAIL with evidence.",
    ].join("\n"),
});
```

That's an LLM reading text and deciding. Same class of problem #4032 identified: LLMs can rationalize. There's no `GateKind` that runs a deterministic script and maps exit-code-0 to Pass.

The gate *infrastructure* is there. The *evaluation source* for deterministic checks is not. That might be intentional — maybe gates are designed to be LLM-evaluated by design. Or it might be a gap. I don't know enough about the intended architecture to say.

---

## The LLM Stays. It Just Goes Through the Gate.

The surf-ace is not anti-LLM. It's deterministic-first, LLM-optional.

If a verification step needs an LLM assessment — a quick Fleet worker to inspect a diff, a summarizer to annotate a receipt, a reviewer to flag edge cases — the surf-ace can spin one up. The surf-ace itself decides. And that decision is recorded in a receipt: "gate passed by script `cargo test`" or "gate passed by script `cargo test` + Fleet reviewer `quick-diff-check`."

The difference from today is: the LLM doesn't get to gate itself. The surf-ace gates the LLM the same way it gates everything else — with a deterministic check, a receipt, and a decision about what happens next.

This is the principle from the original Surf design doc, scaled to the interstice: **deterministic by default, LLM optional.** The LLM is additive. It cannot bypass the gate. It cannot rationalize its way around the receipt. The surf-ace owns the decision.

---

## The Empty Surf-ace

There's one more design constraint that keeps the shape clean: **an empty surf-ace is transparent.**

If you don't configure a verification script, the surf-ace is a passthrough. Input JSON in, output JSON out. Same shape. The receipt just says `"status": "passed"` — because nothing was checked, so nothing failed. The downstream component sees the same data it would have seen without the surf-ace. It doesn't need to know whether verification happened. It just reads the receipt and proceeds.

This is important because it means the surf-ace doesn't force a new contract on every component in the pipeline. It sits *between* components without changing the shape of what flows through (default behaviour). Components that don't know about the surf-ace still work (again default). Components that *do* know about the surf-ace can react to the receipt — block on `"blocked"`, reroute on `"redirect"`, pause on `"inconclusive"`. But the default is: nothing changes. But it can.

The surf-ace is not a new protocol. It's a new *position* — a gap where verification can happen, with receipts that anyone can read. When verification is off, the gap closes. When verification is on, evidence accumulates. Same pipe, same JSON, same stream. 
The Surf-ace is the place (interstace) where a gap becomes a surface. Where the description (docs) becomes part of the geometry (what the docs describe).

---

## Documents (if you're curious)

_"Where the description becomes part of the geometry"_ — this is the deeper insight. Normally docs describe a system from outside. But a receipt is the description, and it is the geometry — it's what the next component reads to decide what to do. The map is the territory. The evidence is the structure.

Five supporting docs are bundled — entirely optional reading:

| File | What it is |
|---|---|
| [`Surf_So_What_Even_Is_This.md`](https://github.com/JayBeest/CodeWhale/blob/wip/sanity-check-surf-ace/Surf-ace/Surf_So_What_Even_Is_This.md) | v1 — the hesitation. "Am I stating the obvious?" |
| [`Surf_So_What_Even_Is_This_v2.md`](https://github.com/JayBeest/CodeWhale/blob/wip/sanity-check-surf-ace/Surf-ace/Surf_So_What_Even_Is_This_v2.md) | v2 — the conviction. What I actually want. |
| [`Surf_Handoff.md`](https://github.com/JayBeest/CodeWhale/blob/wip/sanity-check-surf-ace/Surf-ace/Surf_Handoff.md) | Where the previous PR landed, and what Hmbown advised |
| [`Surf_Bigger_Picture.md`](https://github.com/JayBeest/CodeWhale/blob/wip/sanity-check-surf-ace/Surf-ace/Surf_Handoff.md) | How this pattern connects to Model Lab and the v10.0.0 roadmap |
| [`Surf_Surf-ace_Verification.md`](https://github.com/JayBeest/CodeWhale/blob/wip/sanity-check-surf-ace/Surf-ace/Surf_Handoff.md) | The evidence: `gates.rs` trace — what exists, what doesn't |

They're the trail of how I got here. Not required reading. The question above is the only thing that matters.

---

## Links

- The roadmap: https://codewhale.net/en/roadmap
- Model Lab (#1977): https://github.com/Hmbown/CodeWhale/issues/1977
- The constitutional crisis (#4032): https://github.com/Hmbown/CodeWhale/issues/4032
- The gates source: `crates/workflow/src/gates.rs`

---

*Written with CodeWhale (deepseek-v4-pro), guided by Jay, shaped by a bracket of agents and assistants, human and otherwise.*

*All of it. Fine.* 🏄🐋
