### PR TITLE
fix(tui): stop the ambient jellyfish reading as a face

### DIFF
--- a/crates/tui/src/tui/ambient_life.rs
+++ b/crates/tui/src/tui/ambient_life.rs
@@ -327,7 +327,7 @@ fn build_frame_marks(
     }
 
     // --- Jellyfish: a pulsing dome with lagging tentacles ---
-    // Two dome rows (arc + scalloped skirt) over a row of swaying
+    // Two dome rows (arc + bell rim) over a row of swaying
     // tentacles. The dome opens and closes on a slow floor-bounded sin²;
     // the tentacles repeat the pulse ~350 ms later and sway out of phase
     // with each other — the lag is what sells "jellyfish". Rich/Normal get
@@ -557,12 +557,19 @@ const LEAD_FISH_LEFT: &str = "<o><";
 /// ascii_safe tier needs no fallback mapping for them (len == width).
 ///
 /// Full dome (Rich/Normal), two rows with an open/closed pulse pair: a
-/// rounded arc over a scalloped skirt.
+/// rounded arc over the bell's rim.
+///
+/// The skirt is the bell's lower rim and nothing else: it carries the pulse by
+/// flaring (`\` `/`) and contracting (`(` `)`), the way a real bell swims. It
+/// holds no interior glyphs on purpose — an earlier pair put marks inside the
+/// rim (`(v_v)` / `(v.v)`), which read as two eyes and a mouth. The motion the
+/// silhouette is meant to sell lives in the tentacle row below, not in the
+/// skirt.
 const JELLY_DOME_TOP_FRAMES: &[&str] = &[".-~-.", ".'-.'"];
-const JELLY_DOME_SKIRT_FRAMES: &[&str] = &["(v_v)", "(v.v)"];
+const JELLY_DOME_SKIRT_FRAMES: &[&str] = &["\\___/", "(___)"];
 /// Compact dome for the Sparse (narrow) tier: same two-row read at 3 cells.
 const JELLY_DOME_TOP_COMPACT: &[&str] = &[".-.", "'.'"];
-const JELLY_DOME_SKIRT_COMPACT: &[&str] = &["(v)", "(-)"];
+const JELLY_DOME_SKIRT_COMPACT: &[&str] = &["\\_/", "(_)"];
 /// Tentacle sway frames (all width-1). Each column runs the same table with
 /// a phase offset so the trio lags instead of strobing in sync.
 const JELLY_TENTACLE_FRAMES: &[&str] = &["|", ":", "|", "."];


### PR DESCRIPTION
No-Issue: ambient-life silhouette correction.

The jellyfish skirt frames were `(v_v)` and `(v.v)`. Under a rounded dome that
does not read as a bell — it reads as two eyes and a mouth. The ambient field is
meant to be sea life, not a character looking back at the operator.

## Before / after

```
   before            after
   .-~-.             .-~-.
   (v_v)             \___/
    |||               |||

   .'-.'             .'-.'
   (v.v)             (___)
    |:|               |:|
```

The skirt is now the bell's lower rim and nothing else: `\___/` flared on the
open beat, `(___)` contracted on the closed one. The pulse still reads — flare
then contract is how a bell actually swims — without any interior glyph. The
compact Sparse-tier pair follows the same shape at three cells (`\_/` / `(_)`,
replacing `(v)` / `(-)`).

Motion continues to live where it belongs: the lagging tentacle row below,
which is untouched.

## Why this is safe

- Both frames stay **pure ASCII with `len == width`** (5 and 3), which is the
  invariant `ambient_glyphs_are_ascii_or_have_fallbacks` and the module's
  "ASCII by construction" contract depend on — the `ascii_safe` tier still needs
  no fallback mapping.
- Dome geometry is unchanged: `dome_w` is derived from `dome_top[0].len()`, and
  the top frames are untouched, so positioning, tentacle columns, and the
  render budget are all unaffected.
- The tests match on the constants rather than on literals, so they exercise the
  new glyphs rather than needing an update.

Also corrected two now-inaccurate comments that still described a "scalloped
skirt".

## Receipts (macOS)

```
cargo test -p codewhale-tui --bin codewhale-tui --all-features --locked -- ambient_life::
test result: ok. 16 passed; 0 failed; 0 ignored

  including: jellyfish_reads_as_dome_with_lagging_tentacles
             jellyfish_tentacles_sway_out_of_phase_and_dome_pulses
             sparse_water_gets_a_compact_jellyfish
             reduced_motion_parks_a_complete_jellyfish
             water_holds_only_fish_bubbles_and_jellyfish
             ambient_glyphs_are_ascii_or_have_fallbacks
             frame_stats_stay_within_the_render_budget

cargo fmt --all -- --check    clean
git diff --check              clean
cargo clippy -p codewhale-tui --all-features --locked -- -D warnings <CI allow-list>
  Finished in 15.01s — no warnings, no errors
```