### PR TITLE
test(cli): satisfy strict all-target clippy

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5538,7 +5538,7 @@ model = "qwen-2.5-7b"
         use codewhale_lane::{ControlDomain, ControlOperation, ControlSurface};
 
         for descriptor in codewhale_lane::control::operations_for_domain(ControlDomain::Lane) {
-            let argv = vec![
+            let argv = [
                 "codewhale".to_string(),
                 "lane".to_string(),
                 descriptor.verb.to_string(),


### PR DESCRIPTION
No-Issue: post-v0.9.2 strict lint maintenance

## Summary

Use a fixed-size argv array directly in the lane descriptor test. Rust 1.97 flags the previous `vec!` as `clippy::useless_vec`; ordinary PR CI skips test targets, while the documented release gate includes them.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p codewhale-cli --all-targets --all-features --locked -- -D warnings` (with the documented allow list)
- [ ] `cargo test --workspace --all-features --locked` (mechanical test-only change)

## Checklist

- [x] Updated docs or comments as needed (not applicable)
- [x] Added or updated tests where relevant (existing test only)
- [x] Verified TUI behavior manually if UI changes (not applicable)
- [x] Harvested/co-authored credit uses a GitHub numeric noreply address (not applicable)