### PR TITLE
feat(tui): visual program slices — luminance audit, selection vocabulary, focus texture, opt-in sound, jellyfish (#4813 #4808 #4823 #4817 #4807)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -999,6 +999,16 @@ default_text_model = "deepseek-ai/deepseek-v4-pro"
 # completion_sound = "beep"
 # sound_file = "E:\\google\\downloads\\notify.wav"
 
+# Opt-in per-event sound cues (#4817): deterministic, terminal-bell level
+# (BEL bytes only — functional signals, platform-safe no-op when the terminal
+# ignores BEL). Off by default. When completion_sound is active, turn-complete
+# is left to that channel so the two never double-ding.
+# [notifications.event_sound]
+# enabled = false                                # master switch, default off
+# events = ["turn-complete", "approval-needed"]  # allow-list; unknown names ignored
+# min_interval_ms = 2000                         # per-event rate limit
+# quiet = false                                  # true silences all event sounds
+
 # ─────────────────────────────────────────────────────────────────────────────────
 # Workspace Snapshots (#137)
 # ─────────────────────────────────────────────────────────────────────────────────

--- a/crates/tui/src/commands/groups/config/config.rs
+++ b/crates/tui/src/commands/groups/config/config.rs
@@ -1912,6 +1912,12 @@ pub fn set_config_value(app: &mut App, key: &str, value: &str, persist: bool) ->
                 crate::tui::ocean::OceanTreatment::parse(&settings.ocean_treatment);
             app.needs_redraw = true;
         }
+        "focus_texture" | "texture" => {
+            app.focus_texture =
+                crate::tui::focus_texture::FocusTextureMode::parse(&settings.focus_texture)
+                    .unwrap_or_default();
+            app.needs_redraw = true;
+        }
         "work_surface_placement" | "work_surface" | "work_rail" => {
             app.work_surface.placement = crate::tui::work_surface::WorkSurfacePlacement::parse(
                 &settings.work_surface_placement,

--- a/crates/tui/src/config.rs
+++ b/crates/tui/src/config.rs
@@ -1567,6 +1567,53 @@ pub struct NotificationsConfig {
     /// Path to the WAV sound file used when `completion_sound = "file"`.
     #[serde(default)]
     pub sound_file: Option<PathBuf>,
+
+    /// Opt-in per-event sound policy (`[notifications.event_sound]`).
+    /// Disabled by default; see `tui::sound_policy` for the decision rules.
+    #[serde(default)]
+    pub event_sound: EventSoundConfig,
+}
+
+fn default_event_sound_events() -> Vec<String> {
+    vec!["turn-complete".to_string(), "approval-needed".to_string()]
+}
+
+fn default_event_sound_min_interval_ms() -> u64 {
+    2000
+}
+
+/// Opt-in, deterministic per-event sound policy (#4817). Terminal-bell
+/// level only: cues are BEL (`\x07`) bytes, a platform-safe no-op on
+/// terminals that ignore them. Off by default.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct EventSoundConfig {
+    /// Master switch. Default: `false` (nothing is emitted unless opted in).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Allow-list of event names, kebab-case (`"turn-complete"`,
+    /// `"subagent-terminal"`, `"approval-needed"`, `"input-needed"`,
+    /// `"elevation-needed"`, `"model-notify"`). Unknown names are ignored.
+    /// Default: `["turn-complete", "approval-needed"]`.
+    #[serde(default = "default_event_sound_events")]
+    pub events: Vec<String>,
+    /// Minimum milliseconds between two plays of the same event. Default: 2000.
+    #[serde(default = "default_event_sound_min_interval_ms")]
+    pub min_interval_ms: u64,
+    /// Quiet mode: suppress all event sounds without editing the allow-list.
+    /// Default: `false`.
+    #[serde(default)]
+    pub quiet: bool,
+}
+
+impl Default for EventSoundConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            events: default_event_sound_events(),
+            min_interval_ms: default_event_sound_min_interval_ms(),
+            quiet: false,
+        }
+    }
 }
 
 fn default_snapshots_enabled() -> bool {

--- a/crates/tui/src/config/tests.rs
+++ b/crates/tui/src/config/tests.rs
@@ -9457,6 +9457,51 @@ fn notifications_parse_custom_completion_sound_file() {
 }
 
 #[test]
+fn notifications_parse_event_sound_table() {
+    let config: Config = toml::from_str(
+        r#"
+        [notifications.event_sound]
+        enabled = true
+        events = ["turn-complete", "bogus-event", "approval-needed"]
+        min_interval_ms = 500
+        quiet = true
+        "#,
+    )
+    .expect("event sound config should parse");
+
+    let notifications = config.notifications_config();
+    assert_eq!(
+        notifications.event_sound,
+        EventSoundConfig {
+            enabled: true,
+            events: vec![
+                "turn-complete".to_string(),
+                "bogus-event".to_string(),
+                "approval-needed".to_string(),
+            ],
+            min_interval_ms: 500,
+            quiet: true,
+        }
+    );
+}
+
+#[test]
+fn notifications_event_sound_defaults_when_table_absent() {
+    let config: Config = toml::from_str("[notifications]\nmethod = \"off\"\n")
+        .expect("bare notifications table should parse");
+
+    let event_sound = config.notifications_config().event_sound;
+    assert_eq!(event_sound, EventSoundConfig::default());
+    assert!(!event_sound.enabled);
+    assert_eq!(
+        event_sound.events,
+        vec!["turn-complete".to_string(), "approval-needed".to_string()]
+    );
+    assert_eq!(event_sound.min_interval_ms, 2000);
+    assert!(!event_sound.quiet);
+}
+
+#[test]
 fn huggingface_short_custom_env_url_does_not_inherit_ambient_key() -> Result<()> {
     let _lock = lock_test_env();
     let nanos = SystemTime::now()

--- a/crates/tui/src/config_ui.rs
+++ b/crates/tui/src/config_ui.rs
@@ -62,6 +62,7 @@ pub struct SettingsSection {
     pub low_motion: bool,
     pub fancy_animations: bool,
     pub ocean_treatment: OceanTreatmentValue,
+    pub focus_texture: FocusTextureValue,
     pub work_surface_placement: WorkSurfacePlacementValue,
     #[schemars(range(min = 2, max = 16))]
     pub work_surface_top_height: u16,
@@ -248,6 +249,14 @@ pub enum OceanTreatmentValue {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum FocusTextureValue {
+    Off,
+    Scrim,
+    Grain,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum ComposerDensityValue {
     Compact,
     Comfortable,
@@ -404,6 +413,7 @@ pub fn build_document(app: &App, config: &Config) -> Result<ConfigUiDocument> {
             low_motion: settings.low_motion,
             fancy_animations: settings.fancy_animations,
             ocean_treatment: settings.ocean_treatment.as_str().into(),
+            focus_texture: settings.focus_texture.as_str().into(),
             work_surface_placement: settings.work_surface_placement.as_str().into(),
             work_surface_top_height: settings.work_surface_top_height,
             work_surface_side_width: settings.work_surface_side_width,
@@ -594,6 +604,7 @@ pub fn apply_document(
         ("low_motion", bool_str(doc.settings.low_motion)),
         ("fancy_animations", bool_str(doc.settings.fancy_animations)),
         ("ocean_treatment", doc.settings.ocean_treatment.as_setting()),
+        ("focus_texture", doc.settings.focus_texture.as_setting()),
         (
             "work_surface_placement",
             doc.settings.work_surface_placement.as_setting(),
@@ -1017,6 +1028,26 @@ impl From<&str> for OceanTreatmentValue {
             Self::Flat
         } else {
             Self::Ombre
+        }
+    }
+}
+
+impl FocusTextureValue {
+    fn as_setting(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Scrim => "scrim",
+            Self::Grain => "grain",
+        }
+    }
+}
+
+impl From<&str> for FocusTextureValue {
+    fn from(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "scrim" => Self::Scrim,
+            "grain" => Self::Grain,
+            _ => Self::Off,
         }
     }
 }

--- a/crates/tui/src/palette/contrast.rs
+++ b/crates/tui/src/palette/contrast.rs
@@ -17,10 +17,21 @@
 use ratatui::style::Color;
 
 use super::adapt::blend;
+use super::themes::UiTheme;
 
 /// WCAG 2.x AA contrast floor for body text. Applied to every resolved
 /// foreground we can reason about.
 pub const AA_BODY_CONTRAST: f32 = 4.5;
+
+/// Contrast floor for secondary chrome: hint/dim text and status roles.
+/// Matches the WCAG 2.x AA threshold for large text and UI components (3:1).
+/// Status roles qualify because they are redundant by design — every status
+/// also carries a glyph and a word label, so color is never the only channel.
+///
+/// Consumed by the theme audit below, which runs as a test gate rather than
+/// at runtime — hence the `dead_code` allowance on this audit surface.
+#[allow(dead_code)]
+pub const SECONDARY_CHROME_CONTRAST: f32 = 3.0;
 
 /// Relative luminance per WCAG 2.x, in `0.0..=1.0`.
 ///
@@ -202,4 +213,121 @@ fn indexed_rgb(index: u8) -> (u8, u8, u8) {
         let level = 8 + 10 * (index - 232);
         (level, level, level)
     }
+}
+
+/// A single theme color pair that fails its contrast floor. See
+/// [`theme_contrast_violations`].
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ThemeContrastViolation {
+    /// Static name of the failing pair, e.g. `"text_muted on panel_bg"`.
+    pub pair: &'static str,
+    /// The foreground as shipped by the theme.
+    pub fg: Color,
+    /// The surface it sits on.
+    pub bg: Color,
+    /// The measured WCAG contrast ratio (always below `floor`).
+    pub ratio: f32,
+    /// The floor the pair was audited against.
+    pub floor: f32,
+}
+
+/// `true` when the theme's surfaces belong to the terminal, not to us.
+///
+/// The `Terminal` theme paints [`Color::Reset`] surfaces so the host
+/// terminal's own scheme shows through. Those colors are terminal-owned and
+/// not enforceable: we cannot know their RGB, so the audit neither passes nor
+/// fails them — it stands down. This function is how callers tell that
+/// exemption apart from a clean bill of health.
+#[allow(dead_code)]
+#[must_use]
+pub fn theme_uses_terminal_owned_surfaces(theme: &UiTheme) -> bool {
+    theme.surface_bg == Color::Reset
+}
+
+/// Audit a theme's text and status color pairs against their contrast floors.
+///
+/// Pair table and floors:
+/// - `text_body`, `text_soft`, `text_muted` on each of `surface_bg`,
+///   `panel_bg`, `composer_bg`, `elevated_bg` — [`AA_BODY_CONTRAST`] (4.5:1).
+/// - `text_hint` on the same four surfaces, and `text_dim` on `surface_bg` —
+///   [`SECONDARY_CHROME_CONTRAST`] (3:1). Hint/dim are secondary chrome:
+///   de-emphasized metadata, never the sole carrier of meaning.
+/// - `status_ready` / `status_working` / `status_warning` and
+///   `warning` / `success` / `info` on `surface_bg` — 3:1, because these
+///   roles are redundant: every status is also spelled out by a glyph and a
+///   word label, so color is never the only signal.
+/// - `text_body` on `selection_bg` — 4.5:1 (the theme picker renders body
+///   text on the selection surface).
+/// - `diff_added_fg` on `diff_added_bg`, `diff_deleted_fg` on
+///   `diff_deleted_bg` — 3:1.
+/// - `error_text` on `error_surface` — 4.5:1.
+///
+/// Pairs where either color is terminal-defined ([`Color::Reset`], named
+/// ANSI, `Indexed(0..=15)`) are *skipped*, not passed: their real RGB is
+/// owned by the user's terminal profile and cannot be audited. The
+/// `Terminal` theme is therefore largely exempt by design — see
+/// [`theme_uses_terminal_owned_surfaces`], which makes that exemption
+/// explicit rather than silent.
+#[allow(dead_code)]
+#[must_use]
+pub fn theme_contrast_violations(theme: &UiTheme) -> Vec<ThemeContrastViolation> {
+    let mut violations = Vec::new();
+    let mut check = |pair: &'static str, fg: Color, bg: Color, floor: f32| {
+        // An unresolvable side means the terminal owns the color: skip the
+        // pair rather than recording a pass we cannot substantiate.
+        if let Some(ratio) = contrast_ratio(fg, bg) {
+            if ratio < floor {
+                violations.push(ThemeContrastViolation {
+                    pair,
+                    fg,
+                    bg,
+                    ratio,
+                    floor,
+                });
+            }
+        }
+    };
+    macro_rules! audit {
+        ($floor:expr; $(($fg:ident, $bg:ident)),+ $(,)?) => {
+            $(check(
+                concat!(stringify!($fg), " on ", stringify!($bg)),
+                theme.$fg,
+                theme.$bg,
+                $floor,
+            );)+
+        };
+    }
+    audit!(AA_BODY_CONTRAST;
+        (text_body, surface_bg),
+        (text_body, panel_bg),
+        (text_body, composer_bg),
+        (text_body, elevated_bg),
+        (text_soft, surface_bg),
+        (text_soft, panel_bg),
+        (text_soft, composer_bg),
+        (text_soft, elevated_bg),
+        (text_muted, surface_bg),
+        (text_muted, panel_bg),
+        (text_muted, composer_bg),
+        (text_muted, elevated_bg),
+        (text_body, selection_bg),
+        (error_text, error_surface),
+    );
+    audit!(SECONDARY_CHROME_CONTRAST;
+        (text_hint, surface_bg),
+        (text_hint, panel_bg),
+        (text_hint, composer_bg),
+        (text_hint, elevated_bg),
+        (text_dim, surface_bg),
+        (status_ready, surface_bg),
+        (status_working, surface_bg),
+        (status_warning, surface_bg),
+        (warning, surface_bg),
+        (success, surface_bg),
+        (info, surface_bg),
+        (diff_added_fg, diff_added_bg),
+        (diff_deleted_fg, diff_deleted_bg),
+    );
+    violations
 }

--- a/crates/tui/src/palette/tests.rs
+++ b/crates/tui/src/palette/tests.rs
@@ -617,7 +617,8 @@ fn color_depth_detect_is_safe_without_env() {
 
 use super::contrast::{
     AA_BODY_CONTRAST, contrast_ratio, effective_surface, enforce_contrast, meets_contrast,
-    relative_luminance, symbol_needs_text_contrast,
+    relative_luminance, symbol_needs_text_contrast, theme_contrast_violations,
+    theme_uses_terminal_owned_surfaces,
 };
 use super::detect::TerminalBackground;
 use super::osc11::parse_osc11_reply;
@@ -957,4 +958,85 @@ fn measured_light_background_selects_the_light_theme_end_to_end() {
     assert_eq!(UiTheme::for_mode(measured.mode()), LIGHT_UI_THEME);
     let dark = resolve_terminal_background(Some((0x1E, 0x1E, 0x1E)), None, None);
     assert_eq!(UiTheme::for_mode(dark.mode()), UI_THEME);
+}
+
+// === #4813: cross-theme contrast audit ===
+
+#[test]
+fn every_selectable_theme_clears_the_text_floor() {
+    let mut terminal_owned = Vec::new();
+    for theme_id in SELECTABLE_THEMES {
+        let theme = theme_id.ui_theme();
+        if theme_uses_terminal_owned_surfaces(&theme) {
+            terminal_owned.push(theme_id.name());
+            continue;
+        }
+        let violations = theme_contrast_violations(&theme);
+        assert!(
+            violations.is_empty(),
+            "theme '{}' fails the contrast audit: {violations:?}",
+            theme_id.name(),
+        );
+    }
+    // The transparent-terminal exemption is exactly one theme, by design.
+    assert_eq!(terminal_owned, ["terminal"]);
+}
+
+#[test]
+fn transparent_terminal_theme_is_explicitly_terminal_owned() {
+    // The Terminal theme paints `Color::Reset` surfaces and named-ANSI text:
+    // every audited pair is terminal-defined, so the audit records zero
+    // violations. That is *not* a pass — unresolvable pairs are skipped,
+    // never counted as clearing the floor. `theme_uses_terminal_owned_surfaces`
+    // is what keeps the exemption explicit instead of silent.
+    assert!(theme_uses_terminal_owned_surfaces(&TERMINAL_UI_THEME));
+    assert_eq!(TERMINAL_UI_THEME.surface_bg, Color::Reset);
+    assert!(theme_contrast_violations(&TERMINAL_UI_THEME).is_empty());
+    // A theme with resolvable RGB surfaces never gets the exemption.
+    assert!(!theme_uses_terminal_owned_surfaces(&UI_THEME));
+}
+
+#[test]
+fn high_contrast_grayscale_theme_clears_body_floor_on_every_surface() {
+    // The picker tagline claims "Color-minimal high contrast" — hold the
+    // grayscale theme to the full body-text floor on every surface, not the
+    // 3:1 secondary-chrome floor.
+    let theme = GRAYSCALE_UI_THEME;
+    for fg in [theme.text_body, theme.text_soft, theme.text_muted] {
+        for bg in [
+            theme.surface_bg,
+            theme.panel_bg,
+            theme.composer_bg,
+            theme.elevated_bg,
+        ] {
+            let ratio = contrast_ratio(fg, bg).expect("grayscale colors are all resolvable RGB");
+            assert!(
+                ratio >= AA_BODY_CONTRAST,
+                "grayscale {fg:?} on {bg:?} is {ratio}:1, below the {AA_BODY_CONTRAST}:1 floor",
+            );
+        }
+    }
+}
+
+#[test]
+fn violation_report_names_pair_and_ratio() {
+    let mut bad = UI_THEME;
+    bad.text_muted = bad.surface_bg;
+    let violations = theme_contrast_violations(&bad);
+    // The muted-on-surface color fails against all four text surfaces.
+    let muted_pairs: Vec<_> = violations
+        .iter()
+        .filter(|violation| violation.pair.starts_with("text_muted on "))
+        .collect();
+    assert_eq!(muted_pairs.len(), 4);
+    let violation = violations
+        .iter()
+        .find(|violation| violation.pair == "text_muted on surface_bg")
+        .expect("the report must name the failing pair");
+    assert_eq!(violation.fg, bad.text_muted);
+    assert_eq!(violation.bg, bad.surface_bg);
+    // Identical colors sit at 1:1 — far under the floor the report carries.
+    assert!(violation.ratio < 1.1);
+    assert!(violation.ratio < violation.floor);
+    assert_eq!(violation.floor, AA_BODY_CONTRAST);
 }

--- a/crates/tui/src/palette/themes.rs
+++ b/crates/tui/src/palette/themes.rs
@@ -334,10 +334,10 @@ pub const TOKYO_NIGHT_UI_THEME: UiTheme = UiTheme {
     selection_bg: Color::Rgb(0x28, 0x34, 0x57), // visual selection
     header_bg: Color::Rgb(0x16, 0x16, 0x1e),
     footer_bg: Color::Rgb(0x16, 0x16, 0x1e),
-    text_dim: Color::Rgb(0x56, 0x5f, 0x89),   // comment
-    text_hint: Color::Rgb(0x73, 0x7a, 0xa2),  // dark5
+    text_dim: Color::Rgb(0x5c, 0x65, 0x8d), // comment, lifted to 3:1 on bg
+    text_hint: Color::Rgb(0x73, 0x7a, 0xa2), // dark5
     text_muted: Color::Rgb(0xa9, 0xb1, 0xd6), // fg_dark
-    text_body: Color::Rgb(0xc0, 0xca, 0xf5),  // fg
+    text_body: Color::Rgb(0xc0, 0xca, 0xf5), // fg
     text_soft: Color::Rgb(0xbb, 0xc2, 0xe0),
     border: Color::Rgb(0x41, 0x48, 0x68), // terminal_black
     accent_primary: Color::Rgb(0x7a, 0xa2, 0xf7), // blue
@@ -358,7 +358,7 @@ pub const TOKYO_NIGHT_UI_THEME: UiTheme = UiTheme {
     permission_ask: Color::Rgb(0xe0, 0xaf, 0x68),
     permission_auto_review: Color::Rgb(0xff, 0x9e, 0x64),
     permission_full_access: Color::Rgb(0xf7, 0x76, 0x8e),
-    status_ready: Color::Rgb(0x56, 0x5f, 0x89), // comment
+    status_ready: Color::Rgb(0x5c, 0x65, 0x8d), // comment, lifted to 3:1 on bg
     status_working: Color::Rgb(0x7d, 0xcf, 0xff), // cyan
     status_warning: Color::Rgb(0xe0, 0xaf, 0x68), // yellow
     diff_added_fg: Color::Rgb(0x9e, 0xce, 0x6a), // green
@@ -488,7 +488,7 @@ pub const GRUVBOX_DARK_UI_THEME: UiTheme = UiTheme {
     footer_bg: Color::Rgb(0x1d, 0x20, 0x21),
     text_dim: Color::Rgb(0x92, 0x83, 0x74),         // gray
     text_hint: Color::Rgb(0xa8, 0x99, 0x84),        // fg4
-    text_muted: Color::Rgb(0xbd, 0xae, 0x93),       // fg3
+    text_muted: Color::Rgb(0xc5, 0xb8, 0xa0),       // fg3, lifted to 4.5:1 on bg2
     text_body: Color::Rgb(0xeb, 0xdb, 0xb2),        // fg1
     text_soft: Color::Rgb(0xd5, 0xc4, 0xa1),        // fg2
     border: Color::Rgb(0x66, 0x5c, 0x54),           // bg3
@@ -667,7 +667,7 @@ pub const MATRIX_UI_THEME: UiTheme = UiTheme {
     permission_ask: Color::Rgb(204, 204, 0),
     permission_auto_review: Color::Rgb(255, 170, 60),
     permission_full_access: Color::Rgb(255, 100, 100),
-    status_ready: Color::Rgb(0, 85, 0),
+    status_ready: Color::Rgb(0, 108, 0),
     status_working: Color::Rgb(
         MATRIX_TEXT_BODY_RGB.0,
         MATRIX_TEXT_BODY_RGB.1,
@@ -675,7 +675,7 @@ pub const MATRIX_UI_THEME: UiTheme = UiTheme {
     ),
     status_warning: Color::Rgb(204, 204, 0),
     diff_added_fg: Color::Rgb(0x88, 0xff, 0x88),
-    diff_deleted_fg: Color::Rgb(0xb4, 0, 0),
+    diff_deleted_fg: Color::Rgb(0xbc, 0x1d, 0x1d), // lifted to 3:1 on diff_deleted_bg
     diff_added_bg: Color::Rgb(0x0d, 0x1a, 0x0d),
     diff_deleted_bg: Color::Rgb(0x1a, 0x0d, 0x0d),
     tool_running: Color::Rgb(0x88, 0xff, 0x88),

--- a/crates/tui/src/palette/tokens.rs
+++ b/crates/tui/src/palette/tokens.rs
@@ -47,19 +47,19 @@ pub const WHALE_REASONING_TINT_RGB: (u8, u8, u8) = (24, 36, 52); // #182434
 // Solarized Light palette RGB tuples
 pub const SOLARIZED_BASE03_RGB: (u8, u8, u8) = (0x00, 0x2B, 0x36);
 pub const SOLARIZED_BASE02_RGB: (u8, u8, u8) = (0x07, 0x36, 0x42);
-pub const SOLARIZED_BASE01_RGB: (u8, u8, u8) = (0x58, 0x6E, 0x75);
+pub const SOLARIZED_BASE01_RGB: (u8, u8, u8) = (0x52, 0x66, 0x6D); // lifted for 4.5:1 muted text
 pub const SOLARIZED_BASE00_RGB: (u8, u8, u8) = (0x65, 0x7B, 0x83);
-pub const SOLARIZED_BASE0_RGB: (u8, u8, u8) = (0x83, 0x94, 0x96);
+pub const SOLARIZED_BASE0_RGB: (u8, u8, u8) = (0x72, 0x81, 0x82); // lifted for 3:1 hint text
 pub const SOLARIZED_BASE1_RGB: (u8, u8, u8) = (0x93, 0xA1, 0xA1);
 #[allow(dead_code)]
 pub const SOLARIZED_BASE2_RGB: (u8, u8, u8) = (0xEE, 0xE8, 0xD5);
 pub const SOLARIZED_BASE3_RGB: (u8, u8, u8) = (0xFD, 0xF6, 0xE3);
-pub const SOLARIZED_YELLOW_RGB: (u8, u8, u8) = (0xB5, 0x89, 0x00);
+pub const SOLARIZED_YELLOW_RGB: (u8, u8, u8) = (0xB4, 0x88, 0x00); // lifted for 3:1 on ivory
 pub const SOLARIZED_ORANGE_RGB: (u8, u8, u8) = (0xCB, 0x4B, 0x16);
 pub const SOLARIZED_RED_RGB: (u8, u8, u8) = (0xDC, 0x32, 0x2F);
 pub const SOLARIZED_BLUE_RGB: (u8, u8, u8) = (0x26, 0x8B, 0xD2);
-pub const SOLARIZED_CYAN_RGB: (u8, u8, u8) = (0x2A, 0xA1, 0x98);
-pub const SOLARIZED_GREEN_RGB: (u8, u8, u8) = (0x85, 0x99, 0x00);
+pub const SOLARIZED_CYAN_RGB: (u8, u8, u8) = (0x29, 0x9E, 0x96); // lifted for 3:1 on ivory
+pub const SOLARIZED_GREEN_RGB: (u8, u8, u8) = (0x7F, 0x92, 0x00); // lifted for 3:1 on ivory/diff bg
 pub const SOLARIZED_PANEL_RGB: (u8, u8, u8) = (0xF0, 0xED, 0xE7);
 pub const SOLARIZED_ELEVATED_RGB: (u8, u8, u8) = (0xE4, 0xDF, 0xCF);
 pub const SOLARIZED_SELECT_RGB: (u8, u8, u8) = (0xD6, 0xD2, 0xC9);
@@ -219,10 +219,10 @@ pub const MATRIX_SURFACE_RGB: (u8, u8, u8) = (0, 10, 0); // #000A00
 pub const MATRIX_ELEVATED_RGB: (u8, u8, u8) = (0, 51, 0); // #003300
 pub const MATRIX_SELECTION_RGB: (u8, u8, u8) = (0, 51, 0); // #003300
 pub const MATRIX_TEXT_BODY_RGB: (u8, u8, u8) = (136, 255, 136); // #88FF88
-pub const MATRIX_TEXT_MUTED_RGB: (u8, u8, u8) = (0, 85, 0); // #005500
-pub const MATRIX_TEXT_HINT_RGB: (u8, u8, u8) = (0, 102, 0); // #006600
+pub const MATRIX_TEXT_MUTED_RGB: (u8, u8, u8) = (0, 169, 0); // #00A900, lifted for 4.5:1
+pub const MATRIX_TEXT_HINT_RGB: (u8, u8, u8) = (0, 135, 0); // #008700, lifted for 3:1
 pub const MATRIX_TEXT_SOFT_RGB: (u8, u8, u8) = (221, 255, 221); // #DDFFDD
-pub const MATRIX_TEXT_DIM_RGB: (u8, u8, u8) = (0, 68, 0); // #004400
+pub const MATRIX_TEXT_DIM_RGB: (u8, u8, u8) = (0, 108, 0); // #006C00, lifted for 3:1
 pub const MATRIX_BORDER_RGB: (u8, u8, u8) = (0, 204, 0); // #00CC00
 
 // Semantic colors

--- a/crates/tui/src/settings.rs
+++ b/crates/tui/src/settings.rs
@@ -302,6 +302,11 @@ pub struct Settings {
     /// Background treatment: `ombre` paints the terminal-native water column;
     /// `flat` preserves all state marks on the theme's plain surface.
     pub ocean_treatment: String,
+    /// Focus-context texture prototype for modal views (#4823): `off`
+    /// (default), `scrim` dims the area outside the focused modal, `grain`
+    /// sprinkles deterministic dots over blank cells there. Static texture,
+    /// never obscures text; unknown values fall back to `off` at render time.
+    pub focus_texture: String,
     /// Ocean Tasks / To-do / Workers rail placement: top, left, or right.
     /// The lower edge remains owned by the composer and phase footer.
     pub work_surface_placement: String,
@@ -501,6 +506,7 @@ impl Default for Settings {
             low_motion: false,
             fancy_animations: true,
             ocean_treatment: "ombre".to_string(),
+            focus_texture: "off".to_string(),
             work_surface_placement: "top".to_string(),
             // Cap, not fixed height: the top strip auto-fits its rows and
             // only grows to this many lines (user request, 2026-07-23).
@@ -1064,6 +1070,15 @@ impl Settings {
                 }
                 self.ocean_treatment = normalized;
             }
+            "focus_texture" | "texture" => {
+                let normalized = value.trim().to_ascii_lowercase();
+                if !matches!(normalized.as_str(), "off" | "scrim" | "grain") {
+                    anyhow::bail!(
+                        "Failed to update setting: invalid focus texture '{value}'. Expected: off, scrim, or grain."
+                    );
+                }
+                self.focus_texture = normalized;
+            }
             "work_surface_placement" | "work_surface" | "work_rail" => {
                 let normalized = value.trim().to_ascii_lowercase();
                 if !matches!(normalized.as_str(), "top" | "left" | "right") {
@@ -1342,6 +1357,7 @@ impl Settings {
         lines.push(format!("  low_motion:         {}", self.low_motion));
         lines.push(format!("  fancy_animations:   {}", self.fancy_animations));
         lines.push(format!("  ocean_treatment:    {}", self.ocean_treatment));
+        lines.push(format!("  focus_texture:      {}", self.focus_texture));
         lines.push(format!(
             "  work_surface:       {}",
             self.work_surface_placement
@@ -1476,6 +1492,10 @@ impl Settings {
             (
                 "ocean_treatment",
                 "Transcript background treatment: ombre/flat (independent of motion)",
+            ),
+            (
+                "focus_texture",
+                "Modal focus-context texture prototype: off/scrim/grain (default off)",
             ),
             (
                 "work_surface_placement",
@@ -2749,6 +2769,22 @@ mod tests {
             torn, 0,
             "{torn} of {reads} concurrent reads saw a truncated or unparseable settings file"
         );
+    }
+
+    #[test]
+    fn focus_texture_defaults_off_and_validates() {
+        let mut settings = Settings::default();
+        assert_eq!(settings.focus_texture, "off");
+
+        settings.set("focus_texture", "scrim").unwrap();
+        assert_eq!(settings.focus_texture, "scrim");
+        settings.set("texture", "grain").unwrap();
+        assert_eq!(settings.focus_texture, "grain");
+        settings.set("focus_texture", " OFF ").unwrap();
+        assert_eq!(settings.focus_texture, "off");
+
+        let err = settings.set("focus_texture", "static").unwrap_err();
+        assert!(err.to_string().contains("off, scrim, or grain"));
     }
 
     #[test]

--- a/crates/tui/src/tui/ambient_life.rs
+++ b/crates/tui/src/tui/ambient_life.rs
@@ -8,7 +8,8 @@
 //!
 //! Motion language (shared with the rest of the shell): every mark can lerp
 //! between the water and its ink at a time-varying brightness. Fish carry a
-//! travelling sin² wave, jellyfish a slow floor-bounded pulse, bubbles an
+//! travelling sin² wave, jellyfish a slow floor-bounded pulse that opens and
+//! closes the dome while the tentacles trail it by ~350 ms, bubbles an
 //! occasional raised-cosine glint. Phases are wall-clock keyed and entity
 //! periods deliberately never match, so nothing strobes in sync.
 //!
@@ -18,6 +19,11 @@
 //! fully off-screen.
 //!
 //! Under reduced motion, entities remain visible but static.
+//!
+//! `render_ambient_life` returns per-frame budget counters
+//! ([`AmbientFrameStats`]): marks built always splits exactly into painted +
+//! text-skipped + clipped. Counting is a handful of `u32` increments — no
+//! allocation, no frame requests.
 
 use ratatui::{
     buffer::Buffer,
@@ -130,6 +136,28 @@ struct AmbientMark {
     brightness: Option<f32>,
 }
 
+/// Per-frame render budget counters. `marks_built` splits exactly into
+/// `marks_painted + marks_skipped_text + marks_clipped`. `cells_written`
+/// counts individual cell writes: a multi-cell glyph counts each of its
+/// cells, and two overlapping marks count the shared cell once per write.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AmbientFrameStats {
+    pub marks_built: u32,
+    pub marks_painted: u32,
+    pub marks_skipped_text: u32,
+    pub marks_clipped: u32,
+    pub cells_written: u32,
+}
+
+/// Hard upper bound on marks built in one frame: 7 fish + 2 jellyfish × 5
+/// parts (2 dome rows + 3 tentacles) + 2 bubbles + 2 whale-cameo cells = 21,
+/// plus headroom. This is a test-gate ceiling asserted against
+/// [`AmbientFrameStats::marks_built`], not a runtime clamp: the population is
+/// bounded by construction, and this constant is what fails the build if a
+/// future change makes it unbounded.
+#[allow(dead_code)]
+pub const MAX_FRAME_MARKS: u32 = 24;
+
 /// Optional pointer reaction for fish dart / bubble rise.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AmbientCursor {
@@ -151,6 +179,9 @@ pub struct WhaleCameo {
 const WHALE_CAMEO_MS: u128 = 2_400;
 
 /// Render ambient life into empty water cells of `area`.
+///
+/// Returns per-frame budget counters for tests and debug tooling; the
+/// counting itself is a few `u32` increments, never an allocation.
 #[allow(clippy::too_many_arguments)]
 pub fn render_ambient_life(
     area: Rect,
@@ -161,14 +192,18 @@ pub fn render_ambient_life(
     animated: bool,
     cursor: AmbientCursor,
     whale: WhaleCameo,
-) {
+) -> AmbientFrameStats {
     if area.width < AMBIENT_MIN_WIDTH || area.height < AMBIENT_MIN_HEIGHT {
-        return;
+        return AmbientFrameStats::default();
     }
 
     let density = LifeDensity::from_area(area);
-    let frame = build_frame_marks(area, elapsed_ms, animated, density, cursor, whale);
-    paint_marks(area, buf, inks, lines, &frame);
+    let mut stats = AmbientFrameStats::default();
+    let frame = build_frame_marks(
+        area, elapsed_ms, animated, density, cursor, whale, &mut stats,
+    );
+    paint_marks(area, buf, inks, lines, &frame, &mut stats);
+    stats
 }
 
 fn build_frame_marks(
@@ -178,6 +213,7 @@ fn build_frame_marks(
     density: LifeDensity,
     cursor: AmbientCursor,
     whale: WhaleCameo,
+    stats: &mut AmbientFrameStats,
 ) -> FrameMarks {
     let mut marks = Vec::with_capacity(48);
     let t = if animated { elapsed_ms } else { 0 };
@@ -290,10 +326,16 @@ fn build_frame_marks(
         });
     }
 
-    // --- Jellyfish: a bell with a lagging tentacle pulse ---
-    // The bell pulses on a slow floor-bounded sin²; the tentacle repeats the
-    // pulse ~350 ms later — the lag is what sells "jellyfish". They drift
-    // slowly upward through the side lanes and wrap.
+    // --- Jellyfish: a pulsing dome with lagging tentacles ---
+    // Two dome rows (arc + scalloped skirt) over a row of swaying
+    // tentacles. The dome opens and closes on a slow floor-bounded sin²;
+    // the tentacles repeat the pulse ~350 ms later and sway out of phase
+    // with each other — the lag is what sells "jellyfish". Rich/Normal get
+    // the full 5-cell dome with three tentacles; Sparse (narrow) swaps in a
+    // compact 3-cell dome with two — a real fallback silhouette, not just
+    // fewer jellies. They drift slowly upward through the side lanes, wrap,
+    // and park mid-rise just under the hero band under reduced motion.
+    let in_band = |row: u16| row > quiet_mid_lo && row < quiet_mid_hi;
     for j in 0..density.jellyfish_count() {
         let phase = 3_100u128.saturating_add((j as u128) * 4_700);
         let lane_x = if j % 2 == 0 {
@@ -306,21 +348,33 @@ fn build_frame_marks(
         } else {
             0
         };
+        let compact = density == LifeDensity::Sparse;
+        let (dome_top, dome_skirt, tentacle_cols): (&[&str], &[&str], &[u16]) = if compact {
+            (JELLY_DOME_TOP_COMPACT, JELLY_DOME_SKIRT_COMPACT, &[0, 2])
+        } else {
+            (JELLY_DOME_TOP_FRAMES, JELLY_DOME_SKIRT_FRAMES, &[1, 2, 3])
+        };
+        let dome_w = dome_top[0].len() as u16; // ASCII frames: len == width
         let x = lane_x
             .saturating_add(wobble)
-            .min(area.width.saturating_sub(JELLY_BELL.len() as u16 + 1));
+            .min(area.width.saturating_sub(dome_w + 1));
         let rise_rows = u128::from(area.height.saturating_sub(4).max(1));
         let rise_period = 8_600u128.saturating_add((j as u128) * 1_400);
-        let risen = if animated {
-            ((t.saturating_add(phase) / rise_period) % rise_rows) as u16
+        let y = if animated {
+            let risen = ((t.saturating_add(phase) / rise_period) % rise_rows) as u16;
+            area.height.saturating_sub(3).saturating_sub(risen)
         } else {
-            (rise_rows / 2) as u16
+            // Parked mid-rise, just below the hero band: parking inside the
+            // band would be culled by the quiet-band rule and the static
+            // pose would vanish.
+            quiet_mid_hi
+                .saturating_add(2)
+                .min(area.height.saturating_sub(3))
         };
-        let y = area.height.saturating_sub(2).saturating_sub(risen);
-        if y == 0 || (y > quiet_mid_lo && y < quiet_mid_hi) {
+        if y == 0 || in_band(y) {
             continue;
         }
-        let bell_brightness = if animated {
+        let dome_brightness = if animated {
             JELLY_BRIGHTNESS_FLOOR
                 + (1.0 - JELLY_BRIGHTNESS_FLOOR) * wave01(t, JELLY_PULSE_MS, phase)
         } else {
@@ -337,29 +391,53 @@ fn build_frame_marks(
         } else {
             0.45
         };
-        marks.push(AmbientMark {
-            x,
-            y,
-            glyph: JELLY_BELL,
-            depth: Depth::Midground,
-            style_mod: None,
-            brightness: Some(bell_brightness),
-        });
-        if y + 1 < area.height && !(y + 1 > quiet_mid_lo && y + 1 < quiet_mid_hi) {
-            let sway = if animated {
-                JELLY_TENTACLE_FRAMES
-                    [((t.saturating_add(phase) / 1_400) as usize) % JELLY_TENTACLE_FRAMES.len()]
-            } else {
-                "|"
-            };
-            marks.push(AmbientMark {
-                x: x.saturating_add(1),
-                y: y + 1,
-                glyph: sway,
-                depth: Depth::Background,
-                style_mod: None,
-                brightness: Some(tentacle_brightness),
-            });
+        // The dome opens/closes on the same clock as its glow; the parked
+        // pose holds the half-pulsed (contracted) frame.
+        let pulse_frame = if animated {
+            usize::from(wave01(t, JELLY_PULSE_MS, phase) > 0.5)
+        } else {
+            1
+        };
+        let dome_rows = [
+            (y, dome_top[pulse_frame]),
+            (y.saturating_add(1), dome_skirt[pulse_frame]),
+        ];
+        for (row, glyph) in dome_rows {
+            if row < area.height && !in_band(row) {
+                marks.push(AmbientMark {
+                    x,
+                    y: row,
+                    glyph,
+                    depth: Depth::Midground,
+                    style_mod: None,
+                    brightness: Some(dome_brightness),
+                });
+            }
+        }
+        let tentacle_row = y.saturating_add(2);
+        if tentacle_row < area.height && !in_band(tentacle_row) {
+            for (col, &dx) in tentacle_cols.iter().enumerate() {
+                // Each column runs the sway table with its own phase offset
+                // so the trio lags left-to-right; the parked pose holds a
+                // mid-sway frame.
+                let sway = if animated {
+                    let frame = t
+                        .saturating_add(phase)
+                        .saturating_add((col as u128) * JELLY_TENTACLE_PHASE_STEP_MS)
+                        / JELLY_TENTACLE_SWAY_MS;
+                    JELLY_TENTACLE_FRAMES[(frame as usize) % JELLY_TENTACLE_FRAMES.len()]
+                } else {
+                    JELLY_TENTACLE_FRAMES[1]
+                };
+                marks.push(AmbientMark {
+                    x: x.saturating_add(dx),
+                    y: tentacle_row,
+                    glyph: sway,
+                    depth: Depth::Background,
+                    style_mod: None,
+                    brightness: Some(tentacle_brightness),
+                });
+            }
         }
     }
 
@@ -456,6 +534,7 @@ fn build_frame_marks(
         }
     }
 
+    stats.marks_built = marks.len() as u32;
     FrameMarks { marks }
 }
 
@@ -474,17 +553,27 @@ const FISH_BRIGHTNESS_FLOOR: f32 = 0.45;
 const LEAD_FISH_RIGHT: &str = "><o>";
 const LEAD_FISH_LEFT: &str = "<o><";
 
-/// Jellyfish bell and its swaying tentacle frames (all width-1 ASCII).
-// Dome + lagging tentacle: read as jellyfish, not a parenthetical blob-on-a-string.
-// Keep ASCII-adjacent glyphs that render cleanly in common terminal fonts.
-const JELLY_BELL: &str = "o*";
-// Dome + lagging tentacle: jellyfish silhouette in ASCII-safe glyphs so the
-// low-motion / ascii_safe tier still covers ambient life.
+/// Jellyfish silhouette frames — pure ASCII by construction so the
+/// ascii_safe tier needs no fallback mapping for them (len == width).
+///
+/// Full dome (Rich/Normal), two rows with an open/closed pulse pair: a
+/// rounded arc over a scalloped skirt.
+const JELLY_DOME_TOP_FRAMES: &[&str] = &[".-~-.", ".'-.'"];
+const JELLY_DOME_SKIRT_FRAMES: &[&str] = &["(v_v)", "(v.v)"];
+/// Compact dome for the Sparse (narrow) tier: same two-row read at 3 cells.
+const JELLY_DOME_TOP_COMPACT: &[&str] = &[".-.", "'.'"];
+const JELLY_DOME_SKIRT_COMPACT: &[&str] = &["(v)", "(-)"];
+/// Tentacle sway frames (all width-1). Each column runs the same table with
+/// a phase offset so the trio lags instead of strobing in sync.
 const JELLY_TENTACLE_FRAMES: &[&str] = &["|", ":", "|", "."];
 
 const JELLY_PULSE_MS: u128 = 2_900;
-/// The tentacle repeats the bell pulse this much later.
+/// The tentacles repeat the dome pulse this much later.
 const JELLY_TENTACLE_LAG_MS: u128 = 350;
+/// Wall-clock milliseconds per tentacle sway frame.
+const JELLY_TENTACLE_SWAY_MS: u128 = 1_400;
+/// Per-column sway phase offset, so adjacent tentacles never move in sync.
+const JELLY_TENTACLE_PHASE_STEP_MS: u128 = 450;
 const JELLY_BRIGHTNESS_FLOOR: f32 = 0.35;
 
 /// Bubbles stay mostly steady with occasional glints, not a constant wave.
@@ -537,19 +626,28 @@ fn paint_marks(
     inks: (Color, Color),
     lines: &[Line<'static>],
     frame: &FrameMarks,
+    stats: &mut AmbientFrameStats,
 ) {
     for mark in &frame.marks {
+        let mark_width = UnicodeWidthStr::width(mark.glyph);
+        // Clipped is checked before text collision so a mark that fails
+        // both is charged to the bound it could never satisfy.
+        if mark.x.saturating_add(mark_width as u16) > area.width {
+            stats.marks_clipped += 1;
+            continue;
+        }
         let protected = lines
             .get(usize::from(mark.y))
             .and_then(occupied_text_bounds);
-        let mark_width = UnicodeWidthStr::width(mark.glyph);
         let collides = protected.is_some_and(|(start, end)| {
             usize::from(mark.x) < end.saturating_add(1)
                 && usize::from(mark.x) + mark_width > start.saturating_sub(1)
         });
-        if collides || mark.x.saturating_add(mark_width as u16) > area.width {
+        if collides {
+            stats.marks_skipped_text += 1;
             continue;
         }
+        stats.marks_painted += 1;
         let ink = if mark.depth.ink_index() == 1 {
             inks.1
         } else {
@@ -572,6 +670,7 @@ fn paint_marks(
             }
             cell.set_symbol(&ch.to_string());
             cell.set_style(style);
+            stats.cells_written += 1;
         }
     }
 }
@@ -840,6 +939,7 @@ mod tests {
 
     fn frame_at(t: u128) -> FrameMarks {
         let area = Rect::new(0, 0, 100, 30);
+        let mut stats = AmbientFrameStats::default();
         build_frame_marks(
             area,
             t,
@@ -847,6 +947,7 @@ mod tests {
             LifeDensity::from_area(area),
             AmbientCursor::default(),
             WhaleCameo::default(),
+            &mut stats,
         )
     }
 
@@ -895,7 +996,10 @@ mod tests {
             for mark in frame_at(t).marks {
                 let ok = matches!(mark.glyph, "><>" | "<><" | "><o>" | "<o><")
                     || matches!(mark.glyph, "·" | "˚" | "°")
-                    || mark.glyph == JELLY_BELL
+                    || JELLY_DOME_TOP_FRAMES.contains(&mark.glyph)
+                    || JELLY_DOME_SKIRT_FRAMES.contains(&mark.glyph)
+                    || JELLY_DOME_TOP_COMPACT.contains(&mark.glyph)
+                    || JELLY_DOME_SKIRT_COMPACT.contains(&mark.glyph)
                     || JELLY_TENTACLE_FRAMES.contains(&mark.glyph);
                 assert!(ok, "unexpected ambient glyph {:?} at t={t}", mark.glyph);
             }
@@ -903,30 +1007,219 @@ mod tests {
     }
 
     #[test]
-    fn jellyfish_reads_as_bell_with_lagging_tentacle() {
-        // Find a frame where a jelly is on-screen and assert its two-row
-        // structure: bell, tentacle one row below inside the bell, and the
-        // tentacle pulse trailing the bell pulse.
+    fn ambient_glyphs_are_ascii_or_have_fallbacks() {
+        // Every glyph the water can paint is either pure ASCII (fish and
+        // the whole jellyfish silhouette, by construction) or carries a
+        // glyphs::ascii_fallback entry (bubbles, whale cameo) so
+        // CODEWHALE_ASCII_SAFE=1 covers the whole field.
+        let mut jellyfish: Vec<&str> = Vec::new();
+        jellyfish.extend(JELLY_DOME_TOP_FRAMES);
+        jellyfish.extend(JELLY_DOME_SKIRT_FRAMES);
+        jellyfish.extend(JELLY_DOME_TOP_COMPACT);
+        jellyfish.extend(JELLY_DOME_SKIRT_COMPACT);
+        jellyfish.extend(JELLY_TENTACLE_FRAMES);
+        for glyph in jellyfish {
+            assert!(glyph.is_ascii(), "jellyfish glyph {glyph:?} must be ASCII");
+        }
+        for glyph in ["><>", "<><", "><o>", "<o><"] {
+            assert!(glyph.is_ascii(), "fish glyph {glyph:?} must be ASCII");
+        }
+        for glyph in ["·", "˚", "°", "≈≈>", "≈", "～"] {
+            assert!(
+                glyph.is_ascii() || crate::tui::glyphs::ascii_fallback(glyph).is_some(),
+                "ambient glyph {glyph:?} lacks an ASCII fallback"
+            );
+        }
+    }
+
+    #[test]
+    fn jellyfish_reads_as_dome_with_lagging_tentacles() {
+        // Find a frame where a full jelly is on-screen and assert its
+        // structure: a two-row dome at least four cells wide, exactly three
+        // tentacle columns one row below the skirt, and both dome and
+        // tentacles holding their brightness floors.
         let mut seen = false;
         for probe in 0..240u128 {
             let t = probe * 500;
             let frame = frame_at(t);
-            if let Some(bell) = frame.marks.iter().find(|mark| mark.glyph == JELLY_BELL) {
-                if let Some(tentacle) = frame.marks.iter().find(|mark| {
+            let Some(top) = frame
+                .marks
+                .iter()
+                .find(|mark| JELLY_DOME_TOP_FRAMES.contains(&mark.glyph))
+            else {
+                continue;
+            };
+            let dome_w = UnicodeWidthStr::width(top.glyph) as u16;
+            assert!(dome_w >= 4, "rich dome too narrow: {:?}", top.glyph);
+            let Some(skirt) = frame.marks.iter().find(|mark| {
+                JELLY_DOME_SKIRT_FRAMES.contains(&mark.glyph)
+                    && mark.x == top.x
+                    && mark.y == top.y + 1
+            }) else {
+                continue; // skirt row culled by the quiet band this frame
+            };
+            let tentacles: Vec<&AmbientMark> = frame
+                .marks
+                .iter()
+                .filter(|mark| {
                     JELLY_TENTACLE_FRAMES.contains(&mark.glyph)
-                        && mark.y == bell.y + 1
-                        && mark.x == bell.x + 1
-                }) {
-                    let bell_glow = bell.brightness.expect("bell pulses");
-                    let tentacle_glow = tentacle.brightness.expect("tentacle pulses");
-                    assert!(bell_glow >= JELLY_BRIGHTNESS_FLOOR - f32::EPSILON);
-                    assert!(tentacle_glow >= JELLY_BRIGHTNESS_FLOOR - f32::EPSILON);
-                    seen = true;
-                    break;
-                }
+                        && mark.y == skirt.y + 1
+                        && mark.x > top.x
+                        && mark.x < top.x + dome_w
+                })
+                .collect();
+            if tentacles.len() != 3 {
+                continue; // tentacle row culled by the quiet band this frame
             }
+            let dome_glow = top.brightness.expect("dome pulses");
+            assert!(dome_glow >= JELLY_BRIGHTNESS_FLOOR - f32::EPSILON);
+            for tentacle in &tentacles {
+                let glow = tentacle.brightness.expect("tentacle pulses");
+                assert!(glow >= JELLY_BRIGHTNESS_FLOOR - f32::EPSILON);
+            }
+            seen = true;
+            break;
         }
         assert!(seen, "no complete jellyfish found in 120s of frames");
+    }
+
+    #[test]
+    fn jellyfish_tentacles_sway_out_of_phase_and_dome_pulses() {
+        // Over a sweep: the dome shows both pulse frames within a few
+        // JELLY_PULSE_MS periods, each tentacle column cycles its sway
+        // frames, and the trio is not always in lockstep (per-column phase
+        // offset — the lag is what sells "jellyfish").
+        let mut dome_frames = std::collections::BTreeSet::new();
+        let mut column_frames: [std::collections::BTreeSet<&str>; 3] = Default::default();
+        let mut saw_desync = false;
+        for probe in 0..480u128 {
+            let frame = frame_at(probe * 100);
+            let Some(top) = frame
+                .marks
+                .iter()
+                .find(|mark| JELLY_DOME_TOP_FRAMES.contains(&mark.glyph))
+            else {
+                continue;
+            };
+            dome_frames.insert(top.glyph);
+            let mut trio = [""; 3];
+            let mut found = 0usize;
+            for (col, slot) in trio.iter_mut().enumerate() {
+                if let Some(tentacle) = frame.marks.iter().find(|mark| {
+                    JELLY_TENTACLE_FRAMES.contains(&mark.glyph)
+                        && mark.y == top.y + 2
+                        && mark.x == top.x + 1 + col as u16
+                }) {
+                    *slot = tentacle.glyph;
+                    column_frames[col].insert(tentacle.glyph);
+                    found += 1;
+                }
+            }
+            if found == 3 && !(trio[0] == trio[1] && trio[1] == trio[2]) {
+                saw_desync = true;
+            }
+        }
+        assert_eq!(
+            dome_frames.len(),
+            JELLY_DOME_TOP_FRAMES.len(),
+            "dome pulse should show every frame: {dome_frames:?}"
+        );
+        for (col, set) in column_frames.iter().enumerate() {
+            assert!(set.len() > 1, "tentacle column {col} never swayed");
+        }
+        assert!(saw_desync, "tentacle columns strobed in lockstep");
+    }
+
+    #[test]
+    fn sparse_water_gets_a_compact_jellyfish() {
+        // Narrow fallback: the Sparse tier swaps the full 5-cell dome for a
+        // 3-cell one with two tentacles — a different silhouette, not just
+        // fewer jellies.
+        let area = Rect::new(0, 0, 48, 12);
+        let mut saw_compact = false;
+        let mut saw_full = false;
+        let mut saw_two_tentacles = false;
+        for probe in 0..240u128 {
+            let mut stats = AmbientFrameStats::default();
+            let frame = build_frame_marks(
+                area,
+                probe * 500,
+                true,
+                LifeDensity::from_area(area),
+                AmbientCursor::default(),
+                WhaleCameo::default(),
+                &mut stats,
+            );
+            for mark in &frame.marks {
+                saw_compact |= JELLY_DOME_TOP_COMPACT.contains(&mark.glyph);
+                saw_full |= JELLY_DOME_TOP_FRAMES.contains(&mark.glyph);
+            }
+            let Some(top) = frame
+                .marks
+                .iter()
+                .find(|mark| JELLY_DOME_TOP_COMPACT.contains(&mark.glyph))
+            else {
+                continue;
+            };
+            let tentacles = frame
+                .marks
+                .iter()
+                .filter(|mark| JELLY_TENTACLE_FRAMES.contains(&mark.glyph) && mark.y == top.y + 2)
+                .count();
+            if tentacles > 0 {
+                assert!(tentacles <= 2, "compact dome grew extra tentacles");
+                saw_two_tentacles |= tentacles == 2;
+            }
+        }
+        assert!(saw_compact, "sparse water never showed the compact dome");
+        assert!(!saw_full, "sparse water used the full-size dome");
+        assert!(saw_two_tentacles, "compact jelly lost its tentacles");
+    }
+
+    #[test]
+    fn reduced_motion_parks_a_complete_jellyfish() {
+        // The static pose is deterministic and visible: a half-pulsed dome
+        // with its tentacles mid-sway, parked just below the hero band.
+        let area = Rect::new(0, 0, 100, 30);
+        let build = || {
+            let mut stats = AmbientFrameStats::default();
+            build_frame_marks(
+                area,
+                0,
+                false,
+                LifeDensity::from_area(area),
+                AmbientCursor::default(),
+                WhaleCameo::default(),
+                &mut stats,
+            )
+        };
+        let first = build();
+        let second = build();
+        let pose = |frame: &FrameMarks| {
+            frame
+                .marks
+                .iter()
+                .map(|mark| (mark.glyph, mark.x, mark.y))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(pose(&first), pose(&second), "static pose must repeat");
+        let top = first
+            .marks
+            .iter()
+            .find(|mark| JELLY_DOME_TOP_FRAMES.contains(&mark.glyph))
+            .expect("parked jellyfish dome");
+        assert!(
+            first.marks.iter().any(|mark| {
+                JELLY_DOME_SKIRT_FRAMES.contains(&mark.glyph) && mark.y == top.y + 1
+            }),
+            "parked jellyfish lost its skirt"
+        );
+        let tentacles = first
+            .marks
+            .iter()
+            .filter(|mark| JELLY_TENTACLE_FRAMES.contains(&mark.glyph) && mark.y == top.y + 2)
+            .count();
+        assert!(tentacles >= 3, "parked jellyfish lost its tentacles");
     }
 
     #[test]
@@ -939,6 +1232,121 @@ mod tests {
                 (BUBBLE_BRIGHTNESS_FLOOR..=1.0).contains(&g),
                 "glint01 lost its floor: {g}"
             );
+        }
+    }
+
+    #[test]
+    fn frame_stats_account_for_every_mark() {
+        let area = Rect::new(0, 0, 100, 30);
+        let mut buf = Buffer::empty(area);
+        let stats = render_ambient_life(
+            area,
+            &mut buf,
+            (Color::Cyan, Color::Blue),
+            &[],
+            12_000,
+            true,
+            AmbientCursor::default(),
+            WhaleCameo::default(),
+        );
+        assert_eq!(
+            stats.marks_built,
+            stats.marks_painted + stats.marks_skipped_text + stats.marks_clipped,
+            "every built mark is painted, text-skipped, or clipped: {stats:?}"
+        );
+        assert!(stats.marks_painted > 0, "empty water should paint life");
+        // cells_written counts each cell of a multi-cell glyph (and counts
+        // a shared cell once per overlapping mark), so the honest bound is
+        // per painted mark — at most the widest glyph (the 5-cell dome) —
+        // rather than per area cell.
+        assert!(stats.cells_written >= stats.marks_painted);
+        assert!(
+            stats.cells_written <= stats.marks_painted * 5,
+            "cells_written out of proportion: {stats:?}"
+        );
+    }
+
+    #[test]
+    fn frame_stats_stay_within_the_render_budget() {
+        // Worst case on the largest Rich field with the whale cameo active:
+        // 7 fish + 2 jellies x 5 parts + 2 bubbles + 2 cameo cells. Anything
+        // more is a leak in the O(1)-per-frame budget.
+        let area = Rect::new(0, 0, 160, 40);
+        let mut buf = Buffer::empty(area);
+        let whale = WhaleCameo {
+            elapsed_ms: Some(500), // Spout: cameo glyph plus spray
+            anchor_x: 80,
+            anchor_y: 26,
+        };
+        let stats = render_ambient_life(
+            area,
+            &mut buf,
+            (Color::Cyan, Color::Blue),
+            &[],
+            12_000,
+            true,
+            AmbientCursor::default(),
+            whale,
+        );
+        assert!(
+            stats.marks_built <= MAX_FRAME_MARKS,
+            "frame budget blown: {stats:?}"
+        );
+        assert_eq!(
+            stats.marks_built,
+            stats.marks_painted + stats.marks_skipped_text + stats.marks_clipped,
+            "every built mark is accounted for: {stats:?}"
+        );
+    }
+
+    #[test]
+    fn frame_stats_never_overwrite_text() {
+        // Property: on a text-covered field, colliding marks are charged to
+        // marks_skipped_text and no transcript cell is overwritten.
+        let area = Rect::new(0, 0, 100, 30);
+        let mut buf = Buffer::empty(area);
+        let lines: Vec<Line<'static>> = (0..usize::from(area.height))
+            .map(|i| {
+                Line::from(Span::raw(format!(
+                    "transcript row {i:02} occupies the water"
+                )))
+            })
+            .collect();
+        for (i, line) in lines.iter().enumerate() {
+            buf.set_line(area.x, area.y + i as u16, line, area.width);
+        }
+        let stats = render_ambient_life(
+            area,
+            &mut buf,
+            (Color::Cyan, Color::Blue),
+            &lines,
+            12_000,
+            true,
+            AmbientCursor::default(),
+            WhaleCameo::default(),
+        );
+        assert!(
+            stats.marks_skipped_text > 0,
+            "text-covered water should skip some marks: {stats:?}"
+        );
+        assert_eq!(
+            stats.marks_built,
+            stats.marks_painted + stats.marks_skipped_text + stats.marks_clipped,
+            "every built mark is accounted for: {stats:?}"
+        );
+        for (i, line) in lines.iter().enumerate() {
+            let text: String = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect();
+            for (x, ch) in text.chars().enumerate() {
+                assert_eq!(
+                    buf[(area.x + x as u16, area.y + i as u16)].symbol(),
+                    ch.to_string(),
+                    "ambient life overwrote transcript cell ({x},{i})"
+                );
+            }
         }
     }
 }

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -1211,6 +1211,10 @@ pub struct App {
     /// Typed appearance treatment; appearance is independent from motion
     /// settings, and every underwater treatment keeps ambient life.
     pub ocean_treatment: crate::tui::ocean::OceanTreatment,
+    /// Focus-context texture prototype mode (#4823), parsed once from the
+    /// `focus_texture` setting. `Off` by default; while off the modal render
+    /// path is byte-identical to the pre-prototype path.
+    pub focus_texture: crate::tui::focus_texture::FocusTextureMode,
     /// Distinct pre-session menu. Once dismissed, the normal idle ocean owns
     /// the empty session and this state stays hidden.
     pub launch: LaunchState,

--- a/crates/tui/src/tui/app/init.rs
+++ b/crates/tui/src/tui/app/init.rs
@@ -202,6 +202,9 @@ impl App {
         let constrained_frame_rate = settings.constrained_frame_rate;
         let fancy_animations = settings.fancy_animations;
         let ocean_treatment = crate::tui::ocean::OceanTreatment::parse(&settings.ocean_treatment);
+        let focus_texture =
+            crate::tui::focus_texture::FocusTextureMode::parse(&settings.focus_texture)
+                .unwrap_or_default();
         let work_surface_placement =
             crate::tui::work_surface::WorkSurfacePlacement::parse(&settings.work_surface_placement);
         let work_surface_top_height = settings.work_surface_top_height;
@@ -632,6 +635,7 @@ impl App {
             ocean_receipt_settle_start: None,
             fancy_animations,
             ocean_treatment,
+            focus_texture,
             launch,
             pending_launch_action: None,
             pending_hotbar_slot: None,

--- a/crates/tui/src/tui/command_palette.rs
+++ b/crates/tui/src/tui/command_palette.rs
@@ -23,6 +23,7 @@ use crate::skills;
 use crate::tools::spec::ApprovalRequirement;
 use crate::tools::spec::ToolCapability;
 use crate::tools::{ToolContext, ToolRegistryBuilder};
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent,
     centered_modal_area, render_modal_footer, render_modal_surface,
@@ -969,10 +970,7 @@ impl ModalView for CommandPaletteView {
                 }
 
                 let style = if is_selected {
-                    Style::default()
-                        .fg(palette::SELECTION_TEXT)
-                        .bg(palette::SELECTION_BG)
-                        .add_modifier(Modifier::BOLD)
+                    menu_style::selected_row_style()
                 } else {
                     Style::default().fg(palette::TEXT_PRIMARY)
                 };
@@ -2040,6 +2038,39 @@ mod tests {
                     "{w}x{h}: row {y} overflows width: {row:?}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn command_palette_selected_row_uses_shared_selection_style_at_blocker_sizes() {
+        use crate::tui::views::ViewStack;
+        for (w, h) in BLOCKER_SIZES {
+            let area = Rect::new(0, 0, w, h);
+            let mut buf = Buffer::empty(area);
+            let mut stack = ViewStack::new();
+            stack.push(sample_palette_view());
+            stack.render(area, &mut buf);
+
+            // The first entry ("/config") is selected by default; find its row.
+            let selected_y = (0..h)
+                .find(|&y| {
+                    let row: String = (0..w).map(|x| buf[(x, y)].symbol()).collect();
+                    row.contains("/config")
+                })
+                .unwrap_or_else(|| panic!("{w}x{h}: selected entry should render"));
+            let selected_cells = (0..w)
+                .filter(|&x| {
+                    let cell = &buf[(x, selected_y)];
+                    !cell.symbol().trim().is_empty()
+                        && cell.bg == palette::SELECTION_BG
+                        && cell.fg == palette::SELECTION_TEXT
+                })
+                .count();
+            assert!(
+                selected_cells >= "/config".len(),
+                "{w}x{h}: selected row must render with the shared selection style \
+                 (palette::SELECTION_TEXT on palette::SELECTION_BG)"
+            );
         }
     }
 }

--- a/crates/tui/src/tui/context_inspector.rs
+++ b/crates/tui/src/tui/context_inspector.rs
@@ -21,6 +21,7 @@ use crate::palette;
 use crate::session_manager::SessionContextReference;
 use crate::tui::app::{App, ToolDetailRecord};
 use crate::tui::file_mention::ContextReferenceSource;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
     render_underwater_surface,
@@ -748,10 +749,7 @@ impl ModalView for ContextInspectorView {
             let selected = idx == self.selected;
             let marker = crate::tui::glyphs::selection_marker(selected);
             let style = if selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };

--- a/crates/tui/src/tui/context_menu.rs
+++ b/crates/tui/src/tui/context_menu.rs
@@ -18,6 +18,7 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::palette;
+use crate::tui::menu_style;
 use crate::tui::ocean;
 use crate::tui::views::{ContextMenuAction, ModalKind, ModalView, ViewAction, ViewEvent};
 
@@ -371,13 +372,15 @@ impl ModalView for ContextMenuView {
             }
 
             let selected = idx == self.selected;
-            let row_bg = if selected { soft_accent } else { elevated };
-            let label_fg = if selected {
-                palette::SELECTION_TEXT
-            } else if entry.primary {
-                accent
+            let row_style = if selected {
+                menu_style::selected_row_style()
             } else {
-                palette::TEXT_SOFT
+                let label_fg = if entry.primary {
+                    accent
+                } else {
+                    palette::TEXT_SOFT
+                };
+                Style::default().fg(label_fg).bg(elevated)
             };
             let glyph = if entry.glyph.is_empty() {
                 "·"
@@ -392,10 +395,11 @@ impl ModalView for ContextMenuView {
             let label = trim_to_width(&entry.label, label_budget);
             let pad = label_budget.saturating_sub(UnicodeWidthStr::width(label.as_str()));
             let text = format!(" {glyph} {label}{} {hint} ", " ".repeat(pad));
-            let mut style = Style::default().fg(label_fg).bg(row_bg);
-            if selected || entry.primary {
-                style = style.add_modifier(Modifier::BOLD);
-            }
+            let style = if !selected && entry.primary {
+                row_style.add_modifier(Modifier::BOLD)
+            } else {
+                row_style
+            };
             lines.push(Line::from(Span::styled(text, style)));
         }
 

--- a/crates/tui/src/tui/feedback_picker.rs
+++ b/crates/tui/src/tui/feedback_picker.rs
@@ -10,6 +10,7 @@ use ratatui::{
 };
 
 use crate::palette;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, CommandPaletteAction, ModalKind, ModalView, ViewAction, ViewEvent,
     centered_modal_area, render_modal_footer, render_modal_surface,
@@ -153,17 +154,12 @@ impl ModalView for FeedbackPickerView {
         for (idx, option) in OPTIONS.iter().enumerate() {
             let is_selected = idx == self.selected;
             let row_style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
             let desc_style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_MUTED)
             };

--- a/crates/tui/src/tui/file_picker.rs
+++ b/crates/tui/src/tui/file_picker.rs
@@ -27,6 +27,7 @@ use ratatui::{
 
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
     render_panel_scroll_rail, render_underwater_surface,
@@ -517,9 +518,7 @@ impl ModalView for FilePickerView {
                 let path = &self.candidates[self.filtered[idx]];
                 let selected = idx == self.selected;
                 let style = if selected {
-                    Style::default()
-                        .fg(palette::SELECTION_TEXT)
-                        .bg(palette::SELECTION_BG)
+                    menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
                 } else {
                     Style::default().fg(palette::TEXT_PRIMARY)
                 };

--- a/crates/tui/src/tui/file_tree.rs
+++ b/crates/tui/src/tui/file_tree.rs
@@ -18,6 +18,7 @@ use ratatui::{
 
 use crate::deepseek_theme::Theme;
 use crate::palette;
+use crate::tui::menu_style;
 use crate::tui::ui_text::truncate_line_to_width;
 
 // ---------------------------------------------------------------------------
@@ -526,9 +527,7 @@ pub fn render_file_tree(
             let display = truncate_line_to_width(&raw, content_width.max(1));
 
             let style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };

--- a/crates/tui/src/tui/focus_texture.rs
+++ b/crates/tui/src/tui/focus_texture.rs
@@ -1,0 +1,572 @@
+//! Focus-context texture prototype (#4823).
+//!
+//! When a modal view is open, the area *outside* the focused modal can get a
+//! subtle treatment so the focused region stands out:
+//!
+//! - `scrim` dims the already-rendered background toward the theme surface;
+//! - `grain` sprinkles sparse deterministic dots over blank cells.
+//!
+//! Scope and guarantees, by construction:
+//!
+//! - **Prototype, bounded to modal contexts.** The only consumer is
+//!   `ViewStack::render`, which passes the top view's `occupied_region` as the
+//!   focus rect. Nothing else in the shell opts in.
+//! - **Default off.** `FocusTextureMode::Off` (the default) returns zeroed
+//!   stats and leaves the buffer untouched, so the render path stays
+//!   byte-identical to the pre-prototype path.
+//! - **Static, not animated.** The grain pattern is a pure function of cell
+//!   coordinates with no time component, so it is motion-off-safe: the
+//!   `low_motion` / `MotionPolicy::allows_decorative` path needs no special
+//!   handling here, and two applications over the same buffer produce
+//!   identical output.
+//! - **Explicit fallbacks.** Off is the fallback for unknown setting values;
+//!   cells whose background is `Color::Reset` (transparent terminals) are
+//!   skipped under Scrim — the terminal owns that background; the grain dot
+//!   falls back to `.` when ASCII-safe mode is on.
+//! - **The focus rect is never painted** — the caller applies the texture
+//!   before painting the backdrop and views, so the focused modal is drawn
+//!   afterward at full strength and the texture can never overwrite it.
+//! - **Text is never obscured.** Grain only writes blank/whitespace cells and
+//!   never touches a cell that carries a symbol. Scrim preserves the
+//!   WCAG AA body-text floor (4.5:1) whenever both colors are resolvable:
+//!   after blending, the foreground is lifted with
+//!   `palette::enforce_contrast` against the *new* background. Colors the
+//!   terminal owns (`Reset`, named ANSI) are left alone rather than guessed.
+//!
+//! Near-fullscreen focus regions (covering at least
+//! `FOCUS_COVERAGE_NOOP_PERCENT`% of the frame) and frames smaller than
+//! [`FOCUS_TEXTURE_MIN_WIDTH`]x[`FOCUS_TEXTURE_MIN_HEIGHT`] refuse the
+//! treatment entirely: there is no meaningful outside left to texture.
+
+use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+
+use crate::palette::{self, AA_BODY_CONTRAST, UiTheme};
+
+/// Minimum frame size that earns the texture. Below this, content and
+/// controls own every cell. Mirrors the ambient-life floors.
+pub const FOCUS_TEXTURE_MIN_WIDTH: u16 = crate::tui::ocean::AMBIENT_MIN_WIDTH;
+pub const FOCUS_TEXTURE_MIN_HEIGHT: u16 = crate::tui::ocean::AMBIENT_MIN_HEIGHT;
+
+/// Focus regions covering at least this share of the frame's cells leave no
+/// meaningful outside to texture, so the pass is a no-op.
+const FOCUS_COVERAGE_NOOP_PERCENT: u64 = 90;
+
+/// Scrim background blend toward the theme surface.
+const SCRIM_BG_BLEND: f32 = 0.5;
+/// Scrim foreground blend toward the theme surface, before the contrast
+/// floor lifts the result back to legibility.
+const SCRIM_FG_BLEND: f32 = 0.25;
+
+/// Grain dot glyph. Deterministic placement (see [`grain_dot_at`]) keeps the
+/// texture static; `glyphs::ascii_fallback` maps this to `.` in ASCII-safe
+/// mode.
+const GRAIN_DOT: &str = "·";
+
+/// Focus-context texture mode for modal views (#4823 prototype).
+///
+/// Parsed from the `focus_texture` setting at the consumption point; unknown
+/// values fall back to `Off` and never panic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FocusTextureMode {
+    /// No treatment. The render path is byte-identical to the pre-prototype
+    /// path in this mode.
+    #[default]
+    Off,
+    /// Dim cells outside the focused modal toward the theme surface.
+    Scrim,
+    /// Sparse deterministic dots on blank cells outside the focused modal.
+    Grain,
+}
+
+impl FocusTextureMode {
+    /// Parse a setting value; `None` for anything unknown (callers map that
+    /// to `Off`). Case-insensitive, surrounding whitespace ignored.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" => Some(Self::Off),
+            "scrim" => Some(Self::Scrim),
+            "grain" => Some(Self::Grain),
+            _ => None,
+        }
+    }
+}
+
+/// Accounting for one [`apply_focus_texture`] pass.
+///
+/// Identity: `cells_examined == cells_scrimmed + cells_dotted
+/// + cells_skipped_focus + cells_skipped_transparent + cells_skipped_text`.
+///
+/// Scrim examines every cell of the area. Grain examines focus cells, text
+/// cells, and deterministic dot candidates; blank cells that earn no dot are
+/// left untouched and unexamined, which keeps the identity exact without a
+/// "blank but not dotted" bucket.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FocusTextureStats {
+    pub cells_examined: u32,
+    pub cells_scrimmed: u32,
+    pub cells_dotted: u32,
+    pub cells_skipped_focus: u32,
+    pub cells_skipped_transparent: u32,
+    pub cells_skipped_text: u32,
+}
+
+impl FocusTextureStats {
+    /// The accounting identity asserted by the unit tests. This type's only
+    /// consumer is the test gate below, hence the `dead_code` allowance.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn accounted(&self) -> bool {
+        self.cells_examined
+            == self.cells_scrimmed
+                + self.cells_dotted
+                + self.cells_skipped_focus
+                + self.cells_skipped_transparent
+                + self.cells_skipped_text
+    }
+}
+
+/// `true` when `(x, y)` lies inside `rect`.
+fn rect_contains(rect: Rect, x: u16, y: u16) -> bool {
+    x >= rect.left() && x < rect.right() && y >= rect.top() && y < rect.bottom()
+}
+
+/// Deterministic grain placement: a pure function of the cell coordinates,
+/// so the texture is static (motion-off-safe) and reproducible.
+fn grain_dot_at(x: u16, y: u16) -> bool {
+    x.wrapping_mul(7)
+        .wrapping_add(y.wrapping_mul(13))
+        .is_multiple_of(11)
+}
+
+/// Apply the focus-context texture to `area`, treating `focus` as the
+/// focused modal's occupied region. See the module docs for the guarantees.
+///
+/// Returns zeroed stats and leaves the buffer untouched when the mode is
+/// `Off`, the frame is below the minimum size, or the focus rect (clamped to
+/// the area) covers at least `FOCUS_COVERAGE_NOOP_PERCENT`% of the frame.
+pub fn apply_focus_texture(
+    area: Rect,
+    buf: &mut Buffer,
+    focus: Rect,
+    theme: &UiTheme,
+    mode: FocusTextureMode,
+    ascii_safe: bool,
+) -> FocusTextureStats {
+    let mut stats = FocusTextureStats::default();
+    if mode == FocusTextureMode::Off {
+        return stats;
+    }
+    if area.width < FOCUS_TEXTURE_MIN_WIDTH || area.height < FOCUS_TEXTURE_MIN_HEIGHT {
+        return stats;
+    }
+    let focus = focus.intersection(area);
+    // u64: a full u16-square frame already fits u32, but the *100 coverage
+    // compare would not.
+    let area_cells = u64::from(area.width) * u64::from(area.height);
+    let focus_cells = u64::from(focus.width) * u64::from(focus.height);
+    if area_cells == 0 || focus_cells * 100 >= area_cells * FOCUS_COVERAGE_NOOP_PERCENT {
+        return stats;
+    }
+
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if rect_contains(focus, x, y) {
+                stats.cells_examined += 1;
+                stats.cells_skipped_focus += 1;
+                continue;
+            }
+            match mode {
+                FocusTextureMode::Off => unreachable!("off returns early"),
+                FocusTextureMode::Scrim => {
+                    stats.cells_examined += 1;
+                    let cell = &buf[(x, y)];
+                    // Transparent-terminal fallback: the terminal owns this
+                    // background, so dimming it would be a guess. Skip.
+                    if cell.bg == Color::Reset {
+                        stats.cells_skipped_transparent += 1;
+                        continue;
+                    }
+                    let new_bg =
+                        crate::tui::ocean::mix_colors(cell.bg, theme.surface_bg, SCRIM_BG_BLEND);
+                    let blended_fg =
+                        crate::tui::ocean::mix_colors(cell.fg, theme.surface_bg, SCRIM_FG_BLEND);
+                    // Text is never obscured by construction: when both
+                    // colors are resolvable this lifts the foreground back to
+                    // the AA body floor against the *new* background; when
+                    // either side is terminal-owned the color is left alone.
+                    let new_fg = palette::enforce_contrast(blended_fg, new_bg, AA_BODY_CONTRAST);
+                    let cell = &mut buf[(x, y)];
+                    cell.bg = new_bg;
+                    cell.fg = new_fg;
+                    stats.cells_scrimmed += 1;
+                }
+                FocusTextureMode::Grain => {
+                    let cell = &buf[(x, y)];
+                    // Never write over a cell that carries a symbol: grain is
+                    // a background texture, not an ink.
+                    if !cell.symbol().trim().is_empty() {
+                        stats.cells_examined += 1;
+                        stats.cells_skipped_text += 1;
+                        continue;
+                    }
+                    // Blank cells that earn no dot are left untouched and
+                    // unexamined (see the stats docs).
+                    if !grain_dot_at(x, y) {
+                        continue;
+                    }
+                    stats.cells_examined += 1;
+                    let dot = if ascii_safe {
+                        crate::tui::glyphs::ascii_fallback(GRAIN_DOT).unwrap_or(".")
+                    } else {
+                        GRAIN_DOT
+                    };
+                    let cell = &mut buf[(x, y)];
+                    cell.set_symbol(dot);
+                    // Set the dim ink only when it is resolvable; a
+                    // terminal-owned `text_dim` (the Terminal theme) stays
+                    // as-is rather than being guessed.
+                    if palette::resolvable_rgb(theme.text_dim).is_some() {
+                        cell.set_fg(theme.text_dim);
+                    }
+                    stats.cells_dotted += 1;
+                }
+            }
+        }
+    }
+    stats
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Style;
+
+    /// The Blue Stage theme: fully resolvable (Rgb) surface and dim ink.
+    fn theme() -> UiTheme {
+        let theme = crate::palette::ThemeId::Whale.ui_theme();
+        assert!(palette::resolvable_rgb(theme.surface_bg).is_some());
+        assert!(palette::resolvable_rgb(theme.text_dim).is_some());
+        theme
+    }
+
+    /// A 60x20 frame: large enough for the texture, small enough to eyeball.
+    fn test_area() -> Rect {
+        Rect::new(0, 0, 60, 20)
+    }
+
+    /// A focus rect well under the 90% coverage threshold (200 of 1200).
+    fn test_focus() -> Rect {
+        Rect::new(10, 5, 20, 10)
+    }
+
+    fn blank_buffer(area: Rect) -> Buffer {
+        Buffer::empty(area)
+    }
+
+    fn assert_accounted(stats: FocusTextureStats) {
+        assert!(stats.accounted(), "accounting identity broken: {stats:?}");
+    }
+
+    #[test]
+    fn mode_parse_covers_every_setting_value() {
+        for (value, mode) in [
+            ("off", FocusTextureMode::Off),
+            ("scrim", FocusTextureMode::Scrim),
+            ("grain", FocusTextureMode::Grain),
+        ] {
+            assert_eq!(FocusTextureMode::parse(value), Some(mode));
+        }
+        assert_eq!(
+            FocusTextureMode::parse(" SCRIM "),
+            Some(FocusTextureMode::Scrim)
+        );
+        assert_eq!(
+            FocusTextureMode::parse("Grain"),
+            Some(FocusTextureMode::Grain)
+        );
+        assert_eq!(FocusTextureMode::parse("static"), None);
+        assert_eq!(FocusTextureMode::parse(""), None);
+        assert_eq!(FocusTextureMode::default(), FocusTextureMode::Off);
+    }
+
+    #[test]
+    fn off_leaves_buffer_untouched() {
+        let area = test_area();
+        let mut buf = blank_buffer(area);
+        buf[(0, 0)].set_symbol("a").set_fg(Color::White);
+        buf[(1, 0)].set_bg(Color::Reset);
+        let original = buf.clone();
+
+        let stats = apply_focus_texture(
+            area,
+            &mut buf,
+            test_focus(),
+            &theme(),
+            FocusTextureMode::Off,
+            false,
+        );
+
+        assert_eq!(stats, FocusTextureStats::default());
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn near_fullscreen_focus_is_noop() {
+        let area = test_area();
+        // 59x20 = 1180 of 1200 cells (98%): over the 90% threshold.
+        for focus in [area, Rect::new(0, 0, 59, 20)] {
+            let mut buf = blank_buffer(area);
+            let original = buf.clone();
+            let stats = apply_focus_texture(
+                area,
+                &mut buf,
+                focus,
+                &theme(),
+                FocusTextureMode::Scrim,
+                false,
+            );
+            assert_eq!(stats, FocusTextureStats::default(), "focus {focus:?}");
+            assert_eq!(buf, original, "focus {focus:?}");
+        }
+    }
+
+    #[test]
+    fn small_area_is_noop() {
+        for area in [Rect::new(0, 0, 39, 20), Rect::new(0, 0, 60, 9)] {
+            let mut buf = blank_buffer(area);
+            let original = buf.clone();
+            let stats = apply_focus_texture(
+                area,
+                &mut buf,
+                Rect::new(0, 0, 4, 2),
+                &theme(),
+                FocusTextureMode::Grain,
+                false,
+            );
+            assert_eq!(stats, FocusTextureStats::default(), "area {area:?}");
+            assert_eq!(buf, original, "area {area:?}");
+        }
+    }
+
+    #[test]
+    fn scrim_preserves_focus_and_transparent_cells() {
+        let area = test_area();
+        let focus = test_focus();
+        let mut buf = blank_buffer(area);
+        let focus_style = Style::default().fg(Color::White).bg(Color::Blue);
+        let mut reset_cells = 0_u32;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if rect_contains(focus, x, y) {
+                    buf[(x, y)].set_symbol("F").set_style(focus_style);
+                } else if (x + y) % 2 == 0 {
+                    // Transparent-terminal cells outside the focus.
+                    buf[(x, y)].set_bg(Color::Reset);
+                    reset_cells += 1;
+                } else {
+                    buf[(x, y)]
+                        .set_symbol("t")
+                        .set_fg(Color::Rgb(200, 200, 200))
+                        .set_bg(Color::Rgb(40, 40, 40));
+                }
+            }
+        }
+        let original = buf.clone();
+
+        let stats = apply_focus_texture(
+            area,
+            &mut buf,
+            focus,
+            &theme(),
+            FocusTextureMode::Scrim,
+            false,
+        );
+
+        assert_accounted(stats);
+        assert_eq!(stats.cells_examined, 60 * 20);
+        assert_eq!(stats.cells_skipped_focus, 20 * 10);
+        assert_eq!(stats.cells_skipped_transparent, reset_cells);
+        assert_eq!(stats.cells_dotted, 0);
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if rect_contains(focus, x, y) {
+                    assert_eq!(
+                        buf[(x, y)],
+                        original[(x, y)],
+                        "focus cell ({x},{y}) must stay byte-identical"
+                    );
+                } else if (x + y) % 2 == 0 {
+                    assert_eq!(
+                        buf[(x, y)],
+                        original[(x, y)],
+                        "Reset-bg cell ({x},{y}) must stay untouched"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn scrim_text_keeps_aa_contrast_when_resolvable() {
+        let area = test_area();
+        let focus = test_focus();
+        let theme = theme();
+        let combos = [
+            (Color::Rgb(255, 255, 255), Color::Rgb(30, 30, 30)),
+            (Color::Rgb(200, 200, 200), Color::Rgb(240, 240, 240)),
+            (Color::Rgb(120, 120, 120), Color::Rgb(110, 110, 110)),
+            (Color::Rgb(40, 80, 200), Color::Rgb(20, 20, 30)),
+        ];
+        for (row, (fg, bg)) in combos.iter().enumerate() {
+            let mut buf = blank_buffer(area);
+            let y = row as u16;
+            let mut seeded = Vec::new();
+            for x in area.left()..area.right() {
+                if rect_contains(focus, x, y) {
+                    continue;
+                }
+                buf[(x, y)].set_symbol("t").set_fg(*fg).set_bg(*bg);
+                seeded.push(x);
+            }
+
+            let stats = apply_focus_texture(
+                area,
+                &mut buf,
+                focus,
+                &theme,
+                FocusTextureMode::Scrim,
+                false,
+            );
+
+            assert_accounted(stats);
+            for x in seeded {
+                let cell = &buf[(x, y)];
+                assert_eq!(cell.symbol(), "t", "glyph must survive the scrim");
+                let ratio = palette::contrast_ratio(cell.fg, cell.bg)
+                    .expect("seeded colors are Rgb and stay resolvable");
+                assert!(
+                    ratio >= AA_BODY_CONTRAST,
+                    "combo {fg:?}/{bg:?} ended at {ratio}:1, below the AA floor"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn grain_never_overwrites_text_and_dots_are_deterministic() {
+        let area = test_area();
+        let focus = test_focus();
+        let theme = theme();
+        let mut buf = blank_buffer(area);
+        let mut text_cells = Vec::new();
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if !rect_contains(focus, x, y) && (x + y) % 3 == 0 {
+                    buf[(x, y)].set_symbol("a").set_fg(Color::White);
+                    text_cells.push((x, y));
+                }
+            }
+        }
+        let original = buf.clone();
+
+        let stats = apply_focus_texture(
+            area,
+            &mut buf,
+            focus,
+            &theme,
+            FocusTextureMode::Grain,
+            false,
+        );
+
+        assert_accounted(stats);
+        assert_eq!(stats.cells_skipped_focus, 20 * 10);
+        assert_eq!(stats.cells_skipped_text, text_cells.len() as u32);
+        assert_eq!(stats.cells_scrimmed, 0);
+        // Every seeded text cell is untouched, byte for byte.
+        for (x, y) in &text_cells {
+            assert_eq!(
+                buf[(*x, *y)],
+                original[(*x, *y)],
+                "text cell ({x},{y}) must never be overwritten"
+            );
+        }
+        // Dots land exactly at the deterministic positions on blank cells.
+        let mut expected_dots = 0_u32;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if rect_contains(focus, x, y) || (x + y) % 3 == 0 {
+                    continue;
+                }
+                if grain_dot_at(x, y) {
+                    expected_dots += 1;
+                    assert_eq!(buf[(x, y)].symbol(), GRAIN_DOT, "dot at ({x},{y})");
+                    assert_eq!(buf[(x, y)].fg, theme.text_dim);
+                } else {
+                    assert_eq!(
+                        buf[(x, y)],
+                        original[(x, y)],
+                        "non-dot blank cell ({x},{y}) must stay untouched"
+                    );
+                }
+            }
+        }
+        assert_eq!(stats.cells_dotted, expected_dots);
+    }
+
+    #[test]
+    fn grain_ascii_safe_uses_plain_dot() {
+        let area = test_area();
+        let focus = test_focus();
+        let mut buf = blank_buffer(area);
+
+        let stats = apply_focus_texture(
+            area,
+            &mut buf,
+            focus,
+            &theme(),
+            FocusTextureMode::Grain,
+            true,
+        );
+
+        assert_accounted(stats);
+        assert!(stats.cells_dotted > 0);
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if !rect_contains(focus, x, y) && grain_dot_at(x, y) {
+                    assert_eq!(buf[(x, y)].symbol(), ".", "ascii dot at ({x},{y})");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn grain_is_deterministic_across_applications() {
+        let area = test_area();
+        let focus = test_focus();
+        let theme = theme();
+        let mut first = blank_buffer(area);
+        let mut second = blank_buffer(area);
+
+        apply_focus_texture(
+            area,
+            &mut first,
+            focus,
+            &theme,
+            FocusTextureMode::Grain,
+            false,
+        );
+        apply_focus_texture(
+            area,
+            &mut second,
+            focus,
+            &theme,
+            FocusTextureMode::Grain,
+            false,
+        );
+
+        // Static texture: no time component, so motion-off needs no special
+        // path and repeated passes over the same buffer agree exactly.
+        assert_eq!(first, second);
+    }
+}

--- a/crates/tui/src/tui/footer_ui.rs
+++ b/crates/tui/src/tui/footer_ui.rs
@@ -10,6 +10,7 @@ use crate::tui::app::{App, TaskPanelEntryKind};
 use crate::tui::format_helpers;
 use crate::tui::history::{HistoryCell, ToolCell, ToolStatus, summarize_tool_output};
 use crate::tui::key_shortcuts;
+use crate::tui::menu_style;
 use crate::tui::subagent_routing::{
     active_fanout_counts, agents_sidebar_surface_visible, running_agent_count,
 };
@@ -1161,7 +1162,12 @@ pub(crate) fn footer_state_label(app: &App) -> (&'static str, ratatui::style::Co
     // Sub-agents still surface "working" because that's a distinct lifecycle
     // the user can act on (open `/agents`).
     if running_agent_count(app) > 0 {
-        return ("working", app.ui_theme.status_working);
+        // Word from the shared status mark; the tone stays theme-sourced so
+        // the footer keeps its live-theme status ramp.
+        return (
+            menu_style::status_mark(menu_style::StatusKind::Working).word,
+            app.ui_theme.status_working,
+        );
     }
     // A paused pausable command is an actionable state even after the turn's
     // tools have drained: the user can resume or ESC-to-cancel. Without this
@@ -1173,7 +1179,10 @@ pub(crate) fn footer_state_label(app: &App) -> (&'static str, ratatui::style::Co
     // alongside `app.paused` so the label survives the turn-end window where
     // `app.paused` has been cleared but the hold is still resumable.
     if app.paused || app.paused_quarry.is_some() {
-        return ("paused \u{23F8}", app.ui_theme.status_warning);
+        return (
+            menu_style::status_inline_label(menu_style::StatusKind::Paused),
+            app.ui_theme.status_warning,
+        );
     }
 
     if app.queued_draft.is_some() {
@@ -1188,7 +1197,10 @@ pub(crate) fn footer_state_label(app: &App) -> (&'static str, ratatui::style::Co
         return ("draft", app.ui_theme.text_muted);
     }
 
-    ("idle", app.ui_theme.status_ready)
+    (
+        menu_style::status_mark(menu_style::StatusKind::Ready).word,
+        app.ui_theme.status_ready,
+    )
 }
 
 pub(crate) fn format_token_count_compact(tokens: u64) -> String {

--- a/crates/tui/src/tui/glyphs.rs
+++ b/crates/tui/src/tui/glyphs.rs
@@ -72,6 +72,8 @@ pub fn ascii_fallback(symbol: &str) -> Option<&'static str> {
         "✓" | "✔" | "☑" => Some("Y"),
         "✕" | "×" | "⊘" | "✗" | "✘" | "☒" => Some("X"),
         "⏸" => Some("="),
+        "≈≈>" => Some("~>"),
+        "≈" | "～" => Some("~"),
         "🐳" | "🐋" => Some("w"),
         "…" => Some("."),
         _ => None,
@@ -108,6 +110,9 @@ mod tests {
             (DONE, "Y"),
             (FAILED, "X"),
             (ATTENTION, "*"),
+            ("≈≈>", "~>"),
+            ("≈", "~"),
+            ("～", "~"),
         ] {
             assert_eq!(ascii_fallback(rich), Some(safe));
         }

--- a/crates/tui/src/tui/menu_style.rs
+++ b/crates/tui/src/tui/menu_style.rs
@@ -1,0 +1,267 @@
+//! Shared selection-row styles and non-color status marks for menus/pickers.
+//!
+//! Contract:
+//! - The selection vocabulary is single-sourced here. Every menu, picker, and
+//!   option list renders its selected row with [`selected_row_style`] (or one
+//!   of the documented variants below) instead of hand-copying the
+//!   `SELECTION_TEXT`-on-`SELECTION_BG` + bold trio.
+//! - This module owns *styling* only. Verbs, action-hint labels, keybindings,
+//!   and localized strings stay with the views and `ActionHint`; nothing here
+//!   changes what any surface says.
+//! - Status tones are palette tokens (`palette::STATUS_*`), never per-view
+//!   colors, and every [`StatusKind`] pairs a charter glyph (`glyphs.rs`) with
+//!   an English word so state never depends on color alone. Surfaces that
+//!   already source their tone from the live `UiTheme` (the footer) keep that
+//!   tone and consume only the glyph/word half of the mark.
+
+use ratatui::style::{Color, Modifier, Style};
+
+use crate::palette::{self, UiTheme};
+use crate::tui::glyphs;
+
+/// Canonical selected-row treatment: selection ink on the selection
+/// background, bolded so the active row reads even without color.
+#[must_use]
+pub fn selected_row_style() -> Style {
+    Style::default()
+        .fg(palette::SELECTION_TEXT)
+        .bg(palette::SELECTION_BG)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Selected row with a caller-chosen foreground (the provider picker tints
+/// per-field ink while keeping the shared selection background).
+#[must_use]
+pub fn selected_row_style_with_fg(fg: Color) -> Style {
+    Style::default()
+        .fg(fg)
+        .bg(palette::SELECTION_BG)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Selection background alone, for filler/spacer cells so the highlight band
+/// runs the full width of a selected row.
+#[must_use]
+pub fn selected_row_bg_style() -> Style {
+    Style::default().bg(palette::SELECTION_BG)
+}
+
+/// Selected-but-disabled row (e.g. a locked model): the cursor position is
+/// still visible, but muted ink on the elevated surface plus a dim modifier
+/// says the row cannot be chosen.
+#[must_use]
+pub fn disabled_selected_row_style() -> Style {
+    Style::default()
+        .fg(palette::TEXT_MUTED)
+        .bg(palette::SURFACE_ELEVATED)
+        .add_modifier(Modifier::DIM)
+}
+
+/// Theme-preview variant: the theme picker shows each candidate theme's *own*
+/// selection treatment, so ink and background come from the previewed theme
+/// rather than the global tokens. `UiTheme` has no dedicated selection-ink
+/// field, so the theme's body text reads on its selection background — the
+/// exact pairing the picker has always rendered.
+#[must_use]
+pub fn theme_selected_row_style(theme: &UiTheme) -> Style {
+    Style::default()
+        .fg(theme.text_body)
+        .bg(theme.selection_bg)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Non-color status cue: a charter glyph, an English word, and a palette
+/// status tone. Surfaces may render any subset, but glyph and word are always
+/// both available so the state never depends on color alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatusMark {
+    pub glyph: &'static str,
+    pub word: &'static str,
+    pub tone: Color,
+}
+
+/// The status states shared by the footer, work surface, and pickers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusKind {
+    Ready,
+    Working,
+    Paused,
+    Done,
+    /// Chartered vocabulary entry. No surface renders a failure mark yet, so
+    /// nothing constructs it outside the exhaustiveness sweep below.
+    #[allow(dead_code)]
+    Failed,
+    Attention,
+}
+
+impl StatusKind {
+    /// Every kind, for exhaustive checks. Consumed by the non-color-meaning
+    /// test gate rather than by a runtime renderer.
+    #[allow(dead_code)]
+    pub const ALL: [StatusKind; 6] = [
+        StatusKind::Ready,
+        StatusKind::Working,
+        StatusKind::Paused,
+        StatusKind::Done,
+        StatusKind::Failed,
+        StatusKind::Attention,
+    ];
+}
+
+/// Single source pairing each status with its charter glyph, English word,
+/// and palette tone. Words match the established footer vocabulary
+/// (`working`, `paused`, `idle`); tones are `palette::STATUS_*` tokens, not
+/// per-view colors. `Working` has no dedicated charter glyph yet, so it
+/// borrows the charter's neutral dot until one is chartered.
+#[must_use]
+pub const fn status_mark(kind: StatusKind) -> StatusMark {
+    match kind {
+        StatusKind::Ready => StatusMark {
+            glyph: glyphs::READY,
+            word: "idle",
+            tone: palette::STATUS_SUCCESS,
+        },
+        StatusKind::Working => StatusMark {
+            glyph: glyphs::NEUTRAL,
+            word: "working",
+            tone: palette::STATUS_INFO,
+        },
+        StatusKind::Paused => StatusMark {
+            glyph: glyphs::PAUSED,
+            word: "paused",
+            tone: palette::STATUS_WARNING,
+        },
+        StatusKind::Done => StatusMark {
+            glyph: glyphs::DONE,
+            word: "done",
+            tone: palette::STATUS_SUCCESS,
+        },
+        StatusKind::Failed => StatusMark {
+            glyph: glyphs::FAILED,
+            word: "failed",
+            tone: palette::STATUS_ERROR,
+        },
+        StatusKind::Attention => StatusMark {
+            glyph: glyphs::ATTENTION,
+            word: "attention",
+            tone: palette::STATUS_WARNING,
+        },
+    }
+}
+
+/// Pre-composed inline label for surfaces that print the word and glyph
+/// together (today only the footer's `paused ⏸`). Everything else takes
+/// [`StatusMark::word`] alone.
+#[must_use]
+pub const fn status_inline_label(kind: StatusKind) -> &'static str {
+    match kind {
+        StatusKind::Paused => "paused \u{23F8}",
+        _ => status_mark(kind).word,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selected_row_style_is_the_canonical_trio() {
+        assert_eq!(
+            selected_row_style(),
+            Style::default()
+                .fg(palette::SELECTION_TEXT)
+                .bg(palette::SELECTION_BG)
+                .add_modifier(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn selected_row_variants_keep_the_shared_background() {
+        assert_eq!(
+            selected_row_bg_style(),
+            Style::default().bg(palette::SELECTION_BG)
+        );
+        assert_eq!(
+            selected_row_style_with_fg(palette::WHALE_INFO),
+            Style::default()
+                .fg(palette::WHALE_INFO)
+                .bg(palette::SELECTION_BG)
+                .add_modifier(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn disabled_selected_row_is_muted_ink_on_elevated_surface() {
+        assert_eq!(
+            disabled_selected_row_style(),
+            Style::default()
+                .fg(palette::TEXT_MUTED)
+                .bg(palette::SURFACE_ELEVATED)
+                .add_modifier(Modifier::DIM)
+        );
+    }
+
+    #[test]
+    fn theme_variant_uses_the_previewed_themes_own_tokens() {
+        let theme = palette::UI_THEME;
+        assert_eq!(
+            theme_selected_row_style(&theme),
+            Style::default()
+                .fg(theme.text_body)
+                .bg(theme.selection_bg)
+                .add_modifier(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn every_status_kind_pairs_a_glyph_with_a_word() {
+        // Non-color redundancy: neither cue may be empty, so a status never
+        // depends on color alone.
+        for kind in StatusKind::ALL {
+            let mark = status_mark(kind);
+            assert!(!mark.glyph.trim().is_empty(), "{kind:?} needs a glyph");
+            assert!(!mark.word.trim().is_empty(), "{kind:?} needs a word");
+        }
+    }
+
+    #[test]
+    fn status_tones_are_palette_status_tokens() {
+        let tokens = [
+            palette::STATUS_SUCCESS,
+            palette::STATUS_WARNING,
+            palette::STATUS_ERROR,
+            palette::STATUS_INFO,
+        ];
+        for kind in StatusKind::ALL {
+            let tone = status_mark(kind).tone;
+            assert!(
+                tokens.contains(&tone),
+                "{kind:?} tone is not a STATUS_* token"
+            );
+        }
+        assert_eq!(status_mark(StatusKind::Ready).tone, palette::STATUS_SUCCESS);
+        assert_eq!(status_mark(StatusKind::Working).tone, palette::STATUS_INFO);
+        assert_eq!(
+            status_mark(StatusKind::Paused).tone,
+            palette::STATUS_WARNING
+        );
+        assert_eq!(status_mark(StatusKind::Done).tone, palette::STATUS_SUCCESS);
+        assert_eq!(status_mark(StatusKind::Failed).tone, palette::STATUS_ERROR);
+        assert_eq!(
+            status_mark(StatusKind::Attention).tone,
+            palette::STATUS_WARNING
+        );
+    }
+
+    #[test]
+    fn status_words_match_the_footer_vocabulary() {
+        assert_eq!(status_mark(StatusKind::Ready).word, "idle");
+        assert_eq!(status_mark(StatusKind::Working).word, "working");
+        assert_eq!(status_mark(StatusKind::Paused).word, "paused");
+        assert_eq!(status_inline_label(StatusKind::Paused), "paused \u{23F8}");
+        assert_eq!(
+            status_inline_label(StatusKind::Working),
+            status_mark(StatusKind::Working).word
+        );
+    }
+}

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -57,6 +57,7 @@ pub mod live_transcript;
 pub mod markdown_render;
 mod mcp_routing;
 pub(crate) mod mention_completion;
+pub mod menu_style;
 pub mod model_picker;
 pub mod motion;
 pub mod mouse_ui;

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -84,6 +84,7 @@ mod shell_job_routing;
 pub mod shell_key_routing;
 pub mod sidebar;
 pub mod slash_menu;
+pub mod sound_policy;
 pub mod spinner;
 pub mod startup_defaults;
 pub mod streaming;

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -38,6 +38,7 @@ pub mod file_mention;
 pub mod file_picker;
 pub mod file_picker_relevance;
 pub mod file_tree;
+pub mod focus_texture;
 pub mod footer_ui;
 pub mod format_helpers;
 pub mod frame_rate_limiter;

--- a/crates/tui/src/tui/model_picker.rs
+++ b/crates/tui/src/tui/model_picker.rs
@@ -40,6 +40,7 @@ use crate::provider_lake::{
 };
 use crate::settings::PinnedModel;
 use crate::tui::app::{App, ReasoningEffort};
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ListDetailLayout, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
     render_underwater_surface,
@@ -764,15 +765,9 @@ impl ModelPickerView {
                 crate::tui::glyphs::selection_marker(is_selected)
             };
             let label_style = if is_selected && !locked {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else if is_selected && locked {
-                Style::default()
-                    .fg(palette::TEXT_MUTED)
-                    .bg(palette::SURFACE_ELEVATED)
-                    .add_modifier(Modifier::DIM)
+                menu_style::disabled_selected_row_style()
             } else if locked {
                 Style::default()
                     .fg(palette::TEXT_MUTED)
@@ -781,9 +776,7 @@ impl ModelPickerView {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
             let hint_style = if is_selected && !locked {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_MUTED)
             };

--- a/crates/tui/src/tui/notifications.rs
+++ b/crates/tui/src/tui/notifications.rs
@@ -225,6 +225,15 @@ pub fn notify_done_to<W: Write>(
         "emitting desktop notification"
     );
 
+    // Opt-in event-sound policy (#4817). A no-op unless
+    // `[notifications.event_sound].enabled = true`; errors are swallowed
+    // like every other best-effort terminal write in this module.
+    crate::tui::sound_policy::handle_notification_kind_to(
+        payload.kind(),
+        crate::tui::sound_policy::epoch_millis_now(),
+        sink,
+    );
+
     // macOS Notification Center: handled via osascript, not terminal escapes.
     #[cfg(target_os = "macos")]
     if Method::MacOS == effective {
@@ -768,6 +777,13 @@ pub fn settings(config: &crate::config::Config) -> Option<(Method, Duration, boo
     let notif = config.notifications_config();
     // Initialize completion sound mode from config.
     set_completion_sound(notif.completion_sound, notif.sound_file);
+    // Initialize the opt-in event-sound policy (#4817) from the sibling
+    // `[notifications.event_sound]` table. `completion_sound` active means
+    // the policy defers `turn-complete` to that channel (no double ding).
+    crate::tui::sound_policy::configure(crate::tui::sound_policy::EventSoundPolicy::from_config(
+        &notif.event_sound,
+        notif.completion_sound != crate::config::CompletionSound::Off,
+    ));
     let method = match notif.method {
         crate::config::NotificationMethod::Auto => Method::Auto,
         crate::config::NotificationMethod::Osc9 => Method::Osc9,

--- a/crates/tui/src/tui/provider_picker.rs
+++ b/crates/tui/src/tui/provider_picker.rs
@@ -30,7 +30,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKi
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Widget, Wrap},
 };
@@ -51,6 +51,7 @@ use crate::provider_readiness::{
     credential_state_for_provider, route_identity_for_model,
 };
 use crate::tui::app::ReasoningEffort;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, EmptyState, ListDetailLayout, ModalKind, ModalView, ViewAction, ViewEvent,
     centered_modal_area, render_modal_footer, render_modal_surface,
@@ -1946,17 +1947,6 @@ impl ProviderPickerView {
             .min(max_start)
     }
 
-    fn selected_row_style(fg: Color) -> Style {
-        Style::default()
-            .fg(fg)
-            .bg(palette::SELECTION_BG)
-            .add_modifier(Modifier::BOLD)
-    }
-
-    fn selected_row_bg_style() -> Style {
-        Style::default().bg(palette::SELECTION_BG)
-    }
-
     fn render_list(&self, area: Rect, buf: &mut Buffer) {
         let enter_action = if !self.selected_route_is_valid() {
             self.tr(MessageId::PickerActionUnavailable)
@@ -2079,12 +2069,12 @@ impl ProviderPickerView {
             let arrow = crate::tui::glyphs::selection_marker(is_selected);
             let active_dot = if is_active { " *" } else { "  " };
             let spacer_style = if is_selected {
-                Self::selected_row_bg_style()
+                menu_style::selected_row_bg_style()
             } else {
                 Style::default()
             };
             let label_style = if is_selected {
-                Self::selected_row_style(palette::SELECTION_TEXT)
+                menu_style::selected_row_style_with_fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
@@ -2102,7 +2092,7 @@ impl ProviderPickerView {
                 } else {
                     palette::STATUS_WARNING
                 };
-                Self::selected_row_style(hint_fg)
+                menu_style::selected_row_style_with_fg(hint_fg)
             } else if has_usable_auth {
                 Style::default().fg(palette::TEXT_MUTED)
             } else {
@@ -2125,13 +2115,13 @@ impl ProviderPickerView {
                 Span::styled(hint, hint_style),
             ]);
             if is_selected {
-                line.style = Self::selected_row_bg_style();
+                line.style = menu_style::selected_row_bg_style();
                 let target_width = usize::from(layout.list.width);
                 let line_width = line.width();
                 if line_width < target_width {
                     line.spans.push(Span::styled(
                         " ".repeat(target_width - line_width),
-                        Self::selected_row_bg_style(),
+                        menu_style::selected_row_bg_style(),
                     ));
                 }
             }
@@ -2635,7 +2625,7 @@ impl ProviderPickerView {
             let is_selected = idx == self.model_selected_idx;
             let arrow = crate::tui::glyphs::selection_marker(is_selected);
             let label_style = if is_selected {
-                Self::selected_row_style(palette::SELECTION_TEXT)
+                menu_style::selected_row_style_with_fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
@@ -2656,7 +2646,7 @@ impl ProviderPickerView {
                     Span::styled(
                         format!("  ({default_tag})"),
                         if is_selected {
-                            Self::selected_row_style(palette::TEXT_MUTED)
+                            menu_style::selected_row_style_with_fg(palette::TEXT_MUTED)
                         } else {
                             Style::default().fg(palette::TEXT_MUTED)
                         },
@@ -2664,7 +2654,7 @@ impl ProviderPickerView {
                 },
             ]);
             if is_selected {
-                line.style = Self::selected_row_bg_style();
+                line.style = menu_style::selected_row_bg_style();
             }
             lines.push(line);
         }
@@ -2867,14 +2857,14 @@ impl ProviderPickerView {
         let value = self.custom_form_field_value(field);
         let display = if value.is_empty() { placeholder } else { value };
         let value_style = if selected {
-            Self::selected_row_style(palette::SELECTION_TEXT)
+            menu_style::selected_row_style_with_fg(palette::SELECTION_TEXT)
         } else if value.is_empty() {
             Style::default().fg(palette::TEXT_MUTED)
         } else {
             Style::default().fg(palette::TEXT_PRIMARY)
         };
         let label_style = if selected {
-            Self::selected_row_style(palette::WHALE_INFO)
+            menu_style::selected_row_style_with_fg(palette::WHALE_INFO)
         } else {
             Style::default().fg(palette::TEXT_MUTED)
         };
@@ -2891,7 +2881,7 @@ impl ProviderPickerView {
             ),
         ]);
         if selected {
-            line.style = Self::selected_row_bg_style();
+            line.style = menu_style::selected_row_bg_style();
         }
         Paragraph::new(line).render(area, buf);
     }

--- a/crates/tui/src/tui/session_picker.rs
+++ b/crates/tui/src/tui/session_picker.rs
@@ -21,6 +21,7 @@ use crate::session_manager::{
     SavedSession, SessionManager, SessionMetadata, extract_title, extract_user_prompt,
     strip_thinking_tags,
 };
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, action_footer_lines, render_modal_footer, render_panel_scroll_rail,
     render_underwater_surface,
@@ -826,10 +827,7 @@ fn build_list_lines(
         let mut line = format!("{prefix}{}", format_session_line(session, locale));
         line = truncate(&line, width);
         let style = if idx == selected {
-            Style::default()
-                .fg(palette::SELECTION_TEXT)
-                .bg(palette::SELECTION_BG)
-                .add_modifier(Modifier::BOLD)
+            menu_style::selected_row_style()
         } else {
             Style::default().fg(palette::TEXT_PRIMARY)
         };

--- a/crates/tui/src/tui/sound_policy.rs
+++ b/crates/tui/src/tui/sound_policy.rs
@@ -1,0 +1,575 @@
+//! Opt-in, deterministic event-sound policy for TUI notification events
+//! (#4817).
+//!
+//! This is terminal-bell-level only: every cue is one or two BEL (`\x07`)
+//! bytes written to stdout, exactly the bytes the existing
+//! `bell_sound`/`beep_sound` helpers in [`super::notifications`] emit.
+//! The cues are functional signals (a fixed, documented event → byte
+//! mapping), not designed-for-pleasantness audio — there are no audio
+//! assets and no new dependencies. BEL is inert on terminals that ignore
+//! it and on platforms where the byte is a no-op, and the whole policy is
+//! **off by default**, so a platform with no sound support falls back to
+//! doing nothing.
+//!
+//! The decision function is pure with respect to wall-clock time: the
+//! caller supplies `now_ms`, so rate limiting is deterministic and
+//! testable. The runtime clock used by the wiring in
+//! [`super::notifications::notify_done_to`] is
+//! [`std::time::SystemTime`] epoch millis ([`epoch_millis_now`]) — not
+//! strictly monotonic, but fine for rate limiting, and documented here
+//! rather than implied.
+
+use std::io::{self, Write};
+use std::sync::{OnceLock, RwLock};
+
+use super::notification_payload::NotificationKind;
+
+/// The closed set of events that can produce a sound cue. Mirrors
+/// [`NotificationKind`] one-to-one; kept as a separate type so the sound
+/// policy's surface (parsing, allow-lists, docs) is independent of the
+/// notification payload taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SoundEvent {
+    /// An agent turn finished successfully.
+    TurnComplete,
+    /// A sub-agent reached a terminal status.
+    SubagentTerminal,
+    /// A tool call is blocked waiting for approval.
+    ApprovalNeeded,
+    /// The agent is blocked on a user answer.
+    InputNeeded,
+    /// The sandbox denied an operation; the user must elevate.
+    ElevationNeeded,
+    /// The model called the `notify` tool.
+    ModelNotify,
+}
+
+impl SoundEvent {
+    /// Total mapping from the notification taxonomy. Every
+    /// [`NotificationKind`] has exactly one sound event.
+    #[must_use]
+    pub fn from_notification_kind(kind: NotificationKind) -> SoundEvent {
+        match kind {
+            NotificationKind::TurnComplete => SoundEvent::TurnComplete,
+            NotificationKind::SubagentTerminal => SoundEvent::SubagentTerminal,
+            NotificationKind::ApprovalNeeded => SoundEvent::ApprovalNeeded,
+            NotificationKind::InputNeeded => SoundEvent::InputNeeded,
+            NotificationKind::ElevationNeeded => SoundEvent::ElevationNeeded,
+            NotificationKind::ModelNotify => SoundEvent::ModelNotify,
+        }
+    }
+
+    /// Parse the kebab-case config/docs spelling, e.g. `"turn-complete"`. Unknown strings return `None`;
+    /// callers skip them rather than failing.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<SoundEvent> {
+        match s {
+            "turn-complete" => Some(SoundEvent::TurnComplete),
+            "subagent-terminal" => Some(SoundEvent::SubagentTerminal),
+            "approval-needed" => Some(SoundEvent::ApprovalNeeded),
+            "input-needed" => Some(SoundEvent::InputNeeded),
+            "elevation-needed" => Some(SoundEvent::ElevationNeeded),
+            "model-notify" => Some(SoundEvent::ModelNotify),
+            _ => None,
+        }
+    }
+
+    /// Slot index into [`EventSoundPolicy::last_played_ms`].
+    fn index(self) -> usize {
+        match self {
+            SoundEvent::TurnComplete => 0,
+            SoundEvent::SubagentTerminal => 1,
+            SoundEvent::ApprovalNeeded => 2,
+            SoundEvent::InputNeeded => 3,
+            SoundEvent::ElevationNeeded => 4,
+            SoundEvent::ModelNotify => 5,
+        }
+    }
+}
+
+/// Terminal-safe cues. `Bell` and `Beep` emit the same single BEL byte as
+/// the existing `bell_sound`/`beep_sound` helpers; the distinction is
+/// semantic (which event fired), not a different sound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SoundCue {
+    /// One BEL byte (`\x07`).
+    Bell,
+    /// Two BEL bytes (`\x07\x07`).
+    DoubleBell,
+    /// One BEL byte (`\x07`) — the same bytes `beep_sound` writes.
+    Beep,
+}
+
+/// The deterministic event mapping. Fixed table, documented here and in
+/// `docs/CONFIGURATION.md`; changing it is a behavior change, not a tune.
+/// The cues are functional signals, not designed-for-pleasantness audio.
+#[must_use]
+pub fn cue_for(event: SoundEvent) -> SoundCue {
+    match event {
+        SoundEvent::TurnComplete => SoundCue::Bell,
+        SoundEvent::SubagentTerminal => SoundCue::Bell,
+        SoundEvent::ApprovalNeeded => SoundCue::DoubleBell,
+        SoundEvent::InputNeeded => SoundCue::Beep,
+        SoundEvent::ElevationNeeded => SoundCue::DoubleBell,
+        SoundEvent::ModelNotify => SoundCue::Beep,
+    }
+}
+
+/// Why a sound was not played.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuppressReason {
+    /// The policy is disabled (the default — platform-safe no-op).
+    Disabled,
+    /// Quiet mode is on.
+    QuietMode,
+    /// The event is not in the allow-list.
+    NotListed,
+    /// The event fired within `min_interval_ms` of its previous play.
+    RateLimited,
+    /// `turn-complete` is left to the existing `completion_sound` channel
+    /// so the two never double-ding.
+    TurnCompleteHandledByCompletionSound,
+}
+
+/// The outcome of a policy decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SoundDecision {
+    /// Emit this cue.
+    Play(SoundCue),
+    /// Do not emit; this is why.
+    Suppress(SuppressReason),
+}
+
+/// Deterministic, opt-in event-sound policy.
+///
+/// `decide` is pure apart from recording the play timestamp: the caller
+/// supplies `now_ms`, so there is no wall-clock dependency in the rules.
+#[derive(Debug, Clone)]
+pub struct EventSoundPolicy {
+    /// Master switch. Default `false` — nothing is emitted unless the
+    /// user opts in via `[notifications.event_sound]`.
+    pub enabled: bool,
+    /// Allow-list of events that may play.
+    pub events: Vec<SoundEvent>,
+    /// Minimum milliseconds between two plays of the *same* event.
+    pub min_interval_ms: u64,
+    /// Quiet mode: suppress everything without editing the allow-list.
+    pub quiet: bool,
+    /// Whether the separate `[notifications].completion_sound` channel is
+    /// active. When it is, `turn-complete` is suppressed here (see
+    /// [`SuppressReason::TurnCompleteHandledByCompletionSound`]) to avoid
+    /// a double ding. Stored on the policy (rather than passed to
+    /// `decide`) because it is configuration, not per-call state.
+    pub completion_sound_active: bool,
+    /// Last play timestamp (caller-supplied millis) per event slot.
+    last_played_ms: [Option<u64>; 6],
+}
+
+impl Default for EventSoundPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            events: vec![SoundEvent::TurnComplete, SoundEvent::ApprovalNeeded],
+            min_interval_ms: 2000,
+            quiet: false,
+            completion_sound_active: false,
+            last_played_ms: [None; 6],
+        }
+    }
+}
+
+impl EventSoundPolicy {
+    /// Build a policy from `[notifications.event_sound]`. Unknown event
+    /// strings are ignored (`parse` → `None` → skip); this never panics.
+    ///
+    /// This direction (tui consumes config) matches how
+    /// `CompletionSound` is plumbed and keeps `config.rs` free of tui
+    /// imports.
+    #[must_use]
+    pub fn from_config(
+        config: &crate::config::EventSoundConfig,
+        completion_sound_active: bool,
+    ) -> Self {
+        let events = config
+            .events
+            .iter()
+            .filter_map(|s| SoundEvent::parse(s))
+            .collect();
+        Self {
+            enabled: config.enabled,
+            events,
+            min_interval_ms: config.min_interval_ms,
+            quiet: config.quiet,
+            completion_sound_active,
+            last_played_ms: [None; 6],
+        }
+    }
+
+    /// Decide whether `event` plays at `now_ms`. Rules, in order:
+    ///
+    /// 1. `!enabled` → `Suppress(Disabled)`
+    /// 2. `quiet` → `Suppress(QuietMode)`
+    /// 3. event not in the allow-list → `Suppress(NotListed)`
+    /// 4. `turn-complete` while `completion_sound` is active →
+    ///    `Suppress(TurnCompleteHandledByCompletionSound)`
+    /// 5. within `min_interval_ms` of the last play of this event →
+    ///    `Suppress(RateLimited)`
+    /// 6. otherwise record the timestamp and `Play(cue_for(event))`.
+    pub fn decide(&mut self, event: SoundEvent, now_ms: u64) -> SoundDecision {
+        if !self.enabled {
+            return SoundDecision::Suppress(SuppressReason::Disabled);
+        }
+        if self.quiet {
+            return SoundDecision::Suppress(SuppressReason::QuietMode);
+        }
+        if !self.events.contains(&event) {
+            return SoundDecision::Suppress(SuppressReason::NotListed);
+        }
+        if event == SoundEvent::TurnComplete && self.completion_sound_active {
+            return SoundDecision::Suppress(SuppressReason::TurnCompleteHandledByCompletionSound);
+        }
+        let slot = &mut self.last_played_ms[event.index()];
+        if let Some(last) = *slot {
+            if now_ms.saturating_sub(last) < self.min_interval_ms {
+                return SoundDecision::Suppress(SuppressReason::RateLimited);
+            }
+        }
+        *slot = Some(now_ms);
+        SoundDecision::Play(cue_for(event))
+    }
+}
+
+/// Write the cue's bytes. These are exactly the bytes the existing
+/// `bell_sound`/`beep_sound` helpers emit; BEL is inert on terminals and
+/// platforms that ignore it, so this is a platform-safe no-op-safe write
+/// everywhere.
+pub fn emit(cue: SoundCue, out: &mut dyn Write) -> io::Result<()> {
+    let bytes: &[u8] = match cue {
+        SoundCue::Bell => b"\x07",
+        SoundCue::DoubleBell => b"\x07\x07",
+        SoundCue::Beep => b"\x07",
+    };
+    out.write_all(bytes)
+}
+
+/// Epoch millis for the runtime wiring. Not strictly monotonic (NTP can
+/// step it backwards; `saturating_sub` in `decide` makes that harmless),
+/// but fine for rate limiting.
+#[must_use]
+pub fn epoch_millis_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+static POLICY: OnceLock<RwLock<EventSoundPolicy>> = OnceLock::new();
+
+fn policy_cell() -> &'static RwLock<EventSoundPolicy> {
+    POLICY.get_or_init(|| RwLock::new(EventSoundPolicy::default()))
+}
+
+/// Install a policy process-wide. Called at startup from
+/// [`super::notifications::settings`] alongside `set_completion_sound`.
+pub fn configure(policy: EventSoundPolicy) {
+    if let Ok(mut slot) = policy_cell().write() {
+        *slot = policy;
+    }
+}
+
+/// Run the installed policy for one notification event, writing any cue to
+/// `out`. The sink is injected (matching `notify_done_to`) so no test path
+/// can BEL a real terminal. Best-effort: lock poisoning and write errors
+/// are swallowed, matching the no-op-safe style of the notification module.
+pub fn handle_notification_kind_to(kind: NotificationKind, now_ms: u64, out: &mut dyn Write) {
+    let event = SoundEvent::from_notification_kind(kind);
+    let decision = policy_cell()
+        .write()
+        .map(|mut policy| policy.decide(event, now_ms));
+    if let Ok(SoundDecision::Play(cue)) = decision {
+        let _ = emit(cue, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EventSoundConfig;
+
+    fn all_events() -> [SoundEvent; 6] {
+        [
+            SoundEvent::TurnComplete,
+            SoundEvent::SubagentTerminal,
+            SoundEvent::ApprovalNeeded,
+            SoundEvent::InputNeeded,
+            SoundEvent::ElevationNeeded,
+            SoundEvent::ModelNotify,
+        ]
+    }
+
+    fn enabled_policy(events: Vec<SoundEvent>) -> EventSoundPolicy {
+        EventSoundPolicy {
+            enabled: true,
+            events,
+            ..EventSoundPolicy::default()
+        }
+    }
+
+    /// The deterministic mapping, pinned to the documented table.
+    #[test]
+    fn cue_table_is_the_documented_mapping() {
+        assert_eq!(cue_for(SoundEvent::TurnComplete), SoundCue::Bell);
+        assert_eq!(cue_for(SoundEvent::SubagentTerminal), SoundCue::Bell);
+        assert_eq!(cue_for(SoundEvent::ApprovalNeeded), SoundCue::DoubleBell);
+        assert_eq!(cue_for(SoundEvent::InputNeeded), SoundCue::Beep);
+        assert_eq!(cue_for(SoundEvent::ElevationNeeded), SoundCue::DoubleBell);
+        assert_eq!(cue_for(SoundEvent::ModelNotify), SoundCue::Beep);
+    }
+
+    /// The kebab-case spellings are the documented config vocabulary.
+    #[test]
+    fn parse_covers_the_documented_event_names() {
+        let names = [
+            ("turn-complete", SoundEvent::TurnComplete),
+            ("subagent-terminal", SoundEvent::SubagentTerminal),
+            ("approval-needed", SoundEvent::ApprovalNeeded),
+            ("input-needed", SoundEvent::InputNeeded),
+            ("elevation-needed", SoundEvent::ElevationNeeded),
+            ("model-notify", SoundEvent::ModelNotify),
+        ];
+        assert_eq!(
+            names.iter().map(|(_, event)| *event).collect::<Vec<_>>(),
+            all_events(),
+            "the documented names must cover every event"
+        );
+        for (name, event) in names {
+            assert_eq!(SoundEvent::parse(name), Some(event));
+        }
+        assert_eq!(SoundEvent::parse("not-an-event"), None);
+        assert_eq!(SoundEvent::parse(""), None);
+    }
+
+    /// The mapping from the notification taxonomy is total: all six
+    /// kinds map, and the match in `from_notification_kind` stops
+    /// compiling if a kind is added without a mapping.
+    #[test]
+    fn from_notification_kind_is_total() {
+        let kinds = [
+            NotificationKind::TurnComplete,
+            NotificationKind::SubagentTerminal,
+            NotificationKind::ApprovalNeeded,
+            NotificationKind::InputNeeded,
+            NotificationKind::ElevationNeeded,
+            NotificationKind::ModelNotify,
+        ];
+        let events: Vec<SoundEvent> = kinds
+            .into_iter()
+            .map(SoundEvent::from_notification_kind)
+            .collect();
+        assert_eq!(events, all_events());
+    }
+
+    /// Platform-safe no-op fallback: a fresh default policy is disabled,
+    /// so every event is suppressed and nothing is ever emitted.
+    #[test]
+    fn default_policy_suppresses_everything_as_disabled() {
+        let mut policy = EventSoundPolicy::default();
+        assert!(!policy.enabled);
+        for event in all_events() {
+            assert_eq!(
+                policy.decide(event, 0),
+                SoundDecision::Suppress(SuppressReason::Disabled)
+            );
+            assert_eq!(
+                policy.decide(event, 10_000),
+                SoundDecision::Suppress(SuppressReason::Disabled)
+            );
+        }
+    }
+
+    #[test]
+    fn quiet_mode_suppresses_everything() {
+        let mut policy = EventSoundPolicy {
+            quiet: true,
+            ..enabled_policy(all_events().to_vec())
+        };
+        for event in all_events() {
+            assert_eq!(
+                policy.decide(event, 0),
+                SoundDecision::Suppress(SuppressReason::QuietMode)
+            );
+        }
+    }
+
+    #[test]
+    fn unlisted_event_is_suppressed_as_not_listed() {
+        let mut policy = enabled_policy(vec![SoundEvent::TurnComplete]);
+        for event in all_events() {
+            let expected = if event == SoundEvent::TurnComplete {
+                SoundDecision::Play(SoundCue::Bell)
+            } else {
+                SoundDecision::Suppress(SuppressReason::NotListed)
+            };
+            assert_eq!(policy.decide(event, 0), expected, "{event:?}");
+        }
+    }
+
+    /// Rate-limit property, exercised over several event kinds and
+    /// timestamp sequences with a caller-supplied clock: within
+    /// `min_interval_ms` of a play the same event is rate-limited; at
+    /// exactly `min_interval_ms` it plays again.
+    #[test]
+    fn rate_limit_allows_play_only_after_min_interval() {
+        for event in all_events() {
+            for start in [0u64, 1_000, 123_456] {
+                let mut policy = enabled_policy(vec![event]);
+                let cue = cue_for(event);
+                assert_eq!(policy.decide(event, start), SoundDecision::Play(cue));
+                for t in [start + 500, start + 1999] {
+                    assert_eq!(
+                        policy.decide(event, t),
+                        SoundDecision::Suppress(SuppressReason::RateLimited),
+                        "{event:?} at t={t} (start={start})"
+                    );
+                }
+                assert_eq!(
+                    policy.decide(event, start + 2000),
+                    SoundDecision::Play(cue),
+                    "{event:?} at min_interval boundary"
+                );
+            }
+        }
+    }
+
+    /// Rate limiting is per-event: playing one event does not throttle
+    /// another.
+    #[test]
+    fn rate_limit_is_per_event() {
+        let mut policy = enabled_policy(all_events().to_vec());
+        assert_eq!(
+            policy.decide(SoundEvent::ApprovalNeeded, 0),
+            SoundDecision::Play(SoundCue::DoubleBell)
+        );
+        assert_eq!(
+            policy.decide(SoundEvent::InputNeeded, 1),
+            SoundDecision::Play(SoundCue::Beep)
+        );
+    }
+
+    /// A backwards clock step (NTP) must not panic or double-play.
+    #[test]
+    fn backwards_clock_is_treated_as_rate_limited() {
+        let mut policy = enabled_policy(vec![SoundEvent::ApprovalNeeded]);
+        assert_eq!(
+            policy.decide(SoundEvent::ApprovalNeeded, 5_000),
+            SoundDecision::Play(SoundCue::DoubleBell)
+        );
+        assert_eq!(
+            policy.decide(SoundEvent::ApprovalNeeded, 1_000),
+            SoundDecision::Suppress(SuppressReason::RateLimited)
+        );
+    }
+
+    /// No double-ding with the existing `completion_sound` channel.
+    #[test]
+    fn turn_complete_defers_to_active_completion_sound() {
+        let mut active = EventSoundPolicy {
+            completion_sound_active: true,
+            ..enabled_policy(vec![SoundEvent::TurnComplete])
+        };
+        assert_eq!(
+            active.decide(SoundEvent::TurnComplete, 0),
+            SoundDecision::Suppress(SuppressReason::TurnCompleteHandledByCompletionSound)
+        );
+
+        let mut inactive = enabled_policy(vec![SoundEvent::TurnComplete]);
+        assert_eq!(
+            inactive.decide(SoundEvent::TurnComplete, 0),
+            SoundDecision::Play(SoundCue::Bell)
+        );
+    }
+
+    /// Exact emitted bytes, following the `capture()` byte-assertion
+    /// pattern in `notifications.rs`.
+    #[test]
+    fn emit_writes_exact_bel_bytes() {
+        let mut buf = Vec::new();
+        emit(SoundCue::Bell, &mut buf).unwrap();
+        assert_eq!(buf, b"\x07");
+
+        let mut buf = Vec::new();
+        emit(SoundCue::DoubleBell, &mut buf).unwrap();
+        assert_eq!(buf, b"\x07\x07");
+
+        let mut buf = Vec::new();
+        emit(SoundCue::Beep, &mut buf).unwrap();
+        assert_eq!(buf, b"\x07");
+    }
+
+    #[test]
+    fn from_config_ignores_unknown_events_and_parses_kebab_case() {
+        let config = EventSoundConfig {
+            enabled: true,
+            events: vec![
+                "turn-complete".to_string(),
+                "bogus".to_string(),
+                "ApprovalNeeded".to_string(),
+                "approval-needed".to_string(),
+            ],
+            min_interval_ms: 500,
+            quiet: false,
+        };
+        let policy = EventSoundPolicy::from_config(&config, true);
+        assert!(policy.enabled);
+        assert_eq!(
+            policy.events,
+            vec![SoundEvent::TurnComplete, SoundEvent::ApprovalNeeded]
+        );
+        assert_eq!(policy.min_interval_ms, 500);
+        assert!(!policy.quiet);
+        assert!(policy.completion_sound_active);
+    }
+
+    /// The installed policy is process-global (`POLICY` is a `OnceLock`), so
+    /// any test that touches it must serialize on the crate's test-env lock
+    /// and put the default back before releasing it. The cue goes to an
+    /// injected sink, never the real stdout.
+    #[test]
+    fn installed_policy_drives_the_global_handler() {
+        let _lock = crate::test_support::lock_test_env();
+        configure(enabled_policy(vec![SoundEvent::ApprovalNeeded]));
+
+        let mut out = Vec::new();
+        handle_notification_kind_to(NotificationKind::ApprovalNeeded, 0, &mut out);
+        assert_eq!(out, b"\x07\x07", "the installed allow-list plays");
+
+        let mut out = Vec::new();
+        handle_notification_kind_to(NotificationKind::ApprovalNeeded, 1, &mut out);
+        assert!(
+            out.is_empty(),
+            "the rate limit carries across handler calls"
+        );
+
+        let mut out = Vec::new();
+        handle_notification_kind_to(NotificationKind::InputNeeded, 0, &mut out);
+        assert!(out.is_empty(), "an unlisted event stays silent");
+
+        // Restore the default so no later test inherits an enabled policy.
+        configure(EventSoundPolicy::default());
+        let mut out = Vec::new();
+        handle_notification_kind_to(NotificationKind::ApprovalNeeded, 100_000, &mut out);
+        assert!(out.is_empty(), "the default policy is disabled");
+    }
+
+    #[test]
+    fn from_config_matches_config_defaults() {
+        let policy = EventSoundPolicy::from_config(&EventSoundConfig::default(), false);
+        assert!(!policy.enabled);
+        assert_eq!(
+            policy.events,
+            vec![SoundEvent::TurnComplete, SoundEvent::ApprovalNeeded]
+        );
+        assert_eq!(policy.min_interval_ms, 2000);
+        assert!(!policy.quiet);
+    }
+}

--- a/crates/tui/src/tui/theme_picker.rs
+++ b/crates/tui/src/tui/theme_picker.rs
@@ -26,6 +26,7 @@ use ratatui::{
 
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette::{SELECTABLE_THEMES, ThemeId, UiTheme};
+use crate::tui::menu_style;
 use crate::tui::settings_picker::{
     PickerNavResult, SettingAvailability, SettingOption, SettingValues, SettingsPickerController,
     SettingsPickerLayout, handle_nav_key,
@@ -344,10 +345,7 @@ impl ModalView for ThemePickerView {
                 .unwrap_or(ThemeId::System);
             let is_selected = visible_idx == selected_visible;
             let row_style = if is_selected {
-                Style::default()
-                    .fg(live.text_body)
-                    .bg(live.selection_bg)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::theme_selected_row_style(&live)
             } else {
                 Style::default().fg(live.text_body)
             };

--- a/crates/tui/src/tui/ui.rs
+++ b/crates/tui/src/tui/ui.rs
@@ -12873,6 +12873,11 @@ fn render_classic_header(area: Rect, buf: &mut Buffer, app: &App) {
 fn render(f: &mut Frame, app: &mut App, config: &Config) {
     let size = f.area();
     let classic_shell = app.ocean_treatment.is_classic();
+    // Keep the view stack's focus-context texture prototype (#4823) in step
+    // with the parsed setting each frame: a plain enum/theme copy, no
+    // allocation. `Off` leaves the render byte-identical to before.
+    app.view_stack
+        .set_focus_texture(app.focus_texture, app.ui_theme);
     app.sidebar_hover = crate::tui::app::SidebarHoverState::default();
     app.viewport.last_approval_area = None;
     // Keep the OSC-0 whale title truthful to the current shell phase so

--- a/crates/tui/src/tui/ui/tests.rs
+++ b/crates/tui/src/tui/ui/tests.rs
@@ -17848,6 +17848,7 @@ fn notification_settings_tui_always_keeps_configured_method_no_threshold() {
             sound_file: None,
             include_summary: true,
             subagent_completion: crate::config::SubagentCompletionNotification::default(),
+            event_sound: crate::config::EventSoundConfig::default(),
         }),
         ..Config::default()
     };
@@ -17882,6 +17883,7 @@ fn notification_settings_no_tui_override_uses_notifications_block() {
             sound_file: None,
             include_summary: false,
             subagent_completion: crate::config::SubagentCompletionNotification::default(),
+            event_sound: crate::config::EventSoundConfig::default(),
         }),
         ..Config::default()
     };

--- a/crates/tui/src/tui/user_input.rs
+++ b/crates/tui/src/tui/user_input.rs
@@ -9,6 +9,7 @@ use crate::palette;
 use crate::tools::user_input::{
     UserInputAnswer, UserInputQuestion, UserInputRequest, UserInputResponse,
 };
+use crate::tui::menu_style;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent, render_modal_surface};
 
 fn modal_block(title: &str) -> Block<'static> {
@@ -36,10 +37,7 @@ fn push_option_lines(
     ticked: bool,
 ) {
     let row_style = if selected {
-        Style::default()
-            .fg(palette::SELECTION_TEXT)
-            .bg(palette::SELECTION_BG)
-            .bold()
+        menu_style::selected_row_style()
     } else {
         Style::default().fg(palette::TEXT_PRIMARY)
     };

--- a/crates/tui/src/tui/views/fleet_roster.rs
+++ b/crates/tui/src/tui/views/fleet_roster.rs
@@ -30,6 +30,7 @@ use crate::fleet::worker_runtime::roster_member_agent_type;
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::app::App;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, render_modal_footer,
     truncate_view_text,
@@ -329,10 +330,7 @@ impl FleetRosterView {
                 )
             };
             let style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else {
                 base_style
             };

--- a/crates/tui/src/tui/views/fleet_setup.rs
+++ b/crates/tui/src/tui/views/fleet_setup.rs
@@ -30,6 +30,7 @@ use crate::fleet::profile::FleetProfileScope;
 use crate::localization::{MessageId, tr};
 use crate::palette;
 use crate::tui::app::App;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
     render_modal_footer_with_gutter, render_modal_surface, truncate_view_text,
@@ -1351,10 +1352,7 @@ fn render_choice_step(
         let is_selected = idx == selected;
         let pointer = format!("{} ", crate::tui::glyphs::selection_marker(is_selected));
         let style = if is_selected {
-            Style::default()
-                .fg(palette::SELECTION_TEXT)
-                .bg(palette::SELECTION_BG)
-                .add_modifier(Modifier::BOLD)
+            menu_style::selected_row_style()
         } else {
             Style::default().fg(palette::TEXT_PRIMARY)
         };

--- a/crates/tui/src/tui/views/help.rs
+++ b/crates/tui/src/tui/views/help.rs
@@ -33,6 +33,7 @@ use crate::commands;
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
 use crate::tui::keybindings::KEYBINDINGS;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, render_modal_footer, render_panel_scroll_rail,
     render_underwater_surface,
@@ -620,10 +621,7 @@ impl ModalView for HelpView {
                         let entry = &self.entries[entry_idx];
                         let is_selected = slot == self.selected;
                         let style = if is_selected {
-                            Style::default()
-                                .fg(palette::SELECTION_TEXT)
-                                .bg(palette::SELECTION_BG)
-                                .add_modifier(Modifier::BOLD)
+                            menu_style::selected_row_style()
                         } else {
                             Style::default().fg(palette::TEXT_PRIMARY)
                         };

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -24,6 +24,7 @@ use crate::tools::subagent::{
 };
 use crate::tui::app::App;
 use crate::tui::approval::{ElevationOption, ReviewDecision};
+use crate::tui::focus_texture::FocusTextureMode;
 use crate::tui::history::{HistoryCell, SubAgentCell, summarize_tool_output};
 use crate::tui::menu_style;
 use crate::tui::widgets::agent_card::AgentLifecycle;
@@ -1002,11 +1003,29 @@ pub trait ModalView: std::any::Any {
 #[derive(Default)]
 pub struct ViewStack {
     views: Vec<Box<dyn ModalView>>,
+    /// Focus-context texture prototype mode (#4823). `Off` by default, which
+    /// keeps the render output byte-identical to the pre-prototype path.
+    focus_texture: FocusTextureMode,
+    /// Theme snapshot for the texture pass, set alongside the mode each
+    /// frame. `None` (e.g. tests that never opt in) disables the texture.
+    focus_texture_theme: Option<crate::palette::UiTheme>,
 }
 
 impl ViewStack {
     pub fn new() -> Self {
-        Self { views: Vec::new() }
+        Self {
+            views: Vec::new(),
+            focus_texture: FocusTextureMode::Off,
+            focus_texture_theme: None,
+        }
+    }
+
+    /// Set the focus-context texture mode and theme for subsequent renders
+    /// (#4823 prototype). Called once per frame from the UI render path with
+    /// the parsed setting; a plain enum/theme copy, no allocation.
+    pub fn set_focus_texture(&mut self, mode: FocusTextureMode, theme: crate::palette::UiTheme) {
+        self.focus_texture = mode;
+        self.focus_texture_theme = Some(theme);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1060,6 +1079,26 @@ impl ViewStack {
     }
 
     pub fn render(&self, area: Rect, buf: &mut Buffer) {
+        // Focus-context texture prototype (#4823): runs over the already
+        // rendered background BEFORE any backdrop or view paint, so the
+        // focused modal is painted afterwards at full strength and the
+        // texture can never overwrite it. `Off` (the default) leaves the
+        // buffer untouched, keeping output byte-identical to the
+        // pre-prototype path.
+        if self.focus_texture != FocusTextureMode::Off {
+            if let (Some(focus), Some(theme)) =
+                (self.top_occupied_region(area), self.focus_texture_theme)
+            {
+                crate::tui::focus_texture::apply_focus_texture(
+                    area,
+                    buf,
+                    focus,
+                    &theme,
+                    self.focus_texture,
+                    crate::tui::color_compat::ascii_safe_enabled(),
+                );
+            }
+        }
         // Dim each view's own occupied region rather than the whole frame, so
         // an inline modal (the approval prompt) leaves the transcript above it
         // visible instead of blacking out the screen. Full-screen modals keep
@@ -1597,6 +1636,13 @@ impl ConfigView {
                 section: ConfigSection::Display,
                 key: "ocean_treatment".to_string(),
                 value: settings.ocean_treatment.clone(),
+                editable: true,
+                scope: ConfigScope::Saved,
+            },
+            ConfigRow {
+                section: ConfigSection::Display,
+                key: "focus_texture".to_string(),
+                value: settings.focus_texture.clone(),
                 editable: true,
                 scope: ConfigScope::Saved,
             },
@@ -2925,6 +2971,7 @@ fn config_choice_values(key: &str, provider: ApiProvider) -> Option<Vec<String>>
             vec!["default", "auto", "off", "low", "medium", "high", "max"]
         }
         "ocean_treatment" => vec!["ombre", "flat"],
+        "focus_texture" => vec!["off", "scrim", "grain"],
         "work_surface_placement" => vec!["top", "left", "right"],
         "status_indicator" => vec!["cw", "whale", "dots", "off"],
         "synchronized_output" => vec!["auto", "on", "off"],
@@ -4335,12 +4382,13 @@ fn fit_config_column(text: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ActionHint, ConfigListItem, ConfigScope, ConfigTab, ConfigView, EmptyState, HelpView,
-        ListDetailLayout, ModalKind, ModalView, SettingKind, SettingsRegistry, ViewAction,
-        ViewEvent, ViewStack, action_footer_lines, canonical_config_choice, centered_modal_area,
-        config_choice_detail, config_choice_label, config_choice_values, config_label_for_key,
-        config_label_for_key_for_locale, render_modal_footer_with_gutter,
-        render_underwater_surface, subagent_view_agents, truncate_view_text,
+        ActionHint, ConfigListItem, ConfigScope, ConfigTab, ConfigView, EmptyState,
+        FocusTextureMode, HelpView, ListDetailLayout, ModalKind, ModalView, SettingKind,
+        SettingsRegistry, ViewAction, ViewEvent, ViewStack, action_footer_lines,
+        canonical_config_choice, centered_modal_area, config_choice_detail, config_choice_label,
+        config_choice_values, config_label_for_key, config_label_for_key_for_locale,
+        render_modal_footer_with_gutter, render_underwater_surface, subagent_view_agents,
+        truncate_view_text,
     };
     use crate::config::Config;
     use crate::localization::{Locale, MessageId, tr};
@@ -4444,6 +4492,142 @@ mod tests {
             || SubAgentsView::new(Vec::new()),
             &["close", "refresh", "setup"],
         );
+    }
+
+    /// Focus-texture prototype (#4823): with a mode forced on, a real
+    /// full-screen modal must render exactly as before — the texture pass
+    /// no-ops because the focus region covers (nearly) the whole frame.
+    /// The default `Off` case is pinned by the existing
+    /// `*_modal_is_usable_and_opaque_at_blocker_sizes` tests above: they run
+    /// unmodified because `ViewStack::new()` defaults to `Off`, which leaves
+    /// the buffer byte-identical to the pre-prototype render.
+    #[test]
+    fn focus_texture_modes_keep_fullscreen_modal_usable_and_opaque() {
+        let _lock = crate::test_support::lock_test_env();
+        let theme = crate::palette::ThemeId::Whale.ui_theme();
+        for mode in [FocusTextureMode::Scrim, FocusTextureMode::Grain] {
+            for (w, h) in BLOCKER_SIZES {
+                let area = Rect::new(0, 0, w, h);
+                let mut buf = Buffer::empty(area);
+                let sentinel_style = Style::default().fg(Color::Magenta).bg(Color::Green);
+                for y in 0..h {
+                    for x in 0..w {
+                        buf[(x, y)].set_symbol("X").set_style(sentinel_style);
+                    }
+                }
+                let mut stack = ViewStack::new();
+                stack.push(create_config_view(Locale::En));
+                stack.set_focus_texture(mode, theme);
+                stack.render(area, &mut buf);
+
+                let rows: Vec<String> = (0..h)
+                    .map(|y| {
+                        (0..w)
+                            .map(|x| buf[(x, y)].symbol().to_string())
+                            .collect::<String>()
+                    })
+                    .collect();
+                let text = rows.join("\n");
+
+                assert!(
+                    text.contains("Search"),
+                    "{mode:?} {w}x{h}: missing 'Search'"
+                );
+                let unpainted = (0..h).find_map(|y| {
+                    (0..w).find_map(|x| {
+                        let cell = &buf[(x, y)];
+                        (cell.symbol() == "X"
+                            && cell.fg == Color::Magenta
+                            && cell.bg == Color::Green)
+                            .then_some((x, y))
+                    })
+                });
+                assert!(
+                    unpainted.is_none(),
+                    "{mode:?} {w}x{h}: background bleed-through at {unpainted:?}"
+                );
+                assert_eq!(
+                    buf[(w / 2, h / 2)].bg,
+                    palette::WHALE_BG,
+                    "{mode:?} {w}x{h}: modal interior must be opaque"
+                );
+            }
+        }
+    }
+
+    /// The texture actually engages outside an *inline* modal's band: the
+    /// approval prompt only occupies a bottom strip, so the sentinel field
+    /// above it goes through the scrim/grain pass. The modal is painted
+    /// after the texture, so its band stays fully opaque and its labels
+    /// survive at every blocker size.
+    #[test]
+    fn focus_texture_modes_keep_inline_modal_usable() {
+        let theme = crate::palette::ThemeId::Whale.ui_theme();
+        for mode in [FocusTextureMode::Scrim, FocusTextureMode::Grain] {
+            for (w, h) in BLOCKER_SIZES {
+                let area = Rect::new(0, 0, w, h);
+                let mut buf = Buffer::empty(area);
+                let sentinel_style = Style::default().fg(Color::Magenta).bg(Color::Green);
+                for y in 0..h {
+                    for x in 0..w {
+                        buf[(x, y)].set_symbol("X").set_style(sentinel_style);
+                    }
+                }
+                let request = crate::tui::approval::ApprovalRequest::new(
+                    "test-id",
+                    "read_file",
+                    "Read a file from disk",
+                    &serde_json::json!({"path": "src/main.rs"}),
+                    "tool:read_file",
+                );
+                let mut stack = ViewStack::new();
+                stack.push(crate::tui::approval::ApprovalView::new(request));
+                stack.set_focus_texture(mode, theme);
+                let focus = stack
+                    .top_occupied_region(area)
+                    .expect("approval view on the stack");
+                stack.render(area, &mut buf);
+
+                let rows: Vec<String> = (0..h)
+                    .map(|y| {
+                        (0..w)
+                            .map(|x| buf[(x, y)].symbol().to_string())
+                            .collect::<String>()
+                    })
+                    .collect();
+                let text = rows.join("\n");
+
+                assert!(
+                    text.contains("Do you want to proceed?") && text.contains("read_file"),
+                    "{mode:?} {w}x{h}: approval prompt must survive the texture"
+                );
+                // Zero sentinel bleed INSIDE the focused band: the backdrop
+                // and the modal own every cell there. Outside the band the
+                // texture intentionally leaves the sentinel glyphs in place
+                // (Scrim only re-colors; Grain never overwrites text).
+                let mut whale_bg_cells = 0_u32;
+                for y in focus.top()..focus.bottom() {
+                    for x in focus.left()..focus.right() {
+                        let cell = &buf[(x, y)];
+                        assert!(
+                            !(cell.symbol() == "X"
+                                && cell.fg == Color::Magenta
+                                && cell.bg == Color::Green),
+                            "{mode:?} {w}x{h}: sentinel bleed inside focus at ({x},{y})"
+                        );
+                        if cell.bg == palette::WHALE_BG {
+                            whale_bg_cells += 1;
+                        }
+                    }
+                }
+                // The band keeps the opaque modal ink. (Not every cell: the
+                // selected option row carries its own highlight background.)
+                assert!(
+                    whale_bg_cells > 0,
+                    "{mode:?} {w}x{h}: modal band lost its opaque WHALE_BG surface"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tui/src/tui/views/mod.rs
+++ b/crates/tui/src/tui/views/mod.rs
@@ -25,6 +25,7 @@ use crate::tools::subagent::{
 use crate::tui::app::App;
 use crate::tui::approval::{ElevationOption, ReviewDecision};
 use crate::tui::history::{HistoryCell, SubAgentCell, summarize_tool_output};
+use crate::tui::menu_style;
 use crate::tui::widgets::agent_card::AgentLifecycle;
 
 pub mod fleet_roster;
@@ -3437,10 +3438,7 @@ impl ModalView for ConfigView {
                         truncate_view_text(&label, usize::from(inner.width).saturating_sub(8))
                     ));
                     line.style = if selected {
-                        Style::default()
-                            .fg(palette::SELECTION_TEXT)
-                            .bg(palette::SELECTION_BG)
-                            .bold()
+                        menu_style::selected_row_style()
                     } else {
                         Style::default().fg(palette::TEXT_PRIMARY)
                     };
@@ -3625,10 +3623,7 @@ impl ModalView for ConfigView {
                         row_hitboxes.push((line_y, *idx));
                         let selected = *idx == self.selected;
                         let style = if selected {
-                            Style::default()
-                                .fg(palette::SELECTION_TEXT)
-                                .bg(palette::SELECTION_BG)
-                                .add_modifier(ratatui::style::Modifier::BOLD)
+                            menu_style::selected_row_style()
                         } else {
                             Style::default().fg(palette::TEXT_PRIMARY)
                         };
@@ -3660,7 +3655,7 @@ impl ModalView for ConfigView {
                             ),
                         ]);
                         if selected {
-                            line.style = line.style.bg(palette::SELECTION_BG);
+                            line.style = menu_style::selected_row_bg_style();
                         }
                         lines.push(line);
                     }

--- a/crates/tui/src/tui/views/mode_picker.rs
+++ b/crates/tui/src/tui/views/mode_picker.rs
@@ -15,6 +15,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::localization::Locale;
 use crate::palette;
 use crate::tui::app::AppMode;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
     render_modal_footer, render_modal_surface,
@@ -160,17 +161,12 @@ impl ModalView for ModePickerView {
         for (idx, mode) in VISIBLE_MODES.iter().copied().enumerate() {
             let is_cursor = idx == self.cursor;
             let row_style = if is_cursor {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };
             let hint_style = if is_cursor {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_MUTED)
             };

--- a/crates/tui/src/tui/views/skills_manager.rs
+++ b/crates/tui/src/tui/views/skills_manager.rs
@@ -25,6 +25,7 @@ use crate::skills::audit::{
 use crate::skills::mutation::{ConflictPolicy, SkillMutationRequest, SkillTargetScope};
 use crate::skills::roots::SkillRootKind;
 use crate::tui::app::App;
+use crate::tui::menu_style;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ManagerMode {
@@ -381,10 +382,7 @@ impl SkillsManagerView {
             }
             let selected = idx == self.selected;
             let style = if selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else {
                 Style::default().fg(palette::TEXT_PRIMARY)
             };

--- a/crates/tui/src/tui/views/status_picker.rs
+++ b/crates/tui/src/tui/views/status_picker.rs
@@ -21,6 +21,7 @@ use ratatui::{
 use crate::config::{ApiProvider, StatusItem};
 use crate::localization::{Locale, MessageId, tr};
 use crate::palette;
+use crate::tui::menu_style;
 use crate::tui::views::{
     ActionHint, ModalKind, ModalView, ViewAction, ViewEvent, centered_modal_area,
     render_modal_footer, render_modal_surface,
@@ -230,29 +231,21 @@ impl ModalView for StatusPickerView {
             let mark = if checked { "[✓]" } else { "[ ]" };
 
             let row_style = if is_cursor {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD)
+                menu_style::selected_row_style()
             } else if checked {
                 Style::default().fg(palette::TEXT_PRIMARY)
             } else {
                 Style::default().fg(palette::TEXT_MUTED)
             };
             let hint_style = if is_cursor {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
             } else {
                 Style::default().fg(palette::TEXT_DIM)
             };
             let pointer = crate::tui::glyphs::selection_marker(is_cursor);
 
             if is_cursor {
-                let selected_style = Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
-                    .add_modifier(Modifier::BOLD);
+                let selected_style = menu_style::selected_row_style();
                 let line = status_row_text(pointer, mark, item, content.width as usize);
                 lines.push(Line::from(Span::styled(line, selected_style)));
             } else {

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -36,6 +36,7 @@ use crate::tui::approval::{
     ToolCategory,
 };
 use crate::tui::history::{GenericToolCell, HistoryCell, ToolCell, ToolRun, ToolStatus};
+use crate::tui::menu_style;
 use crate::tui::scrolling::TranscriptLineMeta;
 use crate::tui::ui_text::{grapheme_display_width, text_display_width};
 use crate::tui::underwater::ShellPhase;
@@ -1414,9 +1415,7 @@ impl Renderable for ComposerWidget<'_> {
                 {
                     let is_selected = idx == selected;
                     let style = if is_selected {
-                        Style::default()
-                            .fg(palette::SELECTION_TEXT)
-                            .bg(palette::SELECTION_BG)
+                        menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
                     } else {
                         Style::default().fg(palette::TEXT_MUTED)
                     };
@@ -1464,9 +1463,7 @@ impl Renderable for ComposerWidget<'_> {
             {
                 let is_selected = idx == selected;
                 let style = if is_selected {
-                    Style::default()
-                        .fg(palette::SELECTION_TEXT)
-                        .bg(palette::SELECTION_BG)
+                    menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
                 } else {
                     Style::default().fg(palette::TEXT_MUTED)
                 };
@@ -1531,9 +1528,7 @@ impl Renderable for ComposerWidget<'_> {
             {
                 let is_selected = idx == selected;
                 let sel_style = if is_selected {
-                    Style::default()
-                        .fg(palette::SELECTION_TEXT)
-                        .bg(palette::SELECTION_BG)
+                    menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
                 } else {
                     Style::default().fg(palette::TEXT_MUTED)
                 };
@@ -1548,9 +1543,7 @@ impl Renderable for ComposerWidget<'_> {
 
                 // Description column (muted when not selected, secondary when selected)
                 let desc_style = if is_selected {
-                    Style::default()
-                        .fg(palette::SELECTION_TEXT)
-                        .bg(palette::SELECTION_BG)
+                    menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
                 } else {
                     Style::default().fg(palette::TEXT_DIM)
                 };
@@ -2329,10 +2322,7 @@ fn repo_law_approval_palette() -> ApprovalColors {
 }
 
 fn approval_selected_style() -> Style {
-    Style::default()
-        .fg(palette::SELECTION_TEXT)
-        .bg(palette::SELECTION_BG)
-        .add_modifier(Modifier::BOLD)
+    menu_style::selected_row_style()
 }
 
 fn approval_option_style(is_selected: bool, color: Color) -> Style {
@@ -2928,9 +2918,7 @@ impl Renderable for ElevationWidget<'_> {
         for (i, option) in self.request.options.iter().enumerate() {
             let is_selected = i == self.selected;
             let style = if is_selected {
-                Style::default()
-                    .fg(palette::SELECTION_TEXT)
-                    .bg(palette::SELECTION_BG)
+                menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
             } else {
                 Style::default()
             };

--- a/crates/tui/src/tui/widgets/mod.rs
+++ b/crates/tui/src/tui/widgets/mod.rs
@@ -850,7 +850,10 @@ impl ChatWidget {
                 anchor_x: area.x.saturating_add(area.width / 2),
                 anchor_y: area.y.saturating_add(area.height.saturating_mul(2) / 3),
             };
-            crate::tui::ambient_life::render_ambient_life(
+            // Per-frame budget counters (built/painted/skipped/clipped);
+            // consumed by ambient-life tests and debug tooling, not by the
+            // widget itself.
+            let _ambient_stats = crate::tui::ambient_life::render_ambient_life(
                 area,
                 buf,
                 inks,

--- a/crates/tui/src/tui/widgets/pending_input_preview.rs
+++ b/crates/tui/src/tui/widgets/pending_input_preview.rs
@@ -19,6 +19,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 
 use crate::palette;
+use crate::tui::menu_style;
 use crate::tui::widgets::Renderable;
 
 /// Per-item line cap before we collapse the rest into a `…` overflow row.
@@ -257,19 +258,14 @@ fn push_section_header(lines: &mut Vec<Line<'static>>, header: Line<'static>) {
 
 fn push_context_item(lines: &mut Vec<Line<'static>>, item: &ContextPreviewItem, width: u16) {
     let status_style = if item.selected {
-        Style::default()
-            .fg(palette::SELECTION_TEXT)
-            .bg(palette::SELECTION_BG)
-            .add_modifier(Modifier::BOLD)
+        menu_style::selected_row_style()
     } else if item.included {
         Style::default().fg(palette::TEXT_MUTED)
     } else {
         Style::default().fg(palette::STATUS_WARNING)
     };
     let label_style = if item.selected {
-        Style::default()
-            .fg(palette::SELECTION_TEXT)
-            .bg(palette::SELECTION_BG)
+        menu_style::selected_row_bg_style().fg(palette::SELECTION_TEXT)
     } else if item.included {
         Style::default().fg(palette::TEXT_PRIMARY)
     } else {

--- a/crates/tui/src/tui/work_surface/mod.rs
+++ b/crates/tui/src/tui/work_surface/mod.rs
@@ -975,7 +975,7 @@ mod tests {
             .iter()
             .find(|row| row.selectable)
             .expect("operation row");
-        assert_eq!(row.mark, "!");
+        assert_eq!(row.mark, crate::tui::glyphs::ATTENTION);
         assert!(row.detail.contains("completed · evidence pending"));
         assert_ne!(row.mark, "✓");
         let Some(SidebarRowAction::InspectWork { body, .. }) = row.primary_action.as_ref() else {

--- a/crates/tui/src/tui/work_surface/model.rs
+++ b/crates/tui/src/tui/work_surface/model.rs
@@ -12,6 +12,7 @@ use crate::tui::app::{AgentCurrentActivityStatus, App, SidebarRowAction};
 use crate::tui::history::{
     FileActivityKind, FileActivitySummary, FileMutationReceipt, HistoryCell, ToolCell,
 };
+use crate::tui::menu_style::{StatusKind, status_mark};
 use crate::work_graph::{
     AcceptanceRequirement, EdgeKind, EvidenceKind, EvidenceKindTag, NodeKind, NodeState,
     OperationBinding, OwnerState, Provenance, WorkGraphSnapshot, WorkNode,
@@ -1308,12 +1309,18 @@ fn graph_node_row(snapshot: &WorkGraphSnapshot, node: &WorkNode) -> WorkRow {
         NodeState::Initializing => (crate::tui::glyphs::SELECTION, WorkTone::Live),
         NodeState::Active => (crate::tui::glyphs::SELECTION, WorkTone::Live),
         NodeState::Waiting => (crate::tui::glyphs::ATTENTION, WorkTone::Attention),
-        NodeState::Blocked => ("!", WorkTone::Attention),
+        NodeState::Blocked => (
+            status_mark(StatusKind::Attention).glyph,
+            WorkTone::Attention,
+        ),
         NodeState::Completed if node.acceptance.is_empty() => {
-            (crate::tui::glyphs::DONE, WorkTone::Success)
+            (status_mark(StatusKind::Done).glyph, WorkTone::Success)
         }
-        NodeState::Completed => ("!", WorkTone::Attention),
-        NodeState::Verified => (crate::tui::glyphs::DONE, WorkTone::Success),
+        NodeState::Completed => (
+            status_mark(StatusKind::Attention).glyph,
+            WorkTone::Attention,
+        ),
+        NodeState::Verified => (status_mark(StatusKind::Done).glyph, WorkTone::Success),
         NodeState::Stale => ("?", WorkTone::Attention),
         NodeState::Superseded | NodeState::Cancelled => ("−", WorkTone::Muted),
         NodeState::Failed => (crate::tui::glyphs::FAILED, WorkTone::Attention),

--- a/crates/tui/src/tui/worktree_manager.rs
+++ b/crates/tui/src/tui/worktree_manager.rs
@@ -19,6 +19,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::palette;
 use crate::tui::git_status::{self, GitStatusSnapshot, WorktreeEntry};
+use crate::tui::menu_style;
 use crate::tui::views::{ModalKind, ModalView, ViewAction, ViewEvent};
 
 /// Modes inside the worktree manager.
@@ -315,10 +316,7 @@ impl WorktreeManagerView {
                     .unwrap_or_else(|| entry.path.to_str().unwrap_or("?"));
                 let text = format!("{marker}{path} · {branch}{cur}{locked}");
                 let style = if selected {
-                    Style::default()
-                        .fg(palette::WHALE_ACTION)
-                        .add_modifier(Modifier::BOLD)
-                        .bg(palette::SELECTION_BG)
+                    menu_style::selected_row_style_with_fg(palette::WHALE_ACTION)
                 } else if current {
                     Style::default().fg(palette::WHALE_LIVE)
                 } else {

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -20,6 +20,35 @@ visual motion and density for screen-reader and low-motion users.
 | `show_tool_details` setting | `false` | Set to `true` to expand tool calls inline; details remain available on demand either way. |
 | `inline_diffs` setting | `full` | Use `summary` or `off` to reduce inline File-change density. Exact applied evidence remains available with Alt/Option+V in every mode. |
 
+## Color contrast guarantees
+
+The palette enforces WCAG contrast floors in two places, and this is what
+the code actually guarantees — no more:
+
+* **At draw time**, every text cell is lifted to a 4.5:1 contrast ratio
+  against the surface it will actually render on (`enforce_cell_contrast` in
+  the terminal backend). Frame chrome (borders, block glyphs) is not clamped,
+  and community presets that own a full custom palette (Catppuccin, Tokyo
+  Night, Dracula, Gruvbox, Claude, Matrix, Solarized Light, Terminal) are
+  exempt from this draw-time pass because their authors tuned those pairs.
+* **Per theme**, an audit (`theme_contrast_violations`) holds every
+  selectable preset to the same floors: body, soft, and muted text at 4.5:1
+  on every primary surface (including selection and error surfaces); hint and
+  dim text at 3:1; status, warning, success, and info roles at 3:1 because
+  they are redundant — every status also carries a glyph and a word label,
+  so color is never the only channel. Diff foreground/background pairs are
+  held to 3:1.
+* The **Terminal** (transparent) theme is exempt by design: it paints
+  `Color::Reset` surfaces and ANSI accents so the host terminal's own scheme
+  shows through. Those colors are terminal-owned and cannot be measured, so
+  the audit skips them rather than claiming a pass
+  (`theme_uses_terminal_owned_surfaces` makes the exemption explicit).
+* The **Grayscale** theme's "Color-minimal high contrast" tagline is
+  enforced: its body text hierarchy clears 4.5:1 on every surface.
+* The ASCII tier (`CODEWHALE_ASCII_SAFE=1`) keeps labels, focus, and state
+  available without decorative glyphs, so the non-color redundancy above
+  survives in the plainest rendering mode.
+
 ## Standard env-var surface
 
 Set these in your shell profile so they apply to every session:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1247,6 +1247,16 @@ Common settings keys:
   rail. Side choices fall back to the top layout on narrow terminals and in
   Classic without changing the saved Ocean preference. Set it live with
   `/config work_surface_placement right --save` (or `left` / `top`).
+- `focus_texture` (`off`, `scrim`, or `grain`; default `off`): focus-context
+  texture for modal views. `scrim` dims the already-rendered background
+  outside the focused modal toward the theme surface; `grain` sprinkles
+  sparse dots over blank cells there. The texture is static (no time
+  component, so it is unaffected by `low_motion`), never writes over a cell
+  that carries text, and preserves the 4.5:1 body-text contrast floor
+  wherever both colors are resolvable. It is skipped entirely on frames
+  below the ambient-life minimum size and when the focused modal already
+  covers 90% or more of the frame. Set it live with
+  `/config focus_texture scrim --save`.
 - `mention_menu_limit` (integer, default `128`): maximum number of
   `@`-mention popup candidates retained before the composer renders the
   visible window. The visible rows still depend on terminal height.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1682,6 +1682,11 @@ If you are upgrading from older releases:
   `[notifications].sound_file` on Windows.
 - `[notifications].sound_file` (path, optional): path to a custom WAV file
   used when `completion_sound = "file"`.
+- `[notifications.event_sound]` (table, optional): opt-in, deterministic
+  per-event sound cues. Keys: `enabled` (bool, default `false`), `events`
+  (array of kebab-case event names, default `["turn-complete",
+  "approval-needed"]`), `min_interval_ms` (int, default `2000`), `quiet`
+  (bool, default `false`). See "Event sound cues" below.
 - `tui.alternate_screen` (string, optional): `auto`, `always`, or `never`. This is retained for config compatibility, but interactive sessions now always use the TUI-owned alternate screen so host terminal scrollback cannot hijack the viewport.
 - `tui.mouse_capture` (bool, optional, default `true` on non-Windows terminals and on Windows Terminal/ConEmu/Cmder when the alternate screen is active; `false` on legacy Windows console and inside JetBrains JediTerm — PyCharm/IDEA/CLion/etc. — where mouse-event escapes leak into the input stream as garbled text, see #878 / #898): enable internal mouse scrolling, transcript selection, right-click context actions, and transcript scrollbar dragging. TUI-owned drag selection copies only transcript text, removes visual wrap-column line breaks from paragraphs, and keeps selection scoped to the transcript pane. Set this to `false` or run with `--no-mouse-capture` for raw terminal selection; set it to `true` or run with `--mouse-capture` to opt in anywhere it's defaulted off. On raw terminal selection, especially on legacy Windows console or when mouse capture is disabled, selection may cross the right sidebar and include visual wraps because the terminal, not the TUI, owns the selection.
 - `tui.terminal_probe_timeout_ms` (int, optional, default `500`): startup terminal-mode probe timeout in milliseconds. Values are clamped to `100..=5000`; timeout emits a warning and aborts startup instead of hanging indefinitely.
@@ -1762,6 +1767,41 @@ Windows users who run inside a known OSC-9 terminal (e.g. WezTerm on Windows) ke
 `completion_sound = "file"` is for Windows users who want a per-application
 completion sound without changing the global Windows sound scheme. It plays the
 configured WAV `sound_file` asynchronously via the native Windows audio API.
+
+#### Event sound cues
+
+`[notifications.event_sound]` is an opt-in, deterministic policy that emits a
+terminal-bell-level cue when specific notification events fire (approval
+prompts, blocked-on-input, sub-agent completion, and so on). It is **off by
+default**; with `enabled = false` nothing is emitted, which is the
+platform-safe no-op fallback.
+
+```toml
+[notifications.event_sound]
+enabled = false                              # default: off (opt-in)
+events = ["turn-complete", "approval-needed"] # default allow-list
+min_interval_ms = 2000                       # per-event rate limit
+quiet = false                                # true silences everything without editing the allow-list
+```
+
+The cue table is fixed — cues are functional BEL-based signals, not
+designed-for-pleasantness audio, and every cue is one or two `\x07` bytes
+(inert on terminals that ignore BEL, so this is a platform-safe no-op
+everywhere):
+
+| Event | Cue |
+|---|---|
+| `turn-complete` | BEL (`\x07`) |
+| `subagent-terminal` | BEL (`\x07`) |
+| `approval-needed` | double BEL (`\x07\x07`) |
+| `input-needed` | BEL (`\x07`) |
+| `elevation-needed` | double BEL (`\x07\x07`) |
+| `model-notify` | BEL (`\x07`) |
+
+Decision order: disabled → quiet mode → event not in `events` → `turn-complete`
+deferred to the `completion_sound` channel when that is active (so the two
+never double-ding) → per-event rate limit (`min_interval_ms` since the last
+play of that event) → play. Unknown strings in `events` are ignored.
 
 #### What a notification can contain
 


### PR DESCRIPTION
## Summary

Harvests the five reviewed visual-supervision slices:

- #4813: theme contrast audit (3:1 secondary-chrome floor justified by glyph+word redundancy), theme token lifts, docs/ACCESSIBILITY.md
- #4808 slice: menu_style single-sourced selection vocabulary + StatusKind glyph+word table (non-color-meaning tested), ~15 call sites converted; the context-menu SELECTION_BG behavior change is called out in the commit body
- #4823: default-off provably-static focus texture with exact cell accounting + the missing docs/CONFIGURATION.md entry
- #4817: off-by-default BEL-only sound policy — both required repairs done (sink injection so no test can BEL a terminal; the untested process-global path now has a lock-guarded test)
- #4807: jellyfish silhouette + Sparse variant + static reduced-motion pose + frame budget + ASCII fallbacks (ambient idle-ocean decoration is sanctioned by the issue; the no-decoration-animation rail governs status indication)

No-slop notes: two unused as_str methods deleted with their tests rewritten as literal tables; StatusKind::Done wired for real; MAX_FRAME_MARKS stated as test-asserted, not a runtime clamp; StatusKind::Failed labeled an unwired hook — #4815 is NOT claimed. Nothing harvested for #4814/#4816/#4819-#4822 (honestly not-started).

Receipts: palette 93, menu_style 7, focus_texture 12, sound_policy 14, ambient_life 19, views 159, widgets 286, settings 80, notifications 29, config_ui 13, glyphs 12, work_surface 56 — all green; fmt/diff/exact-clippy clean.

No-Issue: partial slices across five issues; closures with final-SHA receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)