### PR TITLE
feat(tui): registry-derived tool provenance sharing the request manifest digest (#1891 follow-up)

### DIFF
--- a/crates/tui/src/core/engine.rs
+++ b/crates/tui/src/core/engine.rs
@@ -3486,6 +3486,7 @@ impl Engine {
             mcp_tool_names,
             mcp: mcp_state,
             subagent_runtime_model,
+            plugin_tool_names,
         }
     }
 
@@ -3804,6 +3805,7 @@ impl Engine {
         let TurnToolBuild {
             registry: tool_registry,
             catalog: tools,
+            plugin_tool_names,
             ..
         } = self
             .build_turn_tool_registry_and_catalog(
@@ -3829,6 +3831,27 @@ impl Engine {
             )
             .await;
         let tool_catalog_for_event = tools.clone();
+
+        // Resolve, once per turn, the out-of-request facts the read-only
+        // request projection is allowed to report: flattened registry facts,
+        // the MCP pool's own server attribution, and the engine-injected
+        // catalog names. This is where `plugin_tool_names` and the pool lock
+        // live; the snapshot itself is built later, at the request seam, from
+        // the tools actually prepared for that step.
+        let mut tool_surface = crate::tool_inspection::ToolSurfaceContext {
+            registry: tool_registry
+                .as_ref()
+                .map(|registry| registry.registry_facts(&plugin_tool_names))
+                .unwrap_or_default(),
+            mcp_servers: match self.mcp_pool.as_ref() {
+                Some(pool) => pool.lock().await.resolved_tool_servers(),
+                None => std::collections::BTreeMap::new(),
+            },
+            synthetic_names: default_synthetic_catalog_tool_names(),
+            provider: crate::tool_inspection::ProviderAvailability::Unknown,
+        };
+        tool_surface.provider = self.tool_surface_provider_receipt();
+
         let base_url_for_event = if self.model_client_injected {
             None
         } else {
@@ -3848,6 +3871,7 @@ impl Engine {
             tools,
             input_policy.mode,
             input_policy.dynamic_active_tools,
+            Some(tool_surface),
         ))
         .catch_unwind()
         .await;
@@ -5417,6 +5441,10 @@ pub(crate) struct TurnToolBuild {
     /// available. This is an internal receipt, not a manifest field.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) subagent_runtime_model: Option<String>,
+    /// Tools this build loaded from the plugin surface rather than the built-in
+    /// registry builder. Carried out so the read-only request projection can
+    /// tell `plugin` provenance from `builtin` instead of collapsing both.
+    pub(crate) plugin_tool_names: std::collections::HashSet<String>,
 }
 
 /// The route a tool catalog is being shaped for.
@@ -5646,9 +5674,9 @@ use self::streaming::{
 use self::tool_catalog::{
     CODE_EXECUTION_TOOL_NAME, JS_EXECUTION_TOOL_NAME, MULTI_TOOL_PARALLEL_NAME,
     REQUEST_USER_INPUT_NAME, active_tools_for_request, build_model_tool_catalog_with_surface,
-    execute_code_execution_tool, execute_tool_search, is_tool_search_tool,
-    maybe_hydrate_requested_deferred_tool, missing_tool_error_message, plan_turn_tools,
-    tool_catalog_consistency_issues,
+    default_synthetic_catalog_tool_names, execute_code_execution_tool, execute_tool_search,
+    is_tool_search_tool, maybe_hydrate_requested_deferred_tool, missing_tool_error_message,
+    plan_turn_tools, tool_catalog_consistency_issues,
 };
 #[cfg(test)]
 use self::tool_catalog::{

--- a/crates/tui/src/core/engine/preview.rs
+++ b/crates/tui/src/core/engine/preview.rs
@@ -776,7 +776,14 @@ fn preview_billing_facts(
 /// Stable hash over the exact active tool catalog: name, description, and
 /// schema, in catalog order. Changes when a tool is added, removed,
 /// reordered, or has its schema transformed.
-fn active_tool_catalog_sha256(tools: &[Tool]) -> String {
+///
+/// This is the *single* definition of the active-tool-catalog digest. The
+/// request manifest fills `ToolSurfaceFacts::active_tool_catalog_sha256` from
+/// it, and `crate::tool_inspection` reports the same value for the same
+/// prepared request. Neither surface keeps a digest of its own, so a human
+/// reading `/tools` and a human reading `/request` are looking at the same
+/// accounting object rather than two hashes that can silently diverge.
+pub(crate) fn active_tool_catalog_sha256(tools: &[Tool]) -> String {
     let mut canonical = String::new();
     for tool in tools {
         canonical.push_str(&tool.name);

--- a/crates/tui/src/core/engine/tests.rs
+++ b/crates/tui/src/core/engine/tests.rs
@@ -3285,6 +3285,7 @@ async fn tool_request_snapshot_matches_the_exact_mock_request_payload() {
             tools,
             AppMode::Agent,
             Vec::new(),
+            None,
         )
         .await;
     assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
@@ -3329,7 +3330,7 @@ async fn snapshot_for_catalog(
     );
     let mut turn = crate::core::turn::TurnContext::new(2);
     let (status, error) = engine
-        .handle_deepseek_turn(&mut turn, None, catalog, AppMode::Agent, Vec::new())
+        .handle_deepseek_turn(&mut turn, None, catalog, AppMode::Agent, Vec::new(), None)
         .await;
     assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
     let mut events = handle.rx_event.write().await;
@@ -3399,6 +3400,7 @@ async fn request_snapshots_advance_to_the_latest_tool_step() {
             tools,
             AppMode::Agent,
             Vec::new(),
+            None,
         )
         .await;
     assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
@@ -3414,6 +3416,135 @@ async fn request_snapshots_advance_to_the_latest_tool_step() {
     assert_eq!(snapshots[0].step, 0);
     assert_eq!(snapshots[1].step, 1);
     assert_eq!(snapshots[1].turn_id.value, turn.id);
+}
+
+#[tokio::test]
+async fn request_snapshot_reports_registry_provenance_for_the_transmitted_catalog() {
+    use crate::llm_client::mock::{MockLlmClient, canned};
+
+    let workspace = tempdir().expect("tempdir");
+    let mock = std::sync::Arc::new(MockLlmClient::new(vec![canned::simple_text_turn("Done.")]));
+    let client: crate::core::model_client::SharedModelClient = mock.clone();
+    // Pin `read_file` loaded so this step's request actually carries it; the
+    // point of the test is what a *transmitted* tool is reported as.
+    let mut engine_config = deterministic_engine_config(workspace.path());
+    engine_config.tools_always_load = HashSet::from(["read_file".to_string()]);
+    let (mut engine, handle) =
+        Engine::new_with_model_client(engine_config, &Config::default(), client);
+    let context = crate::tools::ToolContext::new(workspace.path().to_path_buf());
+    let mut registry = crate::tools::ToolRegistry::new(context);
+    registry.register(std::sync::Arc::new(crate::tools::file::ReadFileTool));
+    // `read_file` is a hidden compatibility alias, so `to_api_tools` would hand
+    // the turn an empty catalog and nothing would be transmitted. Hand the
+    // engine an explicit catalog instead: the registry is still the source of
+    // the *facts*, including the fact that this tool is not model-visible.
+    let tools = Some(vec![crate::models::Tool {
+        tool_type: None,
+        name: "read_file".to_string(),
+        description: "Read a file".to_string(),
+        input_schema: json!({"type": "object"}),
+        allowed_callers: Some(vec!["direct".to_string()]),
+        defer_loading: Some(false),
+        input_examples: None,
+        strict: None,
+        cache_control: None,
+    }]);
+
+    // The same surface context `handle_send_message` resolves for a real turn:
+    // real registry facts, real (empty) MCP attribution, the engine's own
+    // synthetic-name list, and the resolved model client's receipt.
+    let synthetic_names = super::tool_catalog::default_synthetic_catalog_tool_names();
+    let surface = crate::tool_inspection::ToolSurfaceContext {
+        registry: registry.registry_facts(&HashSet::new()),
+        mcp_servers: std::collections::BTreeMap::new(),
+        synthetic_names: synthetic_names.clone(),
+        provider: engine.tool_surface_provider_receipt(),
+    };
+
+    let mut turn = crate::core::turn::TurnContext::new(4);
+    let (status, error) = engine
+        .handle_deepseek_turn(
+            &mut turn,
+            Some(&registry),
+            tools,
+            AppMode::Agent,
+            Vec::new(),
+            Some(surface),
+        )
+        .await;
+    assert_eq!(status, TurnOutcomeStatus::Completed, "{error:?}");
+
+    let mut events = handle.rx_event.write().await;
+    let snapshot = std::iter::from_fn(|| events.try_recv().ok())
+        .find_map(|event| match event {
+            Event::ToolRequestSnapshot { snapshot } => Some(snapshot),
+            _ => None,
+        })
+        .expect("request snapshot");
+
+    let transmitted = mock
+        .last_request()
+        .expect("captured request")
+        .tools
+        .unwrap_or_default();
+    assert!(!transmitted.is_empty(), "the turn must carry tools");
+
+    // The digest is the request path's, over what was prepared.
+    assert_eq!(
+        snapshot.active_tool_catalog_sha256.as_deref(),
+        Some(crate::core::engine::preview::active_tool_catalog_sha256(&transmitted).as_str())
+    );
+
+    // Provenance is registry-derived truth, not "unavailable".
+    assert!(snapshot.registry_facts_present);
+    assert!(snapshot.provider.is_available());
+    assert_eq!(
+        snapshot.unavailable_for_this_request,
+        vec!["provider_wire_payload"]
+    );
+
+    let read_file = snapshot
+        .tools
+        .iter()
+        .find(|entry| entry.name.value == "read_file")
+        .expect("read_file projected");
+    assert_eq!(
+        read_file.provenance,
+        crate::tool_inspection::Evidence::Known {
+            value: crate::tool_inspection::ToolProvenance::Builtin
+        }
+    );
+    assert!(matches!(
+        read_file.approval,
+        crate::tool_inspection::Evidence::Known { .. }
+    ));
+    // Registry truth, not an inference from the request: this alias is hidden
+    // from the model catalog even though this catalog carried it explicitly.
+    assert_eq!(
+        read_file.model_visible,
+        crate::tool_inspection::Evidence::Known { value: false }
+    );
+    assert!(read_file.visibility.in_request());
+
+    // Anything the engine injected rather than registered is reported as
+    // synthetic, from the engine's own list — never guessed from the name.
+    for entry in &snapshot.tools {
+        if synthetic_names.contains(&entry.name.value) {
+            assert_eq!(
+                entry.provenance,
+                crate::tool_inspection::Evidence::Known {
+                    value: crate::tool_inspection::ToolProvenance::Synthetic
+                },
+                "'{}' is engine-injected, not registry-backed",
+                entry.name.value
+            );
+            // Not in the registry, so capabilities are unknown, not "none".
+            assert!(matches!(
+                entry.capabilities,
+                crate::tool_inspection::Evidence::Unknown { .. }
+            ));
+        }
+    }
 }
 
 fn deterministic_engine_config(workspace: &Path) -> EngineConfig {
@@ -3661,6 +3792,7 @@ async fn coalesced_raw_read_error_touches_working_set_once() {
                 tools,
                 AppMode::Agent,
                 Vec::new(),
+                None,
             )
             .await;
 

--- a/crates/tui/src/core/engine/tool_catalog.rs
+++ b/crates/tui/src/core/engine/tool_catalog.rs
@@ -653,6 +653,29 @@ fn suggest_tool_names(catalog: &[Tool], requested: &str, limit: usize) -> Vec<St
         .collect()
 }
 
+/// Catalog tools the engine injects itself rather than registering, plus the
+/// legacy tool-search spellings. Exposed so the read-only request projection
+/// can label their provenance as `synthetic` from the same source of truth as
+/// [`is_synthetic_catalog_tool`] instead of guessing.
+///
+/// MCP-contributed names are deliberately *not* here: those resolve through the
+/// real pool, and stay unknown when the pool did not resolve them.
+/// [`MULTI_TOOL_PARALLEL_NAME`] is not here either — it is a call name the model
+/// may emit, never a catalog entry, so it can never appear in a transmitted
+/// tool array and has no catalog provenance to report.
+pub(super) fn default_synthetic_catalog_tool_names() -> Vec<String> {
+    let mut names: Vec<String> = vec![
+        TOOL_SEARCH_NAME.to_string(),
+        LEGACY_TOOL_SEARCH_REGEX_NAME.to_string(),
+        LEGACY_TOOL_SEARCH_BM25_NAME.to_string(),
+        CODE_EXECUTION_TOOL_NAME.to_string(),
+        JS_EXECUTION_TOOL_NAME.to_string(),
+    ];
+    names.sort();
+    names.dedup();
+    names
+}
+
 fn is_synthetic_catalog_tool(name: &str) -> bool {
     is_tool_search_tool(name)
         || matches!(name, CODE_EXECUTION_TOOL_NAME | JS_EXECUTION_TOOL_NAME)
@@ -1137,4 +1160,41 @@ pub(super) async fn execute_code_execution_tool(
         success,
         metadata: Some(payload),
     })
+}
+
+#[cfg(test)]
+mod synthetic_name_tests {
+    use super::{default_synthetic_catalog_tool_names, is_synthetic_catalog_tool};
+
+    /// The published synthetic-name list and the predicate that classifies a
+    /// catalog entry as synthetic must agree. A name that appears in the list
+    /// but is not classified synthetic would let the request projection report
+    /// a provenance the engine itself disputes.
+    #[test]
+    fn published_synthetic_names_agree_with_the_synthetic_predicate() {
+        let names = default_synthetic_catalog_tool_names();
+        assert!(!names.is_empty());
+        for name in &names {
+            assert!(
+                is_synthetic_catalog_tool(name),
+                "'{name}' is published as synthetic but the predicate disagrees"
+            );
+        }
+        let mut sorted = names.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(names, sorted, "the list must be sorted and deduplicated");
+
+        // MCP names resolve through the real pool, so they are deliberately
+        // absent here even though the predicate accepts them.
+        assert!(!names.iter().any(|name| name.starts_with("mcp_")));
+
+        // `multi_tool_use.parallel` is a call name, never a catalog entry, so
+        // it has no catalog provenance and must not be published as synthetic.
+        assert!(
+            !names
+                .iter()
+                .any(|name| name == super::MULTI_TOOL_PARALLEL_NAME)
+        );
+    }
 }

--- a/crates/tui/src/core/engine/turn_loop.rs
+++ b/crates/tui/src/core/engine/turn_loop.rs
@@ -304,6 +304,26 @@ impl Engine {
         count
     }
 
+    /// The request projection's provider receipt.
+    ///
+    /// Derived from the *resolved model client*. A tool registry existing says
+    /// nothing about whether a route was resolved, so it is deliberately not
+    /// consulted here.
+    pub(crate) fn tool_surface_provider_receipt(
+        &self,
+    ) -> crate::tool_inspection::ProviderAvailability {
+        if self.model_client.is_some() {
+            crate::tool_inspection::ProviderAvailability::Available {
+                provider: format!("{:?}", self.api_provider),
+                model: self.session.model.clone(),
+            }
+        } else {
+            crate::tool_inspection::ProviderAvailability::Unavailable {
+                reason: "no model client resolved for this turn".to_string(),
+            }
+        }
+    }
+
     pub(super) async fn handle_deepseek_turn(
         &mut self,
         turn: &mut TurnContext,
@@ -311,6 +331,10 @@ impl Engine {
         tools: Option<Vec<Tool>>,
         mode: AppMode,
         dynamic_active_tools: Vec<&'static str>,
+        // Out-of-request facts resolved once for this turn. `None` means the
+        // caller captured none, and the projection reports every
+        // registry-derived field as unknown rather than guessing.
+        tool_surface: Option<crate::tool_inspection::ToolSurfaceContext>,
     ) -> (TurnOutcomeStatus, Option<String>) {
         // Only interactive TUI hosts own terminal chrome. Headless exec,
         // app-server, and stream-json stdout must remain byte-clean.
@@ -708,10 +732,11 @@ impl Engine {
                 top_p: None,
             };
             let tool_request_snapshot =
-                crate::tool_inspection::ToolInspectionSnapshot::from_prepared_request(
+                crate::tool_inspection::ToolInspectionSnapshot::from_prepared_request_with_surface(
                     &turn.id,
                     turn.step,
                     request.tools.as_deref(),
+                    tool_surface.as_ref(),
                 );
 
             // Stream the response. Keep the request around (cloned into the

--- a/crates/tui/src/mcp.rs
+++ b/crates/tui/src/mcp.rs
@@ -3012,6 +3012,62 @@ impl McpPool {
         errors
     }
 
+    /// The single definition of an MCP tool's model-facing name.
+    ///
+    /// [`Self::all_tools`] (which builds the model catalog) and
+    /// [`Self::resolved_tool_servers`] (which tells tool inspection which
+    /// server owns a name) both call this, so a human-facing server
+    /// attribution can never drift from the name the model actually received.
+    #[must_use]
+    pub fn mcp_model_tool_name(server: &str, tool: &str) -> String {
+        format!("mcp_{server}_{tool}")
+    }
+
+    /// Fold `(server, tool)` pairs into `model name -> owning server`.
+    ///
+    /// Mirrors [`Self::all_tools`]' ambiguity rule: when two servers produce
+    /// the same model name, the name is dropped entirely rather than
+    /// attributed to an arbitrary winner. Callers then report it as unknown.
+    #[must_use]
+    pub fn resolve_tool_server_map<'a>(
+        pairs: impl Iterator<Item = (&'a str, &'a str)>,
+    ) -> std::collections::BTreeMap<String, String> {
+        let mut resolved: std::collections::BTreeMap<String, Option<String>> =
+            std::collections::BTreeMap::new();
+        for (server, tool) in pairs {
+            match resolved.entry(Self::mcp_model_tool_name(server, tool)) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(Some(server.to_string()));
+                }
+                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                    entry.insert(None);
+                }
+            }
+        }
+        resolved
+            .into_iter()
+            .filter_map(|(name, server)| server.map(|server| (name, server)))
+            .collect()
+    }
+
+    /// Model tool name -> owning server name, for the tools this pool actually
+    /// resolved. Names the pool did not resolve are simply absent, so callers
+    /// report them as unknown instead of parsing `mcp_{server}_{tool}` (a
+    /// server name may itself contain `_`, so that split is a guess).
+    ///
+    /// Read-only projection used by tool inspection; it never connects or
+    /// executes.
+    #[must_use]
+    pub fn resolved_tool_servers(&self) -> std::collections::BTreeMap<String, String> {
+        Self::resolve_tool_server_map(self.connections.iter().flat_map(|(server, conn)| {
+            let authorized = conn.catalog_authorized();
+            conn.tools().iter().filter_map(move |tool| {
+                (authorized && conn.config().is_tool_enabled(&tool.name))
+                    .then_some((server.as_str(), tool.name.as_str()))
+            })
+        }))
+    }
+
     /// Get all discovered tools with server-prefixed names
     pub fn all_tools(&self) -> Vec<(String, &McpTool)> {
         let mut by_name: std::collections::BTreeMap<String, Option<&McpTool>> =
@@ -3024,8 +3080,7 @@ impl McpPool {
                 if !conn.config().is_tool_enabled(&tool.name) {
                     continue;
                 }
-                // Format: mcp_{server}_{tool}
-                let name = format!("mcp_{}_{}", server, tool.name);
+                let name = Self::mcp_model_tool_name(server, &tool.name);
                 match by_name.entry(name.clone()) {
                     std::collections::btree_map::Entry::Vacant(entry) => {
                         entry.insert(Some(tool));

--- a/crates/tui/src/mcp/tests.rs
+++ b/crates/tui/src/mcp/tests.rs
@@ -5097,3 +5097,45 @@ fn add_runtime_server_config_accepts_new_name() {
     )
     .unwrap();
 }
+
+/// Server attribution and the model-facing tool name must come from one
+/// definition. If they ever drift, a human reading tool provenance would be
+/// told which server owns a name the model never saw.
+#[test]
+fn mcp_model_tool_names_and_server_attribution_share_one_definition() {
+    assert_eq!(
+        McpPool::mcp_model_tool_name("files", "read"),
+        "mcp_files_read"
+    );
+    // A server name containing `_` is exactly why the reverse split is a guess.
+    assert_eq!(
+        McpPool::mcp_model_tool_name("my_server", "read_file"),
+        "mcp_my_server_read_file"
+    );
+
+    let resolved =
+        McpPool::resolve_tool_server_map([("files", "read"), ("git", "status")].into_iter());
+    assert_eq!(
+        resolved.get("mcp_files_read").map(String::as_str),
+        Some("files")
+    );
+    assert_eq!(
+        resolved.get("mcp_git_status").map(String::as_str),
+        Some("git")
+    );
+
+    // Ambiguity: two servers collapse onto the same model name. Neither wins,
+    // so the name resolves to no server and callers report it as unknown —
+    // the same rule `all_tools` applies when it hides the ambiguous tool.
+    let ambiguous = McpPool::resolve_tool_server_map(
+        [("a_b", "c"), ("a", "b_c"), ("solo", "tool")].into_iter(),
+    );
+    assert!(
+        !ambiguous.contains_key("mcp_a_b_c"),
+        "an ambiguous model name must resolve to no server"
+    );
+    assert_eq!(
+        ambiguous.get("mcp_solo_tool").map(String::as_str),
+        Some("solo")
+    );
+}

--- a/crates/tui/src/tool_inspection.rs
+++ b/crates/tui/src/tool_inspection.rs
@@ -73,8 +73,13 @@ pub struct ToolInspectionSnapshot {
     pub rendered_tool_count: usize,
     pub omitted_tool_count: usize,
     pub payload_json_bytes: Option<usize>,
-    pub payload_sha256: Option<String>,
     pub payload_measurement_status: String,
+    /// The active-tool-catalog digest, computed by the *same* function the
+    /// request manifest uses for `active_tool_catalog_sha256`. Absent only when
+    /// the request carried no tools field at all. Covers tool name,
+    /// description, and canonical input schema — not transport-only fields —
+    /// exactly as the manifest does.
+    pub active_tool_catalog_sha256: Option<String>,
     pub unavailable_from_tool_schema: [&'static str; 6],
     pub tools: Vec<ToolProjection>,
 }
@@ -90,8 +95,7 @@ impl ToolInspectionSnapshot {
             .enumerate()
             .map(|(index, tool)| project_tool(index, tool))
             .collect::<Vec<_>>();
-        let (payload_json_bytes, payload_sha256, payload_measurement_status) =
-            measure_payload(tools);
+        let (payload_json_bytes, payload_measurement_status) = measure_payload(tools);
         Self {
             schema_version: 1,
             capture_source: "prepared model-client request",
@@ -103,8 +107,9 @@ impl ToolInspectionSnapshot {
             rendered_tool_count: projected.len(),
             omitted_tool_count: tool_count.saturating_sub(projected.len()),
             payload_json_bytes,
-            payload_sha256,
             payload_measurement_status,
+            active_tool_catalog_sha256: tools
+                .map(crate::core::engine::preview::active_tool_catalog_sha256),
             unavailable_from_tool_schema: [
                 "provider",
                 "model",
@@ -151,8 +156,8 @@ impl ToolInspectionSnapshot {
             self.payload_json_bytes,
         ));
         out.push_str(&format_optional_string(
-            "Model-client tool digest",
-            self.payload_sha256.as_deref(),
+            "Active tool catalog digest (same digest as the request manifest)",
+            self.active_tool_catalog_sha256.as_deref(),
         ));
         out.push_str(
             "Provider-wire tool payload: unavailable (the provider adapter may transform or omit model-client fields)\n",
@@ -265,26 +270,24 @@ fn project_tool(index: usize, tool: &Tool) -> ToolProjection {
     }
 }
 
-fn measure_payload(tools: Option<&[Tool]>) -> (Option<usize>, Option<String>, String) {
+/// Byte accounting only. The digest is deliberately *not* computed here: it is
+/// the request path's [`crate::core::engine::preview::active_tool_catalog_sha256`],
+/// so this projection never defines a second catalog hash.
+fn measure_payload(tools: Option<&[Tool]>) -> (Option<usize>, String) {
     let Some(tools) = tools else {
-        return (None, None, "unavailable (tools field absent)".to_string());
+        return (None, "unavailable (tools field absent)".to_string());
     };
     let mut writer = BoundedWriter::new(MAX_PAYLOAD_MEASUREMENT_BYTES);
     match serde_json::to_writer(&mut writer, tools) {
-        Ok(()) => {
-            let bytes = writer.bytes;
-            (
-                Some(bytes.len()),
-                Some(format!("sha256:{}", crate::hashing::sha256_hex(&bytes))),
-                "exact (within 1048576-byte measurement bound)".to_string(),
-            )
-        }
+        Ok(()) => (
+            Some(writer.bytes.len()),
+            "exact (within 1048576-byte measurement bound)".to_string(),
+        ),
         Err(_) if writer.exceeded => (
-            None,
             None,
             "unavailable (payload exceeds 1048576-byte measurement bound)".to_string(),
         ),
-        Err(_) => (None, None, "unavailable (serialization failed)".to_string()),
+        Err(_) => (None, "unavailable (serialization failed)".to_string()),
     }
 }
 
@@ -430,9 +433,32 @@ mod tests {
         let empty = ToolInspectionSnapshot::from_prepared_request("turn", 1, Some(&[]));
         assert!(!absent.tools_field_present);
         assert_eq!(absent.payload_json_bytes, None);
+        assert!(absent.active_tool_catalog_sha256.is_none());
         assert!(empty.tools_field_present);
         assert_eq!(empty.payload_json_bytes, Some(2));
-        assert!(empty.payload_sha256.is_some());
+        assert!(empty.active_tool_catalog_sha256.is_some());
+    }
+
+    #[test]
+    fn catalog_digest_is_the_request_manifest_digest_not_a_second_definition() {
+        let tools = vec![tool("read_file"), tool("write_file")];
+        let snapshot = ToolInspectionSnapshot::from_prepared_request("turn", 1, Some(&tools));
+
+        // Same prepared request, same accounting object: the value the request
+        // manifest publishes as `active_tool_catalog_sha256`.
+        assert_eq!(
+            snapshot.active_tool_catalog_sha256.as_deref(),
+            Some(crate::core::engine::preview::active_tool_catalog_sha256(&tools).as_str()),
+        );
+
+        // And it is a catalog digest, not an incidental byte hash: reordering
+        // the same tools changes it.
+        let reordered = vec![tools[1].clone(), tools[0].clone()];
+        let reordered = ToolInspectionSnapshot::from_prepared_request("turn", 1, Some(&reordered));
+        assert_ne!(
+            snapshot.active_tool_catalog_sha256,
+            reordered.active_tool_catalog_sha256
+        );
     }
 
     #[test]
@@ -474,6 +500,8 @@ mod tests {
         assert!(snapshot.tools[0].input_schema_json.truncated);
         assert_eq!(snapshot.payload_json_bytes, None);
         assert!(snapshot.payload_measurement_status.contains("exceeds"));
+        // The catalog digest is fixed-width, so it survives the byte bound.
+        assert!(snapshot.active_tool_catalog_sha256.is_some());
         let json = snapshot.render_json().expect("bounded JSON");
         assert!(
             json.len() < 131_072,

--- a/crates/tui/src/tool_inspection.rs
+++ b/crates/tui/src/tool_inspection.rs
@@ -1,9 +1,28 @@
 //! Truthful, bounded inspection of a prepared model-client request's tool field.
 //!
 //! Capture happens at the request-construction seam and retains only a bounded
-//! projection. It never joins against mutable registry, MCP, provider, or
-//! approval state, and it never claims that the prepared request was delivered.
+//! projection. It never claims that the prepared request was delivered.
+//!
+//! Two kinds of fact live here, and they are kept apart on purpose:
+//!
+//! * **Wire facts** come from the prepared request itself — names, schemas,
+//!   descriptions, per-tool transport flags, byte accounting, and the
+//!   active-tool-catalog digest. The digest is not defined here; it is
+//!   [`crate::core::engine::preview::active_tool_catalog_sha256`], the same
+//!   function the request manifest publishes, so `/tools` and `/request` cannot
+//!   report two different hashes of one catalog.
+//! * **Surface facts** come from a [`ToolSurfaceContext`] the engine resolves
+//!   once per turn: flattened registry facts, the MCP pool's resolved server
+//!   attributions, the engine-injected catalog names, and the provider receipt
+//!   taken from the *resolved model client*. When that context is present,
+//!   provenance, MCP server identity, capabilities, approval requirement, and
+//!   model visibility become available and true. When it is absent they stay
+//!   explicitly unknown — the context is optional, never faked.
+//!
+//! What stays unknowable stays unknown regardless: nothing here observes the
+//! provider adapter's wire payload, so it is always reported as unavailable.
 
+use std::collections::BTreeMap;
 use std::io::{self, Write};
 
 use serde::Serialize;
@@ -46,6 +65,162 @@ pub struct CountOnly {
     pub values: &'static str,
 }
 
+/// One registry tool flattened to the exact facts this projection may report.
+///
+/// The engine fills this from `ToolSpec`, so this module never holds a tool
+/// object and therefore cannot execute one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RegistryFacts {
+    pub name: String,
+    pub description: String,
+    pub model_visible: bool,
+    pub capabilities: Vec<String>,
+    pub approval: String,
+    /// `true` when the tool came from the plugin surface rather than the
+    /// built-in registry builder.
+    pub plugin: bool,
+}
+
+/// Where a tool in the prepared request came from.
+///
+/// `Unknown` is a real answer, not a fallback guess: it means the surface
+/// context resolved no origin for that name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolProvenance {
+    /// Registered by the built-in registry builder.
+    Builtin,
+    /// Loaded from the plugin/tools surface or `config.toml` overrides.
+    Plugin,
+    /// Contributed by the MCP pool, as attributed by the pool itself.
+    Mcp,
+    /// Injected into the request catalog by the engine rather than registered
+    /// (`tool_search` and its legacy spellings, `code_execution`,
+    /// `js_execution`).
+    Synthetic,
+    /// Present in the request with no resolved origin.
+    Unknown,
+}
+
+impl ToolProvenance {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::Plugin => "plugin",
+            Self::Mcp => "mcp",
+            Self::Synthetic => "synthetic",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// A tool's state relative to the request that was prepared for this step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolVisibility {
+    /// In this step's request with its schema included.
+    Active,
+    /// In this step's request, marked deferred (schema loads on demand).
+    Deferred,
+    /// In this step's request, with no transport flag to say which.
+    InRequest,
+    /// Registered and model-visible, but not carried by this step's request.
+    RegistryOnly,
+    /// Registered but not model-visible (hidden compatibility alias).
+    Hidden,
+}
+
+impl ToolVisibility {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Deferred => "deferred",
+            Self::InRequest => "in-request",
+            Self::RegistryOnly => "registry-only",
+            Self::Hidden => "hidden",
+        }
+    }
+
+    /// Whether this state means the tool's bytes are carried by the prepared
+    /// request. The only honest source of this answer is the request itself.
+    #[must_use]
+    pub const fn in_request(self) -> bool {
+        matches!(self, Self::Active | Self::Deferred | Self::InRequest)
+    }
+}
+
+/// Provider/route availability, derived from the resolved model client taken at
+/// the request seam — never from the existence of a tool registry.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ProviderAvailability {
+    /// No client receipt was taken, because no surface context was captured.
+    #[default]
+    Unknown,
+    /// A model client was resolved and this request was built for it.
+    Available { provider: String, model: String },
+    /// The seam was reached with no resolved model client. The reason is a safe
+    /// label, never a URL or credential.
+    Unavailable { reason: String },
+}
+
+impl ProviderAvailability {
+    #[must_use]
+    pub const fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+
+    #[must_use]
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Available { .. } => "available",
+            Self::Unavailable { .. } => "unavailable",
+        }
+    }
+}
+
+/// Everything outside the prepared request that this projection is allowed to
+/// report, resolved once per turn by the engine.
+///
+/// Plain data only: no registry, no client, no credentials. Resolving it once
+/// per turn is what keeps the per-step seam from re-locking the MCP pool.
+#[derive(Debug, Clone, Default)]
+pub struct ToolSurfaceContext {
+    /// The real registry, flattened. Sorted by name by the producer.
+    pub registry: Vec<RegistryFacts>,
+    /// Model tool name -> MCP server name, only for names the real pool
+    /// resolved. Absent names stay unknown rather than being split apart.
+    pub mcp_servers: BTreeMap<String, String>,
+    /// Request-catalog names the engine injects rather than registering.
+    pub synthetic_names: Vec<String>,
+    /// Receipt from the resolved model client for this turn.
+    pub provider: ProviderAvailability,
+}
+
+impl ToolSurfaceContext {
+    fn provenance(&self, name: &str) -> ToolProvenance {
+        if let Some(facts) = self.registry.iter().find(|facts| facts.name == name) {
+            if facts.plugin {
+                return ToolProvenance::Plugin;
+            }
+            if self.mcp_servers.contains_key(name) {
+                return ToolProvenance::Mcp;
+            }
+            return ToolProvenance::Builtin;
+        }
+        if self.mcp_servers.contains_key(name) {
+            return ToolProvenance::Mcp;
+        }
+        if self.synthetic_names.iter().any(|entry| entry == name) {
+            return ToolProvenance::Synthetic;
+        }
+        ToolProvenance::Unknown
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ToolProjection {
     pub ordinal: usize,
@@ -58,6 +233,23 @@ pub struct ToolProjection {
     pub input_examples: Evidence<CountOnly>,
     pub strict: Evidence<bool>,
     pub cache_control_type: Evidence<BoundedString>,
+    /// Where this tool came from. Known only when a surface context was
+    /// captured; `ToolProvenance::Unknown` inside `Known` means the context was
+    /// captured and still resolved no origin.
+    pub provenance: Evidence<ToolProvenance>,
+    /// Owning MCP server, only when the real pool attributed this exact model
+    /// tool name.
+    pub mcp_server: Evidence<BoundedString>,
+    /// Declared capabilities from the registry, sorted. Known-and-empty means
+    /// "declares none"; unknown means "not in the registry".
+    pub capabilities: Evidence<BoundedList>,
+    /// Declared approval requirement from the registry.
+    pub approval: Evidence<BoundedString>,
+    /// Registry model visibility. A tool can be registered but hidden.
+    pub model_visible: Evidence<bool>,
+    /// State relative to this prepared request. Always known: the request is
+    /// the evidence.
+    pub visibility: ToolVisibility,
 }
 
 /// Bounded evidence from a prepared model-client request.
@@ -80,22 +272,100 @@ pub struct ToolInspectionSnapshot {
     /// description, and canonical input schema — not transport-only fields —
     /// exactly as the manifest does.
     pub active_tool_catalog_sha256: Option<String>,
-    pub unavailable_from_tool_schema: [&'static str; 6],
+    /// Facts nothing on this path can observe for this request. Shrinks when a
+    /// surface context supplies registry- and client-derived truth; never
+    /// empties, because the provider adapter's wire payload is never visible
+    /// here.
+    pub unavailable_for_this_request: Vec<&'static str>,
+    /// Provider receipt from the resolved model client, or `Unknown` when no
+    /// surface context was captured.
+    pub provider: ProviderAvailability,
+    /// Whether registry-derived facts were captured at all. Absent stays
+    /// distinct from an empty registry.
+    pub registry_facts_present: bool,
+    /// Size of the flattened registry, when it was captured.
+    pub registry_tool_count: Evidence<usize>,
+    /// Registered, model-visible tools this request does *not* carry. Bounded,
+    /// with an explicit omission count.
+    pub registry_only_tools: Evidence<BoundedList>,
     pub tools: Vec<ToolProjection>,
 }
 
 impl ToolInspectionSnapshot {
+    /// Wire facts only. Provenance, attribution, capabilities, approval, and
+    /// provider identity stay explicitly unknown.
     #[must_use]
     pub fn from_prepared_request(turn_id: &str, step: u32, tools: Option<&[Tool]>) -> Self {
+        Self::from_prepared_request_with_surface(turn_id, step, tools, None)
+    }
+
+    /// Wire facts joined against the turn's resolved surface context.
+    ///
+    /// The context is what turns "unavailable" into truth: it is derived from
+    /// the real registry, the real MCP pool's own attribution, the engine's own
+    /// synthetic-name list, and the resolved model client. Passing `None`
+    /// reproduces the wire-only projection exactly.
+    #[must_use]
+    pub fn from_prepared_request_with_surface(
+        turn_id: &str,
+        step: u32,
+        tools: Option<&[Tool]>,
+        surface: Option<&ToolSurfaceContext>,
+    ) -> Self {
         let tool_count = tools.map_or(0, <[Tool]>::len);
         let projected = tools
             .unwrap_or_default()
             .iter()
             .take(MAX_RENDERED_TOOLS)
             .enumerate()
-            .map(|(index, tool)| project_tool(index, tool))
+            .map(|(index, tool)| project_tool(index, tool, surface))
             .collect::<Vec<_>>();
         let (payload_json_bytes, payload_measurement_status) = measure_payload(tools);
+
+        let request_names = tools
+            .unwrap_or_default()
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        let registry_only_tools = surface.map_or_else(
+            || unknown("registry facts not captured for this request"),
+            |surface| {
+                let names = surface
+                    .registry
+                    .iter()
+                    .filter(|facts| {
+                        facts.model_visible && !request_names.contains(facts.name.as_str())
+                    })
+                    .map(|facts| facts.name.as_str())
+                    .collect::<Vec<_>>();
+                let rendered = names
+                    .iter()
+                    .take(MAX_RENDERED_TOOLS)
+                    .map(|name| bounded_chars(name, MAX_NAME_CHARS))
+                    .collect::<Vec<_>>();
+                Evidence::Known {
+                    value: BoundedList {
+                        count: names.len(),
+                        omitted: names.len().saturating_sub(rendered.len()),
+                        rendered,
+                    },
+                }
+            },
+        );
+
+        let mut unavailable_for_this_request = vec!["provider_wire_payload"];
+        if surface.is_none() {
+            unavailable_for_this_request.extend([
+                "provider",
+                "model",
+                "approval",
+                "provenance",
+                "capabilities",
+            ]);
+        } else if !surface.is_some_and(|surface| surface.provider.is_available()) {
+            unavailable_for_this_request.extend(["provider", "model"]);
+        }
+
         Self {
             schema_version: 1,
             capture_source: "prepared model-client request",
@@ -110,14 +380,18 @@ impl ToolInspectionSnapshot {
             payload_measurement_status,
             active_tool_catalog_sha256: tools
                 .map(crate::core::engine::preview::active_tool_catalog_sha256),
-            unavailable_from_tool_schema: [
-                "provider",
-                "model",
-                "approval",
-                "provenance",
-                "capabilities",
-                "provider_wire_payload",
-            ],
+            unavailable_for_this_request,
+            provider: surface.map_or(ProviderAvailability::Unknown, |surface| {
+                surface.provider.clone()
+            }),
+            registry_facts_present: surface.is_some(),
+            registry_tool_count: surface.map_or_else(
+                || unknown("registry facts not captured for this request"),
+                |surface| Evidence::Known {
+                    value: surface.registry.len(),
+                },
+            ),
+            registry_only_tools,
             tools: projected,
         }
     }
@@ -162,9 +436,59 @@ impl ToolInspectionSnapshot {
         out.push_str(
             "Provider-wire tool payload: unavailable (the provider adapter may transform or omit model-client fields)\n",
         );
-        out.push_str(
-            "Provider, model, approval, provenance, and capability metadata: unavailable (not carried by the request tool schema)\n",
-        );
+        match &self.provider {
+            ProviderAvailability::Available { provider, model } => out.push_str(&format!(
+                "Provider: {} (resolved model client)\nModel: {}\n",
+                json_string(provider),
+                json_string(model)
+            )),
+            ProviderAvailability::Unavailable { reason } => {
+                out.push_str(&format!("Provider: unavailable ({reason})\n"));
+            }
+            ProviderAvailability::Unknown => {
+                out.push_str("Provider: unknown (no model-client receipt captured)\n");
+            }
+        }
+        out.push_str(&format!(
+            "Registry facts: {}\n",
+            if self.registry_facts_present {
+                "captured"
+            } else {
+                "not captured"
+            }
+        ));
+        match &self.registry_tool_count {
+            Evidence::Known { value } => {
+                out.push_str(&format!("Registered tools: {value}\n"));
+            }
+            Evidence::Unknown { reason } => {
+                out.push_str(&format!("Registered tools: unknown ({reason})\n"));
+            }
+        }
+        match &self.registry_only_tools {
+            Evidence::Known { value } => {
+                let rendered = value
+                    .rendered
+                    .iter()
+                    .map(|entry| entry.value.as_str())
+                    .collect::<Vec<_>>();
+                out.push_str(&format!(
+                    "Model-visible tools not in this request: {}\n  names: {}\n  omitted by render bound: {}\n",
+                    value.count,
+                    serde_json::to_string(&rendered).unwrap_or_else(|_| "unavailable".to_string()),
+                    value.omitted
+                ));
+            }
+            Evidence::Unknown { reason } => {
+                out.push_str(&format!(
+                    "Model-visible tools not in this request: unknown ({reason})\n"
+                ));
+            }
+        }
+        out.push_str(&format!(
+            "Unavailable for this request: {}\n",
+            self.unavailable_for_this_request.join(", ")
+        ));
 
         for tool in &self.tools {
             out.push_str(&format!(
@@ -218,6 +542,41 @@ impl ToolInspectionSnapshot {
                 }
             }
             render_bounded_evidence(&mut out, "cache control type", &tool.cache_control_type);
+            out.push_str(&format!(
+                "   request state: {}\n   in request: {}\n",
+                tool.visibility.label(),
+                yes_no(tool.visibility.in_request())
+            ));
+            match &tool.provenance {
+                Evidence::Known { value } => {
+                    out.push_str(&format!("   provenance: {}\n", value.label()));
+                }
+                Evidence::Unknown { reason } => {
+                    out.push_str(&format!("   provenance: unknown ({reason})\n"));
+                }
+            }
+            render_bounded_evidence(&mut out, "MCP server", &tool.mcp_server);
+            match &tool.capabilities {
+                Evidence::Known { value } => {
+                    let rendered = value
+                        .rendered
+                        .iter()
+                        .map(|entry| entry.value.as_str())
+                        .collect::<Vec<_>>();
+                    out.push_str(&format!(
+                        "   capabilities: {}\n   capabilities count: {}\n   capabilities omitted: {}\n",
+                        serde_json::to_string(&rendered)
+                            .unwrap_or_else(|_| "unavailable".to_string()),
+                        value.count,
+                        value.omitted
+                    ));
+                }
+                Evidence::Unknown { reason } => {
+                    out.push_str(&format!("   capabilities: unknown ({reason})\n"));
+                }
+            }
+            render_bounded_evidence(&mut out, "approval", &tool.approval);
+            render_bool_evidence(&mut out, "model visible", &tool.model_visible);
         }
         out
     }
@@ -227,7 +586,15 @@ impl ToolInspectionSnapshot {
     }
 }
 
-fn project_tool(index: usize, tool: &Tool) -> ToolProjection {
+fn project_tool(index: usize, tool: &Tool, surface: Option<&ToolSurfaceContext>) -> ToolProjection {
+    let facts = surface.and_then(|surface| {
+        surface
+            .registry
+            .iter()
+            .find(|facts| facts.name == tool.name)
+    });
+    let no_surface = "surface context not captured for this request";
+    let not_registered = "tool is not in the registry";
     ToolProjection {
         ordinal: index + 1,
         name: bounded_chars(&tool.name, MAX_NAME_CHARS),
@@ -267,6 +634,63 @@ fn project_tool(index: usize, tool: &Tool) -> ToolProjection {
                 .as_ref()
                 .map(|value| value.cache_type.as_str()),
         ),
+        provenance: surface.map_or_else(
+            || unknown(no_surface),
+            |surface| Evidence::Known {
+                value: surface.provenance(&tool.name),
+            },
+        ),
+        mcp_server: surface.map_or_else(
+            || unknown(no_surface),
+            |surface| {
+                surface.mcp_servers.get(&tool.name).map_or_else(
+                    || unknown("the MCP pool did not attribute this tool name"),
+                    |server| Evidence::Known {
+                        value: bounded_chars(server, MAX_AUXILIARY_CHARS),
+                    },
+                )
+            },
+        ),
+        capabilities: match (surface, facts) {
+            (None, _) => unknown(no_surface),
+            (Some(_), None) => unknown(not_registered),
+            (Some(_), Some(facts)) => {
+                let rendered = facts
+                    .capabilities
+                    .iter()
+                    .take(MAX_ALLOWED_CALLERS)
+                    .map(|value| bounded_chars(value, MAX_ALLOWED_CALLER_CHARS))
+                    .collect::<Vec<_>>();
+                Evidence::Known {
+                    value: BoundedList {
+                        count: facts.capabilities.len(),
+                        omitted: facts.capabilities.len().saturating_sub(rendered.len()),
+                        rendered,
+                    },
+                }
+            }
+        },
+        approval: match (surface, facts) {
+            (None, _) => unknown(no_surface),
+            (Some(_), None) => unknown(not_registered),
+            (Some(_), Some(facts)) => Evidence::Known {
+                value: bounded_chars(&facts.approval, MAX_AUXILIARY_CHARS),
+            },
+        },
+        model_visible: match (surface, facts) {
+            (None, _) => unknown(no_surface),
+            (Some(_), None) => unknown(not_registered),
+            (Some(_), Some(facts)) => Evidence::Known {
+                value: facts.model_visible,
+            },
+        },
+        // Every projected tool is carried by this prepared request; the
+        // transport flag only says whether its schema rides along now.
+        visibility: match tool.defer_loading {
+            Some(true) => ToolVisibility::Deferred,
+            Some(false) => ToolVisibility::Active,
+            None => ToolVisibility::InRequest,
+        },
     }
 }
 
@@ -473,6 +897,246 @@ mod tests {
         assert!(text.contains("Provider-wire tool payload: unavailable"));
     }
 
+    fn facts(name: &str, plugin: bool, model_visible: bool) -> RegistryFacts {
+        RegistryFacts {
+            name: name.to_string(),
+            description: format!("{name} registry description"),
+            model_visible,
+            capabilities: vec!["ReadOnly".to_string()],
+            approval: "Auto".to_string(),
+            plugin,
+        }
+    }
+
+    fn surface() -> ToolSurfaceContext {
+        ToolSurfaceContext {
+            registry: vec![
+                facts("read_file", false, true),
+                facts("plugin_tool", true, true),
+                facts("hidden_alias", false, false),
+                facts("not_sent", false, true),
+            ],
+            mcp_servers: BTreeMap::from([(
+                "mcp_my_server_read_file".to_string(),
+                "my_server".to_string(),
+            )]),
+            synthetic_names: vec!["tool_search".to_string()],
+            provider: ProviderAvailability::Available {
+                provider: "Deepseek".to_string(),
+                model: "deepseek-chat".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn surface_context_turns_provenance_and_attribution_into_truth() {
+        let tools = vec![
+            tool("read_file"),
+            tool("plugin_tool"),
+            tool("mcp_my_server_read_file"),
+            tool("tool_search"),
+            tool("stranger"),
+        ];
+        let surface = surface();
+        let snapshot = ToolInspectionSnapshot::from_prepared_request_with_surface(
+            "turn",
+            1,
+            Some(&tools),
+            Some(&surface),
+        );
+
+        let provenance = |name: &str| {
+            snapshot
+                .tools
+                .iter()
+                .find(|entry| entry.name.value == name)
+                .map(|entry| entry.provenance.clone())
+                .expect("projected tool")
+        };
+        for (name, expected) in [
+            ("read_file", ToolProvenance::Builtin),
+            ("plugin_tool", ToolProvenance::Plugin),
+            ("mcp_my_server_read_file", ToolProvenance::Mcp),
+            ("tool_search", ToolProvenance::Synthetic),
+            // Captured context, no resolved origin: unknown is the answer.
+            ("stranger", ToolProvenance::Unknown),
+        ] {
+            assert_eq!(
+                provenance(name),
+                Evidence::Known { value: expected },
+                "provenance for {name}"
+            );
+        }
+
+        let mcp = snapshot
+            .tools
+            .iter()
+            .find(|entry| entry.name.value == "mcp_my_server_read_file")
+            .expect("mcp tool");
+        // Attribution comes from the pool, not from splitting on `_`.
+        assert_eq!(
+            mcp.mcp_server,
+            Evidence::Known {
+                value: BoundedString {
+                    value: "my_server".to_string(),
+                    truncated: false,
+                }
+            }
+        );
+
+        let read_file = snapshot
+            .tools
+            .iter()
+            .find(|entry| entry.name.value == "read_file")
+            .expect("read_file");
+        assert!(matches!(read_file.capabilities, Evidence::Known { .. }));
+        assert_eq!(
+            read_file.approval,
+            Evidence::Known {
+                value: BoundedString {
+                    value: "Auto".to_string(),
+                    truncated: false,
+                }
+            }
+        );
+        assert_eq!(read_file.model_visible, Evidence::Known { value: true });
+
+        // Unregistered tools stay unknown rather than being reported as "none".
+        let stranger = snapshot
+            .tools
+            .iter()
+            .find(|entry| entry.name.value == "stranger")
+            .expect("stranger");
+        assert!(matches!(stranger.capabilities, Evidence::Unknown { .. }));
+        assert!(matches!(stranger.approval, Evidence::Unknown { .. }));
+
+        // The unavailable set shrinks to what nothing here can observe.
+        assert_eq!(
+            snapshot.unavailable_for_this_request,
+            vec!["provider_wire_payload"]
+        );
+        assert!(snapshot.provider.is_available());
+        assert!(snapshot.registry_facts_present);
+        assert_eq!(snapshot.registry_tool_count, Evidence::Known { value: 4 });
+
+        let text = snapshot.render_text();
+        assert!(text.contains("provenance: synthetic"), "{text}");
+        assert!(text.contains("MCP server: \"my_server\""), "{text}");
+        assert!(text.contains("Provider: \"Deepseek\""), "{text}");
+        assert!(
+            text.contains("Provider-wire tool payload: unavailable"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn registry_only_tools_are_counted_without_expanding_the_projection() {
+        let tools = vec![tool("read_file")];
+        let surface = surface();
+        let snapshot = ToolInspectionSnapshot::from_prepared_request_with_surface(
+            "turn",
+            1,
+            Some(&tools),
+            Some(&surface),
+        );
+
+        // Only the request's tools are projected; the rest are counted.
+        assert_eq!(snapshot.tools.len(), 1);
+        let Evidence::Known { value } = &snapshot.registry_only_tools else {
+            panic!("registry-only tools must be known when facts were captured");
+        };
+        // `hidden_alias` is not model-visible, so it is not a missing tool.
+        assert_eq!(value.count, 2);
+        let rendered = value
+            .rendered
+            .iter()
+            .map(|entry| entry.value.as_str())
+            .collect::<Vec<_>>();
+        // Order follows the registry facts as supplied; the producer sorts.
+        assert_eq!(rendered, vec!["plugin_tool", "not_sent"]);
+
+        // Everything projected is in the request; the request is the evidence.
+        assert!(snapshot.tools.iter().all(|entry| {
+            entry.visibility.in_request() && entry.visibility == ToolVisibility::Active
+        }));
+    }
+
+    #[test]
+    fn absent_surface_keeps_every_registry_derived_field_unknown() {
+        let tools = vec![tool("read_file")];
+        let snapshot = ToolInspectionSnapshot::from_prepared_request("turn", 1, Some(&tools));
+
+        assert_eq!(snapshot.provider, ProviderAvailability::Unknown);
+        assert!(!snapshot.registry_facts_present);
+        assert!(matches!(
+            snapshot.registry_tool_count,
+            Evidence::Unknown { .. }
+        ));
+        assert!(matches!(
+            snapshot.registry_only_tools,
+            Evidence::Unknown { .. }
+        ));
+        assert_eq!(
+            snapshot.unavailable_for_this_request,
+            vec![
+                "provider_wire_payload",
+                "provider",
+                "model",
+                "approval",
+                "provenance",
+                "capabilities",
+            ]
+        );
+        let entry = &snapshot.tools[0];
+        for evidence in [
+            matches!(entry.provenance, Evidence::Unknown { .. }),
+            matches!(entry.mcp_server, Evidence::Unknown { .. }),
+            matches!(entry.capabilities, Evidence::Unknown { .. }),
+            matches!(entry.approval, Evidence::Unknown { .. }),
+            matches!(entry.model_visible, Evidence::Unknown { .. }),
+        ] {
+            assert!(evidence);
+        }
+        // Wire facts are still exact without a surface context.
+        assert!(entry.visibility.in_request());
+        assert!(snapshot.active_tool_catalog_sha256.is_some());
+    }
+
+    #[test]
+    fn provider_receipt_records_an_unresolved_client_without_borrowing_registry_truth() {
+        let tools = vec![tool("read_file")];
+        let surface = ToolSurfaceContext {
+            registry: vec![facts("read_file", false, true)],
+            provider: ProviderAvailability::Unavailable {
+                reason: "no model client resolved for this turn".to_string(),
+            },
+            ..ToolSurfaceContext::default()
+        };
+        let snapshot = ToolInspectionSnapshot::from_prepared_request_with_surface(
+            "turn",
+            1,
+            Some(&tools),
+            Some(&surface),
+        );
+
+        // A full registry does not make a provider available.
+        assert!(!snapshot.provider.is_available());
+        assert_eq!(snapshot.provider.label(), "unavailable");
+        assert!(snapshot.unavailable_for_this_request.contains(&"provider"));
+        // Registry-derived truth is unaffected by the missing client.
+        assert!(
+            !snapshot
+                .unavailable_for_this_request
+                .contains(&"provenance")
+        );
+        assert_eq!(
+            snapshot.tools[0].provenance,
+            Evidence::Known {
+                value: ToolProvenance::Builtin
+            }
+        );
+    }
+
     #[test]
     fn capture_and_rendering_are_bounded_with_explicit_receipts() {
         let mut tools = (0..40)
@@ -503,8 +1167,12 @@ mod tests {
         // The catalog digest is fixed-width, so it survives the byte bound.
         assert!(snapshot.active_tool_catalog_sha256.is_some());
         let json = snapshot.render_json().expect("bounded JSON");
+        // 160 KiB: the per-tool evidence fields (provenance, MCP server,
+        // capabilities, approval, visibility) each carry an explicit reason
+        // string when unresolved, which is the point — the cap moved, the
+        // bound did not disappear.
         assert!(
-            json.len() < 131_072,
+            json.len() < 163_840,
             "projection grew to {} bytes",
             json.len()
         );

--- a/crates/tui/src/tools/registry.rs
+++ b/crates/tui/src/tools/registry.rs
@@ -286,6 +286,39 @@ impl ToolRegistry {
         tools
     }
 
+    /// Flatten every registered tool into the exact facts the read-only
+    /// request projection is allowed to report: name, description, model
+    /// visibility, declared capabilities, declared approval requirement, and
+    /// whether the tool came from the plugin surface.
+    ///
+    /// This hands out *data*, never tool objects, so the projection layer
+    /// cannot execute anything. Output is sorted by name and does not touch the
+    /// registry's own ordering or the memoised API catalog.
+    #[must_use]
+    pub fn registry_facts(
+        &self,
+        plugin_names: &std::collections::HashSet<String>,
+    ) -> Vec<crate::tool_inspection::RegistryFacts> {
+        let mut facts: Vec<crate::tool_inspection::RegistryFacts> = self
+            .tools
+            .values()
+            .map(|tool| crate::tool_inspection::RegistryFacts {
+                name: tool.name().to_string(),
+                description: tool.description().to_string(),
+                model_visible: tool.model_visible(),
+                capabilities: tool
+                    .capabilities()
+                    .iter()
+                    .map(|capability| format!("{capability:?}"))
+                    .collect(),
+                approval: format!("{:?}", tool.approval_requirement()),
+                plugin: plugin_names.contains(tool.name()),
+            })
+            .collect();
+        facts.sort_by(|a, b| a.name.cmp(&b.name));
+        facts
+    }
+
     /// Filter tools by capability.
     #[must_use]
     #[allow(dead_code)]

--- a/docs/TOOL_SURFACE.md
+++ b/docs/TOOL_SURFACE.md
@@ -189,6 +189,73 @@ RLM child-query batching is a different, cheaper cost class. Its
 `sub_query_batch` helper accepts 1–16 one-shot children inside a live `rlm`
 session; it is not a substitute for tool-carrying `agent` workers.
 
+## Human inspection: `/tools` (`/tool-studio`)
+
+`/tools` renders a **read-only, bounded human projection** of the tool field of
+the request that was prepared for one `(turn, step)`. It is not a second
+registry and not an execution surface.
+
+**The seam.** The snapshot is built in `crates/tui/src/core/engine/turn_loop.rs`
+immediately after `MessageRequest` is constructed, from `request.tools` — the
+same value the model client is handed. The engine resolves the surrounding
+per-turn data once in `engine.rs` (`ToolSurfaceContext`: flattened registry
+facts, the MCP pool's own server attribution, the engine-injected catalog names,
+and the resolved model client's receipt) and passes it as plain data, so the
+per-step seam never re-locks the MCP pool or holds a tool object.
+
+**Turn and step identity.** The tool set can differ between steps of a turn, so
+each snapshot is stamped with turn id and step and each seam emits its own. The
+TUI keeps only the latest (`SessionState.last_tool_request_snapshot`). Before
+the first seam there is no snapshot and `/tools` says so rather than rebuilding
+a registry in the UI.
+
+Two kinds of fact are kept apart:
+
+- **Wire facts** come from the prepared request: name, description, schema,
+  `defer_loading` / `strict` / `allowed_callers` / `cache_control`, byte
+  accounting, and the catalog digest.
+- **Surface facts** come from the `ToolSurfaceContext`: provenance
+  (`builtin` / `plugin` / `mcp` / `synthetic` / `unknown`), MCP server identity,
+  declared capabilities, declared approval requirement, and model visibility.
+
+Contract:
+
+- **One digest.** `active_tool_catalog_sha256`
+  (`crates/tui/src/core/engine/preview.rs`) is the single definition of the
+  active-tool-catalog hash. The request manifest publishes it as
+  `ToolSurfaceFacts::active_tool_catalog_sha256` and `/tools` reports the same
+  value for the same prepared request; neither surface keeps a hash of its own.
+- **Nothing is guessed.** MCP server identity is shown only when the real pool
+  attributed that exact model tool name. `McpPool::mcp_model_tool_name` is the
+  single definition shared by the model catalog and the human attribution, and
+  an ambiguous name (two servers colliding on one model name) resolves to no
+  server. Synthetic provenance comes from
+  `default_synthetic_catalog_tool_names`, which is asserted against the engine's
+  own `is_synthetic_catalog_tool` predicate. A transmitted tool with no registry
+  entry reports `capabilities: unknown`, never "none".
+- **Provider availability follows the resolved client.** It comes from
+  `Engine::tool_surface_provider_receipt`, never from "a tool registry exists".
+  With no client the receipt is `unavailable` even when the registry is full.
+- **Unknown shrinks, it does not vanish.** `unavailable_for_this_request` always
+  contains `provider_wire_payload`: nothing on this path observes what the
+  provider adapter finally transmits. It additionally contains `provider` and
+  `model` without a resolved client, and `provenance` / `capabilities` /
+  `approval` when no surface context was captured.
+- **Absent stays distinct from empty.** A request with no tools field is not a
+  request with an empty tools array; an unresolved field is `unknown` with a
+  reason, not a default.
+- **Bounded.** Rendering is capped by tool count (32), name, description, schema
+  bytes, allowed-caller count, and a payload measurement bound, each with an
+  explicit truncation or omission receipt. Registered tools that this request
+  does *not* carry are reported as a bounded name list plus an exact count
+  rather than expanding the projection.
+- **Inert.** The snapshot lives beside the transcript, never in
+  `session.messages`, so it cannot enter a model request or perturb the
+  provider's prefix cache. It never executes a tool, never reads credentials,
+  never reorders the catalog, and is never registered as a model-callable tool.
+- **Delivery is never claimed.** The capture happens before connection setup, so
+  `delivery_status` stays `unknown`.
+
 ## Release verification
 
 Do not infer the public surface from handler function names. Verify the model


### PR DESCRIPTION
## Summary

Upgrades the landed /tools · /tool-studio projection from 'provenance unavailable' to registry-derived truth, without replacing the landed design:

- One catalog digest: the request manifest's active_tool_catalog_sha256 is now THE definition; the projection's second hash is deleted (equality + reorder-sensitivity tested)
- ToolProvenance (builtin/plugin/MCP/synthetic) with real MCP server attribution (single-definition invariant) and plugin names carried on TurnToolBuild
- Unknown shrinks, never vanishes: fixed unavailable list → computed per-request; provider/model appear only with a resolved client (provider receipt follows the client, not the registry)
- Two lane claims corrected: multi_tool_use.parallel is a call name, not a catalog entry (test keeps it out); the prior snapshot test was vacuous on an empty catalog — new test puts a real catalog on the wire

Receipts: tool_inspection 8, tools_command 3, request_snapshot 4, invariants 3 — 0 failed; fmt/diff clean; workspace clippy (exact CI flags) exit 0.

Honest scope: the lane's full-registry tool_studio rendering layer was NOT harvested (different contract); digest equality is unit+structural, not yet wire-end-to-end.

No-Issue: follow-up hardening on the landed #1891 slice; no issue closes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)