### PR TITLE
Migrate QA PTY test harness from vt100 to rio-vt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures 0.2.17",
 ]
@@ -44,7 +44,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -212,12 +212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,7 +279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -319,7 +313,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if",
+ "cfg-if 1.0.4",
  "event-listener",
  "futures-lite",
  "rustix",
@@ -345,7 +339,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomic-waker",
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-core",
  "futures-io",
  "rustix",
@@ -508,14 +502,14 @@ dependencies = [
  "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -631,9 +625,23 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -673,12 +681,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -704,6 +712,12 @@ checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -726,7 +740,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -909,7 +923,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1121,6 +1135,7 @@ dependencies = [
  "readability",
  "regex",
  "reqwest 0.13.4",
+ "rio-vt",
  "rmcp",
  "rusqlite",
  "rust-i18n",
@@ -1133,7 +1148,7 @@ dependencies = [
  "sha2 0.11.0",
  "shell-words",
  "shellexpand",
- "shlex",
+ "shlex 1.3.0",
  "similar",
  "starlark",
  "syntect",
@@ -1153,10 +1168,9 @@ dependencies = [
  "unicode-width 0.2.2",
  "urlencoding",
  "uuid",
- "vt100",
  "wait-timeout",
  "webbrowser",
- "windows",
+ "windows 0.62.2",
  "windows-sys 0.61.2",
  "wiremock",
 ]
@@ -1218,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -1297,6 +1311,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "corcovado"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bb434a9c882d7615547c604a758ac0d7be142b3cc42c2b58339491d319e3bd"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "libc",
+ "miow 0.5.0",
+ "net2",
+ "slab",
+ "tracing",
+ "windows 0.42.0",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,7 +1379,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1387,7 +1420,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -1502,6 +1535,12 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.11",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
@@ -1715,7 +1754,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dirs-sys-next",
 ]
 
@@ -1865,7 +1904,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2056,7 +2095,7 @@ version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rustix",
  "windows-sys 0.59.0",
 ]
@@ -2087,16 +2126,16 @@ version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "libredox",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -2161,6 +2200,22 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futf"
@@ -2308,7 +2363,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi",
@@ -2321,7 +2376,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -2335,7 +2390,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
@@ -2436,7 +2491,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "zerocopy",
 ]
@@ -2933,6 +2988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,7 +3068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.0",
  "log",
@@ -3019,7 +3083,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
@@ -3074,7 +3138,7 @@ version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "wasm-bindgen",
 ]
@@ -3259,7 +3323,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -3531,7 +3595,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "digest 0.10.7",
 ]
 
@@ -3615,6 +3679,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "net2"
+version = "0.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,7 +3754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.12.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.1.1",
  "libc",
 ]
@@ -3673,7 +3766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.12.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.1",
@@ -4012,7 +4105,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -4352,7 +4445,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -4705,7 +4798,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossterm",
  "instability",
  "ratatui-core",
@@ -4859,9 +4952,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4988,11 +5081,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rio-grapheme-width"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4dcff875ccd52c2b3da56061350469674f4f292cbae02538009f64f48cc3d8"
+dependencies = [
+ "phf 0.13.1",
+ "ucd-trie",
+]
+
+[[package]]
+name = "rio-graphics"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc1807607df800b542b9980aaf20a8732b7168172df24e3d811d18ec4d7addb"
+dependencies = [
+ "rustc-hash",
+ "tracing",
+]
+
+[[package]]
+name = "rio-vt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee35d73ac2bc2628caa2bc677b9a83ec14541e9a189e204aeeb9a452ddc4cf0"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.12.1",
+ "bytemuck",
+ "corcovado",
+ "cursor-icon",
+ "flate2",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "regex",
+ "regex-automata",
+ "rio-grapheme-width",
+ "rio-graphics",
+ "rustc-hash",
+ "serde",
+ "simdutf",
+ "smallvec",
+ "teletypewriter",
+ "tracing",
+ "unicode-width-16",
+ "url",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5253,7 +5397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
  "bitflags 2.12.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "clipboard-win",
  "fd-lock",
  "home",
@@ -5592,7 +5736,7 @@ version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -5603,7 +5747,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -5614,7 +5758,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -5625,7 +5769,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
@@ -5671,10 +5815,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -5688,7 +5848,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -5715,6 +5875,16 @@ checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
  "rustc_version",
  "simdutf8",
+]
+
+[[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags 2.12.1",
+ "cc",
 ]
 
 [[package]]
@@ -5746,9 +5916,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -6126,6 +6296,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "teletypewriter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665b971f857741b1feb472ad1649a4584dd2a2fce91596e8da7a6f6533274dd5"
+dependencies = [
+ "corcovado",
+ "dirs",
+ "iovec",
+ "libc",
+ "miow 0.6.1",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6226,7 +6413,7 @@ dependencies = [
  "pest_derive",
  "phf 0.11.3",
  "sha2 0.10.9",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher 1.0.1",
  "terminfo",
  "termios",
@@ -6308,7 +6495,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -6851,6 +7038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-width-16"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6946,27 +7139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width 0.2.2",
- "vte",
-]
-
-[[package]]
-name = "vte"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
-dependencies = [
- "arrayvec",
- "memchr",
-]
-
-[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7024,7 +7196,7 @@ version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -7263,6 +7435,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
@@ -7360,6 +7547,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "corcovado"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bb434a9c882d7615547c604a758ac0d7be142b3cc42c2b58339491d319e3bd"
+checksum = "d4485657270f8214253b07f52e3a3e06affdd17fa4e06d4fc5b4f0d115f1258d"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1322,8 +1322,8 @@ dependencies = [
  "iovec",
  "libc",
  "miow 0.5.0",
- "net2",
  "slab",
+ "socket2",
  "tracing",
  "windows 0.42.0",
  "windows-sys 0.42.0",
@@ -3722,17 +3722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5090,9 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "rio-grapheme-width"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4dcff875ccd52c2b3da56061350469674f4f292cbae02538009f64f48cc3d8"
+checksum = "50dba44bbb5eb9f53186c804ab1a46a97ed9f0475d434767ef8c9b3ea8d24ec2"
 dependencies = [
  "phf 0.13.1",
  "ucd-trie",
@@ -5100,9 +5089,9 @@ dependencies = [
 
 [[package]]
 name = "rio-graphics"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc1807607df800b542b9980aaf20a8732b7168172df24e3d811d18ec4d7addb"
+checksum = "757d408f94ad2d8cd465a005908c86c62dbab55a1b8ba21444db7c46a3b37af4"
 dependencies = [
  "rustc-hash",
  "tracing",
@@ -5110,9 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "rio-vt"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee35d73ac2bc2628caa2bc677b9a83ec14541e9a189e204aeeb9a452ddc4cf0"
+checksum = "62b52c06372ac0150f6e6bcdc57113256b5e8e8cef223ca1bf6c2c3a10c50449"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.12.1",
@@ -5945,9 +5934,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6297,9 +6286,9 @@ dependencies = [
 
 [[package]]
 name = "teletypewriter"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665b971f857741b1feb472ad1649a4584dd2a2fce91596e8da7a6f6533274dd5"
+checksum = "90ae4da081d603b942e2ed62d063e7a5cf083427caf26c7627c17a1b6a0b22b6"
 dependencies = [
  "corcovado",
  "dirs",

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -104,7 +104,7 @@ codewhale-build-support = { path = "../build-support", version = "0.9.2" }
 cucumber = "0.23.0"
 wiremock = "0.6"
 pretty_assertions = "1.4"
-vt100 = "0.16"
+rio-vt = "0.5.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -104,7 +104,7 @@ codewhale-build-support = { path = "../build-support", version = "0.9.2" }
 cucumber = "0.23.0"
 wiremock = "0.6"
 pretty_assertions = "1.4"
-rio-vt = "0.5.0"
+rio-vt = "0.5.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -3762,7 +3762,11 @@ fn real_tool_lifecycle_crosses_work_status_resize_and_scroll_in_a_unix_pty() -> 
         );
         let done_row = visible_row_with_text(frame, "✓ done").expect("done phase row");
         let done_color = foreground_at_text(frame, done_row, "done");
-        assert_ne!(done_color, qa_harness::Color::Default, "done lost ANSI role");
+        assert_ne!(
+            done_color,
+            qa_harness::Color::Default,
+            "done lost ANSI role"
+        );
         assert_ne!(
             done_color,
             live_colors.expect("live colors").0,

--- a/crates/tui/tests/qa_pty.rs
+++ b/crates/tui/tests/qa_pty.rs
@@ -265,7 +265,7 @@ fn visible_row_with_text(frame: &qa_harness::Frame, needle: &str) -> Option<u16>
     (0..frame.rows()).find(|&row| frame.row(row).contains(needle))
 }
 
-fn foreground_at_text(frame: &qa_harness::Frame, row: u16, needle: &str) -> vt100::Color {
+fn foreground_at_text(frame: &qa_harness::Frame, row: u16, needle: &str) -> qa_harness::Color {
     let col = frame
         .find_text_in_row(row, needle)
         .unwrap_or_else(|| panic!("{needle:?} missing from row {row}: {:?}", frame.row(row)));
@@ -309,7 +309,7 @@ fn assert_control_grammar(
     mode: &str,
     permission: &str,
     placeholder: &str,
-) -> (vt100::Color, vt100::Color) {
+) -> (qa_harness::Color, qa_harness::Color) {
     let dump = frame.debug_dump();
     let header = frame.row(0);
     assert!(
@@ -2689,8 +2689,8 @@ fn work_surface_file_mutation_modes_are_truthful_in_real_pty_frames() -> anyhow:
                     visible_row_with_text(h.frame(), "DIFF-NEW-SENTINEL").expect("added line row");
                 let old_color = foreground_at_text(h.frame(), old_row, "DIFF-OLD-SENTINEL");
                 let new_color = foreground_at_text(h.frame(), new_row, "DIFF-NEW-SENTINEL");
-                assert_ne!(old_color, vt100::Color::Default);
-                assert_ne!(new_color, vt100::Color::Default);
+                assert_ne!(old_color, qa_harness::Color::Default);
+                assert_ne!(new_color, qa_harness::Color::Default);
                 assert_ne!(old_color, new_color, "added/deleted ANSI roles collapsed");
             }
             "summary" => {
@@ -3201,7 +3201,7 @@ fn release_semantic_read_fifo(
     })
 }
 
-fn whale_ansi_signature(frame: &qa_harness::Frame) -> Vec<vt100::Color> {
+fn whale_ansi_signature(frame: &qa_harness::Frame) -> Vec<qa_harness::Color> {
     const WHALE_BACK: &str = "▗▄▄▄▄▄▄▄▄▄▄▄▖";
     let (row, mut col) = frame
         .find_text(WHALE_BACK)
@@ -3218,7 +3218,7 @@ fn whale_ansi_signature(frame: &qa_harness::Frame) -> Vec<vt100::Color> {
         .collect()
 }
 
-fn colored_foreground(frame: &qa_harness::Frame, needle: &str) -> vt100::Color {
+fn colored_foreground(frame: &qa_harness::Frame, needle: &str) -> qa_harness::Color {
     let (row, col) = frame
         .find_text(needle)
         .unwrap_or_else(|| panic!("{needle:?} missing:\n{}", frame.debug_dump()));
@@ -3228,7 +3228,7 @@ fn colored_foreground(frame: &qa_harness::Frame, needle: &str) -> vt100::Color {
         .0;
     assert_ne!(
         foreground,
-        vt100::Color::Default,
+        qa_harness::Color::Default,
         "{needle:?} lost its semantic foreground:\n{}",
         frame.debug_dump()
     );
@@ -3343,7 +3343,7 @@ fn assert_running_tool_lifecycle_frame(
     frame: &qa_harness::Frame,
     cols: u16,
     rows: u16,
-) -> (vt100::Color, vt100::Color) {
+) -> (qa_harness::Color, qa_harness::Color) {
     assert_real_pty_frame_geometry(frame, cols, rows);
     let dump = frame.debug_dump();
     assert!(
@@ -3378,7 +3378,7 @@ fn assert_running_tool_lifecycle_frame(
     let tool_running = foreground_at_text(frame, tool_row, "running");
     assert_ne!(
         tool_running,
-        vt100::Color::Default,
+        qa_harness::Color::Default,
         "Bash running state lost its semantic foreground:\n{dump}"
     );
     (colored_foreground(frame, "using tool"), tool_running)
@@ -3610,7 +3610,7 @@ fn real_tool_lifecycle_crosses_work_status_resize_and_scroll_in_a_unix_pty() -> 
     assert!(
         initial_whale
             .iter()
-            .any(|color| *color != vt100::Color::Default),
+            .any(|color| *color != qa_harness::Color::Default),
         "idle BlueWhale lost its ANSI ink:\n{}",
         h.frame().debug_dump()
     );
@@ -3648,7 +3648,7 @@ fn real_tool_lifecycle_crosses_work_status_resize_and_scroll_in_a_unix_pty() -> 
         assert!(
             whale_ansi_signature(frame)
                 .iter()
-                .any(|color| *color != vt100::Color::Default),
+                .any(|color| *color != qa_harness::Color::Default),
             "BlueWhale ANSI ink missing at {cols}x{rows}:\n{}",
             frame.debug_dump()
         );
@@ -3762,7 +3762,7 @@ fn real_tool_lifecycle_crosses_work_status_resize_and_scroll_in_a_unix_pty() -> 
         );
         let done_row = visible_row_with_text(frame, "✓ done").expect("done phase row");
         let done_color = foreground_at_text(frame, done_row, "done");
-        assert_ne!(done_color, vt100::Color::Default, "done lost ANSI role");
+        assert_ne!(done_color, qa_harness::Color::Default, "done lost ANSI role");
         assert_ne!(
             done_color,
             live_colors.expect("live colors").0,

--- a/crates/tui/tests/support/qa_harness/README.md
+++ b/crates/tui/tests/support/qa_harness/README.md
@@ -21,7 +21,7 @@ spin up a PTY just to assert a function returns the right value.
 - `pty.rs` — `PtySession`. Spawns a binary in a real PTY (via `portable-pty`),
   pumps the child's stdout into a buffer on a background thread, exposes
   `write_bytes`, `drain`, `shutdown`.
-- `frame.rs` — `Frame`. Wraps `vt100::Parser`. Feed bytes in, ask questions
+- `frame.rs` — `Frame`. Wraps `rio-vt`. Feed bytes in, ask questions
   out: `text()`, `row(y)`, `contains(s)`, `cursor()`, `debug_dump()`.
 - `keys.rs` — byte-sequence builders for keys (`key::ch('/')`,
   `key::enter()`, `key::text("hello")`) and for paste (`paste::bracketed(s)`,

--- a/crates/tui/tests/support/qa_harness/frame.rs
+++ b/crates/tui/tests/support/qa_harness/frame.rs
@@ -1,20 +1,47 @@
 //! Terminal frame snapshot built from the PTY output stream.
 //!
-//! Wraps `vt100::Parser` so tests can feed bytes incrementally and ask
+//! Wraps `rio-vt` so tests can feed bytes incrementally and ask
 //! questions about the current screen contents (visible text, individual rows,
 //! does-it-contain-this).
 
 use std::time::Instant;
 
+use rio_vt::ansi::CursorShape;
+use rio_vt::config::colors::{AnsiColor, NamedColor};
+use rio_vt::crosswords::formatter::FormatOptions;
+use rio_vt::crosswords::pos::Column;
+use rio_vt::crosswords::square::{ContentTag, Square, Wide};
+use rio_vt::crosswords::style::Style;
+use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+use rio_vt::event::{VoidListener, WindowId};
+use rio_vt::performer::handler::Processor;
+
+/// Terminal cell color, matching the three cases theme QA asserts on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    Default,
+    Idx(u8),
+    Rgb(u8, u8, u8),
+}
+
 pub struct Frame {
-    parser: vt100::Parser,
+    term: Crosswords<VoidListener>,
+    parser: Processor,
     captured_at: Option<Instant>,
 }
 
 impl Frame {
     pub fn new(rows: u16, cols: u16) -> Self {
         Self {
-            parser: vt100::Parser::new(rows, cols, 0),
+            term: Crosswords::new(
+                grid_size(rows, cols),
+                CursorShape::Block,
+                VoidListener,
+                WindowId::from(0),
+                0,
+                0,
+            ),
+            parser: Processor::default(),
             captured_at: None,
         }
     }
@@ -23,48 +50,52 @@ impl Frame {
         if bytes.is_empty() {
             return;
         }
-        self.parser.process(bytes);
+        self.parser.advance(&mut self.term, bytes);
         self.captured_at = Some(Instant::now());
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) {
-        self.parser.screen_mut().set_size(rows, cols);
+        self.term.resize(grid_size(rows, cols));
     }
 
     pub fn rows(&self) -> u16 {
-        self.parser.screen().size().0
+        self.term.screen_lines() as u16
     }
 
     pub fn cols(&self) -> u16 {
-        self.parser.screen().size().1
+        self.term.columns() as u16
     }
 
     /// Full visible screen as a single string with a `\n` between rows.
-    /// Trailing whitespace on each row is preserved so column-position
-    /// assertions stay meaningful.
     pub fn text(&self) -> String {
-        self.parser.screen().contents()
+        self.term.format(FormatOptions::plain())
     }
 
     /// Single row of the screen, 0-indexed from the top, trimmed at the
     /// right edge. Returns the empty string for out-of-range rows.
     ///
-    /// Use `Screen::rows` rather than concatenating `Cell::contents()`.
-    /// Untouched blank cells have no contents in `vt100`, but they still
-    /// occupy a real terminal column between painted cells. Concatenating
-    /// only cell contents therefore turns truthful PTY output such as
-    /// `read running` into the misleading debug string `readrunning`.
-    /// `Screen::rows` preserves those interior columns and skips the hidden
-    /// continuation cell of a wide glyph.
+    /// Blank cells still occupy a real terminal column between painted cells,
+    /// so they are emitted as spaces; the hidden continuation cell of a wide
+    /// glyph is skipped so `界 read` does not become `界  read`.
     pub fn row(&self, y: u16) -> String {
         if y >= self.rows() {
             return String::new();
         }
-        self.parser
-            .screen()
-            .rows(0, self.cols())
-            .nth(usize::from(y))
-            .unwrap_or_default()
+        let rows = self.term.visible_rows();
+        let Some(row) = rows.get(usize::from(y)) else {
+            return String::new();
+        };
+        let cols = usize::from(self.cols());
+        let mut out = String::with_capacity(cols);
+        for col in 0..cols {
+            let square = row[Column(col)];
+            if matches!(square.wide(), Wide::Spacer) {
+                continue;
+            }
+            let ch = square.c();
+            out.push(if ch == '\u{0}' { ' ' } else { ch });
+        }
+        out.trim_end().to_string()
     }
 
     pub fn contains(&self, needle: &str) -> bool {
@@ -72,8 +103,6 @@ impl Frame {
     }
 
     /// First visible coordinate of `needle`, using terminal display columns.
-    /// PTY mouse tests use this to click the row the renderer actually painted
-    /// instead of hard-coding layout coordinates.
     pub fn find_text(&self, needle: &str) -> Option<(u16, u16)> {
         for row in 0..self.rows() {
             if let Some(col) = self.find_text_in_row(row, needle) {
@@ -84,27 +113,28 @@ impl Frame {
     }
 
     /// Locate text on one parsed terminal row without collapsing blank cells.
-    /// `vt100::Cell::contents()` is empty for untouched spaces, which matters
-    /// for transparent themes whose styled gaps do not need to be emitted.
     pub fn find_text_in_row(&self, row: u16, needle: &str) -> Option<u16> {
         if row >= self.rows() || needle.is_empty() {
             return None;
         }
-        for start in 0..self.cols() {
+        let rows = self.term.visible_rows();
+        let grid_row = rows.get(usize::from(row))?;
+        let cols = self.cols();
+        for start in 0..cols {
             let mut col = start;
             let mut matched = true;
             for ch in needle.chars() {
-                let Some(cell) = self.parser.screen().cell(row, col) else {
+                if col >= cols {
                     matched = false;
                     break;
-                };
-                let contents = cell.contents();
+                }
+                let contents = square_contents(grid_row[Column(usize::from(col))]);
                 let mut encoded = [0_u8; 4];
-                let expected = ch.encode_utf8(&mut encoded);
+                let expected: &str = ch.encode_utf8(&mut encoded);
                 if if ch == ' ' {
-                    !contents.is_empty() && contents != " "
+                    !contents.is_empty() && contents.as_str() != " "
                 } else {
-                    contents != expected
+                    contents.as_str() != expected
                 } {
                     matched = false;
                     break;
@@ -127,22 +157,26 @@ impl Frame {
     /// Foreground/background colors for one terminal cell. Theme QA uses the
     /// parsed ANSI result rather than trusting a screenshot renderer's own
     /// palette or accessibility environment.
-    pub fn colors_at(&self, row: u16, col: u16) -> Option<(vt100::Color, vt100::Color)> {
-        self.parser
-            .screen()
-            .cell(row, col)
-            .map(|cell| (cell.fgcolor(), cell.bgcolor()))
+    pub fn colors_at(&self, row: u16, col: u16) -> Option<(Color, Color)> {
+        let rows = self.term.visible_rows();
+        let grid_row = rows.get(usize::from(row))?;
+        if usize::from(col) >= usize::from(self.cols()) {
+            return None;
+        }
+        let styles = self.term.grid.style_set.styles();
+        Some(square_colors(grid_row[Column(usize::from(col))], styles))
     }
 
     /// Colors on the first cell whose terminal contents equal `symbol`.
-    pub fn first_symbol_colors(&self, symbol: &str) -> Option<(vt100::Color, vt100::Color)> {
-        for row in 0..self.rows() {
-            for col in 0..self.cols() {
-                let Some(cell) = self.parser.screen().cell(row, col) else {
-                    continue;
-                };
-                if cell.contents() == symbol {
-                    return Some((cell.fgcolor(), cell.bgcolor()));
+    pub fn first_symbol_colors(&self, symbol: &str) -> Option<(Color, Color)> {
+        let rows = self.term.visible_rows();
+        let styles = self.term.grid.style_set.styles();
+        let cols = usize::from(self.cols());
+        for grid_row in &rows {
+            for col in 0..cols {
+                let square = grid_row[Column(col)];
+                if square_contents(square).as_str() == symbol {
+                    return Some(square_colors(square, styles));
                 }
             }
         }
@@ -150,19 +184,17 @@ impl Frame {
     }
 
     /// Whether any painted cell carries a 24-bit color. The palette adapter
-    /// downgrades every `Color::Rgb` before it reaches crossterm on terminals
+    /// downgrades every truecolor before it reaches crossterm on terminals
     /// that only advertise 256 or 16 colors, so this is the parsed-ANSI proof
-    /// that the capability tier was honored — not a claim about what the
-    /// renderer intended.
+    /// that the capability tier was honored.
     pub fn any_truecolor_cell(&self) -> bool {
-        for row in 0..self.rows() {
-            for col in 0..self.cols() {
-                let Some(cell) = self.parser.screen().cell(row, col) else {
-                    continue;
-                };
-                if matches!(cell.fgcolor(), vt100::Color::Rgb(..))
-                    || matches!(cell.bgcolor(), vt100::Color::Rgb(..))
-                {
+        let rows = self.term.visible_rows();
+        let styles = self.term.grid.style_set.styles();
+        let cols = usize::from(self.cols());
+        for grid_row in &rows {
+            for col in 0..cols {
+                let (fg, bg) = square_colors(grid_row[Column(col)], styles);
+                if matches!(fg, Color::Rgb(..)) || matches!(bg, Color::Rgb(..)) {
                     return true;
                 }
             }
@@ -170,15 +202,13 @@ impl Frame {
         false
     }
 
-    /// Every distinct character painted on the screen. Unicode/ASCII fallback
-    /// rows classify this set rather than substring-matching known glyphs.
+    /// Every distinct character painted on the screen.
     pub fn painted_chars(&self) -> std::collections::BTreeSet<char> {
         self.text().chars().filter(|c| !c.is_whitespace()).collect()
     }
 
-    /// Whether any row overflows the terminal width. `vt100` clips at the
-    /// right margin, so an overflowing renderer shows up as wrapped content
-    /// rather than a long row; this catches the parser-visible half.
+    /// Widest parsed row. rio-vt clips at the right margin, so an overflowing
+    /// renderer shows up as wrapped content rather than a long row.
     pub fn max_row_width(&self) -> usize {
         (0..self.rows())
             .map(|y| self.row(y).chars().count())
@@ -186,16 +216,18 @@ impl Frame {
             .unwrap_or(0)
     }
 
-    /// Whether any row of the screen has non-blank content. Used to detect a
-    /// fully detached / blank viewport.
+    /// Whether any row of the screen has non-blank content.
     pub fn any_visible_text(&self) -> bool {
         self.text().chars().any(|c| !c.is_whitespace())
     }
 
-    /// Cursor position as (row, col). Useful for asserting the composer
-    /// owns the cursor (#1073) or that it is not at row 0 mid-frame.
+    /// Cursor position as (row, col).
     pub fn cursor(&self) -> (u16, u16) {
-        self.parser.screen().cursor_position()
+        let pos = self.term.cursor().pos;
+        (
+            u16::try_from(pos.row.0.max(0)).unwrap_or(u16::MAX),
+            u16::try_from(pos.col.0).unwrap_or(u16::MAX),
+        )
     }
 
     /// Render the screen to a string for diagnostic dumps when an
@@ -211,6 +243,53 @@ impl Frame {
             out.push_str(&format!("{y:>3} | {}\n", self.row(y).trim_end()));
         }
         out
+    }
+}
+
+fn grid_size(rows: u16, cols: u16) -> CrosswordsSize {
+    CrosswordsSize::new(usize::from(cols.max(1)), usize::from(rows.max(1)))
+}
+
+fn square_contents(square: Square) -> String {
+    if matches!(square.wide(), Wide::Spacer) {
+        return String::new();
+    }
+    match square.c() {
+        ' ' | '\u{0}' => String::new(),
+        ch => ch.to_string(),
+    }
+}
+
+fn square_colors(square: Square, styles: &[Style]) -> (Color, Color) {
+    match square.content_tag() {
+        ContentTag::Codepoint => {
+            let style = styles
+                .get(square.style_id() as usize)
+                .copied()
+                .unwrap_or_default();
+            (map_color(style.fg), map_color(style.bg))
+        }
+        ContentTag::BgPalette => (Color::Default, Color::Idx(square.bg_palette_index())),
+        ContentTag::BgRgb => {
+            let (r, g, b) = square.bg_rgb();
+            (Color::Default, Color::Rgb(r, g, b))
+        }
+    }
+}
+
+fn map_color(color: AnsiColor) -> Color {
+    match color {
+        AnsiColor::Named(NamedColor::Foreground | NamedColor::Background) => Color::Default,
+        AnsiColor::Named(named) => {
+            let index = named as u32;
+            if index < 16 {
+                Color::Idx(index as u8)
+            } else {
+                Color::Default
+            }
+        }
+        AnsiColor::Indexed(index) => Color::Idx(index),
+        AnsiColor::Spec(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
     }
 }
 

--- a/crates/tui/tests/support/qa_harness/mod.rs
+++ b/crates/tui/tests/support/qa_harness/mod.rs
@@ -14,7 +14,10 @@
 //!
 //! Design notes live in `README.md` next to this module.
 
-#![allow(dead_code)]
+// Each test binary `#[path]`-includes this harness and uses a different
+// subset of it, so a re-export unused by one binary (e.g. `Color`) is
+// expected — same reason as `dead_code`.
+#![allow(dead_code, unused_imports)]
 
 pub mod frame;
 pub mod harness;

--- a/crates/tui/tests/support/qa_harness/mod.rs
+++ b/crates/tui/tests/support/qa_harness/mod.rs
@@ -23,7 +23,7 @@ pub mod modes;
 pub mod pty;
 pub mod view_log;
 
-pub use frame::Frame;
+pub use frame::{Color, Frame};
 pub use keys::paste;
 pub use modes::TerminalModeLedger;
 pub use pty::PtySession;


### PR DESCRIPTION
Swaps the QA PTY test harness (`crates/tui/tests`) from vt100 to [rio-vt](https://crates.io/crates/rio-vt), Rio's terminal engine.

The `Frame` helper parsed the TUI's real PTY output with vt100 and read cell text and colors to assert on visible rendering. It now uses rio-vt through the same small surface. Cell colors are surfaced through a neutral `qa_harness::Color` enum (Default/Idx/Rgb) that mirrors exactly what the tests already matched on, so the assertions are unchanged; only the dev-dependency and the harness internals move.

The frame unit tests (blank interior columns, wide-glyph continuation cells) pass, and the PTY integration tests compile and run against the rio-vt harness.

Benchmark against vt100 and alacritty_terminal: https://github.com/raphamorim/rio-vt-benchmark

Background on the engine and why it was split out of Rio: https://rioterm.com/blog/2026/07/27/rio-vt-and-librio

No-Issue: migrate the QA PTY harness from vt100 to rio-vt