### PR TITLE
feat(web): v0.9.2 docs guide/vocabulary, getting-started path, pending media manifest (#3413)

### DIFF
--- a/docs/releases/v0.9.2-media-plan.md
+++ b/docs/releases/v0.9.2-media-plan.md
@@ -1,0 +1,102 @@
+# v0.9.2 real-session media plan (#4906)
+
+> **Status: pending the dogfood recording.** The site renders a visible
+> "recording pending release candidate" state (`web/lib/media-manifest.ts` →
+> `first-fleet-session`, rendered by `web/components/session-media.tsx` on
+> `/docs/guide`). No placeholder, staged, or recycled footage ships. This file
+> is the exact procedure for producing the real assets once the v0.9.2 release
+> candidate is stable and dogfooded, and the checklist for flipping the
+> manifest entry to `published`. It authorizes local recording only — never a
+> deploy, tag, or publication.
+
+## What gets recorded
+
+One continuous real session of the v0.9.2 release candidate, on a **sealed
+local route** (loopback Ollama, exactly like the canonical screenshot in
+`docs/public-surface-facts.json` → `screenshot.capture`; no paid or hosted
+provider, no live account):
+
+1. Install / launch: `codewhale` in a scratch repository.
+2. First keyless session: constitution-first setup, then a read-only Plan-mode
+   exploration.
+3. Provider connection: configure the local Ollama route (provider · model ·
+   reasoning tier visible).
+4. One Fleet workflow: `codewhale fleet init`, a small `fleet run`, and the
+   receipt at the end.
+
+Terminal: **120×32**, **Blue Stage dark** theme — identical to the screenshot
+contract so the moving and still surfaces read as one product.
+
+## Recording procedure (post-dogfood, exact commands)
+
+Prerequisite: the candidate has passed the local dogfood install per the
+release ledger (`scripts/release/install-dogfood.sh`). Seal the environment —
+never record against a real home directory or live credentials:
+
+```sh
+# 1. Sealed scratch environment
+export CW_MEDIA_HOME="$(mktemp -d)"
+mkdir -p "$CW_MEDIA_HOME/.codewhale" /tmp/cw-media-demo && cd /tmp/cw-media-demo
+HOME="$CW_MEDIA_HOME" CODEWHALE_HOME="$CW_MEDIA_HOME/.codewhale" \
+  env -u DEEPSEEK_API_KEY \
+  tmux new-session -d -s cw-media -x 120 -y 32
+
+# 2. Start the local inference route (separate shell)
+ollama serve &   # loopback only; model pulled in advance, e.g. `ollama pull <model>`
+
+# 3. Record with VHS (same tool as the canonical screenshot)
+#    Write the tape to docs/evidence/v092-first-fleet-session.tape, replaying
+#    the four beats above, then:
+vhs docs/evidence/v092-first-fleet-session.tape
+#    → produces the GIF fallback
+
+# 4. Derivatives
+ffmpeg -i first-fleet-session.gif -movflags +faststart -pix_fmt yuv420p \
+  -vf "scale=1280:720" -an web/public/media/first-fleet-session.mp4
+ffmpeg -i first-fleet-session.gif -frames:v 1 \
+  web/public/media/first-fleet-session.png          # poster frame
+cp first-fleet-session.gif web/public/media/first-fleet-session.gif
+```
+
+Then hand-write the caption tracks and transcript from the actual recording
+(never auto-generated filler):
+
+- `web/public/media/first-fleet-session.en.vtt` and
+  `web/public/media/first-fleet-session.zh.vtt` — WebVTT, one cue per beat.
+- `docs/evidence/v092-first-fleet-session-transcript.md` — the full command
+  and receipt transcript, with the same evidence-standard header as
+  `docs/evidence/v091-empty-work-surface-receipt.md`.
+
+## Acceptance checklist (flip `status` to `published` only when every box is true)
+
+- [ ] Recorded from the **exact release-candidate SHA** named in the v0.9.2
+      completion ledger, after `install-dogfood.sh`, in a sealed
+      `HOME`/`CODEWHALE_HOME`.
+- [ ] Sealed local route only — no hosted provider, no account, no credentials
+      visible anywhere in the footage.
+- [ ] Poster is a real frame of the recording, PNG, **1280×720**, ≤ **500 KB**
+      (`MEDIA_BUDGETS.poster`).
+- [ ] Video is **1280×720**, ≤ **120 s**, ≤ **10 MB** (`MEDIA_BUDGETS.video`).
+- [ ] GIF fallback ≤ **6 MB** (`MEDIA_BUDGETS.gifFallback`); it is offered as
+      a download link, not described as a static reduced-motion substitute.
+- [ ] Captions: `en` and `zh` WebVTT tracks, non-empty, cues match the actual
+      session beats.
+- [ ] Transcript committed under `docs/evidence/` and referenced from the
+      manifest entry.
+- [ ] `web/lib/media-manifest.ts`: set `status: "published"` and fill `poster`,
+      `video` (with measured `durationSeconds`), `captions`, `gifFallback`,
+      `transcript`. No other manifest change.
+- [ ] Web gates green locally:
+      `npm ci && npm run prebuild && npm run check:facts && npm run check:docs && npm test && npm run lint && npm run build`
+      (the media-manifest test checks file presence/bytes and PNG poster
+      dimensions; verify actual video dimensions/duration here with media
+      inspection before changing the manifest status).
+- [ ] README GIF swap (same recording) is a **separate** commit updating
+      `docs/public-surface-facts.json` provenance — not part of this flip.
+- [ ] **No deploy.** `app.codewhale.net`/codewhale.net deployment stays
+      manual-dispatch and Hunter-gated per the release ledger.
+
+## Sign-off
+
+Recording, checklist, and manifest flip are maintainer-verified (Hunter)
+before the entry ships. The pending state on the site is correct until then.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -16,6 +16,18 @@ The codewhale.net site (Next.js). Read the repo-root `AGENTS.md` first.
 
 - `check:docs` verifies doc topics against real repo files, the version
   stamp, and install snippets — stale docs fail here, not in production.
+- **Shared public copy lives in `web/lib/content/`.** Locale-aware
+  `{ en, zh }` modules (product vocabulary, the getting-started path) are the
+  single source for the nouns and the new-user path; pages render from them.
+  Keep definitions verbatim with `docs/public-surface-facts.json` /
+  `docs/MODES.md` — `web/lib/content/vocabulary.test.ts` pins this. New
+  locales extend the pairs, not the pages.
+- **Real-session media goes through `web/lib/media-manifest.ts`.** A
+  `pending` entry renders the visible "recording pending release candidate"
+  state via `components/session-media.tsx`; never commit placeholder or staged
+  footage. Flipping to `published` requires the full asset set, the enforceable
+  file/byte/poster checks in `media-manifest.test.ts`, and the physical-media
+  checks in `docs/releases/v0.9.2-media-plan.md`.
 - `AGENT.md` (singular, next to this file) documents the community
   assistant (Cloudflare cron drafting triage/review/digest drafts into
   Workers KV, never posting directly). It is maintainer-owned automation;

--- a/web/app/[locale]/docs/fleet/page.tsx
+++ b/web/app/[locale]/docs/fleet/page.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_TERMS } from "@/lib/content/vocabulary";
 import { buildPageMetadata } from "@/lib/page-meta";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
@@ -19,19 +20,10 @@ export default async function FleetPage({ params }: { params: Promise<{ locale: 
   const bodyClass = isZh
     ? "text-ink-soft leading-[1.9] tracking-wide"
     : "text-ink-soft leading-relaxed";
-  const vocabulary = isZh
-    ? [
-        { term: "Fleet", definition: "谁来做工作：配置好的 worker、角色、模型、主机和信任边界。" },
-        { term: "Workflow", definition: "工作按什么顺序进行：阶段、门禁、预算、回放和汇总。" },
-        { term: "Lane", definition: "一个正在运行的 Workflow 实例及其实时进度。" },
-        { term: "Runtime", definition: "Lane 在哪里、如何执行：本地或远程进程、提供商路由、沙箱和 API 边界。" },
-      ]
-    : [
-        { term: "Fleet", definition: "Who does the work: the configured workers, roles, models, hosts, and trust boundaries." },
-        { term: "Workflow", definition: "What order the work follows: phases, gates, budgets, replay, and fan-in." },
-        { term: "Lane", definition: "One running Workflow instance and its live progress." },
-        { term: "Runtime", definition: "Where and how a Lane executes: local or remote process, provider route, sandbox, and API boundary." },
-      ];
+  const vocabulary = PRODUCT_TERMS.map((row) => ({
+    term: row.term,
+    definition: isZh ? row.long.zh : row.long.en,
+  }));
 
   return (
     <section className="space-y-10">

--- a/web/app/[locale]/docs/guide/page.tsx
+++ b/web/app/[locale]/docs/guide/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { GettingStartedSteps } from "@/components/getting-started-steps";
+import { SessionMedia } from "@/components/session-media";
+import { GUIDE_NEXT_LINKS } from "@/lib/content/getting-started";
+import { getMediaAsset } from "@/lib/media-manifest";
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/guide",
+    locale,
+    title: isZh ? "新手指引 · Codewhale 文档" : "Getting started · Codewhale Docs",
+    description: isZh
+      ? "从安装到第一个 Fleet Workflow 的完整路径：安装、无需密钥的首次会话、连接提供商、运行 Fleet。"
+      : "The full path from install to a first Fleet workflow: install, a first keyless session, provider connection, and Fleet.",
+  });
+}
+
+export default async function GuidePage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+  const session = getMediaAsset("first-fleet-session");
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "新手指引" : "Getting started"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "从一条安装命令到第一个 Fleet Workflow，四步走完。每一步都只陈述当前版本真实的行为；未发布或待录制的内容会明确标注。"
+            : "Four steps from one install command to a first Fleet workflow. Every step states only what the current candidate actually does; anything unreleased or unrecorded is labeled as such."}
+        </p>
+      </section>
+
+      <section id="path" className="scroll-mt-32">
+        <GettingStartedSteps locale={locale} />
+      </section>
+
+      {session && (
+        <section id="session-media" className="scroll-mt-32">
+          <h2 className="font-display text-2xl mb-1">
+            {isZh ? "看一次真实会话" : "Watch a real session"}
+          </h2>
+          <p className={`${bodyClass} mt-3 mb-4`}>
+            {isZh
+              ? "下方是真实会话媒体位。它当前处于待录制状态——这是有意为之：在 v0.9.2 候选版 dogfood 录制完成前，本站不展示任何占位或摆拍影像。"
+              : "Below is the real-session media slot. It is deliberately in the pending state: until the v0.9.2 candidate dogfood recording exists, this site shows no placeholder or staged footage."}
+          </p>
+          <SessionMedia asset={session} locale={locale} />
+        </section>
+      )}
+
+      <section id="next" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">{isZh ? "接下来" : "Where next"}</h2>
+        <div className="hairline-t mt-4">
+          {GUIDE_NEXT_LINKS.map((item) => (
+            <div key={item.href} className="py-4 hairline-b">
+              <h3 className="font-display text-xl">
+                <Link href={`/${locale}${item.href}`} className="hover:text-indigo transition-colors">
+                  {isZh ? item.label.zh : item.label.en}
+                </Link>
+              </h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{isZh ? item.note.zh : item.note.en}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/GUIDE.md, docs/KEYBINDINGS.md · 步骤文案来自 web/lib/content/getting-started.ts；更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/GUIDE.md, docs/KEYBINDINGS.md · Step copy lives in web/lib/content/getting-started.ts; update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/docs/layout.tsx
+++ b/web/app/[locale]/docs/layout.tsx
@@ -28,8 +28,8 @@ export default async function DocsLayout({
           <h1>{isZh ? "查找准确的使用说明。" : "Find the guidance you need."}</h1>
           <p>
             {isZh
-              ? "从安装和首次运行开始，或者直接查找模式、权限、工具、提供商、Fleet、MCP 与运行时 API。这些页面就是正式的产品文档；每页都链接仓库中的源文档，方便查阅完整细节。"
-              : "Start with installation and first run, or go straight to modes, permissions, tools, providers, Fleet, MCP, and the Runtime API. These pages are the product documentation; each one cites the source documents in the repository for full detail."}
+              ? "从新手指引和安装开始，或者直接查找产品名词、模式、权限、工具、提供商、Fleet、钩子、MCP 与运行时 API。这些页面就是正式的产品文档；每页都链接仓库中的源文档，方便查阅完整细节。"
+              : "Start with the getting-started guide and installation, or go straight to vocabulary, modes, permissions, tools, providers, Fleet, hooks, MCP, and the Runtime API. These pages are the product documentation; each one cites the source documents in the repository for full detail."}
           </p>
           <div className="portal-actions">
             <Link href={`/${locale}/install`} className="portal-button portal-button-primary">

--- a/web/app/[locale]/docs/vocabulary/page.tsx
+++ b/web/app/[locale]/docs/vocabulary/page.tsx
@@ -1,0 +1,141 @@
+import { StatusBadge } from "@/components/status-badge";
+import {
+  ADVISORY_ROLE,
+  CONTROL_MODES,
+  MEASUREMENT_PRINCIPLES,
+  PERMISSION_POSTURES,
+  PRODUCT_TERMS,
+  ROUTE_IDENTITY,
+} from "@/lib/content/vocabulary";
+import { buildPageMetadata } from "@/lib/page-meta";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  return buildPageMetadata({
+    path: "/docs/vocabulary",
+    locale,
+    title: isZh ? "产品名词 · Codewhale 文档" : "Vocabulary · Codewhale Docs",
+    description: isZh
+      ? "确切的产品名词：Fleet、Workflow、Lane、Runtime、Consultant，Plan / Act / Operate 与权限姿态，以及请求→实际思考档位、路由来源与测量原则。"
+      : "The exact product nouns: Fleet, Workflow, Lane, Runtime, Consultant, Plan / Act / Operate and permission postures, plus requested→effective reasoning, routing source, and measurement principles.",
+  });
+}
+
+export default async function VocabularyPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const isZh = locale === "zh";
+  const bodyClass = isZh
+    ? "text-ink-soft leading-[1.9] tracking-wide"
+    : "text-ink-soft leading-relaxed";
+
+  return (
+    <section className="space-y-10">
+      <section id="overview" className="scroll-mt-32">
+        <h2 className="font-display text-3xl mb-1">{isZh ? "产品名词" : "Vocabulary"}</h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "这些名词在全站、TUI 和收据里含义完全一致。名词本身不翻译；每条定义都与仓库中的公共事实矩阵逐字对应。"
+            : "These nouns mean the same thing on this site, in the TUI, and in receipts. The nouns themselves are never translated; every definition matches the public fact matrix in the repository verbatim."}
+        </p>
+      </section>
+
+      <section id="execution-nouns" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "执行名词" : "Execution nouns"}
+        </h2>
+        <div className="hairline-t mt-4">
+          {PRODUCT_TERMS.map((row) => (
+            <section key={row.term} className="py-4 hairline-b">
+              <h3 className="font-display text-xl">
+                {row.term}{" "}
+                <span className="text-sm text-ink-mute font-normal">
+                  = {isZh ? row.short.zh : row.short.en}
+                </span>
+              </h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>{isZh ? row.long.zh : row.long.en}</p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="control-nouns" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "模式与权限姿态" : "Modes and permission postures"}
+        </h2>
+        <p className={`${bodyClass} mt-3`}>
+          {isZh
+            ? "模式（Tab 循环，输入框空闲时）决定可见的交互方式；权限姿态（Shift+Tab 循环）决定工具执行前询问的激进程度。两者正交。"
+            : "Modes (Tab, composer idle) decide the visible interaction; permission postures (Shift+Tab) decide how aggressively tools ask before executing. The two are orthogonal."}
+        </p>
+        <div className="hairline-t mt-4">
+          {[...CONTROL_MODES, ...PERMISSION_POSTURES].map((row) => (
+            <section key={row.term} className="py-4 hairline-b">
+              <h3 className="font-display text-xl">{row.term}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>
+                {isZh ? row.description.zh : row.description.en}
+              </p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="route-identity" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh
+            ? "路由身份：provider · 模型 · 请求→实际思考档位 · 来源"
+            : "Route identity: provider · model · requested→effective reasoning · source"}
+        </h2>
+        <div className="hairline-t mt-4">
+          {ROUTE_IDENTITY.map((row) => (
+            <section key={row.term} className="py-4 hairline-b">
+              <h3 className="font-display text-xl">{row.term}</h3>
+              <p className={`${bodyClass} mt-1 text-sm`}>
+                {isZh ? row.description.zh : row.description.en}
+              </p>
+            </section>
+          ))}
+        </div>
+      </section>
+
+      <section id="advisory-role" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "咨询角色" : "Advisory role"}
+        </h2>
+        <div className="hairline-t mt-4 py-4 hairline-b">
+          <h3 className="font-display text-xl">{ADVISORY_ROLE.term}</h3>
+          <p className={`${bodyClass} mt-1 text-sm`}>
+            {isZh ? ADVISORY_ROLE.description.zh : ADVISORY_ROLE.description.en}
+          </p>
+        </div>
+      </section>
+
+      <section id="measurement" className="scroll-mt-32">
+        <h2 className="font-display text-2xl mb-1">
+          {isZh ? "测量原则" : "Measurement principles"}
+        </h2>
+        <ul className="mt-4 space-y-3">
+          {MEASUREMENT_PRINCIPLES.map((principle) => (
+            <li key={principle.en} className={`${bodyClass} text-sm`}>
+              {isZh ? principle.zh : principle.en}
+            </li>
+          ))}
+        </ul>
+        <p className={`${bodyClass} mt-4 text-sm`}>
+          <StatusBadge kind="unavailable" locale={locale} />{" "}
+          {isZh
+            ? "基准排行榜：本站没有，也不会在没有路由身份与测量工具链的情况下出现。"
+            : "Benchmark leaderboard: none on this site, and none will appear without route identity and a measurement harness attached."}
+        </p>
+      </section>
+
+      <section id="source" className="hairline-t pt-8">
+        <p className="text-sm text-ink-mute">
+          {isZh
+            ? "来源文档：docs/FLEET.md, docs/MODES.md, docs/public-surface-facts.json · 名词文案来自 web/lib/content/vocabulary.ts；更新时请同步修改 docs-map.ts。"
+            : "Source documents: docs/FLEET.md, docs/MODES.md, docs/public-surface-facts.json · Vocabulary copy lives in web/lib/content/vocabulary.ts; update docs-map.ts when changing."}
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -79,8 +79,11 @@ export default async function LocaleLayout({
               "(function(){try{var t=localStorage.getItem('cw-theme');if(t==='light'||t==='dark'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}})();",
           }}
         />
+        <a href="#main-content" className="skip-link">
+          {locale === "zh" ? "跳到主要内容" : "Skip to main content"}
+        </a>
         <Nav locale={locale as Locale} />
-        <main>{children}</main>
+        <main id="main-content">{children}</main>
         <Footer locale={locale as Locale} />
       </body>
     </html>

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { GettingStartedSteps } from "@/components/getting-started-steps";
 import { InstallCodeBlock } from "@/components/install-code-block";
 import { Whale } from "@/components/whale";
 import { getFacts } from "@/lib/facts";
@@ -235,6 +236,28 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
             <span>act&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; edit through the selected permission posture</span>
             <span>verify&nbsp;&nbsp;&nbsp; cargo test --locked</span>
             <strong>report&nbsp;&nbsp;&nbsp; checks passed · receipt saved</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="product-start">
+        <div className="product-container">
+          <h2>
+            {isZh ? "第一次使用？四步走完。" : "New to Codewhale? Four steps end to end."}
+          </h2>
+          <p className="product-start-lede">
+            {isZh
+              ? "安装 → 无需密钥的首次会话 → 连接提供商 → 第一个 Fleet Workflow。名词含义见产品名词页。"
+              : "Install → a first keyless session → provider connection → a first Fleet workflow. The nouns are defined on the vocabulary page."}
+          </p>
+          <GettingStartedSteps locale={locale} />
+          <div className="product-start-links">
+            <Link href={`/${locale}/docs/guide`}>
+              {isZh ? "阅读新手指引 →" : "Read the getting-started guide →"}
+            </Link>
+            <Link href={`/${locale}/docs/vocabulary`}>
+              {isZh ? "查看产品名词 →" : "See the product vocabulary →"}
+            </Link>
           </div>
         </div>
       </section>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1406,6 +1406,200 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
   font-weight: 500;
 }
 
+/* ---------- product: start-here band + shared getting-started steps ---------- */
+
+.product-start {
+  padding-block: clamp(4rem, 8vw, 7rem);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.product-start h2 {
+  max-width: 54rem;
+  font-size: clamp(1.8rem, 3.3vw, 3rem);
+}
+
+.product-start-lede {
+  margin-top: 0.9rem;
+  max-width: 46rem;
+  color: var(--ink-soft);
+  line-height: 1.75;
+}
+
+.product-start-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.product-start-links a {
+  color: var(--indigo);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+}
+
+.product-start-links a:hover {
+  color: var(--indigo-deep);
+}
+
+/* Shared step list rendered by <GettingStartedSteps> (homepage band and the
+   /docs/guide page). Light tokens; the docs dark theme re-themes it through
+   the same --hairline/--ink-* vars as the rest of the docs subtree. */
+.gs-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: clamp(2rem, 4vw, 3rem);
+  padding: 0;
+  border-top: 1px solid var(--hairline);
+  list-style: none;
+}
+
+.gs-steps li {
+  padding: 1.35rem 1.5rem 1.5rem 0;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.gs-steps li + li {
+  padding-left: 1.5rem;
+  border-left: 1px solid var(--hairline);
+}
+
+.gs-step-index {
+  color: var(--indigo);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.68rem;
+}
+
+.gs-steps h3 {
+  margin-top: 1.1rem;
+  font-size: 1.05rem;
+}
+
+.gs-steps p {
+  margin-top: 0.6rem;
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+  line-height: 1.7;
+}
+
+.gs-step-commands {
+  margin-top: 0.9rem;
+  font-size: 0.72rem;
+}
+
+.gs-step-link {
+  display: inline-block;
+  margin-top: 0.9rem;
+  color: var(--indigo);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+}
+
+.gs-step-link:hover {
+  color: var(--indigo-deep);
+}
+
+/* ---------- a11y: skip link ---------- */
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -3.5rem;
+  z-index: 60;
+  padding: 0.55rem 0.9rem;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+}
+
+.skip-link:focus-visible {
+  top: 0.5rem;
+  outline: 2px solid var(--indigo);
+  outline-offset: 2px;
+}
+
+/* ---------- honest status badges ---------- */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--hairline);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.status-badge-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+}
+
+.status-badge-experimental .status-badge-dot { background: var(--ochre); }
+.status-badge-preview .status-badge-dot { background: var(--indigo); }
+.status-badge-pending .status-badge-dot { background: var(--ochre); }
+.status-badge-unavailable .status-badge-dot { background: var(--ink-mute); }
+
+/* ---------- session media (real-session surface) ---------- */
+
+.session-media {
+  border: 1px solid var(--hairline);
+}
+
+.session-media video {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: var(--ocean-deep);
+}
+
+.session-media-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border-bottom: 1px solid var(--hairline);
+  background: var(--paper-deep);
+}
+
+.session-media-pending-note {
+  max-width: 44rem;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+.session-media-caption {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  color: var(--ink-soft);
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+.session-media-caption strong {
+  color: var(--ink);
+  font-size: 0.95rem;
+}
+
+.session-media-caption a {
+  color: var(--indigo);
+  font-family: var(--font-mono), "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+}
+
+.session-media-caption a:hover {
+  color: var(--indigo-deep);
+}
+
 .product-boundaries {
   padding-block: clamp(4rem, 8vw, 7rem);
   border-bottom: 1px solid var(--hairline);
@@ -1649,6 +1843,15 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
     border-left: 0;
   }
 
+  .gs-steps {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .gs-steps li:nth-child(3) {
+    padding-left: 0;
+    border-left: 0;
+  }
+
   .product-boundary-list > div,
   .product-surface-list > div {
     grid-template-columns: 1fr;
@@ -1679,6 +1882,17 @@ a.body-link:hover { background-size: 100% 6px; color: var(--ink); }
   .product-workflow-steps li + li,
   .product-workflow-steps li:nth-child(3) {
     min-height: 0;
+    padding: 1.25rem 0;
+    border-left: 0;
+  }
+
+  .gs-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .gs-steps li,
+  .gs-steps li + li,
+  .gs-steps li:nth-child(3) {
     padding: 1.25rem 0;
     border-left: 0;
   }

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -4,7 +4,7 @@ import { SITE_URL } from "@/lib/page-meta";
 
 // Public, indexable routes (locale-prefixed). /admin and /api are
 // intentionally excluded; see app/robots.ts.
-const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/web", "/docs/work", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
+const PATHS = ["", "/install", "/constitution", "/models", "/runtime", "/docs", "/docs/configuration", "/docs/constitution", "/docs/fleet", "/docs/guide", "/docs/hooks", "/docs/mcp", "/docs/modes", "/docs/runtime-api", "/docs/sandbox", "/docs/subagents", "/docs/tools", "/docs/troubleshooting", "/docs/vocabulary", "/docs/web", "/docs/work", "/faq", "/roadmap", "/feed", "/digest", "/contribute", "/community"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -14,18 +14,26 @@ export function Footer({ locale = "en" }: { locale?: Locale }) {
   const product = isZh
     ? [
         { label: "文档", href: "/zh/docs" },
+        { label: "新手指引", href: "/zh/docs/guide" },
         { label: "安装", href: "/zh/install" },
         { label: "模型", href: "/zh/models" },
         { label: "运行时", href: "/zh/runtime" },
+        { label: "常见问题", href: "/zh/faq" },
       ]
     : locale === "en"
       ? [
           { label: "Docs", href: "/en/docs" },
+          { label: "Getting started", href: "/en/docs/guide" },
           { label: "Install", href: "/en/install" },
           { label: "Models", href: "/en/models" },
           { label: "Runtime", href: "/en/runtime" },
+          { label: "FAQ", href: "/en/faq" },
         ]
       : [
+          // No `footerGuide`/`footerFaq` keys exist in the chrome dictionaries,
+          // so the dictionary-driven locales keep main's link set rather than
+          // linking English-only labels. Adding them is a locale-parity change,
+          // not a rebase resolution.
           { label: chrome.footerDocs, href: `/${locale}/docs` },
           { label: chrome.footerInstall, href: `/${locale}/install` },
           { label: chrome.footerModels, href: `/${locale}/models` },

--- a/web/components/getting-started-steps.tsx
+++ b/web/components/getting-started-steps.tsx
@@ -1,0 +1,35 @@
+/**
+ * <GettingStartedSteps> — renders the shared new-user path from
+ * web/lib/content/getting-started.ts: install → first offline session →
+ * provider connection → first Fleet workflow.
+ *
+ * Used by the homepage band and the /docs/guide page so the path reads
+ * identically in both places. Server component, SSG-safe.
+ */
+
+import Link from "next/link";
+import { GETTING_STARTED_STEPS } from "@/lib/content/getting-started";
+
+export function GettingStartedSteps({ locale = "en" }: { locale?: string }) {
+  const isZh = locale === "zh";
+
+  return (
+    <ol className="gs-steps">
+      {GETTING_STARTED_STEPS.map((step, index) => (
+        <li key={step.id} data-step-id={step.id}>
+          <span className="gs-step-index" aria-hidden="true">
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          <h3>{isZh ? step.title.zh : step.title.en}</h3>
+          <p>{isZh ? step.body.zh : step.body.en}</p>
+          {step.commands.length > 0 && (
+            <pre className="code-block gs-step-commands"><code>{step.commands.join("\n")}</code></pre>
+          )}
+          <Link href={`/${locale}${step.link.href}`} className="gs-step-link">
+            {isZh ? step.link.label.zh : step.link.label.en} →
+          </Link>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/components/nav-links.tsx
+++ b/web/components/nav-links.tsx
@@ -9,7 +9,7 @@ export function NavLinks({ links, isZh }: { links: NavLink[]; isZh: boolean }) {
   const pathname = usePathname();
 
   return (
-    <nav className="hidden md:flex items-center gap-7">
+    <nav className="hidden md:flex items-center gap-7" aria-label={isZh ? "主导航" : "Primary"}>
       {links.map((l) => {
         const isActive = pathname === l.href || pathname.startsWith(`${l.href}/`);
         return (

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -9,14 +9,18 @@ import { Whale } from "./whale";
 
 const EN_LINKS = [
   { href: "/en/docs", label: "Docs" },
+  { href: "/en/docs/guide", label: "Start" },
   { href: "/en/install", label: "Install" },
+  { href: "/en/faq", label: "FAQ" },
   { href: "/en/community", label: "Community" },
   { href: "/en/contribute", label: "Contribute" },
 ];
 
 const ZH_LINKS = [
   { href: "/zh/docs", label: "文档" },
+  { href: "/zh/docs/guide", label: "指引" },
   { href: "/zh/install", label: "安装" },
+  { href: "/zh/faq", label: "常见问题" },
   { href: "/zh/community", label: "社区" },
   { href: "/zh/contribute", label: "贡献" },
 ];

--- a/web/components/session-media.tsx
+++ b/web/components/session-media.tsx
@@ -1,0 +1,108 @@
+/**
+ * <SessionMedia> — renders one entry from web/lib/media-manifest.ts.
+ *
+ * Two states, both honest:
+ *
+ *   pending   — a plainly labeled panel: "Recording pending release
+ *               candidate". No mock terminal, no staged screenshot, no
+ *               recycled clip. The panel exists so the absence of footage is
+ *               visible and explained, not hidden.
+ *
+ *   published — a <video> with the declared poster, per-locale WebVTT
+ *               captions, a transcript link, and a GIF fallback link. The
+ *               reduced-motion contract is structural (REDUCED_MOTION_POLICY
+ *               = "static-poster-no-autoplay"): preload="none", no autoPlay,
+ *               user-initiated playback only. The optional GIF is a link,
+ *               not an autoplaying reduced-motion substitute.
+ *
+ * Server component: no client JS, SSG-safe.
+ */
+
+import { REDUCED_MOTION_POLICY, type MediaAsset } from "@/lib/media-manifest";
+import { StatusBadge } from "./status-badge";
+
+const MEDIA_PLAN_DOC =
+  "https://github.com/Hmbown/CodeWhale/blob/main/docs/releases/v0.9.2-media-plan.md";
+const REPO_BLOB_BASE = "https://github.com/Hmbown/CodeWhale/blob/main";
+
+export function SessionMedia({ asset, locale = "en" }: { asset: MediaAsset; locale?: string }) {
+  const isZh = locale === "zh";
+
+  if (asset.status === "pending") {
+    return (
+      <figure
+        className="session-media session-media-pending"
+        data-media-id={asset.id}
+        data-media-status={asset.status}
+        data-reduced-motion-policy={REDUCED_MOTION_POLICY}
+      >
+        <div className="session-media-stage">
+          <StatusBadge kind="pending" locale={locale} label={asset.pendingLabel} />
+          <p className="session-media-pending-note">
+            {isZh
+              ? "此处不展示占位或摆拍影像。录制完成后，这段真实会话将带海报帧、双语字幕、文字稿和可选的 GIF 回退下载一同发布。"
+              : "No placeholder or staged footage is shown here. When the recording exists, the real session ships with a poster frame, bilingual captions, a transcript, and an optional GIF fallback download."}
+          </p>
+        </div>
+        <figcaption className="session-media-caption">
+          <strong>{isZh ? asset.title.zh : asset.title.en}</strong>
+          <span>{isZh ? asset.description.zh : asset.description.en}</span>
+          <a href={MEDIA_PLAN_DOC} target="_blank" rel="noreferrer">
+            {isZh ? "录制计划与验收清单 ↗" : "Recording plan and acceptance checklist ↗"}
+          </a>
+        </figcaption>
+      </figure>
+    );
+  }
+
+  // status === "published": manifest tests require every field and verify
+  // file presence/byte budgets plus poster dimensions. The human recording
+  // checklist remains authoritative for actual video duration/dimensions.
+  const poster = asset.poster!;
+  const video = asset.video!;
+  const captions = asset.captions ?? [];
+
+  return (
+    <figure
+      className="session-media"
+      data-media-id={asset.id}
+      data-media-status={asset.status}
+      data-reduced-motion-policy={REDUCED_MOTION_POLICY}
+    >
+      <video
+        controls
+        preload="none"
+        poster={`/${poster.src}`}
+        width={video.width}
+        height={video.height}
+        aria-label={isZh ? poster.alt.zh : poster.alt.en}
+      >
+        <source src={`/${video.src}`} type="video/mp4" />
+        {captions.map((track) => (
+          <track
+            key={track.srclang}
+            kind="captions"
+            src={`/${track.src}`}
+            srcLang={track.srclang}
+            label={track.label}
+            default={track.srclang === "en"}
+          />
+        ))}
+      </video>
+      <figcaption className="session-media-caption">
+        <strong>{isZh ? asset.title.zh : asset.title.en}</strong>
+        <span>{isZh ? asset.description.zh : asset.description.en}</span>
+        {asset.gifFallback && (
+          <a href={`/${asset.gifFallback.src}`}>
+            {isZh ? "GIF 下载回退（无视频环境）" : "GIF fallback download (no-video environments)"}
+          </a>
+        )}
+        {asset.transcript && (
+          <a href={`${REPO_BLOB_BASE}/${asset.transcript}`} target="_blank" rel="noreferrer">
+            {isZh ? "文字稿 ↗" : "Transcript ↗"}
+          </a>
+        )}
+      </figcaption>
+    </figure>
+  );
+}

--- a/web/components/status-badge.tsx
+++ b/web/components/status-badge.tsx
@@ -1,0 +1,40 @@
+/**
+ * <StatusBadge> — honest availability labels for public surfaces.
+ *
+ * Used wherever the site shows something that is not a shipped, stable
+ * feature: experimental bridges, preview platforms, pending media, and
+ * unavailable states. The label is always visible text — never color alone —
+ * so the state is conveyed accessibly in both locales.
+ */
+
+import type { LocalizedText } from "@/lib/content/vocabulary";
+
+export type StatusKind = "experimental" | "preview" | "pending" | "unavailable";
+
+const DEFAULT_LABELS: Record<StatusKind, LocalizedText> = {
+  experimental: { en: "Experimental", zh: "实验性" },
+  preview: { en: "Preview", zh: "预览" },
+  pending: { en: "Pending", zh: "待就绪" },
+  unavailable: { en: "Unavailable", zh: "暂不可用" },
+};
+
+export function StatusBadge({
+  kind,
+  locale = "en",
+  label,
+}: {
+  kind: StatusKind;
+  locale?: string;
+  /** Overrides the default per-kind label (e.g. a media entry's pendingLabel). */
+  label?: LocalizedText;
+}) {
+  const isZh = locale === "zh";
+  const text = label ? (isZh ? label.zh : label.en) : isZh ? DEFAULT_LABELS[kind].zh : DEFAULT_LABELS[kind].en;
+
+  return (
+    <span className={`status-badge status-badge-${kind}`}>
+      <span className="status-badge-dot" aria-hidden="true" />
+      {text}
+    </span>
+  );
+}

--- a/web/lib/content/getting-started.ts
+++ b/web/lib/content/getting-started.ts
@@ -1,0 +1,117 @@
+/**
+ * getting-started.ts — the canonical new-user path for codewhale.net.
+ *
+ * Four steps, in order: install → first offline session → provider connection
+ * → first Fleet workflow. Both the homepage band and the /docs/guide page
+ * render from this module, so the path reads identically everywhere.
+ *
+ * TRUTH CONTRACT:
+ *   - Step copy must match documented behavior in docs/GUIDE.md, docs/MODES.md,
+ *     docs/PROVIDERS.md, and docs/FLEET.md. The runtime launches without any
+ *     API key (constitution-first setup); model replies require a provider —
+ *     hosted key or a keyless loopback route. Do not imply otherwise.
+ *   - `href` values are locale-relative (no locale prefix); consumers render
+ *     `/${locale}${href}` and the tests assert every target route exists.
+ *
+ * EXTENSION PATH FOR NEW LOCALES: add the locale key to each `{ en, zh }`
+ * pair; commands stay locale-agnostic shell.
+ */
+
+import type { LocalizedText } from "./vocabulary";
+
+export interface GuideStep {
+  id: "install" | "first-session" | "connect-provider" | "fleet-workflow";
+  title: LocalizedText;
+  body: LocalizedText;
+  /** Locale-agnostic shell commands shown for the step (may be empty). */
+  commands: string[];
+  /** Deeper-reading link; href is locale-relative. */
+  link: { href: string; label: LocalizedText };
+}
+
+export const GETTING_STARTED_STEPS: GuideStep[] = [
+  {
+    id: "install",
+    title: { en: "Install Codewhale", zh: "安装 Codewhale" },
+    body: {
+      en: "One npm command installs the dispatcher and the terminal runtime. Cargo, prebuilt archives, Docker, Nix, and China mirrors are documented alternatives; every channel serves published releases only.",
+      zh: "一条 npm 命令即可安装调度器和终端运行时。Cargo、预编译包、Docker、Nix 和中国镜像是有文档的备选渠道；所有渠道只提供已发布版本。",
+    },
+    commands: ["npm install -g codewhale", "codewhale doctor"],
+    link: {
+      href: "/install",
+      label: { en: "Full install guide", zh: "完整安装指南" },
+    },
+  },
+  {
+    id: "first-session",
+    title: { en: "Open a first session — no key needed", zh: "打开第一个会话——无需密钥" },
+    body: {
+      en: "The runtime launches without any API key: a short constitution-first setup (language, provider readiness, runtime posture, your constitution), then the full interface. Explore in Plan mode — it is always read-only. Model replies need a provider; that is the next step.",
+      zh: "运行时无需任何 API 密钥即可启动：先走过一段简短的宪法优先设置（语言、提供商就绪情况、运行姿态、你的宪法），然后进入完整界面。在 Plan 模式中探索——它始终只读。模型回复需要提供商；这正是下一步。",
+    },
+    commands: ["codewhale"],
+    link: {
+      href: "/docs/vocabulary",
+      label: { en: "Learn the product nouns first", zh: "先了解产品名词" },
+    },
+  },
+  {
+    id: "connect-provider",
+    title: { en: "Connect a provider", zh: "连接提供商" },
+    body: {
+      en: "Pick any supported route — a hosted key, a gateway, or a keyless local runtime such as Ollama, vLLM, or SGLang for fully local inference. Provider and model stay explicit; requested and effective reasoning plus routing source are separate provenance fields, and unavailable values stay unavailable.",
+      zh: "任选一条受支持的路由——托管密钥、网关，或 Ollama、vLLM、SGLang 等免密钥本地运行时（推理完全在本地）。Provider 与模型始终明确；请求与实际思考档位及路由来源是分开的来源字段，暂不可用的值保持暂不可用。",
+    },
+    commands: ["codewhale auth set --provider deepseek"],
+    link: {
+      href: "/models",
+      label: { en: "Providers and models", zh: "提供商与模型" },
+    },
+  },
+  {
+    id: "fleet-workflow",
+    title: { en: "Run a first Fleet workflow", zh: "运行第一个 Fleet Workflow" },
+    body: {
+      en: "When work needs durable workers, ordered phases, or receipts, author a reusable agent-team profile and launch a run. Fleet state lives in the workspace ledger and survives restarts; ordinary single tasks need none of this.",
+      zh: "当工作需要持久 worker、有序阶段或收据时，编写可复用的 agent 团队档案并启动运行。Fleet 状态保存在工作区台账中，重启后依然存活；普通的单一任务不需要这些。",
+    },
+    commands: ["codewhale fleet init", "codewhale fleet run tasks.json --max-workers 4"],
+    link: {
+      href: "/docs/fleet",
+      label: { en: "Fleet and Workflow docs", zh: "Fleet 与 Workflow 文档" },
+    },
+  },
+];
+
+/**
+ * Where to go after the path — discovery links rendered at the end of the
+ * /docs/guide page. Hooks are first-class here on purpose: they are the
+ * supported extension point a new user should find without digging.
+ */
+export const GUIDE_NEXT_LINKS: { href: string; label: LocalizedText; note: LocalizedText }[] = [
+  {
+    href: "/docs/hooks",
+    label: { en: "Hooks", zh: "钩子" },
+    note: {
+      en: "React to lifecycle events — before and after tool calls, on turn end, on session events — with project-local trust rules.",
+      zh: "借助项目级信任规则，响应生命周期事件——工具调用前后、回合结束、会话事件。",
+    },
+  },
+  {
+    href: "/docs/modes",
+    label: { en: "Modes and permission postures", zh: "模式与权限姿态" },
+    note: {
+      en: "Plan / Act / Operate and Ask / Auto-Review / Full Access, exactly as the runtime enforces them.",
+      zh: "Plan / Act / Operate 与 Ask / Auto-Review / Full Access，与运行时实际执行的一致。",
+    },
+  },
+  {
+    href: "/docs",
+    label: { en: "Documentation hub", zh: "文档中心" },
+    note: {
+      en: "Every topic, searchable, each page citing its source document in the repository.",
+      zh: "所有主题均可搜索，每个页面都注明仓库中的源文档。",
+    },
+  },
+];

--- a/web/lib/content/vocabulary.test.ts
+++ b/web/lib/content/vocabulary.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared-content contracts: the locale-aware vocabulary and getting-started
+ * modules that pages render from. These tests pin the copy to the repo's
+ * public fact matrix and to real routes/documents, so the localization lane
+ * can extend the modules without ever drifting from runtime truth.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  ADVISORY_ROLE,
+  CONTROL_MODES,
+  MEASUREMENT_PRINCIPLES,
+  PERMISSION_POSTURES,
+  PRODUCT_TERMS,
+  ROUTE_IDENTITY,
+} from "./vocabulary";
+import { GETTING_STARTED_STEPS, GUIDE_NEXT_LINKS } from "./getting-started";
+
+const root = new URL("../../../", import.meta.url);
+
+function repoText(path: string): string {
+  return readFileSync(new URL(path, root), "utf8");
+}
+
+const matrix = JSON.parse(repoText("docs/public-surface-facts.json")) as {
+  product: { terminology: Record<string, string> };
+  control: { modes: string[]; permissionPostures: string[] };
+};
+
+const BANNED_COPY = /\bAgent mode\b|Agent 模式|\bYOLO\b|approval_mode|first-class|一级支持/;
+
+describe("shared product vocabulary", () => {
+  it("keeps the execution nouns verbatim with the public fact matrix", () => {
+    expect(PRODUCT_TERMS.map((t) => t.term)).toEqual(["Fleet", "Workflow", "Lane", "Runtime"]);
+    for (const term of PRODUCT_TERMS) {
+      expect(term.short.en, term.term).toBe(matrix.product.terminology[term.term]);
+    }
+  });
+
+  it("keeps mode and posture names exact", () => {
+    expect(CONTROL_MODES.map((t) => t.term)).toEqual(matrix.control.modes);
+    expect(PERMISSION_POSTURES.map((t) => t.term)).toEqual(matrix.control.permissionPostures);
+    for (const term of [...CONTROL_MODES, ...PERMISSION_POSTURES]) {
+      expect(term.kind).toMatch(/^mode$|^permission-posture$/);
+    }
+  });
+
+  it("has complete en/zh pairs everywhere and no banned legacy copy", () => {
+    const pairs = [
+      ...PRODUCT_TERMS.flatMap((t) => [t.short, t.long]),
+      ...[...CONTROL_MODES, ...PERMISSION_POSTURES, ...ROUTE_IDENTITY].map((t) => t.description),
+      ADVISORY_ROLE.description,
+      ...MEASUREMENT_PRINCIPLES,
+    ];
+    for (const pair of pairs) {
+      expect(pair.en.trim().length).toBeGreaterThan(0);
+      expect(pair.zh.trim().length).toBeGreaterThan(0);
+      expect(pair.en).not.toBe(pair.zh);
+      expect(`${pair.en}\n${pair.zh}`).not.toMatch(BANNED_COPY);
+    }
+  });
+
+  it("states measurement truth without claiming results", () => {
+    expect(MEASUREMENT_PRINCIPLES.length).toBeGreaterThanOrEqual(3);
+    const combined = MEASUREMENT_PRINCIPLES.map((p) => p.en).join("\n");
+    // No fabricated numbers: the module must not publish any benchmark score.
+    expect(combined).not.toMatch(/\b\d+(\.\d+)?\s?(%|percent|tokens\/s|tok\/s)\b/i);
+    expect(combined).toContain("no benchmark leaderboard");
+    expect(combined).toContain("provider, model, requested and effective reasoning");
+  });
+
+  it("separates requested and effective reasoning and names route provenance", () => {
+    const requested = ROUTE_IDENTITY.find((r) => r.term === "Requested reasoning");
+    const effective = ROUTE_IDENTITY.find((r) => r.term === "Effective reasoning");
+    const source = ROUTE_IDENTITY.find((r) => r.term === "Routing source");
+    expect(requested).toBeTruthy();
+    expect(effective?.description.en).toContain("unavailable");
+    expect(source?.description.en).toContain("provenance");
+    for (const tier of ["off", "low", "medium", "high", "max", "auto"]) {
+      expect(requested!.description.en).toContain(tier);
+    }
+  });
+
+  it("uses Consultant publicly and keeps old advisory names as aliases only", () => {
+    expect(ADVISORY_ROLE.term).toBe("Consultant");
+    expect(ADVISORY_ROLE.description.en).toContain("oracle");
+    expect(ADVISORY_ROLE.description.en).toContain("advisor");
+    expect(ADVISORY_ROLE.description.en).toContain("compatibility aliases");
+  });
+});
+
+describe("shared getting-started path", () => {
+  it("keeps the four-step order: install → offline session → provider → fleet", () => {
+    expect(GETTING_STARTED_STEPS.map((s) => s.id)).toEqual([
+      "install",
+      "first-session",
+      "connect-provider",
+      "fleet-workflow",
+    ]);
+  });
+
+  it("points every step and next link at a real on-site route", () => {
+    const knownRoutes = [
+      "/install",
+      "/models",
+      "/docs",
+      "/docs/guide",
+      "/docs/vocabulary",
+      "/docs/fleet",
+      "/docs/hooks",
+      "/docs/modes",
+    ];
+    for (const step of GETTING_STARTED_STEPS) {
+      expect(knownRoutes, step.link.href).toContain(step.link.href);
+      expect(step.title.en.trim().length).toBeGreaterThan(0);
+      expect(step.title.zh.trim().length).toBeGreaterThan(0);
+      expect(`${step.body.en}\n${step.body.zh}`).not.toMatch(BANNED_COPY);
+    }
+    for (const link of GUIDE_NEXT_LINKS) {
+      expect(knownRoutes, link.href).toContain(link.href);
+    }
+    // Hooks discovery is a first-class next step, not buried prose.
+    expect(GUIDE_NEXT_LINKS.some((l) => l.href === "/docs/hooks")).toBe(true);
+  });
+
+  it("describes the first session truthfully: keyless launch, provider for replies", () => {
+    const first = GETTING_STARTED_STEPS.find((s) => s.id === "first-session")!;
+    expect(first.body.en).toContain("without any API key");
+    expect(first.body.en).toContain("Plan mode");
+    expect(first.body.en).toMatch(/Model replies need a provider/);
+    // The keyless-launch claim is documented behavior, not invented copy.
+    const guide = repoText("docs/GUIDE.md");
+    expect(guide).toContain("On first launch, Codewhale starts with a short constitution-first setup path");
+  });
+
+  it("uses only documented commands", () => {
+    const guide = repoText("docs/GUIDE.md");
+    const fleetDoc = repoText("docs/FLEET.md");
+    const install = GETTING_STARTED_STEPS.find((s) => s.id === "install")!;
+    expect(install.commands).toContain("npm install -g codewhale");
+    expect(guide).toContain("codewhale doctor");
+    const provider = GETTING_STARTED_STEPS.find((s) => s.id === "connect-provider")!;
+    expect(provider.commands).toContain("codewhale auth set --provider deepseek");
+    expect(guide).toContain("codewhale auth set --provider deepseek");
+    const fleet = GETTING_STARTED_STEPS.find((s) => s.id === "fleet-workflow")!;
+    for (const command of fleet.commands) {
+      expect(`${fleetDoc}\n${guide}`, command).toContain(command);
+    }
+  });
+
+  it("keeps repo source documents resolvable", () => {
+    for (const path of ["docs/GUIDE.md", "docs/KEYBINDINGS.md", "docs/FLEET.md", "docs/MODES.md"]) {
+      expect(existsSync(new URL(path, root)), path).toBe(true);
+    }
+  });
+});

--- a/web/lib/content/vocabulary.ts
+++ b/web/lib/content/vocabulary.ts
@@ -1,0 +1,208 @@
+/**
+ * vocabulary.ts — shared, locale-aware product vocabulary for codewhale.net.
+ *
+ * This module is the single source of truth for the exact product nouns a new
+ * user meets on the site: the Fleet/Workflow/Lane/Runtime execution nouns,
+ * the Plan/Act/Operate + Ask/Auto-Review/Full Access control vocabulary, the
+ * public Consultant role, and the fields that make route provenance legible.
+ *
+ * TRUTH CONTRACT:
+ *   - `short.en` for every product term MUST equal the verbatim definition in
+ *     docs/public-surface-facts.json → product.terminology, which is itself
+ *     pinned verbatim against docs/FLEET.md by public-surface-contract.test.ts.
+ *   - Mode and posture names MUST equal matrix.control.modes /
+ *     matrix.control.permissionPostures (pinned against docs/MODES.md).
+ *   - No marketing adjectives. Each description states behavior and boundary.
+ *
+ * EXTENSION PATH FOR NEW LOCALES (localization lane):
+ *   Every user-facing string is a `{ en, zh }` pair. Add the new locale key to
+ *   each pair (and widen the `LocalizedText` type) — the consuming components
+ *   and tests pick it up without structural changes. The tests assert key
+ *   parity across locales, so a missing translation fails deterministically.
+ */
+
+export interface LocalizedText {
+  en: string;
+  zh: string;
+}
+
+export interface ProductTerm {
+  /** The exact product noun. Never translate the noun itself. */
+  term: "Fleet" | "Workflow" | "Lane" | "Runtime";
+  /** One-line definition; `en` is verbatim from docs/public-surface-facts.json. */
+  short: LocalizedText;
+  /** One-sentence elaboration used on docs pages. */
+  long: LocalizedText;
+}
+
+export const PRODUCT_TERMS: ProductTerm[] = [
+  {
+    term: "Fleet",
+    short: { en: "who does the work", zh: "谁来做工作" },
+    long: {
+      en: "Who does the work: the configured workers, roles, models, hosts, and trust boundaries.",
+      zh: "谁来做工作：配置好的 worker、角色、模型、主机和信任边界。",
+    },
+  },
+  {
+    term: "Workflow",
+    short: { en: "what order the work follows", zh: "工作按什么顺序进行" },
+    long: {
+      en: "What order the work follows: phases, gates, budgets, replay, and fan-in.",
+      zh: "工作按什么顺序进行：阶段、门禁、预算、回放和汇总。",
+    },
+  },
+  {
+    term: "Lane",
+    short: { en: "one running Workflow instance", zh: "一个正在运行的 Workflow 实例" },
+    long: {
+      en: "One running Workflow instance and its live progress.",
+      zh: "一个正在运行的 Workflow 实例及其实时进度。",
+    },
+  },
+  {
+    term: "Runtime",
+    short: { en: "where and how a Lane executes", zh: "Lane 在哪里、如何执行" },
+    long: {
+      en: "Where and how a Lane executes: local or remote process, provider route, sandbox, and API boundary.",
+      zh: "Lane 在哪里、如何执行：本地或远程进程、提供商路由、沙箱和 API 边界。",
+    },
+  },
+];
+
+export interface ControlTerm {
+  /** The exact control noun. Never translate the noun itself. */
+  term: string;
+  kind: "mode" | "permission-posture";
+  /** Behavioral description aligned with docs/MODES.md. */
+  description: LocalizedText;
+}
+
+/** TUI modes — cycle with Tab when the composer is idle (docs/MODES.md). */
+export const CONTROL_MODES: ControlTerm[] = [
+  {
+    term: "Plan",
+    kind: "mode",
+    description: {
+      en: "Design-first and always read-only: investigation tools stay available, shell and patch execution stay off.",
+      zh: "设计优先且始终只读：调查工具可用，shell 与补丁执行保持关闭。",
+    },
+  },
+  {
+    term: "Act",
+    kind: "mode",
+    description: {
+      en: "The default working mode for new sessions: multi-step tool use with approval prompts gating each shell call.",
+      zh: "新会话的默认工作模式：多步骤工具调用，每次 shell 调用都有审批提示把关。",
+    },
+  },
+  {
+    term: "Operate",
+    kind: "mode",
+    description: {
+      en: "Multitask conductor under the same permission posture, sandbox, and safety rules as Act; background worker dispatch is the default for real multi-step work.",
+      zh: "在与 Act 相同的权限姿态、沙箱和安全规则下进行多任务调度；真正的多步骤工作默认派发给后台 worker。",
+    },
+  },
+];
+
+/** Permission postures — cycle with Shift+Tab when the composer is idle. */
+export const PERMISSION_POSTURES: ControlTerm[] = [
+  {
+    term: "Ask",
+    kind: "permission-posture",
+    description: {
+      en: "The default: Codewhale asks when an unresolved choice materially changes authority, cost, scope, or outcome.",
+      zh: "默认值：当一个未决选择会实质改变权限、成本、范围或结果时，Codewhale 会询问。",
+    },
+  },
+  {
+    term: "Auto-Review",
+    kind: "permission-posture",
+    description: {
+      en: "Fully autonomous: never opens a user question; resolves ambiguity to a safe reversible interpretation or reports that it cannot proceed safely.",
+      zh: "完全自主：从不弹出用户提问；把歧义消解为安全可逆的解释，或明确报告无法安全继续。",
+    },
+  },
+  {
+    term: "Full Access",
+    kind: "permission-posture",
+    description: {
+      en: "Ordinary tool calls skip approval prompts; non-bypassable safety, repository-law, and managed-policy holds still fail closed.",
+      zh: "普通工具调用不再显示审批提示；不可绕过的安全、仓库法则和托管策略拦截仍然会失败关闭。",
+    },
+  },
+];
+
+/**
+ * Route identity vocabulary. Requested and effective reasoning are separate:
+ * an adaptive request is not itself evidence of the tier a provider used.
+ * Routing source is provenance, not a provider or model substitute. Unknown
+ * effective values stay explicitly unknown.
+ */
+export const ROUTE_IDENTITY: { term: string; description: LocalizedText }[] = [
+  {
+    term: "Provider",
+    description: {
+      en: "Who serves inference — a hosted API, a gateway, or a loopback local runtime (Ollama, vLLM, SGLang). A configured provider is never inferred from a model name.",
+      zh: "谁提供推理——托管 API、网关或本机回环本地运行时（Ollama、vLLM、SGLang）。绝不会根据模型名称推断已配置的 provider。",
+    },
+  },
+  {
+    term: "Model",
+    description: {
+      en: "The exact model on that provider. Codewhale treats models as selectable components; no provider or model is privileged over another.",
+      zh: "该提供商上的具体模型。Codewhale 把模型当作可选组件；任何提供商或模型都不享有特权。",
+    },
+  },
+  {
+    term: "Requested reasoning",
+    description: {
+      en: "The policy requested for the frozen route: inherit, off, low, medium, high, max, or auto. Auto permits adaptive reasoning; it never permits a silent provider or model switch.",
+      zh: "为冻结路由请求的策略：inherit、off、low、medium、high、max 或 auto。Auto 允许自适应思考，但绝不允许静默切换 provider 或模型。",
+    },
+  },
+  {
+    term: "Effective reasoning",
+    description: {
+      en: "The tier actually applied for the run when the runtime or provider can establish it. If it cannot be established, the value is unavailable — never copied from the request or invented.",
+      zh: "运行时或 provider 能够确认时，显示该次运行实际采用的档位；无法确认时标为暂不可用，绝不从请求值复制或臆造。",
+    },
+  },
+  {
+    term: "Routing source",
+    description: {
+      en: "Why this configured route was selected, such as an explicit member profile or inherited session setting. Missing provenance stays unavailable rather than being guessed.",
+      zh: "说明为何选择这条已配置路由，例如显式成员档案或继承的会话设置。缺失的来源保持暂不可用，绝不猜测。",
+    },
+  },
+];
+
+/** Public advisory role vocabulary; legacy spellings are input compatibility. */
+export const ADVISORY_ROLE = {
+  term: "Consultant",
+  description: {
+    en: "The public read-only advisory Fleet role. The historical oracle and advisor spellings remain compatibility aliases for saved configuration and replay only; new product surfaces say Consultant.",
+    zh: "面向用户的只读 Fleet 咨询角色。历史拼写 oracle 与 advisor 仅作为已保存配置和回放的兼容别名保留；新的产品界面统一使用 Consultant。",
+  },
+} as const;
+
+/**
+ * Measurement truth — what the site may claim about benchmark-style numbers.
+ * These are policy statements, not results: the site publishes no leaderboard,
+ * and any future number must carry its exact route identity and harness.
+ */
+export const MEASUREMENT_PRINCIPLES: LocalizedText[] = [
+  {
+    en: "Provider token and cache usage is shown locally when the provider reports it; unknown usage stays unknown and is never displayed as zero.",
+    zh: "当提供商上报时，token 与缓存用量会在本地显示；未知用量保持未知，绝不显示为零。",
+  },
+  {
+    en: "Costs, progress, capabilities, and delivery state are shown only when a source establishes them. Unavailable values remain unavailable rather than becoming zero or success.",
+    zh: "成本、进度、能力和交付状态仅在有来源能够确认时显示。暂不可用的值保持暂不可用，绝不会变成零或成功。",
+  },
+  {
+    en: "This site publishes no benchmark leaderboard. Any number Codewhale ever publishes must name its exact provider, model, requested and effective reasoning, and measurement harness alongside the result.",
+    zh: "本站不发布基准排行榜。Codewhale 今后发布任何数字时，都必须同时给出确切的提供商、模型、请求与实际思考档位和测量工具链。",
+  },
+];

--- a/web/lib/docs-ia.test.ts
+++ b/web/lib/docs-ia.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Information-architecture contracts: docs-map registration, sitemap and
+ * hreflang preservation, navigation parity across breakpoints and locales,
+ * and the accessibility hooks (skip link, labelled nav, aria-current).
+ *
+ * These are deterministic source/unit contracts in the same style as
+ * public-copy.test.ts: they read the real sources and assert structure, so a
+ * future IA change fails here first instead of drifting silently.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { DOC_TOPICS, docTopicHref, getTopic } from "./docs-map";
+import { docsTopicIsCurrent } from "./docs-navigation";
+import { locales } from "./i18n/config";
+
+const webRoot = new URL("../", import.meta.url);
+const repoRoot = new URL("../../", import.meta.url);
+
+function webText(path: string): string {
+  return readFileSync(new URL(path, webRoot), "utf8");
+}
+
+const sitemap = webText("app/sitemap.ts");
+const nav = webText("components/nav.tsx");
+const navLinks = webText("components/nav-links.tsx");
+const mobileMenu = webText("components/mobile-menu.tsx");
+const footer = webText("components/footer.tsx");
+const localeLayout = webText("app/[locale]/layout.tsx");
+const css = webText("app/globals.css");
+
+describe("docs-map registration", () => {
+  it("registers the guide and vocabulary topics as first-party pages", () => {
+    const guide = getTopic("guide");
+    const vocabulary = getTopic("vocabulary");
+    expect(guide?.hasPage).toBe(true);
+    expect(vocabulary?.hasPage).toBe(true);
+    expect(vocabulary?.category).toBe("core-concepts");
+    expect(docTopicHref(guide!, "en")).toBe("/en/docs/guide");
+    expect(docTopicHref(vocabulary!, "zh")).toBe("/zh/docs/vocabulary");
+    expect(docsTopicIsCurrent(vocabulary!, "en", "/en/docs/vocabulary")).toBe(true);
+  });
+
+  it("keeps every docs topic repo source on disk", () => {
+    for (const topic of DOC_TOPICS) {
+      const sources = Array.isArray(topic.repoSource) ? topic.repoSource : [topic.repoSource];
+      for (const source of sources) {
+        expect(existsSync(new URL(source, repoRoot)), `${topic.id}: ${source}`).toBe(true);
+      }
+    }
+  });
+
+  it("keeps topic labels and descriptions bilingual", () => {
+    for (const topic of DOC_TOPICS) {
+      for (const pair of [topic.label, topic.description]) {
+        expect(pair.en.trim().length, `${topic.id} en`).toBeGreaterThan(0);
+        expect(pair.zh.trim().length, `${topic.id} zh`).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("sitemap and hreflang preservation", () => {
+  it("indexes every first-party docs page", () => {
+    for (const topic of DOC_TOPICS) {
+      if (!topic.hasPage) continue;
+      const path = topic.sitePath ? `/${topic.sitePath}` : `/docs/${topic.slug}`;
+      expect(sitemap, path).toContain(`"${path}"`);
+    }
+    expect(sitemap).toContain('"/docs/guide"');
+    expect(sitemap).toContain('"/docs/vocabulary"');
+  });
+
+  it("keeps per-locale alternate pairs for every indexed route", () => {
+    expect(sitemap).toContain("alternates");
+    expect(sitemap).toContain("en: `${SITE_URL}/en${path}`");
+    expect(sitemap).toContain("zh: `${SITE_URL}/zh${path}`");
+    // Route generation is driven by the shipped locale set, never hardcoded.
+    expect(sitemap).toContain("locales.map");
+    expect(locales).toEqual(["en", "zh"]);
+  });
+
+  it("keeps the new docs pages on the shared metadata helper", () => {
+    for (const route of ["guide", "vocabulary"]) {
+      const page = webText(`app/[locale]/docs/${route}/page.tsx`);
+      expect(page, route).toContain('import { buildPageMetadata } from "@/lib/page-meta"');
+      expect(page, route).toContain(`path: "/docs/${route}"`);
+    }
+  });
+});
+
+describe("navigation parity and accessibility", () => {
+  it("keeps desktop and mobile navigation on one shared link set", () => {
+    // Both surfaces consume the same `links` prop from nav.tsx — assert the
+    // wiring rather than duplicating the arrays.
+    expect(nav).toContain("<NavLinks links={links} isZh={isZh} />");
+    expect(nav).toContain("links={links}");
+    expect(mobileMenu).toContain("links.map");
+    expect(navLinks).toContain("links.map");
+  });
+
+  it("keeps en/zh nav link paths in exact locale-swap parity", () => {
+    const enHrefs = [...nav.matchAll(/href: "\/en\/([^"]+)"/g)].map((m) => m[1]);
+    const zhHrefs = [...nav.matchAll(/href: "\/zh\/([^"]+)"/g)].map((m) => m[1]);
+    expect(enHrefs.length).toBeGreaterThanOrEqual(4);
+    expect(enHrefs).toEqual(zhHrefs);
+    expect(enHrefs).toContain("docs/guide");
+    expect(enHrefs).toContain("faq");
+  });
+
+  it("labels the primary nav and marks the current page accessibly", () => {
+    expect(navLinks).toContain('aria-label={isZh ? "主导航" : "Primary"}');
+    expect(navLinks).toContain('aria-current={isActive ? "page" : undefined}');
+    expect(mobileMenu).toContain('aria-current={isActive ? "page" : undefined}');
+    expect(mobileMenu).toContain('aria-expanded={open}');
+    expect(mobileMenu).toContain('aria-controls="mobile-menu"');
+    expect(mobileMenu).toContain('role="dialog"');
+  });
+
+  it("ships a keyboard-reachable skip link to the main landmark", () => {
+    expect(localeLayout).toContain('href="#main-content"');
+    expect(localeLayout).toContain('className="skip-link"');
+    expect(localeLayout).toContain('<main id="main-content">');
+    expect(css).toContain(".skip-link:focus-visible");
+  });
+
+  it("keeps responsive breakpoints for the getting-started steps", () => {
+    // 4-up grid by default, 2-up at the tablet breakpoint, 1-up on phones —
+    // the same responsive ladder as the existing workflow steps.
+    expect(css).toMatch(/\.gs-steps\s*\{[^}]*repeat\(4, minmax\(0, 1fr\)\)/);
+    expect(css).toMatch(
+      /@media \(max-width: 760px\)[\s\S]*?\.gs-steps\s*\{[^}]*repeat\(2, minmax\(0, 1fr\)\)/,
+    );
+    expect(css).toMatch(
+      /@media \(max-width: 520px\)[\s\S]*?\.gs-steps\s*\{\s*grid-template-columns: 1fr/,
+    );
+  });
+
+  it("keeps the footer discovery links alongside the pinned legal links", () => {
+    expect(footer).toContain('href: "/en/docs/guide"');
+    expect(footer).toContain('href: "/zh/docs/guide"');
+    expect(footer).toContain('href: "/en/faq"');
+    expect(footer).toContain(
+      '{ label: "MIT license", href: "https://github.com/Hmbown/CodeWhale/blob/main/LICENSE" }',
+    );
+  });
+});
+
+describe("homepage integration", () => {
+  const homepage = webText("app/[locale]/page.tsx");
+
+  it("renders the shared getting-started path on the homepage", () => {
+    expect(homepage).toContain('import { GettingStartedSteps } from "@/components/getting-started-steps"');
+    expect(homepage).toContain("<GettingStartedSteps locale={locale} />");
+    expect(homepage).toContain("product-start");
+    expect(homepage).toContain("/docs/guide");
+    expect(homepage).toContain("/docs/vocabulary");
+  });
+
+  it("keeps the previously pinned homepage facts intact", () => {
+    // Guard against the new band accidentally displacing the public-copy
+    // gate's required surface (the full contract lives in public-copy.test.ts).
+    expect(homepage).toContain("facts.latestPublishedRelease");
+    expect(homepage).toContain("Source candidate");
+    expect(homepage).toContain('src="/codewhale-tui.png"');
+    for (const label of ["Plan", "Act", "Operate", "Ask", "Auto-Review", "Full Access"]) {
+      expect(homepage).toContain(label);
+    }
+  });
+});

--- a/web/lib/docs-ia.test.ts
+++ b/web/lib/docs-ia.test.ts
@@ -72,11 +72,13 @@ describe("sitemap and hreflang preservation", () => {
 
   it("keeps per-locale alternate pairs for every indexed route", () => {
     expect(sitemap).toContain("alternates");
-    expect(sitemap).toContain("en: `${SITE_URL}/en${path}`");
-    expect(sitemap).toContain("zh: `${SITE_URL}/zh${path}`");
-    // Route generation is driven by the shipped locale set, never hardcoded.
+    // Both the routes and their hreflang alternates are generated from the
+    // canonical locale registry, never hardcoded per locale — asserting the
+    // literal `en:` / `zh:` pairs would forbid exactly that generalization.
     expect(sitemap).toContain("locales.map");
-    expect(locales).toEqual(["en", "zh"]);
+    expect(sitemap).toContain("locales.map((l) => [l, `${SITE_URL}/${l}${path}`])");
+    expect(locales).toContain("en");
+    expect(locales).toContain("zh");
   });
 
   it("keeps the new docs pages on the shared metadata helper", () => {

--- a/web/lib/docs-map.ts
+++ b/web/lib/docs-map.ts
@@ -53,8 +53,20 @@ export const DOC_TOPICS: DocTopic[] = [
       zh: "首次运行、会话、命令、快捷键和日常使用流程。",
     },
     repoSource: ["docs/GUIDE.md", "docs/KEYBINDINGS.md"],
-    hasPage: false,
+    hasPage: true,
     category: "getting-started",
+  },
+  {
+    id: "vocabulary",
+    slug: "vocabulary",
+    label: { en: "Vocabulary", zh: "产品名词" },
+    description: {
+      en: "The exact product nouns — Fleet, Workflow, Lane, Runtime; Plan / Act / Operate; Consultant; and explicit route provenance — plus measurement principles.",
+      zh: "确切的产品名词——Fleet、Workflow、Lane、Runtime；Plan / Act / Operate；Consultant；明确的路由来源——以及测量原则。",
+    },
+    repoSource: ["docs/FLEET.md", "docs/MODES.md", "docs/public-surface-facts.json"],
+    hasPage: true,
+    category: "core-concepts",
   },
   {
     id: "configuration",

--- a/web/lib/docs-navigation.test.ts
+++ b/web/lib/docs-navigation.test.ts
@@ -28,8 +28,15 @@ describe("docsTopicIsCurrent", () => {
     expect(docTopicIsExternal(topic("providers"))).toBe(false);
   });
 
+  it("routes the guide to its dedicated docs page in either locale", () => {
+    expect(docTopicHref(topic("guide"), "en")).toBe("/en/docs/guide");
+    expect(docsTopicIsCurrent(topic("guide"), "en", "/en/docs/guide")).toBe(true);
+    expect(docsTopicIsCurrent(topic("guide"), "zh", "/zh/docs/guide/")).toBe(true);
+    expect(docTopicIsExternal(topic("guide"))).toBe(false);
+  });
+
   it("never marks source-document links as local pages", () => {
-    expect(docsTopicIsCurrent(topic("guide"), "en", "/en/docs/guide")).toBe(false);
+    expect(docsTopicIsCurrent(topic("contribution"), "en", "/en/docs/contribution")).toBe(false);
   });
 
   it("routes former link-out topics to their dedicated docs pages", () => {

--- a/web/lib/media-manifest.test.ts
+++ b/web/lib/media-manifest.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Media-manifest contracts for the real-session media surface.
+ *
+ * Two enforceable states:
+ *   pending   — intent only: no asset fields, and no files may exist under
+ *               web/public/media/. The component must render the visible
+ *               "recording pending release candidate" state instead of any
+ *               imagery. This is what keeps the site honest until the v0.9.2
+ *               dogfood recording (#4906) exists.
+ *   published — complete or nothing: poster, video, per-locale captions,
+ *               transcript, and GIF fallback all present. The suite checks
+ *               file presence/bytes and PNG dimensions; video dimensions and
+ *               duration are declared metadata whose physical verification
+ *               remains in the recording checklist.
+ *
+ * The reduced-motion contract is structural: no autoplay anywhere, poster is
+ * the static default, and the GIF is offered only as a link. The test asserts
+ * the component source carries that contract.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  getMediaAsset,
+  MEDIA_ASSETS,
+  MEDIA_BUDGETS,
+  MEDIA_PUBLIC_DIR,
+  REDUCED_MOTION_POLICY,
+  type MediaAsset,
+} from "./media-manifest";
+import { locales } from "./i18n/config";
+
+const webRoot = new URL("../", import.meta.url);
+const repoRoot = new URL("../../", import.meta.url);
+
+function publicFileBytes(src: string): number {
+  return statSync(new URL(`public/${src}`, webRoot)).size;
+}
+
+function pngDimensions(src: string): [number, number] {
+  const image = readFileSync(new URL(`public/${src}`, webRoot));
+  expect(image.subarray(1, 4).toString("ascii")).toBe("PNG");
+  return [image.readUInt32BE(16), image.readUInt32BE(20)];
+}
+
+describe("media manifest integrity", () => {
+  it("has unique asset ids and complete localized copy", () => {
+    const ids = MEDIA_ASSETS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const asset of MEDIA_ASSETS) {
+      for (const pair of [asset.title, asset.description, asset.pendingLabel]) {
+        expect(pair.en.trim().length, `${asset.id} en`).toBeGreaterThan(0);
+        expect(pair.zh.trim().length, `${asset.id} zh`).toBeGreaterThan(0);
+      }
+      expect(asset.id).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("keeps pending entries asset-free on disk and in the manifest", () => {
+    const mediaDir = new URL(`public/${MEDIA_PUBLIC_DIR}/`, webRoot);
+    const onDisk = existsSync(mediaDir) ? readdirSync(mediaDir) : [];
+
+    for (const asset of MEDIA_ASSETS.filter((a) => a.status === "pending")) {
+      expect(asset.poster, asset.id).toBeUndefined();
+      expect(asset.video, asset.id).toBeUndefined();
+      expect(asset.captions, asset.id).toBeUndefined();
+      expect(asset.gifFallback, asset.id).toBeUndefined();
+      expect(asset.transcript, asset.id).toBeUndefined();
+      // No staged or fabricated file may exist for a pending asset.
+      for (const file of onDisk) {
+        expect(file.startsWith(asset.id), `${asset.id}: unexpected file ${file}`).toBe(false);
+      }
+      // The pending state must say why, in both locales.
+      expect(asset.pendingLabel.en).toContain("pending release candidate");
+      expect(asset.pendingLabel.zh.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("requires published entries to be complete and satisfy enforceable budgets", () => {
+    for (const asset of MEDIA_ASSETS.filter((a) => a.status === "published")) {
+      assertPublishedAsset(asset);
+    }
+  });
+
+  it("keeps budgets aligned with the canonical screenshot contract", () => {
+    // The site screenshot contract pins 1280×720 under 500 KB; session-media
+    // posters follow the same budget so the two surfaces stay consistent.
+    expect(MEDIA_BUDGETS.poster).toEqual({ width: 1280, height: 720, maxBytes: 500_000 });
+    expect(MEDIA_BUDGETS.video.width).toBe(MEDIA_BUDGETS.poster.width);
+    expect(MEDIA_BUDGETS.video.height).toBe(MEDIA_BUDGETS.poster.height);
+    expect(MEDIA_BUDGETS.video.maxDurationSeconds).toBeLessThanOrEqual(120);
+    expect(MEDIA_BUDGETS.gifFallback.maxBytes).toBeGreaterThan(0);
+    for (const locale of locales) {
+      expect(MEDIA_BUDGETS.captionLocales).toContain(locale);
+    }
+  });
+});
+
+function assertPublishedAsset(asset: MediaAsset): void {
+  const { poster, video, captions, gifFallback, transcript } = asset;
+  expect(poster, `${asset.id}.poster`).toBeTruthy();
+  expect(video, `${asset.id}.video`).toBeTruthy();
+  expect(captions, `${asset.id}.captions`).toBeTruthy();
+  expect(gifFallback, `${asset.id}.gifFallback`).toBeTruthy();
+  expect(transcript, `${asset.id}.transcript`).toBeTruthy();
+
+  expect(pngDimensions(poster!.src)).toEqual([poster!.width, poster!.height]);
+  expect([poster!.width, poster!.height]).toEqual([
+    MEDIA_BUDGETS.poster.width,
+    MEDIA_BUDGETS.poster.height,
+  ]);
+  expect(publicFileBytes(poster!.src)).toBeLessThanOrEqual(MEDIA_BUDGETS.poster.maxBytes);
+
+  expect([video!.width, video!.height]).toEqual([
+    MEDIA_BUDGETS.video.width,
+    MEDIA_BUDGETS.video.height,
+  ]);
+  expect(video!.durationSeconds).toBeLessThanOrEqual(MEDIA_BUDGETS.video.maxDurationSeconds);
+  expect(publicFileBytes(video!.src)).toBeLessThanOrEqual(MEDIA_BUDGETS.video.maxBytes);
+
+  expect(publicFileBytes(gifFallback!.src)).toBeLessThanOrEqual(
+    MEDIA_BUDGETS.gifFallback.maxBytes,
+  );
+
+  const captionLangs = captions!.map((t) => t.srclang);
+  for (const locale of MEDIA_BUDGETS.captionLocales) {
+    expect(captionLangs, `${asset.id} missing ${locale} captions`).toContain(locale);
+  }
+  for (const track of captions!) {
+    expect(track.src.endsWith(".vtt"), track.src).toBe(true);
+    expect(publicFileBytes(track.src), track.src).toBeGreaterThan(0);
+    expect(track.label.trim().length).toBeGreaterThan(0);
+  }
+
+  expect(existsSync(new URL(transcript!, repoRoot)), `${asset.id}.transcript`).toBe(true);
+}
+
+describe("session media component contract", () => {
+  const component = readFileSync(
+    new URL("../components/session-media.tsx", import.meta.url),
+    "utf8",
+  );
+
+  it("renders the visible pending state instead of any imagery", () => {
+    expect(component).toContain('asset.status === "pending"');
+    expect(component).toContain("session-media-pending");
+    expect(component).toContain("asset.pendingLabel");
+    // Pending copy must explicitly refuse placeholder footage, both locales.
+    expect(component).toContain("No placeholder or staged footage");
+    expect(component).toContain("占位或摆拍影像");
+  });
+
+  it("carries the structural reduced-motion contract: no autoplay, ever", () => {
+    expect(component).toContain("REDUCED_MOTION_POLICY");
+    expect(REDUCED_MOTION_POLICY).toBe("static-poster-no-autoplay");
+    // No autoplay as a JSX/DOM attribute (the policy string and prose may
+    // mention the word; the attribute must never appear).
+    expect(component).not.toMatch(/autoPlay\s*[={]/);
+    expect(component).not.toMatch(/\sautoplay\s*[="]/);
+    expect(component).toContain('preload="none"');
+    expect(component).toContain("controls");
+    expect(component).toContain("poster={`/${poster.src}`}");
+  });
+
+  it("wires captions, transcript, and the GIF fallback for published assets", () => {
+    expect(component).toContain('kind="captions"');
+    expect(component).toContain("srcLang={track.srclang}");
+    expect(component).toContain("asset.gifFallback");
+    expect(component).toContain("asset.transcript");
+  });
+
+  it("exposes machine-checkable state hooks", () => {
+    expect(component).toContain("data-media-id={asset.id}");
+    expect(component).toContain("data-media-status={asset.status}");
+    expect(component).toContain("data-reduced-motion-policy={REDUCED_MOTION_POLICY}");
+  });
+
+  it("documents the recording plan location from the pending state", () => {
+    expect(component).toContain("docs/releases/v0.9.2-media-plan.md");
+    expect(existsSync(new URL("docs/releases/v0.9.2-media-plan.md", repoRoot))).toBe(true);
+  });
+
+  it("keeps the first-fleet-session entry addressable for the guide page", () => {
+    const asset = getMediaAsset("first-fleet-session");
+    expect(asset).toBeTruthy();
+    expect(["pending", "published"]).toContain(asset!.status);
+    const guide = readFileSync(
+      new URL("../app/[locale]/docs/guide/page.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(guide).toContain('getMediaAsset("first-fleet-session")');
+    expect(guide).toContain("<SessionMedia");
+  });
+});

--- a/web/lib/media-manifest.test.ts
+++ b/web/lib/media-manifest.test.ts
@@ -27,7 +27,14 @@ import {
   REDUCED_MOTION_POLICY,
   type MediaAsset,
 } from "./media-manifest";
-import { locales } from "./i18n/config";
+import { ALL_LOCALES } from "./i18n/config";
+
+// Captions are required for locales that ship a complete pack, not for every
+// routed locale: `locales` also includes `partial` locales, which route with an
+// English-fallback pack. Promising a caption track per routed locale would be a
+// claim the recording cannot meet, and the manifest exists to keep those claims
+// honest.
+const shippedLocales = ALL_LOCALES.filter((l) => l.status === "shipped").map((l) => l.code);
 
 const webRoot = new URL("../", import.meta.url);
 const repoRoot = new URL("../../", import.meta.url);
@@ -89,7 +96,7 @@ describe("media manifest integrity", () => {
     expect(MEDIA_BUDGETS.video.height).toBe(MEDIA_BUDGETS.poster.height);
     expect(MEDIA_BUDGETS.video.maxDurationSeconds).toBeLessThanOrEqual(120);
     expect(MEDIA_BUDGETS.gifFallback.maxBytes).toBeGreaterThan(0);
-    for (const locale of locales) {
+    for (const locale of shippedLocales) {
       expect(MEDIA_BUDGETS.captionLocales).toContain(locale);
     }
   });

--- a/web/lib/media-manifest.ts
+++ b/web/lib/media-manifest.ts
@@ -1,0 +1,112 @@
+/**
+ * media-manifest.ts — the real-session media surface for codewhale.net.
+ *
+ * Every real-session asset the site may show is declared here, with its
+ * poster, captions, transcript, GIF fallback, and budgets. The manifest is
+ * the contract: `web/components/session-media.tsx` renders whatever is
+ * declared, and `web/lib/media-manifest.test.ts` enforces the rules below.
+ *
+ * THE HONESTY CONTRACT:
+ *   - A `pending` entry declares intent only. It has NO asset fields, and no
+ *     files may exist for it under `web/public/media/`. The component renders
+ *     a visible "recording pending release candidate" state — never a mock,
+ *     staged, or recycled clip. (Release issue #4906: the dogfood recording
+ *     happens after the v0.9.2 candidate is stable.)
+ *   - A `published` entry is complete or it does not ship: poster, video,
+ *     per-locale captions (WebVTT), a transcript, and a GIF fallback are all
+ *     required. Tests verify presence and byte budgets, inspect PNG poster
+ *     dimensions, and compare declared video metadata with MEDIA_BUDGETS.
+ *     Actual video duration/dimensions remain a recording-checklist gate.
+ *   - Reduced motion is structural, not a media query patch: the video never
+ *     autoplays (`preload="none"`, user-initiated only), the poster is the
+ *     static default, and the GIF fallback link is always visible.
+ *
+ * The exact post-dogfood recording procedure lives in
+ * docs/releases/v0.9.2-media-plan.md. Flip an entry to `published` only by
+ * following that checklist.
+ */
+
+import type { LocalizedText } from "./content/vocabulary";
+
+/** Published-asset budgets; see the module contract for what tests inspect. */
+export const MEDIA_BUDGETS = {
+  poster: { width: 1280, height: 720, maxBytes: 500_000 },
+  video: { width: 1280, height: 720, maxBytes: 10_000_000, maxDurationSeconds: 120 },
+  gifFallback: { maxBytes: 6_000_000 },
+  /** WebVTT caption tracks must exist per shipped locale and be non-empty. */
+  captionLocales: ["en", "zh"],
+} as const;
+
+/**
+ * The reduced-motion policy identifier, referenced by the component and
+ * asserted by the test: static poster, no autoplay, optional GIF link.
+ */
+export const REDUCED_MOTION_POLICY = "static-poster-no-autoplay" as const;
+
+/** Directory under web/public/ that holds published session media. */
+export const MEDIA_PUBLIC_DIR = "media";
+
+export type MediaStatus = "pending" | "published";
+
+export interface MediaPoster {
+  /** Path relative to web/public/ (e.g. "media/first-fleet-session.png"). */
+  src: string;
+  width: number;
+  height: number;
+  alt: LocalizedText;
+}
+
+export interface MediaVideo {
+  src: string;
+  /** Measured duration of the shipped file, seconds. */
+  durationSeconds: number;
+  width: number;
+  height: number;
+}
+
+export interface MediaCaptionsTrack {
+  /** Path relative to web/public/ (WebVTT). */
+  src: string;
+  srclang: string;
+  label: string;
+}
+
+export interface MediaAsset {
+  /** Stable identifier; also the file stem for every asset file. */
+  id: string;
+  title: LocalizedText;
+  description: LocalizedText;
+  status: MediaStatus;
+  /** Shown in place of any imagery while status is "pending". */
+  pendingLabel: LocalizedText;
+  /** Published-only fields; absent while pending (enforced by the test). */
+  poster?: MediaPoster;
+  video?: MediaVideo;
+  captions?: MediaCaptionsTrack[];
+  gifFallback?: { src: string };
+  /** Repo-relative transcript document (e.g. "docs/evidence/..."). */
+  transcript?: string;
+}
+
+export const MEDIA_ASSETS: MediaAsset[] = [
+  {
+    id: "first-fleet-session",
+    title: {
+      en: "A real Codewhale session, end to end",
+      zh: "一次真实的 Codewhale 端到端会话",
+    },
+    description: {
+      en: "Will be recorded from the v0.9.2 release candidate during dogfood: install, first offline session, provider connection, and one Fleet workflow on a sealed local route. Until that recording exists, no footage is shown here — the manifest and budgets above are the contract it must satisfy.",
+      zh: "将在 dogfood 期间从 v0.9.2 发布候选版录制：安装、首次离线会话、连接提供商，以及在密封本地路由上运行一次 Fleet Workflow。在录制完成之前，这里不展示任何影像——上面的清单与预算就是它必须满足的契约。",
+    },
+    status: "pending",
+    pendingLabel: {
+      en: "Recording pending release candidate",
+      zh: "待发布候选版录制",
+    },
+  },
+];
+
+export function getMediaAsset(id: string): MediaAsset | undefined {
+  return MEDIA_ASSETS.find((asset) => asset.id === id);
+}


### PR DESCRIPTION
## Summary

Harvests the web-maturity lane onto the v0.9.2 candidate (targets the integration branch, not main):

- `/docs/guide` and `/docs/vocabulary` routes; docs-map + sitemap registration
- Homepage getting-started path, nav/footer links, skip link + a11y landmarks
- Real-session media manifest landing in explicit `pending` state — no placeholder footage; tests assert no asset file may exist for a pending id
- Vocabulary page verified against `docs/public-surface-facts.json` (Fleet/Workflow/Lane/Runtime verbatim; Consultant public role; "Operation" appears nowhere)

Receipts: web suite 179/179 (24 files), targeted docs-ia 14 / media 10 / vocabulary 11 / navigation 6, eslint clean, tsc clean, check:docs PASS.

Advances #3413; does not close it (media recording and remaining IA work stay open).

No-Issue: partial slice of #3413; closure requires the recording milestone and final-SHA receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)