### PR TITLE
fix: kimi-k3 selection — sticky model memory, lying resolve, missing catalog ids

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -629,6 +629,29 @@ impl Default for ModelRegistry {
                 supports_tools: true,
                 supports_reasoning: true,
             },
+            // Moonshot ships K3 as two distinct products under one provider
+            // id, separated by endpoint (v0.9.1 kimi-k3 dogfood report):
+            //   * `kimi-k3` on the direct platform API (api.moonshot.ai/v1)
+            //   * `k3` on the Kimi Code coding-plan API (api.kimi.com/coding/v1)
+            // Both must be resolvable here or `--model kimi-k3` silently
+            // reports the provider default instead. The endpoint pairing is
+            // enforced separately by `validate_kimi_code_api_model_id`; keep
+            // the two ids in separate entries so neither one's alias set can
+            // launder a request onto the other product's route.
+            ModelInfo {
+                id: "kimi-k3".to_string(),
+                provider: ProviderKind::Moonshot,
+                aliases: vec!["moonshot-kimi-k3".to_string()],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
+            ModelInfo {
+                id: "k3".to_string(),
+                provider: ProviderKind::Moonshot,
+                aliases: vec!["kimi-code-k3".to_string()],
+                supports_tools: true,
+                supports_reasoning: true,
+            },
             ModelInfo {
                 id: "deepseek-ai/DeepSeek-V4-Pro".to_string(),
                 provider: ProviderKind::Sglang,
@@ -1238,8 +1261,16 @@ impl ModelRegistry {
                     fallback_chain,
                 };
             }
+            // The global alias map is a *provider-less* convenience lookup. It
+            // must never answer a provider-scoped question with another
+            // vendor's model: before this fix, `--provider moonshot` asking for
+            // `kimi-k3` was answered with OpenCode Go's `kimi-k3` because the
+            // hinted provider had no such id. A hinted request that the hinted
+            // provider cannot serve falls through to that provider's default
+            // with `used_fallback: true`, which callers already surface.
             if provider_hint != Some(ProviderKind::OpencodeGo)
                 && let Some(idx) = self.alias_map.get(&normalize(name))
+                && provider_hint.is_none_or(|hint| self.models[*idx].provider == hint)
             {
                 return ModelResolution {
                     requested: Some(name.to_string()),
@@ -1570,6 +1601,71 @@ mod tests {
         assert_eq!(resolved.resolved.provider, ProviderKind::Moonshot);
         assert_eq!(resolved.resolved.id, "kimi-k2.6");
         assert!(resolved.resolved.supports_reasoning);
+    }
+
+    /// v0.9.1 dogfood report: a user ran `--provider moonshot --model kimi-k3` and was told
+    /// the model was `kimi-k2.7-code`. The registry knew neither Moonshot K3
+    /// product, so the explicit request fell through to the provider default.
+    #[test]
+    fn moonshot_resolves_both_k3_products_without_crossing_them() {
+        let registry = ModelRegistry::default();
+
+        for (requested, expected) in [("kimi-k3", "kimi-k3"), ("k3", "k3")] {
+            let resolved = registry.resolve(Some(requested), Some(ProviderKind::Moonshot));
+
+            assert_eq!(resolved.resolved.provider, ProviderKind::Moonshot);
+            assert_eq!(resolved.resolved.id, expected, "{resolved:?}");
+            assert!(
+                !resolved.used_fallback,
+                "an explicit Moonshot K3 request is not a fallback: {resolved:?}"
+            );
+        }
+    }
+
+    /// The bare `k3` id belongs to the Kimi Code coding-plan endpoint and
+    /// `kimi-k3` to the direct platform endpoint. Neither may be laundered
+    /// into the other's id by alias expansion.
+    #[test]
+    fn moonshot_k3_ids_are_never_rewritten_into_each_other() {
+        let registry = ModelRegistry::default();
+
+        assert_eq!(
+            registry
+                .resolve(Some("kimi-k3"), Some(ProviderKind::Moonshot))
+                .resolved
+                .id,
+            "kimi-k3"
+        );
+        assert_eq!(
+            registry
+                .resolve(Some("k3"), Some(ProviderKind::Moonshot))
+                .resolved
+                .id,
+            "k3"
+        );
+    }
+
+    /// A provider-scoped question must never be answered with another
+    /// vendor's model. `kimi-k3` also exists in the OpenCode Go catalog;
+    /// before this fix that entry answered `--provider moonshot` requests.
+    #[test]
+    fn a_provider_hint_never_resolves_to_another_providers_model() {
+        let registry = ModelRegistry::default();
+
+        let resolved = registry.resolve(Some("glm-5.2"), Some(ProviderKind::Moonshot));
+        assert_eq!(
+            resolved.resolved.provider,
+            ProviderKind::Moonshot,
+            "a Moonshot request must not be answered by Z.ai: {resolved:?}"
+        );
+        assert!(
+            resolved.used_fallback,
+            "an unservable id must be reported as a fallback, not as the request: {resolved:?}"
+        );
+
+        let go = registry.resolve(Some("kimi-k3"), Some(ProviderKind::OpencodeGo));
+        assert_eq!(go.resolved.provider, ProviderKind::OpencodeGo);
+        assert_eq!(go.resolved.id, "kimi-k3");
     }
 
     #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3614,7 +3614,14 @@ fn run_model_command(
             Ok(())
         }
         ModelCommand::Resolve { model, provider } => {
-            let subcommand_provider = model_command_provider_hint(provider, top_level_provider);
+            // Only `model resolve --provider X` is a hypothetical. The
+            // top-level `--provider` is the route this process is actually on,
+            // and it is already folded into `resolved_runtime` — treating it as
+            // a hypothetical made `codewhale --provider moonshot --model
+            // kimi-k3 model resolve` re-derive a registry default and report
+            // `kimi-k2.7-code` while the runtime used `kimi-k3` (v0.9.1 kimi-k3 dogfood report). The
+            // top-level `--model` was not consulted at all on that path.
+            let subcommand_provider = provider.map(ProviderKind::from);
             let queried = model.as_deref().map(str::trim).filter(|m| !m.is_empty());
 
             // With no explicit query, this reports the route the runtime would
@@ -3647,7 +3654,18 @@ fn run_model_command(
             // registry — but default the provider to the configured one rather
             // than to any single vendor.
             let provider_hint = subcommand_provider.or(Some(resolved_runtime.provider));
-            let resolved = registry.resolve(queried, provider_hint);
+            let mut resolved = registry.resolve(queried, provider_hint);
+            // The registry refuses to answer a provider-scoped question with
+            // another vendor's model. That is right when the *user* named the
+            // provider, but the hint above is often ours: when only a model was
+            // named, "what does this id mean" is still a global question, so
+            // retry unhinted rather than substituting the configured provider's
+            // default for the id the user typed.
+            let provider_named_by_user =
+                subcommand_provider.is_some() || top_level_provider.is_some();
+            if !provider_named_by_user && queried.is_some() && resolved.used_fallback {
+                resolved = registry.resolve(queried, None);
+            }
             println!("requested: {}", resolved.requested.unwrap_or_default());
             println!("resolved: {}", resolved.resolved.id);
             println!("provider: {}", resolved.resolved.provider.as_str());

--- a/crates/cli/tests/model_resolve_provenance.rs
+++ b/crates/cli/tests/model_resolve_provenance.rs
@@ -157,6 +157,127 @@ fn an_explicit_provider_flag_is_reported_as_the_source() {
     );
 }
 
+/// Run `model resolve` with global flags placed before the subcommand, which
+/// is where `--provider` / `--model` actually go.
+fn resolve_with_global_flags(
+    config: &str,
+    global: &[&str],
+    args: &[&str],
+) -> BTreeMap<String, String> {
+    let fixture = TempDir::new().expect("fixture root");
+    let home = fixture.path().join("sealed-home");
+    fs::create_dir_all(home.join(".codewhale")).expect("sealed config dir");
+    fs::write(home.join(".codewhale").join("config.toml"), config).expect("seed config");
+
+    let mut command = Command::new(codewhale_binary());
+    command.args(global).arg("model").arg("resolve").args(args);
+    let output = command
+        .env_clear()
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("CODEWHALE_HOME", home.join(".codewhale"))
+        .env("CODEWHALE_SECRET_BACKEND", "file")
+        .output()
+        .expect("run model resolve");
+
+    assert!(
+        output.status.success(),
+        "model resolve {global:?} {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once(": "))
+        .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+        .collect()
+}
+
+/// v0.9.1 kimi-k3 dogfood report: `codewhale --provider moonshot --model kimi-k3 model resolve`
+/// reported `kimi-k2.7-code`. The top-level flags are the route this process
+/// is on, not a hypothetical, so the diagnostic has to answer with the runtime
+/// resolution instead of re-deriving a registry default and ignoring `--model`.
+#[test]
+fn top_level_provider_and_model_flags_report_the_runtime_route() {
+    let report = resolve_with_global_flags(
+        "provider = \"zai\"\n\n[providers.zai]\napi_key = \"k\"\n",
+        &["--provider", "moonshot", "--model", "kimi-k3"],
+        &[],
+    );
+
+    assert_eq!(report.get("provider").map(String::as_str), Some("moonshot"));
+    assert_eq!(
+        report.get("resolved").map(String::as_str),
+        Some("kimi-k3"),
+        "the diagnostic must not contradict the model the run will use: {report:?}"
+    );
+    assert_eq!(
+        report.get("requested").map(String::as_str),
+        Some("kimi-k3"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("used_fallback").map(String::as_str),
+        Some("false"),
+        "{report:?}"
+    );
+    assert_eq!(
+        report.get("model_source").map(String::as_str),
+        Some("--model"),
+        "{report:?}"
+    );
+}
+
+/// Moonshot ships `kimi-k3` on the direct platform API and `k3` on the Kimi
+/// Code coding-plan API. Both must resolve, and neither may be answered by
+/// another provider's identically named model (OpenCode Go also serves a
+/// `kimi-k3`).
+#[test]
+fn moonshot_k3_products_resolve_without_crossing_providers() {
+    for model in ["kimi-k3", "k3"] {
+        let report = resolve_with_global_flags(
+            "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\n",
+            &[],
+            &[model, "--provider", "moonshot"],
+        );
+
+        assert_eq!(
+            report.get("provider").map(String::as_str),
+            Some("moonshot"),
+            "a Moonshot question must not be answered by another provider: {report:?}"
+        );
+        assert_eq!(
+            report.get("resolved").map(String::as_str),
+            Some(model),
+            "{report:?}"
+        );
+        assert_eq!(
+            report.get("used_fallback").map(String::as_str),
+            Some("false"),
+            "{report:?}"
+        );
+    }
+}
+
+/// An id the selected provider cannot serve must be reported as a fallback,
+/// never as if the request had been honoured.
+#[test]
+fn an_unservable_model_on_the_selected_provider_is_reported_as_a_fallback() {
+    let report = resolve_with_global_flags(
+        "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\n",
+        &[],
+        &["glm-5.2", "--provider", "moonshot"],
+    );
+
+    assert_eq!(report.get("provider").map(String::as_str), Some("moonshot"));
+    assert_eq!(
+        report.get("used_fallback").map(String::as_str),
+        Some("true"),
+        "an unservable id must not be presented as an honoured request: {report:?}"
+    );
+}
+
 fn codewhale_binary() -> PathBuf {
     if let Some(path) = option_env!("CARGO_BIN_EXE_codewhale") {
         return PathBuf::from(path);

--- a/crates/tui/src/client.rs
+++ b/crates/tui/src/client.rs
@@ -4460,6 +4460,54 @@ mod tests {
         assert_k3_request_json_route_boundaries(true).await;
     }
 
+    /// v0.9.1 kimi-k3 dogfood report: the id the user selects has to be the id on the wire. A
+    /// dogfood user selecting `kimi-k3` was served `kimi-k2.7-code`, so this
+    /// asserts the wire `model` field for each K3 product on its own endpoint,
+    /// and that neither one's request carries the other's id.
+    #[tokio::test]
+    async fn selected_moonshot_k3_model_is_the_model_on_the_wire() {
+        let platform = capture_moonshot_chat_request(
+            crate::config::DEFAULT_MOONSHOT_BASE_URL,
+            crate::config::MOONSHOT_KIMI_K3_MODEL,
+            Some("high"),
+            false,
+        )
+        .await;
+        assert_eq!(
+            platform["model"],
+            json!(crate::config::MOONSHOT_KIMI_K3_MODEL),
+            "the direct platform route must send the id the user named: {platform}"
+        );
+        assert_ne!(
+            platform["model"],
+            json!(crate::config::DEFAULT_MOONSHOT_MODEL),
+            "an explicit selection is never replaced by the provider default: {platform}"
+        );
+        assert_ne!(
+            platform["model"],
+            json!(crate::config::KIMI_CODE_K3_MODEL),
+            "the coding-plan id must not leak onto the platform route: {platform}"
+        );
+
+        let membership = capture_moonshot_chat_request(
+            crate::config::DEFAULT_KIMI_CODE_BASE_URL,
+            crate::config::KIMI_CODE_K3_MODEL,
+            Some("high"),
+            false,
+        )
+        .await;
+        assert_eq!(
+            membership["model"],
+            json!(crate::config::KIMI_CODE_K3_MODEL),
+            "the Kimi Code membership route must send bare `k3`: {membership}"
+        );
+        assert_ne!(
+            membership["model"],
+            json!(crate::config::MOONSHOT_KIMI_K3_MODEL),
+            "the platform id must not leak onto the coding-plan route: {membership}"
+        );
+    }
+
     #[tokio::test]
     async fn create_message_request_json_keeps_zai_effort_route_exact() {
         assert_zai_request_truth(false).await;

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1274,7 +1274,22 @@ pub fn model_completion_names_for_provider(provider: ApiProvider) -> Vec<&'stati
             vec![DEFAULT_SILICONFLOW_MODEL, DEFAULT_SILICONFLOW_FLASH_MODEL]
         }
         ApiProvider::Arcee => vec![DEFAULT_ARCEE_MODEL, ARCEE_TRINITY_LARGE_PREVIEW_MODEL],
-        ApiProvider::Moonshot => vec![DEFAULT_MOONSHOT_MODEL],
+        // Moonshot's direct platform API (the provider's default route) serves
+        // `kimi-k3`; advertising only `kimi-k2.7-code` is half of why a
+        // dogfood user reported "I can't find k3" on v0.9.1.
+        //
+        // The bare `k3` id and `kimi-for-coding` deliberately stay out: they
+        // belong to the Kimi Code coding-plan endpoint
+        // (api.kimi.com/coding/v1), which `validate_kimi_code_api_model_id`
+        // enforces. A completion list is a per-provider fallback with no
+        // base-URL context, so offering an id this route would reject would
+        // just move the surprise later. Kimi Code routes surface their own
+        // ids through the configured model and the route-aware picker rows.
+        ApiProvider::Moonshot => vec![
+            DEFAULT_MOONSHOT_MODEL,
+            MOONSHOT_KIMI_K3_MODEL,
+            MOONSHOT_KIMI_K2_6_MODEL,
+        ],
         ApiProvider::Huggingface => {
             vec![DEFAULT_HUGGINGFACE_MODEL, DEFAULT_HUGGINGFACE_FLASH_MODEL]
         }
@@ -9569,6 +9584,22 @@ fn provider_secret_store_api_key_with_mode(
         .ok()
         .flatten()
         .filter(|value| !value.trim().is_empty())
+}
+
+/// The model this launch was explicitly asked for, if any.
+///
+/// The `codewhale` dispatcher forwards `--model` to this binary as
+/// `CODEWHALE_MODEL` (with the legacy `DEEPSEEK_MODEL` alias), so an explicit
+/// flag and an explicit shell export are the same signal here: *the user named
+/// a model for this run*. That has to outrank the remembered per-provider
+/// selection in `settings.toml`, which is a convenience memory of the last
+/// `/model` pick — never a reason to run something the user did not ask for
+/// (v0.9.1 kimi-k3 dogfood report).
+pub(crate) fn explicit_launch_model_override() -> Option<String> {
+    codewhale_env_var("CODEWHALE_MODEL", "DEEPSEEK_MODEL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 pub(crate) fn explicit_cli_api_key_override() -> Option<String> {

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -5222,10 +5222,27 @@ fn model_completion_names_for_openrouter_include_recent_large_models() {
 
 #[test]
 fn model_completion_names_for_moonshot_uses_latest_platform_model() {
-    assert_eq!(
-        model_completion_names_for_provider(ApiProvider::Moonshot),
-        vec![DEFAULT_MOONSHOT_MODEL]
-    );
+    let models = model_completion_names_for_provider(ApiProvider::Moonshot);
+
+    assert_eq!(models.first().copied(), Some(DEFAULT_MOONSHOT_MODEL));
+    // `kimi-k3` is served by this provider's default (direct platform) route
+    // and must be offerable — a dogfood user on v0.9.1 could not find it.
+    assert!(models.contains(&MOONSHOT_KIMI_K3_MODEL), "{models:?}");
+    // The Kimi Code coding-plan ids belong to api.kimi.com/coding/v1, which
+    // this base-URL-less list cannot express. Offering them here would
+    // advertise a pairing `validate_kimi_code_api_model_id` rejects.
+    assert!(!models.contains(&KIMI_CODE_K3_MODEL), "{models:?}");
+    assert!(!models.contains(&DEFAULT_KIMI_CODE_MODEL), "{models:?}");
+    for model in &models {
+        let config = Config {
+            provider: Some(ApiProvider::Moonshot.as_str().to_string()),
+            default_text_model: Some((*model).to_string()),
+            ..Default::default()
+        };
+        config
+            .validate()
+            .expect("every advertised Moonshot model must be valid on its default route");
+    }
 }
 
 #[test]
@@ -10215,4 +10232,144 @@ fn native_memory_backend_owns_explicit_path_and_disables_legacy_fallback() {
         config.memory_path(),
         tmp.path().join("memory/global/MEMORY.md")
     );
+}
+
+/// v0.9.1 kimi-k3 dogfood report: a dogfood user ran `codewhale --provider moonshot --model kimi-k3`
+/// and the session kept reporting `kimi-k2.7-code`. The `--model` flag reaches
+/// this binary as `CODEWHALE_MODEL`, so the route it produces is asserted here
+/// end to end: the effective model, the endpoint, and the id that goes on the
+/// wire must all be the one the user named.
+#[test]
+fn cli_model_flag_selects_kimi_k3_on_the_moonshot_platform_route() -> Result<()> {
+    let _lock = lock_test_env();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_root = env::temp_dir().join(format!(
+        "codewhale-tui-kimi-k3-cli-{}-{nanos}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_root)?;
+    let _guard = EnvGuard::new(&temp_root);
+
+    // `EnvGuard` points DEEPSEEK_CONFIG_PATH at `<home>/.deepseek/config.toml`.
+    let config_path = temp_root.join(".deepseek").join("config.toml");
+    ensure_parent_dir(&config_path)?;
+    fs::write(
+        &config_path,
+        "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\n",
+    )?;
+    // Safety: test-only env mutation guarded by lock_test_env().
+    unsafe {
+        env::set_var("CODEWHALE_PROVIDER", "moonshot");
+        env::set_var("CODEWHALE_MODEL", MOONSHOT_KIMI_K3_MODEL);
+    }
+
+    let config = Config::load(None, None)?;
+
+    assert_eq!(config.api_provider(), ApiProvider::Moonshot);
+    assert_eq!(config.default_model(), MOONSHOT_KIMI_K3_MODEL);
+    assert_eq!(config.deepseek_base_url(), DEFAULT_MOONSHOT_BASE_URL);
+    assert_eq!(
+        wire_model_for_provider_route(
+            ApiProvider::Moonshot,
+            &config.deepseek_base_url(),
+            &config.default_model(),
+        ),
+        MOONSHOT_KIMI_K3_MODEL,
+        "the id the user named must be the id on the wire"
+    );
+    assert_eq!(
+        explicit_launch_model_override().as_deref(),
+        Some(MOONSHOT_KIMI_K3_MODEL),
+        "an explicit --model must remain recognizable as an explicit request"
+    );
+    assert_eq!(
+        moonshot_k3_route_display_name(&config.deepseek_base_url(), &config.default_model()),
+        Some("Moonshot direct / kimi-k3")
+    );
+    Ok(())
+}
+
+/// The bare `k3` id belongs to the Kimi Code coding-plan endpoint. A config
+/// that selects it there must resolve, and must be labelled as the membership
+/// product rather than the direct platform one (v0.9.1 kimi-k3 dogfood report).
+#[test]
+fn config_selects_bare_k3_on_the_kimi_code_route() {
+    let config = Config {
+        provider: Some("moonshot".to_string()),
+        providers: Some(ProvidersConfig {
+            moonshot: ProviderConfig {
+                api_key: Some("k".to_string()),
+                base_url: Some(DEFAULT_KIMI_CODE_BASE_URL.to_string()),
+                model: Some(KIMI_CODE_K3_MODEL.to_string()),
+                ..ProviderConfig::default()
+            },
+            ..ProvidersConfig::default()
+        }),
+        ..Config::default()
+    };
+
+    assert_eq!(config.default_model(), KIMI_CODE_K3_MODEL);
+    assert_eq!(
+        wire_model_for_provider_route(
+            ApiProvider::Moonshot,
+            &config.deepseek_base_url(),
+            &config.default_model(),
+        ),
+        KIMI_CODE_K3_MODEL
+    );
+    assert_eq!(
+        moonshot_k3_route_display_name(&config.deepseek_base_url(), &config.default_model()),
+        Some("Kimi Code membership / k3")
+    );
+}
+
+/// Neither K3 id may be silently served by the other product's endpoint. The
+/// two are different plans with different context windows, so an unservable
+/// pairing has to fail loudly and name both routes (v0.9.1 kimi-k3 dogfood report).
+#[test]
+fn k3_and_kimi_k3_never_cross_products_and_fail_visibly() {
+    let crossed = validate_kimi_code_api_model_id(
+        ApiProvider::Moonshot,
+        DEFAULT_KIMI_CODE_BASE_URL,
+        MOONSHOT_KIMI_K3_MODEL,
+    )
+    .expect_err("kimi-k3 is not a Kimi Code model id");
+    assert!(crossed.contains("api.kimi.com/coding/v1"), "{crossed}");
+    assert!(crossed.contains("api.moonshot.ai/v1"), "{crossed}");
+    assert!(crossed.contains(KIMI_CODE_K3_MODEL), "{crossed}");
+
+    let reversed = validate_kimi_code_api_model_id(
+        ApiProvider::Moonshot,
+        DEFAULT_MOONSHOT_BASE_URL,
+        KIMI_CODE_K3_MODEL,
+    )
+    .expect_err("bare k3 is not a direct-platform model id");
+    assert!(reversed.contains("api.moonshot.ai/v1"), "{reversed}");
+    assert!(reversed.contains("api.kimi.com/coding/v1"), "{reversed}");
+    assert!(reversed.contains(MOONSHOT_KIMI_K3_MODEL), "{reversed}");
+
+    // The exact-route predicates stay disjoint.
+    assert!(is_exact_direct_moonshot_k3_route(
+        ApiProvider::Moonshot,
+        DEFAULT_MOONSHOT_BASE_URL,
+        MOONSHOT_KIMI_K3_MODEL
+    ));
+    assert!(!is_exact_kimi_code_k3_route(
+        ApiProvider::Moonshot,
+        DEFAULT_MOONSHOT_BASE_URL,
+        MOONSHOT_KIMI_K3_MODEL
+    ));
+    assert!(is_exact_kimi_code_k3_route(
+        ApiProvider::Moonshot,
+        DEFAULT_KIMI_CODE_BASE_URL,
+        KIMI_CODE_K3_MODEL
+    ));
+    assert!(!is_exact_direct_moonshot_k3_route(
+        ApiProvider::Moonshot,
+        DEFAULT_KIMI_CODE_BASE_URL,
+        KIMI_CODE_K3_MODEL
+    ));
 }

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -253,19 +253,29 @@ impl App {
             (id.name().to_string(), id, theme)
         });
         let provider_models = settings.provider_models.clone().unwrap_or_default();
-        let model = provider_models
-            .get(&provider_identity)
-            .cloned()
-            .or_else(|| {
-                // default_model is a DeepSeek-centric setting; other providers
-                // get their model from config.toml / env (e.g. OPENAI_MODEL).
-                if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
-                    settings.default_model.clone()
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(model);
+        // `provider_models` remembers the last `/model` pick per provider. It
+        // is a convenience default, not an override: when this launch named a
+        // model explicitly (`--model`, forwarded as `CODEWHALE_MODEL`), that
+        // request wins. Before this fix the memory won unconditionally, so
+        // `codewhale --provider moonshot --model kimi-k3` silently kept running
+        // the remembered `kimi-k2.7-code` while `doctor` reported `kimi-k3`.
+        let model = if crate::config::explicit_launch_model_override().is_some() {
+            model
+        } else {
+            provider_models
+                .get(&provider_identity)
+                .cloned()
+                .or_else(|| {
+                    // default_model is a DeepSeek-centric setting; other providers
+                    // get their model from config.toml / env (e.g. OPENAI_MODEL).
+                    if matches!(provider, ApiProvider::Deepseek | ApiProvider::DeepseekCN) {
+                        settings.default_model.clone()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(model)
+        };
         let auto_model = model.trim().eq_ignore_ascii_case("auto");
         let mut enabled_provider_models = settings.enabled_models.clone().unwrap_or_default();
         for (saved_provider, saved_model) in &provider_models {

--- a/crates/tui/src/tui/app/tests.rs
+++ b/crates/tui/src/tui/app/tests.rs
@@ -6264,3 +6264,59 @@ fn hotbar_mode_row_for_the_live_mode_still_shows_the_saved_receipt() {
         "plan"
     );
 }
+
+/// v0.9.1 kimi-k3 dogfood report: `settings.toml`'s `[provider_models]` is a memory of the last
+/// `/model` pick, so it must not override a model the user named for *this*
+/// launch. A dogfood user ran `codewhale --provider moonshot --model kimi-k3`
+/// and the session header kept showing the remembered `kimi-k2.7-code` while
+/// `doctor` reported `kimi-k3`; header and route have to agree.
+#[test]
+fn an_explicit_launch_model_outranks_the_remembered_provider_model() {
+    let _lock = lock_test_env();
+    let temp = tempfile::tempdir().expect("sealed state root");
+    let config_path = temp.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        "provider = \"moonshot\"\n\n[providers.moonshot]\napi_key = \"k\"\nmodel = \"kimi-k3\"\n",
+    )
+    .expect("seed config");
+    std::fs::write(
+        temp.path().join("settings.toml"),
+        "[provider_models]\nmoonshot = \"kimi-k2.7-code\"\n",
+    )
+    .expect("seed settings");
+    let _config_path_guard = EnvVarGuard::set("DEEPSEEK_CONFIG_PATH", &config_path);
+    let _codewhale_config_path = EnvVarGuard::remove("CODEWHALE_CONFIG_PATH");
+
+    let config = Config::load(Some(config_path.clone()), None).expect("load sealed config");
+
+    // Without an explicit request this launch, the remembered pick still wins:
+    // that stickiness is what `/model` exists for.
+    let _no_flag = EnvVarGuard::remove("CODEWHALE_MODEL");
+    let _no_legacy_flag = EnvVarGuard::remove("DEEPSEEK_MODEL");
+    let remembered = App::new(
+        TuiOptions {
+            model: config.default_model(),
+            ..test_options(false)
+        },
+        &config,
+    );
+    assert_eq!(
+        remembered.model, "kimi-k2.7-code",
+        "the remembered /model pick remains the default when nothing was named"
+    );
+
+    // `--model` reaches this binary as CODEWHALE_MODEL. It must win.
+    let _model_flag = EnvVarGuard::set("CODEWHALE_MODEL", "kimi-k3");
+    let requested = App::new(
+        TuiOptions {
+            model: config.default_model(),
+            ..test_options(false)
+        },
+        &config,
+    );
+    assert_eq!(
+        requested.model, "kimi-k3",
+        "an explicit --model must never be silently replaced by session memory"
+    );
+}


### PR DESCRIPTION
## Summary

Root-causes a live user report (v0.9.1: `--provider moonshot --model kimi-k3` still ran kimi-k2.7-code; 'I can't find k3'). Three defects, all present on 0.9.1 and the candidate:

1. `[provider_models]` session memory unconditionally outranked the explicit `--model` launch flag — header and doctor disagreed. Explicit launch model now wins (both directions tested).
2. `model resolve` with top-level `--provider` reported a registry default while claiming `model_source: --model`. It now reports the runtime route; only the subcommand's `--provider` is a hypothetical.
3. Moonshot's catalog lacked kimi-k3/k3 entirely and the global alias map leaked provider-scoped resolution to opencode-go. Both ids registered as separate products; a provider-hinted request never resolves to another provider's model; k3 and kimi-k3 never cross endpoints (coding-plan ids deliberately excluded from the base-route completion list, with an assertion).

Receipts: agent 61, cli 170 + resolve-provenance 8, config 412, tui::app 269, focused k3/picker/routing 125 — all 0 failed; wire-capture test proves the selected model is the model on the wire for both endpoints; end-to-end sealed-HOME session shows resolve/doctor/wire agreeing. fmt/diff/exact-clippy clean.

Honest gaps: TUI header not visually rendered (its source of truth is unit-proven); defect #1 requires a prior remembered pick to fire — the other two fully explain the report.

No-Issue: fixes an unfiled live dogfood report (jerry, 2026-07-27); cited in commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)